### PR TITLE
dra: reduce validation of PodSchedulingContext

### DIFF
--- a/pkg/apis/resource/validation/validation_podschedulingcontext_test.go
+++ b/pkg/apis/resource/validation/validation_podschedulingcontext_test.go
@@ -194,7 +194,6 @@ func TestValidatePodSchedulingContexts(t *testing.T) {
 
 func TestValidatePodSchedulingUpdate(t *testing.T) {
 	validScheduling := testPodSchedulingContexts("foo", "ns", resource.PodSchedulingContextSpec{})
-	badName := "!@#$%^"
 
 	scenarios := map[string]struct {
 		oldScheduling *resource.PodSchedulingContext
@@ -233,14 +232,6 @@ func TestValidatePodSchedulingUpdate(t *testing.T) {
 				return schedulingCtx
 			},
 		},
-		"invalid-potential-nodes-name": {
-			wantFailures:  field.ErrorList{field.Invalid(field.NewPath("spec", "potentialNodes").Index(0), badName, "a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')")},
-			oldScheduling: validScheduling,
-			update: func(schedulingCtx *resource.PodSchedulingContext) *resource.PodSchedulingContext {
-				schedulingCtx.Spec.PotentialNodes = append(schedulingCtx.Spec.PotentialNodes, badName)
-				return schedulingCtx
-			},
-		},
 	}
 
 	for name, scenario := range scenarios {
@@ -254,7 +245,6 @@ func TestValidatePodSchedulingUpdate(t *testing.T) {
 
 func TestValidatePodSchedulingStatusUpdate(t *testing.T) {
 	validScheduling := testPodSchedulingContexts("foo", "ns", resource.PodSchedulingContextSpec{})
-	badName := "!@#$%^"
 
 	scenarios := map[string]struct {
 		oldScheduling *resource.PodSchedulingContext
@@ -311,22 +301,6 @@ func TestValidatePodSchedulingStatusUpdate(t *testing.T) {
 						fmt.Sprintf("worker%d", i),
 					)
 				}
-				return schedulingCtx
-			},
-		},
-		"invalid-node-name": {
-			wantFailures:  field.ErrorList{field.Invalid(field.NewPath("status", "claims").Index(0).Child("unsuitableNodes").Index(0), badName, "a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')")},
-			oldScheduling: validScheduling,
-			update: func(schedulingCtx *resource.PodSchedulingContext) *resource.PodSchedulingContext {
-				schedulingCtx.Status.ResourceClaims = append(schedulingCtx.Status.ResourceClaims,
-					resource.ResourceClaimSchedulingStatus{
-						Name: "my-claim",
-					},
-				)
-				schedulingCtx.Status.ResourceClaims[0].UnsuitableNodes = append(
-					schedulingCtx.Status.ResourceClaims[0].UnsuitableNodes,
-					badName,
-				)
 				return schedulingCtx
 			},
 		},


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind api-change

#### What this PR does / why we need it:

Validation of the PodSchedulingContext was added "just in case" that it might be useful and/or catch mistakes. But in practice, the validation is never needed because only trusted components (kube-scheduler, DRA drivers) create or update that object. If those are buggy, then the cluster has a bigger problem that can be investigated also without the apiserver validation.

Removing validation of uniqueness and node names provides a significant performance boost:
```
name                                                            old SchedulingThroughput/Average  new SchedulingThroughput/Average    delta
PerfScheduling/SchedulingWithMultipleResourceClaims/2000pods_100nodes-36   16.7±14%              16.9 ± 8%                            ~     (p=0.794 n=5+5)
PerfScheduling/SchedulingWithMultipleResourceClaims/2000pods_200nodes-36   20.9 ±19%              24.1 ± 4%                           +15.26%  (p=0.016 n=5+5)
```

#### Which issue(s) this PR fixes:

Related-to: https://github.com/kubernetes/kubernetes/issues/113889

#### Special notes for your reviewer:

Given the dubious value and the obvious cost of validation, dropping it seems worthwhile. There's just one caveat: if some component really is buggy and stores currently invalid data, then downgrading is not possible because an older apiserver would reject the datafrom etcd. For an alpha feature this seems acceptable.


#### Does this PR introduce a user-facing change?
```release-note
DRA: resource.k8s.io/PodSchedulingContext is no longer checked for duplicates and invalid node names to improve performance. If kube-scheduler or some DRA driver store such broken data, then downgrading to Kubernetes < 1.29 is not possible because such objects would become invalid as part of the downgrade.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [KEP]: https://github.com/kubernetes/kubernetes/issues/113889
```
