### PR TITLE
modify the api documentation for ContainerPort.Name

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -5766,7 +5766,7 @@
           "type": "integer"
         },
         "name": {
-          "description": "If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.",
+          "description": "If specified, this must be an IANA_SVC_NAME. Each named port in a pod must have a unique name, otherwise, if there are duplicate names, only the first port name referred to by services will be chosen.",
           "type": "string"
         },
         "protocol": {

--- a/api/openapi-spec/v3/api__v1_openapi.json
+++ b/api/openapi-spec/v3/api__v1_openapi.json
@@ -1328,7 +1328,7 @@
             "type": "integer"
           },
           "name": {
-            "description": "If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.",
+            "description": "If specified, this must be an IANA_SVC_NAME. Each named port in a pod must have a unique name, otherwise, if there are duplicate names, only the first port name referred to by services will be chosen.",
             "type": "string"
           },
           "protocol": {

--- a/api/openapi-spec/v3/apis__apps__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__apps__v1_openapi.json
@@ -1927,7 +1927,7 @@
             "type": "integer"
           },
           "name": {
-            "description": "If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.",
+            "description": "If specified, this must be an IANA_SVC_NAME. Each named port in a pod must have a unique name, otherwise, if there are duplicate names, only the first port name referred to by services will be chosen.",
             "type": "string"
           },
           "protocol": {

--- a/api/openapi-spec/v3/apis__batch__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__batch__v1_openapi.json
@@ -1244,7 +1244,7 @@
             "type": "integer"
           },
           "name": {
-            "description": "If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.",
+            "description": "If specified, this must be an IANA_SVC_NAME. Each named port in a pod must have a unique name, otherwise, if there are duplicate names, only the first port name referred to by services will be chosen.",
             "type": "string"
           },
           "protocol": {

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -18885,7 +18885,7 @@ func schema_k8sio_api_core_v1_ContainerPort(ref common.ReferenceCallback) common
 				Properties: map[string]spec.Schema{
 					"name": {
 						SchemaProps: spec.SchemaProps{
-							Description: "If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.",
+							Description: "If specified, this must be an IANA_SVC_NAME. Each named port in a pod must have a unique name, otherwise, if there are duplicate names, only the first port name referred to by services will be chosen.",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/staging/src/k8s.io/api/core/v1/generated.proto
+++ b/staging/src/k8s.io/api/core/v1/generated.proto
@@ -886,9 +886,9 @@ message ContainerImage {
 
 // ContainerPort represents a network port in a single container.
 message ContainerPort {
-  // If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
-  // named port in a pod must have a unique name. Name for the port that can be
-  // referred to by services.
+  // If specified, this must be an IANA_SVC_NAME. Each named port in a pod
+  // must have a unique name, otherwise, if there are duplicate names, only the
+  // first port name referred to by services will be chosen.
   // +optional
   optional string name = 1;
 

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -2105,9 +2105,9 @@ type PersistentVolumeClaimTemplate struct {
 
 // ContainerPort represents a network port in a single container.
 type ContainerPort struct {
-	// If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
-	// named port in a pod must have a unique name. Name for the port that can be
-	// referred to by services.
+	// If specified, this must be an IANA_SVC_NAME. Each named port in a pod
+	// must have a unique name, otherwise, if there are duplicate names, only the
+	// first port name referred to by services will be chosen.
 	// +optional
 	Name string `json:"name,omitempty" protobuf:"bytes,1,opt,name=name"`
 	// Number of port to expose on the host.

--- a/staging/src/k8s.io/api/core/v1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/core/v1/types_swagger_doc_generated.go
@@ -392,7 +392,7 @@ func (ContainerImage) SwaggerDoc() map[string]string {
 
 var map_ContainerPort = map[string]string{
 	"":              "ContainerPort represents a network port in a single container.",
-	"name":          "If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.",
+	"name":          "If specified, this must be an IANA_SVC_NAME. Each named port in a pod must have a unique name, otherwise, if there are duplicate names, only the first port name referred to by services will be chosen.",
 	"hostPort":      "Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.",
 	"containerPort": "Number of port to expose on the pod's IP address. This must be a valid port number, 0 < x < 65536.",
 	"protocol":      "Protocol for port. Must be UDP, TCP, or SCTP. Defaults to \"TCP\".",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind documentation
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Previously, we declare in the API document that each named port in a pod must have a unique name, but in fact the port name in the same pod can be repeated; and when the port name is repeated, use service to reference the port name in the pod, will always refer to the first repeated port name.

Given that changing the port name to be non-repeatable is not a backwards compatible change,  so we should declare this in the api documentation


ref: https://github.com/kubernetes/kubernetes/pull/122157#issuecomment-1837193550

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
