### PR TITLE
scheduler: fix performance regression at -v3 + contextual logging

### DIFF
--- a/pkg/scheduler/schedule_one.go
+++ b/pkg/scheduler/schedule_one.go
@@ -77,6 +77,11 @@ func (sched *Scheduler) scheduleOne(ctx context.Context) {
 	}
 
 	pod := podInfo.Pod
+	// TODO(knelasevero): Remove duplicated keys from log entry calls
+	// When contextualized logging hits GA
+	// https://github.com/kubernetes/kubernetes/issues/111672
+	logger = klog.LoggerWithValues(logger, "pod", klog.KObj(pod))
+	ctx = klog.NewContext(ctx, logger)
 	logger.V(4).Info("About to try and schedule pod", "pod", klog.KObj(pod))
 
 	fwk, err := sched.frameworkForPod(pod)


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

This was not present in 1.28. The new code added for 1.29 should be fixed before it gets released.

#### What this PR does / why we need it:

The logging instrumentation for contextual logging that was added for 1.29 slowed down the scheduler (i.e. logging verbosity <= 3) by a significant percentage (-28.66% for SchedulingBasic/5000Nodes at -v3) if (and only if!) contextual logging was enabled.

Retrieving the logger from the context causes no measurable slowdown, it's only the various `WithName/WithValues` calls which cause this.

By being more careful about when to use those, the performance impact can be avoided:
- At -v3 or lower, only `WithValues("pod")` is used once per scheduling cycle. This has the intended effect that all log messages for the cycle include the pod information. Once contextual logging is GA, "pod" key/value pairs can be removed from all log calls.
- At -v4 or higher, richer log entries get produced where `WithValues` is also used for the node (when applicable) and `WithName` is used for the current operation and plugin.

#### Special notes for your reviewer:

With these changes, enabling contextual logging causes no measurable slowdown at -v3 or lower. At -v4, the slowdown depends on the test case (-30.51% throughput for SchedulingBasic/5000Nodes, no change for SchedulingCSIPVs/5000Nodes). For some unknown reason (measuring bias?), SchedulingCSIPVs/500Nodes has a ~3& *higher* throughput with contextual logging.

To reproduce benchmarks, use `go test -timeout=0 -count=10  '-bench=BenchmarkPerfScheduling/(SchedulingBasic|SchedulingCSIPVs)'  -benchtime=1ns -run=xxx ./test/integration/scheduler_perf -args -perf-scheduling-label-filter=performance -v=3 -feature-gate=ContextualLogging=false` and ` -feature-gate=ContextualLogging=true`.

#### Does this PR introduce a user-facing change?

```release-note
scheduler: in 1.29 pre-releases, enabling contextual logging slowed down pod scheduling.
```

/cc @mengjiao-liu @alculquicondor @knelasevero @Huang-Wei 