### PR TITLE
snapshot controller version bump to v6.3.1

### DIFF
--- a/cluster/addons/volumesnapshots/volume-snapshot-controller/volume-snapshot-controller-deployment.yaml
+++ b/cluster/addons/volumesnapshots/volume-snapshot-controller/volume-snapshot-controller-deployment.yaml
@@ -22,7 +22,7 @@ spec:
       serviceAccount: volume-snapshot-controller
       containers:
         - name: volume-snapshot-controller
-          image: registry.k8s.io/sig-storage/snapshot-controller:v6.1.0
+          image: registry.k8s.io/sig-storage/snapshot-controller:v6.3.1
           args:
             - "--v=5"
             - "--metrics-path=/metrics"


### PR DESCRIPTION
This commit make to use snapshot controller `v6.3.1` in snapshot controller deployment .  The new version has many improvements and CVE/bug fixes in place.

/kind cleanup

-->
```release-note

```


```docs

```
