### PR TITLE
controller descriptors should not be feature gated

### DIFF
--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -75,7 +75,6 @@ import (
 	"k8s.io/kubernetes/cmd/kube-controller-manager/names"
 	kubectrlmgrconfig "k8s.io/kubernetes/pkg/controller/apis/config"
 	serviceaccountcontroller "k8s.io/kubernetes/pkg/controller/serviceaccount"
-	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/serviceaccount"
 )
 
@@ -557,10 +556,7 @@ func NewControllerDescriptors() map[string]*ControllerDescriptor {
 	register(newResourceClaimControllerDescriptor())
 	register(newLegacyServiceAccountTokenCleanerControllerDescriptor())
 	register(newValidatingAdmissionPolicyStatusControllerDescriptor())
-	if utilfeature.DefaultFeatureGate.Enabled(features.SeparateTaintEvictionController) {
-		// register the flag only if the SeparateTaintEvictionController flag is enabled
-		register(newTaintEvictionControllerDescriptor())
-	}
+	register(newTaintEvictionControllerDescriptor())
 
 	for _, alias := range aliases.UnsortedList() {
 		if _, ok := controllers[alias]; ok {

--- a/cmd/kube-controller-manager/app/controllermanager_test.go
+++ b/cmd/kube-controller-manager/app/controllermanager_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package app
 
 import (
+	"context"
 	"regexp"
 	"strings"
 	"testing"
@@ -28,9 +29,10 @@ import (
 	cpnames "k8s.io/cloud-provider/names"
 	"k8s.io/component-base/featuregate"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	controllermanagercontroller "k8s.io/controller-manager/controller"
+	"k8s.io/klog/v2/ktesting"
 	"k8s.io/kubernetes/cmd/kube-controller-manager/names"
 	"k8s.io/kubernetes/pkg/features"
-	"k8s.io/utils/strings/slices"
 )
 
 func TestControllerNamesConsistency(t *testing.T) {
@@ -159,16 +161,56 @@ func TestFeatureGatedControllersShouldNotDefineAliases(t *testing.T) {
 	}
 }
 
-// TestTaintEvictionControllerDeclaration ensures that it is possible to run taint-manager as a separated controller
+// TestTaintEvictionControllerGating ensures that it is possible to run taint-manager as a separated controller
 // only when the SeparateTaintEvictionController feature is enabled
-func TestTaintEvictionControllerDeclaration(t *testing.T) {
-	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.SeparateTaintEvictionController, true)()
-	if !slices.Contains(KnownControllers(), names.TaintEvictionController) {
-		t.Errorf("TaintEvictionController should be a registered controller when the SeparateTaintEvictionController feature is enabled")
+func TestTaintEvictionControllerGating(t *testing.T) {
+	tests := []struct {
+		name               string
+		enableFeatureGate  bool
+		expectInitFuncCall bool
+	}{
+		{
+			name:               "standalone taint-eviction-controller should run when SeparateTaintEvictionController feature gate is enabled",
+			enableFeatureGate:  true,
+			expectInitFuncCall: true,
+		},
+		{
+			name:               "standalone taint-eviction-controller should not run when SeparateTaintEvictionController feature gate is not enabled",
+			enableFeatureGate:  false,
+			expectInitFuncCall: false,
+		},
 	}
 
-	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.SeparateTaintEvictionController, false)()
-	if slices.Contains(KnownControllers(), names.TaintEvictionController) {
-		t.Errorf("TaintEvictionController should not be a registered controller when the SeparateTaintEvictionController feature is disabled")
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.SeparateTaintEvictionController, test.enableFeatureGate)()
+			_, ctx := ktesting.NewTestContext(t)
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+
+			controllerCtx := ControllerContext{}
+			controllerCtx.ComponentConfig.Generic.Controllers = []string{names.TaintEvictionController}
+
+			initFuncCalled := false
+
+			taintEvictionControllerDescriptor := NewControllerDescriptors()[names.TaintEvictionController]
+			taintEvictionControllerDescriptor.initFunc = func(ctx context.Context, controllerContext ControllerContext, controllerName string) (controller controllermanagercontroller.Interface, enabled bool, err error) {
+				initFuncCalled = true
+				return nil, true, nil
+			}
+
+			healthCheck, err := StartController(ctx, controllerCtx, taintEvictionControllerDescriptor, nil)
+			if err != nil {
+				t.Errorf("starting a TaintEvictionController controller should not return an error")
+			}
+			if test.expectInitFuncCall != initFuncCalled {
+				t.Errorf("TaintEvictionController init call check failed: expected=%v, got=%v", test.expectInitFuncCall, initFuncCalled)
+			}
+			hasHealthCheck := healthCheck != nil
+			expectHealthCheck := test.expectInitFuncCall
+			if expectHealthCheck != hasHealthCheck {
+				t.Errorf("TaintEvictionController healthCheck check failed: expected=%v, got=%v", expectHealthCheck, hasHealthCheck)
+			}
+		})
 	}
 }

--- a/cmd/kube-controller-manager/app/controllermanager_test.go
+++ b/cmd/kube-controller-manager/app/controllermanager_test.go
@@ -107,6 +107,9 @@ func TestNewControllerDescriptorsShouldNotPanic(t *testing.T) {
 }
 
 func TestNewControllerDescriptorsAlwaysReturnsDescriptorsForAllControllers(t *testing.T) {
+	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, "AllAlpha", false)()
+	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, "AllBeta", false)()
+
 	controllersWithoutFeatureGates := KnownControllers()
 
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, "AllAlpha", true)()


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:

controllers enabled by default should define feature gates in ControllerDescriptor.requiredFeatureGates and not during a descriptor registration in NewControllerDescriptors

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
