### PR TITLE
Fix buildx add --provenance=false for pause image build and windows servercore cache

### DIFF
--- a/build/pause/Makefile
+++ b/build/pause/Makefile
@@ -122,12 +122,12 @@ bin/wincat-windows-${ARCH}: windows/wincat/wincat.go
 
 container: .container-${OS}-$(ARCH)
 .container-linux-$(ARCH): bin/$(BIN)-$(OS)-$(ARCH)
-	docker buildx build --provenance=false --pull --output=type=${OUTPUT_TYPE} --platform ${OS}/$(ARCH) \
+	docker buildx build --provenance=false --sbom=false --pull --output=type=${OUTPUT_TYPE} --platform ${OS}/$(ARCH) \
 		-t $(IMAGE):$(TAG)-${OS}-$(ARCH) --build-arg BASE=${BASE} --build-arg ARCH=$(ARCH) .
 	touch $@
 
 .container-windows-$(ARCH): $(foreach binary, ${BIN}, bin/${binary}-${OS}-${ARCH})
-	docker buildx build --provenance=false --pull --output=type=${OUTPUT_TYPE} --platform ${OS}/$(ARCH) \
+	docker buildx build --provenance=false --sbom=false --pull --output=type=${OUTPUT_TYPE} --platform ${OS}/$(ARCH) \
 		-t $(IMAGE):$(TAG)-${OS}-$(ARCH)-${OSVERSION} --build-arg BASE=${BASE}-windows-${OSVERSION}-${ARCH} --build-arg ARCH=$(ARCH) -f Dockerfile_windows .
 	touch $@
 

--- a/build/pause/Makefile
+++ b/build/pause/Makefile
@@ -122,12 +122,12 @@ bin/wincat-windows-${ARCH}: windows/wincat/wincat.go
 
 container: .container-${OS}-$(ARCH)
 .container-linux-$(ARCH): bin/$(BIN)-$(OS)-$(ARCH)
-	docker buildx build --pull --output=type=${OUTPUT_TYPE} --platform ${OS}/$(ARCH) \
+	docker buildx build --provenance=false --pull --output=type=${OUTPUT_TYPE} --platform ${OS}/$(ARCH) \
 		-t $(IMAGE):$(TAG)-${OS}-$(ARCH) --build-arg BASE=${BASE} --build-arg ARCH=$(ARCH) .
 	touch $@
 
 .container-windows-$(ARCH): $(foreach binary, ${BIN}, bin/${binary}-${OS}-${ARCH})
-	docker buildx build --pull --output=type=${OUTPUT_TYPE} --platform ${OS}/$(ARCH) \
+	docker buildx build --provenance=false --pull --output=type=${OUTPUT_TYPE} --platform ${OS}/$(ARCH) \
 		-t $(IMAGE):$(TAG)-${OS}-$(ARCH)-${OSVERSION} --build-arg BASE=${BASE}-windows-${OSVERSION}-${ARCH} --build-arg ARCH=$(ARCH) -f Dockerfile_windows .
 	touch $@
 

--- a/cluster/images/etcd/Makefile
+++ b/cluster/images/etcd/Makefile
@@ -193,6 +193,7 @@ endif
 	docker buildx build \
 		--pull \
 		--provenance=false \
+		--sbom=false \
 		--output=type=$(OUTPUT_TYPE) \
 		--platform "$(OS)/$(ARCH)" \
 		-t $(REGISTRY)/etcd:$(IMAGE_TAG)-$(IMAGE_SUFFIX) \

--- a/test/images/windows/Makefile
+++ b/test/images/windows/Makefile
@@ -34,7 +34,7 @@ sub-push-%:
 
 sub-repush-as-linux-%:
 	img_version=$(shell cat $*/VERSION); \
-	docker buildx build --progress=plain --no-cache --pull --output=type=registry --platform "linux/amd64" \
+	docker buildx build --provenance=false --sbom=false --progress=plain --no-cache --pull --output=type=registry --platform "linux/amd64" \
 		--build-arg SOURCE="$(REGISTRY)/$*:$${img_version}" -t "$(REGISTRY)/$*:$${img_version}"-linux-cache $*/
 
 all-build: $(foreach image, ${ALL_IMAGES}, sub-build-${image})


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/kind failing-test

#### What this PR does / why we need it:

https://testgrid.k8s.io/sig-k8s-infra-gcb#kubernetes-e2e-windows-servercore-cache
https://testgrid.k8s.io/sig-k8s-infra-gcb#post-kubernetes-push-image-pause. ([#119741](https://github.com/kubernetes/kubernetes/pull/119741)) only changed cloudbuild.yaml image. )

#### Which issue(s) this PR fixes:

xref https://github.com/kubernetes/kubernetes/issues/121786
- following up of https://github.com/kubernetes/kubernetes/pull/121665 fixed a similar problem for etcd build

#### Special notes for your reviewer:

> gcr.io/k8s-staging-e2e-test-images/windows-servercore-cache:1.0-linux-amd64-1809 is a manifest list
make: *** [Makefile:43: all-build-and-push] Error 1
ERROR
ERROR: build step 0 "gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20230623-56e06d7c18" failed: step exited with non-zero status: 2


#### Does this PR introduce a user-facing change?

```release-note
None
```
