### PR TITLE
Automated cherry pick of #121116: KCCM: fix GCP ILB by reintroducing readiness predicate for

### DIFF
--- a/staging/src/k8s.io/cloud-provider/controllers/service/controller.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/service/controller.go
@@ -962,6 +962,7 @@ var (
 	etpLocalNodePredicates []NodeConditionPredicate = []NodeConditionPredicate{
 		nodeIncludedPredicate,
 		nodeUnTaintedPredicate,
+		nodeReadyPredicate,
 	}
 	stableNodeSetPredicates []NodeConditionPredicate = []NodeConditionPredicate{
 		nodeNotDeletedPredicate,

--- a/staging/src/k8s.io/cloud-provider/controllers/service/controller_test.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/service/controller_test.go
@@ -523,6 +523,8 @@ func TestNodeChangesForExternalTrafficPolicyLocalServices(t *testing.T) {
 			},
 		},
 		expectedUpdateCalls: []fakecloud.UpdateBalancerCall{
+			{Service: etpLocalservice1, Hosts: []*v1.Node{node1, node3}},
+			{Service: etpLocalservice2, Hosts: []*v1.Node{node1, node3}},
 			{Service: service3, Hosts: []*v1.Node{node1, node3}},
 		},
 	}, {
@@ -547,6 +549,8 @@ func TestNodeChangesForExternalTrafficPolicyLocalServices(t *testing.T) {
 			},
 		},
 		expectedUpdateCalls: []fakecloud.UpdateBalancerCall{
+			{Service: etpLocalservice1, Hosts: []*v1.Node{node1, node2, node3}},
+			{Service: etpLocalservice2, Hosts: []*v1.Node{node1, node2, node3}},
 			{Service: service3, Hosts: []*v1.Node{node1, node2, node3}},
 		},
 	}, {


### PR DESCRIPTION
Cherry pick of #121116 on release-1.28.

#121116: KCCM: fix GCP ILB by reintroducing readiness predicate for

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```