### PR TITLE
Add sleep in websocket unit tests whose test server returning instantly

### DIFF
--- a/staging/src/k8s.io/client-go/tools/remotecommand/websocket_test.go
+++ b/staging/src/k8s.io/client-go/tools/remotecommand/websocket_test.go
@@ -714,6 +714,7 @@ func TestWebSocketClient_ProtocolVersions(t *testing.T) {
 			t.Fatalf("unable to upgrade to create websocket connection: %v", err)
 		}
 		defer conn.Close()
+		time.Sleep(100 * time.Millisecond)
 	}))
 	defer websocketServer.Close()
 
@@ -895,6 +896,7 @@ func TestWebSocketClient_TextMessageTypeError(t *testing.T) {
 			t.Fatalf("unable to upgrade to create websocket connection: %v", err)
 		}
 		defer conn.Close()
+		time.Sleep(100 * time.Millisecond)
 		msg := []byte("test message with wrong message type.")
 		stdOutMsg := append([]byte{remotecommand.StreamStdOut}, msg...)
 		// Wrong message type "TextMessage".
@@ -902,7 +904,6 @@ func TestWebSocketClient_TextMessageTypeError(t *testing.T) {
 		if err != nil {
 			t.Fatalf("error writing text message to websocket: %v", err)
 		}
-
 	}))
 	defer websocketServer.Close()
 
@@ -962,6 +963,7 @@ func TestWebSocketClient_EmptyMessageHandled(t *testing.T) {
 			t.Fatalf("unable to upgrade to create websocket connection: %v", err)
 		}
 		defer conn.Close()
+		time.Sleep(100 * time.Millisecond)
 		// Send completely empty message, including missing initial stream id.
 		conn.WriteMessage(gwebsocket.BinaryMessage, []byte{}) //nolint:errcheck
 	}))


### PR DESCRIPTION
#### What type of PR is this?
/kind failing-test
/kind flake

#### What this PR does / why we need it:
There are 3 unit tests in remotecommand/websockets whose server returns ~instantly due to it's nature so that causes failure and flakiness.
The reason of the failure is when the connection is established, server returns instantly but websocket's client side hasn't yet started the goroutine that reads the messages from server. Although this can not be happened on production, we need to fix that flakiness.

This PR adds a sleep(100 ms) to give time to client to start listening the server.

```
$ cd staging/src/k8s.io/client-go/tools/
$ go test -race -c ./remotecommand
$ stress ./remotecommand.test -test.run TestWebSocketClient_TextMessageTypeError
failed without the fix
passed 5m0s: 25006 runs so far, 0 failures
$ stress ./remotecommand.test -test.run TestWebSocketClient_ProtocolVersion
failed without the fix
passed 5m0s: 10414 runs so far, 0 failures
$ stress ./remotecommand.test -test.run TestWebSocketClient_EmptyMessageHandled
failed without the fix
passed 2m0s: 10025 runs so far, 0 failures
```

#### Which issue(s) this PR fixes:
Fixes #121233

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
