### PR TITLE
e2e framework: allow random ordering of tags and text, fix some functions

### DIFF
--- a/test/e2e/framework/internal/unittests/bugs/bugs.go
+++ b/test/e2e/framework/internal/unittests/bugs/bugs.go
@@ -105,6 +105,8 @@ func Describe() {
 			})
 		},
 	)
+
+	framework.SIGDescribe("123")
 }
 
 const (
@@ -118,13 +120,14 @@ ERROR: bugs.go:77: WithFeature: unknown feature "no-such-feature"
 ERROR: bugs.go:79: WithEnvironment: unknown environment "no-such-env"
 ERROR: bugs.go:81: WithNodeFeature: unknown environment "no-such-node-env"
 ERROR: bugs.go:83: WithFeatureGate: the feature gate "no-such-feature-gate" is unknown
+ERROR: bugs.go:109: SIG label must be lowercase, no spaces and no sig- prefix, got instead: "123"
 ERROR: buggy/buggy.go:100: hello world
 ERROR: some/relative/path/buggy.go:200: with spaces
 `
 	// Used by unittests/list-tests. It's sorted by test name, not source code location.
 	ListTestsOutput = `The following spec names can be used with 'ginkgo run --focus/skip':
-    ../bugs/bugs.go:103: [sig-testing] abc   space1 space2  [Feature: no-such-feature] [Feature: feature-foo] [Environment: no-such-env] [Environment: Linux] [no-such-node-env] [node-feature-foo] [FeatureGate: no-such-feature-gate] [FeatureGate: TestAlphaFeature] [Alpha] [FeatureGate: TestBetaFeature] [Beta] [FeatureGate: TestGAFeature] [Conformance] [NodeConformance] [Slow] [Serial] [Disruptive] [custom-label] xyz x [foo] should [bar]
-    ../bugs/bugs.go:98: [sig-testing] abc   space1 space2  [Feature: no-such-feature] [Feature: feature-foo] [Environment: no-such-env] [Environment: Linux] [no-such-node-env] [node-feature-foo] [FeatureGate: no-such-feature-gate] [FeatureGate: TestAlphaFeature] [Alpha] [FeatureGate: TestBetaFeature] [Beta] [FeatureGate: TestGAFeature] [Conformance] [NodeConformance] [Slow] [Serial] [Disruptive] [custom-label] xyz y [foo] should [bar]
+    ../bugs/bugs.go:103: [sig-testing] abc   space1 space2  [Feature:no-such-feature] [Feature:feature-foo] [Environment:no-such-env] [Environment:Linux] [NodeFeature:no-such-node-env] [NodeFeature:node-feature-foo] [FeatureGate:no-such-feature-gate] [FeatureGate:TestAlphaFeature] [Alpha] [FeatureGate:TestBetaFeature] [Beta] [FeatureGate:TestGAFeature] [Conformance] [NodeConformance] [Slow] [Serial] [Disruptive] [custom-label] xyz x [foo] should [bar]
+    ../bugs/bugs.go:98: [sig-testing] abc   space1 space2  [Feature:no-such-feature] [Feature:feature-foo] [Environment:no-such-env] [Environment:Linux] [NodeFeature:no-such-node-env] [NodeFeature:node-feature-foo] [FeatureGate:no-such-feature-gate] [FeatureGate:TestAlphaFeature] [Alpha] [FeatureGate:TestBetaFeature] [Beta] [FeatureGate:TestGAFeature] [Conformance] [NodeConformance] [Slow] [Serial] [Disruptive] [custom-label] xyz y [foo] should [bar]
 
 `
 
@@ -134,22 +137,22 @@ ERROR: some/relative/path/buggy.go:200: with spaces
     Beta
     Conformance
     Disruptive
-    Environment: Linux
-    Environment: no-such-env
-    Feature: feature-foo
-    Feature: no-such-feature
-    FeatureGate: TestAlphaFeature
-    FeatureGate: TestBetaFeature
-    FeatureGate: TestGAFeature
-    FeatureGate: no-such-feature-gate
+    Environment:Linux
+    Environment:no-such-env
+    Feature:feature-foo
+    Feature:no-such-feature
+    FeatureGate:TestAlphaFeature
+    FeatureGate:TestBetaFeature
+    FeatureGate:TestGAFeature
+    FeatureGate:no-such-feature-gate
     NodeConformance
+    NodeFeature:no-such-node-env
+    NodeFeature:node-feature-foo
     Serial
     Slow
     bar
     custom-label
     foo
-    no-such-node-env
-    node-feature-foo
     sig-testing
 
 `


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

There are some tests which want to insert a tag before the main Describe text, for example:
   sigDescribe("[Feature:Windows] Cpu Resources [Serial]",
               skipUnlessWindows(func() { ... })

In order to support this without change existing test names, it must be possible to do this instead:
   sigDescribe(feature.Windows, "Cpu Resources", framework.WithSerial(),
               skipUnlessWindows(func() { ... })

There are similar examples for the other functions.

While at it, replace one left-over panic with ReportBug and add the missing `NodeFeature:` prefix.

#### Which issue(s) this PR fixes:
Follow-up to: https://github.com/kubernetes/kubernetes/pull/112894

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
