### PR TITLE
OpenAPI SchemaResolver infinite loop reproducer

### DIFF
--- a/test/integration/apiserver/cel/typeresolution_test.go
+++ b/test/integration/apiserver/cel/typeresolution_test.go
@@ -34,11 +34,13 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 	nodev1 "k8s.io/api/node/v1"
 	storagev1 "k8s.io/api/storage/v1"
+	apiextensionsinstall "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/install"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	extclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
 	commoncel "k8s.io/apiserver/pkg/cel"
@@ -360,6 +362,16 @@ func TestBuiltinResolution(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestResolveRecursiveSchema(t *testing.T) {
+	sch := runtime.NewScheme()
+	apiextensionsinstall.Install(sch)
+	res := resolver.NewDefinitionsSchemaResolver(sch, openapi.GetOpenAPIDefinitions)
+	_, err := res.ResolveSchema(schema.GroupVersionKind{Group: "apiextensions.k8s.io", Version: "v1", Kind: "CustomResourceDefinition"})
+	if err != nil {
+		t.Fatal(err)
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind failing-test

#### What this PR does / why we need it:

Resolving CustomResourceDefinition from the schema resolver results in an infinite loop & crash due to recursive schema. Adds a minimal test case to reproduce it

#### Which issue(s) this PR fixes:

N/A

#### Special notes for your reviewer:

/assign @jiahuif 
/sig api-machinery

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
