### PR TITLE
Make it possible to build with `podman` instead of `docker` using `DOCKER=podman`.

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -28,7 +28,7 @@ USER_ID=$(id -u)
 GROUP_ID=$(id -g)
 
 DOCKER_OPTS=${DOCKER_OPTS:-""}
-IFS=" " read -r -a DOCKER <<< "docker ${DOCKER_OPTS}"
+IFS=" " read -r -a DOCKER <<< "${DOCKER:-docker} ${DOCKER_OPTS}"
 DOCKER_HOST=${DOCKER_HOST:-""}
 GOPROXY=${GOPROXY:-""}
 
@@ -226,7 +226,7 @@ function kube::build::ensure_rsync() {
 }
 
 function kube::build::ensure_docker_in_path() {
-  if [[ -z "$(which docker)" ]]; then
+  if [[ -z "$(which ${DOCKER[0]})" ]]; then
     kube::log::error "Can't find 'docker' in PATH, please fix and retry."
     kube::log::error "See https://docs.docker.com/installation/#installation for installation instructions."
     return 1
@@ -255,7 +255,7 @@ function kube::build::ensure_tar() {
 }
 
 function kube::build::has_docker() {
-  which docker &> /dev/null
+  which "${DOCKER[0]}" &> /dev/null
 }
 
 function kube::build::has_ip() {
@@ -439,7 +439,7 @@ function kube::build::ensure_data_container() {
   local ret=0
   local code=0
 
-  code=$(docker inspect \
+  code=$("${DOCKER[@]}" inspect \
       -f '{{.State.ExitCode}}' \
       "${KUBE_DATA_CONTAINER_NAME}" 2>/dev/null) || ret=$?
   if [[ "${ret}" == 0 && "${code}" != 0 ]]; then

--- a/hack/lib/util.sh
+++ b/hack/lib/util.sh
@@ -615,9 +615,10 @@ function kube::util::list_staging_repos() {
 
 # Determines if docker can be run, failures may simply require that the user be added to the docker group.
 function kube::util::ensure_docker_daemon_connectivity {
+  DOCKER=${DOCKER:-docker}
   DOCKER_OPTS=${DOCKER_OPTS:-""}
   IFS=" " read -ra docker_opts <<< "${DOCKER_OPTS}"
-  if ! docker "${docker_opts[@]:+"${docker_opts[@]}"}" info > /dev/null 2>&1 ; then
+  if ! "${DOCKER}" "${docker_opts[@]:+"${docker_opts[@]}"}" info > /dev/null 2>&1 ; then
     cat <<'EOF' >&2
 Can't connect to 'docker' daemon.  please fix and retry.
 
@@ -729,8 +730,9 @@ function kube::util::ensure-cfssl {
 # Check if we have "docker buildx" commands available
 #
 function kube::util::ensure-docker-buildx {
+  DOCKER=${DOCKER:-docker}
   # podman returns 0 on `docker buildx version`, docker on `docker buildx`. One of them must succeed.
-  if docker buildx version >/dev/null 2>&1 || docker buildx >/dev/null 2>&1; then
+  if "${DOCKER}" buildx version >/dev/null 2>&1 || "${DOCKER}" buildx >/dev/null 2>&1; then
     return 0
   else
     echo "ERROR: docker buildx not available. Docker 19.03 or higher is required with experimental features enabled"

--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -22,7 +22,7 @@ KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 # Usage: `hack/local-up-cluster.sh`.
 
 DOCKER_OPTS=${DOCKER_OPTS:-""}
-export DOCKER=(docker "${DOCKER_OPTS[@]}")
+export DOCKER=("${DOCKER:-docker}" "${DOCKER_OPTS[@]}")
 DOCKER_ROOT=${DOCKER_ROOT:-""}
 ALLOW_PRIVILEGED=${ALLOW_PRIVILEGED:-""}
 DENY_SECURITY_CONTEXT_ADMISSION=${DENY_SECURITY_CONTEXT_ADMISSION:-""}


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

#### What this PR does / why we need it:

This PR expands on the `DOCKER="${DOCKER:-docker}"` logic in `hack/verify-shellcheck.sh` to the whole `build/` suite, making it possible to build Kubernetes with a different docker-compatible command like `podman`. It can be used as `DOCKER=podman build/run.sh make` or `make quick-release DOCKER=podman` (these I tried).

While it was possible to build Kubernetes in a docker-less environment by symlinking `/usr/bin/docker -> podman` or by doing `function docker() { podman "$@"; }; export -f docker`, the first was unnecessarily heavyweight and the second did not work when `make` or `kind build` got involved..

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

I did not amend the build documentation claiming that `podman` was supported so this remains mostly hidden, like the current `hack/verify-shellcheck.sh` mechanism. I can amend to add a note to the documentation, calling it experimental or unsupported or something.

Thanks go to @BenTheElder who pointed me to the `DOCKER` environment variable convention in https://github.com/kubernetes-sigs/kind/pull/3394#discussion_r1370708217.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
