### PR TITLE
add warning message for pv and pod when deprecated flexVolume is used

### DIFF
--- a/pkg/api/persistentvolume/util.go
+++ b/pkg/api/persistentvolume/util.go
@@ -95,5 +95,8 @@ func warningsForPersistentVolumeSpecAndMeta(fieldPath *field.Path, pvSpec *api.P
 	if pvSpec.RBD != nil {
 		warnings = append(warnings, fmt.Sprintf("%s: deprecated in v1.28, non-functional in v1.31+", fieldPath.Child("spec", "rbd")))
 	}
+	if pvSpec.FlexVolume != nil {
+		warnings = append(warnings, fmt.Sprintf("%s: deprecated in v1.23", fieldPath.Child("spec", "flexVolume")))
+	}
 	return warnings
 }

--- a/pkg/api/persistentvolume/util_test.go
+++ b/pkg/api/persistentvolume/util_test.go
@@ -232,6 +232,20 @@ func TestWarnings(t *testing.T) {
 				`spec.rbd: deprecated in v1.28, non-functional in v1.31+`},
 		},
 		{
+			name: "PV FlexVolume deprecation warning",
+			template: &api.PersistentVolume{
+				Spec: api.PersistentVolumeSpec{
+					PersistentVolumeSource: api.PersistentVolumeSource{
+						FlexVolume: &api.FlexPersistentVolumeSource{
+							Driver: "example/driver",
+						},
+					},
+				},
+			},
+			expected: []string{
+				`spec.flexVolume: deprecated in v1.23`},
+		},
+		{
 			name: "PV ScaleIO deprecation warning",
 			template: &api.PersistentVolume{
 				Spec: api.PersistentVolumeSpec{

--- a/pkg/api/pod/warnings.go
+++ b/pkg/api/pod/warnings.go
@@ -166,6 +166,9 @@ func warningsForPodSpecAndMeta(fieldPath *field.Path, podSpec *api.PodSpec, meta
 		if v.RBD != nil {
 			warnings = append(warnings, fmt.Sprintf("%s: deprecated in v1.28, non-functional in v1.31+", fieldPath.Child("spec", "volumes").Index(i).Child("rbd")))
 		}
+		if v.FlexVolume != nil {
+			warnings = append(warnings, fmt.Sprintf("%s: deprecated in v1.23", fieldPath.Child("spec", "volumes").Index(i).Child("flexVolume")))
+		}
 	}
 
 	// duplicate hostAliases (#91670, #58477)

--- a/pkg/api/pod/warnings_test.go
+++ b/pkg/api/pod/warnings_test.go
@@ -224,7 +224,6 @@ func TestWarnings(t *testing.T) {
 			},
 			expected: []string{`spec.volumes[0].cephfs: deprecated in v1.28, non-functional in v1.31+`},
 		},
-
 		{
 			name: "rbd",
 			template: &api.PodTemplateSpec{Spec: api.PodSpec{
@@ -233,6 +232,15 @@ func TestWarnings(t *testing.T) {
 				}},
 			},
 			expected: []string{`spec.volumes[0].rbd: deprecated in v1.28, non-functional in v1.31+`},
+		},
+		{
+			name: "flexVolume",
+			template: &api.PodTemplateSpec{Spec: api.PodSpec{
+				Volumes: []api.Volume{
+					{Name: "s", VolumeSource: api.VolumeSource{FlexVolume: &api.FlexVolumeSource{}}},
+				}},
+			},
+			expected: []string{`spec.volumes[0].flexVolume: deprecated in v1.23`},
 		},
 		{
 			name: "duplicate hostAlias",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

the flexVolume was deprecated in 1.23 without a warning message in k/k. this pr add a warning message for it.

FYI:
- https://github.com/kubernetes/sig-release/discussions/1709#discussioncomment-1515235
- https://github.com/kubernetes/website/issues/30180

/cc @xing-yang @sftim 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Add a warning message for PV and Pod when deprecated flexVolume is used. 
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
