### PR TITLE
automatically setup etcd when running {verify,update}-openapi-spec.sh

### DIFF
--- a/hack/lib/etcd.sh
+++ b/hack/lib/etcd.sh
@@ -144,38 +144,42 @@ kube::etcd::cleanup() {
 }
 
 kube::etcd::install() {
-  (
-    local os
-    local arch
+  local os
+  local arch
 
-    os=$(kube::util::host_os)
-    arch=$(kube::util::host_arch)
+  os=$(kube::util::host_os)
+  arch=$(kube::util::host_arch)
 
-    cd "${KUBE_ROOT}/third_party" || return 1
-    if [[ $(readlink etcd) == etcd-v${ETCD_VERSION}-${os}-* ]]; then
-      kube::log::info "etcd v${ETCD_VERSION} already installed. To use:"
-      kube::log::info "export PATH=\"$(pwd)/etcd:\${PATH}\""
-      return  #already installed
-    fi
-
-    if [[ ${os} == "darwin" ]]; then
-      download_file="etcd-v${ETCD_VERSION}-${os}-${arch}.zip"
-      url="https://github.com/etcd-io/etcd/releases/download/v${ETCD_VERSION}/${download_file}"
-      kube::util::download_file "${url}" "${download_file}"
-      unzip -o "${download_file}"
-      ln -fns "etcd-v${ETCD_VERSION}-${os}-${arch}" etcd
-      rm "${download_file}"
-    elif [[ ${os} == "linux" ]]; then
-      url="https://github.com/coreos/etcd/releases/download/v${ETCD_VERSION}/etcd-v${ETCD_VERSION}-${os}-${arch}.tar.gz"
-      download_file="etcd-v${ETCD_VERSION}-${os}-${arch}.tar.gz"
-      kube::util::download_file "${url}" "${download_file}"
-      tar xzf "${download_file}"
-      ln -fns "etcd-v${ETCD_VERSION}-${os}-${arch}" etcd
-      rm "${download_file}"
-    else
-      kube::log::info "${os} is NOT supported."
-    fi
-    kube::log::info "etcd v${ETCD_VERSION} installed. To use:"
+  cd "${KUBE_ROOT}/third_party" || return 1
+  if [[ $(readlink etcd) == etcd-v${ETCD_VERSION}-${os}-* ]]; then
+    kube::log::info "etcd v${ETCD_VERSION} already installed. To use:"
     kube::log::info "export PATH=\"$(pwd)/etcd:\${PATH}\""
-  )
+    # export into current process
+    PATH="$(pwd)/etcd:${PATH}"
+    export PATH
+    return  #already installed
+  fi
+
+  if [[ ${os} == "darwin" ]]; then
+    download_file="etcd-v${ETCD_VERSION}-${os}-${arch}.zip"
+    url="https://github.com/etcd-io/etcd/releases/download/v${ETCD_VERSION}/${download_file}"
+    kube::util::download_file "${url}" "${download_file}"
+    unzip -o "${download_file}"
+    ln -fns "etcd-v${ETCD_VERSION}-${os}-${arch}" etcd
+    rm "${download_file}"
+  elif [[ ${os} == "linux" ]]; then
+    url="https://github.com/coreos/etcd/releases/download/v${ETCD_VERSION}/etcd-v${ETCD_VERSION}-${os}-${arch}.tar.gz"
+    download_file="etcd-v${ETCD_VERSION}-${os}-${arch}.tar.gz"
+    kube::util::download_file "${url}" "${download_file}"
+    tar xzf "${download_file}"
+    ln -fns "etcd-v${ETCD_VERSION}-${os}-${arch}" etcd
+    rm "${download_file}"
+  else
+    kube::log::info "${os} is NOT supported."
+  fi
+  kube::log::info "etcd v${ETCD_VERSION} installed. To use:"
+  kube::log::info "export PATH=\"$(pwd)/etcd:\${PATH}\""
+  # export into current process
+  PATH="$(pwd)/etcd:${PATH}"
+  export PATH
 }

--- a/hack/update-openapi-spec.sh
+++ b/hack/update-openapi-spec.sh
@@ -28,6 +28,7 @@ source "${KUBE_ROOT}/hack/lib/init.sh"
 
 kube::util::require-jq
 kube::golang::setup_env
+kube::etcd::install
 
 make -C "${KUBE_ROOT}" WHAT=cmd/kube-apiserver
 
@@ -45,8 +46,6 @@ function cleanup()
 }
 
 trap cleanup EXIT SIGINT
-
-kube::golang::setup_env
 
 TMP_DIR=${TMP_DIR:-$(kube::realpath "$(mktemp -d -t "$(basename "$0").XXXXXX")")}
 ETCD_HOST=${ETCD_HOST:-127.0.0.1}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

1. Automatically add etcd to current PATH when calling kube::etcd::install

2. Call kube::etcd::install from update-openapi-spec

Ensures that e.g. `build/run.sh make verify WHAT=openapi-spec` (or just `make verify`) actually works without the user having to manually run the "install etcd into third_party" steps.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/121492
/sig api-machinery
/hold

#### Special notes for your reviewer:


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
