### PR TITLE
sample device plugin: fix incorrect Errorf invocation

### DIFF
--- a/test/images/sample-device-plugin/sampledeviceplugin.go
+++ b/test/images/sample-device-plugin/sampledeviceplugin.go
@@ -162,7 +162,7 @@ func main() {
 
 		err = watcher.Add(triggerPath)
 		if err != nil {
-			klog.Errorf("Failed to add watch to %q: %w", triggerPath, err)
+			klog.Errorf("Failed to add watch to %q: %v", triggerPath, err)
 			panic(err)
 		}
 		for {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Linting together with an upcoming klog update finds this problem:

    test/images/sample-device-plugin/sampledeviceplugin.go:165:4: printf: k8s.io/klog/v2.Errorf does not support error-wrapping directive %w (govet)
    			klog.Errorf("Failed to add watch to %q: %w", triggerPath, err)
     			^


#### Special notes for your reviewer:

Must be merged before the next klog update.

/priority important-soon

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
