### PR TITLE
Automated cherry pick of #110838: Cleanups in controller utils #121327: Fix next schedule time duration

### DIFF
--- a/pkg/controller/cronjob/cronjob_controllerv2.go
+++ b/pkg/controller/cronjob/cronjob_controllerv2.go
@@ -423,13 +423,13 @@ func (jm *ControllerV2) syncCronJob(
 	childrenJobs := make(map[types.UID]bool)
 	for _, j := range jobs {
 		childrenJobs[j.ObjectMeta.UID] = true
-		found := inActiveList(*cronJob, j.ObjectMeta.UID)
+		found := inActiveList(cronJob, j.ObjectMeta.UID)
 		if !found && !IsJobFinished(j) {
 			cjCopy, err := jm.cronJobControl.GetCronJob(ctx, cronJob.Namespace, cronJob.Name)
 			if err != nil {
 				return nil, updateStatus, err
 			}
-			if inActiveList(*cjCopy, j.ObjectMeta.UID) {
+			if inActiveList(cjCopy, j.ObjectMeta.UID) {
 				cronJob = cjCopy
 				continue
 			}
@@ -545,11 +545,11 @@ func (jm *ControllerV2) syncCronJob(
 		t := nextScheduledTimeDuration(*cronJob, sched, now)
 		return t, updateStatus, nil
 	}
-	if isJobInActiveList(&batchv1.Job{
+	if inActiveListByName(cronJob, &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      getJobName(cronJob, *scheduledTime),
 			Namespace: cronJob.Namespace,
-		}}, cronJob.Status.Active) || cronJob.Status.LastScheduleTime.Equal(&metav1.Time{Time: *scheduledTime}) {
+		}}) || cronJob.Status.LastScheduleTime.Equal(&metav1.Time{Time: *scheduledTime}) {
 		klog.V(4).InfoS("Not starting job because the scheduled time is already processed", "cronjob", klog.KRef(cronJob.GetNamespace(), cronJob.GetName()), "schedule", scheduledTime)
 		t := nextScheduledTimeDuration(*cronJob, sched, now)
 		return t, updateStatus, nil
@@ -616,7 +616,7 @@ func (jm *ControllerV2) syncCronJob(
 		}
 
 		// Recheck if the job is missing from the active list before attempting to update the status again.
-		found := inActiveList(*cronJob, job.ObjectMeta.UID)
+		found := inActiveList(cronJob, job.ObjectMeta.UID)
 		if found {
 			return nil, updateStatus, nil
 		}
@@ -743,7 +743,7 @@ func (jm *ControllerV2) removeOldestJobs(cj *batchv1.CronJob, js []*batchv1.Job,
 
 	klog.V(4).InfoS("Cleaning up jobs from CronJob list", "deletejobnum", numToDelete, "jobnum", len(js), "cronjob", klog.KRef(cj.GetNamespace(), cj.GetName()))
 
-	sort.Sort(byJobStartTimeStar(js))
+	sort.Sort(byJobStartTime(js))
 	for i := 0; i < numToDelete; i++ {
 		klog.V(4).InfoS("Removing job from CronJob list", "job", js[i].Name, "cronjob", klog.KRef(cj.GetNamespace(), cj.GetName()))
 		if deleteJob(cj, js[i], jm.jobControl, jm.recorder) {
@@ -751,17 +751,6 @@ func (jm *ControllerV2) removeOldestJobs(cj *batchv1.CronJob, js []*batchv1.Job,
 		}
 	}
 	return updateStatus
-}
-
-// isJobInActiveList take a job and checks if activeJobs has a job with the same
-// name and namespace.
-func isJobInActiveList(job *batchv1.Job, activeJobs []corev1.ObjectReference) bool {
-	for _, j := range activeJobs {
-		if j.Name == job.Name && j.Namespace == job.Namespace {
-			return true
-		}
-	}
-	return false
 }
 
 // deleteJob reaps a job, deleting the job, the pods and the reference in the active list

--- a/pkg/controller/cronjob/cronjob_controllerv2.go
+++ b/pkg/controller/cronjob/cronjob_controllerv2.go
@@ -393,7 +393,7 @@ func (jm *ControllerV2) updateCronJob(old interface{}, curr interface{}) {
 			return
 		}
 		now := jm.now()
-		t := nextScheduledTimeDuration(*newCJ, sched, now)
+		t := nextScheduleTimeDuration(newCJ, now, sched)
 
 		jm.enqueueControllerAfter(curr, *t)
 		return
@@ -509,7 +509,7 @@ func (jm *ControllerV2) syncCronJob(
 		return nil, updateStatus, nil
 	}
 
-	scheduledTime, err := getNextScheduleTime(*cronJob, now, sched, jm.recorder)
+	scheduledTime, err := nextScheduleTime(cronJob, now, sched, jm.recorder)
 	if err != nil {
 		// this is likely a user error in defining the spec value
 		// we should log the error and not reconcile this cronjob until an update to spec
@@ -523,7 +523,7 @@ func (jm *ControllerV2) syncCronJob(
 		// Otherwise, the queue is always suppose to trigger sync function at the time of
 		// the scheduled time, that will give atleast 1 unmet time schedule
 		klog.V(4).InfoS("No unmet start times", "cronjob", klog.KRef(cronJob.GetNamespace(), cronJob.GetName()))
-		t := nextScheduledTimeDuration(*cronJob, sched, now)
+		t := nextScheduleTimeDuration(cronJob, now, sched)
 		return t, updateStatus, nil
 	}
 
@@ -542,7 +542,7 @@ func (jm *ControllerV2) syncCronJob(
 		// Status.LastScheduleTime, Status.LastMissedTime), and then so we won't generate
 		// and event the next time we process it, and also so the user looking at the status
 		// can see easily that there was a missed execution.
-		t := nextScheduledTimeDuration(*cronJob, sched, now)
+		t := nextScheduleTimeDuration(cronJob, now, sched)
 		return t, updateStatus, nil
 	}
 	if inActiveListByName(cronJob, &batchv1.Job{
@@ -551,7 +551,7 @@ func (jm *ControllerV2) syncCronJob(
 			Namespace: cronJob.Namespace,
 		}}) || cronJob.Status.LastScheduleTime.Equal(&metav1.Time{Time: *scheduledTime}) {
 		klog.V(4).InfoS("Not starting job because the scheduled time is already processed", "cronjob", klog.KRef(cronJob.GetNamespace(), cronJob.GetName()), "schedule", scheduledTime)
-		t := nextScheduledTimeDuration(*cronJob, sched, now)
+		t := nextScheduleTimeDuration(cronJob, now, sched)
 		return t, updateStatus, nil
 	}
 	if cronJob.Spec.ConcurrencyPolicy == batchv1.ForbidConcurrent && len(cronJob.Status.Active) > 0 {
@@ -566,7 +566,7 @@ func (jm *ControllerV2) syncCronJob(
 		// But that would mean that you could not inspect prior successes or failures of Forbid jobs.
 		klog.V(4).InfoS("Not starting job because prior execution is still running and concurrency policy is Forbid", "cronjob", klog.KRef(cronJob.GetNamespace(), cronJob.GetName()))
 		jm.recorder.Eventf(cronJob, corev1.EventTypeNormal, "JobAlreadyActive", "Not starting job because prior execution is running and concurrency policy is Forbid")
-		t := nextScheduledTimeDuration(*cronJob, sched, now)
+		t := nextScheduleTimeDuration(cronJob, now, sched)
 		return t, updateStatus, nil
 	}
 	if cronJob.Spec.ConcurrencyPolicy == batchv1.ReplaceConcurrent {
@@ -654,36 +654,12 @@ func (jm *ControllerV2) syncCronJob(
 	cronJob.Status.LastScheduleTime = &metav1.Time{Time: *scheduledTime}
 	updateStatus = true
 
-	t := nextScheduledTimeDuration(*cronJob, sched, now)
+	t := nextScheduleTimeDuration(cronJob, now, sched)
 	return t, updateStatus, nil
 }
 
 func getJobName(cj *batchv1.CronJob, scheduledTime time.Time) string {
 	return fmt.Sprintf("%s-%d", cj.Name, getTimeHashInMinutes(scheduledTime))
-}
-
-// nextScheduledTimeDuration returns the time duration to requeue based on
-// the schedule and last schedule time. It adds a 100ms padding to the next requeue to account
-// for Network Time Protocol(NTP) time skews. If the time drifts are adjusted which in most
-// realistic cases would be around 100s, scheduled cron will still be executed without missing
-// the schedule.
-func nextScheduledTimeDuration(cj batchv1.CronJob, sched cron.Schedule, now time.Time) *time.Duration {
-	earliestTime := cj.ObjectMeta.CreationTimestamp.Time
-	if cj.Status.LastScheduleTime != nil {
-		earliestTime = cj.Status.LastScheduleTime.Time
-	}
-	mostRecentTime, _, err := getMostRecentScheduleTime(earliestTime, now, sched)
-	if err != nil {
-		// we still have to requeue at some point, so aim for the next scheduling slot from now
-		mostRecentTime = &now
-	} else if mostRecentTime == nil {
-		// no missed schedules since earliestTime
-		mostRecentTime = &earliestTime
-	}
-
-	t := sched.Next(*mostRecentTime).Add(nextScheduleDelta).Sub(now)
-
-	return &t
 }
 
 // cleanupFinishedJobs cleanups finished jobs created by a CronJob

--- a/pkg/controller/cronjob/utils.go
+++ b/pkg/controller/cronjob/utils.go
@@ -33,6 +33,27 @@ import (
 
 // Utilities for dealing with Jobs and CronJobs and time.
 
+type missedSchedulesType int
+
+const (
+	noneMissed missedSchedulesType = iota
+	fewMissed
+	manyMissed
+)
+
+func (e missedSchedulesType) String() string {
+	switch e {
+	case noneMissed:
+		return "none"
+	case fewMissed:
+		return "few"
+	case manyMissed:
+		return "many"
+	default:
+		return fmt.Sprintf("unknown(%d)", int(e))
+	}
+}
+
 // inActiveList checks if cronjob's .status.active has a job with the same UID.
 func inActiveList(cj *batchv1.CronJob, uid types.UID) bool {
 	for _, j := range cj.Status.Active {
@@ -72,11 +93,12 @@ func deleteFromActiveList(cj *batchv1.CronJob, uid types.UID) {
 // mostRecentScheduleTime returns:
 //   - the last schedule time or CronJob's creation time,
 //   - the most recent time a Job should be created or nil, if that's after now,
-//   - number of missed schedules
+//   - value indicating either none missed schedules, a few missed or many missed
 //   - error in an edge case where the schedule specification is grammatically correct,
 //     but logically doesn't make sense (31st day for months with only 30 days, for example).
-func mostRecentScheduleTime(cj *batchv1.CronJob, now time.Time, schedule cron.Schedule, includeStartingDeadlineSeconds bool) (time.Time, *time.Time, int64, error) {
+func mostRecentScheduleTime(cj *batchv1.CronJob, now time.Time, schedule cron.Schedule, includeStartingDeadlineSeconds bool) (time.Time, *time.Time, missedSchedulesType, error) {
 	earliestTime := cj.ObjectMeta.CreationTimestamp.Time
+	missedSchedules := noneMissed
 	if cj.Status.LastScheduleTime != nil {
 		earliestTime = cj.Status.LastScheduleTime.Time
 	}
@@ -93,10 +115,10 @@ func mostRecentScheduleTime(cj *batchv1.CronJob, now time.Time, schedule cron.Sc
 	t2 := schedule.Next(t1)
 
 	if now.Before(t1) {
-		return earliestTime, nil, 0, nil
+		return earliestTime, nil, missedSchedules, nil
 	}
 	if now.Before(t2) {
-		return earliestTime, &t1, 1, nil
+		return earliestTime, &t1, missedSchedules, nil
 	}
 
 	// It is possible for cron.ParseStandard("59 23 31 2 *") to return an invalid schedule
@@ -104,13 +126,57 @@ func mostRecentScheduleTime(cj *batchv1.CronJob, now time.Time, schedule cron.Sc
 	// In this case the timeBetweenTwoSchedules will be 0, and we error out the invalid schedule
 	timeBetweenTwoSchedules := int64(t2.Sub(t1).Round(time.Second).Seconds())
 	if timeBetweenTwoSchedules < 1 {
-		return earliestTime, nil, 0, fmt.Errorf("time difference between two schedules is less than 1 second")
+		return earliestTime, nil, missedSchedules, fmt.Errorf("time difference between two schedules is less than 1 second")
 	}
+	// this logic used for calculating number of missed schedules does a rough
+	// approximation, by calculating a diff between two schedules (t1 and t2),
+	// and counting how many of these will fit in between last schedule and now
 	timeElapsed := int64(now.Sub(t1).Seconds())
 	numberOfMissedSchedules := (timeElapsed / timeBetweenTwoSchedules) + 1
-	mostRecentTime := time.Unix(t1.Unix()+((numberOfMissedSchedules-1)*timeBetweenTwoSchedules), 0).UTC()
 
-	return earliestTime, &mostRecentTime, numberOfMissedSchedules, nil
+	var mostRecentTime time.Time
+	// to get the most recent time accurate for regular schedules and the ones
+	// specified with @every form, we first need to calculate the potential earliest
+	// time by multiplying the initial number of missed schedules by its interval,
+	// this is critical to ensure @every starts at the correct time, this explains
+	// the numberOfMissedSchedules-1, the additional -1 serves there to go back
+	// in time one more time unit, and let the cron library calculate a proper
+	// schedule, for case where the schedule is not consistent, for example
+	// something like  30 6-16/4 * * 1-5
+	potentialEarliest := t1.Add(time.Duration((numberOfMissedSchedules-1-1)*timeBetweenTwoSchedules) * time.Second)
+	for t := schedule.Next(potentialEarliest); !t.After(now); t = schedule.Next(t) {
+		mostRecentTime = t
+	}
+
+	// An object might miss several starts. For example, if
+	// controller gets wedged on friday at 5:01pm when everyone has
+	// gone home, and someone comes in on tuesday AM and discovers
+	// the problem and restarts the controller, then all the hourly
+	// jobs, more than 80 of them for one hourly cronJob, should
+	// all start running with no further intervention (if the cronJob
+	// allows concurrency and late starts).
+	//
+	// However, if there is a bug somewhere, or incorrect clock
+	// on controller's server or apiservers (for setting creationTimestamp)
+	// then there could be so many missed start times (it could be off
+	// by decades or more), that it would eat up all the CPU and memory
+	// of this controller. In that case, we want to not try to list
+	// all the missed start times.
+	//
+	// I've somewhat arbitrarily picked 100, as more than 80,
+	// but less than "lots".
+	switch {
+	case numberOfMissedSchedules > 100:
+		missedSchedules = manyMissed
+	// inform about few missed, still
+	case numberOfMissedSchedules > 0:
+		missedSchedules = fewMissed
+	}
+
+	if mostRecentTime.IsZero() {
+		return earliestTime, nil, missedSchedules, nil
+	}
+	return earliestTime, &mostRecentTime, missedSchedules, nil
 }
 
 // nextScheduleTimeDuration returns the time duration to requeue based on
@@ -119,13 +185,18 @@ func mostRecentScheduleTime(cj *batchv1.CronJob, now time.Time, schedule cron.Sc
 // realistic cases should be around 100s, the job will still be executed without missing
 // the schedule.
 func nextScheduleTimeDuration(cj *batchv1.CronJob, now time.Time, schedule cron.Schedule) *time.Duration {
-	earliestTime, mostRecentTime, _, err := mostRecentScheduleTime(cj, now, schedule, false)
+	earliestTime, mostRecentTime, missedSchedules, err := mostRecentScheduleTime(cj, now, schedule, false)
 	if err != nil {
 		// we still have to requeue at some point, so aim for the next scheduling slot from now
 		mostRecentTime = &now
 	} else if mostRecentTime == nil {
-		// no missed schedules since earliestTime
-		mostRecentTime = &earliestTime
+		if missedSchedules == noneMissed {
+			// no missed schedules since earliestTime
+			mostRecentTime = &earliestTime
+		} else {
+			// if there are missed schedules since earliestTime, always use now
+			mostRecentTime = &now
+		}
 	}
 
 	t := schedule.Next(*mostRecentTime).Add(nextScheduleDelta).Sub(now)
@@ -136,7 +207,7 @@ func nextScheduleTimeDuration(cj *batchv1.CronJob, now time.Time, schedule cron.
 // and before now, or nil if no unmet schedule times, and an error.
 // If there are too many (>100) unstarted times, it will also record a warning.
 func nextScheduleTime(cj *batchv1.CronJob, now time.Time, schedule cron.Schedule, recorder record.EventRecorder) (*time.Time, error) {
-	_, mostRecentTime, numberOfMissedSchedules, err := mostRecentScheduleTime(cj, now, schedule, true)
+	_, mostRecentTime, missedSchedules, err := mostRecentScheduleTime(cj, now, schedule, true)
 
 	if mostRecentTime == nil || mostRecentTime.After(now) {
 		return nil, err

--- a/pkg/controller/cronjob/utils.go
+++ b/pkg/controller/cronjob/utils.go
@@ -69,112 +69,84 @@ func deleteFromActiveList(cj *batchv1.CronJob, uid types.UID) {
 	cj.Status.Active = newActive
 }
 
-// getNextScheduleTime gets the time of next schedule after last scheduled and before now
-//
-//	it returns nil if no unmet schedule times.
-//
-// If there are too many (>100) unstarted times, it will raise a warning and but still return
-// the list of missed times.
-func getNextScheduleTime(cj batchv1.CronJob, now time.Time, schedule cron.Schedule, recorder record.EventRecorder) (*time.Time, error) {
-	var (
-		earliestTime time.Time
-	)
+// mostRecentScheduleTime returns:
+//   - the last schedule time or CronJob's creation time,
+//   - the most recent time a Job should be created or nil, if that's after now,
+//   - number of missed schedules
+//   - error in an edge case where the schedule specification is grammatically correct,
+//     but logically doesn't make sense (31st day for months with only 30 days, for example).
+func mostRecentScheduleTime(cj *batchv1.CronJob, now time.Time, schedule cron.Schedule, includeStartingDeadlineSeconds bool) (time.Time, *time.Time, int64, error) {
+	earliestTime := cj.ObjectMeta.CreationTimestamp.Time
 	if cj.Status.LastScheduleTime != nil {
 		earliestTime = cj.Status.LastScheduleTime.Time
-	} else {
-		// If none found, then this is either a recently created cronJob,
-		// or the active/completed info was somehow lost (contract for status
-		// in kubernetes says it may need to be recreated), or that we have
-		// started a job, but have not noticed it yet (distributed systems can
-		// have arbitrary delays).  In any case, use the creation time of the
-		// CronJob as last known start time.
-		earliestTime = cj.ObjectMeta.CreationTimestamp.Time
 	}
-	if cj.Spec.StartingDeadlineSeconds != nil {
-		// Controller is not going to schedule anything below this point
+	if includeStartingDeadlineSeconds && cj.Spec.StartingDeadlineSeconds != nil {
+		// controller is not going to schedule anything below this point
 		schedulingDeadline := now.Add(-time.Second * time.Duration(*cj.Spec.StartingDeadlineSeconds))
 
 		if schedulingDeadline.After(earliestTime) {
 			earliestTime = schedulingDeadline
 		}
 	}
-	if earliestTime.After(now) {
-		return nil, nil
-	}
 
-	t, tooManyMissed, err := getMostRecentScheduleTime(earliestTime, now, schedule)
-
-	if tooManyMissed {
-		recorder.Eventf(&cj, corev1.EventTypeWarning, "TooManyMissedTimes", "too many missed start times. Set or decrease .spec.startingDeadlineSeconds or check clock skew")
-		klog.InfoS("too many missed times", "cronjob", klog.KRef(cj.GetNamespace(), cj.GetName()))
-	}
-	return t, err
-}
-
-// getMostRecentScheduleTime returns the latest schedule time between earliestTime and
-// boolean whether an excessive number of schedules are missed
-func getMostRecentScheduleTime(earliestTime time.Time, now time.Time, schedule cron.Schedule) (*time.Time, bool, error) {
 	t1 := schedule.Next(earliestTime)
 	t2 := schedule.Next(t1)
 
 	if now.Before(t1) {
-		return nil, false, nil
+		return earliestTime, nil, 0, nil
 	}
 	if now.Before(t2) {
-		return &t1, false, nil
+		return earliestTime, &t1, 1, nil
 	}
 
 	// It is possible for cron.ParseStandard("59 23 31 2 *") to return an invalid schedule
-	// seconds - 59, minute - 23, hour - 31 (?!)  dom - 2, and dow is optional, clearly 31 is invalid
+	// minute - 59, hour - 23, dom - 31, month - 2, and dow is optional, clearly 31 is invalid
 	// In this case the timeBetweenTwoSchedules will be 0, and we error out the invalid schedule
 	timeBetweenTwoSchedules := int64(t2.Sub(t1).Round(time.Second).Seconds())
 	if timeBetweenTwoSchedules < 1 {
-		return nil, false, fmt.Errorf("time difference between two schedules less than 1 second")
+		return earliestTime, nil, 0, fmt.Errorf("time difference between two schedules is less than 1 second")
 	}
-	// this logic used for calculating number of missed schedules does a rough
-	// approximation, by calculating a diff between two schedules (t1 and t2),
-	// and counting how many of these will fit in between last schedule and now
 	timeElapsed := int64(now.Sub(t1).Seconds())
 	numberOfMissedSchedules := (timeElapsed / timeBetweenTwoSchedules) + 1
+	mostRecentTime := time.Unix(t1.Unix()+((numberOfMissedSchedules-1)*timeBetweenTwoSchedules), 0).UTC()
 
-	var mostRecentTime time.Time
-	// to get the most recent time accurate for regular schedules and the ones
-	// specified with @every form, we first need to calculate the potential earliest
-	// time by multiplying the initial number of missed schedules by its interval,
-	// this is critical to ensure @every starts at the correct time, this explains
-	// the numberOfMissedSchedules-1, the additional -1 serves there to go back
-	// in time one more time unit, and let the cron library calculate a proper
-	// schedule, for case where the schedule is not consistent, for example
-	// something like  30 6-16/4 * * 1-5
-	potentialEarliest := t1.Add(time.Duration((numberOfMissedSchedules-1-1)*timeBetweenTwoSchedules) * time.Second)
-	for t := schedule.Next(potentialEarliest); !t.After(now); t = schedule.Next(t) {
-		mostRecentTime = t
+	return earliestTime, &mostRecentTime, numberOfMissedSchedules, nil
+}
+
+// nextScheduleTimeDuration returns the time duration to requeue based on
+// the schedule and last schedule time. It adds a 100ms padding to the next requeue to account
+// for Network Time Protocol(NTP) time skews. If the time drifts the adjustment, which in most
+// realistic cases should be around 100s, the job will still be executed without missing
+// the schedule.
+func nextScheduleTimeDuration(cj *batchv1.CronJob, now time.Time, schedule cron.Schedule) *time.Duration {
+	earliestTime, mostRecentTime, _, err := mostRecentScheduleTime(cj, now, schedule, false)
+	if err != nil {
+		// we still have to requeue at some point, so aim for the next scheduling slot from now
+		mostRecentTime = &now
+	} else if mostRecentTime == nil {
+		// no missed schedules since earliestTime
+		mostRecentTime = &earliestTime
 	}
 
-	// An object might miss several starts. For example, if
-	// controller gets wedged on friday at 5:01pm when everyone has
-	// gone home, and someone comes in on tuesday AM and discovers
-	// the problem and restarts the controller, then all the hourly
-	// jobs, more than 80 of them for one hourly cronJob, should
-	// all start running with no further intervention (if the cronJob
-	// allows concurrency and late starts).
-	//
-	// However, if there is a bug somewhere, or incorrect clock
-	// on controller's server or apiservers (for setting creationTimestamp)
-	// then there could be so many missed start times (it could be off
-	// by decades or more), that it would eat up all the CPU and memory
-	// of this controller. In that case, we want to not try to list
-	// all the missed start times.
-	//
-	// I've somewhat arbitrarily picked 100, as more than 80,
-	// but less than "lots".
-	tooManyMissed := numberOfMissedSchedules > 100
+	t := schedule.Next(*mostRecentTime).Add(nextScheduleDelta).Sub(now)
+	return &t
+}
 
-	if mostRecentTime.IsZero() {
-		return nil, tooManyMissed, nil
+// nextScheduleTime returns the time.Time of the next schedule after the last scheduled
+// and before now, or nil if no unmet schedule times, and an error.
+// If there are too many (>100) unstarted times, it will also record a warning.
+func nextScheduleTime(cj *batchv1.CronJob, now time.Time, schedule cron.Schedule, recorder record.EventRecorder) (*time.Time, error) {
+	_, mostRecentTime, numberOfMissedSchedules, err := mostRecentScheduleTime(cj, now, schedule, true)
+
+	if mostRecentTime == nil || mostRecentTime.After(now) {
+		return nil, err
 	}
 
-	return &mostRecentTime, tooManyMissed, nil
+	if missedSchedules == manyMissed {
+		recorder.Eventf(cj, corev1.EventTypeWarning, "TooManyMissedTimes", "too many missed start times. Set or decrease .spec.startingDeadlineSeconds or check clock skew")
+		klog.InfoS("too many missed times", "cronjob", klog.KRef(cj.GetNamespace(), cj.GetName()))
+	}
+	return mostRecentTime, err
 }
 
 func copyLabels(template *batchv1.JobTemplateSpec) labels.Set {

--- a/pkg/controller/cronjob/utils.go
+++ b/pkg/controller/cronjob/utils.go
@@ -33,9 +33,21 @@ import (
 
 // Utilities for dealing with Jobs and CronJobs and time.
 
-func inActiveList(cj batchv1.CronJob, uid types.UID) bool {
+// inActiveList checks if cronjob's .status.active has a job with the same UID.
+func inActiveList(cj *batchv1.CronJob, uid types.UID) bool {
 	for _, j := range cj.Status.Active {
 		if j.UID == uid {
+			return true
+		}
+	}
+	return false
+}
+
+// inActiveListByName checks if cronjob's status.active has a job with the same
+// name and namespace.
+func inActiveListByName(cj *batchv1.CronJob, job *batchv1.Job) bool {
+	for _, j := range cj.Status.Active {
+		if j.Name == job.Name && j.Namespace == job.Namespace {
 			return true
 		}
 	}
@@ -224,31 +236,12 @@ func IsJobFinished(j *batchv1.Job) bool {
 }
 
 // byJobStartTime sorts a list of jobs by start timestamp, using their names as a tie breaker.
-type byJobStartTime []batchv1.Job
+type byJobStartTime []*batchv1.Job
 
 func (o byJobStartTime) Len() int      { return len(o) }
 func (o byJobStartTime) Swap(i, j int) { o[i], o[j] = o[j], o[i] }
 
 func (o byJobStartTime) Less(i, j int) bool {
-	if o[i].Status.StartTime == nil && o[j].Status.StartTime != nil {
-		return false
-	}
-	if o[i].Status.StartTime != nil && o[j].Status.StartTime == nil {
-		return true
-	}
-	if o[i].Status.StartTime.Equal(o[j].Status.StartTime) {
-		return o[i].Name < o[j].Name
-	}
-	return o[i].Status.StartTime.Before(o[j].Status.StartTime)
-}
-
-// byJobStartTimeStar sorts a list of jobs by start timestamp, using their names as a tie breaker.
-type byJobStartTimeStar []*batchv1.Job
-
-func (o byJobStartTimeStar) Len() int      { return len(o) }
-func (o byJobStartTimeStar) Swap(i, j int) { o[i], o[j] = o[j], o[i] }
-
-func (o byJobStartTimeStar) Less(i, j int) bool {
 	if o[i].Status.StartTime == nil && o[j].Status.StartTime != nil {
 		return false
 	}

--- a/pkg/controller/cronjob/utils_test.go
+++ b/pkg/controller/cronjob/utils_test.go
@@ -92,7 +92,7 @@ func TestNextScheduleTime(t *testing.T) {
 	// schedule is hourly on the hour
 	schedule := "0 * * * ?"
 
-	PraseSchedule := func(schedule string) cron.Schedule {
+	ParseSchedule := func(schedule string) cron.Schedule {
 		sched, err := cron.ParseStandard(schedule)
 		if err != nil {
 			t.Errorf("Error parsing schedule: %#v", err)
@@ -124,7 +124,7 @@ func TestNextScheduleTime(t *testing.T) {
 		cj.ObjectMeta.CreationTimestamp = metav1.Time{Time: T1.Add(-10 * time.Minute)}
 		// Current time is more than creation time, but less than T1.
 		now := T1.Add(-7 * time.Minute)
-		schedule, _ := nextScheduleTime(&cj, now, PraseSchedule(cj.Spec.Schedule), recorder)
+		schedule, _ := nextScheduleTime(&cj, now, ParseSchedule(cj.Spec.Schedule), recorder)
 		if schedule != nil {
 			t.Errorf("expected no start time, got:  %v", schedule)
 		}
@@ -135,7 +135,7 @@ func TestNextScheduleTime(t *testing.T) {
 		cj.ObjectMeta.CreationTimestamp = metav1.Time{Time: T1.Add(-10 * time.Minute)}
 		// Current time is after T1
 		now := T1.Add(2 * time.Second)
-		schedule, _ := nextScheduleTime(&cj, now, PraseSchedule(cj.Spec.Schedule), recorder)
+		schedule, _ := nextScheduleTime(&cj, now, ParseSchedule(cj.Spec.Schedule), recorder)
 		if schedule == nil {
 			t.Errorf("expected 1 start time, got nil")
 		} else if !schedule.Equal(T1) {
@@ -150,7 +150,7 @@ func TestNextScheduleTime(t *testing.T) {
 		cj.Status.LastScheduleTime = &metav1.Time{Time: T1}
 		// Current time is after T1
 		now := T1.Add(2 * time.Minute)
-		schedule, _ := nextScheduleTime(&cj, now, PraseSchedule(cj.Spec.Schedule), recorder)
+		schedule, _ := nextScheduleTime(&cj, now, ParseSchedule(cj.Spec.Schedule), recorder)
 		if schedule != nil {
 			t.Errorf("expected 0 start times, got: %v", schedule)
 		}
@@ -163,7 +163,7 @@ func TestNextScheduleTime(t *testing.T) {
 		cj.Status.LastScheduleTime = &metav1.Time{Time: T1}
 		// Current time is after T1 and after T2
 		now := T2.Add(5 * time.Minute)
-		schedule, _ := nextScheduleTime(&cj, now, PraseSchedule(cj.Spec.Schedule), recorder)
+		schedule, _ := nextScheduleTime(&cj, now, ParseSchedule(cj.Spec.Schedule), recorder)
 		if schedule == nil {
 			t.Errorf("expected 1 start times, got nil")
 		} else if !schedule.Equal(T2) {
@@ -176,7 +176,7 @@ func TestNextScheduleTime(t *testing.T) {
 		cj.Status.LastScheduleTime = &metav1.Time{Time: T1.Add(-1 * time.Hour)}
 		// Current time is after T1 and after T2
 		now := T2.Add(5 * time.Minute)
-		schedule, _ := nextScheduleTime(&cj, now, PraseSchedule(cj.Spec.Schedule), recorder)
+		schedule, _ := nextScheduleTime(&cj, now, ParseSchedule(cj.Spec.Schedule), recorder)
 		if schedule == nil {
 			t.Errorf("expected 1 start times, got nil")
 		} else if !schedule.Equal(T2) {
@@ -188,7 +188,7 @@ func TestNextScheduleTime(t *testing.T) {
 		cj.ObjectMeta.CreationTimestamp = metav1.Time{Time: T1.Add(-2 * time.Hour)}
 		cj.Status.LastScheduleTime = &metav1.Time{Time: T1.Add(-1 * time.Hour)}
 		now := T2.Add(10 * 24 * time.Hour)
-		schedule, _ := nextScheduleTime(&cj, now, PraseSchedule(cj.Spec.Schedule), recorder)
+		schedule, _ := nextScheduleTime(&cj, now, ParseSchedule(cj.Spec.Schedule), recorder)
 		if schedule == nil {
 			t.Errorf("expected more than 0 missed times")
 		}
@@ -201,7 +201,7 @@ func TestNextScheduleTime(t *testing.T) {
 		// Deadline is short
 		deadline := int64(2 * 60 * 60)
 		cj.Spec.StartingDeadlineSeconds = &deadline
-		schedule, _ := nextScheduleTime(&cj, now, PraseSchedule(cj.Spec.Schedule), recorder)
+		schedule, _ := nextScheduleTime(&cj, now, ParseSchedule(cj.Spec.Schedule), recorder)
 		if schedule == nil {
 			t.Errorf("expected more than 0 missed times")
 		}
@@ -212,7 +212,7 @@ func TestNextScheduleTime(t *testing.T) {
 		cj.Status.LastScheduleTime = nil
 		now := *deltaTimeAfterTopOfTheHour(1 * time.Hour)
 		// rouge schedule
-		schedule, err := nextScheduleTime(&cj, now, PraseSchedule("59 23 31 2 *"), recorder)
+		schedule, err := nextScheduleTime(&cj, now, ParseSchedule("59 23 31 2 *"), recorder)
 		if schedule != nil {
 			t.Errorf("expected no start time, got:  %v", schedule)
 		}

--- a/pkg/controller/cronjob/utils_test.go
+++ b/pkg/controller/cronjob/utils_test.go
@@ -554,6 +554,7 @@ func TestMostRecentScheduleTime(t *testing.T) {
 func TestNextScheduleTimeDuration(t *testing.T) {
 	metav1TopOfTheHour := metav1.NewTime(*topOfTheHour())
 	metav1HalfPastTheHour := metav1.NewTime(*deltaTimeAfterTopOfTheHour(30 * time.Minute))
+	metav1TwoHoursLater := metav1.NewTime(*deltaTimeAfterTopOfTheHour(2 * time.Hour))
 
 	tests := []struct {
 		name             string
@@ -593,6 +594,35 @@ func TestNextScheduleTimeDuration(t *testing.T) {
 			now:              *deltaTimeAfterTopOfTheHour(30*time.Hour + 30*time.Minute),
 			expectedDuration: 66*time.Hour + nextScheduleDelta,
 		},
+		{
+			name: "once a week cronjob, missed two runs",
+			cj: &batchv1.CronJob{
+				ObjectMeta: metav1.ObjectMeta{
+					CreationTimestamp: metav1TopOfTheHour,
+				},
+				Spec: batchv1.CronJobSpec{
+					Schedule: "0 12 * * 4",
+				},
+				Status: batchv1.CronJobStatus{
+					LastScheduleTime: &metav1TwoHoursLater,
+				},
+			},
+			now:              *deltaTimeAfterTopOfTheHour(19*24*time.Hour + 1*time.Hour + 30*time.Minute),
+			expectedDuration: 48*time.Hour + 30*time.Minute + nextScheduleDelta,
+		},
+		{
+			name: "no previous run of a cronjob",
+			cj: &batchv1.CronJob{
+				ObjectMeta: metav1.ObjectMeta{
+					CreationTimestamp: metav1TopOfTheHour,
+				},
+				Spec: batchv1.CronJobSpec{
+					Schedule: "0 12 * * 5",
+				},
+			},
+			now:              *deltaTimeAfterTopOfTheHour(6 * time.Hour),
+			expectedDuration: 20*time.Hour + nextScheduleDelta,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -601,6 +631,9 @@ func TestNextScheduleTimeDuration(t *testing.T) {
 				t.Errorf("error setting up the test, %s", err)
 			}
 			gotScheduleTimeDuration := nextScheduleTimeDuration(tt.cj, tt.now, sched)
+			if *gotScheduleTimeDuration < 0 {
+				t.Errorf("scheduleTimeDuration should never be less than 0, got %s", gotScheduleTimeDuration)
+			}
 			if !reflect.DeepEqual(gotScheduleTimeDuration, &tt.expectedDuration) {
 				t.Errorf("scheduleTimeDuration - got %s, want %s", gotScheduleTimeDuration, tt.expectedDuration)
 			}

--- a/pkg/controller/cronjob/utils_test.go
+++ b/pkg/controller/cronjob/utils_test.go
@@ -88,7 +88,7 @@ func TestGetJobFromTemplate2(t *testing.T) {
 	}
 }
 
-func TestGetNextScheduleTime(t *testing.T) {
+func TestNextScheduleTime(t *testing.T) {
 	// schedule is hourly on the hour
 	schedule := "0 * * * ?"
 
@@ -102,15 +102,9 @@ func TestGetNextScheduleTime(t *testing.T) {
 	}
 	recorder := record.NewFakeRecorder(50)
 	// T1 is a scheduled start time of that schedule
-	T1, err := time.Parse(time.RFC3339, "2016-05-19T10:00:00Z")
-	if err != nil {
-		t.Errorf("test setup error: %v", err)
-	}
+	T1 := *topOfTheHour()
 	// T2 is a scheduled start time of that schedule after T1
-	T2, err := time.Parse(time.RFC3339, "2016-05-19T11:00:00Z")
-	if err != nil {
-		t.Errorf("test setup error: %v", err)
-	}
+	T2 := *deltaTimeAfterTopOfTheHour(1 * time.Hour)
 
 	cj := batchv1.CronJob{
 		ObjectMeta: metav1.ObjectMeta{
@@ -130,7 +124,7 @@ func TestGetNextScheduleTime(t *testing.T) {
 		cj.ObjectMeta.CreationTimestamp = metav1.Time{Time: T1.Add(-10 * time.Minute)}
 		// Current time is more than creation time, but less than T1.
 		now := T1.Add(-7 * time.Minute)
-		schedule, _ := getNextScheduleTime(cj, now, PraseSchedule(cj.Spec.Schedule), recorder)
+		schedule, _ := nextScheduleTime(&cj, now, PraseSchedule(cj.Spec.Schedule), recorder)
 		if schedule != nil {
 			t.Errorf("expected no start time, got:  %v", schedule)
 		}
@@ -141,7 +135,7 @@ func TestGetNextScheduleTime(t *testing.T) {
 		cj.ObjectMeta.CreationTimestamp = metav1.Time{Time: T1.Add(-10 * time.Minute)}
 		// Current time is after T1
 		now := T1.Add(2 * time.Second)
-		schedule, _ := getNextScheduleTime(cj, now, PraseSchedule(cj.Spec.Schedule), recorder)
+		schedule, _ := nextScheduleTime(&cj, now, PraseSchedule(cj.Spec.Schedule), recorder)
 		if schedule == nil {
 			t.Errorf("expected 1 start time, got nil")
 		} else if !schedule.Equal(T1) {
@@ -156,7 +150,7 @@ func TestGetNextScheduleTime(t *testing.T) {
 		cj.Status.LastScheduleTime = &metav1.Time{Time: T1}
 		// Current time is after T1
 		now := T1.Add(2 * time.Minute)
-		schedule, _ := getNextScheduleTime(cj, now, PraseSchedule(cj.Spec.Schedule), recorder)
+		schedule, _ := nextScheduleTime(&cj, now, PraseSchedule(cj.Spec.Schedule), recorder)
 		if schedule != nil {
 			t.Errorf("expected 0 start times, got: %v", schedule)
 		}
@@ -169,7 +163,7 @@ func TestGetNextScheduleTime(t *testing.T) {
 		cj.Status.LastScheduleTime = &metav1.Time{Time: T1}
 		// Current time is after T1 and after T2
 		now := T2.Add(5 * time.Minute)
-		schedule, _ := getNextScheduleTime(cj, now, PraseSchedule(cj.Spec.Schedule), recorder)
+		schedule, _ := nextScheduleTime(&cj, now, PraseSchedule(cj.Spec.Schedule), recorder)
 		if schedule == nil {
 			t.Errorf("expected 1 start times, got nil")
 		} else if !schedule.Equal(T2) {
@@ -182,7 +176,7 @@ func TestGetNextScheduleTime(t *testing.T) {
 		cj.Status.LastScheduleTime = &metav1.Time{Time: T1.Add(-1 * time.Hour)}
 		// Current time is after T1 and after T2
 		now := T2.Add(5 * time.Minute)
-		schedule, _ := getNextScheduleTime(cj, now, PraseSchedule(cj.Spec.Schedule), recorder)
+		schedule, _ := nextScheduleTime(&cj, now, PraseSchedule(cj.Spec.Schedule), recorder)
 		if schedule == nil {
 			t.Errorf("expected 1 start times, got nil")
 		} else if !schedule.Equal(T2) {
@@ -194,7 +188,7 @@ func TestGetNextScheduleTime(t *testing.T) {
 		cj.ObjectMeta.CreationTimestamp = metav1.Time{Time: T1.Add(-2 * time.Hour)}
 		cj.Status.LastScheduleTime = &metav1.Time{Time: T1.Add(-1 * time.Hour)}
 		now := T2.Add(10 * 24 * time.Hour)
-		schedule, _ := getNextScheduleTime(cj, now, PraseSchedule(cj.Spec.Schedule), recorder)
+		schedule, _ := nextScheduleTime(&cj, now, PraseSchedule(cj.Spec.Schedule), recorder)
 		if schedule == nil {
 			t.Errorf("expected more than 0 missed times")
 		}
@@ -207,9 +201,23 @@ func TestGetNextScheduleTime(t *testing.T) {
 		// Deadline is short
 		deadline := int64(2 * 60 * 60)
 		cj.Spec.StartingDeadlineSeconds = &deadline
-		schedule, _ := getNextScheduleTime(cj, now, PraseSchedule(cj.Spec.Schedule), recorder)
+		schedule, _ := nextScheduleTime(&cj, now, PraseSchedule(cj.Spec.Schedule), recorder)
 		if schedule == nil {
 			t.Errorf("expected more than 0 missed times")
+		}
+	}
+	{
+		// Case 8: ensure the error from mostRecentScheduleTime gets populated up
+		cj.ObjectMeta.CreationTimestamp = metav1.Time{Time: T1.Add(10 * time.Second)}
+		cj.Status.LastScheduleTime = nil
+		now := *deltaTimeAfterTopOfTheHour(1 * time.Hour)
+		// rouge schedule
+		schedule, err := nextScheduleTime(&cj, now, PraseSchedule("59 23 31 2 *"), recorder)
+		if schedule != nil {
+			t.Errorf("expected no start time, got:  %v", schedule)
+		}
+		if err == nil {
+			t.Errorf("expected error")
 		}
 	}
 }
@@ -217,55 +225,55 @@ func TestGetNextScheduleTime(t *testing.T) {
 func TestByJobStartTime(t *testing.T) {
 	now := metav1.NewTime(time.Date(2018, time.January, 1, 2, 3, 4, 5, time.UTC))
 	later := metav1.NewTime(time.Date(2019, time.January, 1, 2, 3, 4, 5, time.UTC))
-	aNil := batchv1.Job{
+	aNil := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{Name: "a"},
 		Status:     batchv1.JobStatus{},
 	}
-	bNil := batchv1.Job{
+	bNil := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{Name: "b"},
 		Status:     batchv1.JobStatus{},
 	}
-	aSet := batchv1.Job{
+	aSet := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{Name: "a"},
 		Status:     batchv1.JobStatus{StartTime: &now},
 	}
-	bSet := batchv1.Job{
+	bSet := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{Name: "b"},
 		Status:     batchv1.JobStatus{StartTime: &now},
 	}
-	aSetLater := batchv1.Job{
+	aSetLater := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{Name: "a"},
 		Status:     batchv1.JobStatus{StartTime: &later},
 	}
 
 	testCases := []struct {
 		name            string
-		input, expected []batchv1.Job
+		input, expected []*batchv1.Job
 	}{
 		{
 			name:     "both have nil start times",
-			input:    []batchv1.Job{bNil, aNil},
-			expected: []batchv1.Job{aNil, bNil},
+			input:    []*batchv1.Job{bNil, aNil},
+			expected: []*batchv1.Job{aNil, bNil},
 		},
 		{
 			name:     "only the first has a nil start time",
-			input:    []batchv1.Job{aNil, bSet},
-			expected: []batchv1.Job{bSet, aNil},
+			input:    []*batchv1.Job{aNil, bSet},
+			expected: []*batchv1.Job{bSet, aNil},
 		},
 		{
 			name:     "only the second has a nil start time",
-			input:    []batchv1.Job{aSet, bNil},
-			expected: []batchv1.Job{aSet, bNil},
+			input:    []*batchv1.Job{aSet, bNil},
+			expected: []*batchv1.Job{aSet, bNil},
 		},
 		{
 			name:     "both have non-nil, equal start time",
-			input:    []batchv1.Job{bSet, aSet},
-			expected: []batchv1.Job{aSet, bSet},
+			input:    []*batchv1.Job{bSet, aSet},
+			expected: []*batchv1.Job{aSet, bSet},
 		},
 		{
 			name:     "both have non-nil, different start time",
-			input:    []batchv1.Job{aSetLater, bSet},
-			expected: []batchv1.Job{bSet, aSetLater},
+			input:    []*batchv1.Job{aSetLater, bSet},
+			expected: []*batchv1.Job{bSet, aSetLater},
 		},
 	}
 
@@ -277,127 +285,179 @@ func TestByJobStartTime(t *testing.T) {
 	}
 }
 
-func TestGetMostRecentScheduleTime(t *testing.T) {
-	type args struct {
-		earliestTime *time.Time
-		now          time.Time
-		schedule     string
-	}
+func TestMostRecentScheduleTime(t *testing.T) {
+	metav1TopOfTheHour := metav1.NewTime(*topOfTheHour())
+	metav1HalfPastTheHour := metav1.NewTime(*deltaTimeAfterTopOfTheHour(30 * time.Minute))
+	oneMinute := int64(60)
+
 	tests := []struct {
-		name                  string
-		args                  args
-		expectedTime          *time.Time
-		expectedTooManyMissed bool
-		wantErr               bool
+		name                   string
+		cj                     *batchv1.CronJob
+		includeSDS             bool
+		now                    time.Time
+		expectedEarliestTime   time.Time
+		expectedRecentTime     *time.Time
+		expectedNumberOfMisses int64
+		wantErr                bool
 	}{
 		{
 			name: "now before next schedule",
-			args: args{
-				earliestTime: topOfTheHour(),
-				now:          topOfTheHour().Add(time.Second * 30),
-				schedule:     "0 * * * *",
+			cj: &batchv1.CronJob{
+				ObjectMeta: metav1.ObjectMeta{
+					CreationTimestamp: metav1TopOfTheHour,
+				},
+				Spec: batchv1.CronJobSpec{
+					Schedule: "0 * * * *",
+				},
 			},
-			expectedTime: nil,
+			now:                  topOfTheHour().Add(30 * time.Second),
+			expectedRecentTime:   nil,
+			expectedEarliestTime: *topOfTheHour(),
 		},
 		{
 			name: "now just after next schedule",
-			args: args{
-				earliestTime: topOfTheHour(),
-				now:          topOfTheHour().Add(time.Minute * 61),
-				schedule:     "0 * * * *",
+			cj: &batchv1.CronJob{
+				ObjectMeta: metav1.ObjectMeta{
+					CreationTimestamp: metav1TopOfTheHour,
+				},
+				Spec: batchv1.CronJobSpec{
+					Schedule: "0 * * * *",
+				},
 			},
-			expectedTime: deltaTimeAfterTopOfTheHour(time.Minute * 60),
+			now:                    topOfTheHour().Add(61 * time.Minute),
+			expectedRecentTime:     deltaTimeAfterTopOfTheHour(60 * time.Minute),
+			expectedEarliestTime:   *topOfTheHour(),
+			expectedNumberOfMisses: 1,
 		},
 		{
 			name: "missed 5 schedules",
-			args: args{
-				earliestTime: deltaTimeAfterTopOfTheHour(time.Second * 10),
-				now:          *deltaTimeAfterTopOfTheHour(time.Minute * 301),
-				schedule:     "0 * * * *",
+			cj: &batchv1.CronJob{
+				ObjectMeta: metav1.ObjectMeta{
+					CreationTimestamp: metav1.NewTime(*deltaTimeAfterTopOfTheHour(10 * time.Second)),
+				},
+				Spec: batchv1.CronJobSpec{
+					Schedule: "0 * * * *",
+				},
 			},
-			expectedTime: deltaTimeAfterTopOfTheHour(time.Minute * 300),
-		},
-		{
-			name: "complex schedule",
-			args: args{
-				earliestTime: deltaTimeAfterTopOfTheHour(30 * time.Minute),
-				now:          *deltaTimeAfterTopOfTheHour(24*time.Hour + 31*time.Minute),
-				schedule:     "30 6-16/4 * * 1-5",
-			},
-			expectedTime: deltaTimeAfterTopOfTheHour(24*time.Hour + 30*time.Minute),
-		},
-		{
-			name: "another complex schedule",
-			args: args{
-				earliestTime: deltaTimeAfterTopOfTheHour(30 * time.Minute),
-				now:          *deltaTimeAfterTopOfTheHour(30*time.Hour + 30*time.Minute),
-				schedule:     "30 10,11,12 * * 1-5",
-			},
-			expectedTime: nil,
-		},
-		{
-			name: "complex schedule with longer diff between executions",
-			args: args{
-				earliestTime: deltaTimeAfterTopOfTheHour(30 * time.Minute),
-				now:          *deltaTimeAfterTopOfTheHour(96*time.Hour + 31*time.Minute),
-				schedule:     "30 6-16/4 * * 1-5",
-			},
-			expectedTime: deltaTimeAfterTopOfTheHour(96*time.Hour + 30*time.Minute),
-		},
-		{
-			name: "complex schedule with shorter diff between executions",
-			args: args{
-				earliestTime: topOfTheHour(),
-				now:          *deltaTimeAfterTopOfTheHour(24*time.Hour + 31*time.Minute),
-				schedule:     "30 6-16/4 * * 1-5",
-			},
-			expectedTime: deltaTimeAfterTopOfTheHour(24*time.Hour + 30*time.Minute),
-		},
-		{
-			name: "@every schedule",
-			args: args{
-				earliestTime: deltaTimeAfterTopOfTheHour(1 * time.Minute),
-				now:          *deltaTimeAfterTopOfTheHour(7 * 24 * time.Hour),
-				schedule:     "@every 1h",
-			},
-			expectedTime:          deltaTimeAfterTopOfTheHour((6 * 24 * time.Hour) + 23*time.Hour + 1*time.Minute),
-			expectedTooManyMissed: true,
+			now:                    *deltaTimeAfterTopOfTheHour(301 * time.Minute),
+			expectedRecentTime:     deltaTimeAfterTopOfTheHour(300 * time.Minute),
+			expectedEarliestTime:   *deltaTimeAfterTopOfTheHour(10 * time.Second),
+			expectedNumberOfMisses: 5,
 		},
 		{
 			name: "rogue cronjob",
-			args: args{
-				earliestTime: deltaTimeAfterTopOfTheHour(time.Second * 10),
-				now:          *deltaTimeAfterTopOfTheHour(time.Hour * 1000000),
-				schedule:     "59 23 31 2 *",
+			cj: &batchv1.CronJob{
+				ObjectMeta: metav1.ObjectMeta{
+					CreationTimestamp: metav1.NewTime(*deltaTimeAfterTopOfTheHour(10 * time.Second)),
+				},
+				Spec: batchv1.CronJobSpec{
+					Schedule: "59 23 31 2 *",
+				},
 			},
-			expectedTime: nil,
-			wantErr:      true,
+			now:                    *deltaTimeAfterTopOfTheHour(1 * time.Hour),
+			expectedRecentTime:     nil,
+			expectedNumberOfMisses: 0,
+			wantErr:                true,
+		},
+		{
+			name: "earliestTime being CreationTimestamp and LastScheduleTime",
+			cj: &batchv1.CronJob{
+				ObjectMeta: metav1.ObjectMeta{
+					CreationTimestamp: metav1TopOfTheHour,
+				},
+				Spec: batchv1.CronJobSpec{
+					Schedule: "0 * * * *",
+				},
+				Status: batchv1.CronJobStatus{
+					LastScheduleTime: &metav1TopOfTheHour,
+				},
+			},
+			now:                  *deltaTimeAfterTopOfTheHour(30 * time.Second),
+			expectedEarliestTime: *topOfTheHour(),
+			expectedRecentTime:   nil,
+		},
+		{
+			name: "earliestTime being LastScheduleTime",
+			cj: &batchv1.CronJob{
+				ObjectMeta: metav1.ObjectMeta{
+					CreationTimestamp: metav1TopOfTheHour,
+				},
+				Spec: batchv1.CronJobSpec{
+					Schedule: "*/5 * * * *",
+				},
+				Status: batchv1.CronJobStatus{
+					LastScheduleTime: &metav1HalfPastTheHour,
+				},
+			},
+			now:                  *deltaTimeAfterTopOfTheHour(31 * time.Minute),
+			expectedEarliestTime: *deltaTimeAfterTopOfTheHour(30 * time.Minute),
+			expectedRecentTime:   nil,
+		},
+		{
+			name: "earliestTime being LastScheduleTime (within StartingDeadlineSeconds)",
+			cj: &batchv1.CronJob{
+				ObjectMeta: metav1.ObjectMeta{
+					CreationTimestamp: metav1TopOfTheHour,
+				},
+				Spec: batchv1.CronJobSpec{
+					Schedule:                "*/5 * * * *",
+					StartingDeadlineSeconds: &oneMinute,
+				},
+				Status: batchv1.CronJobStatus{
+					LastScheduleTime: &metav1HalfPastTheHour,
+				},
+			},
+			now:                  *deltaTimeAfterTopOfTheHour(31 * time.Minute),
+			expectedEarliestTime: *deltaTimeAfterTopOfTheHour(30 * time.Minute),
+			expectedRecentTime:   nil,
+		},
+		{
+			name: "earliestTime being LastScheduleTime (outside StartingDeadlineSeconds)",
+			cj: &batchv1.CronJob{
+				ObjectMeta: metav1.ObjectMeta{
+					CreationTimestamp: metav1TopOfTheHour,
+				},
+				Spec: batchv1.CronJobSpec{
+					Schedule:                "*/5 * * * *",
+					StartingDeadlineSeconds: &oneMinute,
+				},
+				Status: batchv1.CronJobStatus{
+					LastScheduleTime: &metav1HalfPastTheHour,
+				},
+			},
+			includeSDS:           true,
+			now:                  *deltaTimeAfterTopOfTheHour(32 * time.Minute),
+			expectedEarliestTime: *deltaTimeAfterTopOfTheHour(31 * time.Minute),
+			expectedRecentTime:   nil,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			sched, err := cron.ParseStandard(tt.args.schedule)
+			sched, err := cron.ParseStandard(tt.cj.Spec.Schedule)
 			if err != nil {
 				t.Errorf("error setting up the test, %s", err)
 			}
-			gotTime, gotTooManyMissed, err := getMostRecentScheduleTime(*tt.args.earliestTime, tt.args.now, sched)
+			gotEarliestTime, gotRecentTime, gotNumberOfMisses, err := mostRecentScheduleTime(tt.cj, tt.now, sched, tt.includeSDS)
 			if tt.wantErr {
 				if err == nil {
-					t.Error("getMostRecentScheduleTime() got no error when expected one")
+					t.Error("mostRecentScheduleTime() got no error when expected one")
 				}
 				return
 			}
 			if !tt.wantErr && err != nil {
-				t.Error("getMostRecentScheduleTime() got error when none expected")
+				t.Error("mostRecentScheduleTime() got error when none expected")
 			}
-			if gotTime == nil && tt.expectedTime != nil {
-				t.Errorf("getMostRecentScheduleTime() got nil, want %v", tt.expectedTime)
+			if gotEarliestTime.IsZero() {
+				t.Errorf("earliestTime should never be 0, want %v", tt.expectedEarliestTime)
 			}
-			if gotTime != nil && tt.expectedTime != nil && !gotTime.Equal(*tt.expectedTime) {
-				t.Errorf("getMostRecentScheduleTime() got = %v, want %v", gotTime, tt.expectedTime)
+			if !gotEarliestTime.Equal(tt.expectedEarliestTime) {
+				t.Errorf("expectedEarliestTime - got %v, want %v", gotEarliestTime, tt.expectedEarliestTime)
 			}
-			if gotTooManyMissed != tt.expectedTooManyMissed {
-				t.Errorf("getMostRecentScheduleTime() got1 = %v, want %v", gotTooManyMissed, tt.expectedTooManyMissed)
+			if !reflect.DeepEqual(gotRecentTime, tt.expectedRecentTime) {
+				t.Errorf("expectedRecentTime - got %v, want %v", gotRecentTime, tt.expectedRecentTime)
+			}
+			if gotNumberOfMisses != tt.expectedNumberOfMisses {
+				t.Errorf("expectedNumberOfMisses - got %v, want %v", gotNumberOfMisses, tt.expectedNumberOfMisses)
 			}
 		})
 	}


### PR DESCRIPTION
Cherry pick of #110838 #121327 on release-1.26.

#110838: Cleanups in controller utils
#121327: Fix next schedule time duration

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fixes a 1.25+ regression calculating the requeue time in the cronjob controller, which results in properly handling failed/stuck jobs
```