### PR TITLE
k8s.io/code-generator: change generateMemberWith for atomic slice 

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/applyconfiguration/cr/v1/example.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/applyconfiguration/cr/v1/example.go
@@ -174,6 +174,7 @@ func (b *ExampleApplyConfiguration) WithAnnotations(entries map[string]string) *
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *ExampleApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *ExampleApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -185,14 +186,40 @@ func (b *ExampleApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerRefer
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *ExampleApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *ExampleApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *ExampleApplyConfiguration) WithFinalizers(values ...string) *ExampleApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *ExampleApplyConfiguration) WithNewFinalizers(values ...string) *ExampleApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1/customresourcedefinition.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1/customresourcedefinition.go
@@ -173,6 +173,7 @@ func (b *CustomResourceDefinitionApplyConfiguration) WithAnnotations(entries map
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *CustomResourceDefinitionApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *CustomResourceDefinitionApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -184,14 +185,40 @@ func (b *CustomResourceDefinitionApplyConfiguration) WithOwnerReferences(values 
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *CustomResourceDefinitionApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *CustomResourceDefinitionApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *CustomResourceDefinitionApplyConfiguration) WithFinalizers(values ...string) *CustomResourceDefinitionApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *CustomResourceDefinitionApplyConfiguration) WithNewFinalizers(values ...string) *CustomResourceDefinitionApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1/customresourcedefinitionnames.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1/customresourcedefinitionnames.go
@@ -54,10 +54,20 @@ func (b *CustomResourceDefinitionNamesApplyConfiguration) WithSingular(value str
 // WithShortNames adds the given value to the ShortNames field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the ShortNames field.
+// Deprecated: WithShortNames does not replace existing list for atomic list type. Use WithNewShortNames instead.
 func (b *CustomResourceDefinitionNamesApplyConfiguration) WithShortNames(values ...string) *CustomResourceDefinitionNamesApplyConfiguration {
 	for i := range values {
 		b.ShortNames = append(b.ShortNames, values[i])
 	}
+	return b
+}
+
+// WithNewShortNames replaces the ShortNames field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the ShortNames field is set to the values of the last call.
+func (b *CustomResourceDefinitionNamesApplyConfiguration) WithNewShortNames(values ...string) *CustomResourceDefinitionNamesApplyConfiguration {
+	b.ShortNames = make([]string, len(values))
+	copy(b.ShortNames, values)
 	return b
 }
 
@@ -80,9 +90,19 @@ func (b *CustomResourceDefinitionNamesApplyConfiguration) WithListKind(value str
 // WithCategories adds the given value to the Categories field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Categories field.
+// Deprecated: WithCategories does not replace existing list for atomic list type. Use WithNewCategories instead.
 func (b *CustomResourceDefinitionNamesApplyConfiguration) WithCategories(values ...string) *CustomResourceDefinitionNamesApplyConfiguration {
 	for i := range values {
 		b.Categories = append(b.Categories, values[i])
 	}
+	return b
+}
+
+// WithNewCategories replaces the Categories field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Categories field is set to the values of the last call.
+func (b *CustomResourceDefinitionNamesApplyConfiguration) WithNewCategories(values ...string) *CustomResourceDefinitionNamesApplyConfiguration {
+	b.Categories = make([]string, len(values))
+	copy(b.Categories, values)
 	return b
 }

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1/customresourcedefinitionspec.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1/customresourcedefinitionspec.go
@@ -66,10 +66,25 @@ func (b *CustomResourceDefinitionSpecApplyConfiguration) WithScope(value apiexte
 // WithVersions adds the given value to the Versions field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Versions field.
+// Deprecated: WithVersions does not replace existing list for atomic list type. Use WithNewVersions instead.
 func (b *CustomResourceDefinitionSpecApplyConfiguration) WithVersions(values ...*CustomResourceDefinitionVersionApplyConfiguration) *CustomResourceDefinitionSpecApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithVersions")
+		}
+		b.Versions = append(b.Versions, *values[i])
+	}
+	return b
+}
+
+// WithNewVersions replaces the Versions field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Versions field is set to the values of the last call.
+func (b *CustomResourceDefinitionSpecApplyConfiguration) WithNewVersions(values ...*CustomResourceDefinitionVersionApplyConfiguration) *CustomResourceDefinitionSpecApplyConfiguration {
+	b.Versions = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewVersions")
 		}
 		b.Versions = append(b.Versions, *values[i])
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1/customresourcedefinitionstatus.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1/customresourcedefinitionstatus.go
@@ -56,9 +56,19 @@ func (b *CustomResourceDefinitionStatusApplyConfiguration) WithAcceptedNames(val
 // WithStoredVersions adds the given value to the StoredVersions field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the StoredVersions field.
+// Deprecated: WithStoredVersions does not replace existing list for atomic list type. Use WithNewStoredVersions instead.
 func (b *CustomResourceDefinitionStatusApplyConfiguration) WithStoredVersions(values ...string) *CustomResourceDefinitionStatusApplyConfiguration {
 	for i := range values {
 		b.StoredVersions = append(b.StoredVersions, values[i])
 	}
+	return b
+}
+
+// WithNewStoredVersions replaces the StoredVersions field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the StoredVersions field is set to the values of the last call.
+func (b *CustomResourceDefinitionStatusApplyConfiguration) WithNewStoredVersions(values ...string) *CustomResourceDefinitionStatusApplyConfiguration {
+	b.StoredVersions = make([]string, len(values))
+	copy(b.StoredVersions, values)
 	return b
 }

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1/customresourcedefinitionversion.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1/customresourcedefinitionversion.go
@@ -96,10 +96,25 @@ func (b *CustomResourceDefinitionVersionApplyConfiguration) WithSubresources(val
 // WithAdditionalPrinterColumns adds the given value to the AdditionalPrinterColumns field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the AdditionalPrinterColumns field.
+// Deprecated: WithAdditionalPrinterColumns does not replace existing list for atomic list type. Use WithNewAdditionalPrinterColumns instead.
 func (b *CustomResourceDefinitionVersionApplyConfiguration) WithAdditionalPrinterColumns(values ...*CustomResourceColumnDefinitionApplyConfiguration) *CustomResourceDefinitionVersionApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithAdditionalPrinterColumns")
+		}
+		b.AdditionalPrinterColumns = append(b.AdditionalPrinterColumns, *values[i])
+	}
+	return b
+}
+
+// WithNewAdditionalPrinterColumns replaces the AdditionalPrinterColumns field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the AdditionalPrinterColumns field is set to the values of the last call.
+func (b *CustomResourceDefinitionVersionApplyConfiguration) WithNewAdditionalPrinterColumns(values ...*CustomResourceColumnDefinitionApplyConfiguration) *CustomResourceDefinitionVersionApplyConfiguration {
+	b.AdditionalPrinterColumns = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewAdditionalPrinterColumns")
 		}
 		b.AdditionalPrinterColumns = append(b.AdditionalPrinterColumns, *values[i])
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1/jsonschemaprops.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1/jsonschemaprops.go
@@ -232,10 +232,20 @@ func (b *JSONSchemaPropsApplyConfiguration) WithMultipleOf(value float64) *JSONS
 // WithEnum adds the given value to the Enum field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Enum field.
+// Deprecated: WithEnum does not replace existing list for atomic list type. Use WithNewEnum instead.
 func (b *JSONSchemaPropsApplyConfiguration) WithEnum(values ...v1.JSON) *JSONSchemaPropsApplyConfiguration {
 	for i := range values {
 		b.Enum = append(b.Enum, values[i])
 	}
+	return b
+}
+
+// WithNewEnum replaces the Enum field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Enum field is set to the values of the last call.
+func (b *JSONSchemaPropsApplyConfiguration) WithNewEnum(values ...v1.JSON) *JSONSchemaPropsApplyConfiguration {
+	b.Enum = make([]v1.JSON, len(values))
+	copy(b.Enum, values)
 	return b
 }
 
@@ -258,10 +268,20 @@ func (b *JSONSchemaPropsApplyConfiguration) WithMinProperties(value int64) *JSON
 // WithRequired adds the given value to the Required field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Required field.
+// Deprecated: WithRequired does not replace existing list for atomic list type. Use WithNewRequired instead.
 func (b *JSONSchemaPropsApplyConfiguration) WithRequired(values ...string) *JSONSchemaPropsApplyConfiguration {
 	for i := range values {
 		b.Required = append(b.Required, values[i])
 	}
+	return b
+}
+
+// WithNewRequired replaces the Required field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Required field is set to the values of the last call.
+func (b *JSONSchemaPropsApplyConfiguration) WithNewRequired(values ...string) *JSONSchemaPropsApplyConfiguration {
+	b.Required = make([]string, len(values))
+	copy(b.Required, values)
 	return b
 }
 
@@ -276,6 +296,7 @@ func (b *JSONSchemaPropsApplyConfiguration) WithItems(value v1.JSONSchemaPropsOr
 // WithAllOf adds the given value to the AllOf field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the AllOf field.
+// Deprecated: WithAllOf does not replace existing list for atomic list type. Use WithNewAllOf instead.
 func (b *JSONSchemaPropsApplyConfiguration) WithAllOf(values ...*JSONSchemaPropsApplyConfiguration) *JSONSchemaPropsApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
@@ -286,9 +307,24 @@ func (b *JSONSchemaPropsApplyConfiguration) WithAllOf(values ...*JSONSchemaProps
 	return b
 }
 
+// WithNewAllOf replaces the AllOf field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the AllOf field is set to the values of the last call.
+func (b *JSONSchemaPropsApplyConfiguration) WithNewAllOf(values ...*JSONSchemaPropsApplyConfiguration) *JSONSchemaPropsApplyConfiguration {
+	b.AllOf = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewAllOf")
+		}
+		b.AllOf = append(b.AllOf, *values[i])
+	}
+	return b
+}
+
 // WithOneOf adds the given value to the OneOf field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OneOf field.
+// Deprecated: WithOneOf does not replace existing list for atomic list type. Use WithNewOneOf instead.
 func (b *JSONSchemaPropsApplyConfiguration) WithOneOf(values ...*JSONSchemaPropsApplyConfiguration) *JSONSchemaPropsApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
@@ -299,13 +335,42 @@ func (b *JSONSchemaPropsApplyConfiguration) WithOneOf(values ...*JSONSchemaProps
 	return b
 }
 
+// WithNewOneOf replaces the OneOf field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OneOf field is set to the values of the last call.
+func (b *JSONSchemaPropsApplyConfiguration) WithNewOneOf(values ...*JSONSchemaPropsApplyConfiguration) *JSONSchemaPropsApplyConfiguration {
+	b.OneOf = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOneOf")
+		}
+		b.OneOf = append(b.OneOf, *values[i])
+	}
+	return b
+}
+
 // WithAnyOf adds the given value to the AnyOf field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the AnyOf field.
+// Deprecated: WithAnyOf does not replace existing list for atomic list type. Use WithNewAnyOf instead.
 func (b *JSONSchemaPropsApplyConfiguration) WithAnyOf(values ...*JSONSchemaPropsApplyConfiguration) *JSONSchemaPropsApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithAnyOf")
+		}
+		b.AnyOf = append(b.AnyOf, *values[i])
+	}
+	return b
+}
+
+// WithNewAnyOf replaces the AnyOf field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the AnyOf field is set to the values of the last call.
+func (b *JSONSchemaPropsApplyConfiguration) WithNewAnyOf(values ...*JSONSchemaPropsApplyConfiguration) *JSONSchemaPropsApplyConfiguration {
+	b.AnyOf = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewAnyOf")
 		}
 		b.AnyOf = append(b.AnyOf, *values[i])
 	}
@@ -431,10 +496,20 @@ func (b *JSONSchemaPropsApplyConfiguration) WithXIntOrString(value bool) *JSONSc
 // WithXListMapKeys adds the given value to the XListMapKeys field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the XListMapKeys field.
+// Deprecated: WithXListMapKeys does not replace existing list for atomic list type. Use WithNewXListMapKeys instead.
 func (b *JSONSchemaPropsApplyConfiguration) WithXListMapKeys(values ...string) *JSONSchemaPropsApplyConfiguration {
 	for i := range values {
 		b.XListMapKeys = append(b.XListMapKeys, values[i])
 	}
+	return b
+}
+
+// WithNewXListMapKeys replaces the XListMapKeys field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the XListMapKeys field is set to the values of the last call.
+func (b *JSONSchemaPropsApplyConfiguration) WithNewXListMapKeys(values ...string) *JSONSchemaPropsApplyConfiguration {
+	b.XListMapKeys = make([]string, len(values))
+	copy(b.XListMapKeys, values)
 	return b
 }
 

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1/webhookclientconfig.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1/webhookclientconfig.go
@@ -51,9 +51,19 @@ func (b *WebhookClientConfigApplyConfiguration) WithService(value *ServiceRefere
 // WithCABundle adds the given value to the CABundle field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the CABundle field.
+// Deprecated: WithCABundle does not replace existing list for atomic list type. Use WithNewCABundle instead.
 func (b *WebhookClientConfigApplyConfiguration) WithCABundle(values ...byte) *WebhookClientConfigApplyConfiguration {
 	for i := range values {
 		b.CABundle = append(b.CABundle, values[i])
 	}
+	return b
+}
+
+// WithNewCABundle replaces the CABundle field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the CABundle field is set to the values of the last call.
+func (b *WebhookClientConfigApplyConfiguration) WithNewCABundle(values ...byte) *WebhookClientConfigApplyConfiguration {
+	b.CABundle = make([]byte, len(values))
+	copy(b.CABundle, values)
 	return b
 }

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1/webhookconversion.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1/webhookconversion.go
@@ -42,9 +42,19 @@ func (b *WebhookConversionApplyConfiguration) WithClientConfig(value *WebhookCli
 // WithConversionReviewVersions adds the given value to the ConversionReviewVersions field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the ConversionReviewVersions field.
+// Deprecated: WithConversionReviewVersions does not replace existing list for atomic list type. Use WithNewConversionReviewVersions instead.
 func (b *WebhookConversionApplyConfiguration) WithConversionReviewVersions(values ...string) *WebhookConversionApplyConfiguration {
 	for i := range values {
 		b.ConversionReviewVersions = append(b.ConversionReviewVersions, values[i])
 	}
+	return b
+}
+
+// WithNewConversionReviewVersions replaces the ConversionReviewVersions field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the ConversionReviewVersions field is set to the values of the last call.
+func (b *WebhookConversionApplyConfiguration) WithNewConversionReviewVersions(values ...string) *WebhookConversionApplyConfiguration {
+	b.ConversionReviewVersions = make([]string, len(values))
+	copy(b.ConversionReviewVersions, values)
 	return b
 }

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1beta1/customresourceconversion.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1beta1/customresourceconversion.go
@@ -55,9 +55,19 @@ func (b *CustomResourceConversionApplyConfiguration) WithWebhookClientConfig(val
 // WithConversionReviewVersions adds the given value to the ConversionReviewVersions field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the ConversionReviewVersions field.
+// Deprecated: WithConversionReviewVersions does not replace existing list for atomic list type. Use WithNewConversionReviewVersions instead.
 func (b *CustomResourceConversionApplyConfiguration) WithConversionReviewVersions(values ...string) *CustomResourceConversionApplyConfiguration {
 	for i := range values {
 		b.ConversionReviewVersions = append(b.ConversionReviewVersions, values[i])
 	}
+	return b
+}
+
+// WithNewConversionReviewVersions replaces the ConversionReviewVersions field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the ConversionReviewVersions field is set to the values of the last call.
+func (b *CustomResourceConversionApplyConfiguration) WithNewConversionReviewVersions(values ...string) *CustomResourceConversionApplyConfiguration {
+	b.ConversionReviewVersions = make([]string, len(values))
+	copy(b.ConversionReviewVersions, values)
 	return b
 }

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1beta1/customresourcedefinition.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1beta1/customresourcedefinition.go
@@ -173,6 +173,7 @@ func (b *CustomResourceDefinitionApplyConfiguration) WithAnnotations(entries map
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *CustomResourceDefinitionApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *CustomResourceDefinitionApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -184,14 +185,40 @@ func (b *CustomResourceDefinitionApplyConfiguration) WithOwnerReferences(values 
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *CustomResourceDefinitionApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *CustomResourceDefinitionApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *CustomResourceDefinitionApplyConfiguration) WithFinalizers(values ...string) *CustomResourceDefinitionApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *CustomResourceDefinitionApplyConfiguration) WithNewFinalizers(values ...string) *CustomResourceDefinitionApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1beta1/customresourcedefinitionnames.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1beta1/customresourcedefinitionnames.go
@@ -54,10 +54,20 @@ func (b *CustomResourceDefinitionNamesApplyConfiguration) WithSingular(value str
 // WithShortNames adds the given value to the ShortNames field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the ShortNames field.
+// Deprecated: WithShortNames does not replace existing list for atomic list type. Use WithNewShortNames instead.
 func (b *CustomResourceDefinitionNamesApplyConfiguration) WithShortNames(values ...string) *CustomResourceDefinitionNamesApplyConfiguration {
 	for i := range values {
 		b.ShortNames = append(b.ShortNames, values[i])
 	}
+	return b
+}
+
+// WithNewShortNames replaces the ShortNames field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the ShortNames field is set to the values of the last call.
+func (b *CustomResourceDefinitionNamesApplyConfiguration) WithNewShortNames(values ...string) *CustomResourceDefinitionNamesApplyConfiguration {
+	b.ShortNames = make([]string, len(values))
+	copy(b.ShortNames, values)
 	return b
 }
 
@@ -80,9 +90,19 @@ func (b *CustomResourceDefinitionNamesApplyConfiguration) WithListKind(value str
 // WithCategories adds the given value to the Categories field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Categories field.
+// Deprecated: WithCategories does not replace existing list for atomic list type. Use WithNewCategories instead.
 func (b *CustomResourceDefinitionNamesApplyConfiguration) WithCategories(values ...string) *CustomResourceDefinitionNamesApplyConfiguration {
 	for i := range values {
 		b.Categories = append(b.Categories, values[i])
 	}
+	return b
+}
+
+// WithNewCategories replaces the Categories field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Categories field is set to the values of the last call.
+func (b *CustomResourceDefinitionNamesApplyConfiguration) WithNewCategories(values ...string) *CustomResourceDefinitionNamesApplyConfiguration {
+	b.Categories = make([]string, len(values))
+	copy(b.Categories, values)
 	return b
 }

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1beta1/customresourcedefinitionspec.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1beta1/customresourcedefinitionspec.go
@@ -94,6 +94,7 @@ func (b *CustomResourceDefinitionSpecApplyConfiguration) WithSubresources(value 
 // WithVersions adds the given value to the Versions field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Versions field.
+// Deprecated: WithVersions does not replace existing list for atomic list type. Use WithNewVersions instead.
 func (b *CustomResourceDefinitionSpecApplyConfiguration) WithVersions(values ...*CustomResourceDefinitionVersionApplyConfiguration) *CustomResourceDefinitionSpecApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
@@ -104,13 +105,42 @@ func (b *CustomResourceDefinitionSpecApplyConfiguration) WithVersions(values ...
 	return b
 }
 
+// WithNewVersions replaces the Versions field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Versions field is set to the values of the last call.
+func (b *CustomResourceDefinitionSpecApplyConfiguration) WithNewVersions(values ...*CustomResourceDefinitionVersionApplyConfiguration) *CustomResourceDefinitionSpecApplyConfiguration {
+	b.Versions = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewVersions")
+		}
+		b.Versions = append(b.Versions, *values[i])
+	}
+	return b
+}
+
 // WithAdditionalPrinterColumns adds the given value to the AdditionalPrinterColumns field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the AdditionalPrinterColumns field.
+// Deprecated: WithAdditionalPrinterColumns does not replace existing list for atomic list type. Use WithNewAdditionalPrinterColumns instead.
 func (b *CustomResourceDefinitionSpecApplyConfiguration) WithAdditionalPrinterColumns(values ...*CustomResourceColumnDefinitionApplyConfiguration) *CustomResourceDefinitionSpecApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithAdditionalPrinterColumns")
+		}
+		b.AdditionalPrinterColumns = append(b.AdditionalPrinterColumns, *values[i])
+	}
+	return b
+}
+
+// WithNewAdditionalPrinterColumns replaces the AdditionalPrinterColumns field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the AdditionalPrinterColumns field is set to the values of the last call.
+func (b *CustomResourceDefinitionSpecApplyConfiguration) WithNewAdditionalPrinterColumns(values ...*CustomResourceColumnDefinitionApplyConfiguration) *CustomResourceDefinitionSpecApplyConfiguration {
+	b.AdditionalPrinterColumns = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewAdditionalPrinterColumns")
 		}
 		b.AdditionalPrinterColumns = append(b.AdditionalPrinterColumns, *values[i])
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1beta1/customresourcedefinitionstatus.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1beta1/customresourcedefinitionstatus.go
@@ -56,9 +56,19 @@ func (b *CustomResourceDefinitionStatusApplyConfiguration) WithAcceptedNames(val
 // WithStoredVersions adds the given value to the StoredVersions field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the StoredVersions field.
+// Deprecated: WithStoredVersions does not replace existing list for atomic list type. Use WithNewStoredVersions instead.
 func (b *CustomResourceDefinitionStatusApplyConfiguration) WithStoredVersions(values ...string) *CustomResourceDefinitionStatusApplyConfiguration {
 	for i := range values {
 		b.StoredVersions = append(b.StoredVersions, values[i])
 	}
+	return b
+}
+
+// WithNewStoredVersions replaces the StoredVersions field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the StoredVersions field is set to the values of the last call.
+func (b *CustomResourceDefinitionStatusApplyConfiguration) WithNewStoredVersions(values ...string) *CustomResourceDefinitionStatusApplyConfiguration {
+	b.StoredVersions = make([]string, len(values))
+	copy(b.StoredVersions, values)
 	return b
 }

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1beta1/customresourcedefinitionversion.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1beta1/customresourcedefinitionversion.go
@@ -96,10 +96,25 @@ func (b *CustomResourceDefinitionVersionApplyConfiguration) WithSubresources(val
 // WithAdditionalPrinterColumns adds the given value to the AdditionalPrinterColumns field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the AdditionalPrinterColumns field.
+// Deprecated: WithAdditionalPrinterColumns does not replace existing list for atomic list type. Use WithNewAdditionalPrinterColumns instead.
 func (b *CustomResourceDefinitionVersionApplyConfiguration) WithAdditionalPrinterColumns(values ...*CustomResourceColumnDefinitionApplyConfiguration) *CustomResourceDefinitionVersionApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithAdditionalPrinterColumns")
+		}
+		b.AdditionalPrinterColumns = append(b.AdditionalPrinterColumns, *values[i])
+	}
+	return b
+}
+
+// WithNewAdditionalPrinterColumns replaces the AdditionalPrinterColumns field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the AdditionalPrinterColumns field is set to the values of the last call.
+func (b *CustomResourceDefinitionVersionApplyConfiguration) WithNewAdditionalPrinterColumns(values ...*CustomResourceColumnDefinitionApplyConfiguration) *CustomResourceDefinitionVersionApplyConfiguration {
+	b.AdditionalPrinterColumns = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewAdditionalPrinterColumns")
 		}
 		b.AdditionalPrinterColumns = append(b.AdditionalPrinterColumns, *values[i])
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1beta1/jsonschemaprops.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1beta1/jsonschemaprops.go
@@ -232,10 +232,20 @@ func (b *JSONSchemaPropsApplyConfiguration) WithMultipleOf(value float64) *JSONS
 // WithEnum adds the given value to the Enum field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Enum field.
+// Deprecated: WithEnum does not replace existing list for atomic list type. Use WithNewEnum instead.
 func (b *JSONSchemaPropsApplyConfiguration) WithEnum(values ...v1beta1.JSON) *JSONSchemaPropsApplyConfiguration {
 	for i := range values {
 		b.Enum = append(b.Enum, values[i])
 	}
+	return b
+}
+
+// WithNewEnum replaces the Enum field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Enum field is set to the values of the last call.
+func (b *JSONSchemaPropsApplyConfiguration) WithNewEnum(values ...v1beta1.JSON) *JSONSchemaPropsApplyConfiguration {
+	b.Enum = make([]v1beta1.JSON, len(values))
+	copy(b.Enum, values)
 	return b
 }
 
@@ -258,10 +268,20 @@ func (b *JSONSchemaPropsApplyConfiguration) WithMinProperties(value int64) *JSON
 // WithRequired adds the given value to the Required field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Required field.
+// Deprecated: WithRequired does not replace existing list for atomic list type. Use WithNewRequired instead.
 func (b *JSONSchemaPropsApplyConfiguration) WithRequired(values ...string) *JSONSchemaPropsApplyConfiguration {
 	for i := range values {
 		b.Required = append(b.Required, values[i])
 	}
+	return b
+}
+
+// WithNewRequired replaces the Required field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Required field is set to the values of the last call.
+func (b *JSONSchemaPropsApplyConfiguration) WithNewRequired(values ...string) *JSONSchemaPropsApplyConfiguration {
+	b.Required = make([]string, len(values))
+	copy(b.Required, values)
 	return b
 }
 
@@ -276,6 +296,7 @@ func (b *JSONSchemaPropsApplyConfiguration) WithItems(value v1beta1.JSONSchemaPr
 // WithAllOf adds the given value to the AllOf field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the AllOf field.
+// Deprecated: WithAllOf does not replace existing list for atomic list type. Use WithNewAllOf instead.
 func (b *JSONSchemaPropsApplyConfiguration) WithAllOf(values ...*JSONSchemaPropsApplyConfiguration) *JSONSchemaPropsApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
@@ -286,9 +307,24 @@ func (b *JSONSchemaPropsApplyConfiguration) WithAllOf(values ...*JSONSchemaProps
 	return b
 }
 
+// WithNewAllOf replaces the AllOf field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the AllOf field is set to the values of the last call.
+func (b *JSONSchemaPropsApplyConfiguration) WithNewAllOf(values ...*JSONSchemaPropsApplyConfiguration) *JSONSchemaPropsApplyConfiguration {
+	b.AllOf = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewAllOf")
+		}
+		b.AllOf = append(b.AllOf, *values[i])
+	}
+	return b
+}
+
 // WithOneOf adds the given value to the OneOf field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OneOf field.
+// Deprecated: WithOneOf does not replace existing list for atomic list type. Use WithNewOneOf instead.
 func (b *JSONSchemaPropsApplyConfiguration) WithOneOf(values ...*JSONSchemaPropsApplyConfiguration) *JSONSchemaPropsApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
@@ -299,13 +335,42 @@ func (b *JSONSchemaPropsApplyConfiguration) WithOneOf(values ...*JSONSchemaProps
 	return b
 }
 
+// WithNewOneOf replaces the OneOf field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OneOf field is set to the values of the last call.
+func (b *JSONSchemaPropsApplyConfiguration) WithNewOneOf(values ...*JSONSchemaPropsApplyConfiguration) *JSONSchemaPropsApplyConfiguration {
+	b.OneOf = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOneOf")
+		}
+		b.OneOf = append(b.OneOf, *values[i])
+	}
+	return b
+}
+
 // WithAnyOf adds the given value to the AnyOf field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the AnyOf field.
+// Deprecated: WithAnyOf does not replace existing list for atomic list type. Use WithNewAnyOf instead.
 func (b *JSONSchemaPropsApplyConfiguration) WithAnyOf(values ...*JSONSchemaPropsApplyConfiguration) *JSONSchemaPropsApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithAnyOf")
+		}
+		b.AnyOf = append(b.AnyOf, *values[i])
+	}
+	return b
+}
+
+// WithNewAnyOf replaces the AnyOf field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the AnyOf field is set to the values of the last call.
+func (b *JSONSchemaPropsApplyConfiguration) WithNewAnyOf(values ...*JSONSchemaPropsApplyConfiguration) *JSONSchemaPropsApplyConfiguration {
+	b.AnyOf = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewAnyOf")
 		}
 		b.AnyOf = append(b.AnyOf, *values[i])
 	}
@@ -431,10 +496,20 @@ func (b *JSONSchemaPropsApplyConfiguration) WithXIntOrString(value bool) *JSONSc
 // WithXListMapKeys adds the given value to the XListMapKeys field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the XListMapKeys field.
+// Deprecated: WithXListMapKeys does not replace existing list for atomic list type. Use WithNewXListMapKeys instead.
 func (b *JSONSchemaPropsApplyConfiguration) WithXListMapKeys(values ...string) *JSONSchemaPropsApplyConfiguration {
 	for i := range values {
 		b.XListMapKeys = append(b.XListMapKeys, values[i])
 	}
+	return b
+}
+
+// WithNewXListMapKeys replaces the XListMapKeys field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the XListMapKeys field is set to the values of the last call.
+func (b *JSONSchemaPropsApplyConfiguration) WithNewXListMapKeys(values ...string) *JSONSchemaPropsApplyConfiguration {
+	b.XListMapKeys = make([]string, len(values))
+	copy(b.XListMapKeys, values)
 	return b
 }
 

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1beta1/webhookclientconfig.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1beta1/webhookclientconfig.go
@@ -51,9 +51,19 @@ func (b *WebhookClientConfigApplyConfiguration) WithService(value *ServiceRefere
 // WithCABundle adds the given value to the CABundle field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the CABundle field.
+// Deprecated: WithCABundle does not replace existing list for atomic list type. Use WithNewCABundle instead.
 func (b *WebhookClientConfigApplyConfiguration) WithCABundle(values ...byte) *WebhookClientConfigApplyConfiguration {
 	for i := range values {
 		b.CABundle = append(b.CABundle, values[i])
 	}
+	return b
+}
+
+// WithNewCABundle replaces the CABundle field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the CABundle field is set to the values of the last call.
+func (b *WebhookClientConfigApplyConfiguration) WithNewCABundle(values ...byte) *WebhookClientConfigApplyConfiguration {
+	b.CABundle = make([]byte, len(values))
+	copy(b.CABundle, values)
 	return b
 }

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/mutatingwebhook.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/mutatingwebhook.go
@@ -65,10 +65,25 @@ func (b *MutatingWebhookApplyConfiguration) WithClientConfig(value *WebhookClien
 // WithRules adds the given value to the Rules field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Rules field.
+// Deprecated: WithRules does not replace existing list for atomic list type. Use WithNewRules instead.
 func (b *MutatingWebhookApplyConfiguration) WithRules(values ...*RuleWithOperationsApplyConfiguration) *MutatingWebhookApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithRules")
+		}
+		b.Rules = append(b.Rules, *values[i])
+	}
+	return b
+}
+
+// WithNewRules replaces the Rules field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Rules field is set to the values of the last call.
+func (b *MutatingWebhookApplyConfiguration) WithNewRules(values ...*RuleWithOperationsApplyConfiguration) *MutatingWebhookApplyConfiguration {
+	b.Rules = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewRules")
 		}
 		b.Rules = append(b.Rules, *values[i])
 	}
@@ -126,10 +141,20 @@ func (b *MutatingWebhookApplyConfiguration) WithTimeoutSeconds(value int32) *Mut
 // WithAdmissionReviewVersions adds the given value to the AdmissionReviewVersions field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the AdmissionReviewVersions field.
+// Deprecated: WithAdmissionReviewVersions does not replace existing list for atomic list type. Use WithNewAdmissionReviewVersions instead.
 func (b *MutatingWebhookApplyConfiguration) WithAdmissionReviewVersions(values ...string) *MutatingWebhookApplyConfiguration {
 	for i := range values {
 		b.AdmissionReviewVersions = append(b.AdmissionReviewVersions, values[i])
 	}
+	return b
+}
+
+// WithNewAdmissionReviewVersions replaces the AdmissionReviewVersions field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the AdmissionReviewVersions field is set to the values of the last call.
+func (b *MutatingWebhookApplyConfiguration) WithNewAdmissionReviewVersions(values ...string) *MutatingWebhookApplyConfiguration {
+	b.AdmissionReviewVersions = make([]string, len(values))
+	copy(b.AdmissionReviewVersions, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/mutatingwebhookconfiguration.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/mutatingwebhookconfiguration.go
@@ -210,6 +210,7 @@ func (b *MutatingWebhookConfigurationApplyConfiguration) WithAnnotations(entries
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *MutatingWebhookConfigurationApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *MutatingWebhookConfigurationApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -221,14 +222,40 @@ func (b *MutatingWebhookConfigurationApplyConfiguration) WithOwnerReferences(val
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *MutatingWebhookConfigurationApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *MutatingWebhookConfigurationApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *MutatingWebhookConfigurationApplyConfiguration) WithFinalizers(values ...string) *MutatingWebhookConfigurationApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *MutatingWebhookConfigurationApplyConfiguration) WithNewFinalizers(values ...string) *MutatingWebhookConfigurationApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 
@@ -241,10 +268,25 @@ func (b *MutatingWebhookConfigurationApplyConfiguration) ensureObjectMetaApplyCo
 // WithWebhooks adds the given value to the Webhooks field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Webhooks field.
+// Deprecated: WithWebhooks does not replace existing list for atomic list type. Use WithNewWebhooks instead.
 func (b *MutatingWebhookConfigurationApplyConfiguration) WithWebhooks(values ...*MutatingWebhookApplyConfiguration) *MutatingWebhookConfigurationApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithWebhooks")
+		}
+		b.Webhooks = append(b.Webhooks, *values[i])
+	}
+	return b
+}
+
+// WithNewWebhooks replaces the Webhooks field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Webhooks field is set to the values of the last call.
+func (b *MutatingWebhookConfigurationApplyConfiguration) WithNewWebhooks(values ...*MutatingWebhookApplyConfiguration) *MutatingWebhookConfigurationApplyConfiguration {
+	b.Webhooks = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewWebhooks")
 		}
 		b.Webhooks = append(b.Webhooks, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/rule.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/rule.go
@@ -40,6 +40,7 @@ func Rule() *RuleApplyConfiguration {
 // WithAPIGroups adds the given value to the APIGroups field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the APIGroups field.
+// Deprecated: WithAPIGroups does not replace existing list for atomic list type. Use WithNewAPIGroups instead.
 func (b *RuleApplyConfiguration) WithAPIGroups(values ...string) *RuleApplyConfiguration {
 	for i := range values {
 		b.APIGroups = append(b.APIGroups, values[i])
@@ -47,9 +48,19 @@ func (b *RuleApplyConfiguration) WithAPIGroups(values ...string) *RuleApplyConfi
 	return b
 }
 
+// WithNewAPIGroups replaces the APIGroups field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the APIGroups field is set to the values of the last call.
+func (b *RuleApplyConfiguration) WithNewAPIGroups(values ...string) *RuleApplyConfiguration {
+	b.APIGroups = make([]string, len(values))
+	copy(b.APIGroups, values)
+	return b
+}
+
 // WithAPIVersions adds the given value to the APIVersions field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the APIVersions field.
+// Deprecated: WithAPIVersions does not replace existing list for atomic list type. Use WithNewAPIVersions instead.
 func (b *RuleApplyConfiguration) WithAPIVersions(values ...string) *RuleApplyConfiguration {
 	for i := range values {
 		b.APIVersions = append(b.APIVersions, values[i])
@@ -57,13 +68,32 @@ func (b *RuleApplyConfiguration) WithAPIVersions(values ...string) *RuleApplyCon
 	return b
 }
 
+// WithNewAPIVersions replaces the APIVersions field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the APIVersions field is set to the values of the last call.
+func (b *RuleApplyConfiguration) WithNewAPIVersions(values ...string) *RuleApplyConfiguration {
+	b.APIVersions = make([]string, len(values))
+	copy(b.APIVersions, values)
+	return b
+}
+
 // WithResources adds the given value to the Resources field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Resources field.
+// Deprecated: WithResources does not replace existing list for atomic list type. Use WithNewResources instead.
 func (b *RuleApplyConfiguration) WithResources(values ...string) *RuleApplyConfiguration {
 	for i := range values {
 		b.Resources = append(b.Resources, values[i])
 	}
+	return b
+}
+
+// WithNewResources replaces the Resources field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Resources field is set to the values of the last call.
+func (b *RuleApplyConfiguration) WithNewResources(values ...string) *RuleApplyConfiguration {
+	b.Resources = make([]string, len(values))
+	copy(b.Resources, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/rulewithoperations.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/rulewithoperations.go
@@ -38,6 +38,7 @@ func RuleWithOperations() *RuleWithOperationsApplyConfiguration {
 // WithOperations adds the given value to the Operations field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Operations field.
+// Deprecated: WithOperations does not replace existing list for atomic list type. Use WithNewOperations instead.
 func (b *RuleWithOperationsApplyConfiguration) WithOperations(values ...v1.OperationType) *RuleWithOperationsApplyConfiguration {
 	for i := range values {
 		b.Operations = append(b.Operations, values[i])
@@ -45,9 +46,19 @@ func (b *RuleWithOperationsApplyConfiguration) WithOperations(values ...v1.Opera
 	return b
 }
 
+// WithNewOperations replaces the Operations field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Operations field is set to the values of the last call.
+func (b *RuleWithOperationsApplyConfiguration) WithNewOperations(values ...v1.OperationType) *RuleWithOperationsApplyConfiguration {
+	b.Operations = make([]v1.OperationType, len(values))
+	copy(b.Operations, values)
+	return b
+}
+
 // WithAPIGroups adds the given value to the APIGroups field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the APIGroups field.
+// Deprecated: WithAPIGroups does not replace existing list for atomic list type. Use WithNewAPIGroups instead.
 func (b *RuleWithOperationsApplyConfiguration) WithAPIGroups(values ...string) *RuleWithOperationsApplyConfiguration {
 	for i := range values {
 		b.APIGroups = append(b.APIGroups, values[i])
@@ -55,9 +66,19 @@ func (b *RuleWithOperationsApplyConfiguration) WithAPIGroups(values ...string) *
 	return b
 }
 
+// WithNewAPIGroups replaces the APIGroups field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the APIGroups field is set to the values of the last call.
+func (b *RuleWithOperationsApplyConfiguration) WithNewAPIGroups(values ...string) *RuleWithOperationsApplyConfiguration {
+	b.APIGroups = make([]string, len(values))
+	copy(b.APIGroups, values)
+	return b
+}
+
 // WithAPIVersions adds the given value to the APIVersions field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the APIVersions field.
+// Deprecated: WithAPIVersions does not replace existing list for atomic list type. Use WithNewAPIVersions instead.
 func (b *RuleWithOperationsApplyConfiguration) WithAPIVersions(values ...string) *RuleWithOperationsApplyConfiguration {
 	for i := range values {
 		b.APIVersions = append(b.APIVersions, values[i])
@@ -65,13 +86,32 @@ func (b *RuleWithOperationsApplyConfiguration) WithAPIVersions(values ...string)
 	return b
 }
 
+// WithNewAPIVersions replaces the APIVersions field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the APIVersions field is set to the values of the last call.
+func (b *RuleWithOperationsApplyConfiguration) WithNewAPIVersions(values ...string) *RuleWithOperationsApplyConfiguration {
+	b.APIVersions = make([]string, len(values))
+	copy(b.APIVersions, values)
+	return b
+}
+
 // WithResources adds the given value to the Resources field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Resources field.
+// Deprecated: WithResources does not replace existing list for atomic list type. Use WithNewResources instead.
 func (b *RuleWithOperationsApplyConfiguration) WithResources(values ...string) *RuleWithOperationsApplyConfiguration {
 	for i := range values {
 		b.Resources = append(b.Resources, values[i])
 	}
+	return b
+}
+
+// WithNewResources replaces the Resources field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Resources field is set to the values of the last call.
+func (b *RuleWithOperationsApplyConfiguration) WithNewResources(values ...string) *RuleWithOperationsApplyConfiguration {
+	b.Resources = make([]string, len(values))
+	copy(b.Resources, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/validatingwebhook.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/validatingwebhook.go
@@ -64,10 +64,25 @@ func (b *ValidatingWebhookApplyConfiguration) WithClientConfig(value *WebhookCli
 // WithRules adds the given value to the Rules field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Rules field.
+// Deprecated: WithRules does not replace existing list for atomic list type. Use WithNewRules instead.
 func (b *ValidatingWebhookApplyConfiguration) WithRules(values ...*RuleWithOperationsApplyConfiguration) *ValidatingWebhookApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithRules")
+		}
+		b.Rules = append(b.Rules, *values[i])
+	}
+	return b
+}
+
+// WithNewRules replaces the Rules field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Rules field is set to the values of the last call.
+func (b *ValidatingWebhookApplyConfiguration) WithNewRules(values ...*RuleWithOperationsApplyConfiguration) *ValidatingWebhookApplyConfiguration {
+	b.Rules = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewRules")
 		}
 		b.Rules = append(b.Rules, *values[i])
 	}
@@ -125,10 +140,20 @@ func (b *ValidatingWebhookApplyConfiguration) WithTimeoutSeconds(value int32) *V
 // WithAdmissionReviewVersions adds the given value to the AdmissionReviewVersions field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the AdmissionReviewVersions field.
+// Deprecated: WithAdmissionReviewVersions does not replace existing list for atomic list type. Use WithNewAdmissionReviewVersions instead.
 func (b *ValidatingWebhookApplyConfiguration) WithAdmissionReviewVersions(values ...string) *ValidatingWebhookApplyConfiguration {
 	for i := range values {
 		b.AdmissionReviewVersions = append(b.AdmissionReviewVersions, values[i])
 	}
+	return b
+}
+
+// WithNewAdmissionReviewVersions replaces the AdmissionReviewVersions field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the AdmissionReviewVersions field is set to the values of the last call.
+func (b *ValidatingWebhookApplyConfiguration) WithNewAdmissionReviewVersions(values ...string) *ValidatingWebhookApplyConfiguration {
+	b.AdmissionReviewVersions = make([]string, len(values))
+	copy(b.AdmissionReviewVersions, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/validatingwebhookconfiguration.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/validatingwebhookconfiguration.go
@@ -210,6 +210,7 @@ func (b *ValidatingWebhookConfigurationApplyConfiguration) WithAnnotations(entri
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *ValidatingWebhookConfigurationApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *ValidatingWebhookConfigurationApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -221,14 +222,40 @@ func (b *ValidatingWebhookConfigurationApplyConfiguration) WithOwnerReferences(v
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *ValidatingWebhookConfigurationApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *ValidatingWebhookConfigurationApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *ValidatingWebhookConfigurationApplyConfiguration) WithFinalizers(values ...string) *ValidatingWebhookConfigurationApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *ValidatingWebhookConfigurationApplyConfiguration) WithNewFinalizers(values ...string) *ValidatingWebhookConfigurationApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 
@@ -241,10 +268,25 @@ func (b *ValidatingWebhookConfigurationApplyConfiguration) ensureObjectMetaApply
 // WithWebhooks adds the given value to the Webhooks field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Webhooks field.
+// Deprecated: WithWebhooks does not replace existing list for atomic list type. Use WithNewWebhooks instead.
 func (b *ValidatingWebhookConfigurationApplyConfiguration) WithWebhooks(values ...*ValidatingWebhookApplyConfiguration) *ValidatingWebhookConfigurationApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithWebhooks")
+		}
+		b.Webhooks = append(b.Webhooks, *values[i])
+	}
+	return b
+}
+
+// WithNewWebhooks replaces the Webhooks field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Webhooks field is set to the values of the last call.
+func (b *ValidatingWebhookConfigurationApplyConfiguration) WithNewWebhooks(values ...*ValidatingWebhookApplyConfiguration) *ValidatingWebhookConfigurationApplyConfiguration {
+	b.Webhooks = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewWebhooks")
 		}
 		b.Webhooks = append(b.Webhooks, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/webhookclientconfig.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/webhookclientconfig.go
@@ -51,9 +51,19 @@ func (b *WebhookClientConfigApplyConfiguration) WithService(value *ServiceRefere
 // WithCABundle adds the given value to the CABundle field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the CABundle field.
+// Deprecated: WithCABundle does not replace existing list for atomic list type. Use WithNewCABundle instead.
 func (b *WebhookClientConfigApplyConfiguration) WithCABundle(values ...byte) *WebhookClientConfigApplyConfiguration {
 	for i := range values {
 		b.CABundle = append(b.CABundle, values[i])
 	}
+	return b
+}
+
+// WithNewCABundle replaces the CABundle field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the CABundle field is set to the values of the last call.
+func (b *WebhookClientConfigApplyConfiguration) WithNewCABundle(values ...byte) *WebhookClientConfigApplyConfiguration {
+	b.CABundle = make([]byte, len(values))
+	copy(b.CABundle, values)
 	return b
 }

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1alpha1/matchresources.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1alpha1/matchresources.go
@@ -58,6 +58,7 @@ func (b *MatchResourcesApplyConfiguration) WithObjectSelector(value *v1.LabelSel
 // WithResourceRules adds the given value to the ResourceRules field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the ResourceRules field.
+// Deprecated: WithResourceRules does not replace existing list for atomic list type. Use WithNewResourceRules instead.
 func (b *MatchResourcesApplyConfiguration) WithResourceRules(values ...*NamedRuleWithOperationsApplyConfiguration) *MatchResourcesApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
@@ -68,13 +69,42 @@ func (b *MatchResourcesApplyConfiguration) WithResourceRules(values ...*NamedRul
 	return b
 }
 
+// WithNewResourceRules replaces the ResourceRules field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the ResourceRules field is set to the values of the last call.
+func (b *MatchResourcesApplyConfiguration) WithNewResourceRules(values ...*NamedRuleWithOperationsApplyConfiguration) *MatchResourcesApplyConfiguration {
+	b.ResourceRules = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewResourceRules")
+		}
+		b.ResourceRules = append(b.ResourceRules, *values[i])
+	}
+	return b
+}
+
 // WithExcludeResourceRules adds the given value to the ExcludeResourceRules field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the ExcludeResourceRules field.
+// Deprecated: WithExcludeResourceRules does not replace existing list for atomic list type. Use WithNewExcludeResourceRules instead.
 func (b *MatchResourcesApplyConfiguration) WithExcludeResourceRules(values ...*NamedRuleWithOperationsApplyConfiguration) *MatchResourcesApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithExcludeResourceRules")
+		}
+		b.ExcludeResourceRules = append(b.ExcludeResourceRules, *values[i])
+	}
+	return b
+}
+
+// WithNewExcludeResourceRules replaces the ExcludeResourceRules field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the ExcludeResourceRules field is set to the values of the last call.
+func (b *MatchResourcesApplyConfiguration) WithNewExcludeResourceRules(values ...*NamedRuleWithOperationsApplyConfiguration) *MatchResourcesApplyConfiguration {
+	b.ExcludeResourceRules = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewExcludeResourceRules")
 		}
 		b.ExcludeResourceRules = append(b.ExcludeResourceRules, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1alpha1/namedrulewithoperations.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1alpha1/namedrulewithoperations.go
@@ -39,6 +39,7 @@ func NamedRuleWithOperations() *NamedRuleWithOperationsApplyConfiguration {
 // WithResourceNames adds the given value to the ResourceNames field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the ResourceNames field.
+// Deprecated: WithResourceNames does not replace existing list for atomic list type. Use WithNewResourceNames instead.
 func (b *NamedRuleWithOperationsApplyConfiguration) WithResourceNames(values ...string) *NamedRuleWithOperationsApplyConfiguration {
 	for i := range values {
 		b.ResourceNames = append(b.ResourceNames, values[i])
@@ -46,9 +47,19 @@ func (b *NamedRuleWithOperationsApplyConfiguration) WithResourceNames(values ...
 	return b
 }
 
+// WithNewResourceNames replaces the ResourceNames field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the ResourceNames field is set to the values of the last call.
+func (b *NamedRuleWithOperationsApplyConfiguration) WithNewResourceNames(values ...string) *NamedRuleWithOperationsApplyConfiguration {
+	b.ResourceNames = make([]string, len(values))
+	copy(b.ResourceNames, values)
+	return b
+}
+
 // WithOperations adds the given value to the Operations field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Operations field.
+// Deprecated: WithOperations does not replace existing list for atomic list type. Use WithNewOperations instead.
 func (b *NamedRuleWithOperationsApplyConfiguration) WithOperations(values ...admissionregistrationv1.OperationType) *NamedRuleWithOperationsApplyConfiguration {
 	for i := range values {
 		b.Operations = append(b.Operations, values[i])
@@ -56,9 +67,19 @@ func (b *NamedRuleWithOperationsApplyConfiguration) WithOperations(values ...adm
 	return b
 }
 
+// WithNewOperations replaces the Operations field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Operations field is set to the values of the last call.
+func (b *NamedRuleWithOperationsApplyConfiguration) WithNewOperations(values ...admissionregistrationv1.OperationType) *NamedRuleWithOperationsApplyConfiguration {
+	b.Operations = make([]admissionregistrationv1.OperationType, len(values))
+	copy(b.Operations, values)
+	return b
+}
+
 // WithAPIGroups adds the given value to the APIGroups field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the APIGroups field.
+// Deprecated: WithAPIGroups does not replace existing list for atomic list type. Use WithNewAPIGroups instead.
 func (b *NamedRuleWithOperationsApplyConfiguration) WithAPIGroups(values ...string) *NamedRuleWithOperationsApplyConfiguration {
 	for i := range values {
 		b.APIGroups = append(b.APIGroups, values[i])
@@ -66,9 +87,19 @@ func (b *NamedRuleWithOperationsApplyConfiguration) WithAPIGroups(values ...stri
 	return b
 }
 
+// WithNewAPIGroups replaces the APIGroups field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the APIGroups field is set to the values of the last call.
+func (b *NamedRuleWithOperationsApplyConfiguration) WithNewAPIGroups(values ...string) *NamedRuleWithOperationsApplyConfiguration {
+	b.APIGroups = make([]string, len(values))
+	copy(b.APIGroups, values)
+	return b
+}
+
 // WithAPIVersions adds the given value to the APIVersions field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the APIVersions field.
+// Deprecated: WithAPIVersions does not replace existing list for atomic list type. Use WithNewAPIVersions instead.
 func (b *NamedRuleWithOperationsApplyConfiguration) WithAPIVersions(values ...string) *NamedRuleWithOperationsApplyConfiguration {
 	for i := range values {
 		b.APIVersions = append(b.APIVersions, values[i])
@@ -76,13 +107,32 @@ func (b *NamedRuleWithOperationsApplyConfiguration) WithAPIVersions(values ...st
 	return b
 }
 
+// WithNewAPIVersions replaces the APIVersions field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the APIVersions field is set to the values of the last call.
+func (b *NamedRuleWithOperationsApplyConfiguration) WithNewAPIVersions(values ...string) *NamedRuleWithOperationsApplyConfiguration {
+	b.APIVersions = make([]string, len(values))
+	copy(b.APIVersions, values)
+	return b
+}
+
 // WithResources adds the given value to the Resources field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Resources field.
+// Deprecated: WithResources does not replace existing list for atomic list type. Use WithNewResources instead.
 func (b *NamedRuleWithOperationsApplyConfiguration) WithResources(values ...string) *NamedRuleWithOperationsApplyConfiguration {
 	for i := range values {
 		b.Resources = append(b.Resources, values[i])
 	}
+	return b
+}
+
+// WithNewResources replaces the Resources field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Resources field is set to the values of the last call.
+func (b *NamedRuleWithOperationsApplyConfiguration) WithNewResources(values ...string) *NamedRuleWithOperationsApplyConfiguration {
+	b.Resources = make([]string, len(values))
+	copy(b.Resources, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1alpha1/typechecking.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1alpha1/typechecking.go
@@ -33,10 +33,25 @@ func TypeChecking() *TypeCheckingApplyConfiguration {
 // WithExpressionWarnings adds the given value to the ExpressionWarnings field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the ExpressionWarnings field.
+// Deprecated: WithExpressionWarnings does not replace existing list for atomic list type. Use WithNewExpressionWarnings instead.
 func (b *TypeCheckingApplyConfiguration) WithExpressionWarnings(values ...*ExpressionWarningApplyConfiguration) *TypeCheckingApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithExpressionWarnings")
+		}
+		b.ExpressionWarnings = append(b.ExpressionWarnings, *values[i])
+	}
+	return b
+}
+
+// WithNewExpressionWarnings replaces the ExpressionWarnings field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the ExpressionWarnings field is set to the values of the last call.
+func (b *TypeCheckingApplyConfiguration) WithNewExpressionWarnings(values ...*ExpressionWarningApplyConfiguration) *TypeCheckingApplyConfiguration {
+	b.ExpressionWarnings = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewExpressionWarnings")
 		}
 		b.ExpressionWarnings = append(b.ExpressionWarnings, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1alpha1/validatingadmissionpolicy.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1alpha1/validatingadmissionpolicy.go
@@ -211,6 +211,7 @@ func (b *ValidatingAdmissionPolicyApplyConfiguration) WithAnnotations(entries ma
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *ValidatingAdmissionPolicyApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *ValidatingAdmissionPolicyApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -222,14 +223,40 @@ func (b *ValidatingAdmissionPolicyApplyConfiguration) WithOwnerReferences(values
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *ValidatingAdmissionPolicyApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *ValidatingAdmissionPolicyApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *ValidatingAdmissionPolicyApplyConfiguration) WithFinalizers(values ...string) *ValidatingAdmissionPolicyApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *ValidatingAdmissionPolicyApplyConfiguration) WithNewFinalizers(values ...string) *ValidatingAdmissionPolicyApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1alpha1/validatingadmissionpolicybinding.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1alpha1/validatingadmissionpolicybinding.go
@@ -210,6 +210,7 @@ func (b *ValidatingAdmissionPolicyBindingApplyConfiguration) WithAnnotations(ent
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *ValidatingAdmissionPolicyBindingApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *ValidatingAdmissionPolicyBindingApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -221,14 +222,40 @@ func (b *ValidatingAdmissionPolicyBindingApplyConfiguration) WithOwnerReferences
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *ValidatingAdmissionPolicyBindingApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *ValidatingAdmissionPolicyBindingApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *ValidatingAdmissionPolicyBindingApplyConfiguration) WithFinalizers(values ...string) *ValidatingAdmissionPolicyBindingApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *ValidatingAdmissionPolicyBindingApplyConfiguration) WithNewFinalizers(values ...string) *ValidatingAdmissionPolicyBindingApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1alpha1/validatingadmissionpolicyspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1alpha1/validatingadmissionpolicyspec.go
@@ -59,10 +59,25 @@ func (b *ValidatingAdmissionPolicySpecApplyConfiguration) WithMatchConstraints(v
 // WithValidations adds the given value to the Validations field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Validations field.
+// Deprecated: WithValidations does not replace existing list for atomic list type. Use WithNewValidations instead.
 func (b *ValidatingAdmissionPolicySpecApplyConfiguration) WithValidations(values ...*ValidationApplyConfiguration) *ValidatingAdmissionPolicySpecApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithValidations")
+		}
+		b.Validations = append(b.Validations, *values[i])
+	}
+	return b
+}
+
+// WithNewValidations replaces the Validations field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Validations field is set to the values of the last call.
+func (b *ValidatingAdmissionPolicySpecApplyConfiguration) WithNewValidations(values ...*ValidationApplyConfiguration) *ValidatingAdmissionPolicySpecApplyConfiguration {
+	b.Validations = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewValidations")
 		}
 		b.Validations = append(b.Validations, *values[i])
 	}
@@ -80,10 +95,25 @@ func (b *ValidatingAdmissionPolicySpecApplyConfiguration) WithFailurePolicy(valu
 // WithAuditAnnotations adds the given value to the AuditAnnotations field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the AuditAnnotations field.
+// Deprecated: WithAuditAnnotations does not replace existing list for atomic list type. Use WithNewAuditAnnotations instead.
 func (b *ValidatingAdmissionPolicySpecApplyConfiguration) WithAuditAnnotations(values ...*AuditAnnotationApplyConfiguration) *ValidatingAdmissionPolicySpecApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithAuditAnnotations")
+		}
+		b.AuditAnnotations = append(b.AuditAnnotations, *values[i])
+	}
+	return b
+}
+
+// WithNewAuditAnnotations replaces the AuditAnnotations field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the AuditAnnotations field is set to the values of the last call.
+func (b *ValidatingAdmissionPolicySpecApplyConfiguration) WithNewAuditAnnotations(values ...*AuditAnnotationApplyConfiguration) *ValidatingAdmissionPolicySpecApplyConfiguration {
+	b.AuditAnnotations = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewAuditAnnotations")
 		}
 		b.AuditAnnotations = append(b.AuditAnnotations, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/matchresources.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/matchresources.go
@@ -58,6 +58,7 @@ func (b *MatchResourcesApplyConfiguration) WithObjectSelector(value *v1.LabelSel
 // WithResourceRules adds the given value to the ResourceRules field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the ResourceRules field.
+// Deprecated: WithResourceRules does not replace existing list for atomic list type. Use WithNewResourceRules instead.
 func (b *MatchResourcesApplyConfiguration) WithResourceRules(values ...*NamedRuleWithOperationsApplyConfiguration) *MatchResourcesApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
@@ -68,13 +69,42 @@ func (b *MatchResourcesApplyConfiguration) WithResourceRules(values ...*NamedRul
 	return b
 }
 
+// WithNewResourceRules replaces the ResourceRules field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the ResourceRules field is set to the values of the last call.
+func (b *MatchResourcesApplyConfiguration) WithNewResourceRules(values ...*NamedRuleWithOperationsApplyConfiguration) *MatchResourcesApplyConfiguration {
+	b.ResourceRules = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewResourceRules")
+		}
+		b.ResourceRules = append(b.ResourceRules, *values[i])
+	}
+	return b
+}
+
 // WithExcludeResourceRules adds the given value to the ExcludeResourceRules field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the ExcludeResourceRules field.
+// Deprecated: WithExcludeResourceRules does not replace existing list for atomic list type. Use WithNewExcludeResourceRules instead.
 func (b *MatchResourcesApplyConfiguration) WithExcludeResourceRules(values ...*NamedRuleWithOperationsApplyConfiguration) *MatchResourcesApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithExcludeResourceRules")
+		}
+		b.ExcludeResourceRules = append(b.ExcludeResourceRules, *values[i])
+	}
+	return b
+}
+
+// WithNewExcludeResourceRules replaces the ExcludeResourceRules field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the ExcludeResourceRules field is set to the values of the last call.
+func (b *MatchResourcesApplyConfiguration) WithNewExcludeResourceRules(values ...*NamedRuleWithOperationsApplyConfiguration) *MatchResourcesApplyConfiguration {
+	b.ExcludeResourceRules = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewExcludeResourceRules")
 		}
 		b.ExcludeResourceRules = append(b.ExcludeResourceRules, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/mutatingwebhook.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/mutatingwebhook.go
@@ -66,10 +66,25 @@ func (b *MutatingWebhookApplyConfiguration) WithClientConfig(value *WebhookClien
 // WithRules adds the given value to the Rules field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Rules field.
+// Deprecated: WithRules does not replace existing list for atomic list type. Use WithNewRules instead.
 func (b *MutatingWebhookApplyConfiguration) WithRules(values ...*v1.RuleWithOperationsApplyConfiguration) *MutatingWebhookApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithRules")
+		}
+		b.Rules = append(b.Rules, *values[i])
+	}
+	return b
+}
+
+// WithNewRules replaces the Rules field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Rules field is set to the values of the last call.
+func (b *MutatingWebhookApplyConfiguration) WithNewRules(values ...*v1.RuleWithOperationsApplyConfiguration) *MutatingWebhookApplyConfiguration {
+	b.Rules = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewRules")
 		}
 		b.Rules = append(b.Rules, *values[i])
 	}
@@ -127,10 +142,20 @@ func (b *MutatingWebhookApplyConfiguration) WithTimeoutSeconds(value int32) *Mut
 // WithAdmissionReviewVersions adds the given value to the AdmissionReviewVersions field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the AdmissionReviewVersions field.
+// Deprecated: WithAdmissionReviewVersions does not replace existing list for atomic list type. Use WithNewAdmissionReviewVersions instead.
 func (b *MutatingWebhookApplyConfiguration) WithAdmissionReviewVersions(values ...string) *MutatingWebhookApplyConfiguration {
 	for i := range values {
 		b.AdmissionReviewVersions = append(b.AdmissionReviewVersions, values[i])
 	}
+	return b
+}
+
+// WithNewAdmissionReviewVersions replaces the AdmissionReviewVersions field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the AdmissionReviewVersions field is set to the values of the last call.
+func (b *MutatingWebhookApplyConfiguration) WithNewAdmissionReviewVersions(values ...string) *MutatingWebhookApplyConfiguration {
+	b.AdmissionReviewVersions = make([]string, len(values))
+	copy(b.AdmissionReviewVersions, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/mutatingwebhookconfiguration.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/mutatingwebhookconfiguration.go
@@ -210,6 +210,7 @@ func (b *MutatingWebhookConfigurationApplyConfiguration) WithAnnotations(entries
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *MutatingWebhookConfigurationApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *MutatingWebhookConfigurationApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -221,14 +222,40 @@ func (b *MutatingWebhookConfigurationApplyConfiguration) WithOwnerReferences(val
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *MutatingWebhookConfigurationApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *MutatingWebhookConfigurationApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *MutatingWebhookConfigurationApplyConfiguration) WithFinalizers(values ...string) *MutatingWebhookConfigurationApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *MutatingWebhookConfigurationApplyConfiguration) WithNewFinalizers(values ...string) *MutatingWebhookConfigurationApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 
@@ -241,10 +268,25 @@ func (b *MutatingWebhookConfigurationApplyConfiguration) ensureObjectMetaApplyCo
 // WithWebhooks adds the given value to the Webhooks field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Webhooks field.
+// Deprecated: WithWebhooks does not replace existing list for atomic list type. Use WithNewWebhooks instead.
 func (b *MutatingWebhookConfigurationApplyConfiguration) WithWebhooks(values ...*MutatingWebhookApplyConfiguration) *MutatingWebhookConfigurationApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithWebhooks")
+		}
+		b.Webhooks = append(b.Webhooks, *values[i])
+	}
+	return b
+}
+
+// WithNewWebhooks replaces the Webhooks field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Webhooks field is set to the values of the last call.
+func (b *MutatingWebhookConfigurationApplyConfiguration) WithNewWebhooks(values ...*MutatingWebhookApplyConfiguration) *MutatingWebhookConfigurationApplyConfiguration {
+	b.Webhooks = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewWebhooks")
 		}
 		b.Webhooks = append(b.Webhooks, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/namedrulewithoperations.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/namedrulewithoperations.go
@@ -39,6 +39,7 @@ func NamedRuleWithOperations() *NamedRuleWithOperationsApplyConfiguration {
 // WithResourceNames adds the given value to the ResourceNames field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the ResourceNames field.
+// Deprecated: WithResourceNames does not replace existing list for atomic list type. Use WithNewResourceNames instead.
 func (b *NamedRuleWithOperationsApplyConfiguration) WithResourceNames(values ...string) *NamedRuleWithOperationsApplyConfiguration {
 	for i := range values {
 		b.ResourceNames = append(b.ResourceNames, values[i])
@@ -46,9 +47,19 @@ func (b *NamedRuleWithOperationsApplyConfiguration) WithResourceNames(values ...
 	return b
 }
 
+// WithNewResourceNames replaces the ResourceNames field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the ResourceNames field is set to the values of the last call.
+func (b *NamedRuleWithOperationsApplyConfiguration) WithNewResourceNames(values ...string) *NamedRuleWithOperationsApplyConfiguration {
+	b.ResourceNames = make([]string, len(values))
+	copy(b.ResourceNames, values)
+	return b
+}
+
 // WithOperations adds the given value to the Operations field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Operations field.
+// Deprecated: WithOperations does not replace existing list for atomic list type. Use WithNewOperations instead.
 func (b *NamedRuleWithOperationsApplyConfiguration) WithOperations(values ...admissionregistrationv1.OperationType) *NamedRuleWithOperationsApplyConfiguration {
 	for i := range values {
 		b.Operations = append(b.Operations, values[i])
@@ -56,9 +67,19 @@ func (b *NamedRuleWithOperationsApplyConfiguration) WithOperations(values ...adm
 	return b
 }
 
+// WithNewOperations replaces the Operations field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Operations field is set to the values of the last call.
+func (b *NamedRuleWithOperationsApplyConfiguration) WithNewOperations(values ...admissionregistrationv1.OperationType) *NamedRuleWithOperationsApplyConfiguration {
+	b.Operations = make([]admissionregistrationv1.OperationType, len(values))
+	copy(b.Operations, values)
+	return b
+}
+
 // WithAPIGroups adds the given value to the APIGroups field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the APIGroups field.
+// Deprecated: WithAPIGroups does not replace existing list for atomic list type. Use WithNewAPIGroups instead.
 func (b *NamedRuleWithOperationsApplyConfiguration) WithAPIGroups(values ...string) *NamedRuleWithOperationsApplyConfiguration {
 	for i := range values {
 		b.APIGroups = append(b.APIGroups, values[i])
@@ -66,9 +87,19 @@ func (b *NamedRuleWithOperationsApplyConfiguration) WithAPIGroups(values ...stri
 	return b
 }
 
+// WithNewAPIGroups replaces the APIGroups field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the APIGroups field is set to the values of the last call.
+func (b *NamedRuleWithOperationsApplyConfiguration) WithNewAPIGroups(values ...string) *NamedRuleWithOperationsApplyConfiguration {
+	b.APIGroups = make([]string, len(values))
+	copy(b.APIGroups, values)
+	return b
+}
+
 // WithAPIVersions adds the given value to the APIVersions field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the APIVersions field.
+// Deprecated: WithAPIVersions does not replace existing list for atomic list type. Use WithNewAPIVersions instead.
 func (b *NamedRuleWithOperationsApplyConfiguration) WithAPIVersions(values ...string) *NamedRuleWithOperationsApplyConfiguration {
 	for i := range values {
 		b.APIVersions = append(b.APIVersions, values[i])
@@ -76,13 +107,32 @@ func (b *NamedRuleWithOperationsApplyConfiguration) WithAPIVersions(values ...st
 	return b
 }
 
+// WithNewAPIVersions replaces the APIVersions field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the APIVersions field is set to the values of the last call.
+func (b *NamedRuleWithOperationsApplyConfiguration) WithNewAPIVersions(values ...string) *NamedRuleWithOperationsApplyConfiguration {
+	b.APIVersions = make([]string, len(values))
+	copy(b.APIVersions, values)
+	return b
+}
+
 // WithResources adds the given value to the Resources field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Resources field.
+// Deprecated: WithResources does not replace existing list for atomic list type. Use WithNewResources instead.
 func (b *NamedRuleWithOperationsApplyConfiguration) WithResources(values ...string) *NamedRuleWithOperationsApplyConfiguration {
 	for i := range values {
 		b.Resources = append(b.Resources, values[i])
 	}
+	return b
+}
+
+// WithNewResources replaces the Resources field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Resources field is set to the values of the last call.
+func (b *NamedRuleWithOperationsApplyConfiguration) WithNewResources(values ...string) *NamedRuleWithOperationsApplyConfiguration {
+	b.Resources = make([]string, len(values))
+	copy(b.Resources, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/typechecking.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/typechecking.go
@@ -33,10 +33,25 @@ func TypeChecking() *TypeCheckingApplyConfiguration {
 // WithExpressionWarnings adds the given value to the ExpressionWarnings field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the ExpressionWarnings field.
+// Deprecated: WithExpressionWarnings does not replace existing list for atomic list type. Use WithNewExpressionWarnings instead.
 func (b *TypeCheckingApplyConfiguration) WithExpressionWarnings(values ...*ExpressionWarningApplyConfiguration) *TypeCheckingApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithExpressionWarnings")
+		}
+		b.ExpressionWarnings = append(b.ExpressionWarnings, *values[i])
+	}
+	return b
+}
+
+// WithNewExpressionWarnings replaces the ExpressionWarnings field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the ExpressionWarnings field is set to the values of the last call.
+func (b *TypeCheckingApplyConfiguration) WithNewExpressionWarnings(values ...*ExpressionWarningApplyConfiguration) *TypeCheckingApplyConfiguration {
+	b.ExpressionWarnings = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewExpressionWarnings")
 		}
 		b.ExpressionWarnings = append(b.ExpressionWarnings, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/validatingadmissionpolicy.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/validatingadmissionpolicy.go
@@ -211,6 +211,7 @@ func (b *ValidatingAdmissionPolicyApplyConfiguration) WithAnnotations(entries ma
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *ValidatingAdmissionPolicyApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *ValidatingAdmissionPolicyApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -222,14 +223,40 @@ func (b *ValidatingAdmissionPolicyApplyConfiguration) WithOwnerReferences(values
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *ValidatingAdmissionPolicyApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *ValidatingAdmissionPolicyApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *ValidatingAdmissionPolicyApplyConfiguration) WithFinalizers(values ...string) *ValidatingAdmissionPolicyApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *ValidatingAdmissionPolicyApplyConfiguration) WithNewFinalizers(values ...string) *ValidatingAdmissionPolicyApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/validatingadmissionpolicybinding.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/validatingadmissionpolicybinding.go
@@ -210,6 +210,7 @@ func (b *ValidatingAdmissionPolicyBindingApplyConfiguration) WithAnnotations(ent
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *ValidatingAdmissionPolicyBindingApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *ValidatingAdmissionPolicyBindingApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -221,14 +222,40 @@ func (b *ValidatingAdmissionPolicyBindingApplyConfiguration) WithOwnerReferences
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *ValidatingAdmissionPolicyBindingApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *ValidatingAdmissionPolicyBindingApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *ValidatingAdmissionPolicyBindingApplyConfiguration) WithFinalizers(values ...string) *ValidatingAdmissionPolicyBindingApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *ValidatingAdmissionPolicyBindingApplyConfiguration) WithNewFinalizers(values ...string) *ValidatingAdmissionPolicyBindingApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/validatingadmissionpolicyspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/validatingadmissionpolicyspec.go
@@ -59,10 +59,25 @@ func (b *ValidatingAdmissionPolicySpecApplyConfiguration) WithMatchConstraints(v
 // WithValidations adds the given value to the Validations field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Validations field.
+// Deprecated: WithValidations does not replace existing list for atomic list type. Use WithNewValidations instead.
 func (b *ValidatingAdmissionPolicySpecApplyConfiguration) WithValidations(values ...*ValidationApplyConfiguration) *ValidatingAdmissionPolicySpecApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithValidations")
+		}
+		b.Validations = append(b.Validations, *values[i])
+	}
+	return b
+}
+
+// WithNewValidations replaces the Validations field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Validations field is set to the values of the last call.
+func (b *ValidatingAdmissionPolicySpecApplyConfiguration) WithNewValidations(values ...*ValidationApplyConfiguration) *ValidatingAdmissionPolicySpecApplyConfiguration {
+	b.Validations = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewValidations")
 		}
 		b.Validations = append(b.Validations, *values[i])
 	}
@@ -80,10 +95,25 @@ func (b *ValidatingAdmissionPolicySpecApplyConfiguration) WithFailurePolicy(valu
 // WithAuditAnnotations adds the given value to the AuditAnnotations field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the AuditAnnotations field.
+// Deprecated: WithAuditAnnotations does not replace existing list for atomic list type. Use WithNewAuditAnnotations instead.
 func (b *ValidatingAdmissionPolicySpecApplyConfiguration) WithAuditAnnotations(values ...*AuditAnnotationApplyConfiguration) *ValidatingAdmissionPolicySpecApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithAuditAnnotations")
+		}
+		b.AuditAnnotations = append(b.AuditAnnotations, *values[i])
+	}
+	return b
+}
+
+// WithNewAuditAnnotations replaces the AuditAnnotations field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the AuditAnnotations field is set to the values of the last call.
+func (b *ValidatingAdmissionPolicySpecApplyConfiguration) WithNewAuditAnnotations(values ...*AuditAnnotationApplyConfiguration) *ValidatingAdmissionPolicySpecApplyConfiguration {
+	b.AuditAnnotations = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewAuditAnnotations")
 		}
 		b.AuditAnnotations = append(b.AuditAnnotations, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/validatingwebhook.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/validatingwebhook.go
@@ -65,10 +65,25 @@ func (b *ValidatingWebhookApplyConfiguration) WithClientConfig(value *WebhookCli
 // WithRules adds the given value to the Rules field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Rules field.
+// Deprecated: WithRules does not replace existing list for atomic list type. Use WithNewRules instead.
 func (b *ValidatingWebhookApplyConfiguration) WithRules(values ...*v1.RuleWithOperationsApplyConfiguration) *ValidatingWebhookApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithRules")
+		}
+		b.Rules = append(b.Rules, *values[i])
+	}
+	return b
+}
+
+// WithNewRules replaces the Rules field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Rules field is set to the values of the last call.
+func (b *ValidatingWebhookApplyConfiguration) WithNewRules(values ...*v1.RuleWithOperationsApplyConfiguration) *ValidatingWebhookApplyConfiguration {
+	b.Rules = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewRules")
 		}
 		b.Rules = append(b.Rules, *values[i])
 	}
@@ -126,10 +141,20 @@ func (b *ValidatingWebhookApplyConfiguration) WithTimeoutSeconds(value int32) *V
 // WithAdmissionReviewVersions adds the given value to the AdmissionReviewVersions field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the AdmissionReviewVersions field.
+// Deprecated: WithAdmissionReviewVersions does not replace existing list for atomic list type. Use WithNewAdmissionReviewVersions instead.
 func (b *ValidatingWebhookApplyConfiguration) WithAdmissionReviewVersions(values ...string) *ValidatingWebhookApplyConfiguration {
 	for i := range values {
 		b.AdmissionReviewVersions = append(b.AdmissionReviewVersions, values[i])
 	}
+	return b
+}
+
+// WithNewAdmissionReviewVersions replaces the AdmissionReviewVersions field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the AdmissionReviewVersions field is set to the values of the last call.
+func (b *ValidatingWebhookApplyConfiguration) WithNewAdmissionReviewVersions(values ...string) *ValidatingWebhookApplyConfiguration {
+	b.AdmissionReviewVersions = make([]string, len(values))
+	copy(b.AdmissionReviewVersions, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/validatingwebhookconfiguration.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/validatingwebhookconfiguration.go
@@ -210,6 +210,7 @@ func (b *ValidatingWebhookConfigurationApplyConfiguration) WithAnnotations(entri
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *ValidatingWebhookConfigurationApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *ValidatingWebhookConfigurationApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -221,14 +222,40 @@ func (b *ValidatingWebhookConfigurationApplyConfiguration) WithOwnerReferences(v
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *ValidatingWebhookConfigurationApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *ValidatingWebhookConfigurationApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *ValidatingWebhookConfigurationApplyConfiguration) WithFinalizers(values ...string) *ValidatingWebhookConfigurationApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *ValidatingWebhookConfigurationApplyConfiguration) WithNewFinalizers(values ...string) *ValidatingWebhookConfigurationApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 
@@ -241,10 +268,25 @@ func (b *ValidatingWebhookConfigurationApplyConfiguration) ensureObjectMetaApply
 // WithWebhooks adds the given value to the Webhooks field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Webhooks field.
+// Deprecated: WithWebhooks does not replace existing list for atomic list type. Use WithNewWebhooks instead.
 func (b *ValidatingWebhookConfigurationApplyConfiguration) WithWebhooks(values ...*ValidatingWebhookApplyConfiguration) *ValidatingWebhookConfigurationApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithWebhooks")
+		}
+		b.Webhooks = append(b.Webhooks, *values[i])
+	}
+	return b
+}
+
+// WithNewWebhooks replaces the Webhooks field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Webhooks field is set to the values of the last call.
+func (b *ValidatingWebhookConfigurationApplyConfiguration) WithNewWebhooks(values ...*ValidatingWebhookApplyConfiguration) *ValidatingWebhookConfigurationApplyConfiguration {
+	b.Webhooks = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewWebhooks")
 		}
 		b.Webhooks = append(b.Webhooks, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/webhookclientconfig.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/webhookclientconfig.go
@@ -51,9 +51,19 @@ func (b *WebhookClientConfigApplyConfiguration) WithService(value *ServiceRefere
 // WithCABundle adds the given value to the CABundle field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the CABundle field.
+// Deprecated: WithCABundle does not replace existing list for atomic list type. Use WithNewCABundle instead.
 func (b *WebhookClientConfigApplyConfiguration) WithCABundle(values ...byte) *WebhookClientConfigApplyConfiguration {
 	for i := range values {
 		b.CABundle = append(b.CABundle, values[i])
 	}
+	return b
+}
+
+// WithNewCABundle replaces the CABundle field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the CABundle field is set to the values of the last call.
+func (b *WebhookClientConfigApplyConfiguration) WithNewCABundle(values ...byte) *WebhookClientConfigApplyConfiguration {
+	b.CABundle = make([]byte, len(values))
+	copy(b.CABundle, values)
 	return b
 }

--- a/staging/src/k8s.io/client-go/applyconfigurations/apiserverinternal/v1alpha1/storageversion.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apiserverinternal/v1alpha1/storageversion.go
@@ -211,6 +211,7 @@ func (b *StorageVersionApplyConfiguration) WithAnnotations(entries map[string]st
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *StorageVersionApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *StorageVersionApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -222,14 +223,40 @@ func (b *StorageVersionApplyConfiguration) WithOwnerReferences(values ...*v1.Own
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *StorageVersionApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *StorageVersionApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *StorageVersionApplyConfiguration) WithFinalizers(values ...string) *StorageVersionApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *StorageVersionApplyConfiguration) WithNewFinalizers(values ...string) *StorageVersionApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/controllerrevision.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/controllerrevision.go
@@ -214,6 +214,7 @@ func (b *ControllerRevisionApplyConfiguration) WithAnnotations(entries map[strin
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *ControllerRevisionApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *ControllerRevisionApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -225,14 +226,40 @@ func (b *ControllerRevisionApplyConfiguration) WithOwnerReferences(values ...*v1
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *ControllerRevisionApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *ControllerRevisionApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *ControllerRevisionApplyConfiguration) WithFinalizers(values ...string) *ControllerRevisionApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *ControllerRevisionApplyConfiguration) WithNewFinalizers(values ...string) *ControllerRevisionApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/daemonset.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/daemonset.go
@@ -213,6 +213,7 @@ func (b *DaemonSetApplyConfiguration) WithAnnotations(entries map[string]string)
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *DaemonSetApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *DaemonSetApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -224,14 +225,40 @@ func (b *DaemonSetApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerRef
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *DaemonSetApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *DaemonSetApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *DaemonSetApplyConfiguration) WithFinalizers(values ...string) *DaemonSetApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *DaemonSetApplyConfiguration) WithNewFinalizers(values ...string) *DaemonSetApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/daemonsetstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/daemonsetstatus.go
@@ -114,10 +114,25 @@ func (b *DaemonSetStatusApplyConfiguration) WithCollisionCount(value int32) *Dae
 // WithConditions adds the given value to the Conditions field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Conditions field.
+// Deprecated: WithConditions does not replace existing list for atomic list type. Use WithNewConditions instead.
 func (b *DaemonSetStatusApplyConfiguration) WithConditions(values ...*DaemonSetConditionApplyConfiguration) *DaemonSetStatusApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithConditions")
+		}
+		b.Conditions = append(b.Conditions, *values[i])
+	}
+	return b
+}
+
+// WithNewConditions replaces the Conditions field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Conditions field is set to the values of the last call.
+func (b *DaemonSetStatusApplyConfiguration) WithNewConditions(values ...*DaemonSetConditionApplyConfiguration) *DaemonSetStatusApplyConfiguration {
+	b.Conditions = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewConditions")
 		}
 		b.Conditions = append(b.Conditions, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/deployment.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/deployment.go
@@ -213,6 +213,7 @@ func (b *DeploymentApplyConfiguration) WithAnnotations(entries map[string]string
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *DeploymentApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *DeploymentApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -224,14 +225,40 @@ func (b *DeploymentApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerRe
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *DeploymentApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *DeploymentApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *DeploymentApplyConfiguration) WithFinalizers(values ...string) *DeploymentApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *DeploymentApplyConfiguration) WithNewFinalizers(values ...string) *DeploymentApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/deploymentstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/deploymentstatus.go
@@ -88,10 +88,25 @@ func (b *DeploymentStatusApplyConfiguration) WithUnavailableReplicas(value int32
 // WithConditions adds the given value to the Conditions field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Conditions field.
+// Deprecated: WithConditions does not replace existing list for atomic list type. Use WithNewConditions instead.
 func (b *DeploymentStatusApplyConfiguration) WithConditions(values ...*DeploymentConditionApplyConfiguration) *DeploymentStatusApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithConditions")
+		}
+		b.Conditions = append(b.Conditions, *values[i])
+	}
+	return b
+}
+
+// WithNewConditions replaces the Conditions field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Conditions field is set to the values of the last call.
+func (b *DeploymentStatusApplyConfiguration) WithNewConditions(values ...*DeploymentConditionApplyConfiguration) *DeploymentStatusApplyConfiguration {
+	b.Conditions = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewConditions")
 		}
 		b.Conditions = append(b.Conditions, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/replicaset.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/replicaset.go
@@ -213,6 +213,7 @@ func (b *ReplicaSetApplyConfiguration) WithAnnotations(entries map[string]string
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *ReplicaSetApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *ReplicaSetApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -224,14 +225,40 @@ func (b *ReplicaSetApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerRe
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *ReplicaSetApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *ReplicaSetApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *ReplicaSetApplyConfiguration) WithFinalizers(values ...string) *ReplicaSetApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *ReplicaSetApplyConfiguration) WithNewFinalizers(values ...string) *ReplicaSetApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/replicasetstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/replicasetstatus.go
@@ -78,10 +78,25 @@ func (b *ReplicaSetStatusApplyConfiguration) WithObservedGeneration(value int64)
 // WithConditions adds the given value to the Conditions field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Conditions field.
+// Deprecated: WithConditions does not replace existing list for atomic list type. Use WithNewConditions instead.
 func (b *ReplicaSetStatusApplyConfiguration) WithConditions(values ...*ReplicaSetConditionApplyConfiguration) *ReplicaSetStatusApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithConditions")
+		}
+		b.Conditions = append(b.Conditions, *values[i])
+	}
+	return b
+}
+
+// WithNewConditions replaces the Conditions field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Conditions field is set to the values of the last call.
+func (b *ReplicaSetStatusApplyConfiguration) WithNewConditions(values ...*ReplicaSetConditionApplyConfiguration) *ReplicaSetStatusApplyConfiguration {
+	b.Conditions = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewConditions")
 		}
 		b.Conditions = append(b.Conditions, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/statefulset.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/statefulset.go
@@ -213,6 +213,7 @@ func (b *StatefulSetApplyConfiguration) WithAnnotations(entries map[string]strin
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *StatefulSetApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *StatefulSetApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -224,14 +225,40 @@ func (b *StatefulSetApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerR
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *StatefulSetApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *StatefulSetApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *StatefulSetApplyConfiguration) WithFinalizers(values ...string) *StatefulSetApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *StatefulSetApplyConfiguration) WithNewFinalizers(values ...string) *StatefulSetApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/statefulsetspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/statefulsetspec.go
@@ -73,10 +73,25 @@ func (b *StatefulSetSpecApplyConfiguration) WithTemplate(value *corev1.PodTempla
 // WithVolumeClaimTemplates adds the given value to the VolumeClaimTemplates field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the VolumeClaimTemplates field.
+// Deprecated: WithVolumeClaimTemplates does not replace existing list for atomic list type. Use WithNewVolumeClaimTemplates instead.
 func (b *StatefulSetSpecApplyConfiguration) WithVolumeClaimTemplates(values ...*corev1.PersistentVolumeClaimApplyConfiguration) *StatefulSetSpecApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithVolumeClaimTemplates")
+		}
+		b.VolumeClaimTemplates = append(b.VolumeClaimTemplates, *values[i])
+	}
+	return b
+}
+
+// WithNewVolumeClaimTemplates replaces the VolumeClaimTemplates field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the VolumeClaimTemplates field is set to the values of the last call.
+func (b *StatefulSetSpecApplyConfiguration) WithNewVolumeClaimTemplates(values ...*corev1.PersistentVolumeClaimApplyConfiguration) *StatefulSetSpecApplyConfiguration {
+	b.VolumeClaimTemplates = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewVolumeClaimTemplates")
 		}
 		b.VolumeClaimTemplates = append(b.VolumeClaimTemplates, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/statefulsetstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/statefulsetstatus.go
@@ -106,10 +106,25 @@ func (b *StatefulSetStatusApplyConfiguration) WithCollisionCount(value int32) *S
 // WithConditions adds the given value to the Conditions field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Conditions field.
+// Deprecated: WithConditions does not replace existing list for atomic list type. Use WithNewConditions instead.
 func (b *StatefulSetStatusApplyConfiguration) WithConditions(values ...*StatefulSetConditionApplyConfiguration) *StatefulSetStatusApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithConditions")
+		}
+		b.Conditions = append(b.Conditions, *values[i])
+	}
+	return b
+}
+
+// WithNewConditions replaces the Conditions field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Conditions field is set to the values of the last call.
+func (b *StatefulSetStatusApplyConfiguration) WithNewConditions(values ...*StatefulSetConditionApplyConfiguration) *StatefulSetStatusApplyConfiguration {
+	b.Conditions = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewConditions")
 		}
 		b.Conditions = append(b.Conditions, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta1/controllerrevision.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta1/controllerrevision.go
@@ -214,6 +214,7 @@ func (b *ControllerRevisionApplyConfiguration) WithAnnotations(entries map[strin
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *ControllerRevisionApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *ControllerRevisionApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -225,14 +226,40 @@ func (b *ControllerRevisionApplyConfiguration) WithOwnerReferences(values ...*v1
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *ControllerRevisionApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *ControllerRevisionApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *ControllerRevisionApplyConfiguration) WithFinalizers(values ...string) *ControllerRevisionApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *ControllerRevisionApplyConfiguration) WithNewFinalizers(values ...string) *ControllerRevisionApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta1/deployment.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta1/deployment.go
@@ -213,6 +213,7 @@ func (b *DeploymentApplyConfiguration) WithAnnotations(entries map[string]string
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *DeploymentApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *DeploymentApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -224,14 +225,40 @@ func (b *DeploymentApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerRe
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *DeploymentApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *DeploymentApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *DeploymentApplyConfiguration) WithFinalizers(values ...string) *DeploymentApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *DeploymentApplyConfiguration) WithNewFinalizers(values ...string) *DeploymentApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta1/deploymentstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta1/deploymentstatus.go
@@ -88,10 +88,25 @@ func (b *DeploymentStatusApplyConfiguration) WithUnavailableReplicas(value int32
 // WithConditions adds the given value to the Conditions field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Conditions field.
+// Deprecated: WithConditions does not replace existing list for atomic list type. Use WithNewConditions instead.
 func (b *DeploymentStatusApplyConfiguration) WithConditions(values ...*DeploymentConditionApplyConfiguration) *DeploymentStatusApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithConditions")
+		}
+		b.Conditions = append(b.Conditions, *values[i])
+	}
+	return b
+}
+
+// WithNewConditions replaces the Conditions field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Conditions field is set to the values of the last call.
+func (b *DeploymentStatusApplyConfiguration) WithNewConditions(values ...*DeploymentConditionApplyConfiguration) *DeploymentStatusApplyConfiguration {
+	b.Conditions = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewConditions")
 		}
 		b.Conditions = append(b.Conditions, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta1/statefulset.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta1/statefulset.go
@@ -213,6 +213,7 @@ func (b *StatefulSetApplyConfiguration) WithAnnotations(entries map[string]strin
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *StatefulSetApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *StatefulSetApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -224,14 +225,40 @@ func (b *StatefulSetApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerR
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *StatefulSetApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *StatefulSetApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *StatefulSetApplyConfiguration) WithFinalizers(values ...string) *StatefulSetApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *StatefulSetApplyConfiguration) WithNewFinalizers(values ...string) *StatefulSetApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta1/statefulsetspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta1/statefulsetspec.go
@@ -73,10 +73,25 @@ func (b *StatefulSetSpecApplyConfiguration) WithTemplate(value *corev1.PodTempla
 // WithVolumeClaimTemplates adds the given value to the VolumeClaimTemplates field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the VolumeClaimTemplates field.
+// Deprecated: WithVolumeClaimTemplates does not replace existing list for atomic list type. Use WithNewVolumeClaimTemplates instead.
 func (b *StatefulSetSpecApplyConfiguration) WithVolumeClaimTemplates(values ...*corev1.PersistentVolumeClaimApplyConfiguration) *StatefulSetSpecApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithVolumeClaimTemplates")
+		}
+		b.VolumeClaimTemplates = append(b.VolumeClaimTemplates, *values[i])
+	}
+	return b
+}
+
+// WithNewVolumeClaimTemplates replaces the VolumeClaimTemplates field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the VolumeClaimTemplates field is set to the values of the last call.
+func (b *StatefulSetSpecApplyConfiguration) WithNewVolumeClaimTemplates(values ...*corev1.PersistentVolumeClaimApplyConfiguration) *StatefulSetSpecApplyConfiguration {
+	b.VolumeClaimTemplates = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewVolumeClaimTemplates")
 		}
 		b.VolumeClaimTemplates = append(b.VolumeClaimTemplates, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta1/statefulsetstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta1/statefulsetstatus.go
@@ -106,10 +106,25 @@ func (b *StatefulSetStatusApplyConfiguration) WithCollisionCount(value int32) *S
 // WithConditions adds the given value to the Conditions field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Conditions field.
+// Deprecated: WithConditions does not replace existing list for atomic list type. Use WithNewConditions instead.
 func (b *StatefulSetStatusApplyConfiguration) WithConditions(values ...*StatefulSetConditionApplyConfiguration) *StatefulSetStatusApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithConditions")
+		}
+		b.Conditions = append(b.Conditions, *values[i])
+	}
+	return b
+}
+
+// WithNewConditions replaces the Conditions field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Conditions field is set to the values of the last call.
+func (b *StatefulSetStatusApplyConfiguration) WithNewConditions(values ...*StatefulSetConditionApplyConfiguration) *StatefulSetStatusApplyConfiguration {
+	b.Conditions = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewConditions")
 		}
 		b.Conditions = append(b.Conditions, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/controllerrevision.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/controllerrevision.go
@@ -214,6 +214,7 @@ func (b *ControllerRevisionApplyConfiguration) WithAnnotations(entries map[strin
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *ControllerRevisionApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *ControllerRevisionApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -225,14 +226,40 @@ func (b *ControllerRevisionApplyConfiguration) WithOwnerReferences(values ...*v1
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *ControllerRevisionApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *ControllerRevisionApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *ControllerRevisionApplyConfiguration) WithFinalizers(values ...string) *ControllerRevisionApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *ControllerRevisionApplyConfiguration) WithNewFinalizers(values ...string) *ControllerRevisionApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/daemonset.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/daemonset.go
@@ -213,6 +213,7 @@ func (b *DaemonSetApplyConfiguration) WithAnnotations(entries map[string]string)
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *DaemonSetApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *DaemonSetApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -224,14 +225,40 @@ func (b *DaemonSetApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerRef
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *DaemonSetApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *DaemonSetApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *DaemonSetApplyConfiguration) WithFinalizers(values ...string) *DaemonSetApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *DaemonSetApplyConfiguration) WithNewFinalizers(values ...string) *DaemonSetApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/daemonsetstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/daemonsetstatus.go
@@ -114,10 +114,25 @@ func (b *DaemonSetStatusApplyConfiguration) WithCollisionCount(value int32) *Dae
 // WithConditions adds the given value to the Conditions field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Conditions field.
+// Deprecated: WithConditions does not replace existing list for atomic list type. Use WithNewConditions instead.
 func (b *DaemonSetStatusApplyConfiguration) WithConditions(values ...*DaemonSetConditionApplyConfiguration) *DaemonSetStatusApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithConditions")
+		}
+		b.Conditions = append(b.Conditions, *values[i])
+	}
+	return b
+}
+
+// WithNewConditions replaces the Conditions field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Conditions field is set to the values of the last call.
+func (b *DaemonSetStatusApplyConfiguration) WithNewConditions(values ...*DaemonSetConditionApplyConfiguration) *DaemonSetStatusApplyConfiguration {
+	b.Conditions = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewConditions")
 		}
 		b.Conditions = append(b.Conditions, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/deployment.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/deployment.go
@@ -213,6 +213,7 @@ func (b *DeploymentApplyConfiguration) WithAnnotations(entries map[string]string
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *DeploymentApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *DeploymentApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -224,14 +225,40 @@ func (b *DeploymentApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerRe
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *DeploymentApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *DeploymentApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *DeploymentApplyConfiguration) WithFinalizers(values ...string) *DeploymentApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *DeploymentApplyConfiguration) WithNewFinalizers(values ...string) *DeploymentApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/deploymentstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/deploymentstatus.go
@@ -88,10 +88,25 @@ func (b *DeploymentStatusApplyConfiguration) WithUnavailableReplicas(value int32
 // WithConditions adds the given value to the Conditions field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Conditions field.
+// Deprecated: WithConditions does not replace existing list for atomic list type. Use WithNewConditions instead.
 func (b *DeploymentStatusApplyConfiguration) WithConditions(values ...*DeploymentConditionApplyConfiguration) *DeploymentStatusApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithConditions")
+		}
+		b.Conditions = append(b.Conditions, *values[i])
+	}
+	return b
+}
+
+// WithNewConditions replaces the Conditions field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Conditions field is set to the values of the last call.
+func (b *DeploymentStatusApplyConfiguration) WithNewConditions(values ...*DeploymentConditionApplyConfiguration) *DeploymentStatusApplyConfiguration {
+	b.Conditions = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewConditions")
 		}
 		b.Conditions = append(b.Conditions, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/replicaset.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/replicaset.go
@@ -213,6 +213,7 @@ func (b *ReplicaSetApplyConfiguration) WithAnnotations(entries map[string]string
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *ReplicaSetApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *ReplicaSetApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -224,14 +225,40 @@ func (b *ReplicaSetApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerRe
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *ReplicaSetApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *ReplicaSetApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *ReplicaSetApplyConfiguration) WithFinalizers(values ...string) *ReplicaSetApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *ReplicaSetApplyConfiguration) WithNewFinalizers(values ...string) *ReplicaSetApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/replicasetstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/replicasetstatus.go
@@ -78,10 +78,25 @@ func (b *ReplicaSetStatusApplyConfiguration) WithObservedGeneration(value int64)
 // WithConditions adds the given value to the Conditions field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Conditions field.
+// Deprecated: WithConditions does not replace existing list for atomic list type. Use WithNewConditions instead.
 func (b *ReplicaSetStatusApplyConfiguration) WithConditions(values ...*ReplicaSetConditionApplyConfiguration) *ReplicaSetStatusApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithConditions")
+		}
+		b.Conditions = append(b.Conditions, *values[i])
+	}
+	return b
+}
+
+// WithNewConditions replaces the Conditions field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Conditions field is set to the values of the last call.
+func (b *ReplicaSetStatusApplyConfiguration) WithNewConditions(values ...*ReplicaSetConditionApplyConfiguration) *ReplicaSetStatusApplyConfiguration {
+	b.Conditions = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewConditions")
 		}
 		b.Conditions = append(b.Conditions, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/scale.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/scale.go
@@ -173,6 +173,7 @@ func (b *ScaleApplyConfiguration) WithAnnotations(entries map[string]string) *Sc
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *ScaleApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *ScaleApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -184,14 +185,40 @@ func (b *ScaleApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferen
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *ScaleApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *ScaleApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *ScaleApplyConfiguration) WithFinalizers(values ...string) *ScaleApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *ScaleApplyConfiguration) WithNewFinalizers(values ...string) *ScaleApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/statefulset.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/statefulset.go
@@ -213,6 +213,7 @@ func (b *StatefulSetApplyConfiguration) WithAnnotations(entries map[string]strin
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *StatefulSetApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *StatefulSetApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -224,14 +225,40 @@ func (b *StatefulSetApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerR
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *StatefulSetApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *StatefulSetApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *StatefulSetApplyConfiguration) WithFinalizers(values ...string) *StatefulSetApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *StatefulSetApplyConfiguration) WithNewFinalizers(values ...string) *StatefulSetApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/statefulsetspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/statefulsetspec.go
@@ -73,10 +73,25 @@ func (b *StatefulSetSpecApplyConfiguration) WithTemplate(value *corev1.PodTempla
 // WithVolumeClaimTemplates adds the given value to the VolumeClaimTemplates field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the VolumeClaimTemplates field.
+// Deprecated: WithVolumeClaimTemplates does not replace existing list for atomic list type. Use WithNewVolumeClaimTemplates instead.
 func (b *StatefulSetSpecApplyConfiguration) WithVolumeClaimTemplates(values ...*corev1.PersistentVolumeClaimApplyConfiguration) *StatefulSetSpecApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithVolumeClaimTemplates")
+		}
+		b.VolumeClaimTemplates = append(b.VolumeClaimTemplates, *values[i])
+	}
+	return b
+}
+
+// WithNewVolumeClaimTemplates replaces the VolumeClaimTemplates field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the VolumeClaimTemplates field is set to the values of the last call.
+func (b *StatefulSetSpecApplyConfiguration) WithNewVolumeClaimTemplates(values ...*corev1.PersistentVolumeClaimApplyConfiguration) *StatefulSetSpecApplyConfiguration {
+	b.VolumeClaimTemplates = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewVolumeClaimTemplates")
 		}
 		b.VolumeClaimTemplates = append(b.VolumeClaimTemplates, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/statefulsetstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/statefulsetstatus.go
@@ -106,10 +106,25 @@ func (b *StatefulSetStatusApplyConfiguration) WithCollisionCount(value int32) *S
 // WithConditions adds the given value to the Conditions field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Conditions field.
+// Deprecated: WithConditions does not replace existing list for atomic list type. Use WithNewConditions instead.
 func (b *StatefulSetStatusApplyConfiguration) WithConditions(values ...*StatefulSetConditionApplyConfiguration) *StatefulSetStatusApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithConditions")
+		}
+		b.Conditions = append(b.Conditions, *values[i])
+	}
+	return b
+}
+
+// WithNewConditions replaces the Conditions field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Conditions field is set to the values of the last call.
+func (b *StatefulSetStatusApplyConfiguration) WithNewConditions(values ...*StatefulSetConditionApplyConfiguration) *StatefulSetStatusApplyConfiguration {
+	b.Conditions = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewConditions")
 		}
 		b.Conditions = append(b.Conditions, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v1/horizontalpodautoscaler.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v1/horizontalpodautoscaler.go
@@ -213,6 +213,7 @@ func (b *HorizontalPodAutoscalerApplyConfiguration) WithAnnotations(entries map[
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *HorizontalPodAutoscalerApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *HorizontalPodAutoscalerApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -224,14 +225,40 @@ func (b *HorizontalPodAutoscalerApplyConfiguration) WithOwnerReferences(values .
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *HorizontalPodAutoscalerApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *HorizontalPodAutoscalerApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *HorizontalPodAutoscalerApplyConfiguration) WithFinalizers(values ...string) *HorizontalPodAutoscalerApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *HorizontalPodAutoscalerApplyConfiguration) WithNewFinalizers(values ...string) *HorizontalPodAutoscalerApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v1/scale.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v1/scale.go
@@ -172,6 +172,7 @@ func (b *ScaleApplyConfiguration) WithAnnotations(entries map[string]string) *Sc
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *ScaleApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *ScaleApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -183,14 +184,40 @@ func (b *ScaleApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferen
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *ScaleApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *ScaleApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *ScaleApplyConfiguration) WithFinalizers(values ...string) *ScaleApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *ScaleApplyConfiguration) WithNewFinalizers(values ...string) *ScaleApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2/horizontalpodautoscaler.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2/horizontalpodautoscaler.go
@@ -213,6 +213,7 @@ func (b *HorizontalPodAutoscalerApplyConfiguration) WithAnnotations(entries map[
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *HorizontalPodAutoscalerApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *HorizontalPodAutoscalerApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -224,14 +225,40 @@ func (b *HorizontalPodAutoscalerApplyConfiguration) WithOwnerReferences(values .
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *HorizontalPodAutoscalerApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *HorizontalPodAutoscalerApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *HorizontalPodAutoscalerApplyConfiguration) WithFinalizers(values ...string) *HorizontalPodAutoscalerApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *HorizontalPodAutoscalerApplyConfiguration) WithNewFinalizers(values ...string) *HorizontalPodAutoscalerApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2/horizontalpodautoscalerspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2/horizontalpodautoscalerspec.go
@@ -61,10 +61,25 @@ func (b *HorizontalPodAutoscalerSpecApplyConfiguration) WithMaxReplicas(value in
 // WithMetrics adds the given value to the Metrics field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Metrics field.
+// Deprecated: WithMetrics does not replace existing list for atomic list type. Use WithNewMetrics instead.
 func (b *HorizontalPodAutoscalerSpecApplyConfiguration) WithMetrics(values ...*MetricSpecApplyConfiguration) *HorizontalPodAutoscalerSpecApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithMetrics")
+		}
+		b.Metrics = append(b.Metrics, *values[i])
+	}
+	return b
+}
+
+// WithNewMetrics replaces the Metrics field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Metrics field is set to the values of the last call.
+func (b *HorizontalPodAutoscalerSpecApplyConfiguration) WithNewMetrics(values ...*MetricSpecApplyConfiguration) *HorizontalPodAutoscalerSpecApplyConfiguration {
+	b.Metrics = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewMetrics")
 		}
 		b.Metrics = append(b.Metrics, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2/horizontalpodautoscalerstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2/horizontalpodautoscalerstatus.go
@@ -74,10 +74,25 @@ func (b *HorizontalPodAutoscalerStatusApplyConfiguration) WithDesiredReplicas(va
 // WithCurrentMetrics adds the given value to the CurrentMetrics field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the CurrentMetrics field.
+// Deprecated: WithCurrentMetrics does not replace existing list for atomic list type. Use WithNewCurrentMetrics instead.
 func (b *HorizontalPodAutoscalerStatusApplyConfiguration) WithCurrentMetrics(values ...*MetricStatusApplyConfiguration) *HorizontalPodAutoscalerStatusApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithCurrentMetrics")
+		}
+		b.CurrentMetrics = append(b.CurrentMetrics, *values[i])
+	}
+	return b
+}
+
+// WithNewCurrentMetrics replaces the CurrentMetrics field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the CurrentMetrics field is set to the values of the last call.
+func (b *HorizontalPodAutoscalerStatusApplyConfiguration) WithNewCurrentMetrics(values ...*MetricStatusApplyConfiguration) *HorizontalPodAutoscalerStatusApplyConfiguration {
+	b.CurrentMetrics = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewCurrentMetrics")
 		}
 		b.CurrentMetrics = append(b.CurrentMetrics, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2/hpascalingrules.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2/hpascalingrules.go
@@ -55,10 +55,25 @@ func (b *HPAScalingRulesApplyConfiguration) WithSelectPolicy(value v2.ScalingPol
 // WithPolicies adds the given value to the Policies field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Policies field.
+// Deprecated: WithPolicies does not replace existing list for atomic list type. Use WithNewPolicies instead.
 func (b *HPAScalingRulesApplyConfiguration) WithPolicies(values ...*HPAScalingPolicyApplyConfiguration) *HPAScalingRulesApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithPolicies")
+		}
+		b.Policies = append(b.Policies, *values[i])
+	}
+	return b
+}
+
+// WithNewPolicies replaces the Policies field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Policies field is set to the values of the last call.
+func (b *HPAScalingRulesApplyConfiguration) WithNewPolicies(values ...*HPAScalingPolicyApplyConfiguration) *HPAScalingRulesApplyConfiguration {
+	b.Policies = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewPolicies")
 		}
 		b.Policies = append(b.Policies, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta1/horizontalpodautoscaler.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta1/horizontalpodautoscaler.go
@@ -213,6 +213,7 @@ func (b *HorizontalPodAutoscalerApplyConfiguration) WithAnnotations(entries map[
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *HorizontalPodAutoscalerApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *HorizontalPodAutoscalerApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -224,14 +225,40 @@ func (b *HorizontalPodAutoscalerApplyConfiguration) WithOwnerReferences(values .
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *HorizontalPodAutoscalerApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *HorizontalPodAutoscalerApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *HorizontalPodAutoscalerApplyConfiguration) WithFinalizers(values ...string) *HorizontalPodAutoscalerApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *HorizontalPodAutoscalerApplyConfiguration) WithNewFinalizers(values ...string) *HorizontalPodAutoscalerApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta1/horizontalpodautoscalerspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta1/horizontalpodautoscalerspec.go
@@ -60,10 +60,25 @@ func (b *HorizontalPodAutoscalerSpecApplyConfiguration) WithMaxReplicas(value in
 // WithMetrics adds the given value to the Metrics field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Metrics field.
+// Deprecated: WithMetrics does not replace existing list for atomic list type. Use WithNewMetrics instead.
 func (b *HorizontalPodAutoscalerSpecApplyConfiguration) WithMetrics(values ...*MetricSpecApplyConfiguration) *HorizontalPodAutoscalerSpecApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithMetrics")
+		}
+		b.Metrics = append(b.Metrics, *values[i])
+	}
+	return b
+}
+
+// WithNewMetrics replaces the Metrics field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Metrics field is set to the values of the last call.
+func (b *HorizontalPodAutoscalerSpecApplyConfiguration) WithNewMetrics(values ...*MetricSpecApplyConfiguration) *HorizontalPodAutoscalerSpecApplyConfiguration {
+	b.Metrics = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewMetrics")
 		}
 		b.Metrics = append(b.Metrics, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta1/horizontalpodautoscalerstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta1/horizontalpodautoscalerstatus.go
@@ -74,6 +74,7 @@ func (b *HorizontalPodAutoscalerStatusApplyConfiguration) WithDesiredReplicas(va
 // WithCurrentMetrics adds the given value to the CurrentMetrics field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the CurrentMetrics field.
+// Deprecated: WithCurrentMetrics does not replace existing list for atomic list type. Use WithNewCurrentMetrics instead.
 func (b *HorizontalPodAutoscalerStatusApplyConfiguration) WithCurrentMetrics(values ...*MetricStatusApplyConfiguration) *HorizontalPodAutoscalerStatusApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
@@ -84,13 +85,42 @@ func (b *HorizontalPodAutoscalerStatusApplyConfiguration) WithCurrentMetrics(val
 	return b
 }
 
+// WithNewCurrentMetrics replaces the CurrentMetrics field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the CurrentMetrics field is set to the values of the last call.
+func (b *HorizontalPodAutoscalerStatusApplyConfiguration) WithNewCurrentMetrics(values ...*MetricStatusApplyConfiguration) *HorizontalPodAutoscalerStatusApplyConfiguration {
+	b.CurrentMetrics = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewCurrentMetrics")
+		}
+		b.CurrentMetrics = append(b.CurrentMetrics, *values[i])
+	}
+	return b
+}
+
 // WithConditions adds the given value to the Conditions field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Conditions field.
+// Deprecated: WithConditions does not replace existing list for atomic list type. Use WithNewConditions instead.
 func (b *HorizontalPodAutoscalerStatusApplyConfiguration) WithConditions(values ...*HorizontalPodAutoscalerConditionApplyConfiguration) *HorizontalPodAutoscalerStatusApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithConditions")
+		}
+		b.Conditions = append(b.Conditions, *values[i])
+	}
+	return b
+}
+
+// WithNewConditions replaces the Conditions field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Conditions field is set to the values of the last call.
+func (b *HorizontalPodAutoscalerStatusApplyConfiguration) WithNewConditions(values ...*HorizontalPodAutoscalerConditionApplyConfiguration) *HorizontalPodAutoscalerStatusApplyConfiguration {
+	b.Conditions = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewConditions")
 		}
 		b.Conditions = append(b.Conditions, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta2/horizontalpodautoscaler.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta2/horizontalpodautoscaler.go
@@ -213,6 +213,7 @@ func (b *HorizontalPodAutoscalerApplyConfiguration) WithAnnotations(entries map[
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *HorizontalPodAutoscalerApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *HorizontalPodAutoscalerApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -224,14 +225,40 @@ func (b *HorizontalPodAutoscalerApplyConfiguration) WithOwnerReferences(values .
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *HorizontalPodAutoscalerApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *HorizontalPodAutoscalerApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *HorizontalPodAutoscalerApplyConfiguration) WithFinalizers(values ...string) *HorizontalPodAutoscalerApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *HorizontalPodAutoscalerApplyConfiguration) WithNewFinalizers(values ...string) *HorizontalPodAutoscalerApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta2/horizontalpodautoscalerspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta2/horizontalpodautoscalerspec.go
@@ -61,10 +61,25 @@ func (b *HorizontalPodAutoscalerSpecApplyConfiguration) WithMaxReplicas(value in
 // WithMetrics adds the given value to the Metrics field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Metrics field.
+// Deprecated: WithMetrics does not replace existing list for atomic list type. Use WithNewMetrics instead.
 func (b *HorizontalPodAutoscalerSpecApplyConfiguration) WithMetrics(values ...*MetricSpecApplyConfiguration) *HorizontalPodAutoscalerSpecApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithMetrics")
+		}
+		b.Metrics = append(b.Metrics, *values[i])
+	}
+	return b
+}
+
+// WithNewMetrics replaces the Metrics field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Metrics field is set to the values of the last call.
+func (b *HorizontalPodAutoscalerSpecApplyConfiguration) WithNewMetrics(values ...*MetricSpecApplyConfiguration) *HorizontalPodAutoscalerSpecApplyConfiguration {
+	b.Metrics = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewMetrics")
 		}
 		b.Metrics = append(b.Metrics, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta2/horizontalpodautoscalerstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta2/horizontalpodautoscalerstatus.go
@@ -74,6 +74,7 @@ func (b *HorizontalPodAutoscalerStatusApplyConfiguration) WithDesiredReplicas(va
 // WithCurrentMetrics adds the given value to the CurrentMetrics field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the CurrentMetrics field.
+// Deprecated: WithCurrentMetrics does not replace existing list for atomic list type. Use WithNewCurrentMetrics instead.
 func (b *HorizontalPodAutoscalerStatusApplyConfiguration) WithCurrentMetrics(values ...*MetricStatusApplyConfiguration) *HorizontalPodAutoscalerStatusApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
@@ -84,13 +85,42 @@ func (b *HorizontalPodAutoscalerStatusApplyConfiguration) WithCurrentMetrics(val
 	return b
 }
 
+// WithNewCurrentMetrics replaces the CurrentMetrics field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the CurrentMetrics field is set to the values of the last call.
+func (b *HorizontalPodAutoscalerStatusApplyConfiguration) WithNewCurrentMetrics(values ...*MetricStatusApplyConfiguration) *HorizontalPodAutoscalerStatusApplyConfiguration {
+	b.CurrentMetrics = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewCurrentMetrics")
+		}
+		b.CurrentMetrics = append(b.CurrentMetrics, *values[i])
+	}
+	return b
+}
+
 // WithConditions adds the given value to the Conditions field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Conditions field.
+// Deprecated: WithConditions does not replace existing list for atomic list type. Use WithNewConditions instead.
 func (b *HorizontalPodAutoscalerStatusApplyConfiguration) WithConditions(values ...*HorizontalPodAutoscalerConditionApplyConfiguration) *HorizontalPodAutoscalerStatusApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithConditions")
+		}
+		b.Conditions = append(b.Conditions, *values[i])
+	}
+	return b
+}
+
+// WithNewConditions replaces the Conditions field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Conditions field is set to the values of the last call.
+func (b *HorizontalPodAutoscalerStatusApplyConfiguration) WithNewConditions(values ...*HorizontalPodAutoscalerConditionApplyConfiguration) *HorizontalPodAutoscalerStatusApplyConfiguration {
+	b.Conditions = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewConditions")
 		}
 		b.Conditions = append(b.Conditions, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta2/hpascalingrules.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta2/hpascalingrules.go
@@ -55,10 +55,25 @@ func (b *HPAScalingRulesApplyConfiguration) WithSelectPolicy(value v2beta2.Scali
 // WithPolicies adds the given value to the Policies field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Policies field.
+// Deprecated: WithPolicies does not replace existing list for atomic list type. Use WithNewPolicies instead.
 func (b *HPAScalingRulesApplyConfiguration) WithPolicies(values ...*HPAScalingPolicyApplyConfiguration) *HPAScalingRulesApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithPolicies")
+		}
+		b.Policies = append(b.Policies, *values[i])
+	}
+	return b
+}
+
+// WithNewPolicies replaces the Policies field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Policies field is set to the values of the last call.
+func (b *HPAScalingRulesApplyConfiguration) WithNewPolicies(values ...*HPAScalingPolicyApplyConfiguration) *HPAScalingRulesApplyConfiguration {
+	b.Policies = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewPolicies")
 		}
 		b.Policies = append(b.Policies, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/batch/v1/cronjob.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/batch/v1/cronjob.go
@@ -213,6 +213,7 @@ func (b *CronJobApplyConfiguration) WithAnnotations(entries map[string]string) *
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *CronJobApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *CronJobApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -224,14 +225,40 @@ func (b *CronJobApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerRefer
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *CronJobApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *CronJobApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *CronJobApplyConfiguration) WithFinalizers(values ...string) *CronJobApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *CronJobApplyConfiguration) WithNewFinalizers(values ...string) *CronJobApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/batch/v1/cronjobstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/batch/v1/cronjobstatus.go
@@ -40,10 +40,25 @@ func CronJobStatus() *CronJobStatusApplyConfiguration {
 // WithActive adds the given value to the Active field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Active field.
+// Deprecated: WithActive does not replace existing list for atomic list type. Use WithNewActive instead.
 func (b *CronJobStatusApplyConfiguration) WithActive(values ...*v1.ObjectReferenceApplyConfiguration) *CronJobStatusApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithActive")
+		}
+		b.Active = append(b.Active, *values[i])
+	}
+	return b
+}
+
+// WithNewActive replaces the Active field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Active field is set to the values of the last call.
+func (b *CronJobStatusApplyConfiguration) WithNewActive(values ...*v1.ObjectReferenceApplyConfiguration) *CronJobStatusApplyConfiguration {
+	b.Active = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewActive")
 		}
 		b.Active = append(b.Active, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/batch/v1/job.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/batch/v1/job.go
@@ -213,6 +213,7 @@ func (b *JobApplyConfiguration) WithAnnotations(entries map[string]string) *JobA
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *JobApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *JobApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -224,14 +225,40 @@ func (b *JobApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReference
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *JobApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *JobApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *JobApplyConfiguration) WithFinalizers(values ...string) *JobApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *JobApplyConfiguration) WithNewFinalizers(values ...string) *JobApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/batch/v1/jobstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/batch/v1/jobstatus.go
@@ -47,10 +47,25 @@ func JobStatus() *JobStatusApplyConfiguration {
 // WithConditions adds the given value to the Conditions field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Conditions field.
+// Deprecated: WithConditions does not replace existing list for atomic list type. Use WithNewConditions instead.
 func (b *JobStatusApplyConfiguration) WithConditions(values ...*JobConditionApplyConfiguration) *JobStatusApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithConditions")
+		}
+		b.Conditions = append(b.Conditions, *values[i])
+	}
+	return b
+}
+
+// WithNewConditions replaces the Conditions field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Conditions field is set to the values of the last call.
+func (b *JobStatusApplyConfiguration) WithNewConditions(values ...*JobConditionApplyConfiguration) *JobStatusApplyConfiguration {
+	b.Conditions = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewConditions")
 		}
 		b.Conditions = append(b.Conditions, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/batch/v1/jobtemplatespec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/batch/v1/jobtemplatespec.go
@@ -151,6 +151,7 @@ func (b *JobTemplateSpecApplyConfiguration) WithAnnotations(entries map[string]s
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *JobTemplateSpecApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *JobTemplateSpecApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -162,14 +163,40 @@ func (b *JobTemplateSpecApplyConfiguration) WithOwnerReferences(values ...*v1.Ow
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *JobTemplateSpecApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *JobTemplateSpecApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *JobTemplateSpecApplyConfiguration) WithFinalizers(values ...string) *JobTemplateSpecApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *JobTemplateSpecApplyConfiguration) WithNewFinalizers(values ...string) *JobTemplateSpecApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/batch/v1/podfailurepolicy.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/batch/v1/podfailurepolicy.go
@@ -33,10 +33,25 @@ func PodFailurePolicy() *PodFailurePolicyApplyConfiguration {
 // WithRules adds the given value to the Rules field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Rules field.
+// Deprecated: WithRules does not replace existing list for atomic list type. Use WithNewRules instead.
 func (b *PodFailurePolicyApplyConfiguration) WithRules(values ...*PodFailurePolicyRuleApplyConfiguration) *PodFailurePolicyApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithRules")
+		}
+		b.Rules = append(b.Rules, *values[i])
+	}
+	return b
+}
+
+// WithNewRules replaces the Rules field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Rules field is set to the values of the last call.
+func (b *PodFailurePolicyApplyConfiguration) WithNewRules(values ...*PodFailurePolicyRuleApplyConfiguration) *PodFailurePolicyApplyConfiguration {
+	b.Rules = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewRules")
 		}
 		b.Rules = append(b.Rules, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/batch/v1/podfailurepolicyrule.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/batch/v1/podfailurepolicyrule.go
@@ -55,10 +55,25 @@ func (b *PodFailurePolicyRuleApplyConfiguration) WithOnExitCodes(value *PodFailu
 // WithOnPodConditions adds the given value to the OnPodConditions field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OnPodConditions field.
+// Deprecated: WithOnPodConditions does not replace existing list for atomic list type. Use WithNewOnPodConditions instead.
 func (b *PodFailurePolicyRuleApplyConfiguration) WithOnPodConditions(values ...*PodFailurePolicyOnPodConditionsPatternApplyConfiguration) *PodFailurePolicyRuleApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithOnPodConditions")
+		}
+		b.OnPodConditions = append(b.OnPodConditions, *values[i])
+	}
+	return b
+}
+
+// WithNewOnPodConditions replaces the OnPodConditions field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OnPodConditions field is set to the values of the last call.
+func (b *PodFailurePolicyRuleApplyConfiguration) WithNewOnPodConditions(values ...*PodFailurePolicyOnPodConditionsPatternApplyConfiguration) *PodFailurePolicyRuleApplyConfiguration {
+	b.OnPodConditions = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOnPodConditions")
 		}
 		b.OnPodConditions = append(b.OnPodConditions, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/batch/v1beta1/cronjob.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/batch/v1beta1/cronjob.go
@@ -213,6 +213,7 @@ func (b *CronJobApplyConfiguration) WithAnnotations(entries map[string]string) *
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *CronJobApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *CronJobApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -224,14 +225,40 @@ func (b *CronJobApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerRefer
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *CronJobApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *CronJobApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *CronJobApplyConfiguration) WithFinalizers(values ...string) *CronJobApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *CronJobApplyConfiguration) WithNewFinalizers(values ...string) *CronJobApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/batch/v1beta1/cronjobstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/batch/v1beta1/cronjobstatus.go
@@ -40,10 +40,25 @@ func CronJobStatus() *CronJobStatusApplyConfiguration {
 // WithActive adds the given value to the Active field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Active field.
+// Deprecated: WithActive does not replace existing list for atomic list type. Use WithNewActive instead.
 func (b *CronJobStatusApplyConfiguration) WithActive(values ...*v1.ObjectReferenceApplyConfiguration) *CronJobStatusApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithActive")
+		}
+		b.Active = append(b.Active, *values[i])
+	}
+	return b
+}
+
+// WithNewActive replaces the Active field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Active field is set to the values of the last call.
+func (b *CronJobStatusApplyConfiguration) WithNewActive(values ...*v1.ObjectReferenceApplyConfiguration) *CronJobStatusApplyConfiguration {
+	b.Active = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewActive")
 		}
 		b.Active = append(b.Active, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/batch/v1beta1/jobtemplatespec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/batch/v1beta1/jobtemplatespec.go
@@ -152,6 +152,7 @@ func (b *JobTemplateSpecApplyConfiguration) WithAnnotations(entries map[string]s
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *JobTemplateSpecApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *JobTemplateSpecApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -163,14 +164,40 @@ func (b *JobTemplateSpecApplyConfiguration) WithOwnerReferences(values ...*v1.Ow
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *JobTemplateSpecApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *JobTemplateSpecApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *JobTemplateSpecApplyConfiguration) WithFinalizers(values ...string) *JobTemplateSpecApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *JobTemplateSpecApplyConfiguration) WithNewFinalizers(values ...string) *JobTemplateSpecApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/certificates/v1/certificatesigningrequest.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/certificates/v1/certificatesigningrequest.go
@@ -211,6 +211,7 @@ func (b *CertificateSigningRequestApplyConfiguration) WithAnnotations(entries ma
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *CertificateSigningRequestApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *CertificateSigningRequestApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -222,14 +223,40 @@ func (b *CertificateSigningRequestApplyConfiguration) WithOwnerReferences(values
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *CertificateSigningRequestApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *CertificateSigningRequestApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *CertificateSigningRequestApplyConfiguration) WithFinalizers(values ...string) *CertificateSigningRequestApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *CertificateSigningRequestApplyConfiguration) WithNewFinalizers(values ...string) *CertificateSigningRequestApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/certificates/v1/certificatesigningrequestspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/certificates/v1/certificatesigningrequestspec.go
@@ -44,10 +44,20 @@ func CertificateSigningRequestSpec() *CertificateSigningRequestSpecApplyConfigur
 // WithRequest adds the given value to the Request field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Request field.
+// Deprecated: WithRequest does not replace existing list for atomic list type. Use WithNewRequest instead.
 func (b *CertificateSigningRequestSpecApplyConfiguration) WithRequest(values ...byte) *CertificateSigningRequestSpecApplyConfiguration {
 	for i := range values {
 		b.Request = append(b.Request, values[i])
 	}
+	return b
+}
+
+// WithNewRequest replaces the Request field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Request field is set to the values of the last call.
+func (b *CertificateSigningRequestSpecApplyConfiguration) WithNewRequest(values ...byte) *CertificateSigningRequestSpecApplyConfiguration {
+	b.Request = make([]byte, len(values))
+	copy(b.Request, values)
 	return b
 }
 
@@ -70,10 +80,20 @@ func (b *CertificateSigningRequestSpecApplyConfiguration) WithExpirationSeconds(
 // WithUsages adds the given value to the Usages field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Usages field.
+// Deprecated: WithUsages does not replace existing list for atomic list type. Use WithNewUsages instead.
 func (b *CertificateSigningRequestSpecApplyConfiguration) WithUsages(values ...v1.KeyUsage) *CertificateSigningRequestSpecApplyConfiguration {
 	for i := range values {
 		b.Usages = append(b.Usages, values[i])
 	}
+	return b
+}
+
+// WithNewUsages replaces the Usages field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Usages field is set to the values of the last call.
+func (b *CertificateSigningRequestSpecApplyConfiguration) WithNewUsages(values ...v1.KeyUsage) *CertificateSigningRequestSpecApplyConfiguration {
+	b.Usages = make([]v1.KeyUsage, len(values))
+	copy(b.Usages, values)
 	return b
 }
 
@@ -96,10 +116,20 @@ func (b *CertificateSigningRequestSpecApplyConfiguration) WithUID(value string) 
 // WithGroups adds the given value to the Groups field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Groups field.
+// Deprecated: WithGroups does not replace existing list for atomic list type. Use WithNewGroups instead.
 func (b *CertificateSigningRequestSpecApplyConfiguration) WithGroups(values ...string) *CertificateSigningRequestSpecApplyConfiguration {
 	for i := range values {
 		b.Groups = append(b.Groups, values[i])
 	}
+	return b
+}
+
+// WithNewGroups replaces the Groups field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Groups field is set to the values of the last call.
+func (b *CertificateSigningRequestSpecApplyConfiguration) WithNewGroups(values ...string) *CertificateSigningRequestSpecApplyConfiguration {
+	b.Groups = make([]string, len(values))
+	copy(b.Groups, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/certificates/v1/certificatesigningrequeststatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/certificates/v1/certificatesigningrequeststatus.go
@@ -47,9 +47,19 @@ func (b *CertificateSigningRequestStatusApplyConfiguration) WithConditions(value
 // WithCertificate adds the given value to the Certificate field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Certificate field.
+// Deprecated: WithCertificate does not replace existing list for atomic list type. Use WithNewCertificate instead.
 func (b *CertificateSigningRequestStatusApplyConfiguration) WithCertificate(values ...byte) *CertificateSigningRequestStatusApplyConfiguration {
 	for i := range values {
 		b.Certificate = append(b.Certificate, values[i])
 	}
+	return b
+}
+
+// WithNewCertificate replaces the Certificate field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Certificate field is set to the values of the last call.
+func (b *CertificateSigningRequestStatusApplyConfiguration) WithNewCertificate(values ...byte) *CertificateSigningRequestStatusApplyConfiguration {
+	b.Certificate = make([]byte, len(values))
+	copy(b.Certificate, values)
 	return b
 }

--- a/staging/src/k8s.io/client-go/applyconfigurations/certificates/v1alpha1/clustertrustbundle.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/certificates/v1alpha1/clustertrustbundle.go
@@ -210,6 +210,7 @@ func (b *ClusterTrustBundleApplyConfiguration) WithAnnotations(entries map[strin
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *ClusterTrustBundleApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *ClusterTrustBundleApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -221,14 +222,40 @@ func (b *ClusterTrustBundleApplyConfiguration) WithOwnerReferences(values ...*v1
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *ClusterTrustBundleApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *ClusterTrustBundleApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *ClusterTrustBundleApplyConfiguration) WithFinalizers(values ...string) *ClusterTrustBundleApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *ClusterTrustBundleApplyConfiguration) WithNewFinalizers(values ...string) *ClusterTrustBundleApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/certificates/v1beta1/certificatesigningrequest.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/certificates/v1beta1/certificatesigningrequest.go
@@ -211,6 +211,7 @@ func (b *CertificateSigningRequestApplyConfiguration) WithAnnotations(entries ma
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *CertificateSigningRequestApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *CertificateSigningRequestApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -222,14 +223,40 @@ func (b *CertificateSigningRequestApplyConfiguration) WithOwnerReferences(values
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *CertificateSigningRequestApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *CertificateSigningRequestApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *CertificateSigningRequestApplyConfiguration) WithFinalizers(values ...string) *CertificateSigningRequestApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *CertificateSigningRequestApplyConfiguration) WithNewFinalizers(values ...string) *CertificateSigningRequestApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/certificates/v1beta1/certificatesigningrequestspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/certificates/v1beta1/certificatesigningrequestspec.go
@@ -44,10 +44,20 @@ func CertificateSigningRequestSpec() *CertificateSigningRequestSpecApplyConfigur
 // WithRequest adds the given value to the Request field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Request field.
+// Deprecated: WithRequest does not replace existing list for atomic list type. Use WithNewRequest instead.
 func (b *CertificateSigningRequestSpecApplyConfiguration) WithRequest(values ...byte) *CertificateSigningRequestSpecApplyConfiguration {
 	for i := range values {
 		b.Request = append(b.Request, values[i])
 	}
+	return b
+}
+
+// WithNewRequest replaces the Request field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Request field is set to the values of the last call.
+func (b *CertificateSigningRequestSpecApplyConfiguration) WithNewRequest(values ...byte) *CertificateSigningRequestSpecApplyConfiguration {
+	b.Request = make([]byte, len(values))
+	copy(b.Request, values)
 	return b
 }
 
@@ -70,10 +80,20 @@ func (b *CertificateSigningRequestSpecApplyConfiguration) WithExpirationSeconds(
 // WithUsages adds the given value to the Usages field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Usages field.
+// Deprecated: WithUsages does not replace existing list for atomic list type. Use WithNewUsages instead.
 func (b *CertificateSigningRequestSpecApplyConfiguration) WithUsages(values ...v1beta1.KeyUsage) *CertificateSigningRequestSpecApplyConfiguration {
 	for i := range values {
 		b.Usages = append(b.Usages, values[i])
 	}
+	return b
+}
+
+// WithNewUsages replaces the Usages field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Usages field is set to the values of the last call.
+func (b *CertificateSigningRequestSpecApplyConfiguration) WithNewUsages(values ...v1beta1.KeyUsage) *CertificateSigningRequestSpecApplyConfiguration {
+	b.Usages = make([]v1beta1.KeyUsage, len(values))
+	copy(b.Usages, values)
 	return b
 }
 
@@ -96,10 +116,20 @@ func (b *CertificateSigningRequestSpecApplyConfiguration) WithUID(value string) 
 // WithGroups adds the given value to the Groups field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Groups field.
+// Deprecated: WithGroups does not replace existing list for atomic list type. Use WithNewGroups instead.
 func (b *CertificateSigningRequestSpecApplyConfiguration) WithGroups(values ...string) *CertificateSigningRequestSpecApplyConfiguration {
 	for i := range values {
 		b.Groups = append(b.Groups, values[i])
 	}
+	return b
+}
+
+// WithNewGroups replaces the Groups field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Groups field is set to the values of the last call.
+func (b *CertificateSigningRequestSpecApplyConfiguration) WithNewGroups(values ...string) *CertificateSigningRequestSpecApplyConfiguration {
+	b.Groups = make([]string, len(values))
+	copy(b.Groups, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/certificates/v1beta1/certificatesigningrequeststatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/certificates/v1beta1/certificatesigningrequeststatus.go
@@ -47,9 +47,19 @@ func (b *CertificateSigningRequestStatusApplyConfiguration) WithConditions(value
 // WithCertificate adds the given value to the Certificate field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Certificate field.
+// Deprecated: WithCertificate does not replace existing list for atomic list type. Use WithNewCertificate instead.
 func (b *CertificateSigningRequestStatusApplyConfiguration) WithCertificate(values ...byte) *CertificateSigningRequestStatusApplyConfiguration {
 	for i := range values {
 		b.Certificate = append(b.Certificate, values[i])
 	}
+	return b
+}
+
+// WithNewCertificate replaces the Certificate field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Certificate field is set to the values of the last call.
+func (b *CertificateSigningRequestStatusApplyConfiguration) WithNewCertificate(values ...byte) *CertificateSigningRequestStatusApplyConfiguration {
+	b.Certificate = make([]byte, len(values))
+	copy(b.Certificate, values)
 	return b
 }

--- a/staging/src/k8s.io/client-go/applyconfigurations/coordination/v1/lease.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/coordination/v1/lease.go
@@ -212,6 +212,7 @@ func (b *LeaseApplyConfiguration) WithAnnotations(entries map[string]string) *Le
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *LeaseApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *LeaseApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -223,14 +224,40 @@ func (b *LeaseApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferen
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *LeaseApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *LeaseApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *LeaseApplyConfiguration) WithFinalizers(values ...string) *LeaseApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *LeaseApplyConfiguration) WithNewFinalizers(values ...string) *LeaseApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/coordination/v1beta1/lease.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/coordination/v1beta1/lease.go
@@ -212,6 +212,7 @@ func (b *LeaseApplyConfiguration) WithAnnotations(entries map[string]string) *Le
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *LeaseApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *LeaseApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -223,14 +224,40 @@ func (b *LeaseApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferen
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *LeaseApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *LeaseApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *LeaseApplyConfiguration) WithFinalizers(values ...string) *LeaseApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *LeaseApplyConfiguration) WithNewFinalizers(values ...string) *LeaseApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/capabilities.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/capabilities.go
@@ -38,6 +38,7 @@ func Capabilities() *CapabilitiesApplyConfiguration {
 // WithAdd adds the given value to the Add field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Add field.
+// Deprecated: WithAdd does not replace existing list for atomic list type. Use WithNewAdd instead.
 func (b *CapabilitiesApplyConfiguration) WithAdd(values ...v1.Capability) *CapabilitiesApplyConfiguration {
 	for i := range values {
 		b.Add = append(b.Add, values[i])
@@ -45,12 +46,31 @@ func (b *CapabilitiesApplyConfiguration) WithAdd(values ...v1.Capability) *Capab
 	return b
 }
 
+// WithNewAdd replaces the Add field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Add field is set to the values of the last call.
+func (b *CapabilitiesApplyConfiguration) WithNewAdd(values ...v1.Capability) *CapabilitiesApplyConfiguration {
+	b.Add = make([]v1.Capability, len(values))
+	copy(b.Add, values)
+	return b
+}
+
 // WithDrop adds the given value to the Drop field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Drop field.
+// Deprecated: WithDrop does not replace existing list for atomic list type. Use WithNewDrop instead.
 func (b *CapabilitiesApplyConfiguration) WithDrop(values ...v1.Capability) *CapabilitiesApplyConfiguration {
 	for i := range values {
 		b.Drop = append(b.Drop, values[i])
 	}
+	return b
+}
+
+// WithNewDrop replaces the Drop field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Drop field is set to the values of the last call.
+func (b *CapabilitiesApplyConfiguration) WithNewDrop(values ...v1.Capability) *CapabilitiesApplyConfiguration {
+	b.Drop = make([]v1.Capability, len(values))
+	copy(b.Drop, values)
 	return b
 }

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/cephfspersistentvolumesource.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/cephfspersistentvolumesource.go
@@ -38,10 +38,20 @@ func CephFSPersistentVolumeSource() *CephFSPersistentVolumeSourceApplyConfigurat
 // WithMonitors adds the given value to the Monitors field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Monitors field.
+// Deprecated: WithMonitors does not replace existing list for atomic list type. Use WithNewMonitors instead.
 func (b *CephFSPersistentVolumeSourceApplyConfiguration) WithMonitors(values ...string) *CephFSPersistentVolumeSourceApplyConfiguration {
 	for i := range values {
 		b.Monitors = append(b.Monitors, values[i])
 	}
+	return b
+}
+
+// WithNewMonitors replaces the Monitors field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Monitors field is set to the values of the last call.
+func (b *CephFSPersistentVolumeSourceApplyConfiguration) WithNewMonitors(values ...string) *CephFSPersistentVolumeSourceApplyConfiguration {
+	b.Monitors = make([]string, len(values))
+	copy(b.Monitors, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/cephfsvolumesource.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/cephfsvolumesource.go
@@ -38,10 +38,20 @@ func CephFSVolumeSource() *CephFSVolumeSourceApplyConfiguration {
 // WithMonitors adds the given value to the Monitors field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Monitors field.
+// Deprecated: WithMonitors does not replace existing list for atomic list type. Use WithNewMonitors instead.
 func (b *CephFSVolumeSourceApplyConfiguration) WithMonitors(values ...string) *CephFSVolumeSourceApplyConfiguration {
 	for i := range values {
 		b.Monitors = append(b.Monitors, values[i])
 	}
+	return b
+}
+
+// WithNewMonitors replaces the Monitors field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Monitors field is set to the values of the last call.
+func (b *CephFSVolumeSourceApplyConfiguration) WithNewMonitors(values ...string) *CephFSVolumeSourceApplyConfiguration {
+	b.Monitors = make([]string, len(values))
+	copy(b.Monitors, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/componentstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/componentstatus.go
@@ -210,6 +210,7 @@ func (b *ComponentStatusApplyConfiguration) WithAnnotations(entries map[string]s
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *ComponentStatusApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *ComponentStatusApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -221,14 +222,40 @@ func (b *ComponentStatusApplyConfiguration) WithOwnerReferences(values ...*v1.Ow
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *ComponentStatusApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *ComponentStatusApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *ComponentStatusApplyConfiguration) WithFinalizers(values ...string) *ComponentStatusApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *ComponentStatusApplyConfiguration) WithNewFinalizers(values ...string) *ComponentStatusApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 
@@ -241,10 +268,25 @@ func (b *ComponentStatusApplyConfiguration) ensureObjectMetaApplyConfigurationEx
 // WithConditions adds the given value to the Conditions field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Conditions field.
+// Deprecated: WithConditions does not replace existing list for atomic list type. Use WithNewConditions instead.
 func (b *ComponentStatusApplyConfiguration) WithConditions(values ...*ComponentConditionApplyConfiguration) *ComponentStatusApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithConditions")
+		}
+		b.Conditions = append(b.Conditions, *values[i])
+	}
+	return b
+}
+
+// WithNewConditions replaces the Conditions field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Conditions field is set to the values of the last call.
+func (b *ComponentStatusApplyConfiguration) WithNewConditions(values ...*ComponentConditionApplyConfiguration) *ComponentStatusApplyConfiguration {
+	b.Conditions = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewConditions")
 		}
 		b.Conditions = append(b.Conditions, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/configmap.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/configmap.go
@@ -214,6 +214,7 @@ func (b *ConfigMapApplyConfiguration) WithAnnotations(entries map[string]string)
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *ConfigMapApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *ConfigMapApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -225,14 +226,40 @@ func (b *ConfigMapApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerRef
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *ConfigMapApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *ConfigMapApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *ConfigMapApplyConfiguration) WithFinalizers(values ...string) *ConfigMapApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *ConfigMapApplyConfiguration) WithNewFinalizers(values ...string) *ConfigMapApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/configmapprojection.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/configmapprojection.go
@@ -43,10 +43,25 @@ func (b *ConfigMapProjectionApplyConfiguration) WithName(value string) *ConfigMa
 // WithItems adds the given value to the Items field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Items field.
+// Deprecated: WithItems does not replace existing list for atomic list type. Use WithNewItems instead.
 func (b *ConfigMapProjectionApplyConfiguration) WithItems(values ...*KeyToPathApplyConfiguration) *ConfigMapProjectionApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithItems")
+		}
+		b.Items = append(b.Items, *values[i])
+	}
+	return b
+}
+
+// WithNewItems replaces the Items field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Items field is set to the values of the last call.
+func (b *ConfigMapProjectionApplyConfiguration) WithNewItems(values ...*KeyToPathApplyConfiguration) *ConfigMapProjectionApplyConfiguration {
+	b.Items = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewItems")
 		}
 		b.Items = append(b.Items, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/configmapvolumesource.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/configmapvolumesource.go
@@ -44,10 +44,25 @@ func (b *ConfigMapVolumeSourceApplyConfiguration) WithName(value string) *Config
 // WithItems adds the given value to the Items field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Items field.
+// Deprecated: WithItems does not replace existing list for atomic list type. Use WithNewItems instead.
 func (b *ConfigMapVolumeSourceApplyConfiguration) WithItems(values ...*KeyToPathApplyConfiguration) *ConfigMapVolumeSourceApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithItems")
+		}
+		b.Items = append(b.Items, *values[i])
+	}
+	return b
+}
+
+// WithNewItems replaces the Items field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Items field is set to the values of the last call.
+func (b *ConfigMapVolumeSourceApplyConfiguration) WithNewItems(values ...*KeyToPathApplyConfiguration) *ConfigMapVolumeSourceApplyConfiguration {
+	b.Items = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewItems")
 		}
 		b.Items = append(b.Items, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/container.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/container.go
@@ -76,6 +76,7 @@ func (b *ContainerApplyConfiguration) WithImage(value string) *ContainerApplyCon
 // WithCommand adds the given value to the Command field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Command field.
+// Deprecated: WithCommand does not replace existing list for atomic list type. Use WithNewCommand instead.
 func (b *ContainerApplyConfiguration) WithCommand(values ...string) *ContainerApplyConfiguration {
 	for i := range values {
 		b.Command = append(b.Command, values[i])
@@ -83,13 +84,32 @@ func (b *ContainerApplyConfiguration) WithCommand(values ...string) *ContainerAp
 	return b
 }
 
+// WithNewCommand replaces the Command field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Command field is set to the values of the last call.
+func (b *ContainerApplyConfiguration) WithNewCommand(values ...string) *ContainerApplyConfiguration {
+	b.Command = make([]string, len(values))
+	copy(b.Command, values)
+	return b
+}
+
 // WithArgs adds the given value to the Args field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Args field.
+// Deprecated: WithArgs does not replace existing list for atomic list type. Use WithNewArgs instead.
 func (b *ContainerApplyConfiguration) WithArgs(values ...string) *ContainerApplyConfiguration {
 	for i := range values {
 		b.Args = append(b.Args, values[i])
 	}
+	return b
+}
+
+// WithNewArgs replaces the Args field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Args field is set to the values of the last call.
+func (b *ContainerApplyConfiguration) WithNewArgs(values ...string) *ContainerApplyConfiguration {
+	b.Args = make([]string, len(values))
+	copy(b.Args, values)
 	return b
 }
 
@@ -117,6 +137,7 @@ func (b *ContainerApplyConfiguration) WithPorts(values ...*ContainerPortApplyCon
 // WithEnvFrom adds the given value to the EnvFrom field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the EnvFrom field.
+// Deprecated: WithEnvFrom does not replace existing list for atomic list type. Use WithNewEnvFrom instead.
 func (b *ContainerApplyConfiguration) WithEnvFrom(values ...*EnvFromSourceApplyConfiguration) *ContainerApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
@@ -127,13 +148,42 @@ func (b *ContainerApplyConfiguration) WithEnvFrom(values ...*EnvFromSourceApplyC
 	return b
 }
 
+// WithNewEnvFrom replaces the EnvFrom field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the EnvFrom field is set to the values of the last call.
+func (b *ContainerApplyConfiguration) WithNewEnvFrom(values ...*EnvFromSourceApplyConfiguration) *ContainerApplyConfiguration {
+	b.EnvFrom = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewEnvFrom")
+		}
+		b.EnvFrom = append(b.EnvFrom, *values[i])
+	}
+	return b
+}
+
 // WithEnv adds the given value to the Env field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Env field.
+// Deprecated: WithEnv does not replace existing list for atomic list type. Use WithNewEnv instead.
 func (b *ContainerApplyConfiguration) WithEnv(values ...*EnvVarApplyConfiguration) *ContainerApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithEnv")
+		}
+		b.Env = append(b.Env, *values[i])
+	}
+	return b
+}
+
+// WithNewEnv replaces the Env field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Env field is set to the values of the last call.
+func (b *ContainerApplyConfiguration) WithNewEnv(values ...*EnvVarApplyConfiguration) *ContainerApplyConfiguration {
+	b.Env = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewEnv")
 		}
 		b.Env = append(b.Env, *values[i])
 	}
@@ -151,10 +201,25 @@ func (b *ContainerApplyConfiguration) WithResources(value *ResourceRequirementsA
 // WithResizePolicy adds the given value to the ResizePolicy field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the ResizePolicy field.
+// Deprecated: WithResizePolicy does not replace existing list for atomic list type. Use WithNewResizePolicy instead.
 func (b *ContainerApplyConfiguration) WithResizePolicy(values ...*ContainerResizePolicyApplyConfiguration) *ContainerApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithResizePolicy")
+		}
+		b.ResizePolicy = append(b.ResizePolicy, *values[i])
+	}
+	return b
+}
+
+// WithNewResizePolicy replaces the ResizePolicy field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the ResizePolicy field is set to the values of the last call.
+func (b *ContainerApplyConfiguration) WithNewResizePolicy(values ...*ContainerResizePolicyApplyConfiguration) *ContainerApplyConfiguration {
+	b.ResizePolicy = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewResizePolicy")
 		}
 		b.ResizePolicy = append(b.ResizePolicy, *values[i])
 	}
@@ -172,6 +237,7 @@ func (b *ContainerApplyConfiguration) WithRestartPolicy(value corev1.ContainerRe
 // WithVolumeMounts adds the given value to the VolumeMounts field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the VolumeMounts field.
+// Deprecated: WithVolumeMounts does not replace existing list for atomic list type. Use WithNewVolumeMounts instead.
 func (b *ContainerApplyConfiguration) WithVolumeMounts(values ...*VolumeMountApplyConfiguration) *ContainerApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
@@ -182,13 +248,42 @@ func (b *ContainerApplyConfiguration) WithVolumeMounts(values ...*VolumeMountApp
 	return b
 }
 
+// WithNewVolumeMounts replaces the VolumeMounts field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the VolumeMounts field is set to the values of the last call.
+func (b *ContainerApplyConfiguration) WithNewVolumeMounts(values ...*VolumeMountApplyConfiguration) *ContainerApplyConfiguration {
+	b.VolumeMounts = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewVolumeMounts")
+		}
+		b.VolumeMounts = append(b.VolumeMounts, *values[i])
+	}
+	return b
+}
+
 // WithVolumeDevices adds the given value to the VolumeDevices field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the VolumeDevices field.
+// Deprecated: WithVolumeDevices does not replace existing list for atomic list type. Use WithNewVolumeDevices instead.
 func (b *ContainerApplyConfiguration) WithVolumeDevices(values ...*VolumeDeviceApplyConfiguration) *ContainerApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithVolumeDevices")
+		}
+		b.VolumeDevices = append(b.VolumeDevices, *values[i])
+	}
+	return b
+}
+
+// WithNewVolumeDevices replaces the VolumeDevices field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the VolumeDevices field is set to the values of the last call.
+func (b *ContainerApplyConfiguration) WithNewVolumeDevices(values ...*VolumeDeviceApplyConfiguration) *ContainerApplyConfiguration {
+	b.VolumeDevices = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewVolumeDevices")
 		}
 		b.VolumeDevices = append(b.VolumeDevices, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/containerimage.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/containerimage.go
@@ -34,10 +34,20 @@ func ContainerImage() *ContainerImageApplyConfiguration {
 // WithNames adds the given value to the Names field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Names field.
+// Deprecated: WithNames does not replace existing list for atomic list type. Use WithNewNames instead.
 func (b *ContainerImageApplyConfiguration) WithNames(values ...string) *ContainerImageApplyConfiguration {
 	for i := range values {
 		b.Names = append(b.Names, values[i])
 	}
+	return b
+}
+
+// WithNewNames replaces the Names field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Names field is set to the values of the last call.
+func (b *ContainerImageApplyConfiguration) WithNewNames(values ...string) *ContainerImageApplyConfiguration {
+	b.Names = make([]string, len(values))
+	copy(b.Names, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/downwardapiprojection.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/downwardapiprojection.go
@@ -33,10 +33,25 @@ func DownwardAPIProjection() *DownwardAPIProjectionApplyConfiguration {
 // WithItems adds the given value to the Items field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Items field.
+// Deprecated: WithItems does not replace existing list for atomic list type. Use WithNewItems instead.
 func (b *DownwardAPIProjectionApplyConfiguration) WithItems(values ...*DownwardAPIVolumeFileApplyConfiguration) *DownwardAPIProjectionApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithItems")
+		}
+		b.Items = append(b.Items, *values[i])
+	}
+	return b
+}
+
+// WithNewItems replaces the Items field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Items field is set to the values of the last call.
+func (b *DownwardAPIProjectionApplyConfiguration) WithNewItems(values ...*DownwardAPIVolumeFileApplyConfiguration) *DownwardAPIProjectionApplyConfiguration {
+	b.Items = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewItems")
 		}
 		b.Items = append(b.Items, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/downwardapivolumesource.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/downwardapivolumesource.go
@@ -34,10 +34,25 @@ func DownwardAPIVolumeSource() *DownwardAPIVolumeSourceApplyConfiguration {
 // WithItems adds the given value to the Items field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Items field.
+// Deprecated: WithItems does not replace existing list for atomic list type. Use WithNewItems instead.
 func (b *DownwardAPIVolumeSourceApplyConfiguration) WithItems(values ...*DownwardAPIVolumeFileApplyConfiguration) *DownwardAPIVolumeSourceApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithItems")
+		}
+		b.Items = append(b.Items, *values[i])
+	}
+	return b
+}
+
+// WithNewItems replaces the Items field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Items field is set to the values of the last call.
+func (b *DownwardAPIVolumeSourceApplyConfiguration) WithNewItems(values ...*DownwardAPIVolumeFileApplyConfiguration) *DownwardAPIVolumeSourceApplyConfiguration {
+	b.Items = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewItems")
 		}
 		b.Items = append(b.Items, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/endpoints.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/endpoints.go
@@ -212,6 +212,7 @@ func (b *EndpointsApplyConfiguration) WithAnnotations(entries map[string]string)
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *EndpointsApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *EndpointsApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -223,14 +224,40 @@ func (b *EndpointsApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerRef
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *EndpointsApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *EndpointsApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *EndpointsApplyConfiguration) WithFinalizers(values ...string) *EndpointsApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *EndpointsApplyConfiguration) WithNewFinalizers(values ...string) *EndpointsApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 
@@ -243,10 +270,25 @@ func (b *EndpointsApplyConfiguration) ensureObjectMetaApplyConfigurationExists()
 // WithSubsets adds the given value to the Subsets field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Subsets field.
+// Deprecated: WithSubsets does not replace existing list for atomic list type. Use WithNewSubsets instead.
 func (b *EndpointsApplyConfiguration) WithSubsets(values ...*EndpointSubsetApplyConfiguration) *EndpointsApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithSubsets")
+		}
+		b.Subsets = append(b.Subsets, *values[i])
+	}
+	return b
+}
+
+// WithNewSubsets replaces the Subsets field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Subsets field is set to the values of the last call.
+func (b *EndpointsApplyConfiguration) WithNewSubsets(values ...*EndpointSubsetApplyConfiguration) *EndpointsApplyConfiguration {
+	b.Subsets = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewSubsets")
 		}
 		b.Subsets = append(b.Subsets, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/endpointsubset.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/endpointsubset.go
@@ -35,6 +35,7 @@ func EndpointSubset() *EndpointSubsetApplyConfiguration {
 // WithAddresses adds the given value to the Addresses field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Addresses field.
+// Deprecated: WithAddresses does not replace existing list for atomic list type. Use WithNewAddresses instead.
 func (b *EndpointSubsetApplyConfiguration) WithAddresses(values ...*EndpointAddressApplyConfiguration) *EndpointSubsetApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
@@ -45,9 +46,24 @@ func (b *EndpointSubsetApplyConfiguration) WithAddresses(values ...*EndpointAddr
 	return b
 }
 
+// WithNewAddresses replaces the Addresses field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Addresses field is set to the values of the last call.
+func (b *EndpointSubsetApplyConfiguration) WithNewAddresses(values ...*EndpointAddressApplyConfiguration) *EndpointSubsetApplyConfiguration {
+	b.Addresses = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewAddresses")
+		}
+		b.Addresses = append(b.Addresses, *values[i])
+	}
+	return b
+}
+
 // WithNotReadyAddresses adds the given value to the NotReadyAddresses field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the NotReadyAddresses field.
+// Deprecated: WithNotReadyAddresses does not replace existing list for atomic list type. Use WithNewNotReadyAddresses instead.
 func (b *EndpointSubsetApplyConfiguration) WithNotReadyAddresses(values ...*EndpointAddressApplyConfiguration) *EndpointSubsetApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
@@ -58,13 +74,42 @@ func (b *EndpointSubsetApplyConfiguration) WithNotReadyAddresses(values ...*Endp
 	return b
 }
 
+// WithNewNotReadyAddresses replaces the NotReadyAddresses field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the NotReadyAddresses field is set to the values of the last call.
+func (b *EndpointSubsetApplyConfiguration) WithNewNotReadyAddresses(values ...*EndpointAddressApplyConfiguration) *EndpointSubsetApplyConfiguration {
+	b.NotReadyAddresses = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewNotReadyAddresses")
+		}
+		b.NotReadyAddresses = append(b.NotReadyAddresses, *values[i])
+	}
+	return b
+}
+
 // WithPorts adds the given value to the Ports field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Ports field.
+// Deprecated: WithPorts does not replace existing list for atomic list type. Use WithNewPorts instead.
 func (b *EndpointSubsetApplyConfiguration) WithPorts(values ...*EndpointPortApplyConfiguration) *EndpointSubsetApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithPorts")
+		}
+		b.Ports = append(b.Ports, *values[i])
+	}
+	return b
+}
+
+// WithNewPorts replaces the Ports field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Ports field is set to the values of the last call.
+func (b *EndpointSubsetApplyConfiguration) WithNewPorts(values ...*EndpointPortApplyConfiguration) *EndpointSubsetApplyConfiguration {
+	b.Ports = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewPorts")
 		}
 		b.Ports = append(b.Ports, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/ephemeralcontainer.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/ephemeralcontainer.go
@@ -54,6 +54,7 @@ func (b *EphemeralContainerApplyConfiguration) WithImage(value string) *Ephemera
 // WithCommand adds the given value to the Command field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Command field.
+// Deprecated: WithCommand does not replace existing list for atomic list type. Use WithNewCommand instead.
 func (b *EphemeralContainerApplyConfiguration) WithCommand(values ...string) *EphemeralContainerApplyConfiguration {
 	for i := range values {
 		b.Command = append(b.Command, values[i])
@@ -61,13 +62,32 @@ func (b *EphemeralContainerApplyConfiguration) WithCommand(values ...string) *Ep
 	return b
 }
 
+// WithNewCommand replaces the Command field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Command field is set to the values of the last call.
+func (b *EphemeralContainerApplyConfiguration) WithNewCommand(values ...string) *EphemeralContainerApplyConfiguration {
+	b.Command = make([]string, len(values))
+	copy(b.Command, values)
+	return b
+}
+
 // WithArgs adds the given value to the Args field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Args field.
+// Deprecated: WithArgs does not replace existing list for atomic list type. Use WithNewArgs instead.
 func (b *EphemeralContainerApplyConfiguration) WithArgs(values ...string) *EphemeralContainerApplyConfiguration {
 	for i := range values {
 		b.Args = append(b.Args, values[i])
 	}
+	return b
+}
+
+// WithNewArgs replaces the Args field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Args field is set to the values of the last call.
+func (b *EphemeralContainerApplyConfiguration) WithNewArgs(values ...string) *EphemeralContainerApplyConfiguration {
+	b.Args = make([]string, len(values))
+	copy(b.Args, values)
 	return b
 }
 
@@ -95,6 +115,7 @@ func (b *EphemeralContainerApplyConfiguration) WithPorts(values ...*ContainerPor
 // WithEnvFrom adds the given value to the EnvFrom field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the EnvFrom field.
+// Deprecated: WithEnvFrom does not replace existing list for atomic list type. Use WithNewEnvFrom instead.
 func (b *EphemeralContainerApplyConfiguration) WithEnvFrom(values ...*EnvFromSourceApplyConfiguration) *EphemeralContainerApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
@@ -105,13 +126,42 @@ func (b *EphemeralContainerApplyConfiguration) WithEnvFrom(values ...*EnvFromSou
 	return b
 }
 
+// WithNewEnvFrom replaces the EnvFrom field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the EnvFrom field is set to the values of the last call.
+func (b *EphemeralContainerApplyConfiguration) WithNewEnvFrom(values ...*EnvFromSourceApplyConfiguration) *EphemeralContainerApplyConfiguration {
+	b.EnvFrom = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewEnvFrom")
+		}
+		b.EnvFrom = append(b.EnvFrom, *values[i])
+	}
+	return b
+}
+
 // WithEnv adds the given value to the Env field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Env field.
+// Deprecated: WithEnv does not replace existing list for atomic list type. Use WithNewEnv instead.
 func (b *EphemeralContainerApplyConfiguration) WithEnv(values ...*EnvVarApplyConfiguration) *EphemeralContainerApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithEnv")
+		}
+		b.Env = append(b.Env, *values[i])
+	}
+	return b
+}
+
+// WithNewEnv replaces the Env field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Env field is set to the values of the last call.
+func (b *EphemeralContainerApplyConfiguration) WithNewEnv(values ...*EnvVarApplyConfiguration) *EphemeralContainerApplyConfiguration {
+	b.Env = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewEnv")
 		}
 		b.Env = append(b.Env, *values[i])
 	}
@@ -129,10 +179,25 @@ func (b *EphemeralContainerApplyConfiguration) WithResources(value *ResourceRequ
 // WithResizePolicy adds the given value to the ResizePolicy field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the ResizePolicy field.
+// Deprecated: WithResizePolicy does not replace existing list for atomic list type. Use WithNewResizePolicy instead.
 func (b *EphemeralContainerApplyConfiguration) WithResizePolicy(values ...*ContainerResizePolicyApplyConfiguration) *EphemeralContainerApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithResizePolicy")
+		}
+		b.ResizePolicy = append(b.ResizePolicy, *values[i])
+	}
+	return b
+}
+
+// WithNewResizePolicy replaces the ResizePolicy field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the ResizePolicy field is set to the values of the last call.
+func (b *EphemeralContainerApplyConfiguration) WithNewResizePolicy(values ...*ContainerResizePolicyApplyConfiguration) *EphemeralContainerApplyConfiguration {
+	b.ResizePolicy = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewResizePolicy")
 		}
 		b.ResizePolicy = append(b.ResizePolicy, *values[i])
 	}
@@ -150,6 +215,7 @@ func (b *EphemeralContainerApplyConfiguration) WithRestartPolicy(value corev1.Co
 // WithVolumeMounts adds the given value to the VolumeMounts field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the VolumeMounts field.
+// Deprecated: WithVolumeMounts does not replace existing list for atomic list type. Use WithNewVolumeMounts instead.
 func (b *EphemeralContainerApplyConfiguration) WithVolumeMounts(values ...*VolumeMountApplyConfiguration) *EphemeralContainerApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
@@ -160,13 +226,42 @@ func (b *EphemeralContainerApplyConfiguration) WithVolumeMounts(values ...*Volum
 	return b
 }
 
+// WithNewVolumeMounts replaces the VolumeMounts field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the VolumeMounts field is set to the values of the last call.
+func (b *EphemeralContainerApplyConfiguration) WithNewVolumeMounts(values ...*VolumeMountApplyConfiguration) *EphemeralContainerApplyConfiguration {
+	b.VolumeMounts = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewVolumeMounts")
+		}
+		b.VolumeMounts = append(b.VolumeMounts, *values[i])
+	}
+	return b
+}
+
 // WithVolumeDevices adds the given value to the VolumeDevices field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the VolumeDevices field.
+// Deprecated: WithVolumeDevices does not replace existing list for atomic list type. Use WithNewVolumeDevices instead.
 func (b *EphemeralContainerApplyConfiguration) WithVolumeDevices(values ...*VolumeDeviceApplyConfiguration) *EphemeralContainerApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithVolumeDevices")
+		}
+		b.VolumeDevices = append(b.VolumeDevices, *values[i])
+	}
+	return b
+}
+
+// WithNewVolumeDevices replaces the VolumeDevices field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the VolumeDevices field is set to the values of the last call.
+func (b *EphemeralContainerApplyConfiguration) WithNewVolumeDevices(values ...*VolumeDeviceApplyConfiguration) *EphemeralContainerApplyConfiguration {
+	b.VolumeDevices = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewVolumeDevices")
 		}
 		b.VolumeDevices = append(b.VolumeDevices, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/ephemeralcontainercommon.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/ephemeralcontainercommon.go
@@ -76,6 +76,7 @@ func (b *EphemeralContainerCommonApplyConfiguration) WithImage(value string) *Ep
 // WithCommand adds the given value to the Command field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Command field.
+// Deprecated: WithCommand does not replace existing list for atomic list type. Use WithNewCommand instead.
 func (b *EphemeralContainerCommonApplyConfiguration) WithCommand(values ...string) *EphemeralContainerCommonApplyConfiguration {
 	for i := range values {
 		b.Command = append(b.Command, values[i])
@@ -83,13 +84,32 @@ func (b *EphemeralContainerCommonApplyConfiguration) WithCommand(values ...strin
 	return b
 }
 
+// WithNewCommand replaces the Command field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Command field is set to the values of the last call.
+func (b *EphemeralContainerCommonApplyConfiguration) WithNewCommand(values ...string) *EphemeralContainerCommonApplyConfiguration {
+	b.Command = make([]string, len(values))
+	copy(b.Command, values)
+	return b
+}
+
 // WithArgs adds the given value to the Args field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Args field.
+// Deprecated: WithArgs does not replace existing list for atomic list type. Use WithNewArgs instead.
 func (b *EphemeralContainerCommonApplyConfiguration) WithArgs(values ...string) *EphemeralContainerCommonApplyConfiguration {
 	for i := range values {
 		b.Args = append(b.Args, values[i])
 	}
+	return b
+}
+
+// WithNewArgs replaces the Args field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Args field is set to the values of the last call.
+func (b *EphemeralContainerCommonApplyConfiguration) WithNewArgs(values ...string) *EphemeralContainerCommonApplyConfiguration {
+	b.Args = make([]string, len(values))
+	copy(b.Args, values)
 	return b
 }
 
@@ -117,6 +137,7 @@ func (b *EphemeralContainerCommonApplyConfiguration) WithPorts(values ...*Contai
 // WithEnvFrom adds the given value to the EnvFrom field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the EnvFrom field.
+// Deprecated: WithEnvFrom does not replace existing list for atomic list type. Use WithNewEnvFrom instead.
 func (b *EphemeralContainerCommonApplyConfiguration) WithEnvFrom(values ...*EnvFromSourceApplyConfiguration) *EphemeralContainerCommonApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
@@ -127,13 +148,42 @@ func (b *EphemeralContainerCommonApplyConfiguration) WithEnvFrom(values ...*EnvF
 	return b
 }
 
+// WithNewEnvFrom replaces the EnvFrom field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the EnvFrom field is set to the values of the last call.
+func (b *EphemeralContainerCommonApplyConfiguration) WithNewEnvFrom(values ...*EnvFromSourceApplyConfiguration) *EphemeralContainerCommonApplyConfiguration {
+	b.EnvFrom = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewEnvFrom")
+		}
+		b.EnvFrom = append(b.EnvFrom, *values[i])
+	}
+	return b
+}
+
 // WithEnv adds the given value to the Env field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Env field.
+// Deprecated: WithEnv does not replace existing list for atomic list type. Use WithNewEnv instead.
 func (b *EphemeralContainerCommonApplyConfiguration) WithEnv(values ...*EnvVarApplyConfiguration) *EphemeralContainerCommonApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithEnv")
+		}
+		b.Env = append(b.Env, *values[i])
+	}
+	return b
+}
+
+// WithNewEnv replaces the Env field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Env field is set to the values of the last call.
+func (b *EphemeralContainerCommonApplyConfiguration) WithNewEnv(values ...*EnvVarApplyConfiguration) *EphemeralContainerCommonApplyConfiguration {
+	b.Env = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewEnv")
 		}
 		b.Env = append(b.Env, *values[i])
 	}
@@ -151,10 +201,25 @@ func (b *EphemeralContainerCommonApplyConfiguration) WithResources(value *Resour
 // WithResizePolicy adds the given value to the ResizePolicy field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the ResizePolicy field.
+// Deprecated: WithResizePolicy does not replace existing list for atomic list type. Use WithNewResizePolicy instead.
 func (b *EphemeralContainerCommonApplyConfiguration) WithResizePolicy(values ...*ContainerResizePolicyApplyConfiguration) *EphemeralContainerCommonApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithResizePolicy")
+		}
+		b.ResizePolicy = append(b.ResizePolicy, *values[i])
+	}
+	return b
+}
+
+// WithNewResizePolicy replaces the ResizePolicy field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the ResizePolicy field is set to the values of the last call.
+func (b *EphemeralContainerCommonApplyConfiguration) WithNewResizePolicy(values ...*ContainerResizePolicyApplyConfiguration) *EphemeralContainerCommonApplyConfiguration {
+	b.ResizePolicy = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewResizePolicy")
 		}
 		b.ResizePolicy = append(b.ResizePolicy, *values[i])
 	}
@@ -172,6 +237,7 @@ func (b *EphemeralContainerCommonApplyConfiguration) WithRestartPolicy(value cor
 // WithVolumeMounts adds the given value to the VolumeMounts field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the VolumeMounts field.
+// Deprecated: WithVolumeMounts does not replace existing list for atomic list type. Use WithNewVolumeMounts instead.
 func (b *EphemeralContainerCommonApplyConfiguration) WithVolumeMounts(values ...*VolumeMountApplyConfiguration) *EphemeralContainerCommonApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
@@ -182,13 +248,42 @@ func (b *EphemeralContainerCommonApplyConfiguration) WithVolumeMounts(values ...
 	return b
 }
 
+// WithNewVolumeMounts replaces the VolumeMounts field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the VolumeMounts field is set to the values of the last call.
+func (b *EphemeralContainerCommonApplyConfiguration) WithNewVolumeMounts(values ...*VolumeMountApplyConfiguration) *EphemeralContainerCommonApplyConfiguration {
+	b.VolumeMounts = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewVolumeMounts")
+		}
+		b.VolumeMounts = append(b.VolumeMounts, *values[i])
+	}
+	return b
+}
+
 // WithVolumeDevices adds the given value to the VolumeDevices field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the VolumeDevices field.
+// Deprecated: WithVolumeDevices does not replace existing list for atomic list type. Use WithNewVolumeDevices instead.
 func (b *EphemeralContainerCommonApplyConfiguration) WithVolumeDevices(values ...*VolumeDeviceApplyConfiguration) *EphemeralContainerCommonApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithVolumeDevices")
+		}
+		b.VolumeDevices = append(b.VolumeDevices, *values[i])
+	}
+	return b
+}
+
+// WithNewVolumeDevices replaces the VolumeDevices field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the VolumeDevices field is set to the values of the last call.
+func (b *EphemeralContainerCommonApplyConfiguration) WithNewVolumeDevices(values ...*VolumeDeviceApplyConfiguration) *EphemeralContainerCommonApplyConfiguration {
+	b.VolumeDevices = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewVolumeDevices")
 		}
 		b.VolumeDevices = append(b.VolumeDevices, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/event.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/event.go
@@ -225,6 +225,7 @@ func (b *EventApplyConfiguration) WithAnnotations(entries map[string]string) *Ev
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *EventApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *EventApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -236,14 +237,40 @@ func (b *EventApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferen
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *EventApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *EventApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *EventApplyConfiguration) WithFinalizers(values ...string) *EventApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *EventApplyConfiguration) WithNewFinalizers(values ...string) *EventApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/execaction.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/execaction.go
@@ -33,9 +33,19 @@ func ExecAction() *ExecActionApplyConfiguration {
 // WithCommand adds the given value to the Command field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Command field.
+// Deprecated: WithCommand does not replace existing list for atomic list type. Use WithNewCommand instead.
 func (b *ExecActionApplyConfiguration) WithCommand(values ...string) *ExecActionApplyConfiguration {
 	for i := range values {
 		b.Command = append(b.Command, values[i])
 	}
+	return b
+}
+
+// WithNewCommand replaces the Command field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Command field is set to the values of the last call.
+func (b *ExecActionApplyConfiguration) WithNewCommand(values ...string) *ExecActionApplyConfiguration {
+	b.Command = make([]string, len(values))
+	copy(b.Command, values)
 	return b
 }

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/fcvolumesource.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/fcvolumesource.go
@@ -37,10 +37,20 @@ func FCVolumeSource() *FCVolumeSourceApplyConfiguration {
 // WithTargetWWNs adds the given value to the TargetWWNs field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the TargetWWNs field.
+// Deprecated: WithTargetWWNs does not replace existing list for atomic list type. Use WithNewTargetWWNs instead.
 func (b *FCVolumeSourceApplyConfiguration) WithTargetWWNs(values ...string) *FCVolumeSourceApplyConfiguration {
 	for i := range values {
 		b.TargetWWNs = append(b.TargetWWNs, values[i])
 	}
+	return b
+}
+
+// WithNewTargetWWNs replaces the TargetWWNs field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the TargetWWNs field is set to the values of the last call.
+func (b *FCVolumeSourceApplyConfiguration) WithNewTargetWWNs(values ...string) *FCVolumeSourceApplyConfiguration {
+	b.TargetWWNs = make([]string, len(values))
+	copy(b.TargetWWNs, values)
 	return b
 }
 
@@ -71,9 +81,19 @@ func (b *FCVolumeSourceApplyConfiguration) WithReadOnly(value bool) *FCVolumeSou
 // WithWWIDs adds the given value to the WWIDs field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the WWIDs field.
+// Deprecated: WithWWIDs does not replace existing list for atomic list type. Use WithNewWWIDs instead.
 func (b *FCVolumeSourceApplyConfiguration) WithWWIDs(values ...string) *FCVolumeSourceApplyConfiguration {
 	for i := range values {
 		b.WWIDs = append(b.WWIDs, values[i])
 	}
+	return b
+}
+
+// WithNewWWIDs replaces the WWIDs field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the WWIDs field is set to the values of the last call.
+func (b *FCVolumeSourceApplyConfiguration) WithNewWWIDs(values ...string) *FCVolumeSourceApplyConfiguration {
+	b.WWIDs = make([]string, len(values))
+	copy(b.WWIDs, values)
 	return b
 }

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/hostalias.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/hostalias.go
@@ -42,9 +42,19 @@ func (b *HostAliasApplyConfiguration) WithIP(value string) *HostAliasApplyConfig
 // WithHostnames adds the given value to the Hostnames field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Hostnames field.
+// Deprecated: WithHostnames does not replace existing list for atomic list type. Use WithNewHostnames instead.
 func (b *HostAliasApplyConfiguration) WithHostnames(values ...string) *HostAliasApplyConfiguration {
 	for i := range values {
 		b.Hostnames = append(b.Hostnames, values[i])
 	}
+	return b
+}
+
+// WithNewHostnames replaces the Hostnames field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Hostnames field is set to the values of the last call.
+func (b *HostAliasApplyConfiguration) WithNewHostnames(values ...string) *HostAliasApplyConfiguration {
+	b.Hostnames = make([]string, len(values))
+	copy(b.Hostnames, values)
 	return b
 }

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/httpgetaction.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/httpgetaction.go
@@ -74,10 +74,25 @@ func (b *HTTPGetActionApplyConfiguration) WithScheme(value v1.URIScheme) *HTTPGe
 // WithHTTPHeaders adds the given value to the HTTPHeaders field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the HTTPHeaders field.
+// Deprecated: WithHTTPHeaders does not replace existing list for atomic list type. Use WithNewHTTPHeaders instead.
 func (b *HTTPGetActionApplyConfiguration) WithHTTPHeaders(values ...*HTTPHeaderApplyConfiguration) *HTTPGetActionApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithHTTPHeaders")
+		}
+		b.HTTPHeaders = append(b.HTTPHeaders, *values[i])
+	}
+	return b
+}
+
+// WithNewHTTPHeaders replaces the HTTPHeaders field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the HTTPHeaders field is set to the values of the last call.
+func (b *HTTPGetActionApplyConfiguration) WithNewHTTPHeaders(values ...*HTTPHeaderApplyConfiguration) *HTTPGetActionApplyConfiguration {
+	b.HTTPHeaders = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewHTTPHeaders")
 		}
 		b.HTTPHeaders = append(b.HTTPHeaders, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/iscsipersistentvolumesource.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/iscsipersistentvolumesource.go
@@ -91,10 +91,20 @@ func (b *ISCSIPersistentVolumeSourceApplyConfiguration) WithReadOnly(value bool)
 // WithPortals adds the given value to the Portals field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Portals field.
+// Deprecated: WithPortals does not replace existing list for atomic list type. Use WithNewPortals instead.
 func (b *ISCSIPersistentVolumeSourceApplyConfiguration) WithPortals(values ...string) *ISCSIPersistentVolumeSourceApplyConfiguration {
 	for i := range values {
 		b.Portals = append(b.Portals, values[i])
 	}
+	return b
+}
+
+// WithNewPortals replaces the Portals field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Portals field is set to the values of the last call.
+func (b *ISCSIPersistentVolumeSourceApplyConfiguration) WithNewPortals(values ...string) *ISCSIPersistentVolumeSourceApplyConfiguration {
+	b.Portals = make([]string, len(values))
+	copy(b.Portals, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/iscsivolumesource.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/iscsivolumesource.go
@@ -91,10 +91,20 @@ func (b *ISCSIVolumeSourceApplyConfiguration) WithReadOnly(value bool) *ISCSIVol
 // WithPortals adds the given value to the Portals field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Portals field.
+// Deprecated: WithPortals does not replace existing list for atomic list type. Use WithNewPortals instead.
 func (b *ISCSIVolumeSourceApplyConfiguration) WithPortals(values ...string) *ISCSIVolumeSourceApplyConfiguration {
 	for i := range values {
 		b.Portals = append(b.Portals, values[i])
 	}
+	return b
+}
+
+// WithNewPortals replaces the Portals field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Portals field is set to the values of the last call.
+func (b *ISCSIVolumeSourceApplyConfiguration) WithNewPortals(values ...string) *ISCSIVolumeSourceApplyConfiguration {
+	b.Portals = make([]string, len(values))
+	copy(b.Portals, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/limitrange.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/limitrange.go
@@ -212,6 +212,7 @@ func (b *LimitRangeApplyConfiguration) WithAnnotations(entries map[string]string
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *LimitRangeApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *LimitRangeApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -223,14 +224,40 @@ func (b *LimitRangeApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerRe
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *LimitRangeApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *LimitRangeApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *LimitRangeApplyConfiguration) WithFinalizers(values ...string) *LimitRangeApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *LimitRangeApplyConfiguration) WithNewFinalizers(values ...string) *LimitRangeApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/limitrangespec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/limitrangespec.go
@@ -33,10 +33,25 @@ func LimitRangeSpec() *LimitRangeSpecApplyConfiguration {
 // WithLimits adds the given value to the Limits field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Limits field.
+// Deprecated: WithLimits does not replace existing list for atomic list type. Use WithNewLimits instead.
 func (b *LimitRangeSpecApplyConfiguration) WithLimits(values ...*LimitRangeItemApplyConfiguration) *LimitRangeSpecApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithLimits")
+		}
+		b.Limits = append(b.Limits, *values[i])
+	}
+	return b
+}
+
+// WithNewLimits replaces the Limits field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Limits field is set to the values of the last call.
+func (b *LimitRangeSpecApplyConfiguration) WithNewLimits(values ...*LimitRangeItemApplyConfiguration) *LimitRangeSpecApplyConfiguration {
+	b.Limits = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewLimits")
 		}
 		b.Limits = append(b.Limits, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/loadbalanceringress.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/loadbalanceringress.go
@@ -64,10 +64,25 @@ func (b *LoadBalancerIngressApplyConfiguration) WithIPMode(value v1.LoadBalancer
 // WithPorts adds the given value to the Ports field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Ports field.
+// Deprecated: WithPorts does not replace existing list for atomic list type. Use WithNewPorts instead.
 func (b *LoadBalancerIngressApplyConfiguration) WithPorts(values ...*PortStatusApplyConfiguration) *LoadBalancerIngressApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithPorts")
+		}
+		b.Ports = append(b.Ports, *values[i])
+	}
+	return b
+}
+
+// WithNewPorts replaces the Ports field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Ports field is set to the values of the last call.
+func (b *LoadBalancerIngressApplyConfiguration) WithNewPorts(values ...*PortStatusApplyConfiguration) *LoadBalancerIngressApplyConfiguration {
+	b.Ports = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewPorts")
 		}
 		b.Ports = append(b.Ports, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/loadbalancerstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/loadbalancerstatus.go
@@ -33,10 +33,25 @@ func LoadBalancerStatus() *LoadBalancerStatusApplyConfiguration {
 // WithIngress adds the given value to the Ingress field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Ingress field.
+// Deprecated: WithIngress does not replace existing list for atomic list type. Use WithNewIngress instead.
 func (b *LoadBalancerStatusApplyConfiguration) WithIngress(values ...*LoadBalancerIngressApplyConfiguration) *LoadBalancerStatusApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithIngress")
+		}
+		b.Ingress = append(b.Ingress, *values[i])
+	}
+	return b
+}
+
+// WithNewIngress replaces the Ingress field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Ingress field is set to the values of the last call.
+func (b *LoadBalancerStatusApplyConfiguration) WithNewIngress(values ...*LoadBalancerIngressApplyConfiguration) *LoadBalancerStatusApplyConfiguration {
+	b.Ingress = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewIngress")
 		}
 		b.Ingress = append(b.Ingress, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/namespace.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/namespace.go
@@ -211,6 +211,7 @@ func (b *NamespaceApplyConfiguration) WithAnnotations(entries map[string]string)
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *NamespaceApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *NamespaceApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -222,14 +223,40 @@ func (b *NamespaceApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerRef
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *NamespaceApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *NamespaceApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *NamespaceApplyConfiguration) WithFinalizers(values ...string) *NamespaceApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *NamespaceApplyConfiguration) WithNewFinalizers(values ...string) *NamespaceApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/namespacespec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/namespacespec.go
@@ -37,9 +37,19 @@ func NamespaceSpec() *NamespaceSpecApplyConfiguration {
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *NamespaceSpecApplyConfiguration) WithFinalizers(values ...v1.FinalizerName) *NamespaceSpecApplyConfiguration {
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *NamespaceSpecApplyConfiguration) WithNewFinalizers(values ...v1.FinalizerName) *NamespaceSpecApplyConfiguration {
+	b.Finalizers = make([]v1.FinalizerName, len(values))
+	copy(b.Finalizers, values)
 	return b
 }

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/namespacestatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/namespacestatus.go
@@ -46,10 +46,25 @@ func (b *NamespaceStatusApplyConfiguration) WithPhase(value v1.NamespacePhase) *
 // WithConditions adds the given value to the Conditions field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Conditions field.
+// Deprecated: WithConditions does not replace existing list for atomic list type. Use WithNewConditions instead.
 func (b *NamespaceStatusApplyConfiguration) WithConditions(values ...*NamespaceConditionApplyConfiguration) *NamespaceStatusApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithConditions")
+		}
+		b.Conditions = append(b.Conditions, *values[i])
+	}
+	return b
+}
+
+// WithNewConditions replaces the Conditions field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Conditions field is set to the values of the last call.
+func (b *NamespaceStatusApplyConfiguration) WithNewConditions(values ...*NamespaceConditionApplyConfiguration) *NamespaceStatusApplyConfiguration {
+	b.Conditions = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewConditions")
 		}
 		b.Conditions = append(b.Conditions, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/node.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/node.go
@@ -211,6 +211,7 @@ func (b *NodeApplyConfiguration) WithAnnotations(entries map[string]string) *Nod
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *NodeApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *NodeApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -222,14 +223,40 @@ func (b *NodeApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenc
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *NodeApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *NodeApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *NodeApplyConfiguration) WithFinalizers(values ...string) *NodeApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *NodeApplyConfiguration) WithNewFinalizers(values ...string) *NodeApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/nodeaffinity.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/nodeaffinity.go
@@ -42,10 +42,25 @@ func (b *NodeAffinityApplyConfiguration) WithRequiredDuringSchedulingIgnoredDuri
 // WithPreferredDuringSchedulingIgnoredDuringExecution adds the given value to the PreferredDuringSchedulingIgnoredDuringExecution field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the PreferredDuringSchedulingIgnoredDuringExecution field.
+// Deprecated: WithPreferredDuringSchedulingIgnoredDuringExecution does not replace existing list for atomic list type. Use WithNewPreferredDuringSchedulingIgnoredDuringExecution instead.
 func (b *NodeAffinityApplyConfiguration) WithPreferredDuringSchedulingIgnoredDuringExecution(values ...*PreferredSchedulingTermApplyConfiguration) *NodeAffinityApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithPreferredDuringSchedulingIgnoredDuringExecution")
+		}
+		b.PreferredDuringSchedulingIgnoredDuringExecution = append(b.PreferredDuringSchedulingIgnoredDuringExecution, *values[i])
+	}
+	return b
+}
+
+// WithNewPreferredDuringSchedulingIgnoredDuringExecution replaces the PreferredDuringSchedulingIgnoredDuringExecution field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the PreferredDuringSchedulingIgnoredDuringExecution field is set to the values of the last call.
+func (b *NodeAffinityApplyConfiguration) WithNewPreferredDuringSchedulingIgnoredDuringExecution(values ...*PreferredSchedulingTermApplyConfiguration) *NodeAffinityApplyConfiguration {
+	b.PreferredDuringSchedulingIgnoredDuringExecution = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewPreferredDuringSchedulingIgnoredDuringExecution")
 		}
 		b.PreferredDuringSchedulingIgnoredDuringExecution = append(b.PreferredDuringSchedulingIgnoredDuringExecution, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/nodeselector.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/nodeselector.go
@@ -33,10 +33,25 @@ func NodeSelector() *NodeSelectorApplyConfiguration {
 // WithNodeSelectorTerms adds the given value to the NodeSelectorTerms field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the NodeSelectorTerms field.
+// Deprecated: WithNodeSelectorTerms does not replace existing list for atomic list type. Use WithNewNodeSelectorTerms instead.
 func (b *NodeSelectorApplyConfiguration) WithNodeSelectorTerms(values ...*NodeSelectorTermApplyConfiguration) *NodeSelectorApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithNodeSelectorTerms")
+		}
+		b.NodeSelectorTerms = append(b.NodeSelectorTerms, *values[i])
+	}
+	return b
+}
+
+// WithNewNodeSelectorTerms replaces the NodeSelectorTerms field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the NodeSelectorTerms field is set to the values of the last call.
+func (b *NodeSelectorApplyConfiguration) WithNewNodeSelectorTerms(values ...*NodeSelectorTermApplyConfiguration) *NodeSelectorApplyConfiguration {
+	b.NodeSelectorTerms = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewNodeSelectorTerms")
 		}
 		b.NodeSelectorTerms = append(b.NodeSelectorTerms, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/nodeselectorrequirement.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/nodeselectorrequirement.go
@@ -55,9 +55,19 @@ func (b *NodeSelectorRequirementApplyConfiguration) WithOperator(value v1.NodeSe
 // WithValues adds the given value to the Values field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Values field.
+// Deprecated: WithValues does not replace existing list for atomic list type. Use WithNewValues instead.
 func (b *NodeSelectorRequirementApplyConfiguration) WithValues(values ...string) *NodeSelectorRequirementApplyConfiguration {
 	for i := range values {
 		b.Values = append(b.Values, values[i])
 	}
+	return b
+}
+
+// WithNewValues replaces the Values field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Values field is set to the values of the last call.
+func (b *NodeSelectorRequirementApplyConfiguration) WithNewValues(values ...string) *NodeSelectorRequirementApplyConfiguration {
+	b.Values = make([]string, len(values))
+	copy(b.Values, values)
 	return b
 }

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/nodeselectorterm.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/nodeselectorterm.go
@@ -34,6 +34,7 @@ func NodeSelectorTerm() *NodeSelectorTermApplyConfiguration {
 // WithMatchExpressions adds the given value to the MatchExpressions field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the MatchExpressions field.
+// Deprecated: WithMatchExpressions does not replace existing list for atomic list type. Use WithNewMatchExpressions instead.
 func (b *NodeSelectorTermApplyConfiguration) WithMatchExpressions(values ...*NodeSelectorRequirementApplyConfiguration) *NodeSelectorTermApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
@@ -44,13 +45,42 @@ func (b *NodeSelectorTermApplyConfiguration) WithMatchExpressions(values ...*Nod
 	return b
 }
 
+// WithNewMatchExpressions replaces the MatchExpressions field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the MatchExpressions field is set to the values of the last call.
+func (b *NodeSelectorTermApplyConfiguration) WithNewMatchExpressions(values ...*NodeSelectorRequirementApplyConfiguration) *NodeSelectorTermApplyConfiguration {
+	b.MatchExpressions = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewMatchExpressions")
+		}
+		b.MatchExpressions = append(b.MatchExpressions, *values[i])
+	}
+	return b
+}
+
 // WithMatchFields adds the given value to the MatchFields field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the MatchFields field.
+// Deprecated: WithMatchFields does not replace existing list for atomic list type. Use WithNewMatchFields instead.
 func (b *NodeSelectorTermApplyConfiguration) WithMatchFields(values ...*NodeSelectorRequirementApplyConfiguration) *NodeSelectorTermApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithMatchFields")
+		}
+		b.MatchFields = append(b.MatchFields, *values[i])
+	}
+	return b
+}
+
+// WithNewMatchFields replaces the MatchFields field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the MatchFields field is set to the values of the last call.
+func (b *NodeSelectorTermApplyConfiguration) WithNewMatchFields(values ...*NodeSelectorRequirementApplyConfiguration) *NodeSelectorTermApplyConfiguration {
+	b.MatchFields = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewMatchFields")
 		}
 		b.MatchFields = append(b.MatchFields, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/nodespec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/nodespec.go
@@ -47,10 +47,20 @@ func (b *NodeSpecApplyConfiguration) WithPodCIDR(value string) *NodeSpecApplyCon
 // WithPodCIDRs adds the given value to the PodCIDRs field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the PodCIDRs field.
+// Deprecated: WithPodCIDRs does not replace existing list for atomic list type. Use WithNewPodCIDRs instead.
 func (b *NodeSpecApplyConfiguration) WithPodCIDRs(values ...string) *NodeSpecApplyConfiguration {
 	for i := range values {
 		b.PodCIDRs = append(b.PodCIDRs, values[i])
 	}
+	return b
+}
+
+// WithNewPodCIDRs replaces the PodCIDRs field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the PodCIDRs field is set to the values of the last call.
+func (b *NodeSpecApplyConfiguration) WithNewPodCIDRs(values ...string) *NodeSpecApplyConfiguration {
+	b.PodCIDRs = make([]string, len(values))
+	copy(b.PodCIDRs, values)
 	return b
 }
 
@@ -73,10 +83,25 @@ func (b *NodeSpecApplyConfiguration) WithUnschedulable(value bool) *NodeSpecAppl
 // WithTaints adds the given value to the Taints field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Taints field.
+// Deprecated: WithTaints does not replace existing list for atomic list type. Use WithNewTaints instead.
 func (b *NodeSpecApplyConfiguration) WithTaints(values ...*TaintApplyConfiguration) *NodeSpecApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithTaints")
+		}
+		b.Taints = append(b.Taints, *values[i])
+	}
+	return b
+}
+
+// WithNewTaints replaces the Taints field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Taints field is set to the values of the last call.
+func (b *NodeSpecApplyConfiguration) WithNewTaints(values ...*TaintApplyConfiguration) *NodeSpecApplyConfiguration {
+	b.Taints = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewTaints")
 		}
 		b.Taints = append(b.Taints, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/nodestatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/nodestatus.go
@@ -71,6 +71,7 @@ func (b *NodeStatusApplyConfiguration) WithPhase(value v1.NodePhase) *NodeStatus
 // WithConditions adds the given value to the Conditions field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Conditions field.
+// Deprecated: WithConditions does not replace existing list for atomic list type. Use WithNewConditions instead.
 func (b *NodeStatusApplyConfiguration) WithConditions(values ...*NodeConditionApplyConfiguration) *NodeStatusApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
@@ -81,13 +82,42 @@ func (b *NodeStatusApplyConfiguration) WithConditions(values ...*NodeConditionAp
 	return b
 }
 
+// WithNewConditions replaces the Conditions field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Conditions field is set to the values of the last call.
+func (b *NodeStatusApplyConfiguration) WithNewConditions(values ...*NodeConditionApplyConfiguration) *NodeStatusApplyConfiguration {
+	b.Conditions = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewConditions")
+		}
+		b.Conditions = append(b.Conditions, *values[i])
+	}
+	return b
+}
+
 // WithAddresses adds the given value to the Addresses field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Addresses field.
+// Deprecated: WithAddresses does not replace existing list for atomic list type. Use WithNewAddresses instead.
 func (b *NodeStatusApplyConfiguration) WithAddresses(values ...*NodeAddressApplyConfiguration) *NodeStatusApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithAddresses")
+		}
+		b.Addresses = append(b.Addresses, *values[i])
+	}
+	return b
+}
+
+// WithNewAddresses replaces the Addresses field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Addresses field is set to the values of the last call.
+func (b *NodeStatusApplyConfiguration) WithNewAddresses(values ...*NodeAddressApplyConfiguration) *NodeStatusApplyConfiguration {
+	b.Addresses = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewAddresses")
 		}
 		b.Addresses = append(b.Addresses, *values[i])
 	}
@@ -113,6 +143,7 @@ func (b *NodeStatusApplyConfiguration) WithNodeInfo(value *NodeSystemInfoApplyCo
 // WithImages adds the given value to the Images field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Images field.
+// Deprecated: WithImages does not replace existing list for atomic list type. Use WithNewImages instead.
 func (b *NodeStatusApplyConfiguration) WithImages(values ...*ContainerImageApplyConfiguration) *NodeStatusApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
@@ -123,9 +154,24 @@ func (b *NodeStatusApplyConfiguration) WithImages(values ...*ContainerImageApply
 	return b
 }
 
+// WithNewImages replaces the Images field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Images field is set to the values of the last call.
+func (b *NodeStatusApplyConfiguration) WithNewImages(values ...*ContainerImageApplyConfiguration) *NodeStatusApplyConfiguration {
+	b.Images = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewImages")
+		}
+		b.Images = append(b.Images, *values[i])
+	}
+	return b
+}
+
 // WithVolumesInUse adds the given value to the VolumesInUse field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the VolumesInUse field.
+// Deprecated: WithVolumesInUse does not replace existing list for atomic list type. Use WithNewVolumesInUse instead.
 func (b *NodeStatusApplyConfiguration) WithVolumesInUse(values ...v1.UniqueVolumeName) *NodeStatusApplyConfiguration {
 	for i := range values {
 		b.VolumesInUse = append(b.VolumesInUse, values[i])
@@ -133,13 +179,37 @@ func (b *NodeStatusApplyConfiguration) WithVolumesInUse(values ...v1.UniqueVolum
 	return b
 }
 
+// WithNewVolumesInUse replaces the VolumesInUse field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the VolumesInUse field is set to the values of the last call.
+func (b *NodeStatusApplyConfiguration) WithNewVolumesInUse(values ...v1.UniqueVolumeName) *NodeStatusApplyConfiguration {
+	b.VolumesInUse = make([]v1.UniqueVolumeName, len(values))
+	copy(b.VolumesInUse, values)
+	return b
+}
+
 // WithVolumesAttached adds the given value to the VolumesAttached field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the VolumesAttached field.
+// Deprecated: WithVolumesAttached does not replace existing list for atomic list type. Use WithNewVolumesAttached instead.
 func (b *NodeStatusApplyConfiguration) WithVolumesAttached(values ...*AttachedVolumeApplyConfiguration) *NodeStatusApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithVolumesAttached")
+		}
+		b.VolumesAttached = append(b.VolumesAttached, *values[i])
+	}
+	return b
+}
+
+// WithNewVolumesAttached replaces the VolumesAttached field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the VolumesAttached field is set to the values of the last call.
+func (b *NodeStatusApplyConfiguration) WithNewVolumesAttached(values ...*AttachedVolumeApplyConfiguration) *NodeStatusApplyConfiguration {
+	b.VolumesAttached = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewVolumesAttached")
 		}
 		b.VolumesAttached = append(b.VolumesAttached, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/persistentvolume.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/persistentvolume.go
@@ -211,6 +211,7 @@ func (b *PersistentVolumeApplyConfiguration) WithAnnotations(entries map[string]
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *PersistentVolumeApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *PersistentVolumeApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -222,14 +223,40 @@ func (b *PersistentVolumeApplyConfiguration) WithOwnerReferences(values ...*v1.O
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *PersistentVolumeApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *PersistentVolumeApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *PersistentVolumeApplyConfiguration) WithFinalizers(values ...string) *PersistentVolumeApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *PersistentVolumeApplyConfiguration) WithNewFinalizers(values ...string) *PersistentVolumeApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/persistentvolumeclaim.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/persistentvolumeclaim.go
@@ -213,6 +213,7 @@ func (b *PersistentVolumeClaimApplyConfiguration) WithAnnotations(entries map[st
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *PersistentVolumeClaimApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *PersistentVolumeClaimApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -224,14 +225,40 @@ func (b *PersistentVolumeClaimApplyConfiguration) WithOwnerReferences(values ...
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *PersistentVolumeClaimApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *PersistentVolumeClaimApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *PersistentVolumeClaimApplyConfiguration) WithFinalizers(values ...string) *PersistentVolumeClaimApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *PersistentVolumeClaimApplyConfiguration) WithNewFinalizers(values ...string) *PersistentVolumeClaimApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/persistentvolumeclaimspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/persistentvolumeclaimspec.go
@@ -45,10 +45,20 @@ func PersistentVolumeClaimSpec() *PersistentVolumeClaimSpecApplyConfiguration {
 // WithAccessModes adds the given value to the AccessModes field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the AccessModes field.
+// Deprecated: WithAccessModes does not replace existing list for atomic list type. Use WithNewAccessModes instead.
 func (b *PersistentVolumeClaimSpecApplyConfiguration) WithAccessModes(values ...v1.PersistentVolumeAccessMode) *PersistentVolumeClaimSpecApplyConfiguration {
 	for i := range values {
 		b.AccessModes = append(b.AccessModes, values[i])
 	}
+	return b
+}
+
+// WithNewAccessModes replaces the AccessModes field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the AccessModes field is set to the values of the last call.
+func (b *PersistentVolumeClaimSpecApplyConfiguration) WithNewAccessModes(values ...v1.PersistentVolumeAccessMode) *PersistentVolumeClaimSpecApplyConfiguration {
+	b.AccessModes = make([]v1.PersistentVolumeAccessMode, len(values))
+	copy(b.AccessModes, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/persistentvolumeclaimstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/persistentvolumeclaimstatus.go
@@ -50,10 +50,20 @@ func (b *PersistentVolumeClaimStatusApplyConfiguration) WithPhase(value v1.Persi
 // WithAccessModes adds the given value to the AccessModes field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the AccessModes field.
+// Deprecated: WithAccessModes does not replace existing list for atomic list type. Use WithNewAccessModes instead.
 func (b *PersistentVolumeClaimStatusApplyConfiguration) WithAccessModes(values ...v1.PersistentVolumeAccessMode) *PersistentVolumeClaimStatusApplyConfiguration {
 	for i := range values {
 		b.AccessModes = append(b.AccessModes, values[i])
 	}
+	return b
+}
+
+// WithNewAccessModes replaces the AccessModes field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the AccessModes field is set to the values of the last call.
+func (b *PersistentVolumeClaimStatusApplyConfiguration) WithNewAccessModes(values ...v1.PersistentVolumeAccessMode) *PersistentVolumeClaimStatusApplyConfiguration {
+	b.AccessModes = make([]v1.PersistentVolumeAccessMode, len(values))
+	copy(b.AccessModes, values)
 	return b
 }
 
@@ -68,10 +78,25 @@ func (b *PersistentVolumeClaimStatusApplyConfiguration) WithCapacity(value v1.Re
 // WithConditions adds the given value to the Conditions field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Conditions field.
+// Deprecated: WithConditions does not replace existing list for atomic list type. Use WithNewConditions instead.
 func (b *PersistentVolumeClaimStatusApplyConfiguration) WithConditions(values ...*PersistentVolumeClaimConditionApplyConfiguration) *PersistentVolumeClaimStatusApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithConditions")
+		}
+		b.Conditions = append(b.Conditions, *values[i])
+	}
+	return b
+}
+
+// WithNewConditions replaces the Conditions field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Conditions field is set to the values of the last call.
+func (b *PersistentVolumeClaimStatusApplyConfiguration) WithNewConditions(values ...*PersistentVolumeClaimConditionApplyConfiguration) *PersistentVolumeClaimStatusApplyConfiguration {
+	b.Conditions = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewConditions")
 		}
 		b.Conditions = append(b.Conditions, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/persistentvolumeclaimtemplate.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/persistentvolumeclaimtemplate.go
@@ -151,6 +151,7 @@ func (b *PersistentVolumeClaimTemplateApplyConfiguration) WithAnnotations(entrie
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *PersistentVolumeClaimTemplateApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *PersistentVolumeClaimTemplateApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -162,14 +163,40 @@ func (b *PersistentVolumeClaimTemplateApplyConfiguration) WithOwnerReferences(va
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *PersistentVolumeClaimTemplateApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *PersistentVolumeClaimTemplateApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *PersistentVolumeClaimTemplateApplyConfiguration) WithFinalizers(values ...string) *PersistentVolumeClaimTemplateApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *PersistentVolumeClaimTemplateApplyConfiguration) WithNewFinalizers(values ...string) *PersistentVolumeClaimTemplateApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/persistentvolumespec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/persistentvolumespec.go
@@ -229,10 +229,20 @@ func (b *PersistentVolumeSpecApplyConfiguration) WithCSI(value *CSIPersistentVol
 // WithAccessModes adds the given value to the AccessModes field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the AccessModes field.
+// Deprecated: WithAccessModes does not replace existing list for atomic list type. Use WithNewAccessModes instead.
 func (b *PersistentVolumeSpecApplyConfiguration) WithAccessModes(values ...v1.PersistentVolumeAccessMode) *PersistentVolumeSpecApplyConfiguration {
 	for i := range values {
 		b.AccessModes = append(b.AccessModes, values[i])
 	}
+	return b
+}
+
+// WithNewAccessModes replaces the AccessModes field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the AccessModes field is set to the values of the last call.
+func (b *PersistentVolumeSpecApplyConfiguration) WithNewAccessModes(values ...v1.PersistentVolumeAccessMode) *PersistentVolumeSpecApplyConfiguration {
+	b.AccessModes = make([]v1.PersistentVolumeAccessMode, len(values))
+	copy(b.AccessModes, values)
 	return b
 }
 
@@ -263,10 +273,20 @@ func (b *PersistentVolumeSpecApplyConfiguration) WithStorageClassName(value stri
 // WithMountOptions adds the given value to the MountOptions field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the MountOptions field.
+// Deprecated: WithMountOptions does not replace existing list for atomic list type. Use WithNewMountOptions instead.
 func (b *PersistentVolumeSpecApplyConfiguration) WithMountOptions(values ...string) *PersistentVolumeSpecApplyConfiguration {
 	for i := range values {
 		b.MountOptions = append(b.MountOptions, values[i])
 	}
+	return b
+}
+
+// WithNewMountOptions replaces the MountOptions field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the MountOptions field is set to the values of the last call.
+func (b *PersistentVolumeSpecApplyConfiguration) WithNewMountOptions(values ...string) *PersistentVolumeSpecApplyConfiguration {
+	b.MountOptions = make([]string, len(values))
+	copy(b.MountOptions, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/pod.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/pod.go
@@ -213,6 +213,7 @@ func (b *PodApplyConfiguration) WithAnnotations(entries map[string]string) *PodA
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *PodApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *PodApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -224,14 +225,40 @@ func (b *PodApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReference
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *PodApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *PodApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *PodApplyConfiguration) WithFinalizers(values ...string) *PodApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *PodApplyConfiguration) WithNewFinalizers(values ...string) *PodApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/podaffinity.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/podaffinity.go
@@ -34,6 +34,7 @@ func PodAffinity() *PodAffinityApplyConfiguration {
 // WithRequiredDuringSchedulingIgnoredDuringExecution adds the given value to the RequiredDuringSchedulingIgnoredDuringExecution field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the RequiredDuringSchedulingIgnoredDuringExecution field.
+// Deprecated: WithRequiredDuringSchedulingIgnoredDuringExecution does not replace existing list for atomic list type. Use WithNewRequiredDuringSchedulingIgnoredDuringExecution instead.
 func (b *PodAffinityApplyConfiguration) WithRequiredDuringSchedulingIgnoredDuringExecution(values ...*PodAffinityTermApplyConfiguration) *PodAffinityApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
@@ -44,13 +45,42 @@ func (b *PodAffinityApplyConfiguration) WithRequiredDuringSchedulingIgnoredDurin
 	return b
 }
 
+// WithNewRequiredDuringSchedulingIgnoredDuringExecution replaces the RequiredDuringSchedulingIgnoredDuringExecution field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the RequiredDuringSchedulingIgnoredDuringExecution field is set to the values of the last call.
+func (b *PodAffinityApplyConfiguration) WithNewRequiredDuringSchedulingIgnoredDuringExecution(values ...*PodAffinityTermApplyConfiguration) *PodAffinityApplyConfiguration {
+	b.RequiredDuringSchedulingIgnoredDuringExecution = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewRequiredDuringSchedulingIgnoredDuringExecution")
+		}
+		b.RequiredDuringSchedulingIgnoredDuringExecution = append(b.RequiredDuringSchedulingIgnoredDuringExecution, *values[i])
+	}
+	return b
+}
+
 // WithPreferredDuringSchedulingIgnoredDuringExecution adds the given value to the PreferredDuringSchedulingIgnoredDuringExecution field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the PreferredDuringSchedulingIgnoredDuringExecution field.
+// Deprecated: WithPreferredDuringSchedulingIgnoredDuringExecution does not replace existing list for atomic list type. Use WithNewPreferredDuringSchedulingIgnoredDuringExecution instead.
 func (b *PodAffinityApplyConfiguration) WithPreferredDuringSchedulingIgnoredDuringExecution(values ...*WeightedPodAffinityTermApplyConfiguration) *PodAffinityApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithPreferredDuringSchedulingIgnoredDuringExecution")
+		}
+		b.PreferredDuringSchedulingIgnoredDuringExecution = append(b.PreferredDuringSchedulingIgnoredDuringExecution, *values[i])
+	}
+	return b
+}
+
+// WithNewPreferredDuringSchedulingIgnoredDuringExecution replaces the PreferredDuringSchedulingIgnoredDuringExecution field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the PreferredDuringSchedulingIgnoredDuringExecution field is set to the values of the last call.
+func (b *PodAffinityApplyConfiguration) WithNewPreferredDuringSchedulingIgnoredDuringExecution(values ...*WeightedPodAffinityTermApplyConfiguration) *PodAffinityApplyConfiguration {
+	b.PreferredDuringSchedulingIgnoredDuringExecution = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewPreferredDuringSchedulingIgnoredDuringExecution")
 		}
 		b.PreferredDuringSchedulingIgnoredDuringExecution = append(b.PreferredDuringSchedulingIgnoredDuringExecution, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/podaffinityterm.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/podaffinityterm.go
@@ -50,10 +50,20 @@ func (b *PodAffinityTermApplyConfiguration) WithLabelSelector(value *v1.LabelSel
 // WithNamespaces adds the given value to the Namespaces field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Namespaces field.
+// Deprecated: WithNamespaces does not replace existing list for atomic list type. Use WithNewNamespaces instead.
 func (b *PodAffinityTermApplyConfiguration) WithNamespaces(values ...string) *PodAffinityTermApplyConfiguration {
 	for i := range values {
 		b.Namespaces = append(b.Namespaces, values[i])
 	}
+	return b
+}
+
+// WithNewNamespaces replaces the Namespaces field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Namespaces field is set to the values of the last call.
+func (b *PodAffinityTermApplyConfiguration) WithNewNamespaces(values ...string) *PodAffinityTermApplyConfiguration {
+	b.Namespaces = make([]string, len(values))
+	copy(b.Namespaces, values)
 	return b
 }
 
@@ -76,6 +86,7 @@ func (b *PodAffinityTermApplyConfiguration) WithNamespaceSelector(value *v1.Labe
 // WithMatchLabelKeys adds the given value to the MatchLabelKeys field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the MatchLabelKeys field.
+// Deprecated: WithMatchLabelKeys does not replace existing list for atomic list type. Use WithNewMatchLabelKeys instead.
 func (b *PodAffinityTermApplyConfiguration) WithMatchLabelKeys(values ...string) *PodAffinityTermApplyConfiguration {
 	for i := range values {
 		b.MatchLabelKeys = append(b.MatchLabelKeys, values[i])
@@ -83,12 +94,31 @@ func (b *PodAffinityTermApplyConfiguration) WithMatchLabelKeys(values ...string)
 	return b
 }
 
+// WithNewMatchLabelKeys replaces the MatchLabelKeys field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the MatchLabelKeys field is set to the values of the last call.
+func (b *PodAffinityTermApplyConfiguration) WithNewMatchLabelKeys(values ...string) *PodAffinityTermApplyConfiguration {
+	b.MatchLabelKeys = make([]string, len(values))
+	copy(b.MatchLabelKeys, values)
+	return b
+}
+
 // WithMismatchLabelKeys adds the given value to the MismatchLabelKeys field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the MismatchLabelKeys field.
+// Deprecated: WithMismatchLabelKeys does not replace existing list for atomic list type. Use WithNewMismatchLabelKeys instead.
 func (b *PodAffinityTermApplyConfiguration) WithMismatchLabelKeys(values ...string) *PodAffinityTermApplyConfiguration {
 	for i := range values {
 		b.MismatchLabelKeys = append(b.MismatchLabelKeys, values[i])
 	}
+	return b
+}
+
+// WithNewMismatchLabelKeys replaces the MismatchLabelKeys field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the MismatchLabelKeys field is set to the values of the last call.
+func (b *PodAffinityTermApplyConfiguration) WithNewMismatchLabelKeys(values ...string) *PodAffinityTermApplyConfiguration {
+	b.MismatchLabelKeys = make([]string, len(values))
+	copy(b.MismatchLabelKeys, values)
 	return b
 }

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/podantiaffinity.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/podantiaffinity.go
@@ -34,6 +34,7 @@ func PodAntiAffinity() *PodAntiAffinityApplyConfiguration {
 // WithRequiredDuringSchedulingIgnoredDuringExecution adds the given value to the RequiredDuringSchedulingIgnoredDuringExecution field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the RequiredDuringSchedulingIgnoredDuringExecution field.
+// Deprecated: WithRequiredDuringSchedulingIgnoredDuringExecution does not replace existing list for atomic list type. Use WithNewRequiredDuringSchedulingIgnoredDuringExecution instead.
 func (b *PodAntiAffinityApplyConfiguration) WithRequiredDuringSchedulingIgnoredDuringExecution(values ...*PodAffinityTermApplyConfiguration) *PodAntiAffinityApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
@@ -44,13 +45,42 @@ func (b *PodAntiAffinityApplyConfiguration) WithRequiredDuringSchedulingIgnoredD
 	return b
 }
 
+// WithNewRequiredDuringSchedulingIgnoredDuringExecution replaces the RequiredDuringSchedulingIgnoredDuringExecution field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the RequiredDuringSchedulingIgnoredDuringExecution field is set to the values of the last call.
+func (b *PodAntiAffinityApplyConfiguration) WithNewRequiredDuringSchedulingIgnoredDuringExecution(values ...*PodAffinityTermApplyConfiguration) *PodAntiAffinityApplyConfiguration {
+	b.RequiredDuringSchedulingIgnoredDuringExecution = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewRequiredDuringSchedulingIgnoredDuringExecution")
+		}
+		b.RequiredDuringSchedulingIgnoredDuringExecution = append(b.RequiredDuringSchedulingIgnoredDuringExecution, *values[i])
+	}
+	return b
+}
+
 // WithPreferredDuringSchedulingIgnoredDuringExecution adds the given value to the PreferredDuringSchedulingIgnoredDuringExecution field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the PreferredDuringSchedulingIgnoredDuringExecution field.
+// Deprecated: WithPreferredDuringSchedulingIgnoredDuringExecution does not replace existing list for atomic list type. Use WithNewPreferredDuringSchedulingIgnoredDuringExecution instead.
 func (b *PodAntiAffinityApplyConfiguration) WithPreferredDuringSchedulingIgnoredDuringExecution(values ...*WeightedPodAffinityTermApplyConfiguration) *PodAntiAffinityApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithPreferredDuringSchedulingIgnoredDuringExecution")
+		}
+		b.PreferredDuringSchedulingIgnoredDuringExecution = append(b.PreferredDuringSchedulingIgnoredDuringExecution, *values[i])
+	}
+	return b
+}
+
+// WithNewPreferredDuringSchedulingIgnoredDuringExecution replaces the PreferredDuringSchedulingIgnoredDuringExecution field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the PreferredDuringSchedulingIgnoredDuringExecution field is set to the values of the last call.
+func (b *PodAntiAffinityApplyConfiguration) WithNewPreferredDuringSchedulingIgnoredDuringExecution(values ...*WeightedPodAffinityTermApplyConfiguration) *PodAntiAffinityApplyConfiguration {
+	b.PreferredDuringSchedulingIgnoredDuringExecution = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewPreferredDuringSchedulingIgnoredDuringExecution")
 		}
 		b.PreferredDuringSchedulingIgnoredDuringExecution = append(b.PreferredDuringSchedulingIgnoredDuringExecution, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/poddnsconfig.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/poddnsconfig.go
@@ -35,6 +35,7 @@ func PodDNSConfig() *PodDNSConfigApplyConfiguration {
 // WithNameservers adds the given value to the Nameservers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Nameservers field.
+// Deprecated: WithNameservers does not replace existing list for atomic list type. Use WithNewNameservers instead.
 func (b *PodDNSConfigApplyConfiguration) WithNameservers(values ...string) *PodDNSConfigApplyConfiguration {
 	for i := range values {
 		b.Nameservers = append(b.Nameservers, values[i])
@@ -42,9 +43,19 @@ func (b *PodDNSConfigApplyConfiguration) WithNameservers(values ...string) *PodD
 	return b
 }
 
+// WithNewNameservers replaces the Nameservers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Nameservers field is set to the values of the last call.
+func (b *PodDNSConfigApplyConfiguration) WithNewNameservers(values ...string) *PodDNSConfigApplyConfiguration {
+	b.Nameservers = make([]string, len(values))
+	copy(b.Nameservers, values)
+	return b
+}
+
 // WithSearches adds the given value to the Searches field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Searches field.
+// Deprecated: WithSearches does not replace existing list for atomic list type. Use WithNewSearches instead.
 func (b *PodDNSConfigApplyConfiguration) WithSearches(values ...string) *PodDNSConfigApplyConfiguration {
 	for i := range values {
 		b.Searches = append(b.Searches, values[i])
@@ -52,13 +63,37 @@ func (b *PodDNSConfigApplyConfiguration) WithSearches(values ...string) *PodDNSC
 	return b
 }
 
+// WithNewSearches replaces the Searches field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Searches field is set to the values of the last call.
+func (b *PodDNSConfigApplyConfiguration) WithNewSearches(values ...string) *PodDNSConfigApplyConfiguration {
+	b.Searches = make([]string, len(values))
+	copy(b.Searches, values)
+	return b
+}
+
 // WithOptions adds the given value to the Options field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Options field.
+// Deprecated: WithOptions does not replace existing list for atomic list type. Use WithNewOptions instead.
 func (b *PodDNSConfigApplyConfiguration) WithOptions(values ...*PodDNSConfigOptionApplyConfiguration) *PodDNSConfigApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithOptions")
+		}
+		b.Options = append(b.Options, *values[i])
+	}
+	return b
+}
+
+// WithNewOptions replaces the Options field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Options field is set to the values of the last call.
+func (b *PodDNSConfigApplyConfiguration) WithNewOptions(values ...*PodDNSConfigOptionApplyConfiguration) *PodDNSConfigApplyConfiguration {
+	b.Options = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOptions")
 		}
 		b.Options = append(b.Options, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/podsecuritycontext.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/podsecuritycontext.go
@@ -86,10 +86,20 @@ func (b *PodSecurityContextApplyConfiguration) WithRunAsNonRoot(value bool) *Pod
 // WithSupplementalGroups adds the given value to the SupplementalGroups field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the SupplementalGroups field.
+// Deprecated: WithSupplementalGroups does not replace existing list for atomic list type. Use WithNewSupplementalGroups instead.
 func (b *PodSecurityContextApplyConfiguration) WithSupplementalGroups(values ...int64) *PodSecurityContextApplyConfiguration {
 	for i := range values {
 		b.SupplementalGroups = append(b.SupplementalGroups, values[i])
 	}
+	return b
+}
+
+// WithNewSupplementalGroups replaces the SupplementalGroups field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the SupplementalGroups field is set to the values of the last call.
+func (b *PodSecurityContextApplyConfiguration) WithNewSupplementalGroups(values ...int64) *PodSecurityContextApplyConfiguration {
+	b.SupplementalGroups = make([]int64, len(values))
+	copy(b.SupplementalGroups, values)
 	return b
 }
 
@@ -104,10 +114,25 @@ func (b *PodSecurityContextApplyConfiguration) WithFSGroup(value int64) *PodSecu
 // WithSysctls adds the given value to the Sysctls field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Sysctls field.
+// Deprecated: WithSysctls does not replace existing list for atomic list type. Use WithNewSysctls instead.
 func (b *PodSecurityContextApplyConfiguration) WithSysctls(values ...*SysctlApplyConfiguration) *PodSecurityContextApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithSysctls")
+		}
+		b.Sysctls = append(b.Sysctls, *values[i])
+	}
+	return b
+}
+
+// WithNewSysctls replaces the Sysctls field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Sysctls field is set to the values of the last call.
+func (b *PodSecurityContextApplyConfiguration) WithNewSysctls(values ...*SysctlApplyConfiguration) *PodSecurityContextApplyConfiguration {
+	b.Sysctls = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewSysctls")
 		}
 		b.Sysctls = append(b.Sysctls, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/podspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/podspec.go
@@ -75,6 +75,7 @@ func PodSpec() *PodSpecApplyConfiguration {
 // WithVolumes adds the given value to the Volumes field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Volumes field.
+// Deprecated: WithVolumes does not replace existing list for atomic list type. Use WithNewVolumes instead.
 func (b *PodSpecApplyConfiguration) WithVolumes(values ...*VolumeApplyConfiguration) *PodSpecApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
@@ -85,9 +86,24 @@ func (b *PodSpecApplyConfiguration) WithVolumes(values ...*VolumeApplyConfigurat
 	return b
 }
 
+// WithNewVolumes replaces the Volumes field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Volumes field is set to the values of the last call.
+func (b *PodSpecApplyConfiguration) WithNewVolumes(values ...*VolumeApplyConfiguration) *PodSpecApplyConfiguration {
+	b.Volumes = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewVolumes")
+		}
+		b.Volumes = append(b.Volumes, *values[i])
+	}
+	return b
+}
+
 // WithInitContainers adds the given value to the InitContainers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the InitContainers field.
+// Deprecated: WithInitContainers does not replace existing list for atomic list type. Use WithNewInitContainers instead.
 func (b *PodSpecApplyConfiguration) WithInitContainers(values ...*ContainerApplyConfiguration) *PodSpecApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
@@ -98,9 +114,24 @@ func (b *PodSpecApplyConfiguration) WithInitContainers(values ...*ContainerApply
 	return b
 }
 
+// WithNewInitContainers replaces the InitContainers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the InitContainers field is set to the values of the last call.
+func (b *PodSpecApplyConfiguration) WithNewInitContainers(values ...*ContainerApplyConfiguration) *PodSpecApplyConfiguration {
+	b.InitContainers = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewInitContainers")
+		}
+		b.InitContainers = append(b.InitContainers, *values[i])
+	}
+	return b
+}
+
 // WithContainers adds the given value to the Containers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Containers field.
+// Deprecated: WithContainers does not replace existing list for atomic list type. Use WithNewContainers instead.
 func (b *PodSpecApplyConfiguration) WithContainers(values ...*ContainerApplyConfiguration) *PodSpecApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
@@ -111,13 +142,42 @@ func (b *PodSpecApplyConfiguration) WithContainers(values ...*ContainerApplyConf
 	return b
 }
 
+// WithNewContainers replaces the Containers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Containers field is set to the values of the last call.
+func (b *PodSpecApplyConfiguration) WithNewContainers(values ...*ContainerApplyConfiguration) *PodSpecApplyConfiguration {
+	b.Containers = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewContainers")
+		}
+		b.Containers = append(b.Containers, *values[i])
+	}
+	return b
+}
+
 // WithEphemeralContainers adds the given value to the EphemeralContainers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the EphemeralContainers field.
+// Deprecated: WithEphemeralContainers does not replace existing list for atomic list type. Use WithNewEphemeralContainers instead.
 func (b *PodSpecApplyConfiguration) WithEphemeralContainers(values ...*EphemeralContainerApplyConfiguration) *PodSpecApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithEphemeralContainers")
+		}
+		b.EphemeralContainers = append(b.EphemeralContainers, *values[i])
+	}
+	return b
+}
+
+// WithNewEphemeralContainers replaces the EphemeralContainers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the EphemeralContainers field is set to the values of the last call.
+func (b *PodSpecApplyConfiguration) WithNewEphemeralContainers(values ...*EphemeralContainerApplyConfiguration) *PodSpecApplyConfiguration {
+	b.EphemeralContainers = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewEphemeralContainers")
 		}
 		b.EphemeralContainers = append(b.EphemeralContainers, *values[i])
 	}
@@ -160,10 +220,22 @@ func (b *PodSpecApplyConfiguration) WithDNSPolicy(value corev1.DNSPolicy) *PodSp
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, the entries provided by each call will be put on the NodeSelector field,
 // overwriting an existing map entries in NodeSelector field with the same key.
+// Deprecated: WithNodeSelector does not replace existing map for atomic map type. Use WithNewNodeSelector instead.
 func (b *PodSpecApplyConfiguration) WithNodeSelector(entries map[string]string) *PodSpecApplyConfiguration {
 	if b.NodeSelector == nil && len(entries) > 0 {
 		b.NodeSelector = make(map[string]string, len(entries))
 	}
+	for k, v := range entries {
+		b.NodeSelector[k] = v
+	}
+	return b
+}
+
+// WithNewNodeSelector replaces the NodeSelector field in the declarative configuration with given entries
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the NodeSelector field is set to the entries of the last call.
+func (b *PodSpecApplyConfiguration) WithNewNodeSelector(entries map[string]string) *PodSpecApplyConfiguration {
+	b.NodeSelector = make(map[string]string, len(entries))
 	for k, v := range entries {
 		b.NodeSelector[k] = v
 	}
@@ -245,10 +317,25 @@ func (b *PodSpecApplyConfiguration) WithSecurityContext(value *PodSecurityContex
 // WithImagePullSecrets adds the given value to the ImagePullSecrets field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the ImagePullSecrets field.
+// Deprecated: WithImagePullSecrets does not replace existing list for atomic list type. Use WithNewImagePullSecrets instead.
 func (b *PodSpecApplyConfiguration) WithImagePullSecrets(values ...*LocalObjectReferenceApplyConfiguration) *PodSpecApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithImagePullSecrets")
+		}
+		b.ImagePullSecrets = append(b.ImagePullSecrets, *values[i])
+	}
+	return b
+}
+
+// WithNewImagePullSecrets replaces the ImagePullSecrets field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the ImagePullSecrets field is set to the values of the last call.
+func (b *PodSpecApplyConfiguration) WithNewImagePullSecrets(values ...*LocalObjectReferenceApplyConfiguration) *PodSpecApplyConfiguration {
+	b.ImagePullSecrets = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewImagePullSecrets")
 		}
 		b.ImagePullSecrets = append(b.ImagePullSecrets, *values[i])
 	}
@@ -290,6 +377,7 @@ func (b *PodSpecApplyConfiguration) WithSchedulerName(value string) *PodSpecAppl
 // WithTolerations adds the given value to the Tolerations field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Tolerations field.
+// Deprecated: WithTolerations does not replace existing list for atomic list type. Use WithNewTolerations instead.
 func (b *PodSpecApplyConfiguration) WithTolerations(values ...*TolerationApplyConfiguration) *PodSpecApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
@@ -300,13 +388,42 @@ func (b *PodSpecApplyConfiguration) WithTolerations(values ...*TolerationApplyCo
 	return b
 }
 
+// WithNewTolerations replaces the Tolerations field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Tolerations field is set to the values of the last call.
+func (b *PodSpecApplyConfiguration) WithNewTolerations(values ...*TolerationApplyConfiguration) *PodSpecApplyConfiguration {
+	b.Tolerations = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewTolerations")
+		}
+		b.Tolerations = append(b.Tolerations, *values[i])
+	}
+	return b
+}
+
 // WithHostAliases adds the given value to the HostAliases field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the HostAliases field.
+// Deprecated: WithHostAliases does not replace existing list for atomic list type. Use WithNewHostAliases instead.
 func (b *PodSpecApplyConfiguration) WithHostAliases(values ...*HostAliasApplyConfiguration) *PodSpecApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithHostAliases")
+		}
+		b.HostAliases = append(b.HostAliases, *values[i])
+	}
+	return b
+}
+
+// WithNewHostAliases replaces the HostAliases field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the HostAliases field is set to the values of the last call.
+func (b *PodSpecApplyConfiguration) WithNewHostAliases(values ...*HostAliasApplyConfiguration) *PodSpecApplyConfiguration {
+	b.HostAliases = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewHostAliases")
 		}
 		b.HostAliases = append(b.HostAliases, *values[i])
 	}
@@ -340,10 +457,25 @@ func (b *PodSpecApplyConfiguration) WithDNSConfig(value *PodDNSConfigApplyConfig
 // WithReadinessGates adds the given value to the ReadinessGates field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the ReadinessGates field.
+// Deprecated: WithReadinessGates does not replace existing list for atomic list type. Use WithNewReadinessGates instead.
 func (b *PodSpecApplyConfiguration) WithReadinessGates(values ...*PodReadinessGateApplyConfiguration) *PodSpecApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithReadinessGates")
+		}
+		b.ReadinessGates = append(b.ReadinessGates, *values[i])
+	}
+	return b
+}
+
+// WithNewReadinessGates replaces the ReadinessGates field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the ReadinessGates field is set to the values of the last call.
+func (b *PodSpecApplyConfiguration) WithNewReadinessGates(values ...*PodReadinessGateApplyConfiguration) *PodSpecApplyConfiguration {
+	b.ReadinessGates = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewReadinessGates")
 		}
 		b.ReadinessGates = append(b.ReadinessGates, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/podstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/podstatus.go
@@ -61,10 +61,25 @@ func (b *PodStatusApplyConfiguration) WithPhase(value v1.PodPhase) *PodStatusApp
 // WithConditions adds the given value to the Conditions field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Conditions field.
+// Deprecated: WithConditions does not replace existing list for atomic list type. Use WithNewConditions instead.
 func (b *PodStatusApplyConfiguration) WithConditions(values ...*PodConditionApplyConfiguration) *PodStatusApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithConditions")
+		}
+		b.Conditions = append(b.Conditions, *values[i])
+	}
+	return b
+}
+
+// WithNewConditions replaces the Conditions field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Conditions field is set to the values of the last call.
+func (b *PodStatusApplyConfiguration) WithNewConditions(values ...*PodConditionApplyConfiguration) *PodStatusApplyConfiguration {
+	b.Conditions = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewConditions")
 		}
 		b.Conditions = append(b.Conditions, *values[i])
 	}
@@ -106,10 +121,25 @@ func (b *PodStatusApplyConfiguration) WithHostIP(value string) *PodStatusApplyCo
 // WithHostIPs adds the given value to the HostIPs field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the HostIPs field.
+// Deprecated: WithHostIPs does not replace existing list for atomic list type. Use WithNewHostIPs instead.
 func (b *PodStatusApplyConfiguration) WithHostIPs(values ...*HostIPApplyConfiguration) *PodStatusApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithHostIPs")
+		}
+		b.HostIPs = append(b.HostIPs, *values[i])
+	}
+	return b
+}
+
+// WithNewHostIPs replaces the HostIPs field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the HostIPs field is set to the values of the last call.
+func (b *PodStatusApplyConfiguration) WithNewHostIPs(values ...*HostIPApplyConfiguration) *PodStatusApplyConfiguration {
+	b.HostIPs = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewHostIPs")
 		}
 		b.HostIPs = append(b.HostIPs, *values[i])
 	}
@@ -127,10 +157,25 @@ func (b *PodStatusApplyConfiguration) WithPodIP(value string) *PodStatusApplyCon
 // WithPodIPs adds the given value to the PodIPs field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the PodIPs field.
+// Deprecated: WithPodIPs does not replace existing list for atomic list type. Use WithNewPodIPs instead.
 func (b *PodStatusApplyConfiguration) WithPodIPs(values ...*PodIPApplyConfiguration) *PodStatusApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithPodIPs")
+		}
+		b.PodIPs = append(b.PodIPs, *values[i])
+	}
+	return b
+}
+
+// WithNewPodIPs replaces the PodIPs field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the PodIPs field is set to the values of the last call.
+func (b *PodStatusApplyConfiguration) WithNewPodIPs(values ...*PodIPApplyConfiguration) *PodStatusApplyConfiguration {
+	b.PodIPs = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewPodIPs")
 		}
 		b.PodIPs = append(b.PodIPs, *values[i])
 	}
@@ -148,6 +193,7 @@ func (b *PodStatusApplyConfiguration) WithStartTime(value metav1.Time) *PodStatu
 // WithInitContainerStatuses adds the given value to the InitContainerStatuses field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the InitContainerStatuses field.
+// Deprecated: WithInitContainerStatuses does not replace existing list for atomic list type. Use WithNewInitContainerStatuses instead.
 func (b *PodStatusApplyConfiguration) WithInitContainerStatuses(values ...*ContainerStatusApplyConfiguration) *PodStatusApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
@@ -158,13 +204,42 @@ func (b *PodStatusApplyConfiguration) WithInitContainerStatuses(values ...*Conta
 	return b
 }
 
+// WithNewInitContainerStatuses replaces the InitContainerStatuses field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the InitContainerStatuses field is set to the values of the last call.
+func (b *PodStatusApplyConfiguration) WithNewInitContainerStatuses(values ...*ContainerStatusApplyConfiguration) *PodStatusApplyConfiguration {
+	b.InitContainerStatuses = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewInitContainerStatuses")
+		}
+		b.InitContainerStatuses = append(b.InitContainerStatuses, *values[i])
+	}
+	return b
+}
+
 // WithContainerStatuses adds the given value to the ContainerStatuses field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the ContainerStatuses field.
+// Deprecated: WithContainerStatuses does not replace existing list for atomic list type. Use WithNewContainerStatuses instead.
 func (b *PodStatusApplyConfiguration) WithContainerStatuses(values ...*ContainerStatusApplyConfiguration) *PodStatusApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithContainerStatuses")
+		}
+		b.ContainerStatuses = append(b.ContainerStatuses, *values[i])
+	}
+	return b
+}
+
+// WithNewContainerStatuses replaces the ContainerStatuses field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the ContainerStatuses field is set to the values of the last call.
+func (b *PodStatusApplyConfiguration) WithNewContainerStatuses(values ...*ContainerStatusApplyConfiguration) *PodStatusApplyConfiguration {
+	b.ContainerStatuses = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewContainerStatuses")
 		}
 		b.ContainerStatuses = append(b.ContainerStatuses, *values[i])
 	}
@@ -182,10 +257,25 @@ func (b *PodStatusApplyConfiguration) WithQOSClass(value v1.PodQOSClass) *PodSta
 // WithEphemeralContainerStatuses adds the given value to the EphemeralContainerStatuses field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the EphemeralContainerStatuses field.
+// Deprecated: WithEphemeralContainerStatuses does not replace existing list for atomic list type. Use WithNewEphemeralContainerStatuses instead.
 func (b *PodStatusApplyConfiguration) WithEphemeralContainerStatuses(values ...*ContainerStatusApplyConfiguration) *PodStatusApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithEphemeralContainerStatuses")
+		}
+		b.EphemeralContainerStatuses = append(b.EphemeralContainerStatuses, *values[i])
+	}
+	return b
+}
+
+// WithNewEphemeralContainerStatuses replaces the EphemeralContainerStatuses field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the EphemeralContainerStatuses field is set to the values of the last call.
+func (b *PodStatusApplyConfiguration) WithNewEphemeralContainerStatuses(values ...*ContainerStatusApplyConfiguration) *PodStatusApplyConfiguration {
+	b.EphemeralContainerStatuses = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewEphemeralContainerStatuses")
 		}
 		b.EphemeralContainerStatuses = append(b.EphemeralContainerStatuses, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/podtemplate.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/podtemplate.go
@@ -212,6 +212,7 @@ func (b *PodTemplateApplyConfiguration) WithAnnotations(entries map[string]strin
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *PodTemplateApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *PodTemplateApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -223,14 +224,40 @@ func (b *PodTemplateApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerR
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *PodTemplateApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *PodTemplateApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *PodTemplateApplyConfiguration) WithFinalizers(values ...string) *PodTemplateApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *PodTemplateApplyConfiguration) WithNewFinalizers(values ...string) *PodTemplateApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/podtemplatespec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/podtemplatespec.go
@@ -151,6 +151,7 @@ func (b *PodTemplateSpecApplyConfiguration) WithAnnotations(entries map[string]s
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *PodTemplateSpecApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *PodTemplateSpecApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -162,14 +163,40 @@ func (b *PodTemplateSpecApplyConfiguration) WithOwnerReferences(values ...*v1.Ow
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *PodTemplateSpecApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *PodTemplateSpecApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *PodTemplateSpecApplyConfiguration) WithFinalizers(values ...string) *PodTemplateSpecApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *PodTemplateSpecApplyConfiguration) WithNewFinalizers(values ...string) *PodTemplateSpecApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/projectedvolumesource.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/projectedvolumesource.go
@@ -34,10 +34,25 @@ func ProjectedVolumeSource() *ProjectedVolumeSourceApplyConfiguration {
 // WithSources adds the given value to the Sources field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Sources field.
+// Deprecated: WithSources does not replace existing list for atomic list type. Use WithNewSources instead.
 func (b *ProjectedVolumeSourceApplyConfiguration) WithSources(values ...*VolumeProjectionApplyConfiguration) *ProjectedVolumeSourceApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithSources")
+		}
+		b.Sources = append(b.Sources, *values[i])
+	}
+	return b
+}
+
+// WithNewSources replaces the Sources field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Sources field is set to the values of the last call.
+func (b *ProjectedVolumeSourceApplyConfiguration) WithNewSources(values ...*VolumeProjectionApplyConfiguration) *ProjectedVolumeSourceApplyConfiguration {
+	b.Sources = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewSources")
 		}
 		b.Sources = append(b.Sources, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/rbdpersistentvolumesource.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/rbdpersistentvolumesource.go
@@ -40,10 +40,20 @@ func RBDPersistentVolumeSource() *RBDPersistentVolumeSourceApplyConfiguration {
 // WithCephMonitors adds the given value to the CephMonitors field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the CephMonitors field.
+// Deprecated: WithCephMonitors does not replace existing list for atomic list type. Use WithNewCephMonitors instead.
 func (b *RBDPersistentVolumeSourceApplyConfiguration) WithCephMonitors(values ...string) *RBDPersistentVolumeSourceApplyConfiguration {
 	for i := range values {
 		b.CephMonitors = append(b.CephMonitors, values[i])
 	}
+	return b
+}
+
+// WithNewCephMonitors replaces the CephMonitors field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the CephMonitors field is set to the values of the last call.
+func (b *RBDPersistentVolumeSourceApplyConfiguration) WithNewCephMonitors(values ...string) *RBDPersistentVolumeSourceApplyConfiguration {
+	b.CephMonitors = make([]string, len(values))
+	copy(b.CephMonitors, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/rbdvolumesource.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/rbdvolumesource.go
@@ -40,10 +40,20 @@ func RBDVolumeSource() *RBDVolumeSourceApplyConfiguration {
 // WithCephMonitors adds the given value to the CephMonitors field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the CephMonitors field.
+// Deprecated: WithCephMonitors does not replace existing list for atomic list type. Use WithNewCephMonitors instead.
 func (b *RBDVolumeSourceApplyConfiguration) WithCephMonitors(values ...string) *RBDVolumeSourceApplyConfiguration {
 	for i := range values {
 		b.CephMonitors = append(b.CephMonitors, values[i])
 	}
+	return b
+}
+
+// WithNewCephMonitors replaces the CephMonitors field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the CephMonitors field is set to the values of the last call.
+func (b *RBDVolumeSourceApplyConfiguration) WithNewCephMonitors(values ...string) *RBDVolumeSourceApplyConfiguration {
+	b.CephMonitors = make([]string, len(values))
+	copy(b.CephMonitors, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/replicationcontroller.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/replicationcontroller.go
@@ -213,6 +213,7 @@ func (b *ReplicationControllerApplyConfiguration) WithAnnotations(entries map[st
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *ReplicationControllerApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *ReplicationControllerApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -224,14 +225,40 @@ func (b *ReplicationControllerApplyConfiguration) WithOwnerReferences(values ...
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *ReplicationControllerApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *ReplicationControllerApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *ReplicationControllerApplyConfiguration) WithFinalizers(values ...string) *ReplicationControllerApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *ReplicationControllerApplyConfiguration) WithNewFinalizers(values ...string) *ReplicationControllerApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/replicationcontrollerspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/replicationcontrollerspec.go
@@ -53,10 +53,22 @@ func (b *ReplicationControllerSpecApplyConfiguration) WithMinReadySeconds(value 
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, the entries provided by each call will be put on the Selector field,
 // overwriting an existing map entries in Selector field with the same key.
+// Deprecated: WithSelector does not replace existing map for atomic map type. Use WithNewSelector instead.
 func (b *ReplicationControllerSpecApplyConfiguration) WithSelector(entries map[string]string) *ReplicationControllerSpecApplyConfiguration {
 	if b.Selector == nil && len(entries) > 0 {
 		b.Selector = make(map[string]string, len(entries))
 	}
+	for k, v := range entries {
+		b.Selector[k] = v
+	}
+	return b
+}
+
+// WithNewSelector replaces the Selector field in the declarative configuration with given entries
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Selector field is set to the entries of the last call.
+func (b *ReplicationControllerSpecApplyConfiguration) WithNewSelector(entries map[string]string) *ReplicationControllerSpecApplyConfiguration {
+	b.Selector = make(map[string]string, len(entries))
 	for k, v := range entries {
 		b.Selector[k] = v
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/replicationcontrollerstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/replicationcontrollerstatus.go
@@ -78,10 +78,25 @@ func (b *ReplicationControllerStatusApplyConfiguration) WithObservedGeneration(v
 // WithConditions adds the given value to the Conditions field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Conditions field.
+// Deprecated: WithConditions does not replace existing list for atomic list type. Use WithNewConditions instead.
 func (b *ReplicationControllerStatusApplyConfiguration) WithConditions(values ...*ReplicationControllerConditionApplyConfiguration) *ReplicationControllerStatusApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithConditions")
+		}
+		b.Conditions = append(b.Conditions, *values[i])
+	}
+	return b
+}
+
+// WithNewConditions replaces the Conditions field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Conditions field is set to the values of the last call.
+func (b *ReplicationControllerStatusApplyConfiguration) WithNewConditions(values ...*ReplicationControllerConditionApplyConfiguration) *ReplicationControllerStatusApplyConfiguration {
+	b.Conditions = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewConditions")
 		}
 		b.Conditions = append(b.Conditions, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/resourcequota.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/resourcequota.go
@@ -213,6 +213,7 @@ func (b *ResourceQuotaApplyConfiguration) WithAnnotations(entries map[string]str
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *ResourceQuotaApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *ResourceQuotaApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -224,14 +225,40 @@ func (b *ResourceQuotaApplyConfiguration) WithOwnerReferences(values ...*v1.Owne
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *ResourceQuotaApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *ResourceQuotaApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *ResourceQuotaApplyConfiguration) WithFinalizers(values ...string) *ResourceQuotaApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *ResourceQuotaApplyConfiguration) WithNewFinalizers(values ...string) *ResourceQuotaApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/resourcequotaspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/resourcequotaspec.go
@@ -47,10 +47,20 @@ func (b *ResourceQuotaSpecApplyConfiguration) WithHard(value v1.ResourceList) *R
 // WithScopes adds the given value to the Scopes field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Scopes field.
+// Deprecated: WithScopes does not replace existing list for atomic list type. Use WithNewScopes instead.
 func (b *ResourceQuotaSpecApplyConfiguration) WithScopes(values ...v1.ResourceQuotaScope) *ResourceQuotaSpecApplyConfiguration {
 	for i := range values {
 		b.Scopes = append(b.Scopes, values[i])
 	}
+	return b
+}
+
+// WithNewScopes replaces the Scopes field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Scopes field is set to the values of the last call.
+func (b *ResourceQuotaSpecApplyConfiguration) WithNewScopes(values ...v1.ResourceQuotaScope) *ResourceQuotaSpecApplyConfiguration {
+	b.Scopes = make([]v1.ResourceQuotaScope, len(values))
+	copy(b.Scopes, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/scopedresourceselectorrequirement.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/scopedresourceselectorrequirement.go
@@ -55,9 +55,19 @@ func (b *ScopedResourceSelectorRequirementApplyConfiguration) WithOperator(value
 // WithValues adds the given value to the Values field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Values field.
+// Deprecated: WithValues does not replace existing list for atomic list type. Use WithNewValues instead.
 func (b *ScopedResourceSelectorRequirementApplyConfiguration) WithValues(values ...string) *ScopedResourceSelectorRequirementApplyConfiguration {
 	for i := range values {
 		b.Values = append(b.Values, values[i])
 	}
+	return b
+}
+
+// WithNewValues replaces the Values field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Values field is set to the values of the last call.
+func (b *ScopedResourceSelectorRequirementApplyConfiguration) WithNewValues(values ...string) *ScopedResourceSelectorRequirementApplyConfiguration {
+	b.Values = make([]string, len(values))
+	copy(b.Values, values)
 	return b
 }

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/scopeselector.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/scopeselector.go
@@ -33,10 +33,25 @@ func ScopeSelector() *ScopeSelectorApplyConfiguration {
 // WithMatchExpressions adds the given value to the MatchExpressions field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the MatchExpressions field.
+// Deprecated: WithMatchExpressions does not replace existing list for atomic list type. Use WithNewMatchExpressions instead.
 func (b *ScopeSelectorApplyConfiguration) WithMatchExpressions(values ...*ScopedResourceSelectorRequirementApplyConfiguration) *ScopeSelectorApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithMatchExpressions")
+		}
+		b.MatchExpressions = append(b.MatchExpressions, *values[i])
+	}
+	return b
+}
+
+// WithNewMatchExpressions replaces the MatchExpressions field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the MatchExpressions field is set to the values of the last call.
+func (b *ScopeSelectorApplyConfiguration) WithNewMatchExpressions(values ...*ScopedResourceSelectorRequirementApplyConfiguration) *ScopeSelectorApplyConfiguration {
+	b.MatchExpressions = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewMatchExpressions")
 		}
 		b.MatchExpressions = append(b.MatchExpressions, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/secret.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/secret.go
@@ -215,6 +215,7 @@ func (b *SecretApplyConfiguration) WithAnnotations(entries map[string]string) *S
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *SecretApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *SecretApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -226,14 +227,40 @@ func (b *SecretApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerRefere
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *SecretApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *SecretApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *SecretApplyConfiguration) WithFinalizers(values ...string) *SecretApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *SecretApplyConfiguration) WithNewFinalizers(values ...string) *SecretApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/secretprojection.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/secretprojection.go
@@ -43,10 +43,25 @@ func (b *SecretProjectionApplyConfiguration) WithName(value string) *SecretProje
 // WithItems adds the given value to the Items field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Items field.
+// Deprecated: WithItems does not replace existing list for atomic list type. Use WithNewItems instead.
 func (b *SecretProjectionApplyConfiguration) WithItems(values ...*KeyToPathApplyConfiguration) *SecretProjectionApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithItems")
+		}
+		b.Items = append(b.Items, *values[i])
+	}
+	return b
+}
+
+// WithNewItems replaces the Items field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Items field is set to the values of the last call.
+func (b *SecretProjectionApplyConfiguration) WithNewItems(values ...*KeyToPathApplyConfiguration) *SecretProjectionApplyConfiguration {
+	b.Items = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewItems")
 		}
 		b.Items = append(b.Items, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/secretvolumesource.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/secretvolumesource.go
@@ -44,10 +44,25 @@ func (b *SecretVolumeSourceApplyConfiguration) WithSecretName(value string) *Sec
 // WithItems adds the given value to the Items field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Items field.
+// Deprecated: WithItems does not replace existing list for atomic list type. Use WithNewItems instead.
 func (b *SecretVolumeSourceApplyConfiguration) WithItems(values ...*KeyToPathApplyConfiguration) *SecretVolumeSourceApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithItems")
+		}
+		b.Items = append(b.Items, *values[i])
+	}
+	return b
+}
+
+// WithNewItems replaces the Items field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Items field is set to the values of the last call.
+func (b *SecretVolumeSourceApplyConfiguration) WithNewItems(values ...*KeyToPathApplyConfiguration) *SecretVolumeSourceApplyConfiguration {
+	b.Items = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewItems")
 		}
 		b.Items = append(b.Items, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/service.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/service.go
@@ -213,6 +213,7 @@ func (b *ServiceApplyConfiguration) WithAnnotations(entries map[string]string) *
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *ServiceApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *ServiceApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -224,14 +225,40 @@ func (b *ServiceApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerRefer
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *ServiceApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *ServiceApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *ServiceApplyConfiguration) WithFinalizers(values ...string) *ServiceApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *ServiceApplyConfiguration) WithNewFinalizers(values ...string) *ServiceApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/serviceaccount.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/serviceaccount.go
@@ -214,6 +214,7 @@ func (b *ServiceAccountApplyConfiguration) WithAnnotations(entries map[string]st
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *ServiceAccountApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *ServiceAccountApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -225,14 +226,40 @@ func (b *ServiceAccountApplyConfiguration) WithOwnerReferences(values ...*v1.Own
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *ServiceAccountApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *ServiceAccountApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *ServiceAccountApplyConfiguration) WithFinalizers(values ...string) *ServiceAccountApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *ServiceAccountApplyConfiguration) WithNewFinalizers(values ...string) *ServiceAccountApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 
@@ -245,6 +272,7 @@ func (b *ServiceAccountApplyConfiguration) ensureObjectMetaApplyConfigurationExi
 // WithSecrets adds the given value to the Secrets field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Secrets field.
+// Deprecated: WithSecrets does not replace existing list for atomic list type. Use WithNewSecrets instead.
 func (b *ServiceAccountApplyConfiguration) WithSecrets(values ...*ObjectReferenceApplyConfiguration) *ServiceAccountApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
@@ -255,13 +283,42 @@ func (b *ServiceAccountApplyConfiguration) WithSecrets(values ...*ObjectReferenc
 	return b
 }
 
+// WithNewSecrets replaces the Secrets field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Secrets field is set to the values of the last call.
+func (b *ServiceAccountApplyConfiguration) WithNewSecrets(values ...*ObjectReferenceApplyConfiguration) *ServiceAccountApplyConfiguration {
+	b.Secrets = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewSecrets")
+		}
+		b.Secrets = append(b.Secrets, *values[i])
+	}
+	return b
+}
+
 // WithImagePullSecrets adds the given value to the ImagePullSecrets field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the ImagePullSecrets field.
+// Deprecated: WithImagePullSecrets does not replace existing list for atomic list type. Use WithNewImagePullSecrets instead.
 func (b *ServiceAccountApplyConfiguration) WithImagePullSecrets(values ...*LocalObjectReferenceApplyConfiguration) *ServiceAccountApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithImagePullSecrets")
+		}
+		b.ImagePullSecrets = append(b.ImagePullSecrets, *values[i])
+	}
+	return b
+}
+
+// WithNewImagePullSecrets replaces the ImagePullSecrets field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the ImagePullSecrets field is set to the values of the last call.
+func (b *ServiceAccountApplyConfiguration) WithNewImagePullSecrets(values ...*LocalObjectReferenceApplyConfiguration) *ServiceAccountApplyConfiguration {
+	b.ImagePullSecrets = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewImagePullSecrets")
 		}
 		b.ImagePullSecrets = append(b.ImagePullSecrets, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/servicespec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/servicespec.go
@@ -69,10 +69,22 @@ func (b *ServiceSpecApplyConfiguration) WithPorts(values ...*ServicePortApplyCon
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, the entries provided by each call will be put on the Selector field,
 // overwriting an existing map entries in Selector field with the same key.
+// Deprecated: WithSelector does not replace existing map for atomic map type. Use WithNewSelector instead.
 func (b *ServiceSpecApplyConfiguration) WithSelector(entries map[string]string) *ServiceSpecApplyConfiguration {
 	if b.Selector == nil && len(entries) > 0 {
 		b.Selector = make(map[string]string, len(entries))
 	}
+	for k, v := range entries {
+		b.Selector[k] = v
+	}
+	return b
+}
+
+// WithNewSelector replaces the Selector field in the declarative configuration with given entries
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Selector field is set to the entries of the last call.
+func (b *ServiceSpecApplyConfiguration) WithNewSelector(entries map[string]string) *ServiceSpecApplyConfiguration {
+	b.Selector = make(map[string]string, len(entries))
 	for k, v := range entries {
 		b.Selector[k] = v
 	}
@@ -90,10 +102,20 @@ func (b *ServiceSpecApplyConfiguration) WithClusterIP(value string) *ServiceSpec
 // WithClusterIPs adds the given value to the ClusterIPs field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the ClusterIPs field.
+// Deprecated: WithClusterIPs does not replace existing list for atomic list type. Use WithNewClusterIPs instead.
 func (b *ServiceSpecApplyConfiguration) WithClusterIPs(values ...string) *ServiceSpecApplyConfiguration {
 	for i := range values {
 		b.ClusterIPs = append(b.ClusterIPs, values[i])
 	}
+	return b
+}
+
+// WithNewClusterIPs replaces the ClusterIPs field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the ClusterIPs field is set to the values of the last call.
+func (b *ServiceSpecApplyConfiguration) WithNewClusterIPs(values ...string) *ServiceSpecApplyConfiguration {
+	b.ClusterIPs = make([]string, len(values))
+	copy(b.ClusterIPs, values)
 	return b
 }
 
@@ -108,10 +130,20 @@ func (b *ServiceSpecApplyConfiguration) WithType(value corev1.ServiceType) *Serv
 // WithExternalIPs adds the given value to the ExternalIPs field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the ExternalIPs field.
+// Deprecated: WithExternalIPs does not replace existing list for atomic list type. Use WithNewExternalIPs instead.
 func (b *ServiceSpecApplyConfiguration) WithExternalIPs(values ...string) *ServiceSpecApplyConfiguration {
 	for i := range values {
 		b.ExternalIPs = append(b.ExternalIPs, values[i])
 	}
+	return b
+}
+
+// WithNewExternalIPs replaces the ExternalIPs field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the ExternalIPs field is set to the values of the last call.
+func (b *ServiceSpecApplyConfiguration) WithNewExternalIPs(values ...string) *ServiceSpecApplyConfiguration {
+	b.ExternalIPs = make([]string, len(values))
+	copy(b.ExternalIPs, values)
 	return b
 }
 
@@ -134,10 +166,20 @@ func (b *ServiceSpecApplyConfiguration) WithLoadBalancerIP(value string) *Servic
 // WithLoadBalancerSourceRanges adds the given value to the LoadBalancerSourceRanges field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the LoadBalancerSourceRanges field.
+// Deprecated: WithLoadBalancerSourceRanges does not replace existing list for atomic list type. Use WithNewLoadBalancerSourceRanges instead.
 func (b *ServiceSpecApplyConfiguration) WithLoadBalancerSourceRanges(values ...string) *ServiceSpecApplyConfiguration {
 	for i := range values {
 		b.LoadBalancerSourceRanges = append(b.LoadBalancerSourceRanges, values[i])
 	}
+	return b
+}
+
+// WithNewLoadBalancerSourceRanges replaces the LoadBalancerSourceRanges field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the LoadBalancerSourceRanges field is set to the values of the last call.
+func (b *ServiceSpecApplyConfiguration) WithNewLoadBalancerSourceRanges(values ...string) *ServiceSpecApplyConfiguration {
+	b.LoadBalancerSourceRanges = make([]string, len(values))
+	copy(b.LoadBalancerSourceRanges, values)
 	return b
 }
 
@@ -184,10 +226,20 @@ func (b *ServiceSpecApplyConfiguration) WithSessionAffinityConfig(value *Session
 // WithIPFamilies adds the given value to the IPFamilies field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the IPFamilies field.
+// Deprecated: WithIPFamilies does not replace existing list for atomic list type. Use WithNewIPFamilies instead.
 func (b *ServiceSpecApplyConfiguration) WithIPFamilies(values ...corev1.IPFamily) *ServiceSpecApplyConfiguration {
 	for i := range values {
 		b.IPFamilies = append(b.IPFamilies, values[i])
 	}
+	return b
+}
+
+// WithNewIPFamilies replaces the IPFamilies field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the IPFamilies field is set to the values of the last call.
+func (b *ServiceSpecApplyConfiguration) WithNewIPFamilies(values ...corev1.IPFamily) *ServiceSpecApplyConfiguration {
+	b.IPFamilies = make([]corev1.IPFamily, len(values))
+	copy(b.IPFamilies, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/topologyselectorlabelrequirement.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/topologyselectorlabelrequirement.go
@@ -42,9 +42,19 @@ func (b *TopologySelectorLabelRequirementApplyConfiguration) WithKey(value strin
 // WithValues adds the given value to the Values field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Values field.
+// Deprecated: WithValues does not replace existing list for atomic list type. Use WithNewValues instead.
 func (b *TopologySelectorLabelRequirementApplyConfiguration) WithValues(values ...string) *TopologySelectorLabelRequirementApplyConfiguration {
 	for i := range values {
 		b.Values = append(b.Values, values[i])
 	}
+	return b
+}
+
+// WithNewValues replaces the Values field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Values field is set to the values of the last call.
+func (b *TopologySelectorLabelRequirementApplyConfiguration) WithNewValues(values ...string) *TopologySelectorLabelRequirementApplyConfiguration {
+	b.Values = make([]string, len(values))
+	copy(b.Values, values)
 	return b
 }

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/topologyselectorterm.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/topologyselectorterm.go
@@ -33,10 +33,25 @@ func TopologySelectorTerm() *TopologySelectorTermApplyConfiguration {
 // WithMatchLabelExpressions adds the given value to the MatchLabelExpressions field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the MatchLabelExpressions field.
+// Deprecated: WithMatchLabelExpressions does not replace existing list for atomic list type. Use WithNewMatchLabelExpressions instead.
 func (b *TopologySelectorTermApplyConfiguration) WithMatchLabelExpressions(values ...*TopologySelectorLabelRequirementApplyConfiguration) *TopologySelectorTermApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithMatchLabelExpressions")
+		}
+		b.MatchLabelExpressions = append(b.MatchLabelExpressions, *values[i])
+	}
+	return b
+}
+
+// WithNewMatchLabelExpressions replaces the MatchLabelExpressions field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the MatchLabelExpressions field is set to the values of the last call.
+func (b *TopologySelectorTermApplyConfiguration) WithNewMatchLabelExpressions(values ...*TopologySelectorLabelRequirementApplyConfiguration) *TopologySelectorTermApplyConfiguration {
+	b.MatchLabelExpressions = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewMatchLabelExpressions")
 		}
 		b.MatchLabelExpressions = append(b.MatchLabelExpressions, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/topologyspreadconstraint.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/topologyspreadconstraint.go
@@ -101,9 +101,19 @@ func (b *TopologySpreadConstraintApplyConfiguration) WithNodeTaintsPolicy(value 
 // WithMatchLabelKeys adds the given value to the MatchLabelKeys field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the MatchLabelKeys field.
+// Deprecated: WithMatchLabelKeys does not replace existing list for atomic list type. Use WithNewMatchLabelKeys instead.
 func (b *TopologySpreadConstraintApplyConfiguration) WithMatchLabelKeys(values ...string) *TopologySpreadConstraintApplyConfiguration {
 	for i := range values {
 		b.MatchLabelKeys = append(b.MatchLabelKeys, values[i])
 	}
+	return b
+}
+
+// WithNewMatchLabelKeys replaces the MatchLabelKeys field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the MatchLabelKeys field is set to the values of the last call.
+func (b *TopologySpreadConstraintApplyConfiguration) WithNewMatchLabelKeys(values ...string) *TopologySpreadConstraintApplyConfiguration {
+	b.MatchLabelKeys = make([]string, len(values))
+	copy(b.MatchLabelKeys, values)
 	return b
 }

--- a/staging/src/k8s.io/client-go/applyconfigurations/discovery/v1/endpointhints.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/discovery/v1/endpointhints.go
@@ -33,10 +33,25 @@ func EndpointHints() *EndpointHintsApplyConfiguration {
 // WithForZones adds the given value to the ForZones field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the ForZones field.
+// Deprecated: WithForZones does not replace existing list for atomic list type. Use WithNewForZones instead.
 func (b *EndpointHintsApplyConfiguration) WithForZones(values ...*ForZoneApplyConfiguration) *EndpointHintsApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithForZones")
+		}
+		b.ForZones = append(b.ForZones, *values[i])
+	}
+	return b
+}
+
+// WithNewForZones replaces the ForZones field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the ForZones field is set to the values of the last call.
+func (b *EndpointHintsApplyConfiguration) WithNewForZones(values ...*ForZoneApplyConfiguration) *EndpointHintsApplyConfiguration {
+	b.ForZones = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewForZones")
 		}
 		b.ForZones = append(b.ForZones, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/discovery/v1/endpointslice.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/discovery/v1/endpointslice.go
@@ -214,6 +214,7 @@ func (b *EndpointSliceApplyConfiguration) WithAnnotations(entries map[string]str
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *EndpointSliceApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *EndpointSliceApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -225,14 +226,40 @@ func (b *EndpointSliceApplyConfiguration) WithOwnerReferences(values ...*v1.Owne
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *EndpointSliceApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *EndpointSliceApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *EndpointSliceApplyConfiguration) WithFinalizers(values ...string) *EndpointSliceApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *EndpointSliceApplyConfiguration) WithNewFinalizers(values ...string) *EndpointSliceApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 
@@ -253,6 +280,7 @@ func (b *EndpointSliceApplyConfiguration) WithAddressType(value discoveryv1.Addr
 // WithEndpoints adds the given value to the Endpoints field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Endpoints field.
+// Deprecated: WithEndpoints does not replace existing list for atomic list type. Use WithNewEndpoints instead.
 func (b *EndpointSliceApplyConfiguration) WithEndpoints(values ...*EndpointApplyConfiguration) *EndpointSliceApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
@@ -263,13 +291,42 @@ func (b *EndpointSliceApplyConfiguration) WithEndpoints(values ...*EndpointApply
 	return b
 }
 
+// WithNewEndpoints replaces the Endpoints field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Endpoints field is set to the values of the last call.
+func (b *EndpointSliceApplyConfiguration) WithNewEndpoints(values ...*EndpointApplyConfiguration) *EndpointSliceApplyConfiguration {
+	b.Endpoints = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewEndpoints")
+		}
+		b.Endpoints = append(b.Endpoints, *values[i])
+	}
+	return b
+}
+
 // WithPorts adds the given value to the Ports field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Ports field.
+// Deprecated: WithPorts does not replace existing list for atomic list type. Use WithNewPorts instead.
 func (b *EndpointSliceApplyConfiguration) WithPorts(values ...*EndpointPortApplyConfiguration) *EndpointSliceApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithPorts")
+		}
+		b.Ports = append(b.Ports, *values[i])
+	}
+	return b
+}
+
+// WithNewPorts replaces the Ports field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Ports field is set to the values of the last call.
+func (b *EndpointSliceApplyConfiguration) WithNewPorts(values ...*EndpointPortApplyConfiguration) *EndpointSliceApplyConfiguration {
+	b.Ports = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewPorts")
 		}
 		b.Ports = append(b.Ports, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/discovery/v1beta1/endpointhints.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/discovery/v1beta1/endpointhints.go
@@ -33,10 +33,25 @@ func EndpointHints() *EndpointHintsApplyConfiguration {
 // WithForZones adds the given value to the ForZones field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the ForZones field.
+// Deprecated: WithForZones does not replace existing list for atomic list type. Use WithNewForZones instead.
 func (b *EndpointHintsApplyConfiguration) WithForZones(values ...*ForZoneApplyConfiguration) *EndpointHintsApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithForZones")
+		}
+		b.ForZones = append(b.ForZones, *values[i])
+	}
+	return b
+}
+
+// WithNewForZones replaces the ForZones field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the ForZones field is set to the values of the last call.
+func (b *EndpointHintsApplyConfiguration) WithNewForZones(values ...*ForZoneApplyConfiguration) *EndpointHintsApplyConfiguration {
+	b.ForZones = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewForZones")
 		}
 		b.ForZones = append(b.ForZones, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/discovery/v1beta1/endpointslice.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/discovery/v1beta1/endpointslice.go
@@ -214,6 +214,7 @@ func (b *EndpointSliceApplyConfiguration) WithAnnotations(entries map[string]str
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *EndpointSliceApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *EndpointSliceApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -225,14 +226,40 @@ func (b *EndpointSliceApplyConfiguration) WithOwnerReferences(values ...*v1.Owne
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *EndpointSliceApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *EndpointSliceApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *EndpointSliceApplyConfiguration) WithFinalizers(values ...string) *EndpointSliceApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *EndpointSliceApplyConfiguration) WithNewFinalizers(values ...string) *EndpointSliceApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 
@@ -253,6 +280,7 @@ func (b *EndpointSliceApplyConfiguration) WithAddressType(value v1beta1.AddressT
 // WithEndpoints adds the given value to the Endpoints field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Endpoints field.
+// Deprecated: WithEndpoints does not replace existing list for atomic list type. Use WithNewEndpoints instead.
 func (b *EndpointSliceApplyConfiguration) WithEndpoints(values ...*EndpointApplyConfiguration) *EndpointSliceApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
@@ -263,13 +291,42 @@ func (b *EndpointSliceApplyConfiguration) WithEndpoints(values ...*EndpointApply
 	return b
 }
 
+// WithNewEndpoints replaces the Endpoints field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Endpoints field is set to the values of the last call.
+func (b *EndpointSliceApplyConfiguration) WithNewEndpoints(values ...*EndpointApplyConfiguration) *EndpointSliceApplyConfiguration {
+	b.Endpoints = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewEndpoints")
+		}
+		b.Endpoints = append(b.Endpoints, *values[i])
+	}
+	return b
+}
+
 // WithPorts adds the given value to the Ports field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Ports field.
+// Deprecated: WithPorts does not replace existing list for atomic list type. Use WithNewPorts instead.
 func (b *EndpointSliceApplyConfiguration) WithPorts(values ...*EndpointPortApplyConfiguration) *EndpointSliceApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithPorts")
+		}
+		b.Ports = append(b.Ports, *values[i])
+	}
+	return b
+}
+
+// WithNewPorts replaces the Ports field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Ports field is set to the values of the last call.
+func (b *EndpointSliceApplyConfiguration) WithNewPorts(values ...*EndpointPortApplyConfiguration) *EndpointSliceApplyConfiguration {
+	b.Ports = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewPorts")
 		}
 		b.Ports = append(b.Ports, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/events/v1/event.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/events/v1/event.go
@@ -226,6 +226,7 @@ func (b *EventApplyConfiguration) WithAnnotations(entries map[string]string) *Ev
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *EventApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *EventApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -237,14 +238,40 @@ func (b *EventApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferen
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *EventApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *EventApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *EventApplyConfiguration) WithFinalizers(values ...string) *EventApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *EventApplyConfiguration) WithNewFinalizers(values ...string) *EventApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/events/v1beta1/event.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/events/v1beta1/event.go
@@ -226,6 +226,7 @@ func (b *EventApplyConfiguration) WithAnnotations(entries map[string]string) *Ev
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *EventApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *EventApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -237,14 +238,40 @@ func (b *EventApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferen
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *EventApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *EventApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *EventApplyConfiguration) WithFinalizers(values ...string) *EventApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *EventApplyConfiguration) WithNewFinalizers(values ...string) *EventApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/daemonset.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/daemonset.go
@@ -213,6 +213,7 @@ func (b *DaemonSetApplyConfiguration) WithAnnotations(entries map[string]string)
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *DaemonSetApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *DaemonSetApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -224,14 +225,40 @@ func (b *DaemonSetApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerRef
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *DaemonSetApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *DaemonSetApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *DaemonSetApplyConfiguration) WithFinalizers(values ...string) *DaemonSetApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *DaemonSetApplyConfiguration) WithNewFinalizers(values ...string) *DaemonSetApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/daemonsetstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/daemonsetstatus.go
@@ -114,10 +114,25 @@ func (b *DaemonSetStatusApplyConfiguration) WithCollisionCount(value int32) *Dae
 // WithConditions adds the given value to the Conditions field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Conditions field.
+// Deprecated: WithConditions does not replace existing list for atomic list type. Use WithNewConditions instead.
 func (b *DaemonSetStatusApplyConfiguration) WithConditions(values ...*DaemonSetConditionApplyConfiguration) *DaemonSetStatusApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithConditions")
+		}
+		b.Conditions = append(b.Conditions, *values[i])
+	}
+	return b
+}
+
+// WithNewConditions replaces the Conditions field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Conditions field is set to the values of the last call.
+func (b *DaemonSetStatusApplyConfiguration) WithNewConditions(values ...*DaemonSetConditionApplyConfiguration) *DaemonSetStatusApplyConfiguration {
+	b.Conditions = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewConditions")
 		}
 		b.Conditions = append(b.Conditions, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/deployment.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/deployment.go
@@ -213,6 +213,7 @@ func (b *DeploymentApplyConfiguration) WithAnnotations(entries map[string]string
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *DeploymentApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *DeploymentApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -224,14 +225,40 @@ func (b *DeploymentApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerRe
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *DeploymentApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *DeploymentApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *DeploymentApplyConfiguration) WithFinalizers(values ...string) *DeploymentApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *DeploymentApplyConfiguration) WithNewFinalizers(values ...string) *DeploymentApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/deploymentstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/deploymentstatus.go
@@ -88,10 +88,25 @@ func (b *DeploymentStatusApplyConfiguration) WithUnavailableReplicas(value int32
 // WithConditions adds the given value to the Conditions field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Conditions field.
+// Deprecated: WithConditions does not replace existing list for atomic list type. Use WithNewConditions instead.
 func (b *DeploymentStatusApplyConfiguration) WithConditions(values ...*DeploymentConditionApplyConfiguration) *DeploymentStatusApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithConditions")
+		}
+		b.Conditions = append(b.Conditions, *values[i])
+	}
+	return b
+}
+
+// WithNewConditions replaces the Conditions field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Conditions field is set to the values of the last call.
+func (b *DeploymentStatusApplyConfiguration) WithNewConditions(values ...*DeploymentConditionApplyConfiguration) *DeploymentStatusApplyConfiguration {
+	b.Conditions = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewConditions")
 		}
 		b.Conditions = append(b.Conditions, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/httpingressrulevalue.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/httpingressrulevalue.go
@@ -33,10 +33,25 @@ func HTTPIngressRuleValue() *HTTPIngressRuleValueApplyConfiguration {
 // WithPaths adds the given value to the Paths field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Paths field.
+// Deprecated: WithPaths does not replace existing list for atomic list type. Use WithNewPaths instead.
 func (b *HTTPIngressRuleValueApplyConfiguration) WithPaths(values ...*HTTPIngressPathApplyConfiguration) *HTTPIngressRuleValueApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithPaths")
+		}
+		b.Paths = append(b.Paths, *values[i])
+	}
+	return b
+}
+
+// WithNewPaths replaces the Paths field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Paths field is set to the values of the last call.
+func (b *HTTPIngressRuleValueApplyConfiguration) WithNewPaths(values ...*HTTPIngressPathApplyConfiguration) *HTTPIngressRuleValueApplyConfiguration {
+	b.Paths = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewPaths")
 		}
 		b.Paths = append(b.Paths, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/ingress.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/ingress.go
@@ -213,6 +213,7 @@ func (b *IngressApplyConfiguration) WithAnnotations(entries map[string]string) *
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *IngressApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *IngressApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -224,14 +225,40 @@ func (b *IngressApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerRefer
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *IngressApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *IngressApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *IngressApplyConfiguration) WithFinalizers(values ...string) *IngressApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *IngressApplyConfiguration) WithNewFinalizers(values ...string) *IngressApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/ingressloadbalanceringress.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/ingressloadbalanceringress.go
@@ -51,10 +51,25 @@ func (b *IngressLoadBalancerIngressApplyConfiguration) WithHostname(value string
 // WithPorts adds the given value to the Ports field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Ports field.
+// Deprecated: WithPorts does not replace existing list for atomic list type. Use WithNewPorts instead.
 func (b *IngressLoadBalancerIngressApplyConfiguration) WithPorts(values ...*IngressPortStatusApplyConfiguration) *IngressLoadBalancerIngressApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithPorts")
+		}
+		b.Ports = append(b.Ports, *values[i])
+	}
+	return b
+}
+
+// WithNewPorts replaces the Ports field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Ports field is set to the values of the last call.
+func (b *IngressLoadBalancerIngressApplyConfiguration) WithNewPorts(values ...*IngressPortStatusApplyConfiguration) *IngressLoadBalancerIngressApplyConfiguration {
+	b.Ports = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewPorts")
 		}
 		b.Ports = append(b.Ports, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/ingressloadbalancerstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/ingressloadbalancerstatus.go
@@ -33,10 +33,25 @@ func IngressLoadBalancerStatus() *IngressLoadBalancerStatusApplyConfiguration {
 // WithIngress adds the given value to the Ingress field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Ingress field.
+// Deprecated: WithIngress does not replace existing list for atomic list type. Use WithNewIngress instead.
 func (b *IngressLoadBalancerStatusApplyConfiguration) WithIngress(values ...*IngressLoadBalancerIngressApplyConfiguration) *IngressLoadBalancerStatusApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithIngress")
+		}
+		b.Ingress = append(b.Ingress, *values[i])
+	}
+	return b
+}
+
+// WithNewIngress replaces the Ingress field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Ingress field is set to the values of the last call.
+func (b *IngressLoadBalancerStatusApplyConfiguration) WithNewIngress(values ...*IngressLoadBalancerIngressApplyConfiguration) *IngressLoadBalancerStatusApplyConfiguration {
+	b.Ingress = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewIngress")
 		}
 		b.Ingress = append(b.Ingress, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/ingressspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/ingressspec.go
@@ -52,6 +52,7 @@ func (b *IngressSpecApplyConfiguration) WithBackend(value *IngressBackendApplyCo
 // WithTLS adds the given value to the TLS field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the TLS field.
+// Deprecated: WithTLS does not replace existing list for atomic list type. Use WithNewTLS instead.
 func (b *IngressSpecApplyConfiguration) WithTLS(values ...*IngressTLSApplyConfiguration) *IngressSpecApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
@@ -62,13 +63,42 @@ func (b *IngressSpecApplyConfiguration) WithTLS(values ...*IngressTLSApplyConfig
 	return b
 }
 
+// WithNewTLS replaces the TLS field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the TLS field is set to the values of the last call.
+func (b *IngressSpecApplyConfiguration) WithNewTLS(values ...*IngressTLSApplyConfiguration) *IngressSpecApplyConfiguration {
+	b.TLS = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewTLS")
+		}
+		b.TLS = append(b.TLS, *values[i])
+	}
+	return b
+}
+
 // WithRules adds the given value to the Rules field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Rules field.
+// Deprecated: WithRules does not replace existing list for atomic list type. Use WithNewRules instead.
 func (b *IngressSpecApplyConfiguration) WithRules(values ...*IngressRuleApplyConfiguration) *IngressSpecApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithRules")
+		}
+		b.Rules = append(b.Rules, *values[i])
+	}
+	return b
+}
+
+// WithNewRules replaces the Rules field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Rules field is set to the values of the last call.
+func (b *IngressSpecApplyConfiguration) WithNewRules(values ...*IngressRuleApplyConfiguration) *IngressSpecApplyConfiguration {
+	b.Rules = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewRules")
 		}
 		b.Rules = append(b.Rules, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/ingresstls.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/ingresstls.go
@@ -34,10 +34,20 @@ func IngressTLS() *IngressTLSApplyConfiguration {
 // WithHosts adds the given value to the Hosts field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Hosts field.
+// Deprecated: WithHosts does not replace existing list for atomic list type. Use WithNewHosts instead.
 func (b *IngressTLSApplyConfiguration) WithHosts(values ...string) *IngressTLSApplyConfiguration {
 	for i := range values {
 		b.Hosts = append(b.Hosts, values[i])
 	}
+	return b
+}
+
+// WithNewHosts replaces the Hosts field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Hosts field is set to the values of the last call.
+func (b *IngressTLSApplyConfiguration) WithNewHosts(values ...string) *IngressTLSApplyConfiguration {
+	b.Hosts = make([]string, len(values))
+	copy(b.Hosts, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/ipblock.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/ipblock.go
@@ -42,9 +42,19 @@ func (b *IPBlockApplyConfiguration) WithCIDR(value string) *IPBlockApplyConfigur
 // WithExcept adds the given value to the Except field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Except field.
+// Deprecated: WithExcept does not replace existing list for atomic list type. Use WithNewExcept instead.
 func (b *IPBlockApplyConfiguration) WithExcept(values ...string) *IPBlockApplyConfiguration {
 	for i := range values {
 		b.Except = append(b.Except, values[i])
 	}
+	return b
+}
+
+// WithNewExcept replaces the Except field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Except field is set to the values of the last call.
+func (b *IPBlockApplyConfiguration) WithNewExcept(values ...string) *IPBlockApplyConfiguration {
+	b.Except = make([]string, len(values))
+	copy(b.Except, values)
 	return b
 }

--- a/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/networkpolicy.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/networkpolicy.go
@@ -212,6 +212,7 @@ func (b *NetworkPolicyApplyConfiguration) WithAnnotations(entries map[string]str
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *NetworkPolicyApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *NetworkPolicyApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -223,14 +224,40 @@ func (b *NetworkPolicyApplyConfiguration) WithOwnerReferences(values ...*v1.Owne
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *NetworkPolicyApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *NetworkPolicyApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *NetworkPolicyApplyConfiguration) WithFinalizers(values ...string) *NetworkPolicyApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *NetworkPolicyApplyConfiguration) WithNewFinalizers(values ...string) *NetworkPolicyApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/networkpolicyegressrule.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/networkpolicyegressrule.go
@@ -34,6 +34,7 @@ func NetworkPolicyEgressRule() *NetworkPolicyEgressRuleApplyConfiguration {
 // WithPorts adds the given value to the Ports field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Ports field.
+// Deprecated: WithPorts does not replace existing list for atomic list type. Use WithNewPorts instead.
 func (b *NetworkPolicyEgressRuleApplyConfiguration) WithPorts(values ...*NetworkPolicyPortApplyConfiguration) *NetworkPolicyEgressRuleApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
@@ -44,13 +45,42 @@ func (b *NetworkPolicyEgressRuleApplyConfiguration) WithPorts(values ...*Network
 	return b
 }
 
+// WithNewPorts replaces the Ports field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Ports field is set to the values of the last call.
+func (b *NetworkPolicyEgressRuleApplyConfiguration) WithNewPorts(values ...*NetworkPolicyPortApplyConfiguration) *NetworkPolicyEgressRuleApplyConfiguration {
+	b.Ports = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewPorts")
+		}
+		b.Ports = append(b.Ports, *values[i])
+	}
+	return b
+}
+
 // WithTo adds the given value to the To field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the To field.
+// Deprecated: WithTo does not replace existing list for atomic list type. Use WithNewTo instead.
 func (b *NetworkPolicyEgressRuleApplyConfiguration) WithTo(values ...*NetworkPolicyPeerApplyConfiguration) *NetworkPolicyEgressRuleApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithTo")
+		}
+		b.To = append(b.To, *values[i])
+	}
+	return b
+}
+
+// WithNewTo replaces the To field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the To field is set to the values of the last call.
+func (b *NetworkPolicyEgressRuleApplyConfiguration) WithNewTo(values ...*NetworkPolicyPeerApplyConfiguration) *NetworkPolicyEgressRuleApplyConfiguration {
+	b.To = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewTo")
 		}
 		b.To = append(b.To, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/networkpolicyingressrule.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/networkpolicyingressrule.go
@@ -34,6 +34,7 @@ func NetworkPolicyIngressRule() *NetworkPolicyIngressRuleApplyConfiguration {
 // WithPorts adds the given value to the Ports field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Ports field.
+// Deprecated: WithPorts does not replace existing list for atomic list type. Use WithNewPorts instead.
 func (b *NetworkPolicyIngressRuleApplyConfiguration) WithPorts(values ...*NetworkPolicyPortApplyConfiguration) *NetworkPolicyIngressRuleApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
@@ -44,13 +45,42 @@ func (b *NetworkPolicyIngressRuleApplyConfiguration) WithPorts(values ...*Networ
 	return b
 }
 
+// WithNewPorts replaces the Ports field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Ports field is set to the values of the last call.
+func (b *NetworkPolicyIngressRuleApplyConfiguration) WithNewPorts(values ...*NetworkPolicyPortApplyConfiguration) *NetworkPolicyIngressRuleApplyConfiguration {
+	b.Ports = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewPorts")
+		}
+		b.Ports = append(b.Ports, *values[i])
+	}
+	return b
+}
+
 // WithFrom adds the given value to the From field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the From field.
+// Deprecated: WithFrom does not replace existing list for atomic list type. Use WithNewFrom instead.
 func (b *NetworkPolicyIngressRuleApplyConfiguration) WithFrom(values ...*NetworkPolicyPeerApplyConfiguration) *NetworkPolicyIngressRuleApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithFrom")
+		}
+		b.From = append(b.From, *values[i])
+	}
+	return b
+}
+
+// WithNewFrom replaces the From field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the From field is set to the values of the last call.
+func (b *NetworkPolicyIngressRuleApplyConfiguration) WithNewFrom(values ...*NetworkPolicyPeerApplyConfiguration) *NetworkPolicyIngressRuleApplyConfiguration {
+	b.From = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewFrom")
 		}
 		b.From = append(b.From, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/networkpolicyspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/networkpolicyspec.go
@@ -49,6 +49,7 @@ func (b *NetworkPolicySpecApplyConfiguration) WithPodSelector(value *v1.LabelSel
 // WithIngress adds the given value to the Ingress field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Ingress field.
+// Deprecated: WithIngress does not replace existing list for atomic list type. Use WithNewIngress instead.
 func (b *NetworkPolicySpecApplyConfiguration) WithIngress(values ...*NetworkPolicyIngressRuleApplyConfiguration) *NetworkPolicySpecApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
@@ -59,9 +60,24 @@ func (b *NetworkPolicySpecApplyConfiguration) WithIngress(values ...*NetworkPoli
 	return b
 }
 
+// WithNewIngress replaces the Ingress field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Ingress field is set to the values of the last call.
+func (b *NetworkPolicySpecApplyConfiguration) WithNewIngress(values ...*NetworkPolicyIngressRuleApplyConfiguration) *NetworkPolicySpecApplyConfiguration {
+	b.Ingress = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewIngress")
+		}
+		b.Ingress = append(b.Ingress, *values[i])
+	}
+	return b
+}
+
 // WithEgress adds the given value to the Egress field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Egress field.
+// Deprecated: WithEgress does not replace existing list for atomic list type. Use WithNewEgress instead.
 func (b *NetworkPolicySpecApplyConfiguration) WithEgress(values ...*NetworkPolicyEgressRuleApplyConfiguration) *NetworkPolicySpecApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
@@ -72,12 +88,36 @@ func (b *NetworkPolicySpecApplyConfiguration) WithEgress(values ...*NetworkPolic
 	return b
 }
 
+// WithNewEgress replaces the Egress field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Egress field is set to the values of the last call.
+func (b *NetworkPolicySpecApplyConfiguration) WithNewEgress(values ...*NetworkPolicyEgressRuleApplyConfiguration) *NetworkPolicySpecApplyConfiguration {
+	b.Egress = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewEgress")
+		}
+		b.Egress = append(b.Egress, *values[i])
+	}
+	return b
+}
+
 // WithPolicyTypes adds the given value to the PolicyTypes field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the PolicyTypes field.
+// Deprecated: WithPolicyTypes does not replace existing list for atomic list type. Use WithNewPolicyTypes instead.
 func (b *NetworkPolicySpecApplyConfiguration) WithPolicyTypes(values ...extensionsv1beta1.PolicyType) *NetworkPolicySpecApplyConfiguration {
 	for i := range values {
 		b.PolicyTypes = append(b.PolicyTypes, values[i])
 	}
+	return b
+}
+
+// WithNewPolicyTypes replaces the PolicyTypes field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the PolicyTypes field is set to the values of the last call.
+func (b *NetworkPolicySpecApplyConfiguration) WithNewPolicyTypes(values ...extensionsv1beta1.PolicyType) *NetworkPolicySpecApplyConfiguration {
+	b.PolicyTypes = make([]extensionsv1beta1.PolicyType, len(values))
+	copy(b.PolicyTypes, values)
 	return b
 }

--- a/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/replicaset.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/replicaset.go
@@ -213,6 +213,7 @@ func (b *ReplicaSetApplyConfiguration) WithAnnotations(entries map[string]string
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *ReplicaSetApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *ReplicaSetApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -224,14 +225,40 @@ func (b *ReplicaSetApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerRe
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *ReplicaSetApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *ReplicaSetApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *ReplicaSetApplyConfiguration) WithFinalizers(values ...string) *ReplicaSetApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *ReplicaSetApplyConfiguration) WithNewFinalizers(values ...string) *ReplicaSetApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/replicasetstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/replicasetstatus.go
@@ -78,10 +78,25 @@ func (b *ReplicaSetStatusApplyConfiguration) WithObservedGeneration(value int64)
 // WithConditions adds the given value to the Conditions field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Conditions field.
+// Deprecated: WithConditions does not replace existing list for atomic list type. Use WithNewConditions instead.
 func (b *ReplicaSetStatusApplyConfiguration) WithConditions(values ...*ReplicaSetConditionApplyConfiguration) *ReplicaSetStatusApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithConditions")
+		}
+		b.Conditions = append(b.Conditions, *values[i])
+	}
+	return b
+}
+
+// WithNewConditions replaces the Conditions field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Conditions field is set to the values of the last call.
+func (b *ReplicaSetStatusApplyConfiguration) WithNewConditions(values ...*ReplicaSetConditionApplyConfiguration) *ReplicaSetStatusApplyConfiguration {
+	b.Conditions = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewConditions")
 		}
 		b.Conditions = append(b.Conditions, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/scale.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/scale.go
@@ -173,6 +173,7 @@ func (b *ScaleApplyConfiguration) WithAnnotations(entries map[string]string) *Sc
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *ScaleApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *ScaleApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -184,14 +185,40 @@ func (b *ScaleApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferen
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *ScaleApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *ScaleApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *ScaleApplyConfiguration) WithFinalizers(values ...string) *ScaleApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *ScaleApplyConfiguration) WithNewFinalizers(values ...string) *ScaleApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta1/flowschema.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta1/flowschema.go
@@ -211,6 +211,7 @@ func (b *FlowSchemaApplyConfiguration) WithAnnotations(entries map[string]string
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *FlowSchemaApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *FlowSchemaApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -222,14 +223,40 @@ func (b *FlowSchemaApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerRe
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *FlowSchemaApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *FlowSchemaApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *FlowSchemaApplyConfiguration) WithFinalizers(values ...string) *FlowSchemaApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *FlowSchemaApplyConfiguration) WithNewFinalizers(values ...string) *FlowSchemaApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta1/flowschemaspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta1/flowschemaspec.go
@@ -60,10 +60,25 @@ func (b *FlowSchemaSpecApplyConfiguration) WithDistinguisherMethod(value *FlowDi
 // WithRules adds the given value to the Rules field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Rules field.
+// Deprecated: WithRules does not replace existing list for atomic list type. Use WithNewRules instead.
 func (b *FlowSchemaSpecApplyConfiguration) WithRules(values ...*PolicyRulesWithSubjectsApplyConfiguration) *FlowSchemaSpecApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithRules")
+		}
+		b.Rules = append(b.Rules, *values[i])
+	}
+	return b
+}
+
+// WithNewRules replaces the Rules field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Rules field is set to the values of the last call.
+func (b *FlowSchemaSpecApplyConfiguration) WithNewRules(values ...*PolicyRulesWithSubjectsApplyConfiguration) *FlowSchemaSpecApplyConfiguration {
+	b.Rules = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewRules")
 		}
 		b.Rules = append(b.Rules, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta1/policyruleswithsubjects.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta1/policyruleswithsubjects.go
@@ -35,6 +35,7 @@ func PolicyRulesWithSubjects() *PolicyRulesWithSubjectsApplyConfiguration {
 // WithSubjects adds the given value to the Subjects field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Subjects field.
+// Deprecated: WithSubjects does not replace existing list for atomic list type. Use WithNewSubjects instead.
 func (b *PolicyRulesWithSubjectsApplyConfiguration) WithSubjects(values ...*SubjectApplyConfiguration) *PolicyRulesWithSubjectsApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
@@ -45,9 +46,24 @@ func (b *PolicyRulesWithSubjectsApplyConfiguration) WithSubjects(values ...*Subj
 	return b
 }
 
+// WithNewSubjects replaces the Subjects field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Subjects field is set to the values of the last call.
+func (b *PolicyRulesWithSubjectsApplyConfiguration) WithNewSubjects(values ...*SubjectApplyConfiguration) *PolicyRulesWithSubjectsApplyConfiguration {
+	b.Subjects = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewSubjects")
+		}
+		b.Subjects = append(b.Subjects, *values[i])
+	}
+	return b
+}
+
 // WithResourceRules adds the given value to the ResourceRules field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the ResourceRules field.
+// Deprecated: WithResourceRules does not replace existing list for atomic list type. Use WithNewResourceRules instead.
 func (b *PolicyRulesWithSubjectsApplyConfiguration) WithResourceRules(values ...*ResourcePolicyRuleApplyConfiguration) *PolicyRulesWithSubjectsApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
@@ -58,13 +74,42 @@ func (b *PolicyRulesWithSubjectsApplyConfiguration) WithResourceRules(values ...
 	return b
 }
 
+// WithNewResourceRules replaces the ResourceRules field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the ResourceRules field is set to the values of the last call.
+func (b *PolicyRulesWithSubjectsApplyConfiguration) WithNewResourceRules(values ...*ResourcePolicyRuleApplyConfiguration) *PolicyRulesWithSubjectsApplyConfiguration {
+	b.ResourceRules = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewResourceRules")
+		}
+		b.ResourceRules = append(b.ResourceRules, *values[i])
+	}
+	return b
+}
+
 // WithNonResourceRules adds the given value to the NonResourceRules field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the NonResourceRules field.
+// Deprecated: WithNonResourceRules does not replace existing list for atomic list type. Use WithNewNonResourceRules instead.
 func (b *PolicyRulesWithSubjectsApplyConfiguration) WithNonResourceRules(values ...*NonResourcePolicyRuleApplyConfiguration) *PolicyRulesWithSubjectsApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithNonResourceRules")
+		}
+		b.NonResourceRules = append(b.NonResourceRules, *values[i])
+	}
+	return b
+}
+
+// WithNewNonResourceRules replaces the NonResourceRules field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the NonResourceRules field is set to the values of the last call.
+func (b *PolicyRulesWithSubjectsApplyConfiguration) WithNewNonResourceRules(values ...*NonResourcePolicyRuleApplyConfiguration) *PolicyRulesWithSubjectsApplyConfiguration {
+	b.NonResourceRules = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewNonResourceRules")
 		}
 		b.NonResourceRules = append(b.NonResourceRules, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta1/prioritylevelconfiguration.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta1/prioritylevelconfiguration.go
@@ -211,6 +211,7 @@ func (b *PriorityLevelConfigurationApplyConfiguration) WithAnnotations(entries m
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *PriorityLevelConfigurationApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *PriorityLevelConfigurationApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -222,14 +223,40 @@ func (b *PriorityLevelConfigurationApplyConfiguration) WithOwnerReferences(value
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *PriorityLevelConfigurationApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *PriorityLevelConfigurationApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *PriorityLevelConfigurationApplyConfiguration) WithFinalizers(values ...string) *PriorityLevelConfigurationApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *PriorityLevelConfigurationApplyConfiguration) WithNewFinalizers(values ...string) *PriorityLevelConfigurationApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta2/flowschema.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta2/flowschema.go
@@ -211,6 +211,7 @@ func (b *FlowSchemaApplyConfiguration) WithAnnotations(entries map[string]string
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *FlowSchemaApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *FlowSchemaApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -222,14 +223,40 @@ func (b *FlowSchemaApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerRe
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *FlowSchemaApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *FlowSchemaApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *FlowSchemaApplyConfiguration) WithFinalizers(values ...string) *FlowSchemaApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *FlowSchemaApplyConfiguration) WithNewFinalizers(values ...string) *FlowSchemaApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta2/flowschemaspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta2/flowschemaspec.go
@@ -60,10 +60,25 @@ func (b *FlowSchemaSpecApplyConfiguration) WithDistinguisherMethod(value *FlowDi
 // WithRules adds the given value to the Rules field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Rules field.
+// Deprecated: WithRules does not replace existing list for atomic list type. Use WithNewRules instead.
 func (b *FlowSchemaSpecApplyConfiguration) WithRules(values ...*PolicyRulesWithSubjectsApplyConfiguration) *FlowSchemaSpecApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithRules")
+		}
+		b.Rules = append(b.Rules, *values[i])
+	}
+	return b
+}
+
+// WithNewRules replaces the Rules field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Rules field is set to the values of the last call.
+func (b *FlowSchemaSpecApplyConfiguration) WithNewRules(values ...*PolicyRulesWithSubjectsApplyConfiguration) *FlowSchemaSpecApplyConfiguration {
+	b.Rules = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewRules")
 		}
 		b.Rules = append(b.Rules, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta2/policyruleswithsubjects.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta2/policyruleswithsubjects.go
@@ -35,6 +35,7 @@ func PolicyRulesWithSubjects() *PolicyRulesWithSubjectsApplyConfiguration {
 // WithSubjects adds the given value to the Subjects field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Subjects field.
+// Deprecated: WithSubjects does not replace existing list for atomic list type. Use WithNewSubjects instead.
 func (b *PolicyRulesWithSubjectsApplyConfiguration) WithSubjects(values ...*SubjectApplyConfiguration) *PolicyRulesWithSubjectsApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
@@ -45,9 +46,24 @@ func (b *PolicyRulesWithSubjectsApplyConfiguration) WithSubjects(values ...*Subj
 	return b
 }
 
+// WithNewSubjects replaces the Subjects field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Subjects field is set to the values of the last call.
+func (b *PolicyRulesWithSubjectsApplyConfiguration) WithNewSubjects(values ...*SubjectApplyConfiguration) *PolicyRulesWithSubjectsApplyConfiguration {
+	b.Subjects = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewSubjects")
+		}
+		b.Subjects = append(b.Subjects, *values[i])
+	}
+	return b
+}
+
 // WithResourceRules adds the given value to the ResourceRules field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the ResourceRules field.
+// Deprecated: WithResourceRules does not replace existing list for atomic list type. Use WithNewResourceRules instead.
 func (b *PolicyRulesWithSubjectsApplyConfiguration) WithResourceRules(values ...*ResourcePolicyRuleApplyConfiguration) *PolicyRulesWithSubjectsApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
@@ -58,13 +74,42 @@ func (b *PolicyRulesWithSubjectsApplyConfiguration) WithResourceRules(values ...
 	return b
 }
 
+// WithNewResourceRules replaces the ResourceRules field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the ResourceRules field is set to the values of the last call.
+func (b *PolicyRulesWithSubjectsApplyConfiguration) WithNewResourceRules(values ...*ResourcePolicyRuleApplyConfiguration) *PolicyRulesWithSubjectsApplyConfiguration {
+	b.ResourceRules = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewResourceRules")
+		}
+		b.ResourceRules = append(b.ResourceRules, *values[i])
+	}
+	return b
+}
+
 // WithNonResourceRules adds the given value to the NonResourceRules field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the NonResourceRules field.
+// Deprecated: WithNonResourceRules does not replace existing list for atomic list type. Use WithNewNonResourceRules instead.
 func (b *PolicyRulesWithSubjectsApplyConfiguration) WithNonResourceRules(values ...*NonResourcePolicyRuleApplyConfiguration) *PolicyRulesWithSubjectsApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithNonResourceRules")
+		}
+		b.NonResourceRules = append(b.NonResourceRules, *values[i])
+	}
+	return b
+}
+
+// WithNewNonResourceRules replaces the NonResourceRules field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the NonResourceRules field is set to the values of the last call.
+func (b *PolicyRulesWithSubjectsApplyConfiguration) WithNewNonResourceRules(values ...*NonResourcePolicyRuleApplyConfiguration) *PolicyRulesWithSubjectsApplyConfiguration {
+	b.NonResourceRules = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewNonResourceRules")
 		}
 		b.NonResourceRules = append(b.NonResourceRules, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta2/prioritylevelconfiguration.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta2/prioritylevelconfiguration.go
@@ -211,6 +211,7 @@ func (b *PriorityLevelConfigurationApplyConfiguration) WithAnnotations(entries m
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *PriorityLevelConfigurationApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *PriorityLevelConfigurationApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -222,14 +223,40 @@ func (b *PriorityLevelConfigurationApplyConfiguration) WithOwnerReferences(value
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *PriorityLevelConfigurationApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *PriorityLevelConfigurationApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *PriorityLevelConfigurationApplyConfiguration) WithFinalizers(values ...string) *PriorityLevelConfigurationApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *PriorityLevelConfigurationApplyConfiguration) WithNewFinalizers(values ...string) *PriorityLevelConfigurationApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta3/flowschema.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta3/flowschema.go
@@ -211,6 +211,7 @@ func (b *FlowSchemaApplyConfiguration) WithAnnotations(entries map[string]string
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *FlowSchemaApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *FlowSchemaApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -222,14 +223,40 @@ func (b *FlowSchemaApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerRe
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *FlowSchemaApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *FlowSchemaApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *FlowSchemaApplyConfiguration) WithFinalizers(values ...string) *FlowSchemaApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *FlowSchemaApplyConfiguration) WithNewFinalizers(values ...string) *FlowSchemaApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta3/flowschemaspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta3/flowschemaspec.go
@@ -60,10 +60,25 @@ func (b *FlowSchemaSpecApplyConfiguration) WithDistinguisherMethod(value *FlowDi
 // WithRules adds the given value to the Rules field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Rules field.
+// Deprecated: WithRules does not replace existing list for atomic list type. Use WithNewRules instead.
 func (b *FlowSchemaSpecApplyConfiguration) WithRules(values ...*PolicyRulesWithSubjectsApplyConfiguration) *FlowSchemaSpecApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithRules")
+		}
+		b.Rules = append(b.Rules, *values[i])
+	}
+	return b
+}
+
+// WithNewRules replaces the Rules field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Rules field is set to the values of the last call.
+func (b *FlowSchemaSpecApplyConfiguration) WithNewRules(values ...*PolicyRulesWithSubjectsApplyConfiguration) *FlowSchemaSpecApplyConfiguration {
+	b.Rules = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewRules")
 		}
 		b.Rules = append(b.Rules, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta3/policyruleswithsubjects.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta3/policyruleswithsubjects.go
@@ -35,6 +35,7 @@ func PolicyRulesWithSubjects() *PolicyRulesWithSubjectsApplyConfiguration {
 // WithSubjects adds the given value to the Subjects field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Subjects field.
+// Deprecated: WithSubjects does not replace existing list for atomic list type. Use WithNewSubjects instead.
 func (b *PolicyRulesWithSubjectsApplyConfiguration) WithSubjects(values ...*SubjectApplyConfiguration) *PolicyRulesWithSubjectsApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
@@ -45,9 +46,24 @@ func (b *PolicyRulesWithSubjectsApplyConfiguration) WithSubjects(values ...*Subj
 	return b
 }
 
+// WithNewSubjects replaces the Subjects field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Subjects field is set to the values of the last call.
+func (b *PolicyRulesWithSubjectsApplyConfiguration) WithNewSubjects(values ...*SubjectApplyConfiguration) *PolicyRulesWithSubjectsApplyConfiguration {
+	b.Subjects = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewSubjects")
+		}
+		b.Subjects = append(b.Subjects, *values[i])
+	}
+	return b
+}
+
 // WithResourceRules adds the given value to the ResourceRules field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the ResourceRules field.
+// Deprecated: WithResourceRules does not replace existing list for atomic list type. Use WithNewResourceRules instead.
 func (b *PolicyRulesWithSubjectsApplyConfiguration) WithResourceRules(values ...*ResourcePolicyRuleApplyConfiguration) *PolicyRulesWithSubjectsApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
@@ -58,13 +74,42 @@ func (b *PolicyRulesWithSubjectsApplyConfiguration) WithResourceRules(values ...
 	return b
 }
 
+// WithNewResourceRules replaces the ResourceRules field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the ResourceRules field is set to the values of the last call.
+func (b *PolicyRulesWithSubjectsApplyConfiguration) WithNewResourceRules(values ...*ResourcePolicyRuleApplyConfiguration) *PolicyRulesWithSubjectsApplyConfiguration {
+	b.ResourceRules = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewResourceRules")
+		}
+		b.ResourceRules = append(b.ResourceRules, *values[i])
+	}
+	return b
+}
+
 // WithNonResourceRules adds the given value to the NonResourceRules field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the NonResourceRules field.
+// Deprecated: WithNonResourceRules does not replace existing list for atomic list type. Use WithNewNonResourceRules instead.
 func (b *PolicyRulesWithSubjectsApplyConfiguration) WithNonResourceRules(values ...*NonResourcePolicyRuleApplyConfiguration) *PolicyRulesWithSubjectsApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithNonResourceRules")
+		}
+		b.NonResourceRules = append(b.NonResourceRules, *values[i])
+	}
+	return b
+}
+
+// WithNewNonResourceRules replaces the NonResourceRules field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the NonResourceRules field is set to the values of the last call.
+func (b *PolicyRulesWithSubjectsApplyConfiguration) WithNewNonResourceRules(values ...*NonResourcePolicyRuleApplyConfiguration) *PolicyRulesWithSubjectsApplyConfiguration {
+	b.NonResourceRules = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewNonResourceRules")
 		}
 		b.NonResourceRules = append(b.NonResourceRules, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta3/prioritylevelconfiguration.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta3/prioritylevelconfiguration.go
@@ -211,6 +211,7 @@ func (b *PriorityLevelConfigurationApplyConfiguration) WithAnnotations(entries m
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *PriorityLevelConfigurationApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *PriorityLevelConfigurationApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -222,14 +223,40 @@ func (b *PriorityLevelConfigurationApplyConfiguration) WithOwnerReferences(value
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *PriorityLevelConfigurationApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *PriorityLevelConfigurationApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *PriorityLevelConfigurationApplyConfiguration) WithFinalizers(values ...string) *PriorityLevelConfigurationApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *PriorityLevelConfigurationApplyConfiguration) WithNewFinalizers(values ...string) *PriorityLevelConfigurationApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/imagepolicy/v1alpha1/imagereview.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/imagepolicy/v1alpha1/imagereview.go
@@ -211,6 +211,7 @@ func (b *ImageReviewApplyConfiguration) WithAnnotations(entries map[string]strin
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *ImageReviewApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *ImageReviewApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -222,14 +223,40 @@ func (b *ImageReviewApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerR
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *ImageReviewApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *ImageReviewApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *ImageReviewApplyConfiguration) WithFinalizers(values ...string) *ImageReviewApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *ImageReviewApplyConfiguration) WithNewFinalizers(values ...string) *ImageReviewApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/imagepolicy/v1alpha1/imagereviewspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/imagepolicy/v1alpha1/imagereviewspec.go
@@ -35,10 +35,25 @@ func ImageReviewSpec() *ImageReviewSpecApplyConfiguration {
 // WithContainers adds the given value to the Containers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Containers field.
+// Deprecated: WithContainers does not replace existing list for atomic list type. Use WithNewContainers instead.
 func (b *ImageReviewSpecApplyConfiguration) WithContainers(values ...*ImageReviewContainerSpecApplyConfiguration) *ImageReviewSpecApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithContainers")
+		}
+		b.Containers = append(b.Containers, *values[i])
+	}
+	return b
+}
+
+// WithNewContainers replaces the Containers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Containers field is set to the values of the last call.
+func (b *ImageReviewSpecApplyConfiguration) WithNewContainers(values ...*ImageReviewContainerSpecApplyConfiguration) *ImageReviewSpecApplyConfiguration {
+	b.Containers = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewContainers")
 		}
 		b.Containers = append(b.Containers, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/meta/v1/deleteoptions.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/meta/v1/deleteoptions.go
@@ -93,9 +93,19 @@ func (b *DeleteOptionsApplyConfiguration) WithPropagationPolicy(value metav1.Del
 // WithDryRun adds the given value to the DryRun field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the DryRun field.
+// Deprecated: WithDryRun does not replace existing list for atomic list type. Use WithNewDryRun instead.
 func (b *DeleteOptionsApplyConfiguration) WithDryRun(values ...string) *DeleteOptionsApplyConfiguration {
 	for i := range values {
 		b.DryRun = append(b.DryRun, values[i])
 	}
+	return b
+}
+
+// WithNewDryRun replaces the DryRun field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the DryRun field is set to the values of the last call.
+func (b *DeleteOptionsApplyConfiguration) WithNewDryRun(values ...string) *DeleteOptionsApplyConfiguration {
+	b.DryRun = make([]string, len(values))
+	copy(b.DryRun, values)
 	return b
 }

--- a/staging/src/k8s.io/client-go/applyconfigurations/meta/v1/labelselector.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/meta/v1/labelselector.go
@@ -48,10 +48,25 @@ func (b *LabelSelectorApplyConfiguration) WithMatchLabels(entries map[string]str
 // WithMatchExpressions adds the given value to the MatchExpressions field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the MatchExpressions field.
+// Deprecated: WithMatchExpressions does not replace existing list for atomic list type. Use WithNewMatchExpressions instead.
 func (b *LabelSelectorApplyConfiguration) WithMatchExpressions(values ...*LabelSelectorRequirementApplyConfiguration) *LabelSelectorApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithMatchExpressions")
+		}
+		b.MatchExpressions = append(b.MatchExpressions, *values[i])
+	}
+	return b
+}
+
+// WithNewMatchExpressions replaces the MatchExpressions field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the MatchExpressions field is set to the values of the last call.
+func (b *LabelSelectorApplyConfiguration) WithNewMatchExpressions(values ...*LabelSelectorRequirementApplyConfiguration) *LabelSelectorApplyConfiguration {
+	b.MatchExpressions = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewMatchExpressions")
 		}
 		b.MatchExpressions = append(b.MatchExpressions, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/meta/v1/labelselectorrequirement.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/meta/v1/labelselectorrequirement.go
@@ -55,9 +55,19 @@ func (b *LabelSelectorRequirementApplyConfiguration) WithOperator(value v1.Label
 // WithValues adds the given value to the Values field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Values field.
+// Deprecated: WithValues does not replace existing list for atomic list type. Use WithNewValues instead.
 func (b *LabelSelectorRequirementApplyConfiguration) WithValues(values ...string) *LabelSelectorRequirementApplyConfiguration {
 	for i := range values {
 		b.Values = append(b.Values, values[i])
 	}
+	return b
+}
+
+// WithNewValues replaces the Values field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Values field is set to the values of the last call.
+func (b *LabelSelectorRequirementApplyConfiguration) WithNewValues(values ...string) *LabelSelectorRequirementApplyConfiguration {
+	b.Values = make([]string, len(values))
+	copy(b.Values, values)
 	return b
 }

--- a/staging/src/k8s.io/client-go/applyconfigurations/meta/v1/objectmeta.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/meta/v1/objectmeta.go
@@ -150,6 +150,7 @@ func (b *ObjectMetaApplyConfiguration) WithAnnotations(entries map[string]string
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *ObjectMetaApplyConfiguration) WithOwnerReferences(values ...*OwnerReferenceApplyConfiguration) *ObjectMetaApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
@@ -160,12 +161,36 @@ func (b *ObjectMetaApplyConfiguration) WithOwnerReferences(values ...*OwnerRefer
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *ObjectMetaApplyConfiguration) WithNewOwnerReferences(values ...*OwnerReferenceApplyConfiguration) *ObjectMetaApplyConfiguration {
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *ObjectMetaApplyConfiguration) WithFinalizers(values ...string) *ObjectMetaApplyConfiguration {
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *ObjectMetaApplyConfiguration) WithNewFinalizers(values ...string) *ObjectMetaApplyConfiguration {
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }

--- a/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/httpingressrulevalue.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/httpingressrulevalue.go
@@ -33,10 +33,25 @@ func HTTPIngressRuleValue() *HTTPIngressRuleValueApplyConfiguration {
 // WithPaths adds the given value to the Paths field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Paths field.
+// Deprecated: WithPaths does not replace existing list for atomic list type. Use WithNewPaths instead.
 func (b *HTTPIngressRuleValueApplyConfiguration) WithPaths(values ...*HTTPIngressPathApplyConfiguration) *HTTPIngressRuleValueApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithPaths")
+		}
+		b.Paths = append(b.Paths, *values[i])
+	}
+	return b
+}
+
+// WithNewPaths replaces the Paths field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Paths field is set to the values of the last call.
+func (b *HTTPIngressRuleValueApplyConfiguration) WithNewPaths(values ...*HTTPIngressPathApplyConfiguration) *HTTPIngressRuleValueApplyConfiguration {
+	b.Paths = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewPaths")
 		}
 		b.Paths = append(b.Paths, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/ingress.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/ingress.go
@@ -213,6 +213,7 @@ func (b *IngressApplyConfiguration) WithAnnotations(entries map[string]string) *
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *IngressApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *IngressApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -224,14 +225,40 @@ func (b *IngressApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerRefer
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *IngressApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *IngressApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *IngressApplyConfiguration) WithFinalizers(values ...string) *IngressApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *IngressApplyConfiguration) WithNewFinalizers(values ...string) *IngressApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/ingressclass.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/ingressclass.go
@@ -210,6 +210,7 @@ func (b *IngressClassApplyConfiguration) WithAnnotations(entries map[string]stri
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *IngressClassApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *IngressClassApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -221,14 +222,40 @@ func (b *IngressClassApplyConfiguration) WithOwnerReferences(values ...*v1.Owner
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *IngressClassApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *IngressClassApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *IngressClassApplyConfiguration) WithFinalizers(values ...string) *IngressClassApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *IngressClassApplyConfiguration) WithNewFinalizers(values ...string) *IngressClassApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/ingressloadbalanceringress.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/ingressloadbalanceringress.go
@@ -51,10 +51,25 @@ func (b *IngressLoadBalancerIngressApplyConfiguration) WithHostname(value string
 // WithPorts adds the given value to the Ports field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Ports field.
+// Deprecated: WithPorts does not replace existing list for atomic list type. Use WithNewPorts instead.
 func (b *IngressLoadBalancerIngressApplyConfiguration) WithPorts(values ...*IngressPortStatusApplyConfiguration) *IngressLoadBalancerIngressApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithPorts")
+		}
+		b.Ports = append(b.Ports, *values[i])
+	}
+	return b
+}
+
+// WithNewPorts replaces the Ports field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Ports field is set to the values of the last call.
+func (b *IngressLoadBalancerIngressApplyConfiguration) WithNewPorts(values ...*IngressPortStatusApplyConfiguration) *IngressLoadBalancerIngressApplyConfiguration {
+	b.Ports = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewPorts")
 		}
 		b.Ports = append(b.Ports, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/ingressloadbalancerstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/ingressloadbalancerstatus.go
@@ -33,10 +33,25 @@ func IngressLoadBalancerStatus() *IngressLoadBalancerStatusApplyConfiguration {
 // WithIngress adds the given value to the Ingress field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Ingress field.
+// Deprecated: WithIngress does not replace existing list for atomic list type. Use WithNewIngress instead.
 func (b *IngressLoadBalancerStatusApplyConfiguration) WithIngress(values ...*IngressLoadBalancerIngressApplyConfiguration) *IngressLoadBalancerStatusApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithIngress")
+		}
+		b.Ingress = append(b.Ingress, *values[i])
+	}
+	return b
+}
+
+// WithNewIngress replaces the Ingress field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Ingress field is set to the values of the last call.
+func (b *IngressLoadBalancerStatusApplyConfiguration) WithNewIngress(values ...*IngressLoadBalancerIngressApplyConfiguration) *IngressLoadBalancerStatusApplyConfiguration {
+	b.Ingress = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewIngress")
 		}
 		b.Ingress = append(b.Ingress, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/ingressspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/ingressspec.go
@@ -52,6 +52,7 @@ func (b *IngressSpecApplyConfiguration) WithDefaultBackend(value *IngressBackend
 // WithTLS adds the given value to the TLS field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the TLS field.
+// Deprecated: WithTLS does not replace existing list for atomic list type. Use WithNewTLS instead.
 func (b *IngressSpecApplyConfiguration) WithTLS(values ...*IngressTLSApplyConfiguration) *IngressSpecApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
@@ -62,13 +63,42 @@ func (b *IngressSpecApplyConfiguration) WithTLS(values ...*IngressTLSApplyConfig
 	return b
 }
 
+// WithNewTLS replaces the TLS field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the TLS field is set to the values of the last call.
+func (b *IngressSpecApplyConfiguration) WithNewTLS(values ...*IngressTLSApplyConfiguration) *IngressSpecApplyConfiguration {
+	b.TLS = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewTLS")
+		}
+		b.TLS = append(b.TLS, *values[i])
+	}
+	return b
+}
+
 // WithRules adds the given value to the Rules field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Rules field.
+// Deprecated: WithRules does not replace existing list for atomic list type. Use WithNewRules instead.
 func (b *IngressSpecApplyConfiguration) WithRules(values ...*IngressRuleApplyConfiguration) *IngressSpecApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithRules")
+		}
+		b.Rules = append(b.Rules, *values[i])
+	}
+	return b
+}
+
+// WithNewRules replaces the Rules field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Rules field is set to the values of the last call.
+func (b *IngressSpecApplyConfiguration) WithNewRules(values ...*IngressRuleApplyConfiguration) *IngressSpecApplyConfiguration {
+	b.Rules = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewRules")
 		}
 		b.Rules = append(b.Rules, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/ingresstls.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/ingresstls.go
@@ -34,10 +34,20 @@ func IngressTLS() *IngressTLSApplyConfiguration {
 // WithHosts adds the given value to the Hosts field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Hosts field.
+// Deprecated: WithHosts does not replace existing list for atomic list type. Use WithNewHosts instead.
 func (b *IngressTLSApplyConfiguration) WithHosts(values ...string) *IngressTLSApplyConfiguration {
 	for i := range values {
 		b.Hosts = append(b.Hosts, values[i])
 	}
+	return b
+}
+
+// WithNewHosts replaces the Hosts field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Hosts field is set to the values of the last call.
+func (b *IngressTLSApplyConfiguration) WithNewHosts(values ...string) *IngressTLSApplyConfiguration {
+	b.Hosts = make([]string, len(values))
+	copy(b.Hosts, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/ipblock.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/ipblock.go
@@ -42,9 +42,19 @@ func (b *IPBlockApplyConfiguration) WithCIDR(value string) *IPBlockApplyConfigur
 // WithExcept adds the given value to the Except field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Except field.
+// Deprecated: WithExcept does not replace existing list for atomic list type. Use WithNewExcept instead.
 func (b *IPBlockApplyConfiguration) WithExcept(values ...string) *IPBlockApplyConfiguration {
 	for i := range values {
 		b.Except = append(b.Except, values[i])
 	}
+	return b
+}
+
+// WithNewExcept replaces the Except field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Except field is set to the values of the last call.
+func (b *IPBlockApplyConfiguration) WithNewExcept(values ...string) *IPBlockApplyConfiguration {
+	b.Except = make([]string, len(values))
+	copy(b.Except, values)
 	return b
 }

--- a/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/networkpolicy.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/networkpolicy.go
@@ -212,6 +212,7 @@ func (b *NetworkPolicyApplyConfiguration) WithAnnotations(entries map[string]str
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *NetworkPolicyApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *NetworkPolicyApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -223,14 +224,40 @@ func (b *NetworkPolicyApplyConfiguration) WithOwnerReferences(values ...*v1.Owne
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *NetworkPolicyApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *NetworkPolicyApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *NetworkPolicyApplyConfiguration) WithFinalizers(values ...string) *NetworkPolicyApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *NetworkPolicyApplyConfiguration) WithNewFinalizers(values ...string) *NetworkPolicyApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/networkpolicyegressrule.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/networkpolicyegressrule.go
@@ -34,6 +34,7 @@ func NetworkPolicyEgressRule() *NetworkPolicyEgressRuleApplyConfiguration {
 // WithPorts adds the given value to the Ports field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Ports field.
+// Deprecated: WithPorts does not replace existing list for atomic list type. Use WithNewPorts instead.
 func (b *NetworkPolicyEgressRuleApplyConfiguration) WithPorts(values ...*NetworkPolicyPortApplyConfiguration) *NetworkPolicyEgressRuleApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
@@ -44,13 +45,42 @@ func (b *NetworkPolicyEgressRuleApplyConfiguration) WithPorts(values ...*Network
 	return b
 }
 
+// WithNewPorts replaces the Ports field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Ports field is set to the values of the last call.
+func (b *NetworkPolicyEgressRuleApplyConfiguration) WithNewPorts(values ...*NetworkPolicyPortApplyConfiguration) *NetworkPolicyEgressRuleApplyConfiguration {
+	b.Ports = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewPorts")
+		}
+		b.Ports = append(b.Ports, *values[i])
+	}
+	return b
+}
+
 // WithTo adds the given value to the To field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the To field.
+// Deprecated: WithTo does not replace existing list for atomic list type. Use WithNewTo instead.
 func (b *NetworkPolicyEgressRuleApplyConfiguration) WithTo(values ...*NetworkPolicyPeerApplyConfiguration) *NetworkPolicyEgressRuleApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithTo")
+		}
+		b.To = append(b.To, *values[i])
+	}
+	return b
+}
+
+// WithNewTo replaces the To field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the To field is set to the values of the last call.
+func (b *NetworkPolicyEgressRuleApplyConfiguration) WithNewTo(values ...*NetworkPolicyPeerApplyConfiguration) *NetworkPolicyEgressRuleApplyConfiguration {
+	b.To = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewTo")
 		}
 		b.To = append(b.To, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/networkpolicyingressrule.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/networkpolicyingressrule.go
@@ -34,6 +34,7 @@ func NetworkPolicyIngressRule() *NetworkPolicyIngressRuleApplyConfiguration {
 // WithPorts adds the given value to the Ports field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Ports field.
+// Deprecated: WithPorts does not replace existing list for atomic list type. Use WithNewPorts instead.
 func (b *NetworkPolicyIngressRuleApplyConfiguration) WithPorts(values ...*NetworkPolicyPortApplyConfiguration) *NetworkPolicyIngressRuleApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
@@ -44,13 +45,42 @@ func (b *NetworkPolicyIngressRuleApplyConfiguration) WithPorts(values ...*Networ
 	return b
 }
 
+// WithNewPorts replaces the Ports field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Ports field is set to the values of the last call.
+func (b *NetworkPolicyIngressRuleApplyConfiguration) WithNewPorts(values ...*NetworkPolicyPortApplyConfiguration) *NetworkPolicyIngressRuleApplyConfiguration {
+	b.Ports = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewPorts")
+		}
+		b.Ports = append(b.Ports, *values[i])
+	}
+	return b
+}
+
 // WithFrom adds the given value to the From field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the From field.
+// Deprecated: WithFrom does not replace existing list for atomic list type. Use WithNewFrom instead.
 func (b *NetworkPolicyIngressRuleApplyConfiguration) WithFrom(values ...*NetworkPolicyPeerApplyConfiguration) *NetworkPolicyIngressRuleApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithFrom")
+		}
+		b.From = append(b.From, *values[i])
+	}
+	return b
+}
+
+// WithNewFrom replaces the From field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the From field is set to the values of the last call.
+func (b *NetworkPolicyIngressRuleApplyConfiguration) WithNewFrom(values ...*NetworkPolicyPeerApplyConfiguration) *NetworkPolicyIngressRuleApplyConfiguration {
+	b.From = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewFrom")
 		}
 		b.From = append(b.From, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/networkpolicyspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/networkpolicyspec.go
@@ -49,6 +49,7 @@ func (b *NetworkPolicySpecApplyConfiguration) WithPodSelector(value *v1.LabelSel
 // WithIngress adds the given value to the Ingress field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Ingress field.
+// Deprecated: WithIngress does not replace existing list for atomic list type. Use WithNewIngress instead.
 func (b *NetworkPolicySpecApplyConfiguration) WithIngress(values ...*NetworkPolicyIngressRuleApplyConfiguration) *NetworkPolicySpecApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
@@ -59,9 +60,24 @@ func (b *NetworkPolicySpecApplyConfiguration) WithIngress(values ...*NetworkPoli
 	return b
 }
 
+// WithNewIngress replaces the Ingress field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Ingress field is set to the values of the last call.
+func (b *NetworkPolicySpecApplyConfiguration) WithNewIngress(values ...*NetworkPolicyIngressRuleApplyConfiguration) *NetworkPolicySpecApplyConfiguration {
+	b.Ingress = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewIngress")
+		}
+		b.Ingress = append(b.Ingress, *values[i])
+	}
+	return b
+}
+
 // WithEgress adds the given value to the Egress field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Egress field.
+// Deprecated: WithEgress does not replace existing list for atomic list type. Use WithNewEgress instead.
 func (b *NetworkPolicySpecApplyConfiguration) WithEgress(values ...*NetworkPolicyEgressRuleApplyConfiguration) *NetworkPolicySpecApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
@@ -72,12 +88,36 @@ func (b *NetworkPolicySpecApplyConfiguration) WithEgress(values ...*NetworkPolic
 	return b
 }
 
+// WithNewEgress replaces the Egress field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Egress field is set to the values of the last call.
+func (b *NetworkPolicySpecApplyConfiguration) WithNewEgress(values ...*NetworkPolicyEgressRuleApplyConfiguration) *NetworkPolicySpecApplyConfiguration {
+	b.Egress = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewEgress")
+		}
+		b.Egress = append(b.Egress, *values[i])
+	}
+	return b
+}
+
 // WithPolicyTypes adds the given value to the PolicyTypes field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the PolicyTypes field.
+// Deprecated: WithPolicyTypes does not replace existing list for atomic list type. Use WithNewPolicyTypes instead.
 func (b *NetworkPolicySpecApplyConfiguration) WithPolicyTypes(values ...apinetworkingv1.PolicyType) *NetworkPolicySpecApplyConfiguration {
 	for i := range values {
 		b.PolicyTypes = append(b.PolicyTypes, values[i])
 	}
+	return b
+}
+
+// WithNewPolicyTypes replaces the PolicyTypes field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the PolicyTypes field is set to the values of the last call.
+func (b *NetworkPolicySpecApplyConfiguration) WithNewPolicyTypes(values ...apinetworkingv1.PolicyType) *NetworkPolicySpecApplyConfiguration {
+	b.PolicyTypes = make([]apinetworkingv1.PolicyType, len(values))
+	copy(b.PolicyTypes, values)
 	return b
 }

--- a/staging/src/k8s.io/client-go/applyconfigurations/networking/v1alpha1/ipaddress.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/networking/v1alpha1/ipaddress.go
@@ -210,6 +210,7 @@ func (b *IPAddressApplyConfiguration) WithAnnotations(entries map[string]string)
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *IPAddressApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *IPAddressApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -221,14 +222,40 @@ func (b *IPAddressApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerRef
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *IPAddressApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *IPAddressApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *IPAddressApplyConfiguration) WithFinalizers(values ...string) *IPAddressApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *IPAddressApplyConfiguration) WithNewFinalizers(values ...string) *IPAddressApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/networking/v1beta1/httpingressrulevalue.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/networking/v1beta1/httpingressrulevalue.go
@@ -33,10 +33,25 @@ func HTTPIngressRuleValue() *HTTPIngressRuleValueApplyConfiguration {
 // WithPaths adds the given value to the Paths field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Paths field.
+// Deprecated: WithPaths does not replace existing list for atomic list type. Use WithNewPaths instead.
 func (b *HTTPIngressRuleValueApplyConfiguration) WithPaths(values ...*HTTPIngressPathApplyConfiguration) *HTTPIngressRuleValueApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithPaths")
+		}
+		b.Paths = append(b.Paths, *values[i])
+	}
+	return b
+}
+
+// WithNewPaths replaces the Paths field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Paths field is set to the values of the last call.
+func (b *HTTPIngressRuleValueApplyConfiguration) WithNewPaths(values ...*HTTPIngressPathApplyConfiguration) *HTTPIngressRuleValueApplyConfiguration {
+	b.Paths = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewPaths")
 		}
 		b.Paths = append(b.Paths, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/networking/v1beta1/ingress.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/networking/v1beta1/ingress.go
@@ -213,6 +213,7 @@ func (b *IngressApplyConfiguration) WithAnnotations(entries map[string]string) *
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *IngressApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *IngressApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -224,14 +225,40 @@ func (b *IngressApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerRefer
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *IngressApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *IngressApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *IngressApplyConfiguration) WithFinalizers(values ...string) *IngressApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *IngressApplyConfiguration) WithNewFinalizers(values ...string) *IngressApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/networking/v1beta1/ingressclass.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/networking/v1beta1/ingressclass.go
@@ -210,6 +210,7 @@ func (b *IngressClassApplyConfiguration) WithAnnotations(entries map[string]stri
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *IngressClassApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *IngressClassApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -221,14 +222,40 @@ func (b *IngressClassApplyConfiguration) WithOwnerReferences(values ...*v1.Owner
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *IngressClassApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *IngressClassApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *IngressClassApplyConfiguration) WithFinalizers(values ...string) *IngressClassApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *IngressClassApplyConfiguration) WithNewFinalizers(values ...string) *IngressClassApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/networking/v1beta1/ingressloadbalanceringress.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/networking/v1beta1/ingressloadbalanceringress.go
@@ -51,10 +51,25 @@ func (b *IngressLoadBalancerIngressApplyConfiguration) WithHostname(value string
 // WithPorts adds the given value to the Ports field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Ports field.
+// Deprecated: WithPorts does not replace existing list for atomic list type. Use WithNewPorts instead.
 func (b *IngressLoadBalancerIngressApplyConfiguration) WithPorts(values ...*IngressPortStatusApplyConfiguration) *IngressLoadBalancerIngressApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithPorts")
+		}
+		b.Ports = append(b.Ports, *values[i])
+	}
+	return b
+}
+
+// WithNewPorts replaces the Ports field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Ports field is set to the values of the last call.
+func (b *IngressLoadBalancerIngressApplyConfiguration) WithNewPorts(values ...*IngressPortStatusApplyConfiguration) *IngressLoadBalancerIngressApplyConfiguration {
+	b.Ports = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewPorts")
 		}
 		b.Ports = append(b.Ports, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/networking/v1beta1/ingressloadbalancerstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/networking/v1beta1/ingressloadbalancerstatus.go
@@ -33,10 +33,25 @@ func IngressLoadBalancerStatus() *IngressLoadBalancerStatusApplyConfiguration {
 // WithIngress adds the given value to the Ingress field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Ingress field.
+// Deprecated: WithIngress does not replace existing list for atomic list type. Use WithNewIngress instead.
 func (b *IngressLoadBalancerStatusApplyConfiguration) WithIngress(values ...*IngressLoadBalancerIngressApplyConfiguration) *IngressLoadBalancerStatusApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithIngress")
+		}
+		b.Ingress = append(b.Ingress, *values[i])
+	}
+	return b
+}
+
+// WithNewIngress replaces the Ingress field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Ingress field is set to the values of the last call.
+func (b *IngressLoadBalancerStatusApplyConfiguration) WithNewIngress(values ...*IngressLoadBalancerIngressApplyConfiguration) *IngressLoadBalancerStatusApplyConfiguration {
+	b.Ingress = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewIngress")
 		}
 		b.Ingress = append(b.Ingress, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/networking/v1beta1/ingressspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/networking/v1beta1/ingressspec.go
@@ -52,6 +52,7 @@ func (b *IngressSpecApplyConfiguration) WithBackend(value *IngressBackendApplyCo
 // WithTLS adds the given value to the TLS field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the TLS field.
+// Deprecated: WithTLS does not replace existing list for atomic list type. Use WithNewTLS instead.
 func (b *IngressSpecApplyConfiguration) WithTLS(values ...*IngressTLSApplyConfiguration) *IngressSpecApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
@@ -62,13 +63,42 @@ func (b *IngressSpecApplyConfiguration) WithTLS(values ...*IngressTLSApplyConfig
 	return b
 }
 
+// WithNewTLS replaces the TLS field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the TLS field is set to the values of the last call.
+func (b *IngressSpecApplyConfiguration) WithNewTLS(values ...*IngressTLSApplyConfiguration) *IngressSpecApplyConfiguration {
+	b.TLS = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewTLS")
+		}
+		b.TLS = append(b.TLS, *values[i])
+	}
+	return b
+}
+
 // WithRules adds the given value to the Rules field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Rules field.
+// Deprecated: WithRules does not replace existing list for atomic list type. Use WithNewRules instead.
 func (b *IngressSpecApplyConfiguration) WithRules(values ...*IngressRuleApplyConfiguration) *IngressSpecApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithRules")
+		}
+		b.Rules = append(b.Rules, *values[i])
+	}
+	return b
+}
+
+// WithNewRules replaces the Rules field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Rules field is set to the values of the last call.
+func (b *IngressSpecApplyConfiguration) WithNewRules(values ...*IngressRuleApplyConfiguration) *IngressSpecApplyConfiguration {
+	b.Rules = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewRules")
 		}
 		b.Rules = append(b.Rules, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/networking/v1beta1/ingresstls.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/networking/v1beta1/ingresstls.go
@@ -34,10 +34,20 @@ func IngressTLS() *IngressTLSApplyConfiguration {
 // WithHosts adds the given value to the Hosts field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Hosts field.
+// Deprecated: WithHosts does not replace existing list for atomic list type. Use WithNewHosts instead.
 func (b *IngressTLSApplyConfiguration) WithHosts(values ...string) *IngressTLSApplyConfiguration {
 	for i := range values {
 		b.Hosts = append(b.Hosts, values[i])
 	}
+	return b
+}
+
+// WithNewHosts replaces the Hosts field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Hosts field is set to the values of the last call.
+func (b *IngressTLSApplyConfiguration) WithNewHosts(values ...string) *IngressTLSApplyConfiguration {
+	b.Hosts = make([]string, len(values))
+	copy(b.Hosts, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/node/v1/runtimeclass.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/node/v1/runtimeclass.go
@@ -212,6 +212,7 @@ func (b *RuntimeClassApplyConfiguration) WithAnnotations(entries map[string]stri
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *RuntimeClassApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *RuntimeClassApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -223,14 +224,40 @@ func (b *RuntimeClassApplyConfiguration) WithOwnerReferences(values ...*v1.Owner
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *RuntimeClassApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *RuntimeClassApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *RuntimeClassApplyConfiguration) WithFinalizers(values ...string) *RuntimeClassApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *RuntimeClassApplyConfiguration) WithNewFinalizers(values ...string) *RuntimeClassApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/node/v1/scheduling.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/node/v1/scheduling.go
@@ -39,6 +39,7 @@ func Scheduling() *SchedulingApplyConfiguration {
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, the entries provided by each call will be put on the NodeSelector field,
 // overwriting an existing map entries in NodeSelector field with the same key.
+// Deprecated: WithNodeSelector does not replace existing map for atomic map type. Use WithNewNodeSelector instead.
 func (b *SchedulingApplyConfiguration) WithNodeSelector(entries map[string]string) *SchedulingApplyConfiguration {
 	if b.NodeSelector == nil && len(entries) > 0 {
 		b.NodeSelector = make(map[string]string, len(entries))
@@ -49,13 +50,39 @@ func (b *SchedulingApplyConfiguration) WithNodeSelector(entries map[string]strin
 	return b
 }
 
+// WithNewNodeSelector replaces the NodeSelector field in the declarative configuration with given entries
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the NodeSelector field is set to the entries of the last call.
+func (b *SchedulingApplyConfiguration) WithNewNodeSelector(entries map[string]string) *SchedulingApplyConfiguration {
+	b.NodeSelector = make(map[string]string, len(entries))
+	for k, v := range entries {
+		b.NodeSelector[k] = v
+	}
+	return b
+}
+
 // WithTolerations adds the given value to the Tolerations field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Tolerations field.
+// Deprecated: WithTolerations does not replace existing list for atomic list type. Use WithNewTolerations instead.
 func (b *SchedulingApplyConfiguration) WithTolerations(values ...*v1.TolerationApplyConfiguration) *SchedulingApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithTolerations")
+		}
+		b.Tolerations = append(b.Tolerations, *values[i])
+	}
+	return b
+}
+
+// WithNewTolerations replaces the Tolerations field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Tolerations field is set to the values of the last call.
+func (b *SchedulingApplyConfiguration) WithNewTolerations(values ...*v1.TolerationApplyConfiguration) *SchedulingApplyConfiguration {
+	b.Tolerations = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewTolerations")
 		}
 		b.Tolerations = append(b.Tolerations, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/node/v1alpha1/runtimeclass.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/node/v1alpha1/runtimeclass.go
@@ -210,6 +210,7 @@ func (b *RuntimeClassApplyConfiguration) WithAnnotations(entries map[string]stri
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *RuntimeClassApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *RuntimeClassApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -221,14 +222,40 @@ func (b *RuntimeClassApplyConfiguration) WithOwnerReferences(values ...*v1.Owner
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *RuntimeClassApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *RuntimeClassApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *RuntimeClassApplyConfiguration) WithFinalizers(values ...string) *RuntimeClassApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *RuntimeClassApplyConfiguration) WithNewFinalizers(values ...string) *RuntimeClassApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/node/v1alpha1/scheduling.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/node/v1alpha1/scheduling.go
@@ -39,6 +39,7 @@ func Scheduling() *SchedulingApplyConfiguration {
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, the entries provided by each call will be put on the NodeSelector field,
 // overwriting an existing map entries in NodeSelector field with the same key.
+// Deprecated: WithNodeSelector does not replace existing map for atomic map type. Use WithNewNodeSelector instead.
 func (b *SchedulingApplyConfiguration) WithNodeSelector(entries map[string]string) *SchedulingApplyConfiguration {
 	if b.NodeSelector == nil && len(entries) > 0 {
 		b.NodeSelector = make(map[string]string, len(entries))
@@ -49,13 +50,39 @@ func (b *SchedulingApplyConfiguration) WithNodeSelector(entries map[string]strin
 	return b
 }
 
+// WithNewNodeSelector replaces the NodeSelector field in the declarative configuration with given entries
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the NodeSelector field is set to the entries of the last call.
+func (b *SchedulingApplyConfiguration) WithNewNodeSelector(entries map[string]string) *SchedulingApplyConfiguration {
+	b.NodeSelector = make(map[string]string, len(entries))
+	for k, v := range entries {
+		b.NodeSelector[k] = v
+	}
+	return b
+}
+
 // WithTolerations adds the given value to the Tolerations field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Tolerations field.
+// Deprecated: WithTolerations does not replace existing list for atomic list type. Use WithNewTolerations instead.
 func (b *SchedulingApplyConfiguration) WithTolerations(values ...*v1.TolerationApplyConfiguration) *SchedulingApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithTolerations")
+		}
+		b.Tolerations = append(b.Tolerations, *values[i])
+	}
+	return b
+}
+
+// WithNewTolerations replaces the Tolerations field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Tolerations field is set to the values of the last call.
+func (b *SchedulingApplyConfiguration) WithNewTolerations(values ...*v1.TolerationApplyConfiguration) *SchedulingApplyConfiguration {
+	b.Tolerations = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewTolerations")
 		}
 		b.Tolerations = append(b.Tolerations, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/node/v1beta1/runtimeclass.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/node/v1beta1/runtimeclass.go
@@ -212,6 +212,7 @@ func (b *RuntimeClassApplyConfiguration) WithAnnotations(entries map[string]stri
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *RuntimeClassApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *RuntimeClassApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -223,14 +224,40 @@ func (b *RuntimeClassApplyConfiguration) WithOwnerReferences(values ...*v1.Owner
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *RuntimeClassApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *RuntimeClassApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *RuntimeClassApplyConfiguration) WithFinalizers(values ...string) *RuntimeClassApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *RuntimeClassApplyConfiguration) WithNewFinalizers(values ...string) *RuntimeClassApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/node/v1beta1/scheduling.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/node/v1beta1/scheduling.go
@@ -39,6 +39,7 @@ func Scheduling() *SchedulingApplyConfiguration {
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, the entries provided by each call will be put on the NodeSelector field,
 // overwriting an existing map entries in NodeSelector field with the same key.
+// Deprecated: WithNodeSelector does not replace existing map for atomic map type. Use WithNewNodeSelector instead.
 func (b *SchedulingApplyConfiguration) WithNodeSelector(entries map[string]string) *SchedulingApplyConfiguration {
 	if b.NodeSelector == nil && len(entries) > 0 {
 		b.NodeSelector = make(map[string]string, len(entries))
@@ -49,13 +50,39 @@ func (b *SchedulingApplyConfiguration) WithNodeSelector(entries map[string]strin
 	return b
 }
 
+// WithNewNodeSelector replaces the NodeSelector field in the declarative configuration with given entries
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the NodeSelector field is set to the entries of the last call.
+func (b *SchedulingApplyConfiguration) WithNewNodeSelector(entries map[string]string) *SchedulingApplyConfiguration {
+	b.NodeSelector = make(map[string]string, len(entries))
+	for k, v := range entries {
+		b.NodeSelector[k] = v
+	}
+	return b
+}
+
 // WithTolerations adds the given value to the Tolerations field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Tolerations field.
+// Deprecated: WithTolerations does not replace existing list for atomic list type. Use WithNewTolerations instead.
 func (b *SchedulingApplyConfiguration) WithTolerations(values ...*v1.TolerationApplyConfiguration) *SchedulingApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithTolerations")
+		}
+		b.Tolerations = append(b.Tolerations, *values[i])
+	}
+	return b
+}
+
+// WithNewTolerations replaces the Tolerations field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Tolerations field is set to the values of the last call.
+func (b *SchedulingApplyConfiguration) WithNewTolerations(values ...*v1.TolerationApplyConfiguration) *SchedulingApplyConfiguration {
+	b.Tolerations = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewTolerations")
 		}
 		b.Tolerations = append(b.Tolerations, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/policy/v1/eviction.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/policy/v1/eviction.go
@@ -212,6 +212,7 @@ func (b *EvictionApplyConfiguration) WithAnnotations(entries map[string]string) 
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *EvictionApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *EvictionApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -223,14 +224,40 @@ func (b *EvictionApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerRefe
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *EvictionApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *EvictionApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *EvictionApplyConfiguration) WithFinalizers(values ...string) *EvictionApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *EvictionApplyConfiguration) WithNewFinalizers(values ...string) *EvictionApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/policy/v1/poddisruptionbudget.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/policy/v1/poddisruptionbudget.go
@@ -213,6 +213,7 @@ func (b *PodDisruptionBudgetApplyConfiguration) WithAnnotations(entries map[stri
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *PodDisruptionBudgetApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *PodDisruptionBudgetApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -224,14 +225,40 @@ func (b *PodDisruptionBudgetApplyConfiguration) WithOwnerReferences(values ...*v
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *PodDisruptionBudgetApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *PodDisruptionBudgetApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *PodDisruptionBudgetApplyConfiguration) WithFinalizers(values ...string) *PodDisruptionBudgetApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *PodDisruptionBudgetApplyConfiguration) WithNewFinalizers(values ...string) *PodDisruptionBudgetApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/policy/v1beta1/eviction.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/policy/v1beta1/eviction.go
@@ -212,6 +212,7 @@ func (b *EvictionApplyConfiguration) WithAnnotations(entries map[string]string) 
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *EvictionApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *EvictionApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -223,14 +224,40 @@ func (b *EvictionApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerRefe
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *EvictionApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *EvictionApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *EvictionApplyConfiguration) WithFinalizers(values ...string) *EvictionApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *EvictionApplyConfiguration) WithNewFinalizers(values ...string) *EvictionApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/policy/v1beta1/poddisruptionbudget.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/policy/v1beta1/poddisruptionbudget.go
@@ -213,6 +213,7 @@ func (b *PodDisruptionBudgetApplyConfiguration) WithAnnotations(entries map[stri
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *PodDisruptionBudgetApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *PodDisruptionBudgetApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -224,14 +225,40 @@ func (b *PodDisruptionBudgetApplyConfiguration) WithOwnerReferences(values ...*v
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *PodDisruptionBudgetApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *PodDisruptionBudgetApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *PodDisruptionBudgetApplyConfiguration) WithFinalizers(values ...string) *PodDisruptionBudgetApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *PodDisruptionBudgetApplyConfiguration) WithNewFinalizers(values ...string) *PodDisruptionBudgetApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1/aggregationrule.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1/aggregationrule.go
@@ -37,10 +37,25 @@ func AggregationRule() *AggregationRuleApplyConfiguration {
 // WithClusterRoleSelectors adds the given value to the ClusterRoleSelectors field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the ClusterRoleSelectors field.
+// Deprecated: WithClusterRoleSelectors does not replace existing list for atomic list type. Use WithNewClusterRoleSelectors instead.
 func (b *AggregationRuleApplyConfiguration) WithClusterRoleSelectors(values ...*v1.LabelSelectorApplyConfiguration) *AggregationRuleApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithClusterRoleSelectors")
+		}
+		b.ClusterRoleSelectors = append(b.ClusterRoleSelectors, *values[i])
+	}
+	return b
+}
+
+// WithNewClusterRoleSelectors replaces the ClusterRoleSelectors field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the ClusterRoleSelectors field is set to the values of the last call.
+func (b *AggregationRuleApplyConfiguration) WithNewClusterRoleSelectors(values ...*v1.LabelSelectorApplyConfiguration) *AggregationRuleApplyConfiguration {
+	b.ClusterRoleSelectors = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewClusterRoleSelectors")
 		}
 		b.ClusterRoleSelectors = append(b.ClusterRoleSelectors, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1/clusterrole.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1/clusterrole.go
@@ -211,6 +211,7 @@ func (b *ClusterRoleApplyConfiguration) WithAnnotations(entries map[string]strin
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *ClusterRoleApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *ClusterRoleApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -222,14 +223,40 @@ func (b *ClusterRoleApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerR
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *ClusterRoleApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *ClusterRoleApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *ClusterRoleApplyConfiguration) WithFinalizers(values ...string) *ClusterRoleApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *ClusterRoleApplyConfiguration) WithNewFinalizers(values ...string) *ClusterRoleApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 
@@ -242,10 +269,25 @@ func (b *ClusterRoleApplyConfiguration) ensureObjectMetaApplyConfigurationExists
 // WithRules adds the given value to the Rules field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Rules field.
+// Deprecated: WithRules does not replace existing list for atomic list type. Use WithNewRules instead.
 func (b *ClusterRoleApplyConfiguration) WithRules(values ...*PolicyRuleApplyConfiguration) *ClusterRoleApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithRules")
+		}
+		b.Rules = append(b.Rules, *values[i])
+	}
+	return b
+}
+
+// WithNewRules replaces the Rules field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Rules field is set to the values of the last call.
+func (b *ClusterRoleApplyConfiguration) WithNewRules(values ...*PolicyRuleApplyConfiguration) *ClusterRoleApplyConfiguration {
+	b.Rules = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewRules")
 		}
 		b.Rules = append(b.Rules, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1/clusterrolebinding.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1/clusterrolebinding.go
@@ -211,6 +211,7 @@ func (b *ClusterRoleBindingApplyConfiguration) WithAnnotations(entries map[strin
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *ClusterRoleBindingApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *ClusterRoleBindingApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -222,14 +223,40 @@ func (b *ClusterRoleBindingApplyConfiguration) WithOwnerReferences(values ...*v1
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *ClusterRoleBindingApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *ClusterRoleBindingApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *ClusterRoleBindingApplyConfiguration) WithFinalizers(values ...string) *ClusterRoleBindingApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *ClusterRoleBindingApplyConfiguration) WithNewFinalizers(values ...string) *ClusterRoleBindingApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 
@@ -242,10 +269,25 @@ func (b *ClusterRoleBindingApplyConfiguration) ensureObjectMetaApplyConfiguratio
 // WithSubjects adds the given value to the Subjects field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Subjects field.
+// Deprecated: WithSubjects does not replace existing list for atomic list type. Use WithNewSubjects instead.
 func (b *ClusterRoleBindingApplyConfiguration) WithSubjects(values ...*SubjectApplyConfiguration) *ClusterRoleBindingApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithSubjects")
+		}
+		b.Subjects = append(b.Subjects, *values[i])
+	}
+	return b
+}
+
+// WithNewSubjects replaces the Subjects field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Subjects field is set to the values of the last call.
+func (b *ClusterRoleBindingApplyConfiguration) WithNewSubjects(values ...*SubjectApplyConfiguration) *ClusterRoleBindingApplyConfiguration {
+	b.Subjects = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewSubjects")
 		}
 		b.Subjects = append(b.Subjects, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1/policyrule.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1/policyrule.go
@@ -37,6 +37,7 @@ func PolicyRule() *PolicyRuleApplyConfiguration {
 // WithVerbs adds the given value to the Verbs field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Verbs field.
+// Deprecated: WithVerbs does not replace existing list for atomic list type. Use WithNewVerbs instead.
 func (b *PolicyRuleApplyConfiguration) WithVerbs(values ...string) *PolicyRuleApplyConfiguration {
 	for i := range values {
 		b.Verbs = append(b.Verbs, values[i])
@@ -44,9 +45,19 @@ func (b *PolicyRuleApplyConfiguration) WithVerbs(values ...string) *PolicyRuleAp
 	return b
 }
 
+// WithNewVerbs replaces the Verbs field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Verbs field is set to the values of the last call.
+func (b *PolicyRuleApplyConfiguration) WithNewVerbs(values ...string) *PolicyRuleApplyConfiguration {
+	b.Verbs = make([]string, len(values))
+	copy(b.Verbs, values)
+	return b
+}
+
 // WithAPIGroups adds the given value to the APIGroups field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the APIGroups field.
+// Deprecated: WithAPIGroups does not replace existing list for atomic list type. Use WithNewAPIGroups instead.
 func (b *PolicyRuleApplyConfiguration) WithAPIGroups(values ...string) *PolicyRuleApplyConfiguration {
 	for i := range values {
 		b.APIGroups = append(b.APIGroups, values[i])
@@ -54,9 +65,19 @@ func (b *PolicyRuleApplyConfiguration) WithAPIGroups(values ...string) *PolicyRu
 	return b
 }
 
+// WithNewAPIGroups replaces the APIGroups field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the APIGroups field is set to the values of the last call.
+func (b *PolicyRuleApplyConfiguration) WithNewAPIGroups(values ...string) *PolicyRuleApplyConfiguration {
+	b.APIGroups = make([]string, len(values))
+	copy(b.APIGroups, values)
+	return b
+}
+
 // WithResources adds the given value to the Resources field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Resources field.
+// Deprecated: WithResources does not replace existing list for atomic list type. Use WithNewResources instead.
 func (b *PolicyRuleApplyConfiguration) WithResources(values ...string) *PolicyRuleApplyConfiguration {
 	for i := range values {
 		b.Resources = append(b.Resources, values[i])
@@ -64,9 +85,19 @@ func (b *PolicyRuleApplyConfiguration) WithResources(values ...string) *PolicyRu
 	return b
 }
 
+// WithNewResources replaces the Resources field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Resources field is set to the values of the last call.
+func (b *PolicyRuleApplyConfiguration) WithNewResources(values ...string) *PolicyRuleApplyConfiguration {
+	b.Resources = make([]string, len(values))
+	copy(b.Resources, values)
+	return b
+}
+
 // WithResourceNames adds the given value to the ResourceNames field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the ResourceNames field.
+// Deprecated: WithResourceNames does not replace existing list for atomic list type. Use WithNewResourceNames instead.
 func (b *PolicyRuleApplyConfiguration) WithResourceNames(values ...string) *PolicyRuleApplyConfiguration {
 	for i := range values {
 		b.ResourceNames = append(b.ResourceNames, values[i])
@@ -74,12 +105,31 @@ func (b *PolicyRuleApplyConfiguration) WithResourceNames(values ...string) *Poli
 	return b
 }
 
+// WithNewResourceNames replaces the ResourceNames field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the ResourceNames field is set to the values of the last call.
+func (b *PolicyRuleApplyConfiguration) WithNewResourceNames(values ...string) *PolicyRuleApplyConfiguration {
+	b.ResourceNames = make([]string, len(values))
+	copy(b.ResourceNames, values)
+	return b
+}
+
 // WithNonResourceURLs adds the given value to the NonResourceURLs field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the NonResourceURLs field.
+// Deprecated: WithNonResourceURLs does not replace existing list for atomic list type. Use WithNewNonResourceURLs instead.
 func (b *PolicyRuleApplyConfiguration) WithNonResourceURLs(values ...string) *PolicyRuleApplyConfiguration {
 	for i := range values {
 		b.NonResourceURLs = append(b.NonResourceURLs, values[i])
 	}
+	return b
+}
+
+// WithNewNonResourceURLs replaces the NonResourceURLs field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the NonResourceURLs field is set to the values of the last call.
+func (b *PolicyRuleApplyConfiguration) WithNewNonResourceURLs(values ...string) *PolicyRuleApplyConfiguration {
+	b.NonResourceURLs = make([]string, len(values))
+	copy(b.NonResourceURLs, values)
 	return b
 }

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1/role.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1/role.go
@@ -212,6 +212,7 @@ func (b *RoleApplyConfiguration) WithAnnotations(entries map[string]string) *Rol
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *RoleApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *RoleApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -223,14 +224,40 @@ func (b *RoleApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenc
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *RoleApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *RoleApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *RoleApplyConfiguration) WithFinalizers(values ...string) *RoleApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *RoleApplyConfiguration) WithNewFinalizers(values ...string) *RoleApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 
@@ -243,10 +270,25 @@ func (b *RoleApplyConfiguration) ensureObjectMetaApplyConfigurationExists() {
 // WithRules adds the given value to the Rules field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Rules field.
+// Deprecated: WithRules does not replace existing list for atomic list type. Use WithNewRules instead.
 func (b *RoleApplyConfiguration) WithRules(values ...*PolicyRuleApplyConfiguration) *RoleApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithRules")
+		}
+		b.Rules = append(b.Rules, *values[i])
+	}
+	return b
+}
+
+// WithNewRules replaces the Rules field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Rules field is set to the values of the last call.
+func (b *RoleApplyConfiguration) WithNewRules(values ...*PolicyRuleApplyConfiguration) *RoleApplyConfiguration {
+	b.Rules = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewRules")
 		}
 		b.Rules = append(b.Rules, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1/rolebinding.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1/rolebinding.go
@@ -213,6 +213,7 @@ func (b *RoleBindingApplyConfiguration) WithAnnotations(entries map[string]strin
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *RoleBindingApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *RoleBindingApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -224,14 +225,40 @@ func (b *RoleBindingApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerR
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *RoleBindingApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *RoleBindingApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *RoleBindingApplyConfiguration) WithFinalizers(values ...string) *RoleBindingApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *RoleBindingApplyConfiguration) WithNewFinalizers(values ...string) *RoleBindingApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 
@@ -244,10 +271,25 @@ func (b *RoleBindingApplyConfiguration) ensureObjectMetaApplyConfigurationExists
 // WithSubjects adds the given value to the Subjects field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Subjects field.
+// Deprecated: WithSubjects does not replace existing list for atomic list type. Use WithNewSubjects instead.
 func (b *RoleBindingApplyConfiguration) WithSubjects(values ...*SubjectApplyConfiguration) *RoleBindingApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithSubjects")
+		}
+		b.Subjects = append(b.Subjects, *values[i])
+	}
+	return b
+}
+
+// WithNewSubjects replaces the Subjects field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Subjects field is set to the values of the last call.
+func (b *RoleBindingApplyConfiguration) WithNewSubjects(values ...*SubjectApplyConfiguration) *RoleBindingApplyConfiguration {
+	b.Subjects = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewSubjects")
 		}
 		b.Subjects = append(b.Subjects, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1alpha1/aggregationrule.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1alpha1/aggregationrule.go
@@ -37,10 +37,25 @@ func AggregationRule() *AggregationRuleApplyConfiguration {
 // WithClusterRoleSelectors adds the given value to the ClusterRoleSelectors field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the ClusterRoleSelectors field.
+// Deprecated: WithClusterRoleSelectors does not replace existing list for atomic list type. Use WithNewClusterRoleSelectors instead.
 func (b *AggregationRuleApplyConfiguration) WithClusterRoleSelectors(values ...*v1.LabelSelectorApplyConfiguration) *AggregationRuleApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithClusterRoleSelectors")
+		}
+		b.ClusterRoleSelectors = append(b.ClusterRoleSelectors, *values[i])
+	}
+	return b
+}
+
+// WithNewClusterRoleSelectors replaces the ClusterRoleSelectors field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the ClusterRoleSelectors field is set to the values of the last call.
+func (b *AggregationRuleApplyConfiguration) WithNewClusterRoleSelectors(values ...*v1.LabelSelectorApplyConfiguration) *AggregationRuleApplyConfiguration {
+	b.ClusterRoleSelectors = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewClusterRoleSelectors")
 		}
 		b.ClusterRoleSelectors = append(b.ClusterRoleSelectors, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1alpha1/clusterrole.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1alpha1/clusterrole.go
@@ -211,6 +211,7 @@ func (b *ClusterRoleApplyConfiguration) WithAnnotations(entries map[string]strin
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *ClusterRoleApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *ClusterRoleApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -222,14 +223,40 @@ func (b *ClusterRoleApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerR
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *ClusterRoleApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *ClusterRoleApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *ClusterRoleApplyConfiguration) WithFinalizers(values ...string) *ClusterRoleApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *ClusterRoleApplyConfiguration) WithNewFinalizers(values ...string) *ClusterRoleApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 
@@ -242,10 +269,25 @@ func (b *ClusterRoleApplyConfiguration) ensureObjectMetaApplyConfigurationExists
 // WithRules adds the given value to the Rules field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Rules field.
+// Deprecated: WithRules does not replace existing list for atomic list type. Use WithNewRules instead.
 func (b *ClusterRoleApplyConfiguration) WithRules(values ...*PolicyRuleApplyConfiguration) *ClusterRoleApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithRules")
+		}
+		b.Rules = append(b.Rules, *values[i])
+	}
+	return b
+}
+
+// WithNewRules replaces the Rules field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Rules field is set to the values of the last call.
+func (b *ClusterRoleApplyConfiguration) WithNewRules(values ...*PolicyRuleApplyConfiguration) *ClusterRoleApplyConfiguration {
+	b.Rules = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewRules")
 		}
 		b.Rules = append(b.Rules, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1alpha1/clusterrolebinding.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1alpha1/clusterrolebinding.go
@@ -211,6 +211,7 @@ func (b *ClusterRoleBindingApplyConfiguration) WithAnnotations(entries map[strin
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *ClusterRoleBindingApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *ClusterRoleBindingApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -222,14 +223,40 @@ func (b *ClusterRoleBindingApplyConfiguration) WithOwnerReferences(values ...*v1
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *ClusterRoleBindingApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *ClusterRoleBindingApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *ClusterRoleBindingApplyConfiguration) WithFinalizers(values ...string) *ClusterRoleBindingApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *ClusterRoleBindingApplyConfiguration) WithNewFinalizers(values ...string) *ClusterRoleBindingApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 
@@ -242,10 +269,25 @@ func (b *ClusterRoleBindingApplyConfiguration) ensureObjectMetaApplyConfiguratio
 // WithSubjects adds the given value to the Subjects field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Subjects field.
+// Deprecated: WithSubjects does not replace existing list for atomic list type. Use WithNewSubjects instead.
 func (b *ClusterRoleBindingApplyConfiguration) WithSubjects(values ...*SubjectApplyConfiguration) *ClusterRoleBindingApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithSubjects")
+		}
+		b.Subjects = append(b.Subjects, *values[i])
+	}
+	return b
+}
+
+// WithNewSubjects replaces the Subjects field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Subjects field is set to the values of the last call.
+func (b *ClusterRoleBindingApplyConfiguration) WithNewSubjects(values ...*SubjectApplyConfiguration) *ClusterRoleBindingApplyConfiguration {
+	b.Subjects = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewSubjects")
 		}
 		b.Subjects = append(b.Subjects, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1alpha1/policyrule.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1alpha1/policyrule.go
@@ -37,6 +37,7 @@ func PolicyRule() *PolicyRuleApplyConfiguration {
 // WithVerbs adds the given value to the Verbs field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Verbs field.
+// Deprecated: WithVerbs does not replace existing list for atomic list type. Use WithNewVerbs instead.
 func (b *PolicyRuleApplyConfiguration) WithVerbs(values ...string) *PolicyRuleApplyConfiguration {
 	for i := range values {
 		b.Verbs = append(b.Verbs, values[i])
@@ -44,9 +45,19 @@ func (b *PolicyRuleApplyConfiguration) WithVerbs(values ...string) *PolicyRuleAp
 	return b
 }
 
+// WithNewVerbs replaces the Verbs field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Verbs field is set to the values of the last call.
+func (b *PolicyRuleApplyConfiguration) WithNewVerbs(values ...string) *PolicyRuleApplyConfiguration {
+	b.Verbs = make([]string, len(values))
+	copy(b.Verbs, values)
+	return b
+}
+
 // WithAPIGroups adds the given value to the APIGroups field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the APIGroups field.
+// Deprecated: WithAPIGroups does not replace existing list for atomic list type. Use WithNewAPIGroups instead.
 func (b *PolicyRuleApplyConfiguration) WithAPIGroups(values ...string) *PolicyRuleApplyConfiguration {
 	for i := range values {
 		b.APIGroups = append(b.APIGroups, values[i])
@@ -54,9 +65,19 @@ func (b *PolicyRuleApplyConfiguration) WithAPIGroups(values ...string) *PolicyRu
 	return b
 }
 
+// WithNewAPIGroups replaces the APIGroups field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the APIGroups field is set to the values of the last call.
+func (b *PolicyRuleApplyConfiguration) WithNewAPIGroups(values ...string) *PolicyRuleApplyConfiguration {
+	b.APIGroups = make([]string, len(values))
+	copy(b.APIGroups, values)
+	return b
+}
+
 // WithResources adds the given value to the Resources field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Resources field.
+// Deprecated: WithResources does not replace existing list for atomic list type. Use WithNewResources instead.
 func (b *PolicyRuleApplyConfiguration) WithResources(values ...string) *PolicyRuleApplyConfiguration {
 	for i := range values {
 		b.Resources = append(b.Resources, values[i])
@@ -64,9 +85,19 @@ func (b *PolicyRuleApplyConfiguration) WithResources(values ...string) *PolicyRu
 	return b
 }
 
+// WithNewResources replaces the Resources field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Resources field is set to the values of the last call.
+func (b *PolicyRuleApplyConfiguration) WithNewResources(values ...string) *PolicyRuleApplyConfiguration {
+	b.Resources = make([]string, len(values))
+	copy(b.Resources, values)
+	return b
+}
+
 // WithResourceNames adds the given value to the ResourceNames field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the ResourceNames field.
+// Deprecated: WithResourceNames does not replace existing list for atomic list type. Use WithNewResourceNames instead.
 func (b *PolicyRuleApplyConfiguration) WithResourceNames(values ...string) *PolicyRuleApplyConfiguration {
 	for i := range values {
 		b.ResourceNames = append(b.ResourceNames, values[i])
@@ -74,12 +105,31 @@ func (b *PolicyRuleApplyConfiguration) WithResourceNames(values ...string) *Poli
 	return b
 }
 
+// WithNewResourceNames replaces the ResourceNames field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the ResourceNames field is set to the values of the last call.
+func (b *PolicyRuleApplyConfiguration) WithNewResourceNames(values ...string) *PolicyRuleApplyConfiguration {
+	b.ResourceNames = make([]string, len(values))
+	copy(b.ResourceNames, values)
+	return b
+}
+
 // WithNonResourceURLs adds the given value to the NonResourceURLs field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the NonResourceURLs field.
+// Deprecated: WithNonResourceURLs does not replace existing list for atomic list type. Use WithNewNonResourceURLs instead.
 func (b *PolicyRuleApplyConfiguration) WithNonResourceURLs(values ...string) *PolicyRuleApplyConfiguration {
 	for i := range values {
 		b.NonResourceURLs = append(b.NonResourceURLs, values[i])
 	}
+	return b
+}
+
+// WithNewNonResourceURLs replaces the NonResourceURLs field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the NonResourceURLs field is set to the values of the last call.
+func (b *PolicyRuleApplyConfiguration) WithNewNonResourceURLs(values ...string) *PolicyRuleApplyConfiguration {
+	b.NonResourceURLs = make([]string, len(values))
+	copy(b.NonResourceURLs, values)
 	return b
 }

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1alpha1/role.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1alpha1/role.go
@@ -212,6 +212,7 @@ func (b *RoleApplyConfiguration) WithAnnotations(entries map[string]string) *Rol
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *RoleApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *RoleApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -223,14 +224,40 @@ func (b *RoleApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenc
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *RoleApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *RoleApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *RoleApplyConfiguration) WithFinalizers(values ...string) *RoleApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *RoleApplyConfiguration) WithNewFinalizers(values ...string) *RoleApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 
@@ -243,10 +270,25 @@ func (b *RoleApplyConfiguration) ensureObjectMetaApplyConfigurationExists() {
 // WithRules adds the given value to the Rules field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Rules field.
+// Deprecated: WithRules does not replace existing list for atomic list type. Use WithNewRules instead.
 func (b *RoleApplyConfiguration) WithRules(values ...*PolicyRuleApplyConfiguration) *RoleApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithRules")
+		}
+		b.Rules = append(b.Rules, *values[i])
+	}
+	return b
+}
+
+// WithNewRules replaces the Rules field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Rules field is set to the values of the last call.
+func (b *RoleApplyConfiguration) WithNewRules(values ...*PolicyRuleApplyConfiguration) *RoleApplyConfiguration {
+	b.Rules = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewRules")
 		}
 		b.Rules = append(b.Rules, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1alpha1/rolebinding.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1alpha1/rolebinding.go
@@ -213,6 +213,7 @@ func (b *RoleBindingApplyConfiguration) WithAnnotations(entries map[string]strin
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *RoleBindingApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *RoleBindingApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -224,14 +225,40 @@ func (b *RoleBindingApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerR
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *RoleBindingApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *RoleBindingApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *RoleBindingApplyConfiguration) WithFinalizers(values ...string) *RoleBindingApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *RoleBindingApplyConfiguration) WithNewFinalizers(values ...string) *RoleBindingApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 
@@ -244,10 +271,25 @@ func (b *RoleBindingApplyConfiguration) ensureObjectMetaApplyConfigurationExists
 // WithSubjects adds the given value to the Subjects field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Subjects field.
+// Deprecated: WithSubjects does not replace existing list for atomic list type. Use WithNewSubjects instead.
 func (b *RoleBindingApplyConfiguration) WithSubjects(values ...*SubjectApplyConfiguration) *RoleBindingApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithSubjects")
+		}
+		b.Subjects = append(b.Subjects, *values[i])
+	}
+	return b
+}
+
+// WithNewSubjects replaces the Subjects field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Subjects field is set to the values of the last call.
+func (b *RoleBindingApplyConfiguration) WithNewSubjects(values ...*SubjectApplyConfiguration) *RoleBindingApplyConfiguration {
+	b.Subjects = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewSubjects")
 		}
 		b.Subjects = append(b.Subjects, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1beta1/aggregationrule.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1beta1/aggregationrule.go
@@ -37,10 +37,25 @@ func AggregationRule() *AggregationRuleApplyConfiguration {
 // WithClusterRoleSelectors adds the given value to the ClusterRoleSelectors field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the ClusterRoleSelectors field.
+// Deprecated: WithClusterRoleSelectors does not replace existing list for atomic list type. Use WithNewClusterRoleSelectors instead.
 func (b *AggregationRuleApplyConfiguration) WithClusterRoleSelectors(values ...*v1.LabelSelectorApplyConfiguration) *AggregationRuleApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithClusterRoleSelectors")
+		}
+		b.ClusterRoleSelectors = append(b.ClusterRoleSelectors, *values[i])
+	}
+	return b
+}
+
+// WithNewClusterRoleSelectors replaces the ClusterRoleSelectors field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the ClusterRoleSelectors field is set to the values of the last call.
+func (b *AggregationRuleApplyConfiguration) WithNewClusterRoleSelectors(values ...*v1.LabelSelectorApplyConfiguration) *AggregationRuleApplyConfiguration {
+	b.ClusterRoleSelectors = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewClusterRoleSelectors")
 		}
 		b.ClusterRoleSelectors = append(b.ClusterRoleSelectors, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1beta1/clusterrole.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1beta1/clusterrole.go
@@ -211,6 +211,7 @@ func (b *ClusterRoleApplyConfiguration) WithAnnotations(entries map[string]strin
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *ClusterRoleApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *ClusterRoleApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -222,14 +223,40 @@ func (b *ClusterRoleApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerR
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *ClusterRoleApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *ClusterRoleApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *ClusterRoleApplyConfiguration) WithFinalizers(values ...string) *ClusterRoleApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *ClusterRoleApplyConfiguration) WithNewFinalizers(values ...string) *ClusterRoleApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 
@@ -242,10 +269,25 @@ func (b *ClusterRoleApplyConfiguration) ensureObjectMetaApplyConfigurationExists
 // WithRules adds the given value to the Rules field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Rules field.
+// Deprecated: WithRules does not replace existing list for atomic list type. Use WithNewRules instead.
 func (b *ClusterRoleApplyConfiguration) WithRules(values ...*PolicyRuleApplyConfiguration) *ClusterRoleApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithRules")
+		}
+		b.Rules = append(b.Rules, *values[i])
+	}
+	return b
+}
+
+// WithNewRules replaces the Rules field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Rules field is set to the values of the last call.
+func (b *ClusterRoleApplyConfiguration) WithNewRules(values ...*PolicyRuleApplyConfiguration) *ClusterRoleApplyConfiguration {
+	b.Rules = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewRules")
 		}
 		b.Rules = append(b.Rules, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1beta1/clusterrolebinding.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1beta1/clusterrolebinding.go
@@ -211,6 +211,7 @@ func (b *ClusterRoleBindingApplyConfiguration) WithAnnotations(entries map[strin
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *ClusterRoleBindingApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *ClusterRoleBindingApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -222,14 +223,40 @@ func (b *ClusterRoleBindingApplyConfiguration) WithOwnerReferences(values ...*v1
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *ClusterRoleBindingApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *ClusterRoleBindingApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *ClusterRoleBindingApplyConfiguration) WithFinalizers(values ...string) *ClusterRoleBindingApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *ClusterRoleBindingApplyConfiguration) WithNewFinalizers(values ...string) *ClusterRoleBindingApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 
@@ -242,10 +269,25 @@ func (b *ClusterRoleBindingApplyConfiguration) ensureObjectMetaApplyConfiguratio
 // WithSubjects adds the given value to the Subjects field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Subjects field.
+// Deprecated: WithSubjects does not replace existing list for atomic list type. Use WithNewSubjects instead.
 func (b *ClusterRoleBindingApplyConfiguration) WithSubjects(values ...*SubjectApplyConfiguration) *ClusterRoleBindingApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithSubjects")
+		}
+		b.Subjects = append(b.Subjects, *values[i])
+	}
+	return b
+}
+
+// WithNewSubjects replaces the Subjects field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Subjects field is set to the values of the last call.
+func (b *ClusterRoleBindingApplyConfiguration) WithNewSubjects(values ...*SubjectApplyConfiguration) *ClusterRoleBindingApplyConfiguration {
+	b.Subjects = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewSubjects")
 		}
 		b.Subjects = append(b.Subjects, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1beta1/policyrule.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1beta1/policyrule.go
@@ -37,6 +37,7 @@ func PolicyRule() *PolicyRuleApplyConfiguration {
 // WithVerbs adds the given value to the Verbs field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Verbs field.
+// Deprecated: WithVerbs does not replace existing list for atomic list type. Use WithNewVerbs instead.
 func (b *PolicyRuleApplyConfiguration) WithVerbs(values ...string) *PolicyRuleApplyConfiguration {
 	for i := range values {
 		b.Verbs = append(b.Verbs, values[i])
@@ -44,9 +45,19 @@ func (b *PolicyRuleApplyConfiguration) WithVerbs(values ...string) *PolicyRuleAp
 	return b
 }
 
+// WithNewVerbs replaces the Verbs field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Verbs field is set to the values of the last call.
+func (b *PolicyRuleApplyConfiguration) WithNewVerbs(values ...string) *PolicyRuleApplyConfiguration {
+	b.Verbs = make([]string, len(values))
+	copy(b.Verbs, values)
+	return b
+}
+
 // WithAPIGroups adds the given value to the APIGroups field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the APIGroups field.
+// Deprecated: WithAPIGroups does not replace existing list for atomic list type. Use WithNewAPIGroups instead.
 func (b *PolicyRuleApplyConfiguration) WithAPIGroups(values ...string) *PolicyRuleApplyConfiguration {
 	for i := range values {
 		b.APIGroups = append(b.APIGroups, values[i])
@@ -54,9 +65,19 @@ func (b *PolicyRuleApplyConfiguration) WithAPIGroups(values ...string) *PolicyRu
 	return b
 }
 
+// WithNewAPIGroups replaces the APIGroups field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the APIGroups field is set to the values of the last call.
+func (b *PolicyRuleApplyConfiguration) WithNewAPIGroups(values ...string) *PolicyRuleApplyConfiguration {
+	b.APIGroups = make([]string, len(values))
+	copy(b.APIGroups, values)
+	return b
+}
+
 // WithResources adds the given value to the Resources field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Resources field.
+// Deprecated: WithResources does not replace existing list for atomic list type. Use WithNewResources instead.
 func (b *PolicyRuleApplyConfiguration) WithResources(values ...string) *PolicyRuleApplyConfiguration {
 	for i := range values {
 		b.Resources = append(b.Resources, values[i])
@@ -64,9 +85,19 @@ func (b *PolicyRuleApplyConfiguration) WithResources(values ...string) *PolicyRu
 	return b
 }
 
+// WithNewResources replaces the Resources field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Resources field is set to the values of the last call.
+func (b *PolicyRuleApplyConfiguration) WithNewResources(values ...string) *PolicyRuleApplyConfiguration {
+	b.Resources = make([]string, len(values))
+	copy(b.Resources, values)
+	return b
+}
+
 // WithResourceNames adds the given value to the ResourceNames field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the ResourceNames field.
+// Deprecated: WithResourceNames does not replace existing list for atomic list type. Use WithNewResourceNames instead.
 func (b *PolicyRuleApplyConfiguration) WithResourceNames(values ...string) *PolicyRuleApplyConfiguration {
 	for i := range values {
 		b.ResourceNames = append(b.ResourceNames, values[i])
@@ -74,12 +105,31 @@ func (b *PolicyRuleApplyConfiguration) WithResourceNames(values ...string) *Poli
 	return b
 }
 
+// WithNewResourceNames replaces the ResourceNames field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the ResourceNames field is set to the values of the last call.
+func (b *PolicyRuleApplyConfiguration) WithNewResourceNames(values ...string) *PolicyRuleApplyConfiguration {
+	b.ResourceNames = make([]string, len(values))
+	copy(b.ResourceNames, values)
+	return b
+}
+
 // WithNonResourceURLs adds the given value to the NonResourceURLs field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the NonResourceURLs field.
+// Deprecated: WithNonResourceURLs does not replace existing list for atomic list type. Use WithNewNonResourceURLs instead.
 func (b *PolicyRuleApplyConfiguration) WithNonResourceURLs(values ...string) *PolicyRuleApplyConfiguration {
 	for i := range values {
 		b.NonResourceURLs = append(b.NonResourceURLs, values[i])
 	}
+	return b
+}
+
+// WithNewNonResourceURLs replaces the NonResourceURLs field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the NonResourceURLs field is set to the values of the last call.
+func (b *PolicyRuleApplyConfiguration) WithNewNonResourceURLs(values ...string) *PolicyRuleApplyConfiguration {
+	b.NonResourceURLs = make([]string, len(values))
+	copy(b.NonResourceURLs, values)
 	return b
 }

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1beta1/role.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1beta1/role.go
@@ -212,6 +212,7 @@ func (b *RoleApplyConfiguration) WithAnnotations(entries map[string]string) *Rol
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *RoleApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *RoleApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -223,14 +224,40 @@ func (b *RoleApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenc
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *RoleApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *RoleApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *RoleApplyConfiguration) WithFinalizers(values ...string) *RoleApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *RoleApplyConfiguration) WithNewFinalizers(values ...string) *RoleApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 
@@ -243,10 +270,25 @@ func (b *RoleApplyConfiguration) ensureObjectMetaApplyConfigurationExists() {
 // WithRules adds the given value to the Rules field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Rules field.
+// Deprecated: WithRules does not replace existing list for atomic list type. Use WithNewRules instead.
 func (b *RoleApplyConfiguration) WithRules(values ...*PolicyRuleApplyConfiguration) *RoleApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithRules")
+		}
+		b.Rules = append(b.Rules, *values[i])
+	}
+	return b
+}
+
+// WithNewRules replaces the Rules field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Rules field is set to the values of the last call.
+func (b *RoleApplyConfiguration) WithNewRules(values ...*PolicyRuleApplyConfiguration) *RoleApplyConfiguration {
+	b.Rules = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewRules")
 		}
 		b.Rules = append(b.Rules, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1beta1/rolebinding.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1beta1/rolebinding.go
@@ -213,6 +213,7 @@ func (b *RoleBindingApplyConfiguration) WithAnnotations(entries map[string]strin
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *RoleBindingApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *RoleBindingApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -224,14 +225,40 @@ func (b *RoleBindingApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerR
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *RoleBindingApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *RoleBindingApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *RoleBindingApplyConfiguration) WithFinalizers(values ...string) *RoleBindingApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *RoleBindingApplyConfiguration) WithNewFinalizers(values ...string) *RoleBindingApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 
@@ -244,10 +271,25 @@ func (b *RoleBindingApplyConfiguration) ensureObjectMetaApplyConfigurationExists
 // WithSubjects adds the given value to the Subjects field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Subjects field.
+// Deprecated: WithSubjects does not replace existing list for atomic list type. Use WithNewSubjects instead.
 func (b *RoleBindingApplyConfiguration) WithSubjects(values ...*SubjectApplyConfiguration) *RoleBindingApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithSubjects")
+		}
+		b.Subjects = append(b.Subjects, *values[i])
+	}
+	return b
+}
+
+// WithNewSubjects replaces the Subjects field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Subjects field is set to the values of the last call.
+func (b *RoleBindingApplyConfiguration) WithNewSubjects(values ...*SubjectApplyConfiguration) *RoleBindingApplyConfiguration {
+	b.Subjects = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewSubjects")
 		}
 		b.Subjects = append(b.Subjects, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1alpha2/allocationresult.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1alpha2/allocationresult.go
@@ -39,10 +39,25 @@ func AllocationResult() *AllocationResultApplyConfiguration {
 // WithResourceHandles adds the given value to the ResourceHandles field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the ResourceHandles field.
+// Deprecated: WithResourceHandles does not replace existing list for atomic list type. Use WithNewResourceHandles instead.
 func (b *AllocationResultApplyConfiguration) WithResourceHandles(values ...*ResourceHandleApplyConfiguration) *AllocationResultApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithResourceHandles")
+		}
+		b.ResourceHandles = append(b.ResourceHandles, *values[i])
+	}
+	return b
+}
+
+// WithNewResourceHandles replaces the ResourceHandles field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the ResourceHandles field is set to the values of the last call.
+func (b *AllocationResultApplyConfiguration) WithNewResourceHandles(values ...*ResourceHandleApplyConfiguration) *AllocationResultApplyConfiguration {
+	b.ResourceHandles = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewResourceHandles")
 		}
 		b.ResourceHandles = append(b.ResourceHandles, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1alpha2/podschedulingcontext.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1alpha2/podschedulingcontext.go
@@ -213,6 +213,7 @@ func (b *PodSchedulingContextApplyConfiguration) WithAnnotations(entries map[str
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *PodSchedulingContextApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *PodSchedulingContextApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -224,14 +225,40 @@ func (b *PodSchedulingContextApplyConfiguration) WithOwnerReferences(values ...*
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *PodSchedulingContextApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *PodSchedulingContextApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *PodSchedulingContextApplyConfiguration) WithFinalizers(values ...string) *PodSchedulingContextApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *PodSchedulingContextApplyConfiguration) WithNewFinalizers(values ...string) *PodSchedulingContextApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1alpha2/podschedulingcontextspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1alpha2/podschedulingcontextspec.go
@@ -42,9 +42,19 @@ func (b *PodSchedulingContextSpecApplyConfiguration) WithSelectedNode(value stri
 // WithPotentialNodes adds the given value to the PotentialNodes field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the PotentialNodes field.
+// Deprecated: WithPotentialNodes does not replace existing list for atomic list type. Use WithNewPotentialNodes instead.
 func (b *PodSchedulingContextSpecApplyConfiguration) WithPotentialNodes(values ...string) *PodSchedulingContextSpecApplyConfiguration {
 	for i := range values {
 		b.PotentialNodes = append(b.PotentialNodes, values[i])
 	}
+	return b
+}
+
+// WithNewPotentialNodes replaces the PotentialNodes field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the PotentialNodes field is set to the values of the last call.
+func (b *PodSchedulingContextSpecApplyConfiguration) WithNewPotentialNodes(values ...string) *PodSchedulingContextSpecApplyConfiguration {
+	b.PotentialNodes = make([]string, len(values))
+	copy(b.PotentialNodes, values)
 	return b
 }

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1alpha2/resourceclaim.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1alpha2/resourceclaim.go
@@ -213,6 +213,7 @@ func (b *ResourceClaimApplyConfiguration) WithAnnotations(entries map[string]str
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *ResourceClaimApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *ResourceClaimApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -224,14 +225,40 @@ func (b *ResourceClaimApplyConfiguration) WithOwnerReferences(values ...*v1.Owne
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *ResourceClaimApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *ResourceClaimApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *ResourceClaimApplyConfiguration) WithFinalizers(values ...string) *ResourceClaimApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *ResourceClaimApplyConfiguration) WithNewFinalizers(values ...string) *ResourceClaimApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1alpha2/resourceclaimschedulingstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1alpha2/resourceclaimschedulingstatus.go
@@ -42,9 +42,19 @@ func (b *ResourceClaimSchedulingStatusApplyConfiguration) WithName(value string)
 // WithUnsuitableNodes adds the given value to the UnsuitableNodes field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the UnsuitableNodes field.
+// Deprecated: WithUnsuitableNodes does not replace existing list for atomic list type. Use WithNewUnsuitableNodes instead.
 func (b *ResourceClaimSchedulingStatusApplyConfiguration) WithUnsuitableNodes(values ...string) *ResourceClaimSchedulingStatusApplyConfiguration {
 	for i := range values {
 		b.UnsuitableNodes = append(b.UnsuitableNodes, values[i])
 	}
+	return b
+}
+
+// WithNewUnsuitableNodes replaces the UnsuitableNodes field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the UnsuitableNodes field is set to the values of the last call.
+func (b *ResourceClaimSchedulingStatusApplyConfiguration) WithNewUnsuitableNodes(values ...string) *ResourceClaimSchedulingStatusApplyConfiguration {
+	b.UnsuitableNodes = make([]string, len(values))
+	copy(b.UnsuitableNodes, values)
 	return b
 }

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1alpha2/resourceclaimtemplate.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1alpha2/resourceclaimtemplate.go
@@ -212,6 +212,7 @@ func (b *ResourceClaimTemplateApplyConfiguration) WithAnnotations(entries map[st
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *ResourceClaimTemplateApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *ResourceClaimTemplateApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -223,14 +224,40 @@ func (b *ResourceClaimTemplateApplyConfiguration) WithOwnerReferences(values ...
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *ResourceClaimTemplateApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *ResourceClaimTemplateApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *ResourceClaimTemplateApplyConfiguration) WithFinalizers(values ...string) *ResourceClaimTemplateApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *ResourceClaimTemplateApplyConfiguration) WithNewFinalizers(values ...string) *ResourceClaimTemplateApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1alpha2/resourceclaimtemplatespec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1alpha2/resourceclaimtemplatespec.go
@@ -151,6 +151,7 @@ func (b *ResourceClaimTemplateSpecApplyConfiguration) WithAnnotations(entries ma
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *ResourceClaimTemplateSpecApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *ResourceClaimTemplateSpecApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -162,14 +163,40 @@ func (b *ResourceClaimTemplateSpecApplyConfiguration) WithOwnerReferences(values
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *ResourceClaimTemplateSpecApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *ResourceClaimTemplateSpecApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *ResourceClaimTemplateSpecApplyConfiguration) WithFinalizers(values ...string) *ResourceClaimTemplateSpecApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *ResourceClaimTemplateSpecApplyConfiguration) WithNewFinalizers(values ...string) *ResourceClaimTemplateSpecApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1alpha2/resourceclass.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1alpha2/resourceclass.go
@@ -213,6 +213,7 @@ func (b *ResourceClassApplyConfiguration) WithAnnotations(entries map[string]str
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *ResourceClassApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *ResourceClassApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -224,14 +225,40 @@ func (b *ResourceClassApplyConfiguration) WithOwnerReferences(values ...*v1.Owne
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *ResourceClassApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *ResourceClassApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *ResourceClassApplyConfiguration) WithFinalizers(values ...string) *ResourceClassApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *ResourceClassApplyConfiguration) WithNewFinalizers(values ...string) *ResourceClassApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/scheduling/v1/priorityclass.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/scheduling/v1/priorityclass.go
@@ -214,6 +214,7 @@ func (b *PriorityClassApplyConfiguration) WithAnnotations(entries map[string]str
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *PriorityClassApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *PriorityClassApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -225,14 +226,40 @@ func (b *PriorityClassApplyConfiguration) WithOwnerReferences(values ...*v1.Owne
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *PriorityClassApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *PriorityClassApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *PriorityClassApplyConfiguration) WithFinalizers(values ...string) *PriorityClassApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *PriorityClassApplyConfiguration) WithNewFinalizers(values ...string) *PriorityClassApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/scheduling/v1alpha1/priorityclass.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/scheduling/v1alpha1/priorityclass.go
@@ -214,6 +214,7 @@ func (b *PriorityClassApplyConfiguration) WithAnnotations(entries map[string]str
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *PriorityClassApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *PriorityClassApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -225,14 +226,40 @@ func (b *PriorityClassApplyConfiguration) WithOwnerReferences(values ...*v1.Owne
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *PriorityClassApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *PriorityClassApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *PriorityClassApplyConfiguration) WithFinalizers(values ...string) *PriorityClassApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *PriorityClassApplyConfiguration) WithNewFinalizers(values ...string) *PriorityClassApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/scheduling/v1beta1/priorityclass.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/scheduling/v1beta1/priorityclass.go
@@ -214,6 +214,7 @@ func (b *PriorityClassApplyConfiguration) WithAnnotations(entries map[string]str
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *PriorityClassApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *PriorityClassApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -225,14 +226,40 @@ func (b *PriorityClassApplyConfiguration) WithOwnerReferences(values ...*v1.Owne
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *PriorityClassApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *PriorityClassApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *PriorityClassApplyConfiguration) WithFinalizers(values ...string) *PriorityClassApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *PriorityClassApplyConfiguration) WithNewFinalizers(values ...string) *PriorityClassApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/storage/v1/csidriver.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storage/v1/csidriver.go
@@ -210,6 +210,7 @@ func (b *CSIDriverApplyConfiguration) WithAnnotations(entries map[string]string)
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *CSIDriverApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *CSIDriverApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -221,14 +222,40 @@ func (b *CSIDriverApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerRef
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *CSIDriverApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *CSIDriverApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *CSIDriverApplyConfiguration) WithFinalizers(values ...string) *CSIDriverApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *CSIDriverApplyConfiguration) WithNewFinalizers(values ...string) *CSIDriverApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/storage/v1/csidriverspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storage/v1/csidriverspec.go
@@ -86,10 +86,25 @@ func (b *CSIDriverSpecApplyConfiguration) WithFSGroupPolicy(value v1.FSGroupPoli
 // WithTokenRequests adds the given value to the TokenRequests field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the TokenRequests field.
+// Deprecated: WithTokenRequests does not replace existing list for atomic list type. Use WithNewTokenRequests instead.
 func (b *CSIDriverSpecApplyConfiguration) WithTokenRequests(values ...*TokenRequestApplyConfiguration) *CSIDriverSpecApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithTokenRequests")
+		}
+		b.TokenRequests = append(b.TokenRequests, *values[i])
+	}
+	return b
+}
+
+// WithNewTokenRequests replaces the TokenRequests field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the TokenRequests field is set to the values of the last call.
+func (b *CSIDriverSpecApplyConfiguration) WithNewTokenRequests(values ...*TokenRequestApplyConfiguration) *CSIDriverSpecApplyConfiguration {
+	b.TokenRequests = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewTokenRequests")
 		}
 		b.TokenRequests = append(b.TokenRequests, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/storage/v1/csinode.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storage/v1/csinode.go
@@ -210,6 +210,7 @@ func (b *CSINodeApplyConfiguration) WithAnnotations(entries map[string]string) *
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *CSINodeApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *CSINodeApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -221,14 +222,40 @@ func (b *CSINodeApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerRefer
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *CSINodeApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *CSINodeApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *CSINodeApplyConfiguration) WithFinalizers(values ...string) *CSINodeApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *CSINodeApplyConfiguration) WithNewFinalizers(values ...string) *CSINodeApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/storage/v1/csinodedriver.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storage/v1/csinodedriver.go
@@ -52,10 +52,20 @@ func (b *CSINodeDriverApplyConfiguration) WithNodeID(value string) *CSINodeDrive
 // WithTopologyKeys adds the given value to the TopologyKeys field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the TopologyKeys field.
+// Deprecated: WithTopologyKeys does not replace existing list for atomic list type. Use WithNewTopologyKeys instead.
 func (b *CSINodeDriverApplyConfiguration) WithTopologyKeys(values ...string) *CSINodeDriverApplyConfiguration {
 	for i := range values {
 		b.TopologyKeys = append(b.TopologyKeys, values[i])
 	}
+	return b
+}
+
+// WithNewTopologyKeys replaces the TopologyKeys field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the TopologyKeys field is set to the values of the last call.
+func (b *CSINodeDriverApplyConfiguration) WithNewTopologyKeys(values ...string) *CSINodeDriverApplyConfiguration {
+	b.TopologyKeys = make([]string, len(values))
+	copy(b.TopologyKeys, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/storage/v1/csinodespec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storage/v1/csinodespec.go
@@ -33,10 +33,25 @@ func CSINodeSpec() *CSINodeSpecApplyConfiguration {
 // WithDrivers adds the given value to the Drivers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Drivers field.
+// Deprecated: WithDrivers does not replace existing list for atomic list type. Use WithNewDrivers instead.
 func (b *CSINodeSpecApplyConfiguration) WithDrivers(values ...*CSINodeDriverApplyConfiguration) *CSINodeSpecApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithDrivers")
+		}
+		b.Drivers = append(b.Drivers, *values[i])
+	}
+	return b
+}
+
+// WithNewDrivers replaces the Drivers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Drivers field is set to the values of the last call.
+func (b *CSINodeSpecApplyConfiguration) WithNewDrivers(values ...*CSINodeDriverApplyConfiguration) *CSINodeSpecApplyConfiguration {
+	b.Drivers = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewDrivers")
 		}
 		b.Drivers = append(b.Drivers, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/storage/v1/csistoragecapacity.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storage/v1/csistoragecapacity.go
@@ -216,6 +216,7 @@ func (b *CSIStorageCapacityApplyConfiguration) WithAnnotations(entries map[strin
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *CSIStorageCapacityApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *CSIStorageCapacityApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -227,14 +228,40 @@ func (b *CSIStorageCapacityApplyConfiguration) WithOwnerReferences(values ...*v1
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *CSIStorageCapacityApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *CSIStorageCapacityApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *CSIStorageCapacityApplyConfiguration) WithFinalizers(values ...string) *CSIStorageCapacityApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *CSIStorageCapacityApplyConfiguration) WithNewFinalizers(values ...string) *CSIStorageCapacityApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/storage/v1/storageclass.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storage/v1/storageclass.go
@@ -218,6 +218,7 @@ func (b *StorageClassApplyConfiguration) WithAnnotations(entries map[string]stri
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *StorageClassApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *StorageClassApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -229,14 +230,40 @@ func (b *StorageClassApplyConfiguration) WithOwnerReferences(values ...*v1.Owner
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *StorageClassApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *StorageClassApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *StorageClassApplyConfiguration) WithFinalizers(values ...string) *StorageClassApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *StorageClassApplyConfiguration) WithNewFinalizers(values ...string) *StorageClassApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 
@@ -279,10 +306,20 @@ func (b *StorageClassApplyConfiguration) WithReclaimPolicy(value corev1.Persiste
 // WithMountOptions adds the given value to the MountOptions field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the MountOptions field.
+// Deprecated: WithMountOptions does not replace existing list for atomic list type. Use WithNewMountOptions instead.
 func (b *StorageClassApplyConfiguration) WithMountOptions(values ...string) *StorageClassApplyConfiguration {
 	for i := range values {
 		b.MountOptions = append(b.MountOptions, values[i])
 	}
+	return b
+}
+
+// WithNewMountOptions replaces the MountOptions field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the MountOptions field is set to the values of the last call.
+func (b *StorageClassApplyConfiguration) WithNewMountOptions(values ...string) *StorageClassApplyConfiguration {
+	b.MountOptions = make([]string, len(values))
+	copy(b.MountOptions, values)
 	return b
 }
 
@@ -305,10 +342,25 @@ func (b *StorageClassApplyConfiguration) WithVolumeBindingMode(value storagev1.V
 // WithAllowedTopologies adds the given value to the AllowedTopologies field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the AllowedTopologies field.
+// Deprecated: WithAllowedTopologies does not replace existing list for atomic list type. Use WithNewAllowedTopologies instead.
 func (b *StorageClassApplyConfiguration) WithAllowedTopologies(values ...*applyconfigurationscorev1.TopologySelectorTermApplyConfiguration) *StorageClassApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithAllowedTopologies")
+		}
+		b.AllowedTopologies = append(b.AllowedTopologies, *values[i])
+	}
+	return b
+}
+
+// WithNewAllowedTopologies replaces the AllowedTopologies field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the AllowedTopologies field is set to the values of the last call.
+func (b *StorageClassApplyConfiguration) WithNewAllowedTopologies(values ...*applyconfigurationscorev1.TopologySelectorTermApplyConfiguration) *StorageClassApplyConfiguration {
+	b.AllowedTopologies = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewAllowedTopologies")
 		}
 		b.AllowedTopologies = append(b.AllowedTopologies, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/storage/v1/volumeattachment.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storage/v1/volumeattachment.go
@@ -211,6 +211,7 @@ func (b *VolumeAttachmentApplyConfiguration) WithAnnotations(entries map[string]
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *VolumeAttachmentApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *VolumeAttachmentApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -222,14 +223,40 @@ func (b *VolumeAttachmentApplyConfiguration) WithOwnerReferences(values ...*v1.O
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *VolumeAttachmentApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *VolumeAttachmentApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *VolumeAttachmentApplyConfiguration) WithFinalizers(values ...string) *VolumeAttachmentApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *VolumeAttachmentApplyConfiguration) WithNewFinalizers(values ...string) *VolumeAttachmentApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/storage/v1alpha1/csistoragecapacity.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storage/v1alpha1/csistoragecapacity.go
@@ -216,6 +216,7 @@ func (b *CSIStorageCapacityApplyConfiguration) WithAnnotations(entries map[strin
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *CSIStorageCapacityApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *CSIStorageCapacityApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -227,14 +228,40 @@ func (b *CSIStorageCapacityApplyConfiguration) WithOwnerReferences(values ...*v1
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *CSIStorageCapacityApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *CSIStorageCapacityApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *CSIStorageCapacityApplyConfiguration) WithFinalizers(values ...string) *CSIStorageCapacityApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *CSIStorageCapacityApplyConfiguration) WithNewFinalizers(values ...string) *CSIStorageCapacityApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/storage/v1alpha1/volumeattachment.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storage/v1alpha1/volumeattachment.go
@@ -211,6 +211,7 @@ func (b *VolumeAttachmentApplyConfiguration) WithAnnotations(entries map[string]
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *VolumeAttachmentApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *VolumeAttachmentApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -222,14 +223,40 @@ func (b *VolumeAttachmentApplyConfiguration) WithOwnerReferences(values ...*v1.O
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *VolumeAttachmentApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *VolumeAttachmentApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *VolumeAttachmentApplyConfiguration) WithFinalizers(values ...string) *VolumeAttachmentApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *VolumeAttachmentApplyConfiguration) WithNewFinalizers(values ...string) *VolumeAttachmentApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/storage/v1beta1/csidriver.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storage/v1beta1/csidriver.go
@@ -210,6 +210,7 @@ func (b *CSIDriverApplyConfiguration) WithAnnotations(entries map[string]string)
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *CSIDriverApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *CSIDriverApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -221,14 +222,40 @@ func (b *CSIDriverApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerRef
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *CSIDriverApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *CSIDriverApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *CSIDriverApplyConfiguration) WithFinalizers(values ...string) *CSIDriverApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *CSIDriverApplyConfiguration) WithNewFinalizers(values ...string) *CSIDriverApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/storage/v1beta1/csidriverspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storage/v1beta1/csidriverspec.go
@@ -60,10 +60,20 @@ func (b *CSIDriverSpecApplyConfiguration) WithPodInfoOnMount(value bool) *CSIDri
 // WithVolumeLifecycleModes adds the given value to the VolumeLifecycleModes field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the VolumeLifecycleModes field.
+// Deprecated: WithVolumeLifecycleModes does not replace existing list for atomic list type. Use WithNewVolumeLifecycleModes instead.
 func (b *CSIDriverSpecApplyConfiguration) WithVolumeLifecycleModes(values ...v1beta1.VolumeLifecycleMode) *CSIDriverSpecApplyConfiguration {
 	for i := range values {
 		b.VolumeLifecycleModes = append(b.VolumeLifecycleModes, values[i])
 	}
+	return b
+}
+
+// WithNewVolumeLifecycleModes replaces the VolumeLifecycleModes field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the VolumeLifecycleModes field is set to the values of the last call.
+func (b *CSIDriverSpecApplyConfiguration) WithNewVolumeLifecycleModes(values ...v1beta1.VolumeLifecycleMode) *CSIDriverSpecApplyConfiguration {
+	b.VolumeLifecycleModes = make([]v1beta1.VolumeLifecycleMode, len(values))
+	copy(b.VolumeLifecycleModes, values)
 	return b
 }
 
@@ -86,10 +96,25 @@ func (b *CSIDriverSpecApplyConfiguration) WithFSGroupPolicy(value v1beta1.FSGrou
 // WithTokenRequests adds the given value to the TokenRequests field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the TokenRequests field.
+// Deprecated: WithTokenRequests does not replace existing list for atomic list type. Use WithNewTokenRequests instead.
 func (b *CSIDriverSpecApplyConfiguration) WithTokenRequests(values ...*TokenRequestApplyConfiguration) *CSIDriverSpecApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithTokenRequests")
+		}
+		b.TokenRequests = append(b.TokenRequests, *values[i])
+	}
+	return b
+}
+
+// WithNewTokenRequests replaces the TokenRequests field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the TokenRequests field is set to the values of the last call.
+func (b *CSIDriverSpecApplyConfiguration) WithNewTokenRequests(values ...*TokenRequestApplyConfiguration) *CSIDriverSpecApplyConfiguration {
+	b.TokenRequests = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewTokenRequests")
 		}
 		b.TokenRequests = append(b.TokenRequests, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/storage/v1beta1/csinode.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storage/v1beta1/csinode.go
@@ -210,6 +210,7 @@ func (b *CSINodeApplyConfiguration) WithAnnotations(entries map[string]string) *
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *CSINodeApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *CSINodeApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -221,14 +222,40 @@ func (b *CSINodeApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerRefer
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *CSINodeApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *CSINodeApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *CSINodeApplyConfiguration) WithFinalizers(values ...string) *CSINodeApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *CSINodeApplyConfiguration) WithNewFinalizers(values ...string) *CSINodeApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/storage/v1beta1/csinodedriver.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storage/v1beta1/csinodedriver.go
@@ -52,10 +52,20 @@ func (b *CSINodeDriverApplyConfiguration) WithNodeID(value string) *CSINodeDrive
 // WithTopologyKeys adds the given value to the TopologyKeys field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the TopologyKeys field.
+// Deprecated: WithTopologyKeys does not replace existing list for atomic list type. Use WithNewTopologyKeys instead.
 func (b *CSINodeDriverApplyConfiguration) WithTopologyKeys(values ...string) *CSINodeDriverApplyConfiguration {
 	for i := range values {
 		b.TopologyKeys = append(b.TopologyKeys, values[i])
 	}
+	return b
+}
+
+// WithNewTopologyKeys replaces the TopologyKeys field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the TopologyKeys field is set to the values of the last call.
+func (b *CSINodeDriverApplyConfiguration) WithNewTopologyKeys(values ...string) *CSINodeDriverApplyConfiguration {
+	b.TopologyKeys = make([]string, len(values))
+	copy(b.TopologyKeys, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/storage/v1beta1/csinodespec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storage/v1beta1/csinodespec.go
@@ -33,10 +33,25 @@ func CSINodeSpec() *CSINodeSpecApplyConfiguration {
 // WithDrivers adds the given value to the Drivers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Drivers field.
+// Deprecated: WithDrivers does not replace existing list for atomic list type. Use WithNewDrivers instead.
 func (b *CSINodeSpecApplyConfiguration) WithDrivers(values ...*CSINodeDriverApplyConfiguration) *CSINodeSpecApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithDrivers")
+		}
+		b.Drivers = append(b.Drivers, *values[i])
+	}
+	return b
+}
+
+// WithNewDrivers replaces the Drivers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Drivers field is set to the values of the last call.
+func (b *CSINodeSpecApplyConfiguration) WithNewDrivers(values ...*CSINodeDriverApplyConfiguration) *CSINodeSpecApplyConfiguration {
+	b.Drivers = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewDrivers")
 		}
 		b.Drivers = append(b.Drivers, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/storage/v1beta1/csistoragecapacity.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storage/v1beta1/csistoragecapacity.go
@@ -216,6 +216,7 @@ func (b *CSIStorageCapacityApplyConfiguration) WithAnnotations(entries map[strin
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *CSIStorageCapacityApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *CSIStorageCapacityApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -227,14 +228,40 @@ func (b *CSIStorageCapacityApplyConfiguration) WithOwnerReferences(values ...*v1
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *CSIStorageCapacityApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *CSIStorageCapacityApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *CSIStorageCapacityApplyConfiguration) WithFinalizers(values ...string) *CSIStorageCapacityApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *CSIStorageCapacityApplyConfiguration) WithNewFinalizers(values ...string) *CSIStorageCapacityApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/storage/v1beta1/storageclass.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storage/v1beta1/storageclass.go
@@ -218,6 +218,7 @@ func (b *StorageClassApplyConfiguration) WithAnnotations(entries map[string]stri
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *StorageClassApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *StorageClassApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -229,14 +230,40 @@ func (b *StorageClassApplyConfiguration) WithOwnerReferences(values ...*v1.Owner
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *StorageClassApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *StorageClassApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *StorageClassApplyConfiguration) WithFinalizers(values ...string) *StorageClassApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *StorageClassApplyConfiguration) WithNewFinalizers(values ...string) *StorageClassApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 
@@ -279,10 +306,20 @@ func (b *StorageClassApplyConfiguration) WithReclaimPolicy(value corev1.Persiste
 // WithMountOptions adds the given value to the MountOptions field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the MountOptions field.
+// Deprecated: WithMountOptions does not replace existing list for atomic list type. Use WithNewMountOptions instead.
 func (b *StorageClassApplyConfiguration) WithMountOptions(values ...string) *StorageClassApplyConfiguration {
 	for i := range values {
 		b.MountOptions = append(b.MountOptions, values[i])
 	}
+	return b
+}
+
+// WithNewMountOptions replaces the MountOptions field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the MountOptions field is set to the values of the last call.
+func (b *StorageClassApplyConfiguration) WithNewMountOptions(values ...string) *StorageClassApplyConfiguration {
+	b.MountOptions = make([]string, len(values))
+	copy(b.MountOptions, values)
 	return b
 }
 
@@ -305,10 +342,25 @@ func (b *StorageClassApplyConfiguration) WithVolumeBindingMode(value v1beta1.Vol
 // WithAllowedTopologies adds the given value to the AllowedTopologies field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the AllowedTopologies field.
+// Deprecated: WithAllowedTopologies does not replace existing list for atomic list type. Use WithNewAllowedTopologies instead.
 func (b *StorageClassApplyConfiguration) WithAllowedTopologies(values ...*applyconfigurationscorev1.TopologySelectorTermApplyConfiguration) *StorageClassApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithAllowedTopologies")
+		}
+		b.AllowedTopologies = append(b.AllowedTopologies, *values[i])
+	}
+	return b
+}
+
+// WithNewAllowedTopologies replaces the AllowedTopologies field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the AllowedTopologies field is set to the values of the last call.
+func (b *StorageClassApplyConfiguration) WithNewAllowedTopologies(values ...*applyconfigurationscorev1.TopologySelectorTermApplyConfiguration) *StorageClassApplyConfiguration {
+	b.AllowedTopologies = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewAllowedTopologies")
 		}
 		b.AllowedTopologies = append(b.AllowedTopologies, *values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/storage/v1beta1/volumeattachment.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storage/v1beta1/volumeattachment.go
@@ -211,6 +211,7 @@ func (b *VolumeAttachmentApplyConfiguration) WithAnnotations(entries map[string]
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *VolumeAttachmentApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *VolumeAttachmentApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -222,14 +223,40 @@ func (b *VolumeAttachmentApplyConfiguration) WithOwnerReferences(values ...*v1.O
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *VolumeAttachmentApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *VolumeAttachmentApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *VolumeAttachmentApplyConfiguration) WithFinalizers(values ...string) *VolumeAttachmentApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *VolumeAttachmentApplyConfiguration) WithNewFinalizers(values ...string) *VolumeAttachmentApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/code-generator/examples/HyphenGroup/applyconfiguration/example/v1/clustertesttype.go
+++ b/staging/src/k8s.io/code-generator/examples/HyphenGroup/applyconfiguration/example/v1/clustertesttype.go
@@ -173,6 +173,7 @@ func (b *ClusterTestTypeApplyConfiguration) WithAnnotations(entries map[string]s
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *ClusterTestTypeApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *ClusterTestTypeApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -184,14 +185,40 @@ func (b *ClusterTestTypeApplyConfiguration) WithOwnerReferences(values ...*v1.Ow
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *ClusterTestTypeApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *ClusterTestTypeApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *ClusterTestTypeApplyConfiguration) WithFinalizers(values ...string) *ClusterTestTypeApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *ClusterTestTypeApplyConfiguration) WithNewFinalizers(values ...string) *ClusterTestTypeApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/code-generator/examples/HyphenGroup/applyconfiguration/example/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/HyphenGroup/applyconfiguration/example/v1/testtype.go
@@ -174,6 +174,7 @@ func (b *TestTypeApplyConfiguration) WithAnnotations(entries map[string]string) 
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *TestTypeApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *TestTypeApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -185,14 +186,40 @@ func (b *TestTypeApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerRefe
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *TestTypeApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *TestTypeApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *TestTypeApplyConfiguration) WithFinalizers(values ...string) *TestTypeApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *TestTypeApplyConfiguration) WithNewFinalizers(values ...string) *TestTypeApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/code-generator/examples/MixedCase/applyconfiguration/example/v1/clustertesttype.go
+++ b/staging/src/k8s.io/code-generator/examples/MixedCase/applyconfiguration/example/v1/clustertesttype.go
@@ -173,6 +173,7 @@ func (b *ClusterTestTypeApplyConfiguration) WithAnnotations(entries map[string]s
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *ClusterTestTypeApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *ClusterTestTypeApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -184,14 +185,40 @@ func (b *ClusterTestTypeApplyConfiguration) WithOwnerReferences(values ...*v1.Ow
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *ClusterTestTypeApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *ClusterTestTypeApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *ClusterTestTypeApplyConfiguration) WithFinalizers(values ...string) *ClusterTestTypeApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *ClusterTestTypeApplyConfiguration) WithNewFinalizers(values ...string) *ClusterTestTypeApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/code-generator/examples/MixedCase/applyconfiguration/example/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/MixedCase/applyconfiguration/example/v1/testtype.go
@@ -174,6 +174,7 @@ func (b *TestTypeApplyConfiguration) WithAnnotations(entries map[string]string) 
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *TestTypeApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *TestTypeApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -185,14 +186,40 @@ func (b *TestTypeApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerRefe
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *TestTypeApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *TestTypeApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *TestTypeApplyConfiguration) WithFinalizers(values ...string) *TestTypeApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *TestTypeApplyConfiguration) WithNewFinalizers(values ...string) *TestTypeApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/code-generator/examples/crd/applyconfiguration/example/v1/clustertesttype.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/applyconfiguration/example/v1/clustertesttype.go
@@ -173,6 +173,7 @@ func (b *ClusterTestTypeApplyConfiguration) WithAnnotations(entries map[string]s
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *ClusterTestTypeApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *ClusterTestTypeApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -184,14 +185,40 @@ func (b *ClusterTestTypeApplyConfiguration) WithOwnerReferences(values ...*v1.Ow
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *ClusterTestTypeApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *ClusterTestTypeApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *ClusterTestTypeApplyConfiguration) WithFinalizers(values ...string) *ClusterTestTypeApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *ClusterTestTypeApplyConfiguration) WithNewFinalizers(values ...string) *ClusterTestTypeApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/code-generator/examples/crd/applyconfiguration/example/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/applyconfiguration/example/v1/testtype.go
@@ -174,6 +174,7 @@ func (b *TestTypeApplyConfiguration) WithAnnotations(entries map[string]string) 
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *TestTypeApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *TestTypeApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -185,14 +186,40 @@ func (b *TestTypeApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerRefe
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *TestTypeApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *TestTypeApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *TestTypeApplyConfiguration) WithFinalizers(values ...string) *TestTypeApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *TestTypeApplyConfiguration) WithNewFinalizers(values ...string) *TestTypeApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/code-generator/examples/crd/applyconfiguration/example2/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/applyconfiguration/example2/v1/testtype.go
@@ -174,6 +174,7 @@ func (b *TestTypeApplyConfiguration) WithAnnotations(entries map[string]string) 
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *TestTypeApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *TestTypeApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -185,14 +186,40 @@ func (b *TestTypeApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerRefe
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *TestTypeApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *TestTypeApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *TestTypeApplyConfiguration) WithFinalizers(values ...string) *TestTypeApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *TestTypeApplyConfiguration) WithNewFinalizers(values ...string) *TestTypeApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/applyconfiguration/wardle/v1alpha1/fischer.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/applyconfiguration/wardle/v1alpha1/fischer.go
@@ -172,6 +172,7 @@ func (b *FischerApplyConfiguration) WithAnnotations(entries map[string]string) *
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *FischerApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *FischerApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -183,14 +184,40 @@ func (b *FischerApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerRefer
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *FischerApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *FischerApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *FischerApplyConfiguration) WithFinalizers(values ...string) *FischerApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *FischerApplyConfiguration) WithNewFinalizers(values ...string) *FischerApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 
@@ -203,9 +230,19 @@ func (b *FischerApplyConfiguration) ensureObjectMetaApplyConfigurationExists() {
 // WithDisallowedFlunders adds the given value to the DisallowedFlunders field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the DisallowedFlunders field.
+// Deprecated: WithDisallowedFlunders does not replace existing list for atomic list type. Use WithNewDisallowedFlunders instead.
 func (b *FischerApplyConfiguration) WithDisallowedFlunders(values ...string) *FischerApplyConfiguration {
 	for i := range values {
 		b.DisallowedFlunders = append(b.DisallowedFlunders, values[i])
 	}
+	return b
+}
+
+// WithNewDisallowedFlunders replaces the DisallowedFlunders field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the DisallowedFlunders field is set to the values of the last call.
+func (b *FischerApplyConfiguration) WithNewDisallowedFlunders(values ...string) *FischerApplyConfiguration {
+	b.DisallowedFlunders = make([]string, len(values))
+	copy(b.DisallowedFlunders, values)
 	return b
 }

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/applyconfiguration/wardle/v1alpha1/flunder.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/applyconfiguration/wardle/v1alpha1/flunder.go
@@ -175,6 +175,7 @@ func (b *FlunderApplyConfiguration) WithAnnotations(entries map[string]string) *
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *FlunderApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *FlunderApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -186,14 +187,40 @@ func (b *FlunderApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerRefer
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *FlunderApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *FlunderApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *FlunderApplyConfiguration) WithFinalizers(values ...string) *FlunderApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *FlunderApplyConfiguration) WithNewFinalizers(values ...string) *FlunderApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/applyconfiguration/wardle/v1beta1/flunder.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/applyconfiguration/wardle/v1beta1/flunder.go
@@ -175,6 +175,7 @@ func (b *FlunderApplyConfiguration) WithAnnotations(entries map[string]string) *
 // WithOwnerReferences adds the given value to the OwnerReferences field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the OwnerReferences field.
+// Deprecated: WithOwnerReferences does not replace existing list for atomic list type. Use WithNewOwnerReferences instead.
 func (b *FlunderApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *FlunderApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
@@ -186,14 +187,40 @@ func (b *FlunderApplyConfiguration) WithOwnerReferences(values ...*v1.OwnerRefer
 	return b
 }
 
+// WithNewOwnerReferences replaces the OwnerReferences field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the OwnerReferences field is set to the values of the last call.
+func (b *FlunderApplyConfiguration) WithNewOwnerReferences(values ...*v1.OwnerReferenceApplyConfiguration) *FlunderApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.OwnerReferences = nil
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithNewOwnerReferences")
+		}
+		b.OwnerReferences = append(b.OwnerReferences, *values[i])
+	}
+	return b
+}
+
 // WithFinalizers adds the given value to the Finalizers field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Finalizers field.
+// Deprecated: WithFinalizers does not replace existing list for atomic list type. Use WithNewFinalizers instead.
 func (b *FlunderApplyConfiguration) WithFinalizers(values ...string) *FlunderApplyConfiguration {
 	b.ensureObjectMetaApplyConfigurationExists()
 	for i := range values {
 		b.Finalizers = append(b.Finalizers, values[i])
 	}
+	return b
+}
+
+// WithNewFinalizers replaces the Finalizers field in the declarative configuration with given values
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, the Finalizers field is set to the values of the last call.
+func (b *FlunderApplyConfiguration) WithNewFinalizers(values ...string) *FlunderApplyConfiguration {
+	b.ensureObjectMetaApplyConfigurationExists()
+	b.Finalizers = make([]string, len(values))
+	copy(b.Finalizers, values)
 	return b
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Atomic types should be applied with replace instead of append.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/121030


#### Special notes for your reviewer:
Tested with `hack/update-codegen.sh`

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
