### PR TITLE
test/e2e_kubeadm: add test for the kubeadm:cluster-admins CRB

### DIFF
--- a/test/e2e_kubeadm/admin_test.go
+++ b/test/e2e_kubeadm/admin_test.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubeadm
+
+import (
+	"context"
+
+	"github.com/onsi/ginkgo/v2"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/util/version"
+	admissionapi "k8s.io/pod-security-admission/api"
+
+	"k8s.io/kubernetes/test/e2e/framework"
+	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
+)
+
+const (
+	kubeadmClusterAdminsGroupAndCRB = "kubeadm:cluster-admins"
+	clusterAdminClusterRole         = "cluster-admin"
+)
+
+// Define a container for all the tests aimed at verifying that administrators
+// have "cluster-admin" level of access.
+var _ = Describe("admin", func() {
+
+	// Get an instance of the k8s test framework
+	f := framework.NewDefaultFramework("admin")
+	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
+
+	// Tests in this container are not expected to create new objects in the cluster
+	// so we are disabling the creation of a namespace in order to get a faster execution
+	f.SkipNamespaceCreation = true
+
+	ginkgo.It("kubeadm:cluster-admins CRB must exist and be binding the cluster-admin ClusterRole"+
+		" to the kubeadm:cluster-admins Group", func(ctx context.Context) {
+
+		// Use the ClusterConfiguration.kubernetesVersion to decide whether to look for the CRB.
+		// It was added in kubeadm v1.29-pre, but kubeadm supports a maximum skew of N-1
+		// with the control plane, so this is fine as long as kubernetesVersion matches
+		// the kubeadm version. Otherwise this test is skipped.
+		m := getClusterConfiguration(f.ClientSet)
+		const verKey = "kubernetesVersion"
+		verInterface, exists := m[verKey]
+		if !exists {
+			framework.Failf("the kubeadm ConfigMap %s is missing a %s key in %s",
+				kubeadmConfigName,
+				verKey,
+				kubeadmConfigClusterConfigurationConfigMapKey)
+		}
+
+		// Parse the version string
+		verStr, ok := verInterface.(string)
+		if !ok {
+			framework.Failf("cannot cast %s to string", verKey)
+		}
+		ver, err := version.ParseSemantic(verStr)
+		if err != nil {
+			framework.Failf("could not parse the %s key: %v", verKey, err)
+		}
+
+		// If the version is older than the version when this feature was added, skip this test
+		minVer := version.MustParseSemantic("v1.29.0-alpha.2.188+05076de57fc49f")
+		if !ver.AtLeast(minVer) {
+			e2eskipper.Skipf("Skipping because version %s is older than the minimum version %s",
+				ver,
+				minVer)
+		}
+
+		// Expect the CRB to exist
+		ExpectClusterRoleBindingWithSubjectAndRole(f.ClientSet,
+			kubeadmClusterAdminsGroupAndCRB,
+			rbacv1.GroupKind, kubeadmClusterAdminsGroupAndCRB,
+			clusterAdminClusterRole,
+		)
+	})
+})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature
/area test

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Add a test that checks if the CRB (kubeadm:cluster-admins) used for binding admin.conf file users (part of the kubeadm:cluster-admins Group) to the "cluster-admins" ClusterRole exists in kubeadm clusters.

It does that only for versions newer than the version when this feature was added.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
xref https://github.com/kubernetes/kubeadm/issues/2414

#### Special notes for your reviewer:
NONE

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
