### PR TITLE
[FLAKE] Fixed UT pkg/kubelet/kuberuntime/logs/TestReadRotatedLog caused due to data race

### DIFF
--- a/pkg/kubelet/kuberuntime/logs/logs_test.go
+++ b/pkg/kubelet/kuberuntime/logs/logs_test.go
@@ -244,7 +244,7 @@ func TestReadRotatedLog(t *testing.T) {
 		mu.Lock()
 		path := file.Name()
 		mu.Unlock()
-		ReadLogs(ctx, path, containerID, opts, fakeRuntimeService, stdoutBuf, stderrBuf)
+		_ = ReadLogs(ctx, path, containerID, opts, fakeRuntimeService, stdoutBuf, stderrBuf)
 	}(ctx)
 
 	// log in stdout

--- a/pkg/kubelet/kuberuntime/logs/logs_test.go
+++ b/pkg/kubelet/kuberuntime/logs/logs_test.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -214,12 +215,12 @@ func TestReadLogs(t *testing.T) {
 }
 
 func TestReadRotatedLog(t *testing.T) {
+	var mu sync.RWMutex
 	tmpDir := t.TempDir()
 	file, err := os.CreateTemp(tmpDir, "logfile")
 	if err != nil {
 		assert.NoErrorf(t, err, "unable to create temp file")
 	}
-
 	stdoutBuf := &bytes.Buffer{}
 	stderrBuf := &bytes.Buffer{}
 	containerID := "fake-container-id"
@@ -240,7 +241,10 @@ func TestReadRotatedLog(t *testing.T) {
 			Follow: true,
 		}
 		opts := NewLogOptions(&podLogOptions, time.Now())
-		ReadLogs(ctx, file.Name(), containerID, opts, fakeRuntimeService, stdoutBuf, stderrBuf)
+		mu.Lock()
+		path := file.Name()
+		mu.Unlock()
+		ReadLogs(ctx, path, containerID, opts, fakeRuntimeService, stdoutBuf, stderrBuf)
 	}(ctx)
 
 	// log in stdout
@@ -254,6 +258,7 @@ func TestReadRotatedLog(t *testing.T) {
 	// Write 10 lines to log file.
 	// Let ReadLogs start.
 	time.Sleep(50 * time.Millisecond)
+
 	for line := 0; line < 10; line++ {
 		// Write the first three lines to log file
 		now := time.Now().Format(types.RFC3339NanoLenient)
@@ -277,10 +282,13 @@ func TestReadRotatedLog(t *testing.T) {
 			}
 
 			newF := filepath.Join(dir, baseName)
+			mu.Lock()
 			if file, err = os.Create(newF); err != nil {
+				mu.Unlock()
 				assert.NoError(t, err, "unable to create new log file")
 				return
 			}
+			mu.Unlock()
 			time.Sleep(20 * time.Millisecond)
 		}
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/kind flake
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR will fix data race issue observed for UT ```pkg/kubelet/kuberuntime/logs/TestReadRotatedLog```. Data race is happening as ```file``` is getting accessed without obtaining locks.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #121564

#### Special notes for your reviewer:
**1. Race detector o/p before fix:**

```
[root@test kubernetes]# go test ./pkg/kubelet/kuberuntime/logs -c -race
[root@test kubernetes]# /usr/local/go/bin/stress ./logs.test -test.run ^TestReadRotatedLog

/tmp/go-stress-20231027T084859-422659708
==================
WARNING: DATA RACE
Write at 0x00c0000783b0 by goroutine 24:
  k8s.io/kubernetes/pkg/kubelet/kuberuntime/logs.TestReadRotatedLog()
      /root/kubernetes/pkg/kubelet/kuberuntime/logs/logs_test.go:280 +0x9b4
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1682 +0x18c
  testing.(*T).Run.gowrap1()
      /usr/local/go/src/testing/testing.go:1735 +0x64

Previous read at 0x00c0000783b0 by goroutine 25:
  k8s.io/kubernetes/pkg/kubelet/kuberuntime/logs.TestReadRotatedLog.func1()
      /root/kubernetes/pkg/kubelet/kuberuntime/logs/logs_test.go:243 +0xd0
  k8s.io/kubernetes/pkg/kubelet/kuberuntime/logs.TestReadRotatedLog.gowrap1()
      /root/kubernetes/pkg/kubelet/kuberuntime/logs/logs_test.go:244 +0x78

Goroutine 24 (running) created at:
  testing.(*T).Run()
      /usr/local/go/src/testing/testing.go:1735 +0x6ac
  testing.runTests.func1()
      /usr/local/go/src/testing/testing.go:2146 +0x90
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1682 +0x18c
  testing.runTests()
      /usr/local/go/src/testing/testing.go:2144 +0x7fc
  testing.(*M).Run()
      /usr/local/go/src/testing/testing.go:2012 +0xbe8
  main.main()
      _testmain.go:59 +0x2d0

Goroutine 25 (running) created at:
  k8s.io/kubernetes/pkg/kubelet/kuberuntime/logs.TestReadRotatedLog()
      /root/kubernetes/pkg/kubelet/kuberuntime/logs/logs_test.go:238 +0x5a4
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1682 +0x18c
  testing.(*T).Run.gowrap1()
      /usr/local/go/src/testing/testing.go:1735 +0x64
==================
--- FAIL: TestReadRotatedLog (0.10s)
    testing.go:1398: race detected during execution of test
FAIL
```

**2. Race detector o/p after the fix:**

```
[root@test kubernetes]# go test ./pkg/kubelet/kuberuntime/logs -c -race
[root@test kubernetes]# /usr/local/go/bin/stress ./logs.test -test.run ^TestReadRotatedLog
10s: 56 runs so far, 0 failures
15s: 88 runs so far, 0 failures
20s: 120 runs so far, 0 failures
25s: 152 runs so far, 0 failures
30s: 184 runs so far, 0 failures
35s: 218 runs so far, 0 failures
40s: 250 runs so far, 0 failures
.
.
.
.
.
.
23m30s: 9414 runs so far, 0 failures
23m35s: 9450 runs so far, 0 failures
23m40s: 9484 runs so far, 0 failures
23m45s: 9516 runs so far, 0 failures
23m50s: 9548 runs so far, 0 failures
23m55s: 9582 runs so far, 0 failures
24m0s: 9618 runs so far, 0 failures
24m5s: 9652 runs so far, 0 failures
```
#### Does this PR introduce a user-facing change?
NONE
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
