### PR TITLE
etcd: add --provenance=false during etcd multi-arch build

### DIFF
--- a/cluster/images/etcd/Makefile
+++ b/cluster/images/etcd/Makefile
@@ -192,6 +192,7 @@ endif
 	# And build the image
 	docker buildx build \
 		--pull \
+		--provenance=false \
 		--output=type=$(OUTPUT_TYPE) \
 		--platform "$(OS)/$(ARCH)" \
 		-t $(REGISTRY)/etcd:$(IMAGE_TAG)-$(IMAGE_SUFFIX) \


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
See https://docs.docker.com/build/attestations/

#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes/test-infra/issues/31154

#### Special notes for your reviewer:
> Provenance attestations are enabled by default, with the mode=min option. You can disable provenance attestations using the --provenance=false flag, or by setting the [BUILDX_NO_DEFAULT_ATTESTATIONS](https://docs.docker.com/build/building/env-vars/#buildx_no_default_attestations) environment variable.

THis is docker new behavior change for the supply chain security. Not sure if we can fix it like this. 

#### Does this PR introduce a user-facing change?

```release-note
None
```
