### PR TITLE
vac add e2e test

### DIFF
--- a/test/e2e/storage/volumeattributesclass.go
+++ b/test/e2e/storage/volumeattributesclass.go
@@ -1,0 +1,174 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storage
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	storagev1alpha1 "k8s.io/api/storage/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	types "k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
+	"k8s.io/kubernetes/pkg/features"
+	"k8s.io/kubernetes/test/e2e/feature"
+	"k8s.io/kubernetes/test/e2e/framework"
+	"k8s.io/kubernetes/test/e2e/storage/utils"
+	admissionapi "k8s.io/pod-security-admission/api"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+)
+
+var _ = utils.SIGDescribe("VolumeAttributesClass", feature.VolumeAttributesClass, framework.WithFeatureGate(features.VolumeAttributesClass), func() {
+
+	f := framework.NewDefaultFramework("csi-volumeattributesclass")
+	f.NamespacePodSecurityLevel = admissionapi.LevelBaseline
+	/*
+		Release: v1.29
+		Testname: VolumeAttributesClass, lifecycle
+		Description: Creating a VolumeAttributesClass MUST succeed. Reading the VolumeAttributesClass MUST
+		succeed. Patching the VolumeAttributesClass MUST succeed with its new label found. Deleting
+		the VolumeAttributesClass MUST succeed and it MUST be confirmed. Replacement VolumeAttributesClass
+		MUST be created. Updating the VolumeAttributesClass MUST succeed with its new label found.
+		Deleting the VolumeAttributesClass via deleteCollection MUST succeed and it MUST be confirmed.
+	*/
+	framework.It("should run through the lifecycle of a VolumeAttributesClass", func(ctx context.Context) {
+
+		vacClient := f.ClientSet.StorageV1alpha1().VolumeAttributesClasses()
+		var initialVAC, replacementVAC *storagev1alpha1.VolumeAttributesClass
+
+		initialVAC = &storagev1alpha1.VolumeAttributesClass{
+			TypeMeta: metav1.TypeMeta{
+				Kind: "VolumeAttributesClass",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "e2e-",
+			},
+			DriverName: "e2e-fake-csi-driver",
+			Parameters: map[string]string{
+				"foo": "bar",
+			},
+		}
+
+		ginkgo.By("Creating a VolumeAttributesClass")
+		createdVolumeAttributesClass, err := vacClient.Create(ctx, initialVAC, metav1.CreateOptions{})
+		framework.ExpectNoError(err, "failed to create the requested VolumeAttributesClass")
+
+		ginkgo.By(fmt.Sprintf("Get VolumeAttributesClass %q", createdVolumeAttributesClass.Name))
+		retrievedVolumeAttributesClass, err := vacClient.Get(ctx, createdVolumeAttributesClass.Name, metav1.GetOptions{})
+		framework.ExpectNoError(err, "failed to get VolumeAttributesClass %q", createdVolumeAttributesClass.Name)
+
+		ginkgo.By(fmt.Sprintf("Patching the VolumeAttributesClass %q", retrievedVolumeAttributesClass.Name))
+		payload := "{\"metadata\":{\"labels\":{\"" + retrievedVolumeAttributesClass.Name + "\":\"patched\"}}}"
+		patchedVolumeAttributesClass, err := vacClient.Patch(ctx, retrievedVolumeAttributesClass.Name, types.StrategicMergePatchType, []byte(payload), metav1.PatchOptions{})
+		framework.ExpectNoError(err, "failed to patch VolumeAttributesClass %q", retrievedVolumeAttributesClass.Name)
+		gomega.Expect(patchedVolumeAttributesClass.Labels).To(gomega.HaveKeyWithValue(patchedVolumeAttributesClass.Name, "patched"), "checking that patched label has been applied")
+
+		ginkgo.By(fmt.Sprintf("Delete VolumeAttributesClass %q", patchedVolumeAttributesClass.Name))
+		err = vacClient.Delete(ctx, patchedVolumeAttributesClass.Name, metav1.DeleteOptions{})
+		framework.ExpectNoError(err, "failed to delete VolumeAttributesClass %q", patchedVolumeAttributesClass.Name)
+
+		ginkgo.By(fmt.Sprintf("Confirm deletion of VolumeAttributesClass %q", patchedVolumeAttributesClass.Name))
+
+		vacSelector := labels.Set{patchedVolumeAttributesClass.Name: "patched"}.AsSelector().String()
+		type state struct {
+			VolumeAttributesClasses []storagev1alpha1.VolumeAttributesClass
+		}
+
+		err = framework.Gomega().Eventually(ctx, framework.HandleRetry(func(ctx context.Context) (*state, error) {
+			vacList, err := vacClient.List(ctx, metav1.ListOptions{LabelSelector: vacSelector})
+			if err != nil {
+				return nil, fmt.Errorf("failed to list VolumeAttributesClass: %w", err)
+			}
+			return &state{
+				VolumeAttributesClasses: vacList.Items,
+			}, nil
+		})).WithTimeout(30 * time.Second).Should(framework.MakeMatcher(func(s *state) (func() string, error) {
+			if len(s.VolumeAttributesClasses) == 0 {
+				return nil, nil
+			}
+			return func() string {
+				return fmt.Sprintf("expected VolumeAttributesClass to be deleted, found %q", s.VolumeAttributesClasses[0].Name)
+			}, nil
+		}))
+		framework.ExpectNoError(err, "timeout while waiting to confirm VolumeAttributesClass %q deletion", patchedVolumeAttributesClass.Name)
+
+		ginkgo.By("Create a replacement VolumeAttributesClass")
+
+		replacementVAC = &storagev1alpha1.VolumeAttributesClass{
+			TypeMeta: metav1.TypeMeta{
+				Kind: "VolumeAttributesClass",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "e2e-v2-",
+			},
+			DriverName: "e2e-fake-csi-driver",
+			Parameters: map[string]string{
+				"foo": "bar",
+			},
+		}
+
+		replacementVolumeAttributesClass, err := vacClient.Create(ctx, replacementVAC, metav1.CreateOptions{})
+		framework.ExpectNoError(err, "failed to create replacement VolumeAttributesClass")
+
+		ginkgo.By(fmt.Sprintf("Updating VolumeAttributesClass %q", replacementVolumeAttributesClass.Name))
+		var updatedVolumeAttributesClass *storagev1alpha1.VolumeAttributesClass
+
+		err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			vac, err := vacClient.Get(ctx, replacementVolumeAttributesClass.Name, metav1.GetOptions{})
+			framework.ExpectNoError(err, "unable to get VolumeAttributesClass %q", replacementVolumeAttributesClass.Name)
+			vac.Labels = map[string]string{replacementVolumeAttributesClass.Name: "updated"}
+			updatedVolumeAttributesClass, err = vacClient.Update(ctx, vac, metav1.UpdateOptions{})
+			return err
+		})
+		framework.ExpectNoError(err, "failed to update VolumeAttributesClass %q", replacementVolumeAttributesClass.Name)
+		gomega.Expect(updatedVolumeAttributesClass.Labels).To(gomega.HaveKeyWithValue(replacementVolumeAttributesClass.Name, "updated"), "checking that updated label has been applied")
+
+		vacSelector = labels.Set{replacementVolumeAttributesClass.Name: "updated"}.AsSelector().String()
+		ginkgo.By(fmt.Sprintf("Listing all VolumeAttributesClasses with the labelSelector: %q", vacSelector))
+		vacList, err := vacClient.List(ctx, metav1.ListOptions{LabelSelector: vacSelector})
+		framework.ExpectNoError(err, "failed to list VolumeAttributesClasses with the labelSelector: %q", vacSelector)
+		gomega.Expect(vacList.Items).To(gomega.HaveLen(1))
+
+		ginkgo.By(fmt.Sprintf("Deleting VolumeAttributesClass %q via DeleteCollection", updatedVolumeAttributesClass.Name))
+		err = vacClient.DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{LabelSelector: vacSelector})
+		framework.ExpectNoError(err, "failed to delete VolumeAttributesClass %q", updatedVolumeAttributesClass.Name)
+
+		ginkgo.By(fmt.Sprintf("Confirm deletion of VolumeAttributesClass %q", updatedVolumeAttributesClass.Name))
+
+		err = framework.Gomega().Eventually(ctx, framework.HandleRetry(func(ctx context.Context) (*state, error) {
+			vacList, err := vacClient.List(ctx, metav1.ListOptions{LabelSelector: vacSelector})
+			if err != nil {
+				return nil, fmt.Errorf("failed to list VolumeAttributesClass: %w", err)
+			}
+			return &state{
+				VolumeAttributesClasses: vacList.Items,
+			}, nil
+		})).WithTimeout(30 * time.Second).Should(framework.MakeMatcher(func(s *state) (func() string, error) {
+			if len(s.VolumeAttributesClasses) == 0 {
+				return nil, nil
+			}
+			return func() string {
+				return fmt.Sprintf("expected VolumeAttributesClass to be deleted, found %q", s.VolumeAttributesClasses[0].Name)
+			}, nil
+		}))
+		framework.ExpectNoError(err, "timeout while waiting to confirm VolumeAttributesClass %q deletion", updatedVolumeAttributesClass.Name)
+	})
+})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup
/kind feature

#### What this PR does / why we need it:

vac add e2e test

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Ref https://github.com/kubernetes/kubernetes/pull/121104

#### Special notes for your reviewer:



#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-storage/3751-volume-attributes-class
```
