### PR TITLE
Migrate client-go/metadata to contextual logging 

### DIFF
--- a/hack/logcheck.conf
+++ b/hack/logcheck.conf
@@ -26,6 +26,7 @@ structured k8s.io/apiserver/pkg/server/options/encryptionconfig/.*
 # The following packages have been migrated to contextual logging.
 # Packages matched here do not have to be listed above because
 # "contextual" implies "structured".
+contextual k8s.io/client-go/metadata/.*
 contextual k8s.io/client-go/tools/events/.*
 contextual k8s.io/client-go/tools/record/.*
 contextual k8s.io/dynamic-resource-allocation/.*

--- a/staging/src/k8s.io/client-go/metadata/metadata.go
+++ b/staging/src/k8s.io/client-go/metadata/metadata.go
@@ -191,7 +191,7 @@ func (c *client) Get(ctx context.Context, name string, opts metav1.GetOptions, s
 	}
 	obj, err := result.Get()
 	if runtime.IsNotRegisteredError(err) {
-		klog.V(5).Infof("Unable to retrieve PartialObjectMetadata: %#v", err)
+		klog.FromContext(ctx).V(5).Info("Could not retrieve PartialObjectMetadata", "err", err)
 		rawBytes, err := result.Raw()
 		if err != nil {
 			return nil, err
@@ -227,7 +227,7 @@ func (c *client) List(ctx context.Context, opts metav1.ListOptions) (*metav1.Par
 	}
 	obj, err := result.Get()
 	if runtime.IsNotRegisteredError(err) {
-		klog.V(5).Infof("Unable to retrieve PartialObjectMetadataList: %#v", err)
+		klog.FromContext(ctx).V(5).Info("Could not retrieve PartialObjectMetadataList", "err", err)
 		rawBytes, err := result.Raw()
 		if err != nil {
 			return nil, err

--- a/staging/src/k8s.io/client-go/metadata/metadata_test.go
+++ b/staging/src/k8s.io/client-go/metadata/metadata_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package metadata
 
 import (
-	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -32,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/rest"
+	"k8s.io/klog/v2/ktesting"
 )
 
 func TestClient(t *testing.T) {
@@ -78,7 +78,8 @@ func TestClient(t *testing.T) {
 				})
 			},
 			want: func(t *testing.T, client *Client) {
-				obj, err := client.Resource(gvr).Namespace("ns").Get(context.TODO(), "name", metav1.GetOptions{})
+				_, ctx := ktesting.NewTestContext(t)
+				obj, err := client.Resource(gvr).Namespace("ns").Get(ctx, "name", metav1.GetOptions{})
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -126,7 +127,8 @@ func TestClient(t *testing.T) {
 				})
 			},
 			want: func(t *testing.T, client *Client) {
-				objs, err := client.Resource(gvr).Namespace("ns").List(context.TODO(), metav1.ListOptions{})
+				_, ctx := ktesting.NewTestContext(t)
+				objs, err := client.Resource(gvr).Namespace("ns").List(ctx, metav1.ListOptions{})
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -168,7 +170,8 @@ func TestClient(t *testing.T) {
 				})
 			},
 			want: func(t *testing.T, client *Client) {
-				obj, err := client.Resource(gvr).Namespace("ns").Get(context.TODO(), "name", metav1.GetOptions{})
+				_, ctx := ktesting.NewTestContext(t)
+				obj, err := client.Resource(gvr).Namespace("ns").Get(ctx, "name", metav1.GetOptions{})
 				if err == nil || !runtime.IsMissingKind(err) {
 					t.Fatal(err)
 				}
@@ -197,7 +200,8 @@ func TestClient(t *testing.T) {
 				})
 			},
 			want: func(t *testing.T, client *Client) {
-				obj, err := client.Resource(gvr).Namespace("ns").Get(context.TODO(), "name", metav1.GetOptions{})
+				_, ctx := ktesting.NewTestContext(t)
+				obj, err := client.Resource(gvr).Namespace("ns").Get(ctx, "name", metav1.GetOptions{})
 				if err == nil || !runtime.IsMissingVersion(err) {
 					t.Fatal(err)
 				}
@@ -225,7 +229,8 @@ func TestClient(t *testing.T) {
 				})
 			},
 			want: func(t *testing.T, client *Client) {
-				obj, err := client.Resource(gvr).Namespace("ns").Get(context.TODO(), "name", metav1.GetOptions{})
+				_, ctx := ktesting.NewTestContext(t)
+				obj, err := client.Resource(gvr).Namespace("ns").Get(ctx, "name", metav1.GetOptions{})
 				if err == nil || !strings.Contains(err.Error(), "object does not appear to match the ObjectMeta schema") {
 					t.Fatal(err)
 				}
@@ -255,7 +260,8 @@ func TestClient(t *testing.T) {
 				writeJSON(t, w, statusOK)
 			},
 			want: func(t *testing.T, client *Client) {
-				err := client.Resource(gvr).Namespace("ns").Delete(context.TODO(), "name", metav1.DeleteOptions{})
+				_, ctx := ktesting.NewTestContext(t)
+				err := client.Resource(gvr).Namespace("ns").Delete(ctx, "name", metav1.DeleteOptions{})
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -283,7 +289,8 @@ func TestClient(t *testing.T) {
 				writeJSON(t, w, statusOK)
 			},
 			want: func(t *testing.T, client *Client) {
-				err := client.Resource(gvr).Namespace("ns").DeleteCollection(context.TODO(), metav1.DeleteOptions{}, metav1.ListOptions{})
+				_, ctx := ktesting.NewTestContext(t)
+				err := client.Resource(gvr).Namespace("ns").DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{})
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/staging/src/k8s.io/client-go/metadata/metadata_test.go
+++ b/staging/src/k8s.io/client-go/metadata/metadata_test.go
@@ -56,7 +56,7 @@ func TestClient(t *testing.T) {
 	testCases := []struct {
 		name    string
 		handler func(t *testing.T, w http.ResponseWriter, req *http.Request)
-		want    func(t *testing.T, ctx context.Context, client *Client)
+		want    func(ctx context.Context, t *testing.T, client *Client)
 	}{
 		{
 			name: "GET is able to convert a JSON object to PartialObjectMetadata",
@@ -78,7 +78,7 @@ func TestClient(t *testing.T) {
 					},
 				})
 			},
-			want: func(t *testing.T, ctx context.Context, client *Client) {
+			want: func(ctx context.Context, t *testing.T, client *Client) {
 				obj, err := client.Resource(gvr).Namespace("ns").Get(ctx, "name", metav1.GetOptions{})
 				if err != nil {
 					t.Fatal(err)
@@ -126,7 +126,7 @@ func TestClient(t *testing.T) {
 					},
 				})
 			},
-			want: func(t *testing.T, ctx context.Context, client *Client) {
+			want: func(ctx context.Context, t *testing.T, client *Client) {
 				objs, err := client.Resource(gvr).Namespace("ns").List(ctx, metav1.ListOptions{})
 				if err != nil {
 					t.Fatal(err)
@@ -168,7 +168,7 @@ func TestClient(t *testing.T) {
 					},
 				})
 			},
-			want: func(t *testing.T, ctx context.Context, client *Client) {
+			want: func(ctx context.Context, t *testing.T, client *Client) {
 				obj, err := client.Resource(gvr).Namespace("ns").Get(ctx, "name", metav1.GetOptions{})
 				if err == nil || !runtime.IsMissingKind(err) {
 					t.Fatal(err)
@@ -197,7 +197,7 @@ func TestClient(t *testing.T) {
 					},
 				})
 			},
-			want: func(t *testing.T, ctx context.Context, client *Client) {
+			want: func(ctx context.Context, t *testing.T, client *Client) {
 				obj, err := client.Resource(gvr).Namespace("ns").Get(ctx, "name", metav1.GetOptions{})
 				if err == nil || !runtime.IsMissingVersion(err) {
 					t.Fatal(err)
@@ -225,7 +225,7 @@ func TestClient(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{},
 				})
 			},
-			want: func(t *testing.T, ctx context.Context, client *Client) {
+			want: func(ctx context.Context, t *testing.T, client *Client) {
 				obj, err := client.Resource(gvr).Namespace("ns").Get(ctx, "name", metav1.GetOptions{})
 				if err == nil || !strings.Contains(err.Error(), "object does not appear to match the ObjectMeta schema") {
 					t.Fatal(err)
@@ -255,7 +255,7 @@ func TestClient(t *testing.T) {
 				}
 				writeJSON(t, w, statusOK)
 			},
-			want: func(t *testing.T, ctx context.Context, client *Client) {
+			want: func(ctx context.Context, t *testing.T, client *Client) {
 				err := client.Resource(gvr).Namespace("ns").Delete(ctx, "name", metav1.DeleteOptions{})
 				if err != nil {
 					t.Fatal(err)
@@ -283,7 +283,7 @@ func TestClient(t *testing.T) {
 
 				writeJSON(t, w, statusOK)
 			},
-			want: func(t *testing.T, ctx context.Context, client *Client) {
+			want: func(ctx context.Context, t *testing.T, client *Client) {
 				err := client.Resource(gvr).Namespace("ns").DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{})
 				if err != nil {
 					t.Fatal(err)
@@ -300,7 +300,7 @@ func TestClient(t *testing.T) {
 			_, ctx := ktesting.NewTestContext(t)
 			cfg := ConfigFor(&rest.Config{Host: s.URL})
 			client := NewForConfigOrDie(cfg).(*Client)
-			tt.want(t, ctx, client)
+			tt.want(ctx, t, client)
 		})
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Migrate client-go/metadata to contextual logging

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of https://github.com/kubernetes/enhancements/issues/3077

#### Special notes for your reviewer:

Log output before migration

```
I1202 17:13:16.944886 1320000 metadata.go:194] Unable to retrieve PartialObjectMetadata: &runtime.notRegisteredErr{schemeName:"k8s.io/apimachinery/pkg/apis/meta/internalversion/scheme/register.go:27", gvk:schema.GroupVersionKind{Group:"", Version:"v1", Kind:"Pod"}, target:runtime.GroupVersioner(nil), t:reflect.Type(nil)}
I1202 17:25:19.610064 1472026 metadata.go:230] Unable to retrieve PartialObjectMetadataList: &runtime.notRegisteredErr{schemeName:"k8s.io/apimachinery/pkg/apis/meta/internalversion/scheme/register.go:27", gvk:schema.GroupVersionKind{Group:"", Version:"v1", Kind:"PodList"}, target:runtime.GroupVersioner(nil), t:reflect.Type(nil)}
```

Log output after migration

```
I1202 17:10:46.625898 1286529 metadata.go:194] "Could not retrieve PartialObjectMetadata" err="no kind \"Pod\" is registered for version \"v1\" in scheme \"k8s.io/apimachinery/pkg/apis/meta/internalversion/scheme/register.go:27\""
I1202 17:27:14.864645 1496151 metadata.go:230] "Could not retrieve PartialObjectMetadataList" err="no kind \"PodList\" is registered for version \"v1\" in scheme \"k8s.io/apimachinery/pkg/apis/meta/internalversion/scheme/register.go:27\""
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Migrate client-go/metadata to contextual logging
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/42bb993e369d166142b7181e90882066ad6c7651/keps/sig-instrumentation/3077-contextual-logging
```

/wg structured-logging 
/area logging
/priority important-longterm
/cc @kubernetes/wg-structured-logging-reviews