### PR TITLE
chores: Replace deprecation ioutil fucntions

### DIFF
--- a/plugin/pkg/admission/eventratelimit/config.go
+++ b/plugin/pkg/admission/eventratelimit/config.go
@@ -19,7 +19,6 @@ package eventratelimit
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
@@ -50,7 +49,7 @@ func LoadConfiguration(config io.Reader) (*eventratelimitapi.Configuration, erro
 		return internalConfig, nil
 	}
 	// we have a config so parse it.
-	data, err := ioutil.ReadAll(config)
+	data, err := io.ReadAll(config)
 	if err != nil {
 		return nil, err
 	}

--- a/plugin/pkg/admission/podtolerationrestriction/config.go
+++ b/plugin/pkg/admission/podtolerationrestriction/config.go
@@ -19,7 +19,6 @@ package podtolerationrestriction
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
@@ -51,7 +50,7 @@ func loadConfiguration(config io.Reader) (*internalapi.Configuration, error) {
 		return internalConfig, nil
 	}
 	// we have a config so parse it.
-	data, err := ioutil.ReadAll(config)
+	data, err := io.ReadAll(config)
 	if err != nil {
 		return nil, err
 	}

--- a/plugin/pkg/admission/security/podsecurity/admission_test.go
+++ b/plugin/pkg/admission/security/podsecurity/admission_test.go
@@ -19,7 +19,7 @@ package podsecurity
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 
@@ -116,7 +116,7 @@ func BenchmarkVerifyPod(b *testing.B) {
 
 	corePod := &core.Pod{}
 	v1Pod := &corev1.Pod{}
-	data, err := ioutil.ReadFile("testdata/pod_restricted.yaml")
+	data, err := os.ReadFile("testdata/pod_restricted.yaml")
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -205,7 +205,7 @@ func BenchmarkVerifyNamespace(b *testing.B) {
 	}
 
 	v1Pod := &corev1.Pod{}
-	data, err := ioutil.ReadFile("testdata/pod_baseline.yaml")
+	data, err := os.ReadFile("testdata/pod_baseline.yaml")
 	if err != nil {
 		b.Fatal(err)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Go 1.16 deprecated several io/ioutil functions.

`ioutil.ReadFile` -> `os.ReadFile`
`ioutil.ReadAll` -> `io.ReadAll`
`ioutil.ReadDir` -> `os.ReadDir`

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
ref: https://pkg.go.dev/io/ioutil

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
