### PR TITLE
Add support for more complete migration to SSA

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply.go
@@ -17,6 +17,7 @@ limitations under the License.
 package apply
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -882,14 +883,18 @@ func (o *ApplyOptions) migrateToSSAIfNecessary(
 	// There may be multiple owners if multiple managers wrote the same exact
 	// configuration. In this case there are multiple owners, we want to migrate
 	// them all.
-	csaManagers := csaupgrade.FindFieldsOwners(
-		accessor.GetManagedFields(),
-		metav1.ManagedFieldsOperationUpdate,
-		lastAppliedAnnotationFieldPath)
-
 	managerNames := sets.New[string]()
-	for _, entry := range csaManagers {
-		managerNames.Insert(entry.Manager)
+	if o.Overwrite {
+		insertOwnersOfFieldsExceptStatus(accessor.GetManagedFields(), managerNames)
+	} else {
+		csaManagers := csaupgrade.FindFieldsOwners(
+			accessor.GetManagedFields(),
+			metav1.ManagedFieldsOperationUpdate,
+			lastAppliedAnnotationFieldPath)
+
+		for _, entry := range csaManagers {
+			managerNames.Insert(entry.Manager)
+		}
 	}
 
 	// Re-attempt patch as many times as it is conflicting due to ResourceVersion
@@ -1094,5 +1099,31 @@ func WarnIfDeleting(obj runtime.Object, stderr io.Writer) {
 	if metadata != nil && metadata.GetDeletionTimestamp() != nil {
 		// just warn the user about the conflict
 		fmt.Fprintf(stderr, warningChangesOnDeletingResource, metadata.GetName())
+	}
+}
+
+// Finds all managed fields owners of updates except those that owns .status and insert into supplied managerNames
+//
+// If there is an error decoding one of the fieldsets for any reason, it is ignored
+// and assumed not to match the query.
+func insertOwnersOfFieldsExceptStatus(managedFields []metav1.ManagedFieldsEntry, managerNames sets.Set[string]) {
+	status := "status"
+	statusElement := fieldpath.PathElement{FieldName: &status}
+	for _, entry := range managedFields {
+		if entry.Operation != metav1.ManagedFieldsOperationUpdate {
+			continue
+		}
+
+		var fieldSet fieldpath.Set
+		err := fieldSet.FromJSON(bytes.NewReader(entry.FieldsV1.Raw))
+		if err != nil {
+			continue
+		}
+
+		_, hasStatus := fieldSet.Children.Get(statusElement)
+		if hasStatus {
+			continue
+		}
+		managerNames.Insert(entry.Manager)
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:

There are still cases to covered by the current migration to SSA. See https://github.com/kubernetes/kubernetes/issues/99003#issuecomment-1344531558

One typical case for this would be when calling ApplyOptions.Run from https://github.com/kubernetes-sigs/cli-utils/blob/master/pkg/apply/task/apply_task.go#L158 since the cli-utils library in my understanding is built for having a single owner of a resource (except .status).

#### Which issue(s) this PR fixes:

Fixes #99003

#### Special notes for your reviewer:

As far as I can see the Overwrite ApplyOption isn't used for server side apply, so I thought it would be fitting for this use case and thus avoiding changing the API.

If this approach is deemed to be good I will complete the PR with updates to tests and documentation.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
For `kubectl`, `--overwrite` in combination `--server-side` now migrates ownership of all fields except status to the specified `--fieldmanager`. This further reduces risk of fields previously specified using kubectl from being able to live outside of server-side-apply's management and become undeleteable. Note that this only should be used if the given fieldmanager is the only one that needs to update this resource part for controllers updating .status.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
/sig cli
/cc apelisse seans3 alexzielenski