### PR TITLE
Pass External Storage label parameters as individual arguments in framework variadic function

### DIFF
--- a/test/e2e/storage/external/external.go
+++ b/test/e2e/storage/external/external.go
@@ -174,7 +174,7 @@ func AddDriverDefinition(filename string) error {
 	args = append(args, func() {
 		storageframework.DefineTestSuites(driver, testsuites.CSISuites)
 	})
-	framework.Describe(args)
+	framework.Describe(args...)
 
 	return nil
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind failing-test

#### What this PR does / why we need it:
Fixes `test/e2e` tests that run "External Storage" tests using the `--storage.testdriver` argument.

#### Which issue(s) this PR fixes:
Fixes #121789

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
