### PR TITLE
Job: calculate the job completion before calculating the failure rules

### DIFF
--- a/pkg/controller/job/job_controller_test.go
+++ b/pkg/controller/job/job_controller_test.go
@@ -2681,6 +2681,56 @@ func TestSyncJobPastDeadline(t *testing.T) {
 				},
 			},
 		},
+		"nonIndexed job succeeded and exceeded activeDeadlineSeconds": {
+			parallelism:           1,
+			activeDeadlineSeconds: 10,
+			startTime:             15,
+			succeededPods:         1,
+			expectedSucceeded:     1,
+			expectedConditions: []batch.JobCondition{
+				{
+					Type:    batch.JobComplete,
+					Reason:  batch.JobReasonCompletionsReached,
+					Status:  v1.ConditionTrue,
+					Message: "Reached expected number of succeeded pods",
+				},
+			},
+		},
+		"indexed job succeeded and exceeded activeDeadlineSeconds": {
+			parallelism:           2,
+			completions:           2,
+			activeDeadlineSeconds: 10,
+			startTime:             15,
+			succeededPods:         2,
+			expectedSucceeded:     2,
+			expectedConditions: []batch.JobCondition{
+				{
+					Type:    batch.JobComplete,
+					Reason:  batch.JobReasonCompletionsReached,
+					Status:  v1.ConditionTrue,
+					Message: "Reached expected number of succeeded pods",
+				},
+			},
+		},
+		"elasticIndexed job is scaled down and exceeded activeDeadlineSeconds; the number of succeeded pods already reached the completions": {
+			parallelism:           1,
+			completions:           1,
+			activeDeadlineSeconds: 10,
+			startTime:             15,
+			succeededPods:         1,
+			activePods:            2,
+			expectedFailed:        2,
+			expectedSucceeded:     1,
+			expectedDeletions:     2,
+			expectedConditions: []batch.JobCondition{
+				{
+					Type:    batch.JobComplete,
+					Reason:  batch.JobReasonCompletionsReached,
+					Status:  v1.ConditionTrue,
+					Message: "Reached expected number of succeeded pods",
+				},
+			},
+		},
 	}
 
 	for name, tc := range testCases {
@@ -4936,7 +4986,6 @@ func TestSyncJobWithJobSuccessPolicy(t *testing.T) {
 				Succeeded:               1,
 				Terminating:             ptr.To[int32](0),
 				CompletedIndexes:        "1",
-				FailedIndexes:           ptr.To("0"),
 				UncountedTerminatedPods: &batch.UncountedTerminatedPods{},
 				Conditions: []batch.JobCondition{
 					{
@@ -5269,7 +5318,6 @@ func TestSyncJobWithJobBackoffLimitPerIndex(t *testing.T) {
 				Succeeded:               2,
 				Terminating:             ptr.To[int32](0),
 				CompletedIndexes:        "0,1",
-				FailedIndexes:           ptr.To(""),
 				UncountedTerminatedPods: &batch.UncountedTerminatedPods{},
 				Conditions: []batch.JobCondition{
 					{

--- a/test/e2e/apps/job.go
+++ b/test/e2e/apps/job.go
@@ -475,7 +475,7 @@ done`}
 		once all indexes succeeded.
 	*/
 	ginkgo.It("with successPolicy should succeeded when all indexes succeeded", func(ctx context.Context) {
-		parallelism := int32(2)
+		parallelism := int32(1)
 		completions := int32(2)
 		backoffLimit := int32(6) // default value
 
@@ -484,7 +484,7 @@ done`}
 		job.Spec.CompletionMode = ptr.To(batchv1.IndexedCompletion)
 		job.Spec.SuccessPolicy = &batchv1.SuccessPolicy{
 			Rules: []batchv1.SuccessPolicyRule{{
-				SucceededCount: ptr.To[int32](2),
+				SucceededCount: ptr.To[int32](1),
 			}},
 		}
 		job, err := e2ejob.CreateJob(ctx, f.ClientSet, f.Namespace.Name, job)
@@ -495,7 +495,7 @@ done`}
 		framework.ExpectNoError(err, "failed to ensure that job has SuccessCriteriaMet with SuccessPolicy reason condition")
 
 		ginkgo.By("Ensure that the job reaches completions")
-		err = e2ejob.WaitForJobComplete(ctx, f.ClientSet, f.Namespace.Name, job.Name, ptr.To(batchv1.JobReasonSuccessPolicy), completions)
+		err = e2ejob.WaitForJobComplete(ctx, f.ClientSet, f.Namespace.Name, job.Name, ptr.To(batchv1.JobReasonSuccessPolicy), 1)
 		framework.ExpectNoError(err, "failed to ensure that job completed")
 
 		ginkgo.By("Verifying that the job status to ensure correct final state")

--- a/test/integration/job/job_test.go
+++ b/test/integration/job/job_test.go
@@ -527,7 +527,7 @@ func TestSuccessPolicy(t *testing.T) {
 			job: batchv1.Job{
 				Spec: batchv1.JobSpec{
 					Parallelism:    ptr.To[int32](1),
-					Completions:    ptr.To[int32](1),
+					Completions:    ptr.To[int32](2),
 					CompletionMode: completionModePtr(batchv1.IndexedCompletion),
 					Template:       podTemplateSpec,
 					SuccessPolicy: &batchv1.SuccessPolicy{
@@ -1164,7 +1164,7 @@ func TestBackoffLimitPerIndex_JobPodsCreatedWithExponentialBackoff(t *testing.T)
 		Ready:       ptr.To[int32](0),
 		Terminating: ptr.To[int32](0),
 	})
-	validateIndexedJobPods(ctx, t, clientSet, jobObj, sets.New[int](), "0,1", ptr.To(""))
+	validateIndexedJobPods(ctx, t, clientSet, jobObj, sets.New[int](), "0,1", nil)
 	validateJobComplete(ctx, t, clientSet, jobObj)
 
 	for index := 0; index < int(*jobObj.Spec.Completions); index++ {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
As we discussed in https://github.com/kubernetes/kubernetes/pull/121863#pullrequestreview-1923490286, I revised the failure and successful rules evaluation orders in the following so that we can fix the weird terminal phase in the case of reaching both failure and complete rules as reported in https://github.com/kubernetes/kubernetes/issues/117303:

- Previously:

1. Check if the Job already has FailureTraget and SuccessCriteriaMet conditions.
2. Check if the Job has reached failure rules like backoffLimit, activeDeadlineSeconds, backoffLimitPerIndex, and so on.
3. Check if the Job has reached success policies (.spec.successPolicy).
4. Check if the Job has reached Complete rules, which means the controller checks if recorded succeeded Pods reached the desired Completions (.spec.completions). 

- Since This PR:
1. Check if the Job already has FailureTraget and SuccessCriteriaMet conditions.
2. Check if the Job has reached Complete rules, which means the controller checks if recorded succeeded Pods reached the desired Completions (.spec.completions). 
3. Check if the Job has reached failure rules like backoffLimit, activeDeadlineSeconds, backoffLimitPerIndex, and so on.
4. Check if the Job has reached success policies (.spec.successPolicy).

For visibility, the below are differences between the previous and this PR:

```diff
 1. Check if the Job already has FailureTraget and SuccessCriteriaMet conditions.
-2. Check if the Job has reached failure rules like backoffLimit, activeDeadlineSeconds, backoffLimitPerIndex, and so on.
-3. Check if the Job has reached success policies (.spec.successPolicy).
-4. Check if the Job has reached Complete rules, which means the controller checks if recorded succeeded Pods reached the desired Completions (.spec.completions). 
+2. Check if the Job has reached Complete rules, which means the controller checks if recorded succeeded Pods reached the desired Completions (.spec.completions). 
+3. Check if the Job has reached failure rules like backoffLimit, activeDeadlineSeconds, backoffLimitPerIndex, and so on.
+4. Check if the Job has reached success policies (.spec.successPolicy).
```

By these changes, we respect the complete rule (.spec.complete) rather than failure rules. 
So, when the Job reaches both complete and failure rules at the same time, the completion is respected, and the failures are not recorded in the conditions. 
But, as we decided in https://github.com/kubernetes/enhancements/tree/master/keps/sig-apps/3998-job-success-completion-policy#the-situations-where-successpolicy-conflicts-other-terminating-policies, the successPolicy keeps to be evaluated in the final phase, and the terminal rules like complete (.spec.completions) and failure rules are evaluated, first.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #117303

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix a bug in which the complete condition isn't recorded in jobs when the job reaches failure rules like activeDeadlineSeconds.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
