### PR TITLE
node: e2e: topology-mgr: Determine threads per core to disambiguage cores from cpus

### DIFF
--- a/test/e2e_node/topology_manager_metrics_test.go
+++ b/test/e2e_node/topology_manager_metrics_test.go
@@ -41,7 +41,7 @@ var _ = SIGDescribe("Topology Manager Metrics [Serial] [Feature:TopologyManager]
 	ginkgo.Context("when querying /metrics", func() {
 		var oldCfg *kubeletconfig.KubeletConfiguration
 		var testPod *v1.Pod
-		var cpusNumPerNUMA, numaNodes, threadsPerCore int
+		var cpusNumPerNUMA, coresNumPerNUMA, numaNodes, threadsPerCore int
 
 		ginkgo.BeforeEach(func(ctx context.Context) {
 			var err error
@@ -50,15 +50,17 @@ var _ = SIGDescribe("Topology Manager Metrics [Serial] [Feature:TopologyManager]
 				framework.ExpectNoError(err)
 			}
 
-			numaNodes, cpusNumPerNUMA, threadsPerCore = hostCheck()
+			numaNodes, coresNumPerNUMA, threadsPerCore = hostCheck()
+			cpusNumPerNUMA = coresNumPerNUMA * threadsPerCore
 
 			// It is safe to assume that the CPUs are distributed equally across
 			// NUMA nodes and therefore number of CPUs on all NUMA nodes are same
 			// so we just check the CPUs on the first NUMA node
 
 			framework.Logf("numaNodes on the system %d", numaNodes)
-			framework.Logf("CPUs per NUMA on the system %d", cpusNumPerNUMA)
+			framework.Logf("Cores per NUMA on the system %d", coresNumPerNUMA)
 			framework.Logf("Threads per Core on the system %d", threadsPerCore)
+			framework.Logf("CPUs per NUMA on the system %d", cpusNumPerNUMA)
 
 			policy := topologymanager.PolicySingleNumaNode
 			scope := podScopeTopology

--- a/test/e2e_node/topology_manager_test.go
+++ b/test/e2e_node/topology_manager_test.go
@@ -88,6 +88,16 @@ func detectCoresPerSocket() int {
 	return coreCount
 }
 
+func detectThreadPerCore() int {
+	outData, err := exec.Command("/bin/sh", "-c", "lscpu | grep \"Thread(s) per core:\" | cut -d \":\" -f 2").Output()
+	framework.ExpectNoError(err)
+
+	threadCount, err := strconv.Atoi(strings.TrimSpace(string(outData)))
+	framework.ExpectNoError(err)
+
+	return threadCount
+}
+
 func makeContainers(ctnCmd string, ctnAttributes []tmCtnAttribute) (ctns []v1.Container) {
 	for _, ctnAttr := range ctnAttributes {
 		ctn := v1.Container{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind failing-test

#### What this PR does / why we need it:
This PR is to fix topology manager metrics e2e tests by determining threads per cores on the system and use that information to disambiguate cores on the machine from cpus. In the current implementation we are conflating cores on the machine with cpus on the node but that is not accurate. 


In the current implementation of the tests, we obtain`coresPerSocket` in the [hostCheck](https://github.com/kubernetes/kubernetes/blob/release-1.28/test/e2e_node/topology_manager_metrics_test.go#L154) but call the [returned variable](https://github.com/kubernetes/kubernetes/blob/release-1.28/test/e2e_node/topology_manager_metrics_test.go#L53)  as `cpusNumPerNuma` which in my opinion is wrong and is causing the confusion. Let's assume that we have a 1-1 mapping of NUMA Node to Socket (which appears to be the case on the CI machine) we have 8 cores per socket/numa. Subsequently, the test creates a pod that requests 9 cpus (by doing cpusNumPerNuma+1 i.e. 8+1=9). The aim here was to create a pod that requests cpus (not cores!) greater than those available on a single NUMA. This particular node had 8 cores per NUMA but what we need is the count of cpus per NUMA which we do by checking threads per core on the node. The system has hyperthreading enabled so we have 16 cpus per NUMA and need to actually request 17 cpus for the pod that should result in Topology affinity error. Since we requested 9 cpus which is less than number of cpus per NUMA (16) the pod succeeded to run and didn't end up in Topology affinity error which explains point 3 in my initial assessment [here](https://github.com/kubernetes/kubernetes/issues/120725#issuecomment-1768935761).

With the changes proposed in this PR, we can see that the topology manager [build log](https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/121442/pull-kubernetes-node-kubelet-serial-topology-manager/1716426748461060096/build-log.txt) shows us the following:  
```
  Oct 23 12:26:35.381: INFO: numaNodes on the system 2
  Oct 23 12:26:35.381: INFO: Cores per NUMA on the system 8
  Oct 23 12:26:35.381: INFO: Threads per Core on the system 2
  Oct 23 12:26:35.381: INFO: CPUs per NUMA on the system 16
```
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/120725

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
<!--
#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:


This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>

```docs

```
-->