### PR TITLE
code-generator: add ut in ./staging/src/k8s.io/code-generator/generators

### DIFF
--- a/staging/src/k8s.io/code-generator/cmd/conversion-gen/generators/conversion_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/conversion-gen/generators/conversion_test.go
@@ -1,0 +1,328 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package generators
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func Test_extractTag(t *testing.T) {
+	testCases := map[string]struct {
+		comments []string
+		expect   []string
+	}{
+		"no comments": {
+			comments: []string{},
+			expect:   nil,
+		},
+		"no tag": {
+			comments: []string{
+				"+",
+			},
+			expect: nil,
+		},
+		"wrong tag": {
+			comments: []string{
+				"+k8s:wrong-tag",
+			},
+			expect: nil,
+		},
+		"no value": {
+			comments: []string{
+				"+k8s:conversion-gen=",
+			},
+			expect: []string{
+				"",
+			},
+		},
+		"value==false": {
+			comments: []string{
+				"+k8s:conversion-gen=false",
+			},
+			expect: []string{
+				"false",
+			},
+		},
+		"one comment": {
+			comments: []string{
+				"+k8s:conversion-gen=k8s.io/kubernetes/runtime.Object",
+			},
+			expect: []string{
+				"k8s.io/kubernetes/runtime.Object",
+			},
+		},
+		"two different comments": {
+			comments: []string{
+				"+k8s:conversion-gen=k8s.io/kubernetes/runtime.Object",
+				"+k8s:conversion-gen=k8s.io/kubernetes/runtime.List",
+			},
+			expect: []string{
+				"k8s.io/kubernetes/runtime.Object",
+				"k8s.io/kubernetes/runtime.List",
+			},
+		},
+		"two same comments": {
+			comments: []string{
+				"+k8s:conversion-gen=k8s.io/kubernetes/runtime.Object",
+				"+k8s:conversion-gen=k8s.io/kubernetes/runtime.Object",
+			},
+			expect: []string{
+				"k8s.io/kubernetes/runtime.Object",
+				"k8s.io/kubernetes/runtime.Object",
+			},
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			r := extractTag(tc.comments)
+			assert.Equal(t, tc.expect, r)
+		})
+	}
+}
+
+func Test_extractExplicitFromTag(t *testing.T) {
+	testCases := map[string]struct {
+		comments []string
+		expect   []string
+	}{
+		"no comments": {
+			comments: []string{},
+			expect:   nil,
+		},
+		"no tag": {
+			comments: []string{"+"},
+			expect:   nil,
+		},
+		"wrong tag": {
+			comments: []string{"+k8s:wrong-tag"},
+			expect:   nil,
+		},
+		"no value": {
+			comments: []string{"+k8s:conversion-gen:explicit-from="},
+			expect:   []string{""},
+		},
+		"value==false": {
+			comments: []string{"+k8s:conversion-gen:explicit-from=false"},
+			expect:   []string{"false"},
+		},
+		"one comment": {
+			comments: []string{
+				"+k8s:conversion-gen:explicit-from=url.Values",
+			},
+			expect: []string{
+				"url.Values",
+			},
+		},
+		"two different comments": {
+			comments: []string{
+				"+k8s:conversion-gen:explicit-from=url.Values.Object",
+				"+k8s:conversion-gen:explicit-from=url.Values.List",
+			},
+			expect: []string{
+				"url.Values.Object",
+				"url.Values.List",
+			},
+		},
+		"two same comments": {
+			comments: []string{
+				"+k8s:conversion-gen:explicit-from=url.Values.Object",
+				"+k8s:conversion-gen:explicit-from=url.Values.Object",
+			},
+			expect: []string{
+				"url.Values.Object",
+				"url.Values.Object",
+			},
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			r := extractExplicitFromTag(tc.comments)
+			assert.Equal(t, tc.expect, r)
+		})
+	}
+}
+
+func Test_extractExternalTypesTag(t *testing.T) {
+	testCases := map[string]struct {
+		comments []string
+		expect   []string
+	}{
+		"no comments": {
+			comments: []string{},
+			expect:   nil,
+		},
+		"no tag": {
+			comments: []string{"+"},
+			expect:   nil,
+		},
+		"wrong tag": {
+			comments: []string{"+k8s:wrong-tag"},
+			expect:   nil,
+		},
+		"no value": {
+			comments: []string{"+k8s:conversion-gen-external-types="},
+			expect:   []string{""},
+		},
+		"value==false": {
+			comments: []string{"+k8s:conversion-gen-external-types=false"},
+			expect:   []string{"false"},
+		},
+		"one comment": {
+			comments: []string{
+				"+k8s:conversion-gen-external-types=k8s.io/kubernetes/runtime.Object",
+			},
+			expect: []string{
+				"k8s.io/kubernetes/runtime.Object",
+			},
+		},
+		"two different comments": {
+			comments: []string{
+				"+k8s:conversion-gen-external-types=k8s.io/kubernetes/runtime.Object",
+				"+k8s:conversion-gen-external-types=k8s.io/kubernetes/runtime.List",
+			},
+			expect: []string{
+				"k8s.io/kubernetes/runtime.Object",
+				"k8s.io/kubernetes/runtime.List",
+			},
+		},
+		"two same comments": {
+			comments: []string{
+				"+k8s:conversion-gen-external-types=k8s.io/kubernetes/runtime.Object",
+				"+k8s:conversion-gen-external-types=k8s.io/kubernetes/runtime.Object",
+			},
+			expect: []string{
+				"k8s.io/kubernetes/runtime.Object",
+				"k8s.io/kubernetes/runtime.Object",
+			},
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			r := extractExternalTypesTag(tc.comments)
+			assert.Equal(t, tc.expect, r)
+		})
+	}
+}
+
+func Test_isCopyOnly(t *testing.T) {
+	testCases := map[string]struct {
+		comments []string
+		expect   bool
+	}{
+		"no comments": {
+			comments: []string{},
+			expect:   false,
+		},
+		"no tag": {
+			comments: []string{"+"},
+			expect:   false,
+		},
+		"wrong tag": {
+			comments: []string{"+k8s:wrong-tag"},
+			expect:   false,
+		},
+		"no value": {
+			comments: []string{"+k8s:conversion-fn="},
+			expect:   false,
+		},
+		"value==false": {
+			comments: []string{"+k8s:conversion-fn=false"},
+			expect:   false,
+		},
+		"one copy-only": {
+			comments: []string{
+				"+k8s:conversion-fn=copy-only",
+			},
+			expect: true,
+		},
+		"two different comments": {
+			comments: []string{
+				"+k8s:conversion-fn=copy-only",
+				"+k8s:conversion-fn=k8s.io/kubernetes/runtime.List",
+			},
+			expect: false,
+		},
+		"two same copy-only": {
+			comments: []string{
+				"+k8s:conversion-fn=copy-only",
+				"+k8s:conversion-fn=copy-only",
+			},
+			expect: false,
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			r := isCopyOnly(tc.comments)
+			assert.Equal(t, tc.expect, r)
+		})
+	}
+}
+
+func Test_isDrop(t *testing.T) {
+	testCases := map[string]struct {
+		comments []string
+		expect   bool
+	}{
+		"no comments": {
+			comments: []string{},
+			expect:   false,
+		},
+		"no tag": {
+			comments: []string{"+"},
+			expect:   false,
+		},
+		"wrong tag": {
+			comments: []string{"+k8s:wrong-tag"},
+			expect:   false,
+		},
+		"no value": {
+			comments: []string{"+k8s:conversion-fn="},
+			expect:   false,
+		},
+		"value==false": {
+			comments: []string{"+k8s:conversion-fn=false"},
+			expect:   false,
+		},
+		"one isDrop": {
+			comments: []string{
+				"+k8s:conversion-fn=drop",
+			},
+			expect: true,
+		},
+		"two different comments": {
+			comments: []string{
+				"+k8s:conversion-fn=drop",
+				"+k8s:conversion-fn=k8s.io/kubernetes/runtime.List",
+			},
+			expect: false,
+		},
+		"two same isDrop": {
+			comments: []string{
+				"+k8s:conversion-fn=drop",
+				"+k8s:conversion-fn=drop",
+			},
+			expect: false,
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			r := isDrop(tc.comments)
+			assert.Equal(t, tc.expect, r)
+		})
+	}
+}

--- a/staging/src/k8s.io/code-generator/go.mod
+++ b/staging/src/k8s.io/code-generator/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/gogo/protobuf v1.3.2
 	github.com/google/gnostic-models v0.6.8
 	github.com/spf13/pflag v1.0.5
+	github.com/stretchr/testify v1.8.3
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/gengo v0.0.0-20230829151522-9cce18d56c01
 	k8s.io/klog/v2 v2.100.1
@@ -15,6 +16,7 @@ require (
 )
 
 require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emicklei/go-restful/v3 v3.11.0 // indirect
 	github.com/go-logr/logr v1.2.4 // indirect
 	github.com/go-openapi/jsonpointer v0.19.6 // indirect
@@ -32,8 +34,8 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/onsi/ginkgo/v2 v2.13.0 // indirect
 	github.com/onsi/gomega v1.28.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.10.0 // indirect
-	github.com/stretchr/testify v1.8.3 // indirect
 	golang.org/x/mod v0.12.0 // indirect
 	golang.org/x/net v0.17.0 // indirect
 	golang.org/x/sys v0.13.0 // indirect


### PR DESCRIPTION
What type of PR is this?

/kind cleanup

What this PR does / why we need it:

[UT]Increase ut for code-generator
https://github.com/kubernetes/kubernetes/issues/119289
k8s.io/code-generator/cmd/conversion-gen/generators coverage: 0.5% of statements

Which issue(s) this PR fixes:

Fixes #

Special notes for your reviewer:

Does this PR introduce a user-facing change?
```
NONE
````
Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```
NONE
```