### PR TITLE
Optimize non-leader by using cached leases to reduce request calls

### DIFF
--- a/staging/src/k8s.io/client-go/tools/leaderelection/healthzadaptor_test.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/healthzadaptor_test.go
@@ -37,6 +37,11 @@ func (fl *fakeLock) Get(ctx context.Context) (ler *rl.LeaderElectionRecord, rawR
 	return nil, nil, nil
 }
 
+// GetFromCache is a dummy to allow us to have a fakeLock for testing.
+func (fl *fakeLock) GetFromCache(ctx context.Context) (ler *rl.LeaderElectionRecord, rawRecord []byte, err error) {
+	return nil, nil, nil
+}
+
 // Create is a dummy to allow us to have a fakeLock for testing.
 func (fl *fakeLock) Create(ctx context.Context, ler rl.LeaderElectionRecord) error {
 	return nil
@@ -46,6 +51,9 @@ func (fl *fakeLock) Create(ctx context.Context, ler rl.LeaderElectionRecord) err
 func (fl *fakeLock) Update(ctx context.Context, ler rl.LeaderElectionRecord) error {
 	return nil
 }
+
+// StartSync is a dummy to allow us to have a fakeLock for testing.
+func (fl *fakeLock) StartSync(_ <-chan struct{}) {}
 
 // RecordEvent is a dummy to allow us to have a fakeLock for testing.
 func (fl *fakeLock) RecordEvent(string) {}

--- a/staging/src/k8s.io/client-go/tools/leaderelection/resourcelock/multilock.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/resourcelock/multilock.go
@@ -60,6 +60,12 @@ func (ml *MultiLock) Get(ctx context.Context) (*LeaderElectionRecord, []byte, er
 	return primary, ConcatRawRecord(primaryRaw, secondaryRaw), nil
 }
 
+// TODO(linxiulei): support MultiLock
+// GetFromCache returns the older election record of the lock
+func (ml *MultiLock) GetFromCache(ctx context.Context) (*LeaderElectionRecord, []byte, error) {
+	return ml.Get(ctx)
+}
+
 // Create attempts to create both primary lock and secondary lock
 func (ml *MultiLock) Create(ctx context.Context, ler LeaderElectionRecord) error {
 	err := ml.Primary.Create(ctx, ler)
@@ -97,6 +103,11 @@ func (ml *MultiLock) Describe() string {
 // Identity returns the Identity of the lock
 func (ml *MultiLock) Identity() string {
 	return ml.Primary.Identity()
+}
+
+// TODO(linxiulei): support MultiLock
+// StartSync
+func (ml *MultiLock) StartSync(_ context.Context) {
 }
 
 func ConcatRawRecord(primaryRaw, secondaryRaw []byte) []byte {

--- a/staging/src/k8s.io/dynamic-resource-allocation/leaderelection/leaderelection.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/leaderelection/leaderelection.go
@@ -187,7 +187,7 @@ func (l *leaderElection) Run() error {
 		EventRecorder: eventRecorder,
 	}
 
-	lock, err := resourcelock.New(l.resourceLock, l.namespace, sanitizeName(l.lockName), l.clientset.CoreV1(), l.clientset.CoordinationV1(), rlConfig)
+	lock, err := resourcelock.NewFromKubeclient(l.resourceLock, l.namespace, sanitizeName(l.lockName), l.clientset, rlConfig)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR makes leader election client to maintain a lease informer to asynchronously cache leader lease for non-leaders to check if they want to acquire the lock (i.e. elect oneself to be the leader). Getting the current lease from cache instead of requesting from APIServer and ETCD would reduce the overhead to k8s control plane and optimize the performance.

#### Which issue(s) this PR fixes:

Fixes #121806

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
TODO
```
