### PR TITLE
kubeadm: cleanup UnknownCRISocket

### DIFF
--- a/cmd/kubeadm/app/cmd/init_test.go
+++ b/cmd/kubeadm/app/cmd/init_test.go
@@ -81,7 +81,7 @@ func TestNewInitData(t *testing.T) {
 	}{
 		// Init data passed using flags
 		{
-			name: "pass without any flag except the cri socket (use defaults)",
+			name: "pass without any flag (use defaults)",
 		},
 		{
 			name: "fail if unknown feature gates flag are passed",
@@ -188,17 +188,9 @@ func TestNewInitData(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			// initialize an external init option and inject it to the init cmd
 			initOptions := newInitOptions()
+			initOptions.skipCRIDetect = true // avoid CRI detection in unit tests
 			cmd := newCmdInit(nil, initOptions)
 
-			// set the cri socket here, otherwise the testcase might fail if is run on the node with multiple
-			// cri endpoints configured, the failure caused by this is normally not an expected failure.
-			if tc.flags == nil {
-				tc.flags = make(map[string]string)
-			}
-			// set `cri-socket` only if `CfgPath` is not set
-			if _, okay := tc.flags[options.CfgPath]; !okay {
-				tc.flags[options.NodeCRISocket] = constants.UnknownCRISocket
-			}
 			// sets cmd flags (that will be reflected on the init options)
 			for f, v := range tc.flags {
 				cmd.Flags().Set(f, v)

--- a/cmd/kubeadm/app/cmd/join_test.go
+++ b/cmd/kubeadm/app/cmd/join_test.go
@@ -35,7 +35,6 @@ import (
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	kubeadmapiv1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta3"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/options"
-	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	kubeconfigutil "k8s.io/kubernetes/cmd/kubeadm/app/util/kubeconfig"
 )
 
@@ -312,6 +311,7 @@ func TestNewJoinData(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			// initialize an external join option and inject it to the join cmd
 			joinOptions := newJoinOptions()
+			joinOptions.skipCRIDetect = true // avoid CRI detection in unit tests
 			cmd := newCmdJoin(nil, joinOptions)
 
 			// set klog output destination to bytes.Buffer so that log could be fetched and verified later.
@@ -320,15 +320,6 @@ func TestNewJoinData(t *testing.T) {
 			klog.LogToStderr(false)
 			defer klog.LogToStderr(true)
 
-			// set the cri socket here, otherwise the testcase might fail if is run on the node with multiple
-			// cri endpoints configured, the failure caused by this is normally not an expected failure.
-			if tc.flags == nil {
-				tc.flags = make(map[string]string)
-			}
-			// set `cri-socket` only if `CfgPath` is not set
-			if _, okay := tc.flags[options.CfgPath]; !okay {
-				tc.flags[options.NodeCRISocket] = constants.UnknownCRISocket
-			}
 			// sets cmd flags (that will be reflected on the join options)
 			for f, v := range tc.flags {
 				cmd.Flags().Set(f, v)

--- a/cmd/kubeadm/app/cmd/upgrade/diff.go
+++ b/cmd/kubeadm/app/cmd/upgrade/diff.go
@@ -111,7 +111,9 @@ func runDiff(flags *diffFlags, args []string) error {
 	var err error
 	var cfg *kubeadmapi.InitConfiguration
 	if flags.cfgPath != "" {
-		cfg, err = configutil.LoadInitConfigurationFromFile(flags.cfgPath, configutil.LoadOrDefaultConfigurationOptions{})
+		cfg, err = configutil.LoadInitConfigurationFromFile(flags.cfgPath, configutil.LoadOrDefaultConfigurationOptions{
+			SkipCRIDetect: true,
+		})
 	} else {
 		var client *client.Clientset
 		client, err = kubeconfigutil.ClientSetFromFile(flags.kubeConfigPath)

--- a/cmd/kubeadm/app/cmd/upgrade/diff_test.go
+++ b/cmd/kubeadm/app/cmd/upgrade/diff_test.go
@@ -49,12 +49,10 @@ func TestRunDiff(t *testing.T) {
 	testUpgradeDiffConfigContents := []byte(fmt.Sprintf(`
 apiVersion: %s
 kind: InitConfiguration
-nodeRegistration:
-  criSocket: %s
 ---
 apiVersion: %[1]s
 kind: ClusterConfiguration
-kubernetesVersion: %[3]s`, kubeadmapiv1.SchemeGroupVersion.String(), constants.UnknownCRISocket, currentVersion))
+kubernetesVersion: %s`, kubeadmapiv1.SchemeGroupVersion.String(), currentVersion))
 	testUpgradeDiffConfig, err := createTestRunDiffFile(testUpgradeDiffConfigContents)
 	if err != nil {
 		t.Fatal(err)

--- a/cmd/kubeadm/app/constants/constants.go
+++ b/cmd/kubeadm/app/constants/constants.go
@@ -261,9 +261,6 @@ const (
 	// init/join time for use later. kubeadm annotates the node object with this information
 	AnnotationKubeadmCRISocket = "kubeadm.alpha.kubernetes.io/cri-socket"
 
-	// UnknownCRISocket defines the undetected or unknown CRI socket
-	UnknownCRISocket = "unix:///var/run/unknown.sock"
-
 	// KubeadmConfigConfigMap specifies in what ConfigMap in the kube-system namespace the `kubeadm init` configuration should be stored
 	KubeadmConfigConfigMap = "kubeadm-config"
 

--- a/cmd/kubeadm/app/phases/uploadconfig/uploadconfig_test.go
+++ b/cmd/kubeadm/app/phases/uploadconfig/uploadconfig_test.go
@@ -56,7 +56,7 @@ func TestUploadConfiguration(t *testing.T) {
 			cfg.ComponentConfigs = kubeadmapi.ComponentConfigMap{}
 			cfg.ClusterConfiguration.KubernetesVersion = kubeadmconstants.MinimumControlPlaneVersion.WithPatch(10).String()
 			cfg.NodeRegistration.Name = "node-foo"
-			cfg.NodeRegistration.CRISocket = kubeadmconstants.UnknownCRISocket
+			cfg.NodeRegistration.CRISocket = kubeadmconstants.DefaultCRISocket
 
 			client := clientsetfake.NewSimpleClientset()
 			// For idempotent test, we check the result of the second call.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
- skip CRI detection for `kubeadm upgrade diff` (CRI socket is not used at all)
- cleanup `UnknownCRISocket` for unit tests
- remove unused constant `UnknownCRISocket`

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Ref #117614

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
