### PR TITLE
Add comment in noderestriction on Node-bound-tokens

### DIFF
--- a/plugin/pkg/admission/noderestriction/admission.go
+++ b/plugin/pkg/admission/noderestriction/admission.go
@@ -577,6 +577,12 @@ func (p *Plugin) admitServiceAccount(nodeName string, a admission.Attributes) er
 		return admission.NewForbidden(a, fmt.Errorf("node requested token bound to a pod scheduled on a different node"))
 	}
 
+	// Note: A token may only be bound to one object at a time. By requiring
+	// the Pod binding, noderestriction eliminates the opportunity to spoof
+	// a Node binding. Instead, kube-apiserver automatically infers and sets
+	// the Node binding when it receives a Pod binding. See:
+	// https://github.com/kubernetes/kubernetes/issues/121723 for more info.
+
 	return nil
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Explains why we don't explicitly prevent cross-node bindings in noderestriction (it's already implicitly enforced).

#### Which issue(s) this PR fixes:
Fixes #121723

#### Special notes for your reviewer:

Redo of https://github.com/kubernetes/kubernetes/pull/121724, which the GitHub web UI created on a branch in k/k (oops!) instead of my fork.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
