### PR TITLE
e2e_node: mark CDI test as NodeSpecialFeature

### DIFF
--- a/test/e2e_node/device_plugin_test.go
+++ b/test/e2e_node/device_plugin_test.go
@@ -242,7 +242,7 @@ func testDevicePlugin(f *framework.Framework, pluginSockDir string) {
 			gomega.Expect(v1ResourcesForOurPod.Containers[0].Devices[0].DeviceIds).To(gomega.HaveLen(1))
 		})
 
-		ginkgo.It("can make a CDI device accessible in a container", func(ctx context.Context) {
+		ginkgo.It("[NodeSpecialFeature:CDI] can make a CDI device accessible in a container", func(ctx context.Context) {
 			e2eskipper.SkipUnlessFeatureGateEnabled(features.DevicePluginCDIDevices)
 			// check if CDI_DEVICE env variable is set
 			// and only one correspondent device node /tmp/<CDI_DEVICE> is available inside a container


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind failing-test

#### What this PR does / why we need it:

This test depends on CDI support in a runtime and doesn't work with the out-of-the box Containerd. Marking it as a NodeSpecialFeature should fix Containerd CI job failures.

#### Special notes for your reviewer:

Here is an example of failing CI job: https://testgrid.k8s.io/sig-node-containerd#cos-cgroupv1-containerd-node-e2e-serial
Failing test case: `Device Plugin [Feature:DevicePluginProbe][NodeFeature:DevicePluginProbe][Serial] DevicePlugin [Serial] [Disruptive] can make a CDI device accessible in a container [sig-node]`

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
