### PR TITLE
fix: Refactor TestFinalizerCleanup unit test by asserting job and pod informer state

### DIFF
--- a/pkg/controller/job/job_controller_test.go
+++ b/pkg/controller/job/job_controller_test.go
@@ -5253,7 +5253,7 @@ func TestFinalizerCleanup(t *testing.T) {
 	defer cancel()
 
 	clientset := fake.NewSimpleClientset()
-	sharedInformers := informers.NewSharedInformerFactory(clientset, controller.NoResyncPeriodFunc())
+	sharedInformers := informers.NewSharedInformerFactory(clientset, controller.StaticResyncPeriodFunc(1*time.Second)())
 	manager, err := NewController(ctx, sharedInformers.Core().V1().Pods(), sharedInformers.Batch().V1().Jobs(), clientset)
 	if err != nil {
 		t.Fatalf("Error creating Job controller: %v", err)

--- a/pkg/controller/job/job_controller_test.go
+++ b/pkg/controller/job/job_controller_test.go
@@ -5322,6 +5322,7 @@ func TestFinalizerCleanup(t *testing.T) {
 	}); err != nil {
 		t.Errorf("Waiting for Pod to get the finalizer removed: %v", err)
 	}
+
 }
 
 func checkJobCompletionLabel(t *testing.T, p *v1.PodTemplateSpec) {

--- a/pkg/controller/job/job_controller_test.go
+++ b/pkg/controller/job/job_controller_test.go
@@ -5294,7 +5294,7 @@ func TestFinalizerCleanup(t *testing.T) {
 	// Await for the Pod to appear in the podStore to ensure that the pod exists when cleaning up the Job.
 	// In a production environment, there wouldn't be these guarantees, but the Pod would be cleaned up
 	// by the orphan pod worker, when the Pod finishes.
-	if err := wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, wait.ForeverTestTimeout, false, func(ctx context.Context) (bool, error) {
+	if err := wait.PollUntilContextTimeout(ctx, 10*time.Millisecond, wait.ForeverTestTimeout, false, func(ctx context.Context) (bool, error) {
 		pod, _ := manager.podStore.Pods(pod.GetNamespace()).Get(pod.Name)
 		return pod != nil, nil
 	}); err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind failing-test
/kind flake
/sig apps

<!--
Add one of the following kinds:
/kind bug
/kind failing-test
/kind flake

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation

/kind regression
-->

#### What this PR does / why we need it:

This PR attempts to fix the flaky unit test `TestFinalizerCleanup` in the `job_controller_test.go`.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/121652

#### Special notes for your reviewer:
A description on what causes the flaky behaviour is described in the following comment https://github.com/kubernetes/kubernetes/issues/121652#issuecomment-1806701661

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
