### PR TITLE
kubeadm: ensure the kubelet and kube-apiserver wait checks go first

### DIFF
--- a/cmd/kubeadm/app/cmd/phases/init/data.go
+++ b/cmd/kubeadm/app/cmd/phases/init/data.go
@@ -45,6 +45,7 @@ type InitData interface {
 	ExternalCA() bool
 	OutputWriter() io.Writer
 	Client() (clientset.Interface, error)
+	ClientWithoutBootstrap() (clientset.Interface, error)
 	Tokens() []string
 	PatchesDir() string
 }

--- a/cmd/kubeadm/app/cmd/phases/init/data_test.go
+++ b/cmd/kubeadm/app/cmd/phases/init/data_test.go
@@ -31,22 +31,23 @@ type testInitData struct{}
 // testInitData must satisfy InitData.
 var _ InitData = &testInitData{}
 
-func (t *testInitData) UploadCerts() bool                       { return false }
-func (t *testInitData) CertificateKey() string                  { return "" }
-func (t *testInitData) SetCertificateKey(key string)            {}
-func (t *testInitData) SkipCertificateKeyPrint() bool           { return false }
-func (t *testInitData) Cfg() *kubeadmapi.InitConfiguration      { return nil }
-func (t *testInitData) DryRun() bool                            { return false }
-func (t *testInitData) SkipTokenPrint() bool                    { return false }
-func (t *testInitData) IgnorePreflightErrors() sets.Set[string] { return nil }
-func (t *testInitData) CertificateWriteDir() string             { return "" }
-func (t *testInitData) CertificateDir() string                  { return "" }
-func (t *testInitData) KubeConfigDir() string                   { return "" }
-func (t *testInitData) KubeConfigPath() string                  { return "" }
-func (t *testInitData) ManifestDir() string                     { return "" }
-func (t *testInitData) KubeletDir() string                      { return "" }
-func (t *testInitData) ExternalCA() bool                        { return false }
-func (t *testInitData) OutputWriter() io.Writer                 { return nil }
-func (t *testInitData) Client() (clientset.Interface, error)    { return nil, nil }
-func (t *testInitData) Tokens() []string                        { return nil }
-func (t *testInitData) PatchesDir() string                      { return "" }
+func (t *testInitData) UploadCerts() bool                                    { return false }
+func (t *testInitData) CertificateKey() string                               { return "" }
+func (t *testInitData) SetCertificateKey(key string)                         {}
+func (t *testInitData) SkipCertificateKeyPrint() bool                        { return false }
+func (t *testInitData) Cfg() *kubeadmapi.InitConfiguration                   { return nil }
+func (t *testInitData) DryRun() bool                                         { return false }
+func (t *testInitData) SkipTokenPrint() bool                                 { return false }
+func (t *testInitData) IgnorePreflightErrors() sets.Set[string]              { return nil }
+func (t *testInitData) CertificateWriteDir() string                          { return "" }
+func (t *testInitData) CertificateDir() string                               { return "" }
+func (t *testInitData) KubeConfigDir() string                                { return "" }
+func (t *testInitData) KubeConfigPath() string                               { return "" }
+func (t *testInitData) ManifestDir() string                                  { return "" }
+func (t *testInitData) KubeletDir() string                                   { return "" }
+func (t *testInitData) ExternalCA() bool                                     { return false }
+func (t *testInitData) OutputWriter() io.Writer                              { return nil }
+func (t *testInitData) Client() (clientset.Interface, error)                 { return nil, nil }
+func (t *testInitData) ClientWithoutBootstrap() (clientset.Interface, error) { return nil, nil }
+func (t *testInitData) Tokens() []string                                     { return nil }
+func (t *testInitData) PatchesDir() string                                   { return "" }

--- a/cmd/kubeadm/app/cmd/phases/init/waitcontrolplane.go
+++ b/cmd/kubeadm/app/cmd/phases/init/waitcontrolplane.go
@@ -82,9 +82,10 @@ func runWaitControlPlanePhase(c workflow.RunData) error {
 	// waiter holds the apiclient.Waiter implementation of choice, responsible for querying the API server in various ways and waiting for conditions to be fulfilled
 	klog.V(1).Infoln("[wait-control-plane] Waiting for the API server to be healthy")
 
-	client, err := data.Client()
+	// WaitForAPI uses the /healthz endpoint, thus a client without permissions works fine
+	client, err := data.ClientWithoutBootstrap()
 	if err != nil {
-		return errors.Wrap(err, "cannot obtain client")
+		return errors.Wrap(err, "cannot obtain client without bootstrap")
 	}
 
 	timeout := data.Cfg().ClusterConfiguration.APIServer.TimeoutForControlPlane.Duration


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

The addition of the "super-admin.conf" functionality required init.go's Client() to create RBAC rules on its first creation.

However this created a problem with the "wait-control-plane" phase of "kubeadm init" where a client is needed to connect to the API server Discovery API's "/healthz" endpoint. The logic that ensures the RBAC became the step where the API server wait was polled for.

To avoid this, introduce a new InitData function ClientWithoutBootstrap. In "wait-control-plane" use this client, which has no permissions (anonymous), but is sufficient to connect to the "/healthz".

Future, pending changes here would be:
- Stop using the "/healthz", instead a regular REST client from the kubelet cert/key can be constructed and pod status can be monitored.
- Make the wait for kubelet / API server linear (not in go routines).
related PR that modifies the way API server wait happens:
https://github.com/kubernetes/kubernetes/pull/119598

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
xref https://github.com/kubernetes/kubeadm/issues/2414
xref https://github.com/kubernetes/kubernetes/issues/121587

#### Special notes for your reviewer:
NONE

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
