### PR TITLE
KEP 4216: Add changes for alpha version under RuntimeClassInImageCriApi feature gate

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -710,6 +710,13 @@ const (
 	// certificate as expiration approaches.
 	RotateKubeletServerCertificate featuregate.Feature = "RotateKubeletServerCertificate"
 
+	// owner: @kiashok
+	// kep: https://kep.k8s.io/4216
+	// alpha: v1.29
+	//
+	// Adds support to pull images based on the runtime class specified.
+	RuntimeClassInImageCriAPI featuregate.Feature = "RuntimeClassInImageCriApi"
+
 	// owner: @danielvegamyhre
 	// kep: https://kep.k8s.io/2413
 	// beta: v1.27
@@ -1138,6 +1145,8 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	RecoverVolumeExpansionFailure: {Default: false, PreRelease: featuregate.Alpha},
 
 	RotateKubeletServerCertificate: {Default: true, PreRelease: featuregate.Beta},
+
+	RuntimeClassInImageCriAPI: {Default: false, PreRelease: featuregate.Alpha},
 
 	ElasticIndexedJob: {Default: true, PreRelease: featuregate.Beta},
 

--- a/pkg/kubelet/container/helpers.go
+++ b/pkg/kubelet/container/helpers.go
@@ -273,6 +273,7 @@ func ConvertPodStatusToRunningPod(runtimeName string, podStatus *PodStatus) Pod 
 			Name:                 containerStatus.Name,
 			Image:                containerStatus.Image,
 			ImageID:              containerStatus.ImageID,
+			ImageRuntimeHandler:  containerStatus.ImageRuntimeHandler,
 			Hash:                 containerStatus.Hash,
 			HashWithoutResources: containerStatus.HashWithoutResources,
 			State:                containerStatus.State,

--- a/pkg/kubelet/container/runtime.go
+++ b/pkg/kubelet/container/runtime.go
@@ -52,6 +52,8 @@ type Version interface {
 type ImageSpec struct {
 	// ID of the image.
 	Image string
+	// Runtime handler used to pull this image
+	RuntimeHandler string
 	// The annotations for the image.
 	// This should be passed to CRI during image pulls and returned when images are listed.
 	Annotations []Annotation
@@ -282,6 +284,8 @@ type Container struct {
 	Image string
 	// The id of the image used by the container.
 	ImageID string
+	// Runtime handler used to pull the image if any.
+	ImageRuntimeHandler string
 	// Hash of the container, used for comparison. Optional for containers
 	// not managed by kubelet.
 	Hash uint64
@@ -347,6 +351,8 @@ type Status struct {
 	Image string
 	// ID of the image.
 	ImageID string
+	// Runtime handler used to pull the image if any.
+	ImageRuntimeHandler string
 	// Hash of the container, used for comparison.
 	Hash uint64
 	// Hash of the container over fields with Resources field zero'd out.

--- a/pkg/kubelet/images/image_manager.go
+++ b/pkg/kubelet/images/image_manager.go
@@ -98,7 +98,7 @@ func (m *imageManager) logIt(ref *v1.ObjectReference, eventtype, event, prefix, 
 
 // EnsureImageExists pulls the image for the specified pod and container, and returns
 // (imageRef, error message, error).
-func (m *imageManager) EnsureImageExists(ctx context.Context, pod *v1.Pod, container *v1.Container, pullSecrets []v1.Secret, podSandboxConfig *runtimeapi.PodSandboxConfig) (string, string, error) {
+func (m *imageManager) EnsureImageExists(ctx context.Context, pod *v1.Pod, container *v1.Container, pullSecrets []v1.Secret, podSandboxConfig *runtimeapi.PodSandboxConfig, podRuntimeHandler string) (string, string, error) {
 	logPrefix := fmt.Sprintf("%s/%s/%s", pod.Namespace, pod.Name, container.Image)
 	ref, err := kubecontainer.GenerateContainerRef(pod, container)
 	if err != nil {
@@ -122,9 +122,11 @@ func (m *imageManager) EnsureImageExists(ctx context.Context, pod *v1.Pod, conta
 	}
 
 	spec := kubecontainer.ImageSpec{
-		Image:       image,
-		Annotations: podAnnotations,
+		Image:          image,
+		Annotations:    podAnnotations,
+		RuntimeHandler: podRuntimeHandler,
 	}
+
 	imageRef, err := m.imageService.GetImageRef(ctx, spec)
 	if err != nil {
 		msg := fmt.Sprintf("Failed to inspect image %q: %v", container.Image, err)

--- a/pkg/kubelet/images/image_manager_test.go
+++ b/pkg/kubelet/images/image_manager_test.go
@@ -28,9 +28,12 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/flowcontrol"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	crierrors "k8s.io/cri-api/pkg/errors"
+	"k8s.io/kubernetes/pkg/features"
 	. "k8s.io/kubernetes/pkg/kubelet/container"
 	ctest "k8s.io/kubernetes/pkg/kubelet/container/testing"
 	testingclock "k8s.io/utils/clock/testing"
@@ -269,7 +272,7 @@ func TestParallelPuller(t *testing.T) {
 				fakeRuntime.CalledFunctions = nil
 				fakeClock.Step(time.Second)
 
-				_, _, err := puller.EnsureImageExists(ctx, pod, container, nil, nil)
+				_, _, err := puller.EnsureImageExists(ctx, pod, container, nil, nil, "")
 				fakeRuntime.AssertCalls(expected.calls)
 				assert.Equal(t, expected.err, err)
 				assert.Equal(t, expected.shouldRecordStartedPullingTime, fakePodPullingTimeRecorder.startedPullingRecorded)
@@ -301,7 +304,7 @@ func TestSerializedPuller(t *testing.T) {
 				fakeRuntime.CalledFunctions = nil
 				fakeClock.Step(time.Second)
 
-				_, _, err := puller.EnsureImageExists(ctx, pod, container, nil, nil)
+				_, _, err := puller.EnsureImageExists(ctx, pod, container, nil, nil, "")
 				fakeRuntime.AssertCalls(expected.calls)
 				assert.Equal(t, expected.err, err)
 				assert.Equal(t, expected.shouldRecordStartedPullingTime, fakePodPullingTimeRecorder.startedPullingRecorded)
@@ -364,7 +367,7 @@ func TestPullAndListImageWithPodAnnotations(t *testing.T) {
 		fakeRuntime.ImageList = []Image{}
 		fakeClock.Step(time.Second)
 
-		_, _, err := puller.EnsureImageExists(ctx, pod, container, nil, nil)
+		_, _, err := puller.EnsureImageExists(ctx, pod, container, nil, nil, "")
 		fakeRuntime.AssertCalls(c.expected[0].calls)
 		assert.Equal(t, c.expected[0].err, err, "tick=%d", 0)
 		assert.Equal(t, c.expected[0].shouldRecordStartedPullingTime, fakePodPullingTimeRecorder.startedPullingRecorded)
@@ -375,6 +378,67 @@ func TestPullAndListImageWithPodAnnotations(t *testing.T) {
 
 		image := images[0]
 		assert.Equal(t, "missing_image:latest", image.ID, "Image ID")
+		assert.Equal(t, "", image.Spec.RuntimeHandler, "image.Spec.RuntimeHandler not empty", "ImageID", image.ID)
+
+		expectedAnnotations := []Annotation{
+			{
+				Name:  "kubernetes.io/runtimehandler",
+				Value: "handler_name",
+			}}
+		assert.Equal(t, expectedAnnotations, image.Spec.Annotations, "image spec annotations")
+	})
+}
+
+func TestPullAndListImageWithRuntimeHandlerInImageCriAPIFeatureGate(t *testing.T) {
+	runtimeHandler := "handler_name"
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "test_pod",
+			Namespace:       "test-ns",
+			UID:             "bar",
+			ResourceVersion: "42",
+			Annotations: map[string]string{
+				"kubernetes.io/runtimehandler": runtimeHandler,
+			},
+		},
+		Spec: v1.PodSpec{
+			RuntimeClassName: &runtimeHandler,
+		},
+	}
+	c := pullerTestCase{ // pull missing image
+		testName:       "test pull and list image with pod annotations",
+		containerImage: "missing_image",
+		policy:         v1.PullIfNotPresent,
+		inspectErr:     nil,
+		pullerErr:      nil,
+		expected: []pullerExpects{
+			{[]string{"GetImageRef", "PullImage"}, nil, true, true},
+		}}
+
+	useSerializedEnv := true
+	t.Run(c.testName, func(t *testing.T) {
+		defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.RuntimeClassInImageCriAPI, true)()
+		ctx := context.Background()
+		puller, fakeClock, fakeRuntime, container, fakePodPullingTimeRecorder := pullerTestEnv(t, c, useSerializedEnv, nil)
+		fakeRuntime.CalledFunctions = nil
+		fakeRuntime.ImageList = []Image{}
+		fakeClock.Step(time.Second)
+
+		_, _, err := puller.EnsureImageExists(ctx, pod, container, nil, nil, runtimeHandler)
+		fakeRuntime.AssertCalls(c.expected[0].calls)
+		assert.Equal(t, c.expected[0].err, err, "tick=%d", 0)
+		assert.Equal(t, c.expected[0].shouldRecordStartedPullingTime, fakePodPullingTimeRecorder.startedPullingRecorded)
+		assert.Equal(t, c.expected[0].shouldRecordFinishedPullingTime, fakePodPullingTimeRecorder.finishedPullingRecorded)
+
+		images, _ := fakeRuntime.ListImages(ctx)
+		assert.Equal(t, 1, len(images), "ListImages() count")
+
+		image := images[0]
+		assert.Equal(t, "missing_image:latest", image.ID, "Image ID")
+
+		// when RuntimeClassInImageCriAPI feature gate is enabled, check runtime
+		// handler information for every image in the ListImages() response
+		assert.Equal(t, runtimeHandler, image.Spec.RuntimeHandler, "runtime handler returned not as expected", "Image ID", image)
 
 		expectedAnnotations := []Annotation{
 			{
@@ -419,7 +483,7 @@ func TestMaxParallelImagePullsLimit(t *testing.T) {
 	for i := 0; i < maxParallelImagePulls; i++ {
 		wg.Add(1)
 		go func() {
-			_, _, err := puller.EnsureImageExists(ctx, pod, container, nil, nil)
+			_, _, err := puller.EnsureImageExists(ctx, pod, container, nil, nil, "")
 			assert.Nil(t, err)
 			wg.Done()
 		}()
@@ -431,7 +495,7 @@ func TestMaxParallelImagePullsLimit(t *testing.T) {
 	for i := 0; i < 2; i++ {
 		wg.Add(1)
 		go func() {
-			_, _, err := puller.EnsureImageExists(ctx, pod, container, nil, nil)
+			_, _, err := puller.EnsureImageExists(ctx, pod, container, nil, nil, "")
 			assert.Nil(t, err)
 			wg.Done()
 		}()

--- a/pkg/kubelet/images/types.go
+++ b/pkg/kubelet/images/types.go
@@ -48,7 +48,7 @@ var (
 // Implementations are expected to be thread safe.
 type ImageManager interface {
 	// EnsureImageExists ensures that image specified in `container` exists.
-	EnsureImageExists(ctx context.Context, pod *v1.Pod, container *v1.Container, pullSecrets []v1.Secret, podSandboxConfig *runtimeapi.PodSandboxConfig) (string, string, error)
+	EnsureImageExists(ctx context.Context, pod *v1.Pod, container *v1.Container, pullSecrets []v1.Secret, podSandboxConfig *runtimeapi.PodSandboxConfig, podRuntimeHandler string) (string, string, error)
 
 	// TODO(ronl): consolidating image managing and deleting operation in this interface
 }

--- a/pkg/kubelet/kuberuntime/convert_test.go
+++ b/pkg/kubelet/kuberuntime/convert_test.go
@@ -21,7 +21,10 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+	"k8s.io/kubernetes/pkg/features"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 )
 
@@ -103,27 +106,32 @@ func TestConvertToRuntimeAPIImageSpec(t *testing.T) {
 	}{
 		{
 			input: kubecontainer.ImageSpec{
-				Image:       "test",
-				Annotations: nil,
+				Image:          "test",
+				RuntimeHandler: "",
+				Annotations:    nil,
 			},
 			expected: &runtimeapi.ImageSpec{
-				Image:       "test",
-				Annotations: map[string]string{},
+				Image:          "test",
+				RuntimeHandler: "",
+				Annotations:    map[string]string{},
 			},
 		},
 		{
 			input: kubecontainer.ImageSpec{
-				Image:       "test",
-				Annotations: []kubecontainer.Annotation{},
+				Image:          "test",
+				RuntimeHandler: "",
+				Annotations:    []kubecontainer.Annotation{},
 			},
 			expected: &runtimeapi.ImageSpec{
-				Image:       "test",
-				Annotations: map[string]string{},
+				Image:          "test",
+				RuntimeHandler: "",
+				Annotations:    map[string]string{},
 			},
 		},
 		{
 			input: kubecontainer.ImageSpec{
-				Image: "test",
+				Image:          "test",
+				RuntimeHandler: "",
 				Annotations: []kubecontainer.Annotation{
 					{
 						Name:  "kubernetes.io/os",
@@ -136,7 +144,8 @@ func TestConvertToRuntimeAPIImageSpec(t *testing.T) {
 				},
 			},
 			expected: &runtimeapi.ImageSpec{
-				Image: "test",
+				Image:          "test",
+				RuntimeHandler: "",
 				Annotations: map[string]string{
 					"kubernetes.io/os":             "linux",
 					"kubernetes.io/runtimehandler": "handler",
@@ -146,6 +155,145 @@ func TestConvertToRuntimeAPIImageSpec(t *testing.T) {
 	}
 
 	for _, test := range testCases {
+		actual := toRuntimeAPIImageSpec(test.input)
+		assert.Equal(t, test.expected, actual)
+	}
+}
+
+func TestConvertToKubeContainerImageSpecWithRuntimeHandlerInImageSpecCri(t *testing.T) {
+	testCases := []struct {
+		input    *runtimeapi.Image
+		expected kubecontainer.ImageSpec
+	}{
+		{
+			input: &runtimeapi.Image{
+				Id:   "test",
+				Spec: nil,
+			},
+			expected: kubecontainer.ImageSpec{
+				Image:          "test",
+				RuntimeHandler: "",
+				Annotations:    []kubecontainer.Annotation(nil),
+			},
+		},
+		{
+			input: &runtimeapi.Image{
+				Id: "test",
+				Spec: &runtimeapi.ImageSpec{
+					Annotations: nil,
+				},
+			},
+			expected: kubecontainer.ImageSpec{
+				Image:          "test",
+				RuntimeHandler: "",
+				Annotations:    []kubecontainer.Annotation(nil),
+			},
+		},
+		{
+			input: &runtimeapi.Image{
+				Id: "test",
+				Spec: &runtimeapi.ImageSpec{
+					Annotations: map[string]string{},
+				},
+			},
+			expected: kubecontainer.ImageSpec{
+				Image:          "test",
+				RuntimeHandler: "",
+				Annotations:    []kubecontainer.Annotation(nil),
+			},
+		},
+		{
+			input: &runtimeapi.Image{
+				Id: "test",
+				Spec: &runtimeapi.ImageSpec{
+					RuntimeHandler: "test-runtimeHandler",
+					Annotations: map[string]string{
+						"kubernetes.io/os":             "linux",
+						"kubernetes.io/runtimehandler": "handler",
+					},
+				},
+			},
+			expected: kubecontainer.ImageSpec{
+				Image:          "test",
+				RuntimeHandler: "test-runtimeHandler",
+				Annotations: []kubecontainer.Annotation{
+					{
+						Name:  "kubernetes.io/os",
+						Value: "linux",
+					},
+					{
+						Name:  "kubernetes.io/runtimehandler",
+						Value: "handler",
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range testCases {
+		defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.RuntimeClassInImageCriAPI, true)()
+		actual := toKubeContainerImageSpec(test.input)
+		assert.Equal(t, test.expected, actual)
+	}
+}
+
+func TestConvertToRuntimeAPIImageSpecWithRuntimeHandlerInImageSpecCri(t *testing.T) {
+	testCases := []struct {
+		input    kubecontainer.ImageSpec
+		expected *runtimeapi.ImageSpec
+	}{
+		{
+			input: kubecontainer.ImageSpec{
+				Image:          "test",
+				RuntimeHandler: "",
+				Annotations:    nil,
+			},
+			expected: &runtimeapi.ImageSpec{
+				Image:          "test",
+				RuntimeHandler: "",
+				Annotations:    map[string]string{},
+			},
+		},
+		{
+			input: kubecontainer.ImageSpec{
+				Image:          "test",
+				RuntimeHandler: "",
+				Annotations:    []kubecontainer.Annotation{},
+			},
+			expected: &runtimeapi.ImageSpec{
+				Image:          "test",
+				RuntimeHandler: "",
+				Annotations:    map[string]string{},
+			},
+		},
+		{
+			input: kubecontainer.ImageSpec{
+				Image:          "test",
+				RuntimeHandler: "test-runtimeHandler",
+				Annotations: []kubecontainer.Annotation{
+					{
+						Name:  "kubernetes.io/os",
+						Value: "linux",
+					},
+					{
+						Name:  "kubernetes.io/runtimehandler",
+						Value: "handler",
+					},
+				},
+			},
+			expected: &runtimeapi.ImageSpec{
+				Image:          "test",
+				RuntimeHandler: "test-runtimeHandler",
+				Annotations: map[string]string{
+					"kubernetes.io/os":             "linux",
+					"kubernetes.io/runtimehandler": "handler",
+				},
+			},
+		},
+	}
+
+	for _, test := range testCases {
+		defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.RuntimeClassInImageCriAPI, true)()
 		actual := toRuntimeAPIImageSpec(test.input)
 		assert.Equal(t, test.expected, actual)
 	}

--- a/pkg/kubelet/kuberuntime/helpers.go
+++ b/pkg/kubelet/kuberuntime/helpers.go
@@ -97,6 +97,7 @@ func (m *kubeGenericRuntimeManager) toKubeContainer(c *runtimeapi.Container) (*k
 		ID:                   kubecontainer.ContainerID{Type: m.runtimeName, ID: c.Id},
 		Name:                 c.GetMetadata().GetName(),
 		ImageID:              c.ImageRef,
+		ImageRuntimeHandler:  c.Image.RuntimeHandler,
 		Image:                c.Image.Image,
 		Hash:                 annotatedInfo.Hash,
 		HashWithoutResources: annotatedInfo.HashWithoutResources,

--- a/pkg/kubelet/kuberuntime/kuberuntime_image.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_image.go
@@ -21,9 +21,11 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/klog/v2"
 	credentialprovidersecrets "k8s.io/kubernetes/pkg/credentialprovider/secrets"
+	"k8s.io/kubernetes/pkg/features"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/util/parsers"
 )
@@ -105,6 +107,17 @@ func (m *kubeGenericRuntimeManager) ListImages(ctx context.Context) ([]kubeconta
 	}
 
 	for _, img := range allImages {
+		// Container runtimes may choose not to implement changes needed for KEP 4216. If
+		// the changes are not implemented by a container runtime, the exisiting behavior
+		// of not populating the runtimeHandler CRI field in ImageSpec struct is preserved.
+		// Therefore, when RuntimeClassInImageCriAPI feature gate is set, check to see if this
+		// field is empty and log a warning message.
+		if utilfeature.DefaultFeatureGate.Enabled(features.RuntimeClassInImageCriAPI) {
+			if img.Spec == nil || (img.Spec != nil && img.Spec.RuntimeHandler == "") {
+				klog.V(2).InfoS("WARNING: RuntimeHandler is empty", "ImageID", img.Id)
+			}
+		}
+
 		images = append(images, kubecontainer.Image{
 			ID:          img.Id,
 			Size:        int64(img.Size_),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Add changes for alpha release of Image pull per runtime class feature described in KEP 4216: https://github.com/kubernetes/enhancements/issues/4216
  - Adds feature gate "RuntimeClassInImageCriApi" and necessary related alpha changes

#### Which issue(s) this PR fixes:

Add changes for alpha release of Image pull per runtime class feature described in KEP 4216: https://github.com/kubernetes/enhancements/issues/4216
  - Adds feature gate "RuntimeClassInImageCriApi" and necessary related alpha changes
  
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
NONE 

```release-note
Added new feature gate called "RuntimeClassInImageCriApi" to address kubelet changes needed for KEP 4216.
Noteable changes:
1. Populate new RuntimeHandler field in CRI's ImageSpec struct during image pulls from container runtimes.
2. Pass runtimeHandler field in RemoveImage() call to container runtime in kubelet's image garbage collection
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:


```docs

- [KEP]: https://github.com/kubernetes/enhancements/commit/5d2744011e205f6d759bac6ab316a085bec2a605

```
