### PR TITLE
fix: use generic sets in pkg/kubelet/config

### DIFF
--- a/pkg/kubelet/cm/devicemanager/manager_test.go
+++ b/pkg/kubelet/cm/devicemanager/manager_test.go
@@ -313,7 +313,7 @@ func setupPluginManager(t *testing.T, pluginSocketName string, m Manager) plugin
 
 func runPluginManager(pluginManager pluginmanager.PluginManager) {
 	// FIXME: Replace sets.String with sets.Set[string]
-	sourcesReady := config.NewSourcesReady(func(_ sets.String) bool { return true })
+	sourcesReady := config.NewSourcesReady(func(_ sets.Set[string]) bool { return true })
 	go pluginManager.Run(sourcesReady, wait.NeverStop)
 }
 

--- a/pkg/kubelet/config/config.go
+++ b/pkg/kubelet/config/config.go
@@ -68,7 +68,7 @@ type PodConfig struct {
 
 	// contains the list of all configured sources
 	sourcesLock sync.Mutex
-	sources     sets.String
+	sources     sets.Set[string]
 }
 
 // NewPodConfig creates an object that can merge many configuration sources into a stream
@@ -80,7 +80,7 @@ func NewPodConfig(mode PodConfigNotificationMode, recorder record.EventRecorder,
 		pods:    storage,
 		mux:     config.NewMux(storage),
 		updates: updates,
-		sources: sets.String{},
+		sources: sets.New[string](),
 	}
 	return podConfig
 }
@@ -102,8 +102,8 @@ func (c *PodConfig) SeenAllSources(seenSources sets.String) bool {
 	}
 	c.sourcesLock.Lock()
 	defer c.sourcesLock.Unlock()
-	klog.V(5).InfoS("Looking for sources, have seen", "sources", c.sources.List(), "seenSources", seenSources)
-	return seenSources.HasAll(c.sources.List()...) && c.pods.seenSources(c.sources.List()...)
+	klog.V(5).InfoS("Looking for sources, have seen", "sources", sets.List(c.sources), "seenSources", seenSources)
+	return seenSources.HasAll(sets.List(c.sources)...) && c.pods.seenSources(sets.List(c.sources)...)
 }
 
 // Updates returns a channel of updates to the configuration, properly denormalized.

--- a/pkg/kubelet/config/config.go
+++ b/pkg/kubelet/config/config.go
@@ -96,7 +96,7 @@ func (c *PodConfig) Channel(ctx context.Context, source string) chan<- interface
 
 // SeenAllSources returns true if seenSources contains all sources in the
 // config, and also this config has received a SET message from each source.
-func (c *PodConfig) SeenAllSources(seenSources sets.String) bool {
+func (c *PodConfig) SeenAllSources(seenSources sets.Set[string]) bool {
 	if c.pods == nil {
 		return false
 	}

--- a/pkg/kubelet/config/config_test.go
+++ b/pkg/kubelet/config/config_test.go
@@ -466,7 +466,7 @@ func TestPodUpdateLabels(t *testing.T) {
 func TestPodConfigRace(t *testing.T) {
 	eventBroadcaster := record.NewBroadcaster()
 	config := NewPodConfig(PodConfigNotificationIncremental, eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: "kubelet"}), &mockPodStartupSLIObserver{})
-	seenSources := sets.NewString(TestSource)
+	seenSources := sets.New(TestSource)
 	var wg sync.WaitGroup
 	const iterations = 100
 	wg.Add(2)

--- a/pkg/kubelet/config/sources.go
+++ b/pkg/kubelet/config/sources.go
@@ -24,7 +24,7 @@ import (
 )
 
 // SourcesReadyFn is function that returns true if the specified sources have been seen.
-type SourcesReadyFn func(sourcesSeen sets.String) bool
+type SourcesReadyFn func(sourcesSeen sets.Set[string]) bool
 
 // SourcesReady tracks the set of configured sources seen by the kubelet.
 type SourcesReady interface {
@@ -37,7 +37,7 @@ type SourcesReady interface {
 // NewSourcesReady returns a SourcesReady with the specified function.
 func NewSourcesReady(sourcesReadyFn SourcesReadyFn) SourcesReady {
 	return &sourcesImpl{
-		sourcesSeen:    sets.NewString(),
+		sourcesSeen:    sets.New[string](),
 		sourcesReadyFn: sourcesReadyFn,
 	}
 }
@@ -47,7 +47,7 @@ type sourcesImpl struct {
 	// lock protects access to sources seen.
 	lock sync.RWMutex
 	// set of sources seen.
-	sourcesSeen sets.String
+	sourcesSeen sets.Set[string]
 	// sourcesReady is a function that evaluates if the sources are ready.
 	sourcesReadyFn SourcesReadyFn
 }

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -209,7 +209,7 @@ func newTestKubeletWithImageList(
 	if err := os.MkdirAll(kubelet.rootDirectory, 0750); err != nil {
 		t.Fatalf("can't mkdir(%q): %v", kubelet.rootDirectory, err)
 	}
-	kubelet.sourcesReady = config.NewSourcesReady(func(_ sets.String) bool { return true })
+	kubelet.sourcesReady = config.NewSourcesReady(func(_ sets.Set[string]) bool { return true })
 	kubelet.serviceLister = testServiceLister{}
 	kubelet.serviceHasSynced = func() bool { return true }
 	kubelet.nodeHasSynced = func() bool { return true }
@@ -729,7 +729,7 @@ func TestHandlePodRemovesWhenSourcesAreReady(t *testing.T) {
 		{Pod: fakePod},
 	}
 	kubelet := testKubelet.kubelet
-	kubelet.sourcesReady = config.NewSourcesReady(func(_ sets.String) bool { return ready })
+	kubelet.sourcesReady = config.NewSourcesReady(func(_ sets.Set[string]) bool { return ready })
 
 	kubelet.HandlePodRemoves(pods)
 	time.Sleep(2 * time.Second)

--- a/pkg/kubelet/pluginmanager/plugin_manager_test.go
+++ b/pkg/kubelet/pluginmanager/plugin_manager_test.go
@@ -131,7 +131,7 @@ func TestPluginRegistration(t *testing.T) {
 	stopChan := make(chan struct{})
 	defer close(stopChan)
 	go func() {
-		sourcesReady := config.NewSourcesReady(func(_ sets.String) bool { return true })
+		sourcesReady := config.NewSourcesReady(func(_ sets.Set[string]) bool { return true })
 		pluginManager.Run(sourcesReady, stopChan)
 	}()
 

--- a/pkg/kubelet/volumemanager/volume_manager_test.go
+++ b/pkg/kubelet/volumemanager/volume_manager_test.go
@@ -543,7 +543,7 @@ func runVolumeManager(manager VolumeManager) chan struct{} {
 	stopCh := make(chan struct{})
 	//readyCh := make(chan bool, 1)
 	//readyCh <- true
-	sourcesReady := config.NewSourcesReady(func(_ sets.String) bool { return true })
+	sourcesReady := config.NewSourcesReady(func(_ sets.Set[string]) bool { return true })
 	go manager.Run(sourcesReady, stopCh)
 	return stopCh
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup
#### What this PR does / why we need it:
specific sets are deprecated
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
