### PR TITLE
feature: Add csinode filters to default scheduler

### DIFF
--- a/pkg/scheduler/framework/plugins/volumebinding/binder.go
+++ b/pkg/scheduler/framework/plugins/volumebinding/binder.go
@@ -884,6 +884,12 @@ func (b *volumeBinder) checkBoundClaims(logger klog.Logger, claims []*v1.Persist
 			return false, true, err
 		}
 
+		err = volume.CheckCSINodeDriverAffinity(csiNode, pv)
+		if err != nil {
+			logger.V(4).Info("PersistentVolume and csinode driver mismatch for pod", "PV", klog.KRef("", pvName), "csinode", klog.KObj(csiNode), "pod", klog.KObj(pod), "err", err)
+			return false, true, nil
+		}
+
 		err = volume.CheckNodeAffinity(pv, node.Labels)
 		if err != nil {
 			logger.V(4).Info("PersistentVolume and node mismatch for pod", "PV", klog.KRef("", pvName), "node", klog.KObj(node), "pod", klog.KObj(pod), "err", err)

--- a/pkg/scheduler/framework/plugins/volumebinding/binder_test.go
+++ b/pkg/scheduler/framework/plugins/volumebinding/binder_test.go
@@ -119,8 +119,8 @@ var (
 	node1Zone2    = makeNode("node1").withLabel("topology.gke.io/zone", "us-east-2").Node
 
 	// csiNode objects
-	csiNode1Migrated    = makeCSINode("node1", "kubernetes.io/gce-pd")
-	csiNode1NotMigrated = makeCSINode("node1", "")
+	csiNode1Migrated    = makeCSINode("node1", "kubernetes.io/gce-pd", "pd.csi.storage.gke.io")
+	csiNode1NotMigrated = makeCSINode("node1", "", "")
 
 	// node topology
 	nodeLabelKey   = "nodeKey"
@@ -750,8 +750,8 @@ func pvRemoveClaimUID(pv *v1.PersistentVolume) *v1.PersistentVolume {
 	return newPV
 }
 
-func makeCSINode(name, migratedPlugin string) *storagev1.CSINode {
-	return &storagev1.CSINode{
+func makeCSINode(name, migratedPlugin, csiNodeDriver string) *storagev1.CSINode {
+	csiNode := &storagev1.CSINode{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 			Annotations: map[string]string{
@@ -759,6 +759,17 @@ func makeCSINode(name, migratedPlugin string) *storagev1.CSINode {
 			},
 		},
 	}
+	if csiNodeDriver != "" {
+		spec := storagev1.CSINodeSpec{
+			Drivers: []storagev1.CSINodeDriver{
+				{
+					Name: csiNodeDriver,
+				},
+			},
+		}
+		csiNode.Spec = spec
+	}
+	return csiNode
 }
 
 func makeCSIDriver(name string, storageCapacity bool) *storagev1.CSIDriver {

--- a/staging/src/k8s.io/component-helpers/storage/volume/helpers.go
+++ b/staging/src/k8s.io/component-helpers/storage/volume/helpers.go
@@ -71,10 +71,11 @@ func CheckNodeAffinity(pv *v1.PersistentVolume, nodeLabels map[string]string) er
 }
 
 func CheckCSINodeDriverAffinity(csiNode *storageV1.CSINode, pv *v1.PersistentVolume) error {
-	err := fmt.Errorf("no matching CSI node driver")
 	if pv.Spec.CSI == nil {
 		return nil
 	}
+
+	err := fmt.Errorf("no matching CSI node driver")
 	if csiNode == nil || len(csiNode.Spec.Drivers) == 0 {
 		return fmt.Errorf("%s, csinode is empty or csinode drivers is empty", err.Error())
 	}

--- a/staging/src/k8s.io/component-helpers/storage/volume/helpers_test.go
+++ b/staging/src/k8s.io/component-helpers/storage/volume/helpers_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
+	storageV1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -202,6 +203,112 @@ func TestCheckVolumeNodeAffinity(t *testing.T) {
 		}
 		if err == nil && !c.expectSuccess {
 			t.Errorf("CheckTopology %v returned success, expected error", c.name)
+		}
+	}
+}
+
+func testVolumeWithCSINodeDriverAffinity(t *testing.T, volumeSource *v1.CSIPersistentVolumeSource) *v1.PersistentVolume {
+	return &v1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-constraints"},
+		Spec: v1.PersistentVolumeSpec{
+			PersistentVolumeSource: v1.PersistentVolumeSource{
+				CSI: volumeSource,
+			},
+		},
+	}
+}
+
+func testCSINode(t *testing.T, csiDrivers []storageV1.CSINodeDriver) *storageV1.CSINode {
+	return &storageV1.CSINode{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-csinodes"},
+		Spec: storageV1.CSINodeSpec{
+			Drivers: csiDrivers,
+		},
+	}
+}
+
+func TestCheckVolumeCSINodeDriverAffinity(t *testing.T) {
+	type csiNodeDriverAffinityTest struct {
+		name          string
+		expectSuccess bool
+		pv            *v1.PersistentVolume
+		csiNode       *storageV1.CSINode
+	}
+
+	cases := []csiNodeDriverAffinityTest{
+		{
+			name:          "valid-pv-nil",
+			expectSuccess: true,
+			pv:            testVolumeWithCSINodeDriverAffinity(t, nil),
+			csiNode: testCSINode(t, []storageV1.CSINodeDriver{
+				{
+					Name: "test-driver",
+				},
+				{
+					Name: "test-driver2",
+				},
+			}),
+		},
+		{
+			name:          "valid-csi-node-nil",
+			expectSuccess: false,
+			pv: testVolumeWithCSINodeDriverAffinity(t, &v1.CSIPersistentVolumeSource{
+				Driver:       "test-driver",
+				VolumeHandle: "diskId",
+			}),
+			csiNode: nil,
+		},
+		{
+			name:          "valid-pv-csinode-mismatch",
+			expectSuccess: false,
+			pv: testVolumeWithCSINodeDriverAffinity(t, &v1.CSIPersistentVolumeSource{
+				Driver:       "test-driver",
+				VolumeHandle: "diskId",
+			}),
+			csiNode: testCSINode(t, []storageV1.CSINodeDriver{
+				{
+					Name: "test-driver2",
+				},
+				{
+					Name: "test-driver3",
+				},
+			}),
+		},
+		{
+			name:          "valid-pv-csinode-match",
+			expectSuccess: true,
+			pv: testVolumeWithCSINodeDriverAffinity(t, &v1.CSIPersistentVolumeSource{
+				Driver:       "test-driver",
+				VolumeHandle: "diskId",
+			}),
+			csiNode: testCSINode(t, []storageV1.CSINodeDriver{
+				{
+					Name: "test-driver",
+				},
+				{
+					Name: "test-driver1",
+				},
+			}),
+		},
+		{
+			name:          "valid-pv-csinode-empty",
+			expectSuccess: false,
+			pv: testVolumeWithCSINodeDriverAffinity(t, &v1.CSIPersistentVolumeSource{
+				Driver:       "test-driver",
+				VolumeHandle: "diskId",
+			}),
+			csiNode: testCSINode(t, []storageV1.CSINodeDriver{}),
+		},
+	}
+
+	for _, c := range cases {
+		err := CheckCSINodeDriverAffinity(c.csiNode, c.pv)
+
+		if err != nil && c.expectSuccess {
+			t.Errorf("CheckCSINodeDriverAffinity %v returned error: %v", c.name, err)
+		}
+		if err == nil && !c.expectSuccess {
+			t.Errorf("CheckCSINodeDriverAffinity %v returned success, expected error", c.name)
 		}
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

#### What this PR does / why we need it:

Add csinode filters to default scheduler to avoid scheduling to nodes where csi does not exist nor ready, this PR Resolving issues described below:

1. A pod with a volume may be scheduled to a node where the CSI plugin hasn't started, resulting in a mount error within the pod's events.
2. When multiple pending pods with PersistentVolume exist(maybe resource exhausted), and the cluster's autoscaler provisions a new Node. All these pending pods might be assigned to the new node(ignoring volume quotas, csi-agent not started). This can surpass the volume quota on the node, Exceeding the volume quota on the node can cause pods to fail to launch, and they may not recover through automatic retries.

This PR doesn't cover dynamic provisioning of PV scenario, as we cannot determine if the storage driver is a CSI driver based on the provisioner fields in the StorageClass.

However, I still consider this PR valuable as it does address part of the issue.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # None

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
