### PR TITLE
Remove problematic Dbus restart test

### DIFF
--- a/test/e2e_node/node_shutdown_linux_test.go
+++ b/test/e2e_node/node_shutdown_linux_test.go
@@ -374,35 +374,6 @@ var _ = SIGDescribe("GracefulNodeShutdown [Serial] [NodeFeature:GracefulNodeShut
 				return nil
 			}, nodeStatusUpdateTimeout, pollInterval).Should(gomega.Succeed())
 		})
-
-		ginkgo.It("after restart dbus, should be able to gracefully shutdown", func(ctx context.Context) {
-			// allows manual restart of dbus to work in Ubuntu.
-			err := overlayDbusConfig()
-			framework.ExpectNoError(err)
-			defer func() {
-				err := restoreDbusConfig()
-				framework.ExpectNoError(err)
-			}()
-
-			ginkgo.By("Restart Dbus")
-			err = restartDbus()
-			framework.ExpectNoError(err)
-
-			gomega.Eventually(ctx, func(ctx context.Context) error {
-				// re-send the shutdown signal in case the dbus restart is not done
-				ginkgo.By("Emitting Shutdown signal")
-				err = emitSignalPrepareForShutdown(true)
-				if err != nil {
-					return err
-				}
-
-				isReady := getNodeReadyStatus(ctx, f)
-				if isReady {
-					return fmt.Errorf("node did not become shutdown as expected")
-				}
-				return nil
-			}, nodeStatusUpdateTimeout, pollInterval).Should(gomega.Succeed())
-		})
 	})
 
 	ginkgo.Context("when gracefully shutting down with Pod priority", func() {
@@ -678,12 +649,6 @@ func getNodeReadyStatus(ctx context.Context, f *framework.Framework) bool {
 	// Assuming that there is only one node, because this is a node e2e test.
 	gomega.Expect(nodeList.Items).To(gomega.HaveLen(1), "the number of nodes is not as expected")
 	return isNodeReady(&nodeList.Items[0])
-}
-
-func restartDbus() error {
-	cmd := "systemctl restart dbus"
-	_, err := runCommand("sh", "-c", cmd)
-	return err
 }
 
 func systemctlDaemonReload() error {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind failing-test

#### What this PR does / why we need it:

Restarting the Dbus broker service at runtime is generally not recommended or supported according to the feedback from the systemd maintainers.

Many systemd components (but also other software and services) that rely on Dbus wouldn't reconnect to a new Unix socket following the Dbus broker restart. This can lead to anything from authentication timeouts (since the systemd-logind and the polkitd services would be impacted) to the system generally broken following the Dbus broker restart. 

Different software might handle this differently and choose to reconnect on a socket write or read timeout. However, systemd at large is not one of these.

Given that tests are nowadays commonly run on either Googe Container-optimised OS (COS) or Fedora CoreOS, the addition of the Dbus broker restart has unwelcome side effects on these platforms.

Thus, remove a problematic test that performs Dbus broker restart and, in doing so, fix several currently failing tests on platforms that do not handle Dbus service restart gracefully.

#### Which issue(s) this PR fixes:

Fixes #121124

#### Special notes for your reviewer:

NONE

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
