### PR TITLE
fix HostUtil.GetFileType for Windows

### DIFF
--- a/pkg/volume/util/hostutil/hostutil_windows.go
+++ b/pkg/volume/util/hostutil/hostutil_windows.go
@@ -21,14 +21,11 @@ package hostutil
 
 import (
 	"fmt"
-	"io/fs"
 	"os"
 	"path"
 	"path/filepath"
 	"strings"
-	"syscall"
 
-	"golang.org/x/sys/windows"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/util/filesystem"
 	"k8s.io/mount-utils"
@@ -91,25 +88,17 @@ func (hu *HostUtil) MakeRShared(path string) error {
 	return nil
 }
 
-func isSystemCannotAccessErr(err error) bool {
-	if fserr, ok := err.(*fs.PathError); ok {
-		errno, ok := fserr.Err.(syscall.Errno)
-		return ok && errno == windows.ERROR_CANT_ACCESS_FILE
+// GetFileType checks for sockets/block/character devices
+func (hu *HostUtil) GetFileType(pathname string) (FileType, error) {
+	filetype, err := getFileType(pathname)
+	if err == nil {
+		return filetype, nil
 	}
 
-	return false
-}
-
-// GetFileType checks for sockets/block/character devices
-func (hu *(HostUtil)) GetFileType(pathname string) (FileType, error) {
-	filetype, err := getFileType(pathname)
-
-	// os.Stat will return a 1920 error (windows.ERROR_CANT_ACCESS_FILE) if we use it on a Unix Socket
+	// os.Stat will return an unknown error (based on different Windows versions) if we use it on a Unix Socket
 	// on Windows. In this case, we need to use a different method to check if it's a Unix Socket.
-	if isSystemCannotAccessErr(err) {
-		if isSocket, errSocket := filesystem.IsUnixDomainSocket(pathname); errSocket == nil && isSocket {
-			return FileTypeSocket, nil
-		}
+	if isSocket, errSocket := filesystem.IsUnixDomainSocket(pathname); errSocket == nil && isSocket {
+		return FileTypeSocket, nil
 	}
 
 	return filetype, err


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

for different versions of Windows, using `os.Stat` on a Unix Socket will return various errors that cannot be captured.

https://github.com/golang/go/issues/33357

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
