### PR TITLE
kubeadm: cleanup unused CreateCSR and associated functions

### DIFF
--- a/cmd/kubeadm/app/phases/certs/certs.go
+++ b/cmd/kubeadm/app/phases/certs/certs.go
@@ -139,15 +139,6 @@ func NewCSR(certSpec *KubeadmCert, cfg *kubeadmapi.InitConfiguration) (*x509.Cer
 	return pkiutil.NewCSRAndKey(certConfig)
 }
 
-// CreateCSR creates a certificate signing request
-func CreateCSR(certSpec *KubeadmCert, cfg *kubeadmapi.InitConfiguration, path string) error {
-	csr, key, err := NewCSR(certSpec, cfg)
-	if err != nil {
-		return err
-	}
-	return writeCSRFilesIfNotExist(path, certSpec.BaseName, csr, key)
-}
-
 // CreateCertAndKeyFilesWithCA loads the given certificate authority from disk, then generates and writes out the given certificate and key.
 // The certSpec and caCertSpec should both be one of the variables from this package.
 func CreateCertAndKeyFilesWithCA(certSpec *KubeadmCert, caCertSpec *KubeadmCert, cfg *kubeadmapi.InitConfiguration) error {
@@ -265,33 +256,6 @@ func writeCertificateFilesIfNotExist(pkiDir string, baseName string, signingCert
 		}
 		if pkiutil.HasServerAuth(cert) {
 			fmt.Printf("[certs] %s serving cert is signed for DNS names %v and IPs %v\n", baseName, cert.DNSNames, cert.IPAddresses)
-		}
-	}
-
-	return nil
-}
-
-// writeCSRFilesIfNotExist writes a new CSR to the given path.
-// If there already is a CSR file at the given path; kubeadm tries to load it and check if it's a valid certificate.
-// otherwise this function returns an error.
-func writeCSRFilesIfNotExist(csrDir string, baseName string, csr *x509.CertificateRequest, key crypto.Signer) error {
-	if pkiutil.CSROrKeyExist(csrDir, baseName) {
-		_, _, err := pkiutil.TryLoadCSRAndKeyFromDisk(csrDir, baseName)
-		if err != nil {
-			return errors.Wrapf(err, "%s CSR existed but it could not be loaded properly", baseName)
-		}
-
-		fmt.Printf("[certs] Using the existing %q CSR\n", baseName)
-	} else {
-		// Write .key and .csr files to disk
-		fmt.Printf("[certs] Generating %q key and CSR\n", baseName)
-
-		if err := pkiutil.WriteKey(csrDir, baseName, key); err != nil {
-			return errors.Wrapf(err, "failure while saving %s key", baseName)
-		}
-
-		if err := pkiutil.WriteCSR(csrDir, baseName, csr); err != nil {
-			return errors.Wrapf(err, "failure while saving %s CSR", baseName)
 		}
 	}
 

--- a/cmd/kubeadm/app/phases/certs/certs_test.go
+++ b/cmd/kubeadm/app/phases/certs/certs_test.go
@@ -18,8 +18,6 @@ package certs
 
 import (
 	"bytes"
-	"crypto"
-	"crypto/sha256"
 	"crypto/x509"
 	"net"
 	"os"
@@ -40,20 +38,6 @@ import (
 	pkiutiltesting "k8s.io/kubernetes/cmd/kubeadm/app/util/pkiutil/testing"
 	testutil "k8s.io/kubernetes/cmd/kubeadm/test"
 )
-
-func createTestCSR(t *testing.T) (*x509.CertificateRequest, crypto.Signer) {
-	csr, key, err := pkiutil.NewCSRAndKey(
-		&pkiutil.CertConfig{
-			Config: certutil.Config{
-				CommonName: "testCert",
-			},
-		})
-	if err != nil {
-		t.Fatalf("couldn't create test cert: %v", err)
-	}
-
-	return csr, key
-}
 
 func TestWriteCertificateAuthorityFilesIfNotExist(t *testing.T) {
 	setupCert, setupKey := certstestutil.CreateCACert(t)
@@ -233,75 +217,6 @@ func TestWriteCertificateFilesIfNotExist(t *testing.T) {
 			t.Error("created cert does not match expected cert")
 		}
 	}
-}
-
-func TestWriteCSRFilesIfNotExist(t *testing.T) {
-	csr, key := createTestCSR(t)
-	csr2, key2 := createTestCSR(t)
-
-	var tests = []struct {
-		name          string
-		setupFunc     func(csrPath string) error
-		expectedError bool
-		expectedCSR   *x509.CertificateRequest
-	}{
-		{
-			name:        "no files exist",
-			expectedCSR: csr,
-		},
-		{
-			name: "other key exists",
-			setupFunc: func(csrPath string) error {
-				if err := pkiutil.WriteCSR(csrPath, "dummy", csr2); err != nil {
-					return err
-				}
-				return pkiutil.WriteKey(csrPath, "dummy", key2)
-			},
-			expectedCSR: csr2,
-		},
-		{
-			name: "existing CSR is garbage",
-			setupFunc: func(csrPath string) error {
-				return os.WriteFile(filepath.Join(csrPath, "dummy.csr"), []byte("a--bunch--of-garbage"), os.ModePerm)
-			},
-			expectedError: true,
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			tmpdir := testutil.SetupTempDir(t)
-			defer os.RemoveAll(tmpdir)
-
-			if test.setupFunc != nil {
-				if err := test.setupFunc(tmpdir); err != nil {
-					t.Fatalf("couldn't set up test: %v", err)
-				}
-			}
-
-			if err := writeCSRFilesIfNotExist(tmpdir, "dummy", csr, key); err != nil {
-				if test.expectedError {
-					return
-				}
-				t.Fatalf("unexpected error %v: ", err)
-			}
-
-			if test.expectedError {
-				t.Fatal("Expected error, but got none")
-			}
-
-			parsedCSR, _, err := pkiutil.TryLoadCSRAndKeyFromDisk(tmpdir, "dummy")
-			if err != nil {
-				t.Fatalf("couldn't load csr and key: %v", err)
-			}
-
-			if sha256.Sum256(test.expectedCSR.Raw) != sha256.Sum256(parsedCSR.Raw) {
-				t.Error("expected csr's fingerprint does not match ")
-			}
-
-		})
-	}
-
 }
 
 func TestCreateServiceAccountKeyAndPublicKeyFiles(t *testing.T) {

--- a/cmd/kubeadm/app/util/pkiutil/pki_helpers.go
+++ b/cmd/kubeadm/app/util/pkiutil/pki_helpers.go
@@ -334,21 +334,6 @@ func TryLoadKeyFromDisk(pkiPath, name string) (crypto.Signer, error) {
 	return key, nil
 }
 
-// TryLoadCSRAndKeyFromDisk tries to load the CSR and key from the disk
-func TryLoadCSRAndKeyFromDisk(pkiPath, name string) (*x509.CertificateRequest, crypto.Signer, error) {
-	csr, err := TryLoadCSRFromDisk(pkiPath, name)
-	if err != nil {
-		return nil, nil, errors.Wrap(err, "could not load CSR file")
-	}
-
-	key, err := TryLoadKeyFromDisk(pkiPath, name)
-	if err != nil {
-		return nil, nil, errors.Wrap(err, "could not load key file")
-	}
-
-	return csr, key, nil
-}
-
 // TryLoadPrivatePublicKeyFromDisk tries to load the key from the disk and validates that it is valid
 func TryLoadPrivatePublicKeyFromDisk(pkiPath, name string) (crypto.PrivateKey, crypto.PublicKey, error) {
 	privateKeyPath := pathForKey(pkiPath, name)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
`CreateCSR` is unused since https://github.com/kubernetes/kubernetes/pull/77780 refactor. It's time to clean it up.

We prefer to use `NewCSR` and `WriteCSR` instead.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
