### PR TITLE
fix invalid log calls

### DIFF
--- a/cmd/kubeadm/app/features/features.go
+++ b/cmd/kubeadm/app/features/features.go
@@ -146,7 +146,7 @@ func NewFeatureGate(f *FeatureList, value string) (map[string]bool, error) {
 		}
 
 		if featureSpec.PreRelease == featuregate.Deprecated {
-			klog.Warningf("Setting deprecated feature gate %s=%t. It will be removed in a future release.", k, v)
+			klog.Warningf("Setting deprecated feature gate %s=%s. It will be removed in a future release.", k, v)
 		}
 
 		boolValue, err := strconv.ParseBool(v)

--- a/staging/src/k8s.io/code-generator/cmd/prerelease-lifecycle-gen/prerelease-lifecycle-generators/status.go
+++ b/staging/src/k8s.io/code-generator/cmd/prerelease-lifecycle-gen/prerelease-lifecycle-generators/status.go
@@ -204,7 +204,7 @@ func Packages(context *generator.Context, arguments *args.GeneratorArgs) generat
 		if ptag != nil {
 			pkgNeedsGeneration, err = strconv.ParseBool(ptag.value)
 			if err != nil {
-				klog.Fatalf("Package %v: unsupported %s value: %q :%w", i, tagEnabledName, ptag.value, err)
+				klog.Fatalf("Package %v: unsupported %s value: %q :%v", i, tagEnabledName, ptag.value, err)
 			}
 		}
 		if !pkgNeedsGeneration {

--- a/staging/src/k8s.io/legacy-cloud-providers/vsphere/nodemanager.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/vsphere/nodemanager.go
@@ -283,7 +283,7 @@ func (nm *NodeManager) GetNode(nodeName k8stypes.NodeName) (v1.Node, error) {
 	}
 
 	if nm.nodeLister != nil {
-		klog.V(4).Infof("Node %s missing in vSphere cloud provider cache, trying node informer")
+		klog.V(4).Infof("Node %s missing in vSphere cloud provider cache, trying node informer", nodeName)
 		node, err := nm.nodeLister.Get(convertToString(nodeName))
 		if err != nil {
 			if !errors.IsNotFound(err) {
@@ -299,7 +299,7 @@ func (nm *NodeManager) GetNode(nodeName k8stypes.NodeName) (v1.Node, error) {
 	}
 
 	if nm.nodeGetter != nil {
-		klog.V(4).Infof("Node %s missing in vSphere cloud provider caches, trying the API server")
+		klog.V(4).Infof("Node %s missing in vSphere cloud provider caches, trying the API server", nodeName)
 		node, err := nm.nodeGetter.Nodes().Get(context.TODO(), convertToString(nodeName), metav1.GetOptions{})
 		if err != nil {
 			if !errors.IsNotFound(err) {

--- a/test/images/sample-device-plugin/sampledeviceplugin.go
+++ b/test/images/sample-device-plugin/sampledeviceplugin.go
@@ -144,7 +144,7 @@ func handleRegistrationProcess(registerControlFile string) error {
 				if !ok {
 					return
 				}
-				klog.Errorf("error: %w", err)
+				klog.Errorf("error: %v", err)
 				panic(err)
 			}
 		}
@@ -152,7 +152,7 @@ func handleRegistrationProcess(registerControlFile string) error {
 
 	err = watcher.Add(triggerPath)
 	if err != nil {
-		klog.Errorf("Failed to add watch to %q: %w", triggerPath, err)
+		klog.ErrorS(err, "Failed to add watch", "triggerPath", triggerPath)
 		return err
 	}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

These were found with a modified klog that enables "go vet" to check klog call parameters:

    cmd/kubeadm/app/features/features.go:149:4: printf: k8s.io/klog/v2.Warningf format %t has arg v of wrong type string (govet)
    			klog.Warningf("Setting deprecated feature gate %s=%t. It will be removed in a future release.", k, v)
    test/images/sample-device-plugin/sampledeviceplugin.go:147:5: printf: k8s.io/klog/v2.Errorf does not support error-wrapping directive %w (govet)
    				klog.Errorf("error: %w", err)
    test/images/sample-device-plugin/sampledeviceplugin.go:155:3: printf: k8s.io/klog/v2.Errorf does not support error-wrapping directive %w (govet)
    		klog.Errorf("Failed to add watch to %q: %w", triggerPath, err)
    staging/src/k8s.io/code-generator/cmd/prerelease-lifecycle-gen/prerelease-lifecycle-generators/status.go:207:5: printf: k8s.io/klog/v2.Fatalf does not support error-wrapping directive %w (govet)
    				klog.Fatalf("Package %v: unsupported %s value: %q :%w", i, tagEnabledName, ptag.value, err)
    staging/src/k8s.io/legacy-cloud-providers/vsphere/nodemanager.go:286:3: printf: (k8s.io/klog/v2.Verbose).Infof format %s reads arg #1, but call has 0 args (govet)
    		klog.V(4).Infof("Node %s missing in vSphere cloud provider cache, trying node informer")
    staging/src/k8s.io/legacy-cloud-providers/vsphere/nodemanager.go:302:3: printf: (k8s.io/klog/v2.Verbose).Infof format %s reads arg #1, but call has 0 args (govet)
    		klog.V(4).Infof("Node %s missing in vSphere cloud provider caches, trying the API server")

#### Which issue(s) this PR fixes:
Related-to: https://github.com/kubernetes/kubernetes/issues/114568

#### Does this PR introduce a user-facing change?
```release-note
Fixed some invalid and unimportant log calls.
```
