### PR TITLE
feat(kubectl/pkg/drain): validate helper output fields to non-nil

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/drain/default.go
+++ b/staging/src/k8s.io/kubectl/pkg/drain/default.go
@@ -30,18 +30,18 @@ import (
 // example if you want different output behaviour.
 
 var (
-	nilHelperOutNilError    = errors.New("RunNodeDrain error: drain.Helper.Out can't be nil")
-	nilHelperErrOutNilError = errors.New("RunNodeDrain error: drain.Helper.ErrOut can't be nil")
+	errHelperOutNil    = errors.New("RunNodeDrain error: drain.Helper.Out can't be nil")
+	errHelperErrOutNil = errors.New("RunNodeDrain error: drain.Helper.ErrOut can't be nil")
 )
 
 // RunNodeDrain shows the canonical way to drain a node.
 // You should first cordon the node, e.g. using RunCordonOrUncordon
 func RunNodeDrain(drainer *Helper, nodeName string) error {
 	if drainer.Out == nil {
-		return nilHelperOutNilError
+		return errHelperOutNil
 	}
 	if drainer.ErrOut == nil {
-		return nilHelperErrOutNilError
+		return errHelperErrOutNil
 	}
 
 	// TODO(justinsb): Ensure we have adequate e2e coverage of this function in library consumers

--- a/staging/src/k8s.io/kubectl/pkg/drain/default.go
+++ b/staging/src/k8s.io/kubectl/pkg/drain/default.go
@@ -17,6 +17,7 @@ limitations under the License.
 package drain
 
 import (
+	"errors"
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
@@ -28,9 +29,21 @@ import (
 // directly, or their functionality copied into your own code, for
 // example if you want different output behaviour.
 
+var (
+	nilHelperOutNilError    = errors.New("RunNodeDrain error: drain.Helper.Out can't be nil")
+	nilHelperErrOutNilError = errors.New("RunNodeDrain error: drain.Helper.ErrOut can't be nil")
+)
+
 // RunNodeDrain shows the canonical way to drain a node.
 // You should first cordon the node, e.g. using RunCordonOrUncordon
 func RunNodeDrain(drainer *Helper, nodeName string) error {
+	if drainer.Out == nil {
+		return nilHelperOutNilError
+	}
+	if drainer.ErrOut == nil {
+		return nilHelperErrOutNilError
+	}
+
 	// TODO(justinsb): Ensure we have adequate e2e coverage of this function in library consumers
 	list, errs := drainer.GetPodsForDeletion(nodeName)
 	if errs != nil {

--- a/staging/src/k8s.io/kubectl/pkg/drain/default_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/drain/default_test.go
@@ -38,7 +38,7 @@ func TestRunNodeDrain(t *testing.T) {
 				Client: fake.NewSimpleClientset(),
 				ErrOut: os.Stderr,
 			},
-			expectedError: &nilHelperOutNilError,
+			expectedError: &errHelperOutNil,
 		},
 		{
 			description: "nil drainer.ErrOut",
@@ -46,7 +46,7 @@ func TestRunNodeDrain(t *testing.T) {
 				Ctx: context.TODO(),
 				Out: os.Stderr,
 			},
-			expectedError: &nilHelperErrOutNilError,
+			expectedError: &errHelperErrOutNil,
 		},
 	}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Fixes the following panic:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x18 pc=0x1026631f8]

goroutine 925 [running]:
fmt.Fprintf({0x0, 0x0}, {0x105a8afe5, 0x13}, {0x14001457630, 0x2, 0x2})
	go/1.21.4/libexec/src/fmt/print.go:225 +0x58
k8s.io/kubectl/pkg/drain.(*Helper).evictPods.func1({{{0x105a4d8db, 0x3}, {0x105a4d096, 0x2}}, {{0x14000de06c0, 0x1b}, {0x140017c7650, 0x16}, {0x1400150c460, 0xc}, ...}, ...}, ...)
	go/pkg/mod/k8s.io/kubectl@v0.28.3/pkg/drain/drain.go:279 +0x188
created by k8s.io/kubectl/pkg/drain.(*Helper).evictPods in goroutine 909
	go/pkg/mod/k8s.io/kubectl@v0.28.3/pkg/drain/drain.go:272 +0xf8
```

#### Which issue(s) this PR fixes:

NONE

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
drain.RunNodeDrain now returns an error if Helper has missing output writer fields (rather than panic)
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

NONE
