### PR TITLE
call MarkRemountRequired on terminating pods

### DIFF
--- a/pkg/kubelet/volumemanager/populator/desired_state_of_world_populator.go
+++ b/pkg/kubelet/volumemanager/populator/desired_state_of_world_populator.go
@@ -111,7 +111,7 @@ func NewDesiredStateOfWorldPopulator(
 		desiredStateOfWorld: desiredStateOfWorld,
 		actualStateOfWorld:  actualStateOfWorld,
 		pods: processedPods{
-			processedPods: make(map[volumetypes.UniquePodName]bool)},
+			processedPods: make(map[volumetypes.UniquePodName]processedPodState)},
 		hasAddedPods:             false,
 		hasAddedPodsLock:         sync.RWMutex{},
 		csiMigratedPluginManager: csiMigratedPluginManager,
@@ -136,8 +136,13 @@ type desiredStateOfWorldPopulator struct {
 }
 
 type processedPods struct {
-	processedPods map[volumetypes.UniquePodName]bool
+	processedPods map[volumetypes.UniquePodName]processedPodState
 	sync.RWMutex
+}
+
+type processedPodState struct {
+	processed       bool
+	lastProcessedAt time.Time
 }
 
 func (dswp *desiredStateOfWorldPopulator) Run(ctx context.Context, sourcesReady config.SourcesReady) {
@@ -179,12 +184,6 @@ func (dswp *desiredStateOfWorldPopulator) populatorLoop(ctx context.Context) {
 // exist but should
 func (dswp *desiredStateOfWorldPopulator) findAndAddNewPods(ctx context.Context) {
 	for _, pod := range dswp.podManager.GetPods() {
-		// Keep consistency of adding pod during reconstruction
-		if dswp.hasAddedPods && dswp.podStateProvider.ShouldPodContainersBeTerminating(pod.UID) {
-			// Do not (re)add volumes for pods that can't also be starting containers
-			continue
-		}
-
 		if !dswp.hasAddedPods && dswp.podStateProvider.ShouldPodRuntimeBeRemoved(pod.UID) {
 			// When kubelet restarts, we need to add pods to dsw if there is a possibility
 			// that the container may still be running
@@ -284,6 +283,15 @@ func (dswp *desiredStateOfWorldPopulator) processPodVolumes(ctx context.Context,
 		return
 	}
 
+	if dswp.hasAddedPods && dswp.podStateProvider.ShouldPodContainersBeTerminating(pod.UID) {
+		// If a Pod is terminating, we need to continue to refresh volumes.
+		// However, we also do not want to (re)add volumes for pods that can't also
+		// be starting containers
+		dswp.actualStateOfWorld.MarkRemountRequired(logger, uniquePodName)
+		dswp.markPodProcessed(uniquePodName)
+		return
+	}
+
 	allVolumesAdded := true
 	collectSELinuxOptions := utilfeature.DefaultFeatureGate.Enabled(features.SELinuxMountReadWriteOncePod)
 	mounts, devices, seLinuxContainerContexts := util.GetPodVolumeNames(pod, collectSELinuxOptions)
@@ -380,14 +388,17 @@ func (dswp *desiredStateOfWorldPopulator) podPreviouslyProcessed(
 	dswp.pods.RLock()
 	defer dswp.pods.RUnlock()
 
-	return dswp.pods.processedPods[podName]
+	var entry = dswp.pods.processedPods[podName]
+	return entry.processed && time.Since(entry.lastProcessedAt) < time.Minute
 }
 
 // markPodProcessingFailed marks the specified pod from processedPods as false to indicate that it failed processing
 func (dswp *desiredStateOfWorldPopulator) markPodProcessingFailed(
 	podName volumetypes.UniquePodName) {
 	dswp.pods.Lock()
-	dswp.pods.processedPods[podName] = false
+	var entry = dswp.pods.processedPods[podName]
+	entry.processed = false
+	dswp.pods.processedPods[podName] = entry
 	dswp.pods.Unlock()
 }
 
@@ -408,7 +419,10 @@ func (dswp *desiredStateOfWorldPopulator) markPodProcessed(
 	dswp.pods.Lock()
 	defer dswp.pods.Unlock()
 
-	dswp.pods.processedPods[podName] = true
+	var entry = dswp.pods.processedPods[podName]
+	entry.processed = true
+	entry.lastProcessedAt = time.Now()
+	dswp.pods.processedPods[podName] = entry
 }
 
 // deleteProcessedPod removes the specified pod from processedPods

--- a/pkg/kubelet/volumemanager/populator/desired_state_of_world_populator_test.go
+++ b/pkg/kubelet/volumemanager/populator/desired_state_of_world_populator_test.go
@@ -276,7 +276,7 @@ func TestFindAndAddNewPods_FindAndRemoveDeletedPods(t *testing.T) {
 
 	dswp.findAndRemoveDeletedPods(logger)
 
-	if !dswp.pods.processedPods[podName] {
+	if !dswp.pods.processedPods[podName].processed {
 		t.Fatalf("Pod should not been removed from desired state of world since pod state still thinks it exists")
 	}
 
@@ -284,7 +284,7 @@ func TestFindAndAddNewPods_FindAndRemoveDeletedPods(t *testing.T) {
 
 	// the pod state is marked as removed, so here findAndRemoveDeletedPods() will remove the pod and volumes it is mounted
 	dswp.findAndRemoveDeletedPods(logger)
-	if dswp.pods.processedPods[podName] {
+	if dswp.pods.processedPods[podName].processed {
 		t.Fatalf("Failed to remove pods from desired state of world since they no longer exist")
 	}
 
@@ -420,7 +420,7 @@ func TestFindAndRemoveDeletedPodsWithUncertain(t *testing.T) {
 
 	// the pod state now lists the pod as removed, so here findAndRemoveDeletedPods() will remove the pod and volumes it is mounted
 	dswp.findAndRemoveDeletedPods(logger)
-	if dswp.pods.processedPods[podName] {
+	if dswp.pods.processedPods[podName].processed {
 		t.Fatalf("Failed to remove pods from desired state of world since they no longer exist")
 	}
 
@@ -493,7 +493,7 @@ func prepareDSWPWithPodPV(t *testing.T) (*desiredStateOfWorldPopulator, *fakePod
 	tCtx := ktesting.Init(t)
 	dswp.findAndAddNewPods(tCtx)
 
-	if !dswp.pods.processedPods[podName] {
+	if !dswp.pods.processedPods[podName].processed {
 		t.Fatalf("Failed to record that the volumes for the specified pod: %s have been processed by the populator", podName)
 	}
 
@@ -566,7 +566,7 @@ func TestFindAndRemoveNonattachableVolumes(t *testing.T) {
 	tCtx := ktesting.Init(t)
 	dswp.findAndAddNewPods(tCtx)
 
-	if !dswp.pods.processedPods[podName] {
+	if !dswp.pods.processedPods[podName].processed {
 		t.Fatalf("Failed to record that the volumes for the specified pod: %s have been processed by the populator", podName)
 	}
 
@@ -612,7 +612,7 @@ func TestEphemeralVolumeOwnerCheck(t *testing.T) {
 
 	tCtx := ktesting.Init(t)
 	dswp.findAndAddNewPods(tCtx)
-	if dswp.pods.processedPods[podName] {
+	if dswp.pods.processedPods[podName].processed {
 		t.Fatalf("%s should not have been processed by the populator", podName)
 	}
 	require.Equal(t,
@@ -669,7 +669,7 @@ func TestFindAndAddNewPods_FindAndRemoveDeletedPods_Valid_Block_VolumeDevices(t 
 	tCtx := ktesting.Init(t)
 	dswp.findAndAddNewPods(tCtx)
 
-	if !dswp.pods.processedPods[podName] {
+	if !dswp.pods.processedPods[podName].processed {
 		t.Fatalf("Failed to record that the volumes for the specified pod: %s have been processed by the populator", podName)
 	}
 
@@ -704,7 +704,7 @@ func TestFindAndAddNewPods_FindAndRemoveDeletedPods_Valid_Block_VolumeDevices(t 
 
 	//pod is added to fakePodManager but pod state knows the pod is removed, so here findAndRemoveDeletedPods() will remove the pod and volumes it is mounted
 	dswp.findAndRemoveDeletedPods(logger)
-	if dswp.pods.processedPods[podName] {
+	if dswp.pods.processedPods[podName].processed {
 		t.Fatalf("Failed to remove pods from desired state of world since they no longer exist")
 	}
 
@@ -1612,7 +1612,7 @@ func createDswpWithVolumeWithCustomPluginMgr(pv *v1.PersistentVolume, pvc *v1.Pe
 		desiredStateOfWorld: fakesDSW,
 		actualStateOfWorld:  fakeASW,
 		pods: processedPods{
-			processedPods: make(map[types.UniquePodName]bool)},
+			processedPods: make(map[types.UniquePodName]processedPodState)},
 		csiMigratedPluginManager: csimigration.NewPluginManager(csiTranslator),
 		intreeToCSITranslator:    csiTranslator,
 		volumePluginMgr:          fakeVolumePluginMgr,

--- a/test/e2e/auth/service_accounts.go
+++ b/test/e2e/auth/service_accounts.go
@@ -18,6 +18,7 @@ package auth
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"path"
@@ -37,6 +38,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/apimachinery/pkg/util/wait"
 	watch "k8s.io/apimachinery/pkg/watch"
+	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/kubernetes/plugin/pkg/admission/serviceaccount"
 	apimachineryutils "k8s.io/kubernetes/test/e2e/common/apimachinery"
@@ -905,7 +907,166 @@ var _ = SIGDescribe("ServiceAccounts", func() {
 		gomega.Expect(tokenReview.Status.Authenticated).To(gomega.BeTrueBecause("expect that the TokenReview is authenticated"))
 		gomega.Expect(tokenReview.Status.Error).To(gomega.BeEmpty(), "confirm that there are no TokenReview errors")
 	})
+
+	/*
+	   Release: v1.32
+	   Testname: Service Account Token Rotation in Terminating Pods
+	   Description: A projected service account token MUST be rotated by the Kubelet
+	   for a pod that is in the 'Terminating' state. This test creates a pod with a
+	   short-lived token. It then delete a pod and observe in-cluster logs for token rotation.
+	   At the end of the test there should be at least two tokens in the logs.
+	*/
+	f.It("should rotate a projected service account token for a pod in the Terminating state", f.WithSlow(), func(ctx context.Context) {
+		podName := "pod-terminating-token-test-" + string(uuid.NewUUID())
+		containerName := "main-test-container"
+		gracePeriod := int64(1200) // longer than the test run
+		tenMin := int64(10 * 60)
+		pod := &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: podName},
+			Spec: v1.PodSpec{
+				Containers: []v1.Container{{
+					Name:  containerName,
+					Image: imageutils.GetE2EImage(imageutils.Agnhost),
+					Args:  []string{"inclusterclient"},
+					VolumeMounts: []v1.VolumeMount{{
+						MountPath: serviceaccount.DefaultAPITokenMountPath,
+						Name:      "kube-api-access-e2e",
+						ReadOnly:  true,
+					}},
+					Lifecycle: &v1.Lifecycle{
+						PreStop: &v1.LifecycleHandler{
+							Exec: &v1.ExecAction{
+								Command: []string{"sleep", "1200"},
+							},
+						},
+					},
+				}},
+				RestartPolicy:                 v1.RestartPolicyNever,
+				TerminationGracePeriodSeconds: &gracePeriod,
+				ServiceAccountName:            "default",
+				Volumes: []v1.Volume{{
+					Name: "kube-api-access-e2e",
+					VolumeSource: v1.VolumeSource{
+						Projected: &v1.ProjectedVolumeSource{
+							Sources: []v1.VolumeProjection{
+								{
+									ServiceAccountToken: &v1.ServiceAccountTokenProjection{
+										Path:              "token",
+										ExpirationSeconds: &tenMin,
+									},
+								},
+								{
+									ConfigMap: &v1.ConfigMapProjection{
+										LocalObjectReference: v1.LocalObjectReference{
+											Name: "kube-root-ca.crt",
+										},
+										Items: []v1.KeyToPath{
+											{
+												Key:  "ca.crt",
+												Path: "ca.crt",
+											},
+										},
+									},
+								},
+								{
+									DownwardAPI: &v1.DownwardAPIProjection{
+										Items: []v1.DownwardAPIVolumeFile{
+											{
+												Path: "namespace",
+												FieldRef: &v1.ObjectFieldSelector{
+													APIVersion: "v1",
+													FieldPath:  "metadata.namespace",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				}},
+			},
+		}
+		pod, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOptions{})
+		framework.ExpectNoError(err)
+
+		framework.Logf("created pod")
+		framework.ExpectNoError(e2epod.WaitTimeoutForPodReadyInNamespace(ctx, f.ClientSet, pod.Name, f.Namespace.Name, time.Minute))
+
+		framework.Logf("pod is ready")
+
+		framework.Logf("deleting pod")
+		framework.Logf("deleting pod to trigger termination")
+		go func() {
+			err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Delete(ctx, podName, metav1.DeleteOptions{})
+			framework.ExpectNoError(err, "failed to delete pod")
+		}()
+
+		framework.Logf("verifying pod is in Terminating state")
+		err = e2epod.WaitForPodTerminatingInNamespaceTimeout(ctx, f.ClientSet, podName, f.Namespace.Name, time.Minute)
+		framework.ExpectNoError(err, "pod did not enter terminating state")
+
+		var logs string
+		err = wait.PollUntilContextTimeout(ctx, 1*time.Minute, 20*time.Minute, true, func(ctx context.Context) (done bool, err error) {
+			select {
+			case <-ctx.Done():
+				return false, ctx.Err()
+			default:
+				{
+					framework.Logf("polling logs")
+					logs, err = e2epod.GetPodLogs(ctx, f.ClientSet, f.Namespace.Name, podName, containerName)
+					if err != nil {
+						framework.Logf("Error pulling logs: %v", err)
+						return false, nil
+					}
+					tokenCount, err := ParseInClusterClientLogs(logs)
+					if err != nil {
+						return false, fmt.Errorf("inclusterclient reported an error: %w", err)
+					}
+					if tokenCount < 2 {
+						framework.Logf("Retrying. Still waiting to see more unique tokens: got=%d, want=2", tokenCount)
+						return false, nil
+					}
+					return true, nil
+				}
+			}
+		})
+		if err != nil {
+			framework.Failf("Unexpected error: %v\n%s", err, logs)
+		}
+	})
 })
+
+// Helper function to validate a token using the TokenReview API
+func validateToken(ctx context.Context, c clientset.Interface, token, description string) {
+	ginkgo.By(fmt.Sprintf("validating %s token", description))
+	tokenReview := &authenticationv1.TokenReview{
+		Spec: authenticationv1.TokenReviewSpec{Token: token},
+	}
+	result, err := c.AuthenticationV1().TokenReviews().Create(ctx, tokenReview, metav1.CreateOptions{})
+	framework.ExpectNoError(err, "failed to create TokenReview for %s token", description)
+	gomega.Expect(result.Status.Authenticated).To(gomega.BeTrue(), "%s token should be authenticated", description)
+	gomega.Expect(result.Status.Error).To(gomega.BeEmpty(), "TokenReview status should have no error for %s token", description)
+}
+
+// Helper function to decode a JWT and extract its expiration time
+func getExpirationFromToken(token string) (time.Time, error) {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return time.Time{}, fmt.Errorf("invalid JWT format: expected 3 parts, got %d", len(parts))
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return time.Time{}, fmt.Errorf("failed to decode JWT payload: %w", err)
+	}
+	var claims struct {
+		Exp int64 `json:"exp"`
+	}
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return time.Time{}, fmt.Errorf("failed to unmarshal JWT claims: %w", err)
+	}
+	return time.Unix(claims.Exp, 0), nil
+}
 
 var reportLogsParser = regexp.MustCompile("([a-zA-Z0-9-_]*)=([a-zA-Z0-9-_]*)$")
 

--- a/test/e2e/auth/service_accounts.go
+++ b/test/e2e/auth/service_accounts.go
@@ -18,7 +18,6 @@ package auth
 
 import (
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"path"
@@ -38,7 +37,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/apimachinery/pkg/util/wait"
 	watch "k8s.io/apimachinery/pkg/watch"
-	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/kubernetes/plugin/pkg/admission/serviceaccount"
 	apimachineryutils "k8s.io/kubernetes/test/e2e/common/apimachinery"

--- a/test/e2e/auth/service_accounts.go
+++ b/test/e2e/auth/service_accounts.go
@@ -1037,37 +1037,6 @@ var _ = SIGDescribe("ServiceAccounts", func() {
 	})
 })
 
-// Helper function to validate a token using the TokenReview API
-func validateToken(ctx context.Context, c clientset.Interface, token, description string) {
-	ginkgo.By(fmt.Sprintf("validating %s token", description))
-	tokenReview := &authenticationv1.TokenReview{
-		Spec: authenticationv1.TokenReviewSpec{Token: token},
-	}
-	result, err := c.AuthenticationV1().TokenReviews().Create(ctx, tokenReview, metav1.CreateOptions{})
-	framework.ExpectNoError(err, "failed to create TokenReview for %s token", description)
-	gomega.Expect(result.Status.Authenticated).To(gomega.BeTrue(), "%s token should be authenticated", description)
-	gomega.Expect(result.Status.Error).To(gomega.BeEmpty(), "TokenReview status should have no error for %s token", description)
-}
-
-// Helper function to decode a JWT and extract its expiration time
-func getExpirationFromToken(token string) (time.Time, error) {
-	parts := strings.Split(token, ".")
-	if len(parts) != 3 {
-		return time.Time{}, fmt.Errorf("invalid JWT format: expected 3 parts, got %d", len(parts))
-	}
-	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
-	if err != nil {
-		return time.Time{}, fmt.Errorf("failed to decode JWT payload: %w", err)
-	}
-	var claims struct {
-		Exp int64 `json:"exp"`
-	}
-	if err := json.Unmarshal(payload, &claims); err != nil {
-		return time.Time{}, fmt.Errorf("failed to unmarshal JWT claims: %w", err)
-	}
-	return time.Unix(claims.Exp, 0), nil
-}
-
 var reportLogsParser = regexp.MustCompile("([a-zA-Z0-9-_]*)=([a-zA-Z0-9-_]*)$")
 
 // ParseInClusterClientLogs parses logs of pods using inclusterclient.


### PR DESCRIPTION
https://github.com/kubernetes/kubernetes/issues/116481 describes an issue where volumes stop being refreshed once a Pod enters the "Terminating" state. This is a problem for serviceAccount tokens being supplied via projected volumes. The net effect is that if a Pod is in the terminating state for more than 20% of the expiration time of the service account token, it may go stale. This is becoming a more significant issue with the change to limit Kubernetes service account tokens to 1 hour - since a terminationGracePeriod seconds of just 12 minutes could cause the token to become invalid. It's also a challenge for other serviceAccount use cases, such as AWS IAM Roles - where the max lifetime of the token of 1 day means that grace periods greater than 4.8 hours could result in an expired token.

In a running Pod, what happens is:

In one go-routine we:
1. We run findAndAddNewPods() a few times a second
2. That method calls processPodVolumes() (but only if the Pod isn't Terminating)
3. In processPodVolumes(), we check to see if podPreviouslyProcessed() returns true. If it does, we do nothing
4. Otherwise, we call MarkRemountRequired() which results in volumes being refreshed

In a second go-routine we:
1. Call SyncPod() every now and then.
2. SyncPod will call WaitForAttachAndMount()
3. WaitForAttachAndMount() calls ReprocessPod()
4. ReprocessPod() calls markPodProcessingFailed()
5. markPodProcessingFailed() causes the next call to podPreviouslyProcessed() to return false, which is what results in us refreshing volumes

In a terminating Pod, the first loop is still running. However, in the second loop we call SyncTerminatingPod() instead of SyncPod(). And SyncTerminatingPod() never calls WaitForAttachAndMount() which means that ultimately podPreviouslyProcessed() will return true until the Pod shuts down and we'll never refresh any volumes.

So, we have two problems:
1. findAndAddNewPods() skips all Pods that are Terminating. Which means we'll never refresh volumes for terminating Pods.
2. Even if we fix the above issue, when we actually get to processPodVolumes() the call to podPreviouslyProcessed() will always return true for a Terminating pod - so, we'll never refresh any volumes.

The approach to fix the issue in this PR is to change how podPreviouslyProcessed() works. Previously, it would return true up until markPodProcessingFailed() is called (as a result of SyncPod()). We update it so that it will return false if its been more than 60 seconds since markPodProcessed() has been called. This fixes the second problem above, since even though SyncTerminatingPod() won't call the methods we need it to, every 60 seconds processPodVolumes() will be allowed to run and refresh volumes.

The first problem is resolved by removing its check for if a Pod is terminating and then skipping it. Instead, we move that check into processPodVolumes() - where we check to see if the Pod is terminating, and, if so, all we do is refresh volumes and then bail out of the rest of the method were we might add in new volumes.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
7. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
8. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
9. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
10. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Fixes an issue where projected volumes on terminating pods would not be refreshed. This is a problem, because security tokens on those pods could become stale while the pod is terminating.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #116481
Closes #117329

#### Special notes for your reviewer:

I'm a bit unclear if all tests will pass. However, I've validated that the change does appear to fix the problem. If this approach looks reasonable, I'm happy to make sure that the tests are passing.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Project volumes on terminating pods will continue to be refreshed until the Pod terminates.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
N/A

