### PR TITLE
Automated cherry pick of #121001: ValidatingAdmissionPolicy: typed variables support.

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/cel/compile.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/cel/compile.go
@@ -141,6 +141,7 @@ type CompilationResult struct {
 	Program            cel.Program
 	Error              *apiservercel.Error
 	ExpressionAccessor ExpressionAccessor
+	OutputType         *cel.Type
 }
 
 // Compiler provides a CEL expression compiler configured with the desired admission related CEL variables and
@@ -214,6 +215,7 @@ func (c compiler) CompileCELExpression(expressionAccessor ExpressionAccessor, op
 	return CompilationResult{
 		Program:            prog,
 		ExpressionAccessor: expressionAccessor,
+		OutputType:         ast.OutputType(),
 	}
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/cel/composition.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/cel/composition.go
@@ -23,7 +23,6 @@ import (
 	"github.com/google/cel-go/cel"
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
-	"github.com/google/cel-go/common/types/traits"
 
 	v1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -227,18 +226,6 @@ func convertCelTypeToDeclType(celType *cel.Type) *apiservercel.DeclType {
 	case cel.UintType:
 		return apiservercel.UintType
 	default:
-		if celType.HasTrait(traits.ContainerType) && celType.HasTrait(traits.IndexerType) {
-			parameters := celType.Parameters()
-			switch len(parameters) {
-			case 1:
-				elemType := convertCelTypeToDeclType(parameters[0])
-				return apiservercel.NewListType(elemType, -1)
-			case 2:
-				keyType := convertCelTypeToDeclType(parameters[0])
-				valueType := convertCelTypeToDeclType(parameters[1])
-				return apiservercel.NewMapType(keyType, valueType, -1)
-			}
-		}
 		return apiservercel.DynType
 	}
 }

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/cel/composition_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/cel/composition_test.go
@@ -159,32 +159,6 @@ func TestCompositedPolicies(t *testing.T) {
 			expression:     "variables.dict['foo'].contains('bar')",
 			expectedResult: true,
 		},
-		{
-			name: "variable of a list but confused as a map",
-			variables: []NamedExpressionAccessor{
-				&testVariable{
-					name:       "list",
-					expression: "[1, 2, 3, 4]",
-				},
-			},
-			attributes:           endpointCreateAttributes(),
-			expression:           "variables.list['invalid'] == 'invalid'",
-			expectErr:            true,
-			expectedErrorMessage: "found no matching overload for '_[_]' applied to '(list(int), string)'",
-		},
-		{
-			name: "list of strings, but element is confused as an integer",
-			variables: []NamedExpressionAccessor{
-				&testVariable{
-					name:       "list",
-					expression: "['1', '2', '3', '4']",
-				},
-			},
-			attributes:           endpointCreateAttributes(),
-			expression:           "variables.list[0] == 1",
-			expectErr:            true,
-			expectedErrorMessage: "found no matching overload for '_==_' applied to '(string, int)'",
-		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/test/e2e/apimachinery/validatingadmissionpolicy.go
+++ b/test/e2e/apimachinery/validatingadmissionpolicy.go
@@ -205,11 +205,14 @@ var _ = SIGDescribe("ValidatingAdmissionPolicy [Privileged:ClusterAdmin][Alpha][
 					Expression: "object.spec.replicas",
 				}).
 				WithVariable(admissionregistrationv1beta1.Variable{
-					Name:       "replicasReminder", // a bit artificial but good for testing purpose
-					Expression: "variables.replicas % 2",
+					Name:       "oddReplicas",
+					Expression: "variables.replicas % 2 == 1",
 				}).
 				WithValidation(admissionregistrationv1beta1.Validation{
-					Expression: "variables.replicas > 1 && variables.replicasReminder == 1",
+					Expression: "variables.replicas > 1",
+				}).
+				WithValidation(admissionregistrationv1beta1.Validation{
+					Expression: "variables.oddReplicas",
 				}).
 				Build()
 			policy, err := client.AdmissionregistrationV1beta1().ValidatingAdmissionPolicies().Create(ctx, policy, metav1.CreateOptions{})


### PR DESCRIPTION
Cherry pick of #121001 on release-1.28.

/kind feature 

Note that parameters of maps and lists are not supported because the cel-go version that 1.28 uses does not expose parameters types at all.

 #121001: ValidatingAdmissionPolicy: typed variables support.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
ValidatingAdmissionPolicy now preserves types of composition variables, and raise type-related errors early.
```