### PR TITLE
kubeadm: increase ut coverage for bootstraptoken/node

### DIFF
--- a/cmd/kubeadm/app/phases/bootstraptoken/node/tlsbootstrap_test.go
+++ b/cmd/kubeadm/app/phases/bootstraptoken/node/tlsbootstrap_test.go
@@ -1,0 +1,301 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package node
+
+import (
+	"context"
+	"testing"
+
+	rbac "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	clientsetfake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
+)
+
+func TestAllowBootstrapTokensToPostCSRs(t *testing.T) {
+	tests := []struct {
+		name   string
+		client clientset.Interface
+	}{
+		{
+			name:   "ClusterRoleBindings is empty",
+			client: clientsetfake.NewSimpleClientset(),
+		},
+		{
+			name: "ClusterRoleBindings already exists",
+			client: newMockClusterRoleBinddingClientForTest(t, &rbac.ClusterRoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: constants.NodeKubeletBootstrap,
+				},
+				RoleRef: rbac.RoleRef{
+					APIGroup: rbac.GroupName,
+					Kind:     "ClusterRole",
+					Name:     constants.NodeBootstrapperClusterRoleName,
+				},
+				Subjects: []rbac.Subject{
+					{
+						Kind: rbac.GroupKind,
+						Name: constants.NodeBootstrapTokenAuthGroup,
+					},
+				},
+			}),
+		},
+		{
+			name: "Create new ClusterRoleBindings",
+			client: newMockClusterRoleBinddingClientForTest(t, &rbac.ClusterRoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: constants.NodeKubeletBootstrap,
+				},
+				RoleRef: rbac.RoleRef{
+					APIGroup: rbac.GroupName,
+					Kind:     "ClusterRole",
+					Name:     constants.NodeBootstrapperClusterRoleName,
+				},
+				Subjects: []rbac.Subject{
+					{
+						Kind: rbac.GroupKind,
+						Name: constants.KubeProxyClusterRoleName,
+					},
+				},
+			}),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := AllowBootstrapTokensToPostCSRs(tt.client); err != nil {
+				t.Errorf("AllowBootstrapTokensToPostCSRs() return error = %v", err)
+			}
+		})
+	}
+}
+
+func TestAutoApproveNodeBootstrapTokens(t *testing.T) {
+	tests := []struct {
+		name   string
+		client clientset.Interface
+	}{
+		{
+			name:   "ClusterRoleBindings is empty",
+			client: clientsetfake.NewSimpleClientset(),
+		},
+		{
+			name: "ClusterRoleBindings already exists",
+			client: newMockClusterRoleBinddingClientForTest(t, &rbac.ClusterRoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: constants.NodeAutoApproveBootstrapClusterRoleBinding,
+				},
+				RoleRef: rbac.RoleRef{
+					APIGroup: rbac.GroupName,
+					Kind:     "ClusterRole",
+					Name:     constants.CSRAutoApprovalClusterRoleName,
+				},
+				Subjects: []rbac.Subject{
+					{
+						Kind: rbac.GroupKind,
+						Name: constants.NodeBootstrapTokenAuthGroup,
+					},
+				},
+			}),
+		},
+		{
+			name: "Create new ClusterRoleBindings",
+			client: newMockClusterRoleBinddingClientForTest(t, &rbac.ClusterRoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: constants.NodeAutoApproveBootstrapClusterRoleBinding,
+				},
+				RoleRef: rbac.RoleRef{
+					APIGroup: rbac.GroupName,
+					Kind:     "ClusterRole",
+					Name:     constants.NodeSelfCSRAutoApprovalClusterRoleName,
+				},
+				Subjects: []rbac.Subject{
+					{
+						Kind: rbac.GroupKind,
+						Name: constants.NodeBootstrapTokenAuthGroup,
+					},
+				},
+			}),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := AutoApproveNodeBootstrapTokens(tt.client); err != nil {
+				t.Errorf("AutoApproveNodeBootstrapTokens() return error = %v", err)
+			}
+		})
+	}
+}
+
+func TestAutoApproveNodeCertificateRotation(t *testing.T) {
+	tests := []struct {
+		name   string
+		client clientset.Interface
+	}{
+		{
+			name:   "ClusterRoleBindings is empty",
+			client: clientsetfake.NewSimpleClientset(),
+		},
+		{
+			name: "ClusterRoleBindings already exists",
+			client: newMockClusterRoleBinddingClientForTest(t, &rbac.ClusterRoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: constants.NodeAutoApproveCertificateRotationClusterRoleBinding,
+				},
+				RoleRef: rbac.RoleRef{
+					APIGroup: rbac.GroupName,
+					Kind:     "ClusterRole",
+					Name:     constants.NodeSelfCSRAutoApprovalClusterRoleName,
+				},
+				Subjects: []rbac.Subject{
+					{
+						Kind: rbac.GroupKind,
+						Name: constants.NodesGroup,
+					},
+				},
+			}),
+		},
+		{
+			name: "Create new ClusterRoleBindings",
+			client: newMockClusterRoleBinddingClientForTest(t, &rbac.ClusterRoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: constants.NodeAutoApproveCertificateRotationClusterRoleBinding,
+				},
+				RoleRef: rbac.RoleRef{
+					APIGroup: rbac.GroupName,
+					Kind:     "ClusterRole",
+					Name:     constants.NodeSelfCSRAutoApprovalClusterRoleName,
+				},
+				Subjects: []rbac.Subject{
+					{
+						Kind: rbac.GroupKind,
+						Name: constants.NodeBootstrapTokenAuthGroup,
+					},
+				},
+			}),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := AutoApproveNodeCertificateRotation(tt.client); err != nil {
+				t.Errorf("AutoApproveNodeCertificateRotation() return error = %v", err)
+			}
+		})
+	}
+}
+
+func TestAllowBoostrapTokensToGetNodes(t *testing.T) {
+	tests := []struct {
+		name   string
+		client clientset.Interface
+	}{
+		{
+			name:   "RBAC rules are empty",
+			client: clientsetfake.NewSimpleClientset(),
+		},
+		{
+			name: "RBAC rules already exists",
+			client: newMockRbacClientForTest(t, &rbac.ClusterRole{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: constants.GetNodesClusterRoleName,
+				},
+				Rules: []rbac.PolicyRule{
+					{
+						Verbs:     []string{"get"},
+						APIGroups: []string{""},
+						Resources: []string{"nodes"},
+					},
+				},
+			}, &rbac.ClusterRoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: constants.GetNodesClusterRoleName,
+				},
+				RoleRef: rbac.RoleRef{
+					APIGroup: rbac.GroupName,
+					Kind:     "ClusterRole",
+					Name:     constants.GetNodesClusterRoleName,
+				},
+				Subjects: []rbac.Subject{
+					{
+						Kind: rbac.GroupKind,
+						Name: constants.NodeBootstrapTokenAuthGroup,
+					},
+				},
+			}),
+		},
+		{
+			name: "Create new RBAC rules",
+			client: newMockRbacClientForTest(t, &rbac.ClusterRole{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: constants.GetNodesClusterRoleName,
+				},
+				Rules: []rbac.PolicyRule{
+					{
+						Verbs:     []string{"create"},
+						APIGroups: []string{""},
+						Resources: []string{"nodes"},
+					},
+				},
+			}, &rbac.ClusterRoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: constants.GetNodesClusterRoleName,
+				},
+				RoleRef: rbac.RoleRef{
+					APIGroup: rbac.GroupName,
+					Kind:     "ClusterRole",
+					Name:     constants.NodeAutoApproveBootstrapClusterRoleBinding,
+				},
+				Subjects: []rbac.Subject{
+					{
+						Kind: rbac.GroupKind,
+						Name: constants.NodeBootstrapTokenAuthGroup,
+					},
+				},
+			}),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := AllowBoostrapTokensToGetNodes(tt.client); err != nil {
+				t.Errorf("AllowBoostrapTokensToGetNodes() return error = %v", err)
+			}
+		})
+	}
+}
+
+func newMockClusterRoleBinddingClientForTest(t *testing.T, clusterRoleBinding *rbac.ClusterRoleBinding) *clientsetfake.Clientset {
+	client := clientsetfake.NewSimpleClientset()
+	_, err := client.RbacV1().ClusterRoleBindings().Create(context.TODO(), clusterRoleBinding, metav1.CreateOptions{})
+
+	if err != nil {
+		t.Fatalf("error creating ClusterRoleBindings: %v", err)
+	}
+	return client
+}
+
+func newMockRbacClientForTest(t *testing.T, clusterRole *rbac.ClusterRole, clusterRoleBinding *rbac.ClusterRoleBinding) *clientsetfake.Clientset {
+	client := clientsetfake.NewSimpleClientset()
+	_, err := client.RbacV1().ClusterRoles().Create(context.TODO(), clusterRole, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error creating ClusterRoles: %v", err)
+	}
+	_, err = client.RbacV1().ClusterRoleBindings().Create(context.TODO(), clusterRoleBinding, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error creating ClusterRoleBindings: %v", err)
+	}
+	return client
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Increase ut coverage for bootstraptoken/node

before:
```
        k8s.io/kubernetes/cmd/kubeadm/app/phases/bootstraptoken/node    coverage: 45.8% of statements
```

after this change:
```
        k8s.io/kubernetes/cmd/kubeadm/app/phases/bootstraptoken/node    coverage: 83.3% of statements
```


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
