### PR TITLE
Add unit tests for pkg/registry/core/serviceaccount/storage/token.go

### DIFF
--- a/pkg/registry/core/serviceaccount/storage/token_test.go
+++ b/pkg/registry/core/serviceaccount/storage/token_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package storage
 
 import (

--- a/pkg/registry/core/serviceaccount/storage/token_test.go
+++ b/pkg/registry/core/serviceaccount/storage/token_test.go
@@ -1,0 +1,98 @@
+package storage
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/audit"
+	"k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/apiserver/pkg/registry/rest"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	authenticationapi "k8s.io/kubernetes/pkg/apis/authentication"
+	"k8s.io/kubernetes/pkg/features"
+)
+
+func TestCreate_Token_NamespaceNotExist(t *testing.T) {
+	storage, server := newStorage(t)
+	defer server.Terminate(t)
+	defer storage.Store.DestroyFunc()
+
+	// Enable JTI feature
+	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ServiceAccountTokenJTI, true)()
+
+	ctx := context.Background()
+	// Create a test service account
+	serviceAccount := validNewServiceAccount("foo")
+
+	// create an audit context to allow recording audit information
+	ctx = audit.WithAuditContext(ctx)
+	_, err := storage.Token.Create(ctx, serviceAccount.Name, &authenticationapi.TokenRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      serviceAccount.Name,
+			Namespace: serviceAccount.Namespace,
+		},
+		Spec: authenticationapi.TokenRequestSpec{ExpirationSeconds: 3600},
+	}, rest.ValidateAllObjectFunc, &metav1.CreateOptions{})
+	if err == nil {
+		t.Errorf("should create namespace first.")
+	}
+}
+
+func TestCreate_Token_NamespaceNameNotMatched(t *testing.T) {
+	storage, server := newStorage(t)
+	defer server.Terminate(t)
+	defer storage.Store.DestroyFunc()
+
+	// Enable JTI feature
+	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ServiceAccountTokenJTI, true)()
+
+	ctx := context.Background()
+	// Create a test service account
+	serviceAccount := validNewServiceAccount("foo")
+	// add the namespace to the context as it is required
+	ctx = request.WithNamespace(ctx, serviceAccount.Namespace)
+	_, err := storage.Store.Create(ctx, serviceAccount, rest.ValidateAllObjectFunc, &metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("failed creating test service account: %v", err)
+	}
+
+	// create an audit context to allow recording audit information
+	ctx = audit.WithAuditContext(ctx)
+	_, err = storage.Token.Create(ctx, serviceAccount.Name, &authenticationapi.TokenRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: serviceAccount.Namespace,
+		},
+		Spec: authenticationapi.TokenRequestSpec{ExpirationSeconds: 3600},
+	}, rest.ValidateAllObjectFunc, &metav1.CreateOptions{})
+	if err == nil {
+		t.Errorf("service account name should be aligned with name in request.")
+	}
+
+	_, err = storage.Token.Create(ctx, serviceAccount.Name, &authenticationapi.TokenRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: serviceAccount.Namespace,
+		},
+		Spec: authenticationapi.TokenRequestSpec{ExpirationSeconds: 3600},
+	}, rest.ValidateAllObjectFunc, &metav1.CreateOptions{})
+	if err == nil {
+		t.Errorf("service account namespace should be aligned with namespace in request.")
+	}
+
+	// test name/namespace populate
+	_, err = storage.Token.Create(ctx, serviceAccount.Name, &authenticationapi.TokenRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "",
+			Namespace: "",
+		},
+		Spec: authenticationapi.TokenRequestSpec{
+			ExpirationSeconds: 3600,
+		},
+	}, rest.ValidateAllObjectFunc, &metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("failed calling /token endpoint for service account: %v", err)
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Add unit tests for pkg/registry/core/serviceaccount/storage/token.go

Part of Including JTI & node reference in issued service account tokens (kep 4193)

#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes/kubernetes/issues/121515

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-auth/4193-bound-service-account-token-improvements
- [Usage]: https://github.com/kubernetes/website/pull/43590
```
