### PR TITLE
encoding: avoid setting GVK unnecessarily

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/runtime/helper.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/helper.go
@@ -236,10 +236,14 @@ func (e WithVersionEncoder) Encode(obj Object, stream io.Writer) error {
 			gvk = preferredGVK
 		}
 	}
-	kind.SetGroupVersionKind(gvk)
-	err = e.Encoder.Encode(obj, stream)
-	kind.SetGroupVersionKind(oldGVK)
-	return err
+
+	// The gvk only needs to be set if not already as desired.
+	if gvk != oldGVK {
+		kind.SetGroupVersionKind(gvk)
+		defer kind.SetGroupVersionKind(oldGVK)
+	}
+
+	return e.Encoder.Encode(obj, stream)
 }
 
 // WithoutVersionDecoder clears the group version kind of a deserialized object.


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Setting the group/version/kind is not necessary when the object already has it.
In that particular case some extra work and the data race when the
same object is used multiple times in parallel can be avoided.

#### Which issue(s) this PR fixes:
Related-to: https://github.com/kubernetes/kubernetes/pull/117174#discussion_r1161310645

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/cc @lavalamp 