### PR TITLE
KEP-127: Add UserNamespacesPodSecurityStandards e2e test

### DIFF
--- a/test/e2e/common/node/security_context.go
+++ b/test/e2e/common/node/security_context.go
@@ -35,6 +35,7 @@ import (
 	imageutils "k8s.io/kubernetes/test/utils/image"
 	admissionapi "k8s.io/pod-security-admission/api"
 	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
@@ -631,6 +632,39 @@ var _ = SIGDescribe("Security Context", func() {
 			if err := createAndMatchOutput(ctx, podName, "Effective uid: 0", &apeTrue, nonRootTestUserID); err != nil {
 				framework.Failf("Match output for pod %q failed: %v", podName, err)
 			}
+		})
+	})
+})
+
+var _ = SIGDescribe("User Namespaces for Pod Security Standards [LinuxOnly]", func() {
+	f := framework.NewDefaultFramework("user-namespaces-pss-test")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelRestricted
+
+	ginkgo.Context("with UserNamespacesSupport and UserNamespacesPodSecurityStandards enabled", func() {
+		f.It("should allow pod", feature.UserNamespacesPodSecurityStandards, func(ctx context.Context) {
+			name := "pod-user-namespaces-pss-" + string(uuid.NewUUID())
+			pod := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: name},
+				Spec: v1.PodSpec{
+					RestartPolicy:   v1.RestartPolicyNever,
+					HostUsers:       ptr.To(false),
+					SecurityContext: &v1.PodSecurityContext{},
+					Containers: []v1.Container{
+						{
+							Name:    name,
+							Image:   imageutils.GetE2EImage(imageutils.BusyBox),
+							Command: []string{"whoami"},
+							SecurityContext: &v1.SecurityContext{
+								AllowPrivilegeEscalation: ptr.To(false),
+								Capabilities:             &v1.Capabilities{Drop: []v1.Capability{"ALL"}},
+								SeccompProfile:           &v1.SeccompProfile{Type: v1.SeccompProfileTypeRuntimeDefault},
+							},
+						},
+					},
+				},
+			}
+
+			e2epodoutput.TestContainerOutput(ctx, f, "RunAsUser-RunAsNonRoot", pod, 0, []string{"root"})
 		})
 	})
 })

--- a/test/e2e/feature/feature.go
+++ b/test/e2e/feature/feature.go
@@ -328,6 +328,12 @@ var (
 	// TODO: document the feature (owning SIG, when to use this feature for a test)
 	UserNamespacesSupport = framework.WithFeature(framework.ValidFeatures.Add("UserNamespacesSupport"))
 
+	// Owned by SIG Node
+	// Can be used when the UserNamespacesPodSecurityStandards kubelet feature
+	// gate is enabled to relax the application of Pod Security Standards in a
+	// controlled way.
+	UserNamespacesPodSecurityStandards = framework.WithFeature(framework.ValidFeatures.Add("UserNamespacesPodSecurityStandards"))
+
 	// TODO: document the feature (owning SIG, when to use this feature for a test)
 	ValidatingAdmissionPolicy = framework.WithFeature(framework.ValidFeatures.Add("ValidatingAdmissionPolicy"))
 


### PR DESCRIPTION


#### What type of PR is this?


/kind cleanup

#### What this PR does / why we need it:
Adding a e2e test for the functionality added in https://github.com/kubernetes/kubernetes/pull/118760.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
None

#### Special notes for your reviewer:
cc @mrunalp @rata @giuseppe 
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
