### PR TITLE
e2e apimachinery: use feature gate

### DIFF
--- a/test/e2e/apimachinery/validatingadmissionpolicy.go
+++ b/test/e2e/apimachinery/validatingadmissionpolicy.go
@@ -31,12 +31,13 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apiserver/pkg/features"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
 	admissionapi "k8s.io/pod-security-admission/api"
 )
 
-var _ = SIGDescribe("ValidatingAdmissionPolicy [Privileged:ClusterAdmin][Alpha][Feature:ValidatingAdmissionPolicy]", func() {
+var _ = SIGDescribe("ValidatingAdmissionPolicy [Privileged:ClusterAdmin]", framework.WithFeatureGate(features.ValidatingAdmissionPolicy), func() {
 	f := framework.NewDefaultFramework("validating-admission-policy")
 	f.NamespacePodSecurityLevel = admissionapi.LevelBaseline
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Using the feature gate has the advantage that the stability tag gets added automatically and no changes are needed when graduating it. Once it reaches GA, the tag needs to be removed together with the feature gate.

In fact, the current `[ALPHA]` is wrong: the feature has already graduated to beta...

#### Special notes for your reviewer:

The `go test -c ./test/e2e -args -list-tests` output shows this change because of this PR:
```patch
<     apimachinery/validatingadmissionpolicy.go:196: [sig-api-machinery] ValidatingAdmissionPolicy [Privileged:ClusterAdmin][Alpha][Feature:ValidatingAdmissionPolicy] should allow expressions to refer variables.
<     apimachinery/validatingadmissionpolicy.go:121: [sig-api-machinery] ValidatingAdmissionPolicy [Privileged:ClusterAdmin][Alpha][Feature:ValidatingAdmissionPolicy] should type check validation expressions
<     apimachinery/validatingadmissionpolicy.go:64: [sig-api-machinery] ValidatingAdmissionPolicy [Privileged:ClusterAdmin][Alpha][Feature:ValidatingAdmissionPolicy] should validate against a Deployment
---
>     apimachinery/validatingadmissionpolicy.go:197: [sig-api-machinery] ValidatingAdmissionPolicy [Privileged:ClusterAdmin] [FeatureGate: ValidatingAdmissionPolicy] [Beta] should allow expressions to refer variables.
>     apimachinery/validatingadmissionpolicy.go:122: [sig-api-machinery] ValidatingAdmissionPolicy [Privileged:ClusterAdmin] [FeatureGate: ValidatingAdmissionPolicy] [Beta] should type check validation expressions
>     apimachinery/validatingadmissionpolicy.go:65: [sig-api-machinery] ValidatingAdmissionPolicy [Privileged:ClusterAdmin] [FeatureGate: ValidatingAdmissionPolicy] [Beta] should validate against a Deployment
```

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
