### PR TITLE
e2e framework: provide more guidance to developers

### DIFF
--- a/test/e2e/framework/ginkgowrapper.go
+++ b/test/e2e/framework/ginkgowrapper.go
@@ -531,10 +531,17 @@ type label struct {
 	parts []string
 	// extra is an optional fully-formed extra label.
 	extra string
+	// explanation gets set for each label to help developers
+	// who pass a label to a ginkgo function. They need to use
+	// the corresponding framework function instead.
+	explanation string
 }
 
 func newLabel(parts ...string) label {
-	return label{parts: parts}
+	return label{
+		parts:       parts,
+		explanation: "If you see this as part of an 'Unknown Decorator' error from Ginkgo, then you need to replace the ginkgo.It/Context/Describe call with the corresponding framework.It/Context/Describe or (if available) f.It/Context/Describe.",
+	}
 }
 
 // TagsEqual can be used to check whether two tags are the same.


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Developers who are unaware of the Ginkgo wrappers in the framework might end up passing the label decorators directly to Ginkgo. Previously, this led to an error that was hard to understand without background knowledge:

    Unknown Decorator
    ginkgo.It("must deallocate on non graceful node shutdown", f.WithSerial(), f.WithDisruptive(), f.WithSlow(), func(ctx context.Context) {
    /nvme/gopath/src/k8s.io/kubernetes/test/e2e/dra/dra.go:527
      [It] node was passed an unknown decorator:
      'framework.label{parts:[]string{"Serial"}, extra:""}'

    Learn more at: http://onsi.github.io/ginkgo/#node-decorators-overview

When including a special field that Ginkgo dumps the message gets a bit better:

    Unknown Decorator
    ginkgo.It("must deallocate on non graceful node shutdown", f.WithSerial(), f.WithDisruptive(), f.WithSlow(), func(ctx context.Context) {
    /nvme/gopath/src/k8s.io/kubernetes/test/e2e/dra/dra.go:527
      [It] node was passed an unknown decorator:
      'framework.label{parts:[]string{"Serial"}, extra:"", explanation:"If you see
      this as part of an \"Unknown Decorator\" error from Ginkgo, then you need to
      replace the ginkgo.It/Context/Describe call with the corresponding
      framework.It/Context/Describe or (if available) f.It/Context/Describe."}'

    Learn more at: http://onsi.github.io/ginkgo/#node-decorators-overview

#### Which issue(s) this PR fixes:

Related-to: https://github.com/kubernetes/kubernetes/pull/122175#issuecomment-1843955487

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

