### PR TITLE
Fix PersistentVolumeStatus & PersistentVolumeClaimStatus e2e test flake

### DIFF
--- a/test/e2e/storage/persistent_volumes.go
+++ b/test/e2e/storage/persistent_volumes.go
@@ -692,7 +692,7 @@ var _ = utils.SIGDescribe("PersistentVolumes", func() {
 			retrievedPVC := &v1.PersistentVolumeClaim{}
 			err = runtime.DefaultUnstructuredConverter.FromUnstructured(pvcUnstructured.UnstructuredContent(), &retrievedPVC)
 			framework.ExpectNoError(err, "Failed to retrieve %q status.", initialPV.Name)
-			gomega.Expect(string(retrievedPVC.Status.Phase)).To(gomega.Equal("Pending"), "Checking that the PVC status has been read")
+			gomega.Expect(string(retrievedPVC.Status.Phase)).To(gomega.Or(gomega.Equal("Pending"), gomega.Equal("Bound")), "Checking that the PVC status has been read")
 
 			ginkgo.By(fmt.Sprintf("Reading %q Status", initialPV.Name))
 			pvResource := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumes"}


### PR DESCRIPTION
**What type of PR is this?**
/bug

**What this PR does / why we need it:**
One PR #120892  as single flake was detected on the test grid. This would resolve the issue .

**Testgrid Link:** [testgrid-link](https://testgrid.k8s.io/sig-release-master-blocking#gce-cos-master-default&width=5&graph-metrics=test-duration-minutes&include-filter-by-regex=should%20apply%20changes%20to%20a%20pv/pvc%20status)
The issue will not show in testgrid as only 2 day of history is visible at any time.

```
Kubernetes e2e suite: [It] [sig-storage] PersistentVolumes CSI Conformance should apply changes to a pv/pvc status [sig-storage] expand_less 	6s
{ failed [FAILED] Checking that the PVC status has been read
Expected
    <string>: Bound
to equal
    <string>: Pending
In [It] at: test/e2e/storage/persistent_volumes.go:695 @ 10/13/23 05:56:02.051
}
```

**Special notes for your reviewer:**
This is needed ASAP to address the flake

**Does this PR introduce a user-facing change?:**
```
NONE

```

**Release note:**
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:**
```
NONE

```

/sig testing
/sig architecture
/sig storage
/area conformance