### PR TITLE
kubeadm: fill with the DefaultCRISocket when CRI socket detection is not required

### DIFF
--- a/cmd/kubeadm/app/cmd/config.go
+++ b/cmd/kubeadm/app/cmd/config.go
@@ -223,9 +223,6 @@ func getDefaultNodeConfigBytes() ([]byte, error) {
 				UnsafeSkipCAVerification: true, // TODO: UnsafeSkipCAVerification: true needs to be set for validation to pass, but shouldn't be recommended as the default
 			},
 		},
-		NodeRegistration: kubeadmapiv1old.NodeRegistrationOptions{
-			CRISocket: constants.DefaultCRISocket, // avoid CRI detection
-		},
 	}, opts)
 	if err != nil {
 		return []byte{}, err
@@ -238,9 +235,7 @@ func getDefaultResetConfigBytes() ([]byte, error) {
 	opts := configutil.LoadOrDefaultConfigurationOptions{
 		SkipCRIDetect: true,
 	}
-	internalcfg, err := configutil.DefaultedResetConfiguration(&kubeadmapiv1.ResetConfiguration{
-		CRISocket: constants.DefaultCRISocket, // avoid CRI detection
-	}, opts)
+	internalcfg, err := configutil.DefaultedResetConfiguration(&kubeadmapiv1.ResetConfiguration{}, opts)
 	if err != nil {
 		return []byte{}, err
 	}

--- a/cmd/kubeadm/app/util/config/initconfiguration.go
+++ b/cmd/kubeadm/app/util/config/initconfiguration.go
@@ -111,8 +111,8 @@ func SetNodeRegistrationDynamicDefaults(cfg *kubeadmapi.NodeRegistrationOptions,
 
 	if cfg.CRISocket == "" {
 		if skipCRIDetect {
-			klog.V(4).Infof("skip CRI socket detection, fill with placeholder %s", kubeadmconstants.UnknownCRISocket)
-			cfg.CRISocket = kubeadmconstants.UnknownCRISocket // set a value to pass the ValidateSocketPath
+			klog.V(4).Infof("skip CRI socket detection, fill with the default CRI socket %s", kubeadmconstants.DefaultCRISocket)
+			cfg.CRISocket = kubeadmconstants.DefaultCRISocket
 			return nil
 		}
 		cfg.CRISocket, err = kubeadmruntime.DetectCRISocket()

--- a/cmd/kubeadm/app/util/config/resetconfiguration.go
+++ b/cmd/kubeadm/app/util/config/resetconfiguration.go
@@ -40,8 +40,8 @@ func SetResetDynamicDefaults(cfg *kubeadmapi.ResetConfiguration, skipCRIDetect b
 	var err error
 	if cfg.CRISocket == "" {
 		if skipCRIDetect {
-			klog.V(4).Infof("skip CRI socket detection, fill with placeholder %s", constants.UnknownCRISocket)
-			cfg.CRISocket = constants.UnknownCRISocket // set a value to pass the ValidateSocketPath
+			klog.V(4).Infof("skip CRI socket detection, fill with the default CRI socket %s", constants.DefaultCRISocket)
+			cfg.CRISocket = constants.DefaultCRISocket
 			return nil
 		}
 		cfg.CRISocket, err = kubeadmruntime.DetectCRISocket()


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
kubeadm: fill with the DefaultCRISocket when CRI socket detection is not required

To be consistent with the function name "SetNodeRegistrationDynamic**Defaults**" and "SetResetDynamic**Defaults**", I'd like to use `kubeadmconstants.DefaultCRISocket` instead of `kubeadmconstants.UnknownCRISocket` as the default value. 
With this change, we can also remove some references to `constants.DefaultCRISocket // avoid CRI detection`.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
