### PR TITLE
Fix etcd repository path to prevent redirects

### DIFF
--- a/cluster/images/etcd-version-monitor/etcd-version-monitor.go
+++ b/cluster/images/etcd-version-monitor/etcd-version-monitor.go
@@ -61,7 +61,7 @@ var (
 	customMetricRegistry = metrics.NewKubeRegistry()
 
 	// Custom etcd version metric since etcd 3.2- does not export one.
-	// This will be replaced by https://github.com/coreos/etcd/pull/8960 in etcd 3.3.
+	// This will be replaced by https://github.com/etcd-io/etcd/pull/8960 in etcd 3.3.
 	etcdVersion = metrics.NewGaugeVec(
 		&metrics.GaugeOpts{
 			Namespace:      namespace,

--- a/cluster/images/etcd/Makefile
+++ b/cluster/images/etcd/Makefile
@@ -134,7 +134,7 @@ ifeq ($(ARCH),amd64)
 ifeq ($(OS),windows)
 	for version in $(BUNDLED_ETCD_VERSIONS); do \
 		etcd_release_tmp_dir=$(shell mktemp -d); \
-		curl -sSL --retry 5 https://github.com/coreos/etcd/releases/download/v$$version/etcd-v$$version-windows-amd64.zip -o etcd-v$$version-windows-amd64.zip; \
+		curl -sSL --retry 5 https://github.com/etcd-io/etcd/releases/download/v$$version/etcd-v$$version-windows-amd64.zip -o etcd-v$$version-windows-amd64.zip; \
 		unzip -q -d $$etcd_release_tmp_dir etcd-v$$version-windows-amd64.zip; \
 		rm etcd-v$$version-windows-amd64.zip; \
 		$(BIN_INSTALL) $$etcd_release_tmp_dir/etcd-v$$version-windows-amd64/etcd.exe $$etcd_release_tmp_dir/etcd-v$$version-windows-amd64/etcdctl.exe $(TEMP_DIR)/; \
@@ -144,7 +144,7 @@ ifeq ($(OS),windows)
 else
 	for version in $(BUNDLED_ETCD_VERSIONS); do \
 		etcd_release_tmp_dir=$(shell mktemp -d); \
-		curl -sSL --retry 5 https://github.com/coreos/etcd/releases/download/v$$version/etcd-v$$version-linux-amd64.tar.gz | tar -xz -C $$etcd_release_tmp_dir --strip-components=1; \
+		curl -sSL --retry 5 https://github.com/etcd-io/etcd/releases/download/v$$version/etcd-v$$version-linux-amd64.tar.gz | tar -xz -C $$etcd_release_tmp_dir --strip-components=1; \
 		$(BIN_INSTALL) $$etcd_release_tmp_dir/etcd $$etcd_release_tmp_dir/etcdctl $(TEMP_DIR)/; \
 		$(BIN_INSTALL) $(TEMP_DIR)/etcd $(TEMP_DIR)/etcd-$$version; \
 		$(BIN_INSTALL) $(TEMP_DIR)/etcdctl $(TEMP_DIR)/etcdctl-$$version; \
@@ -168,7 +168,7 @@ else
 			etcd_build_dir="/go/src/go.etcd.io/etcd"; \
 		fi; \
 		docker run --rm --interactive -v $${etcd_release_tmp_dir}:/etcdbin golang:$(GOLANG_VERSION)$(DOCKER_VOL_OPTS) /bin/bash -c \
-			"git clone https://github.com/coreos/etcd $$etcd_build_dir \
+			"git clone https://github.com/etcd-io/etcd $$etcd_build_dir \
 			&& cd $$etcd_build_dir \
 			&& git checkout v$${version} \
 			&& $(arch_prefix) GOARCH=$(ARCH) ./build.sh \

--- a/cmd/kubeadm/app/phases/certs/certlist.go
+++ b/cmd/kubeadm/app/phases/certs/certlist.go
@@ -352,7 +352,7 @@ func KubeadmCertEtcdServer() *KubeadmCert {
 		config: pkiutil.CertConfig{
 			Config: certutil.Config{
 				// TODO: etcd 3.2 introduced an undocumented requirement for ClientAuth usage on the
-				// server cert: https://github.com/coreos/etcd/issues/9785#issuecomment-396715692
+				// server cert: https://github.com/etcd-io/etcd/issues/9785#issuecomment-396715692
 				// Once the upstream issue is resolved, this should be returned to only allowing
 				// ServerAuth usage.
 				Usages: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},

--- a/hack/lib/etcd.sh
+++ b/hack/lib/etcd.sh
@@ -168,7 +168,7 @@ kube::etcd::install() {
     ln -fns "etcd-v${ETCD_VERSION}-${os}-${arch}" etcd
     rm "${download_file}"
   elif [[ ${os} == "linux" ]]; then
-    url="https://github.com/coreos/etcd/releases/download/v${ETCD_VERSION}/etcd-v${ETCD_VERSION}-${os}-${arch}.tar.gz"
+    url="https://github.com/etcd-io/etcd/releases/download/v${ETCD_VERSION}/etcd-v${ETCD_VERSION}-${os}-${arch}.tar.gz"
     download_file="etcd-v${ETCD_VERSION}-${os}-${arch}.tar.gz"
     kube::util::download_file "${url}" "${download_file}"
     tar xzf "${download_file}"

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/testing/testingcert/certificates.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/testing/testingcert/certificates.go
@@ -17,7 +17,7 @@ limitations under the License.
 package testingcert
 
 // You can use cfssl tool to generate certificates, please refer
-// https://github.com/coreos/etcd/tree/master/hack/tls-setup for more details.
+// https://github.com/etcd-io/etcd/tree/main/hack/tls-setup for more details.
 //
 // ca-config.json:
 //


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/sig etcd

#### What this PR does / why we need it:

Update the etcd repository path from `https://github.com/coreos/etcd` to `https://github.com/etcd-io/etcd` to prevent unnecessary redirects after the repository was moved following coreos acquisition.


#### Does this PR introduce a user-facing change?

```release-note
NONE
```