### PR TITLE
feat: Add --certificate-revocation-list to apiserver

### DIFF
--- a/pkg/kubeapiserver/options/serving.go
+++ b/pkg/kubeapiserver/options/serving.go
@@ -33,6 +33,7 @@ func NewSecureServingOptions() *genericoptions.SecureServingOptionsWithLoopback 
 			PairName:      "apiserver",
 			CertDirectory: "/var/run/kubernetes",
 		},
+		CertificateRevocationList: "",
 	}
 	return o.WithLoopback()
 }

--- a/staging/src/k8s.io/apiserver/pkg/server/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config.go
@@ -348,6 +348,9 @@ type SecureServingInfo struct {
 
 	// DisableHTTP2 indicates that http2 should not be enabled.
 	DisableHTTP2 bool
+
+	// Certificate revocation list filename
+	CertificateRevocationList string
 }
 
 type AuthenticationInfo struct {

--- a/staging/src/k8s.io/apiserver/pkg/server/options/serving.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/serving.go
@@ -76,6 +76,9 @@ type SecureServingOptions struct {
 
 	// PermitAddressSharing controls if SO_REUSEADDR is used when binding the port.
 	PermitAddressSharing bool
+
+	// Certificate revocation list filename
+	CertificateRevocationList string
 }
 
 type CertKey struct {
@@ -213,6 +216,10 @@ func (s *SecureServingOptions) AddFlags(fs *pflag.FlagSet) {
 		"If true, SO_REUSEADDR will be used when binding the port. This allows binding "+
 			"to wildcard IPs like 0.0.0.0 and specific IPs in parallel, and it avoids waiting "+
 			"for the kernel to release sockets in TIME_WAIT state. [default=false]")
+
+	fs.StringVar(&s.CertificateRevocationList, "certificate-revocation-list", "", ""+
+		"Certificate revocation list. If provided, clients providing a certificate listed in the "+
+		"file will be rejected")
 }
 
 // ApplyTo fills up serving information in the server configuration.
@@ -256,6 +263,7 @@ func (s *SecureServingOptions) ApplyTo(config **server.SecureServingInfo) error 
 	*config = &server.SecureServingInfo{
 		Listener:                     s.Listener,
 		HTTP2MaxStreamsPerConnection: s.HTTP2MaxStreamsPerConnection,
+		CertificateRevocationList:    s.CertificateRevocationList,
 	}
 	c := *config
 

--- a/staging/src/k8s.io/apiserver/pkg/server/options/serving.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/serving.go
@@ -218,7 +218,7 @@ func (s *SecureServingOptions) AddFlags(fs *pflag.FlagSet) {
 			"for the kernel to release sockets in TIME_WAIT state. [default=false]")
 
 	fs.StringVar(&s.CertificateRevocationList, "certificate-revocation-list", "", ""+
-		"Certificate revocation list. If provided, clients providing a certificate listed in the "+
+		"Path to local certificate revocation list. If provided, clients providing a certificate listed in the "+
 		"file will be rejected")
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/server/secure_serving.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/secure_serving.go
@@ -22,7 +22,6 @@ import (
 	"crypto/x509"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net"
 	"net/http"
@@ -95,7 +94,7 @@ func (s *SecureServingInfo) tlsConfig(stopCh <-chan struct{}) (*tls.Config, erro
 			}
 
 			// Load CRL
-			crlBytes, err := ioutil.ReadFile(s.CertificateRevocationList)
+			crlBytes, err := os.ReadFile(s.CertificateRevocationList)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adds optional support for a certificate revocation list (CRL) to the apiserver.

#### Which issue(s) this PR fixes:

See #18982

#### Special notes for your reviewer:

This is similar to how etcd handles CRL files: https://github.com/etcd-io/etcd/pull/8124

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added a `--certificate-revocation-list` command line argument to the kube-apiserver. Specifying a value allows you to
configure the API server to reject connections from clients that present revoked certificates.
```

<!--
#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
```docs

```
-->