### PR TITLE
Automated cherry pick of #119825: Move adding GroupVersion log until after an update is

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/discovery/aggregated/handler.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/discovery/aggregated/handler.go
@@ -229,7 +229,6 @@ func (rdm *resourceDiscoveryManager) AddGroupVersion(source Source, groupName st
 }
 
 func (rdm *resourceDiscoveryManager) addGroupVersionLocked(source Source, groupName string, value apidiscoveryv2beta1.APIVersionDiscovery) {
-	klog.Infof("Adding GroupVersion %s %s to ResourceManager", groupName, value.Version)
 
 	if rdm.apiGroups == nil {
 		rdm.apiGroups = make(map[groupKey]*apidiscoveryv2beta1.APIGroupDiscovery)
@@ -273,6 +272,7 @@ func (rdm *resourceDiscoveryManager) addGroupVersionLocked(source Source, groupN
 		}
 		rdm.apiGroups[key] = group
 	}
+	klog.Infof("Adding GroupVersion %s %s to ResourceManager", groupName, value.Version)
 
 	gv := metav1.GroupVersion{Group: groupName, Version: value.Version}
 	gvKey := groupVersionKey{


### PR DESCRIPTION
Cherry pick of #119825 on release-1.27.

#119825: Move adding GroupVersion log until after an update is

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fixes a kube-apiserver log volume regression bug in default 1.27 configurations (introduced in 1.26, activated by the AggregatedDiscoveryEndpoint feature enablement in 1.27)
```

Requesting cherry pick due to log volume regression xref: https://github.com/kubernetes/kubernetes/issues/119546 the code was introduced as https://github.com/kubernetes/kubernetes/commit/6e83f6750598d394fb257f66c5d0721cf88f45db in 1.26 but the `AggregatedDiscoveryEndpoint` feature was [enabled by default in 1.27](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apiserver/pkg/features/kube_features.go#L274) causing the huge amount of logs to be generated by default.