### PR TITLE
[kep-3751] pvc bind pv with vac

### DIFF
--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -2391,7 +2391,9 @@ func ValidatePersistentVolumeClaimUpdate(newPvc, oldPvc *core.PersistentVolumeCl
 		newPvcClone.Spec.Resources.Requests["storage"] = oldPvc.Spec.Resources.Requests["storage"] // +k8s:verify-mutation:reason=clone
 	}
 	// lets make sure volume attributes class name is same.
-	newPvcClone.Spec.VolumeAttributesClassName = oldPvcClone.Spec.VolumeAttributesClassName // +k8s:verify-mutation:reason=clone
+	if newPvc.Status.Phase == core.ClaimBound && newPvcClone.Spec.VolumeAttributesClassName != nil {
+		newPvcClone.Spec.VolumeAttributesClassName = oldPvcClone.Spec.VolumeAttributesClassName // +k8s:verify-mutation:reason=clone
+	}
 
 	oldSize := oldPvc.Spec.Resources.Requests["storage"]
 	newSize := newPvc.Spec.Resources.Requests["storage"]

--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -3007,6 +3007,20 @@ func TestValidatePersistentVolumeClaimUpdate(t *testing.T) {
 			enableVolumeAttributesClass: true,
 			isExpectedFailure:           true,
 		},
+		"invalid-update-volume-attributes-class-when-claim-not-bound": {
+			oldClaim: func() *core.PersistentVolumeClaim {
+				clone := validClaimVolumeAttributesClass1.DeepCopy()
+				clone.Status.Phase = core.ClaimPending
+				return clone
+			}(),
+			newClaim: func() *core.PersistentVolumeClaim {
+				clone := validClaimVolumeAttributesClass2.DeepCopy()
+				clone.Status.Phase = core.ClaimPending
+				return clone
+			}(),
+			enableVolumeAttributesClass: true,
+			isExpectedFailure:           true,
+		},
 		"invalid-update-volume-attributes-class-to-nil-without-featuregate-enabled": {
 			oldClaim:                    validClaimVolumeAttributesClass1,
 			newClaim:                    validClaimNilVolumeAttributesClass,

--- a/pkg/controller/volume/persistentvolume/framework_test.go
+++ b/pkg/controller/volume/persistentvolume/framework_test.go
@@ -409,6 +409,14 @@ func withExpectedCapacity(capacity string, claims []*v1.PersistentVolumeClaim) [
 	return claims
 }
 
+// withExpectedVAC sets the claim.Status.CurrentVolumeAttributesClassName of the first claim in the
+// array to given value and returns the array.  Meant to be used to compose
+// claims specified inline in a test.
+func withExpectedVAC(vacName *string, claims []*v1.PersistentVolumeClaim) []*v1.PersistentVolumeClaim {
+	claims[0].Status.CurrentVolumeAttributesClassName = vacName
+	return claims
+}
+
 // withMessage saves given message into volume.Status.Message of the first
 // volume in the array and returns the array.  Meant to be used to compose
 // volumes specified inline in a test.
@@ -419,6 +427,7 @@ func withMessage(message string, volumes []*v1.PersistentVolume) []*v1.Persisten
 
 // newVolumeArray returns array with a single volume that would be returned by
 // newVolume() with the same parameters.
+// TODO: make the newVolumeArray function accept volume attributes class name as an input parameter
 func newVolumeArray(name, capacity, boundToClaimUID, boundToClaimName string, phase v1.PersistentVolumePhase, reclaimPolicy v1.PersistentVolumeReclaimPolicy, class string, annotations ...string) []*v1.PersistentVolume {
 	return []*v1.PersistentVolume{
 		newVolume(name, capacity, boundToClaimUID, boundToClaimName, phase, reclaimPolicy, class, annotations...),
@@ -489,6 +498,9 @@ func newClaim(name, claimUID, capacity, boundToVolume string, phase v1.Persisten
 		// For most of the tests it's enough to copy claim's requested capacity,
 		// individual tests can adjust it using withExpectedCapacity()
 		claim.Status.Capacity = claim.Spec.Resources.Requests
+		// For most of the tests it's enough to copy claim's requested vac,
+		// individual tests can adjust it using withExpectedVAC()
+		claim.Status.CurrentVolumeAttributesClassName = claim.Spec.VolumeAttributesClassName
 	}
 
 	return &claim
@@ -496,10 +508,16 @@ func newClaim(name, claimUID, capacity, boundToVolume string, phase v1.Persisten
 
 // newClaimArray returns array with a single claim that would be returned by
 // newClaim() with the same parameters.
+// TODO: make the newClaimArray function accept volume attributes class name as an input parameter
 func newClaimArray(name, claimUID, capacity, boundToVolume string, phase v1.PersistentVolumeClaimPhase, class *string, annotations ...string) []*v1.PersistentVolumeClaim {
 	return []*v1.PersistentVolumeClaim{
 		newClaim(name, claimUID, capacity, boundToVolume, phase, class, annotations...),
 	}
+}
+
+func claimWithVAC(vacName *string, claims []*v1.PersistentVolumeClaim) []*v1.PersistentVolumeClaim {
+	claims[0].Spec.VolumeAttributesClassName = vacName
+	return claims
 }
 
 // claimWithAnnotation saves given annotation into given claims. Meant to be
@@ -534,6 +552,22 @@ func annotateClaim(claim *v1.PersistentVolumeClaim, ann map[string]string) *v1.P
 		claim.Annotations[key] = val
 	}
 	return claim
+}
+
+// volumeWithVAC saves given vac into given volume.
+// Meant to be used to compose volume specified inline in a test.
+func volumeWithVAC(vacName string, volume *v1.PersistentVolume) *v1.PersistentVolume {
+	volume.Spec.VolumeAttributesClassName = &vacName
+	return volume
+}
+
+// volumesWithVAC saves given vac into given volumes.
+// Meant to be used to compose volumes specified inline in a test.
+func volumesWithVAC(vacName string, volumes []*v1.PersistentVolume) []*v1.PersistentVolume {
+	for _, volume := range volumes {
+		volumeWithVAC(vacName, volume)
+	}
+	return volumes
 }
 
 // volumeWithAnnotation saves given annotation into given volume.

--- a/pkg/controller/volume/persistentvolume/index.go
+++ b/pkg/controller/volume/persistentvolume/index.go
@@ -21,9 +21,11 @@ import (
 	"sort"
 
 	v1 "k8s.io/api/core/v1"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/component-helpers/storage/volume"
 	v1helper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
+	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/volume/util"
 )
 
@@ -92,7 +94,7 @@ func (pvIndex *persistentVolumeOrderedIndex) findByClaim(claim *v1.PersistentVol
 			return nil, err
 		}
 
-		bestVol, err := volume.FindMatchingVolume(claim, volumes, nil /* node for topology binding*/, nil /* exclusion map */, delayBinding)
+		bestVol, err := volume.FindMatchingVolume(claim, volumes, nil /* node for topology binding*/, nil /* exclusion map */, delayBinding, utilfeature.DefaultFeatureGate.Enabled(features.VolumeAttributesClass))
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/controller/volume/persistentvolume/index_test.go
+++ b/pkg/controller/volume/persistentvolume/index_test.go
@@ -23,9 +23,12 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/kubernetes/scheme"
 	ref "k8s.io/client-go/tools/reference"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/component-helpers/storage/volume"
+	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/volume/util"
 )
 
@@ -75,6 +78,9 @@ func makeVolumeModePVC(size string, mode *v1.PersistentVolumeMode, modfn func(*v
 }
 
 func TestMatchVolume(t *testing.T) {
+	// Default enable the VolumeAttributesClass feature gate.
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.VolumeAttributesClass, true)
+
 	volList := newPersistentVolumeOrderedIndex()
 	for _, pv := range createTestVolumes() {
 		volList.store.Add(pv)
@@ -132,6 +138,24 @@ func TestMatchVolume(t *testing.T) {
 					},
 				}
 				pvc.Spec.AccessModes = []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce}
+			}),
+		},
+		"successful-match-with-empty-vac": {
+			expectedMatch: "gce-pd-10",
+			claim: makePVC("8G", func(pvc *v1.PersistentVolumeClaim) {
+				pvc.Spec.VolumeAttributesClassName = &classEmpty
+			}),
+		},
+		"successful-match-with-vac": {
+			expectedMatch: "gce-pd-vac-silver1",
+			claim: makePVC("1G", func(pvc *v1.PersistentVolumeClaim) {
+				pvc.Spec.VolumeAttributesClassName = &classSilver
+			}),
+		},
+		"successful-no-match-vac-nonexisting": {
+			expectedMatch: "",
+			claim: makePVC("1G", func(pvc *v1.PersistentVolumeClaim) {
+				pvc.Spec.VolumeAttributesClassName = &classNonExisting
 			}),
 		},
 		"successful-match-with-class": {
@@ -960,6 +984,29 @@ func createTestVolumes() []*v1.PersistentVolume {
 				StorageClassName: classWait,
 				NodeAffinity:     createNodeAffinity("key1", "value4"),
 				VolumeMode:       &fs,
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				UID:  "gce-pd-vac-silver1",
+				Name: "gce-pd-vac-silver1",
+			},
+			Spec: v1.PersistentVolumeSpec{
+				Capacity: v1.ResourceList{
+					v1.ResourceName(v1.ResourceStorage): resource.MustParse("100G"),
+				},
+				PersistentVolumeSource: v1.PersistentVolumeSource{
+					GCEPersistentDisk: &v1.GCEPersistentDiskVolumeSource{},
+				},
+				AccessModes: []v1.PersistentVolumeAccessMode{
+					v1.ReadWriteOnce,
+					v1.ReadOnlyMany,
+				},
+				VolumeAttributesClassName: &classSilver,
+				VolumeMode:                &fs,
+			},
+			Status: v1.PersistentVolumeStatus{
+				Phase: v1.VolumeAvailable,
 			},
 		},
 	}

--- a/pkg/registry/core/persistentvolume/strategy.go
+++ b/pkg/registry/core/persistentvolume/strategy.go
@@ -66,6 +66,7 @@ func (persistentvolumeStrategy) GetResetFields() map[fieldpath.APIVersion]*field
 func (persistentvolumeStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
 	pv := obj.(*api.PersistentVolume)
 	pv.Status = api.PersistentVolumeStatus{}
+	pvutil.DropDisabledSpecFields(&pv.Spec, nil)
 
 	pv.Status.Phase = api.VolumePending
 	now := NowFunc()
@@ -97,6 +98,7 @@ func (persistentvolumeStrategy) PrepareForUpdate(ctx context.Context, obj, old r
 	newPv := obj.(*api.PersistentVolume)
 	oldPv := old.(*api.PersistentVolume)
 	newPv.Status = oldPv.Status
+	pvutil.DropDisabledSpecFields(&newPv.Spec, &oldPv.Spec)
 }
 
 func (persistentvolumeStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.Object) field.ErrorList {

--- a/pkg/scheduler/framework/plugins/volumebinding/binder.go
+++ b/pkg/scheduler/framework/plugins/volumebinding/binder.go
@@ -914,7 +914,7 @@ func (b *volumeBinder) findMatchingVolumes(logger klog.Logger, pod *v1.Pod, clai
 		pvs := unboundVolumesDelayBinding[storageClassName]
 
 		// Find a matching PV
-		pv, err := volume.FindMatchingVolume(pvc, pvs, node, chosenPVs, true)
+		pv, err := volume.FindMatchingVolume(pvc, pvs, node, chosenPVs, true, utilfeature.DefaultFeatureGate.Enabled(features.VolumeAttributesClass))
 		if err != nil {
 			return false, nil, nil, err
 		}

--- a/staging/src/k8s.io/component-helpers/storage/volume/pv_helpers.go
+++ b/staging/src/k8s.io/component-helpers/storage/volume/pv_helpers.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	storagelisters "k8s.io/client-go/listers/storage/v1"
 	"k8s.io/client-go/tools/reference"
+	"k8s.io/utils/ptr"
 )
 
 const (
@@ -187,7 +188,15 @@ func FindMatchingVolume(
 	volumes []*v1.PersistentVolume,
 	node *v1.Node,
 	excludedVolumes map[string]*v1.PersistentVolume,
-	delayBinding bool) (*v1.PersistentVolume, error) {
+	delayBinding bool,
+	vacEnabled bool) (*v1.PersistentVolume, error) {
+
+	if !vacEnabled {
+		claimVAC := ptr.Deref(claim.Spec.VolumeAttributesClassName, "")
+		if claimVAC != "" {
+			return nil, fmt.Errorf("unsupported volumeAttributesClassName is set on claim %s when the feature-gate VolumeAttributesClass is disabled", claimToClaimKey(claim))
+		}
+	}
 
 	var smallestVolume *v1.PersistentVolume
 	var smallestVolumeQty resource.Quantity
@@ -224,6 +233,18 @@ func FindMatchingVolume(
 		}
 		// filter out mismatching volumeModes
 		if CheckVolumeModeMismatches(&claim.Spec, &volume.Spec) {
+			continue
+		}
+
+		claimVAC := ptr.Deref(claim.Spec.VolumeAttributesClassName, "")
+		volumeVAC := ptr.Deref(volume.Spec.VolumeAttributesClassName, "")
+
+		// filter out mismatching volumeAttributesClassName
+		if vacEnabled && claimVAC != volumeVAC {
+			continue
+		}
+		if !vacEnabled && volumeVAC != "" {
+			// when the feature gate is disabled, the PV object has VAC set, then we should not bind at all.
 			continue
 		}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

The fundamental key to the storage design in Kubernetes is the bi-directional "pointer" between PersistentVolumes (PVs) and PersistentVolumeClaims (PVCs), which is represented here as pvc.Spec.VolumeName and pv.Spec.ClaimRef. The binding is two-step process. pv.Spec.Claim is modified to point to the PVC first, and then pvc.Spec.VolumeName is modified to point to the PV second. At any point of this transation, the PV or PVC can be modified by user or other controller (i.e. csi-provisioner or csi-resizer) or completely deleted. So the bi-directionality is complicated to manage in Kubernetes because of lack of transactional support.

After the VolumeAttributesClass API is added into Kubernetes 1.29 and the csi sidecars begin to support it, the PV controller also should be aware of the VolumeAttributesClass API and add support for provisioning an unbound PV with a VolumeAttributesClass and binding each other later. But, unfortunately, it's unimplemented in this release due to the code freeze. Now, it's a good time to implement it in Kubernetes 1.30.

Before we start to implement it, let's review the current PV controller's key points to this change for how to find a best matched PV for a PVC and bind them together.

**Provision (Currnet)** a volume for a PVC.

When no volume is matched for a PVC, the PV controller will provision a new PV for the PVC. For external provisioner and intree provisioner, the provisioner always create a pro-bound pv to the pvc. 

**FindMatchingVolume (Current)** go through all the PVs.

1. For pre-bound PV, check if the node affinity is satisfied. If yes, select it. Otherwise, no PV is selected.
2. For unbound PV, check if the storage class is matched. If yes, means the PV is matched with the PVC. After iterating all the PVs, the smallest PV is selected. 

**bind (Current)** bind the PV (aka volume) and PVC (aka claim) together in the following order.

a. bind volume to claim by updating pv.Spec.ClaimRef to point to the PVC.
b. update volume phase to Bound.
c. bind claim to volume by updating pvc.Spec.VolumeName to point to the PV.
d. update claim status, including phase, capacity.

Each step in the bind workflow is a separate API call to the API server. So, the whole bind workflow is not atomic and can be interrupted by other controllers or users at any point.

Now, let's back to the VolumeAttributesClass feature. Proposed changes are as follows.

**Provision (Proposed)** a volume for a PVC.

Same as the current behavior.

**FindMatchingVolume (Proposed)** go through all the PVs.

- For pre-bound PV, it same as current. If we add a check for the volume attributes class, the PV controller won't select the pre-bound PV to bind the PVC. It will lead to the PVC never be bound to a PV. For the same PVC in any reconcile loop, the provisioner doesn't create more than one PVs once it has been provisioned successfully whenever the PVC is bound to the PV or not, or the VolumeAttributesClass of the PVC is changed by user. So, we don't add a check for the volume attributes class in this case. We should allow the PV can be bound to the PVC even if the volume attributes class is not matched. The mismatched volume attributes class will be handled by csi-resizer later. Eventually, the PV controller will update the PVC's status with the expected volume attributes class.

- For unbound PV, add a new step to check if the volume attributes class is matched. If yes, means the PV is matched with the PVC. Other steps are same as current.

In conclusion, the volume attributes class is used for unbound PV only. For pre-bound PV, it's not used during the matching process.

**bind (Proposed)** bind the PV (aka volume) and PVC (aka claim) together in the following order.

a. same as current.
b. same as current.
c. same as current.
d. same as current expect that status.currentVolumeAttributesClass is updated to the PV's volume attributes class.

Let's discuss implementation details in the following scenarios.

**Scenario 1:** No any interruption during the bind workflow. all steps are executed successfully.

Everything is fine. The PV and PVC are bound together successfully.


**Scenario 2:**  An interruption occurs at the step d during the bind workflow. i.e. request timeout, user or other controller changes the PVC, etc.

the PV and PVC are bound together successfully. But the PVC's status is not updated. It's acceptable because the PVC's status will be updated by the PV controller later in the next reconcile loop. Let's imagine if the step d is failed due to conflict with user changing the PVC's volume attributes class, what will happen? In this case, the PV controller will retry to bind the pre-bound PV created in the previous reconcile loop. Assume that no new interrupt happens during the retry reconcile loop, the PV controller will update the PVC's status with the outdated volume attributes class from the existing pre-bound PV. It's acceptable because the external controller (i.e. csi-resizer sidecar) will trigger a ControllerVolumeModifity and update the PV object with the expected volume attributes class. Then, the PV controller will redo the bind workflow and update the PVC's status with the expected volume attributes class. If more than one interrupt happens during the retry reconcile loop, for example, the external controller do its job before the PV controller retry to bind the pre-bound PV, don't worry, the PV controller will retry to bind the pre-bound PV again in the next reconcile loop. So, the PV controller will update the PVC's status with the expected volume attributes class finally.

In conclusion, everything is fine even if there is an interruption during the bind workflow. The PV and PVC are bound together successfully.

**Scenario 3:** An interruption occurs at the step c during the bind workflow. i.e. request timeout, user or other controller changes the PV, etc.

The PV is pre-bound to the PVC successfully. But the PVC is not bound to the PV. 

We have explained the proposed changes. please refer to the `FindMatchingVolume (Proposed)` section for how to handle this case. It's acceptable.

**Scenario 4:** An interruption occurs at the step b during the bind workflow. i.e. request timeout, user or other controller changes the PV, etc.

The PV is pre-bound to the PVC successfully. But the pv status is not updated and the PVC is not bound to the PV. Run into the Scenario 3. It's acceptable.

**Scenario 5:** An interruption occurs at the step a during the bind workflow. i.e. request timeout, user or other controller changes the PV, etc.

The provisioner always create a pre-bound pv to the pvc. So, the PV is pre-bound to the PVC successfully even through the step a is failed. Run into the Scenario 4. It's acceptable.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
If the feature-gate VolumeAttributesClass is enabled, when finding a suitable persistent volume for a claim, the kube-controller-manager will be aware of the `volumeAttributesClassName` field of PVC and PV objects. The `volumeAttributesClassName` field is a reference to a VolumeAttributesClass object, which contains a set of key-value pairs that present mutable attributes of the volume. It's forbidden to change the `volumeAttributesClassName` field of a PVC object until the PVC is bound to a PV object. During the binding process, if a PVC has a `volumeAttributesClassName` field set, the controller will only consider volumes that have the same `volumeAttributesClassName` as the PVC. If the `volumeAttributesClassName` field is not set or set to an empty string, only volumes with empty `volumeAttributesClassName` will be considered.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]:  https://github.com/kubernetes/enhancements/issues/3751
```
