### PR TITLE
Add script for restricting import of test only libraries

### DIFF
--- a/hack/verify-testing-import.sh
+++ b/hack/verify-testing-import.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+# Copyright 2023 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script checks whether the testing.init symbol is present in any
+# of the release binaries and fails if it finds one. This check is needed
+# to avoid including test libraries in production binaries as they often lack
+# rigorous review and sufficient testing.
+# Usage: `hack/verify-test-code.sh`.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+source "${KUBE_ROOT}/hack/lib/init.sh"
+cd "${KUBE_ROOT}"
+
+RELEASE_BIN_PKGS=(
+  "${KUBE_ROOT}/cmd/cloud-controller-manager"
+  "${KUBE_ROOT}/cmd/kube-apiserver"
+  "${KUBE_ROOT}/cmd/kube-controller-manager"
+  "${KUBE_ROOT}/cmd/kube-proxy"
+  "${KUBE_ROOT}/cmd/kube-scheduler"
+  "${KUBE_ROOT}/cmd/kubectl"
+  "${KUBE_ROOT}/cmd/kubectl-convert"
+  "${KUBE_ROOT}/cmd/kubelet"
+)
+
+pkgs_with_testing_import=()
+for file in "${RELEASE_BIN_PKGS[@]}"
+do
+  if [ "$(go list -json "${file}" | jq 'any(.Deps[]; . == "testing")')" == "true" ]
+  then
+    pkgs_with_testing_import+=( "${file}" )
+  fi
+done
+
+if [ ${#pkgs_with_testing_import[@]} -ne 0 ]; then
+  printf "%s\n" "Testing package imported in:"
+  for file in "${pkgs_with_testing_import[@]}"; do
+    printf "\t%s\n" "${file}"
+  done
+  exit 1
+fi
+
+exit 0
+

--- a/pkg/kubelet/container/testing/fake_runtime.go
+++ b/pkg/kubelet/container/testing/fake_runtime.go
@@ -22,7 +22,6 @@ import (
 	"net/url"
 	"reflect"
 	"sync"
-	"testing"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -32,6 +31,10 @@ import (
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/volume"
 )
+
+type TB interface {
+	Errorf(format string, args ...any)
+}
 
 type FakePod struct {
 	Pod       *kubecontainer.Pod
@@ -65,7 +68,7 @@ type FakeRuntime struct {
 	// from container runtime.
 	BlockImagePulls      bool
 	imagePullTokenBucket chan bool
-	T                    *testing.T
+	T                    TB
 }
 
 const FakeHost = "localhost:12345"

--- a/staging/src/k8s.io/component-base/metrics/testutil/testutil.go
+++ b/staging/src/k8s.io/component-base/metrics/testutil/testutil.go
@@ -19,7 +19,6 @@ package testutil
 import (
 	"fmt"
 	"io"
-	"testing"
 
 	"github.com/prometheus/client_golang/prometheus/testutil"
 
@@ -27,6 +26,12 @@ import (
 	"k8s.io/component-base/metrics"
 	"k8s.io/component-base/metrics/legacyregistry"
 )
+
+type TB interface {
+	Logf(format string, args ...any)
+	Errorf(format string, args ...any)
+	Fatalf(format string, args ...any)
+}
 
 // CollectAndCompare registers the provided Collector with a newly created
 // pedantic Registry. It then does the same as GatherAndCompare, gathering the
@@ -94,7 +99,7 @@ func NewFakeKubeRegistry(ver string) metrics.KubeRegistry {
 	return metrics.NewKubeRegistry()
 }
 
-func AssertVectorCount(t *testing.T, name string, labelFilter map[string]string, wantCount int) {
+func AssertVectorCount(t TB, name string, labelFilter map[string]string, wantCount int) {
 	metrics, err := legacyregistry.DefaultGatherer.Gather()
 	if err != nil {
 		t.Fatalf("Failed to gather metrics: %s", err)
@@ -124,7 +129,7 @@ func AssertVectorCount(t *testing.T, name string, labelFilter map[string]string,
 	}
 }
 
-func AssertHistogramTotalCount(t *testing.T, name string, labelFilter map[string]string, wantCount int) {
+func AssertHistogramTotalCount(t TB, name string, labelFilter map[string]string, wantCount int) {
 	metrics, err := legacyregistry.DefaultGatherer.Gather()
 	if err != nil {
 		t.Fatalf("Failed to gather metrics: %s", err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Presubmit check to restrict test only libraries from linking into prod binaries. 

#### Which issue(s) this PR fixes:

Fixes #115175 

#### Special notes for your reviewer:

I implemented a script following the advice in the issue, but I have a few questions to make sure I understood the problem:
- Should the script check all the packages in the project or only the ones under ./cmd? At the moment, the script checks the presence of the testing import in the packages under ./cmd with only one level of recursion.
- Should the script be called from a build rule? If so, which would be the most appropriate?
- In case testing imports are found and the script is called from a build rule, is it okay to print the packages where they were found (so it's easier to remove them) or printing to stdout isn't allowed during that specific build rule?

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
