### PR TITLE
Use PollUntilContextTimeout to replace PollWithContext in test

### DIFF
--- a/test/e2e/apimachinery/aggregator.go
+++ b/test/e2e/apimachinery/aggregator.go
@@ -766,7 +766,7 @@ func pollTimed(ctx context.Context, interval, timeout time.Duration, condition w
 		elapsed := time.Since(start)
 		framework.Logf(msg, elapsed)
 	}(time.Now(), msg)
-	return wait.PollWithContext(ctx, interval, timeout, condition)
+	return wait.PollUntilContextTimeout(ctx, interval, timeout, false, condition)
 }
 
 func validateErrorWithDebugInfo(ctx context.Context, f *framework.Framework, err error, pods *v1.PodList, msg string, fields ...interface{}) {

--- a/test/e2e/apimachinery/etcd_failure.go
+++ b/test/e2e/apimachinery/etcd_failure.go
@@ -118,7 +118,7 @@ func checkExistingRCRecovers(ctx context.Context, f *framework.Framework) {
 	rcSelector := labels.Set{"name": "baz"}.AsSelector()
 
 	ginkgo.By("deleting pods from existing replication controller")
-	framework.ExpectNoError(wait.PollWithContext(ctx, time.Millisecond*500, time.Second*60, func(ctx context.Context) (bool, error) {
+	framework.ExpectNoError(wait.PollUntilContextTimeout(ctx, time.Millisecond*500, time.Second*60, false, func(ctx context.Context) (bool, error) {
 		options := metav1.ListOptions{LabelSelector: rcSelector.String()}
 		pods, err := podClient.List(ctx, options)
 		if err != nil {
@@ -137,7 +137,7 @@ func checkExistingRCRecovers(ctx context.Context, f *framework.Framework) {
 	}))
 
 	ginkgo.By("waiting for replication controller to recover")
-	framework.ExpectNoError(wait.PollWithContext(ctx, time.Millisecond*500, time.Second*60, func(ctx context.Context) (bool, error) {
+	framework.ExpectNoError(wait.PollUntilContextTimeout(ctx, time.Millisecond*500, time.Second*60, false, func(ctx context.Context) (bool, error) {
 		options := metav1.ListOptions{LabelSelector: rcSelector.String()}
 		pods, err := podClient.List(ctx, options)
 		framework.ExpectNoError(err, "failed to list pods in namespace: %s, that match label selector: %s", f.Namespace.Name, rcSelector.String())

--- a/test/e2e/apimachinery/flowcontrol.go
+++ b/test/e2e/apimachinery/flowcontrol.go
@@ -829,7 +829,7 @@ func createFlowSchema(ctx context.Context, f *framework.Framework, flowSchemaNam
 // by checking: (1) the dangling priority level reference condition in the flow
 // schema status, and (2) metrics. The function times out after 30 seconds.
 func waitForSteadyState(ctx context.Context, f *framework.Framework, flowSchemaName string, priorityLevelName string) {
-	framework.ExpectNoError(wait.PollWithContext(ctx, time.Second, 30*time.Second, func(ctx context.Context) (bool, error) {
+	framework.ExpectNoError(wait.PollUntilContextTimeout(ctx, time.Second, 30*time.Second, false, func(ctx context.Context) (bool, error) {
 		fs, err := f.ClientSet.FlowcontrolV1().FlowSchemas().Get(ctx, flowSchemaName, metav1.GetOptions{})
 		if err != nil {
 			return false, err

--- a/test/e2e/apimachinery/garbage_collector.go
+++ b/test/e2e/apimachinery/garbage_collector.go
@@ -357,7 +357,7 @@ var _ = SIGDescribe("Garbage collector", func() {
 		}
 		ginkgo.By("wait for all pods to be garbage collected")
 		// wait for the RCs and Pods to reach the expected numbers.
-		if err := wait.PollWithContext(ctx, 5*time.Second, (60*time.Second)+gcInformerResyncRetryTimeout, func(ctx context.Context) (bool, error) {
+		if err := wait.PollUntilContextTimeout(ctx, 5*time.Second, (60*time.Second)+gcInformerResyncRetryTimeout, false, func(ctx context.Context) (bool, error) {
 			objects := map[string]int{"ReplicationControllers": 0, "Pods": 0}
 			return verifyRemainingObjects(ctx, f, objects)
 		}); err != nil {
@@ -406,7 +406,7 @@ var _ = SIGDescribe("Garbage collector", func() {
 		// actual qps is less than 5. Also, the e2e tests are running in
 		// parallel, the GC controller might get distracted by other tests.
 		// According to the test logs, 120s is enough time.
-		if err := wait.PollWithContext(ctx, 5*time.Second, 120*time.Second+gcInformerResyncRetryTimeout, func(ctx context.Context) (bool, error) {
+		if err := wait.PollUntilContextTimeout(ctx, 5*time.Second, 120*time.Second+gcInformerResyncRetryTimeout, false, func(ctx context.Context) (bool, error) {
 			rcs, err := rcClient.List(ctx, metav1.ListOptions{})
 			if err != nil {
 				return false, fmt.Errorf("failed to list rcs: %w", err)
@@ -663,7 +663,7 @@ var _ = SIGDescribe("Garbage collector", func() {
 		// owner deletion, but in practice there can be a long delay between owner
 		// deletion and dependent deletion processing. For now, increase the timeout
 		// and investigate the processing delay.
-		if err := wait.PollWithContext(ctx, 1*time.Second, 30*time.Second+gcInformerResyncRetryTimeout, func(ctx context.Context) (bool, error) {
+		if err := wait.PollUntilContextTimeout(ctx, 1*time.Second, 30*time.Second+gcInformerResyncRetryTimeout, false, func(ctx context.Context) (bool, error) {
 			_, err := rcClient.Get(ctx, rc.Name, metav1.GetOptions{})
 			if err == nil {
 				pods, _ := podClient.List(ctx, metav1.ListOptions{})
@@ -755,7 +755,7 @@ var _ = SIGDescribe("Garbage collector", func() {
 		ginkgo.By("wait for the rc to be deleted")
 		// TODO: shorten the timeout when we make GC's periodic API rediscovery more efficient.
 		// Tracked at https://github.com/kubernetes/kubernetes/issues/50046.
-		if err := wait.PollWithContext(ctx, 5*time.Second, 90*time.Second, func(ctx context.Context) (bool, error) {
+		if err := wait.PollUntilContextTimeout(ctx, 5*time.Second, 90*time.Second, false, func(ctx context.Context) (bool, error) {
 			_, err := rcClient.Get(ctx, rc1.Name, metav1.GetOptions{})
 			if err == nil {
 				pods, _ := podClient.List(ctx, metav1.ListOptions{})
@@ -855,7 +855,7 @@ var _ = SIGDescribe("Garbage collector", func() {
 		var err2 error
 		// TODO: shorten the timeout when we make GC's periodic API rediscovery more efficient.
 		// Tracked at https://github.com/kubernetes/kubernetes/issues/50046.
-		if err := wait.PollWithContext(ctx, 5*time.Second, 90*time.Second+gcInformerResyncRetryTimeout, func(ctx context.Context) (bool, error) {
+		if err := wait.PollUntilContextTimeout(ctx, 5*time.Second, 90*time.Second+gcInformerResyncRetryTimeout, false, func(ctx context.Context) (bool, error) {
 			pods, err2 = podClient.List(ctx, metav1.ListOptions{})
 			if err2 != nil {
 				return false, fmt.Errorf("failed to list pods: %w", err)
@@ -985,7 +985,7 @@ var _ = SIGDescribe("Garbage collector", func() {
 		// Ensure the dependent is deleted.
 		var lastDependent *unstructured.Unstructured
 		var err2 error
-		if err := wait.PollWithContext(ctx, 5*time.Second, 60*time.Second, func(ctx context.Context) (bool, error) {
+		if err := wait.PollUntilContextTimeout(ctx, 5*time.Second, 60*time.Second, false, func(ctx context.Context) (bool, error) {
 			lastDependent, err2 = resourceClient.Get(ctx, dependentName, metav1.GetOptions{})
 			return apierrors.IsNotFound(err2), nil
 		}); err != nil {
@@ -1088,7 +1088,7 @@ var _ = SIGDescribe("Garbage collector", func() {
 		}
 
 		ginkgo.By("wait for the owner to be deleted")
-		if err := wait.PollWithContext(ctx, 5*time.Second, 120*time.Second, func(ctx context.Context) (bool, error) {
+		if err := wait.PollUntilContextTimeout(ctx, 5*time.Second, 120*time.Second, false, func(ctx context.Context) (bool, error) {
 			_, err = resourceClient.Get(ctx, ownerName, metav1.GetOptions{})
 			if err == nil {
 				return false, nil
@@ -1150,7 +1150,7 @@ func waitForReplicas(ctx context.Context, rc *v1.ReplicationController, rcClient
 		lastObservedRC *v1.ReplicationController
 		err            error
 	)
-	if err := wait.PollWithContext(ctx, framework.Poll, replicaSyncTimeout, func(ctx context.Context) (bool, error) {
+	if err := wait.PollUntilContextTimeout(ctx, framework.Poll, replicaSyncTimeout, false, func(ctx context.Context) (bool, error) {
 		lastObservedRC, err = rcClient.Get(ctx, rc.Name, metav1.GetOptions{})
 		if err != nil {
 			return false, err

--- a/test/e2e/apimachinery/resource_quota.go
+++ b/test/e2e/apimachinery/resource_quota.go
@@ -165,7 +165,7 @@ var _ = SIGDescribe("ResourceQuota", func() {
 		found, unchanged := 0, 0
 		// On contended servers the service account controller can slow down, leading to the count changing during a run.
 		// Wait up to 5s for the count to stabilize, assuming that updates come at a consistent rate, and are not held indefinitely.
-		err := wait.PollWithContext(ctx, 1*time.Second, 30*time.Second, func(ctx context.Context) (bool, error) {
+		err := wait.PollUntilContextTimeout(ctx, 1*time.Second, 30*time.Second, false, func(ctx context.Context) (bool, error) {
 			secrets, err := f.ClientSet.CoreV1().Secrets(f.Namespace.Name).List(ctx, metav1.ListOptions{})
 			framework.ExpectNoError(err)
 			if len(secrets.Items) == found {
@@ -331,7 +331,7 @@ var _ = SIGDescribe("ResourceQuota", func() {
 		found, unchanged := 0, 0
 		// On contended servers the service account controller can slow down, leading to the count changing during a run.
 		// Wait up to 15s for the count to stabilize, assuming that updates come at a consistent rate, and are not held indefinitely.
-		err := wait.PollWithContext(ctx, 1*time.Second, time.Minute, func(ctx context.Context) (bool, error) {
+		err := wait.PollUntilContextTimeout(ctx, 1*time.Second, time.Minute, false, func(ctx context.Context) (bool, error) {
 			configmaps, err := f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).List(ctx, metav1.ListOptions{})
 			framework.ExpectNoError(err)
 			if len(configmaps.Items) == found {
@@ -2106,7 +2106,7 @@ func deleteResourceQuota(ctx context.Context, c clientset.Interface, namespace, 
 // Wait up to 5s for the count to stabilize, assuming that updates come at a consistent rate, and are not held indefinitely.
 func countResourceQuota(ctx context.Context, c clientset.Interface, namespace string) (int, error) {
 	found, unchanged := 0, 0
-	return found, wait.PollWithContext(ctx, 1*time.Second, 30*time.Second, func(ctx context.Context) (bool, error) {
+	return found, wait.PollUntilContextTimeout(ctx, 1*time.Second, 30*time.Second, false, func(ctx context.Context) (bool, error) {
 		resourceQuotas, err := c.CoreV1().ResourceQuotas(namespace).List(ctx, metav1.ListOptions{})
 		framework.ExpectNoError(err)
 		if len(resourceQuotas.Items) == found {
@@ -2122,7 +2122,7 @@ func countResourceQuota(ctx context.Context, c clientset.Interface, namespace st
 
 // wait for resource quota status to show the expected used resources value
 func waitForResourceQuota(ctx context.Context, c clientset.Interface, ns, quotaName string, used v1.ResourceList) error {
-	return wait.PollWithContext(ctx, framework.Poll, resourceQuotaTimeout, func(ctx context.Context) (bool, error) {
+	return wait.PollUntilContextTimeout(ctx, framework.Poll, resourceQuotaTimeout, false, func(ctx context.Context) (bool, error) {
 		resourceQuota, err := c.CoreV1().ResourceQuotas(ns).Get(ctx, quotaName, metav1.GetOptions{})
 		if err != nil {
 			return false, err
@@ -2145,7 +2145,7 @@ func waitForResourceQuota(ctx context.Context, c clientset.Interface, ns, quotaN
 // updateResourceQuotaUntilUsageAppears updates the resource quota object until the usage is populated
 // for the specific resource name.
 func updateResourceQuotaUntilUsageAppears(ctx context.Context, c clientset.Interface, ns, quotaName string, resourceName v1.ResourceName) error {
-	return wait.PollWithContext(ctx, framework.Poll, resourceQuotaTimeout, func(ctx context.Context) (bool, error) {
+	return wait.PollUntilContextTimeout(ctx, framework.Poll, resourceQuotaTimeout, false, func(ctx context.Context) (bool, error) {
 		resourceQuota, err := c.CoreV1().ResourceQuotas(ns).Get(ctx, quotaName, metav1.GetOptions{})
 		if err != nil {
 			return false, err

--- a/test/e2e/apps/cronjob.go
+++ b/test/e2e/apps/cronjob.go
@@ -605,7 +605,7 @@ func deleteCronJob(ctx context.Context, c clientset.Interface, ns, name string) 
 
 // Wait for at least given amount of active jobs.
 func waitForActiveJobs(ctx context.Context, c clientset.Interface, ns, cronJobName string, active int) error {
-	return wait.PollWithContext(ctx, framework.Poll, cronJobTimeout, func(ctx context.Context) (bool, error) {
+	return wait.PollUntilContextTimeout(ctx, framework.Poll, cronJobTimeout, false, func(ctx context.Context) (bool, error) {
 		curr, err := getCronJob(ctx, c, ns, cronJobName)
 		if err != nil {
 			return false, err
@@ -619,7 +619,7 @@ func waitForActiveJobs(ctx context.Context, c clientset.Interface, ns, cronJobNa
 // the timeout. When failIfNonEmpty is not set, this fails if the active set of jobs is still
 // empty after the timeout.
 func waitForNoJobs(ctx context.Context, c clientset.Interface, ns, jobName string, failIfNonEmpty bool) error {
-	return wait.PollWithContext(ctx, framework.Poll, cronJobTimeout, func(ctx context.Context) (bool, error) {
+	return wait.PollUntilContextTimeout(ctx, framework.Poll, cronJobTimeout, false, func(ctx context.Context) (bool, error) {
 		curr, err := getCronJob(ctx, c, ns, jobName)
 		if err != nil {
 			return false, err
@@ -634,7 +634,7 @@ func waitForNoJobs(ctx context.Context, c clientset.Interface, ns, jobName strin
 
 // Wait till a given job actually goes away from the Active list for a given cronjob
 func waitForJobNotActive(ctx context.Context, c clientset.Interface, ns, cronJobName, jobName string) error {
-	return wait.PollWithContext(ctx, framework.Poll, cronJobTimeout, func(ctx context.Context) (bool, error) {
+	return wait.PollUntilContextTimeout(ctx, framework.Poll, cronJobTimeout, false, func(ctx context.Context) (bool, error) {
 		curr, err := getCronJob(ctx, c, ns, cronJobName)
 		if err != nil {
 			return false, err
@@ -651,7 +651,7 @@ func waitForJobNotActive(ctx context.Context, c clientset.Interface, ns, cronJob
 
 // Wait for a job to disappear by listing them explicitly.
 func waitForJobToDisappear(ctx context.Context, c clientset.Interface, ns string, targetJob *batchv1.Job) error {
-	return wait.PollWithContext(ctx, framework.Poll, cronJobTimeout, func(ctx context.Context) (bool, error) {
+	return wait.PollUntilContextTimeout(ctx, framework.Poll, cronJobTimeout, false, func(ctx context.Context) (bool, error) {
 		jobs, err := c.BatchV1().Jobs(ns).List(ctx, metav1.ListOptions{})
 		if err != nil {
 			return false, err
@@ -668,7 +668,7 @@ func waitForJobToDisappear(ctx context.Context, c clientset.Interface, ns string
 
 // Wait for a pod to disappear by listing them explicitly.
 func waitForJobsPodToDisappear(ctx context.Context, c clientset.Interface, ns string, targetJob *batchv1.Job) error {
-	return wait.PollWithContext(ctx, framework.Poll, cronJobTimeout, func(ctx context.Context) (bool, error) {
+	return wait.PollUntilContextTimeout(ctx, framework.Poll, cronJobTimeout, false, func(ctx context.Context) (bool, error) {
 		options := metav1.ListOptions{LabelSelector: fmt.Sprintf("controller-uid=%s", targetJob.UID)}
 		pods, err := c.CoreV1().Pods(ns).List(ctx, options)
 		if err != nil {
@@ -680,7 +680,7 @@ func waitForJobsPodToDisappear(ctx context.Context, c clientset.Interface, ns st
 
 // Wait for a job to be replaced with a new one.
 func waitForJobReplaced(ctx context.Context, c clientset.Interface, ns, previousJobName string) error {
-	return wait.PollWithContext(ctx, framework.Poll, cronJobTimeout, func(ctx context.Context) (bool, error) {
+	return wait.PollUntilContextTimeout(ctx, framework.Poll, cronJobTimeout, false, func(ctx context.Context) (bool, error) {
 		jobs, err := c.BatchV1().Jobs(ns).List(ctx, metav1.ListOptions{})
 		if err != nil {
 			return false, err
@@ -699,7 +699,7 @@ func waitForJobReplaced(ctx context.Context, c clientset.Interface, ns, previous
 
 // waitForJobsAtLeast waits for at least a number of jobs to appear.
 func waitForJobsAtLeast(ctx context.Context, c clientset.Interface, ns string, atLeast int) error {
-	return wait.PollWithContext(ctx, framework.Poll, cronJobTimeout, func(ctx context.Context) (bool, error) {
+	return wait.PollUntilContextTimeout(ctx, framework.Poll, cronJobTimeout, false, func(ctx context.Context) (bool, error) {
 		jobs, err := c.BatchV1().Jobs(ns).List(ctx, metav1.ListOptions{})
 		if err != nil {
 			return false, err
@@ -710,7 +710,7 @@ func waitForJobsAtLeast(ctx context.Context, c clientset.Interface, ns string, a
 
 // waitForAnyFinishedJob waits for any completed job to appear.
 func waitForAnyFinishedJob(ctx context.Context, c clientset.Interface, ns string) error {
-	return wait.PollWithContext(ctx, framework.Poll, cronJobTimeout, func(ctx context.Context) (bool, error) {
+	return wait.PollUntilContextTimeout(ctx, framework.Poll, cronJobTimeout, false, func(ctx context.Context) (bool, error) {
 		jobs, err := c.BatchV1().Jobs(ns).List(ctx, metav1.ListOptions{})
 		if err != nil {
 			return false, err
@@ -726,7 +726,7 @@ func waitForAnyFinishedJob(ctx context.Context, c clientset.Interface, ns string
 
 // waitForEventWithReason waits for events with a reason within a list has occurred
 func waitForEventWithReason(ctx context.Context, c clientset.Interface, ns, cronJobName string, reasons []string) error {
-	return wait.PollWithContext(ctx, framework.Poll, 30*time.Second, func(ctx context.Context) (bool, error) {
+	return wait.PollUntilContextTimeout(ctx, framework.Poll, 30*time.Second, false, func(ctx context.Context) (bool, error) {
 		sj, err := getCronJob(ctx, c, ns, cronJobName)
 		if err != nil {
 			return false, err

--- a/test/e2e/apps/daemon_restart.go
+++ b/test/e2e/apps/daemon_restart.go
@@ -112,7 +112,7 @@ func (r *RestartDaemonConfig) waitUp(ctx context.Context) {
 			"curl -s -o %v -I -w \"%%{http_code}\" http://localhost:%v/healthz", nullDev, r.healthzPort)
 
 	}
-	err := wait.PollWithContext(ctx, r.pollInterval, r.pollTimeout, func(ctx context.Context) (bool, error) {
+	err := wait.PollUntilContextTimeout(ctx, r.pollInterval, r.pollTimeout, false, func(ctx context.Context) (bool, error) {
 		result, err := e2essh.NodeExec(ctx, r.nodeName, healthzCheck, framework.TestContext.Provider)
 		if err != nil {
 			return false, err

--- a/test/e2e/apps/deployment.go
+++ b/test/e2e/apps/deployment.go
@@ -1156,7 +1156,7 @@ func testDeploymentsControllerRef(ctx context.Context, f *framework.Framework) {
 	framework.ExpectNoError(err)
 
 	ginkgo.By("Wait for the ReplicaSet to be orphaned")
-	err = wait.PollWithContext(ctx, dRetryPeriod, dRetryTimeout, waitDeploymentReplicaSetsOrphaned(c, ns, podLabels))
+	err = wait.PollUntilContextTimeout(ctx, dRetryPeriod, dRetryTimeout, false, waitDeploymentReplicaSetsOrphaned(c, ns, podLabels))
 	framework.ExpectNoError(err, "error waiting for Deployment ReplicaSet to be orphaned")
 
 	deploymentName = "test-adopt-deployment"

--- a/test/e2e/apps/statefulset.go
+++ b/test/e2e/apps/statefulset.go
@@ -2231,7 +2231,7 @@ type updateStatefulSetFunc func(*appsv1.StatefulSet)
 func updateStatefulSetWithRetries(ctx context.Context, c clientset.Interface, namespace, name string, applyUpdate updateStatefulSetFunc) (statefulSet *appsv1.StatefulSet, err error) {
 	statefulSets := c.AppsV1().StatefulSets(namespace)
 	var updateErr error
-	pollErr := wait.PollWithContext(ctx, 10*time.Millisecond, 1*time.Minute, func(ctx context.Context) (bool, error) {
+	pollErr := wait.PollUntilContextTimeout(ctx, 10*time.Millisecond, 1*time.Minute, false, func(ctx context.Context) (bool, error) {
 		if statefulSet, err = statefulSets.Get(ctx, name, metav1.GetOptions{}); err != nil {
 			return false, err
 		}

--- a/test/e2e/framework/auth/helpers.go
+++ b/test/e2e/framework/auth/helpers.go
@@ -65,7 +65,7 @@ func WaitForNamedAuthorizationUpdate(ctx context.Context, c v1authorization.Subj
 		},
 	}
 
-	err := wait.PollWithContext(ctx, policyCachePollInterval, policyCachePollTimeout, func(ctx context.Context) (bool, error) {
+	err := wait.PollUntilContextTimeout(ctx, policyCachePollInterval, policyCachePollTimeout, false, func(ctx context.Context) (bool, error) {
 		response, err := c.SubjectAccessReviews().Create(ctx, review, metav1.CreateOptions{})
 		if err != nil {
 			return false, err

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -720,7 +720,7 @@ func (cl *ClusterVerification) WaitFor(ctx context.Context, atLeast int, timeout
 	pods := []v1.Pod{}
 	var returnedErr error
 
-	err := wait.PollWithContext(ctx, 1*time.Second, timeout, func(ctx context.Context) (bool, error) {
+	err := wait.PollUntilContextTimeout(ctx, 1*time.Second, timeout, false, func(ctx context.Context) (bool, error) {
 		pods, returnedErr = cl.podState.filter(ctx, cl.client, cl.namespace)
 
 		// Failure

--- a/test/e2e/framework/ingress/ingress_utils.go
+++ b/test/e2e/framework/ingress/ingress_utils.go
@@ -790,7 +790,7 @@ func (j *TestJig) WaitForIngress(ctx context.Context, waitForNodePort bool) {
 
 // WaitForIngressToStable waits for the LB return 100 consecutive 200 responses.
 func (j *TestJig) WaitForIngressToStable(ctx context.Context) {
-	if err := wait.PollWithContext(ctx, 10*time.Second, e2eservice.GetServiceLoadBalancerPropagationTimeout(ctx, j.Client), func(ctx context.Context) (bool, error) {
+	if err := wait.PollUntilContextTimeout(ctx, 10*time.Second, e2eservice.GetServiceLoadBalancerPropagationTimeout(ctx, j.Client), false, func(ctx context.Context) (bool, error) {
 		_, err := j.GetDistinctResponseFromIngress(ctx)
 		if err != nil {
 			return false, nil

--- a/test/e2e/framework/job/wait.go
+++ b/test/e2e/framework/job/wait.go
@@ -52,7 +52,7 @@ func WaitForJobPodsSucceeded(ctx context.Context, c clientset.Interface, ns, job
 
 // waitForJobPodsInPhase wait for all pods for the Job named JobName in namespace ns to be in a given phase.
 func waitForJobPodsInPhase(ctx context.Context, c clientset.Interface, ns, jobName string, expectedCount int32, phase v1.PodPhase) error {
-	return wait.PollWithContext(ctx, framework.Poll, JobTimeout, func(ctx context.Context) (bool, error) {
+	return wait.PollUntilContextTimeout(ctx, framework.Poll, JobTimeout, false, func(ctx context.Context) (bool, error) {
 		pods, err := GetJobPods(ctx, c, ns, jobName)
 		if err != nil {
 			return false, err
@@ -69,7 +69,7 @@ func waitForJobPodsInPhase(ctx context.Context, c clientset.Interface, ns, jobNa
 
 // WaitForJobComplete uses c to wait for completions to complete for the Job jobName in namespace ns.
 func WaitForJobComplete(ctx context.Context, c clientset.Interface, ns, jobName string, completions int32) error {
-	return wait.PollWithContext(ctx, framework.Poll, JobTimeout, func(ctx context.Context) (bool, error) {
+	return wait.PollUntilContextTimeout(ctx, framework.Poll, JobTimeout, false, func(ctx context.Context) (bool, error) {
 		curr, err := c.BatchV1().Jobs(ns).Get(ctx, jobName, metav1.GetOptions{})
 		if err != nil {
 			return false, err
@@ -145,7 +145,7 @@ func isJobFinished(j *batchv1.Job) bool {
 
 // WaitForJobGone uses c to wait for up to timeout for the Job named jobName in namespace ns to be removed.
 func WaitForJobGone(ctx context.Context, c clientset.Interface, ns, jobName string, timeout time.Duration) error {
-	return wait.PollWithContext(ctx, framework.Poll, timeout, func(ctx context.Context) (bool, error) {
+	return wait.PollUntilContextTimeout(ctx, framework.Poll, timeout, false, func(ctx context.Context) (bool, error) {
 		_, err := c.BatchV1().Jobs(ns).Get(ctx, jobName, metav1.GetOptions{})
 		if apierrors.IsNotFound(err) {
 			return true, nil

--- a/test/e2e/framework/network/utils.go
+++ b/test/e2e/framework/network/utils.go
@@ -1153,7 +1153,7 @@ func UnblockNetwork(ctx context.Context, from string, to string) {
 	// not coming back. Subsequent tests will run or fewer nodes (some of the tests
 	// may fail). Manual intervention is required in such case (recreating the
 	// cluster solves the problem too).
-	err := wait.PollWithContext(ctx, time.Millisecond*100, time.Second*30, func(ctx context.Context) (bool, error) {
+	err := wait.PollUntilContextTimeout(ctx, time.Millisecond*100, time.Second*30, false, func(ctx context.Context) (bool, error) {
 		result, err := e2essh.SSH(ctx, undropCmd, from, framework.TestContext.Provider)
 		if result.Code == 0 && err == nil {
 			return true, nil

--- a/test/e2e/framework/pod/pod_client.go
+++ b/test/e2e/framework/pod/pod_client.go
@@ -130,7 +130,7 @@ func (c *PodClient) CreateBatch(ctx context.Context, pods []*v1.Pod) []*v1.Pod {
 // there is any other apierrors. name is the pod name, updateFn is the function updating the
 // pod object.
 func (c *PodClient) Update(ctx context.Context, name string, updateFn func(pod *v1.Pod)) {
-	framework.ExpectNoError(wait.PollWithContext(ctx, time.Millisecond*500, time.Second*30, func(ctx context.Context) (bool, error) {
+	framework.ExpectNoError(wait.PollUntilContextTimeout(ctx, time.Millisecond*500, time.Second*30, false, func(ctx context.Context) (bool, error) {
 		pod, err := c.PodInterface.Get(ctx, name, metav1.GetOptions{})
 		if err != nil {
 			return false, fmt.Errorf("failed to get pod %q: %w", name, err)
@@ -264,7 +264,7 @@ func (c *PodClient) WaitForFinish(ctx context.Context, name string, timeout time
 // WaitForErrorEventOrSuccess waits for pod to succeed or an error event for that pod.
 func (c *PodClient) WaitForErrorEventOrSuccess(ctx context.Context, pod *v1.Pod) (*v1.Event, error) {
 	var ev *v1.Event
-	err := wait.PollWithContext(ctx, framework.Poll, framework.PodStartTimeout, func(ctx context.Context) (bool, error) {
+	err := wait.PollUntilContextTimeout(ctx, framework.Poll, framework.PodStartTimeout, false, func(ctx context.Context) (bool, error) {
 		evnts, err := c.f.ClientSet.CoreV1().Events(pod.Namespace).Search(scheme.Scheme, pod)
 		if err != nil {
 			return false, fmt.Errorf("error in listing events: %w", err)

--- a/test/e2e/framework/providers/gce/gce.go
+++ b/test/e2e/framework/providers/gce/gce.go
@@ -192,7 +192,7 @@ func (p *Provider) EnsureLoadBalancerResourcesDeleted(ctx context.Context, ip, p
 		return fmt.Errorf("could not get region for zone %q: %w", framework.TestContext.CloudConfig.Zone, err)
 	}
 
-	return wait.PollWithContext(ctx, 10*time.Second, 5*time.Minute, func(ctx context.Context) (bool, error) {
+	return wait.PollUntilContextTimeout(ctx, 10*time.Second, 5*time.Minute, false, func(ctx context.Context) (bool, error) {
 		computeservice := p.gceCloud.ComputeServices().GA
 		list, err := computeservice.ForwardingRules.List(project, region).Do()
 		if err != nil {
@@ -287,7 +287,7 @@ func (p *Provider) DeletePVSource(ctx context.Context, pvSource *v1.PersistentVo
 // the given name. The name is usually the UUID of the Service prefixed with an
 // alpha-numeric character ('a') to work around cloudprovider rules.
 func (p *Provider) CleanupServiceResources(ctx context.Context, c clientset.Interface, loadBalancerName, region, zone string) {
-	if pollErr := wait.PollWithContext(ctx, 5*time.Second, e2eservice.LoadBalancerCleanupTimeout, func(ctx context.Context) (bool, error) {
+	if pollErr := wait.PollUntilContextTimeout(ctx, 5*time.Second, e2eservice.LoadBalancerCleanupTimeout, false, func(ctx context.Context) (bool, error) {
 		if err := p.cleanupGCEResources(ctx, c, loadBalancerName, region, zone); err != nil {
 			framework.Logf("Still waiting for glbc to cleanup: %v", err)
 			return false, nil

--- a/test/e2e/framework/providers/gce/ingress.go
+++ b/test/e2e/framework/providers/gce/ingress.go
@@ -84,7 +84,7 @@ func (cont *IngressController) CleanupIngressController(ctx context.Context) err
 // CleanupIngressControllerWithTimeout calls the IngressController.Cleanup(false)
 // followed with deleting the static ip, and then a final IngressController.Cleanup(true)
 func (cont *IngressController) CleanupIngressControllerWithTimeout(ctx context.Context, timeout time.Duration) error {
-	pollErr := wait.PollWithContext(ctx, 5*time.Second, timeout, func(ctx context.Context) (bool, error) {
+	pollErr := wait.PollUntilContextTimeout(ctx, 5*time.Second, timeout, false, func(ctx context.Context) (bool, error) {
 		if err := cont.Cleanup(false); err != nil {
 			framework.Logf("Monitoring glbc's cleanup of gce resources:\n%v", err)
 			return false, nil
@@ -105,7 +105,7 @@ func (cont *IngressController) CleanupIngressControllerWithTimeout(ctx context.C
 	// controller. Delete this IP only after the controller has had a chance
 	// to cleanup or it might interfere with the controller, causing it to
 	// throw out confusing events.
-	if ipErr := wait.PollWithContext(ctx, 5*time.Second, 1*time.Minute, func(ctx context.Context) (bool, error) {
+	if ipErr := wait.PollUntilContextTimeout(ctx, 5*time.Second, 1*time.Minute, false, func(ctx context.Context) (bool, error) {
 		if err := cont.deleteStaticIPs(); err != nil {
 			framework.Logf("Failed to delete static-ip: %v\n", err)
 			return false, nil
@@ -605,7 +605,7 @@ func (cont *IngressController) isHTTPErrorCode(err error, code int) bool {
 
 // WaitForNegBackendService waits for the expected backend service to become
 func (cont *IngressController) WaitForNegBackendService(ctx context.Context, svcPorts map[string]v1.ServicePort) error {
-	return wait.PollWithContext(ctx, 5*time.Second, 1*time.Minute, func(ctx context.Context) (bool, error) {
+	return wait.PollUntilContextTimeout(ctx, 5*time.Second, 1*time.Minute, false, func(ctx context.Context) (bool, error) {
 		err := cont.verifyBackendMode(svcPorts, negBackend)
 		if err != nil {
 			framework.Logf("Err while checking if backend service is using NEG: %v", err)
@@ -617,7 +617,7 @@ func (cont *IngressController) WaitForNegBackendService(ctx context.Context, svc
 
 // WaitForIgBackendService returns true only if all global backend service with matching svcPorts pointing to IG as backend
 func (cont *IngressController) WaitForIgBackendService(ctx context.Context, svcPorts map[string]v1.ServicePort) error {
-	return wait.PollWithContext(ctx, 5*time.Second, 1*time.Minute, func(ctx context.Context) (bool, error) {
+	return wait.PollUntilContextTimeout(ctx, 5*time.Second, 1*time.Minute, false, func(ctx context.Context) (bool, error) {
 		err := cont.verifyBackendMode(svcPorts, igBackend)
 		if err != nil {
 			framework.Logf("Err while checking if backend service is using IG: %v", err)

--- a/test/e2e/framework/providers/gce/util.go
+++ b/test/e2e/framework/providers/gce/util.go
@@ -84,7 +84,7 @@ func WaitForNodeBootIdsToChange(ctx context.Context, c clientset.Interface, node
 	errMsg := []string{}
 	for i := range nodes {
 		node := &nodes[i]
-		if err := wait.PollWithContext(ctx, 30*time.Second, timeout, func(ctx context.Context) (bool, error) {
+		if err := wait.PollUntilContextTimeout(ctx, 30*time.Second, timeout, false, func(ctx context.Context) (bool, error) {
 			newNode, err := c.CoreV1().Nodes().Get(ctx, node.Name, metav1.GetOptions{})
 			if err != nil {
 				framework.Logf("Could not get node info: %s. Retrying in %v.", err, 30*time.Second)

--- a/test/e2e/framework/replicaset/wait.go
+++ b/test/e2e/framework/replicaset/wait.go
@@ -30,7 +30,7 @@ import (
 
 // WaitForReadyReplicaSet waits until the replicaset has all of its replicas ready.
 func WaitForReadyReplicaSet(ctx context.Context, c clientset.Interface, ns, name string) error {
-	err := wait.PollWithContext(ctx, framework.Poll, framework.PodStartTimeout, func(ctx context.Context) (bool, error) {
+	err := wait.PollUntilContextTimeout(ctx, framework.Poll, framework.PodStartTimeout, false, func(ctx context.Context) (bool, error) {
 		rs, err := c.AppsV1().ReplicaSets(ns).Get(ctx, name, metav1.GetOptions{})
 		if err != nil {
 			return false, err

--- a/test/e2e/framework/service/jig.go
+++ b/test/e2e/framework/service/jig.go
@@ -440,7 +440,7 @@ func (j *TestJig) waitForAvailableEndpoint(ctx context.Context, timeout time.Dur
 
 	go esController.Run(stopCh)
 
-	err := wait.PollWithContext(ctx, 1*time.Second, timeout, func(ctx context.Context) (bool, error) {
+	err := wait.PollUntilContextTimeout(ctx, 1*time.Second, timeout, false, func(ctx context.Context) (bool, error) {
 		return endpointAvailable && endpointSliceAvailable, nil
 	})
 	if err != nil {

--- a/test/e2e/framework/ssh/ssh.go
+++ b/test/e2e/framework/ssh/ssh.go
@@ -246,7 +246,7 @@ func runSSHCommand(ctx context.Context, cmd, user, host string, signer ssh.Signe
 	}
 	client, err := ssh.Dial("tcp", host, config)
 	if err != nil {
-		err = wait.PollWithContext(ctx, 5*time.Second, 20*time.Second, func(ctx context.Context) (bool, error) {
+		err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 20*time.Second, false, func(ctx context.Context) (bool, error) {
 			fmt.Printf("error dialing %s@%s: '%v', retrying\n", user, host, err)
 			if client, err = ssh.Dial("tcp", host, config); err != nil {
 				return false, nil // retrying, error will be logged above
@@ -300,7 +300,7 @@ func runSSHCommandViaBastion(ctx context.Context, cmd, user, bastion, host strin
 	}
 	bastionClient, err := ssh.Dial("tcp", bastion, config)
 	if err != nil {
-		err = wait.PollWithContext(ctx, 5*time.Second, 20*time.Second, func(ctx context.Context) (bool, error) {
+		err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 20*time.Second, false, func(ctx context.Context) (bool, error) {
 			fmt.Printf("error dialing %s@%s: '%v', retrying\n", user, bastion, err)
 			if bastionClient, err = ssh.Dial("tcp", bastion, config); err != nil {
 				return false, err

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -245,7 +245,7 @@ func WaitForNamespacesDeleted(ctx context.Context, c clientset.Interface, namesp
 		nsMap[ns] = true
 	}
 	//Now POLL until all namespaces have been eradicated.
-	return wait.PollWithContext(ctx, 2*time.Second, timeout,
+	return wait.PollUntilContextTimeout(ctx, 2*time.Second, timeout, false,
 		func(ctx context.Context) (bool, error) {
 			nsList, err := c.CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
 			if err != nil {
@@ -423,7 +423,7 @@ func CheckTestingNSDeletedExcept(ctx context.Context, c clientset.Interface, ski
 // WaitForServiceEndpointsNum waits until the amount of endpoints that implement service to expectNum.
 // Some components use EndpointSlices other Endpoints, we must verify that both objects meet the requirements.
 func WaitForServiceEndpointsNum(ctx context.Context, c clientset.Interface, namespace, serviceName string, expectNum int, interval, timeout time.Duration) error {
-	return wait.PollWithContext(ctx, interval, timeout, func(ctx context.Context) (bool, error) {
+	return wait.PollUntilContextTimeout(ctx, interval, timeout, false, func(ctx context.Context) (bool, error) {
 		Logf("Waiting for amount of service:%s endpoints to be %d", serviceName, expectNum)
 		endpoint, err := c.CoreV1().Endpoints(namespace).Get(ctx, serviceName, metav1.GetOptions{})
 		if err != nil {

--- a/test/e2e/network/endpointslice.go
+++ b/test/e2e/network/endpointslice.go
@@ -752,7 +752,7 @@ func expectEndpointsAndSlices(ctx context.Context, cs clientset.Interface, ns st
 	}
 
 	endpoints := &v1.Endpoints{}
-	if err := wait.PollWithContext(ctx, 5*time.Second, 2*time.Minute, func(ctx context.Context) (bool, error) {
+	if err := wait.PollUntilContextTimeout(ctx, 5*time.Second, 2*time.Minute, false, func(ctx context.Context) (bool, error) {
 		endpointsFound, hasMatchingEndpoints := hasMatchingEndpoints(ctx, cs, ns, svc.Name, len(pods), numSubsets)
 		if !hasMatchingEndpoints {
 			framework.Logf("Matching Endpoints not found")

--- a/test/e2e/network/ingress.go
+++ b/test/e2e/network/ingress.go
@@ -196,7 +196,7 @@ var _ = common.SIGDescribe("Loadbalancing: L7", func() {
 				_, err = f.ClientSet.CoreV1().Services(ns).Update(ctx, &svc, metav1.UpdateOptions{})
 				framework.ExpectNoError(err)
 			}
-			err = wait.PollWithContext(ctx, 5*time.Second, propagationTimeout, func(ctx context.Context) (bool, error) {
+			err = wait.PollUntilContextTimeout(ctx, 5*time.Second, propagationTimeout, false, func(ctx context.Context) (bool, error) {
 				if err := gceController.BackendServiceUsingIG(jig.GetServicePorts(ctx, false)); err != nil {
 					framework.Logf("ginkgo.Failed to verify IG backend service: %v", err)
 					return false, nil
@@ -214,7 +214,7 @@ var _ = common.SIGDescribe("Loadbalancing: L7", func() {
 				_, err = f.ClientSet.CoreV1().Services(ns).Update(ctx, &svc, metav1.UpdateOptions{})
 				framework.ExpectNoError(err)
 			}
-			err = wait.PollWithContext(ctx, 5*time.Second, propagationTimeout, func(ctx context.Context) (bool, error) {
+			err = wait.PollUntilContextTimeout(ctx, 5*time.Second, propagationTimeout, false, func(ctx context.Context) (bool, error) {
 				if err := gceController.BackendServiceUsingNEG(jig.GetServicePorts(ctx, false)); err != nil {
 					framework.Logf("ginkgo.Failed to verify NEG backend service: %v", err)
 					return false, nil

--- a/test/e2e/network/ingressclass.go
+++ b/test/e2e/network/ingressclass.go
@@ -57,7 +57,7 @@ var _ = common.SIGDescribe("IngressClass", feature.Ingress, func() {
 		lastFailure := ""
 
 		// the admission controller may take a few seconds to observe the ingress classes
-		if err := wait.PollWithContext(ctx, time.Second, time.Minute, func(ctx context.Context) (bool, error) {
+		if err := wait.PollUntilContextTimeout(ctx, time.Second, time.Minute, false, func(ctx context.Context) (bool, error) {
 			lastFailure = ""
 
 			ingress, err := createBasicIngress(ctx, cs, f.Namespace.Name)
@@ -94,7 +94,7 @@ var _ = common.SIGDescribe("IngressClass", feature.Ingress, func() {
 		lastFailure := ""
 
 		// the admission controller may take a few seconds to observe the ingress classes
-		if err := wait.PollWithContext(ctx, time.Second, time.Minute, func(ctx context.Context) (bool, error) {
+		if err := wait.PollUntilContextTimeout(ctx, time.Second, time.Minute, false, func(ctx context.Context) (bool, error) {
 			lastFailure = ""
 
 			ingress, err := createBasicIngress(ctx, cs, f.Namespace.Name)

--- a/test/e2e/network/topology_hints.go
+++ b/test/e2e/network/topology_hints.go
@@ -81,7 +81,7 @@ var _ = common.SIGDescribe(feature.TopologyHints, func() {
 			},
 		})
 
-		err = wait.PollWithContext(ctx, 5*time.Second, framework.PodStartTimeout, func(ctx context.Context) (bool, error) {
+		err = wait.PollUntilContextTimeout(ctx, 5*time.Second, framework.PodStartTimeout, false, func(ctx context.Context) (bool, error) {
 			return e2edaemonset.CheckRunningOnAllNodes(ctx, f, ds)
 		})
 		framework.ExpectNoError(err, "timed out waiting for DaemonSets to be ready")
@@ -119,7 +119,7 @@ var _ = common.SIGDescribe(feature.TopologyHints, func() {
 		framework.Logf("Waiting for %d endpoints to be tracked in EndpointSlices", len(schedulableNodes))
 
 		var finalSlices []discoveryv1.EndpointSlice
-		err = wait.PollWithContext(ctx, 5*time.Second, 3*time.Minute, func(ctx context.Context) (bool, error) {
+		err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 3*time.Minute, false, func(ctx context.Context) (bool, error) {
 			slices, listErr := c.DiscoveryV1().EndpointSlices(f.Namespace.Name).List(ctx, metav1.ListOptions{LabelSelector: fmt.Sprintf("%s=%s", discoveryv1.LabelServiceName, svc.Name)})
 			if listErr != nil {
 				return false, listErr
@@ -190,7 +190,7 @@ var _ = common.SIGDescribe(feature.TopologyHints, func() {
 			framework.Logf("Ensuring that requests from %s pod on %s node stay in %s zone", clientPod.Name, nodeName, fromZone)
 
 			var logs string
-			if pollErr := wait.PollWithContext(ctx, 5*time.Second, e2eservice.KubeProxyLagTimeout, func(ctx context.Context) (bool, error) {
+			if pollErr := wait.PollUntilContextTimeout(ctx, 5*time.Second, e2eservice.KubeProxyLagTimeout, false, func(ctx context.Context) (bool, error) {
 				var err error
 				logs, err = e2epod.GetPodLogs(ctx, c, f.Namespace.Name, clientPod.Name, clientPod.Name)
 				framework.ExpectNoError(err)

--- a/test/e2e/node/kubelet.go
+++ b/test/e2e/node/kubelet.go
@@ -86,7 +86,7 @@ func getPodMatches(ctx context.Context, c clientset.Interface, nodeName string, 
 // the scope of this test, we do not expect pod naming conflicts so
 // podNamePrefix should be sufficient to identify the pods.
 func waitTillNPodsRunningOnNodes(ctx context.Context, c clientset.Interface, nodeNames sets.String, podNamePrefix string, namespace string, targetNumPods int, timeout time.Duration) error {
-	return wait.PollWithContext(ctx, pollInterval, timeout, func(ctx context.Context) (bool, error) {
+	return wait.PollUntilContextTimeout(ctx, pollInterval, timeout, false, func(ctx context.Context) (bool, error) {
 		matchCh := make(chan sets.String, len(nodeNames))
 		for _, item := range nodeNames.List() {
 			// Launch a goroutine per node to check the pods running on the nodes.
@@ -248,7 +248,7 @@ func checkPodCleanup(ctx context.Context, c clientset.Interface, pod *v1.Pod, ex
 
 	for _, test := range tests {
 		framework.Logf("Wait up to %v for host's (%v) %q to be %v", timeout, nodeIP, test.feature, condMsg)
-		err = wait.PollWithContext(ctx, poll, timeout, func(ctx context.Context) (bool, error) {
+		err = wait.PollUntilContextTimeout(ctx, poll, timeout, false, func(ctx context.Context) (bool, error) {
 			result, err := e2essh.NodeExec(ctx, nodeIP, test.cmd, framework.TestContext.Provider)
 			framework.ExpectNoError(err)
 			e2essh.LogResult(result)

--- a/test/e2e/storage/pvc_storageclass.go
+++ b/test/e2e/storage/pvc_storageclass.go
@@ -160,7 +160,7 @@ func temporarilyUnsetDefaultClasses(ctx context.Context, client clientset.Interf
 func waitForPVCStorageClass(ctx context.Context, c clientset.Interface, namespace, pvcName, scName string, timeout time.Duration) (*v1.PersistentVolumeClaim, error) {
 	var watchedPVC *v1.PersistentVolumeClaim
 
-	err := wait.PollWithContext(ctx, 1*time.Second, timeout, func(ctx context.Context) (bool, error) {
+	err := wait.PollUntilContextTimeout(ctx, 1*time.Second, timeout, false, func(ctx context.Context) (bool, error) {
 		var err error
 		watchedPVC, err = c.CoreV1().PersistentVolumeClaims(namespace).Get(ctx, pvcName, metav1.GetOptions{})
 		if err != nil {

--- a/test/e2e/storage/volume_metrics.go
+++ b/test/e2e/storage/volume_metrics.go
@@ -245,7 +245,7 @@ var _ = utils.SIGDescribe(framework.WithSerial(), "Volume metrics", func() {
 		// Poll kubelet metrics waiting for the volume to be picked up
 		// by the volume stats collector
 		var kubeMetrics e2emetrics.KubeletMetrics
-		waitErr := wait.PollWithContext(ctx, 30*time.Second, 5*time.Minute, func(ctx context.Context) (bool, error) {
+		waitErr := wait.PollUntilContextTimeout(ctx, 30*time.Second, 5*time.Minute, false, func(ctx context.Context) (bool, error) {
 			framework.Logf("Grabbing Kubelet metrics")
 			// Grab kubelet metrics from the node the pod was scheduled on
 			var err error

--- a/test/e2e/storage/vsphere/vsphere_utils.go
+++ b/test/e2e/storage/vsphere/vsphere_utils.go
@@ -74,7 +74,7 @@ func waitForVSphereDisksToDetach(ctx context.Context, nodeVolumes map[string][]s
 		detachTimeout  = 5 * time.Minute
 		detachPollTime = 10 * time.Second
 	)
-	waitErr := wait.PollWithContext(ctx, detachPollTime, detachTimeout, func(ctx context.Context) (bool, error) {
+	waitErr := wait.PollUntilContextTimeout(ctx, detachPollTime, detachTimeout, false, func(ctx context.Context) (bool, error) {
 		attachedResult, err := disksAreAttached(ctx, nodeVolumes)
 		if err != nil {
 			return false, err
@@ -117,7 +117,7 @@ func waitForVSphereDiskStatus(ctx context.Context, volumePath string, nodeName s
 		volumeStateDetached: "detached from",
 	}
 
-	waitErr := wait.PollWithContext(ctx, pollTime, timeout, func(ctx context.Context) (bool, error) {
+	waitErr := wait.PollUntilContextTimeout(ctx, pollTime, timeout, false, func(ctx context.Context) (bool, error) {
 		diskAttached, err := diskIsAttached(ctx, volumePath, nodeName)
 		if err != nil {
 			return true, err

--- a/test/e2e/storage/vsphere/vsphere_volume_node_poweroff.go
+++ b/test/e2e/storage/vsphere/vsphere_volume_node_poweroff.go
@@ -157,7 +157,7 @@ func waitForPodToFailover(ctx context.Context, client clientset.Interface, deplo
 		pollTime = 10 * time.Second
 	)
 
-	waitErr := wait.PollWithContext(ctx, pollTime, timeout, func(ctx context.Context) (bool, error) {
+	waitErr := wait.PollUntilContextTimeout(ctx, pollTime, timeout, false, func(ctx context.Context) (bool, error) {
 		currentNode, err := getNodeForDeployment(ctx, client, deployment)
 		if err != nil {
 			return true, err

--- a/test/e2e/upgrades/apps/daemonsets.go
+++ b/test/e2e/upgrades/apps/daemonsets.go
@@ -59,7 +59,7 @@ func (t *DaemonSetUpgradeTest) Setup(ctx context.Context, f *framework.Framework
 	}
 
 	ginkgo.By("Waiting for DaemonSet pods to become ready")
-	err = wait.PollWithContext(ctx, framework.Poll, framework.PodStartTimeout, func(ctx context.Context) (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, framework.Poll, framework.PodStartTimeout, false, func(ctx context.Context) (bool, error) {
 		return e2edaemonset.CheckRunningOnAllNodes(ctx, f, t.daemonSet)
 	})
 	framework.ExpectNoError(err)

--- a/test/e2e_node/os_label_rename_test.go
+++ b/test/e2e_node/os_label_rename_test.go
@@ -85,7 +85,7 @@ var _ = SIGDescribe("OSArchLabelReconciliation", framework.WithSerial(), framewo
 func waitForNodeLabels(ctx context.Context, c v1core.CoreV1Interface, nodeName string, timeout time.Duration) error {
 	ginkgo.By(fmt.Sprintf("Waiting for node %v to have appropriate labels", nodeName))
 	// Poll until the node has desired labels
-	return wait.PollWithContext(ctx, framework.Poll, timeout,
+	return wait.PollUntilContextTimeout(ctx, framework.Poll, timeout, false,
 		func(ctx context.Context) (bool, error) {
 			node, err := c.Nodes().Get(ctx, nodeName, metav1.GetOptions{})
 			if err != nil {

--- a/test/integration/apiserver/discovery/framework.go
+++ b/test/integration/apiserver/discovery/framework.go
@@ -142,10 +142,11 @@ func (a applyAPIService) Cleanup(ctx context.Context, client testClient) error {
 		return err
 	}
 
-	err = wait.PollWithContext(
+	err = wait.PollUntilContextTimeout(
 		ctx,
 		250*time.Millisecond,
 		maxTimeout,
+		false,
 		func(ctx context.Context) (done bool, err error) {
 			_, err = client.ApiregistrationV1().APIServices().Get(ctx, name, metav1.GetOptions{})
 			if err == nil {
@@ -210,10 +211,11 @@ func (a applyCRD) Cleanup(ctx context.Context, client testClient) error {
 		return err
 	}
 
-	err = wait.PollWithContext(
+	err = wait.PollUntilContextTimeout(
 		ctx,
 		250*time.Millisecond,
 		maxTimeout,
+		false,
 		func(ctx context.Context) (done bool, err error) {
 			_, err = client.ApiextensionsV1().CustomResourceDefinitions().Get(ctx, name, metav1.GetOptions{})
 			if err == nil {
@@ -589,10 +591,11 @@ func WaitForGroups(ctx context.Context, client testClient, groups ...apidiscover
 func WaitForResultWithCondition(ctx context.Context, client testClient, condition func(result apidiscoveryv2beta1.APIGroupDiscoveryList) bool) error {
 	// Keep repeatedly fetching document from aggregator.
 	// Check to see if it contains our service within a reasonable amount of time
-	return wait.PollWithContext(
+	return wait.PollUntilContextTimeout(
 		ctx,
 		250*time.Millisecond,
 		maxTimeout,
+		false,
 		func(ctx context.Context) (done bool, err error) {
 			groupList, err := FetchV2Discovery(ctx, client)
 			if err != nil {
@@ -610,10 +613,11 @@ func WaitForResultWithCondition(ctx context.Context, client testClient, conditio
 func WaitForV1GroupsWithCondition(ctx context.Context, client testClient, condition func(result metav1.APIGroupList) bool) error {
 	// Keep repeatedly fetching document from aggregator.
 	// Check to see if it contains our service within a reasonable amount of time
-	return wait.PollWithContext(
+	return wait.PollUntilContextTimeout(
 		ctx,
 		250*time.Millisecond,
 		maxTimeout,
+		false,
 		func(ctx context.Context) (done bool, err error) {
 			groupList, err := FetchV1DiscoveryGroups(ctx, client)
 
@@ -632,10 +636,11 @@ func WaitForV1GroupsWithCondition(ctx context.Context, client testClient, condit
 func WaitForV1ResourcesWithCondition(ctx context.Context, client testClient, gv metav1.GroupVersion, condition func(result metav1.APIResourceList) bool) error {
 	// Keep repeatedly fetching document from aggregator.
 	// Check to see if it contains our service within a reasonable amount of time
-	return wait.PollWithContext(
+	return wait.PollUntilContextTimeout(
 		ctx,
 		250*time.Millisecond,
 		maxTimeout,
+		false,
 		func(ctx context.Context) (done bool, err error) {
 			resourceList, err := FetchV1DiscoveryResource(ctx, client, gv)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Use PollUntilContextTimeout to replace PollWithContext in test
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
none
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
none
```
