### PR TITLE
Remove --use-real-proxier support from kubemark

### DIFF
--- a/pkg/proxy/kubemark/hollow_proxy.go
+++ b/pkg/proxy/kubemark/hollow_proxy.go
@@ -27,20 +27,10 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/events"
-	utilsysctl "k8s.io/component-helpers/node/util/sysctl"
 	proxyapp "k8s.io/kubernetes/cmd/kube-proxy/app"
-	"k8s.io/kubernetes/pkg/proxy"
 	proxyconfigapi "k8s.io/kubernetes/pkg/proxy/apis/config"
 	proxyconfig "k8s.io/kubernetes/pkg/proxy/config"
-	"k8s.io/kubernetes/pkg/proxy/iptables"
-	proxyutiliptables "k8s.io/kubernetes/pkg/proxy/util/iptables"
-	utiliptables "k8s.io/kubernetes/pkg/util/iptables"
-	utilnode "k8s.io/kubernetes/pkg/util/node"
-	utilexec "k8s.io/utils/exec"
-	netutils "k8s.io/utils/net"
 	"k8s.io/utils/ptr"
-
-	"k8s.io/klog/v2"
 )
 
 type HollowProxy struct {
@@ -64,67 +54,13 @@ func (*FakeProxier) OnEndpointSliceUpdate(oldSlice, slice *discoveryv1.EndpointS
 func (*FakeProxier) OnEndpointSliceDelete(slice *discoveryv1.EndpointSlice)           {}
 func (*FakeProxier) OnEndpointSlicesSynced()                                          {}
 
-func NewHollowProxyOrDie(
+func NewHollowProxy(
 	nodeName string,
 	client clientset.Interface,
 	eventClient v1core.EventsGetter,
-	iptInterface utiliptables.Interface,
-	sysctl utilsysctl.Interface,
-	execer utilexec.Interface,
 	broadcaster events.EventBroadcaster,
 	recorder events.EventRecorder,
-	useRealProxier bool,
-	proxierSyncPeriod time.Duration,
-	proxierMinSyncPeriod time.Duration,
-) (*HollowProxy, error) {
-	// Create proxier and service/endpoint handlers.
-	var proxier proxy.Provider
-	var err error
-
-	if useRealProxier {
-		nodeIP := utilnode.GetNodeIP(client, nodeName)
-		if nodeIP == nil {
-			klog.InfoS("Can't determine this node's IP, assuming 127.0.0.1")
-			nodeIP = netutils.ParseIPSloppy("127.0.0.1")
-		}
-		family := v1.IPv4Protocol
-		if iptInterface.IsIPv6() {
-			family = v1.IPv6Protocol
-		}
-		// Real proxier with fake iptables, sysctl, etc underneath it.
-		//var err error
-		proxier, err = iptables.NewProxier(
-			family,
-			iptInterface,
-			sysctl,
-			execer,
-			proxierSyncPeriod,
-			proxierMinSyncPeriod,
-			false,
-			false,
-			0,
-			proxyutiliptables.NewNoOpLocalDetector(),
-			nodeName,
-			nodeIP,
-			recorder,
-			nil,
-			[]string{},
-			false,
-		)
-		if err != nil {
-			return nil, fmt.Errorf("unable to create proxier: %v", err)
-		}
-	} else {
-		proxier = &FakeProxier{}
-	}
-
-	// Create a Hollow Proxy instance.
-	nodeRef := &v1.ObjectReference{
-		Kind:      "Node",
-		Name:      nodeName,
-		UID:       types.UID(nodeName),
-		Namespace: "",
-	}
+) *HollowProxy {
 	return &HollowProxy{
 		ProxyServer: &proxyapp.ProxyServer{
 			Config: &proxyconfigapi.KubeProxyConfiguration{
@@ -134,12 +70,17 @@ func NewHollowProxyOrDie(
 			},
 
 			Client:      client,
-			Proxier:     proxier,
+			Proxier:     &FakeProxier{},
 			Broadcaster: broadcaster,
 			Recorder:    recorder,
-			NodeRef:     nodeRef,
+			NodeRef: &v1.ObjectReference{
+				Kind:      "Node",
+				Name:      nodeName,
+				UID:       types.UID(nodeName),
+				Namespace: "",
+			},
 		},
-	}, nil
+	}
 }
 
 func (hp *HollowProxy) Run() error {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -2067,7 +2067,6 @@ k8s.io/component-helpers/auth/rbac/validation
 k8s.io/component-helpers/node/topology
 k8s.io/component-helpers/node/util
 k8s.io/component-helpers/node/util/sysctl
-k8s.io/component-helpers/node/util/sysctl/testing
 k8s.io/component-helpers/scheduling/corev1
 k8s.io/component-helpers/scheduling/corev1/nodeaffinity
 k8s.io/component-helpers/storage/ephemeral


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
kubemark's proxy mode exists to test how kube-proxy affects the load on the apiserver, not how it affects the load on the node. There's no need to generate fake iptables commands, because that all happens entirely independently of the api watchers.

It looks like sig-scalability's jobs [turn this flag off](https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml#L121-L122) anyway, as does the [suggested template](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-scalability/hollow-node_simplified_template.yaml#L72) so this is just getting rid of something probably no one was using (and making kubemark slightly less dependent on undocumented internals of kube-proxy).

(I see there are comments in the kubemark source about splitting up the hollow kubelet and hollow proxy more... We could just add `--proxy-mode=hollow` to the `kube-proxy` binary if you wanted...)

#### Which issue(s) this PR fixes:
none

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

I think? kubemark is just for k8s devs, not end users, right?

/assign @wojtek-t 
/sig scalability