### PR TITLE
e2e: Increases the memory limit for downward API tests

### DIFF
--- a/test/e2e/common/storage/downwardapi_volume.go
+++ b/test/e2e/common/storage/downwardapi_volume.go
@@ -210,7 +210,7 @@ var _ = SIGDescribe("Downward API volume", func() {
 		pod := downwardAPIVolumeForContainerResources(podName, "/etc/podinfo/memory_limit")
 
 		e2epodoutput.TestContainerOutput(ctx, f, "downward API volume plugin", pod, 0, []string{
-			fmt.Sprintf("67108864\n"),
+			"134217728\n",
 		})
 	})
 
@@ -339,7 +339,7 @@ func downwardAPIVolumeBaseContainers(name, filePath string) []v1.Container {
 				},
 				Limits: v1.ResourceList{
 					v1.ResourceCPU:    resource.MustParse("1250m"),
-					v1.ResourceMemory: resource.MustParse("64Mi"),
+					v1.ResourceMemory: resource.MustParse("128Mi"),
 				},
 			},
 			VolumeMounts: []v1.VolumeMount{

--- a/test/e2e/common/storage/projected_downwardapi.go
+++ b/test/e2e/common/storage/projected_downwardapi.go
@@ -210,7 +210,7 @@ var _ = SIGDescribe("Projected downwardAPI", func() {
 		pod := downwardAPIVolumeForContainerResources(podName, "/etc/podinfo/memory_limit")
 
 		e2epodoutput.TestContainerOutput(ctx, f, "downward API volume plugin", pod, 0, []string{
-			fmt.Sprintf("67108864\n"),
+			"134217728\n",
 		})
 	})
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind flake
/sig windows
/sig testing

#### What this PR does / why we need it:

Currently, the downward API tests flake on Windows with a failure to allocate memory when starting the ``agnhost`` binary used in these tests. The tests are spawning pods with a memory limit of 64MB, which is a bit on the low side for a Windows Pod, even if it's a nanoserver-based image.

Increases the memory limit to 128MB, the primary goal of the tests is not to enforce and test the limits, but to check if these details are projected into the Pod.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Partially-Fixes: #95226

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
