### PR TITLE
Promote e2e test for PersistentVolumeStatus & PersistentVolumeClaimStatus Endpoints +6 Endpoints 

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -3007,6 +3007,18 @@
     able to start with Secret and ConfigMap volumes mounted into the container.
   release: v1.13
   file: test/e2e/storage/empty_dir_wrapper.go
+- testname: PersistentVolumes(Claims), apply changes to a pv/pvc status
+  codename: '[sig-storage] PersistentVolumes CSI Conformance should apply changes
+    to a pv/pvc status [Conformance]'
+  description: Creating PV and PVC MUST succeed. Listing PVs with a labelSelector
+    MUST succeed. Listing PVCs in a namespace MUST succeed. Reading PVC status MUST
+    succeed with a valid phase found. Reading PV status MUST succeed with a valid
+    phase found. Patching the PVC status MUST succeed with its new condition found.
+    Patching the PV status MUST succeed with the new reason/message found. Updating
+    the PVC status MUST succeed with its new condition found. Updating the PV status
+    MUST succeed with the new reason/message found.
+  release: v1.29
+  file: test/e2e/storage/persistent_volumes.go
 - testname: PersistentVolumes(Claims), lifecycle
   codename: '[sig-storage] PersistentVolumes CSI Conformance should run through the
     lifecycle of a PV and a PVC [Conformance]'

--- a/test/e2e/storage/persistent_volumes.go
+++ b/test/e2e/storage/persistent_volumes.go
@@ -650,7 +650,18 @@ var _ = utils.SIGDescribe("PersistentVolumes", func() {
 			framework.ExpectNoError(err, "Timeout while waiting to confirm PV %q deletion", retrievedPV.Name)
 		})
 
-		ginkgo.It("should apply changes to a pv/pvc status", func(ctx context.Context) {
+		/*
+			Release: v1.29
+			Testname: PersistentVolumes(Claims), apply changes to a pv/pvc status
+			Description: Creating PV and PVC MUST succeed. Listing PVs with a labelSelector
+			 MUST succeed. Listing PVCs in a namespace MUST succeed. Reading PVC status MUST
+			 succeed with a valid phase found. Reading PV status MUST succeed with a valid
+			 phase found. Patching the PVC status MUST succeed with its new condition found.
+			 Patching the PV status MUST succeed with the new reason/message found. Updating
+			 the PVC status MUST succeed with its new condition found. Updating the PV status
+			 MUST succeed with the new reason/message found.
+		*/
+		framework.ConformanceIt("should apply changes to a pv/pvc status", func(ctx context.Context) {
 
 			pvClient := c.CoreV1().PersistentVolumes()
 			pvcClient := c.CoreV1().PersistentVolumeClaims(ns)


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it:**
This PR adds a test to test the following untested endpoints:
- patchCoreV1NamespacedPersistentVolumeClaimStatus
- patchCoreV1PersistentVolumeStatus
- readCoreV1NamespacedPersistentVolumeClaimStatus
- readCoreV1PersistentVolumeStatus
- replaceCoreV1NamespacedPersistentVolumeClaimStatus
- replaceCoreV1PersistentVolumeStatus

**Which issue(s) this PR fixes:**
Fixes #120891

**Testgrid Link:**
[testgrid-link](https://testgrid.k8s.io/sig-release-master-blocking#gce-cos-master-default&width=5&graph-metrics=test-duration-minutes&include-filter-by-regex=should%20apply%20changes%20to%20a%20pv/pvc%20status)


**Special notes for your reviewer:**
Adds +6 endpoint test coverage (good for conformance)

**Does this PR introduce a user-facing change?:**
```
NONE

```

**Release note:**
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:**
```
NONE

```

/sig testing
/sig architecture
/area conformance