### PR TITLE
feat: add job_pods_creation_total metric for PodReplacementPolicy

### DIFF
--- a/pkg/controller/job/job_controller.go
+++ b/pkg/controller/job/job_controller.go
@@ -1546,7 +1546,7 @@ func (jm *Controller) manageJob(ctx context.Context, job *batch.Job, jobCtx *syn
 		}
 		podTemplate.Finalizers = appendJobCompletionFinalizerIfNotFound(podTemplate.Finalizers)
 
-		// Counters used for the job_pods_created_total_metrics
+		// Counters for pod creation status (used by the job_pods_creation_total metric)
 		creationsSucceeded, creationsFailed := 0, 0
 
 		// Batch the pod creates. Batch sizes start at SlowStartInitialBatchSize

--- a/pkg/controller/job/job_controller.go
+++ b/pkg/controller/job/job_controller.go
@@ -1914,16 +1914,16 @@ func (jm *Controller) cleanupPodFinalizers(job *batch.Job) {
 }
 
 func recordJobPodsCreationTotal(job *batch.Job) {
-	trigger := metrics.New
+	event := metrics.New
 	if feature.DefaultFeatureGate.Enabled(features.JobPodReplacementPolicy) {
 		podsTerminating := job.Status.Terminating != nil && *job.Status.Terminating > 0
 		isRecreateAction := podsTerminating || job.Status.Failed > 0
 		if isRecreateAction {
-			trigger = metrics.RecreateTerminatingOrFailed
+			event = metrics.RecreateTerminatingOrFailed
 			if *job.Spec.PodReplacementPolicy == batch.Failed {
-				trigger = metrics.RecreateFailed
+				event = metrics.RecreateFailed
 			}
 		}
 	}
-	metrics.JobPodsCreationTotal.WithLabelValues(trigger).Inc()
+	metrics.JobPodsCreationTotal.WithLabelValues(event).Inc()
 }

--- a/pkg/controller/job/metrics/metrics.go
+++ b/pkg/controller/job/metrics/metrics.go
@@ -127,18 +127,22 @@ The event label can be "add" or "delete".`,
 		[]string{"status", "backoffLimit"})
 
 	// JobPodsCreationTotal records the number of pods created by the job controller
-	// based on the event which triggered their creation (i.e. if PodReplacementPolicy was specified).
+	// based on the reason for their creation (i.e. if PodReplacementPolicy was specified)
+	// and the status of the creation (i.e. if the Pod creation succeeded or failed).
 	// Possible label values:
-	//   event: new, recreate_terminating_or_failed, recreate_terminated
+	//   reason: new, recreate_terminating_or_failed, recreate_failed
+	//   status: succeeded, failed
 	JobPodsCreationTotal = metrics.NewCounterVec(
 		&metrics.CounterOpts{
 			Subsystem: JobControllerSubsystem,
 			Name:      "job_pods_creation_total",
-			Help: `The number of Pods created by the Job controller labelled with a trigger
-which caused the Pod creation. This metric also distinguishes between Pods created using
-different PodReplacementPolicy settings. Possible values of the trigger label are:
-"new", "recreate_terminating_or_failed", "recreate_terminated".`,
-		}, []string{"event"})
+			Help: `The number of Pods created by the Job controller labelled with a reason for the Pod creation.
+This metric also distinguishes between Pods created using different PodReplacementPolicy settings.
+Possible values of the "reason" label are:
+"new", "recreate_terminating_or_failed", "recreate_failed".
+Possible values of the "status" label are:
+"succeeded", "failed".`,
+		}, []string{"reason", "status"})
 )
 
 const (
@@ -171,11 +175,16 @@ const (
 	Add    = "add"
 	Delete = "delete"
 
-	// Possible values for "event" label in the job_pods_creation_total metric.
+	// Possible values for "reason" label in the job_pods_creation_total metric.
 
-	New                         = "new"
-	RecreateTerminatingOrFailed = "recreate_terminating_or_failed"
-	RecreateFailed              = "recreate_failed"
+	PodCreateNew                   = "new"
+	PodRecreateTerminatingOrFailed = "recreate_terminating_or_failed"
+	PodRecreateFailed              = "recreate_failed"
+
+	// Possible values for "status" label in the job_pods_creation_total metric.
+
+	CreationSucceeded = "succeeded"
+	CreationFailed    = "failed"
 )
 
 var registerMetrics sync.Once

--- a/pkg/controller/job/metrics/metrics.go
+++ b/pkg/controller/job/metrics/metrics.go
@@ -165,13 +165,14 @@ const (
 	// parallelism.
 	JobSyncActionPodsDeleted = "pods_deleted"
 
-	// Possible values for "result" label in the above metrics.
+	// Possible values for "result" and "status" (job_pods_creation_total) labels in the above metrics.
 
 	Succeeded = "succeeded"
 	Failed    = "failed"
 
 	// Possible values for "event"  label in the terminated_pods_tracking_finalizer
 	// metric.
+
 	Add    = "add"
 	Delete = "delete"
 
@@ -180,11 +181,6 @@ const (
 	PodCreateNew                   = "new"
 	PodRecreateTerminatingOrFailed = "recreate_terminating_or_failed"
 	PodRecreateFailed              = "recreate_failed"
-
-	// Possible values for "status" label in the job_pods_creation_total metric.
-
-	CreationSucceeded = "succeeded"
-	CreationFailed    = "failed"
 )
 
 var registerMetrics sync.Once

--- a/pkg/controller/job/metrics/metrics.go
+++ b/pkg/controller/job/metrics/metrics.go
@@ -125,6 +125,20 @@ The event label can be "add" or "delete".`,
 			backoffLimit label are: "perIndex" and "global"`,
 		},
 		[]string{"status", "backoffLimit"})
+
+	// JobPodsCreationTotal records the number of pods created by the job controller
+	// based on the event which triggered their creation (i.e. if PodReplacementPolicy was specified).
+	// Possible label values:
+	//   event: new, recreate_terminating_or_failed, recreate_terminated
+	JobPodsCreationTotal = metrics.NewCounterVec(
+		&metrics.CounterOpts{
+			Subsystem: JobControllerSubsystem,
+			Name:      "job_pods_creation_total",
+			Help: `The number of Pods created by the Job controller labelled with a trigger
+which caused the Pod creation. This metric also distinguishes between Pods created using
+different PodReplacementPolicy settings. Possible values of the trigger label are:
+"new", "recreate_terminating_or_failed", "recreate_terminated".`,
+		}, []string{"event"})
 )
 
 const (
@@ -156,6 +170,12 @@ const (
 	// metric.
 	Add    = "add"
 	Delete = "delete"
+
+	// Possible values for "event" label in the job_pods_creation_total metric.
+
+	New                         = "new"
+	RecreateTerminatingOrFailed = "recreate_terminating_or_failed"
+	RecreateFailed              = "recreate_failed"
 )
 
 var registerMetrics sync.Once
@@ -170,5 +190,6 @@ func Register() {
 		legacyregistry.MustRegister(PodFailuresHandledByFailurePolicy)
 		legacyregistry.MustRegister(TerminatedPodsTrackingFinalizerTotal)
 		legacyregistry.MustRegister(JobFinishedIndexesTotal)
+		legacyregistry.MustRegister(JobPodsCreationTotal)
 	})
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
/sig apps

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Adds job_pods_creation_total metric which tracks Pods created by Job controller based on creation event (i.e. specified PodReplacementPolicy(

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of [kubernetes/enhancements#3939](https://github.com/kubernetes/enhancements/issues/3939)

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Add job_pods_creation_total metrics for tracking Pods created by the Job controller labeled by events which triggered the Pod creation
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/3939
```
