### PR TITLE
kubeadm: add debug log for kubeProxyConfigFromCluster

### DIFF
--- a/cmd/kubeadm/app/componentconfigs/kubeproxy.go
+++ b/cmd/kubeadm/app/componentconfigs/kubeproxy.go
@@ -17,7 +17,9 @@ limitations under the License.
 package componentconfigs
 
 import (
+	"github.com/pkg/errors"
 	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
 	kubeproxyconfig "k8s.io/kube-proxy/config/v1alpha1"
 	netutils "k8s.io/utils/net"
 
@@ -49,7 +51,14 @@ var kubeProxyHandler = handler{
 }
 
 func kubeProxyConfigFromCluster(h *handler, clientset clientset.Interface, _ *kubeadmapi.ClusterConfiguration) (kubeadmapi.ComponentConfig, error) {
-	return h.fromConfigMap(clientset, kubeadmconstants.KubeProxyConfigMap, kubeadmconstants.KubeProxyConfigMapKey, false)
+	configMapName := kubeadmconstants.KubeProxyConfigMap
+	klog.V(1).Infof("attempting to download the KubeProxyConfiguration from ConfigMap %q", configMapName)
+	cm, err := h.fromConfigMap(clientset, configMapName, kubeadmconstants.KubeProxyConfigMapKey, false)
+	if err != nil {
+		return nil, errors.Wrapf(err, "could not download the kube-proxy configuration from ConfigMap %q",
+			configMapName)
+	}
+	return cm, nil
 }
 
 // kubeProxyConfig implements the kubeadmapi.ComponentConfig interface for kube-proxy


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
kubeadm: add debug log for kubeProxyConfigFromCluster

Be consistent with `kubeletConfigFromCluster`:
https://github.com/kubernetes/kubernetes/blob/2c10d9cacb0626219753a3df28a76b6bfae2b34a/cmd/kubeadm/app/componentconfigs/kubelet.go#L72-L81

```sh
I1020 03:05:24.635660   15660 apply.go:106] [upgrade/apply] verifying health of cluster
I1020 03:05:24.635727   15660 apply.go:107] [upgrade/apply] retrieving configuration from cluster
[upgrade/config] Making sure the configuration is correct:
[upgrade/config] Reading configuration from the cluster...
[upgrade/config] FYI: You can look at this config file with 'kubectl -n kube-system get cm kubeadm-config -o yaml'
I1020 03:05:24.649069   15660 kubeproxy.go:54] attempting to download the KubeProxyConfiguration from ConfigMap "kube-proxy"
I1020 03:05:24.653368   15660 kubelet.go:74] attempting to download the KubeletConfiguration from ConfigMap "kubelet-config"
...
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
