### PR TITLE
Automated cherry pick of #120948: Fixing attempt to deploy past allocatable memory limits test

### DIFF
--- a/test/e2e/windows/memory_limits.go
+++ b/test/e2e/windows/memory_limits.go
@@ -108,9 +108,12 @@ func overrideAllocatableMemoryTest(ctx context.Context, f *framework.Framework, 
 	})
 	framework.ExpectNoError(err)
 
+	framework.Logf("Scheduling 1 pod per node to consume all allocatable memory")
 	for _, node := range nodeList.Items {
 		status := node.Status
+		podMemLimt := resource.NewQuantity(status.Allocatable.Memory().Value()-(1024*1024*100), resource.BinarySI)
 		podName := "mem-test-" + string(uuid.NewUUID())
+		framework.Logf("Scheduling pod %s on node %s (allocatable memory=%v) with memory limit %v", podName, node.Name, status.Allocatable.Memory(), podMemLimt)
 		pod := &v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: podName,
@@ -122,7 +125,7 @@ func overrideAllocatableMemoryTest(ctx context.Context, f *framework.Framework, 
 						Image: imageutils.GetPauseImageName(),
 						Resources: v1.ResourceRequirements{
 							Limits: v1.ResourceList{
-								v1.ResourceMemory: status.Allocatable[v1.ResourceMemory],
+								v1.ResourceMemory: *podMemLimt,
 							},
 						},
 					},
@@ -136,6 +139,7 @@ func overrideAllocatableMemoryTest(ctx context.Context, f *framework.Framework, 
 		_, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOptions{})
 		framework.ExpectNoError(err)
 	}
+	framework.Logf("Schedule additional pod which should not get scheduled")
 	podName := "mem-failure-pod"
 	failurePod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -158,6 +162,7 @@ func overrideAllocatableMemoryTest(ctx context.Context, f *framework.Framework, 
 			},
 		},
 	}
+	framework.Logf("Ensuring that pod %s fails to schedule", podName)
 	failurePod, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, failurePod, metav1.CreateOptions{})
 	framework.ExpectNoError(err)
 	gomega.Eventually(ctx, func() bool {
@@ -171,8 +176,7 @@ func overrideAllocatableMemoryTest(ctx context.Context, f *framework.Framework, 
 			}
 		}
 		return false
-	}, 3*time.Minute, 10*time.Second).Should(gomega.Equal(true))
-
+	}, 3*time.Minute, 10*time.Second).Should(gomega.BeTrue())
 }
 
 // getNodeMemory populates a nodeMemory struct with information from the first


### PR DESCRIPTION
Cherry pick of #120948 on release-1.27.

#120948: Fixing attempt to deploy past allocatable memory limits test

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```