### PR TITLE
e2e_node: test device plugin support of CDI devices

### DIFF
--- a/test/e2e/testing-manifests/sample-device-plugin/sample-device-plugin.yaml
+++ b/test/e2e/testing-manifests/sample-device-plugin/sample-device-plugin.yaml
@@ -31,6 +31,9 @@ spec:
       - name: dev
         hostPath:
           path: /dev
+      - name: cdi-dir
+        hostPath:
+          path: /var/run/cdi
       containers:
       - image: registry.k8s.io/e2e-test-images/sample-device-plugin:1.3
         name: sample-device-plugin
@@ -46,5 +49,7 @@ spec:
           mountPath: /var/lib/kubelet/plugins_registry
         - name: dev
           mountPath: /dev
+        - name: cdi-dir
+          mountPath: /var/run/cdi
   updateStrategy:
     type: RollingUpdate


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/sig node
/triage accepted
/priority important-soon

#### What this PR does / why we need it:

It implements CDI support for the sample device plugin and adds a new e2e_node test case to test DevicePluginCDIDevices functionality. 

NOTE, this is a requirement of Beta graduation of the [DevicePluginCDIDevices](https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/4009-add-cdi-devices-to-device-plugin-api) feature.
There are other PRs that are waiting for this one:
- [Device Plugins: add an info about beta graduation](https://github.com/kubernetes/website/pull/43435)
- [Graduate DevicePluginCDIDevices to Beta](https://github.com/kubernetes/kubernetes/pull/121254)

As we're approaching a code freeze, I kindly ask reviewers and approvers to give this PR a higher priority.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

KEP update PR: [Update CDI for device plugins KEP for beta graduation](https://github.com/kubernetes/enhancements/pull/4238)

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
