### PR TITLE
KEP-3221: Implement authorization configuration file reloading

### DIFF
--- a/pkg/controlplane/apiserver/config.go
+++ b/pkg/controlplane/apiserver/config.go
@@ -17,6 +17,7 @@ limitations under the License.
 package apiserver
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -24,6 +25,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 	"k8s.io/apiserver/pkg/endpoints/discovery/aggregated"
 	openapinamer "k8s.io/apiserver/pkg/endpoints/openapi"
@@ -148,7 +150,13 @@ func BuildGenericConfig(
 	}
 
 	var enablesRBAC bool
-	genericConfig.Authorization.Authorizer, genericConfig.RuleResolver, enablesRBAC, err = BuildAuthorizer(s, genericConfig.EgressSelector, versionedInformers)
+	genericConfig.Authorization.Authorizer, genericConfig.RuleResolver, enablesRBAC, err = BuildAuthorizer(
+		wait.ContextForChannel(genericConfig.ShutdownInitiatedNotify()),
+		s,
+		genericConfig.EgressSelector,
+		genericConfig.APIServerID,
+		versionedInformers,
+	)
 	if err != nil {
 		lastErr = fmt.Errorf("invalid authorization config: %v", err)
 		return
@@ -170,7 +178,7 @@ func BuildGenericConfig(
 }
 
 // BuildAuthorizer constructs the authorizer. If authorization is not set in s, it returns nil, nil, false, nil
-func BuildAuthorizer(s controlplaneapiserver.CompletedOptions, egressSelector *egressselector.EgressSelector, versionedInformers clientgoinformers.SharedInformerFactory) (authorizer.Authorizer, authorizer.RuleResolver, bool, error) {
+func BuildAuthorizer(ctx context.Context, s controlplaneapiserver.CompletedOptions, egressSelector *egressselector.EgressSelector, apiserverID string, versionedInformers clientgoinformers.SharedInformerFactory) (authorizer.Authorizer, authorizer.RuleResolver, bool, error) {
 	authorizationConfig, err := s.Authorization.ToAuthorizationConfig(versionedInformers)
 	if err != nil {
 		return nil, nil, false, err
@@ -195,7 +203,7 @@ func BuildAuthorizer(s controlplaneapiserver.CompletedOptions, egressSelector *e
 		}
 	}
 
-	authorizer, ruleResolver, err := authorizationConfig.New()
+	authorizer, ruleResolver, err := authorizationConfig.New(ctx, apiserverID)
 
 	return authorizer, ruleResolver, enablesRBAC, err
 }

--- a/pkg/kubeapiserver/authorizer/config.go
+++ b/pkg/kubeapiserver/authorizer/config.go
@@ -17,7 +17,6 @@ limitations under the License.
 package authorizer
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 
@@ -28,12 +27,7 @@ import (
 	authzconfig "k8s.io/apiserver/pkg/apis/apiserver"
 	"k8s.io/apiserver/pkg/apis/apiserver/load"
 	"k8s.io/apiserver/pkg/apis/apiserver/validation"
-	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
-	"k8s.io/apiserver/pkg/authorization/authorizerfactory"
-	"k8s.io/apiserver/pkg/authorization/union"
-	webhookutil "k8s.io/apiserver/pkg/util/webhook"
-	"k8s.io/apiserver/plugin/pkg/authorizer/webhook"
 	versionedinformers "k8s.io/client-go/informers"
 	"k8s.io/kubernetes/pkg/auth/authorizer/abac"
 	"k8s.io/kubernetes/pkg/auth/nodeidentifier"
@@ -121,88 +115,6 @@ func (config Config) New() (authorizer.Authorizer, authorizer.RuleResolver, erro
 	})
 
 	return r, r, nil
-}
-
-// newForConfig constructs
-func (r *reloadableAuthorizerResolver) newForConfig(authzConfig *authzconfig.AuthorizationConfiguration) (authorizer.Authorizer, authorizer.RuleResolver, error) {
-	if len(authzConfig.Authorizers) == 0 {
-		return nil, nil, fmt.Errorf("at least one authorization mode must be passed")
-	}
-
-	var (
-		authorizers   []authorizer.Authorizer
-		ruleResolvers []authorizer.RuleResolver
-	)
-
-	// Add SystemPrivilegedGroup as an authorizing group
-	superuserAuthorizer := authorizerfactory.NewPrivilegedGroups(user.SystemPrivilegedGroup)
-	authorizers = append(authorizers, superuserAuthorizer)
-
-	for _, configuredAuthorizer := range authzConfig.Authorizers {
-		// Keep cases in sync with constant list in k8s.io/kubernetes/pkg/kubeapiserver/authorizer/modes/modes.go.
-		switch configuredAuthorizer.Type {
-		case authzconfig.AuthorizerType(modes.ModeNode):
-			if r.nodeAuthorizer == nil {
-				return nil, nil, fmt.Errorf("nil nodeAuthorizer")
-			}
-			authorizers = append(authorizers, r.nodeAuthorizer)
-			ruleResolvers = append(ruleResolvers, r.nodeAuthorizer)
-		case authzconfig.AuthorizerType(modes.ModeAlwaysAllow):
-			alwaysAllowAuthorizer := authorizerfactory.NewAlwaysAllowAuthorizer()
-			authorizers = append(authorizers, alwaysAllowAuthorizer)
-			ruleResolvers = append(ruleResolvers, alwaysAllowAuthorizer)
-		case authzconfig.AuthorizerType(modes.ModeAlwaysDeny):
-			alwaysDenyAuthorizer := authorizerfactory.NewAlwaysDenyAuthorizer()
-			authorizers = append(authorizers, alwaysDenyAuthorizer)
-			ruleResolvers = append(ruleResolvers, alwaysDenyAuthorizer)
-		case authzconfig.AuthorizerType(modes.ModeABAC):
-			if r.abacAuthorizer == nil {
-				return nil, nil, fmt.Errorf("nil abacAuthorizer")
-			}
-			authorizers = append(authorizers, r.abacAuthorizer)
-			ruleResolvers = append(ruleResolvers, r.abacAuthorizer)
-		case authzconfig.AuthorizerType(modes.ModeWebhook):
-			if r.initialConfig.WebhookRetryBackoff == nil {
-				return nil, nil, errors.New("retry backoff parameters for authorization webhook has not been specified")
-			}
-			clientConfig, err := webhookutil.LoadKubeconfig(*configuredAuthorizer.Webhook.ConnectionInfo.KubeConfigFile, r.initialConfig.CustomDial)
-			if err != nil {
-				return nil, nil, err
-			}
-			var decisionOnError authorizer.Decision
-			switch configuredAuthorizer.Webhook.FailurePolicy {
-			case authzconfig.FailurePolicyNoOpinion:
-				decisionOnError = authorizer.DecisionNoOpinion
-			case authzconfig.FailurePolicyDeny:
-				decisionOnError = authorizer.DecisionDeny
-			default:
-				return nil, nil, fmt.Errorf("unknown failurePolicy %q", configuredAuthorizer.Webhook.FailurePolicy)
-			}
-			webhookAuthorizer, err := webhook.New(clientConfig,
-				configuredAuthorizer.Webhook.SubjectAccessReviewVersion,
-				configuredAuthorizer.Webhook.AuthorizedTTL.Duration,
-				configuredAuthorizer.Webhook.UnauthorizedTTL.Duration,
-				*r.initialConfig.WebhookRetryBackoff,
-				decisionOnError,
-				configuredAuthorizer.Webhook.MatchConditions,
-			)
-			if err != nil {
-				return nil, nil, err
-			}
-			authorizers = append(authorizers, webhookAuthorizer)
-			ruleResolvers = append(ruleResolvers, webhookAuthorizer)
-		case authzconfig.AuthorizerType(modes.ModeRBAC):
-			if r.rbacAuthorizer == nil {
-				return nil, nil, fmt.Errorf("nil rbacAuthorizer")
-			}
-			authorizers = append(authorizers, r.rbacAuthorizer)
-			ruleResolvers = append(ruleResolvers, r.rbacAuthorizer)
-		default:
-			return nil, nil, fmt.Errorf("unknown authorization mode %s specified", configuredAuthorizer.Type)
-		}
-	}
-
-	return union.New(authorizers...), union.NewRuleResolvers(ruleResolvers...), nil
 }
 
 // RepeatableAuthorizerTypes is the list of Authorizer that can be repeated in the Authorization Config

--- a/pkg/kubeapiserver/authorizer/reload.go
+++ b/pkg/kubeapiserver/authorizer/reload.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package authorizer
+
+import (
+	"context"
+	"sync/atomic"
+
+	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+	"k8s.io/kubernetes/pkg/auth/authorizer/abac"
+	"k8s.io/kubernetes/plugin/pkg/auth/authorizer/node"
+	"k8s.io/kubernetes/plugin/pkg/auth/authorizer/rbac"
+)
+
+type reloadableAuthorizerResolver struct {
+	// initialConfig holds the ReloadFile used to initiate background reloading,
+	// and information used to construct webhooks that isn't exposed in the authorization
+	// configuration file (dial function, backoff settings, etc)
+	initialConfig Config
+
+	nodeAuthorizer *node.NodeAuthorizer
+	rbacAuthorizer *rbac.RBACAuthorizer
+	abacAuthorizer abac.PolicyList
+
+	current atomic.Pointer[authorizerResolver]
+}
+
+type authorizerResolver struct {
+	authorizer   authorizer.Authorizer
+	ruleResolver authorizer.RuleResolver
+}
+
+func (r *reloadableAuthorizerResolver) Authorize(ctx context.Context, a authorizer.Attributes) (authorized authorizer.Decision, reason string, err error) {
+	return r.current.Load().authorizer.Authorize(ctx, a)
+}
+
+func (r *reloadableAuthorizerResolver) RulesFor(user user.Info, namespace string) ([]authorizer.ResourceRuleInfo, []authorizer.NonResourceRuleInfo, bool, error) {
+	return r.current.Load().ruleResolver.RulesFor(user, namespace)
+}

--- a/pkg/kubeapiserver/authorizer/reload.go
+++ b/pkg/kubeapiserver/authorizer/reload.go
@@ -18,11 +18,19 @@ package authorizer
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"sync/atomic"
 
+	authzconfig "k8s.io/apiserver/pkg/apis/apiserver"
 	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
+	"k8s.io/apiserver/pkg/authorization/authorizerfactory"
+	"k8s.io/apiserver/pkg/authorization/union"
+	webhookutil "k8s.io/apiserver/pkg/util/webhook"
+	"k8s.io/apiserver/plugin/pkg/authorizer/webhook"
 	"k8s.io/kubernetes/pkg/auth/authorizer/abac"
+	"k8s.io/kubernetes/pkg/kubeapiserver/authorizer/modes"
 	"k8s.io/kubernetes/plugin/pkg/auth/authorizer/node"
 	"k8s.io/kubernetes/plugin/pkg/auth/authorizer/rbac"
 )
@@ -51,4 +59,86 @@ func (r *reloadableAuthorizerResolver) Authorize(ctx context.Context, a authoriz
 
 func (r *reloadableAuthorizerResolver) RulesFor(user user.Info, namespace string) ([]authorizer.ResourceRuleInfo, []authorizer.NonResourceRuleInfo, bool, error) {
 	return r.current.Load().ruleResolver.RulesFor(user, namespace)
+}
+
+// newForConfig constructs
+func (r *reloadableAuthorizerResolver) newForConfig(authzConfig *authzconfig.AuthorizationConfiguration) (authorizer.Authorizer, authorizer.RuleResolver, error) {
+	if len(authzConfig.Authorizers) == 0 {
+		return nil, nil, fmt.Errorf("at least one authorization mode must be passed")
+	}
+
+	var (
+		authorizers   []authorizer.Authorizer
+		ruleResolvers []authorizer.RuleResolver
+	)
+
+	// Add SystemPrivilegedGroup as an authorizing group
+	superuserAuthorizer := authorizerfactory.NewPrivilegedGroups(user.SystemPrivilegedGroup)
+	authorizers = append(authorizers, superuserAuthorizer)
+
+	for _, configuredAuthorizer := range authzConfig.Authorizers {
+		// Keep cases in sync with constant list in k8s.io/kubernetes/pkg/kubeapiserver/authorizer/modes/modes.go.
+		switch configuredAuthorizer.Type {
+		case authzconfig.AuthorizerType(modes.ModeNode):
+			if r.nodeAuthorizer == nil {
+				return nil, nil, fmt.Errorf("authorizer type Node is not allowed if it was not enabled at initial server startup")
+			}
+			authorizers = append(authorizers, r.nodeAuthorizer)
+			ruleResolvers = append(ruleResolvers, r.nodeAuthorizer)
+		case authzconfig.AuthorizerType(modes.ModeAlwaysAllow):
+			alwaysAllowAuthorizer := authorizerfactory.NewAlwaysAllowAuthorizer()
+			authorizers = append(authorizers, alwaysAllowAuthorizer)
+			ruleResolvers = append(ruleResolvers, alwaysAllowAuthorizer)
+		case authzconfig.AuthorizerType(modes.ModeAlwaysDeny):
+			alwaysDenyAuthorizer := authorizerfactory.NewAlwaysDenyAuthorizer()
+			authorizers = append(authorizers, alwaysDenyAuthorizer)
+			ruleResolvers = append(ruleResolvers, alwaysDenyAuthorizer)
+		case authzconfig.AuthorizerType(modes.ModeABAC):
+			if r.abacAuthorizer == nil {
+				return nil, nil, fmt.Errorf("authorizer type ABAC is not allowed if it was not enabled at initial server startup")
+			}
+			authorizers = append(authorizers, r.abacAuthorizer)
+			ruleResolvers = append(ruleResolvers, r.abacAuthorizer)
+		case authzconfig.AuthorizerType(modes.ModeWebhook):
+			if r.initialConfig.WebhookRetryBackoff == nil {
+				return nil, nil, errors.New("retry backoff parameters for authorization webhook has not been specified")
+			}
+			clientConfig, err := webhookutil.LoadKubeconfig(*configuredAuthorizer.Webhook.ConnectionInfo.KubeConfigFile, r.initialConfig.CustomDial)
+			if err != nil {
+				return nil, nil, err
+			}
+			var decisionOnError authorizer.Decision
+			switch configuredAuthorizer.Webhook.FailurePolicy {
+			case authzconfig.FailurePolicyNoOpinion:
+				decisionOnError = authorizer.DecisionNoOpinion
+			case authzconfig.FailurePolicyDeny:
+				decisionOnError = authorizer.DecisionDeny
+			default:
+				return nil, nil, fmt.Errorf("unknown failurePolicy %q", configuredAuthorizer.Webhook.FailurePolicy)
+			}
+			webhookAuthorizer, err := webhook.New(clientConfig,
+				configuredAuthorizer.Webhook.SubjectAccessReviewVersion,
+				configuredAuthorizer.Webhook.AuthorizedTTL.Duration,
+				configuredAuthorizer.Webhook.UnauthorizedTTL.Duration,
+				*r.initialConfig.WebhookRetryBackoff,
+				decisionOnError,
+				configuredAuthorizer.Webhook.MatchConditions,
+			)
+			if err != nil {
+				return nil, nil, err
+			}
+			authorizers = append(authorizers, webhookAuthorizer)
+			ruleResolvers = append(ruleResolvers, webhookAuthorizer)
+		case authzconfig.AuthorizerType(modes.ModeRBAC):
+			if r.rbacAuthorizer == nil {
+				return nil, nil, fmt.Errorf("authorizer type RBAC is not allowed if it was not enabled at initial server startup")
+			}
+			authorizers = append(authorizers, r.rbacAuthorizer)
+			ruleResolvers = append(ruleResolvers, r.rbacAuthorizer)
+		default:
+			return nil, nil, fmt.Errorf("unknown authorization mode %s specified", configuredAuthorizer.Type)
+		}
+	}
+
+	return union.New(authorizers...), union.NewRuleResolvers(ruleResolvers...), nil
 }

--- a/pkg/kubeapiserver/options/authorization.go
+++ b/pkg/kubeapiserver/options/authorization.go
@@ -249,6 +249,7 @@ func (o *BuiltInAuthorizationOptions) ToAuthorizationConfig(versionedInformerFac
 		VersionedInformerFactory: versionedInformerFactory,
 		WebhookRetryBackoff:      o.WebhookRetryBackoff,
 
+		ReloadFile:                 o.AuthorizationConfigurationFile,
 		AuthorizationConfiguration: authorizationConfiguration,
 	}, nil
 }

--- a/pkg/kubeapiserver/options/authorization.go
+++ b/pkg/kubeapiserver/options/authorization.go
@@ -21,7 +21,6 @@ import (
 	"strings"
 	"time"
 
-	"k8s.io/apiserver/pkg/apis/apiserver/load"
 	genericfeatures "k8s.io/apiserver/pkg/features"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 
@@ -31,7 +30,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	authzconfig "k8s.io/apiserver/pkg/apis/apiserver"
-	"k8s.io/apiserver/pkg/apis/apiserver/validation"
 	genericoptions "k8s.io/apiserver/pkg/server/options"
 	versionedinformers "k8s.io/client-go/informers"
 
@@ -49,9 +47,6 @@ const (
 	authorizationPolicyFileFlag             = "authorization-policy-file"
 	authorizationConfigFlag                 = "authorization-config"
 )
-
-// RepeatableAuthorizerTypes is the list of Authorizer that can be repeated in the Authorization Config
-var repeatableAuthorizerTypes = []string{authzmodes.ModeWebhook}
 
 // BuiltInAuthorizationOptions contains all build-in authorization options for API Server
 type BuiltInAuthorizationOptions struct {
@@ -118,32 +113,10 @@ func (o *BuiltInAuthorizationOptions) Validate() []error {
 			return append(allErrors, fmt.Errorf("--%s can not be specified when --%s or --authorization-webhook-* flags are defined", authorizationConfigFlag, authorizationModeFlag))
 		}
 
-		// load the file and check for errors
-		config, err := load.LoadFromFile(o.AuthorizationConfigurationFile)
+		// load/validate kube-apiserver authz config with no opinion about required modes
+		_, err := authorizer.LoadAndValidateFile(o.AuthorizationConfigurationFile, nil)
 		if err != nil {
-			return append(allErrors, fmt.Errorf("failed to load AuthorizationConfiguration from file: %v", err))
-		}
-
-		// validate the file and return any error
-		if errors := validation.ValidateAuthorizationConfiguration(nil, config,
-			sets.NewString(authzmodes.AuthorizationModeChoices...),
-			sets.NewString(repeatableAuthorizerTypes...),
-		); len(errors) != 0 {
-			allErrors = append(allErrors, errors.ToAggregate().Errors()...)
-		}
-
-		// test to check if the authorizer names passed conform to the authorizers for type!=Webhook
-		// this test is only for kube-apiserver and hence checked here
-		// it preserves compatibility with o.buildAuthorizationConfiguration
-		for _, authorizer := range config.Authorizers {
-			if string(authorizer.Type) == authzmodes.ModeWebhook {
-				continue
-			}
-
-			expectedName := getNameForAuthorizerMode(string(authorizer.Type))
-			if expectedName != authorizer.Name {
-				allErrors = append(allErrors, fmt.Errorf("expected name %s for authorizer %s instead of %s", expectedName, authorizer.Type, authorizer.Name))
-			}
+			return append(allErrors, err)
 		}
 
 		return allErrors
@@ -255,24 +228,14 @@ func (o *BuiltInAuthorizationOptions) ToAuthorizationConfig(versionedInformerFac
 		if !utilfeature.DefaultFeatureGate.Enabled(genericfeatures.StructuredAuthorizationConfiguration) {
 			return nil, fmt.Errorf("--%s cannot be used without enabling StructuredAuthorizationConfiguration feature flag", authorizationConfigFlag)
 		}
-
 		// error out if legacy flags are defined
 		if o.AreLegacyFlagsSet != nil && o.AreLegacyFlagsSet() {
 			return nil, fmt.Errorf("--%s can not be specified when --%s or --authorization-webhook-* flags are defined", authorizationConfigFlag, authorizationModeFlag)
 		}
-
-		// load the file and check for errors
-		authorizationConfiguration, err = load.LoadFromFile(o.AuthorizationConfigurationFile)
+		// load/validate kube-apiserver authz config with no opinion about required modes
+		authorizationConfiguration, err = authorizer.LoadAndValidateFile(o.AuthorizationConfigurationFile, nil)
 		if err != nil {
-			return nil, fmt.Errorf("failed to load AuthorizationConfiguration from file: %v", err)
-		}
-
-		// validate the file and return any error
-		if errors := validation.ValidateAuthorizationConfiguration(nil, authorizationConfiguration,
-			sets.NewString(authzmodes.AuthorizationModeChoices...),
-			sets.NewString(repeatableAuthorizerTypes...),
-		); len(errors) != 0 {
-			return nil, fmt.Errorf(errors.ToAggregate().Error())
+			return nil, err
 		}
 	} else {
 		authorizationConfiguration, err = o.buildAuthorizationConfiguration()
@@ -321,16 +284,10 @@ func (o *BuiltInAuthorizationOptions) buildAuthorizationConfiguration() (*authzc
 		default:
 			authorizers = append(authorizers, authzconfig.AuthorizerConfiguration{
 				Type: authzconfig.AuthorizerType(mode),
-				Name: getNameForAuthorizerMode(mode),
+				Name: authorizer.GetNameForAuthorizerMode(mode),
 			})
 		}
 	}
 
 	return &authzconfig.AuthorizationConfiguration{Authorizers: authorizers}, nil
-}
-
-// getNameForAuthorizerMode returns the name to be set for the mode in AuthorizationConfiguration
-// For now, lower cases the mode name
-func getNameForAuthorizerMode(mode string) string {
-	return strings.ToLower(mode)
 }

--- a/pkg/util/filesystem/watcher.go
+++ b/pkg/util/filesystem/watcher.go
@@ -17,6 +17,10 @@ limitations under the License.
 package filesystem
 
 import (
+	"context"
+	"fmt"
+	"time"
+
 	"github.com/fsnotify/fsnotify"
 )
 
@@ -86,4 +90,127 @@ func (w *fsnotifyWatcher) Run() {
 			}
 		}
 	}()
+}
+
+type watchAddRemover interface {
+	Add(path string) error
+	Remove(path string) error
+}
+type noopWatcher struct{}
+
+func (noopWatcher) Add(path string) error    { return nil }
+func (noopWatcher) Remove(path string) error { return nil }
+
+// WatchUntil watches the specified path for changes and blocks until ctx is canceled.
+// eventHandler() must be non-nil, and pollInterval must be greater than 0.
+// eventHandler() is invoked whenever a change event is observed or pollInterval elapses.
+// errorHandler() is invoked (if non-nil) whenever an error occurs initializing or watching the specified path.
+//
+// If path is a directory, only the directory and immediate children are watched.
+//
+// If path does not exist or cannot be watched, an error is passed to errorHandler() and eventHandler() is called at pollInterval.
+//
+// Multiple observed events may collapse to a single invocation of eventHandler().
+//
+// eventHandler() is invoked immediately after successful initialization of the filesystem watch,
+// in case the path changed concurrent with calling WatchUntil().
+func WatchUntil(ctx context.Context, pollInterval time.Duration, path string, eventHandler func(), errorHandler func(err error)) {
+	if pollInterval <= 0 {
+		panic(fmt.Errorf("pollInterval must be > 0"))
+	}
+	if eventHandler == nil {
+		panic(fmt.Errorf("eventHandler must be non-nil"))
+	}
+	if errorHandler == nil {
+		errorHandler = func(err error) {}
+	}
+
+	// Initialize watcher, fall back to no-op
+	var (
+		eventsCh chan fsnotify.Event
+		errorCh  chan error
+		watcher  watchAddRemover
+	)
+	if w, err := fsnotify.NewWatcher(); err != nil {
+		errorHandler(fmt.Errorf("error creating file watcher, falling back to poll at interval %s: %w", pollInterval, err))
+		watcher = noopWatcher{}
+	} else {
+		watcher = w
+		eventsCh = w.Events
+		errorCh = w.Errors
+		defer func() {
+			_ = w.Close()
+		}()
+	}
+
+	// Initialize background poll
+	t := time.NewTicker(pollInterval)
+	defer t.Stop()
+
+	attemptPeriodicRewatch := false
+
+	// Start watching the path
+	if err := watcher.Add(path); err != nil {
+		errorHandler(err)
+		attemptPeriodicRewatch = true
+	} else {
+		// Invoke handle() at least once after successfully registering the listener,
+		// in case the file changed concurrent with calling WatchUntil.
+		eventHandler()
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+
+		case <-t.C:
+			// Prioritize exiting if context is canceled
+			if ctx.Err() != nil {
+				return
+			}
+
+			// Try to re-establish the watcher if we previously got a watch error
+			if attemptPeriodicRewatch {
+				_ = watcher.Remove(path)
+				if err := watcher.Add(path); err != nil {
+					errorHandler(err)
+				} else {
+					attemptPeriodicRewatch = false
+				}
+			}
+
+			// Handle
+			eventHandler()
+
+		case e := <-eventsCh:
+			// Prioritize exiting if context is canceled
+			if ctx.Err() != nil {
+				return
+			}
+
+			// Try to re-establish the watcher for events which dropped the existing watch
+			if e.Name == path && (e.Has(fsnotify.Remove) || e.Has(fsnotify.Rename)) {
+				_ = watcher.Remove(path)
+				if err := watcher.Add(path); err != nil {
+					errorHandler(err)
+					attemptPeriodicRewatch = true
+				}
+			}
+
+			// Handle
+			eventHandler()
+
+		case err := <-errorCh:
+			// Prioritize exiting if context is canceled
+			if ctx.Err() != nil {
+				return
+			}
+
+			// If the error occurs in response to calling watcher.Add, re-adding here could hot-loop.
+			// The periodic poll will attempt to re-establish the watch.
+			errorHandler(err)
+			attemptPeriodicRewatch = true
+		}
+	}
 }

--- a/staging/src/k8s.io/apiserver/pkg/server/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config.go
@@ -668,6 +668,11 @@ func (c *Config) DrainedNotify() <-chan struct{} {
 	return c.lifecycleSignals.InFlightRequestsDrained.Signaled()
 }
 
+// ShutdownInitiated returns a lifecycle signal of apiserver shutdown having been initiated.
+func (c *Config) ShutdownInitiatedNotify() <-chan struct{} {
+	return c.lifecycleSignals.ShutdownInitiated.Signaled()
+}
+
 // Complete fills in any fields not set that are required to have valid data and can be derived
 // from other fields. If you're going to `ApplyOptions`, do that first. It's mutating the receiver.
 func (c *Config) Complete(informers informers.SharedInformerFactory) CompletedConfig {

--- a/staging/src/k8s.io/apiserver/pkg/server/options/authorizationconfig/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/authorizationconfig/metrics/metrics.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"hash"
+	"sync"
+
+	"k8s.io/component-base/metrics"
+	"k8s.io/component-base/metrics/legacyregistry"
+)
+
+const (
+	namespace = "apiserver"
+	subsystem = "authorization_config_controller"
+)
+
+var (
+	authorizationConfigAutomaticReloadsTotal = metrics.NewCounterVec(
+		&metrics.CounterOpts{
+			Namespace:      namespace,
+			Subsystem:      subsystem,
+			Name:           "automatic_reloads_total",
+			Help:           "Total number of automatic reloads of authorization configuration split by status and apiserver identity.",
+			StabilityLevel: metrics.ALPHA,
+		},
+		[]string{"status", "apiserver_id_hash"},
+	)
+
+	authorizationConfigAutomaticReloadLastTimestampSeconds = metrics.NewGaugeVec(
+		&metrics.GaugeOpts{
+			Namespace:      namespace,
+			Subsystem:      subsystem,
+			Name:           "automatic_reload_last_timestamp_seconds",
+			Help:           "Timestamp of the last automatic reload of authorization configuration split by status and apiserver identity.",
+			StabilityLevel: metrics.ALPHA,
+		},
+		[]string{"status", "apiserver_id_hash"},
+	)
+)
+
+var registerMetrics sync.Once
+var hashPool *sync.Pool
+
+func RegisterMetrics() {
+	registerMetrics.Do(func() {
+		hashPool = &sync.Pool{
+			New: func() interface{} {
+				return sha256.New()
+			},
+		}
+		legacyregistry.MustRegister(authorizationConfigAutomaticReloadsTotal)
+		legacyregistry.MustRegister(authorizationConfigAutomaticReloadLastTimestampSeconds)
+	})
+}
+
+func ResetMetricsForTest() {
+	authorizationConfigAutomaticReloadsTotal.Reset()
+	authorizationConfigAutomaticReloadLastTimestampSeconds.Reset()
+	legacyregistry.Reset()
+}
+
+func RecordAuthorizationConfigAutomaticReloadFailure(apiServerID string) {
+	apiServerIDHash := getHash(apiServerID)
+	authorizationConfigAutomaticReloadsTotal.WithLabelValues("failure", apiServerIDHash).Inc()
+	authorizationConfigAutomaticReloadLastTimestampSeconds.WithLabelValues("failure", apiServerIDHash).SetToCurrentTime()
+}
+
+func RecordAuthorizationConfigAutomaticReloadSuccess(apiServerID string) {
+	apiServerIDHash := getHash(apiServerID)
+	authorizationConfigAutomaticReloadsTotal.WithLabelValues("success", apiServerIDHash).Inc()
+	authorizationConfigAutomaticReloadLastTimestampSeconds.WithLabelValues("success", apiServerIDHash).SetToCurrentTime()
+}
+
+func getHash(data string) string {
+	if len(data) == 0 {
+		return ""
+	}
+	h := hashPool.Get().(hash.Hash)
+	h.Reset()
+	h.Write([]byte(data))
+	dataHash := fmt.Sprintf("sha256:%x", h.Sum(nil))
+	hashPool.Put(h)
+	return dataHash
+}

--- a/staging/src/k8s.io/apiserver/pkg/server/options/authorizationconfig/metrics/metrics_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/authorizationconfig/metrics/metrics_test.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"strings"
+	"testing"
+
+	"k8s.io/component-base/metrics/legacyregistry"
+	"k8s.io/component-base/metrics/testutil"
+)
+
+const (
+	testAPIServerID     = "testAPIServerID"
+	testAPIServerIDHash = "sha256:14f9d63e669337ac6bfda2e2162915ee6a6067743eddd4e5c374b572f951ff37"
+)
+
+func TestRecordAuthorizationConfigAutomaticReloadFailure(t *testing.T) {
+	expectedValue := `
+	# HELP apiserver_authorization_config_controller_automatic_reloads_total [ALPHA] Total number of automatic reloads of authorization configuration split by status and apiserver identity.
+    # TYPE apiserver_authorization_config_controller_automatic_reloads_total counter
+    apiserver_authorization_config_controller_automatic_reloads_total {apiserver_id_hash="sha256:14f9d63e669337ac6bfda2e2162915ee6a6067743eddd4e5c374b572f951ff37",status="failure"} 1
+	`
+	metrics := []string{
+		namespace + "_" + subsystem + "_automatic_reloads_total",
+	}
+
+	authorizationConfigAutomaticReloadsTotal.Reset()
+	RegisterMetrics()
+
+	RecordAuthorizationConfigAutomaticReloadFailure(testAPIServerID)
+	if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(expectedValue), metrics...); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRecordAuthorizationConfigAutomaticReloadSuccess(t *testing.T) {
+	expectedValue := `
+	# HELP apiserver_authorization_config_controller_automatic_reloads_total [ALPHA] Total number of automatic reloads of authorization configuration split by status and apiserver identity.
+    # TYPE apiserver_authorization_config_controller_automatic_reloads_total counter
+    apiserver_authorization_config_controller_automatic_reloads_total {apiserver_id_hash="sha256:14f9d63e669337ac6bfda2e2162915ee6a6067743eddd4e5c374b572f951ff37",status="success"} 1
+	`
+	metrics := []string{
+		namespace + "_" + subsystem + "_automatic_reloads_total",
+	}
+
+	authorizationConfigAutomaticReloadsTotal.Reset()
+	RegisterMetrics()
+
+	RecordAuthorizationConfigAutomaticReloadSuccess(testAPIServerID)
+	if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(expectedValue), metrics...); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestAuthorizationConfigAutomaticReloadLastTimestampSeconds(t *testing.T) {
+	testCases := []struct {
+		expectedValue string
+		resultLabel   string
+		timestamp     int64
+	}{
+		{
+			expectedValue: `
+                # HELP apiserver_authorization_config_controller_automatic_reload_last_timestamp_seconds [ALPHA] Timestamp of the last automatic reload of authorization configuration split by status and apiserver identity.
+                # TYPE apiserver_authorization_config_controller_automatic_reload_last_timestamp_seconds gauge
+                apiserver_authorization_config_controller_automatic_reload_last_timestamp_seconds{apiserver_id_hash="sha256:14f9d63e669337ac6bfda2e2162915ee6a6067743eddd4e5c374b572f951ff37",status="failure"} 1.689101941e+09
+            `,
+			resultLabel: "failure",
+			timestamp:   1689101941,
+		},
+		{
+			expectedValue: `
+                # HELP apiserver_authorization_config_controller_automatic_reload_last_timestamp_seconds [ALPHA] Timestamp of the last automatic reload of authorization configuration split by status and apiserver identity.
+                # TYPE apiserver_authorization_config_controller_automatic_reload_last_timestamp_seconds gauge
+                apiserver_authorization_config_controller_automatic_reload_last_timestamp_seconds{apiserver_id_hash="sha256:14f9d63e669337ac6bfda2e2162915ee6a6067743eddd4e5c374b572f951ff37",status="success"} 1.689101941e+09
+            `,
+			resultLabel: "success",
+			timestamp:   1689101941,
+		},
+	}
+
+	metrics := []string{
+		namespace + "_" + subsystem + "_automatic_reload_last_timestamp_seconds",
+	}
+	RegisterMetrics()
+
+	for _, tc := range testCases {
+		authorizationConfigAutomaticReloadLastTimestampSeconds.Reset()
+		authorizationConfigAutomaticReloadLastTimestampSeconds.WithLabelValues(tc.resultLabel, testAPIServerIDHash).Set(float64(tc.timestamp))
+
+		if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(tc.expectedValue), metrics...); err != nil {
+			t.Fatal(err)
+		}
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1472,6 +1472,7 @@ k8s.io/apiserver/pkg/server/healthz
 k8s.io/apiserver/pkg/server/httplog
 k8s.io/apiserver/pkg/server/mux
 k8s.io/apiserver/pkg/server/options
+k8s.io/apiserver/pkg/server/options/authorizationconfig/metrics
 k8s.io/apiserver/pkg/server/options/encryptionconfig
 k8s.io/apiserver/pkg/server/options/encryptionconfig/controller
 k8s.io/apiserver/pkg/server/options/encryptionconfig/metrics


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Implements reloading of the authorization configuration file. File reloads when an observed file event occurs or a 1 minute poll is encountered.

Best reviewed commit-by-commit, the validation / construction is refactored to split out the rbac / node / abac construction, and move the authorization construction to the reload functions.

Fixes #119102

#### Does this PR introduce a user-facing change?
```release-note
kube-apiserver now reloads the `--authorization-config` file when it changes. Reloads increment the `apiserver_authorization_config_controller_automatic_reload_last_timestamp_seconds` timestamp metric, with `status="success"` for successful reloads and `status="failed"` for failed reloads. Failed reloads keep using the previously loaded authorization configuration.
```

cc @ritazh @palnabarun 