### PR TITLE
Make verify-typecheck.sh only check valid targets for a platform

### DIFF
--- a/hack/verify-typecheck-providerless.sh
+++ b/hack/verify-typecheck-providerless.sh
@@ -26,7 +26,7 @@ KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 cd "${KUBE_ROOT}"
 # verify the providerless build
 # https://github.com/kubernetes/enhancements/blob/master/keps/sig-cloud-provider/1179-building-without-in-tree-providers/README.md
-hack/verify-typecheck.sh --skip-test --tags=providerless --ignore-dirs=test
+hack/verify-typecheck.sh --skip-test --tags=providerless --ignore-dirs=test/e2e
 
 # verify using go list
 if _out="$(go list -mod=readonly -tags "providerless" -e -json  k8s.io/kubernetes/cmd/kubelet/... \

--- a/hack/verify-typecheck.sh
+++ b/hack/verify-typecheck.sh
@@ -28,13 +28,32 @@ kube::golang::verify_go_version
 
 cd "${KUBE_ROOT}"
 
+ret=0
+TYPECHECK_SERIAL="${TYPECHECK_SERIAL:-false}"
+
+SERVER_PLATFORMS=$(echo "${KUBE_SUPPORTED_SERVER_PLATFORMS[@]}" | tr ' ' ',')
+CLIENT_PLATFORMS=$(echo "${KUBE_SUPPORTED_CLIENT_PLATFORMS[@]}" | tr ' ' ',')
+NODE_PLATFORMS=$(echo "${KUBE_SUPPORTED_NODE_PLATFORMS[@]}" | tr ' ' ',')
+TEST_PLATFORMS=$(echo "${KUBE_SUPPORTED_TEST_PLATFORMS[@]}" | tr ' ' ',')
+
 # As of June, 2020 the typecheck tool is written in terms of go/packages, but
 # that library doesn't work well with multiple modules.  Until that is done,
 # force this tooling to run in a fake GOPATH.
-ret=0
-TYPECHECK_SERIAL="${TYPECHECK_SERIAL:-false}"
 hack/run-in-gopath.sh \
-    go run test/typecheck/main.go "$@" "--serial=$TYPECHECK_SERIAL" || ret=$?
+    go run test/typecheck/main.go "$@" --serial="${TYPECHECK_SERIAL}" --platform "${SERVER_PLATFORMS}" "${KUBE_SERVER_TARGETS[@]}" \
+    || ret=$?
+hack/run-in-gopath.sh \
+    go run test/typecheck/main.go "$@" --serial="${TYPECHECK_SERIAL}" --platform "${CLIENT_PLATFORMS}" "${KUBE_CLIENT_TARGETS[@]}" \
+    || ret=$?
+hack/run-in-gopath.sh \
+    go run test/typecheck/main.go "$@" --serial="${TYPECHECK_SERIAL}" --platform "${NODE_PLATFORMS}" "${KUBE_NODE_TARGETS[@]}" \
+    || ret=$?
+
+# $KUBE_TEST_TARGETS doesn't seem to work like the other TARGETS variables...
+hack/run-in-gopath.sh \
+    go run test/typecheck/main.go "$@" --serial="${TYPECHECK_SERIAL}" --platform "${TEST_PLATFORMS}" test/e2e \
+    || ret=$?
+
 if [[ $ret -ne 0 ]]; then
   echo "!!! Type Check has failed. This may cause cross platform build failures." >&2
   echo "!!! Please see https://git.k8s.io/kubernetes/test/typecheck for more information." >&2

--- a/test/typecheck/main.go
+++ b/test/typecheck/main.go
@@ -294,7 +294,11 @@ func main() {
 			}()
 
 			f := false
-			serialFprintf(os.Stdout, "type-checking %s\n", plat)
+			if len(args) != 0 {
+				serialFprintf(os.Stdout, "type-checking %s against %s\n", plat, args)
+			} else {
+				serialFprintf(os.Stdout, "type-checking %s\n", plat)
+			}
 			errors, err := c.verify(plat)
 			if err != nil {
 				serialFprintf(os.Stderr, "ERROR(%s): failed to verify: %v\n", plat, err)


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
`verify-typecheck.sh` currently makes sure that the entire tree builds on all supported platforms, even though we don't normally build some parts of it on some platforms. e.g., as noted in #118020, `verify-typecheck.sh` currently requires kube-proxy to be buildable on OS X, even though we don't normally build it there, and don't expect it to work there. As a result, the platform-related build tags on kube-proxy (and all the things it depends on) are wrong and can't be fixed (as seen in https://github.com/kubernetes/kubernetes/pull/120995#discussion_r1374955990).

This fixes it to only typecheck `KUBE_SERVER_TARGETS` on `KUBE_SUPPORTED_SERVER_PLATFORMS`, `KUBE_NODE_TARGETS` on `KUBE_SUPPORTED_NODE_PLATFORMS`, etc.

If you wanted to do some bash hacking you could probably make this more efficient by merging target groups together and only invoking `typecheck` once for each platform... but it's still pretty fast anyway...

I'm not sure it's testing all of the test-related directories it should be testing.

The integration with `verify-typecheck-providerless.sh` is a bit hacky...

#### Which issue(s) this PR fixes:
Fixes #118020

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/cc @BenTheElder 