### PR TITLE
Fix documentation by clarifying image size is uncompressed in CRI-API

### DIFF
--- a/staging/src/k8s.io/cri-api/pkg/apis/runtime/v1/api.proto
+++ b/staging/src/k8s.io/cri-api/pkg/apis/runtime/v1/api.proto
@@ -1399,7 +1399,7 @@ message Image {
     repeated string repo_tags = 2;
     // Digests by which this image is known.
     repeated string repo_digests = 3;
-    // Size of the image in bytes. Must be > 0.
+    // Size of the image in bytes. Must be > 0 and refer to the uncompressed size (i.e. on disk)
     uint64 size = 4;
     // UID that will run the command(s). This is used as a default if no user is
     // specified when creating the container. UID and the following user name


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

Documentation clarification for the CRI-API.

/kind documentation

#### What this PR does / why we need it:

This quick PR clarifies the CRI-API documentation, which at the moment shows the blob size. We had a discussion on why the CRI-API defaults to using the blob size rather than other sizes (https://github.com/kubernetes/kubernetes/issues/120698#issuecomment-1728191525), and for the short term we will just document it; a KEP will be issued to change the behavior in the near future.

#### Which issue(s) this PR fixes:
Fixes #120698.

#### Special notes for your reviewer:
See discussion in October 10, 2023 sig-node meeting, the issue, and on Slack.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
