### PR TITLE
Fix validation for StorageClass.ReclaimPolicy

### DIFF
--- a/pkg/apis/storage/validation/validation.go
+++ b/pkg/apis/storage/validation/validation.go
@@ -127,10 +127,10 @@ var supportedReclaimPolicy = sets.NewString(string(api.PersistentVolumeReclaimDe
 // provisioning for storage classes with impossible reclaim policies, e.g. EBS is not Recyclable
 func validateReclaimPolicy(reclaimPolicy *api.PersistentVolumeReclaimPolicy, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
-	if len(string(*reclaimPolicy)) > 0 {
-		if !supportedReclaimPolicy.Has(string(*reclaimPolicy)) {
-			allErrs = append(allErrs, field.NotSupported(fldPath, reclaimPolicy, supportedReclaimPolicy.List()))
-		}
+	if reclaimPolicy == nil {
+		allErrs = append(allErrs, field.Required(fldPath, ""))
+	} else if !supportedReclaimPolicy.Has(string(*reclaimPolicy)) {
+		allErrs = append(allErrs, field.NotSupported(fldPath, reclaimPolicy, supportedReclaimPolicy.List()))
 	}
 	return allErrs
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Currently, StorageClass creation succeeds if a user sets a reclaimPolicy to "":

```
$ kubectl get sc thin-csi-copy
NAME            PROVISIONER              RECLAIMPOLICY   VOLUMEBINDINGMODE   ALLOWVOLUMEEXPANSION   AGE
thin-csi-copy   csi.vsphere.vmware.com                   Immediate           true                   19s

$ kubectl get sc thin-csi-copy -o json | jq .reclaimPolicy
""
```

However, that is incorrect, as an empty string is not a valid value for that field.

Ideally, the behavior should be the same as the volumeBindingMode field:

```
$ cat<<EOF| kubectl create -f -
...
> volumeBindingMode: ""
> EOF
The StorageClass "thin-csi-copy" is invalid: volumeBindingMode: Unsupported value: "": supported values: "Immediate", "WaitForFirstConsumer"
```

PS: caught by @duanwei33.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
