### PR TITLE
[prototype] Make apiserver admission plugins retrieve k8s objects dir…

### DIFF
--- a/pkg/controlplane/storageinformers/core/interface.go
+++ b/pkg/controlplane/storageinformers/core/interface.go
@@ -1,0 +1,44 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package core
+
+import (
+	v1 "k8s.io/kubernetes/pkg/controlplane/storageinformers/core/v1"
+	internalinterfaces "k8s.io/kubernetes/pkg/controlplane/storageinformers/internalinterfaces"
+)
+
+// Interface provides access to each of this group's versions.
+type Interface interface {
+	// V1 provides access to shared informers for resources in V1.
+	V1() v1.Interface
+}
+
+type group struct {
+	factory          internalinterfaces.SharedInformerFactory
+	namespace        string
+	tweakListOptions internalinterfaces.TweakListOptionsFunc
+}
+
+// New returns a new Interface.
+func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakListOptions internalinterfaces.TweakListOptionsFunc) Interface {
+	return &group{factory: f, namespace: namespace, tweakListOptions: tweakListOptions}
+}
+
+// V1 returns a new v1.Interface.
+func (g *group) V1() v1.Interface {
+	return v1.New(g.factory, g.namespace, g.tweakListOptions)
+}

--- a/pkg/controlplane/storageinformers/core/v1/interface.go
+++ b/pkg/controlplane/storageinformers/core/v1/interface.go
@@ -1,0 +1,42 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	internalinterfaces "k8s.io/kubernetes/pkg/controlplane/storageinformers/internalinterfaces"
+)
+
+// Interface provides access to all the informers in this group version.
+type Interface interface {
+	Pods() PodInformer
+}
+
+type version struct {
+	factory          internalinterfaces.SharedInformerFactory
+	namespace        string
+	tweakListOptions internalinterfaces.TweakListOptionsFunc
+}
+
+// New returns a new Interface.
+func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakListOptions internalinterfaces.TweakListOptionsFunc) Interface {
+	return &version{factory: f, namespace: namespace, tweakListOptions: tweakListOptions}
+}
+
+// Pods returns a PodInformer.
+func (v *version) Pods() PodInformer {
+	return &podInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
+}

--- a/pkg/controlplane/storageinformers/core/v1/pod.go
+++ b/pkg/controlplane/storageinformers/core/v1/pod.go
@@ -1,0 +1,137 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	time "time"
+
+	corev1 "k8s.io/api/core/v1"
+	internalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	runtime "k8s.io/apimachinery/pkg/runtime"
+	schema "k8s.io/apimachinery/pkg/runtime/schema"
+	watch "k8s.io/apimachinery/pkg/watch"
+	rest "k8s.io/apiserver/pkg/registry/rest"
+	v1 "k8s.io/client-go/listers/core/v1"
+	cache "k8s.io/client-go/tools/cache"
+	core "k8s.io/kubernetes/pkg/apis/core"
+	apiscorev1 "k8s.io/kubernetes/pkg/apis/core/v1"
+	internalinterfaces "k8s.io/kubernetes/pkg/controlplane/storageinformers/internalinterfaces"
+)
+
+// PodInformer provides access to a shared informer and lister for
+// Pods.
+type PodInformer interface {
+	Informer() cache.SharedIndexInformer
+	Lister() v1.PodLister
+}
+
+type podInformer struct {
+	factory          internalinterfaces.SharedInformerFactory
+	tweakListOptions internalinterfaces.TweakListOptionsFunc
+	namespace        string
+}
+
+// NewPodInformer constructs a new informer for Pod type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewPodInformer(gvrStorage map[schema.GroupVersionResource]rest.Storage, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return NewFilteredPodInformer(gvrStorage, namespace, resyncPeriod, indexers, nil)
+}
+
+// NewFilteredPodInformer constructs a new informer for Pod type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewFilteredPodInformer(gvrStorage map[schema.GroupVersionResource]rest.Storage, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformer(
+		&cache.ListWatch{
+			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+
+				gvr := schema.GroupVersionResource{"", "v1", "pods"}
+				s, ok := gvrStorage[gvr]
+				if !ok {
+					return nil, errors.New(fmt.Sprintf("GVR %+v is not provided in storage", gvr))
+				}
+				pred := &internalversion.ListOptions{}
+				if err := internalversion.Convert_v1_ListOptions_To_internalversion_ListOptions(&options, pred, nil); err != nil {
+					return nil, err
+				}
+				lister := s.(rest.Lister)
+				l, err := lister.List(context.TODO(), pred)
+				if err != nil {
+					return nil, err
+				}
+
+				return l, nil
+
+			},
+			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+				if tweakListOptions != nil {
+					tweakListOptions(&options)
+				}
+
+				gvr := schema.GroupVersionResource{"", "v1", "pods"}
+				s, ok := gvrStorage[gvr]
+				if !ok {
+					return nil, errors.New(fmt.Sprintf("GVR %+v is not provided in storage", gvr))
+				}
+				pred := &internalversion.ListOptions{}
+				if err := internalversion.Convert_v1_ListOptions_To_internalversion_ListOptions(&options, pred, nil); err != nil {
+					return nil, err
+				}
+				watcher := s.(rest.Watcher)
+				w, err := watcher.Watch(context.TODO(), pred)
+				if err != nil {
+					return nil, err
+				}
+				return w, nil
+
+			},
+		},
+		&corev1.Pod{},
+		resyncPeriod,
+		indexers,
+	)
+}
+
+func (f *podInformer) defaultInformer(gvrStorage map[schema.GroupVersionResource]rest.Storage, resyncPeriod time.Duration) cache.SharedIndexInformer {
+
+	i := NewFilteredPodInformer(gvrStorage, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	i.SetTransform(func(obj interface{}) (interface{}, error) {
+		t := &corev1.Pod{}
+		if err := apiscorev1.Convert_core_Pod_To_v1_Pod(obj.(*core.Pod), t, nil); err != nil {
+			return nil, err
+		}
+		return t, nil
+	})
+	return i
+
+}
+
+func (f *podInformer) Informer() cache.SharedIndexInformer {
+	return f.factory.InformerFor(&corev1.Pod{}, f.defaultInformer)
+}
+
+func (f *podInformer) Lister() v1.PodLister {
+	return v1.NewPodLister(f.Informer().GetIndexer())
+}

--- a/pkg/controlplane/storageinformers/factory.go
+++ b/pkg/controlplane/storageinformers/factory.go
@@ -1,0 +1,249 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storageinformers
+
+import (
+	reflect "reflect"
+	sync "sync"
+	time "time"
+
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	runtime "k8s.io/apimachinery/pkg/runtime"
+	schema "k8s.io/apimachinery/pkg/runtime/schema"
+	rest "k8s.io/apiserver/pkg/registry/rest"
+	cache "k8s.io/client-go/tools/cache"
+	core "k8s.io/kubernetes/pkg/controlplane/storageinformers/core"
+	internalinterfaces "k8s.io/kubernetes/pkg/controlplane/storageinformers/internalinterfaces"
+)
+
+// SharedInformerOption defines the functional option type for SharedInformerFactory.
+type SharedInformerOption func(*sharedInformerFactory) *sharedInformerFactory
+
+type sharedInformerFactory struct {
+	gvrStorage       map[schema.GroupVersionResource]rest.Storage
+	namespace        string
+	tweakListOptions internalinterfaces.TweakListOptionsFunc
+	lock             sync.Mutex
+	defaultResync    time.Duration
+	customResync     map[reflect.Type]time.Duration
+	transform        cache.TransformFunc
+
+	informers map[reflect.Type]cache.SharedIndexInformer
+	// startedInformers is used for tracking which informers have been started.
+	// This allows Start() to be called multiple times safely.
+	startedInformers map[reflect.Type]bool
+	// wg tracks how many goroutines were started.
+	wg sync.WaitGroup
+	// shuttingDown is true when Shutdown has been called. It may still be running
+	// because it needs to wait for goroutines.
+	shuttingDown bool
+}
+
+// WithCustomResyncConfig sets a custom resync period for the specified informer types.
+func WithCustomResyncConfig(resyncConfig map[v1.Object]time.Duration) SharedInformerOption {
+	return func(factory *sharedInformerFactory) *sharedInformerFactory {
+		for k, v := range resyncConfig {
+			factory.customResync[reflect.TypeOf(k)] = v
+		}
+		return factory
+	}
+}
+
+// WithTweakListOptions sets a custom filter on all listers of the configured SharedInformerFactory.
+func WithTweakListOptions(tweakListOptions internalinterfaces.TweakListOptionsFunc) SharedInformerOption {
+	return func(factory *sharedInformerFactory) *sharedInformerFactory {
+		factory.tweakListOptions = tweakListOptions
+		return factory
+	}
+}
+
+// WithNamespace limits the SharedInformerFactory to the specified namespace.
+func WithNamespace(namespace string) SharedInformerOption {
+	return func(factory *sharedInformerFactory) *sharedInformerFactory {
+		factory.namespace = namespace
+		return factory
+	}
+}
+
+// WithTransform sets a transform on all informers.
+func WithTransform(transform cache.TransformFunc) SharedInformerOption {
+	return func(factory *sharedInformerFactory) *sharedInformerFactory {
+		factory.transform = transform
+		return factory
+	}
+}
+
+// NewSharedInformerFactoryWithOptions constructs a new instance of a SharedInformerFactory with additional options, instead of pulling via kubernetes client, informers created in this factory pull from storage.
+func NewSharedInformerFactoryWithOptions(gvrStorage map[schema.GroupVersionResource]rest.Storage, defaultResync time.Duration, options ...SharedInformerOption) SharedInformerFactory {
+	factory := &sharedInformerFactory{
+		gvrStorage:       gvrStorage,
+		namespace:        v1.NamespaceAll,
+		defaultResync:    defaultResync,
+		informers:        make(map[reflect.Type]cache.SharedIndexInformer),
+		startedInformers: make(map[reflect.Type]bool),
+		customResync:     make(map[reflect.Type]time.Duration),
+	}
+
+	// Apply all options
+	for _, opt := range options {
+		factory = opt(factory)
+	}
+
+	return factory
+}
+
+func (f *sharedInformerFactory) Start(stopCh <-chan struct{}) {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+
+	if f.shuttingDown {
+		return
+	}
+
+	for informerType, informer := range f.informers {
+		if !f.startedInformers[informerType] {
+			f.wg.Add(1)
+			// We need a new variable in each loop iteration,
+			// otherwise the goroutine would use the loop variable
+			// and that keeps changing.
+			informer := informer
+			go func() {
+				defer f.wg.Done()
+				informer.Run(stopCh)
+			}()
+			f.startedInformers[informerType] = true
+		}
+	}
+}
+
+func (f *sharedInformerFactory) Shutdown() {
+	f.lock.Lock()
+	f.shuttingDown = true
+	f.lock.Unlock()
+
+	// Will return immediately if there is nothing to wait for.
+	f.wg.Wait()
+}
+
+func (f *sharedInformerFactory) WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool {
+	informers := func() map[reflect.Type]cache.SharedIndexInformer {
+		f.lock.Lock()
+		defer f.lock.Unlock()
+
+		informers := map[reflect.Type]cache.SharedIndexInformer{}
+		for informerType, informer := range f.informers {
+			if f.startedInformers[informerType] {
+				informers[informerType] = informer
+			}
+		}
+		return informers
+	}()
+
+	res := map[reflect.Type]bool{}
+	for informType, informer := range informers {
+		res[informType] = cache.WaitForCacheSync(stopCh, informer.HasSynced)
+	}
+	return res
+}
+
+// InformerFor returns the SharedIndexInformer for obj using an internal
+// client.
+func (f *sharedInformerFactory) InformerFor(obj runtime.Object, newFunc internalinterfaces.NewInformerFunc) cache.SharedIndexInformer {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+
+	informerType := reflect.TypeOf(obj)
+	informer, exists := f.informers[informerType]
+	if exists {
+		return informer
+	}
+
+	resyncPeriod, exists := f.customResync[informerType]
+	if !exists {
+		resyncPeriod = f.defaultResync
+	}
+
+	informer = newFunc(f.gvrStorage, resyncPeriod)
+
+	if f.transform != nil {
+		informer.SetTransform(f.transform)
+	}
+	f.informers[informerType] = informer
+
+	return informer
+}
+
+// SharedInformerFactory provides shared informers for resources in all known
+// API group versions.
+//
+// It is typically used like this:
+//
+//   ctx, cancel := context.Background()
+//   defer cancel()
+
+//   factory := NewSharedInformerFactory(gvrStorage, resyncPeriod)
+
+// defer factory.WaitForStop()    // Returns immediately if nothing was started.
+// genericInformer := factory.ForResource(resource)
+// typedInformer := factory.SomeAPIGroup().V1().SomeType()
+// factory.Start(ctx.Done())          // Start processing these informers.
+// synced := factory.WaitForCacheSync(ctx.Done())
+//
+//	for v, ok := range synced {
+//	    if !ok {
+//	        fmt.Fprintf(os.Stderr, "caches failed to sync: %v", v)
+//	        return
+//	    }
+//	}
+//
+// // Creating informers can also be created after Start, but then
+// // Start must be called again:
+// anotherGenericInformer := factory.ForResource(resource)
+// factory.Start(ctx.Done())
+type SharedInformerFactory interface {
+	internalinterfaces.SharedInformerFactory
+
+	// Start initializes all requested informers. They are handled in goroutines
+	// which run until the stop channel gets closed.
+	Start(stopCh <-chan struct{})
+
+	// Shutdown marks a factory as shutting down. At that point no new
+	// informers can be started anymore and Start will return without
+	// doing anything.
+	//
+	// In addition, Shutdown blocks until all goroutines have terminated. For that
+	// to happen, the close channel(s) that they were started with must be closed,
+	// either before Shutdown gets called or while it is waiting.
+	//
+	// Shutdown may be called multiple times, even concurrently. All such calls will
+	// block until all goroutines have terminated.
+	Shutdown()
+
+	// WaitForCacheSync blocks until all started informers' caches were synced
+	// or the stop channel gets closed.
+	WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool
+
+	// InformerFor returns the SharedIndexInformer for obj using an internal
+	// client.
+	InformerFor(obj runtime.Object, newFunc internalinterfaces.NewInformerFunc) cache.SharedIndexInformer
+
+	Core() core.Interface
+}
+
+func (f *sharedInformerFactory) Core() core.Interface {
+	return core.New(f, f.namespace, f.tweakListOptions)
+}

--- a/pkg/controlplane/storageinformers/internalinterfaces/factory_interfaces.go
+++ b/pkg/controlplane/storageinformers/internalinterfaces/factory_interfaces.go
@@ -1,0 +1,39 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internalinterfaces
+
+import (
+	time "time"
+
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	runtime "k8s.io/apimachinery/pkg/runtime"
+	schema "k8s.io/apimachinery/pkg/runtime/schema"
+	rest "k8s.io/apiserver/pkg/registry/rest"
+	cache "k8s.io/client-go/tools/cache"
+)
+
+// NewStorageInformerFunc takes rest.Storage and time.Duration to return a SharedIndexInformer.
+type NewInformerFunc func(map[schema.GroupVersionResource]rest.Storage, time.Duration) cache.SharedIndexInformer
+
+// SharedInformerFactory a small interface to allow for adding an informer without an import cycle
+type SharedInformerFactory interface {
+	Start(stopCh <-chan struct{})
+	InformerFor(obj runtime.Object, newFunc NewInformerFunc) cache.SharedIndexInformer
+}
+
+// TweakListOptionsFunc is a function that transforms a v1.ListOptions.
+type TweakListOptionsFunc func(*v1.ListOptions)

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
@@ -1350,7 +1350,11 @@ func (e *Store) Watch(ctx context.Context, options *metainternalversion.ListOpti
 		resourceVersion = options.ResourceVersion
 		predicate.AllowWatchBookmarks = options.AllowWatchBookmarks
 	}
-	return e.WatchPredicate(ctx, predicate, resourceVersion, options.SendInitialEvents)
+	var sendInitialEvents *bool
+	if options != nil {
+		sendInitialEvents = options.SendInitialEvents
+	}
+	return e.WatchPredicate(ctx, predicate, resourceVersion, sendInitialEvents)
 }
 
 // WatchPredicate starts a watch for the items that matches.

--- a/staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go
@@ -284,6 +284,8 @@ type GenericAPIServer struct {
 	// This grace period is orthogonal to other grace periods, and
 	// it is not overridden by any other grace period.
 	ShutdownWatchTerminationGracePeriod time.Duration
+
+	GroupVersionResourceStorageMap map[schema.GroupVersionResource]rest.Storage
 }
 
 // DelegationTarget is an interface which allows for composition of API servers with top level handling that works


### PR DESCRIPTION
Make apiserver admission plugins retrieve k8s objects directly from its storage

Before this commit, admission plugins use informers to sync k8s objects and as a result, there is an additional copy of k8s object in kube-apiserver. This commit allows referencing k8s objects from storage without actually copying them, which reduces significant memory usage in both serving and storage.

Also observed a visible amount of CPU usage reduced in kube-apiserver startup as the admission plugins didn't need to fetch objects from the HTTP endpoints, nor did kube-apiserver need to serve.

Memory measurements and comparisons

```
# create about 9k pods
kubectl get --raw /metrics | grep go_memstats_alloc_bytes
```

Origin:
```
Peak memory alloc: go_memstats_alloc_bytes 7.16614552e+08
Stablized memory alloc: go_memstats_alloc_bytes 4.2804752e+08
```
Optimized:
```
Peak memory alloc: go_memstats_alloc_bytes 3.46012872e+08
Stablized memory alloc: go_memstats_alloc_bytes 2.82520896e+08
```

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This commit allows referencing k8s objects from storage without actually copying them, which reduces significant memory and CPU usage in both serving and storage.

#### Which issue(s) this PR fixes:

Fixes #121657

#### Special notes for your reviewer:

The current PR only have minimal changes for easier reviews and discussion.

The implementation contains three parts:

1. Populating the `restStorage` object from kube-apiserver initialization code, which is needed for retrieving k8s objects
2. Creating a `StorageInformers` factory reusing the current code-autogen of `staging/src/k8s.io/client-go/informers/factory.go` to automatically generate that takes `restStorage` instead of k8s_client to initialize. This new factory will have exactly same interfaces as the current informer factory
3. Adding an interface for apiserver plugins to allow to be initialized with informers created by `StorageInformers`

As for plugin migration, the migration code should be as minimal as just adding an interface and replacing informers to the ones created by `StorageInformers`. Likely, we will migrate all plugins to use the new informers for lower overheads. To safely rollout, we could use a feature gate to guard the change.

#### Does this PR introduce a user-facing change?

```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:


```docs
NONE
```
