### PR TITLE
Customize apiserver serviceName for tracing

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/options/tracing.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/tracing.go
@@ -41,7 +41,7 @@ import (
 	"k8s.io/utils/path"
 )
 
-const apiserverService = "apiserver"
+const defaultApiserverService = "apiserver"
 
 var (
 	cfgScheme = runtime.NewScheme()
@@ -109,9 +109,14 @@ func (o *TracingOptions) ApplyTo(es *egressselector.EgressSelector, c *server.Co
 		}
 	}
 
+	serviceName := defaultApiserverService
+	if traceConfig != nil && traceConfig.ServiceName != nil {
+		serviceName := *traceConfig.ServiceName
+	}
+
 	resourceOpts := []resource.Option{
 		resource.WithAttributes(
-			semconv.ServiceNameKey.String(apiserverService),
+			semconv.ServiceNameKey.String(serviceName),
 			semconv.ServiceInstanceIDKey.String(c.APIServerID),
 		),
 	}

--- a/staging/src/k8s.io/apiserver/pkg/server/options/tracing_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/tracing_test.go
@@ -31,6 +31,7 @@ var (
 	localhost    = "localhost:4317"
 	ipAddress    = "127.0.0.1:4317"
 	samplingRate = int32(12345)
+	serviceName  = "customServiceName"
 )
 
 func strptr(s string) *string {
@@ -106,10 +107,12 @@ apiVersion: apiserver.config.k8s.io/v1alpha1
 kind: TracingConfiguration
 endpoint: localhost:4317
 samplingRatePerMillion: 12345
+serviceName: customServiceName
 `,
 			expectedResult: &tracingapi.TracingConfiguration{
 				Endpoint:               &localhost,
 				SamplingRatePerMillion: &samplingRate,
+				ServiceName:            &serviceName,
 			},
 			expectedError: nil,
 		},

--- a/staging/src/k8s.io/component-base/tracing/api/v1/config.go
+++ b/staging/src/k8s.io/component-base/tracing/api/v1/config.go
@@ -41,6 +41,9 @@ func ValidateTracingConfiguration(traceConfig *TracingConfiguration, featureGate
 	if traceConfig.Endpoint != nil {
 		allErrs = append(allErrs, validateEndpoint(*traceConfig.Endpoint, fldPath.Child("endpoint"))...)
 	}
+	if traceConfig.ServiceName != nil {
+		allErrs = append(allErrs, validateServiceName(*traceConfig.ServiceName, fldPath.Child("serviceName"))...)
+	}
 	return allErrs
 }
 
@@ -84,5 +87,18 @@ func validateEndpoint(endpoint string, fldPath *field.Path) field.ErrorList {
 			fmt.Sprintf("unsupported scheme: %v.  Options are none, dns, unix, or unix-abstract.  See https://github.com/grpc/grpc/blob/master/doc/naming.md", url.Scheme),
 		))
 	}
+	return errs
+}
+
+func validateServiceName(serviceName string, fldPath *field.Path) field.ErrorList {
+	errs := field.ErrorList{}
+	if serviceName == "" {
+		errs = append(errs, field.Invalid(
+			fldPath, serviceName,
+			"serviceName must be non-empty",
+		))
+		return errs
+	}
+
 	return errs
 }

--- a/staging/src/k8s.io/component-base/tracing/api/v1/config_test.go
+++ b/staging/src/k8s.io/component-base/tracing/api/v1/config_test.go
@@ -31,6 +31,8 @@ func TestValidateTracingConfiguration(t *testing.T) {
 	unixEndpoint := "unix://path/to/socket"
 	invalidURL := "dn%2s://localhost:4317"
 	httpEndpoint := "http://localhost:4317"
+	validServiceName := "customServiceName"
+	invalidServiceName := ""
 	testcases := []struct {
 		name        string
 		expectError bool
@@ -90,6 +92,20 @@ func TestValidateTracingConfiguration(t *testing.T) {
 			expectError: true,
 			contents: &TracingConfiguration{
 				Endpoint: &invalidURL,
+			},
+		},
+		{
+			name:        "valid serviceName",
+			expectError: false,
+			contents: &TracingConfiguration{
+				ServiceName: &validServiceName,
+			},
+		},
+		{
+			name:        "invalid serviceName",
+			expectError: true,
+			contents: &TracingConfiguration{
+				ServiceName: &invalidServiceName,
 			},
 		},
 	}

--- a/staging/src/k8s.io/component-base/tracing/api/v1/types.go
+++ b/staging/src/k8s.io/component-base/tracing/api/v1/types.go
@@ -29,4 +29,9 @@ type TracingConfiguration struct {
 	// rate, but otherwise never samples.
 	// +optional
 	SamplingRatePerMillion *int32 `json:"samplingRatePerMillion,omitempty"`
+
+	// ServiceName defines the service.name of traces sent out
+	// Defaults to 'apiserver'
+	// +optional
+	ServiceName *string `json:"serviceName,omitempty"`
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Currently, all traces are sent out with the same `service.name` of `apiserver`. 

This isn't ideal as I'd like to have a single collector route multiple instances of different kube api servers.

As a result, allowing the user to customize the `service.name` is a potential solution.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
