### PR TITLE
kube-proxy: Fix etp:Local for externalIPs

### DIFF
--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -1677,6 +1677,9 @@ func (proxier *Proxier) writeIptablesRules() {
 		"-m", "set", "--match-set", proxier.ipsetList[kubeExternalIPSet].Name, "dst,dst", "-j", "RETURN")
 	proxier.filterRules.Write(
 		"-A", string(kubeIPVSFilterChain),
+		"-m", "set", "--match-set", proxier.ipsetList[kubeExternalIPLocalSet].Name, "dst,dst", "-j", "RETURN")
+	proxier.filterRules.Write(
+		"-A", string(kubeIPVSFilterChain),
 		"-m", "set", "--match-set", proxier.ipsetList[kubeHealthCheckNodePortSet].Name, "dst", "-j", "RETURN")
 	proxier.filterRules.Write(
 		"-A", string(kubeIPVSFilterChain),


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig network
/area kube-proxy
/area ipvs

#### What this PR does / why we need it:

Make `externalIPs` work with `externalTrafficPolicy: Local`. The problem was introduced by PR #108460.

#### Which issue(s) this PR fixes:

Fixes #121909

#### Special notes for your reviewer:

Should probably be back-ported.

#### Does this PR introduce a user-facing change?

```release-note
Fixes a 1.26.0+ regression in kube-proxy to make externalIPs work with externalTrafficPolicy: Local
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

N/A
