### PR TITLE
cleanup: improve assertions for Failed PodReplacementPolicy integration test cases

### DIFF
--- a/test/integration/job/job_test.go
+++ b/test/integration/job/job_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"k8s.io/utils/ptr"
 	"sort"
 	"strconv"
 	"strings"
@@ -59,6 +58,7 @@ import (
 	"k8s.io/kubernetes/test/integration/framework"
 	"k8s.io/kubernetes/test/integration/util"
 	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 const waitInterval = time.Second
@@ -3007,14 +3007,14 @@ func updateJob(ctx context.Context, jobClient typedv1.JobInterface, jobName stri
 
 func addFinalizerAndDeletePods(ctx context.Context, t *testing.T, clientSet clientset.Interface, namespace string) {
 	t.Helper()
-	pods, errList := clientSet.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{})
-	if errList != nil {
-		t.Fatalf("Failed to list pods: %v", errList)
+	pods, err := clientSet.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("Failed to list pods: %v", err)
 	}
 	updatePod(t, clientSet, pods.Items, func(pod *v1.Pod) {
 		pod.Finalizers = append(pod.Finalizers, "fake.example.com/blockDeletion")
 	})
-	err := clientSet.CoreV1().Pods(namespace).DeleteCollection(ctx,
+	err = clientSet.CoreV1().Pods(namespace).DeleteCollection(ctx,
 		metav1.DeleteOptions{},
 		metav1.ListOptions{
 			Limit: 1000,
@@ -3022,14 +3022,8 @@ func addFinalizerAndDeletePods(ctx context.Context, t *testing.T, clientSet clie
 	if err != nil {
 		t.Fatalf("Failed to cleanup Pods: %v", err)
 	}
-
-	podsDelete, errList2 := clientSet.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{})
-	if errList2 != nil {
-		t.Fatalf("Failed to list pods: %v", errList2)
-	}
-	for _, val := range podsDelete.Items {
-		if val.DeletionTimestamp == nil {
-			t.Fatalf("Deletion not registered.")
-		}
+	_, err = clientSet.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("Failed to list pods: %v", err)
 	}
 }

--- a/test/integration/job/job_test.go
+++ b/test/integration/job/job_test.go
@@ -1820,7 +1820,14 @@ func TestJobPodReplacementPolicy(t *testing.T) {
 				t.Fatalf("Error waiting for Job pods to become active: %v", err)
 			}
 			if tc.deletePods {
-				addFinalizerAndDeletePods(ctx, t, clientSet, ns.Name)
+				err = clientSet.CoreV1().Pods(ns.Name).DeleteCollection(ctx,
+					metav1.DeleteOptions{},
+					metav1.ListOptions{
+						Limit: 1000,
+					})
+				if err != nil {
+					t.Fatalf("Failed to delete Pods: %v", err)
+				}
 			}
 			if tc.failPods {
 				err, _ = setJobPodsPhase(ctx, clientSet, jobObj, v1.PodFailed, int(podCount))
@@ -2805,22 +2812,6 @@ func updatePodStatuses(ctx context.Context, clientSet clientset.Interface, updat
 	return int(updated), nil
 }
 
-func updatePod(t *testing.T, clientSet clientset.Interface, pods []v1.Pod, updateFunc func(*v1.Pod)) {
-	for _, val := range pods {
-		if err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-			newPod, err := clientSet.CoreV1().Pods(val.Namespace).Get(context.TODO(), val.Name, metav1.GetOptions{})
-			if err != nil {
-				return err
-			}
-			updateFunc(newPod)
-			_, err = clientSet.CoreV1().Pods(val.Namespace).Update(context.TODO(), newPod, metav1.UpdateOptions{})
-			return err
-		}); err != nil {
-			t.Fatalf("Failed to update pod %s: %v", val.Name, err)
-		}
-	}
-}
-
 func setJobPhaseForIndex(ctx context.Context, clientSet clientset.Interface, jobObj *batchv1.Job, phase v1.PodPhase, ix int) error {
 	pods, err := clientSet.CoreV1().Pods(jobObj.Namespace).List(ctx, metav1.ListOptions{})
 	if err != nil {
@@ -3003,27 +2994,4 @@ func updateJob(ctx context.Context, jobClient typedv1.JobInterface, jobName stri
 		return err
 	})
 	return job, err
-}
-
-func addFinalizerAndDeletePods(ctx context.Context, t *testing.T, clientSet clientset.Interface, namespace string) {
-	t.Helper()
-	pods, err := clientSet.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{})
-	if err != nil {
-		t.Fatalf("Failed to list pods: %v", err)
-	}
-	updatePod(t, clientSet, pods.Items, func(pod *v1.Pod) {
-		pod.Finalizers = append(pod.Finalizers, "fake.example.com/blockDeletion")
-	})
-	err = clientSet.CoreV1().Pods(namespace).DeleteCollection(ctx,
-		metav1.DeleteOptions{},
-		metav1.ListOptions{
-			Limit: 1000,
-		})
-	if err != nil {
-		t.Fatalf("Failed to cleanup Pods: %v", err)
-	}
-	_, err = clientSet.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{})
-	if err != nil {
-		t.Fatalf("Failed to list pods: %v", err)
-	}
 }

--- a/test/integration/job/job_test.go
+++ b/test/integration/job/job_test.go
@@ -1719,7 +1719,7 @@ func TestJobPodReplacementPolicy(t *testing.T) {
 			jobSpec: &batchv1.JobSpec{
 				Parallelism:          pointer.Int32Ptr(podCount),
 				Completions:          pointer.Int32Ptr(podCount),
-				CompletionMode:       &nonIndexedCompletion,
+				CompletionMode:       &indexedCompletion,
 				PodReplacementPolicy: podReplacementPolicy(batchv1.Failed),
 			},
 			wantTerminating: pointer.Int32(podCount),
@@ -1763,7 +1763,7 @@ func TestJobPodReplacementPolicy(t *testing.T) {
 			jobSpec: &batchv1.JobSpec{
 				Parallelism:          pointer.Int32Ptr(podCount),
 				Completions:          pointer.Int32Ptr(podCount),
-				CompletionMode:       &nonIndexedCompletion,
+				CompletionMode:       &indexedCompletion,
 				PodReplacementPolicy: podReplacementPolicy(batchv1.Failed),
 			},
 			wantActive:      int(podCount),

--- a/test/integration/job/job_test.go
+++ b/test/integration/job/job_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"k8s.io/utils/ptr"
 	"sort"
 	"strconv"
 	"strings"
@@ -1757,31 +1758,31 @@ func TestJobPodReplacementPolicy(t *testing.T) {
 			},
 			wantActive: int(podCount),
 		},
-		"feature flag true, delete pods, verify active and failed status and recreate once failed": {
+		"feature flag true, recreate failed pods, and verify active and failed counters": {
 			podReplacementPolicyEnabled: true,
 			failPods:                    true,
 			jobSpec: &batchv1.JobSpec{
-				Parallelism:          pointer.Int32Ptr(podCount),
-				Completions:          pointer.Int32Ptr(podCount),
+				Parallelism:          ptr.To(podCount),
+				Completions:          ptr.To(podCount),
 				CompletionMode:       &indexedCompletion,
 				PodReplacementPolicy: podReplacementPolicy(batchv1.Failed),
 			},
 			wantActive:      int(podCount),
 			wantFailed:      int(podCount),
-			wantTerminating: pointer.Int32(0),
+			wantTerminating: ptr.To[int32](0),
 		},
-		"feature flag true with NonIndexedJob, delete pods, verify active and failed status and recreate once failed": {
+		"feature flag true with NonIndexedJob, recreate failed pods, and verify active and failed counters": {
 			podReplacementPolicyEnabled: true,
 			failPods:                    true,
 			jobSpec: &batchv1.JobSpec{
-				Parallelism:          pointer.Int32Ptr(podCount),
-				Completions:          pointer.Int32Ptr(podCount),
+				Parallelism:          ptr.To(podCount),
+				Completions:          ptr.To(podCount),
 				CompletionMode:       &nonIndexedCompletion,
 				PodReplacementPolicy: podReplacementPolicy(batchv1.Failed),
 			},
 			wantActive:      int(podCount),
 			wantFailed:      int(podCount),
-			wantTerminating: pointer.Int32(0),
+			wantTerminating: ptr.To[int32](0),
 		},
 	}
 	for name, tc := range cases {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup
/sig apps

#### What this PR does / why we need it:

Improves the PodReplacementPolicy integration tests for the Failed policy test cases by adding an assertion which validates pods get recreated when they fail

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

This has been discussed with @mimowo and @alculquicondor 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
