### PR TITLE
Update publishing-bot rules to Go 1.20.12

### DIFF
--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -13,19 +13,19 @@ rules:
       dirs:
       - staging/src/k8s.io/code-generator
   - name: release-1.26
-    go: 1.20.11
+    go: 1.20.12
     source:
       branch: release-1.26
       dirs:
       - staging/src/k8s.io/code-generator
   - name: release-1.27
-    go: 1.20.11
+    go: 1.20.12
     source:
       branch: release-1.27
       dirs:
       - staging/src/k8s.io/code-generator
   - name: release-1.28
-    go: 1.20.11
+    go: 1.20.12
     source:
       branch: release-1.28
       dirs:
@@ -50,19 +50,19 @@ rules:
       dirs:
       - staging/src/k8s.io/apimachinery
   - name: release-1.26
-    go: 1.20.11
+    go: 1.20.12
     source:
       branch: release-1.26
       dirs:
       - staging/src/k8s.io/apimachinery
   - name: release-1.27
-    go: 1.20.11
+    go: 1.20.12
     source:
       branch: release-1.27
       dirs:
       - staging/src/k8s.io/apimachinery
   - name: release-1.28
-    go: 1.20.11
+    go: 1.20.12
     source:
       branch: release-1.28
       dirs:
@@ -94,7 +94,7 @@ rules:
       dirs:
       - staging/src/k8s.io/api
   - name: release-1.26
-    go: 1.20.11
+    go: 1.20.12
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -103,7 +103,7 @@ rules:
       dirs:
       - staging/src/k8s.io/api
   - name: release-1.27
-    go: 1.20.11
+    go: 1.20.12
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -112,7 +112,7 @@ rules:
       dirs:
       - staging/src/k8s.io/api
   - name: release-1.28
-    go: 1.20.11
+    go: 1.20.12
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -162,7 +162,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.26
-    go: 1.20.11
+    go: 1.20.12
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -177,7 +177,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.27
-    go: 1.20.11
+    go: 1.20.12
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -192,7 +192,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.28
-    go: 1.20.11
+    go: 1.20.12
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -250,7 +250,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-base
   - name: release-1.26
-    go: 1.20.11
+    go: 1.20.12
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -263,7 +263,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-base
   - name: release-1.27
-    go: 1.20.11
+    go: 1.20.12
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -276,7 +276,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-base
   - name: release-1.28
-    go: 1.20.11
+    go: 1.20.12
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -330,7 +330,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-helpers
   - name: release-1.26
-    go: 1.20.11
+    go: 1.20.12
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -343,7 +343,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-helpers
   - name: release-1.27
-    go: 1.20.11
+    go: 1.20.12
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -356,7 +356,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-helpers
   - name: release-1.28
-    go: 1.20.11
+    go: 1.20.12
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -393,13 +393,13 @@ rules:
       dirs:
       - staging/src/k8s.io/kms
   - name: release-1.26
-    go: 1.20.11
+    go: 1.20.12
     source:
       branch: release-1.26
       dirs:
       - staging/src/k8s.io/kms
   - name: release-1.27
-    go: 1.20.11
+    go: 1.20.12
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -412,7 +412,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kms
   - name: release-1.28
-    go: 1.20.11
+    go: 1.20.12
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -468,7 +468,7 @@ rules:
       dirs:
       - staging/src/k8s.io/apiserver
   - name: release-1.26
-    go: 1.20.11
+    go: 1.20.12
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -485,7 +485,7 @@ rules:
       dirs:
       - staging/src/k8s.io/apiserver
   - name: release-1.27
-    go: 1.20.11
+    go: 1.20.12
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -502,7 +502,7 @@ rules:
       dirs:
       - staging/src/k8s.io/apiserver
   - name: release-1.28
-    go: 1.20.11
+    go: 1.20.12
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -578,7 +578,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-aggregator
   - name: release-1.26
-    go: 1.20.11
+    go: 1.20.12
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -599,7 +599,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-aggregator
   - name: release-1.27
-    go: 1.20.11
+    go: 1.20.12
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -620,7 +620,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-aggregator
   - name: release-1.28
-    go: 1.20.11
+    go: 1.20.12
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -713,7 +713,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.26
-    go: 1.20.11
+    go: 1.20.12
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -739,7 +739,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.27
-    go: 1.20.11
+    go: 1.20.12
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -765,7 +765,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.28
-    go: 1.20.11
+    go: 1.20.12
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -858,7 +858,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.26
-    go: 1.20.11
+    go: 1.20.12
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -878,7 +878,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.27
-    go: 1.20.11
+    go: 1.20.12
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -898,7 +898,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.28
-    go: 1.20.11
+    go: 1.20.12
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -983,7 +983,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.26
-    go: 1.20.11
+    go: 1.20.12
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -1006,7 +1006,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.27
-    go: 1.20.11
+    go: 1.20.12
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -1029,7 +1029,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.28
-    go: 1.20.11
+    go: 1.20.12
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -1106,7 +1106,7 @@ rules:
       dirs:
       - staging/src/k8s.io/metrics
   - name: release-1.26
-    go: 1.20.11
+    go: 1.20.12
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -1121,7 +1121,7 @@ rules:
       dirs:
       - staging/src/k8s.io/metrics
   - name: release-1.27
-    go: 1.20.11
+    go: 1.20.12
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -1136,7 +1136,7 @@ rules:
       dirs:
       - staging/src/k8s.io/metrics
   - name: release-1.28
-    go: 1.20.11
+    go: 1.20.12
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -1194,7 +1194,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cli-runtime
   - name: release-1.26
-    go: 1.20.11
+    go: 1.20.12
     dependencies:
     - repository: api
       branch: release-1.26
@@ -1207,7 +1207,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cli-runtime
   - name: release-1.27
-    go: 1.20.11
+    go: 1.20.12
     dependencies:
     - repository: api
       branch: release-1.27
@@ -1220,7 +1220,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cli-runtime
   - name: release-1.28
-    go: 1.20.11
+    go: 1.20.12
     dependencies:
     - repository: api
       branch: release-1.28
@@ -1278,7 +1278,7 @@ rules:
       dirs:
       - staging/src/k8s.io/sample-cli-plugin
   - name: release-1.26
-    go: 1.20.11
+    go: 1.20.12
     dependencies:
     - repository: api
       branch: release-1.26
@@ -1293,7 +1293,7 @@ rules:
       dirs:
       - staging/src/k8s.io/sample-cli-plugin
   - name: release-1.27
-    go: 1.20.11
+    go: 1.20.12
     dependencies:
     - repository: api
       branch: release-1.27
@@ -1308,7 +1308,7 @@ rules:
       dirs:
       - staging/src/k8s.io/sample-cli-plugin
   - name: release-1.28
-    go: 1.20.11
+    go: 1.20.12
     dependencies:
     - repository: api
       branch: release-1.28
@@ -1369,7 +1369,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-proxy
   - name: release-1.26
-    go: 1.20.11
+    go: 1.20.12
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -1384,7 +1384,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-proxy
   - name: release-1.27
-    go: 1.20.11
+    go: 1.20.12
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -1399,7 +1399,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-proxy
   - name: release-1.28
-    go: 1.20.11
+    go: 1.20.12
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -1443,19 +1443,19 @@ rules:
       dirs:
       - staging/src/k8s.io/cri-api
   - name: release-1.26
-    go: 1.20.11
+    go: 1.20.12
     source:
       branch: release-1.26
       dirs:
       - staging/src/k8s.io/cri-api
   - name: release-1.27
-    go: 1.20.11
+    go: 1.20.12
     source:
       branch: release-1.27
       dirs:
       - staging/src/k8s.io/cri-api
   - name: release-1.28
-    go: 1.20.11
+    go: 1.20.12
     source:
       branch: release-1.28
       dirs:
@@ -1505,7 +1505,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubelet
   - name: release-1.26
-    go: 1.20.11
+    go: 1.20.12
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -1520,7 +1520,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubelet
   - name: release-1.27
-    go: 1.20.11
+    go: 1.20.12
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -1535,7 +1535,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubelet
   - name: release-1.28
-    go: 1.20.11
+    go: 1.20.12
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -1609,7 +1609,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-scheduler
   - name: release-1.26
-    go: 1.20.11
+    go: 1.20.12
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -1624,7 +1624,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-scheduler
   - name: release-1.27
-    go: 1.20.11
+    go: 1.20.12
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -1639,7 +1639,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-scheduler
   - name: release-1.28
-    go: 1.20.11
+    go: 1.20.12
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -1707,7 +1707,7 @@ rules:
       dirs:
       - staging/src/k8s.io/controller-manager
   - name: release-1.26
-    go: 1.20.11
+    go: 1.20.12
     dependencies:
     - repository: api
       branch: release-1.26
@@ -1726,7 +1726,7 @@ rules:
       dirs:
       - staging/src/k8s.io/controller-manager
   - name: release-1.27
-    go: 1.20.11
+    go: 1.20.12
     dependencies:
     - repository: api
       branch: release-1.27
@@ -1745,7 +1745,7 @@ rules:
       dirs:
       - staging/src/k8s.io/controller-manager
   - name: release-1.28
-    go: 1.20.11
+    go: 1.20.12
     dependencies:
     - repository: api
       branch: release-1.28
@@ -1829,7 +1829,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cloud-provider
   - name: release-1.26
-    go: 1.20.11
+    go: 1.20.12
     dependencies:
     - repository: api
       branch: release-1.26
@@ -1852,7 +1852,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cloud-provider
   - name: release-1.27
-    go: 1.20.11
+    go: 1.20.12
     dependencies:
     - repository: api
       branch: release-1.27
@@ -1875,7 +1875,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cloud-provider
   - name: release-1.28
-    go: 1.20.11
+    go: 1.20.12
     dependencies:
     - repository: api
       branch: release-1.28
@@ -1971,7 +1971,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-controller-manager
   - name: release-1.26
-    go: 1.20.11
+    go: 1.20.12
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -1996,7 +1996,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-controller-manager
   - name: release-1.27
-    go: 1.20.11
+    go: 1.20.12
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -2021,7 +2021,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-controller-manager
   - name: release-1.28
-    go: 1.20.11
+    go: 1.20.12
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -2095,7 +2095,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cluster-bootstrap
   - name: release-1.26
-    go: 1.20.11
+    go: 1.20.12
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -2106,7 +2106,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cluster-bootstrap
   - name: release-1.27
-    go: 1.20.11
+    go: 1.20.12
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -2117,7 +2117,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cluster-bootstrap
   - name: release-1.28
-    go: 1.20.11
+    go: 1.20.12
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -2163,7 +2163,7 @@ rules:
       dirs:
       - staging/src/k8s.io/csi-translation-lib
   - name: release-1.26
-    go: 1.20.11
+    go: 1.20.12
     dependencies:
     - repository: api
       branch: release-1.26
@@ -2174,7 +2174,7 @@ rules:
       dirs:
       - staging/src/k8s.io/csi-translation-lib
   - name: release-1.27
-    go: 1.20.11
+    go: 1.20.12
     dependencies:
     - repository: api
       branch: release-1.27
@@ -2185,7 +2185,7 @@ rules:
       dirs:
       - staging/src/k8s.io/csi-translation-lib
   - name: release-1.28
-    go: 1.20.11
+    go: 1.20.12
     dependencies:
     - repository: api
       branch: release-1.28
@@ -2221,19 +2221,19 @@ rules:
       dirs:
       - staging/src/k8s.io/mount-utils
   - name: release-1.26
-    go: 1.20.11
+    go: 1.20.12
     source:
       branch: release-1.26
       dirs:
       - staging/src/k8s.io/mount-utils
   - name: release-1.27
-    go: 1.20.11
+    go: 1.20.12
     source:
       branch: release-1.27
       dirs:
       - staging/src/k8s.io/mount-utils
   - name: release-1.28
-    go: 1.20.11
+    go: 1.20.12
     source:
       branch: release-1.28
       dirs:
@@ -2299,7 +2299,7 @@ rules:
       dirs:
       - staging/src/k8s.io/legacy-cloud-providers
   - name: release-1.26
-    go: 1.20.11
+    go: 1.20.12
     dependencies:
     - repository: api
       branch: release-1.26
@@ -2328,7 +2328,7 @@ rules:
       dirs:
       - staging/src/k8s.io/legacy-cloud-providers
   - name: release-1.27
-    go: 1.20.11
+    go: 1.20.12
     dependencies:
     - repository: api
       branch: release-1.27
@@ -2353,7 +2353,7 @@ rules:
       dirs:
       - staging/src/k8s.io/legacy-cloud-providers
   - name: release-1.28
-    go: 1.20.11
+    go: 1.20.12
     dependencies:
     - repository: api
       branch: release-1.28
@@ -2451,7 +2451,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubectl
   - name: release-1.26
-    go: 1.20.11
+    go: 1.20.12
     dependencies:
     - repository: api
       branch: release-1.26
@@ -2474,7 +2474,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubectl
   - name: release-1.27
-    go: 1.20.11
+    go: 1.20.12
     dependencies:
     - repository: api
       branch: release-1.27
@@ -2497,7 +2497,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubectl
   - name: release-1.28
-    go: 1.20.11
+    go: 1.20.12
     dependencies:
     - repository: api
       branch: release-1.28
@@ -2581,7 +2581,7 @@ rules:
       dirs:
       - staging/src/k8s.io/pod-security-admission
   - name: release-1.26
-    go: 1.20.11
+    go: 1.20.12
     dependencies:
     - repository: api
       branch: release-1.26
@@ -2600,7 +2600,7 @@ rules:
       dirs:
       - staging/src/k8s.io/pod-security-admission
   - name: release-1.27
-    go: 1.20.11
+    go: 1.20.12
     dependencies:
     - repository: api
       branch: release-1.27
@@ -2619,7 +2619,7 @@ rules:
       dirs:
       - staging/src/k8s.io/pod-security-admission
   - name: release-1.28
-    go: 1.20.11
+    go: 1.20.12
     dependencies:
     - repository: api
       branch: release-1.28
@@ -2680,7 +2680,7 @@ rules:
       dirs:
       - staging/src/k8s.io/dynamic-resource-allocation
   - name: release-1.26
-    go: 1.20.11
+    go: 1.20.12
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -2697,7 +2697,7 @@ rules:
       dirs:
       - staging/src/k8s.io/dynamic-resource-allocation
   - name: release-1.27
-    go: 1.20.11
+    go: 1.20.12
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -2714,7 +2714,7 @@ rules:
       dirs:
       - staging/src/k8s.io/dynamic-resource-allocation
   - name: release-1.28
-    go: 1.20.11
+    go: 1.20.12
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -2772,7 +2772,7 @@ rules:
       dirs:
       - staging/src/k8s.io/endpointslice
   - name: release-1.28
-    go: 1.20.11
+    go: 1.20.12
     dependencies:
     - repository: api
       branch: release-1.28


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

- Update publishing-bot rules to Go 1.20.12

cc @kubernetes/release-engineering 

#### Which issue(s) this PR fixes:

xref https://github.com/kubernetes/release/issues/3383

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
