### PR TITLE
e2e: skip checking the removal of group path if not permitted

### DIFF
--- a/test/e2e/apimachinery/aggregator.go
+++ b/test/e2e/apimachinery/aggregator.go
@@ -745,6 +745,10 @@ func TestSampleAPIServer(ctx context.Context, f *framework.Framework, aggrclient
 			AbsPath("/").
 			SetHeader("Accept", "application/json").DoRaw(ctx)
 		if err != nil {
+			if apierrors.IsForbidden(err) {
+				framework.Logf("Skip checking the removal of the group path due to lack of permission of reading the root path")
+				return true, nil
+			}
 			return false, err
 		}
 		err = json.Unmarshal(statusContent, &rootPaths)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup
/kind failing-test


#### What this PR does / why we need it:

https://github.com/kubernetes/kubernetes/pull/121283/ added the check of the removal of the group path to an e2e test. However, test runners like sonobuoy may not have the permission to read the root path. Skip checking the removal of the group path in that case.

With the patch, the test can succeed when running with sonobuoy:
```
  STEP: APIService deleteCollection with labelSelector: "v1alpha1.wardle.example.com=updated" @ 11/21/23 15:47:34.394
  STEP: Confirm that the generated APIService has been deleted @ 11/21/23 15:47:34.408
  Nov 21 15:47:34.408: INFO: Requesting list of APIServices to confirm quantity
  Nov 21 15:47:34.414: INFO: Found 0 APIService with label "v1alpha1.wardle.example.com=updated"
  Nov 21 15:47:34.414: INFO: APIService v1alpha1.wardle.example.com has been deleted.
  STEP: Confirm that the group path of v1alpha1.wardle.example.com was removed from root paths @ 11/21/23 15:47:34.415
  Nov 21 15:47:34.417: INFO: Skip checking the removal of the group path due to lack of permission of reading the root path
  Nov 21 15:47:34.484: INFO: Waiting up to 7m0s for all (but 0) nodes to be ready
  STEP: Destroying namespace "aggregator-9018" for this suite. @ 11/21/23 15:47:34.488
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #121985

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
