### PR TITLE
kubeapiserver/options: fix cloud provider validation

### DIFF
--- a/pkg/kubeapiserver/options/cloudprovider.go
+++ b/pkg/kubeapiserver/options/cloudprovider.go
@@ -48,10 +48,9 @@ func (opts *CloudProviderOptions) Validate() []error {
 				"please set DisableCloudProviders feature to true", opts.CloudProvider))
 		}
 		if !utilfeature.DefaultFeatureGate.Enabled(features.DisableKubeletCloudCredentialProviders) {
-			errs = append(errs, fmt.Errorf("when using --cloud-provider set to '%s', "+ //nolint:staticcheck,ineffassign // false positive
+			errs = append(errs, fmt.Errorf("when using --cloud-provider set to '%s', "+
 				"please set DisableKubeletCloudCredentialProviders feature to true", opts.CloudProvider))
 		}
-		return nil
 	case cloudprovider.IsDeprecatedInternal(opts.CloudProvider):
 		if utilfeature.DefaultFeatureGate.Enabled(features.DisableCloudProviders) {
 			errs = append(errs, fmt.Errorf("when using --cloud-provider set to '%s', "+


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fixes some `return nil` that shouldn't be there making validation not validate some cases.

Follow-up of  https://github.com/kubernetes/kubernetes/pull/121108.

```release-note
NONE
```