### PR TITLE
WIP: util logs: add structured error helper

### DIFF
--- a/pkg/util/logs/doc.go
+++ b/pkg/util/logs/doc.go
@@ -1,0 +1,22 @@
+/*
+Copyright 2023 The logr Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package logs contains logging helper code similar to klog.KObj which is not
+// ready for inclusion in klog (API not stable yet, too specialized, etc.).
+//
+// Such helpers cannot be in component-base/logs because that package is often
+// too large with too many dependencies (import cycles!).
+package logs

--- a/pkg/util/logs/structured_error.go
+++ b/pkg/util/logs/structured_error.go
@@ -1,0 +1,56 @@
+//go:build go1.21
+// +build go1.21
+
+/*
+Copyright 2023 The logr Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logs
+
+import (
+	"log/slog"
+)
+
+// ErrorWithDetails wraps an error and adds additional information about it
+// which is only used when logging the error. Text and JSON log output in
+// Kubernetes supports this. Other logging backends treat it like a normal
+// error.
+//
+// The details can be a simple value
+//
+//	slog.IntValue(42))
+//
+// or a group of values
+//
+//	slog.GroupValue(slog.Int("answer", 42), slog.StringValue("thank", "fish")))
+func ErrorWithDetails(err error, details slog.Value) error {
+	return structuredError{error: err, Value: details}
+}
+
+type structuredError struct {
+	error
+	slog.Value
+}
+
+var _ error = structuredError{}
+var _ slog.LogValuer = structuredError{}
+
+func (err structuredError) LogValue() slog.Value {
+	return err.Value
+}
+
+func (err structuredError) Unwrap() error {
+	return err.error
+}

--- a/pkg/util/logs/structured_error_test.go
+++ b/pkg/util/logs/structured_error_test.go
@@ -1,0 +1,40 @@
+//go:build go1.21
+// +build go1.21
+
+/*
+Copyright 2023 The logr Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logs_test
+
+import (
+	"errors"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"k8s.io/kubernetes/pkg/util/logs"
+)
+
+func TestErrorWithDetails(t *testing.T) {
+	baseErr := errors.New("hello")
+	details := slog.AnyValue(42)
+	wrappedErr := logs.ErrorWithDetails(baseErr, details)
+
+	require.ErrorIs(t, wrappedErr, baseErr)
+	require.Implements(t, (*slog.LogValuer)(nil), wrappedErr)
+	require.Equal(t, details, wrappedErr.(slog.LogValuer).LogValue())
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The wrapped error gets logged as `err=<err.Error()> errDetails=<additional value or group>` (text output, JSON is similar). This can be used to provide more information about an error when it gets logged.

#### Which issue(s) this PR fixes:
Related-to: https://github.com/kubernetes/klog/issues/357

#### Special notes for your reviewer:

Depends on support in klog and [zapr](https://github.com/go-logr/zapr/pull/56).

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/cc @tallclair 