### PR TITLE
Remove unnecessary sort in kube-proxy ipvs

### DIFF
--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -1865,7 +1865,7 @@ func (proxier *Proxier) syncEndpoint(svcPortName proxy.ServicePortName, onlyNode
 	}
 
 	// Create new endpoints
-	for _, ep := range sets.List(newEndpoints) {
+	for _, ep := range newEndpoints.UnsortedList() {
 		ip, port, err := net.SplitHostPort(ep)
 		if err != nil {
 			klog.ErrorS(err, "Failed to parse endpoint", "endpoint", ep)

--- a/pkg/proxy/ipvs/util/testing/fake.go
+++ b/pkg/proxy/ipvs/util/testing/fake.go
@@ -19,6 +19,7 @@ package testing
 import (
 	"fmt"
 	"net"
+	"sort"
 	"strconv"
 	"time"
 
@@ -51,6 +52,19 @@ type RealServerKey struct {
 
 func (r *RealServerKey) String() string {
 	return net.JoinHostPort(r.Address.String(), strconv.Itoa(int(r.Port)))
+}
+
+// Implement https://pkg.go.dev/sort#Interface
+type byAddress []*utilipvs.RealServer
+
+func (a byAddress) Len() int {
+	return len(a)
+}
+func (a byAddress) Less(i, j int) bool {
+	return a[i].String() < a[j].String()
+}
+func (a byAddress) Swap(i, j int) {
+	a[i], a[j] = a[j], a[i]
 }
 
 // NewFake creates a fake ipvs implementation - a cache store.
@@ -155,6 +169,8 @@ func (f *FakeIPVS) AddRealServer(serv *utilipvs.VirtualServer, dest *utilipvs.Re
 		f.Destinations[key] = dests
 	}
 	f.Destinations[key] = append(f.Destinations[key], dest)
+	// The tests assumes that the slice is sorted
+	sort.Sort(byAddress(f.Destinations[key]))
 	return nil
 }
 


### PR DESCRIPTION
Sorting of endpoints before adding them to ipvs is not needed, nor wanted. It just takes time

#### What type of PR is this?

/kind cleanup
/sig network
/area kube-proxy
/area ipvs

#### What this PR does / why we need it:

The sort in:
https://github.com/kubernetes/kubernetes/blob/c3eebb233d000ac2dbbd559725124a79bf40d0f0/pkg/proxy/ipvs/proxier.go#L1868

is unnecessary, and may even make the initial distribution worse, please see discussion in https://github.com/kubernetes/kubernetes/issues/121591#issuecomment-1792306681.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:



#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

N/A