### PR TITLE
Automated cherry pick of #121566: etcd: Update to version 3.5.10

### DIFF
--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -55,7 +55,7 @@ dependencies:
 
   # etcd
   - name: "etcd"
-    version: 3.5.9
+    version: 3.5.10
     refPaths:
     - path: cluster/gce/manifests/etcd.manifest
       match: etcd_docker_tag|etcd_version

--- a/cluster/gce/manifests/etcd.manifest
+++ b/cluster/gce/manifests/etcd.manifest
@@ -18,7 +18,7 @@
     {
     "name": "etcd-container",
     {{security_context}}
-    "image": "{{ pillar.get('etcd_docker_repository', 'registry.k8s.io/etcd') }}:{{ pillar.get('etcd_docker_tag', '3.5.9-0') }}",
+    "image": "{{ pillar.get('etcd_docker_repository', 'registry.k8s.io/etcd') }}:{{ pillar.get('etcd_docker_tag', '3.5.10-0') }}",
     "resources": {
       "requests": {
         "cpu": {{ cpulimit }}
@@ -34,7 +34,7 @@
         "value": "{{ pillar.get('storage_backend', 'etcd3') }}"
       },
       { "name": "TARGET_VERSION",
-        "value": "{{ pillar.get('etcd_version', '3.5.9') }}"
+        "value": "{{ pillar.get('etcd_version', '3.5.10') }}"
       },
       {
         "name": "DO_NOT_MOVE_BINARIES",

--- a/cluster/gce/upgrade-aliases.sh
+++ b/cluster/gce/upgrade-aliases.sh
@@ -170,8 +170,8 @@ export KUBE_GCE_ENABLE_IP_ALIASES=true
 export SECONDARY_RANGE_NAME="pods-default"
 export STORAGE_BACKEND="etcd3"
 export STORAGE_MEDIA_TYPE="application/vnd.kubernetes.protobuf"
-export ETCD_IMAGE=3.5.9-0
-export ETCD_VERSION=3.5.9
+export ETCD_IMAGE=3.5.10-0
+export ETCD_VERSION=3.5.10
 
 # Upgrade master with updated kube envs
 "${KUBE_ROOT}/cluster/gce/upgrade.sh" -M -l

--- a/cmd/kubeadm/app/constants/constants.go
+++ b/cmd/kubeadm/app/constants/constants.go
@@ -315,7 +315,7 @@ const (
 	MinExternalEtcdVersion = "3.2.18"
 
 	// DefaultEtcdVersion indicates the default etcd version that kubeadm uses
-	DefaultEtcdVersion = "3.5.9-0"
+	DefaultEtcdVersion = "3.5.10-0"
 
 	// Etcd defines variable used internally when referring to etcd component
 	Etcd = "etcd"
@@ -487,6 +487,7 @@ var (
 
 	// SupportedEtcdVersion lists officially supported etcd versions with corresponding Kubernetes releases
 	SupportedEtcdVersion = map[uint8]string{
+<<<<<<< HEAD
 		13: "3.2.24",
 		14: "3.3.10",
 		15: "3.3.10",
@@ -500,6 +501,16 @@ var (
 		23: "3.5.6-0",
 		24: "3.5.6-0",
 		25: "3.5.9-0",
+=======
+		22: "3.5.10-0",
+		23: "3.5.10-0",
+		24: "3.5.10-0",
+		25: "3.5.10-0",
+		26: "3.5.10-0",
+		27: "3.5.10-0",
+		28: "3.5.10-0",
+		29: "3.5.10-0",
+>>>>>>> etcd: Update to version 3.5.10
 	}
 
 	// KubeadmCertsClusterRoleName sets the name for the ClusterRole that allows

--- a/hack/lib/etcd.sh
+++ b/hack/lib/etcd.sh
@@ -16,7 +16,7 @@
 
 # A set of helpers for starting/running etcd for tests
 
-ETCD_VERSION=${ETCD_VERSION:-3.5.9}
+ETCD_VERSION=${ETCD_VERSION:-3.5.10}
 ETCD_HOST=${ETCD_HOST:-127.0.0.1}
 ETCD_PORT=${ETCD_PORT:-2379}
 # This is intentionally not called ETCD_LOG_LEVEL:

--- a/staging/src/k8s.io/sample-apiserver/artifacts/example/deployment.yaml
+++ b/staging/src/k8s.io/sample-apiserver/artifacts/example/deployment.yaml
@@ -26,4 +26,4 @@ spec:
         imagePullPolicy: Never
         args: [ "--etcd-servers=http://localhost:2379" ]
       - name: etcd
-        image: gcr.io/etcd-development/etcd:v3.5.9
+        image: gcr.io/etcd-development/etcd:v3.5.10

--- a/test/e2e/framework/providers/gcp.go
+++ b/test/e2e/framework/providers/gcp.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package providers
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path"
+
+	"k8s.io/kubernetes/test/e2e/framework"
+	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
+)
+
+const etcdImage = "3.5.10-0"
+
+// EtcdUpgrade upgrades etcd on GCE.
+func EtcdUpgrade(targetStorage, targetVersion string) error {
+	switch framework.TestContext.Provider {
+	case "gce":
+		return etcdUpgradeGCE(targetStorage, targetVersion)
+	default:
+		return fmt.Errorf("EtcdUpgrade() is not implemented for provider %s", framework.TestContext.Provider)
+	}
+}
+
+func etcdUpgradeGCE(targetStorage, targetVersion string) error {
+	env := append(
+		os.Environ(),
+		"TEST_ETCD_VERSION="+targetVersion,
+		"STORAGE_BACKEND="+targetStorage,
+		"TEST_ETCD_IMAGE="+etcdImage)
+
+	_, _, err := framework.RunCmdEnv(env, GCEUpgradeScript(), "-l", "-M")
+	return err
+}
+
+// LocationParamGKE returns parameter related to location for gcloud command.
+func LocationParamGKE() string {
+	if framework.TestContext.CloudConfig.MultiMaster {
+		// GKE Regional Clusters are being tested.
+		return fmt.Sprintf("--region=%s", framework.TestContext.CloudConfig.Region)
+	}
+	return fmt.Sprintf("--zone=%s", framework.TestContext.CloudConfig.Zone)
+}
+
+// MasterUpgradeGKE upgrades master node to the specified version on GKE.
+func MasterUpgradeGKE(ctx context.Context, namespace string, v string) error {
+	framework.Logf("Upgrading master to %q", v)
+	args := []string{
+		"container",
+		"clusters",
+		fmt.Sprintf("--project=%s", framework.TestContext.CloudConfig.ProjectID),
+		LocationParamGKE(),
+		"upgrade",
+		framework.TestContext.CloudConfig.Cluster,
+		"--master",
+		fmt.Sprintf("--cluster-version=%s", v),
+		"--quiet",
+	}
+	_, _, err := framework.RunCmd("gcloud", framework.AppendContainerCommandGroupIfNeeded(args)...)
+	if err != nil {
+		return err
+	}
+
+	e2enode.WaitForSSHTunnels(ctx, namespace)
+
+	return nil
+}
+
+// GCEUpgradeScript returns path of script for upgrading on GCE.
+func GCEUpgradeScript() string {
+	if len(framework.TestContext.GCEUpgradeScript) == 0 {
+		return path.Join(framework.TestContext.RepoRoot, "cluster/gce/upgrade.sh")
+	}
+	return framework.TestContext.GCEUpgradeScript
+}

--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -239,12 +239,20 @@ func initImageConfigs(list RegistryList) (map[ImageID]Config, map[ImageID]Config
 	configs[AppArmorLoader] = Config{list.PromoterE2eRegistry, "apparmor-loader", "1.4"}
 	configs[BusyBox] = Config{list.PromoterE2eRegistry, "busybox", "1.29-2"}
 	configs[CudaVectorAdd] = Config{list.PromoterE2eRegistry, "cuda-vector-add", "1.0"}
+<<<<<<< HEAD
 	configs[CudaVectorAdd2] = Config{list.PromoterE2eRegistry, "cuda-vector-add", "2.2"}
 	configs[DistrolessIptables] = Config{list.BuildImageRegistry, "distroless-iptables", "v0.1.1"}
 	configs[Etcd] = Config{list.GcEtcdRegistry, "etcd", "3.5.9-0"}
 	configs[GlusterDynamicProvisioner] = Config{list.PromoterE2eRegistry, "glusterdynamic-provisioner", "v1.3"}
 	configs[Httpd] = Config{list.PromoterE2eRegistry, "httpd", "2.4.38-2"}
 	configs[HttpdNew] = Config{list.PromoterE2eRegistry, "httpd", "2.4.39-2"}
+=======
+	configs[CudaVectorAdd2] = Config{list.PromoterE2eRegistry, "cuda-vector-add", "2.3"}
+	configs[DistrolessIptables] = Config{list.BuildImageRegistry, "distroless-iptables", "v0.4.1"}
+	configs[Etcd] = Config{list.GcEtcdRegistry, "etcd", "3.5.10-0"}
+	configs[Httpd] = Config{list.PromoterE2eRegistry, "httpd", "2.4.38-4"}
+	configs[HttpdNew] = Config{list.PromoterE2eRegistry, "httpd", "2.4.39-4"}
+>>>>>>> etcd: Update to version 3.5.10
 	configs[InvalidRegistryImage] = Config{list.InvalidRegistry, "alpine", "3.1"}
 	configs[IpcUtils] = Config{list.PromoterE2eRegistry, "ipc-utils", "1.3"}
 	configs[JessieDnsutils] = Config{list.PromoterE2eRegistry, "jessie-dnsutils", "1.5"}


### PR DESCRIPTION
Cherry pick of #121566 on release-1.25.

#121566: etcd: Update to version 3.5.10

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```