### PR TITLE
client-go/reflector: introduce a data consistency check for the watch-list feature.

### DIFF
--- a/staging/src/k8s.io/client-go/tools/cache/reflector_data_consistency_detector.go
+++ b/staging/src/k8s.io/client-go/tools/cache/reflector_data_consistency_detector.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"context"
+	"os"
+	"sort"
+	"strconv"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog/v2"
+)
+
+var dataConsistencyDetectionEnabled = false
+
+func init() {
+	dataConsistencyDetectionEnabled, _ = strconv.ParseBool(os.Getenv("KUBE_WATCHLIST_INCONSISTENCY_DETECTOR"))
+}
+
+// checkWatchListConsistencyIfRequested performs a data consistency check only when
+// the KUBE_WATCHLIST_INCONSISTENCY_DETECTOR environment variable was set during a binary startup.
+//
+// The consistency check is meant to be enforced only in the CI, not in production.
+// The check ensures that data retrieved by the watch-list api call
+// is exactly the same as data received by the standard list api call.
+//
+// Note that this function will panic when data inconsistency is detected.
+// This is intentional because we want to catch it in the CI.
+func checkWatchListConsistencyIfRequested(stopCh <-chan struct{}, identity string, lastSyncedResourceVersion string, listerWatcher Lister, store Store) {
+	if !dataConsistencyDetectionEnabled {
+		return
+	}
+	checkWatchListConsistency(stopCh, identity, lastSyncedResourceVersion, listerWatcher, store)
+}
+
+// checkWatchListConsistency exists solely for testing purposes.
+// we cannot use checkWatchListConsistencyIfRequested because
+// it is guarded by an environmental variable.
+// we cannot manipulate the environmental variable because
+// it will affect other tests in this package.
+func checkWatchListConsistency(stopCh <-chan struct{}, identity string, lastSyncedResourceVersion string, listerWatcher Lister, store Store) {
+	klog.Warningf("%s: data consistency check for the watch-list feature is enabled, this will result in an additional call to the API server.", identity)
+	opts := metav1.ListOptions{
+		ResourceVersion:      lastSyncedResourceVersion,
+		ResourceVersionMatch: metav1.ResourceVersionMatchExact,
+	}
+	var list runtime.Object
+	err := wait.PollUntilContextCancel(wait.ContextForChannel(stopCh), time.Second, true, func(_ context.Context) (done bool, err error) {
+		list, err = listerWatcher.List(opts)
+		if err != nil {
+			// the consistency check will only be enabled in the CI
+			// and LIST calls in general will be retired by the client-go library
+			// if we fail simply log and retry
+			klog.Errorf("failed to list data from the server, retrying until stopCh is closed, err: %v", err)
+			return false, nil
+		}
+		return true, nil
+	})
+	if err != nil {
+		klog.Errorf("failed to list data from the server, the watch-list consistency check won't be performed, stopCh was closed, err: %v", err)
+		return
+	}
+
+	rawListItems, err := meta.ExtractListWithAlloc(list)
+	if err != nil {
+		panic(err) // this should never happen
+	}
+
+	listItems := toMetaObjectSliceOrDie(rawListItems)
+	storeItems := toMetaObjectSliceOrDie(store.List())
+
+	sort.Sort(byUID(listItems))
+	sort.Sort(byUID(storeItems))
+
+	if !cmp.Equal(listItems, storeItems) {
+		klog.Infof("%s: data received by the new watch-list api call is different than received by the standard list api call, diff: %v", identity, cmp.Diff(listItems, storeItems))
+		msg := "data inconsistency detected for the watch-list feature, panicking!"
+		panic(msg)
+	}
+}
+
+type byUID []metav1.Object
+
+func (a byUID) Len() int           { return len(a) }
+func (a byUID) Less(i, j int) bool { return a[i].GetUID() < a[j].GetUID() }
+func (a byUID) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+
+func toMetaObjectSliceOrDie[T any](s []T) []metav1.Object {
+	result := make([]metav1.Object, len(s))
+	for i, v := range s {
+		m, err := meta.Accessor(v)
+		if err != nil {
+			panic(err)
+		}
+		result[i] = m
+	}
+	return result
+}

--- a/staging/src/k8s.io/client-go/tools/cache/reflector_data_consistency_detector_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/reflector_data_consistency_detector_test.go
@@ -1,0 +1,143 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+func TestWatchListConsistency(t *testing.T) {
+	scenarios := []struct {
+		name string
+
+		podList      *v1.PodList
+		storeContent []*v1.Pod
+
+		expectedRequestOptions []metav1.ListOptions
+		expectedListRequests   int
+		expectPanic            bool
+	}{
+		{
+			name: "watchlist consistency check won't panic when data is consistent",
+			podList: &v1.PodList{
+				ListMeta: metav1.ListMeta{ResourceVersion: "2"},
+				Items:    []v1.Pod{*makePod("p1", "1"), *makePod("p2", "2")},
+			},
+			storeContent:         []*v1.Pod{makePod("p1", "1"), makePod("p2", "2")},
+			expectedListRequests: 1,
+			expectedRequestOptions: []metav1.ListOptions{
+				{
+					ResourceVersion:      "2",
+					ResourceVersionMatch: metav1.ResourceVersionMatchExact,
+				},
+			},
+		},
+
+		{
+			name: "watchlist consistency check won't panic when there is no data",
+			podList: &v1.PodList{
+				ListMeta: metav1.ListMeta{ResourceVersion: "2"},
+			},
+			expectedListRequests: 1,
+			expectedRequestOptions: []metav1.ListOptions{
+				{
+					ResourceVersion:      "2",
+					ResourceVersionMatch: metav1.ResourceVersionMatchExact,
+				},
+			},
+		},
+
+		{
+			name: "watchlist consistency panics when data is inconsistent",
+			podList: &v1.PodList{
+				ListMeta: metav1.ListMeta{ResourceVersion: "2"},
+				Items:    []v1.Pod{*makePod("p1", "1"), *makePod("p2", "2"), *makePod("p3", "3")},
+			},
+			storeContent:         []*v1.Pod{makePod("p1", "1"), makePod("p2", "2")},
+			expectedListRequests: 1,
+			expectedRequestOptions: []metav1.ListOptions{
+				{
+					ResourceVersion:      "2",
+					ResourceVersionMatch: metav1.ResourceVersionMatchExact,
+				},
+			},
+			expectPanic: true,
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			listWatcher, store, _, stopCh := testData()
+			for _, obj := range scenario.storeContent {
+				require.NoError(t, store.Add(obj))
+			}
+			listWatcher.customListResponse = scenario.podList
+
+			if scenario.expectPanic {
+				require.Panics(t, func() { checkWatchListConsistency(stopCh, "", scenario.podList.ResourceVersion, listWatcher, store) })
+			} else {
+				checkWatchListConsistency(stopCh, "", scenario.podList.ResourceVersion, listWatcher, store)
+			}
+
+			verifyListCounter(t, listWatcher, scenario.expectedListRequests)
+			verifyRequestOptions(t, listWatcher, scenario.expectedRequestOptions)
+		})
+	}
+}
+
+func TestDriveWatchLisConsistencyIfRequired(t *testing.T) {
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	checkWatchListConsistencyIfRequested(stopCh, "", "", nil, nil)
+}
+
+func TestWatchListConsistencyRetry(t *testing.T) {
+	store := NewStore(MetaNamespaceKeyFunc)
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+
+	stopListErrorAfter := 5
+	errLister := &errorLister{stopErrorAfter: stopListErrorAfter}
+
+	checkWatchListConsistency(stopCh, "", "", errLister, store)
+	require.Equal(t, errLister.listCounter, errLister.stopErrorAfter)
+}
+
+type errorLister struct {
+	listCounter    int
+	stopErrorAfter int
+}
+
+func (lw *errorLister) List(_ metav1.ListOptions) (runtime.Object, error) {
+	lw.listCounter++
+	if lw.listCounter == lw.stopErrorAfter {
+		return &v1.PodList{}, nil
+	}
+	return nil, fmt.Errorf("nasty error")
+}
+
+func (lw *errorLister) Watch(_ metav1.ListOptions) (watch.Interface, error) {
+	panic("not implemented")
+}

--- a/staging/src/k8s.io/client-go/tools/cache/reflector_watchlist_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/reflector_watchlist_test.go
@@ -30,6 +30,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/utils/pointer"
 )
@@ -491,7 +492,7 @@ func verifyStore(t *testing.T, s Store, expectedPods []v1.Pod) {
 }
 
 func makePod(name, rv string) *v1.Pod {
-	return &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: name, ResourceVersion: rv}}
+	return &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: name, ResourceVersion: rv, UID: types.UID(name)}}
 }
 
 func testData() (*fakeListWatcher, Store, *Reflector, chan struct{}) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

`checkWatchListConsistencyIfRequested` performs a data consistency check only when
the `KUBE_WATCHLIST_INCONSISTENCY_DETECTOR` environment variable was set during a binary startup.

The consistency check is meant to be enforced only in the CI, not in production.
The check ensures that data retrieved by the watch-list api call
is exactly the same as data received by the standard list api call.

Note that this function will panic when data inconsistency is detected.
This is intentional because we want to catch it in the CI.

xref: https://github.com/kubernetes/enhancements/issues/3157

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/3157-watch-list
```
