### PR TITLE
Use value(name) in gcloud compute instance-groups managed list-instances

### DIFF
--- a/cluster/gce/upgrade.sh
+++ b/cluster/gce/upgrade.sh
@@ -406,7 +406,7 @@ function do-node-upgrade() {
     fi
     instances=()
     while IFS='' read -r line; do instances+=("$line"); done < <(gcloud compute instance-groups managed list-instances "${group}" \
-        --format='value(instance)' \
+        --format='value(name)' \
         --project="${PROJECT}" \
         --zone="${ZONE}" 2>&1) && list_instances_rc=$? || list_instances_rc=$?
     if [[ "${list_instances_rc}" != 0 ]]; then

--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -412,7 +412,7 @@ function detect-node-names() {
     for group in "${INSTANCE_GROUPS[@]}"; do
       kube::util::read-array NODE_NAMES < <(gcloud compute instance-groups managed list-instances \
         "${group}" --zone "${ZONE}" --project "${PROJECT}" \
-        --format='value(instance)')
+        --format='value(name)')
     done
   fi
   # Add heapster node name to the list too (if it exists).
@@ -425,7 +425,7 @@ function detect-node-names() {
     for group in "${WINDOWS_INSTANCE_GROUPS[@]}"; do
       kube::util::read-array WINDOWS_NODE_NAMES < <(gcloud compute instance-groups managed \
         list-instances "${group}" --zone "${ZONE}" --project "${PROJECT}" \
-        --format='value(instance)')
+        --format='value(name)')
     done
   fi
   export WINDOWS_NODE_NAMES


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
#### What this PR does / why we need it:

It looks like something has been changed in gcloud and "--value(instance)" no longer works. TBH I'm wondering why it ever worked given that instance is a string like "https://www.googleapis.com/compute/v1/projects/{PROJECT}/zones/{ZONE}/instances/{VM_INSTANCE}" and we interpret it as a name.

```
➜  test-infra git:(5a589886b1) gcloud-new compute instance-groups managed list-instances "gke-cluster-1-default-pool-1d172952-grp" --zone us-central1-c --project maciejborsz-gke-dev --format='value(instance)'
us-central1-c
us-central1-c
us-central1-c
➜  test-infra git:(5a589886b1) gcloud-old compute instance-groups managed list-instances "gke-cluster-1-default-pool-1d172952-grp" --zone us-central1-c --project maciejborsz-gke-dev --format='value(instance)'
gke-cluster-1-default-pool-1d172952-d3ek
gke-cluster-1-default-pool-1d172952-jw9a
gke-cluster-1-default-pool-1d172952-s3t8
```


`--value(name)` works both for gcloud-old and gcloud-new.


#### Which issue(s) this PR fixes:

detecting NODE_NAMEs as zones makes us trying to dump some non-existing instances and likely contributes to
https://github.com/kubernetes/kubernetes/issues/121320

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/assign @wojtek-t 