### PR TITLE
registry/core: wire NotFound getter instead of nil

### DIFF
--- a/pkg/registry/core/rest/storage_core_generic.go
+++ b/pkg/registry/core/rest/storage_core_generic.go
@@ -17,9 +17,14 @@ limitations under the License.
 package rest
 
 import (
+	"context"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/authentication/authenticator"
 	"k8s.io/apiserver/pkg/registry/generic"
 	"k8s.io/apiserver/pkg/registry/rest"
@@ -90,9 +95,9 @@ func (c *GenericConfig) NewRESTStorage(apiResourceConfigSource serverstorage.API
 
 	var serviceAccountStorage *serviceaccountstore.REST
 	if c.ServiceAccountIssuer != nil {
-		serviceAccountStorage, err = serviceaccountstore.NewREST(restOptionsGetter, c.ServiceAccountIssuer, c.APIAudiences, c.ServiceAccountMaxExpiration, nil, secretStorage.Store, c.ExtendExpiration)
+		serviceAccountStorage, err = serviceaccountstore.NewREST(restOptionsGetter, c.ServiceAccountIssuer, c.APIAudiences, c.ServiceAccountMaxExpiration, newNotFoundGetter(schema.GroupResource{Resource: "pods"}), secretStorage.Store, c.ExtendExpiration)
 	} else {
-		serviceAccountStorage, err = serviceaccountstore.NewREST(restOptionsGetter, nil, nil, 0, nil, nil, false)
+		serviceAccountStorage, err = serviceaccountstore.NewREST(restOptionsGetter, nil, nil, 0, newNotFoundGetter(schema.GroupResource{Resource: "pods"}), newNotFoundGetter(schema.GroupResource{Resource: "secrets"}), false)
 	}
 	if err != nil {
 		return genericapiserver.APIGroupInfo{}, err
@@ -138,4 +143,16 @@ func (c *GenericConfig) NewRESTStorage(apiResourceConfigSource serverstorage.API
 
 func (c *GenericConfig) GroupName() string {
 	return api.GroupName
+}
+
+func newNotFoundGetter(gr schema.GroupResource) rest.Getter {
+	return notFoundGetter{gr: gr}
+}
+
+type notFoundGetter struct {
+	gr schema.GroupResource
+}
+
+func (g notFoundGetter) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
+	return nil, errors.NewNotFound(g.gr, name)
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The generic core storage wired the service account storage with a nil pod getter. This leads to a panic for pod-bound tokens. It's not expected for those token to work, but a panic is obviously not what we want. Hence, wire a getter that returns NotFound errors.

```release-note
NONE
```