### PR TITLE
[node-e2e] add test cases for serialize and parallel image pulling

### DIFF
--- a/test/e2e/nodefeature/nodefeature.go
+++ b/test/e2e/nodefeature/nodefeature.go
@@ -78,9 +78,6 @@ var (
 	LSCIQuotaMonitoring = framework.WithNodeFeature(framework.ValidNodeFeatures.Add("LSCIQuotaMonitoring"))
 
 	// TODO: document the feature (owning SIG, when to use this feature for a test)
-	MaxParallelImagePull = framework.WithNodeFeature(framework.ValidNodeFeatures.Add("MaxParallelImagePull"))
-
-	// TODO: document the feature (owning SIG, when to use this feature for a test)
 	NodeAllocatable = framework.WithNodeFeature(framework.ValidNodeFeatures.Add("NodeAllocatable"))
 
 	// TODO: document the feature (owning SIG, when to use this feature for a test)

--- a/test/e2e/nodefeature/nodefeature.go
+++ b/test/e2e/nodefeature/nodefeature.go
@@ -78,6 +78,9 @@ var (
 	LSCIQuotaMonitoring = framework.WithNodeFeature(framework.ValidNodeFeatures.Add("LSCIQuotaMonitoring"))
 
 	// TODO: document the feature (owning SIG, when to use this feature for a test)
+	MaxParallelImagePull = framework.WithNodeFeature(framework.ValidNodeFeatures.Add("MaxParallelImagePull"))
+
+	// TODO: document the feature (owning SIG, when to use this feature for a test)
 	NodeAllocatable = framework.WithNodeFeature(framework.ValidNodeFeatures.Add("NodeAllocatable"))
 
 	// TODO: document the feature (owning SIG, when to use this feature for a test)

--- a/test/e2e_node/e2e_node_suite_test.go
+++ b/test/e2e_node/e2e_node_suite_test.go
@@ -236,7 +236,7 @@ var _ = ginkgo.SynchronizedBeforeSuite(func(ctx context.Context) []byte {
 	if framework.TestContext.PrepullImages {
 		klog.Infof("Pre-pulling images so that they are cached for the tests.")
 		updateImageAllowList(ctx)
-		err := PrePullAllImages()
+		err := PrePullAllImages(ctx)
 		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 	}
 

--- a/test/e2e_node/eviction_test.go
+++ b/test/e2e_node/eviction_test.go
@@ -692,7 +692,8 @@ func runEvictionTest(f *framework.Framework, pressureTimeout time.Duration, expe
 				if expectedNodeCondition == v1.NodeDiskPressure && framework.TestContext.PrepullImages {
 					// The disk eviction test may cause the prepulled images to be evicted,
 					// prepull those images again to ensure this test not affect following tests.
-					PrePullAllImages()
+					err := PrePullAllImages(ctx)
+					gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 				}
 			}
 			// Run prePull using a defer to make sure it is executed even when the assertions below fails

--- a/test/e2e_node/image_gc_test.go
+++ b/test/e2e_node/image_gc_test.go
@@ -50,8 +50,8 @@ var _ = SIGDescribe("ImageGarbageCollect", framework.WithSerial(), framework.Wit
 		_, is, err = getCRIClient()
 		framework.ExpectNoError(err)
 	})
-	ginkgo.AfterEach(func() {
-		framework.ExpectNoError(PrePullAllImages())
+	ginkgo.AfterEach(func(ctx context.Context) {
+		framework.ExpectNoError(PrePullAllImages(ctx))
 	})
 	ginkgo.Context("when ImageMaximumGCAge is set", func() {
 		tempSetCurrentKubeletConfig(f, func(ctx context.Context, initialConfig *kubeletconfig.KubeletConfiguration) {

--- a/test/e2e_node/image_pull_test.go
+++ b/test/e2e_node/image_pull_test.go
@@ -1,3 +1,6 @@
+//go:build linux
+// +build linux
+
 /*
 Copyright 2024 The Kubernetes Authors.
 
@@ -18,28 +21,32 @@ package e2enode
 
 import (
 	"context"
+	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	"github.com/pkg/errors"
+
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubeletconfig "k8s.io/kubernetes/pkg/kubelet/apis/config"
 	kubeletevents "k8s.io/kubernetes/pkg/kubelet/events"
+	"k8s.io/kubernetes/test/e2e/feature"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
-	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
-	"k8s.io/kubernetes/test/e2e/nodefeature"
+	"k8s.io/kubernetes/test/e2e_node/criproxy"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 	admissionapi "k8s.io/pod-security-admission/api"
 	"k8s.io/utils/ptr"
 )
 
-// This test needs to run in serial to prevent caching of the images by other tests
-// and to prevent the wait time of image pulls to be increased by other images
-var _ = SIGDescribe("Pull Image", framework.WithSerial(), nodefeature.MaxParallelImagePull, func() {
+// CriProxy injector is used to simulate and verify the image pull behavior.
+// These tests need to run in serial to prevent caching of the images by other tests
+// and to prevent the wait time of image pulls to be increased by other images.
+var _ = SIGDescribe("Pull Image", feature.CriProxy, framework.WithSerial(), func() {
 
 	f := framework.NewDefaultFramework("parallel-pull-image-test")
 	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
@@ -52,10 +59,18 @@ var _ = SIGDescribe("Pull Image", framework.WithSerial(), nodefeature.MaxParalle
 		})
 
 		ginkgo.BeforeEach(func(ctx context.Context) {
+			if err := resetCRIProxyInjector(); err != nil {
+				ginkgo.Skip("Skip the test since the CRI Proxy is undefined.")
+			}
+
 			testpods = prepareAndCleanup(ctx, f)
+			gomega.Expect(len(testpods)).To(gomega.BeNumerically("<=", 5))
 		})
 
 		ginkgo.AfterEach(func(ctx context.Context) {
+			err := resetCRIProxyInjector()
+			framework.ExpectNoError(err)
+
 			ginkgo.By("cleanup pods")
 			for _, pod := range testpods {
 				deletePodSyncByName(ctx, f, pod.Name)
@@ -63,60 +78,48 @@ var _ = SIGDescribe("Pull Image", framework.WithSerial(), nodefeature.MaxParalle
 		})
 
 		ginkgo.It("should pull immediately if no more than 5 pods", func(ctx context.Context) {
-			var pods []*v1.Pod
-			for _, testpod := range testpods {
-				pods = append(pods, e2epod.NewPodClient(f).Create(ctx, testpod))
-			}
-			for _, pod := range pods {
-				err := e2epod.WaitForPodCondition(ctx, f.ClientSet, f.Namespace.Name, pod.Name, "Running", 10*time.Minute, func(pod *v1.Pod) (bool, error) {
-					if pod.Status.Phase == v1.PodRunning {
-						return true, nil
-					}
-					return false, nil
-				})
-				framework.ExpectNoError(err)
-			}
-
-			events, err := f.ClientSet.CoreV1().Events(f.Namespace.Name).List(ctx, metav1.ListOptions{})
-			framework.ExpectNoError(err)
-			imagePulled := map[string]*pulledStruct{}
-			// start from pulling event creationTimestamp
-			// end from pulled event creationTimestamp
-			podStartTime, podEndTime := map[string]metav1.Time{}, map[string]metav1.Time{}
-			for _, event := range events.Items {
-				if event.Reason == kubeletevents.PulledImage {
-					podEndTime[event.InvolvedObject.Name] = event.CreationTimestamp
-					for _, testpod := range testpods {
-						if event.InvolvedObject.Name == testpod.Name {
-							pulled, err := getDurationsFromPulledEventMsg(event.Message)
-							imagePulled[testpod.Name] = pulled
-							framework.ExpectNoError(err)
-							break
+			var mu sync.Mutex
+			timeout := 20 * time.Second
+			callCh := make(chan struct{})
+			callStatus := make(map[int]chan struct{})
+			err := addCRIProxyInjector(func(apiName string) error {
+				if apiName == criproxy.PullImage {
+					mu.Lock()
+					callID := len(callStatus)
+					callStatus[callID] = callCh
+					mu.Unlock()
+					if callID == 0 {
+						// wait for next call
+						select {
+						case <-callCh:
+							return nil
+						case <-time.After(timeout):
+							return fmt.Errorf("no parallel image pull after %s", timeout)
 						}
+					} else {
+						// send a signal to the first call
+						callCh <- struct{}{}
 					}
-				} else if event.Reason == kubeletevents.PullingImage {
-					podStartTime[event.InvolvedObject.Name] = event.CreationTimestamp
 				}
-			}
-			gomega.Expect(len(testpods)).To(gomega.BeComparableTo(len(imagePulled)))
+				return nil
+			})
+			framework.ExpectNoError(err)
 
-			// skip if pod1 pulling time and pod2 pulling time are not overlapped
-			if podStartTime[testpods[0].Name].Time.Before(podStartTime[testpods[1].Name].Time) {
-				if podEndTime[testpods[0].Name].Time.Before(podStartTime[testpods[1].Name].Time) {
-					e2eskipper.Skipf("pod1 pulling time and pod2 pulling time are not overlapped")
-				}
-			} else {
-				if podEndTime[testpods[1].Name].Time.Before(podStartTime[testpods[0].Name].Time) {
-					e2eskipper.Skipf("pod1 pulling time and pod2 pulling time are not overlapped")
-				}
+			for _, testpod := range testpods {
+				_ = e2epod.NewPodClient(f).Create(ctx, testpod)
 			}
 
-			// as this is parallel image pulling, the waiting duration should be similar with the pulled duration.
-			// use 1.2 as a common ratio
-			for _, pulled := range imagePulled {
-				if float32(pulled.pulledIncludeWaitingDuration/time.Millisecond)/float32(pulled.pulledDuration/time.Millisecond) > 1.2 {
-					framework.Failf("the pull duration including waiting %v should be similar with the pulled duration %v",
-						pulled.pulledIncludeWaitingDuration, pulled.pulledDuration)
+			imagePulled, podStartTime, podEndTime, err := getPodImagePullDurations(ctx, f, testpods)
+			framework.ExpectNoError(err)
+
+			checkPodPullingOverlap(podStartTime, podEndTime, testpods)
+
+			for _, img := range imagePulled {
+				framework.Logf("Pod pull duration including waiting is %v, and the pulled duration is %v", img.pulledIncludeWaitingDuration, img.pulledDuration)
+				// if a pod image pull hanged for more than 50%, it is a delayed pull.
+				if float32(img.pulledIncludeWaitingDuration.Milliseconds())/float32(img.pulledDuration.Milliseconds()) > 1.5 {
+					// as this is parallel image pulling, the waiting duration should be similar with the pulled duration.
+					framework.Failf("There is a delayed image pulling, which is not expected for parallel image pulling.")
 				}
 			}
 		})
@@ -124,7 +127,7 @@ var _ = SIGDescribe("Pull Image", framework.WithSerial(), nodefeature.MaxParalle
 	})
 })
 
-var _ = SIGDescribe("Pull Image", framework.WithSerial(), nodefeature.MaxParallelImagePull, func() {
+var _ = SIGDescribe("Pull Image", feature.CriProxy, framework.WithSerial(), func() {
 
 	f := framework.NewDefaultFramework("serialize-pull-image-test")
 	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
@@ -139,10 +142,18 @@ var _ = SIGDescribe("Pull Image", framework.WithSerial(), nodefeature.MaxParalle
 		var testpods []*v1.Pod
 
 		ginkgo.BeforeEach(func(ctx context.Context) {
+			if err := resetCRIProxyInjector(); err != nil {
+				ginkgo.Skip("Skip the test since the CRI Proxy is undefined.")
+			}
+
 			testpods = prepareAndCleanup(ctx, f)
+			gomega.Expect(len(testpods)).To(gomega.BeNumerically("<=", 5))
 		})
 
 		ginkgo.AfterEach(func(ctx context.Context) {
+			err := resetCRIProxyInjector()
+			framework.ExpectNoError(err)
+
 			ginkgo.By("cleanup pods")
 			for _, pod := range testpods {
 				deletePodSyncByName(ctx, f, pod.Name)
@@ -150,12 +161,45 @@ var _ = SIGDescribe("Pull Image", framework.WithSerial(), nodefeature.MaxParalle
 		})
 
 		ginkgo.It("should be waiting more", func(ctx context.Context) {
+			// all serialize image pulls should timeout
+			timeout := 20 * time.Second
+			var mu sync.Mutex
+			callCh := make(chan struct{})
+			callStatus := make(map[int]chan struct{})
+			err := addCRIProxyInjector(func(apiName string) error {
+				if apiName == criproxy.PullImage {
+					mu.Lock()
+					callID := len(callStatus)
+					callStatus[callID] = callCh
+					mu.Unlock()
+					if callID == 0 {
+						// wait for next call
+						select {
+						case <-callCh:
+							return errors.New("parallel image pull detected")
+						case <-time.After(timeout):
+							return nil
+						}
+					} else {
+						// send a signal to the first call
+						select {
+						case callCh <- struct{}{}:
+							return errors.New("parallel image pull detected")
+						case <-time.After(timeout):
+							return nil
+						}
+					}
+				}
+				return nil
+			})
+			framework.ExpectNoError(err)
+
 			var pods []*v1.Pod
 			for _, testpod := range testpods {
 				pods = append(pods, e2epod.NewPodClient(f).Create(ctx, testpod))
 			}
 			for _, pod := range pods {
-				err := e2epod.WaitForPodCondition(ctx, f.ClientSet, f.Namespace.Name, pod.Name, "Running", 10*time.Minute, func(pod *v1.Pod) (bool, error) {
+				err := e2epod.WaitForPodCondition(ctx, f.ClientSet, f.Namespace.Name, pod.Name, "Running", 2*time.Minute, func(pod *v1.Pod) (bool, error) {
 					if pod.Status.Phase == v1.PodRunning {
 						return true, nil
 					}
@@ -164,56 +208,74 @@ var _ = SIGDescribe("Pull Image", framework.WithSerial(), nodefeature.MaxParalle
 				framework.ExpectNoError(err)
 			}
 
-			events, err := f.ClientSet.CoreV1().Events(f.Namespace.Name).List(ctx, metav1.ListOptions{})
+			imagePulled, podStartTime, podEndTime, err := getPodImagePullDurations(ctx, f, testpods)
 			framework.ExpectNoError(err)
-			imagePulled := map[string]*pulledStruct{}
-			// start from pulling event creationTimestamp
-			// end from pulled event creationTimestamp
-			podStartTime, podEndTime := map[string]metav1.Time{}, map[string]metav1.Time{}
-			for _, event := range events.Items {
-				if event.Reason == kubeletevents.PulledImage {
-					podEndTime[event.InvolvedObject.Name] = event.CreationTimestamp
-					for _, testpod := range testpods {
-						if event.InvolvedObject.Name == testpod.Name {
-							pulled, err := getDurationsFromPulledEventMsg(event.Message)
-							imagePulled[testpod.Name] = pulled
-							framework.ExpectNoError(err)
-							break
-						}
-					}
-				} else if event.Reason == kubeletevents.PullingImage {
-					podStartTime[event.InvolvedObject.Name] = event.CreationTimestamp
-				}
-			}
 			gomega.Expect(len(testpods)).To(gomega.BeComparableTo(len(imagePulled)))
 
-			// skip if pod1 pulling time and pod2 pulling time are not overlapped
-			if podStartTime[testpods[0].Name].Time.Before(podStartTime[testpods[1].Name].Time) {
-				if podEndTime[testpods[0].Name].Time.Before(podStartTime[testpods[1].Name].Time) {
-					e2eskipper.Skipf("pod1 pulling time and pod2 pulling time are not overlapped")
-				}
-			} else {
-				if podEndTime[testpods[1].Name].Time.Before(podStartTime[testpods[0].Name].Time) {
-					e2eskipper.Skipf("pod1 pulling time and pod2 pulling time are not overlapped")
+			checkPodPullingOverlap(podStartTime, podEndTime, testpods)
+
+			// if a pod image pull hanged for more than 50%, it is a delayed pull.
+			var anyDelayedPull bool
+			for _, img := range imagePulled {
+				framework.Logf("Pod pull duration including waiting is %v, and the pulled duration is %v", img.pulledIncludeWaitingDuration, img.pulledDuration)
+				if float32(img.pulledIncludeWaitingDuration.Milliseconds())/float32(img.pulledDuration.Milliseconds()) > 1.5 {
+					anyDelayedPull = true
 				}
 			}
-
 			// as this is serialize image pulling, the waiting duration should be almost double the duration with the pulled duration.
 			// use 1.5 as a common ratio to avoid some overlap during pod creation
-			if float32(imagePulled[testpods[1].Name].pulledIncludeWaitingDuration/time.Millisecond)/float32(imagePulled[testpods[1].Name].pulledDuration/time.Millisecond) < 1.5 &&
-				float32(imagePulled[testpods[0].Name].pulledIncludeWaitingDuration/time.Millisecond)/float32(imagePulled[testpods[0].Name].pulledDuration/time.Millisecond) < 1.5 {
-				framework.Failf("At least, one of the pull duration including waiting %v/%v should be similar with the pulled duration %v/%v",
-					imagePulled[testpods[1].Name].pulledIncludeWaitingDuration, imagePulled[testpods[0].Name].pulledIncludeWaitingDuration, imagePulled[testpods[1].Name].pulledDuration, imagePulled[testpods[0].Name].pulledDuration)
+			if !anyDelayedPull {
+				framework.Failf("All image pullings are not delayed, which is not expected for serilized image pull")
 			}
 		})
 
 	})
 })
 
+func getPodImagePullDurations(ctx context.Context, f *framework.Framework, testpods []*v1.Pod) (map[string]*pulledStruct, map[string]metav1.Time, map[string]metav1.Time, error) {
+	events, err := f.ClientSet.CoreV1().Events(f.Namespace.Name).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	imagePulled := map[string]*pulledStruct{}
+	podStartTime := map[string]metav1.Time{}
+	podEndTime := map[string]metav1.Time{}
+
+	for _, event := range events.Items {
+		if event.Reason == kubeletevents.PulledImage {
+			podEndTime[event.InvolvedObject.Name] = event.CreationTimestamp
+			for _, testpod := range testpods {
+				if event.InvolvedObject.Name == testpod.Name {
+					pulled, err := getDurationsFromPulledEventMsg(event.Message)
+					if err != nil {
+						return nil, nil, nil, err
+					}
+					imagePulled[testpod.Name] = pulled
+					break
+				}
+			}
+		} else if event.Reason == kubeletevents.PullingImage {
+			podStartTime[event.InvolvedObject.Name] = event.CreationTimestamp
+		}
+	}
+
+	return imagePulled, podStartTime, podEndTime, nil
+}
+
+// as pods are created at the same time and image pull will delay 15s, the image pull time should be overlapped
+func checkPodPullingOverlap(podStartTime map[string]metav1.Time, podEndTime map[string]metav1.Time, testpods []*v1.Pod) {
+	if podStartTime[testpods[0].Name].Time.Before(podStartTime[testpods[1].Name].Time) && podEndTime[testpods[0].Name].Time.Before(podStartTime[testpods[1].Name].Time) {
+		framework.Failf("%v pulling time and %v pulling time are not overlapped", testpods[0].Name, testpods[1].Name)
+	} else if podStartTime[testpods[0].Name].Time.After(podStartTime[testpods[1].Name].Time) && podStartTime[testpods[0].Name].Time.After(podEndTime[testpods[1].Name].Time) {
+		framework.Failf("%v pulling time and %v pulling time are not overlapped", testpods[0].Name, testpods[1].Name)
+	}
+}
+
 func prepareAndCleanup(ctx context.Context, f *framework.Framework) (testpods []*v1.Pod) {
 	// cuda images are > 2Gi and it will reduce the flaky rate
-	image1 := imageutils.GetE2EImage(imageutils.CudaVectorAdd)
-	image2 := imageutils.GetE2EImage(imageutils.CudaVectorAdd2)
+	image1 := imageutils.GetE2EImage(imageutils.Httpd)
+	image2 := imageutils.GetE2EImage(imageutils.HttpdNew)
 	node := getNodeName(ctx, f)
 
 	testpod := &v1.Pod{

--- a/test/e2e_node/image_pull_test.go
+++ b/test/e2e_node/image_pull_test.go
@@ -1,0 +1,283 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2enode
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	"github.com/pkg/errors"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubeletconfig "k8s.io/kubernetes/pkg/kubelet/apis/config"
+	kubeletevents "k8s.io/kubernetes/pkg/kubelet/events"
+	"k8s.io/kubernetes/test/e2e/framework"
+	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
+	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
+	"k8s.io/kubernetes/test/e2e/nodefeature"
+	imageutils "k8s.io/kubernetes/test/utils/image"
+	admissionapi "k8s.io/pod-security-admission/api"
+	"k8s.io/utils/ptr"
+)
+
+// This test needs to run in serial to prevent caching of the images by other tests
+// and to prevent the wait time of image pulls to be increased by other images
+var _ = SIGDescribe("Pull Image", framework.WithSerial(), nodefeature.MaxParallelImagePull, func() {
+
+	f := framework.NewDefaultFramework("parallel-pull-image-test")
+	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
+	var testpods []*v1.Pod
+
+	ginkgo.Context("parallel image pull with MaxParallelImagePulls=5", func() {
+		tempSetCurrentKubeletConfig(f, func(ctx context.Context, initialConfig *kubeletconfig.KubeletConfiguration) {
+			initialConfig.SerializeImagePulls = false
+			initialConfig.MaxParallelImagePulls = ptr.To[int32](5)
+		})
+
+		ginkgo.BeforeEach(func(ctx context.Context) {
+			testpods = prepareAndCleanup(ctx, f)
+		})
+
+		ginkgo.AfterEach(func(ctx context.Context) {
+			ginkgo.By("cleanup pods")
+			for _, pod := range testpods {
+				deletePodSyncByName(ctx, f, pod.Name)
+			}
+		})
+
+		ginkgo.It("should pull immediately if no more than 5 pods", func(ctx context.Context) {
+			var pods []*v1.Pod
+			for _, testpod := range testpods {
+				pods = append(pods, e2epod.NewPodClient(f).Create(ctx, testpod))
+			}
+			for _, pod := range pods {
+				err := e2epod.WaitForPodCondition(ctx, f.ClientSet, f.Namespace.Name, pod.Name, "Running", 10*time.Minute, func(pod *v1.Pod) (bool, error) {
+					if pod.Status.Phase == v1.PodRunning {
+						return true, nil
+					}
+					return false, nil
+				})
+				framework.ExpectNoError(err)
+			}
+
+			events, err := f.ClientSet.CoreV1().Events(f.Namespace.Name).List(ctx, metav1.ListOptions{})
+			framework.ExpectNoError(err)
+			imagePulled := map[string]*pulledStruct{}
+			// start from pulling event creationTimestamp
+			// end from pulled event creationTimestamp
+			podStartTime, podEndTime := map[string]metav1.Time{}, map[string]metav1.Time{}
+			for _, event := range events.Items {
+				if event.Reason == kubeletevents.PulledImage {
+					podEndTime[event.InvolvedObject.Name] = event.CreationTimestamp
+					for _, testpod := range testpods {
+						if event.InvolvedObject.Name == testpod.Name {
+							pulled, err := getDurationsFromPulledEventMsg(event.Message)
+							imagePulled[testpod.Name] = pulled
+							framework.ExpectNoError(err)
+							break
+						}
+					}
+				} else if event.Reason == kubeletevents.PullingImage {
+					podStartTime[event.InvolvedObject.Name] = event.CreationTimestamp
+				}
+			}
+			gomega.Expect(len(testpods)).To(gomega.BeComparableTo(len(imagePulled)))
+
+			// skip if pod1 pulling time and pod2 pulling time are not overlapped
+			if podStartTime[testpods[0].Name].Time.Before(podStartTime[testpods[1].Name].Time) {
+				if podEndTime[testpods[0].Name].Time.Before(podStartTime[testpods[1].Name].Time) {
+					e2eskipper.Skipf("pod1 pulling time and pod2 pulling time are not overlapped")
+				}
+			} else {
+				if podEndTime[testpods[1].Name].Time.Before(podStartTime[testpods[0].Name].Time) {
+					e2eskipper.Skipf("pod1 pulling time and pod2 pulling time are not overlapped")
+				}
+			}
+
+			// as this is parallel image pulling, the waiting duration should be similar with the pulled duration.
+			// use 1.2 as a common ratio
+			for _, pulled := range imagePulled {
+				if float32(pulled.pulledIncludeWaitingDuration/time.Millisecond)/float32(pulled.pulledDuration/time.Millisecond) > 1.2 {
+					framework.Failf("the pull duration including waiting %v should be similar with the pulled duration %v",
+						pulled.pulledIncludeWaitingDuration, pulled.pulledDuration)
+				}
+			}
+		})
+
+	})
+})
+
+var _ = SIGDescribe("Pull Image", framework.WithSerial(), nodefeature.MaxParallelImagePull, func() {
+
+	f := framework.NewDefaultFramework("serialize-pull-image-test")
+	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
+
+	ginkgo.Context("serialize image pull", func() {
+		// this is the default behavior now.
+		tempSetCurrentKubeletConfig(f, func(ctx context.Context, initialConfig *kubeletconfig.KubeletConfiguration) {
+			initialConfig.SerializeImagePulls = true
+			initialConfig.MaxParallelImagePulls = ptr.To[int32](1)
+		})
+
+		var testpods []*v1.Pod
+
+		ginkgo.BeforeEach(func(ctx context.Context) {
+			testpods = prepareAndCleanup(ctx, f)
+		})
+
+		ginkgo.AfterEach(func(ctx context.Context) {
+			ginkgo.By("cleanup pods")
+			for _, pod := range testpods {
+				deletePodSyncByName(ctx, f, pod.Name)
+			}
+		})
+
+		ginkgo.It("should be waiting more", func(ctx context.Context) {
+			var pods []*v1.Pod
+			for _, testpod := range testpods {
+				pods = append(pods, e2epod.NewPodClient(f).Create(ctx, testpod))
+			}
+			for _, pod := range pods {
+				err := e2epod.WaitForPodCondition(ctx, f.ClientSet, f.Namespace.Name, pod.Name, "Running", 10*time.Minute, func(pod *v1.Pod) (bool, error) {
+					if pod.Status.Phase == v1.PodRunning {
+						return true, nil
+					}
+					return false, nil
+				})
+				framework.ExpectNoError(err)
+			}
+
+			events, err := f.ClientSet.CoreV1().Events(f.Namespace.Name).List(ctx, metav1.ListOptions{})
+			framework.ExpectNoError(err)
+			imagePulled := map[string]*pulledStruct{}
+			// start from pulling event creationTimestamp
+			// end from pulled event creationTimestamp
+			podStartTime, podEndTime := map[string]metav1.Time{}, map[string]metav1.Time{}
+			for _, event := range events.Items {
+				if event.Reason == kubeletevents.PulledImage {
+					podEndTime[event.InvolvedObject.Name] = event.CreationTimestamp
+					for _, testpod := range testpods {
+						if event.InvolvedObject.Name == testpod.Name {
+							pulled, err := getDurationsFromPulledEventMsg(event.Message)
+							imagePulled[testpod.Name] = pulled
+							framework.ExpectNoError(err)
+							break
+						}
+					}
+				} else if event.Reason == kubeletevents.PullingImage {
+					podStartTime[event.InvolvedObject.Name] = event.CreationTimestamp
+				}
+			}
+			gomega.Expect(len(testpods)).To(gomega.BeComparableTo(len(imagePulled)))
+
+			// skip if pod1 pulling time and pod2 pulling time are not overlapped
+			if podStartTime[testpods[0].Name].Time.Before(podStartTime[testpods[1].Name].Time) {
+				if podEndTime[testpods[0].Name].Time.Before(podStartTime[testpods[1].Name].Time) {
+					e2eskipper.Skipf("pod1 pulling time and pod2 pulling time are not overlapped")
+				}
+			} else {
+				if podEndTime[testpods[1].Name].Time.Before(podStartTime[testpods[0].Name].Time) {
+					e2eskipper.Skipf("pod1 pulling time and pod2 pulling time are not overlapped")
+				}
+			}
+
+			// as this is serialize image pulling, the waiting duration should be almost double the duration with the pulled duration.
+			// use 1.5 as a common ratio to avoid some overlap during pod creation
+			if float32(imagePulled[testpods[1].Name].pulledIncludeWaitingDuration/time.Millisecond)/float32(imagePulled[testpods[1].Name].pulledDuration/time.Millisecond) < 1.5 &&
+				float32(imagePulled[testpods[0].Name].pulledIncludeWaitingDuration/time.Millisecond)/float32(imagePulled[testpods[0].Name].pulledDuration/time.Millisecond) < 1.5 {
+				framework.Failf("At least, one of the pull duration including waiting %v/%v should be similar with the pulled duration %v/%v",
+					imagePulled[testpods[1].Name].pulledIncludeWaitingDuration, imagePulled[testpods[0].Name].pulledIncludeWaitingDuration, imagePulled[testpods[1].Name].pulledDuration, imagePulled[testpods[0].Name].pulledDuration)
+			}
+		})
+
+	})
+})
+
+func prepareAndCleanup(ctx context.Context, f *framework.Framework) (testpods []*v1.Pod) {
+	// cuda images are > 2Gi and it will reduce the flaky rate
+	image1 := imageutils.GetE2EImage(imageutils.CudaVectorAdd)
+	image2 := imageutils.GetE2EImage(imageutils.CudaVectorAdd2)
+	node := getNodeName(ctx, f)
+
+	testpod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "testpod",
+			Namespace: f.Namespace.Name,
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{{
+				Name:            "testpod",
+				Image:           image1,
+				ImagePullPolicy: v1.PullAlways,
+			}},
+			NodeName:      node,
+			RestartPolicy: v1.RestartPolicyNever,
+		},
+	}
+	testpod2 := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "testpod2",
+			Namespace: f.Namespace.Name,
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{{
+				Name:            "testpod2",
+				Image:           image2,
+				ImagePullPolicy: v1.PullAlways,
+			}},
+			NodeName:      node,
+			RestartPolicy: v1.RestartPolicyNever,
+		},
+	}
+	testpods = []*v1.Pod{testpod, testpod2}
+
+	ginkgo.By("cleanup images")
+	for _, pod := range testpods {
+		_ = RemoveImage(ctx, pod.Spec.Containers[0].Image)
+	}
+	return testpods
+}
+
+type pulledStruct struct {
+	pulledDuration               time.Duration
+	pulledIncludeWaitingDuration time.Duration
+}
+
+// getDurationsFromPulledEventMsg will parse two durations in the pulled message
+// Example msg: `Successfully pulled image \"busybox:1.28\" in 39.356s (49.356s including waiting). Image size: 41901587 bytes.`
+func getDurationsFromPulledEventMsg(msg string) (*pulledStruct, error) {
+	splits := strings.Split(msg, " ")
+	if len(splits) != 13 {
+		return nil, errors.Errorf("pull event message should be spilted to 13: %d", len(splits))
+	}
+	pulledDuration, err := time.ParseDuration(splits[5])
+	if err != nil {
+		return nil, err
+	}
+	// to skip '('
+	pulledIncludeWaitingDuration, err := time.ParseDuration(splits[6][1:])
+	if err != nil {
+		return nil, err
+	}
+	return &pulledStruct{
+		pulledDuration:               pulledDuration,
+		pulledIncludeWaitingDuration: pulledIncludeWaitingDuration,
+	}, nil
+}

--- a/test/e2e_node/split_disk_test.go
+++ b/test/e2e_node/split_disk_test.go
@@ -19,12 +19,13 @@ package e2enode
 import (
 	"context"
 	"fmt"
-	"k8s.io/kubernetes/pkg/features"
-	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
+
+	"k8s.io/kubernetes/pkg/features"
+	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -217,7 +218,7 @@ func runImageFsPressureTest(f *framework.Framework, pressureTimeout time.Duratio
 				if expectedNodeCondition == v1.NodeDiskPressure && framework.TestContext.PrepullImages {
 					// The disk eviction test may cause the pre-pulled images to be evicted,
 					// so pre-pull those images again to ensure this test does not affect subsequent tests.
-					err := PrePullAllImages()
+					err := PrePullAllImages(ctx)
 					framework.ExpectNoError(err)
 				}
 			}

--- a/test/e2e_node/system_node_critical_test.go
+++ b/test/e2e_node/system_node_critical_test.go
@@ -43,15 +43,16 @@ var _ = SIGDescribe("SystemNodeCriticalPod", framework.WithSlow(), framework.Wit
 	// this test only manipulates pods in kube-system
 	f.SkipNamespaceCreation = true
 
-	ginkgo.AfterEach(func() {
-		if framework.TestContext.PrepullImages {
-			// The test may cause the prepulled images to be evicted,
-			// prepull those images again to ensure this test not affect following tests.
-			PrePullAllImages()
-		}
-	})
-
 	ginkgo.Context("when create a system-node-critical pod", func() {
+		ginkgo.AfterEach(func(ctx context.Context) {
+			if framework.TestContext.PrepullImages {
+				// The test may cause the prepulled images to be evicted,
+				// prepull those images again to ensure this test not affect following tests.
+				err := PrePullAllImages(ctx)
+				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+			}
+		})
+
 		tempSetCurrentKubeletConfig(f, func(ctx context.Context, initialConfig *kubeletconfig.KubeletConfiguration) {
 			diskConsumed := resource.MustParse("200Mi")
 			summary := eventuallyGetSummary(ctx)
@@ -110,7 +111,8 @@ var _ = SIGDescribe("SystemNodeCriticalPod", framework.WithSlow(), framework.Wit
 					if framework.TestContext.PrepullImages {
 						// The test may cause the prepulled images to be evicted,
 						// prepull those images again to ensure this test not affect following tests.
-						PrePullAllImages()
+						err := PrePullAllImages(ctx)
+						gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 					}
 				}()
 				ginkgo.By("delete the static pod")

--- a/test/e2e_node/system_node_critical_test.go
+++ b/test/e2e_node/system_node_critical_test.go
@@ -43,16 +43,15 @@ var _ = SIGDescribe("SystemNodeCriticalPod", framework.WithSlow(), framework.Wit
 	// this test only manipulates pods in kube-system
 	f.SkipNamespaceCreation = true
 
+	ginkgo.AfterEach(func(ctx context.Context) {
+		if framework.TestContext.PrepullImages {
+			// The test may cause the prepulled images to be evicted,
+			// prepull those images again to ensure this test not affect following tests.
+			err := PrePullAllImages(ctx)
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+		}
+	})
 	ginkgo.Context("when create a system-node-critical pod", func() {
-		ginkgo.AfterEach(func(ctx context.Context) {
-			if framework.TestContext.PrepullImages {
-				// The test may cause the prepulled images to be evicted,
-				// prepull those images again to ensure this test not affect following tests.
-				err := PrePullAllImages(ctx)
-				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
-			}
-		})
-
 		tempSetCurrentKubeletConfig(f, func(ctx context.Context, initialConfig *kubeletconfig.KubeletConfiguration) {
 			diskConsumed := resource.MustParse("200Mi")
 			summary := eventuallyGetSummary(ctx)


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
- `test/e2e_node/image_pull_test.go`: two cases: serialize and parallel image pulling
- `test/e2e_node/criproxy_test.go`: 5min -> 1min. Not waiting for pod running as the image pull is injected with error.

#### Which issue(s) this PR fixes:
xref https://github.com/kubernetes/enhancements/issues/3673

#### Special notes for your reviewer:
Local run


#### Does this PR introduce a user-facing change?

```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:


```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/3673-kubelet-parallel-image-pull-limit
```
