### PR TITLE
Drop testing dependency from shipped binaries

### DIFF
--- a/pkg/kubelet/container/testing/fake_runtime.go
+++ b/pkg/kubelet/container/testing/fake_runtime.go
@@ -22,7 +22,6 @@ import (
 	"net/url"
 	"reflect"
 	"sync"
-	"testing"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -32,6 +31,10 @@ import (
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/volume"
 )
+
+type TB interface {
+	Errorf(format string, args ...any)
+}
 
 type FakePod struct {
 	Pod       *kubecontainer.Pod
@@ -65,7 +68,7 @@ type FakeRuntime struct {
 	// from container runtime.
 	BlockImagePulls      bool
 	imagePullTokenBucket chan bool
-	T                    *testing.T
+	T                    TB
 }
 
 const FakeHost = "localhost:12345"

--- a/staging/src/k8s.io/component-base/metrics/testutil/testutil.go
+++ b/staging/src/k8s.io/component-base/metrics/testutil/testutil.go
@@ -19,7 +19,6 @@ package testutil
 import (
 	"fmt"
 	"io"
-	"testing"
 
 	"github.com/prometheus/client_golang/prometheus/testutil"
 
@@ -27,6 +26,12 @@ import (
 	"k8s.io/component-base/metrics"
 	"k8s.io/component-base/metrics/legacyregistry"
 )
+
+type TB interface {
+	Logf(format string, args ...any)
+	Errorf(format string, args ...any)
+	Fatalf(format string, args ...any)
+}
 
 // CollectAndCompare registers the provided Collector with a newly created
 // pedantic Registry. It then does the same as GatherAndCompare, gathering the
@@ -94,7 +99,7 @@ func NewFakeKubeRegistry(ver string) metrics.KubeRegistry {
 	return metrics.NewKubeRegistry()
 }
 
-func AssertVectorCount(t *testing.T, name string, labelFilter map[string]string, wantCount int) {
+func AssertVectorCount(t TB, name string, labelFilter map[string]string, wantCount int) {
 	metrics, err := legacyregistry.DefaultGatherer.Gather()
 	if err != nil {
 		t.Fatalf("Failed to gather metrics: %s", err)
@@ -124,7 +129,7 @@ func AssertVectorCount(t *testing.T, name string, labelFilter map[string]string,
 	}
 }
 
-func AssertHistogramTotalCount(t *testing.T, name string, labelFilter map[string]string, wantCount int) {
+func AssertHistogramTotalCount(t TB, name string, labelFilter map[string]string, wantCount int) {
 	metrics, err := legacyregistry.DefaultGatherer.Gather()
 	if err != nil {
 		t.Fatalf("Failed to gather metrics: %s", err)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

xref https://github.com/kubernetes/kubernetes/pull/121735

xref https://github.com/kubernetes/kubernetes/issues/115175

Drops dependencies linking the stdlib testing package into binaries we ship

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

cc @dims
/area code-organization
/sig architecture testing