### PR TITLE
Graduate DevicePluginCDIDevices to Beta

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -214,6 +214,7 @@ const (
 	// owner: @elezar
 	// kep: http://kep.k8s.io/4009
 	// alpha: v1.28
+	// beta: v1.29
 	//
 	// Add support for CDI Device IDs in the Device Plugin API.
 	DevicePluginCDIDevices featuregate.Feature = "DevicePluginCDIDevices"
@@ -955,7 +956,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 
 	DisableKubeletCloudCredentialProviders: {Default: true, PreRelease: featuregate.Beta},
 
-	DevicePluginCDIDevices: {Default: false, PreRelease: featuregate.Alpha},
+	DevicePluginCDIDevices: {Default: true, PreRelease: featuregate.Beta},
 
 	DownwardAPIHugePages: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in v1.29
 


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR graduates DevicePluginCDIDevices to Beta in 1.29

#### Special notes for your reviewer:

KEP update PR has been already merged: https://github.com/kubernetes/enhancements/pull/4238

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
DevicePluginCDIDevices feature has been graduated to Beta and enabled by default in the Kubelet
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
[Documentation update PR]: https://github.com/kubernetes/website/pull/43435
```
