### PR TITLE
feat: add job_pods_creation_total metric

### DIFF
--- a/pkg/controller/job/metrics/metrics.go
+++ b/pkg/controller/job/metrics/metrics.go
@@ -125,6 +125,24 @@ The event label can be "add" or "delete".`,
 			backoffLimit label are: "perIndex" and "global"`,
 		},
 		[]string{"status", "backoffLimit"})
+
+	// JobPodsCreationTotal records the number of pods created by the job controller
+	// based on the reason for their creation (i.e. if PodReplacementPolicy was specified)
+	// and the status of the creation (i.e. if the Pod creation succeeded or failed).
+	// Possible label values:
+	//   reason: new, recreate_terminating_or_failed, recreate_failed
+	//   status: succeeded, failed
+	JobPodsCreationTotal = metrics.NewCounterVec(
+		&metrics.CounterOpts{
+			Subsystem: JobControllerSubsystem,
+			Name:      "job_pods_creation_total",
+			Help: `The number of Pods created by the Job controller labelled with a reason for the Pod creation.
+This metric also distinguishes between Pods created using different PodReplacementPolicy settings.
+Possible values of the "reason" label are:
+"new", "recreate_terminating_or_failed", "recreate_failed".
+Possible values of the "status" label are:
+"succeeded", "failed".`,
+		}, []string{"reason", "status"})
 )
 
 const (
@@ -147,7 +165,7 @@ const (
 	// parallelism.
 	JobSyncActionPodsDeleted = "pods_deleted"
 
-	// Possible values for "result" label in the above metrics.
+	// Possible values for "result" and "status" (job_pods_creation_total) labels in the above metrics.
 
 	Succeeded = "succeeded"
 	Failed    = "failed"
@@ -156,6 +174,12 @@ const (
 	// metric.
 	Add    = "add"
 	Delete = "delete"
+
+	// Possible values for "reason" label in the job_pods_creation_total metric.
+
+	PodCreateNew                   = "new"
+	PodRecreateTerminatingOrFailed = "recreate_terminating_or_failed"
+	PodRecreateFailed              = "recreate_failed"
 )
 
 var registerMetrics sync.Once
@@ -170,5 +194,6 @@ func Register() {
 		legacyregistry.MustRegister(PodFailuresHandledByFailurePolicy)
 		legacyregistry.MustRegister(TerminatedPodsTrackingFinalizerTotal)
 		legacyregistry.MustRegister(JobFinishedIndexesTotal)
+		legacyregistry.MustRegister(JobPodsCreationTotal)
 	})
 }

--- a/test/integration/job/job_test.go
+++ b/test/integration/job/job_test.go
@@ -82,6 +82,7 @@ func TestMetricsOnSuccesses(t *testing.T) {
 		job                       *batchv1.Job
 		wantJobFinishedNumMetric  metricLabelsWithValue
 		wantJobPodsFinishedMetric metricLabelsWithValue
+		wantJobPodsCreatedMetric  metricLabelsWithValue
 	}{
 		"non-indexed job": {
 			job: &batchv1.Job{
@@ -99,6 +100,10 @@ func TestMetricsOnSuccesses(t *testing.T) {
 				Labels: []string{"NonIndexed", "succeeded"},
 				Value:  2,
 			},
+			wantJobPodsCreatedMetric: metricLabelsWithValue{
+				Labels: []string{"new", "succeeded"},
+				Value:  2,
+			},
 		},
 		"indexed job": {
 			job: &batchv1.Job{
@@ -114,6 +119,10 @@ func TestMetricsOnSuccesses(t *testing.T) {
 			},
 			wantJobPodsFinishedMetric: metricLabelsWithValue{
 				Labels: []string{"Indexed", "succeeded"},
+				Value:  2,
+			},
+			wantJobPodsCreatedMetric: metricLabelsWithValue{
+				Labels: []string{"new", "succeeded"},
 				Value:  2,
 			},
 		},
@@ -142,6 +151,7 @@ func TestMetricsOnSuccesses(t *testing.T) {
 			// verify metric values after the job is finished
 			validateCounterMetric(ctx, t, metrics.JobFinishedNum, tc.wantJobFinishedNumMetric)
 			validateCounterMetric(ctx, t, metrics.JobPodsFinished, tc.wantJobPodsFinishedMetric)
+			validateCounterMetric(ctx, t, metrics.JobPodsCreationTotal, tc.wantJobPodsCreatedMetric)
 			validateTerminatedPodsTrackingFinalizerMetric(ctx, t, int(*jobObj.Spec.Parallelism))
 		})
 	}
@@ -1700,11 +1710,17 @@ func TestJobPodReplacementPolicy(t *testing.T) {
 		failed      int
 		terminating *int32
 	}
+	type jobPodsCreationMetrics struct {
+		new                         int
+		recreateTerminatingOrFailed int
+		recreateFailed              int
+	}
 	cases := map[string]struct {
 		podReplacementPolicyEnabled bool
 		jobSpec                     *batchv1.JobSpec
 		wantStatusAfterDeletion     jobStatus
 		wantStatusAfterFailure      jobStatus
+		wantMetrics                 jobPodsCreationMetrics
 	}{
 		"feature flag off, delete & fail pods, recreate terminating pods, and verify job status counters": {
 			jobSpec: &batchv1.JobSpec{
@@ -1724,6 +1740,9 @@ func TestJobPodReplacementPolicy(t *testing.T) {
 			wantStatusAfterFailure: jobStatus{
 				active: 2,
 				failed: 2,
+			},
+			wantMetrics: jobPodsCreationMetrics{
+				new: 4,
 			},
 		},
 		"feature flag true, TerminatingOrFailed policy, delete & fail pods, recreate terminating pods, and verify job status counters": {
@@ -1749,6 +1768,10 @@ func TestJobPodReplacementPolicy(t *testing.T) {
 				failed:      2,
 				terminating: ptr.To[int32](0),
 			},
+			wantMetrics: jobPodsCreationMetrics{
+				new:                         2,
+				recreateTerminatingOrFailed: 2,
+			},
 		},
 		"feature flag true with NonIndexedJob, TerminatingOrFailed policy, delete & fail pods, recreate terminating pods, and verify job status counters": {
 			podReplacementPolicyEnabled: true,
@@ -1772,6 +1795,10 @@ func TestJobPodReplacementPolicy(t *testing.T) {
 				active:      2,
 				failed:      2,
 				terminating: ptr.To[int32](0),
+			},
+			wantMetrics: jobPodsCreationMetrics{
+				new:                         2,
+				recreateTerminatingOrFailed: 2,
 			},
 		},
 		"feature flag false, podFailurePolicy enabled, delete & fail pods, recreate failed pods, and verify job status counters": {
@@ -1804,6 +1831,9 @@ func TestJobPodReplacementPolicy(t *testing.T) {
 			wantStatusAfterFailure: jobStatus{
 				active: 2,
 			},
+			wantMetrics: jobPodsCreationMetrics{
+				new: 2,
+			},
 		},
 		"feature flag true, Failed policy, delete & fail pods, recreate failed pods, and verify job status counters": {
 			podReplacementPolicyEnabled: true,
@@ -1828,6 +1858,10 @@ func TestJobPodReplacementPolicy(t *testing.T) {
 				failed:      2,
 				terminating: ptr.To[int32](0),
 			},
+			wantMetrics: jobPodsCreationMetrics{
+				new:            2,
+				recreateFailed: 2,
+			},
 		},
 		"feature flag true with NonIndexedJob, Failed policy, delete & fail pods, recreate failed pods, and verify job status counters": {
 			podReplacementPolicyEnabled: true,
@@ -1851,6 +1885,10 @@ func TestJobPodReplacementPolicy(t *testing.T) {
 				active:      2,
 				failed:      2,
 				terminating: ptr.To[int32](0),
+			},
+			wantMetrics: jobPodsCreationMetrics{
+				new:            2,
+				recreateFailed: 2,
 			},
 		},
 	}
@@ -1887,13 +1925,31 @@ func TestJobPodReplacementPolicy(t *testing.T) {
 			})
 
 			failTerminatingPods(ctx, t, clientSet, ns.Name)
-
 			validateJobsPodsStatusOnly(ctx, t, clientSet, jobObj, podsByStatus{
 				Terminating: tc.wantStatusAfterFailure.terminating,
 				Failed:      tc.wantStatusAfterFailure.failed,
 				Active:      tc.wantStatusAfterFailure.active,
 				Ready:       ptr.To[int32](0),
 			})
+
+			validateCounterMetric(
+				ctx,
+				t,
+				metrics.JobPodsCreationTotal,
+				metricLabelsWithValue{Labels: []string{"new", "succeeded"}, Value: tc.wantMetrics.new},
+			)
+			validateCounterMetric(
+				ctx,
+				t,
+				metrics.JobPodsCreationTotal,
+				metricLabelsWithValue{Labels: []string{"recreate_terminating_or_failed", "succeeded"}, Value: tc.wantMetrics.recreateTerminatingOrFailed},
+			)
+			validateCounterMetric(
+				ctx,
+				t,
+				metrics.JobPodsCreationTotal,
+				metricLabelsWithValue{Labels: []string{"recreate_failed", "succeeded"}, Value: tc.wantMetrics.recreateFailed},
+			)
 		})
 	}
 }
@@ -3002,6 +3058,7 @@ func resetMetrics() {
 	metrics.JobPodsFinished.Reset()
 	metrics.PodFailuresHandledByFailurePolicy.Reset()
 	metrics.JobFinishedIndexesTotal.Reset()
+	metrics.JobPodsCreationTotal.Reset()
 }
 
 func createJobControllerWithSharedInformers(tb testing.TB, restConfig *restclient.Config, informerSet informers.SharedInformerFactory) (*jobcontroller.Controller, context.Context, context.CancelFunc) {

--- a/test/integration/job/job_test.go
+++ b/test/integration/job/job_test.go
@@ -82,7 +82,6 @@ func TestMetricsOnSuccesses(t *testing.T) {
 		job                       *batchv1.Job
 		wantJobFinishedNumMetric  metricLabelsWithValue
 		wantJobPodsFinishedMetric metricLabelsWithValue
-		wantJobPodsCreatedMetric  metricLabelsWithValue
 	}{
 		"non-indexed job": {
 			job: &batchv1.Job{
@@ -100,10 +99,6 @@ func TestMetricsOnSuccesses(t *testing.T) {
 				Labels: []string{"NonIndexed", "succeeded"},
 				Value:  2,
 			},
-			wantJobPodsCreatedMetric: metricLabelsWithValue{
-				Labels: []string{"new", "succeeded"},
-				Value:  2,
-			},
 		},
 		"indexed job": {
 			job: &batchv1.Job{
@@ -119,10 +114,6 @@ func TestMetricsOnSuccesses(t *testing.T) {
 			},
 			wantJobPodsFinishedMetric: metricLabelsWithValue{
 				Labels: []string{"Indexed", "succeeded"},
-				Value:  2,
-			},
-			wantJobPodsCreatedMetric: metricLabelsWithValue{
-				Labels: []string{"new", "succeeded"},
 				Value:  2,
 			},
 		},
@@ -151,7 +142,6 @@ func TestMetricsOnSuccesses(t *testing.T) {
 			// verify metric values after the job is finished
 			validateCounterMetric(ctx, t, metrics.JobFinishedNum, tc.wantJobFinishedNumMetric)
 			validateCounterMetric(ctx, t, metrics.JobPodsFinished, tc.wantJobPodsFinishedMetric)
-			validateCounterMetric(ctx, t, metrics.JobPodsCreationTotal, tc.wantJobPodsCreatedMetric)
 			validateTerminatedPodsTrackingFinalizerMetric(ctx, t, int(*jobObj.Spec.Parallelism))
 		})
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
/sig apps

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Adds job_pods_creation_total metric which tracks Pods created by Job controller based on creation event (i.e. specified PodReplacementPolicy(

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of [kubernetes/enhancements#3939](https://github.com/kubernetes/enhancements/issues/3939)

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Add job_pods_creation_total metrics for tracking Pods created by the Job controller labeled by events which triggered the Pod creation
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/3939
```
