### PR TITLE
Remove GAed feature gates SeccompDefault

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -715,15 +715,6 @@ const (
 	// which benefits to reduce the useless requeueing.
 	SchedulerQueueingHints featuregate.Feature = "SchedulerQueueingHints"
 
-	// owner: @saschagrunert
-	// kep: https://kep.k8s.io/2413
-	// alpha: v1.22
-	// beta: v1.25
-	// ga: v1.27
-	//
-	// Enables the use of `RuntimeDefault` as the default seccomp profile for all workloads.
-	SeccompDefault featuregate.Feature = "SeccompDefault"
-
 	// owner: @mtardy
 	// alpha: v1.0
 	//
@@ -1082,8 +1073,6 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	ElasticIndexedJob: {Default: true, PreRelease: featuregate.Beta},
 
 	SchedulerQueueingHints: {Default: true, PreRelease: featuregate.Beta},
-
-	SeccompDefault: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.29
 
 	SecurityContextDeny: {Default: false, PreRelease: featuregate.Alpha},
 


### PR DESCRIPTION
What type of PR is this?

/kind cleanup

What this PR does / why we need it:

All of these feature gates have been GAed, and can be removed since v1.29:

- SeccompDefault

Fixes # None

Special notes for your reviewer:

release note
```release-note
Remove GAed feature gates SeccompDefault
```
Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```
None
```