### PR TITLE
Remove conformance test calls to `/`

### DIFF
--- a/test/e2e/apimachinery/aggregator.go
+++ b/test/e2e/apimachinery/aggregator.go
@@ -52,7 +52,6 @@ import (
 	admissionapi "k8s.io/pod-security-admission/api"
 	samplev1alpha1 "k8s.io/sample-apiserver/pkg/apis/wardle/v1alpha1"
 	"k8s.io/utils/pointer"
-	"k8s.io/utils/strings/slices"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
@@ -736,24 +735,6 @@ func TestSampleAPIServer(ctx context.Context, f *framework.Framework, aggrclient
 	err = wait.PollImmediate(apiServiceRetryPeriod, apiServiceRetryTimeout, checkApiServiceListQuantity(ctx, aggrclient, apiServiceLabelSelector, 0))
 	framework.ExpectNoError(err, "failed to count the required APIServices")
 	framework.Logf("APIService %s has been deleted.", apiServiceName)
-
-	ginkgo.By("Confirm that the group path of " + apiServiceName + " was removed from root paths")
-	groupPath := "/apis/" + apiServiceGroupName
-	err = wait.PollUntilContextTimeout(ctx, apiServiceRetryPeriod, apiServiceRetryTimeout, true, func(ctx context.Context) (done bool, err error) {
-		rootPaths := metav1.RootPaths{}
-		statusContent, err = restClient.Get().
-			AbsPath("/").
-			SetHeader("Accept", "application/json").DoRaw(ctx)
-		if err != nil {
-			return false, err
-		}
-		err = json.Unmarshal(statusContent, &rootPaths)
-		if err != nil {
-			return false, err
-		}
-		return !slices.Contains(rootPaths.Paths, groupPath), nil
-	})
-	framework.ExpectNoError(err, "Expected to not find %s from root paths", groupPath)
 
 	cleanupSampleAPIServer(ctx, client, aggrclient, n, apiServiceName)
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind failing-test

#### What this PR does / why we need it:

Reverts the unconsidered conformance test change in https://github.com/kubernetes/kubernetes/pull/121283/commits/0cda42af7ab8b9b63d3b6ce1bf1c3766f15a2b00, moves the functional test validating the APIService cleanup to an integration test

#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/kubernetes/issues/121985

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

/sig architecture api-machinery