### PR TITLE
support namespace indexer for namespaced resources like pods

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -975,6 +975,12 @@ const (
 	// will not graduate or be enabled by default in future Kubernetes
 	// releases.
 	UserNamespacesPodSecurityStandards featuregate.Feature = "UserNamespacesPodSecurityStandards"
+
+	// owner: @ahutsunshine
+	// beta: v1.29
+	//
+	// Allows namespace indexer for namespace scope resources in apiserver cache to accelerate list operations.
+	StorageNamespaceIndex featuregate.Feature = "StorageNamespaceIndex"
 )
 
 func init() {
@@ -1281,4 +1287,6 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	// features that enable backwards compatibility but are scheduled to be removed
 	// ...
 	HPAScaleToZero: {Default: false, PreRelease: featuregate.Alpha},
+
+	StorageNamespaceIndex: {Default: true, PreRelease: featuregate.Beta},
 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
@@ -746,7 +746,7 @@ func (c *Cacher) listItems(ctx context.Context, listRV uint64, key string, pred 
 		}
 		return nil, readResourceVersion, "", nil
 	}
-	return c.watchCache.WaitUntilFreshAndList(ctx, listRV, pred.MatcherIndex())
+	return c.watchCache.WaitUntilFreshAndList(ctx, listRV, pred.MatcherIndex(ctx))
 }
 
 // GetList implements storage.Interface

--- a/staging/src/k8s.io/apiserver/pkg/storage/selection_predicate_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/selection_predicate_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package storage
 
 import (
+	"context"
 	"errors"
 	"reflect"
 	"testing"
@@ -25,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apiserver/pkg/endpoints/request"
 )
 
 type Ignored struct {
@@ -127,12 +129,14 @@ func TestSelectionPredicateMatcherIndex(t *testing.T) {
 		indexLabels                  []string
 		indexFields                  []string
 		expected                     []MatchValue
+		ctx                          context.Context
 	}{
 		"Match nil": {
 			labelSelector: "name=foo",
 			fieldSelector: "uid=12345",
 			indexLabels:   []string{"bar"},
 			indexFields:   []string{},
+			ctx:           context.Background(),
 			expected:      nil,
 		},
 		"Match field": {
@@ -140,13 +144,83 @@ func TestSelectionPredicateMatcherIndex(t *testing.T) {
 			fieldSelector: "uid=12345",
 			indexLabels:   []string{},
 			indexFields:   []string{"uid"},
+			ctx:           context.Background(),
 			expected:      []MatchValue{{IndexName: FieldIndex("uid"), Value: "12345"}},
+		},
+		"Match field for listing namespace pods without metadata.namespace field selector": {
+			labelSelector: "",
+			fieldSelector: "",
+			indexLabels:   []string{},
+			indexFields:   []string{"metadata.namespace"},
+			ctx: request.WithRequestInfo(context.Background(), &request.RequestInfo{
+				IsResourceRequest: true,
+				Path:              "/api/v1/namespaces/default/pods",
+				Verb:              "list",
+				APIPrefix:         "api",
+				APIGroup:          "",
+				APIVersion:        "v1",
+				Namespace:         "default",
+				Resource:          "pods",
+			}),
+			expected: []MatchValue{{IndexName: FieldIndex("metadata.namespace"), Value: "default"}},
+		},
+		"Match field for listing namespace pods with metadata.namespace field selector": {
+			labelSelector: "",
+			fieldSelector: "metadata.namespace=kube-system",
+			indexLabels:   []string{},
+			indexFields:   []string{"metadata.namespace"},
+			ctx: request.WithRequestInfo(context.Background(), &request.RequestInfo{
+				IsResourceRequest: true,
+				Path:              "/api/v1/namespaces/default/pods",
+				Verb:              "list",
+				APIPrefix:         "api",
+				APIGroup:          "",
+				APIVersion:        "v1",
+				Namespace:         "default",
+				Resource:          "pods",
+			}),
+			expected: []MatchValue{{IndexName: FieldIndex("metadata.namespace"), Value: "kube-system"}},
+		},
+		"Match field for listing all pods without metadata.namespace field selector": {
+			labelSelector: "",
+			fieldSelector: "",
+			indexLabels:   []string{},
+			indexFields:   []string{"metadata.namespace"},
+			ctx: request.WithRequestInfo(context.Background(), &request.RequestInfo{
+				IsResourceRequest: true,
+				Path:              "/api/v1/pods",
+				Verb:              "list",
+				APIPrefix:         "api",
+				APIGroup:          "",
+				APIVersion:        "v1",
+				Namespace:         "",
+				Resource:          "pods",
+			}),
+			expected: nil,
+		},
+		"Match field for listing all pods with metadata.namespace field selector": {
+			labelSelector: "",
+			fieldSelector: "metadata.namespace=default",
+			indexLabels:   []string{},
+			indexFields:   []string{"metadata.namespace"},
+			ctx: request.WithRequestInfo(context.Background(), &request.RequestInfo{
+				IsResourceRequest: true,
+				Path:              "/api/v1/pods",
+				Verb:              "list",
+				APIPrefix:         "api",
+				APIGroup:          "",
+				APIVersion:        "v1",
+				Namespace:         "default",
+				Resource:          "pods",
+			}),
+			expected: []MatchValue{{IndexName: FieldIndex("metadata.namespace"), Value: "default"}},
 		},
 		"Match label": {
 			labelSelector: "name=foo",
 			fieldSelector: "uid=12345",
 			indexLabels:   []string{"name"},
 			indexFields:   []string{},
+			ctx:           context.Background(),
 			expected:      []MatchValue{{IndexName: LabelIndex("name"), Value: "foo"}},
 		},
 		"Match field and label": {
@@ -154,6 +228,7 @@ func TestSelectionPredicateMatcherIndex(t *testing.T) {
 			fieldSelector: "uid=12345",
 			indexLabels:   []string{"name"},
 			indexFields:   []string{"uid"},
+			ctx:           context.Background(),
 			expected:      []MatchValue{{IndexName: FieldIndex("uid"), Value: "12345"}, {IndexName: LabelIndex("name"), Value: "foo"}},
 		},
 		"Negative match field and label": {
@@ -161,6 +236,7 @@ func TestSelectionPredicateMatcherIndex(t *testing.T) {
 			fieldSelector: "uid!=12345",
 			indexLabels:   []string{"name"},
 			indexFields:   []string{"uid"},
+			ctx:           context.Background(),
 			expected:      nil,
 		},
 		"Negative match field and match label": {
@@ -168,6 +244,7 @@ func TestSelectionPredicateMatcherIndex(t *testing.T) {
 			fieldSelector: "uid!=12345",
 			indexLabels:   []string{"name"},
 			indexFields:   []string{"uid"},
+			ctx:           context.Background(),
 			expected:      []MatchValue{{IndexName: LabelIndex("name"), Value: "foo"}},
 		},
 		"Negative match label and match field": {
@@ -175,6 +252,7 @@ func TestSelectionPredicateMatcherIndex(t *testing.T) {
 			fieldSelector: "uid=12345",
 			indexLabels:   []string{"name"},
 			indexFields:   []string{"uid"},
+			ctx:           context.Background(),
 			expected:      []MatchValue{{IndexName: FieldIndex("uid"), Value: "12345"}},
 		},
 	}
@@ -194,7 +272,7 @@ func TestSelectionPredicateMatcherIndex(t *testing.T) {
 			IndexLabels: testCase.indexLabels,
 			IndexFields: testCase.indexFields,
 		}
-		actual := sp.MatcherIndex()
+		actual := sp.MatcherIndex(testCase.ctx)
 		if !reflect.DeepEqual(testCase.expected, actual) {
 			t.Errorf("%v: expected %v, got %v", name, testCase.expected, actual)
 		}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
In our cluster, the number of some resources like pods are very large(10w+). When listing a namespace resources like pods from apiserver cache, the apiserver process will firstly get all the resources in all the namespaces and then filter the resources by namespace predicate even it's a very small request. It's heavy for filtering namespaced resource even the resource number in the namespace is very small with many client requests. It consumes lots of cpu & memory that's not expected.

#### Which issue(s) this PR fixes:
feature support and discussion: https://github.com/kubernetes/kubernetes/issues/120778

```release-note
NONE
```

