### PR TITLE
allow empty object to be CEL value.

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/cel/openapi/values_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/openapi/values_test.go
@@ -97,6 +97,9 @@ var (
 			Type:                 []string{"object"},
 			AdditionalProperties: &spec.SchemaOrBool{Schema: stringSchema},
 		}}
+	emptyObjectSchema = &spec.Schema{
+		SchemaProps: spec.SchemaProps{Type: []string{"object"}},
+	}
 )
 
 func TestEquality(t *testing.T) {
@@ -330,6 +333,12 @@ func TestEquality(t *testing.T) {
 			lhs:   UnstructuredToVal([]interface{}{"a", "b"}, atomicListSchema),
 			rhs:   UnstructuredToVal([]interface{}{"a", "b", "c"}, atomicListSchema),
 			equal: false,
+		},
+		{
+			name:  "empty objects are equal",
+			lhs:   UnstructuredToVal(map[string]interface{}{}, emptyObjectSchema),
+			rhs:   UnstructuredToVal(map[string]interface{}{}, emptyObjectSchema),
+			equal: true,
 		},
 		{
 			name:  "identical objects are equal",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR handles the case where a openAPIV3Schema has neither Properties or AdditionalProperties set.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #120226

#### Special notes for your reviewer:
This PR does not change how the value system handles unstructure maps (additionalProperties == true, and without schema), or the behavior of `x-kubernetes-preserve-unknown-fields`.

additionalProperties == false is not allowed in CRDs. [1]

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
CEL can now correctly handle a CRD openAPIV3Schema that has neither Properties nor AdditionalProperties.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [1]: https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#validation
```
