### PR TITLE
Log the actual host path volume mount type

### DIFF
--- a/pkg/volume/hostpath/host_path.go
+++ b/pkg/volume/hostpath/host_path.go
@@ -383,6 +383,7 @@ type hostPathTypeChecker interface {
 	IsChar() bool
 	IsSocket() bool
 	GetPath() string
+	GetType() (string, error)
 }
 
 type fileTypeChecker struct {
@@ -395,15 +396,20 @@ func (ftc *fileTypeChecker) Exists() bool {
 	return exists && err == nil
 }
 
+func (ftc *fileTypeChecker) GetType() (string, error) {
+	pathType, err := ftc.hu.GetFileType(ftc.path)
+	return string(pathType), err
+}
+
 func (ftc *fileTypeChecker) IsFile() bool {
 	if !ftc.Exists() {
 		return false
 	}
-	pathType, err := ftc.hu.GetFileType(ftc.path)
+	pathType, err := ftc.GetType()
 	if err != nil {
 		return false
 	}
-	return string(pathType) == string(v1.HostPathFile)
+	return pathType == string(v1.HostPathFile)
 }
 
 func (ftc *fileTypeChecker) MakeFile() error {
@@ -414,11 +420,11 @@ func (ftc *fileTypeChecker) IsDir() bool {
 	if !ftc.Exists() {
 		return false
 	}
-	pathType, err := ftc.hu.GetFileType(ftc.path)
+	pathType, err := ftc.GetType()
 	if err != nil {
 		return false
 	}
-	return string(pathType) == string(v1.HostPathDirectory)
+	return pathType == string(v1.HostPathDirectory)
 }
 
 func (ftc *fileTypeChecker) MakeDir() error {
@@ -426,27 +432,27 @@ func (ftc *fileTypeChecker) MakeDir() error {
 }
 
 func (ftc *fileTypeChecker) IsBlock() bool {
-	blkDevType, err := ftc.hu.GetFileType(ftc.path)
+	blkDevType, err := ftc.GetType()
 	if err != nil {
 		return false
 	}
-	return string(blkDevType) == string(v1.HostPathBlockDev)
+	return blkDevType == string(v1.HostPathBlockDev)
 }
 
 func (ftc *fileTypeChecker) IsChar() bool {
-	charDevType, err := ftc.hu.GetFileType(ftc.path)
+	charDevType, err := ftc.GetType()
 	if err != nil {
 		return false
 	}
-	return string(charDevType) == string(v1.HostPathCharDev)
+	return charDevType == string(v1.HostPathCharDev)
 }
 
 func (ftc *fileTypeChecker) IsSocket() bool {
-	socketType, err := ftc.hu.GetFileType(ftc.path)
+	socketType, err := ftc.GetType()
 	if err != nil {
 		return false
 	}
-	return string(socketType) == string(v1.HostPathSocket)
+	return socketType == string(v1.HostPathSocket)
 }
 
 func (ftc *fileTypeChecker) GetPath() string {
@@ -462,6 +468,17 @@ func checkType(path string, pathType *v1.HostPathType, hu hostutil.HostUtils) er
 	return checkTypeInternal(newFileTypeChecker(path, hu), pathType)
 }
 
+func typeMatchedOrError(ftc hostPathTypeChecker, match func() bool, expected string) error {
+	if !match() {
+		pathType, err := ftc.GetType()
+		if err != nil {
+			return fmt.Errorf("hostPath type check failed, %s is not a %s, unable to determine its type: %w", ftc.GetPath(), expected, err)
+		}
+		return fmt.Errorf("hostPath type check failed: %s is not a %s, it's a %s", ftc.GetPath(), expected, pathType)
+	}
+	return nil
+}
+
 func checkTypeInternal(ftc hostPathTypeChecker, pathType *v1.HostPathType) error {
 	switch *pathType {
 	case v1.HostPathDirectoryOrCreate:
@@ -470,35 +487,23 @@ func checkTypeInternal(ftc hostPathTypeChecker, pathType *v1.HostPathType) error
 		}
 		fallthrough
 	case v1.HostPathDirectory:
-		if !ftc.IsDir() {
-			return fmt.Errorf("hostPath type check failed: %s is not a directory", ftc.GetPath())
-		}
+		return typeMatchedOrError(ftc, ftc.IsDir, "directory")
 	case v1.HostPathFileOrCreate:
 		if !ftc.Exists() {
 			return ftc.MakeFile()
 		}
 		fallthrough
 	case v1.HostPathFile:
-		if !ftc.IsFile() {
-			return fmt.Errorf("hostPath type check failed: %s is not a file", ftc.GetPath())
-		}
+		return typeMatchedOrError(ftc, ftc.IsFile, "file")
 	case v1.HostPathSocket:
-		if !ftc.IsSocket() {
-			return fmt.Errorf("hostPath type check failed: %s is not a socket file", ftc.GetPath())
-		}
+		return typeMatchedOrError(ftc, ftc.IsSocket, "socket file")
 	case v1.HostPathCharDev:
-		if !ftc.IsChar() {
-			return fmt.Errorf("hostPath type check failed: %s is not a character device", ftc.GetPath())
-		}
+		return typeMatchedOrError(ftc, ftc.IsChar, "character device")
 	case v1.HostPathBlockDev:
-		if !ftc.IsBlock() {
-			return fmt.Errorf("hostPath type check failed: %s is not a block device", ftc.GetPath())
-		}
+		return typeMatchedOrError(ftc, ftc.IsBlock, "block device")
 	default:
 		return fmt.Errorf("%s is an invalid volume type", *pathType)
 	}
-
-	return nil
 }
 
 // makeDir creates a new directory.

--- a/pkg/volume/hostpath/host_path_test.go
+++ b/pkg/volume/hostpath/host_path_test.go
@@ -32,6 +32,7 @@ import (
 	volumetest "k8s.io/kubernetes/pkg/volume/testing"
 	"k8s.io/kubernetes/pkg/volume/util/hostutil"
 	utilpath "k8s.io/utils/path"
+	"k8s.io/utils/ptr"
 )
 
 func newHostPathType(pathType string) *v1.HostPathType {
@@ -503,6 +504,7 @@ func TestOSFileTypeChecker(t *testing.T) {
 type fakeHostPathTypeChecker struct {
 	name            string
 	path            string
+	pathType        *v1.HostPathType
 	exists          bool
 	isDir           bool
 	isFile          bool
@@ -513,21 +515,23 @@ type fakeHostPathTypeChecker struct {
 	invalidpathType []*v1.HostPathType
 }
 
-func (ftc *fakeHostPathTypeChecker) MakeFile() error { return nil }
-func (ftc *fakeHostPathTypeChecker) MakeDir() error  { return nil }
-func (ftc *fakeHostPathTypeChecker) Exists() bool    { return ftc.exists }
-func (ftc *fakeHostPathTypeChecker) IsFile() bool    { return ftc.isFile }
-func (ftc *fakeHostPathTypeChecker) IsDir() bool     { return ftc.isDir }
-func (ftc *fakeHostPathTypeChecker) IsBlock() bool   { return ftc.isBlock }
-func (ftc *fakeHostPathTypeChecker) IsChar() bool    { return ftc.isChar }
-func (ftc *fakeHostPathTypeChecker) IsSocket() bool  { return ftc.isSocket }
-func (ftc *fakeHostPathTypeChecker) GetPath() string { return ftc.path }
+func (ftc *fakeHostPathTypeChecker) MakeFile() error          { return nil }
+func (ftc *fakeHostPathTypeChecker) MakeDir() error           { return nil }
+func (ftc *fakeHostPathTypeChecker) Exists() bool             { return ftc.exists }
+func (ftc *fakeHostPathTypeChecker) IsFile() bool             { return ftc.isFile }
+func (ftc *fakeHostPathTypeChecker) IsDir() bool              { return ftc.isDir }
+func (ftc *fakeHostPathTypeChecker) IsBlock() bool            { return ftc.isBlock }
+func (ftc *fakeHostPathTypeChecker) IsChar() bool             { return ftc.isChar }
+func (ftc *fakeHostPathTypeChecker) IsSocket() bool           { return ftc.isSocket }
+func (ftc *fakeHostPathTypeChecker) GetPath() string          { return ftc.path }
+func (ftc *fakeHostPathTypeChecker) GetType() (string, error) { return string(*ftc.pathType), nil }
 
 func TestHostPathTypeCheckerInternal(t *testing.T) {
 	testCases := []fakeHostPathTypeChecker{
 		{
 			name:          "Existing Folder",
 			path:          "/existingFolder",
+			pathType:      ptr.To(v1.HostPathDirectory),
 			isDir:         true,
 			exists:        true,
 			validpathType: newHostPathTypeList(string(v1.HostPathDirectoryOrCreate), string(v1.HostPathDirectory)),
@@ -537,6 +541,7 @@ func TestHostPathTypeCheckerInternal(t *testing.T) {
 		{
 			name:          "New Folder",
 			path:          "/newFolder",
+			pathType:      ptr.To(v1.HostPathDirectory),
 			isDir:         false,
 			exists:        false,
 			validpathType: newHostPathTypeList(string(v1.HostPathDirectoryOrCreate)),
@@ -546,6 +551,7 @@ func TestHostPathTypeCheckerInternal(t *testing.T) {
 		{
 			name:          "Existing File",
 			path:          "/existingFile",
+			pathType:      ptr.To(v1.HostPathFile),
 			isFile:        true,
 			exists:        true,
 			validpathType: newHostPathTypeList(string(v1.HostPathFileOrCreate), string(v1.HostPathFile)),
@@ -555,6 +561,7 @@ func TestHostPathTypeCheckerInternal(t *testing.T) {
 		{
 			name:          "New File",
 			path:          "/newFile",
+			pathType:      ptr.To(v1.HostPathFile),
 			isFile:        false,
 			exists:        false,
 			validpathType: newHostPathTypeList(string(v1.HostPathFileOrCreate)),
@@ -564,6 +571,7 @@ func TestHostPathTypeCheckerInternal(t *testing.T) {
 		{
 			name:          "Existing Socket",
 			path:          "/existing.socket",
+			pathType:      ptr.To(v1.HostPathSocket),
 			isSocket:      true,
 			isFile:        true,
 			exists:        true,
@@ -574,6 +582,7 @@ func TestHostPathTypeCheckerInternal(t *testing.T) {
 		{
 			name:          "Existing Character Device",
 			path:          "/existing.char",
+			pathType:      ptr.To(v1.HostPathCharDev),
 			isChar:        true,
 			isFile:        true,
 			exists:        true,
@@ -584,6 +593,7 @@ func TestHostPathTypeCheckerInternal(t *testing.T) {
 		{
 			name:          "Existing Block Device",
 			path:          "/existing.block",
+			pathType:      ptr.To(v1.HostPathBlockDev),
 			isBlock:       true,
 			isFile:        true,
 			exists:        true,


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

When a volume mount fails because the host path type doesn't match the expected type, log the actual type; this is useful when debugging volume mount issues.

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Volume mount host path type mismatches log the actual path type along with the expected path type.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
