### PR TITLE
Add tests for ignoring scheduler processing

### DIFF
--- a/test/e2e/autoscaling/cluster_size_autoscaling.go
+++ b/test/e2e/autoscaling/cluster_size_autoscaling.go
@@ -1007,7 +1007,8 @@ var _ = SIGDescribe("Cluster size autoscaling", framework.WithSlow(), func() {
 		// 70% of allocatable memory of a single node * replica count, forcing a scale up in case of normal pods
 		replicaCount := 2 * nodeCount
 		reservedMemory := int(float64(replicaCount) * float64(0.7) * float64(memAllocatableMb))
-		ginkgo.DeferCleanup(ReserveMemoryWithSchedulerName(ctx, f, "memory-reservation", replicaCount, reservedMemory, false, 1, nonExistingBypassedSchedulerName))
+		cleanupFunc := ReserveMemoryWithSchedulerName(ctx, f, "memory-reservation", replicaCount, reservedMemory, false, 1, nonExistingBypassedSchedulerName)
+		defer cleanupFunc()
 		// Verify that cluster size is increased
 		ginkgo.By("Waiting for cluster scale-up")
 		sizeFunc := func(size int) bool {
@@ -1020,7 +1021,8 @@ var _ = SIGDescribe("Cluster size autoscaling", framework.WithSlow(), func() {
 		// 50% of allocatable memory of a single node, so that no scale up would trigger in normal cases
 		replicaCount := 1
 		reservedMemory := int(float64(0.5) * float64(memAllocatableMb))
-		ginkgo.DeferCleanup(ReserveMemoryWithSchedulerName(ctx, f, "memory-reservation", replicaCount, reservedMemory, false, 1, nonExistingBypassedSchedulerName))
+		cleanupFunc := ReserveMemoryWithSchedulerName(ctx, f, "memory-reservation", replicaCount, reservedMemory, false, 1, nonExistingBypassedSchedulerName)
+		defer cleanupFunc()
 		// Verify that cluster size is the same
 		ginkgo.By(fmt.Sprintf("Waiting for scale up hoping it won't happen, polling cluster size for %s", scaleUpTimeout.String()))
 		sizeFunc := func(size int) bool {
@@ -1035,7 +1037,8 @@ var _ = SIGDescribe("Cluster size autoscaling", framework.WithSlow(), func() {
 		replicaCount := 2 * nodeCount
 		reservedMemory := int(float64(replicaCount) * float64(0.7) * float64(memAllocatableMb))
 		schedulerName := "non-existent-scheduler-" + f.UniqueName
-		ginkgo.DeferCleanup(ReserveMemoryWithSchedulerName(ctx, f, "memory-reservation", replicaCount, reservedMemory, false, 1, schedulerName))
+		cleanupFunc := ReserveMemoryWithSchedulerName(ctx, f, "memory-reservation", replicaCount, reservedMemory, false, 1, schedulerName)
+		defer cleanupFunc()
 		// Verify that cluster size is the same
 		ginkgo.By(fmt.Sprintf("Waiting for scale up hoping it won't happen, polling cluster size for %s", scaleUpTimeout.String()))
 		sizeFunc := func(size int) bool {

--- a/test/e2e/autoscaling/cluster_size_autoscaling.go
+++ b/test/e2e/autoscaling/cluster_size_autoscaling.go
@@ -92,6 +92,8 @@ const (
 	highPriorityClassName       = "high-priority"
 
 	gpuLabel = "cloud.google.com/gke-accelerator"
+
+	nonExistingBypassedSchedulerName = "non-existing-bypassed-scheduler"
 )
 
 var _ = SIGDescribe("Cluster size autoscaling", framework.WithSlow(), func() {
@@ -1000,6 +1002,47 @@ var _ = SIGDescribe("Cluster size autoscaling", framework.WithSlow(), func() {
 		framework.ExpectNoError(WaitForClusterSizeFunc(ctx, f.ClientSet,
 			func(size int) bool { return size == increasedSize }, time.Second))
 	})
+
+	f.It("should scale up when unprocessed pod is created and is going to be unschedulable", feature.ClusterScaleUpBypassScheduler, func(ctx context.Context) {
+		// 70% of allocatable memory of a single node * replica count, forcing a scale up in case of normal pods
+		replicaCount := 2 * nodeCount
+		reservedMemory := int(float64(replicaCount) * float64(0.7) * float64(memAllocatableMb))
+		ginkgo.DeferCleanup(ReserveMemoryWithSchedulerName(ctx, f, "memory-reservation", replicaCount, reservedMemory, false, 1, nonExistingBypassedSchedulerName))
+		// Verify that cluster size is increased
+		ginkgo.By("Waiting for cluster scale-up")
+		sizeFunc := func(size int) bool {
+			// Softly checks scale-up since other types of machines can be added which would affect #nodes
+			return size > nodeCount
+		}
+		framework.ExpectNoError(WaitForClusterSizeFuncWithUnready(ctx, f.ClientSet, sizeFunc, scaleUpTimeout, 0))
+	})
+	f.It("shouldn't scale up when unprocessed pod is created and is going to be schedulable", feature.ClusterScaleUpBypassScheduler, func(ctx context.Context) {
+		// 50% of allocatable memory of a single node, so that no scale up would trigger in normal cases
+		replicaCount := 1
+		reservedMemory := int(float64(0.5) * float64(memAllocatableMb))
+		ginkgo.DeferCleanup(ReserveMemoryWithSchedulerName(ctx, f, "memory-reservation", replicaCount, reservedMemory, false, 1, nonExistingBypassedSchedulerName))
+		// Verify that cluster size is the same
+		ginkgo.By(fmt.Sprintf("Waiting for scale up hoping it won't happen, sleep for %s", scaleUpTimeout.String()))
+		time.Sleep(scaleUpTimeout)
+		sizeFunc := func(size int) bool {
+			return size == nodeCount
+		}
+		framework.ExpectNoError(WaitForClusterSizeFuncWithUnready(ctx, f.ClientSet, sizeFunc, time.Second, 0))
+	})
+	f.It("shouldn't scale up when unprocessed pod is created and scheduler is not specified to be bypassed", feature.ClusterScaleUpBypassScheduler, func(ctx context.Context) {
+		// 70% of allocatable memory of a single node * replica count, forcing a scale up in case of normal pods
+		replicaCount := 2 * nodeCount
+		reservedMemory := int(float64(replicaCount) * float64(0.7) * float64(memAllocatableMb))
+		schedulerName := "non-existent-scheduler-" + f.UniqueName
+		ginkgo.DeferCleanup(ReserveMemoryWithSchedulerName(ctx, f, "memory-reservation", replicaCount, reservedMemory, false, 1, schedulerName))
+		// Verify that cluster size is the same
+		ginkgo.By(fmt.Sprintf("Waiting for scale up hoping it won't happen, sleep for %s", scaleUpTimeout.String()))
+		time.Sleep(scaleUpTimeout)
+		sizeFunc := func(size int) bool {
+			return size == nodeCount
+		}
+		framework.ExpectNoError(WaitForClusterSizeFuncWithUnready(ctx, f.ClientSet, sizeFunc, time.Second, 0))
+	})
 })
 
 func installNvidiaDriversDaemonSet(ctx context.Context, f *framework.Framework) {
@@ -1298,7 +1341,7 @@ func getPoolSize(ctx context.Context, f *framework.Framework, poolName string) i
 	return size
 }
 
-func reserveMemory(ctx context.Context, f *framework.Framework, id string, replicas, megabytes int, expectRunning bool, timeout time.Duration, selector map[string]string, tolerations []v1.Toleration, priorityClassName string) func() error {
+func reserveMemory(ctx context.Context, f *framework.Framework, id string, replicas, megabytes int, expectRunning bool, timeout time.Duration, selector map[string]string, tolerations []v1.Toleration, priorityClassName, schedulerName string) func() error {
 	ginkgo.By(fmt.Sprintf("Running RC which reserves %v MB of memory", megabytes))
 	request := int64(1024 * 1024 * megabytes / replicas)
 	config := &testutils.RCConfig{
@@ -1312,6 +1355,7 @@ func reserveMemory(ctx context.Context, f *framework.Framework, id string, repli
 		NodeSelector:      selector,
 		Tolerations:       tolerations,
 		PriorityClassName: priorityClassName,
+		SchedulerName:     schedulerName,
 	}
 	for start := time.Now(); time.Since(start) < rcCreationRetryTimeout; time.Sleep(rcCreationRetryDelay) {
 		err := e2erc.RunRC(ctx, *config)
@@ -1333,19 +1377,25 @@ func reserveMemory(ctx context.Context, f *framework.Framework, id string, repli
 // ReserveMemoryWithPriority creates a replication controller with pods with priority that, in summation,
 // request the specified amount of memory.
 func ReserveMemoryWithPriority(ctx context.Context, f *framework.Framework, id string, replicas, megabytes int, expectRunning bool, timeout time.Duration, priorityClassName string) func() error {
-	return reserveMemory(ctx, f, id, replicas, megabytes, expectRunning, timeout, nil, nil, priorityClassName)
+	return reserveMemory(ctx, f, id, replicas, megabytes, expectRunning, timeout, nil, nil, priorityClassName, "")
 }
 
 // ReserveMemoryWithSelectorAndTolerations creates a replication controller with pods with node selector that, in summation,
 // request the specified amount of memory.
 func ReserveMemoryWithSelectorAndTolerations(ctx context.Context, f *framework.Framework, id string, replicas, megabytes int, expectRunning bool, timeout time.Duration, selector map[string]string, tolerations []v1.Toleration) func() error {
-	return reserveMemory(ctx, f, id, replicas, megabytes, expectRunning, timeout, selector, tolerations, "")
+	return reserveMemory(ctx, f, id, replicas, megabytes, expectRunning, timeout, selector, tolerations, "", "")
+}
+
+// ReserveMemoryWithSchedulerName creates a replication controller with pods with scheduler name that, in summation,
+// request the specified amount of memory.
+func ReserveMemoryWithSchedulerName(ctx context.Context, f *framework.Framework, id string, replicas, megabytes int, expectRunning bool, timeout time.Duration, schedulerName string) func() error {
+	return reserveMemory(ctx, f, id, replicas, megabytes, expectRunning, timeout, nil, nil, "", schedulerName)
 }
 
 // ReserveMemory creates a replication controller with pods that, in summation,
 // request the specified amount of memory.
 func ReserveMemory(ctx context.Context, f *framework.Framework, id string, replicas, megabytes int, expectRunning bool, timeout time.Duration) func() error {
-	return reserveMemory(ctx, f, id, replicas, megabytes, expectRunning, timeout, nil, nil, "")
+	return reserveMemory(ctx, f, id, replicas, megabytes, expectRunning, timeout, nil, nil, "", "")
 }
 
 // WaitForClusterSizeFunc waits until the cluster size matches the given function.

--- a/test/e2e/autoscaling/cluster_size_autoscaling.go
+++ b/test/e2e/autoscaling/cluster_size_autoscaling.go
@@ -1008,7 +1008,7 @@ var _ = SIGDescribe("Cluster size autoscaling", framework.WithSlow(), func() {
 		replicaCount := 2 * nodeCount
 		reservedMemory := int(float64(replicaCount) * float64(0.7) * float64(memAllocatableMb))
 		cleanupFunc := ReserveMemoryWithSchedulerName(ctx, f, "memory-reservation", replicaCount, reservedMemory, false, 1, nonExistingBypassedSchedulerName)
-		defer cleanupFunc()
+		defer framework.ExpectNoError(cleanupFunc())
 		// Verify that cluster size is increased
 		ginkgo.By("Waiting for cluster scale-up")
 		sizeFunc := func(size int) bool {
@@ -1022,7 +1022,7 @@ var _ = SIGDescribe("Cluster size autoscaling", framework.WithSlow(), func() {
 		replicaCount := 1
 		reservedMemory := int(float64(0.5) * float64(memAllocatableMb))
 		cleanupFunc := ReserveMemoryWithSchedulerName(ctx, f, "memory-reservation", replicaCount, reservedMemory, false, 1, nonExistingBypassedSchedulerName)
-		defer cleanupFunc()
+		defer framework.ExpectNoError(cleanupFunc())
 		// Verify that cluster size is the same
 		ginkgo.By(fmt.Sprintf("Waiting for scale up hoping it won't happen, polling cluster size for %s", scaleUpTimeout.String()))
 		sizeFunc := func(size int) bool {
@@ -1038,7 +1038,7 @@ var _ = SIGDescribe("Cluster size autoscaling", framework.WithSlow(), func() {
 		reservedMemory := int(float64(replicaCount) * float64(0.7) * float64(memAllocatableMb))
 		schedulerName := "non-existent-scheduler-" + f.UniqueName
 		cleanupFunc := ReserveMemoryWithSchedulerName(ctx, f, "memory-reservation", replicaCount, reservedMemory, false, 1, schedulerName)
-		defer cleanupFunc()
+		defer framework.ExpectNoError(cleanupFunc())
 		// Verify that cluster size is the same
 		ginkgo.By(fmt.Sprintf("Waiting for scale up hoping it won't happen, polling cluster size for %s", scaleUpTimeout.String()))
 		sizeFunc := func(size int) bool {

--- a/test/e2e/feature/feature.go
+++ b/test/e2e/feature/feature.go
@@ -132,6 +132,7 @@ var (
 	Windows                                 = framework.WithFeature(framework.ValidFeatures.Add("Windows"))
 	WindowsHostProcessContainers            = framework.WithFeature(framework.ValidFeatures.Add("WindowsHostProcessContainers"))
 	WindowsHyperVContainers                 = framework.WithFeature(framework.ValidFeatures.Add("WindowsHyperVContainers"))
+	ClusterScaleUpBypassScheduler           = framework.WithFeature(framework.ValidFeatures.Add("ClusterScaleUpBypassScheduler"))
 )
 
 func init() {

--- a/test/utils/runners.go
+++ b/test/utils/runners.go
@@ -134,6 +134,7 @@ type RCConfig struct {
 	PriorityClassName             string
 	TerminationGracePeriodSeconds *int64
 	Lifecycle                     *v1.Lifecycle
+	SchedulerName                 string
 
 	// Env vars, set the same for every pod.
 	Env map[string]string
@@ -615,7 +616,8 @@ func (config *RCConfig) create() error {
 					Annotations: config.Annotations,
 				},
 				Spec: v1.PodSpec{
-					Affinity: config.Affinity,
+					SchedulerName: config.SchedulerName,
+					Affinity:      config.Affinity,
 					Containers: []v1.Container{
 						{
 							Name:            config.Name,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Adds 3 E2E tests to verify behaviour of [
Bypassing scheduler processing](https://github.com/kubernetes/autoscaler/pull/6235)

The tests are labeled with  `ClusterScaleUpBypassScheduler` feature so they can be easily ignored/focused since without enabling the feature described in [
Bypassing scheduler processing](https://github.com/kubernetes/autoscaler/pull/6235) the tests will fail.

The tests use a scheduler name of `non-existing-bypassed-scheduler`.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
