### PR TITLE
Check cluster domain availability before using it

### DIFF
--- a/test/e2e_node/pod_hostnamefqdn_test.go
+++ b/test/e2e_node/pod_hostnamefqdn_test.go
@@ -119,7 +119,10 @@ var _ = SIGDescribe("Hostname of Pod", framework.WithNodeConformance(), func() {
 		// Set PodSpec subdomain field to generate FQDN for pod
 		pod.Spec.Subdomain = subdomain
 		// Expected Pod FQDN
-		hostFQDN := fmt.Sprintf("%s.%s.%s.svc.%s", pod.ObjectMeta.Name, subdomain, f.Namespace.Name, framework.TestContext.ClusterDNSDomain)
+		hostFQDN := fmt.Sprintf("%s.%s.%s.svc", pod.ObjectMeta.Name, subdomain, f.Namespace.Name)
+		if framework.TestContext.ClusterDNSDomain != "" {
+			hostFQDN += fmt.Sprintf(".%s", framework.TestContext.ClusterDNSDomain)
+		}
 		output := []string{fmt.Sprintf("%s;%s;", pod.ObjectMeta.Name, hostFQDN)}
 		// Create Pod
 		e2eoutput.TestContainerOutput(ctx, f, "shortname and fqdn", pod, 0, output)
@@ -141,7 +144,10 @@ var _ = SIGDescribe("Hostname of Pod", framework.WithNodeConformance(), func() {
 		setHostnameAsFQDN := true
 		pod.Spec.SetHostnameAsFQDN = &setHostnameAsFQDN
 		// Expected Pod FQDN
-		hostFQDN := fmt.Sprintf("%s.%s.%s.svc.%s", pod.ObjectMeta.Name, subdomain, f.Namespace.Name, framework.TestContext.ClusterDNSDomain)
+		hostFQDN := fmt.Sprintf("%s.%s.%s.svc", pod.ObjectMeta.Name, subdomain, f.Namespace.Name)
+		if framework.TestContext.ClusterDNSDomain != "" {
+			hostFQDN += fmt.Sprintf(".%s", framework.TestContext.ClusterDNSDomain)
+		}
 		// Fail if FQDN is longer than 64 characters, otherwise the Pod will remain pending until test timeout.
 		// In Linux, 64 characters is the limit of the hostname kernel field, which this test sets to the pod FQDN.
 		gomega.Expect(len(hostFQDN)).Should(gomega.BeNumerically("<=", 64), "The FQDN of the Pod cannot be longer than 64 characters, requested %s which is %d characters long.", hostFQDN, len(hostFQDN))


### PR DESCRIPTION

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
Approach to test a fix for https://github.com/kubernetes/kubernetes/issues/121868
#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/kubernetes/issues/121868

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
TBD
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
