### PR TITLE
Add  ipv4 TCP settings safe sysctls

### DIFF
--- a/pkg/kubelet/sysctl/safe_sysctls.go
+++ b/pkg/kubelet/sysctl/safe_sysctls.go
@@ -51,6 +51,20 @@ var safeSysctls = []sysctl{
 		name: "net.ipv4.tcp_keepalive_time",
 		// refer to https://github.com/torvalds/linux/commit/13b287e8d1cad951634389f85b8c9b816bd3bb1e.
 		kernel: "4.5",
+	}, {
+		// refer to https://github.com/torvalds/linux/commit/1e579caa18b96f9eb18f4f5416658cd15f37c062.
+		name:   "net.ipv4.tcp_fin_timeout",
+		kernel: "4.6",
+	},
+	{
+		// refer to https://github.com/torvalds/linux/commit/b840d15d39128d08ed4486085e5507d2617b9ae1.
+		name:   "net.ipv4.tcp_keepalive_intvl",
+		kernel: "4.5",
+	},
+	{
+		// refer to https://github.com/torvalds/linux/commit/9bd6861bd4326e3afd3f14a9ec8a723771fb20bb.
+		name:   "net.ipv4.tcp_keepalive_probes",
+		kernel: "4.5",
 	},
 }
 

--- a/pkg/kubelet/sysctl/safe_sysctls_test.go
+++ b/pkg/kubelet/sysctl/safe_sysctls_test.go
@@ -59,7 +59,7 @@ func Test_getSafeSysctlAllowlist(t *testing.T) {
 			},
 		},
 		{
-			name: "kernelVersion is 5.15.0, return safeSysctls with no kernelVersion limit and net.ipv4.ip_local_reserved_ports and net.ipv4.tcp_keepalive_time",
+			name: "kernelVersion is 5.15.0, return safeSysctls with no kernelVersion limit and kernelVersion below 5.15.0",
 			getVersion: func() (*version.Version, error) {
 				kernelVersionStr := "5.15.0-75-generic"
 				return version.ParseGeneric(kernelVersionStr)
@@ -72,6 +72,9 @@ func Test_getSafeSysctlAllowlist(t *testing.T) {
 				"net.ipv4.ip_unprivileged_port_start",
 				"net.ipv4.ip_local_reserved_ports",
 				"net.ipv4.tcp_keepalive_time",
+				"net.ipv4.tcp_fin_timeout",
+				"net.ipv4.tcp_keepalive_intvl",
+				"net.ipv4.tcp_keepalive_probes",
 			},
 		},
 	}

--- a/staging/src/k8s.io/pod-security-admission/policy/check_sysctls.go
+++ b/staging/src/k8s.io/pod-security-admission/policy/check_sysctls.go
@@ -44,6 +44,9 @@ spec.securityContext.sysctls[*].name
 'net.ipv4.ip_unprivileged_port_start'
 'net.ipv4.ip_local_reserved_ports'
 'net.ipv4.tcp_keepalive_time'
+'net.ipv4.tcp_fin_timeout'
+'net.ipv4.tcp_keepalive_intvl'
+'net.ipv4.tcp_keepalive_probes'
 
 */
 
@@ -97,6 +100,9 @@ var (
 		"net.ipv4.ip_unprivileged_port_start",
 		"net.ipv4.ip_local_reserved_ports",
 		"net.ipv4.tcp_keepalive_time",
+		"net.ipv4.tcp_fin_timeout",
+		"net.ipv4.tcp_keepalive_intvl",
+		"net.ipv4.tcp_keepalive_probes",
 	)
 )
 

--- a/staging/src/k8s.io/pod-security-admission/policy/check_sysctls_test.go
+++ b/staging/src/k8s.io/pod-security-admission/policy/check_sysctls_test.go
@@ -63,6 +63,39 @@ func TestSysctls(t *testing.T) {
 			expectReason: `forbidden sysctls`,
 			expectDetail: `net.ipv4.tcp_keepalive_time`,
 		},
+		{
+			name: "new supported sysctls not supported: net.ipv4.tcp_fin_timeout",
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				SecurityContext: &corev1.PodSecurityContext{
+					Sysctls: []corev1.Sysctl{{Name: "net.ipv4.tcp_fin_timeout", Value: "60"}},
+				},
+			}},
+			allowed:      false,
+			expectReason: `forbidden sysctls`,
+			expectDetail: `net.ipv4.tcp_fin_timeout`,
+		},
+		{
+			name: "new supported sysctls not supported: net.ipv4.tcp_keepalive_intvl",
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				SecurityContext: &corev1.PodSecurityContext{
+					Sysctls: []corev1.Sysctl{{Name: "net.ipv4.tcp_keepalive_intvl", Value: "75"}},
+				},
+			}},
+			allowed:      false,
+			expectReason: `forbidden sysctls`,
+			expectDetail: `net.ipv4.tcp_keepalive_intvl`,
+		},
+		{
+			name: "new supported sysctls not supported: net.ipv4.tcp_keepalive_probes",
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				SecurityContext: &corev1.PodSecurityContext{
+					Sysctls: []corev1.Sysctl{{Name: "net.ipv4.tcp_keepalive_probes", Value: "9"}},
+				},
+			}},
+			allowed:      false,
+			expectReason: `forbidden sysctls`,
+			expectDetail: `net.ipv4.tcp_keepalive_probes`,
+		},
 	}
 
 	for _, tc := range tests {
@@ -155,10 +188,37 @@ func TestSysctls_1_29(t *testing.T) {
 			expectDetail: `a, b`,
 		},
 		{
-			name: "new supported sysctls",
+			name: "new supported sysctls: net.ipv4.tcp_keepalive_time",
 			pod: &corev1.Pod{Spec: corev1.PodSpec{
 				SecurityContext: &corev1.PodSecurityContext{
 					Sysctls: []corev1.Sysctl{{Name: "net.ipv4.tcp_keepalive_time", Value: "7200"}},
+				},
+			}},
+			allowed: true,
+		},
+		{
+			name: "new supported sysctls: net.ipv4.tcp_fin_timeout",
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				SecurityContext: &corev1.PodSecurityContext{
+					Sysctls: []corev1.Sysctl{{Name: "net.ipv4.tcp_fin_timeout", Value: "60"}},
+				},
+			}},
+			allowed: true,
+		},
+		{
+			name: "new supported sysctls: net.ipv4.tcp_keepalive_intvl",
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				SecurityContext: &corev1.PodSecurityContext{
+					Sysctls: []corev1.Sysctl{{Name: "net.ipv4.tcp_keepalive_intvl", Value: "75"}},
+				},
+			}},
+			allowed: true,
+		},
+		{
+			name: "new supported sysctls: net.ipv4.tcp_keepalive_probes",
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				SecurityContext: &corev1.PodSecurityContext{
+					Sysctls: []corev1.Sysctl{{Name: "net.ipv4.tcp_keepalive_probes", Value: "9"}},
 				},
 			}},
 			allowed: true,

--- a/staging/src/k8s.io/pod-security-admission/test/fixtures_sysctls.go
+++ b/staging/src/k8s.io/pod-security-admission/test/fixtures_sysctls.go
@@ -133,6 +133,9 @@ func init() {
 						{Name: "net.ipv4.ip_unprivileged_port_start", Value: "1024"},
 						{Name: "net.ipv4.ip_local_reserved_ports", Value: "1024-4999"},
 						{Name: "net.ipv4.tcp_keepalive_time", Value: "7200"},
+						{Name: "net.ipv4.tcp_fin_timeout", Value: "60"},
+						{Name: "net.ipv4.tcp_keepalive_intvl", Value: "75"},
+						{Name: "net.ipv4.tcp_keepalive_probes", Value: "9"},
 					}
 				}),
 			}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.29/pass/sysctls1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.29/pass/sysctls1.yaml
@@ -25,3 +25,9 @@ spec:
       value: 1024-4999
     - name: net.ipv4.tcp_keepalive_time
       value: "7200"
+    - name: net.ipv4.tcp_fin_timeout
+      value: "60"
+    - name: net.ipv4.tcp_keepalive_intvl
+      value: "75"
+    - name: net.ipv4.tcp_keepalive_probes
+      value: "9"

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.29/pass/sysctls1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.29/pass/sysctls1.yaml
@@ -38,3 +38,9 @@ spec:
       value: 1024-4999
     - name: net.ipv4.tcp_keepalive_time
       value: "7200"
+    - name: net.ipv4.tcp_fin_timeout
+      value: "60"
+    - name: net.ipv4.tcp_keepalive_intvl
+      value: "75"
+    - name: net.ipv4.tcp_keepalive_probes
+      value: "9"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Mark net.ipv4.tcp_fin_timeout, net.ipv4.tcp_keepalive_intvl and net.ipv4.tcp_keepalive_probes to safe sysctl.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #119263

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubelet allows pods to use the `net.ipv4.tcp_fin_timeout` , “net.ipv4.tcp_keepalive_intvl” and “net.ipv4.tcp_keepalive_probes“ sysctl by default; Pod Security admission allows this sysctl in v1.29+ versions of the baseline and restricted policies.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
