### PR TITLE
Change pod domain name pattern to omit ClusterDomain if empty

### DIFF
--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -432,8 +432,6 @@ func (kl *Kubelet) GetOrCreateUserNamespaceMappings(pod *v1.Pod) (*runtimeapi.Us
 // GeneratePodHostNameAndDomain creates a hostname and domain name for a pod,
 // given that pod's spec and annotations or returns an error.
 func (kl *Kubelet) GeneratePodHostNameAndDomain(pod *v1.Pod) (string, string, error) {
-	clusterDomain := kl.dnsConfigurer.ClusterDomain
-
 	hostname := pod.Name
 	if len(pod.Spec.Hostname) > 0 {
 		if msgs := utilvalidation.IsDNS1123Label(pod.Spec.Hostname); len(msgs) != 0 {
@@ -452,7 +450,12 @@ func (kl *Kubelet) GeneratePodHostNameAndDomain(pod *v1.Pod) (string, string, er
 		if msgs := utilvalidation.IsDNS1123Label(pod.Spec.Subdomain); len(msgs) != 0 {
 			return "", "", fmt.Errorf("pod Subdomain %q is not a valid DNS label: %s", pod.Spec.Subdomain, strings.Join(msgs, ";"))
 		}
-		hostDomain = fmt.Sprintf("%s.%s.svc.%s", pod.Spec.Subdomain, pod.Namespace, clusterDomain)
+		hostDomain = fmt.Sprintf("%s.%s.svc", pod.Spec.Subdomain, pod.Namespace)
+
+		clusterDomain := kl.dnsConfigurer.ClusterDomain
+		if len(clusterDomain) > 0 {
+			hostDomain = fmt.Sprintf("%s.%s", hostDomain, clusterDomain)
+		}
 	}
 
 	return hostname, hostDomain, nil

--- a/test/e2e_node/pod_hostnamefqdn_test.go
+++ b/test/e2e_node/pod_hostnamefqdn_test.go
@@ -119,7 +119,10 @@ var _ = SIGDescribe("Hostname of Pod", framework.WithNodeConformance(), func() {
 		// Set PodSpec subdomain field to generate FQDN for pod
 		pod.Spec.Subdomain = subdomain
 		// Expected Pod FQDN
-		hostFQDN := fmt.Sprintf("%s.%s.%s.svc.%s", pod.ObjectMeta.Name, subdomain, f.Namespace.Name, framework.TestContext.ClusterDNSDomain)
+		hostFQDN := fmt.Sprintf("%s.%s.%s.svc", pod.ObjectMeta.Name, subdomain, f.Namespace.Name)
+		if framework.TestContext.ClusterDNSDomain != "" {
+			hostFQDN = fmt.Sprintf("%s.%s", hostFQDN, framework.TestContext.ClusterDNSDomain)
+		}
 		output := []string{fmt.Sprintf("%s;%s;", pod.ObjectMeta.Name, hostFQDN)}
 		// Create Pod
 		e2eoutput.TestContainerOutput(ctx, f, "shortname and fqdn", pod, 0, output)
@@ -141,7 +144,10 @@ var _ = SIGDescribe("Hostname of Pod", framework.WithNodeConformance(), func() {
 		setHostnameAsFQDN := true
 		pod.Spec.SetHostnameAsFQDN = &setHostnameAsFQDN
 		// Expected Pod FQDN
-		hostFQDN := fmt.Sprintf("%s.%s.%s.svc.%s", pod.ObjectMeta.Name, subdomain, f.Namespace.Name, framework.TestContext.ClusterDNSDomain)
+		hostFQDN := fmt.Sprintf("%s.%s.%s.svc", pod.ObjectMeta.Name, subdomain, f.Namespace.Name)
+		if framework.TestContext.ClusterDNSDomain != "" {
+			hostFQDN = fmt.Sprintf("%s.%s", hostFQDN, framework.TestContext.ClusterDNSDomain)
+		}
 		// Fail if FQDN is longer than 64 characters, otherwise the Pod will remain pending until test timeout.
 		// In Linux, 64 characters is the limit of the hostname kernel field, which this test sets to the pod FQDN.
 		gomega.Expect(len(hostFQDN)).Should(gomega.BeNumerically("<=", 64), "The FQDN of the Pod cannot be longer than 64 characters, requested %s which is %d characters long.", hostFQDN, len(hostFQDN))


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

During the creation of the fully qualified domain name for a pod, the domain name might end in '.' if the ClusterDomain is empty. This PR makes sure to append the ClusterDomain only if it is not empty, thus making sure the domain name for the pod will not end in a '.'.

#### Which issue(s) this PR fixes:

Fixes #121868 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
