### PR TITLE
Add quota support for PVC with VolumeAttributesClass

### DIFF
--- a/pkg/quota/v1/evaluator/core/persistent_volume_claims.go
+++ b/pkg/quota/v1/evaluator/core/persistent_volume_claims.go
@@ -32,6 +32,7 @@ import (
 	api "k8s.io/kubernetes/pkg/apis/core"
 	k8s_api_v1 "k8s.io/kubernetes/pkg/apis/core/v1"
 	k8sfeatures "k8s.io/kubernetes/pkg/features"
+	"k8s.io/utils/ptr"
 )
 
 // the name used for object count quota
@@ -197,8 +198,9 @@ func (p *pvcEvaluator) Usage(item runtime.Object) (corev1.ResourceList, error) {
 		}
 	}
 
-	if utilfeature.DefaultFeatureGate.Enabled(k8sfeatures.VolumeAttributesClass) && pvc.Spec.VolumeAttributesClassName != nil {
-		volumeAttributesClassClaim := corev1.ResourceName(*pvc.Spec.VolumeAttributesClassName + volumeAttributesClassSuffix + string(corev1.ResourcePersistentVolumeClaims))
+	vacName := ptr.Deref(pvc.Spec.VolumeAttributesClassName, "")
+	if utilfeature.DefaultFeatureGate.Enabled(k8sfeatures.VolumeAttributesClass) && vacName != "" {
+		volumeAttributesClassClaim := corev1.ResourceName(vacName + volumeAttributesClassSuffix + string(corev1.ResourcePersistentVolumeClaims))
 		result[volumeAttributesClassClaim] = *(resource.NewQuantity(1, resource.DecimalSI))
 	}
 

--- a/pkg/quota/v1/evaluator/core/persistent_volume_claims.go
+++ b/pkg/quota/v1/evaluator/core/persistent_volume_claims.go
@@ -64,6 +64,24 @@ func V1ResourceByStorageClass(storageClass string, resourceName corev1.ResourceN
 	return corev1.ResourceName(string(storageClass + storageClassSuffix + string(resourceName)))
 }
 
+// pvcVACResources are the set of static resources managed by quota associated with pvcs.
+// for each resource in this list, it may be refined dynamically based on volume attributes class.
+var pvcVACResources = []corev1.ResourceName{
+	corev1.ResourcePersistentVolumeClaims,
+}
+
+// volumeAttributesClassSuffix is the suffix to the qualified portion of volume attributes class resource name.
+// For example, if you want to quota storage by a volume attributes class, you would have a declaration
+// that follows <volume-attributes-class>.volumeattributesclass.storage.k8s.io/<resource>.
+// For example:
+// * bronze.volumeattributesclass.storage.k8s.io/persistentvolumeclaims: "5"
+const volumeAttributesClassSuffix string = ".volumeattributesclass.storage.k8s.io/"
+
+// V1ResourceByVolumeAttributesClass returns a quota resource name by a volume attributes class.
+func V1ResourceByVolumeAttributesClass(vacName string, resourceName corev1.ResourceName) corev1.ResourceName {
+	return corev1.ResourceName(string(vacName + volumeAttributesClassSuffix + string(resourceName)))
+}
+
 // NewPersistentVolumeClaimEvaluator returns an evaluator that can evaluate persistent volume claims
 func NewPersistentVolumeClaimEvaluator(f quota.ListerForResourceFunc) quota.Evaluator {
 	listFuncByNamespace := generic.ListResourceUsingListerFunc(f, corev1.SchemeGroupVersion.WithResource("persistentvolumeclaims"))
@@ -126,7 +144,7 @@ func (p *pvcEvaluator) MatchingResources(items []corev1.ResourceName) []corev1.R
 			continue
 		}
 		// match pvc resources
-		if quota.Contains(pvcResources, item) {
+		if quota.Contains(pvcResources, item) || quota.Contains(pvcVACResources, item) {
 			result = append(result, item)
 			continue
 		}
@@ -136,6 +154,16 @@ func (p *pvcEvaluator) MatchingResources(items []corev1.ResourceName) []corev1.R
 			if strings.HasSuffix(string(item), byStorageClass) {
 				result = append(result, item)
 				break
+			}
+		}
+		// match pvc resources scoped by volume attributes class (<volume-attributes-class-name>.volumeattributesclass.storage.k8s.io/<resource>)
+		if utilfeature.DefaultFeatureGate.Enabled(k8sfeatures.VolumeAttributesClass) {
+			for _, resource := range pvcVACResources {
+				byVolumeAttributesClass := volumeAttributesClassSuffix + string(resource)
+				if strings.HasSuffix(string(item), byVolumeAttributesClass) {
+					result = append(result, item)
+					break
+				}
 			}
 		}
 	}
@@ -167,6 +195,11 @@ func (p *pvcEvaluator) Usage(item runtime.Object) (corev1.ResourceList, error) {
 			storageClassStorage := corev1.ResourceName(storageClassRef + storageClassSuffix + string(corev1.ResourceRequestsStorage))
 			result[storageClassStorage] = *requestedStorage
 		}
+	}
+
+	if utilfeature.DefaultFeatureGate.Enabled(k8sfeatures.VolumeAttributesClass) && pvc.Spec.VolumeAttributesClassName != nil {
+		volumeAttributesClassClaim := corev1.ResourceName(*pvc.Spec.VolumeAttributesClassName + volumeAttributesClassSuffix + string(corev1.ResourcePersistentVolumeClaims))
+		result[volumeAttributesClassClaim] = *(resource.NewQuantity(1, resource.DecimalSI))
 	}
 
 	return result, nil

--- a/pkg/quota/v1/evaluator/core/persistent_volume_claims_test.go
+++ b/pkg/quota/v1/evaluator/core/persistent_volume_claims_test.go
@@ -87,11 +87,15 @@ func TestPersistentVolumeClaimEvaluatorUsage(t *testing.T) {
 	validClaimByStorageClassWithNonIntegerStorage := validClaimByStorageClass.DeepCopy()
 	validClaimByStorageClassWithNonIntegerStorage.Spec.Resources.Requests[core.ResourceName(core.ResourceStorage)] = resource.MustParse("1001m")
 
+	validClaimByVolumeAttributesClass := validClaimByStorageClass.DeepCopy()
+	validClaimByVolumeAttributesClass.Spec.VolumeAttributesClassName = &classGold
+
 	evaluator := NewPersistentVolumeClaimEvaluator(nil)
 	testCases := map[string]struct {
-		pvc                        *core.PersistentVolumeClaim
-		usage                      corev1.ResourceList
-		enableRecoverFromExpansion bool
+		pvc                         *core.PersistentVolumeClaim
+		usage                       corev1.ResourceList
+		enableRecoverFromExpansion  bool
+		enableVolumeAttributesClass bool
 	}{
 		"pvc-usage": {
 			pvc: validClaim,
@@ -152,10 +156,23 @@ func TestPersistentVolumeClaimEvaluatorUsage(t *testing.T) {
 			},
 			enableRecoverFromExpansion: true,
 		},
+		"pvc-usage-by-volume-attributes-class": {
+			pvc: validClaimByVolumeAttributesClass,
+			usage: corev1.ResourceList{
+				corev1.ResourceRequestsStorage:                                                                    resource.MustParse("10Gi"),
+				corev1.ResourcePersistentVolumeClaims:                                                             resource.MustParse("1"),
+				V1ResourceByStorageClass(classGold, corev1.ResourceRequestsStorage):                               resource.MustParse("10Gi"),
+				V1ResourceByStorageClass(classGold, corev1.ResourcePersistentVolumeClaims):                        resource.MustParse("1"),
+				V1ResourceByVolumeAttributesClass(classGold, corev1.ResourcePersistentVolumeClaims):               resource.MustParse("1"),
+				generic.ObjectCountQuotaResourceNameFor(schema.GroupResource{Resource: "persistentvolumeclaims"}): resource.MustParse("1"),
+			},
+			enableVolumeAttributesClass: true,
+		},
 	}
 	for testName, testCase := range testCases {
 		t.Run(testName, func(t *testing.T) {
 			defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.RecoverVolumeExpansionFailure, testCase.enableRecoverFromExpansion)()
+			defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.VolumeAttributesClass, testCase.enableVolumeAttributesClass)()
 			actual, err := evaluator.Usage(testCase.pvc)
 			if err != nil {
 				t.Errorf("%s unexpected error: %v", testName, err)
@@ -185,8 +202,9 @@ func getPVCWithAllocatedResource(pvcSize, allocatedSize string) *core.Persistent
 func TestPersistentVolumeClaimEvaluatorMatchingResources(t *testing.T) {
 	evaluator := NewPersistentVolumeClaimEvaluator(nil)
 	testCases := map[string]struct {
-		items []corev1.ResourceName
-		want  []corev1.ResourceName
+		items                       []corev1.ResourceName
+		want                        []corev1.ResourceName
+		enableVolumeAttributesClass bool
 	}{
 		"supported-resources": {
 			items: []corev1.ResourceName{
@@ -195,6 +213,7 @@ func TestPersistentVolumeClaimEvaluatorMatchingResources(t *testing.T) {
 				"persistentvolumeclaims",
 				"gold.storageclass.storage.k8s.io/requests.storage",
 				"gold.storageclass.storage.k8s.io/persistentvolumeclaims",
+				"gold.volumeattributesclass.storage.k8s.io/persistentvolumeclaims",
 			},
 
 			want: []corev1.ResourceName{
@@ -203,7 +222,9 @@ func TestPersistentVolumeClaimEvaluatorMatchingResources(t *testing.T) {
 				"persistentvolumeclaims",
 				"gold.storageclass.storage.k8s.io/requests.storage",
 				"gold.storageclass.storage.k8s.io/persistentvolumeclaims",
+				"gold.volumeattributesclass.storage.k8s.io/persistentvolumeclaims",
 			},
+			enableVolumeAttributesClass: true,
 		},
 		"unsupported-resources": {
 			items: []corev1.ResourceName{
@@ -214,10 +235,44 @@ func TestPersistentVolumeClaimEvaluatorMatchingResources(t *testing.T) {
 			},
 			want: []corev1.ResourceName{},
 		},
+		// TODO: remove this test case after featuregate VolumeAttributesClass is GAed
+		"supported-resources-on-featuregate-off": {
+			items: []corev1.ResourceName{
+				"count/persistentvolumeclaims",
+				"requests.storage",
+				"persistentvolumeclaims",
+				"gold.storageclass.storage.k8s.io/requests.storage",
+				"gold.storageclass.storage.k8s.io/persistentvolumeclaims",
+				"gold.volumeattributesclass.storage.k8s.io/persistentvolumeclaims",
+			},
+
+			want: []corev1.ResourceName{
+				"count/persistentvolumeclaims",
+				"requests.storage",
+				"persistentvolumeclaims",
+				"gold.storageclass.storage.k8s.io/requests.storage",
+				"gold.storageclass.storage.k8s.io/persistentvolumeclaims",
+			},
+		},
+		// TODO: remove this test case after featuregate VolumeAttributesClass is GAed
+		"unsupported-resources-on-featuregate-on": {
+			items: []corev1.ResourceName{
+				"storage",
+				"ephemeral-storage",
+				"bronze.storageclass.storage.k8s.io/storage",
+				"gold.storage.k8s.io/requests.storage",
+				"gold.volumeattributesclass.storage.k8s.io/persistentvolumeclaims",
+			},
+			want: []corev1.ResourceName{
+				"gold.volumeattributesclass.storage.k8s.io/persistentvolumeclaims",
+			},
+			enableVolumeAttributesClass: true,
+		},
 	}
 	for testName, testCase := range testCases {
-		actual := evaluator.MatchingResources(testCase.items)
+		defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.VolumeAttributesClass, testCase.enableVolumeAttributesClass)()
 
+		actual := evaluator.MatchingResources(testCase.items)
 		if !reflect.DeepEqual(testCase.want, actual) {
 			t.Errorf("%s expected:\n%v\n, actual:\n%v", testName, testCase.want, actual)
 		}

--- a/test/e2e/apimachinery/resource_quota.go
+++ b/test/e2e/apimachinery/resource_quota.go
@@ -1221,7 +1221,7 @@ var _ = SIGDescribe("ResourceQuota", func() {
 	})
 })
 
-var _ = SIGDescribe("ResourceQuota", framework.WithFeatureGate(features.VolumeAttributesClass), func() {
+var _ = SIGDescribe("ResourceQuota", feature.VolumeAttributesClass, framework.WithFeatureGate(features.VolumeAttributesClass), func() {
 	f := framework.NewDefaultFramework("volume-attributes-class")
 	f.NamespacePodSecurityLevel = admissionapi.LevelBaseline
 

--- a/test/e2e/feature/feature.go
+++ b/test/e2e/feature/feature.go
@@ -331,6 +331,21 @@ var (
 	// TODO: document the feature (owning SIG, when to use this feature for a test)
 	ValidatingAdmissionPolicy = framework.WithFeature(framework.ValidFeatures.Add("ValidatingAdmissionPolicy"))
 
+	// owning-sig: sig-storage
+	// kep: https://kep.k8s.io/3751
+	// test-infra jobs:
+	// - pull-kubernetes-e2e-storage-kind-alpha-features (need manual trigger)
+	// - ci-kubernetes-e2e-storage-kind-alpha-features
+	//
+	// When this label is added to a test, it means that the cluster must be created
+	// with the feature-gate "VolumeAttributesClass=true" and the storage.k8s.io/v1alpha1
+	// API version must be enabled.
+	//
+	// Once the feature and API version are stable, this label should be removed and
+	// these tests will be run by default on any cluster. The test-infra job also should
+	// be updated to not focus on this feature anymore.
+	VolumeAttributesClass = framework.WithFeature(framework.ValidFeatures.Add("VolumeAttributesClass"))
+
 	// TODO: document the feature (owning SIG, when to use this feature for a test)
 	Volumes = framework.WithFeature(framework.ValidFeatures.Add("Volumes"))
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

A cluster admin wants to control costs while giving application developers the freedom to optimize their applications. They set a per VolumeAttributesClass limit to the maximum count of PVCs that can be specified in a cluster ResourceQuota. When an application dev modifies a PVC to request a higher tier of VolumeAttributesClass but there is no quota, the request is rejected. As the ResourceQuota is a cluster-scoped object, only the cluster admin and not application devs can change limits.

An example of defining ResourceQuota for VolumeAttributesClass:

```
apiVersion: v1
kind: ResourceQuota
metadata:
  name: vacquota
spec:
  hard:
  // Across all persistent volume claims associated with the 
  // <volume-attributes-class-name>, the total number of persistent volume claims 
  // that can exist in the namespace.
<volume-attributes-class-name>.volumeattributesclass.storage.k8s.io/persistentvolumeclaims: "5" 
  ...
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #119299

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Add quota support for PVC with VolumeAttributesClass.  For example, if you want to quota storage by a volume attributes class, you would have a declaration that follows <volume-attributes-class>.volumeattributesclass.storage.k8s.io/persistentvolumeclaims.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-storage/3751-volume-attributes-class
```
