### PR TITLE
Self nominate Kevin Hannon for reviewer for job controller

### DIFF
--- a/pkg/controller/job/OWNERS
+++ b/pkg/controller/job/OWNERS
@@ -6,5 +6,6 @@ approvers:
 reviewers:
   - sig-apps-reviewers
   - mimowo
+  - kannon92
 labels:
   - sig/apps


### PR DESCRIPTION
I have  lead the PodReplacementPolicy KEP for alpha and I helped review/fix some issues in beta.  

https://github.com/kubernetes/kubernetes/pulls?q=+is%3Apr+reviewed-by%3Akannon92+label%3Asig%2Fapps+

I have also been an active reviewer and helped GA job tracking last release.  I hope to continue reviewing Job related code.


#### What type of PR is this?


#### What this PR does / why we need it:

Add kannon92 as a reviewer for the job controller code.

- [x] member for at least 3 months: Been member for 1 year. https://github.com/kubernetes/org/issues/3861
- [x] Primary reviewer for at least 5 PRs to the codebase: https://github.com/kubernetes/kubernetes/pulls?q=+is%3Apr+reviewed-by%3Akannon92+label%3Asig%2Fapps+
- [x] Reviewed or merged at least 20 substantial PRs to the codebase: https://github.com/kubernetes/kubernetes/pulls?q=is%3Apr+is%3Aclosed+author%3Akannon92++label%3Asig%2Fapps
- [x] Knowledgeable about the codebase: Yes.
  - Led PodReplacementPolicy KEP and reviewed the beta promotion
  - Helped GA Job Tracking.
  - Triage Job related issues
  - Helped improve usability of Job in other projects like JobSet   
- [x] Sponsored by a subproject approver: Bringing this up to get approver.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
