### PR TITLE
Remove timeout before serving watch

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/get.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/get.go
@@ -258,8 +258,10 @@ func ListResource(r rest.Lister, rw rest.Watcher, scope *RequestScope, forceWatc
 				timeout = time.Duration(float64(minRequestTimeout) * (rand.Float64() + 1.0))
 			}
 			klog.V(3).InfoS("Starting watch", "path", req.URL.Path, "resourceVersion", opts.ResourceVersion, "labels", opts.LabelSelector, "fields", opts.FieldSelector, "timeout", timeout)
-			ctx, cancel := context.WithTimeout(ctx, timeout)
-			defer cancel()
+			// We don't cancel ctx explicitly because
+			//   1) a timeout is only needed to prevent rw.Watch from running forever
+			//   2) serveWatch respects the timeout and closes the watcher
+			ctx, _ := context.WithTimeout(ctx, timeout)
 			watcher, err := rw.Watch(ctx, &opts)
 			if err != nil {
 				scope.err(err, w, req)


### PR DESCRIPTION
It's redundant after watch serving has timeout handling


#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

