### PR TITLE
Automated cherry pick of #121147: Fix panic if there are more terminating pods than active pods

### DIFF
--- a/pkg/controller/job/job_controller.go
+++ b/pkg/controller/job/job_controller.go
@@ -1493,7 +1493,7 @@ func (jm *Controller) manageJob(ctx context.Context, job *batch.Job, jobCtx *syn
 		}
 	}
 
-	rmAtLeast := active + terminating - wantActive
+	rmAtLeast := active - wantActive
 	if rmAtLeast < 0 {
 		rmAtLeast = 0
 	}

--- a/pkg/controller/job/job_controller_test.go
+++ b/pkg/controller/job/job_controller_test.go
@@ -357,9 +357,10 @@ func TestControllerSyncJob(t *testing.T) {
 			jobPodReplacementPolicy: true,
 			terminatingPods:         1,
 			expectedTerminating:     pointer.Int32(1),
-			expectedPodPatches:      2,
-			expectedDeletions:       1,
-			expectedFailed:          1,
+			// Removes finalizer and deletes one failed pod
+			expectedPodPatches: 1,
+			expectedFailed:     1,
+			expectedActive:     1,
 		},
 		"WQ job: recreate pods when terminating or failed": {
 			parallelism:             1,
@@ -375,7 +376,20 @@ func TestControllerSyncJob(t *testing.T) {
 			expectedPodPatches:      2,
 			expectedFailed:          2,
 		},
-
+		"more terminating pods than parallelism": {
+			parallelism:             1,
+			completions:             1,
+			backoffLimit:            6,
+			activePods:              2,
+			failedPods:              0,
+			terminatingPods:         4,
+			podReplacementPolicy:    podReplacementPolicy(batch.Failed),
+			jobPodReplacementPolicy: true,
+			expectedTerminating:     pointer.Int32(4),
+			expectedActive:          1,
+			expectedDeletions:       1,
+			expectedPodPatches:      1,
+		},
 		"too few active pods and active back-off": {
 			parallelism:  1,
 			completions:  1,


### PR DESCRIPTION
Cherry pick of #121147 on release-1.28.

#121147: Fix panic if there are more terminating pods than active pods

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fix panic if there are more terminating pods than active pods
```

I had to modify this PR to resolve some conflicts due to ptr versus pointer. I changed a unit test to use pointer rather than ptr which has minimal impact.

This resolves https://github.com/kubernetes/kubernetes/issues/122235 in case of PodFailurePolicy is set (with PodReplacementPolicy disabled).

/cc @mimowo @alculquicondor @soltysh 