### PR TITLE
kube-proxy: make --init-only a no-op on Windows

### DIFF
--- a/cmd/kube-proxy/app/server_windows.go
+++ b/cmd/kube-proxy/app/server_windows.go
@@ -31,6 +31,7 @@ import (
 	_ "net/http/pprof"
 
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/proxy"
 	proxyconfigapi "k8s.io/kubernetes/pkg/proxy/apis/config"
 	"k8s.io/kubernetes/pkg/proxy/winkernel"
@@ -81,7 +82,8 @@ func (s *ProxyServer) platformCheckSupported() (ipv4Supported, ipv6Supported, du
 // createProxier creates the proxy.Provider
 func (s *ProxyServer) createProxier(config *proxyconfigapi.KubeProxyConfiguration, dualStackMode, initOnly bool) (proxy.Provider, error) {
 	if initOnly {
-		return nil, fmt.Errorf("--init-only is not implemented on Windows")
+		klog.Info("--init-only is not implemented on Windows")
+		return nil, nil
 	}
 	var healthzPort int
 	if len(config.HealthzBindAddress) > 0 {


### PR DESCRIPTION
This will allow the same installation manifest to be used on Windows and Linux

/kind bug
/area kube-proxy
/sig network
/sig windows
/area kubeadm

#### What this PR does / why we need it:

`Kubeadm` makes no difference between Windows/Linux when installing `kube-proxy`. The `--init-only` flag should therefore be a no-op on Windows, rather than an error.

#### Which issue(s) this PR fixes:

It doesn't fix, but it helps https://github.com/kubernetes/kubeadm/issues/2948

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

