### PR TITLE
KEP-4153: Declarative Validation Alpha Feature Gate

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -1115,6 +1115,8 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 
 	genericfeatures.ValidatingAdmissionPolicy: {Default: false, PreRelease: featuregate.Beta},
 
+	genericfeatures.DeclarativeValidation: {Default: false, PreRelease: featuregate.Alpha},
+
 	genericfeatures.CustomResourceValidationExpressions: {Default: true, PreRelease: featuregate.Beta},
 
 	genericfeatures.OpenAPIEnums: {Default: true, PreRelease: featuregate.Beta},

--- a/staging/src/k8s.io/apiserver/pkg/admission/schemavalidation/errors.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/schemavalidation/errors.go
@@ -1,0 +1,38 @@
+package schemavalidation
+
+import (
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+// Naive comparison in first alpha. This will change in a future release
+func diffNativeToDeclarativeErrors(
+	nativeResult field.ErrorList,
+	declarativeResult field.ErrorList,
+) (additions, deletions field.ErrorList) {
+	// Naive error matching requires exact match. Will be replaced/improved
+	// over time.
+	existingErrors := sets.New[string]()
+	declarativeErrors := sets.New[string]()
+	for _, v := range nativeResult {
+		existingErrors.Insert(v.Error())
+	}
+
+	for _, v := range declarativeResult {
+		st := v.Error()
+		declarativeErrors.Insert(st)
+		if _, ok := existingErrors[st]; !ok {
+			additions = append(additions, v)
+		}
+	}
+
+	// Warn for all native errors that were in schema
+	for _, v := range nativeResult {
+		if _, ok := declarativeErrors[v.Error()]; !ok {
+			deletions = append(deletions, v)
+		}
+
+	}
+
+	return additions, deletions
+}

--- a/staging/src/k8s.io/apiserver/pkg/admission/schemavalidation/strategy.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/schemavalidation/strategy.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package schemavalidation
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/apiserver/pkg/features"
+	"k8s.io/apiserver/pkg/registry/rest"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/apiserver/pkg/warning"
+)
+
+// Resources that have opted into Declarative Validation will implement this
+// interface for their strategies.
+type DeclarativeValidationStrategy interface {
+	// SetValidator sets the validator to be used by the strategy. The Validator
+	// must be able to validate any gvk given to the strategy.
+	//
+	// During API installation the APIServer is expected to create the validator
+	// from its OpenAPI configuration and provide it to any applicable strategies.
+	SetValidator(Validator)
+}
+
+// Opts the given RESTCreateStrategy into Declarative Validation if the feature
+// is enabled. Otherwise, returns the strategy unmodified.
+func WrapCreateStrategyIfEnabled(strategy rest.RESTCreateStrategy) rest.RESTCreateStrategy {
+	if !utilfeature.DefaultFeatureGate.Enabled(features.DeclarativeValidation) {
+		return strategy
+	}
+	return &schemaCreateStrategy{strategy, nil}
+}
+
+// Opts the given RESTUpdateStrategy into Declarative Validation if the feature
+// is enabled. Otherwise, returns the strategy unmodified.
+func WrapUpdateStrategyIfEnabled(strategy rest.RESTUpdateStrategy) rest.RESTUpdateStrategy {
+	if !utilfeature.DefaultFeatureGate.Enabled(features.DeclarativeValidation) {
+		return strategy
+	}
+	return &schemaUpdateStrategy{strategy, nil}
+}
+
+type schemaCreateStrategy struct {
+	rest.RESTCreateStrategy
+
+	// Schema validator instantiated from the OpenAPI spec.
+	validator Validator
+}
+
+func (s *schemaCreateStrategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {
+	res := s.RESTCreateStrategy.Validate(ctx, obj)
+	if s.validator != nil {
+		declarativeResult := s.validator.Validate(ctx, obj)
+		additions, deletions := diffNativeToDeclarativeErrors(res, declarativeResult)
+		for _, v := range additions {
+			warning.AddWarning(ctx, "DeclarativeValidation", fmt.Sprintf("Added Error: %v", v.Error()))
+		}
+
+		for _, v := range deletions {
+			warning.AddWarning(ctx, "DeclarativeValidation", fmt.Sprintf("Deleted Error: %v", v.Error()))
+		}
+	}
+	return res
+}
+
+func (s *schemaCreateStrategy) SetValidator(validator Validator) {
+	s.validator = validator
+}
+
+type schemaUpdateStrategy struct {
+	rest.RESTUpdateStrategy
+	validator Validator
+}
+
+func (s *schemaUpdateStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.Object) field.ErrorList {
+	res := s.RESTUpdateStrategy.ValidateUpdate(ctx, obj, old)
+	if s.validator != nil {
+		declarativeResult := s.validator.ValidateUpdate(ctx, obj, old)
+		additions, deletions := diffNativeToDeclarativeErrors(res, declarativeResult)
+		for _, v := range additions {
+			warning.AddWarning(ctx, "DeclarativeValidation", fmt.Sprintf("Added Error: %v", v.Error()))
+		}
+
+		for _, v := range deletions {
+			warning.AddWarning(ctx, "DeclarativeValidation", fmt.Sprintf("Deleted Error: %v", v.Error()))
+		}
+	}
+	return res
+}
+
+func (s *schemaUpdateStrategy) SetValidator(validator Validator) {
+	s.validator = validator
+}

--- a/staging/src/k8s.io/apiserver/pkg/admission/schemavalidation/strategy_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/schemavalidation/strategy_test.go
@@ -1,0 +1,264 @@
+package schemavalidation_test
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/apiserver/pkg/admission/schemavalidation"
+	"k8s.io/apiserver/pkg/features"
+	"k8s.io/apiserver/pkg/registry/rest"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/apiserver/pkg/warning"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
+)
+
+type validateFunc func(ctx context.Context, obj runtime.Object) field.ErrorList
+type validateUpdateFunc func(ctx context.Context, newObj, oldObj runtime.Object) field.ErrorList
+
+type fakeStrategy struct {
+	validateFunc
+	validateUpdateFunc
+}
+
+var _ rest.RESTCreateStrategy = &fakeStrategy{}
+var _ rest.RESTUpdateStrategy = &fakeStrategy{}
+
+type fakeValidator struct {
+	validateFunc
+	validateUpdateFunc
+}
+
+var _ schemavalidation.Validator = &fakeValidator{}
+
+func TestStrategyWrapEnablement(t *testing.T) {
+	// Show that wrapping a strategy with the feature disabled returns the strategy
+	// unmodified, and that wrapping a strategy with the feature enabled returns
+	// the strategy wrapped.
+	myStrategy := &fakeStrategy{}
+	for _, enabled := range []bool{false, true} {
+		t.Run("enabled="+fmt.Sprint(enabled), func(t *testing.T) {
+			defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.DeclarativeValidation, enabled)()
+			create := schemavalidation.WrapCreateStrategyIfEnabled(myStrategy)
+			update := schemavalidation.WrapUpdateStrategyIfEnabled(myStrategy)
+
+			// If feature is enabled, must conform to the interface DeclarativeValidationStrategy
+			// If feature is not enabled, must be equal to the input strategy
+			if _, ok := create.(schemavalidation.DeclarativeValidationStrategy); enabled != ok {
+				t.Errorf("WrapCreateStrategyIfEnabled() is DeclarativeValidationStrategy: %v, want %v", ok, enabled)
+			}
+			if _, ok := update.(schemavalidation.DeclarativeValidationStrategy); enabled != ok {
+				t.Errorf("WrapUpdateStrategyIfEnabled() is DeclarativeValidationStrategy: %v, want %v", ok, enabled)
+			}
+
+			if enabled == (create == myStrategy) {
+				t.Errorf("WrapCreateStrategyIfEnabled() is no-op: %v, want %v", create == myStrategy, enabled)
+			}
+
+			if enabled == (update == myStrategy) {
+				t.Errorf("WrapUpdateStrategyIfEnabled() is no-op: %v, want %v", update == myStrategy, enabled)
+			}
+		})
+	}
+}
+
+func TestWarnings(t *testing.T) {
+	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.DeclarativeValidation, true)()
+	strategyErrors := &field.ErrorList{}
+	validatorErrors := &field.ErrorList{}
+
+	myStrategy := &fakeStrategy{
+		validateFunc: func(ctx context.Context, obj runtime.Object) field.ErrorList {
+			return *strategyErrors
+		},
+		validateUpdateFunc: func(ctx context.Context, newObj, oldObj runtime.Object) field.ErrorList {
+			return *strategyErrors
+		},
+	}
+	myValidator := &fakeValidator{
+		validateFunc: func(ctx context.Context, obj runtime.Object) field.ErrorList {
+			return *validatorErrors
+		},
+		validateUpdateFunc: func(ctx context.Context, newObj, oldObj runtime.Object) field.ErrorList {
+			return *validatorErrors
+		},
+	}
+
+	create := schemavalidation.WrapCreateStrategyIfEnabled(myStrategy)
+	update := schemavalidation.WrapUpdateStrategyIfEnabled(myStrategy)
+
+	create.(schemavalidation.DeclarativeValidationStrategy).SetValidator(myValidator)
+	update.(schemavalidation.DeclarativeValidationStrategy).SetValidator(myValidator)
+
+	warningRecorder := newWarningRecorder()
+	ctx := context.TODO()
+	ctx = warning.WithWarningRecorder(ctx, warningRecorder)
+
+	type testCase struct {
+		name             string
+		strategyErrors   field.ErrorList
+		validatorErrors  field.ErrorList
+		expectedErrors   field.ErrorList
+		expectedWarnings []string
+	}
+
+	cases := []testCase{
+		{
+			name:             "errors raised by the validator but not the strategy are thrown as warnings",
+			strategyErrors:   nil,
+			validatorErrors:  field.ErrorList{field.Invalid(field.NewPath("foo"), "bar", "baz")},
+			expectedErrors:   nil,
+			expectedWarnings: []string{"Added Error: foo: Invalid value: \"bar\": baz"},
+		},
+		// 2. Test that errors raised by the stratgy but not the validator are
+		//		thrown as warnings with prefix `Deleted Error: `
+		{
+			name:             "errors raised by the strategy but not the validator are thrown as errors. but with a warning about the deletion",
+			strategyErrors:   field.ErrorList{field.Invalid(field.NewPath("foo"), "bar", "baz")},
+			validatorErrors:  nil,
+			expectedErrors:   field.ErrorList{field.Invalid(field.NewPath("foo"), "bar", "baz")},
+			expectedWarnings: []string{"Deleted Error: foo: Invalid value: \"bar\": baz"},
+		},
+		// 3. Test that errors thrown by both the strategy and validator are
+		//		not thrown as warnings.
+		{
+			name:             "errors raised by both the strategy and validator are not thrown as warnings",
+			strategyErrors:   field.ErrorList{field.Invalid(field.NewPath("foo"), "bar", "baz")},
+			validatorErrors:  field.ErrorList{field.Invalid(field.NewPath("foo"), "bar", "baz")},
+			expectedErrors:   field.ErrorList{field.Invalid(field.NewPath("foo"), "bar", "baz")},
+			expectedWarnings: nil,
+		},
+
+		// 4. Test that errors thrown by both the strategy and validator are
+		//		not thrown as warnings, but if the validator has extra errors,
+		//		only those are thrown as warnings.
+		{
+			name:             "errors raised by both the strategy and validator are not thrown as warnings, but if the validator has extra errors, only those are thrown as warnings",
+			strategyErrors:   field.ErrorList{field.Invalid(field.NewPath("foo"), "bar", "baz")},
+			validatorErrors:  field.ErrorList{field.Invalid(field.NewPath("foo"), "bar", "baz"), field.Invalid(field.NewPath("foo"), "bar", "Extra error")},
+			expectedErrors:   field.ErrorList{field.Invalid(field.NewPath("foo"), "bar", "baz")},
+			expectedWarnings: []string{"Added Error: foo: Invalid value: \"bar\": Extra error"},
+		},
+	}
+
+	checkCase := func(t *testing.T, c *testCase, errs field.ErrorList, warnings []string) {
+		if len(errs) != len(c.expectedErrors) {
+			t.Errorf("expected %d errors, got %d", len(c.expectedErrors), len(errs))
+		}
+		for i := range errs {
+			if errs[i].Error() != c.expectedErrors[i].Error() {
+				t.Errorf("expected error %q, got %q", c.expectedErrors[i].Error(), errs[i].Error())
+			}
+		}
+
+		if len(warnings) != len(c.expectedWarnings) {
+			t.Errorf("expected %d warnings, got %d", len(c.expectedWarnings), len(warnings))
+		}
+
+		for i := range warnings {
+			if warnings[i] != c.expectedWarnings[i] {
+				t.Errorf("expected warning %q, got %q", c.expectedWarnings[i], warnings[i])
+			}
+		}
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			*strategyErrors = c.strategyErrors
+			*validatorErrors = c.validatorErrors
+
+			t.Run("create", func(t *testing.T) {
+				warningRecorder.Reset()
+				errs := create.Validate(ctx, nil)
+				checkCase(t, &c, errs, warningRecorder.Warnings())
+			})
+
+			t.Run("update", func(t *testing.T) {
+				warningRecorder.Reset()
+				errs := update.ValidateUpdate(ctx, nil, nil)
+				checkCase(t, &c, errs, warningRecorder.Warnings())
+			})
+		})
+	}
+}
+
+func (f *fakeStrategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {
+	if f.validateFunc == nil {
+		return nil
+	}
+	return f.validateFunc(ctx, obj)
+}
+func (f *fakeStrategy) ValidateUpdate(ctx context.Context, newObj, oldObj runtime.Object) field.ErrorList {
+	if f.validateUpdateFunc == nil {
+		return nil
+	}
+
+	return f.validateUpdateFunc(ctx, newObj, oldObj)
+}
+
+// Validate implements schemavalidation.Validator.
+func (v *fakeValidator) Validate(ctx context.Context, new runtime.Object) field.ErrorList {
+	if v.validateFunc == nil {
+		return nil
+	}
+
+	return v.validateFunc(ctx, new)
+}
+
+// ValidateUpdate implements schemavalidation.Validator.
+func (v *fakeValidator) ValidateUpdate(ctx context.Context, new runtime.Object, old runtime.Object) field.ErrorList {
+	if v.validateUpdateFunc == nil {
+		return nil
+	}
+
+	return v.validateUpdateFunc(ctx, new, old)
+}
+
+func (fakeStrategy) Recognizes(gvk schema.GroupVersionKind) bool { return false }
+func (fakeStrategy) ObjectKinds(runtime.Object) ([]schema.GroupVersionKind, bool, error) {
+	return nil, false, nil
+}
+func (fakeStrategy) GenerateName(base string) string                                     { return "" }
+func (fakeStrategy) NamespaceScoped() bool                                               { return true }
+func (fakeStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object)            {}
+func (fakeStrategy) WarningsOnCreate(ctx context.Context, obj runtime.Object) []string   { return nil }
+func (fakeStrategy) Canonicalize(obj runtime.Object)                                     {}
+func (fakeStrategy) AllowCreateOnUpdate() bool                                           { return false }
+func (fakeStrategy) AllowUnconditionalUpdate() bool                                      { return true }
+func (fakeStrategy) PrepareForUpdate(ctx context.Context, newObj, oldObj runtime.Object) {}
+func (fakeStrategy) WarningsOnUpdate(ctx context.Context, obj, old runtime.Object) []string {
+	return nil
+}
+
+type warningRecorder struct {
+	sync.Mutex
+	warnings []string
+}
+
+func newWarningRecorder() *warningRecorder {
+	return &warningRecorder{}
+}
+
+func (r *warningRecorder) AddWarning(_, text string) {
+	r.Lock()
+	defer r.Unlock()
+	r.warnings = append(r.warnings, text)
+}
+
+func (r *warningRecorder) Warnings() []string {
+	r.Lock()
+	defer r.Unlock()
+	res := make([]string, len(r.warnings))
+	copy(res, r.warnings)
+	return res
+}
+
+func (r *warningRecorder) Reset() {
+	r.Lock()
+	defer r.Unlock()
+	r.warnings = nil
+}

--- a/staging/src/k8s.io/apiserver/pkg/admission/schemavalidation/validator.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/schemavalidation/validator.go
@@ -1,0 +1,198 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package schemavalidation
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/apiserver/pkg/cel/openapi/resolver"
+	openapierrors "k8s.io/kube-openapi/pkg/validation/errors"
+	"k8s.io/kube-openapi/pkg/validation/spec"
+	"k8s.io/kube-openapi/pkg/validation/strfmt"
+	"k8s.io/kube-openapi/pkg/validation/validate"
+)
+
+type ValidatorFactory interface {
+	// ForGroupKind prepares and returns a validator that converts any input
+	// of the given GroupResource into the given GVK and validates it with
+	// against the OpenAPI schema for the GVK.
+	ForGroupVersionKind(gvk schema.GroupVersionKind, converter *runtime.Scheme) (Validator, error)
+}
+
+type Validator interface {
+	Validate(ctx context.Context, new runtime.Object) field.ErrorList
+	ValidateUpdate(ctx context.Context, new, old runtime.Object) field.ErrorList
+}
+
+// Returns a validator that is capable of reading the GVK off of the provided
+// object, and validating it against its schema.
+//
+// Should perform following validations from the single entrypoint:
+//  1. OpenAPI
+//  2. CEL
+//  3. Name/Metadata
+//  4. ListType & MapType
+//
+// The validator is also expected to implement ratcheting
+func NewFactory(resolver resolver.SchemaResolver) (ValidatorFactory, error) {
+	return &delegatingValidator{resolver: resolver}, nil
+}
+
+func (v *delegatingValidator) ForGroupVersionKind(gvk schema.GroupVersionKind, converter *runtime.Scheme) (Validator, error) {
+	schema, err := v.resolver.ResolveSchema(gvk)
+	if err != nil {
+		return nil, err
+	}
+	return newSchemaValidator(schema, converter, gvk), nil
+}
+
+func newSchemaValidator(sch *spec.Schema, converter *runtime.Scheme, gvk schema.GroupVersionKind) Validator {
+	return &schemaValidator{schema: sch, converter: converter, gvk: gvk}
+}
+
+type schemaValidator struct {
+	schema    *spec.Schema
+	converter *runtime.Scheme
+	gvk       schema.GroupVersionKind
+}
+
+func (v *schemaValidator) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {
+	return v.ValidateUpdate(ctx, obj, nil)
+}
+
+func (v *schemaValidator) ValidateUpdate(ctx context.Context, obj, old runtime.Object) field.ErrorList {
+	// Convert the object to the target version
+	// Use unsafe since we will only read the object and toss when done, so sharing
+	// fields is acceptable.
+	converted, err := v.converter.UnsafeConvertToVersion(obj, v.gvk.GroupVersion())
+	if err != nil {
+		return field.ErrorList{field.InternalError(field.NewPath(""), err)}
+	}
+
+	var allErrs field.ErrorList
+
+	// Convert the converted object to unstructured
+	// In a future release we may instrument validation to work with
+	// SMD's value.Value which is also used for SSA.
+	u, err := runtime.DefaultUnstructuredConverter.ToUnstructured(converted)
+	if err != nil {
+		return field.ErrorList{field.InternalError(field.NewPath(""), err)}
+	}
+
+	// Old is not yet considered for now, since ratcheting is not yet implemented
+	// included with DeclarativeValidation
+	//
+	// Also not yet validating XListType, XMapType, or CEL expressions for now.
+	validator := validate.NewSchemaValidator(v.schema, nil, "", strfmt.Default)
+	allErrs = append(allErrs, kubeOpenAPIResultToFieldErrors(nil, validator.Validate(u))...)
+	return allErrs
+}
+
+// delegatingValidator reads the GVK from the input object and delegates the
+// validation request to other validators. It throws a validation error
+// if the GVK being requested is not recognized.
+type delegatingValidator struct {
+	resolver resolver.SchemaResolver
+}
+
+// Temporarily copied from apiextensions-apiserver
+func kubeOpenAPIResultToFieldErrors(fldPath *field.Path, result *validate.Result) field.ErrorList {
+	var allErrs field.ErrorList
+	for _, err := range result.Errors {
+		switch err := err.(type) {
+
+		case *openapierrors.Validation:
+			errPath := fldPath
+			if len(err.Name) > 0 && err.Name != "." {
+				errPath = errPath.Child(strings.TrimPrefix(err.Name, "."))
+			}
+
+			switch err.Code() {
+			case openapierrors.RequiredFailCode:
+				allErrs = append(allErrs, field.Required(errPath, ""))
+
+			case openapierrors.EnumFailCode:
+				values := []string{}
+				for _, allowedValue := range err.Values {
+					if s, ok := allowedValue.(string); ok {
+						values = append(values, s)
+					} else {
+						allowedJSON, _ := json.Marshal(allowedValue)
+						values = append(values, string(allowedJSON))
+					}
+				}
+				allErrs = append(allErrs, field.NotSupported(errPath, err.Value, values))
+
+			case openapierrors.TooLongFailCode:
+				value := interface{}("")
+				if err.Value != nil {
+					value = err.Value
+				}
+				max := int64(-1)
+				if i, ok := err.Valid.(int64); ok {
+					max = i
+				}
+				allErrs = append(allErrs, field.TooLongMaxLength(errPath, value, int(max)))
+
+			case openapierrors.MaxItemsFailCode:
+				actual := int64(-1)
+				if i, ok := err.Value.(int64); ok {
+					actual = i
+				}
+				max := int64(-1)
+				if i, ok := err.Valid.(int64); ok {
+					max = i
+				}
+				allErrs = append(allErrs, field.TooMany(errPath, int(actual), int(max)))
+
+			case openapierrors.TooManyPropertiesCode:
+				actual := int64(-1)
+				if i, ok := err.Value.(int64); ok {
+					actual = i
+				}
+				max := int64(-1)
+				if i, ok := err.Valid.(int64); ok {
+					max = i
+				}
+				allErrs = append(allErrs, field.TooMany(errPath, int(actual), int(max)))
+
+			case openapierrors.InvalidTypeCode:
+				value := interface{}("")
+				if err.Value != nil {
+					value = err.Value
+				}
+				allErrs = append(allErrs, field.TypeInvalid(errPath, value, err.Error()))
+
+			default:
+				value := interface{}("")
+				if err.Value != nil {
+					value = err.Value
+				}
+				allErrs = append(allErrs, field.Invalid(errPath, value, err.Error()))
+			}
+
+		default:
+			allErrs = append(allErrs, field.Invalid(fldPath, "", err.Error()))
+		}
+	}
+	return allErrs
+}

--- a/staging/src/k8s.io/apiserver/pkg/admission/schemavalidation/validator_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/schemavalidation/validator_test.go
@@ -1,0 +1,230 @@
+package schemavalidation_test
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/conversion"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apiserver/pkg/admission/schemavalidation"
+	"k8s.io/apiserver/pkg/cel/openapi/resolver"
+	"k8s.io/kube-openapi/pkg/common"
+	"k8s.io/kube-openapi/pkg/validation/spec"
+)
+
+// Show that the factory is capable of giving validators for schemas it knows
+// about, and that it returns errors for schemas it doesn't know about.
+func TestFactory(t *testing.T) {
+	fooV1Bar := schema.GroupVersionKind{Group: "foo", Version: "v1", Kind: "Bar"}
+	reg := &fakeSchemaRegistry{
+		Scheme:   runtime.NewScheme(),
+		registry: map[schema.GroupVersionKind]*spec.Schema{},
+		typeMap:  map[string]schema.GroupVersionKind{},
+	}
+	reg.AddKnownType(fooV1Bar, &runtime.Unknown{}, &spec.Schema{})
+
+	resolve := resolver.NewDefinitionsSchemaResolverFromNamer(reg.GetDefinitionName, reg.GetOpenAPIDefinitions)
+	factory, err := schemavalidation.NewFactory(resolve)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Show that the factory is capable of giving validators for schemas it knows
+	// about
+	validator, err := factory.ForGroupVersionKind(fooV1Bar, reg.Scheme)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if validator == nil {
+		t.Fatalf("unexpected nil validator")
+	}
+
+	// Show that the factory returns errors for schemas it doesn't know about
+	_, err = factory.ForGroupVersionKind(schema.GroupVersionKind{Group: "foo", Version: "v1", Kind: "Baz"}, reg.Scheme)
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+}
+
+type baseObject struct {
+	metav1.ObjectMeta
+	metav1.TypeMeta
+}
+
+func (b *baseObject) GroupVersionKind() schema.GroupVersionKind {
+	gv, err := schema.ParseGroupVersion(b.TypeMeta.APIVersion)
+	if err != nil {
+		panic(err)
+	}
+	return schema.GroupVersionKind{
+		Group:   gv.Group,
+		Version: gv.Version,
+		Kind:    b.TypeMeta.Kind,
+	}
+}
+
+func (b *baseObject) SetGroupVersionKind(gvk schema.GroupVersionKind) {
+	b.TypeMeta.APIVersion = gvk.GroupVersion().String()
+	b.TypeMeta.Kind = gvk.Kind
+}
+
+func (b *baseObject) GetObjectKind() schema.ObjectKind {
+	return b
+}
+
+// Shouldn't be called for these tests
+func (b baseObject) DeepCopyObject() runtime.Object {
+	panic("unimplemented")
+}
+
+// Show that the validator properly converts its input to the versioned
+// schema, and validates the converted input against the schema
+func TestValidatorConversion(t *testing.T) {
+	type FooBar struct {
+		baseObject
+		MyField string `json:"myField,omitempty"`
+	}
+	type FooV1Bar struct {
+		baseObject
+		MyField string `json:"myField,omitempty"`
+	}
+
+	type FooV2Bar struct {
+		baseObject
+		MyField string `json:"myField,omitempty"`
+	}
+
+	fooInternal := schema.GroupVersionKind{Group: "foo", Version: runtime.APIVersionInternal, Kind: "Bar"}
+	fooV2Bar := schema.GroupVersionKind{Group: "foo", Version: "v2", Kind: "Bar"}
+	fooV1Bar := schema.GroupVersionKind{Group: "foo", Version: "v1", Kind: "Bar"}
+
+	reg := &fakeSchemaRegistry{
+		Scheme:   runtime.NewScheme(),
+		registry: map[schema.GroupVersionKind]*spec.Schema{},
+		typeMap:  map[string]schema.GroupVersionKind{},
+	}
+	reg.AddKnownType(fooInternal, &FooBar{}, nil)
+	reg.AddKnownType(fooV1Bar, &FooV1Bar{}, &spec.Schema{
+		SchemaProps: spec.SchemaProps{
+			Type: spec.StringOrArray{"object"},
+			Properties: map[string]spec.Schema{
+				"myField": {
+					SchemaProps: spec.SchemaProps{
+						Type: spec.StringOrArray{"string"},
+						Enum: []interface{}{"v1"},
+					},
+				},
+			},
+		},
+	})
+	reg.AddKnownType(fooV2Bar, &FooV2Bar{}, &spec.Schema{
+		SchemaProps: spec.SchemaProps{
+			Type: spec.StringOrArray{"object"},
+			Properties: map[string]spec.Schema{
+				"myField": {
+					SchemaProps: spec.SchemaProps{
+						Type: spec.StringOrArray{"string"},
+						Enum: []interface{}{"v2"},
+					},
+				},
+			},
+		},
+	})
+
+	reg.AddConversionFunc((*FooBar)(nil), (*FooV1Bar)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		b.(*FooV1Bar).MyField = "notv1"
+		return nil
+	})
+
+	reg.AddConversionFunc((*FooBar)(nil), (*FooV2Bar)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		b.(*FooV2Bar).MyField = "notv2"
+		return nil
+	})
+
+	resolve := resolver.NewDefinitionsSchemaResolverFromNamer(reg.GetDefinitionName, reg.GetOpenAPIDefinitions)
+	factory, err := schemavalidation.NewFactory(resolve)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	fooV1Validator, err := factory.ForGroupVersionKind(fooV1Bar, reg.Scheme)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	fooV2Validator, err := factory.ForGroupVersionKind(fooV2Bar, reg.Scheme)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Show that the validator properly converts its input to the versioned
+	// schema, and validates the converted input against the schema
+	fooBar := &FooBar{}
+	fooBar.SetGroupVersionKind(fooInternal)
+	errs := fooV1Validator.Validate(context.TODO(), fooBar)
+	if len(errs) != 1 {
+		t.Fatalf("expected 1 error, got %v", errs)
+	}
+
+	expectation := `myField: Unsupported value: "notv1": supported values: "v1"`
+	if errs[0].Error() != expectation {
+		t.Fatalf("expected error %q, got %q", expectation, errs[0].Error())
+	}
+
+	expectation = `myField: Unsupported value: "notv2": supported values: "v2"`
+	errs = fooV2Validator.Validate(context.TODO(), fooBar)
+	if len(errs) != 1 {
+		t.Fatalf("expected 1 error, got %v", errs)
+	}
+}
+
+type fakeSchemaRegistry struct {
+	*runtime.Scheme
+	registry map[schema.GroupVersionKind]*spec.Schema
+	typeMap  map[string]schema.GroupVersionKind
+}
+
+func (f *fakeSchemaRegistry) AddKnownType(gvk schema.GroupVersionKind, obj runtime.Object, sch *spec.Schema) {
+
+	f.Scheme.AddKnownTypeWithName(gvk, obj)
+
+	if gvk.Version == runtime.APIVersionInternal {
+		// We don't store schemas of internal versions
+		return
+	}
+
+	typ := reflect.Indirect(reflect.ValueOf(obj)).Type()
+	f.typeMap[typ.String()] = gvk
+	f.registry[gvk] = sch
+}
+
+func (f *fakeSchemaRegistry) GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenAPIDefinition {
+	res := map[string]common.OpenAPIDefinition{}
+	for t, gvk := range f.typeMap {
+		sch := f.registry[gvk]
+		res[t] = common.OpenAPIDefinition{
+			Schema: *sch,
+		}
+	}
+	return res
+}
+
+func (f *fakeSchemaRegistry) GetDefinitionName(s string) (string, spec.Extensions) {
+	gvk, ok := f.typeMap[s]
+	if !ok {
+		return s, nil
+	}
+
+	cs := struct {
+		GVKs []metav1.GroupVersionKind `json:"x-kubernetes-group-version-kind"`
+	}{
+		GVKs: []metav1.GroupVersionKind{metav1.GroupVersionKind(gvk)},
+	}
+	v, e := runtime.DefaultUnstructuredConverter.ToUnstructured(&cs)
+	if e != nil {
+		panic(e)
+	}
+	return s, spec.Extensions(v)
+}

--- a/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
+++ b/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
@@ -104,6 +104,20 @@ const (
 	// Enables expression validation for Custom Resource
 	CustomResourceValidationExpressions featuregate.Feature = "CustomResourceValidationExpressions"
 
+	// owner: @alexzielenski
+	// kep: https://kep.k8s.io/4153
+	// alpha: v1.29
+	//
+	// Employes OpenAPI schemas for validation of builtin resources, when
+	// available. This feature gate is intended to be used in conjunction with
+	// the DeclarativeValidationsInOpenAPI feature gate.
+	//
+	// Only resources opted into Declarative Validation will be validated using
+	// OpenAPI schemas. Resources that have opted in will implement the
+	// DeclarativeValidationStrategy interface for their Create and Update
+	// strategies.
+	DeclarativeValidation featuregate.Feature = "DeclarativeValidation"
+
 	// alpha: v1.20
 	// beta: v1.21
 	// GA: v1.24
@@ -283,6 +297,8 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	APIServerTracing: {Default: true, PreRelease: featuregate.Beta},
 
 	ValidatingAdmissionPolicy: {Default: false, PreRelease: featuregate.Beta},
+
+	DeclarativeValidation: {Default: false, PreRelease: featuregate.Alpha},
 
 	CustomResourceValidationExpressions: {Default: true, PreRelease: featuregate.Beta},
 


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:

Adds the feature gate `DeclarativeValidation` which enables schema-based validation for enabled resources.

1. Declarative Validation is currently only enabled for two basic resource types. 
2. Error comparison is naive direct string comparison. 
3. Unmatched errors are added as warnings. 
4. This is the starting point for future Kubernetes releases to begin instrumenting resources for schema validation.

This PR includes a utility to wrap a resource's strategy, and overrides `Validate` and `ValidateUpdate` to invoke both the native and declarative validation backends. This is the proposed way for resources to opt in once annotated.

This implementation is a naive first step for both wrapping resources and comparing errors. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

/sig api-machinery
/assign @apelisse

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Adds `DeclarativeValidation` alpha feature gate to enable Schema-based validation of enabled resources.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://kep.k8s.io/4153
```
