### PR TITLE
kubeadm: fix "eliptic" typo in API package

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/types.go
+++ b/cmd/kubeadm/app/apis/kubeadm/types.go
@@ -141,7 +141,7 @@ type ClusterConfiguration struct {
 	ClusterName string
 
 	// EncryptionAlgorithm holds the type of asymmetric encryption algorithm used for keys and certificates.
-	// Can be "RSA" (default algorithm, key size is 2048) or "ECDSA" (uses the P-256 eliptic curve).
+	// Can be "RSA" (default algorithm, key size is 2048) or "ECDSA" (uses the P-256 elliptic curve).
 	EncryptionAlgorithm EncryptionAlgorithmType
 }
 

--- a/cmd/kubeadm/app/apis/kubeadm/v1beta4/doc.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1beta4/doc.go
@@ -34,7 +34,7 @@ limitations under the License.
 //     `Scheduler.ExtraArgs`, `Etcd.Local.ExtraArgs`. Also to `NodeRegistrationOptions.KubeletExtraArgs`.
 //   - Add `ClusterConfiguration.EncryptionAlgorithm` that can be used to set the asymmetric encryption algorithm
 //     used for this cluster's keys and certificates. Can be "RSA" (default algorithm, key size is 2048) or
-//     "ECDSA" (uses the P-256 eliptic curve).
+//     "ECDSA" (uses the P-256 elliptic curve).
 //
 // Migration from old kubeadm config versions
 //

--- a/cmd/kubeadm/app/apis/kubeadm/v1beta4/types.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1beta4/types.go
@@ -142,7 +142,7 @@ type ClusterConfiguration struct {
 	ClusterName string `json:"clusterName,omitempty"`
 
 	// EncryptionAlgorithm holds the type of asymmetric encryption algorithm used for keys and certificates.
-	// Can be "RSA" (default algorithm, key size is 2048) or "ECDSA" (uses the P-256 eliptic curve).
+	// Can be "RSA" (default algorithm, key size is 2048) or "ECDSA" (uses the P-256 elliptic curve).
 	// +optional
 	EncryptionAlgorithm EncryptionAlgorithmType `json:"encryptionAlgorithm,omitempty"`
 }


### PR DESCRIPTION
/kind cleanup

#### What this PR does / why we need it:

Should be "elliptic".

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
NONE

#### Special notes for your reviewer:
was found in this PR:
https://github.com/kubernetes/kubernetes/pull/121268

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
