### PR TITLE
Make e2e node image ID test more flexible

### DIFF
--- a/test/e2e_node/image_id_test.go
+++ b/test/e2e_node/image_id_test.go
@@ -60,12 +60,12 @@ var _ = SIGDescribe("ImageID [NodeFeature: ImageID]", func() {
 		framework.ExpectNoError(err)
 
 		status := runningPod.Status
-
-		if len(status.ContainerStatuses) == 0 {
-			framework.Failf("Unexpected pod status; %s", dump.Pretty(status))
-			return
-		}
-
-		gomega.Expect(status.ContainerStatuses[0].ImageID).To(gomega.ContainSubstring(busyBoxImage))
+		gomega.Expect(status.ContainerStatuses).To(gomega.HaveLen(1), dump.Pretty(status))
+		gomega.Expect(status.ContainerStatuses[0].ImageID).To(
+			gomega.SatisfyAny(
+				gomega.Equal(busyBoxImage),
+				gomega.MatchRegexp(`[[:xdigit:]]{64}`),
+			),
+		)
 	})
 })


### PR DESCRIPTION
#### What type of PR is this?


/kind failing-test

#### What this PR does / why we need it:
Container runtimes like CRI-O actually show the image identifier in the `ImageID` field rather than the repo digest. For the digest we already have the `Image` field. We still allow the digest in the `ImageID` field for historic reasons.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Found in https://github.com/kubernetes/kubernetes/pull/121506
Refers to https://github.com/cri-o/cri-o/pull/7149, https://github.com/cri-o/cri-o/issues/7143

Fixes https://github.com/kubernetes/kubernetes/pull/121531
#### Special notes for your reviewer:
PTAL @kubernetes/sig-node-cri-o-test-maintainers 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
