### PR TITLE
Leaving device uncertain if volume was previously reconstructed.

### DIFF
--- a/pkg/volume/util/operationexecutor/operation_generator.go
+++ b/pkg/volume/util/operationexecutor/operation_generator.go
@@ -781,6 +781,10 @@ func (og *operationGenerator) checkForFailedMount(volumeToMount VolumeToMount, m
 func (og *operationGenerator) markDeviceErrorState(volumeToMount VolumeToMount, devicePath, deviceMountPath string, mountError error, actualStateOfWorld ActualStateOfWorldMounterUpdater) {
 	if volumetypes.IsOperationFinishedError(mountError) &&
 		actualStateOfWorld.GetDeviceMountState(volumeToMount.VolumeName) == DeviceMountUncertain {
+		if actualStateOfWorld.IsVolumeReconstructed(volumeToMount.VolumeName, volumeToMount.PodName) {
+			klog.V(3).InfoS("MountDevice.markDeviceErrorState leaving device uncertain", "volumeName", volumeToMount.VolumeName)
+			return
+		}
 		// Only devices which were uncertain can be marked as unmounted
 		markDeviceUnmountError := actualStateOfWorld.MarkDeviceAsUnmounted(volumeToMount.VolumeName)
 		if markDeviceUnmountError != nil {


### PR DESCRIPTION
#### What type of PR is this?
/kind bug


#### What this PR does / why we need it:
When node reboots to reproduce #119608, kubelet has following error log
```
I1023 20:29:02.933275    4275 reconciler.go:357] "operationExecutor.VerifyControllerAttachedVolume started for volume \"pvc-32d31dd8-f044-4632-a713-377822eb136c\" (UniqueName: \"kubernetes.io/csi/rbd.csi.ceph.com^0001-0024-c9bd12b4-c264-58a3-a099-8f3ea155e4a2-0000000000000003-f65d47b6-7153-11ee-b397-000000035d1a\") pod \"virt-launcher-bar-node-3-vm-10-7q6qb\" (UID: \"9463cd4c-a6cd-4e97-9474-cdf2088de1fc\") " pod="admin/virt-launcher-bar-node-3-vm-10-7q6qb"
I1023 20:29:08.006007    4275 operation_generator.go:1582] "Controller attach succeeded for volume \"pvc-32d31dd8-f044-4632-a713-377822eb136c\" (UniqueName: \"kubernetes.io/csi/rbd.csi.ceph.com^0001-0024-c9bd12b4-c264-58a3-a099-8f3ea155e4a2-0000000000000003-f65d47b6-7153-11ee-b397-000000035d1a\") pod \"virt-launcher-bar-node-3-vm-10-7q6qb\" (UID: \"9463cd4c-a6cd-4e97-9474-cdf2088de1fc\") device path: \"\"" pod="admin/virt-launcher-bar-node-3-vm-10-7q6qb"
I1023 20:29:08.006442    4275 operation_generator.go:1103] "MapVolume.WaitForAttach entering for volume \"pvc-32d31dd8-f044-4632-a713-377822eb136c\" (UniqueName: \"kubernetes.io/csi/rbd.csi.ceph.com^0001-0024-c9bd12b4-c264-58a3-a099-8f3ea155e4a2-0000000000000003-f65d47b6-7153-11ee-b397-000000035d1a\") pod \"virt-launcher-bar-node-3-vm-10-7q6qb\" (UID: \"9463cd4c-a6cd-4e97-9474-cdf2088de1fc\") DevicePath \"\"" pod="admin/virt-launcher-bar-node-3-vm-10-7q6qb"
I1023 20:29:08.405058    4275 operation_generator.go:1113] "MapVolume.WaitForAttach succeeded for volume \"pvc-32d31dd8-f044-4632-a713-377822eb136c\" (UniqueName: \"kubernetes.io/csi/rbd.csi.ceph.com^0001-0024-c9bd12b4-c264-58a3-a099-8f3ea155e4a2-0000000000000003-f65d47b6-7153-11ee-b397-000000035d1a\") pod \"virt-launcher-bar-node-3-vm-10-7q6qb\" (UID: \"9463cd4c-a6cd-4e97-9474-cdf2088de1fc\") DevicePath \"csi-333945ae440b2f30274cda5a2981acad02e10de8e07be7780418cea06bc838c8\"" pod="admin/virt-launcher-bar-node-3-vm-10-7q6qb"
E1023 20:29:08.805118    4275 nestedpendingoperations.go:348] Operation for "{volumeName:kubernetes.io/csi/rbd.csi.ceph.com^0001-0024-c9bd12b4-c264-58a3-a099-8f3ea155e4a2-0000000000000003-f65d47b6-7153-11ee-b397-000000035d1a podName: nodeName:}" failed. No retries permitted until 2023-10-23 20:29:09.305096069 +0800 CST m=+22.786362809 (durationBeforeRetry 500ms). Error: MapVolume.SetUpDevice failed for volume "pvc-32d31dd8-f044-4632-a713-377822eb136c" (UniqueName: "kubernetes.io/csi/rbd.csi.ceph.com^0001-0024-c9bd12b4-c264-58a3-a099-8f3ea155e4a2-0000000000000003-f65d47b6-7153-11ee-b397-000000035d1a") pod "virt-launcher-bar-node-3-vm-10-7q6qb" (UID: "9463cd4c-a6cd-4e97-9474-cdf2088de1fc") : kubernetes.io/csi: blockMapper.SetUpDevice failed to get CSI client: driver name rbd.csi.ceph.com not found in the list of registered CSI drivers
I1023 20:29:08.818483    4275 reconciler.go:211] "operationExecutor.UnmountVolume started for volume \"pvc-32d31dd8-f044-4632-a713-377822eb136c\" (UniqueName: \"kubernetes.io/csi/rbd.csi.ceph.com^0001-0024-c9bd12b4-c264-58a3-a099-8f3ea155e4a2-0000000000000003-f65d47b6-7153-11ee-b397-000000035d1a\") pod \"9463cd4c-a6cd-4e97-9474-cdf2088de1fc\" (UID: \"9463cd4c-a6cd-4e97-9474-cdf2088de1fc\") "
E1023 20:29:08.818676    4275 nestedpendingoperations.go:348] Operation for "{volumeName:kubernetes.io/csi/rbd.csi.ceph.com^0001-0024-c9bd12b4-c264-58a3-a099-8f3ea155e4a2-0000000000000003-f65d47b6-7153-11ee-b397-000000035d1a podName:9463cd4c-a6cd-4e97-9474-cdf2088de1fc nodeName:}" failed. No retries permitted until 2023-10-23 20:29:09.318649564 +0800 CST m=+22.799916304 (durationBeforeRetry 500ms). Error: UnmapVolume.UnmapBlockVolume failed for volume "pvc-32d31dd8-f044-4632-a713-377822eb136c" (UniqueName: "kubernetes.io/csi/rbd.csi.ceph.com^0001-0024-c9bd12b4-c264-58a3-a099-8f3ea155e4a2-0000000000000003-f65d47b6-7153-11ee-b397-000000035d1a") pod "9463cd4c-a6cd-4e97-9474-cdf2088de1fc" (UID: "9463cd4c-a6cd-4e97-9474-cdf2088de1fc") : blkUtil.DetachFileDevice failed. globalUnmapPath:, podUID: 9463cd4c-a6cd-4e97-9474-cdf2088de1fc, bindMount: true: failed to unmap device from map path. mapPath is empty
I1023 20:29:09.325491    4275 reconciler.go:211] "operationExecutor.UnmountVolume started for volume \"pvc-32d31dd8-f044-4632-a713-377822eb136c\" (UniqueName: \"kubernetes.io/csi/rbd.csi.ceph.com^0001-0024-c9bd12b4-c264-58a3-a099-8f3ea155e4a2-0000000000000003-f65d47b6-7153-11ee-b397-000000035d1a\") pod \"9463cd4c-a6cd-4e97-9474-cdf2088de1fc\" (UID: \"9463cd4c-a6cd-4e97-9474-cdf2088de1fc\") "
E1023 20:29:09.325678    4275 nestedpendingoperations.go:348] Operation for "{volumeName:kubernetes.io/csi/rbd.csi.ceph.com^0001-0024-c9bd12b4-c264-58a3-a099-8f3ea155e4a2-0000000000000003-f65d47b6-7153-11ee-b397-000000035d1a podName:9463cd4c-a6cd-4e97-9474-cdf2088de1fc nodeName:}" failed. No retries permitted until 2023-10-23 20:29:10.325652574 +0800 CST m=+23.806919313 (durationBeforeRetry 1s). Error: UnmapVolume.UnmapBlockVolume failed for volume "pvc-32d31dd8-f044-4632-a713-377822eb136c" (UniqueName: "kubernetes.io/csi/rbd.csi.ceph.com^0001-0024-c9bd12b4-c264-58a3-a099-8f3ea155e4a2-0000000000000003-f65d47b6-7153-11ee-b397-000000035d1a") pod "9463cd4c-a6cd-4e97-9474-cdf2088de1fc" (UID: "9463cd4c-a6cd-4e97-9474-cdf2088de1fc") : blkUtil.DetachFileDevice failed. globalUnmapPath:, podUID: 9463cd4c-a6cd-4e97-9474-cdf2088de1fc, bindMount: true: failed to unmap device from map path. mapPath is empty
I1023 20:29:10.336931    4275 reconciler.go:211] "operationExecutor.UnmountVolume started for volume \"pvc-32d31dd8-f044-4632-a713-377822eb136c\" (UniqueName: \"kubernetes.io/csi/rbd.csi.ceph.com^0001-0024-c9bd12b4-c264-58a3-a099-8f3ea155e4a2-0000000000000003-f65d47b6-7153-11ee-b397-000000035d1a\") pod \"9463cd4c-a6cd-4e97-9474-cdf2088de1fc\" (UID: \"9463cd4c-a6cd-4e97-9474-cdf2088de1fc\") "
E1023 20:29:10.337194    4275 nestedpendingoperations.go:348] Operation for "{volumeName:kubernetes.io/csi/rbd.csi.ceph.com^0001-0024-c9bd12b4-c264-58a3-a099-8f3ea155e4a2-0000000000000003-f65d47b6-7153-11ee-b397-000000035d1a podName:9463cd4c-a6cd-4e97-9474-cdf2088de1fc nodeName:}" failed. No retries permitted until 2023-10-23 20:29:12.337159698 +0800 CST m=+25.818426436 (durationBeforeRetry 2s). Error: UnmapVolume.UnmapBlockVolume failed for volume "pvc-32d31dd8-f044-4632-a713-377822eb136c" (UniqueName: "kubernetes.io/csi/rbd.csi.ceph.com^0001-0024-c9bd12b4-c264-58a3-a099-8f3ea155e4a2-0000000000000003-f65d47b6-7153-11ee-b397-000000035d1a") pod "9463cd4c-a6cd-4e97-9474-cdf2088de1fc" (UID: "9463cd4c-a6cd-4e97-9474-cdf2088de1fc") : blkUtil.DetachFileDevice failed. globalUnmapPath:, podUID: 9463cd4c-a6cd-4e97-9474-cdf2088de1fc, bindMount: true: failed to unmap device from map path. mapPath is empty
...
```
Kubelet calls `csi.(*csiBlockMapper).SetUpDevice` in `GenerateMapVolumeFunc`. If `csi nodeplugin` is not ready, the error msg is `blockMapper.SetUpDevice failed to get CSI client: driver name rbd.csi.ceph.com not found in the list of registered CSI drivers`, and kubelet will set `volumeObj.deviceMountPath` to empty.
Like [markVolumeErrorState](https://github.com/kubernetes/kubernetes/blob/8453eb0c24ea61794157b451e4442ea570abce45/pkg/volume/util/operationexecutor/operation_generator.go#L808), skip `actualStateOfWorld.MarkDeviceAsUnmounted` if volume was previously reconstructed.

#### Which issue(s) this PR fixes:
Fixes #119608

