### PR TITLE
WIP: node: podresources: e2e: ensure client before doing gRPC calls

### DIFF
--- a/test/e2e_node/device_manager_test.go
+++ b/test/e2e_node/device_manager_test.go
@@ -22,8 +22,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"regexp"
-	"sort"
 	"strings"
 	"time"
 
@@ -33,18 +31,12 @@ import (
 	"k8s.io/apimachinery/pkg/util/uuid"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/klog/v2"
-	kubeletpodresourcesv1 "k8s.io/kubelet/pkg/apis/podresources/v1"
-	"k8s.io/kubernetes/pkg/kubelet/apis/podresources"
-	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager"
-	"k8s.io/kubernetes/pkg/kubelet/cm/devicemanager/checkpoint"
-	"k8s.io/kubernetes/pkg/kubelet/util"
 	admissionapi "k8s.io/pod-security-admission/api"
 
 	"k8s.io/kubernetes/test/e2e/feature"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
-	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 	e2etestfiles "k8s.io/kubernetes/test/e2e/framework/testfiles"
 	"k8s.io/kubernetes/test/e2e/nodefeature"
 	testutils "k8s.io/kubernetes/test/utils"
@@ -57,226 +49,12 @@ import (
 
 const (
 	devicePluginDir = "/var/lib/kubelet/device-plugins"
-	checkpointName  = "kubelet_internal_checkpoint"
 )
 
 // Serial because the test updates kubelet configuration.
 var _ = SIGDescribe("Device Manager", framework.WithSerial(), feature.DeviceManager, nodefeature.DeviceManager, func() {
-	checkpointFullPath := filepath.Join(devicePluginDir, checkpointName)
 	f := framework.NewDefaultFramework("devicemanager-test")
 	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
-
-	ginkgo.Context("With SRIOV devices in the system", func() {
-		// this test wants to reproduce what happened in https://github.com/kubernetes/kubernetes/issues/102880
-		ginkgo.It("should be able to recover V1 (aka pre-1.20) checkpoint data and reject pods before device re-registration", func(ctx context.Context) {
-			if sriovdevCount, err := countSRIOVDevices(); err != nil || sriovdevCount == 0 {
-				e2eskipper.Skipf("this test is meant to run on a system with at least one configured VF from SRIOV device")
-			}
-
-			configMap := getSRIOVDevicePluginConfigMap(framework.TestContext.SriovdpConfigMapFile)
-			sd := setupSRIOVConfigOrFail(ctx, f, configMap)
-
-			waitForSRIOVResources(ctx, f, sd)
-
-			cntName := "gu-container"
-			// we create and delete a pod to make sure the internal device manager state contains a pod allocation
-			ginkgo.By(fmt.Sprintf("Successfully admit one guaranteed pod with 1 core, 1 %s device", sd.resourceName))
-			var initCtnAttrs []tmCtnAttribute
-			ctnAttrs := []tmCtnAttribute{
-				{
-					ctnName:       cntName,
-					cpuRequest:    "1000m",
-					cpuLimit:      "1000m",
-					deviceName:    sd.resourceName,
-					deviceRequest: "1",
-					deviceLimit:   "1",
-				},
-			}
-
-			podName := "gu-pod-rec-pre-1"
-			framework.Logf("creating pod %s attrs %v", podName, ctnAttrs)
-			pod := makeTopologyManagerTestPod(podName, ctnAttrs, initCtnAttrs)
-			pod = e2epod.NewPodClient(f).CreateSync(ctx, pod)
-
-			// now we need to simulate a node drain, so we remove all the pods, including the sriov device plugin.
-
-			ginkgo.By("deleting the pod")
-			// note we delete right now because we know the current implementation of devicemanager will NOT
-			// clean up on pod deletion. When this changes, the deletion needs to be done after the test is done.
-			deletePodSyncByName(ctx, f, pod.Name)
-			waitForAllContainerRemoval(ctx, pod.Name, pod.Namespace)
-
-			ginkgo.By("teardown the sriov device plugin")
-			// since we will NOT be recreating the plugin, we clean up everything now
-			teardownSRIOVConfigOrFail(ctx, f, sd)
-
-			ginkgo.By("stopping the kubelet")
-			killKubelet("SIGSTOP")
-
-			ginkgo.By("rewriting the kubelet checkpoint file as v1")
-			err := rewriteCheckpointAsV1(devicePluginDir, checkpointName)
-			// make sure we remove any leftovers
-			defer os.Remove(checkpointFullPath)
-			framework.ExpectNoError(err)
-
-			// this mimics a kubelet restart after the upgrade
-			// TODO: is SIGTERM (less brutal) good enough?
-			ginkgo.By("killing the kubelet")
-			killKubelet("SIGKILL")
-
-			ginkgo.By("waiting for the kubelet to be ready again")
-			// Wait for the Kubelet to be ready.
-			gomega.Eventually(ctx, func(ctx context.Context) bool {
-				nodes, err := e2enode.TotalReady(ctx, f.ClientSet)
-				framework.ExpectNoError(err)
-				return nodes == 1
-			}, time.Minute, time.Second).Should(gomega.BeTrue())
-
-			// note we DO NOT start the sriov device plugin. This is intentional.
-			// issue#102880 reproduces because of a race on startup caused by corrupted device manager
-			// state which leads to v1.Node object not updated on apiserver.
-			// So to hit the issue we need to receive the pod *before* the device plugin registers itself.
-			// The simplest and safest way to reproduce is just avoid to run the device plugin again
-
-			podName = "gu-pod-rec-post-2"
-			framework.Logf("creating pod %s attrs %v", podName, ctnAttrs)
-			pod = makeTopologyManagerTestPod(podName, ctnAttrs, initCtnAttrs)
-
-			pod = e2epod.NewPodClient(f).Create(ctx, pod)
-			err = e2epod.WaitForPodCondition(ctx, f.ClientSet, f.Namespace.Name, pod.Name, "Failed", 30*time.Second, func(pod *v1.Pod) (bool, error) {
-				if pod.Status.Phase != v1.PodPending {
-					return true, nil
-				}
-				return false, nil
-			})
-			framework.ExpectNoError(err)
-			pod, err = e2epod.NewPodClient(f).Get(ctx, pod.Name, metav1.GetOptions{})
-			framework.ExpectNoError(err)
-
-			if pod.Status.Phase != v1.PodFailed {
-				framework.Failf("pod %s not failed: %v", pod.Name, pod.Status)
-			}
-
-			framework.Logf("checking pod %s status reason (%s)", pod.Name, pod.Status.Reason)
-			if !isUnexpectedAdmissionError(pod) {
-				framework.Failf("pod %s failed for wrong reason: %q", pod.Name, pod.Status.Reason)
-			}
-
-			deletePodSyncByName(ctx, f, pod.Name)
-		})
-
-		ginkgo.It("should be able to recover V1 (aka pre-1.20) checkpoint data and update topology info on device re-registration", func(ctx context.Context) {
-			if sriovdevCount, err := countSRIOVDevices(); err != nil || sriovdevCount == 0 {
-				e2eskipper.Skipf("this test is meant to run on a system with at least one configured VF from SRIOV device")
-			}
-
-			endpoint, err := util.LocalEndpoint(defaultPodResourcesPath, podresources.Socket)
-			framework.ExpectNoError(err)
-
-			configMap := getSRIOVDevicePluginConfigMap(framework.TestContext.SriovdpConfigMapFile)
-
-			sd := setupSRIOVConfigOrFail(ctx, f, configMap)
-			waitForSRIOVResources(ctx, f, sd)
-
-			cli, conn, err := podresources.GetV1Client(endpoint, defaultPodResourcesTimeout, defaultPodResourcesMaxSize)
-			framework.ExpectNoError(err)
-
-			resp, err := cli.GetAllocatableResources(ctx, &kubeletpodresourcesv1.AllocatableResourcesRequest{})
-			conn.Close()
-			framework.ExpectNoError(err)
-
-			suitableDevs := 0
-			for _, dev := range resp.GetDevices() {
-				for _, node := range dev.GetTopology().GetNodes() {
-					if node.GetID() != 0 {
-						suitableDevs++
-					}
-				}
-			}
-			if suitableDevs == 0 {
-				teardownSRIOVConfigOrFail(ctx, f, sd)
-				e2eskipper.Skipf("no devices found on NUMA Cell other than 0")
-			}
-
-			cntName := "gu-container"
-			// we create and delete a pod to make sure the internal device manager state contains a pod allocation
-			ginkgo.By(fmt.Sprintf("Successfully admit one guaranteed pod with 1 core, 1 %s device", sd.resourceName))
-			var initCtnAttrs []tmCtnAttribute
-			ctnAttrs := []tmCtnAttribute{
-				{
-					ctnName:       cntName,
-					cpuRequest:    "1000m",
-					cpuLimit:      "1000m",
-					deviceName:    sd.resourceName,
-					deviceRequest: "1",
-					deviceLimit:   "1",
-				},
-			}
-
-			podName := "gu-pod-rec-pre-1"
-			framework.Logf("creating pod %s attrs %v", podName, ctnAttrs)
-			pod := makeTopologyManagerTestPod(podName, ctnAttrs, initCtnAttrs)
-			pod = e2epod.NewPodClient(f).CreateSync(ctx, pod)
-
-			// now we need to simulate a node drain, so we remove all the pods, including the sriov device plugin.
-
-			ginkgo.By("deleting the pod")
-			// note we delete right now because we know the current implementation of devicemanager will NOT
-			// clean up on pod deletion. When this changes, the deletion needs to be done after the test is done.
-			deletePodSyncByName(ctx, f, pod.Name)
-			waitForAllContainerRemoval(ctx, pod.Name, pod.Namespace)
-
-			ginkgo.By("teardown the sriov device plugin")
-			// no need to delete the config now (speed up later)
-			deleteSRIOVPodOrFail(ctx, f, sd)
-
-			ginkgo.By("stopping the kubelet")
-			killKubelet("SIGSTOP")
-
-			ginkgo.By("rewriting the kubelet checkpoint file as v1")
-			err = rewriteCheckpointAsV1(devicePluginDir, checkpointName)
-			// make sure we remove any leftovers
-			defer os.Remove(checkpointFullPath)
-			framework.ExpectNoError(err)
-
-			// this mimics a kubelet restart after the upgrade
-			// TODO: is SIGTERM (less brutal) good enough?
-			ginkgo.By("killing the kubelet")
-			killKubelet("SIGKILL")
-
-			ginkgo.By("waiting for the kubelet to be ready again")
-			// Wait for the Kubelet to be ready.
-			gomega.Eventually(ctx, func(ctx context.Context) bool {
-				nodes, err := e2enode.TotalReady(ctx, f.ClientSet)
-				framework.ExpectNoError(err)
-				return nodes == 1
-			}, time.Minute, time.Second).Should(gomega.BeTrue())
-
-			sd2 := &sriovData{
-				configMap:      sd.configMap,
-				serviceAccount: sd.serviceAccount,
-			}
-			sd2.pod = createSRIOVPodOrFail(ctx, f)
-			ginkgo.DeferCleanup(teardownSRIOVConfigOrFail, f, sd2)
-			waitForSRIOVResources(ctx, f, sd2)
-
-			compareSRIOVResources(sd, sd2)
-
-			cli, conn, err = podresources.GetV1Client(endpoint, defaultPodResourcesTimeout, defaultPodResourcesMaxSize)
-			framework.ExpectNoError(err)
-			defer conn.Close()
-
-			resp2, err := cli.GetAllocatableResources(ctx, &kubeletpodresourcesv1.AllocatableResourcesRequest{})
-			framework.ExpectNoError(err)
-
-			cntDevs := stringifyContainerDevices(resp.GetDevices())
-			cntDevs2 := stringifyContainerDevices(resp2.GetDevices())
-			if cntDevs != cntDevs2 {
-				framework.Failf("different allocatable resources expected %v got %v", cntDevs, cntDevs2)
-			}
-		})
-
-	})
 
 	/*
 		This end to end test is to simulate a scenario where after kubelet restart/node
@@ -511,90 +289,6 @@ var _ = SIGDescribe("Device Manager", framework.WithSerial(), feature.DeviceMana
 	})
 
 })
-
-func compareSRIOVResources(expected, got *sriovData) {
-	if expected.resourceName != got.resourceName {
-		framework.Failf("different SRIOV resource name: expected %q got %q", expected.resourceName, got.resourceName)
-	}
-	if expected.resourceAmount != got.resourceAmount {
-		framework.Failf("different SRIOV resource amount: expected %d got %d", expected.resourceAmount, got.resourceAmount)
-	}
-}
-
-func isUnexpectedAdmissionError(pod *v1.Pod) bool {
-	re := regexp.MustCompile(`Unexpected.*Admission.*Error`)
-	return re.MatchString(pod.Status.Reason)
-}
-
-func rewriteCheckpointAsV1(dir, name string) error {
-	ginkgo.By(fmt.Sprintf("Creating temporary checkpoint manager (dir=%q)", dir))
-	checkpointManager, err := checkpointmanager.NewCheckpointManager(dir)
-	if err != nil {
-		return err
-	}
-	cp := checkpoint.New(make([]checkpoint.PodDevicesEntry, 0), make(map[string][]string))
-	err = checkpointManager.GetCheckpoint(name, cp)
-	if err != nil {
-		return err
-	}
-
-	ginkgo.By(fmt.Sprintf("Read checkpoint %q %#v", name, cp))
-
-	podDevices, registeredDevs := cp.GetDataInLatestFormat()
-	podDevicesV1 := convertPodDeviceEntriesToV1(podDevices)
-	cpV1 := checkpoint.NewV1(podDevicesV1, registeredDevs)
-
-	blob, err := cpV1.MarshalCheckpoint()
-	if err != nil {
-		return err
-	}
-
-	// TODO: why `checkpointManager.CreateCheckpoint(name, cpV1)` doesn't seem to work?
-	ckPath := filepath.Join(dir, name)
-	os.WriteFile(filepath.Join("/tmp", name), blob, 0600)
-	return os.WriteFile(ckPath, blob, 0600)
-}
-
-func convertPodDeviceEntriesToV1(entries []checkpoint.PodDevicesEntry) []checkpoint.PodDevicesEntryV1 {
-	entriesv1 := []checkpoint.PodDevicesEntryV1{}
-	for _, entry := range entries {
-		deviceIDs := []string{}
-		for _, perNUMANodeDevIDs := range entry.DeviceIDs {
-			deviceIDs = append(deviceIDs, perNUMANodeDevIDs...)
-		}
-		entriesv1 = append(entriesv1, checkpoint.PodDevicesEntryV1{
-			PodUID:        entry.PodUID,
-			ContainerName: entry.ContainerName,
-			ResourceName:  entry.ResourceName,
-			DeviceIDs:     deviceIDs,
-			AllocResp:     entry.AllocResp,
-		})
-	}
-	return entriesv1
-}
-
-func stringifyContainerDevices(devs []*kubeletpodresourcesv1.ContainerDevices) string {
-	entries := []string{}
-	for _, dev := range devs {
-		devIDs := dev.GetDeviceIds()
-		if devIDs != nil {
-			for _, devID := range dev.DeviceIds {
-				nodes := dev.GetTopology().GetNodes()
-				if nodes != nil {
-					for _, node := range nodes {
-						entries = append(entries, fmt.Sprintf("%s[%s]@NUMA=%d", dev.ResourceName, devID, node.GetID()))
-					}
-				} else {
-					entries = append(entries, fmt.Sprintf("%s[%s]@NUMA=none", dev.ResourceName, devID))
-				}
-			}
-		} else {
-			entries = append(entries, dev.ResourceName)
-		}
-	}
-	sort.Strings(entries)
-	return strings.Join(entries, ", ")
-}
 
 func makeBusyboxDeviceRequiringPod(resourceName, cmd string) *v1.Pod {
 	podName := "device-manager-test-" + string(uuid.NewUUID())

--- a/test/e2e_node/device_plugin_test.go
+++ b/test/e2e_node/device_plugin_test.go
@@ -113,7 +113,7 @@ func testDevicePlugin(f *framework.Framework, pluginSockDir string) {
 			// This is done in a gomega.Eventually with retries since a prior test in a different test suite could've run and the deletion of it's resources may still be in progress.
 			// xref: https://issue.k8s.io/115381
 			gomega.Eventually(ctx, func(ctx context.Context) error {
-				v1PodResources, err = getV1NodeDevices(ctx)
+				v1PodResources, err = GetV1NodeDevices(ctx)
 				if err != nil {
 					return fmt.Errorf("failed to get node local podresources by accessing the (v1) podresources API endpoint: %v", err)
 				}
@@ -179,7 +179,7 @@ func testDevicePlugin(f *framework.Framework, pluginSockDir string) {
 			framework.ExpectNoError(err, "getting logs for pod %q", pod1.Name)
 			gomega.Expect(devID1).To(gomega.Not(gomega.Equal("")), "pod1 requested a device but started successfully without")
 
-			v1PodResources, err = getV1NodeDevices(ctx)
+			v1PodResources, err = GetV1NodeDevices(ctx)
 			framework.ExpectNoError(err)
 
 			framework.Logf("v1PodResources.PodResources:%+v\n", v1PodResources.PodResources)
@@ -247,7 +247,7 @@ func testDevicePlugin(f *framework.Framework, pluginSockDir string) {
 			// crosscheck from the device assignment is preserved and stable from perspective of the kubelet.
 			// needs to match the container perspective.
 			ginkgo.By("Verifying the device assignment after container restart using podresources API")
-			v1PodResources, err = getV1NodeDevices(ctx)
+			v1PodResources, err = GetV1NodeDevices(ctx)
 			if err != nil {
 				framework.ExpectNoError(err, "getting pod resources assignment after pod restart")
 			}
@@ -266,7 +266,7 @@ func testDevicePlugin(f *framework.Framework, pluginSockDir string) {
 			gomega.Expect(devID2).To(gomega.Not(gomega.Equal("")), "pod2 requested a device but started successfully without")
 
 			ginkgo.By("Verifying the device assignment after extra container start using podresources API")
-			v1PodResources, err = getV1NodeDevices(ctx)
+			v1PodResources, err = GetV1NodeDevices(ctx)
 			if err != nil {
 				framework.ExpectNoError(err, "getting pod resources assignment after pod restart")
 			}
@@ -323,7 +323,7 @@ func testDevicePlugin(f *framework.Framework, pluginSockDir string) {
 			// is useless.
 			ginkgo.By("Verifying the device assignment after kubelet restart using podresources API")
 			gomega.Eventually(ctx, func() error {
-				v1PodResources, err = getV1NodeDevices(ctx)
+				v1PodResources, err = GetV1NodeDevices(ctx)
 				return err
 			}, 30*time.Second, framework.Poll).ShouldNot(gomega.HaveOccurred(), "cannot fetch the compute resource assignment after kubelet restart")
 
@@ -388,7 +388,7 @@ func testDevicePlugin(f *framework.Framework, pluginSockDir string) {
 
 			ginkgo.By("Verifying the device assignment after pod and kubelet restart using podresources API")
 			gomega.Eventually(ctx, func() error {
-				v1PodResources, err = getV1NodeDevices(ctx)
+				v1PodResources, err = GetV1NodeDevices(ctx)
 				return err
 			}, 30*time.Second, framework.Poll).ShouldNot(gomega.HaveOccurred(), "cannot fetch the compute resource assignment after kubelet restart")
 
@@ -442,7 +442,7 @@ func testDevicePlugin(f *framework.Framework, pluginSockDir string) {
 			// is useless.
 			ginkgo.By("Verifying the device assignment after device plugin restart using podresources API")
 			gomega.Eventually(ctx, func() error {
-				v1PodResources, err = getV1NodeDevices(ctx)
+				v1PodResources, err = GetV1NodeDevices(ctx)
 				return err
 			}, 30*time.Second, framework.Poll).ShouldNot(gomega.HaveOccurred(), "cannot fetch the compute resource assignment after kubelet restart")
 
@@ -484,7 +484,7 @@ func testDevicePlugin(f *framework.Framework, pluginSockDir string) {
 			// is useless.
 			ginkgo.By("Verifying the device assignment after kubelet restart using podresources API")
 			gomega.Eventually(ctx, func() error {
-				v1PodResources, err = getV1NodeDevices(ctx)
+				v1PodResources, err = GetV1NodeDevices(ctx)
 				return err
 			}, 30*time.Second, framework.Poll).ShouldNot(gomega.HaveOccurred(), "cannot fetch the compute resource assignment after kubelet restart")
 
@@ -565,7 +565,7 @@ func testDevicePlugin(f *framework.Framework, pluginSockDir string) {
 
 			ginkgo.By("Verifying the device assignment after device plugin restart using podresources API")
 			gomega.Eventually(ctx, func() error {
-				v1PodResources, err = getV1NodeDevices(ctx)
+				v1PodResources, err = GetV1NodeDevices(ctx)
 				return err
 			}, 30*time.Second, framework.Poll).ShouldNot(gomega.HaveOccurred(), "cannot fetch the compute resource assignment after kubelet restart")
 			err, allocated := checkPodResourcesAssignment(v1PodResources, pod.Namespace, pod.Name, pod.Spec.Containers[0].Name, SampleDeviceResourceName, []string{})
@@ -634,7 +634,7 @@ func testDevicePlugin(f *framework.Framework, pluginSockDir string) {
 
 			gomega.Expect(devID3).NotTo(gomega.Equal(devID2), "pod1's restartable init container and regular container should not share the same device")
 
-			podResources, err := getV1NodeDevices(ctx)
+			podResources, err := GetV1NodeDevices(ctx)
 			framework.ExpectNoError(err)
 
 			framework.Logf("PodResources.PodResources:%+v\n", podResources.PodResources)
@@ -694,7 +694,7 @@ func testDevicePluginNodeReboot(f *framework.Framework, pluginSockDir string) {
 			// This is done in a gomega.Eventually with retries since a prior test in a different test suite could've run and the deletion of it's resources may still be in progress.
 			// xref: https://issue.k8s.io/115381
 			gomega.Eventually(ctx, func(ctx context.Context) error {
-				v1PodResources, err = getV1NodeDevices(ctx)
+				v1PodResources, err = GetV1NodeDevices(ctx)
 				if err != nil {
 					return fmt.Errorf("failed to get node local podresources by accessing the (v1) podresources API endpoint: %v", err)
 				}
@@ -858,7 +858,7 @@ func testDevicePluginNodeReboot(f *framework.Framework, pluginSockDir string) {
 			// is useless.
 			ginkgo.By("Verifying the device assignment after kubelet restart using podresources API")
 			gomega.Eventually(ctx, func() error {
-				v1PodResources, err = getV1NodeDevices(ctx)
+				v1PodResources, err = GetV1NodeDevices(ctx)
 				return err
 			}, 30*time.Second, framework.Poll).ShouldNot(gomega.HaveOccurred(), "cannot fetch the compute resource assignment after kubelet restart")
 

--- a/test/e2e_node/memory_manager_test.go
+++ b/test/e2e_node/memory_manager_test.go
@@ -378,11 +378,7 @@ var _ = SIGDescribe("Memory Manager", framework.WithDisruptive(), framework.With
 
 		// TODO: move the test to pod resource API test suite, see - https://github.com/kubernetes/kubernetes/issues/101945
 		ginkgo.It("should report memory data during request to pod resources GetAllocatableResources", func(ctx context.Context) {
-			endpoint, err := util.LocalEndpoint(defaultPodResourcesPath, podresources.Socket)
-			framework.ExpectNoError(err)
-
-			cli, conn, err := podresources.GetV1Client(endpoint, defaultPodResourcesTimeout, defaultPodResourcesMaxSize)
-			framework.ExpectNoError(err)
+			cli, conn := MustGetPodResourcesClient(context.TODO(), podresourcesDefaultTestTimeout)
 			defer conn.Close()
 
 			resp, err := cli.GetAllocatableResources(ctx, &kubeletpodresourcesv1.AllocatableResourcesRequest{})

--- a/test/e2e_node/util.go
+++ b/test/e2e_node/util.go
@@ -155,12 +155,16 @@ func getV1NodeDevices(ctx context.Context) (*kubeletpodresourcesv1.ListPodResour
 		return nil, fmt.Errorf("Error getting gRPC client: %w", err)
 	}
 	defer conn.Close()
+	framework.Logf("podresources gRPC client available")
+
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 	resp, err := client.List(ctx, &kubeletpodresourcesv1.ListPodResourcesRequest{})
 	if err != nil {
-		return nil, fmt.Errorf("%v.Get(_) = _, %v", client, err)
+		return nil, fmt.Errorf("%v.List(_) = _, %v", client, err)
 	}
+	framework.Logf("podresources List call done (%d entries)", len(resp.PodResources))
+
 	return resp, nil
 }
 

--- a/test/e2e_node/util.go
+++ b/test/e2e_node/util.go
@@ -471,18 +471,6 @@ func stopKubelet() func() {
 	}
 }
 
-// killKubelet sends a signal (SIGINT, SIGSTOP, SIGTERM...) to the running kubelet
-func killKubelet(sig string) {
-	kubeletServiceName := findKubeletServiceName(true)
-
-	// reset the kubelet service start-limit-hit
-	stdout, err := exec.Command("sudo", "systemctl", "reset-failed", kubeletServiceName).CombinedOutput()
-	framework.ExpectNoError(err, "Failed to reset kubelet start-limit-hit with systemctl: %v, %v", err, stdout)
-
-	stdout, err = exec.Command("sudo", "systemctl", "kill", "-s", sig, kubeletServiceName).CombinedOutput()
-	framework.ExpectNoError(err, "Failed to stop kubelet with systemctl: %v, %v", err, stdout)
-}
-
 func kubeletHealthCheck(url string) bool {
 	insecureTransport := http.DefaultTransport.(*http.Transport).Clone()
 	insecureTransport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}

--- a/test/e2e_node/util.go
+++ b/test/e2e_node/util.go
@@ -49,7 +49,6 @@ import (
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/klog/v2"
 	kubeletpodresourcesv1 "k8s.io/kubelet/pkg/apis/podresources/v1"
-	kubeletpodresourcesv1alpha1 "k8s.io/kubelet/pkg/apis/podresources/v1alpha1"
 	stats "k8s.io/kubelet/pkg/apis/stats/v1alpha1"
 	"k8s.io/kubelet/pkg/types"
 	"k8s.io/kubernetes/pkg/cluster/ports"
@@ -124,25 +123,6 @@ func getNodeSummary(ctx context.Context) (*stats.Summary, error) {
 		return nil, fmt.Errorf("failed to parse /stats/summary to go struct: %+v", resp)
 	}
 	return &summary, nil
-}
-
-func getV1alpha1NodeDevices(ctx context.Context) (*kubeletpodresourcesv1alpha1.ListPodResourcesResponse, error) {
-	endpoint, err := util.LocalEndpoint(defaultPodResourcesPath, podresources.Socket)
-	if err != nil {
-		return nil, fmt.Errorf("Error getting local endpoint: %w", err)
-	}
-	client, conn, err := podresources.GetV1alpha1Client(endpoint, defaultPodResourcesTimeout, defaultPodResourcesMaxSize)
-	if err != nil {
-		return nil, fmt.Errorf("Error getting grpc client: %w", err)
-	}
-	defer conn.Close()
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
-	defer cancel()
-	resp, err := client.List(ctx, &kubeletpodresourcesv1alpha1.ListPodResourcesRequest{})
-	if err != nil {
-		return nil, fmt.Errorf("%v.Get(_) = _, %v", client, err)
-	}
-	return resp, nil
 }
 
 func getV1NodeDevices(ctx context.Context) (*kubeletpodresourcesv1.ListPodResourcesResponse, error) {

--- a/test/e2e_node/util.go
+++ b/test/e2e_node/util.go
@@ -48,16 +48,13 @@ import (
 	internalapi "k8s.io/cri-api/pkg/apis"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/klog/v2"
-	kubeletpodresourcesv1 "k8s.io/kubelet/pkg/apis/podresources/v1"
 	stats "k8s.io/kubelet/pkg/apis/stats/v1alpha1"
 	"k8s.io/kubelet/pkg/types"
 	"k8s.io/kubernetes/pkg/cluster/ports"
 	kubeletconfig "k8s.io/kubernetes/pkg/kubelet/apis/config"
-	"k8s.io/kubernetes/pkg/kubelet/apis/podresources"
 	"k8s.io/kubernetes/pkg/kubelet/cm"
 	"k8s.io/kubernetes/pkg/kubelet/cri/remote"
 	kubeletmetrics "k8s.io/kubernetes/pkg/kubelet/metrics"
-	"k8s.io/kubernetes/pkg/kubelet/util"
 
 	"github.com/coreos/go-systemd/v22/dbus"
 	"k8s.io/kubernetes/test/e2e/framework"
@@ -123,29 +120,6 @@ func getNodeSummary(ctx context.Context) (*stats.Summary, error) {
 		return nil, fmt.Errorf("failed to parse /stats/summary to go struct: %+v", resp)
 	}
 	return &summary, nil
-}
-
-func getV1NodeDevices(ctx context.Context) (*kubeletpodresourcesv1.ListPodResourcesResponse, error) {
-	endpoint, err := util.LocalEndpoint(defaultPodResourcesPath, podresources.Socket)
-	if err != nil {
-		return nil, fmt.Errorf("Error getting local endpoint: %w", err)
-	}
-	client, conn, err := podresources.GetV1Client(endpoint, defaultPodResourcesTimeout, defaultPodResourcesMaxSize)
-	if err != nil {
-		return nil, fmt.Errorf("Error getting gRPC client: %w", err)
-	}
-	defer conn.Close()
-	framework.Logf("podresources gRPC client available")
-
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
-	defer cancel()
-	resp, err := client.List(ctx, &kubeletpodresourcesv1.ListPodResourcesRequest{})
-	if err != nil {
-		return nil, fmt.Errorf("%v.List(_) = _, %v", client, err)
-	}
-	framework.Logf("podresources List call done (%d entries)", len(resp.PodResources))
-
-	return resp, nil
 }
 
 // Returns the current KubeletConfiguration


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind flake

#### What this PR does / why we need it:
Add a facility to make sure (as  much as the gRPC libs allow to know) podresources client over gRPC is connected before to attempt any call. The intent is to minimize/reduce
```
rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: dial unix /var/lib/kubelet/pod-resources/kubelet.sock: connect: connection refused": rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: dial unix /var/lib/kubelet/pod-resources/kubelet.sock: connect: connection refused"
```
which create noise and flakes in the logs

#### Which issue(s) this PR fixes:
Related to #119602

#### Special notes for your reviewer:
second try after https://github.com/kubernetes/kubernetes/pull/121261

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
