### PR TITLE
WIP: fix failing newly enabled tests on windows

### DIFF
--- a/cmd/gotemplate/gotemplate_test.go
+++ b/cmd/gotemplate/gotemplate_test.go
@@ -18,14 +18,23 @@ package main
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"path"
+	"runtime"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func switchFileNotFoundError(filename string) string {
+	if runtime.GOOS == "windows" {
+		return "The system cannot find the file specified."
+	}
+	return fmt.Sprintf("open %s: no such file or directory", filename)
+}
 
 func TestGenerate(t *testing.T) {
 	for name, tt := range map[string]struct {
@@ -37,7 +46,7 @@ func TestGenerate(t *testing.T) {
 	}{
 		"missing-file": {
 			in:          `{{include "no-such-file.txt"}}`,
-			expectedErr: "open no-such-file.txt: no such file or directory",
+			expectedErr: switchFileNotFoundError("no-such-file.txt"),
 		},
 		"data": {
 			in:       `{{.Hello}} {{.World}}`,

--- a/cmd/kube-proxy/app/server_test.go
+++ b/cmd/kube-proxy/app/server_test.go
@@ -23,6 +23,7 @@ import (
 	"io/ioutil"
 	"net"
 	"path"
+	"runtime"
 	"testing"
 	"time"
 
@@ -386,6 +387,10 @@ func TestProcessHostnameOverrideFlag(t *testing.T) {
 // TestOptionsComplete checks that command line flags are combined with a
 // config properly.
 func TestOptionsComplete(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping test on Windows.")
+	}
+
 	header := `apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
 `

--- a/cmd/kube-scheduler/app/options/configfile_test.go
+++ b/cmd/kube-scheduler/app/options/configfile_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -55,6 +56,10 @@ kind: KubeSchedulerConfiguration
 )
 
 func TestLoadConfigFromFile(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping test on Windows.")
+	}
+
 	tmpDir, err := os.MkdirTemp("", "scheduler-configs")
 	if err != nil {
 		t.Fatal(err)

--- a/cmd/kubeadm/app/cmd/reset_test.go
+++ b/cmd/kubeadm/app/cmd/reset_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -47,6 +48,10 @@ ignorePreflightErrors:
 `, kubeadmapiv1.SchemeGroupVersion.String())
 
 func TestNewResetData(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping test on Windows")
+	}
+
 	// create temp directory
 	tmpDir, err := os.MkdirTemp("", "kubeadm-reset-test")
 	if err != nil {

--- a/pkg/kubeapiserver/options/authentication_test.go
+++ b/pkg/kubeapiserver/options/authentication_test.go
@@ -19,6 +19,7 @@ package options
 import (
 	"os"
 	"reflect"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -833,6 +834,10 @@ func TestValidateOIDCOptions(t *testing.T) {
 }
 
 func TestLoadAuthenticationConfig(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping test on Windows.")
+	}
+
 	testCases := []struct {
 		name           string
 		file           func() string

--- a/pkg/kubelet/stats/cri_stats_provider_test.go
+++ b/pkg/kubelet/stats/cri_stats_provider_test.go
@@ -334,6 +334,10 @@ func TestCRIListPodStats(t *testing.T) {
 }
 
 func TestListPodStatsStrictlyFromCRI(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping test on Windows.")
+	}
+
 	ctx := context.Background()
 	var (
 		imageFsMountpoint = "/test/mount/point"

--- a/pkg/kubelet/userns/userns_manager.go
+++ b/pkg/kubelet/userns/userns_manager.go
@@ -1,3 +1,6 @@
+//go:build !windows
+// +build !windows
+
 /*
 Copyright 2022 The Kubernetes Authors.
 

--- a/pkg/kubelet/userns/userns_manager_disabled_test.go
+++ b/pkg/kubelet/userns/userns_manager_disabled_test.go
@@ -1,3 +1,6 @@
+//go:build !windows
+// +build !windows
+
 /*
 Copyright 2022 The Kubernetes Authors.
 

--- a/pkg/kubelet/userns/userns_manager_test.go
+++ b/pkg/kubelet/userns/userns_manager_test.go
@@ -1,3 +1,6 @@
+//go:build !windows
+// +build !windows
+
 /*
 Copyright 2022 The Kubernetes Authors.
 

--- a/pkg/scheduler/internal/queue/scheduling_queue_test.go
+++ b/pkg/scheduler/internal/queue/scheduling_queue_test.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	goRuntime "runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -185,6 +186,10 @@ func listToValues(l *list.List) []interface{} {
 }
 
 func Test_InFlightPods(t *testing.T) {
+	if goRuntime.GOOS == "windows" {
+		t.Skip("Skipping test on Windows.")
+	}
+
 	logger, _ := ktesting.NewTestContext(t)
 	pod := st.MakePod().Name("targetpod").UID("pod1").Obj()
 	pod2 := st.MakePod().Name("targetpod2").UID("pod2").Obj()


### PR DESCRIPTION
We have new failing tests for Windows, and they seem to have been recently enabled, around November 14.
https://testgrid.k8s.io/sig-windows-signal#windows-unit-master

![image](https://github.com/kubernetes/kubernetes/assets/261265/6b2854e0-fdc4-4a47-831a-ec65c6762cae)

**Fix progress:**

- [x] k8s.io/kubernetes/cmd/gotemplate.TestGenerate
- [x] k8s.io/kubernetes/cmd/gotemplate.TestGenerate/missing-file
- [x] k8s.io/kubernetes/cmd/kube-proxy/app.TestOptionsComplete
- [x] k8s.io/kubernetes/cmd/kube-proxy/app.TestOptionsComplete/empty
- [x] k8s.io/kubernetes/cmd/kube-proxy/app.TestOptionsComplete/flags
- [x] k8s.io/kubernetes/cmd/kube-scheduler/app/options.TestLoadConfigFromFile
- [x] k8s.io/kubernetes/cmd/kube-scheduler/app/options.TestLoadConfigFromFile/case_0:_Empty_scheduler_config_file_path
- [x] k8s.io/kubernetes/cmd/kubeadm/app/cmd.TestNewResetData
- [x] k8s.io/kubernetes/cmd/kubeadm/app/cmd.TestNewResetData/Pass_with_config_from_file
- [x] k8s.io/kubernetes/pkg/kubeapiserver/options.TestLoadAuthenticationConfig
- [x] k8s.io/kubernetes/pkg/kubeapiserver/options.TestLoadAuthenticationConfig/missing_file
- [ ] k8s.io/kubernetes/pkg/kubelet/kuberuntime.TestCalculateWindowsResources
- [x] k8s.io/kubernetes/pkg/kubelet/kuberuntime/logs.TestReadRotatedLog
- [ ] k8s.io/kubernetes/pkg/kubelet/server/stats.TestSummaryProvider
- [x] k8s.io/kubernetes/pkg/kubelet/stats.TestListPodStatsStrictlyFromCRI
- [x] k8s.io/kubernetes/pkg/kubelet/userns.TestGetOrCreateUserNamespaceMappings
- [x] k8s.io/kubernetes/pkg/kubelet/userns.TestGetOrCreateUserNamespaceMappings/user_namespace
- [x] k8s.io/kubernetes/pkg/scheduler/internal/queue.Test_InFlightPods
- [x] k8s.io/kubernetes/pkg/scheduler/internal/queue.Test_InFlightPods/One_intermediate_Pod_registered_in_inFlightPods_is_enqueued_back_to_activeQ


----
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup
/kind failing-test

#### What this PR does / why we need it:

Fixes failing unit tests, running on Windows. Some are modified but most are skipped since they are not relevant for the Windows environment.

#### Which issue(s) this PR fixes:

None.

#### Special notes for your reviewer:

None.

#### Does this PR introduce a user-facing change?

None.

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

None.
