### PR TITLE
Automated cherry pick of #121224: Register UnauthenticatedHTTP2DOSMitigation into kube

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -1151,6 +1151,8 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 
 	genericfeatures.ServerSideFieldValidation: {Default: true, PreRelease: featuregate.Beta},
 
+	genericfeatures.UnauthenticatedHTTP2DOSMitigation: {Default: false, PreRelease: featuregate.Beta},
+
 	// features that enable backwards compatibility but are scheduled to be removed
 	// ...
 	HPAScaleToZero: {Default: false, PreRelease: featuregate.Alpha},


### PR DESCRIPTION
Cherry pick of #121224 on release-1.25.

#121224: Register UnauthenticatedHTTP2DOSMitigation into kube

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

the release note in the previous PR that added the gate is sufficient - this PR makes the gate work consistently

```release-note
NONE
```