### PR TITLE
Automated cherry pick of #118365: Fixing gmsa-webhook install steps for Windows GMSA full tests

### DIFF
--- a/test/e2e/windows/gmsa_full.go
+++ b/test/e2e/windows/gmsa_full.go
@@ -327,8 +327,8 @@ func deployGmsaWebhook(f *framework.Framework) (func(), error) {
 	bindClusterRBACRoleToServiceAccount(f, s, "cluster-admin")
 
 	installSteps := []string{
-		"echo \"@testing http://dl-cdn.alpinelinux.org/alpine/edge/testing/\" >> /etc/apk/repositories",
-		"&& apk add kubectl@testing gettext openssl",
+		"echo \"@community http://dl-cdn.alpinelinux.org/alpine/edge/community/\" >> /etc/apk/repositories",
+		"&& apk add kubectl@community gettext openssl",
 		"&& apk add --update coreutils",
 		fmt.Sprintf("&& curl %s > gmsa.sh", gmsaWebhookDeployScriptURL),
 		"&& chmod +x gmsa.sh",


### PR DESCRIPTION
Cherry pick of #118365 on release-1.26.

#118365: Fixing gmsa-webhook install steps for Windows GMSA full tests

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```