### PR TITLE
e2e: avoid redundant labels in JUnit file

### DIFF
--- a/test/e2e/framework/internal/junit/junit.go
+++ b/test/e2e/framework/internal/junit/junit.go
@@ -36,6 +36,10 @@ func WriteJUnitReport(report ginkgo.Report, filename string) error {
 		// both, then tools like kettle and spyglass would concatenate
 		// the two strings and thus show duplicated information.
 		OmitFailureMessageAttr: true,
+
+		// All labels are also part of the spec texts in inline [] tags,
+		// so we don't need to write them separately.
+		OmitSpecLabels: true,
 	}
 
 	return reporters.GenerateJUnitReportWithConfig(report, filename, config)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Because labels are currently typically added also to the spec texts, we don't need to write them separately.

#### Special notes for your reviewer:

This redundancy got introduced in f2cfbf44b1 when registering all inline tags also as labels.


#### Does this PR introduce a user-facing change?
```release-note
NONE
```
