### PR TITLE
endpoint and endpointslices allow duplicate IPs

### DIFF
--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -19881,6 +19881,15 @@ func TestValidateEndpointsCreate(t *testing.T) {
 				}},
 			},
 		},
+		"duplicate ready and not ready address": {
+			endpoints: core.Endpoints{
+				ObjectMeta: metav1.ObjectMeta{Name: "mysvc", Namespace: "namespace"},
+				Subsets: []core.EndpointSubset{{
+					Addresses:         []core.EndpointAddress{{IP: "10.10.3.3"}},
+					NotReadyAddresses: []core.EndpointAddress{{IP: "10.10.3.3"}},
+				}},
+			},
+		},
 	}
 
 	for name, tc := range successCases {

--- a/pkg/apis/discovery/validation/validation_test.go
+++ b/pkg/apis/discovery/validation/validation_test.go
@@ -635,6 +635,24 @@ func TestValidateEndpointSliceCreate(t *testing.T) {
 				}},
 			},
 		},
+		"good-slice-duplicate-endpoint": {
+			expectedErrors: 0,
+			endpointSlice: &discovery.EndpointSlice{
+				ObjectMeta:  standardMeta,
+				AddressType: discovery.AddressTypeIPv4,
+				Ports: []discovery.EndpointPort{{
+					Name:     utilpointer.String("http"),
+					Protocol: protocolPtr(api.ProtocolTCP),
+				}},
+				Endpoints: []discovery.Endpoint{{
+					Addresses: generateIPAddresses(1),
+					Hostname:  utilpointer.String("valid-123"),
+				}, {
+					Addresses: generateIPAddresses(1),
+					Hostname:  utilpointer.String("valid-123"),
+				}},
+			},
+		},
 		"good-slice-node-name": {
 			expectedErrors: 0,
 			endpointSlice: &discovery.EndpointSlice{


### PR DESCRIPTION
both Endpoints and EndpointSlices can contain the same IP duplicate. In case of Endpoints this means the same IP is at the same time Ready and NotReady, leaving to implementations how to best deal with it.

This was not a problem in the past for Endpoints, before https://github.com/kubernetes/kubernetes/pull/94112, because the kube-apiserver canonicalized the Endpoints using the RepackSubsets function https://github.com/kubernetes/kubernetes/blob/ea5e4bc2326c71250774f6a4f5545492c5621760/pkg/api/v1/endpoints/util_test.go#L206-L221 , removing the duplication.

This patch just adds two unit tests to document this and verify that we maintain the existing behavior, since does not sound likely we strict validation now not allowing IPs to be duplicated.


/kind documentation

#### Special notes for your reviewer:

I just found out about this while debugging https://github.com/kubernetes/kubernetes/issues/121231#issuecomment-1763245731

```
kubectl get endpoints kubernetes -o yaml
apiVersion: v1
kind: Endpoints
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"v1","kind":"Endpoints","metadata":{"annotations":{},"labels":{"endpointslice.kubernetes.io/skip-mirror":"true"},"name":"kubernetes","namespace":"default"},"subsets":[{"addresses":[{"ip":"192.168.8.4"}],"ports":[{"name":"https","port":6443,"protocol":"TCP"}]},{"notReadyAddresses":[{"ip":"192.168.8.4"}],"ports":[{"name":"https","port":6443,"protocol":"TCP"}]}]}
  creationTimestamp: "2023-10-12T16:22:09Z"
  labels:
    endpointslice.kubernetes.io/skip-mirror: "true"
  name: kubernetes
  namespace: default
  resourceVersion: "854537"
  uid: c6a8f3b3-afbe-48e6-89c3-2b27d4284c5d
subsets:
- addresses:
  - ip: 192.168.8.4
  ports:
  - name: https
    port: 6443
    protocol: TCP
- notReadyAddresses:
  - ip: 192.168.8.4
  ports:
  - name: https
    port: 6443
    protocol: TCP
```

```release-note
NONE
```
