### PR TITLE
Update SIG Network reviewers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -265,6 +265,7 @@ aliases:
     - khenidak
     - mrhohn
     - robscott
+    - shaneutt
     - thockin
   sig-network-reviewers:
     - andrewsykim
@@ -275,6 +276,7 @@ aliases:
     - dcbw
     - khenidak
     - robscott
+    - shaneutt
     - thockin
   sig-apps-approvers:
     - kow3ns
@@ -357,9 +359,11 @@ aliases:
     - vincepri
   sig-network-api-approvers:
     - danwinship
+    - shaneutt
     - thockin
   sig-network-api-reviewers:
     - danwinship
+    - shaneutt
     - thockin
   sig-scheduling-api-approvers:
     - msau42

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -273,9 +273,7 @@ aliases:
     - caseydavenport
     - danwinship
     - dcbw
-    - freehan
     - khenidak
-    - mrhohn
     - robscott
     - thockin
   sig-apps-approvers:
@@ -358,11 +356,8 @@ aliases:
     - neolit123
     - vincepri
   sig-network-api-approvers:
-    - smarterclayton
     - thockin
   sig-network-api-reviewers:
-    - andrewsykim
-    - caseydavenport
     - danwinship
     - thockin
   sig-scheduling-api-approvers:

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -356,6 +356,7 @@ aliases:
     - neolit123
     - vincepri
   sig-network-api-approvers:
+    - danwinship
     - thockin
   sig-network-api-reviewers:
     - danwinship


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind documentation

#### What this PR does / why we need it:

Our approvers and reviewers file had gotten way out of day, with some inactive users still present and not having reflected the leads changes of the last year.

#### Special notes for your reviewer:

/cc @thockin check this out

#### Does this PR introduce a user-facing change?

```release-note
NONE
```