### PR TITLE
scheduler: fix invalid LoggerWithValues call

### DIFF
--- a/pkg/scheduler/framework/runtime/framework.go
+++ b/pkg/scheduler/framework/runtime/framework.go
@@ -758,7 +758,7 @@ func (f *frameworkImpl) RunPreFilterExtensionRemovePod(
 	// TODO(knelasevero): Remove duplicated keys from log entry calls
 	// When contextualized logging hits GA
 	// https://github.com/kubernetes/kubernetes/issues/111672
-	logger = klog.LoggerWithValues(logger, klog.KObj(podToSchedule), "node", klog.KObj(nodeInfo.Node()))
+	logger = klog.LoggerWithValues(logger, "pod", klog.KObj(podToSchedule), "node", klog.KObj(nodeInfo.Node()))
 	for _, pl := range f.preFilterPlugins {
 		if pl.PreFilterExtensions() == nil || state.SkipFilterPlugins.Has(pl.Name()) {
 			continue


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The "pod" key was missing. Found when updating to logcheck 0.7.0 thanks to https://github.com/kubernetes-sigs/logtools/pull/20.

#### Special notes for your reviewer:

This bug was introduced in 1.29. No need to backport, nor for a release note.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/cc @kerthcet 