### PR TITLE
Remove GAed feature gates TopologyManager

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -787,14 +787,6 @@ const (
 	// Enables topology aware hints for EndpointSlices
 	TopologyAwareHints featuregate.Feature = "TopologyAwareHints"
 
-	// owner: @lmdaly, @swatisehgal (for GA graduation)
-	// alpha: v1.16
-	// beta: v1.18
-	// GA: v1.27
-	//
-	// Enable resource managers to make NUMA aligned decisions
-	TopologyManager featuregate.Feature = "TopologyManager"
-
 	// owner: @PiotrProkop
 	// kep: https://kep.k8s.io/3545
 	// alpha: v1.26
@@ -1100,8 +1092,6 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	StatefulSetStartOrdinal: {Default: true, PreRelease: featuregate.Beta},
 
 	TopologyAwareHints: {Default: true, PreRelease: featuregate.Beta},
-
-	TopologyManager: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // GA in 1.27; remove in 1.29
 
 	TopologyManagerPolicyAlphaOptions: {Default: false, PreRelease: featuregate.Alpha},
 


### PR DESCRIPTION
What type of PR is this?

/kind cleanup

What this PR does / why we need it:

All of these feature gates have been GAed, and can be removed since v1.29:

- TopologyManager

Fixes # None

Special notes for your reviewer:

release note
```release-note
Remove GAed feature gates TopologyManager
````
Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/693-topology-manager
```