### PR TITLE
[WIP][POC]: prove type aliases for features

### DIFF
--- a/cmd/kube-controller-manager/app/config/config.go
+++ b/cmd/kube-controller-manager/app/config/config.go
@@ -21,6 +21,7 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/internal/feature"
 	kubectrlmgrconfig "k8s.io/kubernetes/pkg/controller/apis/config"
 )
 
@@ -43,6 +44,8 @@ type Config struct {
 
 	EventBroadcaster record.EventBroadcaster
 	EventRecorder    record.EventRecorder
+
+	dummyFeature feature.Feature
 }
 
 type completedConfig struct {

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@
 
 module k8s.io/kubernetes
 
-go 1.21
+go 1.21.4
 
 require (
 	bitbucket.org/bertimus9/systemstat v0.5.0
@@ -241,6 +241,7 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
+	k8s.io/internal v0.0.0 // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.28.0 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/kustomize/api v0.13.5-0.20230601165947-6ce0bf390ce3 // indirect
@@ -265,6 +266,7 @@ replace (
 	k8s.io/csi-translation-lib => ./staging/src/k8s.io/csi-translation-lib
 	k8s.io/dynamic-resource-allocation => ./staging/src/k8s.io/dynamic-resource-allocation
 	k8s.io/endpointslice => ./staging/src/k8s.io/endpointslice
+	k8s.io/internal => ./staging/src/k8s.io/internal
 	k8s.io/kms => ./staging/src/k8s.io/kms
 	k8s.io/kube-aggregator => ./staging/src/k8s.io/kube-aggregator
 	k8s.io/kube-controller-manager => ./staging/src/k8s.io/kube-controller-manager

--- a/go.mod
+++ b/go.mod
@@ -111,6 +111,7 @@ require (
 	k8s.io/dynamic-resource-allocation v0.0.0
 	k8s.io/endpointslice v0.0.0
 	k8s.io/gengo v0.0.0-20230829151522-9cce18d56c01
+	k8s.io/internal v0.0.0
 	k8s.io/klog/v2 v2.110.1
 	k8s.io/kms v0.0.0
 	k8s.io/kube-aggregator v0.0.0
@@ -241,7 +242,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
-	k8s.io/internal v0.0.0 // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.28.0 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/kustomize/api v0.13.5-0.20230601165947-6ce0bf390ce3 // indirect

--- a/staging/src/k8s.io/api/go.mod
+++ b/staging/src/k8s.io/api/go.mod
@@ -2,7 +2,7 @@
 
 module k8s.io/api
 
-go 1.21
+go 1.21.4
 
 require (
 	github.com/gogo/protobuf v1.3.2

--- a/staging/src/k8s.io/apiextensions-apiserver/go.mod
+++ b/staging/src/k8s.io/apiextensions-apiserver/go.mod
@@ -2,7 +2,7 @@
 
 module k8s.io/apiextensions-apiserver
 
-go 1.21
+go 1.21.4
 
 require (
 	github.com/emicklei/go-restful/v3 v3.11.0
@@ -123,6 +123,7 @@ require (
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/gengo v0.0.0-20230829151522-9cce18d56c01 // indirect
+	k8s.io/internal v0.0.0 // indirect
 	k8s.io/kms v0.0.0 // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.28.0 // indirect
 )
@@ -135,5 +136,6 @@ replace (
 	k8s.io/client-go => ../client-go
 	k8s.io/code-generator => ../code-generator
 	k8s.io/component-base => ../component-base
+	k8s.io/internal => ../internal
 	k8s.io/kms => ../kms
 )

--- a/staging/src/k8s.io/apimachinery/go.mod
+++ b/staging/src/k8s.io/apimachinery/go.mod
@@ -2,7 +2,7 @@
 
 module k8s.io/apimachinery
 
-go 1.21
+go 1.21.4
 
 require (
 	github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5

--- a/staging/src/k8s.io/apiserver/go.mod
+++ b/staging/src/k8s.io/apiserver/go.mod
@@ -2,7 +2,7 @@
 
 module k8s.io/apiserver
 
-go 1.21
+go 1.21.4
 
 require (
 	github.com/coreos/go-oidc v2.2.1+incompatible
@@ -123,6 +123,7 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+	k8s.io/internal v0.0.0 // indirect
 )
 
 replace (
@@ -131,5 +132,6 @@ replace (
 	k8s.io/apiserver => ../apiserver
 	k8s.io/client-go => ../client-go
 	k8s.io/component-base => ../component-base
+	k8s.io/internal => ../internal
 	k8s.io/kms => ../kms
 )

--- a/staging/src/k8s.io/cli-runtime/go.mod
+++ b/staging/src/k8s.io/cli-runtime/go.mod
@@ -2,7 +2,7 @@
 
 module k8s.io/cli-runtime
 
-go 1.21
+go 1.21.4
 
 require (
 	github.com/evanphx/json-patch v4.12.0+incompatible
@@ -75,4 +75,5 @@ replace (
 	k8s.io/apimachinery => ../apimachinery
 	k8s.io/cli-runtime => ../cli-runtime
 	k8s.io/client-go => ../client-go
+	k8s.io/internal => ../internal
 )

--- a/staging/src/k8s.io/client-go/features/kube_features.go
+++ b/staging/src/k8s.io/client-go/features/kube_features.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package features
+
+import (
+	"k8s.io/internal/feature"
+)
+
+const (
+	// Every feature gate should add method here following this template:
+	//
+	// // owner: @username
+	// // alpha: v1.4
+	// MyFeature featuregate.Feature = "MyFeature"
+	//
+	// Feature gates should be listed in alphabetical, case-sensitive
+	// (upper before any lower case character) order. This reduces the risk
+	// of code conflicts because changes are more likely to be scattered
+	// across the file.
+
+	// owner: @p0lyn0mial
+	// alpha: v1.27
+	// beta: v1.29
+	//
+	// Allow the API server to stream individual items instead of chunking
+	WatchList feature.Feature = "WatchListClient"
+)
+
+// AddFeaturesToExistingFeatureGates adds the default feature gates to the provided set.
+// Usually this function is combined with SetFeatureGates to take control of the
+// features exposed by this library.
+func AddFeaturesToExistingFeatureGates(mutableFeatureGates feature.MutableFeatureGate) error {
+	return mutableFeatureGates.Add(defaultKubernetesFeatureGates)
+}
+
+// defaultKubernetesFeatureGates consists of all known Kubernetes-specific feature keys.
+//
+// To add a new feature, define a key for it above and add it here. The features will be
+// available throughout Kubernetes binaries.
+var defaultKubernetesFeatureGates = map[feature.Feature]feature.FeatureSpec{
+	WatchList: {Default: false, PreRelease: feature.Beta},
+}

--- a/staging/src/k8s.io/client-go/go.mod
+++ b/staging/src/k8s.io/client-go/go.mod
@@ -2,7 +2,7 @@
 
 module k8s.io/client-go
 
-go 1.21
+go 1.21.4
 
 require (
 	github.com/evanphx/json-patch v4.12.0+incompatible
@@ -26,6 +26,7 @@ require (
 	google.golang.org/protobuf v1.31.0
 	k8s.io/api v0.0.0
 	k8s.io/apimachinery v0.0.0
+	k8s.io/internal v0.0.0
 	k8s.io/klog/v2 v2.110.1
 	k8s.io/kube-openapi v0.0.0-20231010175941-2dd684a91f00
 	k8s.io/utils v0.0.0-20230726121419-3b25d923346b
@@ -64,4 +65,5 @@ replace (
 	k8s.io/api => ../api
 	k8s.io/apimachinery => ../apimachinery
 	k8s.io/client-go => ../client-go
+	k8s.io/internal => ../internal
 )

--- a/staging/src/k8s.io/cloud-provider/go.mod
+++ b/staging/src/k8s.io/cloud-provider/go.mod
@@ -2,7 +2,7 @@
 
 module k8s.io/cloud-provider
 
-go 1.21
+go 1.21.4
 
 require (
 	github.com/google/go-cmp v0.6.0
@@ -102,6 +102,7 @@ require (
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+	k8s.io/internal v0.0.0 // indirect
 	k8s.io/kms v0.0.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20231010175941-2dd684a91f00 // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.28.0 // indirect
@@ -119,5 +120,6 @@ replace (
 	k8s.io/component-base => ../component-base
 	k8s.io/component-helpers => ../component-helpers
 	k8s.io/controller-manager => ../controller-manager
+	k8s.io/internal => ../internal
 	k8s.io/kms => ../kms
 )

--- a/staging/src/k8s.io/cluster-bootstrap/go.mod
+++ b/staging/src/k8s.io/cluster-bootstrap/go.mod
@@ -2,7 +2,7 @@
 
 module k8s.io/cluster-bootstrap
 
-go 1.21
+go 1.21.4
 
 require (
 	github.com/stretchr/testify v1.8.4

--- a/staging/src/k8s.io/code-generator/examples/go.mod
+++ b/staging/src/k8s.io/code-generator/examples/go.mod
@@ -2,7 +2,7 @@
 
 module k8s.io/code-generator/examples
 
-go 1.21
+go 1.21.4
 
 require (
 	k8s.io/api v0.0.0

--- a/staging/src/k8s.io/code-generator/go.mod
+++ b/staging/src/k8s.io/code-generator/go.mod
@@ -2,7 +2,7 @@
 
 module k8s.io/code-generator
 
-go 1.21
+go 1.21.4
 
 require (
 	github.com/gogo/protobuf v1.3.2

--- a/staging/src/k8s.io/component-base/featuregate/feature_gate.go
+++ b/staging/src/k8s.io/component-base/featuregate/feature_gate.go
@@ -29,10 +29,11 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/naming"
 	featuremetrics "k8s.io/component-base/metrics/prometheus/feature"
+	"k8s.io/internal/feature"
 	"k8s.io/klog/v2"
 )
 
-type Feature string
+type Feature = feature.Feature
 
 const (
 	flagName = "feature-gates"
@@ -64,58 +65,24 @@ var (
 	}
 )
 
-type FeatureSpec struct {
-	// Default is the default enablement state for the feature
-	Default bool
-	// LockToDefault indicates that the feature is locked to its default and cannot be changed
-	LockToDefault bool
-	// PreRelease indicates the maturity level of the feature
-	PreRelease prerelease
-}
-
-type prerelease string
+type FeatureSpec = feature.FeatureSpec
 
 const (
 	// Values for PreRelease.
-	Alpha = prerelease("ALPHA")
-	Beta  = prerelease("BETA")
-	GA    = prerelease("")
+	Alpha = feature.Alpha
+	Beta  = feature.Beta
+	GA    = feature.GA
 
 	// Deprecated
-	Deprecated = prerelease("DEPRECATED")
+	Deprecated = feature.Deprecated
 )
 
 // FeatureGate indicates whether a given feature is enabled or not
-type FeatureGate interface {
-	// Enabled returns true if the key is enabled.
-	Enabled(key Feature) bool
-	// KnownFeatures returns a slice of strings describing the FeatureGate's known features.
-	KnownFeatures() []string
-	// DeepCopy returns a deep copy of the FeatureGate object, such that gates can be
-	// set on the copy without mutating the original. This is useful for validating
-	// config against potential feature gate changes before committing those changes.
-	DeepCopy() MutableFeatureGate
-}
+type FeatureGate = feature.FeatureGate
 
 // MutableFeatureGate parses and stores flag gates for known features from
 // a string like feature1=true,feature2=false,...
-type MutableFeatureGate interface {
-	FeatureGate
-
-	// AddFlag adds a flag for setting global feature gates to the specified FlagSet.
-	AddFlag(fs *pflag.FlagSet)
-	// Set parses and stores flag gates for known features
-	// from a string like feature1=true,feature2=false,...
-	Set(value string) error
-	// SetFromMap stores flag gates for known features from a map[string]bool or returns an error
-	SetFromMap(m map[string]bool) error
-	// Add adds features to the featureGate.
-	Add(features map[Feature]FeatureSpec) error
-	// GetAll returns a copy of the map of known feature names to feature specs.
-	GetAll() map[Feature]FeatureSpec
-	// AddMetrics adds feature enablement metrics
-	AddMetrics()
-}
+type MutableFeatureGate = feature.MutableFeatureGate
 
 // featureGate implements FeatureGate as well as pflag.Value for flag parsing.
 type featureGate struct {

--- a/staging/src/k8s.io/component-base/go.mod
+++ b/staging/src/k8s.io/component-base/go.mod
@@ -2,7 +2,7 @@
 
 module k8s.io/component-base
 
-go 1.21
+go 1.21.4
 
 require (
 	github.com/blang/semver/v4 v4.0.0
@@ -27,6 +27,7 @@ require (
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/apimachinery v0.0.0
 	k8s.io/client-go v0.0.0
+	k8s.io/internal v0.0.0
 	k8s.io/klog/v2 v2.110.1
 	k8s.io/utils v0.0.0-20230726121419-3b25d923346b
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd
@@ -87,4 +88,5 @@ replace (
 	k8s.io/apimachinery => ../apimachinery
 	k8s.io/client-go => ../client-go
 	k8s.io/component-base => ../component-base
+	k8s.io/internal => ../internal
 )

--- a/staging/src/k8s.io/component-helpers/go.mod
+++ b/staging/src/k8s.io/component-helpers/go.mod
@@ -2,7 +2,7 @@
 
 module k8s.io/component-helpers
 
-go 1.21
+go 1.21.4
 
 require (
 	github.com/google/go-cmp v0.6.0
@@ -57,4 +57,5 @@ replace (
 	k8s.io/apimachinery => ../apimachinery
 	k8s.io/client-go => ../client-go
 	k8s.io/component-helpers => ../component-helpers
+	k8s.io/internal => ../internal
 )

--- a/staging/src/k8s.io/controller-manager/go.mod
+++ b/staging/src/k8s.io/controller-manager/go.mod
@@ -2,7 +2,7 @@
 
 module k8s.io/controller-manager
 
-go 1.21
+go 1.21.4
 
 require (
 	github.com/spf13/pflag v1.0.5
@@ -96,6 +96,7 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+	k8s.io/internal v0.0.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20231010175941-2dd684a91f00 // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.28.0 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
@@ -110,5 +111,6 @@ replace (
 	k8s.io/client-go => ../client-go
 	k8s.io/component-base => ../component-base
 	k8s.io/controller-manager => ../controller-manager
+	k8s.io/internal => ../internal
 	k8s.io/kms => ../kms
 )

--- a/staging/src/k8s.io/cri-api/go.mod
+++ b/staging/src/k8s.io/cri-api/go.mod
@@ -2,7 +2,7 @@
 
 module k8s.io/cri-api
 
-go 1.21
+go 1.21.4
 
 require (
 	github.com/gogo/protobuf v1.3.2

--- a/staging/src/k8s.io/csi-translation-lib/go.mod
+++ b/staging/src/k8s.io/csi-translation-lib/go.mod
@@ -2,7 +2,7 @@
 
 module k8s.io/csi-translation-lib
 
-go 1.21
+go 1.21.4
 
 require (
 	github.com/stretchr/testify v1.8.4

--- a/staging/src/k8s.io/dynamic-resource-allocation/go.mod
+++ b/staging/src/k8s.io/dynamic-resource-allocation/go.mod
@@ -2,7 +2,7 @@
 
 module k8s.io/dynamic-resource-allocation
 
-go 1.21
+go 1.21.4
 
 require (
 	github.com/go-logr/logr v1.3.0
@@ -64,5 +64,6 @@ replace (
 	k8s.io/component-base => ../component-base
 	k8s.io/cri-api => ../cri-api
 	k8s.io/dynamic-resource-allocation => ../dynamic-resource-allocation
+	k8s.io/internal => ../internal
 	k8s.io/kubelet => ../kubelet
 )

--- a/staging/src/k8s.io/endpointslice/go.mod
+++ b/staging/src/k8s.io/endpointslice/go.mod
@@ -2,7 +2,7 @@
 
 module k8s.io/endpointslice
 
-go 1.21
+go 1.21.4
 
 require (
 	github.com/davecgh/go-spew v1.1.1
@@ -69,4 +69,5 @@ replace (
 	k8s.io/client-go => ../client-go
 	k8s.io/component-base => ../component-base
 	k8s.io/endpointslice => ../endpointslice
+	k8s.io/internal => ../internal
 )

--- a/staging/src/k8s.io/internal/feature/feature.go
+++ b/staging/src/k8s.io/internal/feature/feature.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package feature
+
+import (
+	"github.com/spf13/pflag"
+)
+
+type Feature string
+
+type FeatureSpec struct {
+	// Default is the default enablement state for the feature
+	Default bool
+	// LockToDefault indicates that the feature is locked to its default and cannot be changed
+	LockToDefault bool
+	// PreRelease indicates the maturity level of the feature
+	PreRelease prerelease
+}
+
+type prerelease string
+
+const (
+	// Values for PreRelease.
+	Alpha = prerelease("ALPHA")
+	Beta  = prerelease("BETA")
+	GA    = prerelease("")
+
+	// Deprecated
+	Deprecated = prerelease("DEPRECATED")
+)
+
+// FeatureGate indicates whether a given feature is enabled or not
+type FeatureGate interface {
+	// Enabled returns true if the key is enabled.
+	Enabled(key Feature) bool
+	// KnownFeatures returns a slice of strings describing the FeatureGate's known features.
+	KnownFeatures() []string
+	// DeepCopy returns a deep copy of the FeatureGate object, such that gates can be
+	// set on the copy without mutating the original. This is useful for validating
+	// config against potential feature gate changes before committing those changes.
+	DeepCopy() MutableFeatureGate
+}
+
+// MutableFeatureGate parses and stores flag gates for known features from
+// a string like feature1=true,feature2=false,...
+type MutableFeatureGate interface {
+	FeatureGate
+
+	// AddFlag adds a flag for setting global feature gates to the specified FlagSet.
+	AddFlag(fs *pflag.FlagSet)
+	// Set parses and stores flag gates for known features
+	// from a string like feature1=true,feature2=false,...
+	Set(value string) error
+	// SetFromMap stores flag gates for known features from a map[string]bool or returns an error
+	SetFromMap(m map[string]bool) error
+	// Add adds features to the featureGate.
+	Add(features map[Feature]FeatureSpec) error
+	// GetAll returns a copy of the map of known feature names to feature specs.
+	GetAll() map[Feature]FeatureSpec
+	// AddMetrics adds feature enablement metrics
+	AddMetrics()
+}

--- a/staging/src/k8s.io/internal/go.mod
+++ b/staging/src/k8s.io/internal/go.mod
@@ -1,5 +1,9 @@
-module k8s.io/kubernetes/staging/src/k8s.io/internal
+// This is a generated file. Do not edit directly.
 
-go 1.21.3
+module k8s.io/internal
+
+go 1.21.4
 
 require github.com/spf13/pflag v1.0.5
+
+replace k8s.io/internal => ../internal

--- a/staging/src/k8s.io/internal/go.mod
+++ b/staging/src/k8s.io/internal/go.mod
@@ -1,0 +1,5 @@
+module k8s.io/kubernetes/staging/src/k8s.io/internal
+
+go 1.21.3
+
+require github.com/spf13/pflag v1.0.5

--- a/staging/src/k8s.io/internal/go.sum
+++ b/staging/src/k8s.io/internal/go.sum
@@ -1,0 +1,2 @@
+github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
+github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=

--- a/staging/src/k8s.io/kms/go.mod
+++ b/staging/src/k8s.io/kms/go.mod
@@ -2,7 +2,7 @@
 
 module k8s.io/kms
 
-go 1.21
+go 1.21.4
 
 require (
 	github.com/gogo/protobuf v1.3.2

--- a/staging/src/k8s.io/kms/internal/plugins/_mock/go.mod
+++ b/staging/src/k8s.io/kms/internal/plugins/_mock/go.mod
@@ -1,6 +1,6 @@
 module k8s.io/kms/plugins/mock
 
-go 1.21
+go 1.21.4
 
 require (
 	github.com/ThalesIgnite/crypto11 v1.2.5

--- a/staging/src/k8s.io/kube-aggregator/go.mod
+++ b/staging/src/k8s.io/kube-aggregator/go.mod
@@ -2,7 +2,7 @@
 
 module k8s.io/kube-aggregator
 
-go 1.21
+go 1.21.4
 
 require (
 	github.com/emicklei/go-restful/v3 v3.11.0
@@ -106,6 +106,7 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/gengo v0.0.0-20230829151522-9cce18d56c01 // indirect
+	k8s.io/internal v0.0.0 // indirect
 	k8s.io/kms v0.0.0 // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.28.0 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
@@ -119,6 +120,7 @@ replace (
 	k8s.io/client-go => ../client-go
 	k8s.io/code-generator => ../code-generator
 	k8s.io/component-base => ../component-base
+	k8s.io/internal => ../internal
 	k8s.io/kms => ../kms
 	k8s.io/kube-aggregator => ../kube-aggregator
 )

--- a/staging/src/k8s.io/kube-controller-manager/go.mod
+++ b/staging/src/k8s.io/kube-controller-manager/go.mod
@@ -2,7 +2,7 @@
 
 module k8s.io/kube-controller-manager
 
-go 1.21
+go 1.21.4
 
 require (
 	k8s.io/apimachinery v0.0.0
@@ -39,6 +39,7 @@ replace (
 	k8s.io/component-base => ../component-base
 	k8s.io/component-helpers => ../component-helpers
 	k8s.io/controller-manager => ../controller-manager
+	k8s.io/internal => ../internal
 	k8s.io/kms => ../kms
 	k8s.io/kube-controller-manager => ../kube-controller-manager
 )

--- a/staging/src/k8s.io/kube-proxy/go.mod
+++ b/staging/src/k8s.io/kube-proxy/go.mod
@@ -2,7 +2,7 @@
 
 module k8s.io/kube-proxy
 
-go 1.21
+go 1.21.4
 
 require (
 	k8s.io/apimachinery v0.0.0
@@ -36,6 +36,7 @@ require (
 	google.golang.org/protobuf v1.31.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
+	k8s.io/internal v0.0.0 // indirect
 	k8s.io/klog/v2 v2.110.1 // indirect
 	k8s.io/utils v0.0.0-20230726121419-3b25d923346b // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
@@ -48,5 +49,6 @@ replace (
 	k8s.io/apimachinery => ../apimachinery
 	k8s.io/client-go => ../client-go
 	k8s.io/component-base => ../component-base
+	k8s.io/internal => ../internal
 	k8s.io/kube-proxy => ../kube-proxy
 )

--- a/staging/src/k8s.io/kube-scheduler/go.mod
+++ b/staging/src/k8s.io/kube-scheduler/go.mod
@@ -2,7 +2,7 @@
 
 module k8s.io/kube-scheduler
 
-go 1.21
+go 1.21.4
 
 require (
 	github.com/google/go-cmp v0.6.0
@@ -34,5 +34,6 @@ replace (
 	k8s.io/apimachinery => ../apimachinery
 	k8s.io/client-go => ../client-go
 	k8s.io/component-base => ../component-base
+	k8s.io/internal => ../internal
 	k8s.io/kube-scheduler => ../kube-scheduler
 )

--- a/staging/src/k8s.io/kubectl/go.mod
+++ b/staging/src/k8s.io/kubectl/go.mod
@@ -2,7 +2,7 @@
 
 module k8s.io/kubectl
 
-go 1.21
+go 1.21.4
 
 require (
 	github.com/MakeNowJust/heredoc v1.0.0
@@ -103,6 +103,7 @@ replace (
 	k8s.io/code-generator => ../code-generator
 	k8s.io/component-base => ../component-base
 	k8s.io/component-helpers => ../component-helpers
+	k8s.io/internal => ../internal
 	k8s.io/kubectl => ../kubectl
 	k8s.io/metrics => ../metrics
 )

--- a/staging/src/k8s.io/kubelet/go.mod
+++ b/staging/src/k8s.io/kubelet/go.mod
@@ -2,7 +2,7 @@
 
 module k8s.io/kubelet
 
-go 1.21
+go 1.21.4
 
 require (
 	github.com/emicklei/go-restful/v3 v3.11.0
@@ -55,6 +55,7 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+	k8s.io/internal v0.0.0 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
@@ -67,6 +68,7 @@ replace (
 	k8s.io/client-go => ../client-go
 	k8s.io/component-base => ../component-base
 	k8s.io/cri-api => ../cri-api
+	k8s.io/internal => ../internal
 	k8s.io/kms => ../kms
 	k8s.io/kubelet => ../kubelet
 )

--- a/staging/src/k8s.io/legacy-cloud-providers/go.mod
+++ b/staging/src/k8s.io/legacy-cloud-providers/go.mod
@@ -2,7 +2,7 @@
 
 module k8s.io/legacy-cloud-providers
 
-go 1.21
+go 1.21.4
 
 require (
 	cloud.google.com/go/compute/metadata v0.2.3
@@ -103,6 +103,7 @@ replace (
 	k8s.io/component-base => ../component-base
 	k8s.io/component-helpers => ../component-helpers
 	k8s.io/controller-manager => ../controller-manager
+	k8s.io/internal => ../internal
 	k8s.io/kms => ../kms
 	k8s.io/legacy-cloud-providers => ../legacy-cloud-providers
 )

--- a/staging/src/k8s.io/metrics/go.mod
+++ b/staging/src/k8s.io/metrics/go.mod
@@ -2,7 +2,7 @@
 
 module k8s.io/metrics
 
-go 1.21
+go 1.21.4
 
 require (
 	github.com/gogo/protobuf v1.3.2
@@ -62,5 +62,6 @@ replace (
 	k8s.io/apimachinery => ../apimachinery
 	k8s.io/client-go => ../client-go
 	k8s.io/code-generator => ../code-generator
+	k8s.io/internal => ../internal
 	k8s.io/metrics => ../metrics
 )

--- a/staging/src/k8s.io/mount-utils/go.mod
+++ b/staging/src/k8s.io/mount-utils/go.mod
@@ -2,7 +2,7 @@
 
 module k8s.io/mount-utils
 
-go 1.21
+go 1.21.4
 
 require (
 	github.com/moby/sys/mountinfo v0.6.2

--- a/staging/src/k8s.io/pod-security-admission/go.mod
+++ b/staging/src/k8s.io/pod-security-admission/go.mod
@@ -2,7 +2,7 @@
 
 module k8s.io/pod-security-admission
 
-go 1.21
+go 1.21.4
 
 require (
 	github.com/blang/semver/v4 v4.0.0
@@ -99,6 +99,7 @@ require (
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+	k8s.io/internal v0.0.0 // indirect
 	k8s.io/kms v0.0.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20231010175941-2dd684a91f00 // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.28.0 // indirect
@@ -112,6 +113,7 @@ replace (
 	k8s.io/apiserver => ../apiserver
 	k8s.io/client-go => ../client-go
 	k8s.io/component-base => ../component-base
+	k8s.io/internal => ../internal
 	k8s.io/kms => ../kms
 	k8s.io/pod-security-admission => ../pod-security-admission
 )

--- a/staging/src/k8s.io/sample-apiserver/go.mod
+++ b/staging/src/k8s.io/sample-apiserver/go.mod
@@ -2,7 +2,7 @@
 
 module k8s.io/sample-apiserver
 
-go 1.21
+go 1.21.4
 
 require (
 	github.com/google/gofuzz v1.2.0
@@ -100,6 +100,7 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/api v0.0.0 // indirect
 	k8s.io/gengo v0.0.0-20230829151522-9cce18d56c01 // indirect
+	k8s.io/internal v0.0.0 // indirect
 	k8s.io/klog/v2 v2.110.1 // indirect
 	k8s.io/kms v0.0.0 // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.28.0 // indirect
@@ -114,6 +115,7 @@ replace (
 	k8s.io/client-go => ../client-go
 	k8s.io/code-generator => ../code-generator
 	k8s.io/component-base => ../component-base
+	k8s.io/internal => ../internal
 	k8s.io/kms => ../kms
 	k8s.io/sample-apiserver => ../sample-apiserver
 )

--- a/staging/src/k8s.io/sample-cli-plugin/go.mod
+++ b/staging/src/k8s.io/sample-cli-plugin/go.mod
@@ -2,7 +2,7 @@
 
 module k8s.io/sample-cli-plugin
 
-go 1.21
+go 1.21.4
 
 require (
 	github.com/spf13/cobra v1.7.0
@@ -73,5 +73,6 @@ replace (
 	k8s.io/apimachinery => ../apimachinery
 	k8s.io/cli-runtime => ../cli-runtime
 	k8s.io/client-go => ../client-go
+	k8s.io/internal => ../internal
 	k8s.io/sample-cli-plugin => ../sample-cli-plugin
 )

--- a/staging/src/k8s.io/sample-controller/go.mod
+++ b/staging/src/k8s.io/sample-controller/go.mod
@@ -2,7 +2,7 @@
 
 module k8s.io/sample-controller
 
-go 1.21
+go 1.21.4
 
 require (
 	golang.org/x/time v0.3.0
@@ -62,5 +62,6 @@ replace (
 	k8s.io/apimachinery => ../apimachinery
 	k8s.io/client-go => ../client-go
 	k8s.io/code-generator => ../code-generator
+	k8s.io/internal => ../internal
 	k8s.io/sample-controller => ../sample-controller
 )

--- a/vendor/k8s.io/internal
+++ b/vendor/k8s.io/internal
@@ -1,0 +1,1 @@
+../../staging/src/k8s.io/internal

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1268,7 +1268,7 @@ gopkg.in/yaml.v2
 ## explicit
 gopkg.in/yaml.v3
 # k8s.io/api v0.0.0 => ./staging/src/k8s.io/api
-## explicit; go 1.21
+## explicit; go 1.21.4
 k8s.io/api/admission/v1
 k8s.io/api/admission/v1beta1
 k8s.io/api/admissionregistration/v1
@@ -1325,7 +1325,7 @@ k8s.io/api/storage/v1
 k8s.io/api/storage/v1alpha1
 k8s.io/api/storage/v1beta1
 # k8s.io/apiextensions-apiserver v0.0.0 => ./staging/src/k8s.io/apiextensions-apiserver
-## explicit; go 1.21
+## explicit; go 1.21.4
 k8s.io/apiextensions-apiserver/pkg/apihelpers
 k8s.io/apiextensions-apiserver/pkg/apis/apiextensions
 k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/install
@@ -1375,7 +1375,7 @@ k8s.io/apiextensions-apiserver/pkg/registry/customresourcedefinition
 k8s.io/apiextensions-apiserver/test/integration
 k8s.io/apiextensions-apiserver/test/integration/fixtures
 # k8s.io/apimachinery v0.0.0 => ./staging/src/k8s.io/apimachinery
-## explicit; go 1.21
+## explicit; go 1.21.4
 k8s.io/apimachinery/pkg/api/apitesting
 k8s.io/apimachinery/pkg/api/apitesting/fuzzer
 k8s.io/apimachinery/pkg/api/apitesting/naming
@@ -1450,7 +1450,7 @@ k8s.io/apimachinery/third_party/forked/golang/json
 k8s.io/apimachinery/third_party/forked/golang/netutil
 k8s.io/apimachinery/third_party/forked/golang/reflect
 # k8s.io/apiserver v0.0.0 => ./staging/src/k8s.io/apiserver
-## explicit; go 1.21
+## explicit; go 1.21.4
 k8s.io/apiserver/pkg/admission
 k8s.io/apiserver/pkg/admission/cel
 k8s.io/apiserver/pkg/admission/configuration
@@ -1627,13 +1627,13 @@ k8s.io/apiserver/plugin/pkg/authenticator/token/oidc
 k8s.io/apiserver/plugin/pkg/authenticator/token/webhook
 k8s.io/apiserver/plugin/pkg/authorizer/webhook
 # k8s.io/cli-runtime v0.0.0 => ./staging/src/k8s.io/cli-runtime
-## explicit; go 1.21
+## explicit; go 1.21.4
 k8s.io/cli-runtime/pkg/genericclioptions
 k8s.io/cli-runtime/pkg/genericiooptions
 k8s.io/cli-runtime/pkg/printers
 k8s.io/cli-runtime/pkg/resource
 # k8s.io/client-go v0.0.0 => ./staging/src/k8s.io/client-go
-## explicit; go 1.21
+## explicit; go 1.21.4
 k8s.io/client-go/applyconfigurations
 k8s.io/client-go/applyconfigurations/admissionregistration/v1
 k8s.io/client-go/applyconfigurations/admissionregistration/v1alpha1
@@ -1979,7 +1979,7 @@ k8s.io/client-go/util/retry
 k8s.io/client-go/util/testing
 k8s.io/client-go/util/workqueue
 # k8s.io/cloud-provider v0.0.0 => ./staging/src/k8s.io/cloud-provider
-## explicit; go 1.21
+## explicit; go 1.21.4
 k8s.io/cloud-provider
 k8s.io/cloud-provider/api
 k8s.io/cloud-provider/app
@@ -2006,20 +2006,20 @@ k8s.io/cloud-provider/volume
 k8s.io/cloud-provider/volume/errors
 k8s.io/cloud-provider/volume/helpers
 # k8s.io/cluster-bootstrap v0.0.0 => ./staging/src/k8s.io/cluster-bootstrap
-## explicit; go 1.21
+## explicit; go 1.21.4
 k8s.io/cluster-bootstrap/token/api
 k8s.io/cluster-bootstrap/token/jws
 k8s.io/cluster-bootstrap/token/util
 k8s.io/cluster-bootstrap/util/secrets
 k8s.io/cluster-bootstrap/util/tokens
 # k8s.io/code-generator v0.0.0 => ./staging/src/k8s.io/code-generator
-## explicit; go 1.21
+## explicit; go 1.21.4
 k8s.io/code-generator/cmd/go-to-protobuf
 k8s.io/code-generator/cmd/go-to-protobuf/protobuf
 k8s.io/code-generator/cmd/go-to-protobuf/protoc-gen-gogo
 k8s.io/code-generator/third_party/forked/golang/reflect
 # k8s.io/component-base v0.0.0 => ./staging/src/k8s.io/component-base
-## explicit; go 1.21
+## explicit; go 1.21.4
 k8s.io/component-base/cli
 k8s.io/component-base/cli/flag
 k8s.io/component-base/cli/globalflag
@@ -2059,7 +2059,7 @@ k8s.io/component-base/tracing/api/v1
 k8s.io/component-base/version
 k8s.io/component-base/version/verflag
 # k8s.io/component-helpers v0.0.0 => ./staging/src/k8s.io/component-helpers
-## explicit; go 1.21
+## explicit; go 1.21.4
 k8s.io/component-helpers/apimachinery/lease
 k8s.io/component-helpers/apps/poddisruptionbudget
 k8s.io/component-helpers/auth/rbac/reconciliation
@@ -2073,7 +2073,7 @@ k8s.io/component-helpers/scheduling/corev1/nodeaffinity
 k8s.io/component-helpers/storage/ephemeral
 k8s.io/component-helpers/storage/volume
 # k8s.io/controller-manager v0.0.0 => ./staging/src/k8s.io/controller-manager
-## explicit; go 1.21
+## explicit; go 1.21.4
 k8s.io/controller-manager/app
 k8s.io/controller-manager/config
 k8s.io/controller-manager/config/v1
@@ -2090,23 +2090,23 @@ k8s.io/controller-manager/pkg/leadermigration
 k8s.io/controller-manager/pkg/leadermigration/config
 k8s.io/controller-manager/pkg/leadermigration/options
 # k8s.io/cri-api v0.0.0 => ./staging/src/k8s.io/cri-api
-## explicit; go 1.21
+## explicit; go 1.21.4
 k8s.io/cri-api/pkg/apis
 k8s.io/cri-api/pkg/apis/runtime/v1
 k8s.io/cri-api/pkg/apis/testing
 k8s.io/cri-api/pkg/errors
 # k8s.io/csi-translation-lib v0.0.0 => ./staging/src/k8s.io/csi-translation-lib
-## explicit; go 1.21
+## explicit; go 1.21.4
 k8s.io/csi-translation-lib
 k8s.io/csi-translation-lib/plugins
 # k8s.io/dynamic-resource-allocation v0.0.0 => ./staging/src/k8s.io/dynamic-resource-allocation
-## explicit; go 1.21
+## explicit; go 1.21.4
 k8s.io/dynamic-resource-allocation/controller
 k8s.io/dynamic-resource-allocation/kubeletplugin
 k8s.io/dynamic-resource-allocation/leaderelection
 k8s.io/dynamic-resource-allocation/resourceclaim
 # k8s.io/endpointslice v0.0.0 => ./staging/src/k8s.io/endpointslice
-## explicit; go 1.21
+## explicit; go 1.21.4
 k8s.io/endpointslice
 k8s.io/endpointslice/metrics
 k8s.io/endpointslice/topologycache
@@ -2123,6 +2123,9 @@ k8s.io/gengo/generator
 k8s.io/gengo/namer
 k8s.io/gengo/parser
 k8s.io/gengo/types
+# k8s.io/internal v0.0.0 => ./staging/src/k8s.io/internal
+## explicit; go 1.21.4
+k8s.io/internal/feature
 # k8s.io/klog/v2 v2.110.1
 ## explicit; go 1.13
 k8s.io/klog/v2
@@ -2138,13 +2141,13 @@ k8s.io/klog/v2/ktesting/init
 k8s.io/klog/v2/test
 k8s.io/klog/v2/textlogger
 # k8s.io/kms v0.0.0 => ./staging/src/k8s.io/kms
-## explicit; go 1.21
+## explicit; go 1.21.4
 k8s.io/kms/apis/v1beta1
 k8s.io/kms/apis/v2
 k8s.io/kms/pkg/service
 k8s.io/kms/pkg/util
 # k8s.io/kube-aggregator v0.0.0 => ./staging/src/k8s.io/kube-aggregator
-## explicit; go 1.21
+## explicit; go 1.21.4
 k8s.io/kube-aggregator/pkg/apis/apiregistration
 k8s.io/kube-aggregator/pkg/apis/apiregistration/install
 k8s.io/kube-aggregator/pkg/apis/apiregistration/v1
@@ -2175,7 +2178,7 @@ k8s.io/kube-aggregator/pkg/registry/apiservice
 k8s.io/kube-aggregator/pkg/registry/apiservice/etcd
 k8s.io/kube-aggregator/pkg/registry/apiservice/rest
 # k8s.io/kube-controller-manager v0.0.0 => ./staging/src/k8s.io/kube-controller-manager
-## explicit; go 1.21
+## explicit; go 1.21.4
 k8s.io/kube-controller-manager/config/v1alpha1
 # k8s.io/kube-openapi v0.0.0-20231010175941-2dd684a91f00
 ## explicit; go 1.19
@@ -2209,14 +2212,14 @@ k8s.io/kube-openapi/pkg/validation/strfmt
 k8s.io/kube-openapi/pkg/validation/strfmt/bson
 k8s.io/kube-openapi/pkg/validation/validate
 # k8s.io/kube-proxy v0.0.0 => ./staging/src/k8s.io/kube-proxy
-## explicit; go 1.21
+## explicit; go 1.21.4
 k8s.io/kube-proxy/config/v1alpha1
 # k8s.io/kube-scheduler v0.0.0 => ./staging/src/k8s.io/kube-scheduler
-## explicit; go 1.21
+## explicit; go 1.21.4
 k8s.io/kube-scheduler/config/v1
 k8s.io/kube-scheduler/extender/v1
 # k8s.io/kubectl v0.0.0 => ./staging/src/k8s.io/kubectl
-## explicit; go 1.21
+## explicit; go 1.21.4
 k8s.io/kubectl/pkg/apps
 k8s.io/kubectl/pkg/cmd
 k8s.io/kubectl/pkg/cmd/annotate
@@ -2300,7 +2303,7 @@ k8s.io/kubectl/pkg/util/templates
 k8s.io/kubectl/pkg/util/term
 k8s.io/kubectl/pkg/validation
 # k8s.io/kubelet v0.0.0 => ./staging/src/k8s.io/kubelet
-## explicit; go 1.21
+## explicit; go 1.21.4
 k8s.io/kubelet/config/v1
 k8s.io/kubelet/config/v1alpha1
 k8s.io/kubelet/config/v1beta1
@@ -2322,7 +2325,7 @@ k8s.io/kubelet/pkg/cri/streaming/portforward
 k8s.io/kubelet/pkg/cri/streaming/remotecommand
 k8s.io/kubelet/pkg/types
 # k8s.io/legacy-cloud-providers v0.0.0 => ./staging/src/k8s.io/legacy-cloud-providers
-## explicit; go 1.21
+## explicit; go 1.21.4
 k8s.io/legacy-cloud-providers/azure
 k8s.io/legacy-cloud-providers/azure/auth
 k8s.io/legacy-cloud-providers/azure/cache
@@ -2365,7 +2368,7 @@ k8s.io/legacy-cloud-providers/vsphere/testing
 k8s.io/legacy-cloud-providers/vsphere/vclib
 k8s.io/legacy-cloud-providers/vsphere/vclib/diskmanagers
 # k8s.io/metrics v0.0.0 => ./staging/src/k8s.io/metrics
-## explicit; go 1.21
+## explicit; go 1.21.4
 k8s.io/metrics/pkg/apis/custom_metrics
 k8s.io/metrics/pkg/apis/custom_metrics/v1beta1
 k8s.io/metrics/pkg/apis/custom_metrics/v1beta2
@@ -2387,10 +2390,10 @@ k8s.io/metrics/pkg/client/custom_metrics/scheme
 k8s.io/metrics/pkg/client/external_metrics
 k8s.io/metrics/pkg/client/external_metrics/fake
 # k8s.io/mount-utils v0.0.0 => ./staging/src/k8s.io/mount-utils
-## explicit; go 1.21
+## explicit; go 1.21.4
 k8s.io/mount-utils
 # k8s.io/pod-security-admission v0.0.0 => ./staging/src/k8s.io/pod-security-admission
-## explicit; go 1.21
+## explicit; go 1.21.4
 k8s.io/pod-security-admission/admission
 k8s.io/pod-security-admission/admission/api
 k8s.io/pod-security-admission/admission/api/load
@@ -2406,7 +2409,7 @@ k8s.io/pod-security-admission/metrics
 k8s.io/pod-security-admission/policy
 k8s.io/pod-security-admission/test
 # k8s.io/sample-apiserver v0.0.0 => ./staging/src/k8s.io/sample-apiserver
-## explicit; go 1.21
+## explicit; go 1.21.4
 k8s.io/sample-apiserver/pkg/admission/plugin/banflunder
 k8s.io/sample-apiserver/pkg/admission/wardleinitializer
 k8s.io/sample-apiserver/pkg/apis/wardle
@@ -2581,6 +2584,7 @@ sigs.k8s.io/yaml
 # k8s.io/csi-translation-lib => ./staging/src/k8s.io/csi-translation-lib
 # k8s.io/dynamic-resource-allocation => ./staging/src/k8s.io/dynamic-resource-allocation
 # k8s.io/endpointslice => ./staging/src/k8s.io/endpointslice
+# k8s.io/internal => ./staging/src/k8s.io/internal
 # k8s.io/kms => ./staging/src/k8s.io/kms
 # k8s.io/kube-aggregator => ./staging/src/k8s.io/kube-aggregator
 # k8s.io/kube-controller-manager => ./staging/src/k8s.io/kube-controller-manager


### PR DESCRIPTION
This PR demonstrates that type aliases function correctly. The key takeaway is to remember to update the import rules for a repository.

Additionally, it shows that there is no concept of an `internal module` in Go. Defining a package within a module named `internal` does not hide it.