### PR TITLE
Fix dns autoscaling test to run with coredns

### DIFF
--- a/test/e2e/autoscaling/dns_autoscaling.go
+++ b/test/e2e/autoscaling/dns_autoscaling.go
@@ -39,12 +39,15 @@ import (
 	"github.com/onsi/ginkgo/v2"
 )
 
+// This test requires coredns to be installed on the cluster with autoscaling enabled.
+// Compare your coredns manifest against the command below
+// helm template coredns -n kube-system coredns/coredns --set k8sAppLabelOverride=kube-dns --set fullnameOverride=coredns --set autoscaler.enabled=true
+
 // Constants used in dns-autoscaling test.
 const (
-	DNSdefaultTimeout      = 5 * time.Minute
-	ClusterAddonLabelKey   = "k8s-app"
-	DNSLabelName           = "kube-dns"
-	DNSAutoscalerLabelName = "kube-dns-autoscaler"
+	DNSdefaultTimeout    = 5 * time.Minute
+	ClusterAddonLabelKey = "k8s-app"
+	DNSLabelName         = "kube-dns"
 )
 
 var _ = SIGDescribe("DNS horizontal autoscaling", func() {
@@ -52,6 +55,7 @@ var _ = SIGDescribe("DNS horizontal autoscaling", func() {
 	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
 	var c clientset.Interface
 	var previousParams map[string]string
+	var configMapNames map[string]string
 	var originDNSReplicasCount int
 	var DNSParams1 DNSParamsLinear
 	var DNSParams2 DNSParamsLinear
@@ -66,10 +70,21 @@ var _ = SIGDescribe("DNS horizontal autoscaling", func() {
 		nodeCount := len(nodes.Items)
 
 		ginkgo.By("Collecting original replicas count and DNS scaling params")
-		originDNSReplicasCount, err = getDNSReplicas(ctx, c)
+
+		// Check if we are running coredns or kube-dns, the only difference is the name of the autoscaling CM.
+		// The test should be have identically on both dns providers
+		provider, err := detectDNSProvider(ctx, c)
 		framework.ExpectNoError(err)
 
-		pcm, err := fetchDNSScalingConfigMap(ctx, c)
+		originDNSReplicasCount, err = getDNSReplicas(ctx, c)
+		framework.ExpectNoError(err)
+		configMapNames = map[string]string{
+			"kube-dns": "kube-dns-autoscaler",
+			"coredns":  "coredns-autoscaler",
+		}
+
+		pcm, err := fetchDNSScalingConfigMap(ctx, c, configMapNames[provider])
+		framework.Logf("original DNS scaling params: %v", pcm)
 		framework.ExpectNoError(err)
 		previousParams = pcm.Data
 
@@ -110,12 +125,19 @@ var _ = SIGDescribe("DNS horizontal autoscaling", func() {
 		numNodes, err := e2enode.TotalRegistered(ctx, c)
 		framework.ExpectNoError(err)
 
+		configMapNames = map[string]string{
+			"kube-dns": "kube-dns-autoscaler",
+			"coredns":  "coredns-autoscaler",
+		}
+		provider, err := detectDNSProvider(ctx, c)
+		framework.ExpectNoError(err)
+
 		ginkgo.By("Replace the dns autoscaling parameters with testing parameters")
-		err = updateDNSScalingConfigMap(ctx, c, packDNSScalingConfigMap(packLinearParams(&DNSParams1)))
+		err = updateDNSScalingConfigMap(ctx, c, packDNSScalingConfigMap(configMapNames[provider], packLinearParams(&DNSParams1)))
 		framework.ExpectNoError(err)
 		defer func() {
 			ginkgo.By("Restoring initial dns autoscaling parameters")
-			err = updateDNSScalingConfigMap(ctx, c, packDNSScalingConfigMap(previousParams))
+			err = updateDNSScalingConfigMap(ctx, c, packDNSScalingConfigMap(configMapNames[provider], previousParams))
 			framework.ExpectNoError(err)
 
 			ginkgo.By("Wait for number of running and ready kube-dns pods recover")
@@ -152,7 +174,7 @@ var _ = SIGDescribe("DNS horizontal autoscaling", func() {
 		framework.ExpectNoError(err)
 
 		ginkgo.By("Replace the dns autoscaling parameters with another testing parameters")
-		err = updateDNSScalingConfigMap(ctx, c, packDNSScalingConfigMap(packLinearParams(&DNSParams3)))
+		err = updateDNSScalingConfigMap(ctx, c, packDNSScalingConfigMap(configMapNames[provider], packLinearParams(&DNSParams3)))
 		framework.ExpectNoError(err)
 
 		ginkgo.By("Wait for kube-dns scaled to expected number")
@@ -172,12 +194,21 @@ var _ = SIGDescribe("DNS horizontal autoscaling", func() {
 
 	ginkgo.It("kube-dns-autoscaler should scale kube-dns pods in both nonfaulty and faulty scenarios", func(ctx context.Context) {
 
+		configMapNames = map[string]string{
+			"kube-dns": "kube-dns-autoscaler",
+			"coredns":  "coredns-autoscaler",
+		}
+		provider, err := detectDNSProvider(ctx, c)
+		framework.ExpectNoError(err)
+
 		ginkgo.By("Replace the dns autoscaling parameters with testing parameters")
-		err := updateDNSScalingConfigMap(ctx, c, packDNSScalingConfigMap(packLinearParams(&DNSParams1)))
+		cm := packDNSScalingConfigMap(configMapNames[provider], packLinearParams(&DNSParams1))
+		framework.Logf("Updating the following cm: %v", cm)
+		err = updateDNSScalingConfigMap(ctx, c, cm)
 		framework.ExpectNoError(err)
 		defer func() {
 			ginkgo.By("Restoring initial dns autoscaling parameters")
-			err = updateDNSScalingConfigMap(ctx, c, packDNSScalingConfigMap(previousParams))
+			err = updateDNSScalingConfigMap(ctx, c, packDNSScalingConfigMap(configMapNames[provider], previousParams))
 			framework.ExpectNoError(err)
 		}()
 		ginkgo.By("Wait for kube-dns scaled to expected number")
@@ -187,7 +218,7 @@ var _ = SIGDescribe("DNS horizontal autoscaling", func() {
 
 		ginkgo.By("--- Scenario: should scale kube-dns based on changed parameters ---")
 		ginkgo.By("Replace the dns autoscaling parameters with another testing parameters")
-		err = updateDNSScalingConfigMap(ctx, c, packDNSScalingConfigMap(packLinearParams(&DNSParams3)))
+		err = updateDNSScalingConfigMap(ctx, c, packDNSScalingConfigMap(configMapNames[provider], packLinearParams(&DNSParams3)))
 		framework.ExpectNoError(err)
 		ginkgo.By("Wait for kube-dns scaled to expected number")
 		getExpectReplicasLinear = getExpectReplicasFuncLinear(ctx, c, &DNSParams3)
@@ -196,30 +227,30 @@ var _ = SIGDescribe("DNS horizontal autoscaling", func() {
 
 		ginkgo.By("--- Scenario: should re-create scaling parameters with default value when parameters got deleted ---")
 		ginkgo.By("Delete the ConfigMap for autoscaler")
-		err = deleteDNSScalingConfigMap(ctx, c)
+		err = deleteDNSScalingConfigMap(ctx, c, configMapNames[provider])
 		framework.ExpectNoError(err)
 
 		ginkgo.By("Wait for the ConfigMap got re-created")
-		_, err = waitForDNSConfigMapCreated(ctx, c, DNSdefaultTimeout)
+		_, err = waitForDNSConfigMapCreated(ctx, c, DNSdefaultTimeout, configMapNames[provider])
 		framework.ExpectNoError(err)
 
 		ginkgo.By("Replace the dns autoscaling parameters with another testing parameters")
-		err = updateDNSScalingConfigMap(ctx, c, packDNSScalingConfigMap(packLinearParams(&DNSParams2)))
+		err = updateDNSScalingConfigMap(ctx, c, packDNSScalingConfigMap(configMapNames[provider], packLinearParams(&DNSParams2)))
 		framework.ExpectNoError(err)
-		ginkgo.By("Wait for kube-dns scaled to expected number")
+		ginkgo.By("Wait for kube-dns/coredns scaled to expected number")
 		getExpectReplicasLinear = getExpectReplicasFuncLinear(ctx, c, &DNSParams2)
 		err = waitForDNSReplicasSatisfied(ctx, c, getExpectReplicasLinear, DNSdefaultTimeout)
 		framework.ExpectNoError(err)
 
 		ginkgo.By("--- Scenario: should recover after autoscaler pod got deleted ---")
-		ginkgo.By("Delete the autoscaler pod for kube-dns")
+		ginkgo.By("Delete the autoscaler pod for kube-dns/coredns")
 		err = deleteDNSAutoscalerPod(ctx, c)
 		framework.ExpectNoError(err)
 
 		ginkgo.By("Replace the dns autoscaling parameters with another testing parameters")
-		err = updateDNSScalingConfigMap(ctx, c, packDNSScalingConfigMap(packLinearParams(&DNSParams1)))
+		err = updateDNSScalingConfigMap(ctx, c, packDNSScalingConfigMap(configMapNames[provider], packLinearParams(&DNSParams1)))
 		framework.ExpectNoError(err)
-		ginkgo.By("Wait for kube-dns scaled to expected number")
+		ginkgo.By("Wait for kube-dns/coredns scaled to expected number")
 		getExpectReplicasLinear = getExpectReplicasFuncLinear(ctx, c, &DNSParams1)
 		err = waitForDNSReplicasSatisfied(ctx, c, getExpectReplicasLinear, DNSdefaultTimeout)
 		framework.ExpectNoError(err)
@@ -262,16 +293,30 @@ func getSchedulableCores(nodes []v1.Node) int64 {
 	return sc.Value()
 }
 
-func fetchDNSScalingConfigMap(ctx context.Context, c clientset.Interface) (*v1.ConfigMap, error) {
-	cm, err := c.CoreV1().ConfigMaps(metav1.NamespaceSystem).Get(ctx, DNSAutoscalerLabelName, metav1.GetOptions{})
+func detectDNSProvider(ctx context.Context, c clientset.Interface) (string, error) {
+	cm, err := c.CoreV1().ConfigMaps(metav1.NamespaceSystem).Get(ctx, "coredns-autoscaler", metav1.GetOptions{})
+	if cm != nil && err == nil {
+		return "coredns", nil
+	}
+
+	cm, err = c.CoreV1().ConfigMaps(metav1.NamespaceSystem).Get(ctx, "kube-dns-autoscaler", metav1.GetOptions{})
+	if cm != nil && err == nil {
+		return "kube-dns", nil
+	}
+
+	return "", fmt.Errorf("the cluster doesn't have kube-dns or coredns autoscaling configured")
+}
+
+func fetchDNSScalingConfigMap(ctx context.Context, c clientset.Interface, configMapName string) (*v1.ConfigMap, error) {
+	cm, err := c.CoreV1().ConfigMaps(metav1.NamespaceSystem).Get(ctx, configMapName, metav1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}
 	return cm, nil
 }
 
-func deleteDNSScalingConfigMap(ctx context.Context, c clientset.Interface) error {
-	if err := c.CoreV1().ConfigMaps(metav1.NamespaceSystem).Delete(ctx, DNSAutoscalerLabelName, metav1.DeleteOptions{}); err != nil {
+func deleteDNSScalingConfigMap(ctx context.Context, c clientset.Interface, configMapName string) error {
+	if err := c.CoreV1().ConfigMaps(metav1.NamespaceSystem).Delete(ctx, configMapName, metav1.DeleteOptions{}); err != nil {
 		return err
 	}
 	framework.Logf("DNS autoscaling ConfigMap deleted.")
@@ -288,9 +333,9 @@ func packLinearParams(params *DNSParamsLinear) map[string]string {
 	return paramsMap
 }
 
-func packDNSScalingConfigMap(params map[string]string) *v1.ConfigMap {
+func packDNSScalingConfigMap(configMapName string, params map[string]string) *v1.ConfigMap {
 	configMap := v1.ConfigMap{}
-	configMap.ObjectMeta.Name = DNSAutoscalerLabelName
+	configMap.ObjectMeta.Name = configMapName
 	configMap.ObjectMeta.Namespace = metav1.NamespaceSystem
 	configMap.Data = params
 	return &configMap
@@ -321,8 +366,8 @@ func getDNSReplicas(ctx context.Context, c clientset.Interface) (int, error) {
 }
 
 func deleteDNSAutoscalerPod(ctx context.Context, c clientset.Interface) error {
-	label := labels.SelectorFromSet(labels.Set(map[string]string{ClusterAddonLabelKey: DNSAutoscalerLabelName}))
-	listOpts := metav1.ListOptions{LabelSelector: label.String()}
+	selector, _ := labels.Parse(fmt.Sprintf("%s in (kube-dns-autoscaler, coredns-autoscaler)", ClusterAddonLabelKey))
+	listOpts := metav1.ListOptions{LabelSelector: selector.String()}
 	pods, err := c.CoreV1().Pods(metav1.NamespaceSystem).List(ctx, listOpts)
 	if err != nil {
 		return err
@@ -343,7 +388,7 @@ func waitForDNSReplicasSatisfied(ctx context.Context, c clientset.Interface, get
 	var current int
 	var expected int
 	framework.Logf("Waiting up to %v for kube-dns to reach expected replicas", timeout)
-	condition := func() (bool, error) {
+	condition := func(ctx context.Context) (bool, error) {
 		current, err = getDNSReplicas(ctx, c)
 		if err != nil {
 			return false, err
@@ -356,24 +401,24 @@ func waitForDNSReplicasSatisfied(ctx context.Context, c clientset.Interface, get
 		return true, nil
 	}
 
-	if err = wait.Poll(2*time.Second, timeout, condition); err != nil {
+	if err = wait.PollUntilContextTimeout(ctx, 2*time.Second, timeout, false, condition); err != nil {
 		return fmt.Errorf("err waiting for DNS replicas to satisfy %v, got %v: %w", expected, current, err)
 	}
 	framework.Logf("kube-dns reaches expected replicas: %v", expected)
 	return nil
 }
 
-func waitForDNSConfigMapCreated(ctx context.Context, c clientset.Interface, timeout time.Duration) (configMap *v1.ConfigMap, err error) {
-	framework.Logf("Waiting up to %v for DNS autoscaling ConfigMap got re-created", timeout)
-	condition := func() (bool, error) {
-		configMap, err = fetchDNSScalingConfigMap(ctx, c)
+func waitForDNSConfigMapCreated(ctx context.Context, c clientset.Interface, timeout time.Duration, configMapName string) (configMap *v1.ConfigMap, err error) {
+	framework.Logf("Waiting up to %v for DNS autoscaling ConfigMap to be re-created", timeout)
+	condition := func(ctx context.Context) (bool, error) {
+		configMap, err = fetchDNSScalingConfigMap(ctx, c, configMapName)
 		if err != nil {
 			return false, nil
 		}
 		return true, nil
 	}
 
-	if err = wait.Poll(time.Second, timeout, condition); err != nil {
+	if err = wait.PollUntilContextTimeout(ctx, time.Second, timeout, false, condition); err != nil {
 		return nil, fmt.Errorf("err waiting for DNS autoscaling ConfigMap got re-created: %w", err)
 	}
 	return configMap, nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
The DNS autoscaler test fails if you are using upstream CoreDNS manifests. The test now looks for coredns-autoscaler and kube-dns-autoscaler configmaps to determine which one to mutate.

Failing test: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/e2e-ci-kubernetes-e2e-cos-gce-canary/1716081107411144704

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of https://github.com/kubernetes/kubernetes/issues/120989


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
Part of https://github.com/kubernetes/enhancements/issues/4224