### PR TITLE
Fix error check in GetChainsFromTables

### DIFF
--- a/pkg/util/iptables/save_restore.go
+++ b/pkg/util/iptables/save_restore.go
@@ -40,7 +40,7 @@ func GetChainsFromTable(save []byte) map[Chain]struct{} {
 		start := i + 2
 		save = save[start:]
 		end := bytes.Index(save, []byte(" "))
-		if i == -1 {
+		if end == -1 {
 			// shouldn't happen, but...
 			break
 		}


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:

- Small fix up to raise error correctly in [GetChainsFromTables](https://github.com/kubernetes/kubernetes/blob/master/pkg/util/iptables/save_restore.go#L43) found when reviewing https://github.com/kubernetes/kubernetes/pull/122048#discussion_r1406959577
- Wraps error returned from `iptables --version` to make it more clear what failed

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```