### PR TITLE
[KEP - 3085] Add e2e test for PodReadyToStartContainerCondition when config map is created

### DIFF
--- a/test/e2e_node/pod_conditions_test.go
+++ b/test/e2e_node/pod_conditions_test.go
@@ -134,6 +134,66 @@ func runPodFailingConditionsTest(f *framework.Framework, hasInitContainers, chec
 		// Verify PodReady is not set (since sandboxcreation is blocked)
 		_, err = getTransitionTimeForPodConditionWithStatus(p, v1.PodReady, false)
 		framework.ExpectNoError(err)
+
+		// this testcase is creating the missing volume that unblock the pod above,
+		// and check PodReadyToStartContainer is setting correctly.
+		ginkgo.By("checking pod condition for a pod when volumes source is created")
+
+		configmap := v1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "cm-that-unblock-pod-condition",
+			},
+			Data: map[string]string{
+				"key": "value",
+			},
+			BinaryData: map[string][]byte{
+				"binaryKey": []byte("value"),
+			},
+		}
+
+		_, err = f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Create(ctx, &configmap, metav1.CreateOptions{})
+		framework.ExpectNoError(err)
+
+		defer func() {
+			err = f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Delete(ctx, "cm-that-unblock-pod-condition", metav1.DeleteOptions{})
+			framework.ExpectNoError(err, "unable to delete configmap")
+		}()
+
+		p2 := webserverPodSpec("pod2-"+string(uuid.NewUUID()), "web2", "init2", hasInitContainers)
+		p2.Spec.Volumes = []v1.Volume{
+			{
+				Name: "cm-2",
+				VolumeSource: v1.VolumeSource{
+					ConfigMap: &v1.ConfigMapVolumeSource{
+						LocalObjectReference: v1.LocalObjectReference{Name: "cm-that-unblock-pod-condition"},
+					},
+				},
+			},
+		}
+		p2.Spec.Containers[0].VolumeMounts = []v1.VolumeMount{
+			{
+				Name:      "cm-2",
+				MountPath: "/config",
+			},
+		}
+
+		p2 = e2epod.NewPodClient(f).Create(ctx, p2)
+		framework.ExpectNoError(e2epod.WaitTimeoutForPodReadyInNamespace(ctx, f.ClientSet, p2.Name, p2.Namespace, framework.PodStartTimeout))
+
+		p2, err = e2epod.NewPodClient(f).Get(ctx, p2.Name, metav1.GetOptions{})
+		framework.ExpectNoError(err)
+
+		_, err = getTransitionTimeForPodConditionWithStatus(p2, v1.PodScheduled, true)
+		framework.ExpectNoError(err)
+
+		_, err = getTransitionTimeForPodConditionWithStatus(p2, v1.PodInitialized, true)
+		framework.ExpectNoError(err)
+
+		// Verify PodReadyToStartContainers is set (since sandboxcreation is unblocked)
+		if checkPodReadyToStart {
+			_, err = getTransitionTimeForPodConditionWithStatus(p2, v1.PodReadyToStartContainers, true)
+			framework.ExpectNoError(err)
+		}
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind flake
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
add e2e test for podreadytostartcontainercondition, as this is part of KEP 3085
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #121317

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
