### PR TITLE
test/e2e_kubeadm/dns_addon_test.go: drop kube-dns tests

### DIFF
--- a/test/e2e_kubeadm/dns_addon_test.go
+++ b/test/e2e_kubeadm/dns_addon_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 
 	"k8s.io/kubernetes/test/e2e/framework"
-	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 	admissionapi "k8s.io/pod-security-admission/api"
 
 	"github.com/onsi/ginkgo/v2"
@@ -36,17 +35,10 @@ const (
 	coreDNSRoleName           = "system:coredns"
 	coreDNSRoleBindingName    = coreDNSRoleName
 	coreDNSDeploymentName     = "coredns"
-
-	kubeDNSServiceAccountName = "kube-dns"
-	kubeDNSDeploymentName     = "kube-dns"
-)
-
-var (
-	dnsType = ""
 )
 
 // Define container for all the test specification aimed at verifying
-// that kubeadm configures the dns as expected
+// that kubeadm configures the DNS addon as expected
 var _ = Describe("DNS addon", func() {
 
 	// Get an instance of the k8s test framework
@@ -57,66 +49,13 @@ var _ = Describe("DNS addon", func() {
 	// so we are disabling the creation of a namespace in order to get a faster execution
 	f.SkipNamespaceCreation = true
 
-	// kubeadm supports two type of DNS addon, and so
-	// it is necessary to get it from the kubeadm-config ConfigMap before testing
-	ginkgo.BeforeEach(func() {
-		// if the dnsType name is already known exit
-		if dnsType != "" {
-			return
-		}
-
-		// gets the ClusterConfiguration from the kubeadm kubeadm-config ConfigMap as a untyped map
-		m := getClusterConfiguration(f.ClientSet)
-
-		// Extract the dnsType
-		dnsType = "CoreDNS"
-		if _, ok := m["dns"]; ok {
-			d := m["dns"].(map[interface{}]interface{})
-			if t, ok := d["type"]; ok {
-				dnsType = t.(string)
-			}
-		}
-	})
-
-	ginkgo.Context("kube-dns", func() {
-		ginkgo.Context("kube-dns ServiceAccount", func() {
-			ginkgo.It("should exist", func(ctx context.Context) {
-				if dnsType != "kube-dns" {
-					e2eskipper.Skipf("Skipping because DNS type is %s", dnsType)
-				}
-
-				ExpectServiceAccount(f.ClientSet, kubeSystemNamespace, kubeDNSServiceAccountName)
-			})
-		})
-
-		ginkgo.Context("kube-dns Deployment", func() {
-			ginkgo.It("should exist and be properly configured", func(ctx context.Context) {
-				if dnsType != "kube-dns" {
-					e2eskipper.Skipf("Skipping because DNS type is %s", dnsType)
-				}
-
-				d := GetDeployment(f.ClientSet, kubeSystemNamespace, kubeDNSDeploymentName)
-
-				gomega.Expect(d.Spec.Template.Spec.ServiceAccountName).To(gomega.Equal(kubeDNSServiceAccountName))
-			})
-		})
-	})
-
 	ginkgo.Context("CoreDNS", func() {
 		ginkgo.Context("CoreDNS ServiceAccount", func() {
 			ginkgo.It("should exist", func(ctx context.Context) {
-				if dnsType != "CoreDNS" {
-					e2eskipper.Skipf("Skipping because DNS type is %s", dnsType)
-				}
-
 				ExpectServiceAccount(f.ClientSet, kubeSystemNamespace, coreDNSServiceAccountName)
 			})
 
 			ginkgo.It("should have related ClusterRole and ClusterRoleBinding", func(ctx context.Context) {
-				if dnsType != "CoreDNS" {
-					e2eskipper.Skipf("Skipping because DNS type is %s", dnsType)
-				}
-
 				ExpectClusterRole(f.ClientSet, coreDNSRoleName)
 				ExpectClusterRoleBinding(f.ClientSet, coreDNSRoleBindingName)
 			})
@@ -124,24 +63,14 @@ var _ = Describe("DNS addon", func() {
 
 		ginkgo.Context("CoreDNS ConfigMap", func() {
 			ginkgo.It("should exist and be properly configured", func(ctx context.Context) {
-				if dnsType != "CoreDNS" {
-					e2eskipper.Skipf("Skipping because DNS type is %s", dnsType)
-				}
-
 				cm := GetConfigMap(f.ClientSet, kubeSystemNamespace, coreDNSConfigMap)
-
 				gomega.Expect(cm.Data).To(gomega.HaveKey(coreDNSConfigMapKey))
 			})
 		})
 
 		ginkgo.Context("CoreDNS Deployment", func() {
 			ginkgo.It("should exist and be properly configured", func(ctx context.Context) {
-				if dnsType != "CoreDNS" {
-					e2eskipper.Skipf("Skipping because DNS type is %s", dnsType)
-				}
-
 				d := GetDeployment(f.ClientSet, kubeSystemNamespace, coreDNSDeploymentName)
-
 				gomega.Expect(d.Spec.Template.Spec.ServiceAccountName).To(gomega.Equal(coreDNSServiceAccountName))
 			})
 		})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?



<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup
/area test

#### What this PR does / why we need it:

kube-dns as an alternative DNS addon to CoreDNS hasn't been supported since 1.22 when kubeadm's v1beta3 API was added.

Remove the related tests from the e2e_kubeadm test framework.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
NONE

#### Special notes for your reviewer:
NONE

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
