### PR TITLE
Make the decode function respect the timeout context

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/errors.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/errors.go
@@ -33,6 +33,7 @@ const (
 	ErrCodeResourceVersionConflicts
 	ErrCodeInvalidObj
 	ErrCodeUnreachable
+	ErrCodeTimeout
 )
 
 var errCodeToMessage = map[int]string{
@@ -41,6 +42,7 @@ var errCodeToMessage = map[int]string{
 	ErrCodeResourceVersionConflicts: "resource version conflicts",
 	ErrCodeInvalidObj:               "invalid object",
 	ErrCodeUnreachable:              "server unreachable",
+	ErrCodeTimeout:                  "request timeout",
 }
 
 func NewKeyNotFoundError(key string, rv int64) *StorageError {
@@ -72,6 +74,14 @@ func NewUnreachableError(key string, rv int64) *StorageError {
 		Code:            ErrCodeUnreachable,
 		Key:             key,
 		ResourceVersion: rv,
+	}
+}
+
+func NewTimeoutError(key, msg string) *StorageError {
+	return &StorageError{
+		Code:               ErrCodeTimeout,
+		Key:                key,
+		AdditionalErrorMsg: msg,
 	}
 }
 
@@ -113,6 +123,11 @@ func IsUnreachable(err error) bool {
 // IsConflict returns true if and only if err is a write conflict.
 func IsConflict(err error) bool {
 	return isErrCode(err, ErrCodeResourceVersionConflicts)
+}
+
+// IsRequestTimeout returns true if and only if err indicates that the request has timed out.
+func IsRequestTimeout(err error) bool {
+	return isErrCode(err, ErrCodeTimeout)
 }
 
 // IsInvalidObj returns true if and only if err is invalid error

--- a/staging/src/k8s.io/apiserver/pkg/storage/errors/storage.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/errors/storage.go
@@ -28,7 +28,7 @@ func InterpretListError(err error, qualifiedResource schema.GroupResource) error
 	switch {
 	case storage.IsNotFound(err):
 		return errors.NewNotFound(qualifiedResource, "")
-	case storage.IsUnreachable(err):
+	case storage.IsUnreachable(err), storage.IsRequestTimeout(err):
 		return errors.NewServerTimeout(qualifiedResource, "list", 2) // TODO: make configurable or handled at a higher level
 	case storage.IsInternalError(err):
 		return errors.NewInternalError(err)

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
@@ -741,6 +741,14 @@ func (s *store) GetList(ctx context.Context, key string, opts storage.ListOption
 				return storage.NewInternalErrorf("unable to transform key %q: %v", kv.Key, err)
 			}
 
+			// Check if the request has already timed out before decode object
+			select {
+			case <-ctx.Done():
+				// parent context is canceled or timed out, no point in continuing
+				return storage.NewTimeoutError(string(kv.Key), "request did not complete within requested timeout")
+			default:
+			}
+
 			if err := appendListItem(v, data, uint64(kv.ModRevision), opts.Predicate, s.codec, s.versioner, newItemFunc); err != nil {
 				recordDecodeError(s.groupResourceString, string(kv.Key))
 				return err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
It is possible to issue a list request that exceeds the duration set by the apiserver request-timeout flag. While the apiserver is decoding etcd's response, the request timeout is not enforced.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/121267

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Make decoding etcd's response respect the timeout context.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
