### PR TITLE
fix issue with using feature HonorPVReclaimPolicy in csi-provisioner

### DIFF
--- a/pkg/controller/volume/persistentvolume/delete_test.go
+++ b/pkg/controller/volume/persistentvolume/delete_test.go
@@ -148,9 +148,9 @@ func TestDeleteSync(t *testing.T) {
 		},
 		{
 			// PV requires external deleter
-			name:            "8-10 - external deleter",
-			initialVolumes:  []*v1.PersistentVolume{newExternalProvisionedVolume("volume8-10", "1Gi", "uid10-1", "claim10-1", v1.VolumeBound, v1.PersistentVolumeReclaimDelete, classEmpty, gceDriver, nil, volume.AnnBoundByController)},
-			expectedVolumes: []*v1.PersistentVolume{newExternalProvisionedVolume("volume8-10", "1Gi", "uid10-1", "claim10-1", v1.VolumeReleased, v1.PersistentVolumeReclaimDelete, classEmpty, gceDriver, nil, volume.AnnBoundByController)},
+			name:            "8-10-1 - external deleter when volume is dynamic provisioning",
+			initialVolumes:  []*v1.PersistentVolume{newExternalProvisionedVolume("volume8-10-1", "1Gi", "uid10-1-1", "claim10-1-1", v1.VolumeBound, v1.PersistentVolumeReclaimDelete, classEmpty, gceDriver, nil, volume.AnnBoundByController)},
+			expectedVolumes: []*v1.PersistentVolume{newExternalProvisionedVolume("volume8-10-1", "1Gi", "uid10-1-1", "claim10-1-1", v1.VolumeReleased, v1.PersistentVolumeReclaimDelete, classEmpty, gceDriver, nil, volume.AnnBoundByController)},
 			initialClaims:   noclaims,
 			expectedClaims:  noclaims,
 			expectedEvents:  noevents,
@@ -161,6 +161,28 @@ func TestDeleteSync(t *testing.T) {
 				test.expectedVolumes[0].Annotations[volume.AnnDynamicallyProvisioned] = "external.io/test"
 				return testSyncVolume(ctrl, reactor, test)
 			},
+		},
+		{
+			// PV requires external deleter
+			name:            "8-10-2 - external deleter when volume is static provisioning",
+			initialVolumes:  []*v1.PersistentVolume{newExternalProvisionedVolume("volume8-10-2", "1Gi", "uid10-1-2", "claim10-1-2", v1.VolumeBound, v1.PersistentVolumeReclaimDelete, classEmpty, gceDriver, nil, volume.AnnBoundByController)},
+			expectedVolumes: []*v1.PersistentVolume{newExternalProvisionedVolume("volume8-10-2", "1Gi", "uid10-1-2", "claim10-1-2", v1.VolumeReleased, v1.PersistentVolumeReclaimDelete, classEmpty, gceDriver, nil, volume.AnnBoundByController)},
+			initialClaims:   noclaims,
+			expectedClaims:  noclaims,
+			expectedEvents:  noevents,
+			errors:          noerrors,
+			test:            testSyncVolume,
+		},
+		{
+			// PV requires external deleter
+			name:            "8-10-3 - external deleter when volume is migrated",
+			initialVolumes:  []*v1.PersistentVolume{volumeWithAnnotation(volume.AnnMigratedTo, "pd.csi.storage.gke.io", volumeWithAnnotation(volume.AnnDynamicallyProvisioned, "kubernetes.io/gce-pd", newVolume("volume8-10-3", "1Gi", "uid10-1-3", "claim10-1-3", v1.VolumeBound, v1.PersistentVolumeReclaimDelete, classEmpty, volume.AnnDynamicallyProvisioned)))},
+			expectedVolumes: []*v1.PersistentVolume{volumeWithAnnotation(volume.AnnMigratedTo, "pd.csi.storage.gke.io", volumeWithAnnotation(volume.AnnDynamicallyProvisioned, "kubernetes.io/gce-pd", newVolume("volume8-10-3", "1Gi", "uid10-1-3", "claim10-1-3", v1.VolumeReleased, v1.PersistentVolumeReclaimDelete, classEmpty, volume.AnnDynamicallyProvisioned)))},
+			initialClaims:   noclaims,
+			expectedClaims:  noclaims,
+			expectedEvents:  noevents,
+			errors:          noerrors,
+			test:            testSyncVolume,
 		},
 		{
 			// delete success - two PVs are provisioned for a single claim.

--- a/pkg/controller/volume/persistentvolume/pv_controller.go
+++ b/pkg/controller/volume/persistentvolume/pv_controller.go
@@ -1952,6 +1952,18 @@ func (ctrl *PersistentVolumeController) findDeletablePlugin(volume *v1.Persisten
 		}
 	}
 
+	if utilfeature.DefaultFeatureGate.Enabled(features.HonorPVReclaimPolicy) {
+		if metav1.HasAnnotation(volume.ObjectMeta, storagehelpers.AnnMigratedTo) {
+			// CSI migration scenario - do not depend on in-tree plugin
+			return nil, nil
+		}
+
+		if volume.Spec.CSI != nil {
+			// CSI volume source scenario - external provisioner is requested
+			return nil, nil
+		}
+	}
+
 	// The plugin that provisioned the volume was not found or the volume
 	// was not dynamically provisioned. Try to find a plugin by spec.
 	spec := vol.NewSpecFromPersistentVolume(volume, false)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

For the volume statically provisioned by user who create the pv with an existing class, according to the current implementation of the findDeletablePlugin func, the func will return the an error if the volume does not be annotated with the pv.kubernetes.io/provisioned-by annotaion.

The annotation is automatically added to a pv that has been dynamically provsioned by either the pv controller or an external provisioner. Its value is name of volume plugin or provisioner that creates the volume. Its serves both user (to slow where a PV comes from) and Kubernetes (to recongize dynamically provisioned PVs in its decisions). 

If a pv is annotated and its annoation value doesn't contain the 'kuberentes.io/', the external provsioner will handle the pv when the pv is deleted after the pv is marked as Released. If a pv is not annotated, the pv controller will treat it as statically provisioned and try to find a in-tree plugin to handle it by volume spec. If no suitable plugin is found, the pv controller will mark the pv as failed with the error that is no deletable volume plugin matched.

In this issue, the pv is created by users with a csi type. So the volume won't be never annotated even through the pv has specified an existing storageclass. so when the pv is deleted, the pv controller will mark it as Failed.

the [KEP-2644](https://github.com/kubernetes/enhancements/tree/master/keps/sig-storage/2644-honor-pv-reclaim-policy) introduces a new finalizer `external-provisioner.volume.kubernetes.io/finalizer` to honor pv's reclaim policy whatever the pv is dynamically or statically provsioned. 

For statically provsioned pvs, if its volume source is csi, the pv controller cannot find a plugin by volume spec because this csi plugin does not implemenet the DeletableVolumePlugin interface. Those pvs deletion behavior is expected to be handled by the external provisioner. however, the current implement of the findDeletablePlugin func cannot recognize this situation and wrongly changes the volume phase from Release to Fail when the pv controller watches the pv deletion event or the resync period is reached, the pv is put into queue and then handle by the syncVolume func.

In the log pasted by @reenakabra, we can see that the external provsioner do delete pv and try to remove the finalizer but failed due to the resourceVersion conflict. even though the external provsioner retries its job but the pv phase may have been changed to Failed. Once a pv state is not Release, the external provisioner won't be able to remove the pv's finalizers in subsequent reconcile cycles. So the pv deletion will be stuck forever due to the finalizer existing.

In order to fix this issue, the findDeletablePlugin func should recongize the volume which may be able to handled by an external provioner when the volume source is csi or the pv has migrated annotation whatever the pv is dynamically or statically provsioned. 

With this patch, the pv controller won't changes PV's phase to Failed and the external provisioner can remove the finalizer in next reconcile loop. Unfortunately if the provious existing pv has the Failed state, this patch won't take effort. It requires users to remove finalizer.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #121799 

#### Special notes for your reviewer:

Should we do cherry-pick it into pervious releases?

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
For statically provisioned PVs, if its volume source is CSI type or it has migrated annotation, when it's deleted, the PersisentVolume controller won't changes its phase to the Failed state. 

With this patch, the external provisioner can remove the finalizer in next reconcile loop. Unfortunately if the provious existing pv has the Failed state, this patch won't take effort. It requires users to remove finalizer.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/2644
```
