### PR TITLE
clean up unused parameters for volume zone unit test

### DIFF
--- a/pkg/scheduler/framework/plugins/volumezone/volume_zone_test.go
+++ b/pkg/scheduler/framework/plugins/volumezone/volume_zone_test.go
@@ -35,7 +35,7 @@ import (
 	tf "k8s.io/kubernetes/pkg/scheduler/testing/framework"
 )
 
-func createPodWithVolume(pod, pv, pvc string) *v1.Pod {
+func createPodWithVolume(pod, pvc string) *v1.Pod {
 	return st.MakePod().Name(pod).Namespace(metav1.NamespaceDefault).PVC(pvc).Obj()
 }
 
@@ -112,7 +112,7 @@ func TestSingleZone(t *testing.T) {
 		},
 		{
 			name: "node without labels",
-			Pod:  createPodWithVolume("pod_1", "vol_1", "PVC_1"),
+			Pod:  createPodWithVolume("pod_1", "PVC_1"),
 			Node: &v1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "host1",
@@ -121,7 +121,7 @@ func TestSingleZone(t *testing.T) {
 		},
 		{
 			name: "beta zone label matched",
-			Pod:  createPodWithVolume("pod_1", "vol_1", "PVC_1"),
+			Pod:  createPodWithVolume("pod_1", "PVC_1"),
 			Node: &v1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:   "host1",
@@ -131,7 +131,7 @@ func TestSingleZone(t *testing.T) {
 		},
 		{
 			name: "beta region label matched",
-			Pod:  createPodWithVolume("pod_1", "vol_1", "PVC_2"),
+			Pod:  createPodWithVolume("pod_1", "PVC_2"),
 			Node: &v1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:   "host1",
@@ -141,7 +141,7 @@ func TestSingleZone(t *testing.T) {
 		},
 		{
 			name: "beta region label doesn't match",
-			Pod:  createPodWithVolume("pod_1", "vol_1", "PVC_2"),
+			Pod:  createPodWithVolume("pod_1", "PVC_2"),
 			Node: &v1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:   "host1",
@@ -152,7 +152,7 @@ func TestSingleZone(t *testing.T) {
 		},
 		{
 			name: "beta zone label doesn't match",
-			Pod:  createPodWithVolume("pod_1", "vol_1", "PVC_1"),
+			Pod:  createPodWithVolume("pod_1", "PVC_1"),
 			Node: &v1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:   "host1",
@@ -163,7 +163,7 @@ func TestSingleZone(t *testing.T) {
 		},
 		{
 			name: "zone label matched",
-			Pod:  createPodWithVolume("pod_1", "Vol_Stable_1", "PVC_Stable_1"),
+			Pod:  createPodWithVolume("pod_1", "PVC_Stable_1"),
 			Node: &v1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:   "host1",
@@ -173,7 +173,7 @@ func TestSingleZone(t *testing.T) {
 		},
 		{
 			name: "region label matched",
-			Pod:  createPodWithVolume("pod_1", "Vol_Stable_2", "PVC_Stable_2"),
+			Pod:  createPodWithVolume("pod_1", "PVC_Stable_2"),
 			Node: &v1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:   "host1",
@@ -183,7 +183,7 @@ func TestSingleZone(t *testing.T) {
 		},
 		{
 			name: "region label doesn't match",
-			Pod:  createPodWithVolume("pod_1", "Vol_Stable_2", "PVC_Stable_2"),
+			Pod:  createPodWithVolume("pod_1", "PVC_Stable_2"),
 			Node: &v1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:   "host1",
@@ -194,7 +194,7 @@ func TestSingleZone(t *testing.T) {
 		},
 		{
 			name: "zone label doesn't match",
-			Pod:  createPodWithVolume("pod_1", "Vol_Stable_1", "PVC_Stable_1"),
+			Pod:  createPodWithVolume("pod_1", "PVC_Stable_1"),
 			Node: &v1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:   "host1",
@@ -205,7 +205,7 @@ func TestSingleZone(t *testing.T) {
 		},
 		{
 			name: "pv with zone and region, node with only zone",
-			Pod:  createPodWithVolume("pod_1", "Vol_Stable_3", "PVC_Stable_3"),
+			Pod:  createPodWithVolume("pod_1", "PVC_Stable_3"),
 			Node: &v1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "host1",
@@ -218,7 +218,7 @@ func TestSingleZone(t *testing.T) {
 		},
 		{
 			name: "pv with zone,node with beta zone",
-			Pod:  createPodWithVolume("pod_1", "Vol_Stable_1", "PVC_Stable_1"),
+			Pod:  createPodWithVolume("pod_1", "PVC_Stable_1"),
 			Node: &v1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "host1",
@@ -231,7 +231,7 @@ func TestSingleZone(t *testing.T) {
 		},
 		{
 			name: "pv with beta label,node with ga label, matched",
-			Pod:  createPodWithVolume("pod_1", "Vol_1", "PVC_1"),
+			Pod:  createPodWithVolume("pod_1", "PVC_1"),
 			Node: &v1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "host1",
@@ -243,7 +243,7 @@ func TestSingleZone(t *testing.T) {
 		},
 		{
 			name: "pv with beta label,node with ga label, don't match",
-			Pod:  createPodWithVolume("pod_1", "vol_1", "PVC_1"),
+			Pod:  createPodWithVolume("pod_1", "PVC_1"),
 			Node: &v1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "host1",
@@ -337,7 +337,7 @@ func TestMultiZone(t *testing.T) {
 	}{
 		{
 			name: "node without labels",
-			Pod:  createPodWithVolume("pod_1", "Vol_3", "PVC_3"),
+			Pod:  createPodWithVolume("pod_1", "PVC_3"),
 			Node: &v1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "host1",
@@ -346,7 +346,7 @@ func TestMultiZone(t *testing.T) {
 		},
 		{
 			name: "beta zone label matched",
-			Pod:  createPodWithVolume("pod_1", "Vol_3", "PVC_3"),
+			Pod:  createPodWithVolume("pod_1", "PVC_3"),
 			Node: &v1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:   "host1",
@@ -356,7 +356,7 @@ func TestMultiZone(t *testing.T) {
 		},
 		{
 			name: "beta zone label doesn't match",
-			Pod:  createPodWithVolume("pod_1", "vol_1", "PVC_1"),
+			Pod:  createPodWithVolume("pod_1", "PVC_1"),
 			Node: &v1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:   "host1",
@@ -367,7 +367,7 @@ func TestMultiZone(t *testing.T) {
 		},
 		{
 			name: "zone label matched",
-			Pod:  createPodWithVolume("pod_1", "Vol_Stable_2", "PVC_Stable_2"),
+			Pod:  createPodWithVolume("pod_1", "PVC_Stable_2"),
 			Node: &v1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:   "host1",
@@ -377,7 +377,7 @@ func TestMultiZone(t *testing.T) {
 		},
 		{
 			name: "zone label doesn't match",
-			Pod:  createPodWithVolume("pod_1", "Vol_Stable_1", "PVC_Stable_1"),
+			Pod:  createPodWithVolume("pod_1", "PVC_Stable_1"),
 			Node: &v1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:   "host1",
@@ -477,12 +477,12 @@ func TestWithBinding(t *testing.T) {
 	}{
 		{
 			name: "label zone failure domain matched",
-			Pod:  createPodWithVolume("pod_1", "vol_1", "PVC_1"),
+			Pod:  createPodWithVolume("pod_1", "PVC_1"),
 			Node: testNode,
 		},
 		{
 			name: "unbound volume empty storage class",
-			Pod:  createPodWithVolume("pod_1", "vol_1", "PVC_EmptySC"),
+			Pod:  createPodWithVolume("pod_1", "PVC_EmptySC"),
 			Node: testNode,
 			wantPreFilterStatus: framework.NewStatus(framework.UnschedulableAndUnresolvable,
 				"PersistentVolumeClaim had no pv name and storageClass name"),
@@ -491,7 +491,7 @@ func TestWithBinding(t *testing.T) {
 		},
 		{
 			name: "unbound volume no storage class",
-			Pod:  createPodWithVolume("pod_1", "vol_1", "PVC_NoSC"),
+			Pod:  createPodWithVolume("pod_1", "PVC_NoSC"),
 			Node: testNode,
 			wantPreFilterStatus: framework.NewStatus(framework.UnschedulableAndUnresolvable,
 				"unable to find storage class: Class_0"),
@@ -500,14 +500,14 @@ func TestWithBinding(t *testing.T) {
 		},
 		{
 			name:                "unbound volume immediate binding mode",
-			Pod:                 createPodWithVolume("pod_1", "vol_1", "PVC_ImmediateSC"),
+			Pod:                 createPodWithVolume("pod_1", "PVC_ImmediateSC"),
 			Node:                testNode,
 			wantPreFilterStatus: framework.NewStatus(framework.UnschedulableAndUnresolvable, "VolumeBindingMode not set for StorageClass \"Class_Immediate\""),
 			wantFilterStatus:    framework.NewStatus(framework.UnschedulableAndUnresolvable, "VolumeBindingMode not set for StorageClass \"Class_Immediate\""),
 		},
 		{
 			name:                "unbound volume wait binding mode",
-			Pod:                 createPodWithVolume("pod_1", "vol_1", "PVC_WaitSC"),
+			Pod:                 createPodWithVolume("pod_1", "PVC_WaitSC"),
 			Node:                testNode,
 			wantPreFilterStatus: framework.NewStatus(framework.Skip),
 		},
@@ -550,7 +550,7 @@ func BenchmarkVolumeZone(b *testing.B) {
 	}{
 		{
 			Name:      "with prefilter",
-			Pod:       createPodWithVolume("pod_0", "Vol_Stable_0", "PVC_Stable_0"),
+			Pod:       createPodWithVolume("pod_0", "PVC_Stable_0"),
 			NumPV:     1000,
 			NumPVC:    1000,
 			NumNodes:  1000,
@@ -558,7 +558,7 @@ func BenchmarkVolumeZone(b *testing.B) {
 		},
 		{
 			Name:      "without prefilter",
-			Pod:       createPodWithVolume("pod_0", "Vol_Stable_0", "PVC_Stable_0"),
+			Pod:       createPodWithVolume("pod_0", "PVC_Stable_0"),
 			NumPV:     1000,
 			NumPVC:    1000,
 			NumNodes:  1000,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Followup #109684: clean up unused parameters for volume zone unit test

After #109684 is merged, the PV name is always the same as the PVC name.
https://github.com/kubernetes/kubernetes/blob/ad9b60e2c9ddb21e8b00cabbe27e639638a0ea88/pkg/scheduler/testing/wrappers.go#L403-L411

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Ref #109684

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
