### PR TITLE
controllers + apiserver: enhance context support

### DIFF
--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -20,6 +20,7 @@ limitations under the License.
 package app
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"net/http"
@@ -114,7 +115,7 @@ cluster's shared state through which all other components interact.`,
 			}
 			// add feature enablement metrics
 			utilfeature.DefaultMutableFeatureGate.AddMetrics()
-			return Run(completedOptions, genericapiserver.SetupSignalHandler())
+			return Run(cmd.Context(), completedOptions)
 		},
 		Args: func(cmd *cobra.Command, args []string) error {
 			for _, arg := range args {
@@ -125,6 +126,7 @@ cluster's shared state through which all other components interact.`,
 			return nil
 		},
 	}
+	cmd.SetContext(genericapiserver.SetupSignalContext())
 
 	fs := cmd.Flags()
 	namedFlagSets := s.Flags()
@@ -142,7 +144,7 @@ cluster's shared state through which all other components interact.`,
 }
 
 // Run runs the specified APIServer.  This should never exit.
-func Run(opts options.CompletedOptions, stopCh <-chan struct{}) error {
+func Run(ctx context.Context, opts options.CompletedOptions) error {
 	// To help debugging, immediately log version
 	klog.Infof("Version: %+v", version.Get())
 
@@ -166,7 +168,7 @@ func Run(opts options.CompletedOptions, stopCh <-chan struct{}) error {
 		return err
 	}
 
-	return prepared.Run(stopCh)
+	return prepared.Run(ctx)
 }
 
 // CreateServerChain creates the apiservers connected via delegation.

--- a/pkg/controlplane/instance.go
+++ b/pkg/controlplane/instance.go
@@ -420,7 +420,7 @@ func (c CompletedConfig) New(delegationTarget genericapiserver.DelegationTarget)
 			)
 			// The default serviceCIDR must exist before the apiserver is healthy
 			// otherwise the allocators for Services will not work.
-			controller.Start(hookContext.StopCh)
+			controller.Start(hookContext)
 			return nil
 		})
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/main.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/main.go
@@ -25,8 +25,8 @@ import (
 )
 
 func main() {
-	stopCh := genericapiserver.SetupSignalHandler()
-	cmd := server.NewServerCommand(os.Stdout, os.Stderr, stopCh)
+	ctx := genericapiserver.SetupSignalContext()
+	cmd := server.NewServerCommand(ctx, os.Stdout, os.Stderr)
 	code := cli.Run(cmd)
 	os.Exit(code)
 }

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/cmd/server/server.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/cmd/server/server.go
@@ -17,6 +17,7 @@ limitations under the License.
 package server
 
 import (
+	"context"
 	"io"
 
 	"github.com/spf13/cobra"
@@ -25,7 +26,7 @@ import (
 	genericapiserver "k8s.io/apiserver/pkg/server"
 )
 
-func NewServerCommand(out, errOut io.Writer, stopCh <-chan struct{}) *cobra.Command {
+func NewServerCommand(ctx context.Context, out, errOut io.Writer) *cobra.Command {
 	o := options.NewCustomResourceDefinitionsServerOptions(out, errOut)
 
 	cmd := &cobra.Command{
@@ -38,19 +39,20 @@ func NewServerCommand(out, errOut io.Writer, stopCh <-chan struct{}) *cobra.Comm
 			if err := o.Validate(); err != nil {
 				return err
 			}
-			if err := Run(o, stopCh); err != nil {
+			if err := Run(c.Context(), o); err != nil {
 				return err
 			}
 			return nil
 		},
 	}
+	cmd.SetContext(ctx)
 
 	fs := cmd.Flags()
 	o.AddFlags(fs)
 	return cmd
 }
 
-func Run(o *options.CustomResourceDefinitionsServerOptions, stopCh <-chan struct{}) error {
+func Run(ctx context.Context, o *options.CustomResourceDefinitionsServerOptions) error {
 	config, err := o.Config()
 	if err != nil {
 		return err
@@ -60,5 +62,5 @@ func Run(o *options.CustomResourceDefinitionsServerOptions, stopCh <-chan struct
 	if err != nil {
 		return err
 	}
-	return server.GenericAPIServer.PrepareRun().Run(stopCh)
+	return server.GenericAPIServer.PrepareRun().RunWithContext(ctx)
 }

--- a/staging/src/k8s.io/apiserver/pkg/server/genericapiserver_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/genericapiserver_test.go
@@ -52,6 +52,7 @@ import (
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
 	restclient "k8s.io/client-go/rest"
+	"k8s.io/klog/v2/ktesting"
 	kubeopenapi "k8s.io/kube-openapi/pkg/common"
 	"k8s.io/kube-openapi/pkg/validation/spec"
 	netutils "k8s.io/utils/net"
@@ -317,17 +318,16 @@ func TestInstallAPIGroups(t *testing.T) {
 }
 
 func TestPrepareRun(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
 	s, config, assert := newMaster(t)
 
 	assert.NotNil(config.OpenAPIConfig)
 
 	server := httptest.NewServer(s.Handler.Director)
 	defer server.Close()
-	done := make(chan struct{})
-	defer close(done)
 
 	s.PrepareRun()
-	s.RunPostStartHooks(done)
+	s.RunPostStartHooks(ctx)
 
 	// openapi is installed in PrepareRun
 	resp, err := http.Get(server.URL + "/openapi/v2")
@@ -353,9 +353,10 @@ func TestPrepareRun(t *testing.T) {
 }
 
 func TestUpdateOpenAPISpec(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
 	s, _, assert := newMaster(t)
 	s.PrepareRun()
-	s.RunPostStartHooks(make(chan struct{}))
+	s.RunPostStartHooks(ctx)
 
 	server := httptest.NewServer(s.Handler.Director)
 	defer server.Close()

--- a/staging/src/k8s.io/apiserver/pkg/server/hooks.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/hooks.go
@@ -17,6 +17,7 @@ limitations under the License.
 package server
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -48,8 +49,13 @@ type PreShutdownHookFunc func() error
 type PostStartHookContext struct {
 	// LoopbackClientConfig is a config for a privileged loopback connection to the API server
 	LoopbackClientConfig *restclient.Config
-	// StopCh is the channel that will be closed when the server stops
+	// StopCh is the channel that will be closed when the server stops.
+	//
+	// Deprecated: use the PostStartHookContext itself instead, it contains a context that
+	// gets cancelled when the server stops. StopCh keeps getting provided for existing code.
 	StopCh <-chan struct{}
+	// Context gets cancelled when the server stops.
+	context.Context
 }
 
 // PostStartHookProvider is an interface in addition to provide a post start hook for the api server
@@ -151,15 +157,16 @@ func (s *GenericAPIServer) AddPreShutdownHookOrDie(name string, hook PreShutdown
 	}
 }
 
-// RunPostStartHooks runs the PostStartHooks for the server
-func (s *GenericAPIServer) RunPostStartHooks(stopCh <-chan struct{}) {
+// RunPostStartHooks runs the PostStartHooks for the server.
+func (s *GenericAPIServer) RunPostStartHooks(ctx context.Context) {
 	s.postStartHookLock.Lock()
 	defer s.postStartHookLock.Unlock()
 	s.postStartHooksCalled = true
 
 	context := PostStartHookContext{
 		LoopbackClientConfig: s.LoopbackClientConfig,
-		StopCh:               stopCh,
+		StopCh:               ctx.Done(),
+		Context:              ctx,
 	}
 
 	for hookName, hookEntry := range s.postStartHooks {

--- a/staging/src/k8s.io/apiserver/pkg/server/options/serving_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/serving_test.go
@@ -18,6 +18,7 @@ package options
 
 import (
 	"bytes"
+	"context"
 	cryptorand "crypto/rand"
 	"crypto/rsa"
 	"crypto/tls"
@@ -25,6 +26,7 @@ import (
 	"crypto/x509/pkix"
 	"encoding/base64"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"math/big"
@@ -44,6 +46,7 @@ import (
 	"k8s.io/client-go/discovery"
 	restclient "k8s.io/client-go/rest"
 	cliflag "k8s.io/component-base/cli/flag"
+	"k8s.io/klog/v2/ktesting"
 	netutils "k8s.io/utils/net"
 )
 
@@ -215,6 +218,10 @@ func TestServerRunWithSNI(t *testing.T) {
 		test := tests[title]
 		t.Run(title, func(t *testing.T) {
 			t.Parallel()
+			_, ctx := ktesting.NewTestContext(t)
+			ctx, cancel := context.WithCancelCause(ctx)
+			defer cancel(errors.New("test has completed"))
+
 			// create server cert
 			certDir := "testdata/" + specToName(test.Cert)
 			serverCertBundleFile := filepath.Join(certDir, "cert")
@@ -267,9 +274,6 @@ func TestServerRunWithSNI(t *testing.T) {
 				signatures[sig] = j
 			}
 
-			stopCh := make(chan struct{})
-			defer close(stopCh)
-
 			// launch server
 			config := setUp(t)
 
@@ -316,7 +320,7 @@ func TestServerRunWithSNI(t *testing.T) {
 			preparedServer := s.PrepareRun()
 			preparedServerErrors := make(chan error)
 			go func() {
-				if err := preparedServer.Run(stopCh); err != nil {
+				if err := preparedServer.RunWithContext(ctx); err != nil {
 					preparedServerErrors <- err
 				}
 			}()

--- a/staging/src/k8s.io/kube-aggregator/main.go
+++ b/staging/src/k8s.io/kube-aggregator/main.go
@@ -32,9 +32,9 @@ import (
 )
 
 func main() {
-	stopCh := genericapiserver.SetupSignalHandler()
+	ctx := genericapiserver.SetupSignalContext()
 	options := server.NewDefaultOptions(os.Stdout, os.Stderr)
-	cmd := server.NewCommandStartAggregator(options, stopCh)
+	cmd := server.NewCommandStartAggregator(ctx, options)
 	code := cli.Run(cmd)
 	os.Exit(code)
 }

--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/apiserver.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/apiserver.go
@@ -115,7 +115,7 @@ type CompletedConfig struct {
 }
 
 type runnable interface {
-	Run(stopCh <-chan struct{}) error
+	RunWithContext(ctx context.Context) error
 }
 
 // preparedGenericAPIServer is a private wrapper that enforces a call of PrepareRun() before Run can be invoked.
@@ -479,8 +479,8 @@ func (s *APIAggregator) PrepareRun() (preparedAPIAggregator, error) {
 	return preparedAPIAggregator{APIAggregator: s, runnable: prepared}, nil
 }
 
-func (s preparedAPIAggregator) Run(stopCh <-chan struct{}) error {
-	return s.runnable.Run(stopCh)
+func (s preparedAPIAggregator) Run(ctx context.Context) error {
+	return s.runnable.RunWithContext(ctx)
 }
 
 // AddAPIService adds an API service.  It is not thread-safe, so only call it on one thread at a time please.

--- a/staging/src/k8s.io/kube-aggregator/pkg/cmd/server/start.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/cmd/server/start.go
@@ -17,6 +17,7 @@ limitations under the License.
 package server
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -55,7 +56,7 @@ type AggregatorOptions struct {
 
 // NewCommandStartAggregator provides a CLI handler for 'start master' command
 // with a default AggregatorOptions.
-func NewCommandStartAggregator(defaults *AggregatorOptions, stopCh <-chan struct{}) *cobra.Command {
+func NewCommandStartAggregator(ctx context.Context, defaults *AggregatorOptions) *cobra.Command {
 	o := *defaults
 	cmd := &cobra.Command{
 		Short: "Launch a API aggregator and proxy server",
@@ -67,12 +68,13 @@ func NewCommandStartAggregator(defaults *AggregatorOptions, stopCh <-chan struct
 			if err := o.Validate(args); err != nil {
 				return err
 			}
-			if err := o.RunAggregator(stopCh); err != nil {
+			if err := o.RunAggregator(c.Context()); err != nil {
 				return err
 			}
 			return nil
 		},
 	}
+	cmd.SetContext(ctx)
 
 	o.AddFlags(cmd.Flags())
 	return cmd
@@ -119,7 +121,7 @@ func (o *AggregatorOptions) Complete() error {
 }
 
 // RunAggregator runs the API Aggregator.
-func (o AggregatorOptions) RunAggregator(stopCh <-chan struct{}) error {
+func (o AggregatorOptions) RunAggregator(ctx context.Context) error {
 	// TODO have a "real" external address
 	if err := o.RecommendedOptions.SecureServing.MaybeDefaultWithSelfSignedCerts("localhost", nil, nil); err != nil {
 		return fmt.Errorf("error creating self-signed certificates: %v", err)
@@ -171,5 +173,5 @@ func (o AggregatorOptions) RunAggregator(stopCh <-chan struct{}) error {
 	if err != nil {
 		return err
 	}
-	return prepared.Run(stopCh)
+	return prepared.Run(ctx)
 }

--- a/staging/src/k8s.io/sample-apiserver/main.go
+++ b/staging/src/k8s.io/sample-apiserver/main.go
@@ -25,9 +25,9 @@ import (
 )
 
 func main() {
-	stopCh := genericapiserver.SetupSignalHandler()
+	ctx := genericapiserver.SetupSignalContext()
 	options := server.NewWardleServerOptions(os.Stdout, os.Stderr)
-	cmd := server.NewCommandStartWardleServer(options, stopCh)
+	cmd := server.NewCommandStartWardleServer(ctx, options)
 	code := cli.Run(cmd)
 	os.Exit(code)
 }

--- a/staging/src/k8s.io/sample-apiserver/pkg/cmd/server/start.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/cmd/server/start.go
@@ -17,6 +17,7 @@ limitations under the License.
 package server
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net"
@@ -71,7 +72,7 @@ func NewWardleServerOptions(out, errOut io.Writer) *WardleServerOptions {
 
 // NewCommandStartWardleServer provides a CLI handler for 'start master' command
 // with a default WardleServerOptions.
-func NewCommandStartWardleServer(defaults *WardleServerOptions, stopCh <-chan struct{}) *cobra.Command {
+func NewCommandStartWardleServer(ctx context.Context, defaults *WardleServerOptions) *cobra.Command {
 	o := *defaults
 	cmd := &cobra.Command{
 		Short: "Launch a wardle API server",
@@ -83,12 +84,13 @@ func NewCommandStartWardleServer(defaults *WardleServerOptions, stopCh <-chan st
 			if err := o.Validate(args); err != nil {
 				return err
 			}
-			if err := o.RunWardleServer(stopCh); err != nil {
+			if err := o.RunWardleServer(c.Context()); err != nil {
 				return err
 			}
 			return nil
 		},
 	}
+	cmd.SetContext(ctx)
 
 	flags := cmd.Flags()
 	o.RecommendedOptions.AddFlags(flags)
@@ -154,7 +156,7 @@ func (o *WardleServerOptions) Config() (*apiserver.Config, error) {
 }
 
 // RunWardleServer starts a new WardleServer given WardleServerOptions
-func (o WardleServerOptions) RunWardleServer(stopCh <-chan struct{}) error {
+func (o WardleServerOptions) RunWardleServer(ctx context.Context) error {
 	config, err := o.Config()
 	if err != nil {
 		return err
@@ -171,5 +173,5 @@ func (o WardleServerOptions) RunWardleServer(stopCh <-chan struct{}) error {
 		return nil
 	})
 
-	return server.GenericAPIServer.PrepareRun().Run(stopCh)
+	return server.GenericAPIServer.PrepareRun().RunWithContext(ctx)
 }

--- a/staging/src/k8s.io/sample-controller/controller.go
+++ b/staging/src/k8s.io/sample-controller/controller.go
@@ -101,7 +101,7 @@ func NewController(
 	utilruntime.Must(samplescheme.AddToScheme(scheme.Scheme))
 	logger.V(4).Info("Creating event broadcaster")
 
-	eventBroadcaster := record.NewBroadcaster()
+	eventBroadcaster := record.NewBroadcaster(record.WithContext(ctx))
 	eventBroadcaster.StartStructuredLogging(0)
 	eventBroadcaster.StartRecordingToSink(&typedcorev1.EventSinkImpl{Interface: kubeclientset.CoreV1().Events("")})
 	recorder := eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: controllerAgentName})

--- a/test/e2e_node/services/internal_services.go
+++ b/test/e2e_node/services/internal_services.go
@@ -24,8 +24,8 @@ import (
 	etcd3testing "k8s.io/apiserver/pkg/storage/etcd3/testing"
 	"k8s.io/apiserver/pkg/storage/storagebackend"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
-	"k8s.io/klog/v2/ktesting"
 	"k8s.io/kubernetes/test/e2e/framework"
+	"k8s.io/kubernetes/test/utils/ktesting"
 
 	"k8s.io/klog/v2"
 )
@@ -58,17 +58,17 @@ func (es *e2eServices) run(t *testing.T) error {
 
 // start starts the tests embedded services or returns an error.
 func (es *e2eServices) start(t *testing.T) error {
-	_, ctx := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
 	klog.Info("Starting e2e services...")
 	err := es.startEtcd(t)
 	if err != nil {
 		return err
 	}
-	err = es.startAPIServer(es.etcdStorage)
+	err = es.startAPIServer(tCtx, es.etcdStorage)
 	if err != nil {
 		return err
 	}
-	err = es.startNamespaceController(ctx)
+	err = es.startNamespaceController(tCtx)
 	if err != nil {
 		return nil
 	}
@@ -121,10 +121,10 @@ func (es *e2eServices) startEtcd(t *testing.T) error {
 }
 
 // startAPIServer starts the embedded API server or returns an error.
-func (es *e2eServices) startAPIServer(etcdStorage *storagebackend.Config) error {
+func (es *e2eServices) startAPIServer(ctx context.Context, etcdStorage *storagebackend.Config) error {
 	klog.Info("Starting API server")
 	es.apiServer = NewAPIServer(*etcdStorage)
-	return es.apiServer.Start()
+	return es.apiServer.Start(ctx)
 }
 
 // startNamespaceController starts the embedded namespace controller or returns an error.

--- a/test/integration/controlplane/transformation/secrets_transformation_test.go
+++ b/test/integration/controlplane/transformation/secrets_transformation_test.go
@@ -94,7 +94,7 @@ func TestSecretsShouldBeTransformed(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to create test secret, error: %v", err)
 		}
-		test.runResource(test.logger, tt.unSealFunc, tt.transformerPrefix, "", "v1", "secrets", test.secret.Name, test.secret.Namespace)
+		test.runResource(test.TContext, tt.unSealFunc, tt.transformerPrefix, "", "v1", "secrets", test.secret.Name, test.secret.Namespace)
 		test.cleanUp()
 	}
 }

--- a/test/integration/controlplane/transformation/transformation_test.go
+++ b/test/integration/controlplane/transformation/transformation_test.go
@@ -50,6 +50,7 @@ import (
 	"k8s.io/kubernetes/test/integration"
 	"k8s.io/kubernetes/test/integration/etcd"
 	"k8s.io/kubernetes/test/integration/framework"
+	"k8s.io/kubernetes/test/utils/ktesting"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/yaml"
 )
@@ -75,7 +76,7 @@ const (
 type unSealSecret func(ctx context.Context, cipherText []byte, dataCtx value.Context, config apiserverv1.ProviderConfiguration) ([]byte, error)
 
 type transformTest struct {
-	logger            kubeapiservertesting.Logger
+	ktesting.TContext
 	storageConfig     *storagebackend.Config
 	configDir         string
 	transformerConfig string
@@ -85,12 +86,13 @@ type transformTest struct {
 	secret            *corev1.Secret
 }
 
-func newTransformTest(l kubeapiservertesting.Logger, transformerConfigYAML string, reload bool, configDir string, storageConfig *storagebackend.Config) (*transformTest, error) {
+func newTransformTest(tb testing.TB, transformerConfigYAML string, reload bool, configDir string, storageConfig *storagebackend.Config) (*transformTest, error) {
+	tCtx := ktesting.Init(tb)
 	if storageConfig == nil {
 		storageConfig = framework.SharedEtcd()
 	}
 	e := transformTest{
-		logger:            l,
+		TContext:          tCtx,
 		transformerConfig: transformerConfigYAML,
 		storageConfig:     storageConfig,
 	}
@@ -113,7 +115,7 @@ func newTransformTest(l kubeapiservertesting.Logger, transformerConfigYAML strin
 		return nil, fmt.Errorf("failed to read config file: %w", err)
 	}
 
-	if e.kubeAPIServer, err = kubeapiservertesting.StartTestServer(l, nil, e.getEncryptionOptions(reload), e.storageConfig); err != nil {
+	if e.kubeAPIServer, err = kubeapiservertesting.StartTestServer(tb, nil, e.getEncryptionOptions(reload), e.storageConfig); err != nil {
 		e.cleanUp()
 		return nil, fmt.Errorf("failed to start KubeAPI server: %w", err)
 	}
@@ -131,11 +133,11 @@ func newTransformTest(l kubeapiservertesting.Logger, transformerConfigYAML strin
 
 	if transformerConfigYAML != "" && reload {
 		// when reloading is enabled, this healthz endpoint is always present
-		mustBeHealthy(l, "/kms-providers", "ok", e.kubeAPIServer.ClientConfig)
-		mustNotHaveLivez(l, "/kms-providers", "404 page not found", e.kubeAPIServer.ClientConfig)
+		mustBeHealthy(tCtx, "/kms-providers", "ok", e.kubeAPIServer.ClientConfig)
+		mustNotHaveLivez(tCtx, "/kms-providers", "404 page not found", e.kubeAPIServer.ClientConfig)
 
 		// excluding healthz endpoints even if they do not exist should work
-		mustBeHealthy(l, "", `warn: some health checks cannot be excluded: no matches for "kms-provider-0","kms-provider-1","kms-provider-2","kms-provider-3"`,
+		mustBeHealthy(tCtx, "", `warn: some health checks cannot be excluded: no matches for "kms-provider-0","kms-provider-1","kms-provider-2","kms-provider-3"`,
 			e.kubeAPIServer.ClientConfig, "kms-provider-0", "kms-provider-1", "kms-provider-2", "kms-provider-3")
 	}
 
@@ -530,7 +532,7 @@ func (e *transformTest) writeRawRecordToETCD(path string, data []byte) (*clientv
 }
 
 func (e *transformTest) printMetrics() error {
-	e.logger.Logf("Transformation Metrics:")
+	e.Logf("Transformation Metrics:")
 	metrics, err := legacyregistry.DefaultGatherer.Gather()
 	if err != nil {
 		return fmt.Errorf("failed to gather metrics: %s", err)
@@ -538,9 +540,9 @@ func (e *transformTest) printMetrics() error {
 
 	for _, mf := range metrics {
 		if strings.HasPrefix(*mf.Name, metricsPrefix) {
-			e.logger.Logf("%s", *mf.Name)
+			e.Logf("%s", *mf.Name)
 			for _, metric := range mf.GetMetric() {
-				e.logger.Logf("%v", metric)
+				e.Logf("%v", metric)
 			}
 		}
 	}

--- a/test/integration/examples/apiserver_test.go
+++ b/test/integration/examples/apiserver_test.go
@@ -62,9 +62,6 @@ func TestAPIServiceWaitOnStart(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 	t.Cleanup(cancel)
 
-	stopCh := make(chan struct{})
-	defer close(stopCh)
-
 	etcdConfig := framework.SharedEtcd()
 
 	etcd3Client, _, err := integration.GetEtcdClients(etcdConfig.Transport)
@@ -235,9 +232,6 @@ func TestAggregatedAPIServer(t *testing.T) {
 	// makes the kube-apiserver very responsive.  it's normally a minute
 	dynamiccertificates.FileRefreshDuration = 1 * time.Second
 
-	stopCh := make(chan struct{})
-	defer close(stopCh)
-
 	// we need the wardle port information first to set up the service resolver
 	listener, wardlePort, err := genericapiserveroptions.CreateListener("tcp", "127.0.0.1:0", net.ListenConfig{})
 	if err != nil {
@@ -291,7 +285,7 @@ func TestAggregatedAPIServer(t *testing.T) {
 		}
 		o.RecommendedOptions.SecureServing.Listener = listener
 		o.RecommendedOptions.SecureServing.BindAddress = netutils.ParseIPSloppy("127.0.0.1")
-		wardleCmd := sampleserver.NewCommandStartWardleServer(o, stopCh)
+		wardleCmd := sampleserver.NewCommandStartWardleServer(ctx, o)
 		wardleCmd.SetArgs([]string{
 			"--authentication-kubeconfig", wardleToKASKubeConfigFile,
 			"--authorization-kubeconfig", wardleToKASKubeConfigFile,

--- a/test/integration/framework/test_server.go
+++ b/test/integration/framework/test_server.go
@@ -176,7 +176,7 @@ func StartTestServer(ctx context.Context, t testing.TB, setup TestServerSetup) (
 	errCh = make(chan error)
 	go func() {
 		defer close(errCh)
-		if err := kubeAPIServer.ControlPlane.GenericAPIServer.PrepareRun().Run(ctx.Done()); err != nil {
+		if err := kubeAPIServer.ControlPlane.GenericAPIServer.PrepareRun().RunWithContext(ctx); err != nil {
 			errCh <- err
 		}
 	}()


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

27a68aee3a4834 introduced context support for events. Creating an event
broadcaster with context makes tests more resilient against leaking goroutines
when that context gets canceled at the end of a test and enables per-test
output via ktesting.
    
#### Special notes for your reviewer:

The context could get passed to the constructor. A cleaner solution is to
enhance context support for the apiserver and then pass the context into the
controller's run method. This ripples up the call stack to all places which
start an apiserver.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
