### PR TITLE
verify-golangci-lint.sh: clarify intended usage of warnings

### DIFF
--- a/hack/verify-golangci-lint.sh
+++ b/hack/verify-golangci-lint.sh
@@ -199,18 +199,30 @@ else
     echo 'If the above warnings do not make sense, you can exempt this warning with a comment'
     echo ' (if your reviewer is okay with it).'
     if [ "$strict" ]; then
-        echo 'The more strict golangci-strict.yaml was used.'
+        echo
+        echo 'golangci-strict.yaml was used as configuration. Warnings must be fixed in'
+        echo 'new or modified code.'
     elif [ "$hints" ]; then
-        echo 'The golangci-hints.yaml was used. Some of the reported issues may have to be fixed'
-        echo 'while others can be ignored, depending on the circumstances and/or personal'
-        echo 'preferences. To determine which issues have to be fixed, check the report that'
-        echo 'uses golangci-strict.yaml.'
+        echo
+        echo 'golangci-hints.yaml was used as configuration. Some of the reported issues may'
+        echo 'have to be fixed while others can be ignored, depending on the circumstances'
+        echo 'and/or personal preferences. To determine which issues have to be fixed, check'
+        echo 'the report that uses golangci-strict.yaml (= pull-kubernetes-verify-lint).'
     fi
     if [ "$strict" ] || [ "$hints" ]; then
+        echo
         echo 'If you feel that this warns about issues that should be ignored by default,'
         echo 'then please discuss with your reviewer and propose'
         echo 'a change for hack/golangci.yaml.in as part of your PR.'
+        echo
+        echo 'Please do not create PRs which fix these issues in existing code just'
+        echo 'because the linter warns about them. Often they are harmless and not'
+        echo 'worth the cost associated with a PR (time required to review, code churn).'
+        echo 'Instead, propose to fix certain linter issues in an issue first and'
+        echo 'discuss there with maintainers. PRs are welcome if they address a real'
+        echo 'problem, which then needs to be explained in the PR.'
     fi
+    echo
     echo 'In general please prefer to fix the error, we have already disabled specific lints'
     echo ' that the project chooses to ignore.'
     echo 'See: https://golangci-lint.run/usage/false-positives/'


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Contributors have created PRs because the linter found issues. That is often not necessary and should be discussed before working on a PR.

While at it, output formatting gets updated a bit (extra blank lines, wording).

#### Does this PR introduce a user-facing change?
```release-note
NONE
```