### PR TITLE
Update sig-auth aliases

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -10,7 +10,6 @@ aliases:
     - sttts
     - tallclair
   sig-auth-audit-reviewers:
-    - hzxuzhonghu
     - sttts
     - tallclair
   sig-auth-authenticators-approvers:
@@ -45,16 +44,11 @@ aliases:
     - mikedanese
     - smarterclayton
   sig-auth-certificates-reviewers:
-    - caesarxuchao
     - deads2k
     - dims
     - enj
     - liggitt
     - mikedanese
-    - smarterclayton
-    - sttts
-    - thockin
-    - wojtek-t
   sig-auth-encryption-at-rest-approvers:
     - smarterclayton
     - enj
@@ -82,6 +76,7 @@ aliases:
     - krmayankk
   sig-auth-serviceaccounts-approvers:
     - deads2k
+    - enj
     - liggitt
     - mikedanese
   sig-auth-serviceaccounts-reviewers:
@@ -498,6 +493,7 @@ aliases:
     - derekwaynecarr # Node
     - dims # Architecture
     - ehashman # Instrumentation
+    - enj # Auth
     - janetkuo # Apps
     - jayunit100 # Windows
     - jpbetz # API Machinery


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Updates sig-auth aliases, adds @enj to feature approvers as auth TL, prunes some folks for auth subproject aliases who haven't been reviewing for those areas.

```release-note
NONE
```

/assign @dims