### PR TITLE
e2e resourcequota fail if unexpected answer on Get

### DIFF
--- a/test/e2e/apimachinery/resource_quota.go
+++ b/test/e2e/apimachinery/resource_quota.go
@@ -1194,7 +1194,7 @@ var _ = SIGDescribe("ResourceQuota", func() {
 		err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 6*time.Minute, true, func(ctx context.Context) (bool, error) {
 			resourceQuotaResult, err := rqClient.Get(ctx, rqName, metav1.GetOptions{})
 			if err != nil {
-				return false, nil
+				return false, err
 			}
 
 			if *resourceQuotaResult.Spec.Hard.Cpu() == *resourceQuotaResult.Status.Hard.Cpu() {


### PR DESCRIPTION

/kind cleanup
```release-note
NONE
```

Follow up on comment https://github.com/kubernetes/kubernetes/pull/121951/files#r1399310072