### PR TITLE
DeclarativeValidation: Add Alpha Feature Gate to expose CEL validations on native types in OpenAPI

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -1124,6 +1124,8 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 
 	genericfeatures.APIResponseCompression: {Default: true, PreRelease: featuregate.Beta},
 
+	genericfeatures.DeclarativeValidationsInOpenAPI: {Default: false, PreRelease: featuregate.Alpha},
+
 	genericfeatures.ValidatingAdmissionPolicy: {Default: false, PreRelease: featuregate.Beta},
 
 	genericfeatures.CustomResourceValidationExpressions: {Default: true, PreRelease: featuregate.Beta},

--- a/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
+++ b/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
@@ -104,6 +104,17 @@ const (
 	// Enables expression validation for Custom Resource
 	CustomResourceValidationExpressions featuregate.Feature = "CustomResourceValidationExpressions"
 
+	// owner: @alexzielenski
+	// kep: https://kep.k8s.io/4153
+	// alpha: v1.29
+	//
+	// Exposes following new `x-kubernetes` extensions in OpenAPI schema for
+	// native types:
+	//	- x-kubernetes-validations
+	//  - more may be added during alpha/beta as native types are ported and
+	//		problem space explored
+	DeclarativeValidationsInOpenAPI featuregate.Feature = "DeclarativeValidationsInOpenAPI"
+
 	// alpha: v1.20
 	// beta: v1.21
 	// GA: v1.24
@@ -285,6 +296,8 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	ValidatingAdmissionPolicy: {Default: false, PreRelease: featuregate.Beta},
 
 	CustomResourceValidationExpressions: {Default: true, PreRelease: featuregate.Beta},
+
+	DeclarativeValidationsInOpenAPI: {Default: false, PreRelease: featuregate.Alpha},
 
 	EfficientWatchResumption: {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 

--- a/staging/src/k8s.io/apiserver/pkg/util/openapi/enablement.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/openapi/enablement.go
@@ -61,11 +61,15 @@ func restoreDefinitions(defs map[string]common.OpenAPIDefinition) {
 var whitelistedExtensions sets.String = func() sets.String {
 	res := sets.NewString(
 		"x-kubernetes-list-type",
-		"x-kubernetes-map-keys",
+		"x-kubernetes-list-map-keys",
 		"x-kubernetes-map-type",
 		"x-kubernetes-patch-strategy",
 		"x-kubernetes-patch-merge-key",
 	)
+
+	if utilfeature.DefaultFeatureGate.Enabled(genericfeatures.DeclarativeValidationsInOpenAPI) {
+		res.Insert("x-kubernetes-validations")
+	}
 
 	return res
 }()


### PR DESCRIPTION
#### What type of PR is this?

/kind feature


#### What this PR does / why we need it:

This PR adds one of the two feature gates described in KEP-4153: Declarative Validation. This gate controls whether the new x-kubernetes extensions added as part of this KEP are published in the openapi. For now this list includes `x-kubernetes-validations`, but others may be added in a future alpha.

#### Which issue(s) this PR fixes:

N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Adds DeclarativeValidationsInOpenAPI which exposes additional validations used for native types in OpenAPI.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://kep.k8s.io/4153
```

/sig api-machinery
/assign @apelisse