### PR TITLE
verify-no-vendor-cycles: set up Go environment

### DIFF
--- a/hack/verify-no-vendor-cycles.sh
+++ b/hack/verify-no-vendor-cycles.sh
@@ -27,6 +27,9 @@ source "${KUBE_ROOT}/hack/lib/init.sh"
 
 export GO111MODULE=on
 
+kube::golang::verify_go_version
+kube::golang::setup_env
+
 staging_repos=()
 kube::util::read-array staging_repos < <(kube::util::list_staging_repos)
 staging_repos_pattern=$(IFS="|"; echo "${staging_repos[*]}")
@@ -34,7 +37,7 @@ staging_repos_pattern=$(IFS="|"; echo "${staging_repos[*]}")
 cd "${KUBE_ROOT}"
 
 # Check for any module that is not main or staging and depends on main or staging
-bad_deps=$(go mod graph | grep -vE "^k8s.io\/(kubernetes|${staging_repos_pattern})" | grep -E "\sk8s.io\/(kubernetes|${staging_repos_pattern})" || true)
+bad_deps=$(go mod graph | grep -vE "^k8s.io/(kubernetes|${staging_repos_pattern})" | grep -E "\sk8s.io/(kubernetes|${staging_repos_pattern})" || true)
 if [[ -n "${bad_deps}" ]]; then
   echo "Found disallowed dependencies that transitively depend on k8s.io/kubernetes or staging modules:"
   echo "${bad_deps}"


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This script relies on Go but doesn't set up the private Go environment (which ensures that the go command meets k/k's requirements). This fixes that.

As a drive-by improvement, drop two unnecessary backslashes from regexes (before / which doesn't need to be escaped).

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
