### PR TITLE
DRA helper: enhance context support

### DIFF
--- a/staging/src/k8s.io/dynamic-resource-allocation/controller/controller.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/controller/controller.go
@@ -189,7 +189,7 @@ func New(
 	schedulingCtxInformer := informerFactory.Resource().V1alpha2().PodSchedulingContexts()
 	claimNameLookup := resourceclaim.NewNameLookup(kubeClient)
 
-	eventBroadcaster := record.NewBroadcaster()
+	eventBroadcaster := record.NewBroadcaster(record.WithContext(ctx))
 	go func() {
 		<-ctx.Done()
 		eventBroadcaster.Shutdown()

--- a/staging/src/k8s.io/dynamic-resource-allocation/leaderelection/leaderelection.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/leaderelection/leaderelection.go
@@ -161,6 +161,10 @@ func (l *leaderElection) PrepareHealthCheck(s Server) {
 }
 
 func (l *leaderElection) Run() error {
+	ctx := l.ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	if l.identity == "" {
 		id, err := defaultLeaderElectionIdentity()
 		if err != nil {
@@ -174,7 +178,7 @@ func (l *leaderElection) Run() error {
 		l.namespace = inClusterNamespace()
 	}
 
-	broadcaster := record.NewBroadcaster()
+	broadcaster := record.NewBroadcaster(record.WithContext(ctx))
 	broadcaster.StartRecordingToSink(&corev1.EventSinkImpl{Interface: l.clientset.CoreV1().Events(l.namespace)})
 	eventRecorder := broadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: fmt.Sprintf("%s/%s", l.lockName, l.identity)})
 
@@ -188,10 +192,6 @@ func (l *leaderElection) Run() error {
 		return err
 	}
 
-	ctx := l.ctx
-	if ctx == nil {
-		ctx = context.Background()
-	}
 	leaderConfig := leaderelection.LeaderElectionConfig{
 		Lock:          lock,
 		LeaseDuration: l.leaseDuration,


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

27a68aee3a4834 introduced context support for events. Creating an event broadcaster with context makes tests more resilient against leaking goroutines when that context gets canceled at the end of a test and enables per-test output via ktesting.


#### Does this PR introduce a user-facing change?
```release-note
NONE
```
