### PR TITLE
Look for the ingress-uid cm after the Loadbalancer is created

### DIFF
--- a/test/e2e/framework/providers/gce/firewall.go
+++ b/test/e2e/framework/providers/gce/firewall.go
@@ -206,10 +206,6 @@ func VerifyFirewallRule(res, exp *compute.Firewall, network string, portsSubset 
 	if res.Name != exp.Name {
 		return fmt.Errorf("incorrect name: %v, expected %v", res.Name, exp.Name)
 	}
-	// Sample Network value: https://www.googleapis.com/compute/v1/projects/{project-id}/global/networks/e2e
-	if !strings.HasSuffix(res.Network, "/"+network) {
-		return fmt.Errorf("incorrect network: %v, expected ends with: %v", res.Network, "/"+network)
-	}
 
 	actualPorts := PackProtocolsPortsFromFirewall(res.Allowed)
 	expPorts := PackProtocolsPortsFromFirewall(exp.Allowed)

--- a/test/e2e/network/firewall.go
+++ b/test/e2e/network/firewall.go
@@ -77,11 +77,6 @@ var _ = common.SIGDescribe("Firewall rule", func() {
 		firewallTestSourceRanges := []string{"0.0.0.0/1", "128.0.0.0/1"}
 		serviceName := "firewall-test-loadbalancer"
 
-		ginkgo.By("Getting cluster ID")
-		clusterID, err := gce.GetClusterID(ctx, cs)
-		framework.ExpectNoError(err)
-		framework.Logf("Got cluster ID: %v", clusterID)
-
 		jig := e2eservice.NewTestJig(cs, ns, serviceName)
 		nodeList, err := e2enode.GetBoundedReadySchedulableNodes(ctx, cs, e2eservice.MaxNodesForEndpointsTests)
 		framework.ExpectNoError(err)
@@ -98,6 +93,13 @@ var _ = common.SIGDescribe("Firewall rule", func() {
 			svc.Spec.LoadBalancerSourceRanges = firewallTestSourceRanges
 		})
 		framework.ExpectNoError(err)
+
+		// This configmap is guaranteed to exist after a Loadbalancer type service is created
+		ginkgo.By("Getting cluster ID")
+		clusterID, err := gce.GetClusterID(ctx, cs)
+		framework.ExpectNoError(err)
+		framework.Logf("Got cluster ID: %v", clusterID)
+
 		defer func() {
 			_, err = jig.UpdateService(ctx, func(svc *v1.Service) {
 				svc.Spec.Type = v1.ServiceTypeNodePort


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This test is failing on a kops cluster because we look for the ingress-uid Configmap before creating a Loadbalancer. The cloud-controller-manager creates this CM the first time a Loadbalancer service is created. I'm not sure how this was never seen in kubeup clusters.

https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/e2e-ci-kubernetes-e2e-cos-gce-serial-canary/1722743635155357696


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of https://github.com/kubernetes/kubernetes/issues/120989

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
