### PR TITLE
proxy chain creation cleanup

### DIFF
--- a/pkg/util/iptables/save_restore.go
+++ b/pkg/util/iptables/save_restore.go
@@ -19,6 +19,8 @@ package iptables
 import (
 	"bytes"
 	"fmt"
+
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 // MakeChainLine return an iptables-save/restore formatted chain line given a Chain
@@ -27,10 +29,10 @@ func MakeChainLine(chain Chain) string {
 }
 
 // GetChainsFromTable parses iptables-save data to find the chains that are defined. It
-// assumes that save contains a single table's data, and returns a map with keys for every
+// assumes that save contains a single table's data, and returns a set with keys for every
 // chain defined in that table.
-func GetChainsFromTable(save []byte) map[Chain]struct{} {
-	chainsMap := make(map[Chain]struct{})
+func GetChainsFromTable(save []byte) sets.Set[Chain] {
+	chainsSet := sets.New[Chain]()
 
 	for {
 		i := bytes.Index(save, []byte("\n:"))
@@ -45,8 +47,8 @@ func GetChainsFromTable(save []byte) map[Chain]struct{} {
 			break
 		}
 		chain := Chain(save[:end])
-		chainsMap[chain] = struct{}{}
+		chainsSet.Insert(chain)
 		save = save[end:]
 	}
-	return chainsMap
+	return chainsSet
 }

--- a/pkg/util/iptables/save_restore_test.go
+++ b/pkg/util/iptables/save_restore_test.go
@@ -20,19 +20,19 @@ import (
 	"testing"
 
 	"github.com/lithammer/dedent"
+
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
-func checkChains(t *testing.T, save []byte, expected map[Chain]struct{}) {
+func checkChains(t *testing.T, save []byte, expected sets.Set[Chain]) {
 	chains := GetChainsFromTable(save)
-	for chain := range expected {
-		if _, exists := chains[chain]; !exists {
-			t.Errorf("GetChainsFromTable expected chain not present: %s", chain)
-		}
+	missing := expected.Difference(chains)
+	if len(missing) != 0 {
+		t.Errorf("GetChainsFromTable expected chains not present: %v", missing.UnsortedList())
 	}
-	for chain := range chains {
-		if _, exists := expected[chain]; !exists {
-			t.Errorf("GetChainsFromTable chain unexpectedly present: %s", chain)
-		}
+	extra := chains.Difference(expected)
+	if len(extra) != 0 {
+		t.Errorf("GetChainsFromTable expected chains unexpectedly present: %v", extra.UnsortedList())
 	}
 }
 
@@ -77,22 +77,23 @@ func TestGetChainsFromTable(t *testing.T) {
 		-A KUBE-SVC-6666666666666666 -m comment --comment "kube-system/kube-dns:dns" -j KUBE-SVC-1111111111111111
 		COMMIT
 		`)
-	expected := map[Chain]struct{}{
-		ChainPrerouting:                    {},
-		Chain("INPUT"):                     {},
-		Chain("OUTPUT"):                    {},
-		ChainPostrouting:                   {},
-		Chain("DOCKER"):                    {},
-		Chain("KUBE-NODEPORT-CONTAINER"):   {},
-		Chain("KUBE-NODEPORT-HOST"):        {},
-		Chain("KUBE-PORTALS-CONTAINER"):    {},
-		Chain("KUBE-PORTALS-HOST"):         {},
-		Chain("KUBE-SVC-1111111111111111"): {},
-		Chain("KUBE-SVC-2222222222222222"): {},
-		Chain("KUBE-SVC-3333333333333333"): {},
-		Chain("KUBE-SVC-4444444444444444"): {},
-		Chain("KUBE-SVC-5555555555555555"): {},
-		Chain("KUBE-SVC-6666666666666666"): {},
-	}
+
+	expected := sets.New(
+		ChainPrerouting,
+		Chain("INPUT"),
+		Chain("OUTPUT"),
+		ChainPostrouting,
+		Chain("DOCKER"),
+		Chain("KUBE-NODEPORT-CONTAINER"),
+		Chain("KUBE-NODEPORT-HOST"),
+		Chain("KUBE-PORTALS-CONTAINER"),
+		Chain("KUBE-PORTALS-HOST"),
+		Chain("KUBE-SVC-1111111111111111"),
+		Chain("KUBE-SVC-2222222222222222"),
+		Chain("KUBE-SVC-3333333333333333"),
+		Chain("KUBE-SVC-4444444444444444"),
+		Chain("KUBE-SVC-5555555555555555"),
+		Chain("KUBE-SVC-6666666666666666"),
+	)
 	checkChains(t, []byte(iptablesSave), expected)
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/sig network
/priority backlog

#### What this PR does / why we need it:
#110266 did a lot of reorganization to support `MinimizeIPTablesRestore`, but some of that reorg became unnecessary after #119140 (since we now always run through the entire loop rather than `continue`-ing over the bottom half of it when skipping a service). This cleans that up. See also https://github.com/kubernetes/kubernetes/pull/122048#discussion_r1409075017.

Also pulls in the drive-by "use generic Sets"-ification that got removed from #122048.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/assign @aojea