### PR TITLE
return not-found errors properly from fake listers

### DIFF
--- a/pkg/scheduler/framework/plugins/nodevolumelimits/csi_test.go
+++ b/pkg/scheduler/framework/plugins/nodevolumelimits/csi_test.go
@@ -495,7 +495,7 @@ func TestCSILimits(t *testing.T) {
 			ephemeralEnabled: true,
 			driverNames:      []string{ebsCSIDriverName},
 			test:             "ephemeral volume missing",
-			wantStatus:       framework.AsStatus(errors.New(`looking up PVC test/abc-xyz: persistentvolumeclaim "abc-xyz" not found`)),
+			wantStatus:       framework.AsStatus(errors.New(`looking up PVC test/abc-xyz: persistentvolumeclaims "abc-xyz" not found`)),
 		},
 		{
 			newPod:           ephemeralVolumePod,
@@ -595,7 +595,7 @@ func TestCSILimits(t *testing.T) {
 			ephemeralEnabled: true,
 			driverNames:      []string{ebsCSIDriverName},
 			test:             "don't skip Filter when the pod has ephemeral volumes",
-			wantStatus:       framework.AsStatus(errors.New(`looking up PVC test/abc-xyz: persistentvolumeclaim "abc-xyz" not found`)),
+			wantStatus:       framework.AsStatus(errors.New(`looking up PVC test/abc-xyz: persistentvolumeclaims "abc-xyz" not found`)),
 		},
 		{
 			newPod:           inlineMigratablePodWithConfigmapAndSecret,

--- a/pkg/scheduler/framework/plugins/nodevolumelimits/non_csi_test.go
+++ b/pkg/scheduler/framework/plugins/nodevolumelimits/non_csi_test.go
@@ -139,7 +139,7 @@ func TestEphemeralLimits(t *testing.T) {
 			newPod:           ephemeralVolumePod,
 			ephemeralEnabled: true,
 			test:             "volume missing",
-			wantStatus:       framework.AsStatus(errors.New(`looking up PVC test/abc-xyz: persistentvolumeclaim "abc-xyz" not found`)),
+			wantStatus:       framework.AsStatus(errors.New(`looking up PVC test/abc-xyz: persistentvolumeclaims "abc-xyz" not found`)),
 		},
 		{
 			newPod:           ephemeralVolumePod,

--- a/pkg/scheduler/framework/plugins/volumezone/volume_zone_test.go
+++ b/pkg/scheduler/framework/plugins/volumezone/volume_zone_test.go
@@ -494,9 +494,9 @@ func TestWithBinding(t *testing.T) {
 			Pod:  createPodWithVolume("pod_1", "vol_1", "PVC_NoSC"),
 			Node: testNode,
 			wantPreFilterStatus: framework.NewStatus(framework.UnschedulableAndUnresolvable,
-				"unable to find storage class: Class_0"),
+				`storageclasses.storage.k8s.io "Class_0" not found`),
 			wantFilterStatus: framework.NewStatus(framework.UnschedulableAndUnresolvable,
-				"unable to find storage class: Class_0"),
+				`storageclasses.storage.k8s.io "Class_0" not found`),
 		},
 		{
 			name:                "unbound volume immediate binding mode",

--- a/pkg/scheduler/testing/framework/fake_listers.go
+++ b/pkg/scheduler/testing/framework/fake_listers.go
@@ -195,7 +195,7 @@ func (f *persistentVolumeClaimNamespaceLister) Get(name string) (*v1.PersistentV
 			return pvc, nil
 		}
 	}
-	return nil, fmt.Errorf("persistentvolumeclaim %q not found", name)
+	return nil, errors.NewNotFound(v1.Resource("persistentvolumeclaims"), name)
 }
 
 func (f persistentVolumeClaimNamespaceLister) List(selector labels.Selector) (ret []*v1.PersistentVolumeClaim, err error) {
@@ -266,7 +266,7 @@ func (n CSINodeLister) Get(name string) (*storagev1.CSINode, error) {
 			return &cn, nil
 		}
 	}
-	return nil, fmt.Errorf("csiNode %q not found", name)
+	return nil, errors.NewNotFound(storagev1.Resource("csinodes"), name)
 }
 
 // List lists all CSINodes in the indexer.
@@ -286,7 +286,7 @@ func (pvs PersistentVolumeLister) Get(pvID string) (*v1.PersistentVolume, error)
 			return &pv, nil
 		}
 	}
-	return nil, fmt.Errorf("unable to find persistent volume: %s", pvID)
+	return nil, errors.NewNotFound(v1.Resource("persistentvolumes"), pvID)
 }
 
 // List lists all PersistentVolumes in the indexer.
@@ -306,12 +306,7 @@ func (classes StorageClassLister) Get(name string) (*storagev1.StorageClass, err
 			return &sc, nil
 		}
 	}
-	return nil, &errors.StatusError{
-		ErrStatus: metav1.Status{
-			Reason:  metav1.StatusReasonNotFound,
-			Message: fmt.Sprintf("unable to find storage class: %s", name),
-		},
-	}
+	return nil, errors.NewNotFound(storagev1.Resource("storageclasses"), name)
 }
 
 // List lists all StorageClass in the indexer.


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:

Implementing https://github.com/kubernetes/kubernetes/pull/121508, I found `apierrors.IsNotFound` doesn't work well. Because the original error was returned by the fake lister,` apierrors.IsNotFound` did not work properly. This was not a good way to test, so it has been fixed.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
