### PR TITLE
kubelet: multiple volumes reference one PVC in one Pod

### DIFF
--- a/pkg/kubelet/volumemanager/cache/actual_state_of_world.go
+++ b/pkg/kubelet/volumemanager/cache/actual_state_of_world.go
@@ -356,12 +356,6 @@ type mountedPod struct {
 	// /var/lib/kubelet/pods/{podUID}/volumes/{escapeQualifiedPluginName}/{volumeSpecName}/
 	volumeSpec *volume.Spec
 
-	// outerVolumeSpecName is the volume.Spec.Name() of the volume as referenced
-	// directly in the pod. If the volume was referenced through a persistent
-	// volume claim, this contains the volume.Spec.Name() of the persistent
-	// volume claim
-	outerVolumeSpecName string
-
 	// remountRequired indicates the underlying volume has been successfully
 	// mounted to this pod but it should be remounted to reflect changes in the
 	// referencing pod.
@@ -484,7 +478,6 @@ func (asw *actualStateOfWorld) CheckAndMarkVolumeAsUncertainViaReconstruction(op
 	volumeName := opts.VolumeName
 	mounter := opts.Mounter
 	blockVolumeMapper := opts.BlockVolumeMapper
-	outerVolumeSpecName := opts.OuterVolumeSpecName
 	volumeGIDValue := opts.VolumeGIDVolume
 	volumeSpec := opts.VolumeSpec
 
@@ -493,7 +486,6 @@ func (asw *actualStateOfWorld) CheckAndMarkVolumeAsUncertainViaReconstruction(op
 		podUID:                 podUID,
 		mounter:                mounter,
 		blockVolumeMapper:      blockVolumeMapper,
-		outerVolumeSpecName:    outerVolumeSpecName,
 		volumeGIDValue:         volumeGIDValue,
 		volumeSpec:             volumeSpec,
 		remountRequired:        false,
@@ -731,7 +723,6 @@ func (asw *actualStateOfWorld) AddPodToVolume(markVolumeOpts operationexecutor.M
 	volumeName := markVolumeOpts.VolumeName
 	mounter := markVolumeOpts.Mounter
 	blockVolumeMapper := markVolumeOpts.BlockVolumeMapper
-	outerVolumeSpecName := markVolumeOpts.OuterVolumeSpecName
 	volumeGIDValue := markVolumeOpts.VolumeGIDVolume
 	volumeSpec := markVolumeOpts.VolumeSpec
 	asw.Lock()
@@ -760,7 +751,6 @@ func (asw *actualStateOfWorld) AddPodToVolume(markVolumeOpts operationexecutor.M
 			podUID:                 podUID,
 			mounter:                mounter,
 			blockVolumeMapper:      blockVolumeMapper,
-			outerVolumeSpecName:    outerVolumeSpecName,
 			volumeGIDValue:         volumeGIDValue,
 			volumeSpec:             volumeSpec,
 			volumeMountStateForPod: markVolumeOpts.VolumeMountState,
@@ -1307,7 +1297,6 @@ func getMountedVolume(
 			PodName:             mountedPod.podName,
 			VolumeName:          attachedVolume.volumeName,
 			InnerVolumeSpecName: mountedPod.volumeSpec.Name(),
-			OuterVolumeSpecName: mountedPod.outerVolumeSpecName,
 			PluginName:          attachedVolume.pluginName,
 			PodUID:              mountedPod.podUID,
 			Mounter:             mountedPod.mounter,

--- a/pkg/kubelet/volumemanager/cache/actual_state_of_world_test.go
+++ b/pkg/kubelet/volumemanager/cache/actual_state_of_world_test.go
@@ -232,13 +232,12 @@ func Test_AddPodToVolume_Positive_ExistingVolumeNewNode(t *testing.T) {
 
 	// Act
 	markVolumeOpts := operationexecutor.MarkVolumeOpts{
-		PodName:             podName,
-		PodUID:              pod.UID,
-		VolumeName:          generatedVolumeName,
-		Mounter:             mounter,
-		BlockVolumeMapper:   mapper,
-		OuterVolumeSpecName: volumeSpec.Name(),
-		VolumeSpec:          volumeSpec,
+		PodName:           podName,
+		PodUID:            pod.UID,
+		VolumeName:        generatedVolumeName,
+		Mounter:           mounter,
+		BlockVolumeMapper: mapper,
+		VolumeSpec:        volumeSpec,
 	}
 	err = asw.AddPodToVolume(markVolumeOpts)
 	// Assert
@@ -307,13 +306,12 @@ func Test_AddPodToVolume_Positive_ExistingVolumeExistingNode(t *testing.T) {
 	}
 
 	markVolumeOpts := operationexecutor.MarkVolumeOpts{
-		PodName:             podName,
-		PodUID:              pod.UID,
-		VolumeName:          generatedVolumeName,
-		Mounter:             mounter,
-		BlockVolumeMapper:   mapper,
-		OuterVolumeSpecName: volumeSpec.Name(),
-		VolumeSpec:          volumeSpec,
+		PodName:           podName,
+		PodUID:            pod.UID,
+		VolumeName:        generatedVolumeName,
+		Mounter:           mounter,
+		BlockVolumeMapper: mapper,
+		VolumeSpec:        volumeSpec,
 	}
 	err = asw.AddPodToVolume(markVolumeOpts)
 	if err != nil {
@@ -415,13 +413,12 @@ func Test_AddTwoPodsToVolume_Positive(t *testing.T) {
 	}
 
 	markVolumeOpts1 := operationexecutor.MarkVolumeOpts{
-		PodName:             podName1,
-		PodUID:              pod1.UID,
-		VolumeName:          generatedVolumeName1,
-		Mounter:             mounter1,
-		BlockVolumeMapper:   mapper1,
-		OuterVolumeSpecName: volumeSpec1.Name(),
-		VolumeSpec:          volumeSpec1,
+		PodName:           podName1,
+		PodUID:            pod1.UID,
+		VolumeName:        generatedVolumeName1,
+		Mounter:           mounter1,
+		BlockVolumeMapper: mapper1,
+		VolumeSpec:        volumeSpec1,
 	}
 	err = asw.AddPodToVolume(markVolumeOpts1)
 	if err != nil {
@@ -441,13 +438,12 @@ func Test_AddTwoPodsToVolume_Positive(t *testing.T) {
 	}
 
 	markVolumeOpts2 := operationexecutor.MarkVolumeOpts{
-		PodName:             podName2,
-		PodUID:              pod2.UID,
-		VolumeName:          generatedVolumeName1,
-		Mounter:             mounter2,
-		BlockVolumeMapper:   mapper2,
-		OuterVolumeSpecName: volumeSpec2.Name(),
-		VolumeSpec:          volumeSpec2,
+		PodName:           podName2,
+		PodUID:            pod2.UID,
+		VolumeName:        generatedVolumeName1,
+		Mounter:           mounter2,
+		BlockVolumeMapper: mapper2,
+		VolumeSpec:        volumeSpec2,
 	}
 	err = asw.AddPodToVolume(markVolumeOpts2)
 	if err != nil {
@@ -603,14 +599,13 @@ func TestActualStateOfWorld_FoundDuringReconstruction(t *testing.T) {
 			}
 
 			markVolumeOpts1 := operationexecutor.MarkVolumeOpts{
-				PodName:             podName1,
-				PodUID:              pod1.UID,
-				VolumeName:          generatedVolumeName1,
-				Mounter:             mounter1,
-				BlockVolumeMapper:   mapper1,
-				OuterVolumeSpecName: volumeSpec1.Name(),
-				VolumeSpec:          volumeSpec1,
-				VolumeMountState:    operationexecutor.VolumeMountUncertain,
+				PodName:           podName1,
+				PodUID:            pod1.UID,
+				VolumeName:        generatedVolumeName1,
+				Mounter:           mounter1,
+				BlockVolumeMapper: mapper1,
+				VolumeSpec:        volumeSpec1,
+				VolumeMountState:  operationexecutor.VolumeMountUncertain,
 			}
 			_, err = asw.CheckAndMarkVolumeAsUncertainViaReconstruction(markVolumeOpts1)
 			if err != nil {
@@ -687,13 +682,12 @@ func Test_MarkVolumeAsDetached_Negative_PodInVolume(t *testing.T) {
 	}
 
 	markVolumeOpts := operationexecutor.MarkVolumeOpts{
-		PodName:             podName,
-		PodUID:              pod.UID,
-		VolumeName:          generatedVolumeName,
-		Mounter:             mounter,
-		BlockVolumeMapper:   mapper,
-		OuterVolumeSpecName: volumeSpec.Name(),
-		VolumeSpec:          volumeSpec,
+		PodName:           podName,
+		PodUID:            pod.UID,
+		VolumeName:        generatedVolumeName,
+		Mounter:           mounter,
+		BlockVolumeMapper: mapper,
+		VolumeSpec:        volumeSpec,
 	}
 	err = asw.AddPodToVolume(markVolumeOpts)
 	if err != nil {
@@ -794,13 +788,12 @@ func Test_AddPodToVolume_Negative_VolumeDoesntExist(t *testing.T) {
 
 	// Act
 	markVolumeOpts := operationexecutor.MarkVolumeOpts{
-		PodName:             podName,
-		PodUID:              pod.UID,
-		VolumeName:          volumeName,
-		Mounter:             mounter,
-		BlockVolumeMapper:   mapper,
-		OuterVolumeSpecName: volumeSpec.Name(),
-		VolumeSpec:          volumeSpec,
+		PodName:           podName,
+		PodUID:            pod.UID,
+		VolumeName:        volumeName,
+		Mounter:           mounter,
+		BlockVolumeMapper: mapper,
+		VolumeSpec:        volumeSpec,
 	}
 	err = asw.AddPodToVolume(markVolumeOpts)
 	// Assert
@@ -930,7 +923,6 @@ func Test_AddPodToVolume_Positive_SELinux(t *testing.T) {
 		VolumeName:          generatedVolumeName,
 		Mounter:             mounter,
 		BlockVolumeMapper:   mapper,
-		OuterVolumeSpecName: volumeSpec.Name(),
 		VolumeSpec:          volumeSpec,
 		SELinuxMountContext: "system_u:object_r:container_file_t:s0:c0,c1",
 		VolumeMountState:    operationexecutor.VolumeMounted,
@@ -1044,13 +1036,12 @@ func TestUncertainVolumeMounts(t *testing.T) {
 	}
 
 	markVolumeOpts1 := operationexecutor.MarkVolumeOpts{
-		PodName:             podName1,
-		PodUID:              pod1.UID,
-		VolumeName:          generatedVolumeName1,
-		Mounter:             mounter1,
-		OuterVolumeSpecName: volumeSpec1.Name(),
-		VolumeSpec:          volumeSpec1,
-		VolumeMountState:    operationexecutor.VolumeMountUncertain,
+		PodName:          podName1,
+		PodUID:           pod1.UID,
+		VolumeName:       generatedVolumeName1,
+		Mounter:          mounter1,
+		VolumeSpec:       volumeSpec1,
+		VolumeMountState: operationexecutor.VolumeMountUncertain,
 	}
 	err = asw.AddPodToVolume(markVolumeOpts1)
 	if err != nil {

--- a/pkg/kubelet/volumemanager/cache/desired_state_of_world_test.go
+++ b/pkg/kubelet/volumemanager/cache/desired_state_of_world_test.go
@@ -18,6 +18,7 @@ package cache
 
 import (
 	"maps"
+	"slices"
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
@@ -77,7 +78,7 @@ func Test_AddPodToVolume_Positive_NewPodNewVolume(t *testing.T) {
 
 	verifyVolumeExistsDsw(t, generatedVolumeName, "" /* SELinuxContext */, dsw)
 	verifyVolumeExistsInVolumesToMount(
-		t, generatedVolumeName, false /* expectReportedInUse */, dsw)
+		t, generatedVolumeName, []string{"volume-name"}, false /* expectReportedInUse */, dsw)
 	verifyPodExistsInVolumeDsw(t, podName, generatedVolumeName, "" /* SELinuxContext */, dsw)
 	verifyVolumeExistsWithSpecNameInVolumeDsw(t, podName, volumeSpec.Name(), dsw)
 }
@@ -131,14 +132,14 @@ func Test_AddPodToVolume_Positive_ExistingPodExistingVolume(t *testing.T) {
 	}
 	verifyVolumeExistsDsw(t, generatedVolumeName, "" /* SELinuxContext */, dsw)
 	verifyVolumeExistsInVolumesToMount(
-		t, generatedVolumeName, false /* expectReportedInUse */, dsw)
+		t, generatedVolumeName, []string{"volume-name"}, false /* expectReportedInUse */, dsw)
 	verifyPodExistsInVolumeDsw(t, podName, generatedVolumeName, "" /* SELinuxContext */, dsw)
 	verifyVolumeExistsWithSpecNameInVolumeDsw(t, podName, volumeSpec.Name(), dsw)
 }
 
 // Call AddPodToVolume() on different pods for different kinds of volumes
-// Verities generated names are same for different pods if volume is device mountable or attachable
-// Verities generated names are different for different pods if volume is not device mountble and attachable
+// Verifies generated names are same for different pods if volume is device mountable or attachable
+// Verifies generated names are different for different pods if volume is not device mountble and attachable
 func Test_AddPodToVolume_Positive_NamesForDifferentPodsAndDifferentVolumes(t *testing.T) {
 	logger, _ := ktesting.NewTestContext(t)
 	// Arrange
@@ -300,6 +301,59 @@ func Test_AddPodToVolume_Positive_NamesForDifferentPodsAndDifferentVolumes(t *te
 
 }
 
+func Test_AddPodToVolume_Positive_MultiOuterNames(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
+	// Arrange
+	volumePluginMgr, _ := volumetesting.GetTestKubeletVolumePluginMgr(t)
+	seLinuxTranslator := util.NewFakeSELinuxLabelTranslator()
+	dsw := NewDesiredStateOfWorld(volumePluginMgr, seLinuxTranslator)
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pod5",
+			UID:  "pod5uid",
+		},
+		Spec: v1.PodSpec{
+			Volumes: []v1.Volume{
+				{
+					Name: "volume-name-1",
+					VolumeSource: v1.VolumeSource{
+						GCEPersistentDisk: &v1.GCEPersistentDiskVolumeSource{
+							PDName: "fake-device1",
+						},
+					},
+				}, {
+					Name: "volume-name-2",
+					VolumeSource: v1.VolumeSource{
+						GCEPersistentDisk: &v1.GCEPersistentDiskVolumeSource{
+							PDName: "fake-device1",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	volumeSpec1 := &volume.Spec{Volume: &pod.Spec.Volumes[0]}
+	volumeSpec2 := &volume.Spec{Volume: &pod.Spec.Volumes[1]}
+	podName := util.GetUniquePodName(pod)
+
+	// Act
+	_, err := dsw.AddPodToVolume(
+		logger, podName, pod, volumeSpec1, volumeSpec1.Name(), "" /* volumeGIDValue */, nil /* seLinuxContainerContexts */)
+	if err != nil {
+		t.Fatalf("AddPodToVolume failed. Expected: <no error> Actual: <%v>", err)
+	}
+	generatedVolumeName, err := dsw.AddPodToVolume(
+		logger, podName, pod, volumeSpec2, volumeSpec2.Name(), "" /* volumeGIDValue */, nil /* seLinuxContainerContexts */)
+	if err != nil {
+		t.Fatalf("AddPodToVolume failed. Expected: <no error> Actual: <%v>", err)
+	}
+
+	// Assert
+	verifyVolumeExistsInVolumesToMount(
+		t, generatedVolumeName, []string{"volume-name-1", "volume-name-2"}, false /* expectReportedInUse */, dsw)
+}
+
 // Populates data struct with a new volume/pod
 // Calls DeletePodFromVolume() to removes the pod
 // Verifies newly added pod/volume are deleted
@@ -337,7 +391,7 @@ func Test_DeletePodFromVolume_Positive_PodExistsVolumeExists(t *testing.T) {
 	}
 	verifyVolumeExistsDsw(t, generatedVolumeName, "" /* SELinuxContext */, dsw)
 	verifyVolumeExistsInVolumesToMount(
-		t, generatedVolumeName, false /* expectReportedInUse */, dsw)
+		t, generatedVolumeName, []string{"volume-name"}, false /* expectReportedInUse */, dsw)
 	verifyPodExistsInVolumeDsw(t, podName, generatedVolumeName, "" /* SELinuxContext */, dsw)
 
 	// Act
@@ -455,15 +509,15 @@ func Test_MarkVolumesReportedInUse_Positive_NewPodNewVolume(t *testing.T) {
 	// Assert
 	verifyVolumeExistsDsw(t, generatedVolume1Name, "" /* SELinuxContext */, dsw)
 	verifyVolumeExistsInVolumesToMount(
-		t, generatedVolume1Name, false /* expectReportedInUse */, dsw)
+		t, generatedVolume1Name, []string{"volume1-name"}, false /* expectReportedInUse */, dsw)
 	verifyPodExistsInVolumeDsw(t, pod1Name, generatedVolume1Name, "" /* SELinuxContext */, dsw)
 	verifyVolumeExistsDsw(t, generatedVolume2Name, "" /* SELinuxContext */, dsw)
 	verifyVolumeExistsInVolumesToMount(
-		t, generatedVolume2Name, true /* expectReportedInUse */, dsw)
+		t, generatedVolume2Name, []string{"volume2-name"}, true /* expectReportedInUse */, dsw)
 	verifyPodExistsInVolumeDsw(t, pod2Name, generatedVolume2Name, "" /* SELinuxContext */, dsw)
 	verifyVolumeExistsDsw(t, generatedVolume3Name, "" /* SELinuxContext */, dsw)
 	verifyVolumeExistsInVolumesToMount(
-		t, generatedVolume3Name, false /* expectReportedInUse */, dsw)
+		t, generatedVolume3Name, []string{"volume3-name"}, false /* expectReportedInUse */, dsw)
 	verifyPodExistsInVolumeDsw(t, pod3Name, generatedVolume3Name, "" /* SELinuxContext */, dsw)
 
 	// Act
@@ -473,15 +527,15 @@ func Test_MarkVolumesReportedInUse_Positive_NewPodNewVolume(t *testing.T) {
 	// Assert
 	verifyVolumeExistsDsw(t, generatedVolume1Name, "" /* SELinuxContext */, dsw)
 	verifyVolumeExistsInVolumesToMount(
-		t, generatedVolume1Name, false /* expectReportedInUse */, dsw)
+		t, generatedVolume1Name, []string{"volume1-name"}, false /* expectReportedInUse */, dsw)
 	verifyPodExistsInVolumeDsw(t, pod1Name, generatedVolume1Name, "" /* SELinuxContext */, dsw)
 	verifyVolumeExistsDsw(t, generatedVolume2Name, "" /* SELinuxContext */, dsw)
 	verifyVolumeExistsInVolumesToMount(
-		t, generatedVolume2Name, false /* expectReportedInUse */, dsw)
+		t, generatedVolume2Name, []string{"volume2-name"}, false /* expectReportedInUse */, dsw)
 	verifyPodExistsInVolumeDsw(t, pod2Name, generatedVolume2Name, "" /* SELinuxContext */, dsw)
 	verifyVolumeExistsDsw(t, generatedVolume3Name, "" /* SELinuxContext */, dsw)
 	verifyVolumeExistsInVolumesToMount(
-		t, generatedVolume3Name, true /* expectReportedInUse */, dsw)
+		t, generatedVolume3Name, []string{"volume3-name"}, true /* expectReportedInUse */, dsw)
 	verifyPodExistsInVolumeDsw(t, pod3Name, generatedVolume3Name, "" /* SELinuxContext */, dsw)
 }
 
@@ -881,7 +935,7 @@ func Test_AddPodToVolume_SELinuxSinglePod(t *testing.T) {
 
 			// Act
 			generatedVolumeName, err := dsw.AddPodToVolume(
-				logger, podName, pod, volumeSpec, volumeSpec.Name(), "" /* volumeGIDValue */, seLinuxContainerContexts)
+				logger, podName, pod, volumeSpec, pod.Spec.Volumes[0].Name, "" /* volumeGIDValue */, seLinuxContainerContexts)
 
 			// Assert
 			if tc.expectError {
@@ -896,7 +950,7 @@ func Test_AddPodToVolume_SELinuxSinglePod(t *testing.T) {
 
 			verifyVolumeExistsDsw(t, generatedVolumeName, tc.expectedSELinuxLabel, dsw)
 			verifyVolumeExistsInVolumesToMount(
-				t, generatedVolumeName, false /* expectReportedInUse */, dsw)
+				t, generatedVolumeName, []string{"volume-name"}, false /* expectReportedInUse */, dsw)
 			verifyPodExistsInVolumeDsw(t, podName, generatedVolumeName, tc.expectedSELinuxLabel, dsw)
 			verifyVolumeExistsWithSpecNameInVolumeDsw(t, podName, volumeSpec.Name(), dsw)
 		})
@@ -1231,7 +1285,7 @@ func Test_AddPodToVolume_SELinux_MultiplePods(t *testing.T) {
 
 			// Act
 			generatedVolumeName, err := dsw.AddPodToVolume(
-				logger, podName, pod, volumeSpec, volumeSpec.Name(), "" /* volumeGIDValue */, seLinuxContainerContexts)
+				logger, podName, pod, volumeSpec, pod.Spec.Volumes[0].Name, "" /* volumeGIDValue */, seLinuxContainerContexts)
 
 			// Assert
 			if err != nil {
@@ -1240,7 +1294,7 @@ func Test_AddPodToVolume_SELinux_MultiplePods(t *testing.T) {
 
 			verifyVolumeExistsDsw(t, generatedVolumeName, tc.expectedSELinuxLabel, dsw)
 			verifyVolumeExistsInVolumesToMount(
-				t, generatedVolumeName, false /* expectReportedInUse */, dsw)
+				t, generatedVolumeName, []string{"volume-name"}, false /* expectReportedInUse */, dsw)
 			verifyPodExistsInVolumeDsw(t, podName, generatedVolumeName, tc.expectedSELinuxLabel, dsw)
 			verifyVolumeExistsWithSpecNameInVolumeDsw(t, podName, volumeSpec.Name(), dsw)
 
@@ -1255,7 +1309,7 @@ func Test_AddPodToVolume_SELinux_MultiplePods(t *testing.T) {
 
 			// Act
 			generatedVolumeName2, err := dsw.AddPodToVolume(
-				logger, pod2Name, pod2, volumeSpec, volumeSpec.Name(), "" /* volumeGIDValue */, seLinuxContainerContexts)
+				logger, pod2Name, pod2, volumeSpec, pod2.Spec.Volumes[0].Name, "" /* volumeGIDValue */, seLinuxContainerContexts)
 			// Assert
 			if tc.expectError {
 				if err == nil {
@@ -1397,6 +1451,7 @@ func verifyVolumeDoesntExist(
 func verifyVolumeExistsInVolumesToMount(
 	t *testing.T,
 	expectedVolumeName v1.UniqueVolumeName,
+	expectedOuterNames []string,
 	expectReportedInUse bool,
 	dsw DesiredStateOfWorld) {
 	volumesToMount := dsw.GetVolumesToMount()
@@ -1408,6 +1463,12 @@ func verifyVolumeExistsInVolumesToMount(
 					expectedVolumeName,
 					expectReportedInUse,
 					volume.ReportedInUse)
+			}
+
+			names := volume.OuterVolumeSpecNames
+			slices.Sort(names)
+			if !slices.Equal(names, expectedOuterNames) {
+				t.Fatalf("Expected outer volume spec names to be %v, got %v", expectedOuterNames, names)
 			}
 
 			return

--- a/pkg/kubelet/volumemanager/cache/desired_state_of_world_test.go
+++ b/pkg/kubelet/volumemanager/cache/desired_state_of_world_test.go
@@ -1298,6 +1298,14 @@ func TestGetVolumeNamesForPod(t *testing.T) {
 					},
 				},
 				{
+					Name: "volume1-dup",
+					VolumeSource: v1.VolumeSource{
+						GCEPersistentDisk: &v1.GCEPersistentDiskVolumeSource{
+							PDName: "fake-device1",
+						},
+					},
+				},
+				{
 					Name: "volume3-name",
 					VolumeSource: v1.VolumeSource{
 						GCEPersistentDisk: &v1.GCEPersistentDiskVolumeSource{
@@ -1341,6 +1349,7 @@ func TestGetVolumeNamesForPod(t *testing.T) {
 
 	addVolume(pod1, 0)
 	addVolume(pod1, 1)
+	addVolume(pod1, 2)
 	addVolume(pod2, 0)
 
 	verifyVolumeNames := func(pod *v1.Pod, expectedVolumeNames map[string]v1.UniqueVolumeName) {
@@ -1355,6 +1364,7 @@ func TestGetVolumeNamesForPod(t *testing.T) {
 	}
 	verifyVolumeNames(pod1, map[string]v1.UniqueVolumeName{
 		"volume1-name": "fake-plugin/fake-device1",
+		"volume1-dup":  "fake-plugin/fake-device1",
 		"volume3-name": "fake-plugin/fake-device3",
 	})
 	verifyVolumeNames(pod2, map[string]v1.UniqueVolumeName{

--- a/pkg/kubelet/volumemanager/metrics/metrics_test.go
+++ b/pkg/kubelet/volumemanager/metrics/metrics_test.go
@@ -83,14 +83,13 @@ func TestMetricCollection(t *testing.T) {
 	}
 
 	markVolumeOpts := operationexecutor.MarkVolumeOpts{
-		PodName:             podName,
-		PodUID:              pod.UID,
-		VolumeName:          generatedVolumeName,
-		Mounter:             mounter,
-		BlockVolumeMapper:   mapper,
-		OuterVolumeSpecName: volumeSpec.Name(),
-		VolumeSpec:          volumeSpec,
-		VolumeMountState:    operationexecutor.VolumeMounted,
+		PodName:           podName,
+		PodUID:            pod.UID,
+		VolumeName:        generatedVolumeName,
+		Mounter:           mounter,
+		BlockVolumeMapper: mapper,
+		VolumeSpec:        volumeSpec,
+		VolumeMountState:  operationexecutor.VolumeMounted,
 	}
 	err = asw.AddPodToVolume(markVolumeOpts)
 	if err != nil {

--- a/pkg/kubelet/volumemanager/populator/desired_state_of_world_populator_test.go
+++ b/pkg/kubelet/volumemanager/populator/desired_state_of_world_populator_test.go
@@ -406,13 +406,12 @@ func TestFindAndRemoveDeletedPodsWithUncertain(t *testing.T) {
 
 	// Mark the volume as uncertain
 	opts := operationexecutor.MarkVolumeOpts{
-		PodName:             util.GetUniquePodName(pod),
-		PodUID:              pod.UID,
-		VolumeName:          expectedVolumeName,
-		OuterVolumeSpecName: "dswp-test-volume-name",
-		VolumeGIDVolume:     "",
-		VolumeSpec:          volume.NewSpecFromPersistentVolume(pv, false),
-		VolumeMountState:    operationexecutor.VolumeMountUncertain,
+		PodName:          util.GetUniquePodName(pod),
+		PodUID:           pod.UID,
+		VolumeName:       expectedVolumeName,
+		VolumeGIDVolume:  "",
+		VolumeSpec:       volume.NewSpecFromPersistentVolume(pv, false),
+		VolumeMountState: operationexecutor.VolumeMountUncertain,
 	}
 	err := dswp.actualStateOfWorld.MarkVolumeMountAsUncertain(opts)
 	if err != nil {
@@ -1394,13 +1393,12 @@ func reconcileASW(asw cache.ActualStateOfWorld, dsw cache.DesiredStateOfWorld, t
 			t.Fatalf("Unexpected error when MarkVolumeAsAttached: %v", err)
 		}
 		markVolumeOpts := operationexecutor.MarkVolumeOpts{
-			PodName:             volumeToMount.PodName,
-			PodUID:              volumeToMount.Pod.UID,
-			VolumeName:          volumeToMount.VolumeName,
-			OuterVolumeSpecName: volumeToMount.OuterVolumeSpecName,
-			VolumeGIDVolume:     volumeToMount.VolumeGIDValue,
-			VolumeSpec:          volumeToMount.VolumeSpec,
-			VolumeMountState:    operationexecutor.VolumeMounted,
+			PodName:          volumeToMount.PodName,
+			PodUID:           volumeToMount.Pod.UID,
+			VolumeName:       volumeToMount.VolumeName,
+			VolumeGIDVolume:  volumeToMount.VolumeGIDValue,
+			VolumeSpec:       volumeToMount.VolumeSpec,
+			VolumeMountState: operationexecutor.VolumeMounted,
 		}
 		err = asw.MarkVolumeAsMounted(markVolumeOpts)
 		if err != nil {

--- a/pkg/kubelet/volumemanager/reconciler/reconstruct.go
+++ b/pkg/kubelet/volumemanager/reconciler/reconstruct.go
@@ -114,7 +114,6 @@ func (rc *reconciler) updateStates(logger klog.Logger, reconstructedVolumes map[
 				VolumeName:          volume.volumeName,
 				Mounter:             volume.mounter,
 				BlockVolumeMapper:   volume.blockVolumeMapper,
-				OuterVolumeSpecName: volume.outerVolumeSpecName,
 				VolumeGIDVolume:     volume.volumeGIDValue,
 				VolumeSpec:          volume.volumeSpec,
 				VolumeMountState:    operationexecutor.VolumeMountUncertain,

--- a/pkg/kubelet/volumemanager/reconciler/reconstruct_common.go
+++ b/pkg/kubelet/volumemanager/reconciler/reconstruct_common.go
@@ -72,7 +72,6 @@ type reconstructedVolume struct {
 	volumeName          v1.UniqueVolumeName
 	podName             volumetypes.UniquePodName
 	volumeSpec          *volumepkg.Spec
-	outerVolumeSpecName string
 	pod                 *v1.Pod
 	volumeGIDValue      string
 	devicePath          string
@@ -87,7 +86,6 @@ func (rv reconstructedVolume) MarshalLog() interface{} {
 		VolumeName          string `json:"volumeName"`
 		PodName             string `json:"podName"`
 		VolumeSpecName      string `json:"volumeSpecName"`
-		OuterVolumeSpecName string `json:"outerVolumeSpecName"`
 		PodUID              string `json:"podUID"`
 		VolumeGIDValue      string `json:"volumeGIDValue"`
 		DevicePath          string `json:"devicePath"`
@@ -96,7 +94,6 @@ func (rv reconstructedVolume) MarshalLog() interface{} {
 		VolumeName:          string(rv.volumeName),
 		PodName:             string(rv.podName),
 		VolumeSpecName:      rv.volumeSpec.Name(),
-		OuterVolumeSpecName: rv.outerVolumeSpecName,
 		PodUID:              string(rv.pod.UID),
 		VolumeGIDValue:      rv.volumeGIDValue,
 		DevicePath:          rv.devicePath,
@@ -376,17 +373,12 @@ func (rc *reconciler) reconstructVolume(volume podVolume) (rvolume *reconstructe
 	}
 
 	reconstructedVolume := &reconstructedVolume{
-		volumeName: uniqueVolumeName,
-		podName:    volume.podName,
-		volumeSpec: volumeSpec,
-		// volume.volumeSpecName is actually InnerVolumeSpecName. It will not be used
-		// for volume cleanup.
-		// in case reconciler calls mountOrAttachVolumes, outerVolumeSpecName will
-		// be updated from dsw information in ASW.MarkVolumeAsMounted().
-		outerVolumeSpecName: volume.volumeSpecName,
-		pod:                 pod,
-		deviceMounter:       deviceMounter,
-		volumeGIDValue:      "",
+		volumeName:     uniqueVolumeName,
+		podName:        volume.podName,
+		volumeSpec:     volumeSpec,
+		pod:            pod,
+		deviceMounter:  deviceMounter,
+		volumeGIDValue: "",
 		// devicePath is updated during updateStates() by checking node status's VolumesAttached data.
 		// TODO: get device path directly from the volume mount path.
 		devicePath:          "",

--- a/pkg/kubelet/volumemanager/volume_manager.go
+++ b/pkg/kubelet/volumemanager/volume_manager.go
@@ -491,9 +491,9 @@ func (vm *volumeManager) WaitForUnmount(ctx context.Context, pod *v1.Pod) error 
 		vm.verifyVolumesUnmountedFunc(uniquePodName))
 
 	if err != nil {
-		var mountedVolumes []string
+		var mountedVolumes []v1.UniqueVolumeName
 		for _, v := range vm.actualStateOfWorld.GetMountedVolumesForPod(uniquePodName) {
-			mountedVolumes = append(mountedVolumes, v.OuterVolumeSpecName)
+			mountedVolumes = append(mountedVolumes, v.VolumeName)
 		}
 		if len(mountedVolumes) == 0 {
 			return nil

--- a/pkg/kubelet/volumemanager/volume_manager.go
+++ b/pkg/kubelet/volumemanager/volume_manager.go
@@ -437,7 +437,7 @@ func (vm *volumeManager) WaitForAttachAndMount(ctx context.Context, pod *v1.Pod)
 
 		unattachedVolumes := []string{}
 		for _, volumeToMount := range unattachedVolumeMounts {
-			unattachedVolumes = append(unattachedVolumes, volumeToMount.OuterVolumeSpecName)
+			unattachedVolumes = append(unattachedVolumes, volumeToMount.OuterVolumeSpecNames...)
 		}
 		slices.Sort(unattachedVolumes)
 
@@ -533,7 +533,7 @@ func (vm *volumeManager) getVolumesNotInDSW(uniquePodName types.UniquePodName, e
 
 	for _, volumeToMount := range vm.desiredStateOfWorld.GetVolumesToMount() {
 		if volumeToMount.PodName == uniquePodName {
-			volumesNotInDSW.Delete(volumeToMount.OuterVolumeSpecName)
+			volumesNotInDSW.Delete(volumeToMount.OuterVolumeSpecNames...)
 		}
 	}
 

--- a/pkg/volume/util/operationexecutor/operation_executor.go
+++ b/pkg/volume/util/operationexecutor/operation_executor.go
@@ -758,13 +758,13 @@ type MountedVolume struct {
 // GenerateMsgDetailed returns detailed msgs for mounted volumes
 func (volume *MountedVolume) GenerateMsgDetailed(prefixMsg, suffixMsg string) (detailedMsg string) {
 	detailedStr := fmt.Sprintf("(UniqueName: %q) pod %q (UID: %q)", volume.VolumeName, volume.PodName, volume.PodUID)
-	return generateVolumeMsgDetailed(prefixMsg, suffixMsg, volume.OuterVolumeSpecName, detailedStr)
+	return generateVolumeMsgDetailed(prefixMsg, suffixMsg, string(volume.VolumeName), detailedStr)
 }
 
 // GenerateMsg returns simple and detailed msgs for mounted volumes
 func (volume *MountedVolume) GenerateMsg(prefixMsg, suffixMsg string) (simpleMsg, detailedMsg string) {
 	detailedStr := fmt.Sprintf("(UniqueName: %q) pod %q (UID: %q)", volume.VolumeName, volume.PodName, volume.PodUID)
-	return generateVolumeMsg(prefixMsg, suffixMsg, volume.OuterVolumeSpecName, detailedStr)
+	return generateVolumeMsg(prefixMsg, suffixMsg, string(volume.VolumeName), detailedStr)
 }
 
 // GenerateErrorDetailed returns simple and detailed errors for mounted volumes

--- a/pkg/volume/util/operationexecutor/operation_executor.go
+++ b/pkg/volume/util/operationexecutor/operation_executor.go
@@ -421,10 +421,8 @@ type VolumeToMount struct {
 	// InnerVolumeSpecName.
 	VolumeSpec *volume.Spec
 
-	// outerVolumeSpecName is the podSpec.Volume[x].Name of the volume. If the
-	// volume was referenced through a persistent volume claim, this contains
-	// the podSpec.Volume[x].Name of the persistent volume claim.
-	OuterVolumeSpecName string
+	// outerVolumeSpecNames are the podSpec.Volume[x].Name of the volume.
+	OuterVolumeSpecNames []string
 
 	// Pod to mount the volume to. Used to create NewMounter.
 	Pod *v1.Pod

--- a/pkg/volume/util/operationexecutor/operation_executor.go
+++ b/pkg/volume/util/operationexecutor/operation_executor.go
@@ -169,7 +169,6 @@ type MarkVolumeOpts struct {
 	VolumeName          v1.UniqueVolumeName
 	Mounter             volume.Mounter
 	BlockVolumeMapper   volume.BlockVolumeMapper
-	OuterVolumeSpecName string
 	VolumeGIDVolume     string
 	VolumeSpec          *volume.Spec
 	VolumeMountState    VolumeMountState
@@ -678,44 +677,6 @@ type MountedVolume struct {
 	//     	   pdName: my-data-disk
 	//     	   fsType: ext4
 	InnerVolumeSpecName string
-
-	// outerVolumeSpecName is the podSpec.Volume[x].Name of the volume. If the
-	// volume was referenced through a persistent volume claim, this contains
-	// the podSpec.Volume[x].Name of the persistent volume claim.
-	// PVC example:
-	//   kind: Pod
-	//   apiVersion: v1
-	//   metadata:
-	//     name: mypod
-	//   spec:
-	//     containers:
-	//       - name: myfrontend
-	//         image: dockerfile/nginx
-	//         volumeMounts:
-	//         - mountPath: "/var/www/html"
-	//           name: mypd
-	//     volumes:
-	//       - name: mypd				<- OuterVolumeSpecName
-	//         persistentVolumeClaim:
-	//           claimName: myclaim
-	// Non-PVC example:
-	//   apiVersion: v1
-	//   kind: Pod
-	//   metadata:
-	//     name: test-pd
-	//   spec:
-	//     containers:
-	//     - image: registry.k8s.io/test-webserver
-	//     	 name: test-container
-	//     	 volumeMounts:
-	//     	 - mountPath: /test-pd
-	//     	   name: test-volume
-	//     volumes:
-	//     - name: test-volume			<- OuterVolumeSpecName
-	//     	 gcePersistentDisk:
-	//     	   pdName: my-data-disk
-	//     	   fsType: ext4
-	OuterVolumeSpecName string
 
 	// PluginName is the "Unescaped Qualified" name of the volume plugin used to
 	// mount and unmount this volume. It can be used to fetch the volume plugin

--- a/pkg/volume/util/operationexecutor/operation_generator.go
+++ b/pkg/volume/util/operationexecutor/operation_generator.go
@@ -593,7 +593,6 @@ func (og *operationGenerator) GenerateMountVolumeFunc(
 			PodUID:              volumeToMount.Pod.UID,
 			VolumeName:          volumeToMount.VolumeName,
 			Mounter:             volumeMounter,
-			OuterVolumeSpecName: volumeToMount.OuterVolumeSpecName,
 			VolumeGIDVolume:     volumeToMount.VolumeGIDValue,
 			VolumeSpec:          volumeToMount.VolumeSpec,
 			VolumeMountState:    VolumeMounted,
@@ -759,13 +758,12 @@ func (og *operationGenerator) GenerateUnmountVolumeFunc(
 		if unmountErr != nil {
 			// Mark the volume as uncertain, so SetUp is called for new pods. Teardown may be already in progress.
 			opts := MarkVolumeOpts{
-				PodName:             volumeToUnmount.PodName,
-				PodUID:              volumeToUnmount.PodUID,
-				VolumeName:          volumeToUnmount.VolumeName,
-				OuterVolumeSpecName: volumeToUnmount.OuterVolumeSpecName,
-				VolumeGIDVolume:     volumeToUnmount.VolumeGIDValue,
-				VolumeSpec:          volumeToUnmount.VolumeSpec,
-				VolumeMountState:    VolumeMountUncertain,
+				PodName:          volumeToUnmount.PodName,
+				PodUID:           volumeToUnmount.PodUID,
+				VolumeName:       volumeToUnmount.VolumeName,
+				VolumeGIDVolume:  volumeToUnmount.VolumeGIDValue,
+				VolumeSpec:       volumeToUnmount.VolumeSpec,
+				VolumeMountState: VolumeMountUncertain,
 			}
 			markMountUncertainErr := actualStateOfWorld.MarkVolumeMountAsUncertain(opts)
 			if markMountUncertainErr != nil {
@@ -1024,14 +1022,13 @@ func (og *operationGenerator) GenerateMapVolumeFunc(
 		}
 
 		markVolumeOpts := MarkVolumeOpts{
-			PodName:             volumeToMount.PodName,
-			PodUID:              volumeToMount.Pod.UID,
-			VolumeName:          volumeToMount.VolumeName,
-			BlockVolumeMapper:   blockVolumeMapper,
-			OuterVolumeSpecName: volumeToMount.OuterVolumeSpecName,
-			VolumeGIDVolume:     volumeToMount.VolumeGIDValue,
-			VolumeSpec:          volumeToMount.VolumeSpec,
-			VolumeMountState:    VolumeMounted,
+			PodName:           volumeToMount.PodName,
+			PodUID:            volumeToMount.Pod.UID,
+			VolumeName:        volumeToMount.VolumeName,
+			BlockVolumeMapper: blockVolumeMapper,
+			VolumeGIDVolume:   volumeToMount.VolumeGIDValue,
+			VolumeSpec:        volumeToMount.VolumeSpec,
+			VolumeMountState:  VolumeMounted,
 		}
 
 		// Call MapPodDevice if blockVolumeMapper implements CustomBlockVolumeMapper
@@ -1198,13 +1195,12 @@ func (og *operationGenerator) GenerateUnmapVolumeFunc(
 		// cases below. The volume is marked as fully un-mapped at the end of this function, when everything
 		// succeeds.
 		markVolumeOpts := MarkVolumeOpts{
-			PodName:             volumeToUnmount.PodName,
-			PodUID:              volumeToUnmount.PodUID,
-			VolumeName:          volumeToUnmount.VolumeName,
-			OuterVolumeSpecName: volumeToUnmount.OuterVolumeSpecName,
-			VolumeGIDVolume:     volumeToUnmount.VolumeGIDValue,
-			VolumeSpec:          volumeToUnmount.VolumeSpec,
-			VolumeMountState:    VolumeMountUncertain,
+			PodName:          volumeToUnmount.PodName,
+			PodUID:           volumeToUnmount.PodUID,
+			VolumeName:       volumeToUnmount.VolumeName,
+			VolumeGIDVolume:  volumeToUnmount.VolumeGIDValue,
+			VolumeSpec:       volumeToUnmount.VolumeSpec,
+			VolumeMountState: VolumeMountUncertain,
 		}
 		markVolumeUncertainErr := actualStateOfWorld.MarkVolumeMountAsUncertain(markVolumeOpts)
 		if markVolumeUncertainErr != nil {

--- a/pkg/volume/util/operationexecutor/operation_generator.go
+++ b/pkg/volume/util/operationexecutor/operation_generator.go
@@ -779,9 +779,8 @@ func (og *operationGenerator) GenerateUnmountVolumeFunc(
 		}
 
 		klog.Infof(
-			"UnmountVolume.TearDown succeeded for volume %q (OuterVolumeSpecName: %q) pod %q (UID: %q). InnerVolumeSpecName %q. PluginName %q, VolumeGIDValue %q",
+			"UnmountVolume.TearDown succeeded for volume %q pod %q (UID: %q). InnerVolumeSpecName %q. PluginName %q, VolumeGIDValue %q",
 			volumeToUnmount.VolumeName,
-			volumeToUnmount.OuterVolumeSpecName,
 			volumeToUnmount.PodName,
 			volumeToUnmount.PodUID,
 			volumeToUnmount.InnerVolumeSpecName,
@@ -1234,9 +1233,8 @@ func (og *operationGenerator) GenerateUnmapVolumeFunc(
 		}
 
 		klog.Infof(
-			"UnmapVolume succeeded for volume %q (OuterVolumeSpecName: %q) pod %q (UID: %q). InnerVolumeSpecName %q. PluginName %q, VolumeGIDValue %q",
+			"UnmapVolume succeeded for volume %q pod %q (UID: %q). InnerVolumeSpecName %q. PluginName %q, VolumeGIDValue %q",
 			volumeToUnmount.VolumeName,
-			volumeToUnmount.OuterVolumeSpecName,
 			volumeToUnmount.PodName,
 			volumeToUnmount.PodUID,
 			volumeToUnmount.InnerVolumeSpecName,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Previously, pod with multiple volumes references one PVC is stuck at ContainerCreating without any error message.
Fixing this by storing multiple OuterVolumeSpecNames per volume.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Pod can have multiple volumes reference the same PVC
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
