### PR TITLE
WIP: convert client-go/tools to contextual logging

### DIFF
--- a/cmd/kube-controller-manager/app/bootstrap.go
+++ b/cmd/kube-controller-manager/app/bootstrap.go
@@ -35,6 +35,7 @@ func newBootstrapSignerControllerDescriptor() *ControllerDescriptor {
 }
 func startBootstrapSignerController(ctx context.Context, controllerContext ControllerContext, controllerName string) (controller.Interface, bool, error) {
 	bsc, err := bootstrap.NewSigner(
+		ctx,
 		controllerContext.ClientBuilder.ClientOrDie("bootstrap-signer"),
 		controllerContext.InformerFactory.Core().V1().Secrets(),
 		controllerContext.InformerFactory.Core().V1().ConfigMaps(),
@@ -57,6 +58,7 @@ func newTokenCleanerControllerDescriptor() *ControllerDescriptor {
 }
 func startTokenCleanerController(ctx context.Context, controllerContext ControllerContext, controllerName string) (controller.Interface, bool, error) {
 	tcc, err := bootstrap.NewTokenCleaner(
+		ctx,
 		controllerContext.ClientBuilder.ClientOrDie("token-cleaner"),
 		controllerContext.InformerFactory.Core().V1().Secrets(),
 		bootstrap.DefaultTokenCleanerOptions(),

--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -705,7 +705,7 @@ func StartControllers(ctx context.Context, controllerCtx ControllerContext, cont
 	// Initialize the cloud provider with a reference to the clientBuilder only after token controller
 	// has started in case the cloud provider uses the client builder.
 	if controllerCtx.Cloud != nil {
-		controllerCtx.Cloud.Initialize(controllerCtx.ClientBuilder, ctx.Done())
+		controllerCtx.Cloud.Initialize(ctx, controllerCtx.ClientBuilder)
 	}
 
 	// Each controller is passed a context where the logger has the name of

--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -837,6 +837,7 @@ func startServiceAccountTokenController(ctx context.Context, controllerContext C
 		return nil, false, fmt.Errorf("failed to build token generator: %v", err)
 	}
 	tokenController, err := serviceaccountcontroller.NewTokensController(
+		ctx,
 		controllerContext.InformerFactory.Core().V1().ServiceAccounts(),
 		controllerContext.InformerFactory.Core().V1().Secrets(),
 		rootClientBuilder.ClientOrDie("tokens-controller"),

--- a/cmd/kube-controller-manager/app/core.go
+++ b/cmd/kube-controller-manager/app/core.go
@@ -626,6 +626,7 @@ func newServiceAccountControllerDescriptor() *ControllerDescriptor {
 
 func startServiceAccountController(ctx context.Context, controllerContext ControllerContext, controllerName string) (controller.Interface, bool, error) {
 	sac, err := serviceaccountcontroller.NewServiceAccountsController(
+		ctx,
 		controllerContext.InformerFactory.Core().V1().ServiceAccounts(),
 		controllerContext.InformerFactory.Core().V1().Namespaces(),
 		controllerContext.ClientBuilder.ClientOrDie("service-account-controller"),

--- a/cmd/kube-scheduler/app/options/options.go
+++ b/cmd/kube-scheduler/app/options/options.go
@@ -236,7 +236,7 @@ func (o *Options) ApplyTo(logger klog.Logger, c *schedulerappconfig.Config) erro
 	// Build kubeconfig first to so that if it fails, it doesn't cause leaking
 	// goroutines (started from initializing secure serving - which underneath
 	// creates a queue which in its constructor starts a goroutine).
-	kubeConfig, err := createKubeConfig(c.ComponentConfig.ClientConnection, o.Master)
+	kubeConfig, err := createKubeConfig(logger, c.ComponentConfig.ClientConnection, o.Master)
 	if err != nil {
 		return err
 	}
@@ -370,8 +370,8 @@ func makeLeaderElectionConfig(config componentbaseconfig.LeaderElectionConfigura
 
 // createKubeConfig creates a kubeConfig from the given config and masterOverride.
 // TODO remove masterOverride when CLI flags are removed.
-func createKubeConfig(config componentbaseconfig.ClientConnectionConfiguration, masterOverride string) (*restclient.Config, error) {
-	kubeConfig, err := clientcmd.BuildConfigFromFlags(masterOverride, config.Kubeconfig)
+func createKubeConfig(logger klog.Logger, config componentbaseconfig.ClientConnectionConfiguration, masterOverride string) (*restclient.Config, error) {
+	kubeConfig, err := clientcmd.BuildConfigFromFlagsWithContext(klog.NewContext(context.Background(), logger), masterOverride, config.Kubeconfig)
 	if err != nil {
 		return nil, err
 	}

--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -131,6 +131,7 @@ linters-settings: # please keep this alphabetized
           contextual k8s.io/api/.*
           contextual k8s.io/apimachinery/pkg/util/runtime/.*
           contextual k8s.io/client-go/metadata/.*
+          contextual k8s.io/client-go/tools/cache/.*
           contextual k8s.io/client-go/tools/events/.*
           contextual k8s.io/client-go/tools/record/.*
           contextual k8s.io/component-helpers/.*

--- a/hack/golangci-strict.yaml
+++ b/hack/golangci-strict.yaml
@@ -177,6 +177,7 @@ linters-settings: # please keep this alphabetized
           contextual k8s.io/api/.*
           contextual k8s.io/apimachinery/pkg/util/runtime/.*
           contextual k8s.io/client-go/metadata/.*
+          contextual k8s.io/client-go/tools/cache/.*
           contextual k8s.io/client-go/tools/events/.*
           contextual k8s.io/client-go/tools/record/.*
           contextual k8s.io/component-helpers/.*

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -180,6 +180,7 @@ linters-settings: # please keep this alphabetized
           contextual k8s.io/api/.*
           contextual k8s.io/apimachinery/pkg/util/runtime/.*
           contextual k8s.io/client-go/metadata/.*
+          contextual k8s.io/client-go/tools/cache/.*
           contextual k8s.io/client-go/tools/events/.*
           contextual k8s.io/client-go/tools/record/.*
           contextual k8s.io/component-helpers/.*

--- a/hack/logcheck.conf
+++ b/hack/logcheck.conf
@@ -27,6 +27,7 @@ structured k8s.io/apiserver/pkg/server/options/encryptionconfig/.*
 contextual k8s.io/api/.*
 contextual k8s.io/apimachinery/pkg/util/runtime/.*
 contextual k8s.io/client-go/metadata/.*
+contextual k8s.io/client-go/tools/cache/.*
 contextual k8s.io/client-go/tools/events/.*
 contextual k8s.io/client-go/tools/record/.*
 contextual k8s.io/component-helpers/.*

--- a/pkg/controller/certificates/cleaner/cleaner.go
+++ b/pkg/controller/certificates/cleaner/cleaner.go
@@ -77,7 +77,7 @@ func NewCSRCleanerController(
 
 // Run the main goroutine responsible for watching and syncing jobs.
 func (ccc *CSRCleanerController) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	logger := klog.FromContext(ctx)
 	logger.Info("Starting CSR cleaner controller")

--- a/pkg/controller/certificates/rootcacertpublisher/publisher_test.go
+++ b/pkg/controller/certificates/rootcacertpublisher/publisher_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package rootcacertpublisher
 
 import (
-	"context"
 	"reflect"
 	"testing"
 
@@ -31,6 +30,7 @@ import (
 	clienttesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/kubernetes/pkg/controller"
+	"k8s.io/kubernetes/test/utils/ktesting"
 )
 
 func TestConfigMapCreation(t *testing.T) {
@@ -122,6 +122,7 @@ func TestConfigMapCreation(t *testing.T) {
 
 	for k, tc := range testcases {
 		t.Run(k, func(t *testing.T) {
+			_, ctx := ktesting.NewTestContext(t)
 			client := fake.NewSimpleClientset(caConfigMap, existNS)
 			informers := informers.NewSharedInformerFactory(fake.NewSimpleClientset(), controller.NoResyncPeriodFunc())
 			cmInformer := informers.Core().V1().ConfigMaps()
@@ -155,7 +156,6 @@ func TestConfigMapCreation(t *testing.T) {
 				cmStore.Add(tc.UpdatedConfigMap)
 				controller.configMapUpdated(nil, tc.UpdatedConfigMap)
 			}
-			ctx := context.TODO()
 			for controller.queue.Len() != 0 {
 				controller.processNextWorkItem(ctx)
 			}
@@ -250,6 +250,7 @@ func TestConfigMapUpdateNoHotLoop(t *testing.T) {
 
 	for k, tc := range testcases {
 		t.Run(k, func(t *testing.T) {
+			_, ctx := ktesting.NewTestContext(t)
 			client := fake.NewSimpleClientset(tc.ExistingConfigMaps...)
 			configMapIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 			for _, obj := range tc.ExistingConfigMaps {
@@ -264,7 +265,6 @@ func TestConfigMapUpdateNoHotLoop(t *testing.T) {
 				cmListerSynced: func() bool { return true },
 				nsListerSynced: func() bool { return true },
 			}
-			ctx := context.TODO()
 			err := controller.syncNamespace(ctx, "default")
 			if err != nil {
 				t.Fatal(err)

--- a/pkg/controller/endpointslicemirroring/endpointslicemirroring_controller_test.go
+++ b/pkg/controller/endpointslicemirroring/endpointslicemirroring_controller_test.go
@@ -32,7 +32,6 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 
-	"k8s.io/klog/v2"
 	"k8s.io/klog/v2/ktesting"
 	"k8s.io/kubernetes/pkg/controller"
 )
@@ -64,7 +63,7 @@ func newController(ctx context.Context, batchPeriod time.Duration) (*fake.Client
 
 	// The event processing pipeline is normally started via Run() method.
 	// However, since we don't start it in unit tests, we explicitly start it here.
-	esController.eventBroadcaster.StartLogging(klog.Infof)
+	esController.eventBroadcaster.StartStructuredLogging(0)
 	esController.eventBroadcaster.StartRecordingToSink(&v1core.EventSinkImpl{Interface: client.CoreV1().Events("")})
 
 	esController.endpointsSynced = alwaysReady

--- a/pkg/controller/endpointslicemirroring/utils.go
+++ b/pkg/controller/endpointslicemirroring/utils.go
@@ -161,12 +161,12 @@ func getServiceFromDeleteAction(obj interface{}) *corev1.Service {
 	// is unrecorded.
 	tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
 	if !ok {
-		utilruntime.HandleError(fmt.Errorf("couldn't get object from tombstone %#v", obj))
+		utilruntime.HandleError(fmt.Errorf("couldn't get object from tombstone %#v", obj)) //nolint:logcheck // Not reached, shouldn't have unknown objects.
 		return nil
 	}
 	service, ok := tombstone.Obj.(*corev1.Service)
 	if !ok {
-		utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a Service resource: %#v", obj))
+		utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a Service resource: %#v", obj)) //nolint:logcheck // Not reached, shouldn't have unknown objects.
 		return nil
 	}
 	return service
@@ -182,12 +182,12 @@ func getEndpointsFromDeleteAction(obj interface{}) *corev1.Endpoints {
 	// final state is unrecorded.
 	tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
 	if !ok {
-		utilruntime.HandleError(fmt.Errorf("couldn't get object from tombstone %#v", obj))
+		utilruntime.HandleError(fmt.Errorf("couldn't get object from tombstone %#v", obj)) //nolint:logcheck // Not reached, shouldn't have unknown objects.
 		return nil
 	}
 	endpoints, ok := tombstone.Obj.(*corev1.Endpoints)
 	if !ok {
-		utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not an Endpoints resource: %#v", obj))
+		utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not an Endpoints resource: %#v", obj)) //nolint:logcheck // Not reached, shouldn't have unknown objects.
 		return nil
 	}
 	return endpoints
@@ -202,12 +202,12 @@ func getEndpointSliceFromDeleteAction(obj interface{}) *discovery.EndpointSlice 
 	// state is unrecorded.
 	tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
 	if !ok {
-		utilruntime.HandleError(fmt.Errorf("couldn't get object from tombstone %#v", obj))
+		utilruntime.HandleError(fmt.Errorf("couldn't get object from tombstone %#v", obj)) //nolint:logcheck // Not reached, shouldn't have unknown objects.
 		return nil
 	}
 	endpointSlice, ok := tombstone.Obj.(*discovery.EndpointSlice)
 	if !ok {
-		utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not an EndpointSlice resource: %#v", obj))
+		utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not an EndpointSlice resource: %#v", obj)) //nolint:logcheck // Not reached, shouldn't have unknown objects.
 		return nil
 	}
 	return endpointSlice

--- a/pkg/controller/garbagecollector/dump.go
+++ b/pkg/controller/garbagecollector/dump.go
@@ -141,7 +141,7 @@ func NewDOTVertex(node *node) *dotVertex {
 	gv, err := schema.ParseGroupVersion(node.identity.APIVersion)
 	if err != nil {
 		// this indicates a bad data serialization that should be prevented during storage of the API
-		utilruntime.HandleError(err)
+		utilruntime.HandleError(err) //nolint:logcheck // Probably never reached?
 	}
 	return &dotVertex{
 		uid:                node.identity.UID,
@@ -159,7 +159,7 @@ func NewMissingdotVertex(ownerRef metav1.OwnerReference) *dotVertex {
 	gv, err := schema.ParseGroupVersion(ownerRef.APIVersion)
 	if err != nil {
 		// this indicates a bad data serialization that should be prevented during storage of the API
-		utilruntime.HandleError(err)
+		utilruntime.HandleError(err) //nolint:logcheck // Should not be reached.
 	}
 	return &dotVertex{
 		uid:              ownerRef.UID,

--- a/pkg/controller/namespace/deletion/namespaced_resources_deleter.go
+++ b/pkg/controller/namespace/deletion/namespaced_resources_deleter.go
@@ -159,7 +159,7 @@ func (d *namespacedResourcesDeleter) initOpCache(ctx context.Context) {
 	// TODO(sttts): get rid of opCache and http 405 logic around it and trust discovery info
 	resources, err := d.discoverResourcesFn()
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("unable to get all supported resources from server: %v", err))
+		utilruntime.HandleErrorWithContext(ctx, err, "Unable to get all supported resources from server")
 	}
 	logger := klog.FromContext(ctx)
 	if len(resources) == 0 {
@@ -554,7 +554,7 @@ func (d *namespacedResourcesDeleter) deleteAllContent(ctx context.Context, ns *v
 	// NOT remove the resource instance.
 	if hasChanged := conditionUpdater.Update(ns); hasChanged {
 		if _, err = d.nsClient.UpdateStatus(ctx, ns, metav1.UpdateOptions{}); err != nil {
-			utilruntime.HandleError(fmt.Errorf("couldn't update status condition for namespace %q: %v", namespace, err))
+			utilruntime.HandleErrorWithContext(ctx, err, "Couldn't update status condition", "namespace", namespace)
 		}
 	}
 

--- a/pkg/controller/namespace/deletion/namespaced_resources_deleter_test.go
+++ b/pkg/controller/namespace/deletion/namespaced_resources_deleter_test.go
@@ -253,6 +253,7 @@ func testSyncNamespaceThatIsTerminating(t *testing.T, versions *metav1.APIVersio
 }
 
 func TestRetryOnConflictError(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
 	mockClient := &fake.Clientset{}
 	numTries := 0
 	retryOnce := func(ctx context.Context, namespace *v1.Namespace) (*v1.Namespace, error) {
@@ -266,7 +267,7 @@ func TestRetryOnConflictError(t *testing.T) {
 	d := namespacedResourcesDeleter{
 		nsClient: mockClient.CoreV1().Namespaces(),
 	}
-	_, err := d.retryOnConflictError(context.Background(), namespace, retryOnce)
+	_, err := d.retryOnConflictError(ctx, namespace, retryOnce)
 	if err != nil {
 		t.Errorf("Unexpected error %v", err)
 	}

--- a/pkg/controller/nodeipam/node_ipam_controller.go
+++ b/pkg/controller/nodeipam/node_ipam_controller.go
@@ -19,6 +19,8 @@ package nodeipam
 import (
 	"context"
 	"fmt"
+	"net"
+
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	coreinformers "k8s.io/client-go/informers/core/v1"
 	clientset "k8s.io/client-go/kubernetes"
@@ -30,7 +32,6 @@ import (
 	controllersmetrics "k8s.io/component-base/metrics/prometheus/controllers"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/controller/nodeipam/ipam"
-	"net"
 )
 
 // ipamController is an interface abstracting an interface for
@@ -132,7 +133,7 @@ func NewNodeIpamController(
 
 // Run starts an asynchronous loop that monitors the status of cluster nodes.
 func (nc *Controller) Run(ctx context.Context) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	// Start event processing pipeline.
 	nc.eventBroadcaster.StartStructuredLogging(3)
@@ -141,7 +142,7 @@ func (nc *Controller) Run(ctx context.Context) {
 	klog.FromContext(ctx).Info("Starting ipam controller")
 	defer klog.FromContext(ctx).Info("Shutting down ipam controller")
 
-	if !cache.WaitForNamedCacheSync("node", ctx.Done(), nc.nodeInformerSynced) {
+	if !cache.WaitForNamedCacheSyncWithContext(ctx, nc.nodeInformerSynced) {
 		return
 	}
 

--- a/pkg/controller/replication/conversion.go
+++ b/pkg/controller/replication/conversion.go
@@ -74,7 +74,11 @@ func (i conversionInformer) AddEventHandler(handler cache.ResourceEventHandler) 
 }
 
 func (i conversionInformer) AddEventHandlerWithResyncPeriod(handler cache.ResourceEventHandler, resyncPeriod time.Duration) (cache.ResourceEventHandlerRegistration, error) {
-	return i.SharedIndexInformer.AddEventHandlerWithResyncPeriod(conversionEventHandler{handler}, resyncPeriod)
+	return i.SharedIndexInformer.AddEventHandlerWithResyncPeriod(conversionEventHandler{handler}, resyncPeriod) //nolint:logcheck // Should not get called.
+}
+
+func (i conversionInformer) AddEventHandlerWithConfig(ctx context.Context, handler cache.ResourceEventHandler, config cache.HandlerConfig) (cache.ResourceEventHandlerRegistration, error) {
+	return i.SharedIndexInformer.AddEventHandlerWithConfig(ctx, conversionEventHandler{handler}, config)
 }
 
 type conversionLister struct {
@@ -128,7 +132,7 @@ type conversionEventHandler struct {
 func (h conversionEventHandler) OnAdd(obj interface{}, isInInitialList bool) {
 	rs, err := convertRCtoRS(obj.(*v1.ReplicationController), nil)
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("dropping RC OnAdd event: can't convert object %#v to RS: %v", obj, err))
+		utilruntime.HandleError(fmt.Errorf("dropping RC OnAdd event: can't convert object %#v to RS: %v", obj, err)) //nolint:logcheck // Not reached, shouldn't have unknown objects.
 		return
 	}
 	h.handler.OnAdd(rs, isInInitialList)
@@ -137,12 +141,12 @@ func (h conversionEventHandler) OnAdd(obj interface{}, isInInitialList bool) {
 func (h conversionEventHandler) OnUpdate(oldObj, newObj interface{}) {
 	oldRS, err := convertRCtoRS(oldObj.(*v1.ReplicationController), nil)
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("dropping RC OnUpdate event: can't convert old object %#v to RS: %v", oldObj, err))
+		utilruntime.HandleError(fmt.Errorf("dropping RC OnUpdate event: can't convert old object %#v to RS: %v", oldObj, err)) //nolint:logcheck // Not reached, shouldn't have unknown objects.
 		return
 	}
 	newRS, err := convertRCtoRS(newObj.(*v1.ReplicationController), nil)
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("dropping RC OnUpdate event: can't convert new object %#v to RS: %v", newObj, err))
+		utilruntime.HandleError(fmt.Errorf("dropping RC OnUpdate event: can't convert new object %#v to RS: %v", newObj, err)) //nolint:logcheck // Not reached, shouldn't have unknown objects.
 		return
 	}
 	h.handler.OnUpdate(oldRS, newRS)
@@ -154,17 +158,17 @@ func (h conversionEventHandler) OnDelete(obj interface{}) {
 		// Convert the Obj inside DeletedFinalStateUnknown.
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
-			utilruntime.HandleError(fmt.Errorf("dropping RC OnDelete event: couldn't get object from tombstone %+v", obj))
+			utilruntime.HandleError(fmt.Errorf("dropping RC OnDelete event: couldn't get object from tombstone %+v", obj)) //nolint:logcheck // Not reached, shouldn't have unknown objects.
 			return
 		}
 		rc, ok = tombstone.Obj.(*v1.ReplicationController)
 		if !ok {
-			utilruntime.HandleError(fmt.Errorf("dropping RC OnDelete event: tombstone contained object that is not a RC %#v", obj))
+			utilruntime.HandleError(fmt.Errorf("dropping RC OnDelete event: tombstone contained object that is not a RC %#v", obj)) //nolint:logcheck // Not reached, shouldn't have unknown objects.
 			return
 		}
 		rs, err := convertRCtoRS(rc, nil)
 		if err != nil {
-			utilruntime.HandleError(fmt.Errorf("dropping RC OnDelete event: can't convert object %#v to RS: %v", obj, err))
+			utilruntime.HandleError(fmt.Errorf("dropping RC OnDelete event: can't convert object %#v to RS: %v", obj, err)) //nolint:logcheck // Not reached, shouldn't have unknown objects.
 			return
 		}
 		h.handler.OnDelete(cache.DeletedFinalStateUnknown{Key: tombstone.Key, Obj: rs})
@@ -174,7 +178,7 @@ func (h conversionEventHandler) OnDelete(obj interface{}) {
 	// It's a regular RC object.
 	rs, err := convertRCtoRS(rc, nil)
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("dropping RC OnDelete event: can't convert object %#v to RS: %v", obj, err))
+		utilruntime.HandleError(fmt.Errorf("dropping RC OnDelete event: can't convert object %#v to RS: %v", obj, err)) //nolint:logcheck // Not reached, shouldn't have unknown objects.
 		return
 	}
 	h.handler.OnDelete(rs)

--- a/pkg/controller/resourceclaim/controller.go
+++ b/pkg/controller/resourceclaim/controller.go
@@ -391,7 +391,7 @@ func (ec *Controller) enqueueResourceClaim(logger klog.Logger, obj interface{}, 
 }
 
 func (ec *Controller) Run(ctx context.Context, workers int) {
-	defer runtime.HandleCrash()
+	defer runtime.HandleCrashWithContext(ctx)
 	defer ec.queue.ShutDown()
 
 	logger := klog.FromContext(ctx)
@@ -399,12 +399,12 @@ func (ec *Controller) Run(ctx context.Context, workers int) {
 	defer logger.Info("Shutting down resource claim controller")
 
 	eventBroadcaster := record.NewBroadcaster(record.WithContext(ctx))
-	eventBroadcaster.StartLogging(klog.Infof)
+	eventBroadcaster.StartStructuredLogging(0)
 	eventBroadcaster.StartRecordingToSink(&v1core.EventSinkImpl{Interface: ec.kubeClient.CoreV1().Events("")})
 	ec.recorder = eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: "resource_claim"})
 	defer eventBroadcaster.Shutdown()
 
-	if !cache.WaitForNamedCacheSync("resource_claim", ctx.Done(), ec.podSynced, ec.podSchedulingSynced, ec.claimsSynced, ec.templatesSynced) {
+	if !cache.WaitForNamedCacheSyncWithContext(ctx, ec.podSynced, ec.podSchedulingSynced, ec.claimsSynced, ec.templatesSynced) {
 		return
 	}
 
@@ -433,7 +433,7 @@ func (ec *Controller) processNextWorkItem(ctx context.Context) bool {
 		return true
 	}
 
-	runtime.HandleError(fmt.Errorf("%v failed with: %v", key, err))
+	runtime.HandleErrorWithContext(ctx, err, "Syncing failed", "key", key)
 	ec.queue.AddRateLimited(key)
 
 	return true

--- a/pkg/controller/resourceclaim/controller.go
+++ b/pkg/controller/resourceclaim/controller.go
@@ -195,7 +195,7 @@ func NewController(
 	if err := claimInformerCache.AddIndexers(cache.Indexers{claimPodOwnerIndex: claimPodOwnerIndexFunc}); err != nil {
 		return nil, fmt.Errorf("could not initialize ResourceClaim controller: %w", err)
 	}
-	ec.claimCache = cache.NewIntegerResourceVersionMutationCache(claimInformerCache, claimInformerCache,
+	ec.claimCache = cache.NewIntegerResourceVersionMutationCache(klog.NewContext(context.Background(), logger), claimInformerCache, claimInformerCache,
 		// Very long time to live, unlikely to be needed because
 		// the informer cache should get updated soon.
 		time.Hour,

--- a/pkg/controller/serviceaccount/legacy_serviceaccount_token_cleaner.go
+++ b/pkg/controller/serviceaccount/legacy_serviceaccount_token_cleaner.go
@@ -97,13 +97,13 @@ func NewLegacySATokenCleaner(saInformer coreinformers.ServiceAccountInformer, se
 }
 
 func (tc *LegacySATokenCleaner) Run(ctx context.Context) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	logger := klog.FromContext(ctx)
 	logger.Info("Starting legacy service account token cleaner controller")
 	defer logger.Info("Shutting down legacy service account token cleaner controller")
 
-	if !cache.WaitForNamedCacheSync("legacy-service-account-token-cleaner", ctx.Done(), tc.saInformerSynced, tc.secretInformerSynced, tc.podInformerSynced) {
+	if !cache.WaitForNamedCacheSyncWithContext(ctx, tc.saInformerSynced, tc.secretInformerSynced, tc.podInformerSynced) {
 		return
 	}
 

--- a/pkg/controller/serviceaccount/serviceaccounts_controller_test.go
+++ b/pkg/controller/serviceaccount/serviceaccounts_controller_test.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	core "k8s.io/client-go/testing"
 	"k8s.io/kubernetes/pkg/controller"
+	"k8s.io/kubernetes/test/utils/ktesting"
 )
 
 func TestServiceAccountCreation(t *testing.T) {
@@ -152,86 +153,88 @@ func TestServiceAccountCreation(t *testing.T) {
 	}
 
 	for k, tc := range testcases {
-		client := fake.NewSimpleClientset(defaultServiceAccount, managedServiceAccount)
-		informers := informers.NewSharedInformerFactory(fake.NewSimpleClientset(), controller.NoResyncPeriodFunc())
-		options := DefaultServiceAccountsControllerOptions()
-		options.ServiceAccounts = []v1.ServiceAccount{
-			{ObjectMeta: metav1.ObjectMeta{Name: defaultName}},
-			{ObjectMeta: metav1.ObjectMeta{Name: managedName}},
-		}
-		saInformer := informers.Core().V1().ServiceAccounts()
-		nsInformer := informers.Core().V1().Namespaces()
-		controller, err := NewServiceAccountsController(
-			saInformer,
-			nsInformer,
-			client,
-			options,
-		)
-		if err != nil {
-			t.Fatalf("error creating ServiceAccounts controller: %v", err)
-		}
-		controller.saListerSynced = alwaysReady
-		controller.nsListerSynced = alwaysReady
-
-		saStore := saInformer.Informer().GetStore()
-		nsStore := nsInformer.Informer().GetStore()
-
-		syncCalls := make(chan struct{}, 1)
-		controller.syncHandler = func(ctx context.Context, key string) error {
-			err := controller.syncNamespace(ctx, key)
+		t.Run(k, func(t *testing.T) {
+			tCtx := ktesting.Init(t)
+			client := fake.NewSimpleClientset(defaultServiceAccount, managedServiceAccount)
+			informers := informers.NewSharedInformerFactory(fake.NewSimpleClientset(), controller.NoResyncPeriodFunc())
+			options := DefaultServiceAccountsControllerOptions()
+			options.ServiceAccounts = []v1.ServiceAccount{
+				{ObjectMeta: metav1.ObjectMeta{Name: defaultName}},
+				{ObjectMeta: metav1.ObjectMeta{Name: managedName}},
+			}
+			saInformer := informers.Core().V1().ServiceAccounts()
+			nsInformer := informers.Core().V1().Namespaces()
+			controller, err := NewServiceAccountsController(
+				tCtx,
+				saInformer,
+				nsInformer,
+				client,
+				options,
+			)
 			if err != nil {
-				t.Logf("%s: %v", k, err)
+				t.Fatalf("error creating ServiceAccounts controller: %v", err)
+			}
+			controller.saListerSynced = alwaysReady
+			controller.nsListerSynced = alwaysReady
+
+			saStore := saInformer.Informer().GetStore()
+			nsStore := nsInformer.Informer().GetStore()
+
+			syncCalls := make(chan struct{}, 1)
+			controller.syncHandler = func(ctx context.Context, key string) error {
+				err := controller.syncNamespace(ctx, key)
+				if err != nil {
+					t.Logf("%s: %v", k, err)
+				}
+
+				syncCalls <- struct{}{}
+				return err
+			}
+			go controller.Run(tCtx, 1)
+
+			if tc.ExistingNamespace != nil {
+				nsStore.Add(tc.ExistingNamespace)
+			}
+			for _, s := range tc.ExistingServiceAccounts {
+				saStore.Add(s)
 			}
 
-			syncCalls <- struct{}{}
-			return err
-		}
-		stopCh := make(chan struct{})
-		defer close(stopCh)
-		go controller.Run(context.TODO(), 1)
-
-		if tc.ExistingNamespace != nil {
-			nsStore.Add(tc.ExistingNamespace)
-		}
-		for _, s := range tc.ExistingServiceAccounts {
-			saStore.Add(s)
-		}
-
-		if tc.AddedNamespace != nil {
-			nsStore.Add(tc.AddedNamespace)
-			controller.namespaceAdded(tc.AddedNamespace)
-		}
-		if tc.UpdatedNamespace != nil {
-			nsStore.Add(tc.UpdatedNamespace)
-			controller.namespaceUpdated(nil, tc.UpdatedNamespace)
-		}
-		if tc.DeletedServiceAccount != nil {
-			controller.serviceAccountDeleted(tc.DeletedServiceAccount)
-		}
-
-		// wait to be called
-		select {
-		case <-syncCalls:
-		case <-time.After(10 * time.Second):
-			t.Errorf("%s: took too long", k)
-		}
-
-		actions := client.Actions()
-		if len(tc.ExpectCreatedServiceAccounts) != len(actions) {
-			t.Errorf("%s: Expected to create accounts %#v. Actual actions were: %#v", k, tc.ExpectCreatedServiceAccounts, actions)
-			continue
-		}
-		for i, expectedName := range tc.ExpectCreatedServiceAccounts {
-			action := actions[i]
-			if !action.Matches("create", "serviceaccounts") {
-				t.Errorf("%s: Unexpected action %s", k, action)
-				break
+			if tc.AddedNamespace != nil {
+				nsStore.Add(tc.AddedNamespace)
+				controller.namespaceAdded(tc.AddedNamespace)
 			}
-			createdAccount := action.(core.CreateAction).GetObject().(*v1.ServiceAccount)
-			if createdAccount.Name != expectedName {
-				t.Errorf("%s: Expected %s to be created, got %s", k, expectedName, createdAccount.Name)
+			if tc.UpdatedNamespace != nil {
+				nsStore.Add(tc.UpdatedNamespace)
+				controller.namespaceUpdated(nil, tc.UpdatedNamespace)
 			}
-		}
+			if tc.DeletedServiceAccount != nil {
+				controller.serviceAccountDeleted(tc.DeletedServiceAccount)
+			}
+
+			// wait to be called
+			select {
+			case <-syncCalls:
+			case <-time.After(10 * time.Second):
+				t.Errorf("%s: took too long", k)
+			}
+
+			actions := client.Actions()
+			if len(tc.ExpectCreatedServiceAccounts) != len(actions) {
+				t.Errorf("%s: Expected to create accounts %#v. Actual actions were: %#v", k, tc.ExpectCreatedServiceAccounts, actions)
+				return
+			}
+			for i, expectedName := range tc.ExpectCreatedServiceAccounts {
+				action := actions[i]
+				if !action.Matches("create", "serviceaccounts") {
+					t.Errorf("%s: Unexpected action %s", k, action)
+					break
+				}
+				createdAccount := action.(core.CreateAction).GetObject().(*v1.ServiceAccount)
+				if createdAccount.Name != expectedName {
+					t.Errorf("%s: Expected %s to be created, got %s", k, expectedName, createdAccount.Name)
+				}
+			}
+		})
 	}
 }
 

--- a/pkg/controller/serviceaccount/tokens_controller.go
+++ b/pkg/controller/serviceaccount/tokens_controller.go
@@ -69,7 +69,7 @@ type TokensControllerOptions struct {
 }
 
 // NewTokensController returns a new *TokensController.
-func NewTokensController(serviceAccounts informers.ServiceAccountInformer, secrets informers.SecretInformer, cl clientset.Interface, options TokensControllerOptions) (*TokensController, error) {
+func NewTokensController(ctx context.Context, serviceAccounts informers.ServiceAccountInformer, secrets informers.SecretInformer, cl clientset.Interface, options TokensControllerOptions) (*TokensController, error) {
 	maxRetries := options.MaxRetries
 	if maxRetries == 0 {
 		maxRetries = 10
@@ -104,7 +104,7 @@ func NewTokensController(serviceAccounts informers.ServiceAccountInformer, secre
 	)
 
 	secretCache := secrets.Informer().GetIndexer()
-	e.updatedSecrets = cache.NewIntegerResourceVersionMutationCache(secretCache, secretCache, 60*time.Second, true)
+	e.updatedSecrets = cache.NewIntegerResourceVersionMutationCache(ctx, secretCache, secretCache, 60*time.Second, true)
 	e.secretSynced = secrets.Informer().HasSynced
 	secrets.Informer().AddEventHandlerWithResyncPeriod(
 		cache.FilteringResourceEventHandler{

--- a/pkg/controller/serviceaccount/tokens_controller_test.go
+++ b/pkg/controller/serviceaccount/tokens_controller_test.go
@@ -454,7 +454,7 @@ func TestTokenCreation(t *testing.T) {
 			secretInformer := informers.Core().V1().Secrets().Informer()
 			secrets := secretInformer.GetStore()
 			serviceAccounts := informers.Core().V1().ServiceAccounts().Informer().GetStore()
-			controller, err := NewTokensController(informers.Core().V1().ServiceAccounts(), informers.Core().V1().Secrets(), client, TokensControllerOptions{TokenGenerator: generator, RootCA: []byte("CA Data"), MaxRetries: tc.MaxRetries})
+			controller, err := NewTokensController(ctx, informers.Core().V1().ServiceAccounts(), informers.Core().V1().Secrets(), client, TokensControllerOptions{TokenGenerator: generator, RootCA: []byte("CA Data"), MaxRetries: tc.MaxRetries})
 			if err != nil {
 				t.Fatalf("error creating Tokens controller: %v", err)
 			}

--- a/pkg/controller/statefulset/stateful_pod_control.go
+++ b/pkg/controller/statefulset/stateful_pod_control.go
@@ -187,7 +187,7 @@ func (spc *StatefulPodControl) UpdateStatefulPod(ctx context.Context, set *apps.
 			// make a copy so we don't mutate the shared cache
 			pod = updated.DeepCopy()
 		} else {
-			utilruntime.HandleError(fmt.Errorf("error getting updated Pod %s/%s: %w", set.Namespace, pod.Name, err))
+			utilruntime.HandleErrorWithContext(ctx, err, "Error getting updated Pod", "pod", klog.KObj(pod))
 		}
 
 		return updateErr

--- a/pkg/controller/statefulset/stateful_set_status_updater.go
+++ b/pkg/controller/statefulset/stateful_set_status_updater.go
@@ -18,7 +18,6 @@ package statefulset
 
 import (
 	"context"
-	"fmt"
 
 	apps "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -26,6 +25,7 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	appslisters "k8s.io/client-go/listers/apps/v1"
 	"k8s.io/client-go/util/retry"
+	"k8s.io/klog/v2"
 )
 
 // StatefulSetStatusUpdaterInterface is an interface used to update the StatefulSetStatus associated with a StatefulSet.
@@ -65,7 +65,7 @@ func (ssu *realStatefulSetStatusUpdater) UpdateStatefulSetStatus(
 			// make a copy so we don't mutate the shared cache
 			set = updated.DeepCopy()
 		} else {
-			utilruntime.HandleError(fmt.Errorf("error getting updated StatefulSet %s/%s from lister: %v", set.Namespace, set.Name, err))
+			utilruntime.HandleErrorWithContext(ctx, err, "Error getting updated StatefulSet", "statefulset", klog.KObj(set))
 		}
 
 		return updateErr

--- a/pkg/controller/storageversionmigrator/resourceversion.go
+++ b/pkg/controller/storageversionmigrator/resourceversion.go
@@ -110,7 +110,7 @@ func (rv *ResourceVersionController) updateSVM(logger klog.Logger, oldObj, newOb
 func (rv *ResourceVersionController) enqueue(svm *svmv1alpha1.StorageVersionMigration) {
 	key, err := controller.KeyFunc(svm)
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("couldn't get key for object %#v: %w", svm, err))
+		utilruntime.HandleError(fmt.Errorf("couldn't get key for object %#v: %w", svm, err)) //nolint:logcheck // Should not be reached.
 		return
 	}
 
@@ -118,14 +118,14 @@ func (rv *ResourceVersionController) enqueue(svm *svmv1alpha1.StorageVersionMigr
 }
 
 func (rv *ResourceVersionController) Run(ctx context.Context) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 	defer rv.queue.ShutDown()
 
 	logger := klog.FromContext(ctx)
 	logger.Info("Starting", "controller", ResourceVersionControllerName)
 	defer logger.Info("Shutting down", "controller", ResourceVersionControllerName)
 
-	if !cache.WaitForNamedCacheSync(ResourceVersionControllerName, ctx.Done(), rv.svmSynced) {
+	if !cache.WaitForNamedCacheSyncWithContext(ctx, rv.svmSynced) {
 		return
 	}
 

--- a/pkg/controller/storageversionmigrator/storageversionmigrator.go
+++ b/pkg/controller/storageversionmigrator/storageversionmigrator.go
@@ -117,7 +117,7 @@ func (svmc *SVMController) updateSVM(logger klog.Logger, oldObj, newObj interfac
 func (svmc *SVMController) enqueue(svm *svmv1alpha1.StorageVersionMigration) {
 	key, err := controller.KeyFunc(svm)
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("couldn't get key for object %#v: %w", svm, err))
+		utilruntime.HandleError(fmt.Errorf("couldn't get key for object %#v: %w", svm, err)) //nolint:logcheck // Should not be reached.
 		return
 	}
 
@@ -125,14 +125,14 @@ func (svmc *SVMController) enqueue(svm *svmv1alpha1.StorageVersionMigration) {
 }
 
 func (svmc *SVMController) Run(ctx context.Context) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 	defer svmc.queue.ShutDown()
 
 	logger := klog.FromContext(ctx)
 	logger.Info("Starting", "controller", svmc.controllerName)
 	defer logger.Info("Shutting down", "controller", svmc.controllerName)
 
-	if !cache.WaitForNamedCacheSync(svmc.controllerName, ctx.Done(), svmc.svmSynced) {
+	if !cache.WaitForNamedCacheSyncWithContext(ctx, svmc.svmSynced) {
 		return
 	}
 

--- a/pkg/controller/tainteviction/taint_eviction.go
+++ b/pkg/controller/tainteviction/taint_eviction.go
@@ -254,11 +254,11 @@ func New(ctx context.Context, c clientset.Interface, podInformer corev1informers
 	}
 
 	_, err = nodeInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: controllerutil.CreateAddNodeHandler(func(node *v1.Node) error {
+		AddFunc: controllerutil.CreateAddNodeHandler(logger, func(node *v1.Node) error {
 			tm.NodeUpdated(nil, node)
 			return nil
 		}),
-		UpdateFunc: controllerutil.CreateUpdateNodeHandler(func(oldNode, newNode *v1.Node) error {
+		UpdateFunc: controllerutil.CreateUpdateNodeHandler(logger, func(oldNode, newNode *v1.Node) error {
 			tm.NodeUpdated(oldNode, newNode)
 			return nil
 		}),
@@ -276,7 +276,7 @@ func New(ctx context.Context, c clientset.Interface, podInformer corev1informers
 
 // Run starts the controller which will run in loop until `stopCh` is closed.
 func (tc *Controller) Run(ctx context.Context) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 	logger := klog.FromContext(ctx)
 	logger.Info("Starting", "controller", tc.name)
 	defer logger.Info("Shutting down controller", "controller", tc.name)
@@ -295,7 +295,7 @@ func (tc *Controller) Run(ctx context.Context) {
 	defer tc.podUpdateQueue.ShutDown()
 
 	// wait for the cache to be synced
-	if !cache.WaitForNamedCacheSync(tc.name, ctx.Done(), tc.podListerSynced, tc.nodeListerSynced) {
+	if !cache.WaitForNamedCacheSyncWithContext(ctx, tc.podListerSynced, tc.nodeListerSynced) {
 		return
 	}
 
@@ -500,7 +500,7 @@ func (tc *Controller) handlePodUpdate(ctx context.Context, podUpdate podUpdateIt
 			tc.cancelWorkWithEvent(logger, podNamespacedName)
 			return
 		}
-		utilruntime.HandleError(fmt.Errorf("could not get pod %s/%s: %v", podUpdate.podName, podUpdate.podNamespace, err))
+		utilruntime.HandleErrorWithContext(ctx, err, "Could not get pod", "pod", klog.KRef(podUpdate.podNamespace, podUpdate.podName))
 		return
 	}
 
@@ -542,7 +542,7 @@ func (tc *Controller) handleNodeUpdate(ctx context.Context, nodeUpdate nodeUpdat
 			delete(tc.taintedNodes, nodeUpdate.nodeName)
 			return
 		}
-		utilruntime.HandleError(fmt.Errorf("cannot get node %s: %v", nodeUpdate.nodeName, err))
+		utilruntime.HandleErrorWithContext(ctx, err, "Cannot get node", "node", klog.KRef("", nodeUpdate.nodeName))
 		return
 	}
 

--- a/pkg/controller/util/node/controller_utils.go
+++ b/pkg/controller/util/node/controller_utils.go
@@ -200,24 +200,14 @@ func SwapNodeControllerTaint(ctx context.Context, kubeClient clientset.Interface
 
 	err := controller.AddOrUpdateTaintOnNode(ctx, kubeClient, node.Name, taintsToAdd...)
 	if err != nil {
-		utilruntime.HandleError(
-			fmt.Errorf(
-				"unable to taint %+v unresponsive Node %q: %v",
-				taintsToAdd,
-				node.Name,
-				err))
+		utilruntime.HandleErrorWithContext(ctx, err, "Unable to taint unresponsive node", "taints", taintsToAdd, "node", klog.KObj(node))
 		return false
 	}
 	logger.V(4).Info("Added taint to node", "taint", taintsToAdd, "node", klog.KRef("", node.Name))
 
 	err = controller.RemoveTaintOffNode(ctx, kubeClient, node.Name, node, taintsToRemove...)
 	if err != nil {
-		utilruntime.HandleError(
-			fmt.Errorf(
-				"unable to remove %+v unneeded taint from unresponsive Node %q: %v",
-				taintsToRemove,
-				node.Name,
-				err))
+		utilruntime.HandleErrorWithContext(ctx, err, "Unable to remove unneeded taint from unresponsive node", "taints", taintsToRemove, "node", klog.KObj(node))
 		return false
 	}
 	logger.V(4).Info("Made sure that node has no taint", "node", klog.KRef("", node.Name), "taint", taintsToRemove)
@@ -230,12 +220,7 @@ func SwapNodeControllerTaint(ctx context.Context, kubeClient clientset.Interface
 func AddOrUpdateLabelsOnNode(ctx context.Context, kubeClient clientset.Interface, labelsToUpdate map[string]string, node *v1.Node) bool {
 	logger := klog.FromContext(ctx)
 	if err := controller.AddOrUpdateLabelsOnNode(kubeClient, node.Name, labelsToUpdate); err != nil {
-		utilruntime.HandleError(
-			fmt.Errorf(
-				"unable to update labels %+v for Node %q: %v",
-				labelsToUpdate,
-				node.Name,
-				err))
+		utilruntime.HandleErrorWithContext(ctx, err, "Unable to update labels for node", "labels", labelsToUpdate, "node", klog.KObj(node))
 		return false
 	}
 	logger.V(4).Info("Updated labels to node", "label", labelsToUpdate, "node", klog.KRef("", node.Name))
@@ -243,23 +228,25 @@ func AddOrUpdateLabelsOnNode(ctx context.Context, kubeClient clientset.Interface
 }
 
 // CreateAddNodeHandler creates an add node handler.
-func CreateAddNodeHandler(f func(node *v1.Node) error) func(obj interface{}) {
+func CreateAddNodeHandler(logger klog.Logger, f func(node *v1.Node) error) func(obj interface{}) {
+	ctx := klog.NewContext(context.Background(), logger)
 	return func(originalObj interface{}) {
 		node := originalObj.(*v1.Node).DeepCopy()
 		if err := f(node); err != nil {
-			utilruntime.HandleError(fmt.Errorf("Error while processing Node Add: %v", err))
+			utilruntime.HandleErrorWithContext(ctx, err, "Error while processing Node Add")
 		}
 	}
 }
 
 // CreateUpdateNodeHandler creates a node update handler. (Common to lifecycle and ipam)
-func CreateUpdateNodeHandler(f func(oldNode, newNode *v1.Node) error) func(oldObj, newObj interface{}) {
+func CreateUpdateNodeHandler(logger klog.Logger, f func(oldNode, newNode *v1.Node) error) func(oldObj, newObj interface{}) {
+	ctx := klog.NewContext(context.Background(), logger)
 	return func(origOldObj, origNewObj interface{}) {
 		node := origNewObj.(*v1.Node).DeepCopy()
 		prevNode := origOldObj.(*v1.Node).DeepCopy()
 
 		if err := f(prevNode, node); err != nil {
-			utilruntime.HandleError(fmt.Errorf("Error while processing Node Add/Delete: %v", err))
+			utilruntime.HandleErrorWithContext(ctx, err, "Error while processing Node Add/Delete")
 		}
 	}
 }
@@ -284,7 +271,7 @@ func CreateDeleteNodeHandler(logger klog.Logger, f func(node *v1.Node) error) fu
 		}
 		node := originalNode.DeepCopy()
 		if err := f(node); err != nil {
-			utilruntime.HandleError(fmt.Errorf("Error while processing Node Add/Delete: %v", err))
+			utilruntime.HandleErrorWithContext(klog.NewContext(context.Background(), logger), err, "Error while processing Node Add/Delete")
 		}
 	}
 }

--- a/pkg/controller/volume/attachdetach/attach_detach_controller_test.go
+++ b/pkg/controller/volume/attachdetach/attach_detach_controller_test.go
@@ -344,7 +344,7 @@ func attachDetachRecoveryTestCase(t *testing.T, extraPods1 []*v1.Pod, extraPods2
 
 	informerFactory.Start(tCtx.Done())
 
-	if !kcache.WaitForNamedCacheSync("attach detach", tCtx.Done(),
+	if !kcache.WaitForNamedCacheSyncWithContext(tCtx,
 		informerFactory.Core().V1().Pods().Informer().HasSynced,
 		informerFactory.Core().V1().Nodes().Informer().HasSynced,
 		informerFactory.Storage().V1().CSINodes().Informer().HasSynced) {
@@ -622,7 +622,7 @@ func volumeAttachmentRecoveryTestCase(t *testing.T, tc vaTest) {
 	// Makesure the informer cache is synced
 	informerFactory.Start(tCtx.Done())
 
-	if !kcache.WaitForNamedCacheSync("attach detach", tCtx.Done(),
+	if !kcache.WaitForNamedCacheSyncWithContext(tCtx,
 		informerFactory.Core().V1().Pods().Informer().HasSynced,
 		informerFactory.Core().V1().Nodes().Informer().HasSynced,
 		informerFactory.Core().V1().PersistentVolumes().Informer().HasSynced,

--- a/pkg/controller/volume/attachdetach/populator/desired_state_of_world_populator.go
+++ b/pkg/controller/volume/attachdetach/populator/desired_state_of_world_populator.go
@@ -20,7 +20,6 @@ package populator
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"k8s.io/klog/v2"
@@ -127,7 +126,7 @@ func (dswp *desiredStateOfWorldPopulator) findAndRemoveDeletedPods(logger klog.L
 		// Retrieve the pod object from pod informer with the namespace key
 		namespace, name, err := kcache.SplitMetaNamespaceKey(dswPodKey)
 		if err != nil {
-			utilruntime.HandleError(fmt.Errorf("error splitting dswPodKey %q: %v", dswPodKey, err))
+			utilruntime.HandleErrorWithContext(klog.NewContext(context.Background(), logger), err, "Error splitting dswPodKey", "key", dswPodKey)
 			continue
 		}
 		informerPod, err := dswp.podLister.Pods(namespace).Get(name)

--- a/pkg/controller/volume/persistentvolume/pv_controller_base.go
+++ b/pkg/controller/volume/persistentvolume/pv_controller_base.go
@@ -295,7 +295,7 @@ func (ctrl *PersistentVolumeController) deleteClaim(ctx context.Context, claim *
 
 // Run starts all of this controller's control loops
 func (ctrl *PersistentVolumeController) Run(ctx context.Context) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 	defer ctrl.claimQueue.ShutDown()
 	defer ctrl.volumeQueue.ShutDown()
 
@@ -308,7 +308,7 @@ func (ctrl *PersistentVolumeController) Run(ctx context.Context) {
 	logger.Info("Starting persistent volume controller")
 	defer logger.Info("Shutting down persistent volume controller")
 
-	if !cache.WaitForNamedCacheSync("persistent volume", ctx.Done(), ctrl.volumeListerSynced, ctrl.claimListerSynced, ctrl.classListerSynced, ctrl.podListerSynced, ctrl.NodeListerSynced) {
+	if !cache.WaitForNamedCacheSyncWithContext(ctx, ctrl.volumeListerSynced, ctrl.claimListerSynced, ctrl.classListerSynced, ctrl.podListerSynced, ctrl.NodeListerSynced) {
 		return
 	}
 

--- a/pkg/controlplane/apiserver/server.go
+++ b/pkg/controlplane/apiserver/server.go
@@ -262,7 +262,7 @@ func (c completedConfig) New(name string, delegationTarget genericapiserver.Dele
 				IdentityLeaseGCPeriod,
 				metav1.NamespaceSystem,
 				IdentityLeaseComponentLabelKey+"="+name,
-			).Run(hookContext.Done())
+			).Run(hookContext)
 			return nil
 		})
 	}

--- a/pkg/controlplane/controller/apiserverleasegc/gc_controller_test.go
+++ b/pkg/controlplane/controller/apiserverleasegc/gc_controller_test.go
@@ -25,6 +25,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/kubernetes/test/utils/ktesting"
 	testingclock "k8s.io/utils/clock/testing"
 	"k8s.io/utils/pointer"
 )
@@ -131,9 +132,10 @@ func Test_Controller(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			tCtx := ktesting.Init(t)
 			clientset := fake.NewSimpleClientset(test.lease)
 			controller := NewAPIServerLeaseGC(clientset, 100*time.Millisecond, metav1.NamespaceSystem, "apiserver.kubernetes.io/identity=kube-apiserver")
-			go controller.Run(nil)
+			go controller.Run(tCtx)
 
 			time.Sleep(time.Second)
 

--- a/pkg/controlplane/controller/clusterauthenticationtrust/cluster_authentication_trust_controller.go
+++ b/pkg/controlplane/controller/clusterauthenticationtrust/cluster_authentication_trust_controller.go
@@ -444,7 +444,7 @@ func (c *Controller) Run(ctx context.Context, workers int) {
 	defer klog.Infof("Shutting down cluster_authentication_trust_controller controller")
 
 	// we have a personal informer that is narrowly scoped, start it.
-	go c.kubeSystemConfigMapInformer.Run(ctx.Done())
+	go c.kubeSystemConfigMapInformer.RunWithContext(ctx)
 
 	// wait for your secondary caches to fill before starting your work
 	if !cache.WaitForNamedCacheSync("cluster_authentication_trust_controller", ctx.Done(), c.preRunCaches...) {

--- a/pkg/kubelet/config/apiserver.go
+++ b/pkg/kubelet/config/apiserver.go
@@ -17,13 +17,13 @@ limitations under the License.
 package config
 
 import (
+	"context"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
@@ -34,7 +34,7 @@ import (
 const WaitForAPIServerSyncPeriod = 1 * time.Second
 
 // NewSourceApiserver creates a config source that watches and pulls from the apiserver.
-func NewSourceApiserver(c clientset.Interface, nodeName types.NodeName, nodeHasSynced func() bool, updates chan<- interface{}) {
+func NewSourceApiserver(ctx context.Context, c clientset.Interface, nodeName types.NodeName, nodeHasSynced func() bool, updates chan<- interface{}) {
 	lw := cache.NewListWatchFromClient(c.CoreV1().RESTClient(), "pods", metav1.NamespaceAll, fields.OneTermEqualSelector("spec.nodeName", string(nodeName)))
 
 	// The Reflector responsible for watching pods at the apiserver should be run only after
@@ -50,12 +50,12 @@ func NewSourceApiserver(c clientset.Interface, nodeName types.NodeName, nodeHasS
 			klog.V(4).InfoS("node sync has not completed yet")
 		}
 		klog.InfoS("Watching apiserver")
-		newSourceApiserverFromLW(lw, updates)
+		newSourceApiserverFromLW(ctx, lw, updates)
 	}()
 }
 
 // newSourceApiserverFromLW holds creates a config source that watches and pulls from the apiserver.
-func newSourceApiserverFromLW(lw cache.ListerWatcher, updates chan<- interface{}) {
+func newSourceApiserverFromLW(ctx context.Context, lw cache.ListerWatcher, updates chan<- interface{}) {
 	send := func(objs []interface{}) {
 		var pods []*v1.Pod
 		for _, o := range objs {
@@ -64,5 +64,5 @@ func newSourceApiserverFromLW(lw cache.ListerWatcher, updates chan<- interface{}
 		updates <- kubetypes.PodUpdate{Pods: pods, Op: kubetypes.SET, Source: kubetypes.ApiserverSource}
 	}
 	r := cache.NewReflector(lw, &v1.Pod{}, cache.NewUndeltaStore(send, cache.MetaNamespaceKeyFunc), 0)
-	go r.Run(wait.NeverStop)
+	go r.RunWithContext(ctx)
 }

--- a/pkg/kubelet/configmap/configmap_manager.go
+++ b/pkg/kubelet/configmap/configmap_manager.go
@@ -135,7 +135,7 @@ func NewCachingConfigMapManager(kubeClient clientset.Interface, getTTL manager.G
 //   - whenever a pod is created or updated, we start individual watches for all
 //     referenced objects that aren't referenced from other registered pods
 //   - every GetObject() returns a value from local cache propagated via watches
-func NewWatchingConfigMapManager(kubeClient clientset.Interface, resyncInterval time.Duration) Manager {
+func NewWatchingConfigMapManager(ctx context.Context, kubeClient clientset.Interface, resyncInterval time.Duration) Manager {
 	listConfigMap := func(namespace string, opts metav1.ListOptions) (runtime.Object, error) {
 		return kubeClient.CoreV1().ConfigMaps(namespace).List(context.TODO(), opts)
 	}
@@ -153,6 +153,6 @@ func NewWatchingConfigMapManager(kubeClient clientset.Interface, resyncInterval 
 	}
 	gr := corev1.Resource("configmap")
 	return &configMapManager{
-		manager: manager.NewWatchBasedManager(listConfigMap, watchConfigMap, newConfigMap, isImmutable, gr, resyncInterval, getConfigMapNames),
+		manager: manager.NewWatchBasedManager(ctx, listConfigMap, watchConfigMap, newConfigMap, isImmutable, gr, resyncInterval, getConfigMapNames),
 	}
 }

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -312,7 +312,7 @@ func makePodSourceConfig(kubeCfg *kubeletconfiginternal.KubeletConfiguration, ku
 
 	if kubeDeps.KubeClient != nil {
 		klog.InfoS("Adding apiserver pod source")
-		config.NewSourceApiserver(kubeDeps.KubeClient, nodeName, nodeHasSynced, cfg.Channel(ctx, kubetypes.ApiserverSource))
+		config.NewSourceApiserver(ctx, kubeDeps.KubeClient, nodeName, nodeHasSynced, cfg.Channel(ctx, kubetypes.ApiserverSource))
 	}
 	return cfg, nil
 }
@@ -587,8 +587,8 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 	if klet.kubeClient != nil {
 		switch kubeCfg.ConfigMapAndSecretChangeDetectionStrategy {
 		case kubeletconfiginternal.WatchChangeDetectionStrategy:
-			secretManager = secret.NewWatchingSecretManager(klet.kubeClient, klet.resyncInterval)
-			configMapManager = configmap.NewWatchingConfigMapManager(klet.kubeClient, klet.resyncInterval)
+			secretManager = secret.NewWatchingSecretManager(ctx, klet.kubeClient, klet.resyncInterval)
+			configMapManager = configmap.NewWatchingConfigMapManager(ctx, klet.kubeClient, klet.resyncInterval)
 		case kubeletconfiginternal.TTLCacheChangeDetectionStrategy:
 			secretManager = secret.NewCachingSecretManager(
 				klet.kubeClient, manager.GetObjectTTLFromNodeFunc(klet.GetNode))

--- a/pkg/kubelet/secret/secret_manager.go
+++ b/pkg/kubelet/secret/secret_manager.go
@@ -136,7 +136,7 @@ func NewCachingSecretManager(kubeClient clientset.Interface, getTTL manager.GetO
 //   - whenever a pod is created or updated, we start individual watches for all
 //     referenced objects that aren't referenced from other registered pods
 //   - every GetObject() returns a value from local cache propagated via watches
-func NewWatchingSecretManager(kubeClient clientset.Interface, resyncInterval time.Duration) Manager {
+func NewWatchingSecretManager(ctx context.Context, kubeClient clientset.Interface, resyncInterval time.Duration) Manager {
 	listSecret := func(namespace string, opts metav1.ListOptions) (runtime.Object, error) {
 		return kubeClient.CoreV1().Secrets(namespace).List(context.TODO(), opts)
 	}
@@ -154,6 +154,6 @@ func NewWatchingSecretManager(kubeClient clientset.Interface, resyncInterval tim
 	}
 	gr := corev1.Resource("secret")
 	return &secretManager{
-		manager: manager.NewWatchBasedManager(listSecret, watchSecret, newSecret, isImmutable, gr, resyncInterval, getSecretNames),
+		manager: manager.NewWatchBasedManager(ctx, listSecret, watchSecret, newSecret, isImmutable, gr, resyncInterval, getSecretNames),
 	}
 }

--- a/pkg/scheduler/eventhandlers.go
+++ b/pkg/scheduler/eventhandlers.go
@@ -148,7 +148,7 @@ func (sched *Scheduler) addPodToSchedulingQueue(obj interface{}) {
 	pod := obj.(*v1.Pod)
 	logger.V(3).Info("Add event for unscheduled pod", "pod", klog.KObj(pod))
 	if err := sched.SchedulingQueue.Add(logger, pod); err != nil {
-		utilruntime.HandleError(fmt.Errorf("unable to queue %T: %v", obj, err))
+		utilruntime.HandleError(fmt.Errorf("unable to queue %T: %v", obj, err)) //nolint:logcheck // Should not be reached.
 	}
 }
 
@@ -165,7 +165,7 @@ func (sched *Scheduler) updatePodInSchedulingQueue(oldObj, newObj interface{}) {
 
 	isAssumed, err := sched.Cache.IsAssumedPod(newPod)
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("failed to check whether pod %s/%s is assumed: %v", newPod.Namespace, newPod.Name, err))
+		utilruntime.HandleError(fmt.Errorf("failed to check whether pod %s/%s is assumed: %v", newPod.Namespace, newPod.Name, err)) //nolint:logcheck // Should not be reached.
 	}
 	if isAssumed {
 		return
@@ -173,7 +173,7 @@ func (sched *Scheduler) updatePodInSchedulingQueue(oldObj, newObj interface{}) {
 
 	logger.V(4).Info("Update event for unscheduled pod", "pod", klog.KObj(newPod))
 	if err := sched.SchedulingQueue.Update(logger, oldPod, newPod); err != nil {
-		utilruntime.HandleError(fmt.Errorf("unable to update %T: %v", newObj, err))
+		utilruntime.HandleError(fmt.Errorf("unable to update %T: %v", newObj, err)) //nolint:logcheck // Should not be reached.
 	}
 }
 
@@ -190,17 +190,17 @@ func (sched *Scheduler) deletePodFromSchedulingQueue(obj interface{}) {
 		var ok bool
 		pod, ok = t.Obj.(*v1.Pod)
 		if !ok {
-			utilruntime.HandleError(fmt.Errorf("unable to convert object %T to *v1.Pod in %T", obj, sched))
+			utilruntime.HandleError(fmt.Errorf("unable to convert object %T to *v1.Pod in %T", obj, sched)) //nolint:logcheck // Should not be reached.
 			return
 		}
 	default:
-		utilruntime.HandleError(fmt.Errorf("unable to handle object in %T: %T", sched, obj))
+		utilruntime.HandleError(fmt.Errorf("unable to handle object in %T: %T", sched, obj)) //nolint:logcheck // Should not be reached.
 		return
 	}
 
 	logger.V(3).Info("Delete event for unscheduled pod", "pod", klog.KObj(pod))
 	if err := sched.SchedulingQueue.Delete(pod); err != nil {
-		utilruntime.HandleError(fmt.Errorf("unable to dequeue %T: %v", obj, err))
+		utilruntime.HandleError(fmt.Errorf("unable to dequeue %T: %v", obj, err)) //nolint:logcheck // Should not be reached.
 	}
 	fwk, err := sched.frameworkForPod(pod)
 	if err != nil {
@@ -373,10 +373,10 @@ func addAllEventHandlers(
 						// it's assigned or not. Attempting to cleanup anyways.
 						return true
 					}
-					utilruntime.HandleError(fmt.Errorf("unable to convert object %T to *v1.Pod in %T", obj, sched))
+					utilruntime.HandleError(fmt.Errorf("unable to convert object %T to *v1.Pod in %T", obj, sched)) //nolint:logcheck // Should not be reached.
 					return false
 				default:
-					utilruntime.HandleError(fmt.Errorf("unable to handle object in %T: %T", sched, obj))
+					utilruntime.HandleError(fmt.Errorf("unable to handle object in %T: %T", sched, obj)) //nolint:logcheck // Should not be reached.
 					return false
 				}
 			},
@@ -404,10 +404,10 @@ func addAllEventHandlers(
 						// it's assigned or not.
 						return responsibleForPod(pod, sched.Profiles)
 					}
-					utilruntime.HandleError(fmt.Errorf("unable to convert object %T to *v1.Pod in %T", obj, sched))
+					utilruntime.HandleError(fmt.Errorf("unable to convert object %T to *v1.Pod in %T", obj, sched)) //nolint:logcheck // Should not be reached.
 					return false
 				default:
-					utilruntime.HandleError(fmt.Errorf("unable to handle object in %T: %T", sched, obj))
+					utilruntime.HandleError(fmt.Errorf("unable to handle object in %T: %T", sched, obj)) //nolint:logcheck // Should not be reached.
 					return false
 				}
 			},

--- a/pkg/scheduler/schedule_one.go
+++ b/pkg/scheduler/schedule_one.go
@@ -387,8 +387,7 @@ func (sched *Scheduler) skipPodSchedule(ctx context.Context, fwk framework.Frame
 	// during its previous scheduling cycle but before getting assumed.
 	isAssumed, err := sched.Cache.IsAssumedPod(pod)
 	if err != nil {
-		// TODO(91633): pass ctx into a revised HandleError
-		utilruntime.HandleError(fmt.Errorf("failed to check whether pod %s/%s is assumed: %v", pod.Namespace, pod.Name, err))
+		utilruntime.HandleErrorWithContext(ctx, err, "Failed to check whether pod is assumed", "pod", klog.KObj(pod))
 		return false
 	}
 	return isAssumed

--- a/pkg/scheduler/util/assumecache/assume_cache.go
+++ b/pkg/scheduler/util/assumecache/assume_cache.go
@@ -518,7 +518,7 @@ func (c *AssumeCache) emitEvents() {
 			return
 		}
 		func() {
-			defer utilruntime.HandleCrash()
+			defer utilruntime.HandleCrash() //nolint:logcheck // Should not be reached.
 			deliver()
 		}()
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/apiserver.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/apiserver.go
@@ -17,6 +17,7 @@ limitations under the License.
 package apiserver
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"time"
@@ -210,7 +211,7 @@ func (c completedConfig) New(delegationTarget genericapiserver.DelegationTarget)
 		aggregatedDiscoveryManager = aggregatedDiscoveryManager.WithSource(aggregated.CRDSource)
 	}
 	discoveryController := NewDiscoveryController(s.Informers.Apiextensions().V1().CustomResourceDefinitions(), versionDiscoveryHandler, groupDiscoveryHandler, aggregatedDiscoveryManager)
-	namingController := status.NewNamingConditionController(s.Informers.Apiextensions().V1().CustomResourceDefinitions(), crdClient.ApiextensionsV1())
+	namingController := status.NewNamingConditionController(context.TODO() /* for contextual logging */, s.Informers.Apiextensions().V1().CustomResourceDefinitions(), crdClient.ApiextensionsV1())
 	nonStructuralSchemaController := nonstructuralschema.NewConditionController(s.Informers.Apiextensions().V1().CustomResourceDefinitions(), crdClient.ApiextensionsV1())
 	apiApprovalController := apiapproval.NewKubernetesAPIApprovalPolicyConformantConditionController(s.Informers.Apiextensions().V1().CustomResourceDefinitions(), crdClient.ApiextensionsV1())
 	finalizingController := finalizer.NewCRDFinalizer(

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/status/naming_controller.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/status/naming_controller.go
@@ -62,6 +62,7 @@ type NamingConditionController struct {
 }
 
 func NewNamingConditionController(
+	ctx context.Context,
 	crdInformer informers.CustomResourceDefinitionInformer,
 	crdClient client.CustomResourceDefinitionsGetter,
 ) *NamingConditionController {
@@ -76,7 +77,7 @@ func NewNamingConditionController(
 	}
 
 	informerIndexer := crdInformer.Informer().GetIndexer()
-	c.crdMutationCache = cache.NewIntegerResourceVersionMutationCache(informerIndexer, informerIndexer, 60*time.Second, false)
+	c.crdMutationCache = cache.NewIntegerResourceVersionMutationCache(ctx, informerIndexer, informerIndexer, 60*time.Second, false)
 
 	crdInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    c.addCustomResourceDefinition,

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/status/naming_controller_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/status/naming_controller_test.go
@@ -27,6 +27,7 @@ import (
 	listers "k8s.io/apiextensions-apiserver/pkg/client/listers/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2/ktesting"
 )
 
 type crdBuilder struct {
@@ -321,25 +322,30 @@ func TestSync(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		crdIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
-		for _, obj := range tc.existing {
-			crdIndexer.Add(obj)
-		}
+		t.Run(tc.name, func(t *testing.T) {
+			_, ctx := ktesting.NewTestContext(t)
+			crdIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+			for _, obj := range tc.existing {
+				if err := crdIndexer.Add(obj); err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+			}
 
-		c := NamingConditionController{
-			crdLister:        listers.NewCustomResourceDefinitionLister(crdIndexer),
-			crdMutationCache: cache.NewIntegerResourceVersionMutationCache(crdIndexer, crdIndexer, 60*time.Second, false),
-		}
-		actualNames, actualNameConflictCondition, establishedCondition := c.calculateNamesAndConditions(tc.in)
+			c := NamingConditionController{
+				crdLister:        listers.NewCustomResourceDefinitionLister(crdIndexer),
+				crdMutationCache: cache.NewIntegerResourceVersionMutationCache(ctx, crdIndexer, crdIndexer, 60*time.Second, false),
+			}
+			actualNames, actualNameConflictCondition, establishedCondition := c.calculateNamesAndConditions(tc.in)
 
-		if e, a := tc.expectedNames, actualNames; !reflect.DeepEqual(e, a) {
-			t.Errorf("%v expected %v, got %#v", tc.name, e, a)
-		}
-		if e, a := tc.expectedNameConflictCondition, actualNameConflictCondition; !apiextensionshelpers.IsCRDConditionEquivalent(&e, &a) {
-			t.Errorf("%v expected %v, got %v", tc.name, e, a)
-		}
-		if e, a := tc.expectedEstablishedCondition, establishedCondition; !apiextensionshelpers.IsCRDConditionEquivalent(&e, &a) {
-			t.Errorf("%v expected %v, got %v", tc.name, e, a)
-		}
+			if e, a := tc.expectedNames, actualNames; !reflect.DeepEqual(e, a) {
+				t.Errorf("expected %v, got %#v", e, a)
+			}
+			if e, a := tc.expectedNameConflictCondition, actualNameConflictCondition; !apiextensionshelpers.IsCRDConditionEquivalent(&e, &a) {
+				t.Errorf("expected %v, got %v", e, a)
+			}
+			if e, a := tc.expectedEstablishedCondition, establishedCondition; !apiextensionshelpers.IsCRDConditionEquivalent(&e, &a) {
+				t.Errorf("expected %v, got %v", e, a)
+			}
+		})
 	}
 }

--- a/staging/src/k8s.io/apimachinery/pkg/util/runtime/runtime.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/runtime/runtime.go
@@ -45,7 +45,7 @@ var PanicHandlers = []func(context.Context, interface{}){logPanic}
 //
 // E.g., you can provide one or more additional handlers for something like shutting down go routines gracefully.
 //
-// TODO(pohly): logcheck:context // HandleCrashWithContext should be used instead of HandleCrash in code which supports contextual logging.
+//logcheck:context // HandleCrashWithContext should be used instead of HandleCrash in code which supports contextual logging.
 func HandleCrash(additionalHandlers ...func(interface{})) {
 	if r := recover(); r != nil {
 		additionalHandlersWithContext := make([]func(context.Context, interface{}), len(additionalHandlers))
@@ -146,7 +146,7 @@ type ErrorHandler func(ctx context.Context, err error, msg string, keysAndValues
 // is preferable to logging the error - the default behavior is to log but the
 // errors may be sent to a remote server for analysis.
 //
-// TODO(pohly): logcheck:context // HandleErrorWithContext should be used instead of HandleError in code which supports contextual logging.
+//logcheck:context // HandleErrorWithContext should be used instead of HandleError in code which supports contextual logging.
 func HandleError(err error) {
 	// this is sometimes called with a nil error.  We probably shouldn't fail and should do nothing instead
 	if err == nil {

--- a/staging/src/k8s.io/apimachinery/pkg/watch/watch.go
+++ b/staging/src/k8s.io/apimachinery/pkg/watch/watch.go
@@ -302,7 +302,7 @@ var _ Interface = &ProxyWatcher{}
 // NewProxyWatcher creates new ProxyWatcher by wrapping a channel.
 // The ProxyWatcher runs until Stop is called.
 //
-// TODO (https://github.com/kubernetes/kubernetes/issues/126379): logcheck:context // NewProxyWatcherWithContext should be used instead of NewProxyWatcher in code which supports contextual logging.
+//logcheck:context // NewProxyWatcherWithContext should be used instead of NewProxyWatcher in code which supports contextual logging.
 func NewProxyWatcher(ch chan Event) *ProxyWatcher {
 	return NewProxyWatcherWithContext(context.Background(), ch)
 }
@@ -347,7 +347,7 @@ func (pw *ProxyWatcher) ResultChan() <-chan Event {
 
 // StopChan returns stop channel
 //
-// TODO (https://github.com/kubernetes/kubernetes/issues/126379): logcheck:context // Context should be used instead of StopCh in code which supports contextual logging.
+//logcheck:context // Context should be used instead of StopCh in code which supports contextual logging.
 func (pw *ProxyWatcher) StopChan() <-chan struct{} {
 	return pw.ctx.Done()
 }

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/storage_factory.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/storage_factory.go
@@ -17,6 +17,7 @@ limitations under the License.
 package registry
 
 import (
+	"context"
 	"fmt"
 	"sync"
 
@@ -54,6 +55,7 @@ func StorageWithCacher() generic.StorageDecorator {
 		}
 
 		cacherConfig := cacherstorage.Config{
+			Ctx:            context.TODO(), // TODO (https://github.com/kubernetes/enhancements/issues/3077): allow caller to pass in a context.
 			Storage:        s,
 			Versioner:      storage.APIObjectVersioner{},
 			GroupResource:  storageConfig.GroupResource,

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store_test.go
@@ -61,6 +61,7 @@ import (
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/tools/cache"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	"k8s.io/klog/v2/ktesting"
 )
 
 var scheme = runtime.NewScheme()
@@ -2414,6 +2415,7 @@ func TestStoreWatch(t *testing.T) {
 }
 
 func newTestGenericStoreRegistry(t *testing.T, scheme *runtime.Scheme, hasCacheEnabled bool) (factory.DestroyFunc, *Store) {
+	_, ctx := ktesting.NewTestContext(t)
 	podPrefix := "/pods"
 	server, sc := etcd3testing.NewUnsecuredEtcd3TestClientServer(t)
 	strategy := &testRESTStrategy{scheme, names.SimpleNameGenerator, true, false, true}
@@ -2432,6 +2434,7 @@ func newTestGenericStoreRegistry(t *testing.T, scheme *runtime.Scheme, hasCacheE
 	}
 	if hasCacheEnabled {
 		config := cacherstorage.Config{
+			Ctx:            ctx,
 			Storage:        s,
 			Versioner:      storage.APIObjectVersioner{},
 			GroupResource:  schema.GroupResource{Resource: "pods"},

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_test.go
@@ -38,6 +38,7 @@ import (
 	storagetesting "k8s.io/apiserver/pkg/storage/testing"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	"k8s.io/klog/v2/ktesting"
 	"k8s.io/utils/clock"
 )
 
@@ -427,6 +428,7 @@ func testSetup(t *testing.T, opts ...setupOption) (context.Context, *Cacher, tea
 }
 
 func testSetupWithEtcdServer(t *testing.T, opts ...setupOption) (context.Context, *Cacher, *etcd3testing.EtcdTestServer, tearDownFunc) {
+	_, ctx := ktesting.NewTestContext(t)
 	setupOpts := setupOptions{}
 	opts = append([]setupOption{withDefaults}, opts...)
 	for _, opt := range opts {
@@ -441,6 +443,7 @@ func testSetupWithEtcdServer(t *testing.T, opts ...setupOption) (context.Context
 	}
 
 	config := Config{
+		Ctx:            ctx,
 		Storage:        wrappedStorage,
 		Versioner:      storage.APIObjectVersioner{},
 		GroupResource:  schema.GroupResource{Resource: "pods"},
@@ -457,7 +460,6 @@ func testSetupWithEtcdServer(t *testing.T, opts ...setupOption) (context.Context
 	if err != nil {
 		t.Fatalf("Failed to initialize cacher: %v", err)
 	}
-	ctx := context.Background()
 	terminate := func() {
 		cacher.Stop()
 		server.Terminate(t)

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -32,7 +33,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/apiserver/pkg/features"
 	"k8s.io/apiserver/pkg/storage"
@@ -675,7 +675,7 @@ func TestReflectorForWatchCache(t *testing.T) {
 		},
 	}
 	r := cache.NewReflector(lw, &v1.Pod{}, store, 0)
-	r.ListAndWatch(wait.NeverStop)
+	require.NoError(t, r.ListAndWatchWithContext(ctx))
 
 	{
 		_, version, _, err := store.WaitUntilFreshAndList(ctx, 10, "", nil)

--- a/staging/src/k8s.io/client-go/metadata/metadatainformer/informer_test.go
+++ b/staging/src/k8s.io/client-go/metadata/metadatainformer/informer_test.go
@@ -138,8 +138,8 @@ func TestMetadataSharedInformerFactory(t *testing.T) {
 			// act
 			informerListerForGvr := target.ForResource(ts.gvr)
 			informerListerForGvr.Informer().AddEventHandler(ts.handler(informerReciveObjectCh))
-			target.Start(ctx.Done())
-			if synced := target.WaitForCacheSync(ctx.Done()); !synced[ts.gvr] {
+			target.StartWithContext(ctx)
+			if synced := target.WaitForCacheSyncWithContext(ctx); !synced[ts.gvr] {
 				t.Fatalf("informer for %s hasn't synced", ts.gvr)
 			}
 

--- a/staging/src/k8s.io/client-go/metadata/metadatainformer/interface.go
+++ b/staging/src/k8s.io/client-go/metadata/metadatainformer/interface.go
@@ -29,7 +29,7 @@ type SharedInformerFactory interface {
 	// Start initializes all requested informers. They are handled in goroutines
 	// which run until the stop channel gets closed.
 	//
-	// TODO (https://github.com/kubernetes/kubernetes/issues/126379): logcheck:context // StartWithContext should be used instead of Start in code which supports contextual logging.
+	//logcheck:context // StartWithContext should be used instead of Start in code which supports contextual logging.
 	Start(stopCh <-chan struct{})
 
 	// ForResource gives generic access to a shared informer of the matching type.
@@ -37,7 +37,7 @@ type SharedInformerFactory interface {
 
 	// WaitForCacheSync blocks until all started informers' caches were synced
 	// or the stop channel gets closed.
-	// TODO (https://github.com/kubernetes/kubernetes/issues/126379): logcheck:context // WaitForCacheSyncWithContext should be used instead of WaitForCacheSync in code which supports contextual logging.
+	//logcheck:context // WaitForCacheSyncWithContext should be used instead of WaitForCacheSync in code which supports contextual logging.
 	WaitForCacheSync(stopCh <-chan struct{}) map[schema.GroupVersionResource]bool
 
 	// Shutdown marks a factory as shutting down. At that point no new

--- a/staging/src/k8s.io/client-go/tools/cache/cache_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/cache_test.go
@@ -1,0 +1,25 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"k8s.io/klog/v2"
+)
+
+func init() {
+	klog.InitFlags(nil)
+}

--- a/staging/src/k8s.io/client-go/tools/cache/controller.go
+++ b/staging/src/k8s.io/client-go/tools/cache/controller.go
@@ -81,7 +81,7 @@ type Config struct {
 
 	// Called whenever the ListAndWatch drops the connection with an error.
 	//
-	// TODO (https://github.com/kubernetes/kubernetes/issues/126379): logcheck:context // WatchErrorHandlerWithContext should be used instead of WatchErrorHandler in code which supports contextual logging.
+	//logcheck:context // WatchErrorHandlerWithContext should be used instead of WatchErrorHandler in code which supports contextual logging.
 	WatchErrorHandler WatchErrorHandler
 
 	// Called whenever the ListAndWatch drops the connection with an error.
@@ -124,7 +124,7 @@ type Controller interface {
 	// Run does the same as RunWithContext with a stop channel instead of
 	// a context.
 	//
-	// TODO (https://github.com/kubernetes/kubernetes/issues/126379): logcheck:context // RunWithcontext should be used instead of Run in code which supports contextual logging.
+	//logcheck:context // RunWithcontext should be used instead of Run in code which supports contextual logging.
 	Run(stopCh <-chan struct{})
 
 	// HasSynced delegates to the Config's Queue

--- a/staging/src/k8s.io/client-go/tools/cache/controller.go
+++ b/staging/src/k8s.io/client-go/tools/cache/controller.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cache
 
 import (
+	"context"
 	"errors"
 	"sync"
 	"time"
@@ -79,7 +80,12 @@ type Config struct {
 	RetryOnError bool
 
 	// Called whenever the ListAndWatch drops the connection with an error.
+	//
+	// TODO (https://github.com/kubernetes/kubernetes/issues/126379): logcheck:context // WatchErrorHandlerWithContext should be used instead of WatchErrorHandler in code which supports contextual logging.
 	WatchErrorHandler WatchErrorHandler
+
+	// Called whenever the ListAndWatch drops the connection with an error.
+	WatchErrorHandlerWithContext WatchErrorHandlerWithContext
 
 	// WatchListPageSize is the requested chunk size of initial and relist watch lists.
 	WatchListPageSize int64
@@ -104,12 +110,21 @@ type controller struct {
 // Controller is a low-level controller that is parameterized by a
 // Config and used in sharedIndexInformer.
 type Controller interface {
-	// Run does two things.  One is to construct and run a Reflector
+	// RunWithContext does two things.  One is to construct and run a Reflector
 	// to pump objects/notifications from the Config's ListerWatcher
 	// to the Config's Queue and possibly invoke the occasional Resync
 	// on that Queue.  The other is to repeatedly Pop from the Queue
 	// and process with the Config's ProcessFunc.  Both of these
-	// continue until `stopCh` is closed.
+	// continue until the context is canceled.
+	//
+	// It's an error to call Run more than once.
+	// RunWithContext blocks; call via go.
+	RunWithContext(ctx context.Context)
+
+	// Run does the same as RunWithContext with a stop channel instead of
+	// a context.
+	//
+	// TODO (https://github.com/kubernetes/kubernetes/issues/126379): logcheck:context // RunWithcontext should be used instead of Run in code which supports contextual logging.
 	Run(stopCh <-chan struct{})
 
 	// HasSynced delegates to the Config's Queue
@@ -129,13 +144,16 @@ func New(c *Config) Controller {
 	return ctlr
 }
 
-// Run begins processing items, and will continue until a value is sent down stopCh or it is closed.
-// It's an error to call Run more than once.
-// Run blocks; call via go.
+// Run implements [Controller.Run].
 func (c *controller) Run(stopCh <-chan struct{}) {
-	defer utilruntime.HandleCrash()
+	c.RunWithContext(wait.ContextForChannel(stopCh))
+}
+
+// RunWithContext implements [Controller.RunWithContext].
+func (c *controller) RunWithContext(ctx context.Context) {
+	defer utilruntime.HandleCrashWithContext(ctx)
 	go func() {
-		<-stopCh
+		<-ctx.Done()
 		c.config.Queue.Close()
 	}()
 	r := NewReflectorWithOptions(
@@ -152,7 +170,11 @@ func (c *controller) Run(stopCh <-chan struct{}) {
 	r.ShouldResync = c.config.ShouldResync
 	r.WatchListPageSize = c.config.WatchListPageSize
 	if c.config.WatchErrorHandler != nil {
-		r.watchErrorHandler = c.config.WatchErrorHandler
+		r.watchErrorHandler = func(_ context.Context, r *Reflector, err error) {
+			c.config.WatchErrorHandler(r, err)
+		}
+	} else if c.config.WatchErrorHandlerWithContext != nil {
+		r.watchErrorHandler = c.config.WatchErrorHandlerWithContext
 	}
 
 	c.reflectorMutex.Lock()
@@ -161,9 +183,9 @@ func (c *controller) Run(stopCh <-chan struct{}) {
 
 	var wg wait.Group
 
-	wg.StartWithChannel(stopCh, r.Run)
+	wg.StartWithContext(ctx, r.RunWithContext)
 
-	wait.Until(c.processLoop, time.Second, stopCh)
+	wait.UntilWithContext(ctx, c.processLoop, time.Second)
 	wg.Wait()
 }
 
@@ -185,13 +207,11 @@ func (c *controller) LastSyncResourceVersion() string {
 // TODO: Consider doing the processing in parallel. This will require a little thought
 // to make sure that we don't end up processing the same object multiple times
 // concurrently.
-//
-// TODO: Plumb through the stopCh here (and down to the queue) so that this can
-// actually exit when the controller is stopped. Or just give up on this stuff
-// ever being stoppable. Converting this whole package to use Context would
-// also be helpful.
-func (c *controller) processLoop() {
+func (c *controller) processLoop(ctx context.Context) {
 	for {
+		// TODO: Plumb through the ctx so that this can
+		// actually exit when the controller is stopped. Or just give up on this stuff
+		// ever being stoppable.
 		obj, err := c.config.Queue.Pop(PopProcessFunc(c.config.Process))
 		if err != nil {
 			if err == ErrFIFOClosed {

--- a/staging/src/k8s.io/client-go/tools/cache/delta_fifo.go
+++ b/staging/src/k8s.io/client-go/tools/cache/delta_fifo.go
@@ -55,6 +55,9 @@ type DeltaFIFOOptions struct {
 	// If set, will be called for objects before enqueueing them. Please
 	// see the comment on TransformFunc for details.
 	Transformer TransformFunc
+
+	// If set, log output will go to this logger instead of klog.Background().
+	Logger *klog.Logger
 }
 
 // DeltaFIFO is like FIFO, but differs in two ways.  One is that the
@@ -136,6 +139,10 @@ type DeltaFIFO struct {
 
 	// Called with every object if non-nil.
 	transformer TransformFunc
+
+	// logger is a per-instance logger. This gets chosen when constructing
+	// the instance, with klog.Background() as default.
+	logger klog.Logger
 }
 
 // TransformFunc allows for transforming an object before it will be processed.
@@ -253,6 +260,10 @@ func NewDeltaFIFOWithOptions(opts DeltaFIFOOptions) *DeltaFIFO {
 
 		emitDeltaTypeReplaced: opts.EmitDeltaTypeReplaced,
 		transformer:           opts.Transformer,
+		logger:                klog.Background(),
+	}
+	if opts.Logger != nil {
+		f.logger = *opts.Logger
 	}
 	f.cond.L = &f.lock
 	return f
@@ -487,10 +498,10 @@ func (f *DeltaFIFO) queueActionInternalLocked(actionType, internalActionType Del
 		// when given a non-empty list (as it is here).
 		// If somehow it happens anyway, deal with it but complain.
 		if oldDeltas == nil {
-			klog.Errorf("Impossible dedupDeltas for id=%q: oldDeltas=%#+v, obj=%#+v; ignoring", id, oldDeltas, obj)
+			f.logger.Error(nil, "Impossible dedupDeltas", "id", id, "oldDeltas", oldDeltas, "obj", obj)
 			return nil
 		}
-		klog.Errorf("Impossible dedupDeltas for id=%q: oldDeltas=%#+v, obj=%#+v; breaking invariant by storing empty Deltas", id, oldDeltas, obj)
+		f.logger.Error(nil, "Impossible dedupDeltas, breaking invariant by storing empty Deltas", "id", id, "oldDeltas", oldDeltas, "obj", obj)
 		f.items[id] = newDeltas
 		return fmt.Errorf("Impossible dedupDeltas for id=%q: oldDeltas=%#+v, obj=%#+v; broke DeltaFIFO invariant by storing empty Deltas", id, oldDeltas, obj)
 	}
@@ -597,7 +608,7 @@ func (f *DeltaFIFO) Pop(process PopProcessFunc) (interface{}, error) {
 		item, ok := f.items[id]
 		if !ok {
 			// This should never happen
-			klog.Errorf("Inconceivable! %q was in f.queue but not f.items; ignoring.", id)
+			f.logger.Error(nil, "Inconceivable! Item was in f.queue but not f.items; ignoring", "key", id)
 			continue
 		}
 		delete(f.items, id)
@@ -694,10 +705,10 @@ func (f *DeltaFIFO) Replace(list []interface{}, _ string) error {
 			deletedObj, exists, err := f.knownObjects.GetByKey(k)
 			if err != nil {
 				deletedObj = nil
-				klog.Errorf("Unexpected error %v during lookup of key %v, placing DeleteFinalStateUnknown marker without object", err, k)
+				f.logger.Error(err, "Unexpected error during lookup, placing DeleteFinalStateUnknown marker without object", "key", k)
 			} else if !exists {
 				deletedObj = nil
-				klog.Infof("Key %v does not exist in known objects store, placing DeleteFinalStateUnknown marker without object", k)
+				f.logger.Info("Key does not exist in known objects store, placing DeleteFinalStateUnknown marker without object", "key", k)
 			}
 			queuedDeletions++
 			if err := f.queueActionLocked(Deleted, DeletedFinalStateUnknown{k, deletedObj}); err != nil {
@@ -737,10 +748,10 @@ func (f *DeltaFIFO) Resync() error {
 func (f *DeltaFIFO) syncKeyLocked(key string) error {
 	obj, exists, err := f.knownObjects.GetByKey(key)
 	if err != nil {
-		klog.Errorf("Unexpected error %v during lookup of key %v, unable to queue object for sync", err, key)
+		f.logger.Error(err, "Unexpected error during lookup, unable to queue object for sync", "key", key)
 		return nil
 	} else if !exists {
-		klog.Infof("Key %v does not exist in known objects store, unable to queue object for sync", key)
+		f.logger.Info("Key does not exist in known objects store, unable to queue object for sync", "key", key)
 		return nil
 	}
 

--- a/staging/src/k8s.io/client-go/tools/cache/listers.go
+++ b/staging/src/k8s.io/client-go/tools/cache/listers.go
@@ -62,7 +62,12 @@ func ListAllByNamespace(indexer Indexer, namespace string, selector labels.Selec
 	items, err := indexer.Index(NamespaceIndex, &metav1.ObjectMeta{Namespace: namespace})
 	if err != nil {
 		// Ignore error; do slow search without index.
-		klog.Warningf("can not retrieve list of objects using index : %v", err)
+		//
+		// ListAllByNamespace is called by generated code
+		// (k8s.io/client-go/listers) and probably not worth converting
+		// to contextual logging, which would require changing all of
+		// those APIs.
+		klog.TODO().Error(err, "can not retrieve list of objects using index")
 		for _, m := range indexer.List() {
 			metadata, err := meta.Accessor(m)
 			if err != nil {

--- a/staging/src/k8s.io/client-go/tools/cache/mutation_detector.go
+++ b/staging/src/k8s.io/client-go/tools/cache/mutation_detector.go
@@ -50,6 +50,7 @@ func NewCacheMutationDetector(name string) MutationDetector {
 	if !mutationDetectionEnabled {
 		return dummyMutationDetector{}
 	}
+	//nolint:logcheck // This code shouldn't be used in production.
 	klog.Warningln("Mutation detector is enabled, this will result in memory leakage.")
 	return &defaultCacheMutationDetector{name: name, period: 1 * time.Second, retainDuration: 2 * time.Minute}
 }

--- a/staging/src/k8s.io/client-go/tools/cache/reflector.go
+++ b/staging/src/k8s.io/client-go/tools/cache/reflector.go
@@ -314,7 +314,7 @@ var internalPackages = []string{"client-go/tools/cache/"}
 // objects and subsequent deltas.
 // Run will exit when stopCh is closed.
 //
-// TODO (https://github.com/kubernetes/kubernetes/issues/126379): logcheck:context // RunWithContext should be used instead of Run in code which supports contextual logging.
+//logcheck:context // RunWithContext should be used instead of Run in code which supports contextual logging.
 func (r *Reflector) Run(stopCh <-chan struct{}) {
 	r.RunWithContext(wait.ContextForChannel(stopCh))
 }
@@ -360,7 +360,7 @@ func (r *Reflector) resyncChan() (<-chan time.Time, func() bool) {
 // and then use the resource version to watch.
 // It returns error if ListAndWatch didn't even try to initialize watch.
 //
-// TODO (https://github.com/kubernetes/kubernetes/issues/126379): logcheck:context // ListAndWatchWithContext should be used instead of ListAndWatch in code which supports contextual logging.
+//logcheck:context // ListAndWatchWithContext should be used instead of ListAndWatch in code which supports contextual logging.
 func (r *Reflector) ListAndWatch(stopCh <-chan struct{}) error {
 	return r.ListAndWatchWithContext(wait.ContextForChannel(stopCh))
 }

--- a/staging/src/k8s.io/client-go/tools/cache/reflector.go
+++ b/staging/src/k8s.io/client-go/tools/cache/reflector.go
@@ -95,7 +95,7 @@ type Reflector struct {
 	// lastSyncResourceVersionMutex guards read/write access to lastSyncResourceVersion
 	lastSyncResourceVersionMutex sync.RWMutex
 	// Called whenever the ListAndWatch drops the connection with an error.
-	watchErrorHandler WatchErrorHandler
+	watchErrorHandler WatchErrorHandlerWithContext
 	// WatchListPageSize is the requested chunk size of initial and resync watch lists.
 	// If unset, for consistent reads (RV="") or reads that opt-into arbitrarily old data
 	// (RV="0") it will default to pager.PageSize, for the rest (RV != "" && RV != "0")
@@ -142,20 +142,32 @@ type ResourceVersionUpdater interface {
 // should be offloaded.
 type WatchErrorHandler func(r *Reflector, err error)
 
-// DefaultWatchErrorHandler is the default implementation of WatchErrorHandler
-func DefaultWatchErrorHandler(r *Reflector, err error) {
+// The WatchErrorHandler is called whenever ListAndWatch drops the
+// connection with an error. After calling this handler, the informer
+// will backoff and retry.
+//
+// The default implementation looks at the error type and tries to log
+// the error message at an appropriate level.
+//
+// Implementations of this handler may display the error message in other
+// ways. Implementations should return quickly - any expensive processing
+// should be offloaded.
+type WatchErrorHandlerWithContext func(ctx context.Context, r *Reflector, err error)
+
+// DefaultWatchErrorHandler is the default implementation of WatchErrorHandlerWithContext.
+func DefaultWatchErrorHandler(ctx context.Context, r *Reflector, err error) {
 	switch {
 	case isExpiredError(err):
 		// Don't set LastSyncResourceVersionUnavailable - LIST call with ResourceVersion=RV already
 		// has a semantic that it returns data at least as fresh as provided RV.
 		// So first try to LIST with setting RV to resource version of last observed object.
-		klog.V(4).Infof("%s: watch of %v closed with: %v", r.name, r.typeDescription, err)
+		klog.FromContext(ctx).V(4).Info("Watch closed", "reflector", r.name, "type", r.typeDescription, "err", err)
 	case err == io.EOF:
 		// watch closed normally
 	case err == io.ErrUnexpectedEOF:
-		klog.V(1).Infof("%s: Watch for %v closed with unexpected EOF: %v", r.name, r.typeDescription, err)
+		klog.FromContext(ctx).V(1).Info("Watch closed with unexpected EOF", "reflector", r.name, "type", r.typeDescription, "err", err)
 	default:
-		utilruntime.HandleError(fmt.Errorf("%s: Failed to watch %v: %v", r.name, r.typeDescription, err))
+		utilruntime.HandleErrorWithContext(ctx, err, "Failed to watch", "reflector", r.name, "type", r.typeDescription)
 	}
 }
 
@@ -235,7 +247,7 @@ func NewReflectorWithOptions(lw ListerWatcher, expectedType interface{}, store S
 		// 0.22 QPS. If we don't backoff for 2min, assume API server is healthy and we reset the backoff.
 		backoffManager:    wait.NewExponentialBackoffManager(800*time.Millisecond, 30*time.Second, 2*time.Minute, 2.0, 1.0, reflectorClock),
 		clock:             reflectorClock,
-		watchErrorHandler: WatchErrorHandler(DefaultWatchErrorHandler),
+		watchErrorHandler: WatchErrorHandlerWithContext(DefaultWatchErrorHandler),
 		expectedType:      reflect.TypeOf(expectedType),
 	}
 
@@ -301,14 +313,24 @@ var internalPackages = []string{"client-go/tools/cache/"}
 // Run repeatedly uses the reflector's ListAndWatch to fetch all the
 // objects and subsequent deltas.
 // Run will exit when stopCh is closed.
+//
+// TODO (https://github.com/kubernetes/kubernetes/issues/126379): logcheck:context // RunWithContext should be used instead of Run in code which supports contextual logging.
 func (r *Reflector) Run(stopCh <-chan struct{}) {
-	klog.V(3).Infof("Starting reflector %s (%s) from %s", r.typeDescription, r.resyncPeriod, r.name)
+	r.RunWithContext(wait.ContextForChannel(stopCh))
+}
+
+// RunWithContext repeatedly uses the reflector's ListAndWatch to fetch all the
+// objects and subsequent deltas.
+// Run will exit when the context is canceled.
+func (r *Reflector) RunWithContext(ctx context.Context) {
+	logger := klog.FromContext(ctx)
+	logger.V(3).Info("Starting reflector", "type", r.typeDescription, "resyncPeriod", r.resyncPeriod, "reflector", r.name)
 	wait.BackoffUntil(func() {
-		if err := r.ListAndWatch(stopCh); err != nil {
-			r.watchErrorHandler(r, err)
+		if err := r.ListAndWatchWithContext(ctx); err != nil {
+			r.watchErrorHandler(ctx, r, err)
 		}
-	}, r.backoffManager, true, stopCh)
-	klog.V(3).Infof("Stopping reflector %s (%s) from %s", r.typeDescription, r.resyncPeriod, r.name)
+	}, r.backoffManager, true, ctx.Done())
+	klog.FromContext(ctx).V(3).Info("Stopping reflector", "type", r.typeDescription, "resyncPeriod", r.resyncPeriod, "reflector", r.name)
 }
 
 var (
@@ -337,21 +359,32 @@ func (r *Reflector) resyncChan() (<-chan time.Time, func() bool) {
 // ListAndWatch first lists all items and get the resource version at the moment of call,
 // and then use the resource version to watch.
 // It returns error if ListAndWatch didn't even try to initialize watch.
+//
+// TODO (https://github.com/kubernetes/kubernetes/issues/126379): logcheck:context // ListAndWatchWithContext should be used instead of ListAndWatch in code which supports contextual logging.
 func (r *Reflector) ListAndWatch(stopCh <-chan struct{}) error {
-	klog.V(3).Infof("Listing and watching %v from %s", r.typeDescription, r.name)
+	return r.ListAndWatchWithContext(wait.ContextForChannel(stopCh))
+}
+
+// ListAndWatchWithContext first lists all items and get the resource version at the moment of call,
+// and then use the resource version to watch.
+// It returns error if ListAndWatchWithContext didn't even try to initialize watch.
+func (r *Reflector) ListAndWatchWithContext(ctx context.Context) error {
+	stopCh := ctx.Done()
+	logger := klog.FromContext(ctx)
+	logger.V(3).Info("Listing and watching", "type", r.typeDescription, "reflector", r.name)
 	var err error
 	var w watch.Interface
 	useWatchList := ptr.Deref(r.UseWatchList, false)
 	fallbackToList := !useWatchList
 
 	if useWatchList {
-		w, err = r.watchList(stopCh)
+		w, err = r.watchList(ctx)
 		if w == nil && err == nil {
 			// stopCh was closed
 			return nil
 		}
 		if err != nil {
-			klog.Warningf("The watchlist request ended with an error, falling back to the standard LIST/WATCH semantics because making progress is better than deadlocking, err = %v", err)
+			logger.Error(err, "The watchlist request ended with an error, falling back to the standard LIST/WATCH semantics because making progress is better than deadlocking")
 			fallbackToList = true
 			// ensure that we won't accidentally pass some garbage down the watch.
 			w = nil
@@ -365,14 +398,15 @@ func (r *Reflector) ListAndWatch(stopCh <-chan struct{}) error {
 		}
 	}
 
-	klog.V(2).Infof("Caches populated for %v from %s", r.typeDescription, r.name)
-	return r.watchWithResync(w, stopCh)
+	logger.V(2).Info("Caches populated", "type", r.typeDescription, "reflector", r.name)
+	return r.watchWithResync(ctx, w)
 }
 
 // startResync periodically calls r.store.Resync() method.
 // Note that this method is blocking and should be
 // called in a separate goroutine.
-func (r *Reflector) startResync(stopCh <-chan struct{}, cancelCh <-chan struct{}, resyncerrc chan error) {
+func (r *Reflector) startResync(ctx context.Context, resyncerrc chan error) {
+	logger := klog.FromContext(ctx)
 	resyncCh, cleanup := r.resyncChan()
 	defer func() {
 		cleanup() // Call the last one written into cleanup
@@ -380,13 +414,11 @@ func (r *Reflector) startResync(stopCh <-chan struct{}, cancelCh <-chan struct{}
 	for {
 		select {
 		case <-resyncCh:
-		case <-stopCh:
-			return
-		case <-cancelCh:
+		case <-ctx.Done():
 			return
 		}
 		if r.ShouldResync == nil || r.ShouldResync() {
-			klog.V(4).Infof("%s: forcing resync", r.name)
+			logger.V(4).Info("Forcing resync", "reflector", r.name)
 			if err := r.store.Resync(); err != nil {
 				resyncerrc <- err
 				return
@@ -398,16 +430,18 @@ func (r *Reflector) startResync(stopCh <-chan struct{}, cancelCh <-chan struct{}
 }
 
 // watchWithResync runs watch with startResync in the background.
-func (r *Reflector) watchWithResync(w watch.Interface, stopCh <-chan struct{}) error {
+func (r *Reflector) watchWithResync(ctx context.Context, w watch.Interface) error {
 	resyncerrc := make(chan error, 1)
-	cancelCh := make(chan struct{})
-	defer close(cancelCh)
-	go r.startResync(stopCh, cancelCh, resyncerrc)
-	return r.watch(w, stopCh, resyncerrc)
+	cancelCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	go r.startResync(cancelCtx, resyncerrc)
+	return r.watch(ctx, w, resyncerrc)
 }
 
 // watch simply starts a watch request with the server.
-func (r *Reflector) watch(w watch.Interface, stopCh <-chan struct{}, resyncerrc chan error) error {
+func (r *Reflector) watch(ctx context.Context, w watch.Interface, resyncerrc chan error) error {
+	stopCh := ctx.Done()
+	logger := klog.FromContext(ctx)
 	var err error
 	retry := NewRetryWithDeadline(r.MaxInternalErrorRetryDuration, time.Minute, apierrors.IsInternalError, r.clock)
 
@@ -443,7 +477,7 @@ func (r *Reflector) watch(w watch.Interface, stopCh <-chan struct{}, resyncerrc 
 			w, err = r.listerWatcher.Watch(options)
 			if err != nil {
 				if canRetry := isWatchErrorRetriable(err); canRetry {
-					klog.V(4).Infof("%s: watch of %v returned %v - backing off", r.name, r.typeDescription, err)
+					logger.V(4).Info("Watch failed - backing off", "reflector", r.name, "type", r.typeDescription, "err", err)
 					select {
 					case <-stopCh:
 						return nil
@@ -455,8 +489,8 @@ func (r *Reflector) watch(w watch.Interface, stopCh <-chan struct{}, resyncerrc 
 			}
 		}
 
-		err = handleWatch(start, w, r.store, r.expectedType, r.expectedGVK, r.name, r.typeDescription, r.setLastSyncResourceVersion,
-			r.clock, resyncerrc, stopCh)
+		err = handleWatch(ctx, start, w, r.store, r.expectedType, r.expectedGVK, r.name, r.typeDescription, r.setLastSyncResourceVersion,
+			r.clock, resyncerrc)
 		// Ensure that watch will not be reused across iterations.
 		w.Stop()
 		w = nil
@@ -468,9 +502,9 @@ func (r *Reflector) watch(w watch.Interface, stopCh <-chan struct{}, resyncerrc 
 					// Don't set LastSyncResourceVersionUnavailable - LIST call with ResourceVersion=RV already
 					// has a semantic that it returns data at least as fresh as provided RV.
 					// So first try to LIST with setting RV to resource version of last observed object.
-					klog.V(4).Infof("%s: watch of %v closed with: %v", r.name, r.typeDescription, err)
+					logger.V(4).Info("Watch closed", "reflector", r.name, "type", r.typeDescription, "err", err)
 				case apierrors.IsTooManyRequests(err):
-					klog.V(2).Infof("%s: watch of %v returned 429 - backing off", r.name, r.typeDescription)
+					logger.V(2).Info("Watch returned 429 - backing off", "reflector", r.name, "type", r.typeDescription)
 					select {
 					case <-stopCh:
 						return nil
@@ -478,10 +512,11 @@ func (r *Reflector) watch(w watch.Interface, stopCh <-chan struct{}, resyncerrc 
 						continue
 					}
 				case apierrors.IsInternalError(err) && retry.ShouldRetry():
-					klog.V(2).Infof("%s: retrying watch of %v internal error: %v", r.name, r.typeDescription, err)
+					logger.V(2).Info("Retrying watch after internal error", "reflector", r.name, "type", r.typeDescription, "err", err)
 					continue
 				default:
-					klog.Warningf("%s: watch of %v ended with: %v", r.name, r.typeDescription, err)
+					// TODO: should this be a runtime.HandleErrorWithContext?
+					logger.Info("Warning: watch ended with error", "reflector", r.name, "type", r.typeDescription, "err", err)
 				}
 			}
 			return nil
@@ -558,7 +593,6 @@ func (r *Reflector) list(stopCh <-chan struct{}) error {
 	}
 	initTrace.Step("Objects listed", trace.Field{Key: "error", Value: err})
 	if err != nil {
-		klog.Warningf("%s: failed to list %v: %v", r.name, r.typeDescription, err)
 		return fmt.Errorf("failed to list %v: %w", r.typeDescription, err)
 	}
 
@@ -616,7 +650,9 @@ func (r *Reflector) list(stopCh <-chan struct{}) error {
 // After receiving a "Bookmark" event the reflector is considered to be synchronized.
 // It replaces its internal store with the collected items and
 // reuses the current watch requests for getting further events.
-func (r *Reflector) watchList(stopCh <-chan struct{}) (watch.Interface, error) {
+func (r *Reflector) watchList(ctx context.Context) (watch.Interface, error) {
+	stopCh := ctx.Done()
+	logger := klog.FromContext(ctx)
 	var w watch.Interface
 	var err error
 	var temporaryStore Store
@@ -626,7 +662,7 @@ func (r *Reflector) watchList(stopCh <-chan struct{}) (watch.Interface, error) {
 	//  could be unified with the r.watch method
 	isErrorRetriableWithSideEffectsFn := func(err error) bool {
 		if canRetry := isWatchErrorRetriable(err); canRetry {
-			klog.V(2).Infof("%s: watch-list of %v returned %v - backing off", r.name, r.typeDescription, err)
+			logger.V(2).Info("watch-list failed - backing off", "reflector", r.name, "type", r.typeDescription, "err", err)
 			<-r.backoffManager.Backoff().C()
 			return true
 		}
@@ -673,9 +709,9 @@ func (r *Reflector) watchList(stopCh <-chan struct{}) (watch.Interface, error) {
 			}
 			return nil, err
 		}
-		watchListBookmarkReceived, err := handleListWatch(start, w, temporaryStore, r.expectedType, r.expectedGVK, r.name, r.typeDescription,
+		watchListBookmarkReceived, err := handleListWatch(ctx, start, w, temporaryStore, r.expectedType, r.expectedGVK, r.name, r.typeDescription,
 			func(rv string) { resourceVersion = rv },
-			r.clock, make(chan error), stopCh)
+			r.clock, make(chan error))
 		if err != nil {
 			w.Stop() // stop and retry with clean state
 			if errors.Is(err, errorStopRequested) {
@@ -698,7 +734,7 @@ func (r *Reflector) watchList(stopCh <-chan struct{}) (watch.Interface, error) {
 	// we utilize the temporaryStore to ensure independence from the current store implementation.
 	// as of today, the store is implemented as a queue and will be drained by the higher-level
 	// component as soon as it finishes replacing the content.
-	checkWatchListDataConsistencyIfRequested(wait.ContextForChannel(stopCh), r.name, resourceVersion, wrapListFuncWithContext(r.listerWatcher.List), temporaryStore.List)
+	checkWatchListDataConsistencyIfRequested(ctx, r.name, resourceVersion, wrapListFuncWithContext(r.listerWatcher.List), temporaryStore.List)
 
 	if err := r.store.Replace(temporaryStore.List(), resourceVersion); err != nil {
 		return nil, fmt.Errorf("unable to sync watch-list result: %w", err)
@@ -723,6 +759,7 @@ func (r *Reflector) syncWith(items []runtime.Object, resourceVersion string) err
 // retry. If successful, the watcher will be left open after receiving the
 // initial set of objects, to allow watching for future events.
 func handleListWatch(
+	ctx context.Context,
 	start time.Time,
 	w watch.Interface,
 	store Store,
@@ -733,17 +770,17 @@ func handleListWatch(
 	setLastSyncResourceVersion func(string),
 	clock clock.Clock,
 	errCh chan error,
-	stopCh <-chan struct{},
 ) (bool, error) {
 	exitOnWatchListBookmarkReceived := true
-	return handleAnyWatch(start, w, store, expectedType, expectedGVK, name, expectedTypeName,
-		setLastSyncResourceVersion, exitOnWatchListBookmarkReceived, clock, errCh, stopCh)
+	return handleAnyWatch(ctx, start, w, store, expectedType, expectedGVK, name, expectedTypeName,
+		setLastSyncResourceVersion, exitOnWatchListBookmarkReceived, clock, errCh)
 }
 
 // handleListWatch consumes events from w, updates the Store, and records the
 // last seen ResourceVersion, to allow continuing from that ResourceVersion on
 // retry. The watcher will always be stopped on exit.
 func handleWatch(
+	ctx context.Context,
 	start time.Time,
 	w watch.Interface,
 	store Store,
@@ -754,11 +791,10 @@ func handleWatch(
 	setLastSyncResourceVersion func(string),
 	clock clock.Clock,
 	errCh chan error,
-	stopCh <-chan struct{},
 ) error {
 	exitOnWatchListBookmarkReceived := false
-	_, err := handleAnyWatch(start, w, store, expectedType, expectedGVK, name, expectedTypeName,
-		setLastSyncResourceVersion, exitOnWatchListBookmarkReceived, clock, errCh, stopCh)
+	_, err := handleAnyWatch(ctx, start, w, store, expectedType, expectedGVK, name, expectedTypeName,
+		setLastSyncResourceVersion, exitOnWatchListBookmarkReceived, clock, errCh)
 	return err
 }
 
@@ -771,7 +807,9 @@ func handleWatch(
 // The watcher will always be stopped, unless exitOnWatchListBookmarkReceived is
 // true and watchListBookmarkReceived is true. This allows the same watch stream
 // to be re-used by the caller to continue watching for new events.
-func handleAnyWatch(start time.Time,
+func handleAnyWatch(
+	ctx context.Context,
+	start time.Time,
 	w watch.Interface,
 	store Store,
 	expectedType reflect.Type,
@@ -782,17 +820,16 @@ func handleAnyWatch(start time.Time,
 	exitOnWatchListBookmarkReceived bool,
 	clock clock.Clock,
 	errCh chan error,
-	stopCh <-chan struct{},
 ) (bool, error) {
 	watchListBookmarkReceived := false
 	eventCount := 0
-	initialEventsEndBookmarkWarningTicker := newInitialEventsEndBookmarkTicker(name, clock, start, exitOnWatchListBookmarkReceived)
+	initialEventsEndBookmarkWarningTicker := newInitialEventsEndBookmarkTicker(ctx, name, clock, start, exitOnWatchListBookmarkReceived)
 	defer initialEventsEndBookmarkWarningTicker.Stop()
 
 loop:
 	for {
 		select {
-		case <-stopCh:
+		case <-ctx.Done():
 			return watchListBookmarkReceived, errorStopRequested
 		case err := <-errCh:
 			return watchListBookmarkReceived, err
@@ -805,19 +842,19 @@ loop:
 			}
 			if expectedType != nil {
 				if e, a := expectedType, reflect.TypeOf(event.Object); e != a {
-					utilruntime.HandleError(fmt.Errorf("%s: expected type %v, but watch event object had type %v", name, e, a))
+					utilruntime.HandleErrorWithContext(ctx, nil, "Unexpected watch event object type", "reflector", name, "expectedType", e, "actualType", a)
 					continue
 				}
 			}
 			if expectedGVK != nil {
 				if e, a := *expectedGVK, event.Object.GetObjectKind().GroupVersionKind(); e != a {
-					utilruntime.HandleError(fmt.Errorf("%s: expected gvk %v, but watch event object had gvk %v", name, e, a))
+					utilruntime.HandleErrorWithContext(ctx, nil, "Unexpected watch event object gvk", "reflector", name, "expectedGVK", e, "actualGVK", a)
 					continue
 				}
 			}
 			meta, err := meta.Accessor(event.Object)
 			if err != nil {
-				utilruntime.HandleError(fmt.Errorf("%s: unable to understand watch event %#v", name, event))
+				utilruntime.HandleErrorWithContext(ctx, err, "Unable to understand watch event", "reflector", name, "event", event)
 				continue
 			}
 			resourceVersion := meta.GetResourceVersion()
@@ -825,12 +862,12 @@ loop:
 			case watch.Added:
 				err := store.Add(event.Object)
 				if err != nil {
-					utilruntime.HandleError(fmt.Errorf("%s: unable to add watch event object (%#v) to store: %v", name, event.Object, err))
+					utilruntime.HandleErrorWithContext(ctx, err, "Unable to add watch event object to store", "reflector", name, "object", event.Object)
 				}
 			case watch.Modified:
 				err := store.Update(event.Object)
 				if err != nil {
-					utilruntime.HandleError(fmt.Errorf("%s: unable to update watch event object (%#v) to store: %v", name, event.Object, err))
+					utilruntime.HandleErrorWithContext(ctx, err, "Unable to update watch event object to store", "reflector", name, "object", event.Object)
 				}
 			case watch.Deleted:
 				// TODO: Will any consumers need access to the "last known
@@ -838,7 +875,7 @@ loop:
 				// to change this.
 				err := store.Delete(event.Object)
 				if err != nil {
-					utilruntime.HandleError(fmt.Errorf("%s: unable to delete watch event object (%#v) from store: %v", name, event.Object, err))
+					utilruntime.HandleErrorWithContext(ctx, err, "Unable to delete watch event object from store", "reflector", name, "object", event.Object)
 				}
 			case watch.Bookmark:
 				// A `Bookmark` means watch has synced here, just update the resourceVersion
@@ -846,7 +883,7 @@ loop:
 					watchListBookmarkReceived = true
 				}
 			default:
-				utilruntime.HandleError(fmt.Errorf("%s: unable to understand watch event %#v", name, event))
+				utilruntime.HandleErrorWithContext(ctx, err, "Unknown watch event", "reflector", name, "event", event)
 			}
 			setLastSyncResourceVersion(resourceVersion)
 			if rvu, ok := store.(ResourceVersionUpdater); ok {
@@ -855,7 +892,7 @@ loop:
 			eventCount++
 			if exitOnWatchListBookmarkReceived && watchListBookmarkReceived {
 				watchDuration := clock.Since(start)
-				klog.V(4).Infof("exiting %v Watch because received the bookmark that marks the end of initial events stream, total %v items received in %v", name, eventCount, watchDuration)
+				klog.FromContext(ctx).V(4).Info("Exiting watch because received the bookmark that marks the end of initial events stream", "reflector", name, "totalItems", eventCount, "duration", watchDuration)
 				return watchListBookmarkReceived, nil
 			}
 			initialEventsEndBookmarkWarningTicker.observeLastEventTimeStamp(clock.Now())
@@ -868,7 +905,7 @@ loop:
 	if watchDuration < 1*time.Second && eventCount == 0 {
 		return watchListBookmarkReceived, fmt.Errorf("very short watch: %s: Unexpected watch close - watch lasted less than a second and no items received", name)
 	}
-	klog.V(4).Infof("%s: Watch close - %v total %v items received", name, expectedTypeName, eventCount)
+	klog.FromContext(ctx).V(4).Info("Watch close", "reflector", name, "type", expectedTypeName, "totalItems", eventCount)
 	return watchListBookmarkReceived, nil
 }
 
@@ -996,8 +1033,9 @@ func wrapListFuncWithContext(listFn ListFunc) func(ctx context.Context, options 
 // The methods exposed by this type are not thread-safe.
 type initialEventsEndBookmarkTicker struct {
 	clock.Ticker
-	clock clock.Clock
-	name  string
+	clock  clock.Clock
+	name   string
+	logger klog.Logger
 
 	watchStart           time.Time
 	tickInterval         time.Duration
@@ -1011,15 +1049,16 @@ type initialEventsEndBookmarkTicker struct {
 // Note that the caller controls whether to call t.C() and t.Stop().
 //
 // In practice, the reflector exits the watchHandler as soon as the bookmark event is received and calls the t.C() method.
-func newInitialEventsEndBookmarkTicker(name string, c clock.Clock, watchStart time.Time, exitOnWatchListBookmarkReceived bool) *initialEventsEndBookmarkTicker {
-	return newInitialEventsEndBookmarkTickerInternal(name, c, watchStart, 10*time.Second, exitOnWatchListBookmarkReceived)
+func newInitialEventsEndBookmarkTicker(ctx context.Context, name string, c clock.Clock, watchStart time.Time, exitOnWatchListBookmarkReceived bool) *initialEventsEndBookmarkTicker {
+	return newInitialEventsEndBookmarkTickerInternal(ctx, name, c, watchStart, 10*time.Second, exitOnWatchListBookmarkReceived)
 }
 
-func newInitialEventsEndBookmarkTickerInternal(name string, c clock.Clock, watchStart time.Time, tickInterval time.Duration, exitOnWatchListBookmarkReceived bool) *initialEventsEndBookmarkTicker {
+func newInitialEventsEndBookmarkTickerInternal(ctx context.Context, name string, c clock.Clock, watchStart time.Time, tickInterval time.Duration, exitOnWatchListBookmarkReceived bool) *initialEventsEndBookmarkTicker {
+	logger := klog.FromContext(ctx)
 	clockWithTicker, ok := c.(clock.WithTicker)
 	if !ok || !exitOnWatchListBookmarkReceived {
 		if exitOnWatchListBookmarkReceived {
-			klog.Warningf("clock does not support WithTicker interface but exitOnInitialEventsEndBookmark was requested")
+			logger.Info("WARNING: clock does not support WithTicker interface but exitOnInitialEventsEndBookmark was requested")
 		}
 		return &initialEventsEndBookmarkTicker{
 			Ticker: &noopTicker{},
@@ -1030,6 +1069,7 @@ func newInitialEventsEndBookmarkTickerInternal(name string, c clock.Clock, watch
 		Ticker:       clockWithTicker.NewTicker(tickInterval),
 		clock:        c,
 		name:         name,
+		logger:       logger,
 		watchStart:   watchStart,
 		tickInterval: tickInterval,
 	}
@@ -1041,7 +1081,7 @@ func (t *initialEventsEndBookmarkTicker) observeLastEventTimeStamp(lastEventObse
 
 func (t *initialEventsEndBookmarkTicker) warnIfExpired() {
 	if err := t.produceWarningIfExpired(); err != nil {
-		klog.Warning(err)
+		t.logger.Info("WARNING: event bookmark expired", "err", err)
 	}
 }
 

--- a/staging/src/k8s.io/client-go/tools/cache/shared_informer.go
+++ b/staging/src/k8s.io/client-go/tools/cache/shared_informer.go
@@ -161,7 +161,7 @@ type SharedInformer interface {
 	// It returns a registration handle for the handler that can be used to remove
 	// the handler again and an error if the handler cannot be added.
 	//
-	// TODO: logcheck:context // AddEventHandlerWithConfig should be used instead of AddEventHandlerWithResyncPeriod in code which supports contextual logging.
+	//logcheck:context // AddEventHandlerWithConfig should be used instead of AddEventHandlerWithResyncPeriod in code which supports contextual logging.
 	AddEventHandlerWithResyncPeriod(handler ResourceEventHandler, resyncPeriod time.Duration) (ResourceEventHandlerRegistration, error)
 	// AddEventHandler is a variant of AddEventHandler and AddEventHandlerWithResyncPeriod
 	// where additional optional parameters are passed in a struct. If no resync period
@@ -179,7 +179,7 @@ type SharedInformer interface {
 	// Run starts and runs the shared informer, returning after it stops.
 	// The informer will be stopped when stopCh is closed.
 	//
-	// TODO: logcheck:context // RunWithContext should be used instead of Run in code which uses contextual logging.
+	//logcheck:context // RunWithContext should be used instead of Run in code which uses contextual logging.
 	Run(stopCh <-chan struct{})
 	// RunWithContext starts and runs the shared informer, returning after it stops.
 	// The informer will be stopped when the context is canceled.
@@ -211,7 +211,7 @@ type SharedInformer interface {
 	// The handler should return quickly - any expensive processing should be
 	// offloaded.
 	//
-	// TODO: logcheck:context // SetWatchErrorHandlerWithContext should be used instead of SetWatchErrorHandler in code which supports contextual logging.
+	//logcheck:context // SetWatchErrorHandlerWithContext should be used instead of SetWatchErrorHandler in code which supports contextual logging.
 	SetWatchErrorHandler(handler WatchErrorHandler) error
 
 	// SetWatchErrorHandlerWithContext is a variant of SetWatchErrorHandler where
@@ -334,7 +334,7 @@ const (
 // indicating that the caller identified by name is waiting for syncs, followed by
 // either a successful or failed sync.
 //
-// TODO: logcheck:context // WaitForNamedCacheSyncWithContext should be used instead of WaitForNamedCacheSync in code which supports contextual logging.
+//logcheck:context // WaitForNamedCacheSyncWithContext should be used instead of WaitForNamedCacheSync in code which supports contextual logging.
 func WaitForNamedCacheSync(controllerName string, stopCh <-chan struct{}, cacheSyncs ...InformerSynced) bool {
 	klog.Background().Info("Waiting for caches to sync", "controller", controllerName)
 

--- a/staging/src/k8s.io/client-go/tools/cache/shared_informer.go
+++ b/staging/src/k8s.io/client-go/tools/cache/shared_informer.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cache
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"sync"
@@ -159,7 +160,14 @@ type SharedInformer interface {
 	// be competing load and scheduling noise.
 	// It returns a registration handle for the handler that can be used to remove
 	// the handler again and an error if the handler cannot be added.
+	//
+	// TODO: logcheck:context // AddEventHandlerWithConfig should be used instead of AddEventHandlerWithResyncPeriod in code which supports contextual logging.
 	AddEventHandlerWithResyncPeriod(handler ResourceEventHandler, resyncPeriod time.Duration) (ResourceEventHandlerRegistration, error)
+	// AddEventHandler is a variant of AddEventHandler and AddEventHandlerWithResyncPeriod
+	// where additional optional parameters are passed in a struct. If no resync period
+	// is specified there, AddEventHandlerWithConfig behaves like AddEventHandler.
+	// The context is used for contextual logging.
+	AddEventHandlerWithConfig(ctx context.Context, handler ResourceEventHandler, config HandlerConfig) (ResourceEventHandlerRegistration, error)
 	// RemoveEventHandler removes a formerly added event handler given by
 	// its registration handle.
 	// This function is guaranteed to be idempotent, and thread-safe.
@@ -170,7 +178,12 @@ type SharedInformer interface {
 	GetController() Controller
 	// Run starts and runs the shared informer, returning after it stops.
 	// The informer will be stopped when stopCh is closed.
+	//
+	// TODO: logcheck:context // RunWithContext should be used instead of Run in code which uses contextual logging.
 	Run(stopCh <-chan struct{})
+	// RunWithContext starts and runs the shared informer, returning after it stops.
+	// The informer will be stopped when the context is canceled.
+	RunWithContext(ctx context.Context)
 	// HasSynced returns true if the shared informer's store has been
 	// informed by at least one full LIST of the authoritative state
 	// of the informer's object collection.  This is unrelated to "resync".
@@ -197,7 +210,13 @@ type SharedInformer interface {
 	// The handler is intended for visibility, not to e.g. pause the consumers.
 	// The handler should return quickly - any expensive processing should be
 	// offloaded.
+	//
+	// TODO: logcheck:context // SetWatchErrorHandlerWithContext should be used instead of SetWatchErrorHandler in code which supports contextual logging.
 	SetWatchErrorHandler(handler WatchErrorHandler) error
+
+	// SetWatchErrorHandlerWithContext is a variant of SetWatchErrorHandler where
+	// the handler is passed an additional context parameter.
+	SetWatchErrorHandlerWithContext(handler WatchErrorHandlerWithContext) error
 
 	// The TransformFunc is called for each object which is about to be stored.
 	//
@@ -226,6 +245,11 @@ type ResourceEventHandlerRegistration interface {
 	// HasSynced reports if both the parent has synced and all pre-sync
 	// events have been delivered.
 	HasSynced() bool
+}
+
+// Optional configuration options for AddEventHandlerWithConfig.
+type HandlerConfig struct {
+	ResyncPeriod time.Duration
 }
 
 // SharedIndexInformer provides add and get Indexers ability based on SharedInformer.
@@ -309,15 +333,33 @@ const (
 // WaitForNamedCacheSync is a wrapper around WaitForCacheSync that generates log messages
 // indicating that the caller identified by name is waiting for syncs, followed by
 // either a successful or failed sync.
+//
+// TODO: logcheck:context // WaitForNamedCacheSyncWithContext should be used instead of WaitForNamedCacheSync in code which supports contextual logging.
 func WaitForNamedCacheSync(controllerName string, stopCh <-chan struct{}, cacheSyncs ...InformerSynced) bool {
-	klog.Infof("Waiting for caches to sync for %s", controllerName)
+	klog.Background().Info("Waiting for caches to sync", "controller", controllerName)
 
 	if !WaitForCacheSync(stopCh, cacheSyncs...) {
-		utilruntime.HandleError(fmt.Errorf("unable to sync caches for %s", controllerName))
+		utilruntime.HandleErrorWithContext(context.Background(), nil, "Unable to sync caches", "controller", controllerName)
 		return false
 	}
 
-	klog.Infof("Caches are synced for %s", controllerName)
+	klog.Background().Info("Caches are synced", "controller", controllerName)
+	return true
+}
+
+// WaitForNamedCacheSyncWithContext is a wrapper around WaitForCacheSyncWithContext that generates log messages
+// indicating that the caller is waiting for syncs, followed by either a successful or failed sync.
+// Contextual logging can be used to identify the caller in those log messages.
+func WaitForNamedCacheSyncWithContext(ctx context.Context, cacheSyncs ...InformerSynced) bool {
+	logger := klog.FromContext(ctx)
+	logger.Info("Waiting for caches to sync")
+
+	if !WaitForCacheSync(ctx.Done(), cacheSyncs...) {
+		utilruntime.HandleErrorWithContext(ctx, nil, "Unable to sync caches")
+		return false
+	}
+
+	logger.Info("Caches are synced")
 	return true
 }
 
@@ -389,7 +431,7 @@ type sharedIndexInformer struct {
 	blockDeltas sync.Mutex
 
 	// Called whenever the ListAndWatch drops the connection with an error.
-	watchErrorHandler WatchErrorHandler
+	watchErrorHandler WatchErrorHandlerWithContext
 
 	transform TransformFunc
 }
@@ -401,6 +443,9 @@ type sharedIndexInformer struct {
 // notice any change in behavior.
 type dummyController struct {
 	informer *sharedIndexInformer
+}
+
+func (v *dummyController) RunWithContext(context.Context) {
 }
 
 func (v *dummyController) Run(stopCh <-chan struct{}) {
@@ -433,6 +478,12 @@ type deleteNotification struct {
 }
 
 func (s *sharedIndexInformer) SetWatchErrorHandler(handler WatchErrorHandler) error {
+	return s.SetWatchErrorHandlerWithContext(func(_ context.Context, r *Reflector, err error) {
+		handler(r, err)
+	})
+}
+
+func (s *sharedIndexInformer) SetWatchErrorHandlerWithContext(handler WatchErrorHandlerWithContext) error {
 	s.startedLock.Lock()
 	defer s.startedLock.Unlock()
 
@@ -457,10 +508,15 @@ func (s *sharedIndexInformer) SetTransform(handler TransformFunc) error {
 }
 
 func (s *sharedIndexInformer) Run(stopCh <-chan struct{}) {
-	defer utilruntime.HandleCrash()
+	s.RunWithContext(wait.ContextForChannel(stopCh))
+}
+
+func (s *sharedIndexInformer) RunWithContext(ctx context.Context) {
+	defer utilruntime.HandleCrashWithContext(ctx)
+	logger := klog.FromContext(ctx)
 
 	if s.HasStarted() {
-		klog.Warningf("The sharedIndexInformer has started, run more than once is not allowed")
+		logger.Info("Warning: the sharedIndexInformer has started, run more than once is not allowed")
 		return
 	}
 
@@ -483,8 +539,8 @@ func (s *sharedIndexInformer) Run(stopCh <-chan struct{}) {
 			RetryOnError:      false,
 			ShouldResync:      s.processor.shouldResync,
 
-			Process:           s.HandleDeltas,
-			WatchErrorHandler: s.watchErrorHandler,
+			Process:                      s.HandleDeltas,
+			WatchErrorHandlerWithContext: s.watchErrorHandler,
 		}
 
 		s.controller = New(cfg)
@@ -492,20 +548,23 @@ func (s *sharedIndexInformer) Run(stopCh <-chan struct{}) {
 		s.started = true
 	}()
 
-	// Separate stop channel because Processor should be stopped strictly after controller
-	processorStopCh := make(chan struct{})
+	// Separate stop context because Processor should be stopped strictly after controller.
+	// Cancelation in the parent context is ignored.
+	processorStopCtx, stopProcessor := context.WithCancelCause(context.WithoutCancel(ctx))
 	var wg wait.Group
-	defer wg.Wait()              // Wait for Processor to stop
-	defer close(processorStopCh) // Tell Processor to stop
-	wg.StartWithChannel(processorStopCh, s.cacheMutationDetector.Run)
-	wg.StartWithChannel(processorStopCh, s.processor.run)
+	defer wg.Wait()                                         // Wait for Processor to stop
+	defer stopProcessor(errors.New("informer is stopping")) // Tell Processor to stop
+	// TODO: extend the MutationDetector interface so that it optionally
+	// has a RunWithContext method that we can use here.
+	wg.StartWithChannel(processorStopCtx.Done(), s.cacheMutationDetector.Run)
+	wg.StartWithContext(processorStopCtx, s.processor.run)
 
 	defer func() {
 		s.startedLock.Lock()
 		defer s.startedLock.Unlock()
 		s.stopped = true // Don't want any new listeners
 	}()
-	s.controller.Run(stopCh)
+	s.controller.RunWithContext(ctx)
 }
 
 func (s *sharedIndexInformer) HasStarted() bool {
@@ -558,19 +617,19 @@ func (s *sharedIndexInformer) GetController() Controller {
 }
 
 func (s *sharedIndexInformer) AddEventHandler(handler ResourceEventHandler) (ResourceEventHandlerRegistration, error) {
-	return s.AddEventHandlerWithResyncPeriod(handler, s.defaultEventHandlerResyncPeriod)
+	return s.AddEventHandlerWithConfig(context.Background(), handler, HandlerConfig{ResyncPeriod: s.defaultEventHandlerResyncPeriod})
 }
 
-func determineResyncPeriod(desired, check time.Duration) time.Duration {
+func determineResyncPeriod(logger klog.Logger, desired, check time.Duration) time.Duration {
 	if desired == 0 {
 		return desired
 	}
 	if check == 0 {
-		klog.Warningf("The specified resyncPeriod %v is invalid because this shared informer doesn't support resyncing", desired)
+		logger.Info("Warning: the specified resync period is invalid because this shared informer doesn't support resyncing", "resyncPeriod", desired)
 		return 0
 	}
 	if desired < check {
-		klog.Warningf("The specified resyncPeriod %v is being increased to the minimum resyncCheckPeriod %v", desired, check)
+		logger.Info("Warning: the specified resync period is being increased to the minimum resync check period", "resyncPeriod", desired, "resyncCheckPeriod", check)
 		return check
 	}
 	return desired
@@ -579,6 +638,10 @@ func determineResyncPeriod(desired, check time.Duration) time.Duration {
 const minimumResyncPeriod = 1 * time.Second
 
 func (s *sharedIndexInformer) AddEventHandlerWithResyncPeriod(handler ResourceEventHandler, resyncPeriod time.Duration) (ResourceEventHandlerRegistration, error) {
+	return s.AddEventHandlerWithConfig(context.Background(), handler, HandlerConfig{ResyncPeriod: resyncPeriod})
+}
+
+func (s *sharedIndexInformer) AddEventHandlerWithConfig(ctx context.Context, handler ResourceEventHandler, config HandlerConfig) (ResourceEventHandlerRegistration, error) {
 	s.startedLock.Lock()
 	defer s.startedLock.Unlock()
 
@@ -586,30 +649,32 @@ func (s *sharedIndexInformer) AddEventHandlerWithResyncPeriod(handler ResourceEv
 		return nil, fmt.Errorf("handler %v was not added to shared informer because it has stopped already", handler)
 	}
 
+	logger := klog.FromContext(ctx)
+	resyncPeriod := config.ResyncPeriod
 	if resyncPeriod > 0 {
 		if resyncPeriod < minimumResyncPeriod {
-			klog.Warningf("resyncPeriod %v is too small. Changing it to the minimum allowed value of %v", resyncPeriod, minimumResyncPeriod)
+			logger.Info("Warning: resync period is too small. Changing it to the minimum allowed value", "resyncPeriod", resyncPeriod, "minimumResyncPeriod", minimumResyncPeriod)
 			resyncPeriod = minimumResyncPeriod
 		}
 
 		if resyncPeriod < s.resyncCheckPeriod {
 			if s.started {
-				klog.Warningf("resyncPeriod %v is smaller than resyncCheckPeriod %v and the informer has already started. Changing it to %v", resyncPeriod, s.resyncCheckPeriod, s.resyncCheckPeriod)
+				logger.Info("Warning: resync period is smaller than resync check period and the informer has already started. Changing it to the resync check period", "resyncPeriod", resyncPeriod, "resyncCheckPeriod", s.resyncCheckPeriod)
 				resyncPeriod = s.resyncCheckPeriod
 			} else {
 				// if the event handler's resyncPeriod is smaller than the current resyncCheckPeriod, update
 				// resyncCheckPeriod to match resyncPeriod and adjust the resync periods of all the listeners
 				// accordingly
 				s.resyncCheckPeriod = resyncPeriod
-				s.processor.resyncCheckPeriodChanged(resyncPeriod)
+				s.processor.resyncCheckPeriodChanged(logger, resyncPeriod)
 			}
 		}
 	}
 
-	listener := newProcessListener(handler, resyncPeriod, determineResyncPeriod(resyncPeriod, s.resyncCheckPeriod), s.clock.Now(), initialBufferSize, s.HasSynced)
+	listener := newProcessListener(ctx, handler, resyncPeriod, determineResyncPeriod(logger, resyncPeriod, s.resyncCheckPeriod), s.clock.Now(), initialBufferSize, s.HasSynced)
 
 	if !s.started {
-		return s.processor.addListener(listener), nil
+		return s.processor.addListener(ctx, listener), nil
 	}
 
 	// in order to safely join, we have to
@@ -620,7 +685,7 @@ func (s *sharedIndexInformer) AddEventHandlerWithResyncPeriod(handler ResourceEv
 	s.blockDeltas.Lock()
 	defer s.blockDeltas.Unlock()
 
-	handle := s.processor.addListener(listener)
+	handle := s.processor.addListener(ctx, listener)
 	for _, item := range s.indexer.List() {
 		// Note that we enqueue these notifications with the lock held
 		// and before returning the handle. That means there is never a
@@ -734,7 +799,7 @@ func (p *sharedProcessor) getListener(registration ResourceEventHandlerRegistrat
 	return nil
 }
 
-func (p *sharedProcessor) addListener(listener *processorListener) ResourceEventHandlerRegistration {
+func (p *sharedProcessor) addListener(ctx context.Context, listener *processorListener) ResourceEventHandlerRegistration {
 	p.listenersLock.Lock()
 	defer p.listenersLock.Unlock()
 
@@ -745,7 +810,7 @@ func (p *sharedProcessor) addListener(listener *processorListener) ResourceEvent
 	p.listeners[listener] = true
 
 	if p.listenersStarted {
-		p.wg.Start(listener.run)
+		p.wg.StartWithContext(ctx, listener.run)
 		p.wg.Start(listener.pop)
 	}
 
@@ -794,17 +859,17 @@ func (p *sharedProcessor) distribute(obj interface{}, sync bool) {
 	}
 }
 
-func (p *sharedProcessor) run(stopCh <-chan struct{}) {
+func (p *sharedProcessor) run(ctx context.Context) {
 	func() {
 		p.listenersLock.RLock()
 		defer p.listenersLock.RUnlock()
 		for listener := range p.listeners {
-			p.wg.Start(listener.run)
+			p.wg.StartWithContext(ctx, listener.run)
 			p.wg.Start(listener.pop)
 		}
 		p.listenersStarted = true
 	}()
-	<-stopCh
+	<-ctx.Done()
 
 	p.listenersLock.Lock()
 	defer p.listenersLock.Unlock()
@@ -844,13 +909,13 @@ func (p *sharedProcessor) shouldResync() bool {
 	return resyncNeeded
 }
 
-func (p *sharedProcessor) resyncCheckPeriodChanged(resyncCheckPeriod time.Duration) {
+func (p *sharedProcessor) resyncCheckPeriodChanged(logger klog.Logger, resyncCheckPeriod time.Duration) {
 	p.listenersLock.RLock()
 	defer p.listenersLock.RUnlock()
 
 	for listener := range p.listeners {
 		resyncPeriod := determineResyncPeriod(
-			listener.requestedResyncPeriod, resyncCheckPeriod)
+			logger, listener.requestedResyncPeriod, resyncCheckPeriod)
 		listener.setResyncPeriod(resyncPeriod)
 	}
 }
@@ -867,6 +932,7 @@ func (p *sharedProcessor) resyncCheckPeriodChanged(resyncCheckPeriod time.Durati
 // processorListener also keeps track of the adjusted requested resync
 // period of the listener.
 type processorListener struct {
+	ctx    context.Context
 	nextCh chan interface{}
 	addCh  chan interface{}
 
@@ -910,8 +976,9 @@ func (p *processorListener) HasSynced() bool {
 	return p.syncTracker.HasSynced()
 }
 
-func newProcessListener(handler ResourceEventHandler, requestedResyncPeriod, resyncPeriod time.Duration, now time.Time, bufferSize int, hasSynced func() bool) *processorListener {
+func newProcessListener(ctx context.Context, handler ResourceEventHandler, requestedResyncPeriod, resyncPeriod time.Duration, now time.Time, bufferSize int, hasSynced func() bool) *processorListener {
 	ret := &processorListener{
+		ctx:                   ctx,
 		nextCh:                make(chan interface{}),
 		addCh:                 make(chan interface{}),
 		handler:               handler,
@@ -934,7 +1001,7 @@ func (p *processorListener) add(notification interface{}) {
 }
 
 func (p *processorListener) pop() {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(p.ctx)
 	defer close(p.nextCh) // Tell .run() to stop
 
 	var nextCh chan<- interface{}
@@ -963,7 +1030,7 @@ func (p *processorListener) pop() {
 	}
 }
 
-func (p *processorListener) run() {
+func (p *processorListener) run(ctx context.Context) {
 	// this call blocks until the channel is closed.  When a panic happens during the notification
 	// we will catch it, **the offending item will be skipped!**, and after a short delay (one second)
 	// the next notification will be attempted.  This is usually better than the alternative of never
@@ -982,7 +1049,7 @@ func (p *processorListener) run() {
 			case deleteNotification:
 				p.handler.OnDelete(notification.oldObj)
 			default:
-				utilruntime.HandleError(fmt.Errorf("unrecognized notification: %T", next))
+				utilruntime.HandleErrorWithContext(ctx, nil, "unrecognized notification", "notificationType", fmt.Sprintf("%T", next))
 			}
 		}
 		// the only way to get here is if the p.nextCh is empty and closed

--- a/staging/src/k8s.io/client-go/tools/cache/shared_informer_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/shared_informer_test.go
@@ -453,7 +453,7 @@ func TestSharedInformerErrorHandling(t *testing.T) {
 	informer := NewSharedInformer(source, &v1.Pod{}, 1*time.Second).(*sharedIndexInformer)
 
 	errCh := make(chan error)
-	_ = informer.SetWatchErrorHandler(func(_ *Reflector, err error) {
+	_ = informer.SetWatchErrorHandlerWithContext(func(_ context.Context, _ *Reflector, err error) {
 		errCh <- err
 	})
 
@@ -488,7 +488,7 @@ func TestSharedInformerStartRace(t *testing.T) {
 			informer.SetTransform(func(i interface{}) (interface{}, error) {
 				return i, nil
 			})
-			informer.SetWatchErrorHandler(func(r *Reflector, err error) {
+			_ = informer.SetWatchErrorHandlerWithContext(func(ctx context.Context, r *Reflector, err error) {
 			})
 		}
 	}()

--- a/staging/src/k8s.io/client-go/tools/clientcmd/client_config.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/client_config.go
@@ -656,7 +656,7 @@ func (config *inClusterClientConfig) Possible() bool {
 // are passed in we fallback to inClusterConfig. If inClusterConfig fails, we fallback
 // to the default config.
 //
-// TODO (https://github.com/kubernetes/kubernetes/issues/126379): logcheck:context // BuildConfigFromFlagsWithContext should be used instead of BuildConfigFromFlags in code which supports contextual logging.
+//logcheck:context // BuildConfigFromFlagsWithContext should be used instead of BuildConfigFromFlags in code which supports contextual logging.
 func BuildConfigFromFlags(masterUrl, kubeconfigPath string) (*restclient.Config, error) {
 	return BuildConfigFromFlagsWithContext(context.Background(), masterUrl, kubeconfigPath)
 }

--- a/staging/src/k8s.io/client-go/tools/clientcmd/client_config_test.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/client_config_test.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	restclient "k8s.io/client-go/rest"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	"k8s.io/klog/v2/ktesting"
 )
 
 func TestMergoSemantics(t *testing.T) {
@@ -890,6 +891,7 @@ func TestNamespaceOverride(t *testing.T) {
 }
 
 func TestAuthConfigMerge(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
 	content := `
 apiVersion: v1
 clusters:
@@ -928,7 +930,7 @@ users:
 	if err := os.WriteFile(tmpfile.Name(), []byte(content), 0666); err != nil {
 		t.Error(err)
 	}
-	config, err := BuildConfigFromFlags("", tmpfile.Name())
+	config, err := BuildConfigFromFlagsWithContext(ctx, "", tmpfile.Name())
 	if err != nil {
 		t.Error(err)
 	}

--- a/staging/src/k8s.io/client-go/tools/clientcmd/config.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/config.go
@@ -488,10 +488,13 @@ func getConfigFromFile(filename string) (*clientcmdapi.Config, error) {
 	return config, nil
 }
 
-// GetConfigFromFileOrDie tries to read a kubeconfig file and if it can't, it calls exit.  One exception, missing files result in empty configs, not an exit
+// GetConfigFromFileOrDie tries to read a kubeconfig file and if it can't, it calls exit.  One exception, missing files result in empty configs, not an exit.
+//
+// Deprecated: LoadFromFile and k8s.io/client-go/tools/clientcmd/api.NewConfig should be used instead, with error handling implemented by the caller.
 func GetConfigFromFileOrDie(filename string) *clientcmdapi.Config {
 	config, err := getConfigFromFile(filename)
 	if err != nil {
+		//nolint:logcheck // Historic API that cannot be made context-aware.
 		klog.FatalDepth(1, err)
 	}
 

--- a/staging/src/k8s.io/client-go/tools/clientcmd/loader.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/loader.go
@@ -129,15 +129,16 @@ type ClientConfigLoadingRules struct {
 	// In case of missing files, it warns the user about the missing files.
 	WarnIfAllMissing bool
 
-	// Warner is the warning log callback to use in case of missing files.
+	// Warner is the warning log callback to use in case of missing files
 	Warner WarningHandler
 }
 
-// WarningHandler allows to set the logging function to use
+// WarningHandler allows to set the logging function to use.
 type WarningHandler func(error)
 
 func (handler WarningHandler) Warn(err error) {
 	if handler == nil {
+		//nolint:logcheck // Historic API, cannot be made context-aware.
 		klog.V(1).Info(err)
 	} else {
 		handler(err)
@@ -392,6 +393,7 @@ func LoadFromFile(filename string) (*clientcmdapi.Config, error) {
 	if err != nil {
 		return nil, err
 	}
+	//nolint:logcheck // Not worth adding a new public API for a single log call.
 	klog.V(6).Infoln("Config loaded from file: ", filename)
 
 	// set LocationOfOrigin on every Cluster, User, and Context

--- a/staging/src/k8s.io/client-go/tools/clientcmd/merged_client_builder.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/merged_client_builder.go
@@ -118,6 +118,7 @@ func (config *DeferredLoadingClientConfig) ClientConfig() (*restclient.Config, e
 
 	// check for in-cluster configuration and use it
 	if config.icc.Possible() {
+		//nolint:logcheck // Single message (albeit at V(4)), not worth a new API?
 		klog.V(4).Infof("Using in-cluster configuration")
 		return config.icc.ClientConfig()
 	}
@@ -160,6 +161,7 @@ func (config *DeferredLoadingClientConfig) Namespace() (string, bool, error) {
 		}
 	}
 
+	//nolint:logcheck // Single message (albeit at V(4)), not worth a new API?
 	klog.V(4).Infof("Using in-cluster namespace")
 
 	// allow the namespace from the service account token directory to be used.

--- a/staging/src/k8s.io/client-go/tools/events/event_broadcaster.go
+++ b/staging/src/k8s.io/client-go/tools/events/event_broadcaster.go
@@ -345,7 +345,7 @@ func (e *eventBroadcasterImpl) StartLogging(logger klog.Logger) (func(), error) 
 // StartEventWatcher starts sending events received from this EventBroadcaster to the given event handler function.
 // The return value is used to stop recording
 //
-// TODO: logcheck:context // StartEventWatcherWithContext should be used instead of StartEventWatcher in code which supports contextual logging.
+//logcheck:context // StartEventWatcherWithContext should be used instead of StartEventWatcher in code which supports contextual logging.
 func (e *eventBroadcasterImpl) StartEventWatcher(eventHandler func(event runtime.Object)) (func(), error) {
 	return e.StartEventWatcherWithContext(context.Background(), eventHandler)
 }

--- a/staging/src/k8s.io/client-go/tools/events/event_recorder.go
+++ b/staging/src/k8s.io/client-go/tools/events/event_recorder.go
@@ -17,6 +17,7 @@ limitations under the License.
 package events
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -83,7 +84,8 @@ func (recorder *recorderImpl) eventf(logger klog.Logger, regarding runtime.Objec
 	}
 	event := recorder.makeEvent(refRegarding, refRelated, timestamp, eventtype, reason, message, recorder.reportingController, recorder.reportingInstance, action)
 	go func() {
-		defer utilruntime.HandleCrash()
+		ctx := klog.NewContext(context.Background(), logger)
+		defer utilruntime.HandleCrashWithContext(ctx)
 		recorder.Action(watch.Added, event)
 	}()
 }

--- a/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection_test.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection_test.go
@@ -37,6 +37,7 @@ import (
 	fakeclient "k8s.io/client-go/testing"
 	rl "k8s.io/client-go/tools/leaderelection/resourcelock"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/klog/v2/ktesting"
 	"k8s.io/utils/clock"
 )
 
@@ -583,6 +584,8 @@ func testReleaseLease(t *testing.T, objectType string) {
 	for i := range tests {
 		test := &tests[i]
 		t.Run(test.name, func(t *testing.T) {
+			_, ctx := ktesting.NewTestContext(t)
+
 			// OnNewLeader is called async so we have to wait for it.
 			var wg sync.WaitGroup
 			wg.Add(1)
@@ -644,7 +647,7 @@ func testReleaseLease(t *testing.T, objectType string) {
 			wg.Wait()
 			wg.Add(1)
 
-			if test.expectSuccess != le.release() {
+			if test.expectSuccess != le.release(ctx) {
 				t.Errorf("unexpected result of release: [succeeded=%v]", !test.expectSuccess)
 			}
 

--- a/staging/src/k8s.io/client-go/tools/pager/pager.go
+++ b/staging/src/k8s.io/client-go/tools/pager/pager.go
@@ -219,7 +219,7 @@ func (p *ListPager) eachListChunkBuffered(ctx context.Context, options metav1.Li
 	chunkC := make(chan runtime.Object, p.PageBufferSize)
 	bgResultC := make(chan error, 1)
 	go func() {
-		defer utilruntime.HandleCrash()
+		defer utilruntime.HandleCrashWithContext(ctx)
 
 		var err error
 		defer func() {

--- a/staging/src/k8s.io/client-go/tools/portforward/fallback_dialer.go
+++ b/staging/src/k8s.io/client-go/tools/portforward/fallback_dialer.go
@@ -50,6 +50,7 @@ func NewFallbackDialer(primary, secondary httpstream.Dialer, shouldFallback func
 func (f *FallbackDialer) Dial(protocols ...string) (httpstream.Connection, string, error) {
 	conn, version, err := f.primary.Dial(protocols...)
 	if err != nil && f.shouldFallback(err) {
+		//nolint:logcheck // Single log call, not worth a new API?
 		klog.V(4).Infof("fallback to secondary dialer from primary dialer err: %v", err)
 		return f.secondary.Dial(protocols...)
 	}

--- a/staging/src/k8s.io/client-go/tools/portforward/portforward.go
+++ b/staging/src/k8s.io/client-go/tools/portforward/portforward.go
@@ -157,7 +157,7 @@ func parseAddresses(addressesToParse []string) ([]listenAddress, error) {
 
 // New creates a new PortForwarder with localhost listen addresses.
 //
-// TODO (https://github.com/kubernetes/kubernetes/issues/126379): logcheck:context // NewWithContext should be used instead of New in code which supports contextual logging.
+//logcheck:context // NewWithContext should be used instead of New in code which supports contextual logging.
 func New(dialer httpstream.Dialer, ports []string, stopChan <-chan struct{}, readyChan chan struct{}, out, errOut io.Writer) (*PortForwarder, error) {
 	return NewWithContext(wait.ContextForChannel(stopChan), dialer, ports, readyChan, out, errOut)
 }
@@ -169,7 +169,7 @@ func NewWithContext(ctx context.Context, dialer httpstream.Dialer, ports []strin
 
 // NewOnAddresses creates a new PortForwarder with custom listen addresses.
 //
-// TODO (https://github.com/kubernetes/kubernetes/issues/126379): logcheck:context // NewOnAddressesWithContext should be used instead of NewOnAddresses in code which supports contextual logging.
+//logcheck:context // NewOnAddressesWithContext should be used instead of NewOnAddresses in code which supports contextual logging.
 func NewOnAddresses(dialer httpstream.Dialer, addresses []string, ports []string, stopChan <-chan struct{}, readyChan chan struct{}, out, errOut io.Writer) (*PortForwarder, error) {
 	return NewOnAddressesWithContext(wait.ContextForChannel(stopChan), dialer, addresses, ports, readyChan, out, errOut)
 }

--- a/staging/src/k8s.io/client-go/tools/portforward/tunneling_connection.go
+++ b/staging/src/k8s.io/client-go/tools/portforward/tunneling_connection.go
@@ -45,7 +45,7 @@ type TunnelingConnection struct {
 // NewTunnelingConnection wraps the passed gorilla/websockets connection
 // with the TunnelingConnection struct (implementing net.Conn).
 //
-// TODO (https://github.com/kubernetes/kubernetes/issues/126379): logcheck:context // NewTunnelingConnectionWithContext should be used instead of NewTunnelingConnection in code which supports contextual logging.
+//logcheck:context // NewTunnelingConnectionWithContext should be used instead of NewTunnelingConnection in code which supports contextual logging.
 func NewTunnelingConnection(name string, conn *gwebsocket.Conn) *TunnelingConnection {
 	return NewTunnelingConnectionWithContext(context.Background(), name, conn)
 }

--- a/staging/src/k8s.io/client-go/tools/portforward/tunneling_dialer.go
+++ b/staging/src/k8s.io/client-go/tools/portforward/tunneling_dialer.go
@@ -17,6 +17,7 @@ limitations under the License.
 package portforward
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -35,6 +36,7 @@ const PingPeriod = 10 * time.Second
 
 // tunnelingDialer implements "httpstream.Dial" interface
 type tunnelingDialer struct {
+	ctx       context.Context
 	url       *url.URL
 	transport http.RoundTripper
 	holder    websocket.ConnectionHolder
@@ -43,12 +45,22 @@ type tunnelingDialer struct {
 // NewTunnelingDialer creates and returns the tunnelingDialer structure which implemements the "httpstream.Dialer"
 // interface. The dialer can upgrade a websocket request, creating a websocket connection. This function
 // returns an error if one occurs.
+//
+// TODO (https://github.com/kubernetes/kubernetes/issues/126379): logcheck:context // NewSPDYOverWebsocketDialerWithContext should be used instead of NewSPDYOverWebsocketDialer in code which supports contextual logging.
 func NewSPDYOverWebsocketDialer(url *url.URL, config *restclient.Config) (httpstream.Dialer, error) {
+	return NewSPDYOverWebsocketDialerWithContext(context.Background(), url, config)
+}
+
+// NewTunnelingDialerWithContext creates and returns the tunnelingDialer structure which implemements the "httpstream.Dialer"
+// interface. The dialer can upgrade a websocket request, creating a websocket connection. This function
+// returns an error if one occurs.
+func NewSPDYOverWebsocketDialerWithContext(ctx context.Context, url *url.URL, config *restclient.Config) (httpstream.Dialer, error) {
 	transport, holder, err := websocket.RoundTripperFor(config)
 	if err != nil {
 		return nil, err
 	}
 	return &tunnelingDialer{
+		ctx:       ctx,
 		url:       url,
 		transport: transport,
 		holder:    holder,
@@ -59,12 +71,12 @@ func NewSPDYOverWebsocketDialer(url *url.URL, config *restclient.Config) (httpst
 // containing a WebSockets connection (which implements "net.Conn"). Also
 // returns the protocol negotiated, or an error.
 func (d *tunnelingDialer) Dial(protocols ...string) (httpstream.Connection, string, error) {
-	// There is no passed context, so skip the context when creating request for now.
 	// Websockets requires "GET" method: RFC 6455 Sec. 4.1 (page 17).
-	req, err := http.NewRequest("GET", d.url.String(), nil)
+	req, err := http.NewRequestWithContext(d.ctx, "GET", d.url.String(), nil)
 	if err != nil {
 		return nil, "", err
 	}
+	logger := klog.FromContext(d.ctx)
 	// Add the spdy tunneling prefix to the requested protocols. The tunneling
 	// handler will know how to negotiate these protocols.
 	tunnelingProtocols := []string{}
@@ -72,7 +84,7 @@ func (d *tunnelingDialer) Dial(protocols ...string) (httpstream.Connection, stri
 		tunnelingProtocol := constants.WebsocketsSPDYTunnelingPrefix + protocol
 		tunnelingProtocols = append(tunnelingProtocols, tunnelingProtocol)
 	}
-	klog.V(4).Infoln("Before WebSocket Upgrade Connection...")
+	logger.V(4).Info("Before WebSocket Upgrade Connection...")
 	conn, err := websocket.Negotiate(d.transport, d.holder, req, tunnelingProtocols...)
 	if err != nil {
 		return nil, "", err
@@ -82,10 +94,10 @@ func (d *tunnelingDialer) Dial(protocols ...string) (httpstream.Connection, stri
 	}
 	protocol := conn.Subprotocol()
 	protocol = strings.TrimPrefix(protocol, constants.WebsocketsSPDYTunnelingPrefix)
-	klog.V(4).Infof("negotiated protocol: %s", protocol)
+	logger.V(4).Info("Protocol negotiated completed", "protocol", protocol)
 
 	// Wrap the websocket connection which implements "net.Conn".
-	tConn := NewTunnelingConnection("client", conn)
+	tConn := NewTunnelingConnectionWithContext(d.ctx, "client", conn)
 	// Create SPDY connection injecting the previously created tunneling connection.
 	spdyConn, err := spdy.NewClientConnectionWithPings(tConn, PingPeriod)
 

--- a/staging/src/k8s.io/client-go/tools/portforward/tunneling_dialer.go
+++ b/staging/src/k8s.io/client-go/tools/portforward/tunneling_dialer.go
@@ -46,7 +46,7 @@ type tunnelingDialer struct {
 // interface. The dialer can upgrade a websocket request, creating a websocket connection. This function
 // returns an error if one occurs.
 //
-// TODO (https://github.com/kubernetes/kubernetes/issues/126379): logcheck:context // NewSPDYOverWebsocketDialerWithContext should be used instead of NewSPDYOverWebsocketDialer in code which supports contextual logging.
+//logcheck:context // NewSPDYOverWebsocketDialerWithContext should be used instead of NewSPDYOverWebsocketDialer in code which supports contextual logging.
 func NewSPDYOverWebsocketDialer(url *url.URL, config *restclient.Config) (httpstream.Dialer, error) {
 	return NewSPDYOverWebsocketDialerWithContext(context.Background(), url, config)
 }

--- a/staging/src/k8s.io/client-go/tools/record/event.go
+++ b/staging/src/k8s.io/client-go/tools/record/event.go
@@ -140,7 +140,7 @@ type EventBroadcaster interface {
 	// StartLogging starts sending events received from this EventBroadcaster to the given logging
 	// function. The return value can be ignored or used to stop recording, if desired.
 	//
-	// TODO (https://github.com/kubernetes/kubernetes/issues/126379) logcheck:context // StartStructuredLogging should be used instead of StartLogging in code which supports contextual logging.
+	//logcheck:context // StartStructuredLogging should be used instead of StartLogging in code which supports contextual logging.
 	StartLogging(logf func(format string, args ...interface{})) watch.Interface
 
 	// StartStructuredLogging starts sending events received from this EventBroadcaster to the structured

--- a/staging/src/k8s.io/client-go/tools/record/event_test.go
+++ b/staging/src/k8s.io/client-go/tools/record/event_test.go
@@ -727,6 +727,7 @@ func TestEventfNoNamespace(t *testing.T) {
 
 	for index, item := range table {
 		clock.Step(1 * time.Second)
+		//nolint:logcheck // Intentionally using StartLogging here to get notified.
 		logWatcher := eventBroadcaster.StartLogging(func(formatter string, args ...interface{}) {
 			if e, a := item.expectLog, fmt.Sprintf(formatter, args...); e != a {
 				t.Errorf("Expected '%v', got '%v'", e, a)

--- a/staging/src/k8s.io/client-go/tools/remotecommand/fallback.go
+++ b/staging/src/k8s.io/client-go/tools/remotecommand/fallback.go
@@ -53,7 +53,7 @@ func (f *FallbackExecutor) Stream(options StreamOptions) error {
 func (f *FallbackExecutor) StreamWithContext(ctx context.Context, options StreamOptions) error {
 	err := f.primary.StreamWithContext(ctx, options)
 	if f.shouldFallback(err) {
-		klog.V(4).Infof("RemoteCommand fallback: %v", err)
+		klog.FromContext(ctx).V(4).Info("RemoteCommand fallback", "err", err)
 		return f.secondary.StreamWithContext(ctx, options)
 	}
 	return err

--- a/staging/src/k8s.io/client-go/tools/remotecommand/remotecommand.go
+++ b/staging/src/k8s.io/client-go/tools/remotecommand/remotecommand.go
@@ -50,9 +50,9 @@ type Executor interface {
 }
 
 type streamCreator interface {
-	CreateStream(headers http.Header) (httpstream.Stream, error)
+	createStream(ctx context.Context, headers http.Header) (httpstream.Stream, error)
 }
 
 type streamProtocolHandler interface {
-	stream(conn streamCreator) error
+	stream(ctx context.Context, conn streamCreator) error
 }

--- a/staging/src/k8s.io/client-go/tools/remotecommand/spdy_test.go
+++ b/staging/src/k8s.io/client-go/tools/remotecommand/spdy_test.go
@@ -352,7 +352,7 @@ func TestStreamExitsAfterConnectionIsClosed(t *testing.T) {
 
 	errorChan := make(chan error)
 	go func() {
-		errorChan <- streamer.stream(conn)
+		errorChan <- streamer.stream(ctx, spdyStreamCreator{conn: conn})
 	}()
 
 	// Wait until stream goroutine starts.

--- a/staging/src/k8s.io/client-go/tools/remotecommand/v5.go
+++ b/staging/src/k8s.io/client-go/tools/remotecommand/v5.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package remotecommand
 
+import "context"
+
 // streamProtocolV5 add support for V5 of the remote command subprotocol.
 // For the streamProtocolHandler, this version is the same as V4.
 type streamProtocolV5 struct {
@@ -30,6 +32,6 @@ func newStreamProtocolV5(options StreamOptions) streamProtocolHandler {
 	}
 }
 
-func (p *streamProtocolV5) stream(conn streamCreator) error {
-	return p.streamProtocolV4.stream(conn)
+func (p *streamProtocolV5) stream(ctx context.Context, conn streamCreator) error {
+	return p.streamProtocolV4.stream(ctx, conn)
 }

--- a/staging/src/k8s.io/client-go/tools/watch/informerwatcher.go
+++ b/staging/src/k8s.io/client-go/tools/watch/informerwatcher.go
@@ -105,7 +105,7 @@ func (e *eventProcessor) stop() {
 // so you can use it anywhere where you'd have used a regular Watcher returned from Watch method.
 // it also returns a channel you can use to wait for the informers to fully shutdown.
 //
-// TODO (https://github.com/kubernetes/kubernetes/issues/126379): logcheck:context // NewIndexerInformerWatcherWithContext should be used instead of NewIndexerInformerWatcher in code which supports contextual logging.
+//logcheck:context // NewIndexerInformerWatcherWithContext should be used instead of NewIndexerInformerWatcher in code which supports contextual logging.
 func NewIndexerInformerWatcher(lw cache.ListerWatcher, objType runtime.Object) (cache.Indexer, cache.Controller, watch.Interface, <-chan struct{}) {
 	return NewIndexerInformerWatcherWithContext(context.Background(), lw, objType)
 }

--- a/staging/src/k8s.io/client-go/tools/watch/retrywatcher.go
+++ b/staging/src/k8s.io/client-go/tools/watch/retrywatcher.go
@@ -59,7 +59,7 @@ type RetryWatcher struct {
 // It will make sure that watches gets restarted in case of recoverable errors.
 // The initialResourceVersion will be given to watch method when first called.
 //
-// TODO (https://github.com/kubernetes/kubernetes/issues/126379): logcheck:context // NewRetryWatcherWithContext should be used instead of NewRetryWatcher in code which supports contextual logging.
+//logcheck:context // NewRetryWatcherWithContext should be used instead of NewRetryWatcher in code which supports contextual logging.
 func NewRetryWatcher(initialResourceVersion string, watcherClient cache.Watcher) (*RetryWatcher, error) {
 	return NewRetryWatcherWithContext(context.Background(), initialResourceVersion, watcherClient)
 }

--- a/staging/src/k8s.io/client-go/tools/watch/retrywatcher.go
+++ b/staging/src/k8s.io/client-go/tools/watch/retrywatcher.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"sync"
 	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -48,23 +47,35 @@ type resourceVersionGetter interface {
 // Please note that this is not resilient to etcd cache not having the resource version anymore - you would need to
 // use Informers for that.
 type RetryWatcher struct {
+	cancel              func(error)
 	lastResourceVersion string
 	watcherClient       cache.Watcher
 	resultChan          chan watch.Event
-	stopChan            chan struct{}
 	doneChan            chan struct{}
 	minRestartDelay     time.Duration
-	stopChanLock        sync.Mutex
 }
 
 // NewRetryWatcher creates a new RetryWatcher.
 // It will make sure that watches gets restarted in case of recoverable errors.
 // The initialResourceVersion will be given to watch method when first called.
+//
+// TODO (https://github.com/kubernetes/kubernetes/issues/126379): logcheck:context // NewRetryWatcherWithContext should be used instead of NewRetryWatcher in code which supports contextual logging.
 func NewRetryWatcher(initialResourceVersion string, watcherClient cache.Watcher) (*RetryWatcher, error) {
-	return newRetryWatcher(initialResourceVersion, watcherClient, 1*time.Second)
+	return NewRetryWatcherWithContext(context.Background(), initialResourceVersion, watcherClient)
 }
 
-func newRetryWatcher(initialResourceVersion string, watcherClient cache.Watcher, minRestartDelay time.Duration) (*RetryWatcher, error) {
+// NewRetryWatcher creates a new RetryWatcher.
+// It will make sure that watches gets restarted in case of recoverable errors.
+// The initialResourceVersion will be given to watch method when first called.
+//
+// The watcher can be stopped in two ways:
+// - canceling the context
+// - calling the Stop method
+func NewRetryWatcherWithContext(ctx context.Context, initialResourceVersion string, watcherClient cache.Watcher) (*RetryWatcher, error) {
+	return newRetryWatcher(ctx, initialResourceVersion, watcherClient, 1*time.Second)
+}
+
+func newRetryWatcher(ctx context.Context, initialResourceVersion string, watcherClient cache.Watcher, minRestartDelay time.Duration) (*RetryWatcher, error) {
 	switch initialResourceVersion {
 	case "", "0":
 		// TODO: revisit this if we ever get WATCH v2 where it means start "now"
@@ -74,37 +85,46 @@ func newRetryWatcher(initialResourceVersion string, watcherClient cache.Watcher,
 		break
 	}
 
+	ctx, cancel := context.WithCancelCause(ctx)
+
 	rw := &RetryWatcher{
+		cancel:              cancel,
 		lastResourceVersion: initialResourceVersion,
 		watcherClient:       watcherClient,
-		stopChan:            make(chan struct{}),
 		doneChan:            make(chan struct{}),
 		resultChan:          make(chan watch.Event, 0),
 		minRestartDelay:     minRestartDelay,
 	}
 
-	go rw.receive()
+	// Prevent resource leak if context gets canceled.
+	go func() {
+		<-ctx.Done()
+		cancel(errors.New("parent context was canceled"))
+	}()
+
+	go rw.receive(ctx)
 	return rw, nil
 }
 
-func (rw *RetryWatcher) send(event watch.Event) bool {
+func (rw *RetryWatcher) send(ctx context.Context, event watch.Event) bool {
 	// Writing to an unbuffered channel is blocking operation
 	// and we need to check if stop wasn't requested while doing so.
 	select {
 	case rw.resultChan <- event:
 		return true
-	case <-rw.stopChan:
+	case <-ctx.Done():
 		return false
 	}
 }
 
 // doReceive returns true when it is done, false otherwise.
 // If it is not done the second return value holds the time to wait before calling it again.
-func (rw *RetryWatcher) doReceive() (bool, time.Duration) {
+func (rw *RetryWatcher) doReceive(ctx context.Context) (bool, time.Duration) {
 	watcher, err := rw.watcherClient.Watch(metav1.ListOptions{
 		ResourceVersion:     rw.lastResourceVersion,
 		AllowWatchBookmarks: true,
 	})
+	logger := klog.FromContext(ctx)
 	// We are very unlikely to hit EOF here since we are just establishing the call,
 	// but it may happen that the apiserver is just shutting down (e.g. being restarted)
 	// This is consistent with how it is handled for informers
@@ -117,24 +137,24 @@ func (rw *RetryWatcher) doReceive() (bool, time.Duration) {
 		return false, 0
 
 	case io.ErrUnexpectedEOF:
-		klog.V(1).InfoS("Watch closed with unexpected EOF", "err", err)
+		logger.V(1).Info("Watch closed with unexpected EOF", "err", err)
 		return false, 0
 
 	default:
 		msg := "Watch failed"
 		if net.IsProbableEOF(err) || net.IsTimeout(err) {
-			klog.V(5).InfoS(msg, "err", err)
+			logger.V(5).Info(msg, "err", err)
 			// Retry
 			return false, 0
 		}
 
-		klog.ErrorS(err, msg)
+		logger.Error(err, msg)
 		// Retry
 		return false, 0
 	}
 
 	if watcher == nil {
-		klog.ErrorS(nil, "Watch returned nil watcher")
+		logger.Error(nil, "Watch returned nil watcher")
 		// Retry
 		return false, 0
 	}
@@ -144,12 +164,12 @@ func (rw *RetryWatcher) doReceive() (bool, time.Duration) {
 
 	for {
 		select {
-		case <-rw.stopChan:
-			klog.V(4).InfoS("Stopping RetryWatcher.")
+		case <-ctx.Done():
+			logger.V(4).Info("Stopping RetryWatcher.")
 			return true, 0
 		case event, ok := <-ch:
 			if !ok {
-				klog.V(4).InfoS("Failed to get event! Re-creating the watcher.", "resourceVersion", rw.lastResourceVersion)
+				logger.V(4).Info("Failed to get event! Re-creating the watcher.", "resourceVersion", rw.lastResourceVersion)
 				return false, 0
 			}
 
@@ -158,7 +178,7 @@ func (rw *RetryWatcher) doReceive() (bool, time.Duration) {
 			case watch.Added, watch.Modified, watch.Deleted, watch.Bookmark:
 				metaObject, ok := event.Object.(resourceVersionGetter)
 				if !ok {
-					_ = rw.send(watch.Event{
+					_ = rw.send(ctx, watch.Event{
 						Type:   watch.Error,
 						Object: &apierrors.NewInternalError(errors.New("retryWatcher: doesn't support resourceVersion")).ErrStatus,
 					})
@@ -168,7 +188,7 @@ func (rw *RetryWatcher) doReceive() (bool, time.Duration) {
 
 				resourceVersion := metaObject.GetResourceVersion()
 				if resourceVersion == "" {
-					_ = rw.send(watch.Event{
+					_ = rw.send(ctx, watch.Event{
 						Type:   watch.Error,
 						Object: &apierrors.NewInternalError(fmt.Errorf("retryWatcher: object %#v doesn't support resourceVersion", event.Object)).ErrStatus,
 					})
@@ -178,7 +198,7 @@ func (rw *RetryWatcher) doReceive() (bool, time.Duration) {
 
 				// All is fine; send the non-bookmark events and update resource version.
 				if event.Type != watch.Bookmark {
-					ok = rw.send(event)
+					ok = rw.send(ctx, event)
 					if !ok {
 						return true, 0
 					}
@@ -192,7 +212,7 @@ func (rw *RetryWatcher) doReceive() (bool, time.Duration) {
 				errObject := apierrors.FromObject(event.Object)
 				statusErr, ok := errObject.(*apierrors.StatusError)
 				if !ok {
-					klog.Error(fmt.Sprintf("Received an error which is not *metav1.Status but %s", dump.Pretty(event.Object)))
+					logger.Error(nil, "Received an error which is not *metav1.Status", "err", dump.Pretty(event.Object))
 					// Retry unknown errors
 					return false, 0
 				}
@@ -207,7 +227,7 @@ func (rw *RetryWatcher) doReceive() (bool, time.Duration) {
 				switch status.Code {
 				case http.StatusGone:
 					// Never retry RV too old errors
-					_ = rw.send(event)
+					_ = rw.send(ctx, event)
 					return true, 0
 
 				case http.StatusGatewayTimeout, http.StatusInternalServerError:
@@ -221,15 +241,15 @@ func (rw *RetryWatcher) doReceive() (bool, time.Duration) {
 
 					// Log here so we have a record of hitting the unexpected error
 					// and we can whitelist some error codes if we missed any that are expected.
-					klog.V(5).Info(fmt.Sprintf("Retrying after unexpected error: %s", dump.Pretty(event.Object)))
+					logger.V(5).Info("Retrying after unexpected error", "err", dump.Pretty(event.Object))
 
 					// Retry
 					return false, statusDelay
 				}
 
 			default:
-				klog.Errorf("Failed to recognize Event type %q", event.Type)
-				_ = rw.send(watch.Event{
+				logger.Error(nil, "Failed to recognize Event", "eventType", event.Type)
+				_ = rw.send(ctx, watch.Event{
 					Type:   watch.Error,
 					Object: &apierrors.NewInternalError(fmt.Errorf("retryWatcher failed to recognize Event type %q", event.Type)).ErrStatus,
 				})
@@ -241,29 +261,21 @@ func (rw *RetryWatcher) doReceive() (bool, time.Duration) {
 }
 
 // receive reads the result from a watcher, restarting it if necessary.
-func (rw *RetryWatcher) receive() {
+func (rw *RetryWatcher) receive(ctx context.Context) {
 	defer close(rw.doneChan)
 	defer close(rw.resultChan)
+	logger := klog.FromContext(ctx)
 
-	klog.V(4).Info("Starting RetryWatcher.")
-	defer klog.V(4).Info("Stopping RetryWatcher.")
+	logger.V(4).Info("Starting RetryWatcher.")
+	defer logger.V(4).Info("Stopping RetryWatcher.")
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	go func() {
-		select {
-		case <-rw.stopChan:
-			cancel()
-			return
-		case <-ctx.Done():
-			return
-		}
-	}()
 
 	// We use non sliding until so we don't introduce delays on happy path when WATCH call
 	// timeouts or gets closed and we need to reestablish it while also avoiding hot loops.
 	wait.NonSlidingUntilWithContext(ctx, func(ctx context.Context) {
-		done, retryAfter := rw.doReceive()
+		done, retryAfter := rw.doReceive(ctx)
 		if done {
 			cancel()
 			return
@@ -277,7 +289,7 @@ func (rw *RetryWatcher) receive() {
 		case <-timer.C:
 		}
 
-		klog.V(4).Infof("Restarting RetryWatcher at RV=%q", rw.lastResourceVersion)
+		logger.V(4).Info("Restarting RetryWatcher", "resourceVersion", rw.lastResourceVersion)
 	}, rw.minRestartDelay)
 }
 
@@ -288,15 +300,7 @@ func (rw *RetryWatcher) ResultChan() <-chan watch.Event {
 
 // Stop implements Interface.
 func (rw *RetryWatcher) Stop() {
-	rw.stopChanLock.Lock()
-	defer rw.stopChanLock.Unlock()
-
-	// Prevent closing an already closed channel to prevent a panic
-	select {
-	case <-rw.stopChan:
-	default:
-		close(rw.stopChan)
-	}
+	rw.cancel(errors.New("Stop was called"))
 }
 
 // Done allows the caller to be notified when Retry watcher stops.

--- a/staging/src/k8s.io/client-go/tools/watch/until.go
+++ b/staging/src/k8s.io/client-go/tools/watch/until.go
@@ -105,7 +105,7 @@ func UntilWithoutRetry(ctx context.Context, watcher watch.Interface, conditions 
 //
 // The most frequent usage for Until would be a test where you want to verify exact order of events ("edges").
 func Until(ctx context.Context, initialResourceVersion string, watcherClient cache.Watcher, conditions ...ConditionFunc) (*watch.Event, error) {
-	w, err := NewRetryWatcher(initialResourceVersion, watcherClient)
+	w, err := NewRetryWatcherWithContext(ctx, initialResourceVersion, watcherClient)
 	if err != nil {
 		return nil, err
 	}
@@ -126,7 +126,7 @@ func Until(ctx context.Context, initialResourceVersion string, watcherClient cac
 // The most frequent usage would be a command that needs to watch the "state of the world" and should't fail, like:
 // waiting for object reaching a state, "small" controllers, ...
 func UntilWithSync(ctx context.Context, lw cache.ListerWatcher, objType runtime.Object, precondition PreconditionFunc, conditions ...ConditionFunc) (*watch.Event, error) {
-	indexer, informer, watcher, done := NewIndexerInformerWatcher(lw, objType)
+	indexer, informer, watcher, done := NewIndexerInformerWatcherWithContext(ctx, lw, objType)
 	// We need to wait for the internal informers to fully stop so it's easier to reason about
 	// and it works with non-thread safe clients.
 	defer func() { <-done }()
@@ -156,7 +156,7 @@ func UntilWithSync(ctx context.Context, lw cache.ListerWatcher, objType runtime.
 func ContextWithOptionalTimeout(parent context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
 	if timeout < 0 {
 		// This should be handled in validation
-		klog.Errorf("Timeout for context shall not be negative!")
+		klog.FromContext(parent).Error(nil, "Timeout for context shall not be negative!")
 		timeout = 0
 	}
 

--- a/staging/src/k8s.io/cloud-provider/cloud.go
+++ b/staging/src/k8s.io/cloud-provider/cloud.go
@@ -43,8 +43,8 @@ type ControllerClientBuilder interface {
 type Interface interface {
 	// Initialize provides the cloud with a kubernetes client builder and may spawn goroutines
 	// to perform housekeeping or run custom controllers specific to the cloud provider.
-	// Any tasks started here should be cleaned up when the stop channel closes.
-	Initialize(clientBuilder ControllerClientBuilder, stop <-chan struct{})
+	// Any tasks started here should be cleaned up when the context is done.
+	Initialize(ctx context.Context, clientBuilder ControllerClientBuilder)
 	// LoadBalancer returns a balancer interface. Also returns true if the interface is supported, false otherwise.
 	LoadBalancer() (LoadBalancer, bool)
 	// Instances returns an instances interface. Also returns true if the interface is supported, false otherwise.

--- a/staging/src/k8s.io/cloud-provider/fake/fake.go
+++ b/staging/src/k8s.io/cloud-provider/fake/fake.go
@@ -126,7 +126,7 @@ func (f *Cloud) ClearCalls() {
 }
 
 // Initialize passes a Kubernetes clientBuilder interface to the cloud provider
-func (f *Cloud) Initialize(clientBuilder cloudprovider.ControllerClientBuilder, stop <-chan struct{}) {
+func (f *Cloud) Initialize(ctx context.Context, clientBuilder cloudprovider.ControllerClientBuilder) {
 }
 
 // ListClusters lists the names of the available clusters.

--- a/staging/src/k8s.io/dynamic-resource-allocation/controller/controller.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/controller/controller.go
@@ -197,7 +197,7 @@ func New(
 	// cache and after an update made by the controller returns a more
 	// recent copy until the informer catches up.
 	claimInformerCache := claimInformer.Informer().GetIndexer()
-	claimCache := cache.NewIntegerResourceVersionMutationCache(claimInformerCache, claimInformerCache, 60*time.Second,
+	claimCache := cache.NewIntegerResourceVersionMutationCache(ctx, claimInformerCache, claimInformerCache, 60*time.Second,
 		false /* only cache updated claims that exist in the informer cache */)
 
 	ctrl := &controller{

--- a/staging/src/k8s.io/dynamic-resource-allocation/controller/controller.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/controller/controller.go
@@ -170,19 +170,7 @@ func New(
 	schedulingCtxInformer := informerFactory.Resource().V1alpha3().PodSchedulingContexts()
 
 	eventBroadcaster := record.NewBroadcaster(record.WithContext(ctx))
-	go func() {
-		<-ctx.Done()
-		eventBroadcaster.Shutdown()
-	}()
-	// TODO: use contextual logging in eventBroadcaster once it
-	// supports it. There is a StartStructuredLogging API, but it
-	// uses the global klog, which is worse than redirecting an unstructured
-	// string into our logger, in particular during testing.
-	eventBroadcaster.StartLogging(func(format string, args ...interface{}) {
-		helper, logger := logger.WithCallStackHelper()
-		helper()
-		logger.V(2).Info(fmt.Sprintf(format, args...))
-	})
+	eventBroadcaster.StartStructuredLogging(2)
 	eventBroadcaster.StartRecordingToSink(&corev1types.EventSinkImpl{Interface: kubeClient.CoreV1().Events(v1.NamespaceAll)})
 	eventRecorder := eventBroadcaster.NewRecorder(scheme.Scheme,
 		v1.EventSource{Component: fmt.Sprintf("resource driver %s", name)})

--- a/test/e2e/apps/daemon_restart.go
+++ b/test/e2e/apps/daemon_restart.go
@@ -267,7 +267,7 @@ var _ = SIGDescribe("DaemonRestart", framework.WithDisruptive(), func() {
 				},
 			},
 		)
-		go controller.Run(backgroundCtx.Done())
+		go controller.RunWithContext(backgroundCtx)
 	})
 
 	ginkgo.It("Controller Manager should not create/delete replicas across restart", func(ctx context.Context) {

--- a/test/e2e/cloud/gcp/reboot.go
+++ b/test/e2e/cloud/gcp/reboot.go
@@ -242,7 +242,7 @@ func printStatusAndLogsForNotReadyPods(ctx context.Context, c clientset.Interfac
 func rebootNode(ctx context.Context, c clientset.Interface, provider, name, rebootCmd string) bool {
 	// Setup
 	ns := metav1.NamespaceSystem
-	ps, err := testutils.NewPodStore(c, ns, labels.Everything(), fields.OneTermEqualSelector("spec.nodeName", name))
+	ps, err := testutils.NewPodStore(ctx, c, ns, labels.Everything(), fields.OneTermEqualSelector("spec.nodeName", name))
 	if err != nil {
 		framework.Logf("Couldn't initialize pod store: %v", err)
 		return false

--- a/test/e2e/common/node/pods.go
+++ b/test/e2e/common/node/pods.go
@@ -264,7 +264,7 @@ var _ = SIGDescribe("Pods", func() {
 				return podClient.Watch(ctx, options)
 			},
 		}
-		_, informer, w, _ := watchtools.NewIndexerInformerWatcher(lw, &v1.Pod{})
+		_, informer, w, _ := watchtools.NewIndexerInformerWatcherWithContext(ctx, lw, &v1.Pod{})
 		defer w.Stop()
 
 		ctxUntil, cancelCtx := context.WithTimeout(ctx, wait.ForeverTestTimeout)

--- a/test/e2e/dra/deploy.go
+++ b/test/e2e/dra/deploy.go
@@ -134,7 +134,7 @@ func NewNodes(f *framework.Framework, minNodes, maxNodes int) *Nodes {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			claimInformer.Run(cancelCtx.Done())
+			claimInformer.RunWithContext(cancelCtx)
 		}()
 	})
 	return nodes

--- a/test/e2e/dra/test-driver/app/server.go
+++ b/test/e2e/dra/test-driver/app/server.go
@@ -121,7 +121,7 @@ func NewCommand() *cobra.Command {
 				return fmt.Errorf("create in-cluster client configuration: %w", err)
 			}
 		} else {
-			config, err = clientcmd.BuildConfigFromFlags("", *kubeconfig)
+			config, err = clientcmd.BuildConfigFromFlagsWithContext(cmd.Context(), "", *kubeconfig)
 			if err != nil {
 				return fmt.Errorf("create out-of-cluster client configuration: %w", err)
 			}

--- a/test/e2e/framework/ingress/ingress_utils.go
+++ b/test/e2e/framework/ingress/ingress_utils.go
@@ -1009,7 +1009,7 @@ func (cont *NginxIngressController) Init(ctx context.Context) {
 
 	framework.Logf("waiting for pods with label %v", rc.Spec.Selector)
 	sel := labels.SelectorFromSet(labels.Set(rc.Spec.Selector))
-	framework.ExpectNoError(testutils.WaitForPodsWithLabelRunning(cont.Client, cont.Ns, sel))
+	framework.ExpectNoError(testutils.WaitForPodsWithLabelRunning(ctx, cont.Client, cont.Ns, sel))
 	pods, err := cont.Client.CoreV1().Pods(cont.Ns).List(ctx, metav1.ListOptions{LabelSelector: sel.String()})
 	framework.ExpectNoError(err)
 	if len(pods.Items) == 0 {

--- a/test/e2e/framework/resource/resources.go
+++ b/test/e2e/framework/resource/resources.go
@@ -119,7 +119,7 @@ func deleteObjectAndWaitForGC(ctx context.Context, c clientset.Interface, rtObje
 		return err
 	}
 
-	ps, err := testutils.NewPodStore(c, ns, selector, fields.Everything())
+	ps, err := testutils.NewPodStore(ctx, c, ns, selector, fields.Everything())
 	if err != nil {
 		return err
 	}
@@ -229,7 +229,7 @@ func WaitForControlledPodsRunning(ctx context.Context, c clientset.Interface, ns
 	if err != nil {
 		return err
 	}
-	err = testutils.WaitForEnoughPodsWithLabelRunning(c, ns, selector, int(replicas))
+	err = testutils.WaitForEnoughPodsWithLabelRunning(ctx, c, ns, selector, int(replicas))
 	if err != nil {
 		return fmt.Errorf("Error while waiting for replication controller %s pods to be running: %w", name, err)
 	}

--- a/test/e2e/framework/service/resource.go
+++ b/test/e2e/framework/service/resource.go
@@ -125,7 +125,7 @@ func CreateServiceForSimpleAppWithPods(ctx context.Context, c clientset.Interfac
 	theService := CreateServiceForSimpleApp(ctx, c, contPort, svcPort, namespace, appName)
 	e2enode.CreatePodsPerNodeForSimpleApp(ctx, c, namespace, appName, podSpec, count)
 	if block {
-		err = testutils.WaitForPodsWithLabelRunning(c, namespace, labels.SelectorFromSet(labels.Set(theService.Spec.Selector)))
+		err = testutils.WaitForPodsWithLabelRunning(ctx, c, namespace, labels.SelectorFromSet(labels.Set(theService.Spec.Selector)))
 	}
 	return theService, err
 }

--- a/test/e2e/kubectl/kubectl.go
+++ b/test/e2e/kubectl/kubectl.go
@@ -1795,7 +1795,7 @@ metadata:
 
 			ginkgo.By("verifying the pod " + podName + " is running")
 			label := labels.SelectorFromSet(labels.Set(map[string]string{"run": podName}))
-			err := testutils.WaitForPodsWithLabelRunning(c, ns, label)
+			err := testutils.WaitForPodsWithLabelRunning(ctx, c, ns, label)
 			if err != nil {
 				framework.Failf("Failed getting pod %s: %v", podName, err)
 			}
@@ -1997,7 +1997,7 @@ metadata:
 
 			ginkgo.By("verifying the pod " + podName + " is running")
 			label := labels.SelectorFromSet(map[string]string{"run": podName})
-			err := testutils.WaitForPodsWithLabelRunning(c, ns, label)
+			err := testutils.WaitForPodsWithLabelRunning(ctx, c, ns, label)
 			if err != nil {
 				framework.Failf("Failed getting pod %s: %v", podName, err)
 			}
@@ -2271,7 +2271,7 @@ func curl(url string) (string, error) {
 func validateGuestbookApp(ctx context.Context, c clientset.Interface, ns string) {
 	framework.Logf("Waiting for all frontend pods to be Running.")
 	label := labels.SelectorFromSet(labels.Set(map[string]string{"tier": "frontend", "app": "guestbook"}))
-	err := testutils.WaitForPodsWithLabelRunning(c, ns, label)
+	err := testutils.WaitForPodsWithLabelRunning(ctx, c, ns, label)
 	framework.ExpectNoError(err)
 	framework.Logf("Waiting for frontend to serve content.")
 	if !waitForGuestbookResponse(ctx, c, "get", "", `{"data":""}`, guestbookStartupTimeout, ns) {

--- a/test/e2e/node/taints.go
+++ b/test/e2e/node/taints.go
@@ -142,7 +142,7 @@ func createTestController(ctx context.Context, cs clientset.Interface, observedD
 		},
 	)
 	framework.Logf("Starting informer...")
-	go controller.Run(ctx.Done())
+	go controller.RunWithContext(ctx)
 }
 
 const (

--- a/test/e2e/scheduling/events.go
+++ b/test/e2e/scheduling/events.go
@@ -94,9 +94,9 @@ func observeEventAfterAction(ctx context.Context, c clientset.Interface, ns stri
 	)
 
 	// Start the informer and block this goroutine waiting for the started signal.
-	informerStopChan := make(chan struct{})
-	defer func() { close(informerStopChan) }()
-	go controller.Run(informerStopChan)
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	go controller.RunWithContext(ctx)
 	<-informerStartedChan
 
 	// Invoke the action function.

--- a/test/e2e/scheduling/limit_range.go
+++ b/test/e2e/scheduling/limit_range.go
@@ -91,7 +91,7 @@ var _ = SIGDescribe("LimitRange", func() {
 				return f.ClientSet.CoreV1().LimitRanges(f.Namespace.Name).Watch(ctx, options)
 			},
 		}
-		_, informer, w, _ := watchtools.NewIndexerInformerWatcher(lw, &v1.LimitRange{})
+		_, informer, w, _ := watchtools.NewIndexerInformerWatcherWithContext(ctx, lw, &v1.LimitRange{})
 		defer w.Stop()
 
 		timeoutCtx, cancel := context.WithTimeout(ctx, wait.ForeverTestTimeout)

--- a/test/e2e/scheduling/predicates.go
+++ b/test/e2e/scheduling/predicates.go
@@ -170,7 +170,7 @@ var _ = SIGDescribe("SchedulerPredicates", framework.WithSerial(), func() {
 		// and there is no need to create additional pods.
 		// StartPods requires at least one pod to replicate.
 		if podsNeededForSaturation > 0 {
-			framework.ExpectNoError(testutils.StartPods(cs, podsNeededForSaturation, ns, "overcommit",
+			framework.ExpectNoError(testutils.StartPods(ctx, cs, podsNeededForSaturation, ns, "overcommit",
 				*initPausePod(f, pausePodConfig{
 					Name:   "",
 					Labels: map[string]string{"name": ""},

--- a/test/e2e/scheduling/preemption.go
+++ b/test/e2e/scheduling/preemption.go
@@ -653,7 +653,7 @@ var _ = SIGDescribe("SchedulerPreemption", framework.WithSerial(), func() {
 					},
 				},
 			)
-			go podController.Run(ctx.Done())
+			go podController.RunWithContext(ctx)
 
 			// prepare three ReplicaSet
 			rsConfs := []pauseRSConfig{

--- a/test/e2e/scheduling/priorities.go
+++ b/test/e2e/scheduling/priorities.go
@@ -450,7 +450,7 @@ func createBalancedPodForNodes(ctx context.Context, f *framework.Framework, cs c
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			err := testutils.StartPods(cs, 1, ns, string(uuid.NewUUID()),
+			err := testutils.StartPods(ctx, cs, 1, ns, string(uuid.NewUUID()),
 				*initPausePod(f, *podConfig), true, framework.Logf)
 			if err != nil {
 				errChan <- err

--- a/test/e2e/scheduling/ubernetes_lite.go
+++ b/test/e2e/scheduling/ubernetes_lite.go
@@ -120,7 +120,7 @@ func SpreadServiceOrFail(ctx context.Context, f *framework.Framework, replicaCou
 	// Based on the callers, replicas is always positive number: zoneCount >= 0 implies (2*zoneCount)+1 > 0.
 	// Thus, no need to test for it. Once the precondition changes to zero number of replicas,
 	// test for replicaCount > 0. Otherwise, StartPods panics.
-	framework.ExpectNoError(testutils.StartPods(f.ClientSet, replicaCount, f.Namespace.Name, serviceName, *podSpec, false, framework.Logf))
+	framework.ExpectNoError(testutils.StartPods(ctx, f.ClientSet, replicaCount, f.Namespace.Name, serviceName, *podSpec, false, framework.Logf))
 
 	// Wait for all of them to be scheduled
 	selector := labels.SelectorFromSet(labels.Set(map[string]string{"service": serviceName}))

--- a/test/integration/apimachinery/watchlist_test.go
+++ b/test/integration/apimachinery/watchlist_test.go
@@ -74,7 +74,7 @@ func TestReflectorWatchListFallback(t *testing.T) {
 	reflectorCtx, reflectorCtxCancel := context.WithCancel(context.Background())
 	defer reflectorCtxCancel()
 	store.setCancelOnReplace(reflectorCtxCancel)
-	err = target.ListAndWatch(reflectorCtx.Done())
+	err = target.ListAndWatchWithContext(reflectorCtx)
 	require.NoError(t, err)
 
 	t.Log("Verifying if the secret reflector was properly synchronised")
@@ -91,7 +91,7 @@ func TestReflectorWatchListFallback(t *testing.T) {
 	reflectorCtx, reflectorCtxCancel = context.WithCancel(context.Background())
 	defer reflectorCtxCancel()
 	store.setCancelOnReplace(reflectorCtxCancel)
-	err = target.ListAndWatch(reflectorCtx.Done())
+	err = target.ListAndWatchWithContext(reflectorCtx)
 	require.NoError(t, err)
 
 	t.Log("Verifying if the secret reflector was properly synchronised")

--- a/test/integration/kubelet/watch_manager_test.go
+++ b/test/integration/kubelet/watch_manager_test.go
@@ -65,9 +65,9 @@ func TestWatchBasedManager(t *testing.T) {
 	isImmutable := func(_ runtime.Object) bool { return false }
 	fakeClock := testingclock.NewFakeClock(time.Now())
 
-	stopCh := make(chan struct{})
-	defer close(stopCh)
-	store := manager.NewObjectCache(listObj, watchObj, newObj, isImmutable, schema.GroupResource{Group: "v1", Resource: "secrets"}, fakeClock, time.Minute, stopCh)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	store := manager.NewObjectCache(ctx, listObj, watchObj, newObj, isImmutable, schema.GroupResource{Group: "v1", Resource: "secrets"}, fakeClock, time.Minute)
 
 	// create 1000 secrets in parallel
 	t.Log(time.Now(), "creating 1000 secrets")

--- a/test/integration/serviceaccount/service_account_test.go
+++ b/test/integration/serviceaccount/service_account_test.go
@@ -407,6 +407,7 @@ func startServiceAccountTestServerAndWaitForCaches(ctx context.Context, t *testi
 	go tokenController.Run(ctx, 1)
 
 	serviceAccountController, err := serviceaccountcontroller.NewServiceAccountsController(
+		ctx,
 		informers.Core().V1().ServiceAccounts(),
 		informers.Core().V1().Namespaces(),
 		rootClientset,

--- a/test/integration/serviceaccount/service_account_test.go
+++ b/test/integration/serviceaccount/service_account_test.go
@@ -393,6 +393,7 @@ func startServiceAccountTestServerAndWaitForCaches(ctx context.Context, t *testi
 		return rootClientset, clientConfig, stop, informers, err
 	}
 	tokenController, err := serviceaccountcontroller.NewTokensController(
+		ctx,
 		informers.Core().V1().ServiceAccounts(),
 		informers.Core().V1().Secrets(),
 		rootClientset,

--- a/test/utils/runners.go
+++ b/test/utils/runners.go
@@ -636,7 +636,7 @@ func (config *RCConfig) start(ctx context.Context) error {
 
 	label := labels.SelectorFromSet(labels.Set(map[string]string{"name": config.Name}))
 
-	ps, err := NewPodStore(config.Client, config.Namespace, label, fields.Everything())
+	ps, err := NewPodStore(ctx, config.Client, config.Namespace, label, fields.Everything())
 	if err != nil {
 		return err
 	}
@@ -722,7 +722,7 @@ func (config *RCConfig) start(ctx context.Context) error {
 // Simplified version of RunRC, that does not create RC, but creates plain Pods.
 // Optionally waits for pods to start running (if waitForRunning == true).
 // The number of replicas must be non-zero.
-func StartPods(c clientset.Interface, replicas int, namespace string, podNamePrefix string,
+func StartPods(ctx context.Context, c clientset.Interface, replicas int, namespace string, podNamePrefix string,
 	pod v1.Pod, waitForRunning bool, logFunc func(fmt string, args ...interface{})) error {
 	// no pod to start
 	if replicas < 1 {
@@ -742,7 +742,7 @@ func StartPods(c clientset.Interface, replicas int, namespace string, podNamePre
 	logFunc("Waiting for running...")
 	if waitForRunning {
 		label := labels.SelectorFromSet(labels.Set(map[string]string{"startPodsID": startPodsID}))
-		err := WaitForPodsWithLabelRunning(c, namespace, label)
+		err := WaitForPodsWithLabelRunning(ctx, c, namespace, label)
 		if err != nil {
 			return fmt.Errorf("error waiting for %d pods to be running - probably a timeout: %v", replicas, err)
 		}
@@ -752,15 +752,15 @@ func StartPods(c clientset.Interface, replicas int, namespace string, podNamePre
 
 // Wait up to 10 minutes for all matching pods to become Running and at least one
 // matching pod exists.
-func WaitForPodsWithLabelRunning(c clientset.Interface, ns string, label labels.Selector) error {
-	return WaitForEnoughPodsWithLabelRunning(c, ns, label, -1)
+func WaitForPodsWithLabelRunning(ctx context.Context, c clientset.Interface, ns string, label labels.Selector) error {
+	return WaitForEnoughPodsWithLabelRunning(ctx, c, ns, label, -1)
 }
 
 // Wait up to 10 minutes for at least 'replicas' many pods to be Running and at least
 // one matching pod exists. If 'replicas' is < 0, wait for all matching pods running.
-func WaitForEnoughPodsWithLabelRunning(c clientset.Interface, ns string, label labels.Selector, replicas int) error {
+func WaitForEnoughPodsWithLabelRunning(ctx context.Context, c clientset.Interface, ns string, label labels.Selector, replicas int) error {
 	running := false
-	ps, err := NewPodStore(c, ns, label, fields.Everything())
+	ps, err := NewPodStore(ctx, c, ns, label, fields.Everything())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind api-change

#### What this PR does / why we need it:

In Kubernetes commands which have been converted to contextual logging still produce log output from client-go helper code which ignores the context. For example, at -v6 kube-controller-output prints log entries that cannot be correlated with the controller that has activated the helper code.

#### Which issue(s) this PR fixes:

Related-to: https://github.com/kubernetes/enhancements/issues/3077

#### Special notes for your reviewer:

This PR will be split up, do not review yet.

Depends on:
- [x] https://github.com/kubernetes/kubernetes/pull/120637
- [x] https://github.com/kubernetes/kubernetes/pull/122148
- [x] https://github.com/kubernetes/kubernetes/pull/122145
- [ ] https://github.com/kubernetes/kubernetes/pull/126387

#### Does this PR introduce a user-facing change?

TODO

```release-note
```

