### PR TITLE
Promote flowcontrol tests to conformance

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -1,3 +1,25 @@
+- testname: Priority and Fairness FlowSchema API
+  codename: '[sig-api-machinery] API priority and fairness should support FlowSchema
+    API operations [Conformance]'
+  description: ' The flowcontrol.apiserver.k8s.io API group MUST exist in the /apis
+    discovery document. The flowcontrol.apiserver.k8s.io/v1 API group/version MUST
+    exist in the /apis/flowcontrol.apiserver.k8s.io discovery document. The flowschemas
+    and flowschemas/status resources MUST exist in the /apis/flowcontrol.apiserver.k8s.io/v1
+    discovery document. The flowschema resource must support create, get, list, watch,
+    update, patch, delete, and deletecollection.'
+  release: v1.29
+  file: test/e2e/apimachinery/flowcontrol.go
+- testname: Priority and Fairness PriorityLevelConfiguration API
+  codename: '[sig-api-machinery] API priority and fairness should support PriorityLevelConfiguration
+    API operations [Conformance]'
+  description: ' The flowcontrol.apiserver.k8s.io API group MUST exist in the /apis
+    discovery document. The flowcontrol.apiserver.k8s.io/v1 API group/version MUST
+    exist in the /apis/flowcontrol.apiserver.k8s.io discovery document. The prioritylevelconfiguration
+    and prioritylevelconfiguration/status resources MUST exist in the /apis/flowcontrol.apiserver.k8s.io/v1
+    discovery document. The prioritylevelconfiguration resource must support create,
+    get, list, watch, update, patch, delete, and deletecollection.'
+  release: v1.29
+  file: test/e2e/apimachinery/flowcontrol.go
 - testname: Admission webhook, list mutating webhooks
   codename: '[sig-api-machinery] AdmissionWebhook [Privileged:ClusterAdmin] listing
     mutating webhooks should work [Conformance]'

--- a/test/e2e/apimachinery/flowcontrol.go
+++ b/test/e2e/apimachinery/flowcontrol.go
@@ -255,18 +255,19 @@ var _ = SIGDescribe("API priority and fairness", func() {
 	})
 
 	/*
-			   Release: v1.29
-			   Testname: FlowSchema API
-		           Description:
-			   The flowcontrol.apiserver.k8s.io API group MUST exist in the /apis discovery document.
-			   The flowcontrol.apiserver.k8s.io/v1 API group/version MUST exist
-			    in the /apis/flowcontrol.apiserver.k8s.io discovery document.
-			   The flowschemas and flowschemas/status resources MUST exist
-			    in the /apis/flowcontrol.apiserver.k8s.io/v1 discovery document.
-			   The flowschema resource must support create, get, list, watch,
-			    update, patch, delete, and deletecollection.
+	   Release: v1.29
+	   Testname: Priority and Fairness FlowSchema API
+	   Description:
+	   The flowcontrol.apiserver.k8s.io API group MUST exist in the
+	     /apis discovery document.
+	   The flowcontrol.apiserver.k8s.io/v1 API group/version MUST exist
+	     in the /apis/flowcontrol.apiserver.k8s.io discovery document.
+	   The flowschemas and flowschemas/status resources MUST exist
+	     in the /apis/flowcontrol.apiserver.k8s.io/v1 discovery document.
+	   The flowschema resource must support create, get, list, watch,
+	     update, patch, delete, and deletecollection.
 	*/
-	ginkgo.It("should support Priority and Fairness FlowSchema API operations", func(ctx context.Context) {
+	framework.ConformanceIt("should support FlowSchema API operations", func(ctx context.Context) {
 		fsVersion := "v1"
 		ginkgo.By("getting /apis")
 		{
@@ -497,18 +498,20 @@ var _ = SIGDescribe("API priority and fairness", func() {
 	})
 
 	/*
-					Release: v1.29
-					Testname: PriorityLevelConfiguration API
-					Description:
-					The flowcontrol.apiserver.k8s.io API group MUST exist in the /apis discovery document.
-					The flowcontrol.apiserver.k8s.io/v1 API group/version MUST exist
-					  in the /apis/flowcontrol.apiserver.k8s.io discovery document.
-					The prioritylevelconfiguration and prioritylevelconfiguration/status resources
-		                          MUST exist in the /apis/flowcontrol.apiserver.k8s.io/v1 discovery document.
-					The prioritylevelconfiguration resource must support create, get, list, watch,
-				          update, patch, delete, and deletecollection.
+	   Release: v1.29
+	   Testname: Priority and Fairness PriorityLevelConfiguration API
+	   Description:
+	   The flowcontrol.apiserver.k8s.io API group MUST exist in the
+	     /apis discovery document.
+	   The flowcontrol.apiserver.k8s.io/v1 API group/version MUST exist
+	     in the /apis/flowcontrol.apiserver.k8s.io discovery document.
+	   The prioritylevelconfiguration and prioritylevelconfiguration/status
+	     resources MUST exist in the
+	     /apis/flowcontrol.apiserver.k8s.io/v1 discovery document.
+	   The prioritylevelconfiguration resource must support create, get,
+	     list, watch, update, patch, delete, and deletecollection.
 	*/
-	ginkgo.It("should support Priority and Fairness PriorityLevelConfiguration API operations", func(ctx context.Context) {
+	framework.ConformanceIt("should support PriorityLevelConfiguration API operations", func(ctx context.Context) {
 		plVersion := "v1"
 		ginkgo.By("getting /apis")
 		{


### PR DESCRIPTION
#### What type of PR is this?

/kind feature


#### What this PR does / why we need it:

- This PR promotes the priority & fairness `FlowSchema` and  `PriorityLevelConfiguration` API tests to conformance tests
- flake free run history: https://testgrid.k8s.io/sig-release-master-blocking#kind-master-parallel&include-filter-by-regex=Priority&width=20&include-filter-by-regex=(FlowSchema%7CPriorityLevelConfiguration)%20API%20operations

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
KEP: https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/1040-priority-and-fairness
```
