### PR TITLE
cluster/gce: add webhook to replace PersistentVolumeLabel admission controller

### DIFF
--- a/cluster/gce/addons/cloud-pvl-admission/mutating-webhook-configuration.yaml
+++ b/cluster/gce/addons/cloud-pvl-admission/mutating-webhook-configuration.yaml
@@ -1,0 +1,22 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: "cloud-pvl-admission.k8s.io"
+  labels:
+    addonmanager.kubernetes.io/mode: Reconcile
+    k8s-app: cloud-pvl-admission
+webhooks:
+- name: "cloud-pvl-admission.k8s.io"
+  rules:
+  - apiGroups:   [""]
+    apiVersions: ["v1"]
+    operations:  ["CREATE"]
+    resources:   ["persistentvolumes"]
+    scope:       "*"
+  clientConfig:
+    url: "https://127.0.0.1:9001/admit"
+    caBundle: "__CLOUD_PVL_ADMISSION_CA_CERT__"
+  admissionReviewVersions: ["v1"]
+  sideEffects: None
+  timeoutSeconds: 5
+  failurePolicy: Fail

--- a/cluster/gce/config-default.sh
+++ b/cluster/gce/config-default.sh
@@ -362,7 +362,7 @@ fi
 CUSTOM_INGRESS_YAML="${CUSTOM_INGRESS_YAML:-}"
 
 # Admission Controllers to invoke prior to persisting objects in cluster
-ADMISSION_CONTROL=NamespaceLifecycle,LimitRanger,ServiceAccount,PersistentVolumeLabel,DefaultStorageClass,PersistentVolumeClaimResize,DefaultTolerationSeconds,NodeRestriction,Priority,StorageObjectInUseProtection,RuntimeClass
+ADMISSION_CONTROL=NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,PersistentVolumeClaimResize,DefaultTolerationSeconds,NodeRestriction,Priority,StorageObjectInUseProtection,RuntimeClass
 
 # MutatingAdmissionWebhook should be the last controller that modifies the
 # request object, otherwise users will be confused if the mutating webhooks'

--- a/cluster/gce/config-test.sh
+++ b/cluster/gce/config-test.sh
@@ -407,7 +407,7 @@ fi
 CUSTOM_INGRESS_YAML=${CUSTOM_INGRESS_YAML:-}
 
 if [[ -z "${KUBE_ADMISSION_CONTROL:-}" ]]; then
-  ADMISSION_CONTROL='NamespaceLifecycle,LimitRanger,ServiceAccount,PersistentVolumeLabel,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,Priority,StorageObjectInUseProtection,PersistentVolumeClaimResize,RuntimeClass'
+  ADMISSION_CONTROL='NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,Priority,StorageObjectInUseProtection,PersistentVolumeClaimResize,RuntimeClass'
   # ResourceQuota must come last, or a creation is recorded, but the pod may be forbidden.
   ADMISSION_CONTROL="${ADMISSION_CONTROL},MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota"
 else

--- a/cluster/gce/manifests/cloud-controller-manager.manifest
+++ b/cluster/gce/manifests/cloud-controller-manager.manifest
@@ -74,6 +74,50 @@
         "mountPath": "/etc/pki",
         "readOnly": true}
       ]
+    },
+    {
+    "name": "cloud-pvl-admission",
+    "image": "gcr.io/k8s-staging-cloud-pv-labeler/cloud-pv-admission-labeler:v0.3.0",
+    "resources": {
+      "requests": {
+        "cpu": "10m"
+      }
+    },
+    "command": [
+      "/cloud-pv-admission-labeler",
+      "--addr=localhost:9001",
+      "--tls-cert-path=/etc/srv/kubernetes/pki/cloud-pvl-admission/server.crt",
+      "--tls-key-path=/etc/srv/kubernetes/pki/cloud-pvl-admission/server.key",
+      "--cloud-provider=gce",
+      "--cloud-config=/etc/gce.conf"
+    ],
+    "volumeMounts": [
+        {{cloud_config_mount}}
+        {{additional_cloud_config_mount}}
+        {{pv_recycler_mount}}
+        { "name": "srvkube",
+        "mountPath": "/etc/srv/kubernetes",
+        "readOnly": true},
+        {{flexvolume_hostpath_mount}}
+        { "name": "logfile",
+        "mountPath": "/var/log/cloud-pvl-admission.log",
+        "readOnly": false},
+        { "name": "etcssl",
+        "mountPath": "/etc/ssl",
+        "readOnly": true},
+        { "name": "usrsharecacerts",
+        "mountPath": "/usr/share/ca-certificates",
+        "readOnly": true},
+        { "name": "varssl",
+        "mountPath": "/var/ssl",
+        "readOnly": true},
+        { "name": "etcopenssl",
+        "mountPath": "/etc/openssl",
+        "readOnly": true},
+        { "name": "etcpki",
+        "mountPath": "/etc/pki",
+        "readOnly": true}
+      ]
     }
 ],
 "volumes":[


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Update scripts in cluster/ to replace the deprecated PersistentVolumeLabel admission controller with an admission webhook. The webhook is based on https://github.com/kubernetes-sigs/cloud-pv-admission-labeler, which is a webhook server that uses the same logic by calling GetVolumeLabels.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
cluster/gce: add webhook to replace PersistentVolumeLabel admission controller
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
