### PR TITLE
kubeadm: check ignore preflights errors len instead of nil

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/validation/validation.go
+++ b/cmd/kubeadm/app/apis/kubeadm/validation/validation.go
@@ -656,7 +656,7 @@ func ValidateIgnorePreflightErrors(featureList map[string]bool, ignorePreflightE
 	allErrs := field.ErrorList{}
 	ignorePreflightErr := ignorePreflightErrorsFromConfigFile
 
-	if ignorePreflightErrorsFromCLI != nil {
+	if len(ignorePreflightErrorsFromCLI) != 0 {
 		if features.Enabled(featureList, features.MergeCLIArgumentsWithConfig) {
 			ignorePreflightErr = append(ignorePreflightErr, ignorePreflightErrorsFromCLI...)
 		} else {

--- a/cmd/kubeadm/app/apis/kubeadm/validation/validation_test.go
+++ b/cmd/kubeadm/app/apis/kubeadm/validation/validation_test.go
@@ -896,7 +896,7 @@ func TestValidateIgnorePreflightErrors(t *testing.T) {
 		{ // empty list in CLI only
 			[]string{},
 			[]string{"a"},
-			sets.New[string](),
+			sets.New[string]("a"),
 			false,
 			false,
 		},


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
when dig into https://github.com/kubernetes/kubeadm/issues/2943

```release-note
None
```
