### PR TITLE
kubeadm: Add `FeatureGates` for `ResetConfiguration` of v1beta4

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/types.go
+++ b/cmd/kubeadm/app/apis/kubeadm/types.go
@@ -500,6 +500,9 @@ type ResetConfiguration struct {
 	// DryRun tells if the dry run mode is enabled, don't apply any change if it is and just output what would be done.
 	DryRun bool
 
+	// FeatureGates enabled by the user.
+	FeatureGates map[string]bool
+
 	// Force flag instructs kubeadm to reset the node without prompting for confirmation.
 	Force bool
 

--- a/cmd/kubeadm/app/apis/kubeadm/v1beta4/types.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1beta4/types.go
@@ -493,6 +493,10 @@ type ResetConfiguration struct {
 	// +optional
 	DryRun bool `json:"dryRun,omitempty"`
 
+	// FeatureGates enabled by the user.
+	// +optional
+	FeatureGates map[string]bool `json:"featureGates,omitempty"`
+
 	// Force flag instructs kubeadm to reset the node without prompting for confirmation.
 	// +optional
 	Force bool `json:"force,omitempty"`

--- a/cmd/kubeadm/app/apis/kubeadm/v1beta4/zz_generated.conversion.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1beta4/zz_generated.conversion.go
@@ -853,6 +853,7 @@ func autoConvert_v1beta4_ResetConfiguration_To_kubeadm_ResetConfiguration(in *Re
 	out.CertificatesDir = in.CertificatesDir
 	out.CRISocket = in.CRISocket
 	out.DryRun = in.DryRun
+	out.FeatureGates = *(*map[string]bool)(unsafe.Pointer(&in.FeatureGates))
 	out.Force = in.Force
 	out.IgnorePreflightErrors = *(*[]string)(unsafe.Pointer(&in.IgnorePreflightErrors))
 	out.SkipPhases = *(*[]string)(unsafe.Pointer(&in.SkipPhases))
@@ -869,6 +870,7 @@ func autoConvert_kubeadm_ResetConfiguration_To_v1beta4_ResetConfiguration(in *ku
 	out.CleanupTmpDir = in.CleanupTmpDir
 	out.CRISocket = in.CRISocket
 	out.DryRun = in.DryRun
+	out.FeatureGates = *(*map[string]bool)(unsafe.Pointer(&in.FeatureGates))
 	out.Force = in.Force
 	out.IgnorePreflightErrors = *(*[]string)(unsafe.Pointer(&in.IgnorePreflightErrors))
 	out.SkipPhases = *(*[]string)(unsafe.Pointer(&in.SkipPhases))

--- a/cmd/kubeadm/app/apis/kubeadm/v1beta4/zz_generated.deepcopy.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1beta4/zz_generated.deepcopy.go
@@ -550,6 +550,13 @@ func (in *Patches) DeepCopy() *Patches {
 func (in *ResetConfiguration) DeepCopyInto(out *ResetConfiguration) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
+	if in.FeatureGates != nil {
+		in, out := &in.FeatureGates, &out.FeatureGates
+		*out = make(map[string]bool, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.IgnorePreflightErrors != nil {
 		in, out := &in.IgnorePreflightErrors, &out.IgnorePreflightErrors
 		*out = make([]string, len(*in))

--- a/cmd/kubeadm/app/apis/kubeadm/zz_generated.deepcopy.go
+++ b/cmd/kubeadm/app/apis/kubeadm/zz_generated.deepcopy.go
@@ -580,6 +580,13 @@ func (in *Patches) DeepCopy() *Patches {
 func (in *ResetConfiguration) DeepCopyInto(out *ResetConfiguration) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
+	if in.FeatureGates != nil {
+		in, out := &in.FeatureGates, &out.FeatureGates
+		*out = make(map[string]bool, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.IgnorePreflightErrors != nil {
 		in, out := &in.IgnorePreflightErrors, &out.IgnorePreflightErrors
 		*out = make([]string, len(*in))


### PR DESCRIPTION
Our latest finding is that InitConfiguration is not able to be retrieved from cluster on worker nodes, and hence, the `FeatureGates` configuration from current cluster is unknown as well, adding `FeatureGates` to `ResetConfiguration` provides a way for users to specify the information where it's needed.

/kind api-change

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
see: https://github.com/kubernetes/kubernetes/pull/121281#discussion_r1361841252 for the more context about this change.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
