### PR TITLE
Register UnauthenticatedHTTP2DOSMitigation into kube components

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -1232,6 +1232,8 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 
 	genericfeatures.ServerSideFieldValidation: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.29
 
+	genericfeatures.UnauthenticatedHTTP2DOSMitigation: {Default: true, PreRelease: featuregate.Beta},
+
 	// inherited features from apiextensions-apiserver, relisted here to get a conflict if it is changed
 	// unintentionally on either side:
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Ensures the UnauthenticatedHTTP2DOSMitigation gate is register for all kube components, so deployments that manage feature gates homogenously across all components can use it.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/cc @enj @dims @jeremyrickard 