### PR TITLE
etcd: Update to version 3.5.10

### DIFF
--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -64,7 +64,7 @@ dependencies:
 
   # etcd
   - name: "etcd"
-    version: 3.5.9
+    version: 3.5.10
     refPaths:
     - path: cluster/gce/manifests/etcd.manifest
       match: etcd_docker_tag|etcd_version

--- a/cluster/gce/manifests/etcd.manifest
+++ b/cluster/gce/manifests/etcd.manifest
@@ -18,7 +18,7 @@
     {
     "name": "etcd-container",
     {{security_context}}
-    "image": "{{ pillar.get('etcd_docker_repository', 'registry.k8s.io/etcd') }}:{{ pillar.get('etcd_docker_tag', '3.5.9-0') }}",
+    "image": "{{ pillar.get('etcd_docker_repository', 'registry.k8s.io/etcd') }}:{{ pillar.get('etcd_docker_tag', '3.5.10-0') }}",
     "resources": {
       "requests": {
         "cpu": {{ cpulimit }}
@@ -34,7 +34,7 @@
         "value": "{{ pillar.get('storage_backend', 'etcd3') }}"
       },
       { "name": "TARGET_VERSION",
-        "value": "{{ pillar.get('etcd_version', '3.5.9') }}"
+        "value": "{{ pillar.get('etcd_version', '3.5.10') }}"
       },
       {
         "name": "DO_NOT_MOVE_BINARIES",

--- a/cluster/gce/upgrade-aliases.sh
+++ b/cluster/gce/upgrade-aliases.sh
@@ -170,8 +170,8 @@ export KUBE_GCE_ENABLE_IP_ALIASES=true
 export SECONDARY_RANGE_NAME="pods-default"
 export STORAGE_BACKEND="etcd3"
 export STORAGE_MEDIA_TYPE="application/vnd.kubernetes.protobuf"
-export ETCD_IMAGE=3.5.9-0
-export ETCD_VERSION=3.5.9
+export ETCD_IMAGE=3.5.10-0
+export ETCD_VERSION=3.5.10
 
 # Upgrade master with updated kube envs
 "${KUBE_ROOT}/cluster/gce/upgrade.sh" -M -l

--- a/cmd/kubeadm/app/constants/constants.go
+++ b/cmd/kubeadm/app/constants/constants.go
@@ -309,7 +309,7 @@ const (
 	MinExternalEtcdVersion = "3.4.13-4"
 
 	// DefaultEtcdVersion indicates the default etcd version that kubeadm uses
-	DefaultEtcdVersion = "3.5.9-0"
+	DefaultEtcdVersion = "3.5.10-0"
 
 	// Etcd defines variable used internally when referring to etcd component
 	Etcd = "etcd"
@@ -464,14 +464,14 @@ var (
 
 	// SupportedEtcdVersion lists officially supported etcd versions with corresponding Kubernetes releases
 	SupportedEtcdVersion = map[uint8]string{
-		22: "3.5.9-0",
-		23: "3.5.9-0",
-		24: "3.5.9-0",
-		25: "3.5.9-0",
-		26: "3.5.9-0",
-		27: "3.5.9-0",
-		28: "3.5.9-0",
-		29: "3.5.9-0",
+		22: "3.5.10-0",
+		23: "3.5.10-0",
+		24: "3.5.10-0",
+		25: "3.5.10-0",
+		26: "3.5.10-0",
+		27: "3.5.10-0",
+		28: "3.5.10-0",
+		29: "3.5.10-0",
 	}
 
 	// KubeadmCertsClusterRoleName sets the name for the ClusterRole that allows

--- a/hack/lib/etcd.sh
+++ b/hack/lib/etcd.sh
@@ -16,7 +16,7 @@
 
 # A set of helpers for starting/running etcd for tests
 
-ETCD_VERSION=${ETCD_VERSION:-3.5.9}
+ETCD_VERSION=${ETCD_VERSION:-3.5.10}
 ETCD_HOST=${ETCD_HOST:-127.0.0.1}
 ETCD_PORT=${ETCD_PORT:-2379}
 # This is intentionally not called ETCD_LOG_LEVEL:

--- a/staging/src/k8s.io/sample-apiserver/artifacts/example/deployment.yaml
+++ b/staging/src/k8s.io/sample-apiserver/artifacts/example/deployment.yaml
@@ -26,4 +26,4 @@ spec:
         imagePullPolicy: Never
         args: [ "--etcd-servers=http://localhost:2379" ]
       - name: etcd
-        image: gcr.io/etcd-development/etcd:v3.5.9
+        image: gcr.io/etcd-development/etcd:v3.5.10

--- a/test/e2e/framework/providers/gcp.go
+++ b/test/e2e/framework/providers/gcp.go
@@ -26,7 +26,7 @@ import (
 	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 )
 
-const etcdImage = "3.5.9-0"
+const etcdImage = "3.5.10-0"
 
 // EtcdUpgrade upgrades etcd on GCE.
 func EtcdUpgrade(targetStorage, targetVersion string) error {

--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -242,7 +242,7 @@ func initImageConfigs(list RegistryList) (map[ImageID]Config, map[ImageID]Config
 	configs[CudaVectorAdd] = Config{list.PromoterE2eRegistry, "cuda-vector-add", "1.0"}
 	configs[CudaVectorAdd2] = Config{list.PromoterE2eRegistry, "cuda-vector-add", "2.3"}
 	configs[DistrolessIptables] = Config{list.BuildImageRegistry, "distroless-iptables", "v0.4.1"}
-	configs[Etcd] = Config{list.GcEtcdRegistry, "etcd", "3.5.9-0"}
+	configs[Etcd] = Config{list.GcEtcdRegistry, "etcd", "3.5.10-0"}
 	configs[Httpd] = Config{list.PromoterE2eRegistry, "httpd", "2.4.38-4"}
 	configs[HttpdNew] = Config{list.PromoterE2eRegistry, "httpd", "2.4.39-4"}
 	configs[InvalidRegistryImage] = Config{list.InvalidRegistry, "alpine", "3.1"}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Update etcd to version 3.5.10 See release: [v3.5.10](https://github.com/etcd-io/etcd/releases/tag/v3.5.10).

**Which issue(s) this PR fixes**:
Fixes NONE #

**Does this PR introduce a user-facing change?**:
NONE


```release-note
etcd: Update to v3.5.10
```
