### PR TITLE
Fix/flake TestNewManagerImplStartProbeMode  unit test

### DIFF
--- a/pkg/kubelet/cm/devicemanager/manager.go
+++ b/pkg/kubelet/cm/devicemanager/manager.go
@@ -236,12 +236,12 @@ func (m *ManagerImpl) PluginDisconnected(resourceName string) {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 
-	if _, exists := m.endpoints[resourceName]; exists {
+	if ep, exists := m.endpoints[resourceName]; exists {
 		m.markResourceUnhealthy(resourceName)
-		klog.V(2).InfoS("Endpoint became unhealthy", "resourceName", resourceName, "endpoint", m.endpoints[resourceName])
-	}
+		klog.V(2).InfoS("Endpoint became unhealthy", "resourceName", resourceName, "endpoint", ep)
 
-	m.endpoints[resourceName].e.setStopTime(time.Now())
+		ep.e.setStopTime(time.Now())
+	}
 }
 
 // PluginListAndWatchReceiver receives ListAndWatchResponse from a device plugin

--- a/pkg/kubelet/cm/devicemanager/plugin/v1beta1/client.go
+++ b/pkg/kubelet/cm/devicemanager/plugin/v1beta1/client.go
@@ -69,8 +69,10 @@ func (c *client) Connect() error {
 		klog.ErrorS(err, "Unable to connect to device plugin client with socket path", "path", c.socket)
 		return err
 	}
+	c.mutex.Lock()
 	c.grpc = conn
 	c.client = client
+	c.mutex.Unlock()
 	return c.handler.PluginConnected(c.resource, c)
 }
 


### PR DESCRIPTION

/kind bug

/kind flake

```release-note
NONE
```

```
$ go test -timeout 30s -run ^TestNewManagerImplStartProbeMode$ k8s.io/kubernetes/pkg/kubelet/cm/devicemanager -v -count 1 -c -race
aojea@aojea:~/src/kubernetes$ stress ./devicemanager.test -test.run TestNewManagerImplStartProbeMode
5s: 162 runs so far, 0 failures
10s: 384 runs so far, 0 failures
15s: 578 runs so far, 0 failures
20s: 783 runs so far, 0 failures
25s: 995 runs so far, 0 failures
30s: 1206 runs so far, 0 failures
35s: 1412 runs so far, 0 failures
40s: 1620 runs so far, 0 failures
45s: 1830 runs so far, 0 failures
50s: 2039 runs so far, 0 failures
55s: 2247 runs so far, 0 failures
1m0s: 2451 runs so far, 0 failures
1m5s: 2668 runs so far, 0 failures
1m10s: 2877 runs so far, 0 failures
1m15s: 3082 runs so far, 0 failures
1m20s: 3287 runs so far, 0 failures
1m25s: 3501 runs so far, 0 failures
1m30s: 3709 runs so far, 0 failures
1m35s: 3915 runs so far, 0 failures
1m40s: 4121 runs so far, 0 failures
1m45s: 4334 runs so far, 0 failures
1m50s: 4542 runs so far, 0 failures
1m55s: 4750 runs so far, 0 failures
2m0s: 4960 runs so far, 0 failures
2m5s: 5170 runs so far, 0 failures
2m10s: 5378 runs so far, 0 failures
```


Fixes: https://github.com/kubernetes/kubernetes/issues/121451


All the credit to @wzshiming , just speeding it up to make the ci signal green again
https://testgrid.k8s.io/sig-release-master-blocking#ci-kubernetes-unit

I still don't know why it does not show up in  https://storage.googleapis.com/k8s-triage/index.html?pr=1&test=TestNewManagerImplStartProbeMode


