### PR TITLE
k8s.io/code-generator: kube_codegen.sh: allow all files

### DIFF
--- a/staging/src/k8s.io/code-generator/kube_codegen.sh
+++ b/staging/src/k8s.io/code-generator/kube_codegen.sh
@@ -557,6 +557,10 @@ function kube::codegen::gen_client() {
         ) | LC_ALL=C sort -u
     )
 
+    # remove duplicates for any entries
+    IFS=" " read -r -a group_versions <<< "$(tr ' ' '\n' <<< "${group_versions[@]}" | sort -u | tr '\n' ' ')"
+    IFS=" " read -r -a input_pkgs <<< "$(tr ' ' '\n' <<< "${input_pkgs[@]}" | sort -u | tr '\n' ' ')"
+
     if [ "${#group_versions[@]}" == 0 ]; then
         return 0
     fi

--- a/staging/src/k8s.io/code-generator/kube_codegen.sh
+++ b/staging/src/k8s.io/code-generator/kube_codegen.sh
@@ -552,7 +552,7 @@ function kube::codegen::gen_client() {
     done < <(
         ( kube::codegen::internal::git_grep -l \
             -e '+genclient' \
-            ":(glob)${in_root}"/'**/types.go' \
+            ":(glob)${in_root}"/'**/*.go' \
             || true \
         ) | LC_ALL=C sort -u
     )


### PR DESCRIPTION
The other generators in this file are not opinionated on the filename in which generator markers are written, so it seems like the client generator should not be, either.

/kind bug

```release-note
NONE
```

```docs

```

/assign @thockin