### PR TITLE
kubeadm coredns use drop ALL instead of all

### DIFF
--- a/cmd/kubeadm/app/phases/addons/dns/dns_test.go
+++ b/cmd/kubeadm/app/phases/addons/dns/dns_test.go
@@ -742,7 +742,7 @@ spec:
             add:
             - NET_BIND_SERVICE
             drop:
-            - all
+            - ALL
           readOnlyRootFilesystem: true
       dnsPolicy: Default
       volumes:
@@ -1007,7 +1007,7 @@ spec:
             add:
             - NET_BIND_SERVICE
             drop:
-            - all
+            - ALL
           readOnlyRootFilesystem: true
       dnsPolicy: Default
       volumes:

--- a/cmd/kubeadm/app/phases/addons/dns/manifests.go
+++ b/cmd/kubeadm/app/phases/addons/dns/manifests.go
@@ -141,7 +141,7 @@ spec:
             add:
             - NET_BIND_SERVICE
             drop:
-            - all
+            - ALL
           readOnlyRootFilesystem: true
       dnsPolicy: Default
       volumes:


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
https://github.com/kubernetes/kubernetes/pull/121351#issuecomment-1772287714

Either `all` or `ALL` is logically OK, and `ALL` **may be preferred.** 

It is case-insensitive in container runtime according to https://github.com/kubernetes/kubernetes/issues/119569.

#### Which issue(s) this PR fixes:

Fixes None

#### Special notes for your reviewer:
/priority backlog
**and not have to.**

#### Does this PR introduce a user-facing change?
```release-note
None
```
