### PR TITLE
framework: add SSH support for Azure

### DIFF
--- a/test/e2e/framework/ssh/ssh.go
+++ b/test/e2e/framework/ssh/ssh.go
@@ -86,6 +86,11 @@ func GetSigner(provider string) (ssh.Signer, error) {
 		if keyfile == "" {
 			keyfile = "id_rsa"
 		}
+	case "azure":
+		keyfile = os.Getenv("AZURE_SSH_KEY")
+		if keyfile == "" {
+			keyfile = "id_rsa"
+		}
 	default:
 		return nil, fmt.Errorf("GetSigner(...) not implemented for %s", provider)
 	}

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -136,7 +136,7 @@ var (
 	BusyBoxImage = imageutils.GetE2EImage(imageutils.BusyBox)
 
 	// ProvidersWithSSH are those providers where each node is accessible with SSH
-	ProvidersWithSSH = []string{"gce", "gke", "aws", "local"}
+	ProvidersWithSSH = []string{"gce", "gke", "aws", "local", "azure"}
 
 	// ServeHostnameImage is a serve hostname image name.
 	ServeHostnameImage = imageutils.GetE2EImage(imageutils.Agnhost)


### PR DESCRIPTION
#### What this PR does / why we need it:
Add Azure to the list of providers that support accessing nodes using SSH. This will allow running NodeLogQuery e2e tests introduced in https://github.com/kubernetes/kubernetes/pull/121707

#### Special notes for your reviewer:
This will require a follow up PR adding the required environment variables, AZURE_SSH_KEY, KUBE_SSH_BASTION to the test configuration. Ref: https://github.com/kubernetes-sigs/windows-testing/pull/412

