### PR TITLE
add warnings for cases one of projected volume types get overwritten by service account token

### DIFF
--- a/pkg/api/pod/warnings_test.go
+++ b/pkg/api/pod/warnings_test.go
@@ -236,6 +236,86 @@ func TestWarnings(t *testing.T) {
 			expected: []string{`spec.volumes[0].rbd: deprecated in v1.28, non-functional in v1.31+`},
 		},
 		{
+			name: "duplicated path in projected volumes - secret and service account token",
+			template: &api.PodTemplateSpec{Spec: api.PodSpec{
+				Volumes: []api.Volume{
+					{
+						Name: "t",
+						VolumeSource: api.VolumeSource{
+							Projected: &api.ProjectedVolumeSource{
+								Sources: []api.VolumeProjection{
+									{Secret: &api.SecretProjection{Items: []api.KeyToPath{{Path: "/test-path", Key: "test"}}}},
+									{ServiceAccountToken: &api.ServiceAccountTokenProjection{Path: "/test-path"}},
+								}},
+						},
+					},
+				},
+			}},
+			expected: []string{
+				"spec.volumes[0].projected.sources.secrets[0]: has duplicated path with ServiceAccountToken \"/test-path\"",
+			},
+		},
+		{
+			name: "duplicated path in projected volumes - configMap and service account token",
+			template: &api.PodTemplateSpec{Spec: api.PodSpec{
+				Volumes: []api.Volume{
+					{
+						Name: "t",
+						VolumeSource: api.VolumeSource{
+							Projected: &api.ProjectedVolumeSource{
+								Sources: []api.VolumeProjection{
+									{ConfigMap: &api.ConfigMapProjection{Items: []api.KeyToPath{{Path: "/test-path", Key: "test"}}}},
+									{ServiceAccountToken: &api.ServiceAccountTokenProjection{Path: "/test-path"}},
+								}},
+						},
+					},
+				},
+			}},
+			expected: []string{
+				"spec.volumes[0].projected.sources.configMap[0]: has duplicated path with ServiceAccountToken \"/test-path\"",
+			},
+		},
+		{
+			name: "duplicated path in projected volumes - downwardAPI and service account token",
+			template: &api.PodTemplateSpec{Spec: api.PodSpec{
+				Volumes: []api.Volume{
+					{
+						Name: "t",
+						VolumeSource: api.VolumeSource{
+							Projected: &api.ProjectedVolumeSource{
+								Sources: []api.VolumeProjection{
+									{DownwardAPI: &api.DownwardAPIProjection{Items: []api.DownwardAPIVolumeFile{{Path: "/test-path"}}}},
+									{ServiceAccountToken: &api.ServiceAccountTokenProjection{Path: "/test-path"}},
+								}},
+						},
+					},
+				},
+			}},
+			expected: []string{
+				"spec.volumes[0].projected.sources.downwardAPI[0]: has duplicated path with ServiceAccountToken \"/test-path\"",
+			},
+		},
+		{
+			name: "duplicated path in projected volumes - ClusterTrustBundle and service account token",
+			template: &api.PodTemplateSpec{Spec: api.PodSpec{
+				Volumes: []api.Volume{
+					{
+						Name: "t",
+						VolumeSource: api.VolumeSource{
+							Projected: &api.ProjectedVolumeSource{
+								Sources: []api.VolumeProjection{
+									{ClusterTrustBundle: &api.ClusterTrustBundleProjection{Path: "/test-path"}},
+									{ServiceAccountToken: &api.ServiceAccountTokenProjection{Path: "/test-path"}},
+								}},
+						},
+					},
+				},
+			}},
+			expected: []string{
+				"spec.volumes[0].projected.sources.ClusterTrustBundle: has duplicated path with ServiceAccountToken \"/test-path\"",
+			},
+		},
+		{
 			name: "duplicate hostAlias",
 			template: &api.PodTemplateSpec{Spec: api.PodSpec{
 				HostAliases: []api.HostAlias{


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
Fixes #121414 

#### Special notes for your reviewer:

Add warnings whenever there are overlaps in the virtual mounting paths for the following volumes:
* ConfigMap
* Secret
* DownwardAPI
* Projected

Example 

```
name: myconfig
items:
   - key: key1
     path: path
   - key: key2
     path: path/path2
```
This would produce a warning message because `path/path2` is contained in `path`.

#### Does this PR introduce a user-facing change?

```release-note
* Add warnings for overlap paths in ConfigMap, Secret, DownwardAPI, Projected
* Add warning for cases when ProjectedVolume with sources is provided. 
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
