### PR TITLE
Add a hack to iptables kube-proxy to work around certain missed updates

### DIFF
--- a/pkg/proxy/endpoints.go
+++ b/pkg/proxy/endpoints.go
@@ -200,6 +200,9 @@ func (ect *EndpointsChangeTracker) EndpointSliceUpdate(endpointSlice *discovery.
 			ect.lastChangeTriggerTimes[namespacedName] =
 				append(ect.lastChangeTriggerTimes[namespacedName], t)
 		}
+		klog.V(4).InfoS("EndpointSlice updated", "service", namespacedName, "endpointSlice", klog.KObj(endpointSlice))
+	} else {
+		klog.V(4).InfoS("EndpointSlice update does not affect proxying", "service", namespacedName, "endpointSlice", klog.KObj(endpointSlice))
 	}
 
 	return changeNeeded

--- a/pkg/proxy/metrics/metrics.go
+++ b/pkg/proxy/metrics/metrics.go
@@ -160,6 +160,18 @@ var (
 		},
 	)
 
+	// IptablesPartialRestoreMistakesTotal is the number of mistakes in partial
+	// restore handling (expecting that it can do a partial restore but discovering
+	// that chains are actually missing) that the proxy has seen.
+	IptablesPartialRestoreMistakesTotal = metrics.NewCounter(
+		&metrics.CounterOpts{
+			Subsystem:      kubeProxySubsystem,
+			Name:           "sync_proxy_rules_iptables_partial_restore_mistakes_total",
+			Help:           "Cumulative proxy iptables partial restore mistakes",
+			StabilityLevel: metrics.ALPHA,
+		},
+	)
+
 	// IptablesRulesTotal is the total number of iptables rules that the iptables
 	// proxy has installed.
 	IptablesRulesTotal = metrics.NewGaugeVec(
@@ -252,6 +264,7 @@ func RegisterMetrics() {
 		legacyregistry.MustRegister(IptablesRulesLastSync)
 		legacyregistry.MustRegister(IptablesRestoreFailuresTotal)
 		legacyregistry.MustRegister(IptablesPartialRestoreFailuresTotal)
+		legacyregistry.MustRegister(IptablesPartialRestoreMistakesTotal)
 		legacyregistry.MustRegister(SyncProxyRulesLastQueuedTimestamp)
 		legacyregistry.MustRegister(SyncProxyRulesNoLocalEndpointsTotal)
 		legacyregistry.MustRegister(ProxyHealthzTotal)

--- a/pkg/proxy/service.go
+++ b/pkg/proxy/service.go
@@ -324,6 +324,7 @@ func (sct *ServiceChangeTracker) Update(previous, current *v1.Service) bool {
 	// if change.previous equal to change.current, it means no change
 	if reflect.DeepEqual(change.previous, change.current) {
 		delete(sct.items, namespacedName)
+		klog.V(4).InfoS("Service update does not affect proxying", "service", klog.KObj(svc))
 	} else {
 		klog.V(4).InfoS("Service updated ports", "service", klog.KObj(svc), "portCount", len(change.current))
 	}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/kind regression
/priority important-soon
/sig network

#### What this PR does / why we need it:
This is an attempt to mitigate #121362; if we notice that we were about to skip an update for a service that is currently missing endpoints we believe it should have, then we un-skip it.

This also adds some more debugging to hopefully help us figure out how this is happening.

I intend to backport this to 1.29, 1.28, and 1.27.

#### Which issue(s) this PR fixes:
This is a mitigation for #121362 but not a proper fix.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
kube-proxy in iptables mode now attempts to work around a bug that could cause it to sometimes fail to sync newly-added endpoints for an existing service. The underlying bug is not yet fixed.
```

/assign @aojea 