### PR TITLE
Add unit test for Job Controller for panic when PodFailurePolicy is used on 1.28

### DIFF
--- a/pkg/controller/job/job_controller_test.go
+++ b/pkg/controller/job/job_controller_test.go
@@ -256,6 +256,7 @@ func TestControllerSyncJob(t *testing.T) {
 		wasSuspended         bool
 		suspend              bool
 		podReplacementPolicy *batch.PodReplacementPolicy
+		podFailurePolicy     *batch.PodFailurePolicy
 		initialStatus        *jobInitialStatus
 		backoffRecord        *backoffRecord
 		controllerTime       *time.Time
@@ -293,6 +294,7 @@ func TestControllerSyncJob(t *testing.T) {
 		// features
 		podIndexLabelDisabled   bool
 		jobPodReplacementPolicy bool
+		jobPodFailurePolicy     bool
 	}{
 		"job start": {
 			parallelism:       2,
@@ -406,6 +408,22 @@ func TestControllerSyncJob(t *testing.T) {
 			expectedActive:          1,
 			expectedDeletions:       1,
 			expectedPodPatches:      1,
+		},
+		"more terminating pods than parallelism; PodFailurePolicy used": {
+			// Repro for https://github.com/kubernetes/kubernetes/issues/122235
+			parallelism:         1,
+			completions:         1,
+			backoffLimit:        6,
+			activePods:          2,
+			failedPods:          0,
+			terminatingPods:     4,
+			jobPodFailurePolicy: true,
+			podFailurePolicy:    &batch.PodFailurePolicy{},
+			expectedTerminating: nil,
+			expectedReady:       ptr.To[int32](0),
+			expectedActive:      1,
+			expectedDeletions:   1,
+			expectedPodPatches:  1,
 		},
 		"too few active pods and active back-off": {
 			parallelism:  1,
@@ -935,6 +953,7 @@ func TestControllerSyncJob(t *testing.T) {
 			logger, _ := ktesting.NewTestContext(t)
 			defer featuregatetesting.SetFeatureGateDuringTest(t, feature.DefaultFeatureGate, features.PodIndexLabel, !tc.podIndexLabelDisabled)()
 			defer featuregatetesting.SetFeatureGateDuringTest(t, feature.DefaultFeatureGate, features.JobPodReplacementPolicy, tc.jobPodReplacementPolicy)()
+			defer featuregatetesting.SetFeatureGateDuringTest(t, feature.DefaultFeatureGate, features.JobPodFailurePolicy, tc.jobPodFailurePolicy)()
 			// job manager setup
 			clientSet := clientset.NewForConfigOrDie(&restclient.Config{Host: "", ContentConfig: restclient.ContentConfig{GroupVersion: &schema.GroupVersion{Group: "", Version: "v1"}}})
 
@@ -956,6 +975,9 @@ func TestControllerSyncJob(t *testing.T) {
 			job.Spec.Suspend = ptr.To(tc.suspend)
 			if tc.jobPodReplacementPolicy {
 				job.Spec.PodReplacementPolicy = tc.podReplacementPolicy
+			}
+			if tc.jobPodFailurePolicy {
+				job.Spec.PodFailurePolicy = tc.podFailurePolicy
 			}
 			if tc.initialStatus != nil {
 				startTime := metav1.Now()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

/sig apps

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of https://github.com/kubernetes/kubernetes/issues/122235

#### Special notes for your reviewer:

This PR demonstrates the scenario which is problematic on 1.28, which does not contain the fix yet: https://github.com/kubernetes/kubernetes/pull/121147. 

This PR tests on github CI the new test when the fix is reverted: https://github.com/kubernetes/kubernetes/pull/122262
Here is the failure: https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/122262/pull-kubernetes-unit/1734157708581408768

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
