### PR TITLE
kubelet: avoid printing container sensitive information in kubelet logs

### DIFF
--- a/pkg/kubelet/kuberuntime/helpers.go
+++ b/pkg/kubelet/kuberuntime/helpers.go
@@ -267,3 +267,9 @@ func (m *kubeGenericRuntimeManager) getSeccompProfile(annotations map[string]str
 		ProfileType: runtimeapi.SecurityProfile_Unconfined,
 	}, nil
 }
+
+func removeContainerSensitiveInformation(container *v1.Container) *v1.Container {
+	c := container.DeepCopy()
+	c.Env = nil
+	return c
+}

--- a/pkg/kubelet/kuberuntime/helpers_test.go
+++ b/pkg/kubelet/kuberuntime/helpers_test.go
@@ -359,3 +359,39 @@ func TestToKubeContainerState(t *testing.T) {
 		})
 	}
 }
+
+func TestRemoveSensitiveContainerInformation(t *testing.T) {
+	for _, test := range []struct {
+		description string
+		container   *v1.Container
+	}{
+		{
+			description: "no env var",
+			container: &v1.Container{
+				Name:  "test_container",
+				Image: "foo/image:v1",
+			},
+		},
+		{
+			description: "with env var",
+			container: &v1.Container{
+				Name:  "test_container_2",
+				Image: "foo/image:v2",
+				Env: []v1.EnvVar{
+					{
+						Name:  "baz",
+						Value: "qux",
+					},
+					{
+						Name:  "another",
+						Value: "value",
+					},
+				},
+			},
+		},
+	} {
+		t.Run(test.description, func(t *testing.T) {
+			assert.Nil(t, removeContainerSensitiveInformation(test.container).Env)
+		})
+	}
+}

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -1235,7 +1235,7 @@ func (m *kubeGenericRuntimeManager) SyncPod(ctx context.Context, pod *v1.Pod, po
 		isInBackOff, msg, err := m.doBackOff(pod, spec.container, podStatus, backOff)
 		if isInBackOff {
 			startContainerResult.Fail(err, msg)
-			klog.V(4).InfoS("Backing Off restarting container in pod", "containerType", typeName, "container", spec.container, "pod", klog.KObj(pod))
+			klog.V(4).InfoS("Backing Off restarting container in pod", "containerType", typeName, "container", removeContainerSensitiveInformation(spec.container), "pod", klog.KObj(pod))
 			return err
 		}
 
@@ -1243,7 +1243,7 @@ func (m *kubeGenericRuntimeManager) SyncPod(ctx context.Context, pod *v1.Pod, po
 		if sc.HasWindowsHostProcessRequest(pod, spec.container) {
 			metrics.StartedHostProcessContainersTotal.WithLabelValues(metricLabel).Inc()
 		}
-		klog.V(4).InfoS("Creating container in pod", "containerType", typeName, "container", spec.container, "pod", klog.KObj(pod))
+		klog.V(4).InfoS("Creating container in pod", "containerType", typeName, "container", removeContainerSensitiveInformation(spec.container), "pod", klog.KObj(pod))
 		// NOTE (aramase) podIPs are populated for single stack and dual stack clusters. Send only podIPs.
 		if msg, err := m.startContainer(ctx, podSandboxID, podSandboxConfig, spec, pod, podStatus, pullSecrets, podIP, podIPs); err != nil {
 			// startContainer() returns well-defined error codes that have reasonable cardinality for metrics and are
@@ -1257,9 +1257,9 @@ func (m *kubeGenericRuntimeManager) SyncPod(ctx context.Context, pod *v1.Pod, po
 			// repetitive log spam
 			switch {
 			case err == images.ErrImagePullBackOff:
-				klog.V(3).InfoS("Container start failed in pod", "containerType", typeName, "container", spec.container, "pod", klog.KObj(pod), "containerMessage", msg, "err", err)
+				klog.V(3).InfoS("Container start failed in pod", "containerType", typeName, "container", removeContainerSensitiveInformation(spec.container), "pod", klog.KObj(pod), "containerMessage", msg, "err", err)
 			default:
-				utilruntime.HandleError(fmt.Errorf("%v %+v start failed in pod %v: %v: %s", typeName, spec.container, format.Pod(pod), err, msg))
+				utilruntime.HandleError(fmt.Errorf("%v %+v start failed in pod %v: %v: %s", typeName, removeContainerSensitiveInformation(spec.container), format.Pod(pod), err, msg))
 			}
 			return err
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

If applied this commit will prevent printing container sensitive information in kubelet logs.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #122101

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
