### PR TITLE
golangci-lint: tone down comment checking

### DIFF
--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -67,6 +67,16 @@ issues:
         - gocritic
       text: "ifElseChain: rewrite if-else to switch statement"
 
+    # Only packages listed here opt into the strict "exported symbols must be documented".
+    #
+    # Exclude texts from https://github.com/golangci/golangci-lint/blob/ab3c3cd69e602ff53bb4c3e2c188f0caeb80305d/pkg/config/issues.go#L11-L103
+    - linters:
+        - golint
+        - revive
+        - stylecheck
+      text: comment on exported (method|function|type|const)|should have( a package)? comment|comment should be of the form|comment on exported (method|function|type|const)|should have( a package)? comment|comment should be of the form|exported (.+) should have comment( \(or a comment on this block\))? or be unexported|package comment should be of the form "(.+)...|comment on exported (.+) should be of the form "(.+)...|should have a package comment
+      path-except: cmd/kubeadm
+
 linters:
   disable-all: false
   enable: # please keep this alphabetized

--- a/hack/golangci-strict.yaml
+++ b/hack/golangci-strict.yaml
@@ -67,6 +67,16 @@ issues:
         - gocritic
       text: "ifElseChain: rewrite if-else to switch statement"
 
+    # Only packages listed here opt into the strict "exported symbols must be documented".
+    #
+    # Exclude texts from https://github.com/golangci/golangci-lint/blob/ab3c3cd69e602ff53bb4c3e2c188f0caeb80305d/pkg/config/issues.go#L11-L103
+    - linters:
+        - golint
+        - revive
+        - stylecheck
+      text: comment on exported (method|function|type|const)|should have( a package)? comment|comment should be of the form|comment on exported (method|function|type|const)|should have( a package)? comment|comment should be of the form|exported (.+) should have comment( \(or a comment on this block\))? or be unexported|package comment should be of the form "(.+)...|comment on exported (.+) should be of the form "(.+)...|should have a package comment
+      path-except: cmd/kubeadm
+
     # The following issues were deemed "might be worth fixing, needs to be
     # decided on a case-by-case basis".  This was initially decided by a
     # majority of the developers who voted in
@@ -92,12 +102,6 @@ issues:
     - linters:
         - gosimple
       text: "S1033: unnecessary guard around call to delete"
-
-    # Only packages listed here opt into the strict "exported symbols must be documented".
-    - linters:
-        - revive
-      text: "(exported: exported .* or be unexported|exported: comment on exported.*should be of the form)"
-      path-except: cmd/kubeadm
 
     # Didn't make it into https://github.com/kubernetes/kubernetes/issues/117288.
     # Discussion on Slack concluded that "it's hard to have a universal policy for all

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -73,6 +73,16 @@ issues:
         - gocritic
       text: "ifElseChain: rewrite if-else to switch statement"
 
+    # Only packages listed here opt into the strict "exported symbols must be documented".
+    #
+    # Exclude texts from https://github.com/golangci/golangci-lint/blob/ab3c3cd69e602ff53bb4c3e2c188f0caeb80305d/pkg/config/issues.go#L11-L103
+    - linters:
+        - golint
+        - revive
+        - stylecheck
+      text: comment on exported (method|function|type|const)|should have( a package)? comment|comment should be of the form|comment on exported (method|function|type|const)|should have( a package)? comment|comment should be of the form|exported (.+) should have comment( \(or a comment on this block\))? or be unexported|package comment should be of the form "(.+)...|comment on exported (.+) should be of the form "(.+)...|should have a package comment
+      path-except: cmd/kubeadm
+
     # The following issues were deemed "might be worth fixing, needs to be
     # decided on a case-by-case basis".  This was initially decided by a
     # majority of the developers who voted in
@@ -98,12 +108,6 @@ issues:
     - linters:
         - gosimple
       text: "S1033: unnecessary guard around call to delete"
-
-    # Only packages listed here opt into the strict "exported symbols must be documented".
-    - linters:
-        - revive
-      text: "(exported: exported .* or be unexported|exported: comment on exported.*should be of the form)"
-      path-except: cmd/kubeadm
 
     # Didn't make it into https://github.com/kubernetes/kubernetes/issues/117288.
     # Discussion on Slack concluded that "it's hard to have a universal policy for all

--- a/hack/golangci.yaml.in
+++ b/hack/golangci.yaml.in
@@ -76,6 +76,16 @@ issues:
         - gocritic
       text: "ifElseChain: rewrite if-else to switch statement"
 
+    # Only packages listed here opt into the strict "exported symbols must be documented".
+    #
+    # Exclude texts from https://github.com/golangci/golangci-lint/blob/ab3c3cd69e602ff53bb4c3e2c188f0caeb80305d/pkg/config/issues.go#L11-L103
+    - linters:
+        - golint
+        - revive
+        - stylecheck
+      text: comment on exported (method|function|type|const)|should have( a package)? comment|comment should be of the form|comment on exported (method|function|type|const)|should have( a package)? comment|comment should be of the form|exported (.+) should have comment( \(or a comment on this block\))? or be unexported|package comment should be of the form "(.+)...|comment on exported (.+) should be of the form "(.+)...|should have a package comment
+      path-except: cmd/kubeadm
+
     {{- if not .Hints}}
 
     # The following issues were deemed "might be worth fixing, needs to be
@@ -103,12 +113,6 @@ issues:
     - linters:
         - gosimple
       text: "S1033: unnecessary guard around call to delete"
-
-    # Only packages listed here opt into the strict "exported symbols must be documented".
-    - linters:
-        - revive
-      text: "(exported: exported .* or be unexported|exported: comment on exported.*should be of the form)"
-      path-except: cmd/kubeadm
 
     # Didn't make it into https://github.com/kubernetes/kubernetes/issues/117288.
     # Discussion on Slack concluded that "it's hard to have a universal policy for all


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind failing-test

#### What this PR does / why we need it:

39df946c06 was meant to enable stricter comment checking only for cmd/kubeadm because the maintainers of that want that. However, the exclude rule didn't capture all possible error texts and therefore some checks were enabled across the entire code base.

The extended pattern is now based on the golangci-lint source code.

Also, the hint config didn't suppress any of these checks.

#### Which issue(s) this PR fixes:
Fixes #121660

#### Special notes for your reviewer:

I verified that https://github.com/kubernetes/kubernetes/pull/116516 and https://github.com/kubernetes/kubernetes/pull/121456 pass without issues, while errors in cmd/kubeadm are still caught.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/cc @aojea @neolit123 @kiashok 