### PR TITLE
Deduplicate set expression values in metav1.LabelSelector fuzzer.

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/fuzzer/fuzzer.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/fuzzer/fuzzer.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	runtimeserializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 func genericFuzzerFuncs(codecs runtimeserializer.CodecFactory) []interface{} {
@@ -249,8 +250,9 @@ func v1FuzzerFuncs(codecs runtimeserializer.CodecFactory) []interface{} {
 			}
 
 			if j.MatchExpressions != nil {
-				// NB: the label selector parser code sorts match expressions by key, and sorts the values,
-				// so we need to make sure ours are sorted as well here to preserve round-trip comparison.
+				// NB: the label selector parser code sorts match expressions by key, and
+				// sorts and deduplicates the values, so we need to make sure ours are
+				// sorted and deduplicated as well here to preserve round-trip comparison.
 				// In practice, not sorting doesn't hurt anything...
 
 				for i := range j.MatchExpressions {
@@ -266,7 +268,7 @@ func v1FuzzerFuncs(codecs runtimeserializer.CodecFactory) []interface{} {
 						for i := range req.Values {
 							req.Values[i] = randomLabelPart(c, true)
 						}
-						sort.Strings(req.Values)
+						req.Values = sets.List(sets.New(req.Values...))
 					} else {
 						req.Values = nil
 					}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind flake

#### What this PR does / why we need it:

Internal versions of ScaleStatus types use metav1.LabelSelector to represent label selectors, while
external versions use the textual representation. During conversion to and from text, match
expressions are sorted by key, and values for set operations "in" and "notin" are sorted and
deduplicated. This loss of order and duplication is detected by roundtrip testing.

The existing fuzz function for metav1.LabelSelector sorts match expressions by key and sorts, but
does not deduplicate, set expression values. That function now also deduplicates set expression
values so that fuzzed metav1.LabelSelectors can faithfully roundtrip through the textual label
selector representation.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

/sig api-machinery

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
