### PR TITLE
1.26 Cherry pick of #120492: service controller: improve node lifecycle updates - update

### DIFF
--- a/pkg/controller/disruption/disruption.go
+++ b/pkg/controller/disruption/disruption.go
@@ -35,7 +35,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
-	corev1apply "k8s.io/client-go/applyconfigurations/core/v1"
 	"k8s.io/client-go/discovery"
 	appsv1informers "k8s.io/client-go/informers/apps/v1"
 	coreinformers "k8s.io/client-go/informers/core/v1"
@@ -75,9 +74,6 @@ const (
 	// Once the timeout is reached, this controller attempts to set the status
 	// of the condition to False.
 	stalePodDisruptionTimeout = 2 * time.Minute
-
-	// field manager used to disable the pod failure condition
-	fieldManager = "DisruptionController"
 )
 
 type updater func(context.Context, *policy.PodDisruptionBudget) error
@@ -751,16 +747,15 @@ func (dc *DisruptionController) syncStalePodDisruption(ctx context.Context, key 
 		return nil
 	}
 
-	podApply := corev1apply.Pod(pod.Name, pod.Namespace).
-		WithStatus(corev1apply.PodStatus()).
-		WithResourceVersion(pod.ResourceVersion)
-	podApply.Status.WithConditions(corev1apply.PodCondition().
-		WithType(v1.DisruptionTarget).
-		WithStatus(v1.ConditionFalse).
-		WithLastTransitionTime(metav1.Now()),
-	)
-
-	if _, err := dc.kubeClient.CoreV1().Pods(pod.Namespace).ApplyStatus(ctx, podApply, metav1.ApplyOptions{FieldManager: fieldManager, Force: true}); err != nil {
+	newPod := pod.DeepCopy()
+	updated := apipod.UpdatePodCondition(&newPod.Status, &v1.PodCondition{
+		Type:   v1.DisruptionTarget,
+		Status: v1.ConditionFalse,
+	})
+	if !updated {
+		return nil
+	}
+	if _, err := dc.kubeClient.CoreV1().Pods(pod.Namespace).UpdateStatus(ctx, newPod, metav1.UpdateOptions{}); err != nil {
 		return err
 	}
 	klog.V(2).InfoS("Reset stale DisruptionTarget condition to False", "pod", klog.KObj(pod))

--- a/pkg/controller/nodelifecycle/scheduler/taint_manager.go
+++ b/pkg/controller/nodelifecycle/scheduler/taint_manager.go
@@ -31,16 +31,17 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apiserver/pkg/util/feature"
-	corev1apply "k8s.io/client-go/applyconfigurations/core/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
 	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
+	apipod "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/apis/core/helper"
 	v1helper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
 	"k8s.io/kubernetes/pkg/features"
+	utilpod "k8s.io/kubernetes/pkg/util/pod"
 
 	"k8s.io/klog/v2"
 )
@@ -55,9 +56,6 @@ const (
 	UpdateWorkerSize     = 8
 	podUpdateChannelSize = 1
 	retries              = 5
-
-	// fieldManager used to add pod disruption condition when evicting pods due to NoExecute taint
-	fieldManager = "TaintManager"
 )
 
 type nodeUpdateItem struct {
@@ -127,16 +125,17 @@ func addConditionAndDeletePod(ctx context.Context, c clientset.Interface, name, 
 		if err != nil {
 			return err
 		}
-		podApply := corev1apply.Pod(pod.Name, pod.Namespace).WithStatus(corev1apply.PodStatus())
-		podApply.Status.WithConditions(corev1apply.PodCondition().
-			WithType(v1.DisruptionTarget).
-			WithStatus(v1.ConditionTrue).
-			WithReason("DeletionByTaintManager").
-			WithMessage("Taint manager: deleting due to NoExecute taint").
-			WithLastTransitionTime(metav1.Now()),
-		)
-		if _, err := c.CoreV1().Pods(pod.Namespace).ApplyStatus(ctx, podApply, metav1.ApplyOptions{FieldManager: fieldManager, Force: true}); err != nil {
-			return err
+		newStatus := pod.Status.DeepCopy()
+		updated := apipod.UpdatePodCondition(newStatus, &v1.PodCondition{
+			Type:    v1.DisruptionTarget,
+			Status:  v1.ConditionTrue,
+			Reason:  "DeletionByTaintManager",
+			Message: "Taint manager: deleting due to NoExecute taint",
+		})
+		if updated {
+			if _, _, _, err := utilpod.PatchPodStatus(ctx, c, pod.Namespace, pod.Name, pod.UID, pod.Status, *newStatus); err != nil {
+				return err
+			}
 		}
 	}
 	return c.CoreV1().Pods(ns).Delete(ctx, name, metav1.DeleteOptions{})

--- a/pkg/controller/podgc/gc_controller_test.go
+++ b/pkg/controller/podgc/gc_controller_test.go
@@ -18,14 +18,17 @@ package podgc
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"k8s.io/apimachinery/pkg/util/wait"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/informers"
@@ -36,10 +39,12 @@ import (
 	"k8s.io/client-go/util/workqueue"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	metricstestutil "k8s.io/component-base/metrics/testutil"
+	"k8s.io/klog/v2/ktesting"
 	"k8s.io/kubernetes/pkg/controller"
 	"k8s.io/kubernetes/pkg/controller/testutil"
 	"k8s.io/kubernetes/pkg/features"
 	testingclock "k8s.io/utils/clock/testing"
+	"k8s.io/utils/pointer"
 )
 
 func alwaysReady() bool { return true }
@@ -635,6 +640,128 @@ func TestGCTerminating(t *testing.T) {
 	}
 	// deletingPodsTotal is 7 in this test
 	testDeletingPodsMetrics(t, 7)
+}
+
+func TestGCInspectingPatchedPodBeforeDeletion(t *testing.T) {
+	testCases := []struct {
+		name                 string
+		pod                  *v1.Pod
+		expectedPatchedPod   *v1.Pod
+		expectedDeleteAction *clienttesting.DeleteActionImpl
+	}{
+		{
+			name: "orphaned pod should have DisruptionTarget condition added before deletion",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "testPod",
+				},
+				Spec: v1.PodSpec{
+					NodeName: "deletedNode",
+				},
+				Status: v1.PodStatus{
+					Phase: v1.PodRunning,
+					Conditions: []v1.PodCondition{
+						{
+							Type:   v1.PodReady,
+							Status: v1.ConditionTrue,
+						},
+					},
+				},
+			},
+			expectedPatchedPod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "testPod",
+				},
+				Spec: v1.PodSpec{
+					NodeName: "deletedNode",
+				},
+				Status: v1.PodStatus{
+					Phase: v1.PodFailed,
+					Conditions: []v1.PodCondition{
+						{
+							Type:   v1.PodReady,
+							Status: v1.ConditionTrue,
+						},
+						{
+							Type:    v1.DisruptionTarget,
+							Status:  v1.ConditionTrue,
+							Reason:  "DeletionByPodGC",
+							Message: "PodGC: node no longer exists",
+						},
+					},
+				},
+			},
+			expectedDeleteAction: &clienttesting.DeleteActionImpl{
+				Name:          "testPod",
+				DeleteOptions: metav1.DeleteOptions{GracePeriodSeconds: pointer.Int64(0)},
+			},
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			_, ctx := ktesting.NewTestContext(t)
+			defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.PodDisruptionConditions, true)()
+
+			pods := []*v1.Pod{test.pod}
+
+			client := setupNewSimpleClient(nil, pods)
+			gcc, podInformer, _ := NewFromClient(client, -1)
+			gcc.quarantineTime = time.Duration(-1)
+			podInformer.Informer().GetStore().Add(test.pod)
+			gcc.gc(ctx)
+
+			actions := client.Actions()
+
+			var patchAction clienttesting.PatchAction
+			var deleteAction clienttesting.DeleteAction
+
+			for _, action := range actions {
+				if action.GetVerb() == "patch" {
+					patchAction = action.(clienttesting.PatchAction)
+				}
+
+				if action.GetVerb() == "delete" {
+					deleteAction = action.(clienttesting.DeleteAction)
+				}
+			}
+
+			if patchAction != nil && test.expectedPatchedPod == nil {
+				t.Fatalf("Pod was pactched but expectedPatchedPod is nil")
+			}
+			if test.expectedPatchedPod != nil {
+				patchedPodBytes := patchAction.GetPatch()
+				originalPod, err := json.Marshal(test.pod)
+				if err != nil {
+					t.Fatalf("Failed to marshal original pod %#v: %v", originalPod, err)
+				}
+				updated, err := strategicpatch.StrategicMergePatch(originalPod, patchedPodBytes, v1.Pod{})
+				if err != nil {
+					t.Fatalf("Failed to apply strategic merge patch %q on pod %#v: %v", patchedPodBytes, originalPod, err)
+				}
+
+				updatedPod := &v1.Pod{}
+				if err := json.Unmarshal(updated, updatedPod); err != nil {
+					t.Fatalf("Failed to unmarshal updated pod %q: %v", updated, err)
+				}
+
+				if diff := cmp.Diff(test.expectedPatchedPod, updatedPod, cmpopts.IgnoreFields(v1.Pod{}, "TypeMeta"), cmpopts.IgnoreFields(v1.PodCondition{}, "LastTransitionTime")); diff != "" {
+					t.Fatalf("Unexpected diff on pod (-want,+got):\n%s", diff)
+				}
+			}
+
+			if deleteAction != nil && test.expectedDeleteAction == nil {
+				t.Fatalf("Pod was deleted but expectedDeleteAction is nil")
+			}
+			if test.expectedDeleteAction != nil {
+				if diff := cmp.Diff(*test.expectedDeleteAction, deleteAction, cmpopts.IgnoreFields(clienttesting.DeleteActionImpl{}, "ActionImpl")); diff != "" {
+					t.Fatalf("Unexpected diff on deleteAction (-want,+got):\n%s", diff)
+				}
+			}
+		})
+	}
 }
 
 func verifyDeletedAndPatchedPods(t *testing.T, client *fake.Clientset, wantDeletedPodNames, wantPatchedPodNames sets.String) {

--- a/pkg/volume/csi/csi_attacher.go
+++ b/pkg/volume/csi/csi_attacher.go
@@ -287,7 +287,9 @@ func (c *csiAttacher) MountDevice(spec *volume.Spec, devicePath string, deviceMo
 	if c.csiClient == nil {
 		c.csiClient, err = newCsiDriverClient(csiDriverName(csiSource.Driver))
 		if err != nil {
-			return errors.New(log("attacher.MountDevice failed to create newCsiDriverClient: %v", err))
+			// Treat the absence of the CSI driver as a transient error
+			// See https://github.com/kubernetes/kubernetes/issues/120268
+			return volumetypes.NewTransientOperationFailure(log("attacher.MountDevice failed to create newCsiDriverClient: %v", err))
 		}
 	}
 	csi := c.csiClient
@@ -607,7 +609,9 @@ func (c *csiAttacher) UnmountDevice(deviceMountPath string) error {
 	if c.csiClient == nil {
 		c.csiClient, err = newCsiDriverClient(csiDriverName(driverName))
 		if err != nil {
-			return errors.New(log("attacher.UnmountDevice failed to create newCsiDriverClient: %v", err))
+			// Treat the absence of the CSI driver as a transient error
+			// See https://github.com/kubernetes/kubernetes/issues/120268
+			return volumetypes.NewTransientOperationFailure(log("attacher.UnmountDevice failed to create newCsiDriverClient: %v", err))
 		}
 	}
 	csi := c.csiClient

--- a/pkg/volume/csi/csi_attacher_test.go
+++ b/pkg/volume/csi/csi_attacher_test.go
@@ -1110,6 +1110,7 @@ func TestAttacherMountDevice(t *testing.T) {
 		exitError                      error
 		spec                           *volume.Spec
 		watchTimeout                   time.Duration
+		skipClientSetup                bool
 	}{
 		{
 			testName:         "normal PV",
@@ -1250,6 +1251,20 @@ func TestAttacherMountDevice(t *testing.T) {
 			createAttachment:               true,
 			spec:                           volume.NewSpecFromPersistentVolume(makeTestPV(pvName, 10, testDriver, "test-vol1"), false),
 		},
+		{
+			testName:                "driver not specified",
+			volName:                 "test-vol1",
+			devicePath:              "path1",
+			deviceMountPath:         "path2",
+			fsGroup:                 &testFSGroup,
+			stageUnstageSet:         true,
+			createAttachment:        true,
+			populateDeviceMountPath: false,
+			spec:                    volume.NewSpecFromPersistentVolume(makeTestPV(pvName, 10, "not-found", "test-vol1"), false),
+			exitError:               transientError,
+			shouldFail:              true,
+			skipClientSetup:         true,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -1278,7 +1293,9 @@ func TestAttacherMountDevice(t *testing.T) {
 				t.Fatalf("failed to create new attacher: %v", err0)
 			}
 			csiAttacher := getCsiAttacherFromVolumeAttacher(attacher, tc.watchTimeout)
-			csiAttacher.csiClient = setupClientWithVolumeMountGroup(t, tc.stageUnstageSet, tc.driverSupportsVolumeMountGroup)
+			if !tc.skipClientSetup {
+				csiAttacher.csiClient = setupClientWithVolumeMountGroup(t, tc.stageUnstageSet, tc.driverSupportsVolumeMountGroup)
+			}
 
 			if tc.deviceMountPath != "" {
 				tc.deviceMountPath = filepath.Join(tmpDir, tc.deviceMountPath)
@@ -1343,14 +1360,13 @@ func TestAttacherMountDevice(t *testing.T) {
 						t.Errorf("failed to modify permissions after test: %v", err)
 					}
 				}
+				if tc.exitError != nil && reflect.TypeOf(tc.exitError) != reflect.TypeOf(err) {
+					t.Fatalf("expected exitError type: %v got: %v (%v)", reflect.TypeOf(tc.exitError), reflect.TypeOf(err), err)
+				}
 				return
 			}
 			if tc.shouldFail {
 				t.Errorf("test should fail, but no error occurred")
-			}
-
-			if tc.exitError != nil && reflect.TypeOf(tc.exitError) != reflect.TypeOf(err) {
-				t.Fatalf("expected exitError: %v got: %v", tc.exitError, err)
 			}
 
 			// Verify call goes through all the way
@@ -1570,6 +1586,7 @@ func TestAttacherMountDeviceWithInline(t *testing.T) {
 }
 
 func TestAttacherUnmountDevice(t *testing.T) {
+	transientError := volumetypes.NewTransientOperationFailure("")
 	testCases := []struct {
 		testName        string
 		volID           string
@@ -1579,6 +1596,8 @@ func TestAttacherUnmountDevice(t *testing.T) {
 		stageUnstageSet bool
 		shouldFail      bool
 		watchTimeout    time.Duration
+		exitError       error
+		unsetClient     bool
 	}{
 		// PV agnostic path positive test cases
 		{
@@ -1609,6 +1628,17 @@ func TestAttacherUnmountDevice(t *testing.T) {
 			jsonFile:        `{"driverName"}}`,
 			stageUnstageSet: true,
 			shouldFail:      true,
+		},
+		// Ensure that a transient error is returned if the client is not established
+		{
+			testName:        "fail with transient error, json file exists but client not found",
+			volID:           "project/zone/test-vol1",
+			deviceMountPath: "plugins/csi/" + generateSha("project/zone/test-vol1") + "/globalmount",
+			jsonFile:        `{"driverName": "unknown-driver", "volumeHandle":"project/zone/test-vol1"}`,
+			stageUnstageSet: true,
+			shouldFail:      true,
+			exitError:       transientError,
+			unsetClient:     true,
 		},
 	}
 
@@ -1657,6 +1687,11 @@ func TestAttacherUnmountDevice(t *testing.T) {
 					t.Fatalf("Failed to create PV: %v", err)
 				}
 			}
+			// Clear out the client if specified
+			// The lookup to generate a new client will fail
+			if tc.unsetClient {
+				csiAttacher.csiClient = nil
+			}
 
 			// Run
 			err := csiAttacher.UnmountDevice(tc.deviceMountPath)
@@ -1664,6 +1699,9 @@ func TestAttacherUnmountDevice(t *testing.T) {
 			if err != nil {
 				if !tc.shouldFail {
 					t.Errorf("test should not fail, but error occurred: %v", err)
+				}
+				if tc.exitError != nil && reflect.TypeOf(tc.exitError) != reflect.TypeOf(err) {
+					t.Fatalf("expected exitError type: %v got: %v (%v)", reflect.TypeOf(tc.exitError), reflect.TypeOf(err), err)
 				}
 				return
 			}

--- a/pkg/volume/csi/csi_block.go
+++ b/pkg/volume/csi/csi_block.go
@@ -319,7 +319,9 @@ func (m *csiBlockMapper) SetUpDevice() (string, error) {
 
 	csiClient, err := m.csiClientGetter.Get()
 	if err != nil {
-		return "", errors.New(log("blockMapper.SetUpDevice failed to get CSI client: %v", err))
+		// Treat the absence of the CSI driver as a transient error
+		// See https://github.com/kubernetes/kubernetes/issues/120268
+		return "", volumetypes.NewTransientOperationFailure(log("blockMapper.SetUpDevice failed to get CSI client: %v", err))
 	}
 
 	// Call NodeStageVolume
@@ -379,7 +381,9 @@ func (m *csiBlockMapper) MapPodDevice() (string, error) {
 
 	csiClient, err := m.csiClientGetter.Get()
 	if err != nil {
-		return "", errors.New(log("blockMapper.MapPodDevice failed to get CSI client: %v", err))
+		// Treat the absence of the CSI driver as a transient error
+		// See https://github.com/kubernetes/kubernetes/issues/120268
+		return "", volumetypes.NewTransientOperationFailure(log("blockMapper.MapPodDevice failed to get CSI client: %v", err))
 	}
 
 	// Call NodePublishVolume
@@ -444,7 +448,9 @@ func (m *csiBlockMapper) TearDownDevice(globalMapPath, devicePath string) error 
 
 	csiClient, err := m.csiClientGetter.Get()
 	if err != nil {
-		return errors.New(log("blockMapper.TearDownDevice failed to get CSI client: %v", err))
+		// Treat the absence of the CSI driver as a transient error
+		// See https://github.com/kubernetes/kubernetes/issues/120268
+		return volumetypes.NewTransientOperationFailure(log("blockMapper.TearDownDevice failed to get CSI client: %v", err))
 	}
 
 	// Call NodeUnstageVolume
@@ -506,7 +512,9 @@ func (m *csiBlockMapper) UnmapPodDevice() error {
 
 	csiClient, err := m.csiClientGetter.Get()
 	if err != nil {
-		return errors.New(log("blockMapper.UnmapPodDevice failed to get CSI client: %v", err))
+		// Treat the absence of the CSI driver as a transient error
+		// See https://github.com/kubernetes/kubernetes/issues/120268
+		return volumetypes.NewTransientOperationFailure(log("blockMapper.UnmapPodDevice failed to get CSI client: %v", err))
 	}
 
 	ctx, cancel := createCSIOperationContext(m.spec, csiTimeout)

--- a/pkg/volume/csi/csi_mounter.go
+++ b/pkg/volume/csi/csi_mounter.go
@@ -105,6 +105,8 @@ func (c *csiMountMgr) SetUpAt(dir string, mounterArgs volume.MounterArgs) error 
 
 	csi, err := c.csiClientGetter.Get()
 	if err != nil {
+		// Treat the absence of the CSI driver as a transient error
+		// See https://github.com/kubernetes/kubernetes/issues/120268
 		return volumetypes.NewTransientOperationFailure(log("mounter.SetUpAt failed to get CSI client: %v", err))
 	}
 
@@ -419,7 +421,9 @@ func (c *csiMountMgr) TearDownAt(dir string) error {
 	volID := c.volumeID
 	csi, err := c.csiClientGetter.Get()
 	if err != nil {
-		return errors.New(log("Unmounter.TearDownAt failed to get CSI client: %v", err))
+		// Treat the absence of the CSI driver as a transient error
+		// See https://github.com/kubernetes/kubernetes/issues/120268
+		return volumetypes.NewTransientOperationFailure(log("Unmounter.TearDownAt failed to get CSI client: %v", err))
 	}
 
 	// Could not get spec info on whether this is a migrated operation because c.spec is nil

--- a/pkg/volume/csi/csi_mounter_test.go
+++ b/pkg/volume/csi/csi_mounter_test.go
@@ -367,6 +367,7 @@ func TestMounterSetUp(t *testing.T) {
 func TestMounterSetUpSimple(t *testing.T) {
 	fakeClient := fakeclient.NewSimpleClientset()
 	plug, tmpDir := newTestPlugin(t, fakeClient)
+	transientError := volumetypes.NewTransientOperationFailure("")
 	defer os.RemoveAll(tmpDir)
 
 	testCases := []struct {
@@ -378,6 +379,8 @@ func TestMounterSetUpSimple(t *testing.T) {
 		spec                 func(string, []string) *volume.Spec
 		newMounterShouldFail bool
 		setupShouldFail      bool
+		unsetClient          bool
+		exitError            error
 	}{
 		{
 			name:            "setup with ephemeral source",
@@ -416,6 +419,21 @@ func TestMounterSetUpSimple(t *testing.T) {
 			newMounterShouldFail: true,
 			spec:                 func(fsType string, options []string) *volume.Spec { return nil },
 		},
+		{
+			name:   "setup with unknown CSI driver",
+			podUID: types.UID(fmt.Sprintf("%08X", rand.Uint64())),
+			mode:   storage.VolumeLifecyclePersistent,
+			fsType: "zfs",
+			spec: func(fsType string, options []string) *volume.Spec {
+				pvSrc := makeTestPV("pv1", 20, "unknown-driver", "vol1")
+				pvSrc.Spec.CSI.FSType = fsType
+				pvSrc.Spec.MountOptions = options
+				return volume.NewSpecFromPersistentVolume(pvSrc, false)
+			},
+			setupShouldFail: true,
+			unsetClient:     true,
+			exitError:       transientError,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -451,13 +469,26 @@ func TestMounterSetUpSimple(t *testing.T) {
 				t.Fatalf("failed to setup VolumeAttachment: %v", err)
 			}
 
+			if tc.unsetClient {
+				// Clear out the clients
+				csiMounter.csiClient = nil
+				csiMounter.csiClientGetter.csiClient = nil
+				t.Log("driver name is ", csiMounter.csiClientGetter.driverName)
+			}
+
 			// Mounter.SetUp()
 			err = csiMounter.SetUp(volume.MounterArgs{})
-			if tc.setupShouldFail && err != nil {
-				t.Log(err)
-				return
-			}
-			if !tc.setupShouldFail && err != nil {
+			if tc.setupShouldFail {
+				if err != nil {
+					if tc.exitError != nil && reflect.TypeOf(tc.exitError) != reflect.TypeOf(err) {
+						t.Fatalf("expected exitError type: %v got: %v (%v)", reflect.TypeOf(tc.exitError), reflect.TypeOf(err), err)
+					}
+					t.Log(err)
+					return
+				} else {
+					t.Error("test should fail, but no error occurred")
+				}
+			} else if err != nil {
 				t.Fatal("unexpected error:", err)
 			}
 
@@ -1062,6 +1093,64 @@ func TestUnmounterTeardown(t *testing.T) {
 		t.Error("csi server may not have received NodeUnpublishVolume call")
 	}
 
+}
+
+func TestUnmounterTeardownNoClientError(t *testing.T) {
+	transientError := volumetypes.NewTransientOperationFailure("")
+	plug, tmpDir := newTestPlugin(t, nil)
+	defer os.RemoveAll(tmpDir)
+	registerFakePlugin(testDriver, "endpoint", []string{"1.0.0"}, t)
+	pv := makeTestPV("test-pv", 10, testDriver, testVol)
+
+	// save the data file prior to unmount
+	targetDir := getTargetPath(testPodUID, pv.ObjectMeta.Name, plug.host)
+	dir := filepath.Join(targetDir, "mount")
+	if err := os.MkdirAll(dir, 0755); err != nil && !os.IsNotExist(err) {
+		t.Errorf("failed to create dir [%s]: %v", dir, err)
+	}
+
+	// do a fake local mount
+	diskMounter := util.NewSafeFormatAndMountFromHost(plug.GetPluginName(), plug.host)
+	device := "/fake/device"
+	if goruntime.GOOS == "windows" {
+		// We need disk numbers on Windows.
+		device = "1"
+	}
+	if err := diskMounter.FormatAndMount(device, dir, "testfs", nil); err != nil {
+		t.Errorf("failed to mount dir [%s]: %v", dir, err)
+	}
+
+	if err := saveVolumeData(
+		targetDir,
+		volDataFileName,
+		map[string]string{
+			volDataKey.specVolID:  pv.ObjectMeta.Name,
+			volDataKey.driverName: testDriver,
+			volDataKey.volHandle:  testVol,
+		},
+	); err != nil {
+		t.Fatalf("failed to save volume data: %v", err)
+	}
+
+	unmounter, err := plug.NewUnmounter(pv.ObjectMeta.Name, testPodUID)
+	if err != nil {
+		t.Fatalf("failed to make a new Unmounter: %v", err)
+	}
+
+	csiUnmounter := unmounter.(*csiMountMgr)
+
+	// Clear out the cached client
+	// The lookup to generate a new client will fail when it tries to query a driver with an unknown name
+	csiUnmounter.csiClientGetter.csiClient = nil
+	// Note that registerFakePlugin above will create a driver with a name of "test-driver"
+	csiUnmounter.csiClientGetter.driverName = "unknown-driver"
+
+	err = csiUnmounter.TearDownAt(dir)
+	if err == nil {
+		t.Errorf("test should fail, but no error occurred")
+	} else if reflect.TypeOf(transientError) != reflect.TypeOf(err) {
+		t.Fatalf("expected exitError type: %v got: %v (%v)", reflect.TypeOf(transientError), reflect.TypeOf(err), err)
+	}
 }
 
 func TestIsCorruptedDir(t *testing.T) {

--- a/pkg/volume/csi/expander.go
+++ b/pkg/volume/csi/expander.go
@@ -46,7 +46,9 @@ func (c *csiPlugin) NodeExpand(resizeOptions volume.NodeResizeOptions) (bool, er
 
 	csClient, err := newCsiDriverClient(csiDriverName(csiSource.Driver))
 	if err != nil {
-		return false, err
+		// Treat the absence of the CSI driver as a transient error
+		// See https://github.com/kubernetes/kubernetes/issues/120268
+		return false, volumetypes.NewTransientOperationFailure(err.Error())
 	}
 	fsVolume, err := util.CheckVolumeModeFilesystem(resizeOptions.VolumeSpec)
 	if err != nil {

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/controller_policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/controller_policy.go
@@ -139,7 +139,7 @@ func buildControllerRoles() ([]rbacv1.ClusterRole, []rbacv1.ClusterRoleBinding) 
 			},
 		}
 		if utilfeature.DefaultFeatureGate.Enabled(features.PodDisruptionConditions) {
-			role.Rules = append(role.Rules, rbacv1helpers.NewRule("patch").Groups(legacyGroup).Resources("pods/status").RuleOrDie())
+			role.Rules = append(role.Rules, rbacv1helpers.NewRule("patch", "update").Groups(legacyGroup).Resources("pods/status").RuleOrDie())
 		}
 		return role
 	}())

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/controller-roles.yaml
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/controller-roles.yaml
@@ -436,6 +436,7 @@ items:
     - pods/status
     verbs:
     - patch
+    - update
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRole
   metadata:

--- a/staging/src/k8s.io/cloud-provider/controllers/service/controller.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/service/controller.go
@@ -710,9 +710,11 @@ func (c *Controller) nodeSyncService(svc *v1.Service, oldNodes, newNodes []*v1.N
 	}
 	newNodes = filterWithPredicates(newNodes, getNodePredicatesForService(svc)...)
 	oldNodes = filterWithPredicates(oldNodes, getNodePredicatesForService(svc)...)
-	if nodeNames(newNodes).Equal(nodeNames(oldNodes)) {
+
+	if nodesSufficientlyEqual(oldNodes, newNodes) {
 		return retSuccess
 	}
+
 	klog.V(4).Infof("nodeSyncService started for service %s/%s", svc.Namespace, svc.Name)
 	if err := c.lockedUpdateLoadBalancerHosts(svc, newNodes); err != nil {
 		runtime.HandleError(fmt.Errorf("failed to update load balancer hosts for service %s/%s: %v", svc.Namespace, svc.Name, err))
@@ -720,6 +722,34 @@ func (c *Controller) nodeSyncService(svc *v1.Service, oldNodes, newNodes []*v1.N
 	}
 	klog.V(4).Infof("nodeSyncService finished successfully for service %s/%s", svc.Namespace, svc.Name)
 	return retSuccess
+}
+
+func nodesSufficientlyEqual(oldNodes, newNodes []*v1.Node) bool {
+	if len(oldNodes) != len(newNodes) {
+		return false
+	}
+
+	// This holds the Node fields which trigger a sync when changed.
+	type protoNode struct {
+		providerID string
+	}
+	distill := func(n *v1.Node) protoNode {
+		return protoNode{
+			providerID: n.Spec.ProviderID,
+		}
+	}
+
+	mOld := map[string]protoNode{}
+	for _, n := range oldNodes {
+		mOld[n.Name] = distill(n)
+	}
+
+	mNew := map[string]protoNode{}
+	for _, n := range newNodes {
+		mNew[n.Name] = distill(n)
+	}
+
+	return reflect.DeepEqual(mOld, mNew)
 }
 
 // updateLoadBalancerHosts updates all existing load balancers so that

--- a/staging/src/k8s.io/cloud-provider/controllers/service/controller_test.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/service/controller_test.go
@@ -882,6 +882,65 @@ func compareUpdateCalls(t *testing.T, left, right []fakecloud.UpdateBalancerCall
 	}
 }
 
+func TestNodesNotEqual(t *testing.T) {
+	controller, cloud, _ := newController()
+
+	services := []*v1.Service{
+		newService("s0", "123", v1.ServiceTypeLoadBalancer),
+		newService("s1", "123", v1.ServiceTypeLoadBalancer),
+	}
+
+	node1 := makeNode(tweakName("node1"))
+	node2 := makeNode(tweakName("node2"))
+	node3 := makeNode(tweakName("node3"))
+	node1WithProviderID := makeNode(tweakName("node1"), tweakProviderID("cumulus/1"))
+	node2WithProviderID := makeNode(tweakName("node2"), tweakProviderID("cumulus/2"))
+
+	testCases := []struct {
+		desc                string
+		lastSyncNodes       []*v1.Node
+		newNodes            []*v1.Node
+		expectedUpdateCalls []fakecloud.UpdateBalancerCall
+	}{
+		{
+			desc:          "Nodes with updated providerID",
+			lastSyncNodes: []*v1.Node{node1, node2},
+			newNodes:      []*v1.Node{node1WithProviderID, node2WithProviderID},
+			expectedUpdateCalls: []fakecloud.UpdateBalancerCall{
+				{Service: newService("s0", "123", v1.ServiceTypeLoadBalancer), Hosts: []*v1.Node{node1WithProviderID, node2WithProviderID}},
+				{Service: newService("s1", "123", v1.ServiceTypeLoadBalancer), Hosts: []*v1.Node{node1WithProviderID, node2WithProviderID}},
+			},
+		},
+		{
+			desc:                "Nodes unchanged",
+			lastSyncNodes:       []*v1.Node{node1WithProviderID, node2},
+			newNodes:            []*v1.Node{node1WithProviderID, node2},
+			expectedUpdateCalls: []fakecloud.UpdateBalancerCall{},
+		},
+		{
+			desc:          "Change node with empty providerID",
+			lastSyncNodes: []*v1.Node{node1WithProviderID, node2},
+			newNodes:      []*v1.Node{node1WithProviderID, node3},
+			expectedUpdateCalls: []fakecloud.UpdateBalancerCall{
+				{Service: newService("s0", "123", v1.ServiceTypeLoadBalancer), Hosts: []*v1.Node{node1WithProviderID, node3}},
+				{Service: newService("s1", "123", v1.ServiceTypeLoadBalancer), Hosts: []*v1.Node{node1WithProviderID, node3}},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			controller.nodeLister = newFakeNodeLister(nil, tc.newNodes...)
+			controller.lastSyncedNodes = tc.lastSyncNodes
+			controller.updateLoadBalancerHosts(ctx, services, 5)
+			compareUpdateCalls(t, tc.expectedUpdateCalls, cloud.UpdateCalls)
+			cloud.UpdateCalls = []fakecloud.UpdateBalancerCall{}
+		})
+	}
+}
+
 func TestProcessServiceCreateOrUpdate(t *testing.T) {
 	controller, _, client := newController()
 
@@ -1906,6 +1965,46 @@ func TestListWithPredicate(t *testing.T) {
 }
 
 var providerID = "providerID"
+
+type nodeTweak func(n *v1.Node)
+
+// TODO: use this pattern in all the tests above.
+func makeNode(tweaks ...nodeTweak) *v1.Node {
+	n := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "node",
+			Labels: map[string]string{},
+		},
+		Spec: v1.NodeSpec{
+			Taints:     []v1.Taint{},
+			ProviderID: providerID,
+		},
+		Status: v1.NodeStatus{
+			Conditions: []v1.NodeCondition{{
+				Type:   v1.NodeReady,
+				Status: v1.ConditionTrue,
+			}},
+		},
+	}
+
+	for _, tw := range tweaks {
+		tw(n)
+	}
+	return n
+}
+
+func tweakName(name string) nodeTweak {
+	return func(n *v1.Node) {
+		n.Name = name
+	}
+}
+
+// returns a function to change Provider ID in Node Specs
+func tweakProviderID(providerID string) nodeTweak {
+	return func(n *v1.Node) {
+		n.Spec.ProviderID = providerID
+	}
+}
 
 func Test_shouldSyncUpdatedNode_individualPredicates(t *testing.T) {
 	testcases := []struct {


### PR DESCRIPTION
Cherry pick of https://github.com/kubernetes/kubernetes/pull/120492 on release-1.26.

https://github.com/kubernetes/kubernetes/pull/120492: service controller: improve node lifecycle updates - update

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Service Controller: update load balancer hosts after node's ProviderID is updated
```