### PR TITLE
bump kube-dns to v1.22.27

### DIFF
--- a/cluster/addons/dns/kube-dns/kube-dns.yaml.base
+++ b/cluster/addons/dns/kube-dns/kube-dns.yaml.base
@@ -114,7 +114,7 @@ spec:
         kubernetes.io/os: linux
       containers:
       - name: kubedns
-        image: registry.k8s.io/dns/k8s-dns-kube-dns:1.22.23
+        image: registry.k8s.io/dns/k8s-dns-kube-dns:1.22.27
         resources:
           # TODO: Set memory limits when we've profiled the container for large
           # clusters, then set request = limit to keep this container in
@@ -170,7 +170,7 @@ spec:
           runAsUser: 1001
           runAsGroup: 1001
       - name: dnsmasq
-        image: registry.k8s.io/dns/k8s-dns-dnsmasq-nanny:1.22.23
+        image: registry.k8s.io/dns/k8s-dns-dnsmasq-nanny:1.22.27
         livenessProbe:
           httpGet:
             path: /healthcheck/dnsmasq
@@ -217,7 +217,7 @@ spec:
               - NET_BIND_SERVICE
               - SETGID
       - name: sidecar
-        image: registry.k8s.io/dns/k8s-dns-sidecar:1.22.23
+        image: registry.k8s.io/dns/k8s-dns-sidecar:1.22.27
         livenessProbe:
           httpGet:
             path: /metrics

--- a/cluster/addons/dns/kube-dns/kube-dns.yaml.in
+++ b/cluster/addons/dns/kube-dns/kube-dns.yaml.in
@@ -114,7 +114,7 @@ spec:
         kubernetes.io/os: linux
       containers:
       - name: kubedns
-        image: registry.k8s.io/dns/k8s-dns-kube-dns:1.22.23
+        image: registry.k8s.io/dns/k8s-dns-kube-dns:1.22.27
         resources:
           # TODO: Set memory limits when we've profiled the container for large
           # clusters, then set request = limit to keep this container in
@@ -170,7 +170,7 @@ spec:
           runAsUser: 1001
           runAsGroup: 1001
       - name: dnsmasq
-        image: registry.k8s.io/dns/k8s-dns-dnsmasq-nanny:1.22.23
+        image: registry.k8s.io/dns/k8s-dns-dnsmasq-nanny:1.22.27
         livenessProbe:
           httpGet:
             path: /healthcheck/dnsmasq
@@ -217,7 +217,7 @@ spec:
               - NET_BIND_SERVICE
               - SETGID
       - name: sidecar
-        image: registry.k8s.io/dns/k8s-dns-sidecar:1.22.23
+        image: registry.k8s.io/dns/k8s-dns-sidecar:1.22.27
         livenessProbe:
           httpGet:
             path: /metrics

--- a/cluster/addons/dns/kube-dns/kube-dns.yaml.sed
+++ b/cluster/addons/dns/kube-dns/kube-dns.yaml.sed
@@ -114,7 +114,7 @@ spec:
         kubernetes.io/os: linux
       containers:
       - name: kubedns
-        image: registry.k8s.io/dns/k8s-dns-kube-dns:1.22.23
+        image: registry.k8s.io/dns/k8s-dns-kube-dns:1.22.27
         resources:
           # TODO: Set memory limits when we've profiled the container for large
           # clusters, then set request = limit to keep this container in
@@ -170,7 +170,7 @@ spec:
           runAsUser: 1001
           runAsGroup: 1001
       - name: dnsmasq
-        image: registry.k8s.io/dns/k8s-dns-dnsmasq-nanny:1.22.23
+        image: registry.k8s.io/dns/k8s-dns-dnsmasq-nanny:1.22.27
         livenessProbe:
           httpGet:
             path: /healthcheck/dnsmasq
@@ -217,7 +217,7 @@ spec:
               - NET_BIND_SERVICE
               - SETGID
       - name: sidecar
-        image: registry.k8s.io/dns/k8s-dns-sidecar:1.22.23
+        image: registry.k8s.io/dns/k8s-dns-sidecar:1.22.27
         livenessProbe:
           httpGet:
             path: /metrics

--- a/cluster/addons/dns/nodelocaldns/nodelocaldns.yaml
+++ b/cluster/addons/dns/nodelocaldns/nodelocaldns.yaml
@@ -138,7 +138,7 @@ spec:
         operator: "Exists"
       containers:
       - name: node-cache
-        image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.23
+        image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.27
         resources:
           requests:
             cpu: 25m


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it:**
bump kube-dns to v1.22.27:

- fix broken links to testgrid dashboard in https://github.com/kubernetes/dns/pull/595
- upgrate go to 1.20.7 and remove hardcoded crypto version in https://github.com/kubernetes/dns/pull/599
- Update OWNERS in https://github.com/kubernetes/dns/pull/600
- Don't run kubelet in the E2E test mock cluster in https://github.com/kubernetes/dns/pull/606
- Bump for vulnerability fixes in https://github.com/kubernetes/dns/pull/604
- Bump k8s.io/kubernetes and google.golang.org/grpc to fix vulnerabilities in https://github.com/kubernetes/dns/pull/607

**Which issue(s) this PR fixes:**
Fixes #

**Special notes for your reviewer:**
Does this PR introduce a user-facing change?
```release-note
Update kube-dns to v1.22.27
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:**
```
```