### PR TITLE
Do not look at the default network's routes/firewall-rules

### DIFF
--- a/cluster/gce/list-resources.sh
+++ b/cluster/gce/list-resources.sh
@@ -91,8 +91,8 @@ gcloud-list compute addresses "${REGION:+"region=(${REGION}) AND "}name ~ 'a.*|$
 # Match either the header or a line with the specified e2e network.
 # This assumes that the network name is the second field in the output.
 GREP_REGEX="^NAME\|^[^ ]\+[ ]\+\(${NETWORK}\) "
-gcloud-list compute routes "name ~ 'default.*|${INSTANCE_PREFIX}.*'"
-gcloud-list compute firewall-rules "name ~ 'default.*|k8s-fw.*|${INSTANCE_PREFIX}.*'"
+gcloud-list compute routes "name ~ '${INSTANCE_PREFIX}.*'"
+gcloud-list compute firewall-rules "name ~ 'k8s-fw.*|${INSTANCE_PREFIX}.*'"
 GREP_REGEX=""
 gcloud-list compute forwarding-rules ${REGION:+"region=(${REGION})"}
 gcloud-list compute target-pools ${REGION:+"region=(${REGION})"}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind cleanup

#### What this PR does / why we need it:

When running e2e tests of K8s in GCP using [kubetest](https://github.com/kubernetes/test-infra/tree/master/kubetest) they use `list-resources.sh` before and after the test to establish whether there's any leakage of cloud resources.

When there's a new GCP location turnup during the test, `default` VPC network receives new route(s) that would make the test fail despite the test cluster using a completely different network.

#### Which issue(s) this PR fixes:

No issue is opened for that.

#### Special notes for your reviewer:

This is a follow-up to https://github.com/kubernetes/kubernetes/pull/116950.

/assign @mborsz

#### Does this PR introduce a user-facing change?
```release-note
NONE
```