### PR TITLE
Bump distroless-iptables to 0.2.8 based on Go 1.20.11

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -96,7 +96,7 @@ readonly KUBE_RSYNC_PORT="${KUBE_RSYNC_PORT:-}"
 readonly KUBE_CONTAINER_RSYNC_PORT=8730
 
 # These are the default versions (image tags) for their respective base images.
-readonly __default_distroless_iptables_version=v0.2.7
+readonly __default_distroless_iptables_version=v0.2.8
 readonly __default_go_runner_version=v2.3.1-go1.20.11-bullseye.0
 readonly __default_setcap_version=bookworm-v1.0.0
 

--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -158,7 +158,7 @@ dependencies:
       match: BASE_IMAGE_VERSION\?=
 
   - name: "registry.k8s.io/distroless-iptables: dependents"
-    version: v0.2.7
+    version: v0.2.8
     refPaths:
     - path: build/common.sh
       match: __default_distroless_iptables_version=

--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -241,7 +241,7 @@ func initImageConfigs(list RegistryList) (map[ImageID]Config, map[ImageID]Config
 	configs[BusyBox] = Config{list.PromoterE2eRegistry, "busybox", "1.29-4"}
 	configs[CudaVectorAdd] = Config{list.PromoterE2eRegistry, "cuda-vector-add", "1.0"}
 	configs[CudaVectorAdd2] = Config{list.PromoterE2eRegistry, "cuda-vector-add", "2.3"}
-	configs[DistrolessIptables] = Config{list.BuildImageRegistry, "distroless-iptables", "v0.2.7"}
+	configs[DistrolessIptables] = Config{list.BuildImageRegistry, "distroless-iptables", "v0.2.8"}
 	configs[Etcd] = Config{list.GcEtcdRegistry, "etcd", "3.5.9-0"}
 	configs[Httpd] = Config{list.PromoterE2eRegistry, "httpd", "2.4.38-4"}
 	configs[HttpdNew] = Config{list.PromoterE2eRegistry, "httpd", "2.4.39-4"}


### PR DESCRIPTION
#### What type of PR is this?

#### What this PR does / why we need it:

- Bump distroless-iptables to 0.2.8 based on Go 1.20.11

#### Which issue(s) this PR fixes:

xref https://github.com/kubernetes/release/issues/3347

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Bump distroless-iptables to 0.2.8 based on Go 1.20.11
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```

/assign @saschagrunert @liggitt @ameukam @dims @xmudrii  
cc @kubernetes/release-engineering