### PR TITLE
etcd: Build image 3.5.11

### DIFF
--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -82,7 +82,7 @@ dependencies:
       match: configs\[Etcd\] = Config{list\.GcEtcdRegistry, "etcd", "\d+\.\d+.\d+(-(alpha|beta|rc).\d+)?(-\d+)?"}
 
   - name: "etcd-image"
-    version: 3.5.10
+    version: 3.5.11
     refPaths:
     - path: cluster/images/etcd/Makefile
       match: BUNDLED_ETCD_VERSIONS\?|LATEST_ETCD_VERSION\?
@@ -111,7 +111,7 @@ dependencies:
 
   # From https://github.com/etcd-io/etcd/blob/main/Makefile
   - name: "golang: etcd release version"
-    version: 1.20.10 # https://github.com/etcd-io/etcd/blob/main/CHANGELOG/CHANGELOG-3.5.md
+    version: 1.20.12 # https://github.com/etcd-io/etcd/blob/main/CHANGELOG/CHANGELOG-3.5.md
     refPaths:
     - path: cluster/images/etcd/Makefile
       match: 'GOLANG_VERSION := \d+.\d+(alpha|beta|rc)?\.?(\d+)?'

--- a/cluster/images/etcd/Makefile
+++ b/cluster/images/etcd/Makefile
@@ -26,10 +26,10 @@
 # Except from etcd-$(version) and etcdctl-$(version) binaries, we also
 # need etcd and etcdctl binaries for backward compatibility reasons.
 # That binary will be set to the last version from $(BUNDLED_ETCD_VERSIONS).
-BUNDLED_ETCD_VERSIONS?=3.4.18 3.5.10
+BUNDLED_ETCD_VERSIONS?=3.4.18 3.5.11
 
 # LATEST_ETCD_VERSION identifies the most recent etcd version available.
-LATEST_ETCD_VERSION?=3.5.10
+LATEST_ETCD_VERSION?=3.5.11
 
 # REVISION provides a version number for this image and all it's bundled
 # artifacts. It should start at zero for each LATEST_ETCD_VERSION and increment
@@ -83,7 +83,7 @@ endif
 # This option is for running docker manifest command
 export DOCKER_CLI_EXPERIMENTAL := enabled
 # golang version should match the golang version of the official build from https://github.com/etcd-io/etcd/releases.
-GOLANG_VERSION := 1.20.10
+GOLANG_VERSION := 1.20.12
 GOARM?=7
 TEMP_DIR:=$(shell mktemp -d)
 

--- a/cluster/images/etcd/migrate/options.go
+++ b/cluster/images/etcd/migrate/options.go
@@ -28,7 +28,7 @@ import (
 )
 
 var (
-	supportedEtcdVersions = []string{"3.4.18", "3.5.10"}
+	supportedEtcdVersions = []string{"3.4.18", "3.5.11"}
 )
 
 const (


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Build Image for [v3.5.11](https://github.com/etcd-io/etcd/releases/tag/v3.5.11).

**Which issue(s) this PR fixes**:
Fixes NONE #

**Does this PR introduce a user-facing change?**:
```
NONE
```

```release-note
etcd: build image for v3.5.11
```