### PR TITLE
Add kubelet_pod_emptydir_volume_{used,size_limit}_bytes Prometheus metrics

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1497,6 +1497,7 @@ func (kl *Kubelet) initializeModules() error {
 	metrics.Register(
 		collectors.NewVolumeStatsCollector(kl),
 		collectors.NewLogMetricsCollector(kl.StatsProvider.ListPodStats),
+		collectors.NewEmptyDirMetricsCollector(kl),
 	)
 	metrics.SetNodeName(kl.nodeName)
 	servermetrics.Register()

--- a/pkg/kubelet/metrics/collectors/emptydir_metrics.go
+++ b/pkg/kubelet/metrics/collectors/emptydir_metrics.go
@@ -1,0 +1,143 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package collectors
+
+import (
+	"context"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/component-base/metrics"
+	"k8s.io/klog/v2"
+
+	kubeletmetrics "k8s.io/kubernetes/pkg/kubelet/metrics"
+	serverstats "k8s.io/kubernetes/pkg/kubelet/server/stats"
+)
+
+var (
+	emptyDirUsedBytesDesc = metrics.NewDesc(
+		metrics.BuildFQName(
+			"",
+			kubeletmetrics.KubeletSubsystem,
+			kubeletmetrics.EmptyDirUsedBytesKey,
+		),
+		"Bytes used by the emptyDir volume. Only volumes on the default medium are considered.",
+		[]string{
+			"volume_name",
+			"namespace",
+			"pod",
+		},
+		nil,
+		metrics.ALPHA,
+		"",
+	)
+	emptyDirSizeLimitBytesDesc = metrics.NewDesc(
+		metrics.BuildFQName(
+			"",
+			kubeletmetrics.KubeletSubsystem,
+			kubeletmetrics.EmptyDirSizeLimitBytesKey,
+		),
+		"Size limit of the emptyDir volume in bytes, if set. Only volumes on the default medium are considered.",
+		[]string{
+			"volume_name",
+			"namespace",
+			"pod",
+		},
+		nil,
+		metrics.ALPHA,
+		"",
+	)
+)
+
+type emptyDirMetricsCollector struct {
+	metrics.BaseStableCollector
+
+	statsProvider serverstats.Provider
+}
+
+// Check if emptyDirMetricsCollector implements necessary interface
+var _ metrics.StableCollector = &emptyDirMetricsCollector{}
+
+// NewEmptyDirMetricsCollector implements the metrics.StableCollector interface and
+// exposes metrics about pod's emptyDir.
+func NewEmptyDirMetricsCollector(statsProvider serverstats.Provider) metrics.StableCollector {
+	return &emptyDirMetricsCollector{statsProvider: statsProvider}
+}
+
+// DescribeWithStability implements the metrics.StableCollector interface.
+func (c *emptyDirMetricsCollector) DescribeWithStability(ch chan<- *metrics.Desc) {
+	ch <- emptyDirUsedBytesDesc
+	ch <- emptyDirSizeLimitBytesDesc
+}
+
+// CollectWithStability implements the metrics.StableCollector interface.
+func (c *emptyDirMetricsCollector) CollectWithStability(ch chan<- metrics.Metric) {
+	podStats, err := c.statsProvider.ListPodStats(context.Background())
+	if err != nil {
+		klog.ErrorS(err, "Failed to get pod stats")
+		return
+	}
+
+	for _, podStat := range podStats {
+		podName := podStat.PodRef.Name
+		podNamespace := podStat.PodRef.Namespace
+
+		if podStat.VolumeStats == nil {
+			klog.V(5).InfoS("Pod has no volume stats", "pod", podName, "namespace", podNamespace)
+			continue
+		}
+
+		pod, found := c.statsProvider.GetPodByName(podNamespace, podName)
+		if !found {
+			klog.V(5).InfoS("Couldn't get pod", "pod", podName, "namespace", podNamespace)
+			continue
+		}
+
+		podVolumes := make(map[string]v1.Volume, len(pod.Spec.Volumes))
+		for _, volume := range pod.Spec.Volumes {
+			podVolumes[volume.Name] = volume
+		}
+
+		for _, volumeStat := range podStat.VolumeStats {
+			if volume, found := podVolumes[volumeStat.Name]; found {
+				// Only consider volumes on the default medium.
+				if volume.EmptyDir != nil && volume.EmptyDir.Medium == v1.StorageMediumDefault {
+					if volumeStat.UsedBytes != nil {
+						ch <- metrics.NewLazyConstMetric(
+							emptyDirUsedBytesDesc,
+							metrics.GaugeValue,
+							float64(*volumeStat.UsedBytes),
+							volumeStat.Name,
+							podNamespace,
+							podName,
+						)
+					}
+					if volume.EmptyDir.SizeLimit != nil {
+						ch <- metrics.NewLazyConstMetric(
+							emptyDirSizeLimitBytesDesc,
+							metrics.GaugeValue,
+							volume.EmptyDir.SizeLimit.AsApproximateFloat64(),
+							volumeStat.Name,
+							podNamespace,
+							podName,
+						)
+					}
+				}
+			}
+
+		}
+	}
+}

--- a/pkg/kubelet/metrics/collectors/emptydir_metrics_test.go
+++ b/pkg/kubelet/metrics/collectors/emptydir_metrics_test.go
@@ -1,0 +1,158 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package collectors
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/component-base/metrics/testutil"
+	statsapi "k8s.io/kubelet/pkg/apis/stats/v1alpha1"
+	statstest "k8s.io/kubernetes/pkg/kubelet/server/stats/testing"
+)
+
+func TestEmptyDirCollector(t *testing.T) {
+
+	testNamespace := "test-namespace"
+	existingPodNameWithStats := "foo"
+	podNameWithoutStats := "bar"
+
+	podStats := []statsapi.PodStats{
+		{
+			PodRef: statsapi.PodReference{
+				Name:      existingPodNameWithStats,
+				Namespace: testNamespace,
+				UID:       "UID_foo",
+			},
+			StartTime: metav1.Now(),
+			VolumeStats: []statsapi.VolumeStats{
+				{
+					Name: "foo-emptydir-1",
+					FsStats: statsapi.FsStats{
+						UsedBytes: newUint64Pointer(2101248),
+					},
+				},
+				{
+					Name: "foo-emptydir-2",
+					FsStats: statsapi.FsStats{
+						UsedBytes: newUint64Pointer(6488064),
+					},
+				},
+				{
+					Name: "foo-memory-emptydir",
+					FsStats: statsapi.FsStats{
+						UsedBytes: newUint64Pointer(25362432),
+					},
+				},
+				{
+					Name: "foo-configmap",
+					FsStats: statsapi.FsStats{
+						UsedBytes: newUint64Pointer(4096),
+					},
+				},
+			},
+		},
+	}
+
+	existingPod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      existingPodNameWithStats,
+			Namespace: testNamespace,
+		},
+		Spec: v1.PodSpec{
+			Volumes: []v1.Volume{
+				{
+					Name: "foo-emptydir-1",
+					VolumeSource: v1.VolumeSource{
+						EmptyDir: &v1.EmptyDirVolumeSource{SizeLimit: resource.NewQuantity(3000100, resource.BinarySI)},
+					},
+				},
+				{
+					Name: "foo-emptydir-2",
+					VolumeSource: v1.VolumeSource{
+						EmptyDir: &v1.EmptyDirVolumeSource{},
+					},
+				},
+				{
+					Name: "foo-memory-emptydir",
+					VolumeSource: v1.VolumeSource{
+						EmptyDir: &v1.EmptyDirVolumeSource{Medium: v1.StorageMediumMemory},
+					},
+				},
+				{
+					Name: "foo-configmap",
+					VolumeSource: v1.VolumeSource{
+						ConfigMap: &v1.ConfigMapVolumeSource{},
+					},
+				},
+			},
+		},
+	}
+
+	podWithoutStats := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      podNameWithoutStats,
+			Namespace: testNamespace,
+		},
+		Spec: v1.PodSpec{
+			Volumes: []v1.Volume{
+				{
+					Name: "bar-emptydir",
+					VolumeSource: v1.VolumeSource{
+						EmptyDir: &v1.EmptyDirVolumeSource{},
+					},
+				},
+			},
+		},
+	}
+
+	mockStatsProvider := statstest.NewMockProvider(t)
+
+	mockStatsProvider.EXPECT().ListPodStats(context.Background()).Return(podStats, nil).Maybe()
+	mockStatsProvider.EXPECT().
+		GetPodByName(testNamespace, existingPodNameWithStats).
+		Return(existingPod, true).
+		Maybe()
+	mockStatsProvider.EXPECT().
+		GetPodByName(testNamespace, podNameWithoutStats).
+		Return(podWithoutStats, true).
+		Maybe()
+
+	err := testutil.CustomCollectAndCompare(
+		&emptyDirMetricsCollector{statsProvider: mockStatsProvider},
+		strings.NewReader(`
+		# HELP kubelet_pod_emptydir_volume_size_limit_bytes [ALPHA] Size limit of the emptyDir volume in bytes, if set. Only volumes on the default medium are considered.
+		# TYPE kubelet_pod_emptydir_volume_size_limit_bytes gauge
+		kubelet_pod_emptydir_volume_size_limit_bytes{namespace="test-namespace",pod="foo",volume_name="foo-emptydir-1"} 3.0001e+06
+		# HELP kubelet_pod_emptydir_volume_used_bytes [ALPHA] Bytes used by the emptyDir volume. Only volumes on the default medium are considered.
+		# TYPE kubelet_pod_emptydir_volume_used_bytes gauge
+		kubelet_pod_emptydir_volume_used_bytes{namespace="test-namespace",pod="foo",volume_name="foo-emptydir-1"} 2.101248e+06
+		kubelet_pod_emptydir_volume_used_bytes{namespace="test-namespace",pod="foo",volume_name="foo-emptydir-2"} 6.488064e+06
+		`),
+		"kubelet_pod_emptydir_volume_size_limit_bytes",
+		"kubelet_pod_emptydir_volume_used_bytes",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+}

--- a/pkg/kubelet/metrics/metrics.go
+++ b/pkg/kubelet/metrics/metrics.go
@@ -58,6 +58,8 @@ const (
 	PreemptionsKey                     = "preemptions"
 	VolumeStatsCapacityBytesKey        = "volume_stats_capacity_bytes"
 	VolumeStatsAvailableBytesKey       = "volume_stats_available_bytes"
+	EmptyDirUsedBytesKey               = "pod_emptydir_volume_used_bytes"
+	EmptyDirSizeLimitBytesKey          = "pod_emptydir_volume_size_limit_bytes"
 	VolumeStatsUsedBytesKey            = "volume_stats_used_bytes"
 	VolumeStatsInodesKey               = "volume_stats_inodes"
 	VolumeStatsInodesFreeKey           = "volume_stats_inodes_free"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature


#### What this PR does / why we need it:
Exposes `emptyDir` usage and size limit per Pod as Prometheus metrics

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #69507

#### Special notes for your reviewer:
- Do we need to expose the`capacityBytes` as well (I don't think it's really informative)? What about cases when `emptyDir.sizeLimit` is set? DONE => for the capacity, maybe in a follow-up PR if it turns out relevant.
- ~Could unit test more cases.~
- Linked the new collector in `pkg/kubelet/kubelet.go`, not sure if it's sufficient, any doc about that is welcome.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Add kubelet_pod_emptydir_volume_{used,size_limit}_bytes Prometheus metrics to expose the used and limit bytes for volumes on the default medium, per Pod. 
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
