### PR TITLE
Allow using upper and lower case true|false when setting kubectl feature flags

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
@@ -432,7 +432,7 @@ const (
 // IsEnabled returns true iff environment variable is set to true.
 // All other cases, it returns false.
 func (f FeatureGate) IsEnabled() bool {
-	return os.Getenv(string(f)) == "true"
+	return strings.ToLower(os.Getenv(string(f))) == "true"
 }
 
 // IsDisabled returns true iff environment variable is set to false.
@@ -440,7 +440,7 @@ func (f FeatureGate) IsEnabled() bool {
 // This function is used for the cases where feature is enabled by default,
 // but it may be needed to provide a way to ability to disable this feature.
 func (f FeatureGate) IsDisabled() bool {
-	return os.Getenv(string(f)) == "false"
+	return strings.ToLower(os.Getenv(string(f))) == "false"
 }
 
 func AddValidateFlags(cmd *cobra.Command) {


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/sig cli

#### What this PR does / why we need it:
I've noticed this while reviewing https://github.com/kubernetes/kubernetes/pull/120663, this allows reading feature flag value respectively of case. 

#### Which issue(s) this PR fixes:
none

#### Special notes for your reviewer:
/assign @ardaguclu 

#### Does this PR introduce a user-facing change?
```release-note
Allow using lower and upper case feature flag value, the name has to match still
```

