### PR TITLE
hostpath: use tests with real files where possible

### DIFF
--- a/pkg/volume/hostpath/host_path.go
+++ b/pkg/volume/hostpath/host_path.go
@@ -370,137 +370,51 @@ func getVolumeSource(spec *volume.Spec) (*v1.HostPathVolumeSource, bool, error) 
 	return nil, false, fmt.Errorf("spec does not reference an HostPath volume type")
 }
 
-type hostPathTypeChecker interface {
-	Exists() bool
-	IsFile() bool
-	MakeFile() error
-	IsDir() bool
-	MakeDir() error
-	IsBlock() bool
-	IsChar() bool
-	IsSocket() bool
-	GetPath() string
-	GetType() (string, error)
-}
-
-type fileTypeChecker struct {
-	path string
-	hu   hostutil.HostUtils
-}
-
-func (ftc *fileTypeChecker) Exists() bool {
-	exists, err := ftc.hu.PathExists(ftc.path)
+func exists(path string, hu hostutil.HostUtils) bool {
+	exists, err := hu.PathExists(path)
 	return exists && err == nil
-}
-
-func (ftc *fileTypeChecker) GetType() (string, error) {
-	pathType, err := ftc.hu.GetFileType(ftc.path)
-	return string(pathType), err
-}
-
-func (ftc *fileTypeChecker) IsFile() bool {
-	if !ftc.Exists() {
-		return false
-	}
-	pathType, err := ftc.GetType()
-	if err != nil {
-		return false
-	}
-	return pathType == string(v1.HostPathFile)
-}
-
-func (ftc *fileTypeChecker) MakeFile() error {
-	return makeFile(ftc.path)
-}
-
-func (ftc *fileTypeChecker) IsDir() bool {
-	if !ftc.Exists() {
-		return false
-	}
-	pathType, err := ftc.GetType()
-	if err != nil {
-		return false
-	}
-	return pathType == string(v1.HostPathDirectory)
-}
-
-func (ftc *fileTypeChecker) MakeDir() error {
-	return makeDir(ftc.path)
-}
-
-func (ftc *fileTypeChecker) IsBlock() bool {
-	blkDevType, err := ftc.GetType()
-	if err != nil {
-		return false
-	}
-	return blkDevType == string(v1.HostPathBlockDev)
-}
-
-func (ftc *fileTypeChecker) IsChar() bool {
-	charDevType, err := ftc.GetType()
-	if err != nil {
-		return false
-	}
-	return charDevType == string(v1.HostPathCharDev)
-}
-
-func (ftc *fileTypeChecker) IsSocket() bool {
-	socketType, err := ftc.GetType()
-	if err != nil {
-		return false
-	}
-	return socketType == string(v1.HostPathSocket)
-}
-
-func (ftc *fileTypeChecker) GetPath() string {
-	return ftc.path
-}
-
-func newFileTypeChecker(path string, hu hostutil.HostUtils) hostPathTypeChecker {
-	return &fileTypeChecker{path: path, hu: hu}
 }
 
 // checkType checks whether the given path is the exact pathType
 func checkType(path string, pathType *v1.HostPathType, hu hostutil.HostUtils) error {
-	return checkTypeInternal(newFileTypeChecker(path, hu), pathType)
-}
-
-func typeMatchedOrError(ftc hostPathTypeChecker, match func() bool, expected string) error {
-	if !match() {
-		pathType, err := ftc.GetType()
-		if err != nil {
-			return fmt.Errorf("hostPath type check failed, %s is not a %s, unable to determine its type: %w", ftc.GetPath(), expected, err)
-		}
-		return fmt.Errorf("hostPath type check failed: %s is not a %s, it's a %s", ftc.GetPath(), expected, pathType)
-	}
-	return nil
-}
-
-func checkTypeInternal(ftc hostPathTypeChecker, pathType *v1.HostPathType) error {
 	switch *pathType {
 	case v1.HostPathDirectoryOrCreate:
-		if !ftc.Exists() {
-			return ftc.MakeDir()
+		if !exists(path, hu) {
+			return makeDir(path)
 		}
 		fallthrough
 	case v1.HostPathDirectory:
-		return typeMatchedOrError(ftc, ftc.IsDir, "directory")
+		return typeMatchedOrError(path, hu, new(v1.HostPathDirectory), "directory")
 	case v1.HostPathFileOrCreate:
-		if !ftc.Exists() {
-			return ftc.MakeFile()
+		if !exists(path, hu) {
+			return makeFile(path)
 		}
 		fallthrough
 	case v1.HostPathFile:
-		return typeMatchedOrError(ftc, ftc.IsFile, "file")
+		return typeMatchedOrError(path, hu, new(v1.HostPathFile), "file")
 	case v1.HostPathSocket:
-		return typeMatchedOrError(ftc, ftc.IsSocket, "socket file")
+		return typeMatchedOrError(path, hu, new(v1.HostPathSocket), "socket file")
 	case v1.HostPathCharDev:
-		return typeMatchedOrError(ftc, ftc.IsChar, "character device")
+		return typeMatchedOrError(path, hu, new(v1.HostPathCharDev), "character device")
 	case v1.HostPathBlockDev:
-		return typeMatchedOrError(ftc, ftc.IsBlock, "block device")
+		return typeMatchedOrError(path, hu, new(v1.HostPathBlockDev), "block device")
 	default:
 		return fmt.Errorf("%s is an invalid volume type", *pathType)
 	}
+}
+
+func typeMatchedOrError(path string, hu hostutil.HostUtils, expectedType *v1.HostPathType, expectedDescription string) error {
+	if !exists(path, hu) {
+		return fmt.Errorf("hostPath %s doesn't exist", path)
+	}
+	pathType, err := hu.GetFileType(path)
+	if err != nil {
+		return fmt.Errorf("hostPath type check failed, %s is not a %s, unable to determine its type: %w", path, expectedDescription, err)
+	}
+	if string(pathType) != string(*expectedType) {
+		return fmt.Errorf("hostPath type check failed: %s is not a %s, it's a %s", path, expectedDescription, pathType)
+	}
+	return nil
 }
 
 // makeDir creates a new directory.

--- a/pkg/volume/hostpath/host_path_test.go
+++ b/pkg/volume/hostpath/host_path_test.go
@@ -17,8 +17,10 @@ limitations under the License.
 package hostpath
 
 import (
+	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
@@ -32,23 +34,7 @@ import (
 	volumetest "k8s.io/kubernetes/pkg/volume/testing"
 	"k8s.io/kubernetes/pkg/volume/util/hostutil"
 	utilpath "k8s.io/utils/path"
-	"k8s.io/utils/ptr"
 )
-
-func newHostPathType(pathType string) *v1.HostPathType {
-	hostPathType := new(v1.HostPathType)
-	*hostPathType = v1.HostPathType(pathType)
-	return hostPathType
-}
-
-func newHostPathTypeList(pathType ...string) []*v1.HostPathType {
-	typeList := []*v1.HostPathType{}
-	for _, ele := range pathType {
-		typeList = append(typeList, newHostPathType(ele))
-	}
-
-	return typeList
-}
 
 func TestCanSupport(t *testing.T) {
 	plugMgr := volume.VolumePluginMgr{}
@@ -240,7 +226,7 @@ func TestPlugin(t *testing.T) {
 	volPath := "/tmp/vol1"
 	spec := &v1.Volume{
 		Name:         "vol1",
-		VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: volPath, Type: newHostPathType(string(v1.HostPathDirectoryOrCreate))}},
+		VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: volPath, Type: new(v1.HostPathDirectoryOrCreate)}},
 	}
 	pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{UID: types.UID("poduid")}}
 	defer os.RemoveAll(volPath)
@@ -281,7 +267,7 @@ func TestPersistentClaimReadOnlyFlag(t *testing.T) {
 		},
 		Spec: v1.PersistentVolumeSpec{
 			PersistentVolumeSource: v1.PersistentVolumeSource{
-				HostPath: &v1.HostPathVolumeSource{Path: "foo", Type: newHostPathType(string(v1.HostPathDirectoryOrCreate))},
+				HostPath: &v1.HostPathVolumeSource{Path: "foo", Type: new(v1.HostPathDirectoryOrCreate)},
 			},
 			ClaimRef: &v1.ObjectReference{
 				Name: "claimA",
@@ -322,299 +308,126 @@ func TestPersistentClaimReadOnlyFlag(t *testing.T) {
 	}
 }
 
-func setUp() error {
-	err := os.MkdirAll("/tmp/ExistingFolder", os.FileMode(0755))
-	if err != nil {
-		return err
-	}
-
-	f, err := os.OpenFile("/tmp/ExistingFolder/foo", os.O_CREATE, os.FileMode(0644))
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-
-	return nil
-}
-
-func tearDown() {
-	os.RemoveAll("/tmp/ExistingFolder")
-}
-
 func TestOSFileTypeChecker(t *testing.T) {
-	err := setUp()
+	tempDir, err := os.MkdirTemp("", "hostpathtest")
 	if err != nil {
 		t.Error(err)
 	}
-	defer tearDown()
+	//nolint:errcheck // We don't care if we fail to remove the temporary directory
+	defer os.RemoveAll(tempDir)
 	testCases := []struct {
-		name        string
-		path        string
-		desiredType string
-		isDir       bool
-		isFile      bool
-		isSocket    bool
-		isBlock     bool
-		isChar      bool
+		name           string
+		path           string
+		pathType       *v1.HostPathType
+		simulatedType  *hostutil.FileType
+		expectError    bool
+		checkExistence bool
+		checkDirectory bool
 	}{
+		// The order of these test cases is significant, some of them create files or directories
 		{
-			name:        "Existing Folder",
-			path:        "/tmp/ExistingFolder",
-			desiredType: string(hostutil.FileTypeDirectory),
-			isDir:       true,
+			name:        "Missing file",
+			path:        filepath.Join(tempDir, "nosuchfile"),
+			pathType:    new(v1.HostPathFile),
+			expectError: true,
 		},
 		{
-			name:        "Existing File",
-			path:        "/tmp/ExistingFolder/foo",
-			desiredType: string(hostutil.FileTypeFile),
-			isFile:      true,
+			name:           "File to create",
+			path:           filepath.Join(tempDir, "newfile"),
+			pathType:       new(v1.HostPathFileOrCreate),
+			checkExistence: true,
 		},
 		{
-			name:        "Existing Socket File",
-			path:        "/tmp/ExistingFolder/foo",
-			desiredType: string(v1.HostPathSocket),
-			isSocket:    true,
+			name:           "Created file",
+			path:           filepath.Join(tempDir, "newfile"),
+			pathType:       new(v1.HostPathFile),
+			checkExistence: true,
 		},
 		{
-			name:        "Existing Character Device",
-			path:        "/tmp/ExistingFolder/foo",
-			desiredType: string(v1.HostPathCharDev),
-			isChar:      true,
+			name:           "Created file (mounted with OrCreate)",
+			path:           filepath.Join(tempDir, "newfile"),
+			pathType:       new(v1.HostPathFileOrCreate),
+			checkExistence: true,
 		},
 		{
-			name:        "Existing Block Device",
-			path:        "/tmp/ExistingFolder/foo",
-			desiredType: string(v1.HostPathBlockDev),
-			isBlock:     true,
-		},
-	}
-
-	for i, tc := range testCases {
-		fakeFTC := hostutil.NewFakeHostUtil(
-			map[string]hostutil.FileType{
-				tc.path: hostutil.FileType(tc.desiredType),
-			})
-		oftc := newFileTypeChecker(tc.path, fakeFTC)
-
-		path := oftc.GetPath()
-		if path != tc.path {
-			t.Errorf("[%d: %q] got unexpected path: %s", i, tc.name, path)
-		}
-
-		exist := oftc.Exists()
-		if !exist {
-			t.Errorf("[%d: %q] path: %s does not exist", i, tc.name, path)
-		}
-
-		if tc.isDir {
-			if !oftc.IsDir() {
-				t.Errorf("[%d: %q] expected folder, got unexpected: %s", i, tc.name, path)
-			}
-			if oftc.IsFile() {
-				t.Errorf("[%d: %q] expected folder, got unexpected file: %s", i, tc.name, path)
-			}
-			if oftc.IsSocket() {
-				t.Errorf("[%d: %q] expected folder, got unexpected socket file: %s", i, tc.name, path)
-			}
-			if oftc.IsBlock() {
-				t.Errorf("[%d: %q] expected folder, got unexpected block device: %s", i, tc.name, path)
-			}
-			if oftc.IsChar() {
-				t.Errorf("[%d: %q] expected folder, got unexpected character device: %s", i, tc.name, path)
-			}
-		}
-
-		if tc.isFile {
-			if !oftc.IsFile() {
-				t.Errorf("[%d: %q] expected file, got unexpected: %s", i, tc.name, path)
-			}
-			if oftc.IsDir() {
-				t.Errorf("[%d: %q] expected file, got unexpected folder: %s", i, tc.name, path)
-			}
-			if oftc.IsSocket() {
-				t.Errorf("[%d: %q] expected file, got unexpected socket file: %s", i, tc.name, path)
-			}
-			if oftc.IsBlock() {
-				t.Errorf("[%d: %q] expected file, got unexpected block device: %s", i, tc.name, path)
-			}
-			if oftc.IsChar() {
-				t.Errorf("[%d: %q] expected file, got unexpected character device: %s", i, tc.name, path)
-			}
-		}
-
-		if tc.isSocket {
-			if !oftc.IsSocket() {
-				t.Errorf("[%d: %q] expected socket file, got unexpected: %s", i, tc.name, path)
-			}
-			if oftc.IsDir() {
-				t.Errorf("[%d: %q] expected socket file, got unexpected folder: %s", i, tc.name, path)
-			}
-			if oftc.IsFile() {
-				t.Errorf("[%d: %q] expected socket file, got unexpected file: %s", i, tc.name, path)
-			}
-			if oftc.IsBlock() {
-				t.Errorf("[%d: %q] expected socket file, got unexpected block device: %s", i, tc.name, path)
-			}
-			if oftc.IsChar() {
-				t.Errorf("[%d: %q] expected socket file, got unexpected character device: %s", i, tc.name, path)
-			}
-		}
-
-		if tc.isChar {
-			if !oftc.IsChar() {
-				t.Errorf("[%d: %q] expected character device, got unexpected: %s", i, tc.name, path)
-			}
-			if oftc.IsDir() {
-				t.Errorf("[%d: %q] expected character device, got unexpected folder: %s", i, tc.name, path)
-			}
-			if oftc.IsFile() {
-				t.Errorf("[%d: %q] expected character device, got unexpected file: %s", i, tc.name, path)
-			}
-			if oftc.IsSocket() {
-				t.Errorf("[%d: %q] expected character device, got unexpected socket file: %s", i, tc.name, path)
-			}
-			if oftc.IsBlock() {
-				t.Errorf("[%d: %q] expected character device, got unexpected block device: %s", i, tc.name, path)
-			}
-		}
-
-		if tc.isBlock {
-			if !oftc.IsBlock() {
-				t.Errorf("[%d: %q] expected block device, got unexpected: %s", i, tc.name, path)
-			}
-			if oftc.IsDir() {
-				t.Errorf("[%d: %q] expected block device, got unexpected folder: %s", i, tc.name, path)
-			}
-			if oftc.IsFile() {
-				t.Errorf("[%d: %q] expected block device, got unexpected file: %s", i, tc.name, path)
-			}
-			if oftc.IsSocket() {
-				t.Errorf("[%d: %q] expected block device, got unexpected socket file: %s", i, tc.name, path)
-			}
-			if oftc.IsChar() {
-				t.Errorf("[%d: %q] expected block device, got unexpected character device: %s", i, tc.name, path)
-			}
-		}
-	}
-
-}
-
-type fakeHostPathTypeChecker struct {
-	name            string
-	path            string
-	pathType        *v1.HostPathType
-	exists          bool
-	isDir           bool
-	isFile          bool
-	isSocket        bool
-	isBlock         bool
-	isChar          bool
-	validpathType   []*v1.HostPathType
-	invalidpathType []*v1.HostPathType
-}
-
-func (ftc *fakeHostPathTypeChecker) MakeFile() error          { return nil }
-func (ftc *fakeHostPathTypeChecker) MakeDir() error           { return nil }
-func (ftc *fakeHostPathTypeChecker) Exists() bool             { return ftc.exists }
-func (ftc *fakeHostPathTypeChecker) IsFile() bool             { return ftc.isFile }
-func (ftc *fakeHostPathTypeChecker) IsDir() bool              { return ftc.isDir }
-func (ftc *fakeHostPathTypeChecker) IsBlock() bool            { return ftc.isBlock }
-func (ftc *fakeHostPathTypeChecker) IsChar() bool             { return ftc.isChar }
-func (ftc *fakeHostPathTypeChecker) IsSocket() bool           { return ftc.isSocket }
-func (ftc *fakeHostPathTypeChecker) GetPath() string          { return ftc.path }
-func (ftc *fakeHostPathTypeChecker) GetType() (string, error) { return string(*ftc.pathType), nil }
-
-func TestHostPathTypeCheckerInternal(t *testing.T) {
-	testCases := []fakeHostPathTypeChecker{
-		{
-			name:          "Existing Folder",
-			path:          "/existingFolder",
-			pathType:      ptr.To(v1.HostPathDirectory),
-			isDir:         true,
-			exists:        true,
-			validpathType: newHostPathTypeList(string(v1.HostPathDirectoryOrCreate), string(v1.HostPathDirectory)),
-			invalidpathType: newHostPathTypeList(string(v1.HostPathFileOrCreate), string(v1.HostPathFile),
-				string(v1.HostPathSocket), string(v1.HostPathCharDev), string(v1.HostPathBlockDev)),
+			name:        "Directory conflicting with a file",
+			path:        filepath.Join(tempDir, "newfile"),
+			pathType:    new(v1.HostPathDirectory),
+			expectError: true,
 		},
 		{
-			name:          "New Folder",
-			path:          "/newFolder",
-			pathType:      ptr.To(v1.HostPathDirectory),
-			isDir:         false,
-			exists:        false,
-			validpathType: newHostPathTypeList(string(v1.HostPathDirectoryOrCreate)),
-			invalidpathType: newHostPathTypeList(string(v1.HostPathDirectory), string(v1.HostPathFile),
-				string(v1.HostPathSocket), string(v1.HostPathCharDev), string(v1.HostPathBlockDev)),
+			name:        "Missing directory",
+			path:        filepath.Join(tempDir, "nosuchdirectory"),
+			pathType:    new(v1.HostPathDirectory),
+			expectError: true,
 		},
 		{
-			name:          "Existing File",
-			path:          "/existingFile",
-			pathType:      ptr.To(v1.HostPathFile),
-			isFile:        true,
-			exists:        true,
-			validpathType: newHostPathTypeList(string(v1.HostPathFileOrCreate), string(v1.HostPathFile)),
-			invalidpathType: newHostPathTypeList(string(v1.HostPathDirectoryOrCreate), string(v1.HostPathDirectory),
-				string(v1.HostPathSocket), string(v1.HostPathCharDev), string(v1.HostPathBlockDev)),
+			name:           "Directory to create",
+			path:           filepath.Join(tempDir, "newdirectory"),
+			pathType:       new(v1.HostPathDirectoryOrCreate),
+			checkExistence: true,
+			checkDirectory: true,
 		},
 		{
-			name:          "New File",
-			path:          "/newFile",
-			pathType:      ptr.To(v1.HostPathFile),
-			isFile:        false,
-			exists:        false,
-			validpathType: newHostPathTypeList(string(v1.HostPathFileOrCreate)),
-			invalidpathType: newHostPathTypeList(string(v1.HostPathDirectory),
-				string(v1.HostPathSocket), string(v1.HostPathCharDev), string(v1.HostPathBlockDev)),
+			name:           "Created directory",
+			path:           filepath.Join(tempDir, "newdirectory"),
+			pathType:       new(v1.HostPathDirectory),
+			checkExistence: true,
+			checkDirectory: true,
 		},
 		{
-			name:          "Existing Socket",
-			path:          "/existing.socket",
-			pathType:      ptr.To(v1.HostPathSocket),
-			isSocket:      true,
-			isFile:        true,
-			exists:        true,
-			validpathType: newHostPathTypeList(string(v1.HostPathSocket), string(v1.HostPathFileOrCreate), string(v1.HostPathFile)),
-			invalidpathType: newHostPathTypeList(string(v1.HostPathDirectoryOrCreate), string(v1.HostPathDirectory),
-				string(v1.HostPathCharDev), string(v1.HostPathBlockDev)),
+			name:           "Created directory (mounted with OrCreate)",
+			path:           filepath.Join(tempDir, "newdirectory"),
+			pathType:       new(v1.HostPathDirectoryOrCreate),
+			checkExistence: true,
+			checkDirectory: true,
 		},
 		{
-			name:          "Existing Character Device",
-			path:          "/existing.char",
-			pathType:      ptr.To(v1.HostPathCharDev),
-			isChar:        true,
-			isFile:        true,
-			exists:        true,
-			validpathType: newHostPathTypeList(string(v1.HostPathCharDev), string(v1.HostPathFileOrCreate), string(v1.HostPathFile)),
-			invalidpathType: newHostPathTypeList(string(v1.HostPathDirectoryOrCreate), string(v1.HostPathDirectory),
-				string(v1.HostPathSocket), string(v1.HostPathBlockDev)),
+			name:          "Simulated Socket File",
+			path:          filepath.Join(tempDir, "socket"),
+			pathType:      new(v1.HostPathSocket),
+			simulatedType: new(hostutil.FileTypeSocket),
 		},
 		{
-			name:          "Existing Block Device",
-			path:          "/existing.block",
-			pathType:      ptr.To(v1.HostPathBlockDev),
-			isBlock:       true,
-			isFile:        true,
-			exists:        true,
-			validpathType: newHostPathTypeList(string(v1.HostPathBlockDev), string(v1.HostPathFileOrCreate), string(v1.HostPathFile)),
-			invalidpathType: newHostPathTypeList(string(v1.HostPathDirectoryOrCreate), string(v1.HostPathDirectory),
-				string(v1.HostPathSocket), string(v1.HostPathCharDev)),
+			name:          "Simulated Character Device",
+			path:          filepath.Join(tempDir, "chardev"),
+			pathType:      new(v1.HostPathCharDev),
+			simulatedType: new(hostutil.FileTypeCharDev),
+		},
+		{
+			name:          "Simulated Block Device",
+			path:          filepath.Join(tempDir, "blockdev"),
+			pathType:      new(v1.HostPathBlockDev),
+			simulatedType: new(hostutil.FileTypeBlockDev),
 		},
 	}
 
 	for i, tc := range testCases {
-		for _, pathType := range tc.validpathType {
-			err := checkTypeInternal(&tc, pathType)
-			if err != nil {
-				t.Errorf("[%d: %q] [%q] expected nil, got %v", i, tc.name, string(*pathType), err)
-			}
+		var hu hostutil.HostUtils
+		if tc.simulatedType != nil {
+			hu = hostutil.NewFakeHostUtil(
+				map[string]hostutil.FileType{
+					tc.path: hostutil.FileType(*tc.simulatedType),
+				})
+		} else {
+			hu = hostutil.NewHostUtil()
 		}
 
-		for _, pathType := range tc.invalidpathType {
-			checkResult := checkTypeInternal(&tc, pathType)
-			if checkResult == nil {
-				t.Errorf("[%d: %q] [%q] expected error, got nil", i, tc.name, string(*pathType))
+		err := checkType(tc.path, tc.pathType, hu)
+		if tc.expectError && err == nil {
+			t.Errorf("[%d: %s] expected an error but didn't get one", i, tc.name)
+		}
+		if !tc.expectError && err != nil {
+			t.Errorf("[%d: %s] didn't expect an error but got one: %v", i, tc.name, err)
+		}
+		if tc.checkExistence {
+			fi, err := os.Stat(tc.path)
+			if errors.Is(err, os.ErrNotExist) {
+				t.Errorf("[%d: %q] path %q does not exist", i, tc.name, tc.path)
+			}
+			if tc.checkDirectory && !fi.IsDir() {
+				t.Errorf("[%d: %q] path %q is not a directory", i, tc.name, tc.path)
 			}
 		}
 	}
-
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The setup and teardown functions intended for TestOSFileTypeChecker suggest that it was intended to use real files where possible, but it doesn't (or no longer does). This reworks the test function to use a temporary directory and real files for all appropriate tests (based on directories and files), and adds scenarios to cover the various code paths in the checkType().

The resulting coverage includes all the code covered by TestHostPathTypeCheckerInternal, so the latter can be dropped, which allows checkType() to be simplified and the whole hostPathTypeChecker interface and implementations to be dropped. Type checks all end up comparing strings returned by HostUtils, so the IsDir(), IsFile() etc. functions are also dropped in favour of direct type comparisons.

Overall hostpath test coverage increases from 65.8% to 68.1%, on fewer lines of code.

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
