### PR TITLE
dra: enable adding ReservedFor entries through strategic-merge-patch

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -14387,7 +14387,9 @@
           "x-kubernetes-list-map-keys": [
             "uid"
           ],
-          "x-kubernetes-list-type": "map"
+          "x-kubernetes-list-type": "map",
+          "x-kubernetes-patch-merge-key": "uid",
+          "x-kubernetes-patch-strategy": "merge"
         }
       },
       "type": "object"

--- a/api/openapi-spec/v3/apis__resource.k8s.io__v1alpha2_openapi.json
+++ b/api/openapi-spec/v3/apis__resource.k8s.io__v1alpha2_openapi.json
@@ -478,7 +478,9 @@
             "x-kubernetes-list-map-keys": [
               "uid"
             ],
-            "x-kubernetes-list-type": "map"
+            "x-kubernetes-list-type": "map",
+            "x-kubernetes-patch-merge-key": "uid",
+            "x-kubernetes-patch-strategy": "merge"
           }
         },
         "type": "object"

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -42805,7 +42805,9 @@ func schema_k8sio_api_resource_v1alpha2_ResourceClaimStatus(ref common.Reference
 								"x-kubernetes-list-map-keys": []interface{}{
 									"uid",
 								},
-								"x-kubernetes-list-type": "map",
+								"x-kubernetes-list-type":       "map",
+								"x-kubernetes-patch-merge-key": "uid",
+								"x-kubernetes-patch-strategy":  "merge",
 							},
 						},
 						SchemaProps: spec.SchemaProps{

--- a/staging/src/k8s.io/api/resource/v1alpha2/generated.proto
+++ b/staging/src/k8s.io/api/resource/v1alpha2/generated.proto
@@ -257,6 +257,8 @@ message ResourceClaimStatus {
   //
   // +listType=map
   // +listMapKey=uid
+  // +patchStrategy=merge
+  // +patchMergeKey=uid
   // +optional
   repeated ResourceClaimConsumerReference reservedFor = 3;
 

--- a/staging/src/k8s.io/api/resource/v1alpha2/types.go
+++ b/staging/src/k8s.io/api/resource/v1alpha2/types.go
@@ -114,8 +114,10 @@ type ResourceClaimStatus struct {
 	//
 	// +listType=map
 	// +listMapKey=uid
+	// +patchStrategy=merge
+	// +patchMergeKey=uid
 	// +optional
-	ReservedFor []ResourceClaimConsumerReference `json:"reservedFor,omitempty" protobuf:"bytes,3,opt,name=reservedFor"`
+	ReservedFor []ResourceClaimConsumerReference `json:"reservedFor,omitempty" protobuf:"bytes,3,opt,name=reservedFor" patchStrategy:"merge" patchMergeKey:"uid"`
 
 	// DeallocationRequested indicates that a ResourceClaim is to be
 	// deallocated.


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind api-change

#### What this PR does / why we need it:

When moving the reservation of a claim for a pod into the PreBind phase in a [future PR](https://github.com/kubernetes/kubernetes/pull/121876), multiple different update attempts will be executed concurrently. We want an attempt to succeed if and only if adding the entry passes validation. Without patch strategy and key, strategic-merge-patch replaces the entire ReservedFor instead of adding new entries.

Server-side-apply cannot be used because each attempt may start with a stale ResourceClaim (thus cannot send the entire ReservedFor) and SSA doesn't support merging when using the same manager string. Using different managers (one for each entry) would work, but sounds like a bad hack.

#### Which issue(s) this PR fixes:

Related-to: https://github.com/kubernetes/kubernetes/issues/113700

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
resource.k8s.io/ResourceClaim (alpha API): the strategic merge patch strategy for the `status.reservedFor` array was changed such that a strategic-merge-patch can add individual entries. This breaks clients using strategic merge patch to update status which rely on the previous behavior (replacing the entire array).
```

/assign @apelisse 