### PR TITLE
Move invocation to not to cause ginkgo panic

### DIFF
--- a/test/e2e/kubectl/rollout.go
+++ b/test/e2e/kubectl/rollout.go
@@ -39,6 +39,7 @@ import (
 
 var _ = SIGDescribe("Kubectl rollout", func() {
 	defer ginkgo.GinkgoRecover()
+	var deploymentYaml string
 	f := framework.NewDefaultFramework("kubectl-rollout")
 	f.NamespacePodSecurityLevel = admissionapi.LevelBaseline
 
@@ -47,10 +48,10 @@ var _ = SIGDescribe("Kubectl rollout", func() {
 	ginkgo.BeforeEach(func() {
 		c = f.ClientSet
 		ns = f.Namespace.Name
+		deploymentYaml = commonutils.SubstituteImageName(string(readTestFileOrDie(httpdDeployment1Filename)))
 	})
 
 	ginkgo.Describe("undo", func() {
-		deploymentYaml := commonutils.SubstituteImageName(string(readTestFileOrDie(httpdDeployment1Filename)))
 		ginkgo.AfterEach(func() {
 			cleanupKubectlInputs(deploymentYaml, ns, "app=httpd")
 		})


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/sig cli

#### What this PR does / why we need it:
Found this while working on pulling in newer version of k8s into openshift. I'm not sure why we're not seeing this here, but downstream I'm seeing:
```
Assertion or Panic detected during tree construction
ginkgo.Describe("undo", func() {
/go/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/kubectl/rollout.go:52
  Ginkgo detected a panic while constructing the spec tree.
  You may be trying to make an assertion in the body of a container node
  (i.e. Describe, Context, or When).

  Please ensure all assertions are inside leaf nodes such as BeforeEach,
  It, etc.

  Here's the content of the panic that was caught:
  Your Test Panicked
  deploymentYaml :=
  commonutils.SubstituteImageName(string(readTestFileOrDie(httpdDeployment1Filename)))
  /go/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/kubectl/rollout.go:53
    When you, or your assertion library, calls Ginkgo's Fail(),
    Ginkgo panics to prevent subsequent assertions from running.

    Normally Ginkgo rescues this panic so you shouldn't see it.

    However, if you make an assertion in a goroutine, Ginkgo can't capture the
    panic.
    To circumvent this, you should call

    	defer GinkgoRecover()

    at the top of the goroutine that caused this panic.

    Alternatively, you may have made an assertion outside of a Ginkgo
    leaf node (e.g. in a container node or some out-of-band function) - please
    move your assertion to
    an appropriate Ginkgo node (e.g. a BeforeSuite, BeforeEach, It, etc...).

    Learn more at:
    http://onsi.github.io/ginkgo/#mental-model-how-ginkgo-handles-failure


  Learn more at: http://onsi.github.io/ginkgo/#no-assertions-in-container-nodes
```

The fix is to ensure that `commonutils.SubstituteImageName(string(readTestFileOrDie(httpdDeployment1Filename)))`
line is invoked either in `BeforeEach` or inside `It`. 


#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
/assign @atiratree @ardaguclu 

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
