### PR TITLE
Resubmit "Make StatefulSet restart pods with phase Succeeded"

### DIFF
--- a/pkg/controller/statefulset/stateful_set_control.go
+++ b/pkg/controller/statefulset/stateful_set_control.go
@@ -375,13 +375,27 @@ func (ssc *defaultStatefulSetControl) processReplica(
 	replicas []*v1.Pod,
 	i int) (bool, error) {
 	logger := klog.FromContext(ctx)
-	// delete and recreate failed pods
-	if isFailed(replicas[i]) {
-		ssc.recorder.Eventf(set, v1.EventTypeWarning, "RecreatingFailedPod",
-			"StatefulSet %s/%s is recreating failed Pod %s",
-			set.Namespace,
-			set.Name,
-			replicas[i].Name)
+	// Delete and recreate pods which finished running.
+	//
+	// Note that pods with phase Succeeded will also trigger this event. This is
+	// because final pod phase of evicted or otherwise forcibly stopped pods
+	// (e.g. terminated on node reboot) is determined by the exit code of the
+	// container, not by the reason for pod termination. We should restart the pod
+	// regardless of the exit code.
+	if isFailed(replicas[i]) || isSucceeded(replicas[i]) {
+		if isFailed(replicas[i]) {
+			ssc.recorder.Eventf(set, v1.EventTypeWarning, "RecreatingFailedPod",
+				"StatefulSet %s/%s is recreating failed Pod %s",
+				set.Namespace,
+				set.Name,
+				replicas[i].Name)
+		} else {
+			ssc.recorder.Eventf(set, v1.EventTypeNormal, "RecreatingTerminatedPod",
+				"StatefulSet %s/%s is recreating terminated Pod %s",
+				set.Namespace,
+				set.Name,
+				replicas[i].Name)
+		}
 		if err := ssc.podControl.DeleteStatefulPod(set, replicas[i]); err != nil {
 			return true, err
 		}

--- a/pkg/controller/statefulset/stateful_set_utils.go
+++ b/pkg/controller/statefulset/stateful_set_utils.go
@@ -426,6 +426,11 @@ func isFailed(pod *v1.Pod) bool {
 	return pod.Status.Phase == v1.PodFailed
 }
 
+// isSucceeded returns true if pod has a Phase of PodSucceeded
+func isSucceeded(pod *v1.Pod) bool {
+	return pod.Status.Phase == v1.PodSucceeded
+}
+
 // isTerminating returns true if pod's DeletionTimestamp has been set
 func isTerminating(pod *v1.Pod) bool {
 	return pod.DeletionTimestamp != nil


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig apps

#### What this PR does / why we need it:

After the changes in #115331, pod phase determination changed. It is now possible for StatefulSet pods to get in `Succeeded` pod phase. This can happen when a pod is evicted or a node is stopped and the pod container exists with 0. StatefulSet should restart such pods. It is not possible for a StatefulSet pod to ever truly complete, as validation enforces `restartPolicy=Always`.

This was merged in #120398 and reverted in #120755. The test failures caused by it have been fixed in #120731.

#### Which issue(s) this PR fixes:

Part of #118310

#### Does this PR introduce a user-facing change?

```release-note
Fixes a 1.27 regression where StatefulSet might not restart a pod after eviction or node failure.
```

/cc @mimowo
