### PR TITLE
Automated cherry pick of #114279 #115603: update coredns to v1.10.1

### DIFF
--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -39,7 +39,7 @@ dependencies:
       match: registry.k8s.io/coredns
 
   - name: "coredns-kubeadm"
-    version: 1.9.3
+    version: 1.10.0
     refPaths:
     - path: cmd/kubeadm/app/constants/constants.go
       match: CoreDNSVersion =

--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -29,7 +29,7 @@ dependencies:
 
   # CoreDNS
   - name: "coredns-kube-up"
-    version: 1.9.3
+    version: 1.10.0
     refPaths:
     - path: cluster/addons/dns/coredns/coredns.yaml.base
       match: registry.k8s.io/coredns

--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -29,7 +29,7 @@ dependencies:
 
   # CoreDNS
   - name: "coredns-kube-up"
-    version: 1.10.0
+    version: 1.10.1
     refPaths:
     - path: cluster/addons/dns/coredns/coredns.yaml.base
       match: registry.k8s.io/coredns
@@ -39,7 +39,7 @@ dependencies:
       match: registry.k8s.io/coredns
 
   - name: "coredns-kubeadm"
-    version: 1.10.0
+    version: 1.10.1
     refPaths:
     - path: cmd/kubeadm/app/constants/constants.go
       match: CoreDNSVersion =

--- a/cluster/addons/dns/coredns/coredns.yaml.base
+++ b/cluster/addons/dns/coredns/coredns.yaml.base
@@ -139,7 +139,7 @@ spec:
         kubernetes.io/os: linux
       containers:
       - name: coredns
-        image: registry.k8s.io/coredns/coredns:v1.9.3
+        image: registry.k8s.io/coredns/coredns:v1.10.0
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/cluster/addons/dns/coredns/coredns.yaml.base
+++ b/cluster/addons/dns/coredns/coredns.yaml.base
@@ -139,7 +139,7 @@ spec:
         kubernetes.io/os: linux
       containers:
       - name: coredns
-        image: registry.k8s.io/coredns/coredns:v1.10.0
+        image: registry.k8s.io/coredns/coredns:v1.10.1
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/cluster/addons/dns/coredns/coredns.yaml.in
+++ b/cluster/addons/dns/coredns/coredns.yaml.in
@@ -139,7 +139,7 @@ spec:
         kubernetes.io/os: linux
       containers:
       - name: coredns
-        image: registry.k8s.io/coredns/coredns:v1.9.3
+        image: registry.k8s.io/coredns/coredns:v1.10.0
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/cluster/addons/dns/coredns/coredns.yaml.in
+++ b/cluster/addons/dns/coredns/coredns.yaml.in
@@ -139,7 +139,7 @@ spec:
         kubernetes.io/os: linux
       containers:
       - name: coredns
-        image: registry.k8s.io/coredns/coredns:v1.10.0
+        image: registry.k8s.io/coredns/coredns:v1.10.1
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/cluster/addons/dns/coredns/coredns.yaml.sed
+++ b/cluster/addons/dns/coredns/coredns.yaml.sed
@@ -139,7 +139,7 @@ spec:
         kubernetes.io/os: linux
       containers:
       - name: coredns
-        image: registry.k8s.io/coredns/coredns:v1.9.3
+        image: registry.k8s.io/coredns/coredns:v1.10.0
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/cluster/addons/dns/coredns/coredns.yaml.sed
+++ b/cluster/addons/dns/coredns/coredns.yaml.sed
@@ -139,7 +139,7 @@ spec:
         kubernetes.io/os: linux
       containers:
       - name: coredns
-        image: registry.k8s.io/coredns/coredns:v1.10.0
+        image: registry.k8s.io/coredns/coredns:v1.10.1
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/cmd/kubeadm/app/constants/constants.go
+++ b/cmd/kubeadm/app/constants/constants.go
@@ -347,7 +347,7 @@ const (
 	CoreDNSImageName = "coredns"
 
 	// CoreDNSVersion is the version of CoreDNS to be deployed if it is used
-	CoreDNSVersion = "v1.9.3"
+	CoreDNSVersion = "v1.10.0"
 
 	// ClusterConfigurationKind is the string kind value for the ClusterConfiguration struct
 	ClusterConfigurationKind = "ClusterConfiguration"

--- a/cmd/kubeadm/app/constants/constants.go
+++ b/cmd/kubeadm/app/constants/constants.go
@@ -347,7 +347,7 @@ const (
 	CoreDNSImageName = "coredns"
 
 	// CoreDNSVersion is the version of CoreDNS to be deployed if it is used
-	CoreDNSVersion = "v1.10.0"
+	CoreDNSVersion = "v1.10.1"
 
 	// ClusterConfigurationKind is the string kind value for the ClusterConfiguration struct
 	ClusterConfigurationKind = "ClusterConfiguration"

--- a/cmd/kubeadm/app/images/images_test.go
+++ b/cmd/kubeadm/app/images/images_test.go
@@ -233,7 +233,7 @@ func TestGetDNSImage(t *testing.T) {
 		cfg      *kubeadmapi.ClusterConfiguration
 	}{
 		{
-			expected: "foo.io/coredns:v1.9.3",
+			expected: "foo.io/coredns:v1.10.0",
 			cfg: &kubeadmapi.ClusterConfiguration{
 				ImageRepository: "foo.io",
 				DNS: kubeadmapi.DNS{
@@ -242,7 +242,7 @@ func TestGetDNSImage(t *testing.T) {
 			},
 		},
 		{
-			expected: kubeadmapiv1beta2.DefaultImageRepository + "/coredns/coredns:v1.9.3",
+			expected: kubeadmapiv1beta2.DefaultImageRepository + "/coredns/coredns:v1.10.0",
 			cfg: &kubeadmapi.ClusterConfiguration{
 				ImageRepository: kubeadmapiv1beta2.DefaultImageRepository,
 				DNS: kubeadmapi.DNS{
@@ -251,7 +251,7 @@ func TestGetDNSImage(t *testing.T) {
 			},
 		},
 		{
-			expected: "foo.io/coredns/coredns:v1.9.3",
+			expected: "foo.io/coredns/coredns:v1.10.0",
 			cfg: &kubeadmapi.ClusterConfiguration{
 				ImageRepository: "foo.io",
 				DNS: kubeadmapi.DNS{

--- a/cmd/kubeadm/app/images/images_test.go
+++ b/cmd/kubeadm/app/images/images_test.go
@@ -233,7 +233,7 @@ func TestGetDNSImage(t *testing.T) {
 		cfg      *kubeadmapi.ClusterConfiguration
 	}{
 		{
-			expected: "foo.io/coredns:v1.10.0",
+			expected: "foo.io/coredns:v1.10.1",
 			cfg: &kubeadmapi.ClusterConfiguration{
 				ImageRepository: "foo.io",
 				DNS: kubeadmapi.DNS{
@@ -242,7 +242,7 @@ func TestGetDNSImage(t *testing.T) {
 			},
 		},
 		{
-			expected: kubeadmapiv1beta2.DefaultImageRepository + "/coredns/coredns:v1.10.0",
+			expected: kubeadmapiv1beta2.DefaultImageRepository + "/coredns/coredns:v1.10.1",
 			cfg: &kubeadmapi.ClusterConfiguration{
 				ImageRepository: kubeadmapiv1beta2.DefaultImageRepository,
 				DNS: kubeadmapi.DNS{
@@ -251,7 +251,7 @@ func TestGetDNSImage(t *testing.T) {
 			},
 		},
 		{
-			expected: "foo.io/coredns/coredns:v1.10.0",
+			expected: "foo.io/coredns/coredns:v1.10.1",
 			cfg: &kubeadmapi.ClusterConfiguration{
 				ImageRepository: "foo.io",
 				DNS: kubeadmapi.DNS{

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/aws/aws-sdk-go v1.44.116
 	github.com/blang/semver/v4 v4.0.0
 	github.com/container-storage-interface/spec v1.7.0
-	github.com/coredns/corefile-migration v1.0.17
+	github.com/coredns/corefile-migration v1.0.18
 	github.com/coreos/go-oidc v2.1.0+incompatible
 	github.com/coreos/go-systemd/v22 v22.3.2
 	github.com/cpuguy83/go-md2man/v2 v2.0.2

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/aws/aws-sdk-go v1.44.116
 	github.com/blang/semver/v4 v4.0.0
 	github.com/container-storage-interface/spec v1.7.0
-	github.com/coredns/corefile-migration v1.0.18
+	github.com/coredns/corefile-migration v1.0.20
 	github.com/coreos/go-oidc v2.1.0+incompatible
 	github.com/coreos/go-systemd/v22 v22.3.2
 	github.com/cpuguy83/go-md2man/v2 v2.0.2

--- a/go.sum
+++ b/go.sum
@@ -180,8 +180,8 @@ github.com/containerd/typeurl v1.0.2 h1:Chlt8zIieDbzQFzXzAeBEF92KhExuE4p9p92/QmY
 github.com/containerd/typeurl v1.0.2/go.mod h1:9trJWW2sRlGub4wZJRTW83VtbOLS6hwcDZXTn6oPz9s=
 github.com/coredns/caddy v1.1.0 h1:ezvsPrT/tA/7pYDBZxu0cT0VmWk75AfIaf6GSYCNMf0=
 github.com/coredns/caddy v1.1.0/go.mod h1:A6ntJQlAWuQfFlsd9hvigKbo2WS0VUs2l1e2F+BawD4=
-github.com/coredns/corefile-migration v1.0.17 h1:tNwh8+4WOANV6NjSljwgW7qViJfhvPUt1kosj4rR8yg=
-github.com/coredns/corefile-migration v1.0.17/go.mod h1:XnhgULOEouimnzgn0t4WPuFDN2/PJQcTxdWKC5eXNGE=
+github.com/coredns/corefile-migration v1.0.18 h1:zs5PJm/VGZVje1ESRj6ZqyUuVsVfagExkbLU2QKV5mI=
+github.com/coredns/corefile-migration v1.0.18/go.mod h1:XnhgULOEouimnzgn0t4WPuFDN2/PJQcTxdWKC5eXNGE=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=

--- a/go.sum
+++ b/go.sum
@@ -180,8 +180,8 @@ github.com/containerd/typeurl v1.0.2 h1:Chlt8zIieDbzQFzXzAeBEF92KhExuE4p9p92/QmY
 github.com/containerd/typeurl v1.0.2/go.mod h1:9trJWW2sRlGub4wZJRTW83VtbOLS6hwcDZXTn6oPz9s=
 github.com/coredns/caddy v1.1.0 h1:ezvsPrT/tA/7pYDBZxu0cT0VmWk75AfIaf6GSYCNMf0=
 github.com/coredns/caddy v1.1.0/go.mod h1:A6ntJQlAWuQfFlsd9hvigKbo2WS0VUs2l1e2F+BawD4=
-github.com/coredns/corefile-migration v1.0.18 h1:zs5PJm/VGZVje1ESRj6ZqyUuVsVfagExkbLU2QKV5mI=
-github.com/coredns/corefile-migration v1.0.18/go.mod h1:XnhgULOEouimnzgn0t4WPuFDN2/PJQcTxdWKC5eXNGE=
+github.com/coredns/corefile-migration v1.0.20 h1:MdOkT6F3ehju/n9tgxlGct8XAajOX2vN+wG7To4BWSI=
+github.com/coredns/corefile-migration v1.0.20/go.mod h1:XnhgULOEouimnzgn0t4WPuFDN2/PJQcTxdWKC5eXNGE=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=

--- a/vendor/github.com/coredns/corefile-migration/migration/migrate.go
+++ b/vendor/github.com/coredns/corefile-migration/migration/migrate.go
@@ -10,6 +10,8 @@ import (
 	"fmt"
 	"regexp"
 	"sort"
+	"strconv"
+	"strings"
 
 	"github.com/coredns/corefile-migration/migration/corefile"
 )
@@ -420,7 +422,26 @@ func ValidVersions() []string {
 	for vStr := range Versions {
 		vStrs = append(vStrs, vStr)
 	}
-	sort.Strings(vStrs)
+	sort.Slice(vStrs, func(i, j int) bool {
+		iSegs := strings.Split(vStrs[i], ".")
+		jSegs := strings.Split(vStrs[j], ".")
+		for k, iSeg := range iSegs {
+			if iSeg == jSegs[k] {
+				continue
+			}
+			iInt, err := strconv.Atoi(iSeg)
+			if err != nil {
+				panic(err)
+			}
+			jInt, err := strconv.Atoi(jSegs[k])
+			if err != nil {
+				panic(err)
+			}
+			return iInt < jInt
+		}
+		return false
+	})
+
 	return vStrs
 }
 

--- a/vendor/github.com/coredns/corefile-migration/migration/migrate.go
+++ b/vendor/github.com/coredns/corefile-migration/migration/migrate.go
@@ -20,12 +20,18 @@ import (
 // any deprecated, removed, or ignored plugins/directives present in the Corefile.  Notifications are also returned for
 // any new default plugins that would be added in a migration.
 func Deprecated(fromCoreDNSVersion, toCoreDNSVersion, corefileStr string) ([]Notice, error) {
+	if fromCoreDNSVersion == toCoreDNSVersion {
+		return nil, nil
+	}
 	return getStatus(fromCoreDNSVersion, toCoreDNSVersion, corefileStr, SevAll)
 }
 
 // Unsupported returns a list notifications of plugins/options that are not handled supported by this migration tool,
 // but may still be valid in CoreDNS.
 func Unsupported(fromCoreDNSVersion, toCoreDNSVersion, corefileStr string) ([]Notice, error) {
+	if fromCoreDNSVersion == toCoreDNSVersion {
+		return nil, nil
+	}
 	return getStatus(fromCoreDNSVersion, toCoreDNSVersion, corefileStr, SevUnsupported)
 }
 

--- a/vendor/github.com/coredns/corefile-migration/migration/versions.go
+++ b/vendor/github.com/coredns/corefile-migration/migration/versions.go
@@ -30,27 +30,22 @@ type release struct {
 
 // Versions holds a map of plugin/option migrations per CoreDNS release (since 1.1.4)
 var Versions = map[string]release{
+	"1.10.0": {
+		priorVersion:   "1.9.4",
+		dockerImageSHA: "017727efcfeb7d053af68e51436ce8e65edbc6ca573720afb4f79c8594036955",
+		plugins:        plugins_1_9_3,
+	},
+	"1.9.4": {
+		nextVersion:    "1.10.0",
+		priorVersion:   "1.9.3",
+		dockerImageSHA: "b82e294de6be763f73ae71266c8f5466e7e03c69f3a1de96efd570284d35bb18",
+		plugins:        plugins_1_9_3,
+	},
 	"1.9.3": {
+		nextVersion:    "1.9.4",
 		priorVersion:   "1.9.2",
 		dockerImageSHA: "8e352a029d304ca7431c6507b56800636c321cb52289686a581ab70aaa8a2e2a",
-		plugins: map[string]plugin{
-			"errors":       plugins["errors"]["v3"], // stacktrace option added
-			"log":          plugins["log"]["v1"],
-			"health":       plugins["health"]["v1"],
-			"ready":        {},
-			"autopath":     {},
-			"kubernetes":   plugins["kubernetes"]["v8"],
-			"k8s_external": plugins["k8s_external"]["v1"],
-			"prometheus":   {},
-			"forward":      plugins["forward"]["v3"],
-			"cache":        plugins["cache"]["v1"],
-			"loop":         {},
-			"reload":       {},
-			"loadbalance":  {},
-			"hosts":        plugins["hosts"]["v1"],
-			"rewrite":      plugins["rewrite"]["v2"],
-			"transfer":     plugins["transfer"]["v1"],
-		},
+		plugins:        plugins_1_9_3,
 	},
 	"1.9.2": {
 		nextVersion:    "1.9.3",
@@ -742,6 +737,25 @@ var Versions = map[string]release{
     cache 30
     reload
 }`},
+}
+
+var plugins_1_9_3 = map[string]plugin{
+	"errors":       plugins["errors"]["v3"], // stacktrace option added
+	"log":          plugins["log"]["v1"],
+	"health":       plugins["health"]["v1"],
+	"ready":        {},
+	"autopath":     {},
+	"kubernetes":   plugins["kubernetes"]["v8"],
+	"k8s_external": plugins["k8s_external"]["v1"],
+	"prometheus":   {},
+	"forward":      plugins["forward"]["v3"],
+	"cache":        plugins["cache"]["v1"],
+	"loop":         {},
+	"reload":       {},
+	"loadbalance":  {},
+	"hosts":        plugins["hosts"]["v1"],
+	"rewrite":      plugins["rewrite"]["v2"],
+	"transfer":     plugins["transfer"]["v1"],
 }
 
 var plugins_1_8_3 = map[string]plugin{

--- a/vendor/github.com/coredns/corefile-migration/migration/versions.go
+++ b/vendor/github.com/coredns/corefile-migration/migration/versions.go
@@ -30,7 +30,13 @@ type release struct {
 
 // Versions holds a map of plugin/option migrations per CoreDNS release (since 1.1.4)
 var Versions = map[string]release{
+	"1.10.1": {
+		priorVersion:   "1.10.0",
+		dockerImageSHA: "a0ead06651cf580044aeb0a0feba63591858fb2e43ade8c9dea45a6a89ae7e5e",
+		plugins:        plugins_1_9_3,
+	},
 	"1.10.0": {
+		nextVersion:    "1.10.1",
 		priorVersion:   "1.9.4",
 		dockerImageSHA: "017727efcfeb7d053af68e51436ce8e65edbc6ca573720afb4f79c8594036955",
 		plugins:        plugins_1_9_3,

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -199,7 +199,7 @@ github.com/containerd/ttrpc
 # github.com/coredns/caddy v1.1.0
 ## explicit; go 1.13
 github.com/coredns/caddy/caddyfile
-# github.com/coredns/corefile-migration v1.0.17
+# github.com/coredns/corefile-migration v1.0.18
 ## explicit; go 1.14
 github.com/coredns/corefile-migration/migration
 github.com/coredns/corefile-migration/migration/corefile

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -199,7 +199,7 @@ github.com/containerd/ttrpc
 # github.com/coredns/caddy v1.1.0
 ## explicit; go 1.13
 github.com/coredns/caddy/caddyfile
-# github.com/coredns/corefile-migration v1.0.18
+# github.com/coredns/corefile-migration v1.0.20
 ## explicit; go 1.14
 github.com/coredns/corefile-migration/migration
 github.com/coredns/corefile-migration/migration/corefile


### PR DESCRIPTION
Cherry pick of #114279 #115603 on release-1.26.

#114279: update coredns kube up to v1.10.0
#115603: update coredns to v1.10.1

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```
See https://github.com/kubernetes/kubernetes/issues/113543#issuecomment-1780227913



Kubernetes Version | CoreDNS version installed by kubeadm | Problem
-- | -- | --
v1.28 | v1.10.1 |  
v1.27 | v1.10.1 |  
v1.26 | v1.9.3 |  coredns 1.9.3-4 do not work for arm64
v1.25 | v1.9.3 |  coredns 1.9.3-4 do not work for arm64 (end of life in 2 days when I submitted this PR, so not mentioned.)
v1.24 | v1.8.6 | 

v1.10.1 is OK. So only v1.26 needs this cherry-pick.
