### PR TITLE
[WIP] Storage version compatibilty mode

### DIFF
--- a/cmd/kube-apiserver/app/aggregator.go
+++ b/cmd/kube-apiserver/app/aggregator.go
@@ -102,8 +102,7 @@ func createAggregatorConfig(
 	// override MergedResourceConfig with aggregator defaults and registry
 	if err := commandOptions.APIEnablement.ApplyTo(
 		&genericConfig,
-		aggregatorapiserver.DefaultAPIResourceConfigSource(),
-		aggregatorscheme.Scheme); err != nil {
+		aggregatorapiserver.DefaultAPIResourceConfigSource(aggregatorscheme.Scheme)); err != nil {
 		return nil, err
 	}
 

--- a/cmd/kube-apiserver/app/options/options_test.go
+++ b/cmd/kube-apiserver/app/options/options_test.go
@@ -31,6 +31,7 @@ import (
 	apiserveroptions "k8s.io/apiserver/pkg/server/options"
 	"k8s.io/apiserver/pkg/storage/etcd3"
 	"k8s.io/apiserver/pkg/storage/storagebackend"
+	serverversion "k8s.io/apiserver/pkg/util/version"
 	auditbuffered "k8s.io/apiserver/plugin/pkg/audit/buffered"
 	audittruncate "k8s.io/apiserver/plugin/pkg/audit/truncate"
 	cliflag "k8s.io/component-base/cli/flag"
@@ -121,7 +122,7 @@ func TestAddFlags(t *testing.T) {
 		"--storage-backend=etcd3",
 		"--service-cluster-ip-range=192.168.128.0/17",
 		"--lease-reuse-duration-seconds=100",
-		"--emulation-version=v1.29.0",
+		"--emulated-version=1.31",
 	}
 	fs.Parse(args)
 
@@ -277,8 +278,7 @@ func TestAddFlags(t *testing.T) {
 				WebhookRetryBackoff:         apiserveroptions.DefaultAuthWebhookRetryBackoff(),
 			},
 			APIEnablement: &apiserveroptions.APIEnablementOptions{
-				RuntimeConfig:    cliflag.ConfigurationMap{},
-				EmulationVersion: "v1.29.0",
+				RuntimeConfig: cliflag.ConfigurationMap{},
 			},
 			EgressSelector: &apiserveroptions.EgressSelectorOptions{
 				ConfigFile: "/var/run/kubernetes/egress-selector/connectivity.yaml",
@@ -337,5 +337,9 @@ func TestAddFlags(t *testing.T) {
 
 	if !reflect.DeepEqual(expected, s) {
 		t.Errorf("Got different run options than expected.\nDifference detected on:\n%s", cmp.Diff(expected, s, cmpopts.IgnoreUnexported(admission.Plugins{}, kubeoptions.OIDCAuthenticationOptions{})))
+	}
+
+	if serverversion.Effective.EmulationVersion().String() != "1.31.0" {
+		t.Errorf("Got emulation version %s, wanted %s", serverversion.Effective.EmulationVersion().String(), "1.31.0")
 	}
 }

--- a/cmd/kube-apiserver/app/options/options_test.go
+++ b/cmd/kube-apiserver/app/options/options_test.go
@@ -121,6 +121,7 @@ func TestAddFlags(t *testing.T) {
 		"--storage-backend=etcd3",
 		"--service-cluster-ip-range=192.168.128.0/17",
 		"--lease-reuse-duration-seconds=100",
+		"--emulation-version=v1.29.0",
 	}
 	fs.Parse(args)
 
@@ -276,7 +277,8 @@ func TestAddFlags(t *testing.T) {
 				WebhookRetryBackoff:         apiserveroptions.DefaultAuthWebhookRetryBackoff(),
 			},
 			APIEnablement: &apiserveroptions.APIEnablementOptions{
-				RuntimeConfig: cliflag.ConfigurationMap{},
+				RuntimeConfig:    cliflag.ConfigurationMap{},
+				EmulationVersion: "v1.29.0",
 			},
 			EgressSelector: &apiserveroptions.EgressSelectorOptions{
 				ConfigFile: "/var/run/kubernetes/egress-selector/connectivity.yaml",

--- a/pkg/controlplane/apiserver/apiextensions.go
+++ b/pkg/controlplane/apiserver/apiextensions.go
@@ -17,7 +17,7 @@ limitations under the License.
 package apiserver
 
 import (
-	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	apiextensionsapiserver "k8s.io/apiextensions-apiserver/pkg/apiserver"
 	apiextensionsoptions "k8s.io/apiextensions-apiserver/pkg/cmd/server/options"
@@ -62,8 +62,7 @@ func CreateAPIExtensionsConfig(
 	// override MergedResourceConfig with apiextensions defaults and registry
 	if err := commandOptions.APIEnablement.ApplyTo(
 		&genericConfig,
-		apiextensionsapiserver.DefaultAPIResourceConfigSource(),
-		apiextensionsapiserver.Scheme); err != nil {
+		apiextensionsapiserver.DefaultAPIResourceConfigSource(apiextensionsapiserver.Scheme)); err != nil {
 		return nil, err
 	}
 	apiextensionsConfig := &apiextensionsapiserver.Config{

--- a/pkg/controlplane/apiserver/config.go
+++ b/pkg/controlplane/apiserver/config.go
@@ -68,7 +68,7 @@ func BuildGenericConfig(
 	lastErr error,
 ) {
 	genericConfig = genericapiserver.NewConfig(legacyscheme.Codecs)
-	genericConfig.MergedResourceConfig = controlplane.DefaultAPIResourceConfigSource()
+	genericConfig.MergedResourceConfig = controlplane.DefaultAPIResourceConfigSource(legacyscheme.Scheme)
 
 	if lastErr = s.GenericServerRunOptions.ApplyTo(genericConfig); lastErr != nil {
 		return
@@ -98,7 +98,7 @@ func BuildGenericConfig(
 	if lastErr = s.Features.ApplyTo(genericConfig, clientgoExternalClient, versionedInformers); lastErr != nil {
 		return
 	}
-	if lastErr = s.APIEnablement.ApplyTo(genericConfig, controlplane.DefaultAPIResourceConfigSource(), legacyscheme.Scheme); lastErr != nil {
+	if lastErr = s.APIEnablement.ApplyTo(genericConfig, controlplane.DefaultAPIResourceConfigSource(legacyscheme.Scheme)); lastErr != nil {
 		return
 	}
 	if lastErr = s.EgressSelector.ApplyTo(genericConfig); lastErr != nil {

--- a/pkg/controlplane/apiserver/options/options.go
+++ b/pkg/controlplane/apiserver/options/options.go
@@ -24,9 +24,11 @@ import (
 	"strings"
 	"time"
 
+	apimachineryversion "k8s.io/apimachinery/pkg/util/version"
 	peerreconcilers "k8s.io/apiserver/pkg/reconcilers"
 	genericoptions "k8s.io/apiserver/pkg/server/options"
 	"k8s.io/apiserver/pkg/storage/storagebackend"
+	serverversion "k8s.io/apiserver/pkg/util/version"
 	"k8s.io/client-go/util/keyutil"
 	cliflag "k8s.io/component-base/cli/flag"
 	"k8s.io/component-base/logs"
@@ -281,6 +283,8 @@ func (o *Options) Complete(alternateDNS []string, alternateIPs []net.IP) (Comple
 			delete(completed.APIEnablement.RuntimeConfig, key)
 		}
 	}
+	// Set emulation version
+	serverversion.Effective.SetEmulationVersion(apimachineryversion.MustParse(completed.APIEnablement.EmulationVersion))
 
 	return CompletedOptions{
 		completedOptions: &completed,

--- a/pkg/controlplane/apiserver/options/options.go
+++ b/pkg/controlplane/apiserver/options/options.go
@@ -24,9 +24,12 @@ import (
 	"strings"
 	"time"
 
+	genericfeatures "k8s.io/apiserver/pkg/features"
 	peerreconcilers "k8s.io/apiserver/pkg/reconcilers"
 	genericoptions "k8s.io/apiserver/pkg/server/options"
 	"k8s.io/apiserver/pkg/storage/storagebackend"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	serverversion "k8s.io/apiserver/pkg/util/version"
 	"k8s.io/client-go/util/keyutil"
 	cliflag "k8s.io/component-base/cli/flag"
 	"k8s.io/component-base/logs"
@@ -197,6 +200,12 @@ func (o *Options) Complete(alternateDNS []string, alternateIPs []net.IP) (Comple
 
 	completed := completedOptions{
 		Options: *o,
+	}
+	// set feature gate emulation version first.
+	if utilfeature.DefaultFeatureGate.Enabled(genericfeatures.EmulationVersion) {
+		if err := utilfeature.DefaultMutableVersionedFeatureGate.SetEmulationVersion(serverversion.Effective.EmulationVersion()); err != nil {
+			return CompletedOptions{}, err
+		}
 	}
 
 	// set defaults

--- a/pkg/controlplane/apiserver/options/options.go
+++ b/pkg/controlplane/apiserver/options/options.go
@@ -24,11 +24,9 @@ import (
 	"strings"
 	"time"
 
-	apimachineryversion "k8s.io/apimachinery/pkg/util/version"
 	peerreconcilers "k8s.io/apiserver/pkg/reconcilers"
 	genericoptions "k8s.io/apiserver/pkg/server/options"
 	"k8s.io/apiserver/pkg/storage/storagebackend"
-	serverversion "k8s.io/apiserver/pkg/util/version"
 	"k8s.io/client-go/util/keyutil"
 	cliflag "k8s.io/component-base/cli/flag"
 	"k8s.io/component-base/logs"
@@ -283,8 +281,6 @@ func (o *Options) Complete(alternateDNS []string, alternateIPs []net.IP) (Comple
 			delete(completed.APIEnablement.RuntimeConfig, key)
 		}
 	}
-	// Set emulation version
-	serverversion.Effective.SetEmulationVersion(apimachineryversion.MustParse(completed.APIEnablement.EmulationVersion))
 
 	return CompletedOptions{
 		completedOptions: &completed,

--- a/pkg/controlplane/apiserver/options/options_test.go
+++ b/pkg/controlplane/apiserver/options/options_test.go
@@ -108,6 +108,7 @@ func TestAddFlags(t *testing.T) {
 		"--request-timeout=2m",
 		"--storage-backend=etcd3",
 		"--lease-reuse-duration-seconds=100",
+		"--emulation-version=v1.29.0",
 	}
 	fs.Parse(args)
 
@@ -262,7 +263,8 @@ func TestAddFlags(t *testing.T) {
 			WebhookRetryBackoff:         apiserveroptions.DefaultAuthWebhookRetryBackoff(),
 		},
 		APIEnablement: &apiserveroptions.APIEnablementOptions{
-			RuntimeConfig: cliflag.ConfigurationMap{},
+			RuntimeConfig:    cliflag.ConfigurationMap{},
+			EmulationVersion: "v1.29.0",
 		},
 		EgressSelector: &apiserveroptions.EgressSelectorOptions{
 			ConfigFile: "/var/run/kubernetes/egress-selector/connectivity.yaml",

--- a/pkg/controlplane/apiserver/options/options_test.go
+++ b/pkg/controlplane/apiserver/options/options_test.go
@@ -30,6 +30,7 @@ import (
 	apiserveroptions "k8s.io/apiserver/pkg/server/options"
 	"k8s.io/apiserver/pkg/storage/etcd3"
 	"k8s.io/apiserver/pkg/storage/storagebackend"
+	serverversion "k8s.io/apiserver/pkg/util/version"
 	auditbuffered "k8s.io/apiserver/plugin/pkg/audit/buffered"
 	audittruncate "k8s.io/apiserver/plugin/pkg/audit/truncate"
 	cliflag "k8s.io/component-base/cli/flag"
@@ -108,7 +109,7 @@ func TestAddFlags(t *testing.T) {
 		"--request-timeout=2m",
 		"--storage-backend=etcd3",
 		"--lease-reuse-duration-seconds=100",
-		"--emulation-version=v1.29.0",
+		"--emulated-version=1.31",
 	}
 	fs.Parse(args)
 
@@ -263,8 +264,7 @@ func TestAddFlags(t *testing.T) {
 			WebhookRetryBackoff:         apiserveroptions.DefaultAuthWebhookRetryBackoff(),
 		},
 		APIEnablement: &apiserveroptions.APIEnablementOptions{
-			RuntimeConfig:    cliflag.ConfigurationMap{},
-			EmulationVersion: "v1.29.0",
+			RuntimeConfig: cliflag.ConfigurationMap{},
 		},
 		EgressSelector: &apiserveroptions.EgressSelectorOptions{
 			ConfigFile: "/var/run/kubernetes/egress-selector/connectivity.yaml",
@@ -292,5 +292,9 @@ func TestAddFlags(t *testing.T) {
 
 	if !reflect.DeepEqual(expected, s) {
 		t.Errorf("Got different run options than expected.\nDifference detected on:\n%s", cmp.Diff(expected, s, cmpopts.IgnoreUnexported(admission.Plugins{}, kubeoptions.OIDCAuthenticationOptions{})))
+	}
+
+	if serverversion.Effective.EmulationVersion().String() != "1.31.0" {
+		t.Errorf("Got emulation version %s, wanted %s", serverversion.Effective.EmulationVersion().String(), "1.31.0")
 	}
 }

--- a/pkg/controlplane/apiserver/options/validation.go
+++ b/pkg/controlplane/apiserver/options/validation.go
@@ -100,6 +100,7 @@ func validateUnknownVersionInteroperabilityProxyFlags(options *Options) []error 
 func (s *Options) Validate() []error {
 	var errs []error
 
+	errs = append(errs, s.GenericServerRunOptions.Validate()...)
 	errs = append(errs, s.Etcd.Validate()...)
 	errs = append(errs, validateAPIPriorityAndFairness(s)...)
 	errs = append(errs, s.SecureServing.Validate()...)

--- a/pkg/controlplane/instance.go
+++ b/pkg/controlplane/instance.go
@@ -785,8 +785,8 @@ var (
 )
 
 // DefaultAPIResourceConfigSource returns default configuration for an APIResource.
-func DefaultAPIResourceConfigSource() *serverstorage.ResourceConfig {
-	ret := serverstorage.NewResourceConfig()
+func DefaultAPIResourceConfigSource(registry serverstorage.GroupVersionRegistry) *serverstorage.ResourceConfig {
+	ret := serverstorage.NewResourceConfig(registry)
 	// NOTE: GroupVersions listed here will be enabled by default. Don't put alpha or beta versions in the list.
 	ret.EnableVersions(stableAPIGroupVersionsEnabledByDefault...)
 

--- a/pkg/controlplane/instance_test.go
+++ b/pkg/controlplane/instance_test.go
@@ -79,7 +79,7 @@ func setUp(t *testing.T) (*etcd3testing.EtcdTestServer, Config, *assert.Assertio
 	config := &Config{
 		GenericConfig: genericapiserver.NewConfig(legacyscheme.Codecs),
 		ExtraConfig: ExtraConfig{
-			APIResourceConfigSource: DefaultAPIResourceConfigSource(),
+			APIResourceConfigSource: DefaultAPIResourceConfigSource(nil),
 			APIServerServicePort:    443,
 			MasterCount:             1,
 			EndpointReconcilerType:  reconcilers.MasterCountReconcilerType,
@@ -90,7 +90,7 @@ func setUp(t *testing.T) (*etcd3testing.EtcdTestServer, Config, *assert.Assertio
 	storageFactoryConfig := kubeapiserver.NewStorageFactoryConfig()
 	storageConfig.StorageObjectCountTracker = config.GenericConfig.StorageObjectCountTracker
 	resourceEncoding := resourceconfig.MergeResourceEncodingConfigs(storageFactoryConfig.DefaultResourceEncoding, storageFactoryConfig.ResourceEncodingOverrides)
-	storageFactory := serverstorage.NewDefaultStorageFactory(*storageConfig, "application/vnd.kubernetes.protobuf", storageFactoryConfig.Serializer, resourceEncoding, DefaultAPIResourceConfigSource(), nil)
+	storageFactory := serverstorage.NewDefaultStorageFactory(*storageConfig, "application/vnd.kubernetes.protobuf", storageFactoryConfig.Serializer, resourceEncoding, DefaultAPIResourceConfigSource(nil), nil)
 	etcdOptions := options.NewEtcdOptions(storageConfig)
 	// unit tests don't need watch cache and it leaks lots of goroutines with etcd testing functions during unit tests
 	etcdOptions.EnableWatchCache = false
@@ -172,7 +172,7 @@ func TestLegacyRestStorageStrategies(t *testing.T) {
 		t.Fatalf("unexpected error from REST storage: %v", err)
 	}
 
-	apiGroupInfo, err := storageProvider.NewRESTStorage(serverstorage.NewResourceConfig(), apiserverCfg.GenericConfig.RESTOptionsGetter)
+	apiGroupInfo, err := storageProvider.NewRESTStorage(serverstorage.NewResourceConfigIgnoreLifecycle(), apiserverCfg.GenericConfig.RESTOptionsGetter)
 	if err != nil {
 		t.Errorf("failed to create legacy REST storage: %v", err)
 	}
@@ -354,7 +354,7 @@ func TestStorageVersionHashes(t *testing.T) {
 }
 
 func TestNoAlphaVersionsEnabledByDefault(t *testing.T) {
-	config := DefaultAPIResourceConfigSource()
+	config := DefaultAPIResourceConfigSource(nil)
 	for gv, enable := range config.GroupVersionConfigs {
 		if enable && strings.Contains(gv.Version, "alpha") {
 			t.Errorf("Alpha API version %s enabled by default", gv.String())
@@ -377,7 +377,7 @@ func TestNoAlphaVersionsEnabledByDefault(t *testing.T) {
 }
 
 func TestNoBetaVersionsEnabledByDefault(t *testing.T) {
-	config := DefaultAPIResourceConfigSource()
+	config := DefaultAPIResourceConfigSource(nil)
 	for gv, enable := range config.GroupVersionConfigs {
 		if enable && strings.Contains(gv.Version, "beta") {
 			t.Errorf("Beta API version %s enabled by default", gv.String())
@@ -457,7 +457,7 @@ func TestNewBetaResourcesEnabledByDefault(t *testing.T) {
 		flowcontrolv1bet3.SchemeGroupVersion.WithResource("prioritylevelconfigurations").GroupResource(): true,
 	}
 
-	config := DefaultAPIResourceConfigSource()
+	config := DefaultAPIResourceConfigSource(nil)
 	for gvr, enable := range config.ResourceConfigs {
 		if !strings.Contains(gvr.Version, "beta") {
 			continue // only check beta things

--- a/pkg/features/client_adapter_test.go
+++ b/pkg/features/client_adapter_test.go
@@ -19,6 +19,8 @@ package features
 import (
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	clientfeatures "k8s.io/client-go/features"
 	"k8s.io/component-base/featuregate"
 )
@@ -78,8 +80,7 @@ func TestClientAdapterAdd(t *testing.T) {
 			t.Errorf("expected feature %q not found", name)
 			continue
 		}
-
-		if actual != expected {
+		if diff := cmp.Diff(actual, expected, cmpopts.IgnoreFields(featuregate.FeatureSpec{}, "Version")); diff != "" {
 			t.Errorf("expected feature %q spec %#v, got spec %#v", name, expected, actual)
 		}
 	}

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -1194,6 +1194,8 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 
 	genericfeatures.EfficientWatchResumption: {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 
+	genericfeatures.EmulationVersion: {Default: false, PreRelease: featuregate.Alpha},
+
 	genericfeatures.KMSv1: {Default: false, PreRelease: featuregate.Deprecated},
 
 	genericfeatures.KMSv2: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.31

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -19,6 +19,7 @@ package features
 import (
 	apiextensionsfeatures "k8s.io/apiextensions-apiserver/pkg/features"
 	"k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/version"
 	genericfeatures "k8s.io/apiserver/pkg/features"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	clientfeatures "k8s.io/client-go/features"
@@ -919,6 +920,7 @@ const (
 
 func init() {
 	runtime.Must(utilfeature.DefaultMutableFeatureGate.Add(defaultKubernetesFeatureGates))
+	runtime.Must(utilfeature.DefaultMutableVersionedFeatureGate.AddVersioned(defaultVersionedKubernetesFeatureGates))
 
 	// Register all client-go features with kube's feature gate instance and make all client-go
 	// feature checks use kube's instance. The effect is that for kube binaries, client-go
@@ -928,6 +930,18 @@ func init() {
 	ca := &clientAdapter{utilfeature.DefaultMutableFeatureGate}
 	runtime.Must(clientfeatures.AddFeaturesToExistingFeatureGates(ca))
 	clientfeatures.ReplaceFeatureGates(ca)
+}
+
+// defaultVersionedKubernetesFeatureGates consists of all known Kubernetes-specific feature keys with VersionedSpecs.
+// To add a new feature, define a key for it above and add it here. The features will be
+// available throughout Kubernetes binaries.
+//
+// Entries are separated from each other with blank lines to avoid sweeping gofmt changes
+// when adding or removing one entry.
+var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate.VersionedSpecs{
+	genericfeatures.EmulationVersion: featuregate.VersionedSpecs{
+		{Version: version.MustParse("1.30"), Default: false, PreRelease: featuregate.Alpha},
+	},
 }
 
 // defaultKubernetesFeatureGates consists of all known Kubernetes-specific feature keys.
@@ -1193,8 +1207,6 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	genericfeatures.CustomResourceValidationExpressions: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.31
 
 	genericfeatures.EfficientWatchResumption: {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
-
-	genericfeatures.EmulationVersion: {Default: false, PreRelease: featuregate.Alpha},
 
 	genericfeatures.KMSv1: {Default: false, PreRelease: featuregate.Deprecated},
 

--- a/pkg/features/kube_features_test.go
+++ b/pkg/features/kube_features_test.go
@@ -62,6 +62,9 @@ func TestAllRegisteredFeaturesExpected(t *testing.T) {
 	if err := knownFeatureGates.Add(defaultKubernetesFeatureGates); err != nil {
 		t.Fatal(err)
 	}
+	if err := knownFeatureGates.AddVersioned(defaultVersionedKubernetesFeatureGates); err != nil {
+		t.Fatal(err)
+	}
 	knownFeatures := knownFeatureGates.GetAll()
 
 	for registeredFeature := range registeredFeatures {

--- a/pkg/registry/registrytest/etcd.go
+++ b/pkg/registry/registrytest/etcd.go
@@ -39,7 +39,7 @@ func NewEtcdStorageForResource(t *testing.T, resource schema.GroupResource) (*st
 
 	options := options.NewEtcdOptions(config)
 	completedConfig := kubeapiserver.NewStorageFactoryConfig().Complete(options)
-	completedConfig.APIResourceConfig = serverstorage.NewResourceConfig()
+	completedConfig.APIResourceConfig = serverstorage.NewResourceConfigIgnoreLifecycle()
 	factory, err := completedConfig.New()
 	if err != nil {
 		t.Fatalf("Error while making storage factory: %v", err)

--- a/staging/src/k8s.io/api/flowcontrol/v1beta1/register.go
+++ b/staging/src/k8s.io/api/flowcontrol/v1beta1/register.go
@@ -20,6 +20,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/version"
 )
 
 // GroupName is the name of api group
@@ -54,5 +55,14 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 		&PriorityLevelConfigurationList{},
 	)
 	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)
+
+	// Registers the lifecycle of the group version, which is checked to make sure a gvr is not available before its type is introduced or after it is removed.
+	// All individual resource types of this group share the lifecycle of the group and
+	// do not require their own lifecycles to be specified, like: scheme.SetResourceLifecycle(SchemeGroupVersion.WithResource("flowschema"), &FlowSchema{})
+	scheme.SetGroupVersionLifecycle(SchemeGroupVersion, schema.APILifecycle{
+		IntroducedVersion: version.MajorMinor(1, 20),
+		RemovedVersion:    version.MajorMinor(1, 26),
+	})
+
 	return nil
 }

--- a/staging/src/k8s.io/api/flowcontrol/v1beta1/register.go
+++ b/staging/src/k8s.io/api/flowcontrol/v1beta1/register.go
@@ -47,6 +47,7 @@ var (
 )
 
 // Adds the list of known types to the given scheme.
+// Do not remove before feature EmulationVersion graduates. Types used in integration tests TestEnableEmulationVersion.
 func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		&FlowSchema{},

--- a/staging/src/k8s.io/api/flowcontrol/v1beta2/register.go
+++ b/staging/src/k8s.io/api/flowcontrol/v1beta2/register.go
@@ -20,6 +20,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/version"
 )
 
 // GroupName is the name of api group
@@ -54,5 +55,14 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 		&PriorityLevelConfigurationList{},
 	)
 	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)
+
+	// Registers the lifecycle of the group version, which is checked to make sure a gvr is not available before its type is introduced or after it is removed.
+	// All individual resource types of this group share the lifecycle of the group version and
+	// do not require their own lifecycles to be specified, like: scheme.SetResourceLifecycle(SchemeGroupVersion.WithResource("flowschema"), &FlowSchema{})
+	scheme.SetGroupVersionLifecycle(SchemeGroupVersion, schema.APILifecycle{
+		IntroducedVersion: version.MajorMinor(1, 23),
+		RemovedVersion:    version.MajorMinor(1, 29),
+	})
+
 	return nil
 }

--- a/staging/src/k8s.io/api/flowcontrol/v1beta2/register.go
+++ b/staging/src/k8s.io/api/flowcontrol/v1beta2/register.go
@@ -47,6 +47,7 @@ var (
 )
 
 // Adds the list of known types to the given scheme.
+// Do not remove before feature EmulationVersion graduates. Types used in integration tests TestEnableEmulationVersion.
 func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		&FlowSchema{},

--- a/staging/src/k8s.io/api/flowcontrol/v1beta3/register.go
+++ b/staging/src/k8s.io/api/flowcontrol/v1beta3/register.go
@@ -46,6 +46,7 @@ var (
 )
 
 // Adds the list of known types to the given scheme.
+// Do not remove before feature EmulationVersion graduates. Types used in integration tests TestEnableEmulationVersion.
 func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		&FlowSchema{},

--- a/staging/src/k8s.io/api/flowcontrol/v1beta3/register.go
+++ b/staging/src/k8s.io/api/flowcontrol/v1beta3/register.go
@@ -54,5 +54,11 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 		&PriorityLevelConfigurationList{},
 	)
 	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)
+
+	// Registers the lifecycle of the resource types, which is checked to make sure a gvr is not available before its type is introduced or after it is removed.
+	scheme.SetResourceLifecycle(SchemeGroupVersion.WithResource("flowschema"), &FlowSchema{})
+	scheme.SetResourceLifecycle(SchemeGroupVersion.WithResource("flowschemas"), &FlowSchemaList{})
+	scheme.SetResourceLifecycle(SchemeGroupVersion.WithResource("prioritylevelconfiguration"), &PriorityLevelConfiguration{})
+	scheme.SetResourceLifecycle(SchemeGroupVersion.WithResource("prioritylevelconfigurations"), &PriorityLevelConfigurationList{})
 	return nil
 }

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/apiserver.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/apiserver.go
@@ -278,8 +278,8 @@ func (c completedConfig) New(delegationTarget genericapiserver.DelegationTarget)
 	return s, nil
 }
 
-func DefaultAPIResourceConfigSource() *serverstorage.ResourceConfig {
-	ret := serverstorage.NewResourceConfig()
+func DefaultAPIResourceConfigSource(registry serverstorage.GroupVersionRegistry) *serverstorage.ResourceConfig {
+	ret := serverstorage.NewResourceConfig(registry)
 	// NOTE: GroupVersions listed here will be enabled by default. Don't put alpha versions in the list.
 	ret.EnableVersions(
 		v1beta1.SchemeGroupVersion,

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/cmd/server/options/options.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/cmd/server/options/options.go
@@ -109,7 +109,7 @@ func (o CustomResourceDefinitionsServerOptions) Config() (*apiserver.Config, err
 	if err := o.RecommendedOptions.ApplyTo(serverConfig); err != nil {
 		return nil, err
 	}
-	if err := o.APIEnablement.ApplyTo(&serverConfig.Config, apiserver.DefaultAPIResourceConfigSource(), apiserver.Scheme); err != nil {
+	if err := o.APIEnablement.ApplyTo(&serverConfig.Config, apiserver.DefaultAPIResourceConfigSource(apiserver.Scheme)); err != nil {
 		return nil, err
 	}
 

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/cmd/server/options/options.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/cmd/server/options/options.go
@@ -32,13 +32,16 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	openapinamer "k8s.io/apiserver/pkg/endpoints/openapi"
+	genericfeatures "k8s.io/apiserver/pkg/features"
 	genericregistry "k8s.io/apiserver/pkg/registry/generic"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	genericoptions "k8s.io/apiserver/pkg/server/options"
 	storagevalue "k8s.io/apiserver/pkg/storage/value"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	flowcontrolrequest "k8s.io/apiserver/pkg/util/flowcontrol/request"
 	"k8s.io/apiserver/pkg/util/openapi"
 	"k8s.io/apiserver/pkg/util/proxy"
+	serverversion "k8s.io/apiserver/pkg/util/version"
 	"k8s.io/apiserver/pkg/util/webhook"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	corev1 "k8s.io/client-go/listers/core/v1"
@@ -92,6 +95,10 @@ func (o CustomResourceDefinitionsServerOptions) Validate() error {
 
 // Complete fills in missing options.
 func (o *CustomResourceDefinitionsServerOptions) Complete() error {
+	// set feature gate emulation version before Validate().
+	if utilfeature.DefaultFeatureGate.Enabled(genericfeatures.EmulationVersion) {
+		return utilfeature.DefaultMutableVersionedFeatureGate.SetEmulationVersion(serverversion.Effective.EmulationVersion())
+	}
 	return nil
 }
 

--- a/staging/src/k8s.io/apimachinery/pkg/util/version/version.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/version/version.go
@@ -345,6 +345,17 @@ func onlyZeros(array []uint) bool {
 	return true
 }
 
+// EqualTo tests if a version is equal to a given version.
+func (v *Version) EqualTo(other *Version) bool {
+	if v == nil {
+		return other == nil
+	}
+	if other == nil {
+		return false
+	}
+	return v.compareInternal(other) == 0
+}
+
 // AtLeast tests if a version is at least equal to a given minimum version. If both
 // Versions are Semantic Versions, this will use the Semantic Version comparison
 // algorithm. Otherwise, it will compare only the numeric components, with non-present

--- a/staging/src/k8s.io/apimachinery/pkg/util/version/version.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/version/version.go
@@ -145,6 +145,25 @@ func MustParseGeneric(str string) *Version {
 	return v
 }
 
+// Parse tries to do ParseSemantic first to keep more information.
+// If ParseSemantic fails, it would just do ParseGeneric.
+func Parse(str string) (*Version, error) {
+	v, err := parse(str, true)
+	if err != nil {
+		return parse(str, false)
+	}
+	return v, err
+}
+
+// MustParse is like Parse except that it panics on error
+func MustParse(str string) *Version {
+	v, err := Parse(str)
+	if err != nil {
+		panic(err)
+	}
+	return v
+}
+
 // ParseMajorMinor parses a "generic" version string and returns a version with the major and minor version.
 func ParseMajorMinor(str string) (*Version, error) {
 	v, err := ParseGeneric(str)
@@ -229,6 +248,18 @@ func (v *Version) WithMajor(major uint) *Version {
 // WithMinor returns copy of the version object with requested minor number
 func (v *Version) WithMinor(minor uint) *Version {
 	result := *v
+	result.components = []uint{v.Major(), minor, v.Patch()}
+	return &result
+}
+
+// SubtractMinor returns the version diff minor versions back, with the same major and patch.
+// If diff >= current minor, the minor would be 0.
+func (v *Version) SubtractMinor(diff uint) *Version {
+	result := *v
+	var minor uint
+	if diff < v.Minor() {
+		minor = v.Minor() - diff
+	}
 	result.components = []uint{v.Major(), minor, v.Patch()}
 	return &result
 }

--- a/staging/src/k8s.io/apimachinery/pkg/util/version/version.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/version/version.go
@@ -145,6 +145,24 @@ func MustParseGeneric(str string) *Version {
 	return v
 }
 
+// ParseMajorMinor parses a "generic" version string and returns a version with the major and minor version.
+func ParseMajorMinor(str string) (*Version, error) {
+	v, err := ParseGeneric(str)
+	if err != nil {
+		return nil, err
+	}
+	return MajorMinor(v.Major(), v.Minor()), nil
+}
+
+// MustParseMajorMinor is like ParseMajorMinor except that it panics on error
+func MustParseMajorMinor(str string) *Version {
+	v, err := ParseMajorMinor(str)
+	if err != nil {
+		panic(err)
+	}
+	return v
+}
+
 // ParseSemantic parses a version string that exactly obeys the syntax and semantics of
 // the "Semantic Versioning" specification (http://semver.org/) (although it ignores
 // leading and trailing whitespace, and allows the version to be preceded by "v"). For
@@ -369,6 +387,11 @@ func (v *Version) AtLeast(min *Version) bool {
 // "is v new enough?".)
 func (v *Version) LessThan(other *Version) bool {
 	return v.compareInternal(other) == -1
+}
+
+// GreaterThan tests if a version is greater than a given version.
+func (v *Version) GreaterThan(other *Version) bool {
+	return v.compareInternal(other) == 1
 }
 
 // Compare compares v against a version string (which will be parsed as either Semantic

--- a/staging/src/k8s.io/apimachinery/pkg/util/version/version_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/version/version_test.go
@@ -452,3 +452,94 @@ func TestHighestSupportedVersion(t *testing.T) {
 		}
 	}
 }
+
+func TestSubtractMinor(t *testing.T) {
+	var tests = []struct {
+		version            string
+		diff               uint
+		expectedComponents []uint
+	}{
+		{
+			version:            "1.0.2",
+			diff:               3,
+			expectedComponents: []uint{1, 0, 2},
+		},
+		{
+			version:            "1.3.2-alpha+001",
+			diff:               2,
+			expectedComponents: []uint{1, 1, 2},
+		},
+		{
+			version:            "1.3.2-alpha+001",
+			diff:               3,
+			expectedComponents: []uint{1, 0, 2},
+		},
+		{
+			version:            "1.20",
+			diff:               5,
+			expectedComponents: []uint{1, 15, 0},
+		},
+	}
+
+	for _, test := range tests {
+		version, _ := ParseGeneric(test.version)
+		if !reflect.DeepEqual(test.expectedComponents, version.SubtractMinor(test.diff).Components()) {
+			t.Error("parse returned un'expected components")
+		}
+	}
+}
+
+func TestParse(t *testing.T) {
+
+	var tests = []struct {
+		version               string
+		expectErr             bool
+		expectedComponents    []uint
+		expectedPreRelease    string
+		expectedBuildMetadata string
+	}{
+		{
+			version:            "1.0.2",
+			expectedComponents: []uint{1, 0, 2},
+		},
+		{
+			version:               "1.0.2-alpha+001",
+			expectedComponents:    []uint{1, 0, 2},
+			expectedPreRelease:    "alpha",
+			expectedBuildMetadata: "001",
+		},
+		{
+			version:            "1.2",
+			expectedComponents: []uint{1, 2},
+		},
+		{
+			version:               "1.0.2-beta+exp.sha.5114f85",
+			expectedComponents:    []uint{1, 0, 2},
+			expectedPreRelease:    "beta",
+			expectedBuildMetadata: "exp.sha.5114f85",
+		},
+		{
+			version:   "a.b.c",
+			expectErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		version, err := Parse(test.version)
+		if test.expectErr {
+			if err == nil {
+				t.Fatalf("got no err, expected err")
+			}
+			continue
+		}
+		if !reflect.DeepEqual(test.expectedComponents, version.Components()) {
+			t.Error("parse returned un'expected components")
+		}
+		if test.expectedPreRelease != version.PreRelease() {
+			t.Errorf("parse returned version.PreRelease %s, expected %s", test.expectedPreRelease, version.PreRelease())
+		}
+		if test.expectedBuildMetadata != version.BuildMetadata() {
+			t.Errorf("parse returned version.BuildMetadata %s, expected %s", test.expectedBuildMetadata, version.BuildMetadata())
+		}
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/cel/environment/base.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/environment/base.go
@@ -44,12 +44,7 @@ import (
 // desirable because it means that CEL expressions are portable across a wider range
 // of Kubernetes versions.
 func DefaultCompatibilityVersion() *version.Version {
-	v := utilversion.Effective.MinCompatibilityVersion()
-	// the MinCompatibilityVersion is not set for tests.
-	if v.Major() == 0 && v.Minor() == 0 {
-		return version.MajorMinor(1, 29)
-	}
-	return v
+	return utilversion.Effective.MinCompatibilityVersion()
 }
 
 var baseOpts = []VersionedOptions{

--- a/staging/src/k8s.io/apiserver/pkg/cel/environment/base.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/environment/base.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/version"
 	celconfig "k8s.io/apiserver/pkg/apis/cel"
 	"k8s.io/apiserver/pkg/cel/library"
+	utilversion "k8s.io/apiserver/pkg/util/version"
 )
 
 // DefaultCompatibilityVersion returns a default compatibility version for use with EnvSet
@@ -43,7 +44,12 @@ import (
 // desirable because it means that CEL expressions are portable across a wider range
 // of Kubernetes versions.
 func DefaultCompatibilityVersion() *version.Version {
-	return version.MajorMinor(1, 29)
+	v := utilversion.Effective.MinCompatibilityVersion()
+	// the MinCompatibilityVersion is not set for tests.
+	if v.Major() == 0 && v.Minor() == 0 {
+		return version.MajorMinor(1, 29)
+	}
+	return v
 }
 
 var baseOpts = []VersionedOptions{

--- a/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
+++ b/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
@@ -103,6 +103,14 @@ const (
 	// Enables expression validation in Admission Control
 	ValidatingAdmissionPolicy featuregate.Feature = "ValidatingAdmissionPolicy"
 
+	// owner: @siyuanfoundation @jpbetz
+	// kep: http://kep.k8s.io/4330
+	// alpha: v1.30
+	//
+	// Enables use of the --emulated-version flag, allowing components be
+	// emulate the behavior (features, APIs, ...) of a prior Kubernetes version.
+	EmulationVersion featuregate.Feature = "EmulationVersion"
+
 	// owner: @cici37
 	// kep: https://kep.k8s.io/2876
 	// alpha: v1.23
@@ -300,6 +308,8 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	APIServingWithRoutine: {Default: true, PreRelease: featuregate.Beta},
 
 	ValidatingAdmissionPolicy: {Default: false, PreRelease: featuregate.Beta},
+
+	EmulationVersion: {Default: false, PreRelease: featuregate.Alpha},
 
 	CustomResourceValidationExpressions: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.31
 

--- a/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
+++ b/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
@@ -18,6 +18,7 @@ package features
 
 import (
 	"k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/version"
 
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/component-base/featuregate"
@@ -284,6 +285,16 @@ const (
 
 func init() {
 	runtime.Must(utilfeature.DefaultMutableFeatureGate.Add(defaultKubernetesFeatureGates))
+	runtime.Must(utilfeature.DefaultMutableVersionedFeatureGate.AddVersioned(defaultVersionedKubernetesFeatureGates))
+}
+
+// defaultVersionedKubernetesFeatureGates consists of all known Kubernetes-specific feature keys with VersionedSpecs.
+// To add a new feature, define a key for it above and add it here. The features will be
+// available throughout Kubernetes binaries.
+var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate.VersionedSpecs{
+	EmulationVersion: featuregate.VersionedSpecs{
+		{Version: version.MustParse("1.30"), Default: false, PreRelease: featuregate.Alpha},
+	},
 }
 
 // defaultKubernetesFeatureGates consists of all known Kubernetes-specific feature keys.
@@ -308,8 +319,6 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	APIServingWithRoutine: {Default: true, PreRelease: featuregate.Beta},
 
 	ValidatingAdmissionPolicy: {Default: false, PreRelease: featuregate.Beta},
-
-	EmulationVersion: {Default: false, PreRelease: featuregate.Alpha},
 
 	CustomResourceValidationExpressions: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.31
 

--- a/staging/src/k8s.io/apiserver/pkg/server/deleted_kinds.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/deleted_kinds.go
@@ -17,6 +17,7 @@ limitations under the License.
 package server
 
 import (
+	"fmt"
 	"os"
 	"strconv"
 	"strings"
@@ -25,16 +26,15 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
-	apimachineryversion "k8s.io/apimachinery/pkg/version"
+	apimachineryversion "k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/klog/v2"
 )
 
 // resourceExpirationEvaluator holds info for deciding if a particular rest.Storage needs to excluded from the API
 type resourceExpirationEvaluator struct {
-	currentMajor int
-	currentMinor int
-	isAlpha      bool
+	currentVersion *apimachineryversion.Version
+	isAlpha        bool
 	// This is usually set for testing for which tests need to be removed.  This prevent insta-failing CI.
 	// Set KUBE_APISERVER_STRICT_REMOVED_API_HANDLING_IN_ALPHA to see what will be removed when we tag beta
 	strictRemovedHandlingInAlpha bool
@@ -53,30 +53,17 @@ type ResourceExpirationEvaluator interface {
 	ShouldServeForVersion(majorRemoved, minorRemoved int) bool
 }
 
-func NewResourceExpirationEvaluator(currentVersion apimachineryversion.Info) (ResourceExpirationEvaluator, error) {
+func NewResourceExpirationEvaluator(currentVersion *apimachineryversion.Version) (ResourceExpirationEvaluator, error) {
+	if currentVersion == nil {
+		return nil, fmt.Errorf("empty NewResourceExpirationEvaluator currentVersion")
+	}
+	klog.V(1).Infof("NewResourceExpirationEvaluator with currentVersion: %s.", currentVersion)
 	ret := &resourceExpirationEvaluator{
 		strictRemovedHandlingInAlpha: false,
 	}
-	if len(currentVersion.Major) > 0 {
-		currentMajor64, err := strconv.ParseInt(currentVersion.Major, 10, 32)
-		if err != nil {
-			return nil, err
-		}
-		ret.currentMajor = int(currentMajor64)
-	}
-	if len(currentVersion.Minor) > 0 {
-		// split the "normal" + and - for semver stuff
-		minorString := strings.Split(currentVersion.Minor, "+")[0]
-		minorString = strings.Split(minorString, "-")[0]
-		minorString = strings.Split(minorString, ".")[0]
-		currentMinor64, err := strconv.ParseInt(minorString, 10, 32)
-		if err != nil {
-			return nil, err
-		}
-		ret.currentMinor = int(currentMinor64)
-	}
-
-	ret.isAlpha = strings.Contains(currentVersion.GitVersion, "alpha")
+	// Only keeps the major and minor versions from input version.
+	ret.currentVersion = apimachineryversion.MajorMinor(currentVersion.Major(), currentVersion.Minor())
+	ret.isAlpha = strings.Contains(currentVersion.PreRelease(), "alpha")
 
 	if envString, ok := os.LookupEnv("KUBE_APISERVER_STRICT_REMOVED_API_HANDLING_IN_ALPHA"); !ok {
 		// do nothing
@@ -121,16 +108,11 @@ func (e *resourceExpirationEvaluator) shouldServe(gv schema.GroupVersion, versio
 }
 
 func (e *resourceExpirationEvaluator) ShouldServeForVersion(majorRemoved, minorRemoved int) bool {
-	if e.currentMajor < majorRemoved {
+	removedVer := apimachineryversion.MajorMinor(uint(majorRemoved), uint(minorRemoved))
+	if removedVer.GreaterThan(e.currentVersion) {
 		return true
 	}
-	if e.currentMajor > majorRemoved {
-		return false
-	}
-	if e.currentMinor < minorRemoved {
-		return true
-	}
-	if e.currentMinor > minorRemoved {
+	if removedVer.LessThan(e.currentVersion) {
 		return false
 	}
 	// at this point major and minor are equal, so this API should be removed when the current release GAs.

--- a/staging/src/k8s.io/apiserver/pkg/server/genericapiserver_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/genericapiserver_test.go
@@ -585,7 +585,7 @@ func fakeVersion() version.Info {
 	return version.Info{
 		Major:        "42",
 		Minor:        "42",
-		GitVersion:   "42",
+		GitVersion:   "42.42",
 		GitCommit:    "34973274ccef6ab4dfaaf86599792fa9c3fe4689",
 		GitTreeState: "Dirty",
 		BuildDate:    time.Now().String(),

--- a/staging/src/k8s.io/apiserver/pkg/server/options/api_enablement.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/api_enablement.go
@@ -22,25 +22,21 @@ import (
 
 	"github.com/spf13/pflag"
 
-	apimachineryversion "k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/apiserver/pkg/server"
 	"k8s.io/apiserver/pkg/server/resourceconfig"
 	serverstore "k8s.io/apiserver/pkg/server/storage"
-	serverversion "k8s.io/apiserver/pkg/util/version"
 	cliflag "k8s.io/component-base/cli/flag"
 )
 
 // APIEnablementOptions contains the options for which resources to turn on and off.
 // Given small aggregated API servers, this option isn't required for "normal" API servers
 type APIEnablementOptions struct {
-	RuntimeConfig    cliflag.ConfigurationMap
-	EmulationVersion string
+	RuntimeConfig cliflag.ConfigurationMap
 }
 
 func NewAPIEnablementOptions() *APIEnablementOptions {
 	return &APIEnablementOptions{
-		RuntimeConfig:    make(cliflag.ConfigurationMap),
-		EmulationVersion: serverversion.Effective.BinaryVersion().String(),
+		RuntimeConfig: make(cliflag.ConfigurationMap),
 	}
 }
 
@@ -58,11 +54,6 @@ func (s *APIEnablementOptions) AddFlags(fs *pflag.FlagSet) {
 		"api/beta=true|false controls all API versions of the form v[0-9]+beta[0-9]+\n"+
 		"api/alpha=true|false controls all API versions of the form v[0-9]+alpha[0-9]+\n"+
 		"api/legacy is deprecated, and will be removed in a future version")
-	fs.StringVar(&s.EmulationVersion, "emulation-version", serverversion.Effective.BinaryVersion().String(), ""+
-		"The version API server emulates its capabilities (APIs, features, ...) of.\n"+
-		"If set, the server would behave like the set version instead of the underlying binary version.\n"+
-		"Defaults to the binary version. Should be between 1.{binaryMinorVersion-1}..{binaryVersion}.\n"+
-		"Format could be semantic or generic version, like v1.30.0-alpha|v1.30|1.30")
 }
 
 // Validate validates RuntimeConfig with a list of registries.
@@ -92,16 +83,6 @@ func (s *APIEnablementOptions) Validate(registries ...GroupRegistry) []error {
 	}
 	if len(groups) != 0 {
 		errors = append(errors, fmt.Errorf("unknown api groups %s", strings.Join(groups, ",")))
-	}
-
-	v, err := apimachineryversion.Parse(s.EmulationVersion)
-	if err != nil {
-		errors = append(errors, err)
-		return errors
-	}
-	serverversion.Effective.SetEmulationVersion(v)
-	if errs := serverversion.Effective.Validate(); len(errs) > 0 {
-		errors = append(errors, errs...)
 	}
 
 	return errors

--- a/staging/src/k8s.io/apiserver/pkg/server/options/api_enablement.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/api_enablement.go
@@ -22,21 +22,25 @@ import (
 
 	"github.com/spf13/pflag"
 
+	apimachineryversion "k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/apiserver/pkg/server"
 	"k8s.io/apiserver/pkg/server/resourceconfig"
 	serverstore "k8s.io/apiserver/pkg/server/storage"
+	serverversion "k8s.io/apiserver/pkg/util/version"
 	cliflag "k8s.io/component-base/cli/flag"
 )
 
 // APIEnablementOptions contains the options for which resources to turn on and off.
 // Given small aggregated API servers, this option isn't required for "normal" API servers
 type APIEnablementOptions struct {
-	RuntimeConfig cliflag.ConfigurationMap
+	RuntimeConfig    cliflag.ConfigurationMap
+	EmulationVersion string
 }
 
 func NewAPIEnablementOptions() *APIEnablementOptions {
 	return &APIEnablementOptions{
-		RuntimeConfig: make(cliflag.ConfigurationMap),
+		RuntimeConfig:    make(cliflag.ConfigurationMap),
+		EmulationVersion: serverversion.Effective.BinaryVersion().String(),
 	}
 }
 
@@ -54,6 +58,11 @@ func (s *APIEnablementOptions) AddFlags(fs *pflag.FlagSet) {
 		"api/beta=true|false controls all API versions of the form v[0-9]+beta[0-9]+\n"+
 		"api/alpha=true|false controls all API versions of the form v[0-9]+alpha[0-9]+\n"+
 		"api/legacy is deprecated, and will be removed in a future version")
+	fs.StringVar(&s.EmulationVersion, "emulation-version", serverversion.Effective.BinaryVersion().String(), ""+
+		"The version API server emulates its capabilities (APIs, features, ...) of.\n"+
+		"If set, the server would behave like the set version instead of the underlying binary version.\n"+
+		"Defaults to the binary version. Should be between 1.{binaryMinorVersion-1}..{binaryVersion}.\n"+
+		"Format could be semantic or generic version, like v1.30.0-alpha|v1.30|1.30")
 }
 
 // Validate validates RuntimeConfig with a list of registries.
@@ -83,6 +92,16 @@ func (s *APIEnablementOptions) Validate(registries ...GroupRegistry) []error {
 	}
 	if len(groups) != 0 {
 		errors = append(errors, fmt.Errorf("unknown api groups %s", strings.Join(groups, ",")))
+	}
+
+	v, err := apimachineryversion.Parse(s.EmulationVersion)
+	if err != nil {
+		errors = append(errors, err)
+		return errors
+	}
+	serverversion.Effective.SetEmulationVersion(v)
+	if errs := serverversion.Effective.Validate(); len(errs) > 0 {
+		errors = append(errors, errs...)
 	}
 
 	return errors

--- a/staging/src/k8s.io/apiserver/pkg/server/options/api_enablement.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/api_enablement.go
@@ -88,13 +88,12 @@ func (s *APIEnablementOptions) Validate(registries ...GroupRegistry) []error {
 	return errors
 }
 
-// ApplyTo override MergedResourceConfig with defaults and registry
-func (s *APIEnablementOptions) ApplyTo(c *server.Config, defaultResourceConfig *serverstore.ResourceConfig, registry resourceconfig.GroupVersionRegistry) error {
+// ApplyTo override MergedResourceConfig with defaults
+func (s *APIEnablementOptions) ApplyTo(c *server.Config, defaultResourceConfig *serverstore.ResourceConfig) error {
 	if s == nil {
 		return nil
 	}
-
-	mergedResourceConfig, err := resourceconfig.MergeAPIResourceConfigs(defaultResourceConfig, s.RuntimeConfig, registry)
+	mergedResourceConfig, err := resourceconfig.MergeAPIResourceConfigs(defaultResourceConfig, s.RuntimeConfig)
 	c.MergedResourceConfig = mergedResourceConfig
 
 	return err

--- a/staging/src/k8s.io/apiserver/pkg/server/options/api_enablement_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/api_enablement_test.go
@@ -21,12 +21,7 @@ import (
 	"testing"
 
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
-	apimachineryversion "k8s.io/apimachinery/pkg/util/version"
-	genericfeatures "k8s.io/apiserver/pkg/features"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
-	serverversion "k8s.io/apiserver/pkg/util/version"
 	cliflag "k8s.io/component-base/cli/flag"
-	featuregatetesting "k8s.io/component-base/featuregate/testing"
 )
 
 type fakeGroupRegistry struct{}
@@ -36,8 +31,6 @@ func (f fakeGroupRegistry) IsGroupRegistered(group string) bool {
 }
 
 func TestAPIEnablementOptionsValidate(t *testing.T) {
-	t.Cleanup(serverversion.Effective.SetBinaryVersionForTests(apimachineryversion.MustParse("v1.30.0")))
-	binaryVersion := serverversion.Effective.BinaryVersion().String()
 	testCases := []struct {
 		name          string
 		testOptions   *APIEnablementOptions
@@ -72,63 +65,7 @@ func TestAPIEnablementOptionsValidate(t *testing.T) {
 	for _, testcase := range testCases {
 		t.Run(testcase.name, func(t *testing.T) {
 			testOptions := &APIEnablementOptions{
-				RuntimeConfig:    testcase.runtimeConfig,
-				EmulationVersion: binaryVersion,
-			}
-			errs := testOptions.Validate(testGroupRegistry)
-			if len(testcase.expectErr) != 0 && !strings.Contains(utilerrors.NewAggregate(errs).Error(), testcase.expectErr) {
-				t.Errorf("got err: %v, expected err: %s", errs, testcase.expectErr)
-			}
-
-			if len(testcase.expectErr) == 0 && len(errs) != 0 {
-				t.Errorf("got err: %s, expected err nil", errs)
-			}
-		})
-	}
-}
-
-func TestAPIEnablementOptionsValidateEmulationVersion(t *testing.T) {
-	t.Cleanup(serverversion.Effective.SetBinaryVersionForTests(apimachineryversion.MustParse("v1.30.0")))
-	binaryVersion := serverversion.Effective.BinaryVersion().String()
-	testCases := []struct {
-		name             string
-		emulationVersion string
-		expectErr        string
-	}{
-		{
-			name:      "test empty version",
-			expectErr: "could not parse \"\" as version",
-		},
-		{
-			name:             "test misformat version",
-			emulationVersion: "a.b.c",
-			expectErr:        "could not parse \"a.b.c\" as version",
-		},
-		{
-			name:             "test binaryVersion",
-			emulationVersion: binaryVersion,
-		},
-		{
-			name:             "test valid emulation version",
-			emulationVersion: "v1.29.0",
-		},
-		{
-			name:             "test non semantic emulation version",
-			emulationVersion: "1.29",
-		},
-		{
-			name:             "test invalid emulation version",
-			emulationVersion: "1.31.0",
-			expectErr:        "emulation version 1.31.0 is not between [1.29.0, 1.30.0]",
-		},
-	}
-	testGroupRegistry := fakeGroupRegistry{}
-
-	for _, testcase := range testCases {
-		t.Run(testcase.name, func(t *testing.T) {
-			defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.EmulationVersion, true)()
-			testOptions := &APIEnablementOptions{
-				EmulationVersion: testcase.emulationVersion,
+				RuntimeConfig: testcase.runtimeConfig,
 			}
 			errs := testOptions.Validate(testGroupRegistry)
 			if len(testcase.expectErr) != 0 && !strings.Contains(utilerrors.NewAggregate(errs).Error(), testcase.expectErr) {

--- a/staging/src/k8s.io/apiserver/pkg/server/options/server_run_options.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/server_run_options.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apiserver/pkg/server"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	serverversion "k8s.io/apiserver/pkg/util/version"
 
 	"github.com/spf13/pflag"
 )
@@ -196,6 +197,9 @@ func (s *ServerRunOptions) Validate() []error {
 	if err := validateCorsAllowedOriginList(s.CorsAllowedOriginList); err != nil {
 		errors = append(errors, err)
 	}
+	if errs := serverversion.Effective.Validate(); len(errs) != 0 {
+		errors = append(errors, errs...)
+	}
 	return errors
 }
 
@@ -338,4 +342,5 @@ func (s *ServerRunOptions) AddUniversalFlags(fs *pflag.FlagSet) {
 		"for active watch request(s) to drain during the graceful server shutdown window.")
 
 	utilfeature.DefaultMutableFeatureGate.AddFlag(fs)
+	serverversion.Effective.AddFlags(fs)
 }

--- a/staging/src/k8s.io/apiserver/pkg/server/options/server_run_options.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/server_run_options.go
@@ -197,6 +197,9 @@ func (s *ServerRunOptions) Validate() []error {
 	if err := validateCorsAllowedOriginList(s.CorsAllowedOriginList); err != nil {
 		errors = append(errors, err)
 	}
+	if errs := utilfeature.DefaultMutableVersionedFeatureGate.Validate(); len(errs) != 0 {
+		errors = append(errors, errs...)
+	}
 	if errs := serverversion.Effective.Validate(); len(errs) != 0 {
 		errors = append(errors, errs...)
 	}
@@ -341,6 +344,7 @@ func (s *ServerRunOptions) AddUniversalFlags(fs *pflag.FlagSet) {
 		"This option, if set, represents the maximum amount of grace period the apiserver will wait "+
 		"for active watch request(s) to drain during the graceful server shutdown window.")
 
+	utilfeature.DefaultMutableVersionedFeatureGate.DeferErrorsToValidation(true)
 	utilfeature.DefaultMutableFeatureGate.AddFlag(fs)
 	serverversion.Effective.AddFlags(fs)
 }

--- a/staging/src/k8s.io/apiserver/pkg/server/options/serving_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/serving_test.go
@@ -460,7 +460,7 @@ func fakeVersion() version.Info {
 	return version.Info{
 		Major:        "42",
 		Minor:        "42",
-		GitVersion:   "42",
+		GitVersion:   "42.42",
 		GitCommit:    "34973274ccef6ab4dfaaf86599792fa9c3fe4689",
 		GitTreeState: "Dirty",
 	}

--- a/staging/src/k8s.io/apiserver/pkg/server/resourceconfig/helpers.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/resourceconfig/helpers.go
@@ -28,16 +28,6 @@ import (
 	cliflag "k8s.io/component-base/cli/flag"
 )
 
-// GroupVersionRegistry provides access to registered group versions.
-type GroupVersionRegistry interface {
-	// IsGroupRegistered returns true if given group is registered.
-	IsGroupRegistered(group string) bool
-	// IsVersionRegistered returns true if given version is registered.
-	IsVersionRegistered(v schema.GroupVersion) bool
-	// PrioritizedVersionsAllGroups returns all registered group versions.
-	PrioritizedVersionsAllGroups() []schema.GroupVersion
-}
-
 // MergeResourceEncodingConfigs merges the given defaultResourceConfig with specific GroupVersionResource overrides.
 func MergeResourceEncodingConfigs(
 	defaultResourceEncoding *serverstore.DefaultResourceEncodingConfig,
@@ -84,7 +74,6 @@ var (
 func MergeAPIResourceConfigs(
 	defaultAPIResourceConfig *serverstore.ResourceConfig,
 	resourceConfigOverrides cliflag.ConfigurationMap,
-	registry GroupVersionRegistry,
 ) (*serverstore.ResourceConfig, error) {
 	resourceConfig := defaultAPIResourceConfig
 	overrides := resourceConfigOverrides
@@ -134,12 +123,12 @@ func MergeAPIResourceConfigs(
 		}
 
 		// Exclude group not registered into the registry.
-		if !registry.IsGroupRegistered(groupVersion.Group) {
+		if !resourceConfig.IsGroupRegistered(groupVersion.Group) {
 			continue
 		}
 
 		// Verify that the groupVersion is registered into registry.
-		if !registry.IsVersionRegistered(groupVersion) {
+		if !resourceConfig.IsVersionRegistered(groupVersion) {
 			return nil, fmt.Errorf("group version %s that has not been registered", groupVersion.String())
 		}
 		enabled, err := getRuntimeConfigValue(overrides, key, false)

--- a/staging/src/k8s.io/apiserver/pkg/server/resourceconfig/helpers_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/resourceconfig/helpers_test.go
@@ -37,8 +37,8 @@ import (
 )
 
 func TestParseRuntimeConfig(t *testing.T) {
-	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.EmulationVersion, true)()
 	t.Cleanup(utilversion.Effective.SetBinaryVersionForTests(apimachineryversion.MustParse("v1.30.0")))
+	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.EmulationVersion, true)()
 	scheme := newFakeScheme(t)
 	apiv1GroupVersion := apiv1.SchemeGroupVersion
 	testCases := []struct {

--- a/staging/src/k8s.io/apiserver/pkg/server/resourceconfig/helpers_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/resourceconfig/helpers_test.go
@@ -28,12 +28,17 @@ import (
 	flowcontrolv1beta1 "k8s.io/api/flowcontrol/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/util/version"
+	apimachineryversion "k8s.io/apimachinery/pkg/util/version"
+	"k8s.io/apiserver/pkg/features"
 	serverstore "k8s.io/apiserver/pkg/server/storage"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	utilversion "k8s.io/apiserver/pkg/util/version"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
 )
 
 func TestParseRuntimeConfig(t *testing.T) {
+	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.EmulationVersion, true)()
+	t.Cleanup(utilversion.Effective.SetBinaryVersionForTests(apimachineryversion.MustParse("v1.30.0")))
 	scheme := newFakeScheme(t)
 	apiv1GroupVersion := apiv1.SchemeGroupVersion
 	testCases := []struct {
@@ -553,8 +558,6 @@ func TestParseRuntimeConfig(t *testing.T) {
 }
 
 func newFakeAPIResourceConfigSource(scheme *runtime.Scheme) *serverstore.ResourceConfig {
-	emuVer := version.MustParseGeneric("1.30")
-	utilversion.Effective.Set(emuVer, emuVer, emuVer)
 	ret := serverstore.NewResourceConfig(scheme)
 	// NOTE: GroupVersions listed here will be enabled by default. Don't put alpha versions in the list.
 	ret.EnableVersions(

--- a/staging/src/k8s.io/apiserver/pkg/server/storage/resource_config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/storage/resource_config.go
@@ -156,17 +156,21 @@ func (o *ResourceConfig) apiAvailable(lifecycle schema.APILifecycle) (bool, erro
 	if !utilfeature.DefaultFeatureGate.Enabled(features.EmulationVersion) {
 		return true, nil
 	}
+	return isAPIAvailable(lifecycle, o.emulationVersion)
+}
+
+func isAPIAvailable(lifecycle schema.APILifecycle, emulationVersion *version.Version) (bool, error) {
 	// emulationVersion is not set.
-	if o.emulationVersion.Major() == 0 && o.emulationVersion.Minor() == 0 {
+	if emulationVersion.Major() == 0 && emulationVersion.Minor() == 0 {
 		return true, nil
 	}
 	// GroupVersion is introduced after the emulationVersion.
-	if lifecycle.IntroducedVersion != nil && o.emulationVersion.LessThan(lifecycle.IntroducedVersion) {
-		return false, fmt.Errorf("api introduced at %s, after the emulationVersion %s", lifecycle.IntroducedVersion.String(), o.emulationVersion.String())
+	if lifecycle.IntroducedVersion != nil && emulationVersion.LessThan(lifecycle.IntroducedVersion) {
+		return false, fmt.Errorf("api introduced at %s, after the emulationVersion %s", lifecycle.IntroducedVersion.String(), emulationVersion.String())
 	}
 	// GroupVersion is removed before the emulationVersion.
-	if lifecycle.RemovedVersion != nil && o.emulationVersion.GreaterThan(lifecycle.RemovedVersion) {
-		return false, fmt.Errorf("api removed at %s, before the emulationVersion %s", lifecycle.RemovedVersion.String(), o.emulationVersion.String())
+	if lifecycle.RemovedVersion != nil && emulationVersion.GreaterThan(lifecycle.RemovedVersion) {
+		return false, fmt.Errorf("api removed at %s, before the emulationVersion %s", lifecycle.RemovedVersion.String(), emulationVersion.String())
 	}
 	// TODO: handle remove when RemovedVersion equals emulationVersion like resourceExpirationEvaluator.ShouldServeForVersion.
 	return true, nil

--- a/staging/src/k8s.io/apiserver/pkg/server/storage/resource_config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/storage/resource_config.go
@@ -17,7 +17,12 @@ limitations under the License.
 package storage
 
 import (
+	"fmt"
+
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/version"
+	utilversion "k8s.io/apiserver/pkg/util/version"
+	"k8s.io/klog/v2"
 )
 
 // APIResourceConfigSource is the interface to determine which groups and versions are enabled
@@ -26,14 +31,38 @@ type APIResourceConfigSource interface {
 	AnyResourceForGroupEnabled(group string) bool
 }
 
+// GroupVersionRegistry provides access to registered group versions.
+type GroupVersionRegistry interface {
+	// IsGroupRegistered returns true if given group is registered.
+	IsGroupRegistered(group string) bool
+	// IsVersionRegistered returns true if given version is registered.
+	IsVersionRegistered(v schema.GroupVersion) bool
+	// PrioritizedVersionsAllGroups returns all registered group versions.
+	PrioritizedVersionsAllGroups() []schema.GroupVersion
+	// GroupVersionLifecycle returns the APILifecycle for the GroupVersion.
+	GroupVersionLifecycle(gv schema.GroupVersion) schema.APILifecycle
+	// ResourceLifecycle returns the APILifecycle for the GroupVersionResource.
+	ResourceLifecycle(gvr schema.GroupVersionResource) schema.APILifecycle
+}
+
 var _ APIResourceConfigSource = &ResourceConfig{}
 
 type ResourceConfig struct {
 	GroupVersionConfigs map[schema.GroupVersion]bool
 	ResourceConfigs     map[schema.GroupVersionResource]bool
+	emulationVersion    *version.Version
+	GroupVersionRegistry
 }
 
-func NewResourceConfig() *ResourceConfig {
+func NewResourceConfig(registry GroupVersionRegistry) *ResourceConfig {
+	emuVer := utilversion.Effective.EmulationVersion()
+	return &ResourceConfig{GroupVersionConfigs: map[schema.GroupVersion]bool{}, ResourceConfigs: map[schema.GroupVersionResource]bool{},
+		emulationVersion: emuVer, GroupVersionRegistry: registry}
+}
+
+// NewResourceConfigIgnoreLifecycle creates a ResourceConfig that allows enabling/disabling resources regardless of their APILifecycle.
+// Mainly used in tests.
+func NewResourceConfigIgnoreLifecycle() *ResourceConfig {
 	return &ResourceConfig{GroupVersionConfigs: map[schema.GroupVersion]bool{}, ResourceConfigs: map[schema.GroupVersionResource]bool{}}
 }
 
@@ -53,7 +82,12 @@ func (o *ResourceConfig) DisableMatchingVersions(matcher func(gv schema.GroupVer
 func (o *ResourceConfig) EnableMatchingVersions(matcher func(gv schema.GroupVersion) bool) {
 	for version := range o.GroupVersionConfigs {
 		if matcher(version) {
-			o.GroupVersionConfigs[version] = true
+			if available, err := o.versionAvailable(version); available {
+				o.GroupVersionConfigs[version] = true
+			} else {
+				o.GroupVersionConfigs[version] = false
+				klog.V(1).Infof("version %s cannot be enabled because: %s", version.String(), err.Error())
+			}
 			o.removeMatchingResourcePreferences(resourceMatcherForVersion(version))
 		}
 	}
@@ -85,22 +119,25 @@ func (o *ResourceConfig) removeMatchingResourcePreferences(matcher func(gvr sche
 func (o *ResourceConfig) DisableVersions(versions ...schema.GroupVersion) {
 	for _, version := range versions {
 		o.GroupVersionConfigs[version] = false
-
 		// a preference about a version takes priority over the previously set resources
 		o.removeMatchingResourcePreferences(resourceMatcherForVersion(version))
 	}
 }
 
 // EnableVersions enables all resources in a given groupVersion.
+// A groupVersion can only be enabled if its APILifecyle is available for the emulation version.
 // This will remove any preferences previously set on individual resources.
 func (o *ResourceConfig) EnableVersions(versions ...schema.GroupVersion) {
 	for _, version := range versions {
-		o.GroupVersionConfigs[version] = true
-
+		if available, err := o.versionAvailable(version); available {
+			o.GroupVersionConfigs[version] = true
+		} else {
+			o.GroupVersionConfigs[version] = false
+			klog.V(1).Infof("version %s cannot be enabled because: %s", version.String(), err.Error())
+		}
 		// a preference about a version takes priority over the previously set resources
 		o.removeMatchingResourcePreferences(resourceMatcherForVersion(version))
 	}
-
 }
 
 // TODO this must be removed and we enable/disable individual resources.
@@ -109,15 +146,62 @@ func (o *ResourceConfig) versionEnabled(version schema.GroupVersion) bool {
 	return enabled
 }
 
+// apiAvailable compares the APILifecycle against the emulationVersion.
+// An API is unavailable if it introduced after the emulationVersion,
+// or removed before the emulationVersion.
+func (o *ResourceConfig) apiAvailable(lifecycle schema.APILifecycle) (bool, error) {
+	// emulationVersion is not set.
+	if o.emulationVersion == nil {
+		return true, nil
+	}
+	// GroupVersion is introduced after the emulationVersion.
+	if lifecycle.IntroducedVersion != nil && o.emulationVersion.LessThan(lifecycle.IntroducedVersion) {
+		return false, fmt.Errorf("api introduced at %s, after the emulationVersion %s", lifecycle.IntroducedVersion.String(), o.emulationVersion.String())
+	}
+	// GroupVersion is removed before the emulationVersion.
+	if lifecycle.RemovedVersion != nil && o.emulationVersion.GreaterThan(lifecycle.RemovedVersion) {
+		return false, fmt.Errorf("api removed at %s, before the emulationVersion %s", lifecycle.RemovedVersion.String(), o.emulationVersion.String())
+	}
+	// TODO: handle remove when RemovedVersion equals emulationVersion like resourceExpirationEvaluator.ShouldServeForVersion.
+	return true, nil
+}
+
+// versionAvailable checks if a GroupVersion is available based on its APILifecycle.
+func (o *ResourceConfig) versionAvailable(version schema.GroupVersion) (bool, error) {
+	if o.GroupVersionRegistry == nil {
+		return true, nil
+	}
+	return o.apiAvailable(o.GroupVersionLifecycle(version))
+}
+
+// versionAvailable checks if a GroupVersionResource is available based on its APILifecycle.
+func (o *ResourceConfig) resourceAvailable(resource schema.GroupVersionResource) (bool, error) {
+	if o.GroupVersionRegistry == nil {
+		return true, nil
+	}
+	// both the group version and resource have to avaible.
+	if available, err := o.apiAvailable(o.ResourceLifecycle(resource)); !available {
+		return available, err
+	}
+	return o.versionAvailable(resource.GroupVersion())
+}
+
 func (o *ResourceConfig) DisableResources(resources ...schema.GroupVersionResource) {
 	for _, resource := range resources {
 		o.ResourceConfigs[resource] = false
 	}
 }
 
+// EnableResources enables resources explicitly.
+// A resource can only be enabled if its APILifecyle is available for the emulation version.
 func (o *ResourceConfig) EnableResources(resources ...schema.GroupVersionResource) {
 	for _, resource := range resources {
-		o.ResourceConfigs[resource] = true
+		if available, err := o.resourceAvailable(resource); available {
+			o.ResourceConfigs[resource] = true
+		} else {
+			o.ResourceConfigs[resource] = false
+			klog.V(1).Infof("resource %s cannot be enabled because: %s", resource.String(), err.Error())
+		}
 	}
 }
 
@@ -127,7 +211,9 @@ func (o *ResourceConfig) ResourceEnabled(resource schema.GroupVersionResource) b
 	if explicitlySet {
 		return resourceEnabled
 	}
-
+	if available, _ := o.resourceAvailable(resource); !available {
+		return false
+	}
 	if !o.versionEnabled(resource.GroupVersion()) {
 		return false
 	}

--- a/staging/src/k8s.io/apiserver/pkg/server/storage/resource_config_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/storage/resource_config_test.go
@@ -249,7 +249,7 @@ func TestEnabledVersionWithEmulationVersion(t *testing.T) {
 		RemovedVersion: version.MajorMinor(1, 28),
 	})
 	t.Cleanup(utilversion.Effective.SetBinaryVersionForTests(version.MustParse("v1.29.0")))
-	utilversion.Effective.SetEmulationVersion(version.MustParse("1.28.2"))
+	utilversion.Effective.Set(version.MustParse("v1.29.0"), version.MustParse("v1.28.2"), version.MustParse("v1.28.0"))
 	config := NewResourceConfig(scheme)
 
 	config.DisableVersions(g1v1)
@@ -409,7 +409,7 @@ func TestEnabledResourceWithEmulationVersion(t *testing.T) {
 			defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.EmulationVersion, true)()
 			scheme := runtime.NewScheme()
 			t.Cleanup(utilversion.Effective.SetBinaryVersionForTests(version.MustParse("v1.29.0")))
-			utilversion.Effective.SetEmulationVersion(version.MustParse("1.28.2"))
+			utilversion.Effective.Set(version.MustParse("v1.29.0"), version.MustParse("v1.28.2"), version.MustParse("v1.28.0"))
 			config := NewResourceConfig(scheme)
 			gv := schema.GroupVersion{Group: "group", Version: "version"}
 			r := gv.WithResource("resource")

--- a/staging/src/k8s.io/apiserver/pkg/server/storage/resource_config_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/storage/resource_config_test.go
@@ -184,6 +184,7 @@ func TestAnyVersionForGroupEnabled(t *testing.T) {
 }
 
 func TestEnabledVersionWithEmulationVersionOff(t *testing.T) {
+	t.Cleanup(utilversion.Effective.SetBinaryVersionForTests(version.MustParse("v1.30.0")))
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.EmulationVersion, false)()
 	g1v1 := schema.GroupVersion{Group: "group1", Version: "version1"}
 	g1v2 := schema.GroupVersion{Group: "group1", Version: "version2"}
@@ -193,18 +194,17 @@ func TestEnabledVersionWithEmulationVersionOff(t *testing.T) {
 
 	scheme := runtime.NewScheme()
 	scheme.SetGroupVersionLifecycle(g1v2, schema.APILifecycle{
-		IntroducedVersion: version.MajorMinor(1, 29),
+		IntroducedVersion: version.MajorMinor(1, 31),
 	})
 	scheme.SetGroupVersionLifecycle(g2v1, schema.APILifecycle{
-		RemovedVersion: version.MajorMinor(1, 27),
+		RemovedVersion: version.MajorMinor(1, 29),
 	})
 	scheme.SetGroupVersionLifecycle(g2v2, schema.APILifecycle{
-		IntroducedVersion: version.MajorMinor(1, 26),
+		IntroducedVersion: version.MajorMinor(1, 28),
 	})
 	scheme.SetGroupVersionLifecycle(g2v3, schema.APILifecycle{
-		RemovedVersion: version.MajorMinor(1, 28),
+		RemovedVersion: version.MajorMinor(1, 30),
 	})
-	t.Cleanup(utilversion.Effective.SetBinaryVersionForTests(version.MustParse("v1.28.0")))
 	config := NewResourceConfig(scheme)
 
 	config.DisableVersions(g1v1)
@@ -228,6 +228,7 @@ func TestEnabledVersionWithEmulationVersionOff(t *testing.T) {
 }
 
 func TestEnabledVersionWithEmulationVersion(t *testing.T) {
+	t.Cleanup(utilversion.Effective.SetBinaryVersionForTests(version.MustParse("v1.31.0")))
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.EmulationVersion, true)()
 	g1v1 := schema.GroupVersion{Group: "group1", Version: "version1"}
 	g1v2 := schema.GroupVersion{Group: "group1", Version: "version2"}
@@ -237,19 +238,19 @@ func TestEnabledVersionWithEmulationVersion(t *testing.T) {
 
 	scheme := runtime.NewScheme()
 	scheme.SetGroupVersionLifecycle(g1v2, schema.APILifecycle{
-		IntroducedVersion: version.MajorMinor(1, 29),
+		IntroducedVersion: version.MajorMinor(1, 31),
 	})
 	scheme.SetGroupVersionLifecycle(g2v1, schema.APILifecycle{
-		RemovedVersion: version.MajorMinor(1, 27),
+		RemovedVersion: version.MajorMinor(1, 29),
 	})
 	scheme.SetGroupVersionLifecycle(g2v2, schema.APILifecycle{
-		IntroducedVersion: version.MajorMinor(1, 26),
+		IntroducedVersion: version.MajorMinor(1, 28),
 	})
 	scheme.SetGroupVersionLifecycle(g2v3, schema.APILifecycle{
-		RemovedVersion: version.MajorMinor(1, 28),
+		RemovedVersion: version.MajorMinor(1, 30),
 	})
-	t.Cleanup(utilversion.Effective.SetBinaryVersionForTests(version.MustParse("v1.29.0")))
-	utilversion.Effective.Set(version.MustParse("v1.29.0"), version.MustParse("v1.28.2"), version.MustParse("v1.28.0"))
+
+	utilversion.Effective.Set(version.MustParse("v1.31.0"), version.MustParse("v1.30.2"), version.MustParse("v1.30.0"))
 	config := NewResourceConfig(scheme)
 
 	config.DisableVersions(g1v1)
@@ -325,6 +326,7 @@ func TestApiAvailable(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Cleanup(utilversion.Effective.SetBinaryVersionForTests(version.MustParse("v1.30.0")))
 			defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.EmulationVersion, true)()
 			config := ResourceConfig{emulationVersion: tc.emulationVersion}
 			available, _ := config.apiAvailable(schema.APILifecycle{IntroducedVersion: tc.introducedVersion, RemovedVersion: tc.removedVersion})
@@ -360,45 +362,45 @@ func TestEnabledResourceWithEmulationVersion(t *testing.T) {
 	}{
 		{
 			name:                   "enable gv introduced before emulation version",
-			groupVersionIntroduced: version.MajorMinor(1, 27),
+			groupVersionIntroduced: version.MajorMinor(1, 29),
 			enableGroupVersion:     true,
 			enableResource:         true,
 			expectedResult:         true,
 		},
 		{
 			name:                   "enable gv introduced after emulation version",
-			groupVersionIntroduced: version.MajorMinor(1, 29),
+			groupVersionIntroduced: version.MajorMinor(1, 31),
 			enableGroupVersion:     true,
 			enableResource:         true,
 			expectedResult:         false,
 		},
 		{
 			name:                   "enable resource for disabled gv introduced before emulation version",
-			groupVersionIntroduced: version.MajorMinor(1, 27),
+			groupVersionIntroduced: version.MajorMinor(1, 29),
 			enableGroupVersion:     false,
 			enableResource:         true,
 			expectedResult:         true,
 		},
 		{
 			name:                   "enable resource introduced before and gv introduced before emulation version",
-			groupVersionIntroduced: version.MajorMinor(1, 27),
-			resourceIntroduced:     version.MajorMinor(1, 26),
+			groupVersionIntroduced: version.MajorMinor(1, 29),
+			resourceIntroduced:     version.MajorMinor(1, 28),
 			enableGroupVersion:     true,
 			enableResource:         true,
 			expectedResult:         true,
 		},
 		{
 			name:                   "enable resource introduced after and gv introduced before emulation version",
-			groupVersionIntroduced: version.MajorMinor(1, 27),
-			resourceIntroduced:     version.MajorMinor(1, 29),
+			groupVersionIntroduced: version.MajorMinor(1, 29),
+			resourceIntroduced:     version.MajorMinor(1, 31),
 			enableGroupVersion:     true,
 			enableResource:         true,
 			expectedResult:         false,
 		},
 		{
 			name:                   "enable resource introduced before and gv introduced after emulation version",
-			groupVersionIntroduced: version.MajorMinor(1, 29),
-			resourceIntroduced:     version.MajorMinor(1, 27),
+			groupVersionIntroduced: version.MajorMinor(1, 31),
+			resourceIntroduced:     version.MajorMinor(1, 29),
 			enableGroupVersion:     true,
 			enableResource:         true,
 			expectedResult:         false,
@@ -406,10 +408,10 @@ func TestEnabledResourceWithEmulationVersion(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Cleanup(utilversion.Effective.SetBinaryVersionForTests(version.MustParse("v1.31.0")))
 			defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.EmulationVersion, true)()
 			scheme := runtime.NewScheme()
-			t.Cleanup(utilversion.Effective.SetBinaryVersionForTests(version.MustParse("v1.29.0")))
-			utilversion.Effective.Set(version.MustParse("v1.29.0"), version.MustParse("v1.28.2"), version.MustParse("v1.28.0"))
+			utilversion.Effective.Set(version.MustParse("v1.31.0"), version.MustParse("v1.30.2"), version.MustParse("v1.30.0"))
 			config := NewResourceConfig(scheme)
 			gv := schema.GroupVersion{Group: "group", Version: "version"}
 			r := gv.WithResource("resource")

--- a/staging/src/k8s.io/apiserver/pkg/server/storage/resource_encoding_config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/storage/resource_encoding_config.go
@@ -21,6 +21,10 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/version"
+	"k8s.io/apiserver/pkg/features"
+	"k8s.io/apiserver/pkg/util/feature"
+	utilversion "k8s.io/apiserver/pkg/util/version"
 )
 
 type ResourceEncodingConfig interface {
@@ -35,8 +39,10 @@ type ResourceEncodingConfig interface {
 
 type DefaultResourceEncodingConfig struct {
 	// resources records the overriding encoding configs for individual resources.
-	resources map[schema.GroupResource]*OverridingResourceEncoding
-	scheme    *runtime.Scheme
+	resources               map[schema.GroupResource]*OverridingResourceEncoding
+	scheme                  *runtime.Scheme
+	emulationVersion        *version.Version
+	minCompatibilityVersion *version.Version
 }
 
 type OverridingResourceEncoding struct {
@@ -47,7 +53,10 @@ type OverridingResourceEncoding struct {
 var _ ResourceEncodingConfig = &DefaultResourceEncodingConfig{}
 
 func NewDefaultResourceEncodingConfig(scheme *runtime.Scheme) *DefaultResourceEncodingConfig {
-	return &DefaultResourceEncodingConfig{resources: map[schema.GroupResource]*OverridingResourceEncoding{}, scheme: scheme}
+	emuVer := utilversion.Effective.EmulationVersion()
+	compatVer := utilversion.Effective.MinCompatibilityVersion()
+	return &DefaultResourceEncodingConfig{resources: map[schema.GroupResource]*OverridingResourceEncoding{}, scheme: scheme,
+		emulationVersion: version.MajorMinor(emuVer.Major(), emuVer.Minor()), minCompatibilityVersion: version.MajorMinor(compatVer.Major(), compatVer.Minor())}
 }
 
 func (o *DefaultResourceEncodingConfig) SetResourceEncoding(resourceBeingStored schema.GroupResource, externalEncodingVersion, internalVersion schema.GroupVersion) {
@@ -67,6 +76,26 @@ func (o *DefaultResourceEncodingConfig) StorageEncodingFor(resource schema.Group
 		return resourceOverride.ExternalResourceEncoding, nil
 	}
 
+	if feature.DefaultFeatureGate.Enabled(features.EmulationVersion) && o.emulationVersion != nil && o.minCompatibilityVersion != nil {
+		// List all versions for this group.
+		knownVersionsToBinary := o.scheme.PrioritizedVersionsForGroup(resource.Group)
+		emulationVersions := enabledVersions(resource.Resource, o.scheme, o.emulationVersion, knownVersionsToBinary)
+		minCompatibilityVersions := enabledVersions(resource.Resource, o.scheme, o.minCompatibilityVersion, knownVersionsToBinary)
+
+		// Return the first GV that is common to both the emulation and the
+		// minimum compatibility versions. The lists are sorted by priority
+		// so returning the first match will give the highest priority version
+		for _, emulationGV := range emulationVersions {
+			for _, minWindowGV := range minCompatibilityVersions {
+				if emulationGV == minWindowGV {
+					return emulationGV, nil
+				}
+			}
+		}
+
+		return schema.GroupVersion{}, fmt.Errorf("resource not codable by both emulation version and min compatibility version: %v", resource)
+	}
+
 	// return the most preferred external version for the group
 	return o.scheme.PrioritizedVersionsForGroup(resource.Group)[0], nil
 }
@@ -81,4 +110,29 @@ func (o *DefaultResourceEncodingConfig) InMemoryEncodingFor(resource schema.Grou
 		return resourceOverride.InternalResourceEncoding, nil
 	}
 	return schema.GroupVersion{Group: resource.Group, Version: runtime.APIVersionInternal}, nil
+}
+
+func enabledVersions(
+	resource string,
+	registry GroupVersionRegistry,
+	emulationVersion *version.Version,
+	prioritizedVersions []schema.GroupVersion,
+) []schema.GroupVersion {
+	var enabledVersions []schema.GroupVersion
+	for _, gv := range prioritizedVersions {
+		gvr := schema.GroupVersionResource{
+			Group:    gv.Group,
+			Version:  gv.Version,
+			Resource: resource,
+		}
+
+		if enabled, _ := isAPIAvailable(registry.GroupVersionLifecycle(gv), emulationVersion); !enabled {
+			continue
+		} else if enabled, _ := isAPIAvailable(registry.ResourceLifecycle(gvr), emulationVersion); !enabled {
+			continue
+		}
+
+		enabledVersions = append(enabledVersions, gv)
+	}
+	return enabledVersions
 }

--- a/staging/src/k8s.io/apiserver/pkg/server/storage/storage_factory_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/storage/storage_factory_test.go
@@ -107,7 +107,7 @@ func (n *fakeNegotiater) DecoderToVersion(serializer runtime.Decoder, gv runtime
 
 func TestConfigurableStorageFactory(t *testing.T) {
 	ns := &fakeNegotiater{types: []string{"test/test"}}
-	f := NewDefaultStorageFactory(storagebackend.Config{}, "test/test", ns, NewDefaultResourceEncodingConfig(scheme), NewResourceConfig(), nil)
+	f := NewDefaultStorageFactory(storagebackend.Config{}, "test/test", ns, NewDefaultResourceEncodingConfig(scheme), NewResourceConfigIgnoreLifecycle(), nil)
 	f.AddCohabitatingResources(example.Resource("test"), schema.GroupResource{Resource: "test2", Group: "2"})
 	called := false
 	testEncoderChain := func(e runtime.Encoder) runtime.Encoder {
@@ -159,7 +159,7 @@ func TestUpdateEtcdOverrides(t *testing.T) {
 				ServerList: defaultEtcdLocation,
 			},
 		}
-		storageFactory := NewDefaultStorageFactory(defaultConfig, "", codecs, NewDefaultResourceEncodingConfig(scheme), NewResourceConfig(), nil)
+		storageFactory := NewDefaultStorageFactory(defaultConfig, "", codecs, NewDefaultResourceEncodingConfig(scheme), NewResourceConfigIgnoreLifecycle(), nil)
 		storageFactory.SetEtcdLocation(test.resource, test.servers)
 
 		var err error
@@ -232,7 +232,7 @@ func TestConfigs(t *testing.T) {
 				ServerList: defaultEtcdLocations,
 			},
 		}
-		storageFactory := NewDefaultStorageFactory(defaultConfig, "", codecs, NewDefaultResourceEncodingConfig(scheme), NewResourceConfig(), nil)
+		storageFactory := NewDefaultStorageFactory(defaultConfig, "", codecs, NewDefaultResourceEncodingConfig(scheme), NewResourceConfigIgnoreLifecycle(), nil)
 		if test.resource != nil {
 			storageFactory.SetEtcdLocation(*test.resource, test.servers)
 		}

--- a/staging/src/k8s.io/apiserver/pkg/util/feature/feature_gate.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/feature/feature_gate.go
@@ -21,11 +21,14 @@ import (
 )
 
 var (
+	// DefaultMutableVersionedFeatureGate is DefaultMutableFeatureGate with access to settings specific to the emuation version.
+	// Only top-level commands/options setup and the k8s.io/component-base/featuregate/testing package should make use of this.
+	DefaultMutableVersionedFeatureGate featuregate.MutableVersionedFeatureGate = featuregate.NewFeatureGate()
 	// DefaultMutableFeatureGate is a mutable version of DefaultFeatureGate.
 	// Only top-level commands/options setup and the k8s.io/component-base/featuregate/testing package should make use of this.
 	// Tests that need to modify feature gates for the duration of their test should use:
 	//   defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.<FeatureName>, <value>)()
-	DefaultMutableFeatureGate featuregate.MutableFeatureGate = featuregate.NewFeatureGate()
+	DefaultMutableFeatureGate featuregate.MutableFeatureGate = DefaultMutableVersionedFeatureGate
 
 	// DefaultFeatureGate is a shared global FeatureGate.
 	// Top-level commands/options setup that needs to modify this feature gate should use DefaultMutableFeatureGate.

--- a/staging/src/k8s.io/apiserver/pkg/util/version/version.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/version/version.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package version
+
+import (
+	"sync/atomic"
+
+	"k8s.io/apimachinery/pkg/util/version"
+	baseversion "k8s.io/component-base/version"
+)
+
+var Effective MutableEffectiveVersions = newEffectiveVersion()
+
+type EffectiveVersions interface {
+	BinaryVersion() *version.Version
+	EmulationVersion() *version.Version
+	MinCompatibilityVersion() *version.Version
+}
+
+type MutableEffectiveVersions interface {
+	EffectiveVersions
+	Set(binaryVersion, emulationVersion, minCompatibilityVersion *version.Version)
+	SetEmulationVersion(emulationVersion *version.Version)
+	SetMinCompatibilityVersion(minCompatibilityVersion *version.Version)
+}
+
+type effectiveVersions struct {
+	binaryVersion           *version.Version
+	emulationVersion        *version.Version
+	minCompatibilityVersion *version.Version
+}
+
+func (m *effectiveVersions) BinaryVersion() *version.Version {
+	return m.binaryVersion
+}
+
+func (m *effectiveVersions) EmulationVersion() *version.Version {
+	return m.emulationVersion
+}
+
+func (m *effectiveVersions) MinCompatibilityVersion() *version.Version {
+	return m.minCompatibilityVersion
+}
+
+type mutableEffectiveVersions struct {
+	effectiveVersions atomic.Pointer[effectiveVersions]
+}
+
+func newEffectiveVersion() MutableEffectiveVersions {
+	effective := &mutableEffectiveVersions{}
+	binaryVersionInfo := baseversion.Get()
+	binaryVersion := version.MustParseGeneric(binaryVersionInfo.String())
+	compatVersion := version.MajorMinor(binaryVersion.Major(), binaryVersion.Minor()-1)
+	effective.Set(binaryVersion, binaryVersion, compatVersion)
+	return effective
+}
+
+func (m *mutableEffectiveVersions) Set(binaryVersion, emulationVersion, minCompatibilityVersion *version.Version) {
+	m.effectiveVersions.Store(&effectiveVersions{
+		binaryVersion:           binaryVersion,
+		emulationVersion:        emulationVersion,
+		minCompatibilityVersion: minCompatibilityVersion,
+	})
+}
+
+func (m *mutableEffectiveVersions) SetEmulationVersion(emulationVersion *version.Version) {
+	m.Set(m.BinaryVersion(), emulationVersion, m.MinCompatibilityVersion())
+}
+
+func (m *mutableEffectiveVersions) SetMinCompatibilityVersion(minCompatibilityVersion *version.Version) {
+	m.Set(m.BinaryVersion(), m.EmulationVersion(), minCompatibilityVersion)
+}
+
+func (m *mutableEffectiveVersions) BinaryVersion() *version.Version {
+	return m.effectiveVersions.Load().BinaryVersion()
+}
+
+func (m *mutableEffectiveVersions) EmulationVersion() *version.Version {
+	return m.effectiveVersions.Load().EmulationVersion()
+}
+
+func (m *mutableEffectiveVersions) MinCompatibilityVersion() *version.Version {
+	return m.effectiveVersions.Load().MinCompatibilityVersion()
+}

--- a/staging/src/k8s.io/apiserver/pkg/util/version/version_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/version/version_test.go
@@ -1,0 +1,203 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package version
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/version"
+	genericfeatures "k8s.io/apiserver/pkg/features"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/component-base/featuregate"
+
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
+)
+
+func TestValidateWhenEmulationVersionEnabled(t *testing.T) {
+	tests := []struct {
+		name                    string
+		featuresEnabled         []featuregate.Feature
+		binaryVersion           string
+		emulationVersion        string
+		minCompatibilityVersion string
+		expectErrors            bool
+	}{
+		{
+			name:                    "patch version diff ok",
+			binaryVersion:           "v1.30.2",
+			emulationVersion:        "v1.30.1",
+			minCompatibilityVersion: "v1.29.5",
+		},
+		{
+			name:                    "emulation version one minor lower than binary ok",
+			binaryVersion:           "v1.30.2",
+			emulationVersion:        "v1.29.1",
+			minCompatibilityVersion: "v1.29.0",
+		},
+		{
+			name:                    "emulation version two minor lower than binary not ok",
+			binaryVersion:           "v1.30.2",
+			emulationVersion:        "v1.28.1",
+			minCompatibilityVersion: "v1.29.0",
+			expectErrors:            true,
+		},
+		{
+			name:                    "emulation version one minor higher than binary not ok",
+			binaryVersion:           "v1.30.2",
+			emulationVersion:        "v1.31.1",
+			minCompatibilityVersion: "v1.29.0",
+			expectErrors:            true,
+		},
+		{
+			name:                    "emulation version two minor higher than binary not ok",
+			binaryVersion:           "v1.30.2",
+			emulationVersion:        "v1.32.1",
+			minCompatibilityVersion: "v1.29.0",
+			expectErrors:            true,
+		},
+		{
+			name:                    "compatibility version same as binary not ok",
+			binaryVersion:           "v1.30.2",
+			emulationVersion:        "v1.30.1",
+			minCompatibilityVersion: "v1.30.0",
+			expectErrors:            true,
+		},
+		{
+			name:                    "compatibility version two minor lower than binary not ok",
+			binaryVersion:           "v1.30.2",
+			emulationVersion:        "v1.30.1",
+			minCompatibilityVersion: "v1.28.0",
+			expectErrors:            true,
+		},
+		{
+			name:                    "compatibility version one minor higher than binary not ok",
+			binaryVersion:           "v1.30.2",
+			emulationVersion:        "v1.30.1",
+			minCompatibilityVersion: "v1.31.0",
+			expectErrors:            true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.EmulationVersion, true)()
+
+			effective := &mutableEffectiveVersions{}
+			binaryVersion := version.MustParseGeneric(test.binaryVersion)
+			emulationVersion := version.MustParseGeneric(test.emulationVersion)
+			minCompatibilityVersion := version.MustParseGeneric(test.minCompatibilityVersion)
+			effective.Set(binaryVersion, emulationVersion, minCompatibilityVersion)
+
+			errs := effective.Validate()
+			if len(errs) > 0 && !test.expectErrors {
+				t.Errorf("expected no errors, errors found %+v", errs)
+			}
+
+			if len(errs) == 0 && test.expectErrors {
+				t.Errorf("expected errors, no errors found")
+			}
+		})
+	}
+}
+
+func TestValidateWhenEmulationVersionDisabled(t *testing.T) {
+	tests := []struct {
+		name                    string
+		featuresEnabled         []featuregate.Feature
+		binaryVersion           string
+		emulationVersion        string
+		minCompatibilityVersion string
+		expectErrors            bool
+	}{
+		{
+			name:                    "patch version diff ok",
+			binaryVersion:           "v1.30.2",
+			emulationVersion:        "v1.30.1",
+			minCompatibilityVersion: "v1.29.5",
+		},
+		{
+			name:                    "emulation version one minor lower than binary not ok",
+			binaryVersion:           "v1.30.2",
+			emulationVersion:        "v1.29.1",
+			minCompatibilityVersion: "v1.29",
+			expectErrors:            true,
+		},
+		{
+			name:                    "emulation version two minor lower than binary not ok",
+			binaryVersion:           "v1.30.2",
+			emulationVersion:        "v1.28.1",
+			minCompatibilityVersion: "v1.29",
+			expectErrors:            true,
+		},
+		{
+			name:                    "emulation version one minor higher than binary not ok",
+			binaryVersion:           "v1.30.2",
+			emulationVersion:        "v1.31.1",
+			minCompatibilityVersion: "v1.29",
+			expectErrors:            true,
+		},
+		{
+			name:                    "emulation version two minor higher than binary not ok",
+			binaryVersion:           "v1.30.2",
+			emulationVersion:        "v1.32.1",
+			minCompatibilityVersion: "v1.29",
+			expectErrors:            true,
+		},
+		{
+			name:                    "compatibility version same as binary not ok",
+			binaryVersion:           "v1.30.2",
+			emulationVersion:        "v1.30.1",
+			minCompatibilityVersion: "v1.30",
+			expectErrors:            true,
+		},
+		{
+			name:                    "compatibility version two minor lower than binary not ok",
+			binaryVersion:           "v1.30.2",
+			emulationVersion:        "v1.30.1",
+			minCompatibilityVersion: "v1.28",
+			expectErrors:            true,
+		},
+		{
+			name:                    "compatibility version one minor higher than binary not ok",
+			binaryVersion:           "v1.30.2",
+			emulationVersion:        "v1.30.1",
+			minCompatibilityVersion: "v1.31",
+			expectErrors:            true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.EmulationVersion, false)()
+
+			effective := &mutableEffectiveVersions{}
+			binaryVersion := version.MustParseGeneric(test.binaryVersion)
+			emulationVersion := version.MustParseGeneric(test.emulationVersion)
+			minCompatibilityVersion := version.MustParseGeneric(test.minCompatibilityVersion)
+			effective.Set(binaryVersion, emulationVersion, minCompatibilityVersion)
+
+			errs := effective.Validate()
+			if len(errs) > 0 && !test.expectErrors {
+				t.Errorf("expected no errors, errors found %+v", errs)
+			}
+
+			if len(errs) == 0 && test.expectErrors {
+				t.Errorf("expected errors, no errors found")
+			}
+		})
+	}
+}

--- a/staging/src/k8s.io/component-base/featuregate/feature_gate.go
+++ b/staging/src/k8s.io/component-base/featuregate/feature_gate.go
@@ -19,6 +19,7 @@ package featuregate
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"sort"
 	"strconv"
 	"strings"
@@ -27,8 +28,11 @@ import (
 
 	"github.com/spf13/pflag"
 
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/naming"
+	"k8s.io/apimachinery/pkg/util/version"
 	featuremetrics "k8s.io/component-base/metrics/prometheus/feature"
+	baseversion "k8s.io/component-base/version"
 	"k8s.io/klog/v2"
 )
 
@@ -52,13 +56,13 @@ const (
 
 var (
 	// The generic features.
-	defaultFeatures = map[Feature]FeatureSpec{
-		allAlphaGate: {Default: false, PreRelease: Alpha},
-		allBetaGate:  {Default: false, PreRelease: Beta},
+	defaultFeatures = map[Feature]VersionedSpecs{
+		allAlphaGate: {{Default: false, PreRelease: Alpha, Version: version.MajorMinor(0, 0)}},
+		allBetaGate:  {{Default: false, PreRelease: Beta, Version: version.MajorMinor(0, 0)}},
 	}
 
 	// Special handling for a few gates.
-	specialFeatures = map[Feature]func(known map[Feature]FeatureSpec, enabled map[Feature]bool, val bool){
+	specialFeatures = map[Feature]func(known map[Feature]VersionedSpecs, enabled map[Feature]bool, val bool, cVer *version.Version){
 		allAlphaGate: setUnsetAlphaGates,
 		allBetaGate:  setUnsetBetaGates,
 	}
@@ -69,13 +73,26 @@ type FeatureSpec struct {
 	Default bool
 	// LockToDefault indicates that the feature is locked to its default and cannot be changed
 	LockToDefault bool
-	// PreRelease indicates the maturity level of the feature
+	// PreRelease indicates the current maturity level of the feature
 	PreRelease prerelease
+	// Version indicates the version from which this configuration is valid.
+	Version *version.Version
 }
+
+type VersionedSpecs []FeatureSpec
+
+func (g VersionedSpecs) Len() int { return len(g) }
+func (g VersionedSpecs) Less(i, j int) bool {
+	return g[i].Version.LessThan(g[j].Version)
+}
+func (g VersionedSpecs) Swap(i, j int) { g[i], g[j] = g[j], g[i] }
+
+type PromotionVersionMapping map[prerelease]string
 
 type prerelease string
 
 const (
+	PreAlpha = prerelease("PRE-ALPHA")
 	// Values for PreRelease.
 	Alpha = prerelease("ALPHA")
 	Beta  = prerelease("BETA")
@@ -95,6 +112,10 @@ type FeatureGate interface {
 	// set on the copy without mutating the original. This is useful for validating
 	// config against potential feature gate changes before committing those changes.
 	DeepCopy() MutableFeatureGate
+	// EmulationVersion returns the version the feature gate is set to emulate.
+	// If set, the feature gate would enable/disable features based on
+	// feature availability and pre-release at the emulated version instead of the binary version.
+	EmulationVersion() *version.Version
 }
 
 // MutableFeatureGate parses and stores flag gates for known features from
@@ -128,11 +149,30 @@ type MutableFeatureGate interface {
 	OverrideDefault(name Feature, override bool) error
 }
 
+type MutableVersionedFeatureGate interface {
+	MutableFeatureGate
+	// SetEmulationVersion overrides the emulationVersion of the feature gate.
+	// Otherwise, the emulationVersion will be the same as the binary version.
+	// If set, the feature defaults and availability will be as if the binary is at the emulated version.
+	SetEmulationVersion(emulationVersion *version.Version) error
+	// DeferErrorsToValidation defers the errors of Set function to the Validate() function if true.
+	// This is used when the user wants to set the feature gate flag before the emulationVersion is finalized.
+	// Validate() should aways be called later to check for flag errors if deferErrorsToValidation is true.
+	DeferErrorsToValidation(val bool)
+	// Validate checks if the flag gates are valid at the emulated version.
+	// Should always be called after Set when DeferErrorsToValidation is set to true.
+	Validate() []error
+	// GetAll returns a copy of the map of known feature names to versioned feature specs.
+	GetAllVersioned() map[Feature]VersionedSpecs
+	// AddVersioned adds versioned feature specs to the featureGate.
+	AddVersioned(features map[Feature]VersionedSpecs) error
+}
+
 // featureGate implements FeatureGate as well as pflag.Value for flag parsing.
 type featureGate struct {
 	featureGateName string
 
-	special map[Feature]func(map[Feature]FeatureSpec, map[Feature]bool, bool)
+	special map[Feature]func(map[Feature]VersionedSpecs, map[Feature]bool, bool, *version.Version)
 
 	// lock guards writes to known, enabled, and reads/writes of closed
 	lock sync.Mutex
@@ -140,13 +180,22 @@ type featureGate struct {
 	known atomic.Value
 	// enabled holds a map[Feature]bool
 	enabled atomic.Value
+	// enabledRaw holds a map[string]bool of the parsed flag
+	enabledRaw atomic.Value
 	// closed is set to true when AddFlag is called, and prevents subsequent calls to Add
 	closed bool
+
+	deferErrorsToValidation bool
+	emulationVersion        atomic.Pointer[version.Version]
 }
 
-func setUnsetAlphaGates(known map[Feature]FeatureSpec, enabled map[Feature]bool, val bool) {
+func setUnsetAlphaGates(known map[Feature]VersionedSpecs, enabled map[Feature]bool, val bool, cVer *version.Version) {
 	for k, v := range known {
-		if v.PreRelease == Alpha {
+		if k == "AllAlpha" || k == "AllBeta" {
+			continue
+		}
+		currentVersion := getCurrentVersion(v, cVer)
+		if currentVersion.PreRelease == Alpha {
 			if _, found := enabled[k]; !found {
 				enabled[k] = val
 			}
@@ -154,9 +203,13 @@ func setUnsetAlphaGates(known map[Feature]FeatureSpec, enabled map[Feature]bool,
 	}
 }
 
-func setUnsetBetaGates(known map[Feature]FeatureSpec, enabled map[Feature]bool, val bool) {
+func setUnsetBetaGates(known map[Feature]VersionedSpecs, enabled map[Feature]bool, val bool, cVer *version.Version) {
 	for k, v := range known {
-		if v.PreRelease == Beta {
+		if k == "AllAlpha" || k == "AllBeta" {
+			continue
+		}
+		currentVersion := getCurrentVersion(v, cVer)
+		if currentVersion.PreRelease == Beta {
 			if _, found := enabled[k]; !found {
 				enabled[k] = val
 			}
@@ -171,8 +224,10 @@ var _ pflag.Value = &featureGate{}
 // call chains, so they'd be unhelpful as names.
 var internalPackages = []string{"k8s.io/component-base/featuregate/feature_gate.go"}
 
-func NewFeatureGate() *featureGate {
-	known := map[Feature]FeatureSpec{}
+// NewVersionedFeatureGate creates a feature gate with the emulation version set to the provided version.
+// SetEmulationVersion can be called after to change emulation version to a desired value.
+func NewVersionedFeatureGate(emulationVersion *version.Version) *featureGate {
+	known := map[Feature]VersionedSpecs{}
 	for k, v := range defaultFeatures {
 		known[k] = v
 	}
@@ -183,8 +238,16 @@ func NewFeatureGate() *featureGate {
 	}
 	f.known.Store(known)
 	f.enabled.Store(map[Feature]bool{})
-
+	f.enabledRaw.Store(map[string]bool{})
+	f.emulationVersion.Store(emulationVersion)
+	klog.V(1).Infof("new feature gate with emulationVersion=%s", f.emulationVersion.Load().String())
 	return f
+}
+
+// NewFeatureGate creates a feature gate with the current binary version.
+func NewFeatureGate() *featureGate {
+	binaryVersison := version.MustParse(baseversion.Get().String())
+	return NewVersionedFeatureGate(binaryVersison)
 }
 
 // Set parses a string of the form "key1=value1,key2=value2,..." into a
@@ -207,7 +270,68 @@ func (f *featureGate) Set(value string) error {
 		}
 		m[k] = boolValue
 	}
-	return f.SetFromMap(m)
+	err := f.SetFromMap(m)
+	// ignores SetFromMap error, because the emulationVersion may not be the final emulationVersion when the flag is set.
+	// Validate() should aways be called later to check for flag errors if deferErrorsToValidation is true.
+	if f.deferErrorsToValidation {
+		return nil
+	}
+	return err
+}
+
+// Validate checks if the flag gates are valid at the emulated version.
+// Should always be called after Set when DeferErrorsToValidation is set to true.
+func (f *featureGate) Validate() []error {
+	m, ok := f.enabledRaw.Load().(map[string]bool)
+	if !ok {
+		return []error{fmt.Errorf("cannot cast enabledRaw to map[string]bool")}
+	}
+	enabled := map[Feature]bool{}
+	return f.unsafeSetFromMap(enabled, m)
+}
+
+// unsafeSetFromMap stores flag gates for known features from a map[string]bool into an enabled map.
+func (f *featureGate) unsafeSetFromMap(enabled map[Feature]bool, m map[string]bool) []error {
+	var errs []error
+	// Copy existing state
+	known := map[Feature]VersionedSpecs{}
+	for k, v := range f.known.Load().(map[Feature]VersionedSpecs) {
+		sort.Sort(v)
+		known[k] = v
+	}
+
+	for k, v := range m {
+		key := Feature(k)
+		versionedSpecs, ok := known[key]
+		if !ok {
+			// early return if encounters an unknown feature.
+			errs = append(errs, fmt.Errorf("unrecognized feature gate: %s", k))
+			return errs
+		}
+		currentVersion := f.getCurrentVersion(versionedSpecs)
+		if currentVersion.LockToDefault && currentVersion.Default != v {
+			errs = append(errs, fmt.Errorf("cannot set feature gate %v to %v, feature is locked to %v", k, v, currentVersion.Default))
+			continue
+		}
+		// Handle "special" features like "all alpha gates"
+		if fn, found := f.special[key]; found {
+			fn(known, enabled, v, f.emulationVersion.Load())
+			enabled[key] = v
+			continue
+		}
+		if currentVersion.PreRelease == PreAlpha {
+			errs = append(errs, fmt.Errorf("cannot set feature gate %v to %v, feature is PreAlpha at emulated version %s", k, v, f.EmulationVersion().String()))
+			continue
+		}
+		enabled[key] = v
+
+		if currentVersion.PreRelease == Deprecated {
+			klog.Warningf("Setting deprecated feature gate %s=%t. It will be removed in a future release.", k, v)
+		} else if currentVersion.PreRelease == GA {
+			klog.Warningf("Setting GA feature gate %s=%t. It will be removed in a future release.", k, v)
+		}
+	}
+	return errs
 }
 
 // SetFromMap stores flag gates for known features from a map[string]bool or returns an error
@@ -216,43 +340,30 @@ func (f *featureGate) SetFromMap(m map[string]bool) error {
 	defer f.lock.Unlock()
 
 	// Copy existing state
-	known := map[Feature]FeatureSpec{}
-	for k, v := range f.known.Load().(map[Feature]FeatureSpec) {
-		known[k] = v
-	}
 	enabled := map[Feature]bool{}
 	for k, v := range f.enabled.Load().(map[Feature]bool) {
 		enabled[k] = v
 	}
-
-	for k, v := range m {
-		k := Feature(k)
-		featureSpec, ok := known[k]
-		if !ok {
-			return fmt.Errorf("unrecognized feature gate: %s", k)
-		}
-		if featureSpec.LockToDefault && featureSpec.Default != v {
-			return fmt.Errorf("cannot set feature gate %v to %v, feature is locked to %v", k, v, featureSpec.Default)
-		}
-		enabled[k] = v
-		// Handle "special" features like "all alpha gates"
-		if fn, found := f.special[k]; found {
-			fn(known, enabled, v)
-		}
-
-		if featureSpec.PreRelease == Deprecated {
-			klog.Warningf("Setting deprecated feature gate %s=%t. It will be removed in a future release.", k, v)
-		} else if featureSpec.PreRelease == GA {
-			klog.Warningf("Setting GA feature gate %s=%t. It will be removed in a future release.", k, v)
-		}
+	enabledRaw := map[string]bool{}
+	for k, v := range f.enabledRaw.Load().(map[string]bool) {
+		enabledRaw[k] = v
 	}
 
-	// Persist changes
-	f.known.Store(known)
-	f.enabled.Store(enabled)
+	// Update enabledRaw first.
+	// SetFromMap might be called when emulationVersion is not finalized yet, and we do not know the final state of enabled.
+	// But the flags still need to be saved.
+	for k, v := range m {
+		enabledRaw[k] = v
+	}
+	f.enabledRaw.Store(enabledRaw)
 
-	klog.V(1).Infof("feature gates: %v", f.enabled)
-	return nil
+	errs := f.unsafeSetFromMap(enabled, enabledRaw)
+	if len(errs) == 0 {
+		// Persist changes
+		f.enabled.Store(enabled)
+		klog.V(1).Infof("feature gates: %v", f.enabled)
+	}
+	return utilerrors.NewAggregate(errs)
 }
 
 // String returns a string containing all enabled feature gates, formatted as "key1=value1,key2=value2,...".
@@ -271,6 +382,17 @@ func (f *featureGate) Type() string {
 
 // Add adds features to the featureGate.
 func (f *featureGate) Add(features map[Feature]FeatureSpec) error {
+	vs := map[Feature]VersionedSpecs{}
+	for name, spec := range features {
+		// if no version is provided for the FeatureSpec, it is defaulted to version 0.0 so that it can be enabled/disabled regardless of emulation version.
+		spec.Version = version.MajorMinor(0, 0)
+		vs[name] = VersionedSpecs{spec}
+	}
+	return f.AddVersioned(vs)
+}
+
+// AddVersioned adds versioned feature specs to the featureGate.
+func (f *featureGate) AddVersioned(features map[Feature]VersionedSpecs) error {
 	f.lock.Lock()
 	defer f.lock.Unlock()
 
@@ -279,20 +401,21 @@ func (f *featureGate) Add(features map[Feature]FeatureSpec) error {
 	}
 
 	// Copy existing state
-	known := map[Feature]FeatureSpec{}
-	for k, v := range f.known.Load().(map[Feature]FeatureSpec) {
+	known := map[Feature]VersionedSpecs{}
+	for k, v := range f.known.Load().(map[Feature]VersionedSpecs) {
 		known[k] = v
 	}
 
-	for name, spec := range features {
+	for name, specs := range features {
+		sort.Sort(specs)
 		if existingSpec, found := known[name]; found {
-			if existingSpec == spec {
+			sort.Sort(existingSpec)
+			if reflect.DeepEqual(existingSpec, specs) {
 				continue
 			}
 			return fmt.Errorf("feature gate %q with different spec already exists: %v", name, existingSpec)
 		}
-
-		known[name] = spec
+		known[name] = specs
 	}
 
 	// Persist updated state
@@ -309,17 +432,22 @@ func (f *featureGate) OverrideDefault(name Feature, override bool) error {
 		return fmt.Errorf("cannot override default for feature %q: gates already added to a flag set", name)
 	}
 
-	known := map[Feature]FeatureSpec{}
-	for name, spec := range f.known.Load().(map[Feature]FeatureSpec) {
-		known[name] = spec
+	known := map[Feature]VersionedSpecs{}
+	for k, v := range f.known.Load().(map[Feature]VersionedSpecs) {
+		sort.Sort(v)
+		known[k] = v
 	}
 
-	spec, ok := known[name]
-	switch {
-	case !ok:
+	specs, ok := known[name]
+	if !ok {
 		return fmt.Errorf("cannot override default: feature %q is not registered", name)
+	}
+	spec := f.getCurrentVersion(specs)
+	switch {
 	case spec.LockToDefault:
 		return fmt.Errorf("cannot override default: feature %q default is locked to %t", name, spec.Default)
+	case spec.PreRelease == PreAlpha:
+		return fmt.Errorf("cannot override default: feature %q is not available before emulation version %s", name, f.EmulationVersion().String())
 	case spec.PreRelease == Deprecated:
 		klog.Warningf("Overriding default of deprecated feature gate %s=%t. It will be removed in a future release.", name, override)
 	case spec.PreRelease == GA:
@@ -327,31 +455,105 @@ func (f *featureGate) OverrideDefault(name Feature, override bool) error {
 	}
 
 	spec.Default = override
-	known[name] = spec
+	known[name] = specs
 	f.known.Store(known)
 
 	return nil
 }
 
-// GetAll returns a copy of the map of known feature names to feature specs.
+// GetAll returns a copy of the map of known feature names to feature specs for the current emulationVersion.
 func (f *featureGate) GetAll() map[Feature]FeatureSpec {
 	retval := map[Feature]FeatureSpec{}
-	for k, v := range f.known.Load().(map[Feature]FeatureSpec) {
+	for k, v := range f.GetAllVersioned() {
+		spec := f.getCurrentVersion(v)
+		if spec.PreRelease == PreAlpha {
+			// The feature is not available at the emulation version.
+			continue
+		}
+		retval[k] = *f.getCurrentVersion(v)
+	}
+	return retval
+}
+
+// GetAllVersioned returns a copy of the map of known feature names to versioned feature specs.
+func (f *featureGate) GetAllVersioned() map[Feature]VersionedSpecs {
+	retval := map[Feature]VersionedSpecs{}
+	for k, v := range f.known.Load().(map[Feature]VersionedSpecs) {
 		retval[k] = v
 	}
 	return retval
 }
 
+func (f *featureGate) DeferErrorsToValidation(val bool) {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+	f.deferErrorsToValidation = val
+}
+
+func (f *featureGate) SetEmulationVersion(emulationVersion *version.Version) error {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+	klog.V(1).Infof("set feature gate emulationVersion to %s", emulationVersion.String())
+	f.emulationVersion.Store(emulationVersion)
+
+	// Copy existing state
+	enabledRaw := map[string]bool{}
+	for k, v := range f.enabledRaw.Load().(map[string]bool) {
+		enabledRaw[k] = v
+	}
+	// enabled map should be reset whenever emulationVersion is changed.
+	enabled := map[Feature]bool{}
+	errs := f.unsafeSetFromMap(enabled, enabledRaw)
+	if len(errs) == 0 {
+		// Persist changes
+		f.enabled.Store(enabled)
+	}
+	return utilerrors.NewAggregate(errs)
+}
+
+func (f *featureGate) EmulationVersion() *version.Version {
+	return f.emulationVersion.Load()
+}
+
+// FeatureSpec returns the FeatureSpec at the EmulationVersion if the key exists, an error otherwise.
+func (f *featureGate) FeatureSpec(key Feature) (FeatureSpec, error) {
+	if v, ok := f.known.Load().(map[Feature]VersionedSpecs)[key]; ok {
+		currentVersion := f.getCurrentVersion(v)
+		return *currentVersion, nil
+	}
+	return FeatureSpec{}, fmt.Errorf("feature %q is not registered in FeatureGate %q", key, f.featureGateName)
+}
+
 // Enabled returns true if the key is enabled.  If the key is not known, this call will panic.
 func (f *featureGate) Enabled(key Feature) bool {
+	// fallback to default behavior, since we don't have emulation version set
 	if v, ok := f.enabled.Load().(map[Feature]bool)[key]; ok {
 		return v
 	}
-	if v, ok := f.known.Load().(map[Feature]FeatureSpec)[key]; ok {
-		return v.Default
+	if v, ok := f.known.Load().(map[Feature]VersionedSpecs)[key]; ok {
+		return f.getCurrentVersion(v).Default
 	}
 
 	panic(fmt.Errorf("feature %q is not registered in FeatureGate %q", key, f.featureGateName))
+}
+
+func (f *featureGate) getCurrentVersion(v VersionedSpecs) *FeatureSpec {
+	return getCurrentVersion(v, f.EmulationVersion())
+}
+
+func getCurrentVersion(v VersionedSpecs, emulationVersion *version.Version) *FeatureSpec {
+	i := len(v) - 1
+	for ; i >= 0; i-- {
+		if v[i].Version.GreaterThan(emulationVersion) {
+			continue
+		}
+		return &v[i]
+	}
+	return &FeatureSpec{
+		Default:    false,
+		PreRelease: PreAlpha,
+		Version:    version.MajorMinor(0, 0),
+	}
 }
 
 // AddFlag adds a flag for setting global feature gates to the specified FlagSet.
@@ -377,14 +579,19 @@ func (f *featureGate) AddMetrics() {
 }
 
 // KnownFeatures returns a slice of strings describing the FeatureGate's known features.
-// Deprecated and GA features are hidden from the list.
+// preAlpha, Deprecated and GA features are hidden from the list.
 func (f *featureGate) KnownFeatures() []string {
 	var known []string
-	for k, v := range f.known.Load().(map[Feature]FeatureSpec) {
-		if v.PreRelease == GA || v.PreRelease == Deprecated {
+	for k, v := range f.known.Load().(map[Feature]VersionedSpecs) {
+		if k == "AllAlpha" || k == "AllBeta" {
+			known = append(known, fmt.Sprintf("%s=true|false (%s - default=%t)", k, v[0].PreRelease, v[0].Default))
 			continue
 		}
-		known = append(known, fmt.Sprintf("%s=true|false (%s - default=%t)", k, v.PreRelease, v.Default))
+		currentV := f.getCurrentVersion(v)
+		if currentV.PreRelease == GA || currentV.PreRelease == Deprecated || currentV.PreRelease == PreAlpha {
+			continue
+		}
+		known = append(known, fmt.Sprintf("%s=true|false (%s - default=%t)", k, currentV.PreRelease, currentV.Default))
 	}
 	sort.Strings(known)
 	return known
@@ -395,13 +602,17 @@ func (f *featureGate) KnownFeatures() []string {
 // config against potential feature gate changes before committing those changes.
 func (f *featureGate) DeepCopy() MutableFeatureGate {
 	// Copy existing state.
-	known := map[Feature]FeatureSpec{}
-	for k, v := range f.known.Load().(map[Feature]FeatureSpec) {
+	known := map[Feature]VersionedSpecs{}
+	for k, v := range f.known.Load().(map[Feature]VersionedSpecs) {
 		known[k] = v
 	}
 	enabled := map[Feature]bool{}
 	for k, v := range f.enabled.Load().(map[Feature]bool) {
 		enabled[k] = v
+	}
+	enabledRaw := map[string]bool{}
+	for k, v := range f.enabledRaw.Load().(map[string]bool) {
+		enabledRaw[k] = v
 	}
 
 	// Construct a new featureGate around the copied state.
@@ -411,9 +622,9 @@ func (f *featureGate) DeepCopy() MutableFeatureGate {
 		special: specialFeatures,
 		closed:  f.closed,
 	}
-
+	fg.emulationVersion.Store(f.EmulationVersion())
 	fg.known.Store(known)
 	fg.enabled.Store(enabled)
-
+	fg.enabledRaw.Store(enabledRaw)
 	return fg
 }

--- a/staging/src/k8s.io/component-base/featuregate/feature_gate_test.go
+++ b/staging/src/k8s.io/component-base/featuregate/feature_gate_test.go
@@ -18,12 +18,17 @@ package featuregate
 
 import (
 	"fmt"
+	"reflect"
+	"sort"
 	"strings"
 	"testing"
 
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/component-base/metrics/legacyregistry"
 	featuremetrics "k8s.io/component-base/metrics/prometheus/feature"
 	"k8s.io/component-base/metrics/testutil"
@@ -33,6 +38,8 @@ func TestFeatureGateFlag(t *testing.T) {
 	// gates for testing
 	const testAlphaGate Feature = "TestAlpha"
 	const testBetaGate Feature = "TestBeta"
+	const testDeprecatedGate Feature = "TestDeprecated"
+	const testLockedFalseGate Feature = "TestLockedFalse"
 
 	tests := []struct {
 		arg        string
@@ -42,93 +49,126 @@ func TestFeatureGateFlag(t *testing.T) {
 		{
 			arg: "",
 			expect: map[Feature]bool{
-				allAlphaGate:  false,
-				allBetaGate:   false,
-				testAlphaGate: false,
-				testBetaGate:  false,
+				allAlphaGate:        false,
+				allBetaGate:         false,
+				testAlphaGate:       false,
+				testBetaGate:        false,
+				testDeprecatedGate:  false,
+				testLockedFalseGate: false,
 			},
+		},
+		{
+			arg: "TestDeprecated=true",
+			expect: map[Feature]bool{
+				allAlphaGate:        false,
+				allBetaGate:         false,
+				testAlphaGate:       false,
+				testBetaGate:        false,
+				testDeprecatedGate:  true,
+				testLockedFalseGate: false,
+			},
+		},
+		{
+			arg: "TestLockedFalse=true",
+			expect: map[Feature]bool{
+				allAlphaGate:        false,
+				allBetaGate:         false,
+				testAlphaGate:       false,
+				testBetaGate:        false,
+				testLockedFalseGate: false,
+			},
+			parseError: "cannot set feature gate TestLockedFalse to true, feature is locked to false",
 		},
 		{
 			arg: "fooBarBaz=true",
 			expect: map[Feature]bool{
-				allAlphaGate:  false,
-				allBetaGate:   false,
-				testAlphaGate: false,
-				testBetaGate:  false,
+				allAlphaGate:        false,
+				allBetaGate:         false,
+				testAlphaGate:       false,
+				testBetaGate:        false,
+				testLockedFalseGate: false,
 			},
 			parseError: "unrecognized feature gate: fooBarBaz",
 		},
 		{
 			arg: "AllAlpha=false",
 			expect: map[Feature]bool{
-				allAlphaGate:  false,
-				allBetaGate:   false,
-				testAlphaGate: false,
-				testBetaGate:  false,
+				allAlphaGate:        false,
+				allBetaGate:         false,
+				testAlphaGate:       false,
+				testBetaGate:        false,
+				testLockedFalseGate: false,
 			},
 		},
 		{
 			arg: "AllAlpha=true",
 			expect: map[Feature]bool{
-				allAlphaGate:  true,
-				allBetaGate:   false,
-				testAlphaGate: true,
-				testBetaGate:  false,
+				allAlphaGate:        true,
+				allBetaGate:         false,
+				testAlphaGate:       true,
+				testBetaGate:        false,
+				testLockedFalseGate: false,
 			},
 		},
 		{
 			arg: "AllAlpha=banana",
 			expect: map[Feature]bool{
-				allAlphaGate:  false,
-				allBetaGate:   false,
-				testAlphaGate: false,
-				testBetaGate:  false,
+				allAlphaGate:        false,
+				allBetaGate:         false,
+				testAlphaGate:       false,
+				testBetaGate:        false,
+				testLockedFalseGate: false,
 			},
 			parseError: "invalid value of AllAlpha",
 		},
 		{
 			arg: "AllAlpha=false,TestAlpha=true",
 			expect: map[Feature]bool{
-				allAlphaGate:  false,
-				allBetaGate:   false,
-				testAlphaGate: true,
-				testBetaGate:  false,
+				allAlphaGate:        false,
+				allBetaGate:         false,
+				testAlphaGate:       true,
+				testBetaGate:        false,
+				testLockedFalseGate: false,
 			},
 		},
 		{
 			arg: "TestAlpha=true,AllAlpha=false",
 			expect: map[Feature]bool{
-				allAlphaGate:  false,
-				allBetaGate:   false,
-				testAlphaGate: true,
-				testBetaGate:  false,
+				allAlphaGate:        false,
+				allBetaGate:         false,
+				testAlphaGate:       true,
+				testBetaGate:        false,
+				testLockedFalseGate: false,
 			},
 		},
 		{
 			arg: "AllAlpha=true,TestAlpha=false",
 			expect: map[Feature]bool{
-				allAlphaGate:  true,
-				allBetaGate:   false,
-				testAlphaGate: false,
-				testBetaGate:  false,
+				allAlphaGate:        true,
+				allBetaGate:         false,
+				testAlphaGate:       false,
+				testBetaGate:        false,
+				testLockedFalseGate: false,
 			},
 		},
 		{
 			arg: "TestAlpha=false,AllAlpha=true",
 			expect: map[Feature]bool{
-				allAlphaGate:  true,
-				allBetaGate:   false,
-				testAlphaGate: false,
-				testBetaGate:  false,
+				allAlphaGate:        true,
+				allBetaGate:         false,
+				testAlphaGate:       false,
+				testBetaGate:        false,
+				testLockedFalseGate: false,
 			},
 		},
 		{
 			arg: "TestBeta=true,AllAlpha=false",
 			expect: map[Feature]bool{
-				allAlphaGate:  false,
-				allBetaGate:   false,
-				testAlphaGate: false,
-				testBetaGate:  true,
+				allAlphaGate:        false,
+				allBetaGate:         false,
+				testAlphaGate:       false,
+				testBetaGate:        true,
+				testLockedFalseGate: false,
 			},
 		},
 
@@ -144,65 +184,72 @@ func TestFeatureGateFlag(t *testing.T) {
 		{
 			arg: "AllBeta=true",
 			expect: map[Feature]bool{
-				allAlphaGate:  false,
-				allBetaGate:   true,
-				testAlphaGate: false,
-				testBetaGate:  true,
+				allAlphaGate:        false,
+				allBetaGate:         true,
+				testAlphaGate:       false,
+				testBetaGate:        true,
+				testLockedFalseGate: false,
 			},
 		},
 		{
 			arg: "AllBeta=banana",
 			expect: map[Feature]bool{
-				allAlphaGate:  false,
-				allBetaGate:   false,
-				testAlphaGate: false,
-				testBetaGate:  false,
+				allAlphaGate:        false,
+				allBetaGate:         false,
+				testAlphaGate:       false,
+				testBetaGate:        false,
+				testLockedFalseGate: false,
 			},
 			parseError: "invalid value of AllBeta",
 		},
 		{
 			arg: "AllBeta=false,TestBeta=true",
 			expect: map[Feature]bool{
-				allAlphaGate:  false,
-				allBetaGate:   false,
-				testAlphaGate: false,
-				testBetaGate:  true,
+				allAlphaGate:        false,
+				allBetaGate:         false,
+				testAlphaGate:       false,
+				testBetaGate:        true,
+				testLockedFalseGate: false,
 			},
 		},
 		{
 			arg: "TestBeta=true,AllBeta=false",
 			expect: map[Feature]bool{
-				allAlphaGate:  false,
-				allBetaGate:   false,
-				testAlphaGate: false,
-				testBetaGate:  true,
+				allAlphaGate:        false,
+				allBetaGate:         false,
+				testAlphaGate:       false,
+				testBetaGate:        true,
+				testLockedFalseGate: false,
 			},
 		},
 		{
 			arg: "AllBeta=true,TestBeta=false",
 			expect: map[Feature]bool{
-				allAlphaGate:  false,
-				allBetaGate:   true,
-				testAlphaGate: false,
-				testBetaGate:  false,
+				allAlphaGate:        false,
+				allBetaGate:         true,
+				testAlphaGate:       false,
+				testBetaGate:        false,
+				testLockedFalseGate: false,
 			},
 		},
 		{
 			arg: "TestBeta=false,AllBeta=true",
 			expect: map[Feature]bool{
-				allAlphaGate:  false,
-				allBetaGate:   true,
-				testAlphaGate: false,
-				testBetaGate:  false,
+				allAlphaGate:        false,
+				allBetaGate:         true,
+				testAlphaGate:       false,
+				testBetaGate:        false,
+				testLockedFalseGate: false,
 			},
 		},
 		{
 			arg: "TestAlpha=true,AllBeta=false",
 			expect: map[Feature]bool{
-				allAlphaGate:  false,
-				allBetaGate:   false,
-				testAlphaGate: true,
-				testBetaGate:  false,
+				allAlphaGate:        false,
+				allBetaGate:         false,
+				testAlphaGate:       true,
+				testBetaGate:        false,
+				testLockedFalseGate: false,
 			},
 		},
 	}
@@ -210,13 +257,22 @@ func TestFeatureGateFlag(t *testing.T) {
 		t.Run(test.arg, func(t *testing.T) {
 			fs := pflag.NewFlagSet("testfeaturegateflag", pflag.ContinueOnError)
 			f := NewFeatureGate()
-			f.Add(map[Feature]FeatureSpec{
-				testAlphaGate: {Default: false, PreRelease: Alpha},
-				testBetaGate:  {Default: false, PreRelease: Beta},
+			err := f.Add(map[Feature]FeatureSpec{
+				testAlphaGate:       {Default: false, PreRelease: Alpha},
+				testBetaGate:        {Default: false, PreRelease: Beta},
+				testDeprecatedGate:  {Default: false, PreRelease: Deprecated},
+				testLockedFalseGate: {Default: false, PreRelease: GA, LockToDefault: true},
 			})
+			require.NoError(t, err)
 			f.AddFlag(fs)
-
-			err := fs.Parse([]string{fmt.Sprintf("--%s=%s", flagName, test.arg)})
+			var errs []error
+			err = fs.Parse([]string{fmt.Sprintf("--%s=%s", flagName, test.arg)})
+			if err != nil {
+				errs = append(errs, err)
+			} else {
+				errs = f.Validate()
+			}
+			err = utilerrors.NewAggregate(errs)
 			if test.parseError != "" {
 				if !strings.Contains(err.Error(), test.parseError) {
 					t.Errorf("%d: Parse() Expected %v, Got %v", i, test.parseError, err)
@@ -239,12 +295,16 @@ func TestFeatureGateOverride(t *testing.T) {
 
 	// Don't parse the flag, assert defaults are used.
 	var f *featureGate = NewFeatureGate()
-	f.Add(map[Feature]FeatureSpec{
+	err := f.Add(map[Feature]FeatureSpec{
 		testAlphaGate: {Default: false, PreRelease: Alpha},
 		testBetaGate:  {Default: false, PreRelease: Beta},
 	})
+	require.NoError(t, err)
 
 	f.Set("TestAlpha=true,TestBeta=true")
+	if errs := f.Validate(); len(errs) > 0 {
+		t.Fatalf("Validate() Expected no error, Got %v", errs)
+	}
 	if f.Enabled(testAlphaGate) != true {
 		t.Errorf("Expected true")
 	}
@@ -253,6 +313,9 @@ func TestFeatureGateOverride(t *testing.T) {
 	}
 
 	f.Set("TestAlpha=false")
+	if errs := f.Validate(); len(errs) > 0 {
+		t.Fatalf("Validate() Expected no error, Got %v", errs)
+	}
 	if f.Enabled(testAlphaGate) != false {
 		t.Errorf("Expected false")
 	}
@@ -268,10 +331,11 @@ func TestFeatureGateFlagDefaults(t *testing.T) {
 
 	// Don't parse the flag, assert defaults are used.
 	var f *featureGate = NewFeatureGate()
-	f.Add(map[Feature]FeatureSpec{
+	err := f.Add(map[Feature]FeatureSpec{
 		testAlphaGate: {Default: false, PreRelease: Alpha},
 		testBetaGate:  {Default: true, PreRelease: Beta},
 	})
+	require.NoError(t, err)
 
 	if f.Enabled(testAlphaGate) != false {
 		t.Errorf("Expected false")
@@ -292,13 +356,13 @@ func TestFeatureGateKnownFeatures(t *testing.T) {
 
 	// Don't parse the flag, assert defaults are used.
 	var f *featureGate = NewFeatureGate()
-	f.Add(map[Feature]FeatureSpec{
+	err := f.Add(map[Feature]FeatureSpec{
 		testAlphaGate:      {Default: false, PreRelease: Alpha},
 		testBetaGate:       {Default: true, PreRelease: Beta},
 		testGAGate:         {Default: true, PreRelease: GA},
 		testDeprecatedGate: {Default: false, PreRelease: Deprecated},
 	})
-
+	require.NoError(t, err)
 	known := strings.Join(f.KnownFeatures(), " ")
 
 	assert.Contains(t, known, testAlphaGate)
@@ -399,13 +463,14 @@ func TestFeatureGateSetFromMap(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("SetFromMap %s", test.name), func(t *testing.T) {
 			f := NewFeatureGate()
-			f.Add(map[Feature]FeatureSpec{
+			err := f.Add(map[Feature]FeatureSpec{
 				testAlphaGate:       {Default: false, PreRelease: Alpha},
 				testBetaGate:        {Default: false, PreRelease: Beta},
 				testLockedTrueGate:  {Default: true, PreRelease: GA, LockToDefault: true},
 				testLockedFalseGate: {Default: false, PreRelease: GA, LockToDefault: true},
 			})
-			err := f.SetFromMap(test.setmap)
+			require.NoError(t, err)
+			err = f.SetFromMap(test.setmap)
 			if test.setmapError != "" {
 				if err == nil {
 					t.Errorf("expected error, got none")
@@ -450,7 +515,7 @@ func TestFeatureGateMetrics(t *testing.T) {
 		testBetaGate:     {Default: true, PreRelease: Beta},
 		testBetaDisabled: {Default: true, PreRelease: Alpha},
 	}
-	f.Add(fMap)
+	require.NoError(t, f.Add(fMap))
 	f.SetFromMap(map[string]bool{"TestAlphaEnabled": true, "TestBetaDisabled": false})
 	f.AddMetrics()
 	if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(expectedOutput), testedMetrics...); err != nil {
@@ -499,8 +564,8 @@ func TestFeatureGateString(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("SetFromMap %s", test.expect), func(t *testing.T) {
 			f := NewFeatureGate()
-			f.Add(featuremap)
-			f.SetFromMap(test.setmap)
+			require.NoError(t, f.Add(featuremap))
+			require.NoError(t, f.SetFromMap(test.setmap))
 			result := f.String()
 			if result != test.expect {
 				t.Errorf("%d: SetFromMap(%#v) Expected %s, Got %s", i, test.setmap, test.expect, result)
@@ -518,12 +583,8 @@ func TestFeatureGateOverrideDefault(t *testing.T) {
 		}); err != nil {
 			t.Fatal(err)
 		}
-		if err := f.OverrideDefault("TestFeature1", false); err != nil {
-			t.Fatal(err)
-		}
-		if err := f.OverrideDefault("TestFeature2", true); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, f.OverrideDefault("TestFeature1", false))
+		require.NoError(t, f.OverrideDefault("TestFeature2", true))
 		if f.Enabled("TestFeature1") {
 			t.Error("expected TestFeature1 to have effective default of false")
 		}
@@ -534,12 +595,8 @@ func TestFeatureGateOverrideDefault(t *testing.T) {
 
 	t.Run("overrides are preserved across deep copies", func(t *testing.T) {
 		f := NewFeatureGate()
-		if err := f.Add(map[Feature]FeatureSpec{"TestFeature": {Default: false}}); err != nil {
-			t.Fatal(err)
-		}
-		if err := f.OverrideDefault("TestFeature", true); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, f.Add(map[Feature]FeatureSpec{"TestFeature": {Default: false}}))
+		require.NoError(t, f.OverrideDefault("TestFeature", true))
 		fcopy := f.DeepCopy()
 		if !fcopy.Enabled("TestFeature") {
 			t.Error("default override was not preserved by deep copy")
@@ -554,9 +611,7 @@ func TestFeatureGateOverrideDefault(t *testing.T) {
 		}}); err != nil {
 			t.Fatal(err)
 		}
-		if err := f.OverrideDefault("TestFeature", true); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, f.OverrideDefault("TestFeature", true))
 		var found bool
 		for _, s := range f.KnownFeatures() {
 			if !strings.Contains(s, "TestFeature") {
@@ -592,15 +647,9 @@ func TestFeatureGateOverrideDefault(t *testing.T) {
 
 	t.Run("does not supersede explicitly-set value", func(t *testing.T) {
 		f := NewFeatureGate()
-		if err := f.Add(map[Feature]FeatureSpec{"TestFeature": {Default: true}}); err != nil {
-			t.Fatal(err)
-		}
-		if err := f.OverrideDefault("TestFeature", false); err != nil {
-			t.Fatal(err)
-		}
-		if err := f.SetFromMap(map[string]bool{"TestFeature": true}); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, f.Add(map[Feature]FeatureSpec{"TestFeature": {Default: true}}))
+		require.NoError(t, f.OverrideDefault("TestFeature", false))
+		require.NoError(t, f.SetFromMap(map[string]bool{"TestFeature": true}))
 		if !f.Enabled("TestFeature") {
 			t.Error("expected feature to be effectively enabled despite default override")
 		}
@@ -616,9 +665,7 @@ func TestFeatureGateOverrideDefault(t *testing.T) {
 		}); err != nil {
 			t.Fatal(err)
 		}
-		if err := f.OverrideDefault("TestFeature", false); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, f.OverrideDefault("TestFeature", false))
 		if err := f.Add(map[Feature]FeatureSpec{
 			"TestFeature": {
 				Default:    true,
@@ -645,4 +692,795 @@ func TestFeatureGateOverrideDefault(t *testing.T) {
 			t.Error("expected a non-nil error to be returned")
 		}
 	})
+}
+
+func TestVersionedFeatureGateFlag(t *testing.T) {
+	// gates for testing
+	const testGAGate Feature = "TestGA"
+	const testAlphaGate Feature = "TestAlpha"
+	const testBetaGate Feature = "TestBeta"
+	const testLockedFalseGate Feature = "TestLockedFalse"
+	const testAlphaGateNoVersion Feature = "TestAlphaNoVersion"
+	const testBetaGateNoVersion Feature = "TestBetaNoVersion"
+
+	tests := []struct {
+		arg        string
+		expect     map[Feature]bool
+		parseError string
+	}{
+		{
+			arg: "",
+			expect: map[Feature]bool{
+				testGAGate:             false,
+				allAlphaGate:           false,
+				allBetaGate:            false,
+				testAlphaGate:          false,
+				testBetaGate:           false,
+				testLockedFalseGate:    false,
+				testAlphaGateNoVersion: false,
+				testBetaGateNoVersion:  false,
+			},
+		},
+		{
+			arg: "TestLockedFalse=true",
+			expect: map[Feature]bool{
+				allAlphaGate:           false,
+				allBetaGate:            false,
+				testAlphaGate:          false,
+				testBetaGate:           false,
+				testLockedFalseGate:    true,
+				testAlphaGateNoVersion: false,
+				testBetaGateNoVersion:  false,
+			},
+		},
+		{
+			arg: "fooBarBaz=true",
+			expect: map[Feature]bool{
+				allAlphaGate:           false,
+				allBetaGate:            false,
+				testGAGate:             false,
+				testAlphaGate:          false,
+				testBetaGate:           false,
+				testLockedFalseGate:    false,
+				testAlphaGateNoVersion: false,
+				testBetaGateNoVersion:  false,
+			},
+			parseError: "unrecognized feature gate: fooBarBaz",
+		},
+		{
+			arg: "AllAlpha=false",
+			expect: map[Feature]bool{
+				allAlphaGate:           false,
+				allBetaGate:            false,
+				testGAGate:             false,
+				testAlphaGate:          false,
+				testBetaGate:           false,
+				testLockedFalseGate:    false,
+				testAlphaGateNoVersion: false,
+				testBetaGateNoVersion:  false,
+			},
+		},
+		{
+			arg: "AllAlpha=true",
+			expect: map[Feature]bool{
+				allAlphaGate:           true,
+				allBetaGate:            false,
+				testAlphaGate:          false,
+				testGAGate:             false,
+				testBetaGate:           true,
+				testLockedFalseGate:    false,
+				testAlphaGateNoVersion: true,
+				testBetaGateNoVersion:  false,
+			},
+		},
+		{
+			arg: "AllAlpha=banana",
+			expect: map[Feature]bool{
+				allAlphaGate:           false,
+				allBetaGate:            false,
+				testGAGate:             false,
+				testAlphaGate:          false,
+				testBetaGate:           false,
+				testLockedFalseGate:    false,
+				testAlphaGateNoVersion: false,
+				testBetaGateNoVersion:  false,
+			},
+			parseError: "invalid value of AllAlpha",
+		},
+		{
+			arg: "AllAlpha=false,TestAlpha=true,TestAlphaNoVersion=true",
+			expect: map[Feature]bool{
+				allAlphaGate:           false,
+				allBetaGate:            false,
+				testGAGate:             false,
+				testAlphaGate:          false,
+				testBetaGate:           false,
+				testLockedFalseGate:    false,
+				testAlphaGateNoVersion: true,
+				testBetaGateNoVersion:  false,
+			},
+			parseError: "cannot set feature gate TestAlpha to true, feature is PreAlpha at emulated version 1.28",
+		},
+		{
+			arg: "AllAlpha=false,TestAlphaNoVersion=true",
+			expect: map[Feature]bool{
+				allAlphaGate:           false,
+				allBetaGate:            false,
+				testGAGate:             false,
+				testAlphaGate:          false,
+				testBetaGate:           false,
+				testLockedFalseGate:    false,
+				testAlphaGateNoVersion: true,
+				testBetaGateNoVersion:  false,
+			},
+		},
+		{
+			arg: "TestAlpha=true,TestAlphaNoVersion=true,AllAlpha=false",
+			expect: map[Feature]bool{
+				allAlphaGate:           false,
+				allBetaGate:            false,
+				testGAGate:             false,
+				testAlphaGate:          false,
+				testBetaGate:           false,
+				testLockedFalseGate:    false,
+				testAlphaGateNoVersion: true,
+				testBetaGateNoVersion:  false,
+			},
+			parseError: "cannot set feature gate TestAlpha to true, feature is PreAlpha at emulated version 1.28",
+		},
+		{
+			arg: "AllAlpha=true,TestAlpha=false,TestAlphaNoVersion=false",
+			expect: map[Feature]bool{
+				allAlphaGate:           true,
+				allBetaGate:            false,
+				testGAGate:             false,
+				testAlphaGate:          false,
+				testBetaGate:           true,
+				testLockedFalseGate:    false,
+				testAlphaGateNoVersion: false,
+				testBetaGateNoVersion:  false,
+			},
+			parseError: "cannot set feature gate TestAlpha to false, feature is PreAlpha at emulated version 1.28",
+		},
+		{
+			arg: "AllAlpha=true,TestAlphaNoVersion=false",
+			expect: map[Feature]bool{
+				allAlphaGate:           true,
+				allBetaGate:            false,
+				testGAGate:             false,
+				testAlphaGate:          false,
+				testBetaGate:           true,
+				testLockedFalseGate:    false,
+				testAlphaGateNoVersion: false,
+				testBetaGateNoVersion:  false,
+			},
+		},
+		{
+			arg: "TestAlpha=false,TestAlphaNoVersion=false,AllAlpha=true",
+			expect: map[Feature]bool{
+				allAlphaGate:           true,
+				allBetaGate:            false,
+				testGAGate:             false,
+				testAlphaGate:          false,
+				testBetaGate:           true,
+				testLockedFalseGate:    false,
+				testAlphaGateNoVersion: false,
+				testBetaGateNoVersion:  false,
+			},
+			parseError: "cannot set feature gate TestAlpha to false, feature is PreAlpha at emulated version 1.28",
+		},
+		{
+			arg: "TestBeta=true,TestBetaNoVersion=true,TestGA=true,AllAlpha=false",
+			expect: map[Feature]bool{
+				allAlphaGate:           false,
+				allBetaGate:            false,
+				testGAGate:             true,
+				testAlphaGate:          false,
+				testBetaGate:           true,
+				testLockedFalseGate:    false,
+				testAlphaGateNoVersion: false,
+				testBetaGateNoVersion:  true,
+			},
+		},
+
+		{
+			arg: "AllBeta=false",
+			expect: map[Feature]bool{
+				allAlphaGate:           false,
+				allBetaGate:            false,
+				testGAGate:             false,
+				testAlphaGate:          false,
+				testBetaGate:           false,
+				testLockedFalseGate:    false,
+				testAlphaGateNoVersion: false,
+				testBetaGateNoVersion:  false,
+			},
+		},
+		{
+			arg: "AllBeta=true",
+			expect: map[Feature]bool{
+				allAlphaGate:           false,
+				allBetaGate:            true,
+				testGAGate:             true,
+				testAlphaGate:          false,
+				testBetaGate:           false,
+				testLockedFalseGate:    false,
+				testAlphaGateNoVersion: false,
+				testBetaGateNoVersion:  true,
+			},
+		},
+		{
+			arg: "AllBeta=banana",
+			expect: map[Feature]bool{
+				allAlphaGate:           false,
+				allBetaGate:            false,
+				testGAGate:             false,
+				testAlphaGate:          false,
+				testBetaGate:           false,
+				testAlphaGateNoVersion: false,
+				testBetaGateNoVersion:  false,
+			},
+			parseError: "invalid value of AllBeta",
+		},
+		{
+			arg: "AllBeta=false,TestBeta=true,TestBetaNoVersion=true,TestGA=true",
+			expect: map[Feature]bool{
+				allAlphaGate:           false,
+				allBetaGate:            false,
+				testGAGate:             true,
+				testAlphaGate:          false,
+				testBetaGate:           true,
+				testLockedFalseGate:    false,
+				testAlphaGateNoVersion: false,
+				testBetaGateNoVersion:  true,
+			},
+		},
+		{
+			arg: "TestBeta=true,TestBetaNoVersion=true,AllBeta=false",
+			expect: map[Feature]bool{
+				allAlphaGate:           false,
+				allBetaGate:            false,
+				testGAGate:             false,
+				testAlphaGate:          false,
+				testBetaGate:           true,
+				testLockedFalseGate:    false,
+				testAlphaGateNoVersion: false,
+				testBetaGateNoVersion:  true,
+			},
+		},
+		{
+			arg: "AllBeta=true,TestBetaNoVersion=false,TestBeta=false,TestGA=false",
+			expect: map[Feature]bool{
+				allAlphaGate:           false,
+				allBetaGate:            true,
+				testGAGate:             false,
+				testAlphaGate:          false,
+				testBetaGate:           false,
+				testLockedFalseGate:    false,
+				testAlphaGateNoVersion: false,
+				testBetaGateNoVersion:  false,
+			},
+		},
+		{
+			arg: "TestBeta=false,TestBetaNoVersion=false,AllBeta=true",
+			expect: map[Feature]bool{
+				allAlphaGate:           false,
+				allBetaGate:            true,
+				testGAGate:             true,
+				testAlphaGate:          false,
+				testBetaGate:           false,
+				testLockedFalseGate:    false,
+				testAlphaGateNoVersion: false,
+				testBetaGateNoVersion:  false,
+			},
+		},
+		{
+			arg: "TestAlpha=true,AllBeta=false",
+			expect: map[Feature]bool{
+				allAlphaGate:           false,
+				allBetaGate:            false,
+				testGAGate:             false,
+				testAlphaGate:          true,
+				testBetaGate:           false,
+				testLockedFalseGate:    false,
+				testAlphaGateNoVersion: false,
+				testBetaGateNoVersion:  false,
+			},
+			parseError: "cannot set feature gate TestAlpha to true, feature is PreAlpha at emulated version 1.28",
+		},
+	}
+	for i, test := range tests {
+		t.Run(test.arg, func(t *testing.T) {
+			fs := pflag.NewFlagSet("testfeaturegateflag", pflag.ContinueOnError)
+			f := NewVersionedFeatureGate(version.MustParse("1.29"))
+			f.DeferErrorsToValidation(true)
+			err := f.AddVersioned(map[Feature]VersionedSpecs{
+				testGAGate: VersionedSpecs{
+					{Version: version.MustParse("1.29"), Default: true, PreRelease: GA},
+					{Version: version.MustParse("1.28"), Default: false, PreRelease: Beta},
+					{Version: version.MustParse("1.27"), Default: false, PreRelease: Alpha},
+				},
+				testAlphaGate: VersionedSpecs{
+					{Version: version.MustParse("1.29"), Default: false, PreRelease: Alpha},
+				},
+				testBetaGate: VersionedSpecs{
+					{Version: version.MustParse("1.29"), Default: false, PreRelease: Beta},
+					{Version: version.MustParse("1.28"), Default: false, PreRelease: Alpha},
+				},
+				testLockedFalseGate: VersionedSpecs{
+					{Version: version.MustParse("1.29"), Default: false, PreRelease: GA, LockToDefault: true},
+					{Version: version.MustParse("1.28"), Default: false, PreRelease: GA},
+				},
+			})
+			require.NoError(t, err)
+			err = f.Add(map[Feature]FeatureSpec{
+				testAlphaGateNoVersion: {Default: false, PreRelease: Alpha},
+				testBetaGateNoVersion:  {Default: false, PreRelease: Beta},
+			})
+			require.NoError(t, err)
+			f.AddFlag(fs)
+
+			var errs []error
+			err = fs.Parse([]string{fmt.Sprintf("--%s=%s", flagName, test.arg)})
+			if err != nil {
+				errs = append(errs, err)
+			} else {
+				errs = append(errs, f.SetEmulationVersion(version.MustParse("1.28")))
+			}
+			err = utilerrors.NewAggregate(errs)
+			if test.parseError != "" {
+				if !strings.Contains(err.Error(), test.parseError) {
+					t.Errorf("%d: Parse() Expected %v, Got %v", i, test.parseError, err)
+				}
+				return
+			} else if err != nil {
+				t.Errorf("%d: Parse() Expected nil, Got %v", i, err)
+			}
+			for k, v := range test.expect {
+				if actual := f.enabled.Load().(map[Feature]bool)[k]; actual != v {
+					t.Errorf("%d: expected %s=%v, Got %v", i, k, v, actual)
+				}
+			}
+		})
+	}
+}
+
+func TestVersionedFeatureGateOverride(t *testing.T) {
+	const testAlphaGate Feature = "TestAlpha"
+	const testBetaGate Feature = "TestBeta"
+
+	// Don't parse the flag, assert defaults are used.
+	var f *featureGate = NewVersionedFeatureGate(version.MustParse("1.29"))
+
+	err := f.AddVersioned(map[Feature]VersionedSpecs{
+		testAlphaGate: VersionedSpecs{
+			{Version: version.MustParse("1.29"), Default: false, PreRelease: Alpha},
+		},
+		testBetaGate: VersionedSpecs{
+			{Version: version.MustParse("1.29"), Default: false, PreRelease: Beta},
+			{Version: version.MustParse("1.28"), Default: false, PreRelease: Alpha},
+		},
+	})
+	require.NoError(t, err)
+	if f.Enabled(testAlphaGate) != false {
+		t.Errorf("Expected false")
+	}
+	if f.Enabled(testBetaGate) != false {
+		t.Errorf("Expected false")
+	}
+	if errs := f.Validate(); len(errs) > 0 {
+		t.Errorf("Expected no errors when emulation version is equal to binary version.")
+	}
+
+	require.NoError(t, f.Set("TestAlpha=true,TestBeta=true"))
+	if f.Enabled(testAlphaGate) != true {
+		t.Errorf("Expected false")
+	}
+	if f.Enabled(testBetaGate) != true {
+		t.Errorf("Expected true")
+	}
+
+	require.NoError(t, f.Set("TestAlpha=false"))
+	if f.Enabled(testAlphaGate) != false {
+		t.Errorf("Expected false")
+	}
+	if f.Enabled(testBetaGate) != true {
+		t.Errorf("Expected true")
+	}
+	if errs := f.Validate(); len(errs) > 0 {
+		t.Errorf("Expected no errors when emulation version is equal to binary version.")
+	}
+
+	if err := f.SetEmulationVersion(version.MustParse("1.28")); err == nil {
+		t.Errorf("Expected errors when emulation version is 1.28.")
+	}
+}
+
+func TestVersionedFeatureGateFlagDefaults(t *testing.T) {
+	// gates for testing
+	const testGAGate Feature = "TestGA"
+	const testAlphaGate Feature = "TestAlpha"
+	const testBetaGate Feature = "TestBeta"
+
+	// Don't parse the flag, assert defaults are used.
+	var f *featureGate = NewVersionedFeatureGate(version.MustParse("1.29"))
+	require.NoError(t, f.SetEmulationVersion(version.MustParse("1.28")))
+
+	err := f.AddVersioned(map[Feature]VersionedSpecs{
+		testGAGate: VersionedSpecs{
+			{Version: version.MustParse("1.29"), Default: true, PreRelease: GA},
+			{Version: version.MustParse("1.27"), Default: true, PreRelease: Beta},
+			{Version: version.MustParse("1.25"), Default: true, PreRelease: Alpha},
+		},
+		testAlphaGate: VersionedSpecs{
+			{Version: version.MustParse("1.29"), Default: false, PreRelease: Alpha},
+		},
+		testBetaGate: VersionedSpecs{
+			{Version: version.MustParse("1.29"), Default: true, PreRelease: Beta},
+			{Version: version.MustParse("1.28"), Default: false, PreRelease: Beta},
+			{Version: version.MustParse("1.26"), Default: false, PreRelease: Alpha},
+		},
+	})
+	require.NoError(t, err)
+
+	if f.Enabled(testAlphaGate) != false {
+		t.Errorf("Expected false")
+	}
+	if fs, _ := f.FeatureSpec(testAlphaGate); fs.PreRelease != PreAlpha || fs.Version.String() != "0.0" {
+		t.Errorf("Expected (PreAlpha, 0.0)")
+	}
+	if f.Enabled(testBetaGate) != false {
+		t.Errorf("Expected false")
+	}
+	if fs, _ := f.FeatureSpec(testBetaGate); fs.PreRelease != Beta || fs.Version.String() != "1.28" {
+		t.Errorf("Expected (Beta, 1.28)")
+	}
+	if f.Enabled(testGAGate) != true {
+		t.Errorf("Expected true")
+	}
+	if fs, _ := f.FeatureSpec(testGAGate); fs.PreRelease != Beta || fs.Version.String() != "1.27" {
+		t.Errorf("Expected (Beta, 1.27)")
+	}
+	if _, err := f.FeatureSpec("NonExist"); err == nil {
+		t.Errorf("Expected Error")
+	}
+	allFeatures := f.GetAll()
+	expectedAllFeatures := []Feature{testGAGate, testBetaGate, allAlphaGate, allBetaGate}
+	if len(allFeatures) != 4 {
+		t.Errorf("Expected 4 features from GetAll(), got %d", len(allFeatures))
+	}
+	for _, feature := range expectedAllFeatures {
+		if _, ok := allFeatures[feature]; !ok {
+			t.Errorf("Expected feature %s to be in GetAll()", feature)
+		}
+	}
+}
+
+func TestVersionedFeatureGateKnownFeatures(t *testing.T) {
+	// gates for testing
+	const (
+		testPreAlphaGate            Feature = "TestPreAlpha"
+		testAlphaGate               Feature = "TestAlpha"
+		testBetaGate                Feature = "TestBeta"
+		testGAGate                  Feature = "TestGA"
+		testDeprecatedGate          Feature = "TestDeprecated"
+		testGAGateNoVersion         Feature = "TestGANoVersion"
+		testAlphaGateNoVersion      Feature = "TestAlphaNoVersion"
+		testBetaGateNoVersion       Feature = "TestBetaNoVersion"
+		testDeprecatedGateNoVersion Feature = "TestDeprecatedNoVersion"
+	)
+
+	// Don't parse the flag, assert defaults are used.
+	var f *featureGate = NewVersionedFeatureGate(version.MustParse("1.29"))
+	require.NoError(t, f.SetEmulationVersion(version.MustParse("1.28")))
+	err := f.AddVersioned(map[Feature]VersionedSpecs{
+		testGAGate: VersionedSpecs{
+			{Version: version.MustParse("1.27"), Default: false, PreRelease: Beta},
+			{Version: version.MustParse("1.28"), Default: true, PreRelease: GA},
+		},
+		testPreAlphaGate: VersionedSpecs{
+			{Version: version.MustParse("1.29"), Default: false, PreRelease: Alpha},
+		},
+		testAlphaGate: VersionedSpecs{
+			{Version: version.MustParse("1.28"), Default: false, PreRelease: Alpha},
+		},
+		testBetaGate: VersionedSpecs{
+			{Version: version.MustParse("1.28"), Default: false, PreRelease: Beta},
+		},
+		testDeprecatedGate: VersionedSpecs{
+			{Version: version.MustParse("1.28"), Default: true, PreRelease: Deprecated},
+			{Version: version.MustParse("1.26"), Default: false, PreRelease: Alpha},
+		},
+	})
+	require.NoError(t, err)
+	err = f.Add(map[Feature]FeatureSpec{
+		testAlphaGateNoVersion:      {Default: false, PreRelease: Alpha},
+		testBetaGateNoVersion:       {Default: false, PreRelease: Beta},
+		testGAGateNoVersion:         {Default: false, PreRelease: GA},
+		testDeprecatedGateNoVersion: {Default: false, PreRelease: Deprecated},
+	})
+	require.NoError(t, err)
+
+	known := strings.Join(f.KnownFeatures(), " ")
+
+	assert.NotContains(t, known, testPreAlphaGate)
+	assert.Contains(t, known, testAlphaGate)
+	assert.Contains(t, known, testBetaGate)
+	assert.NotContains(t, known, testGAGate)
+	assert.NotContains(t, known, testDeprecatedGate)
+	assert.Contains(t, known, testAlphaGateNoVersion)
+	assert.Contains(t, known, testBetaGateNoVersion)
+	assert.NotContains(t, known, testGAGateNoVersion)
+	assert.NotContains(t, known, testDeprecatedGateNoVersion)
+}
+
+func TestVersionedFeatureGateMetrics(t *testing.T) {
+	// gates for testing
+	featuremetrics.ResetFeatureInfoMetric()
+	const testAlphaGate Feature = "TestAlpha"
+	const testBetaGate Feature = "TestBeta"
+	const testAlphaEnabled Feature = "TestAlphaEnabled"
+	const testBetaDisabled Feature = "TestBetaDisabled"
+	testedMetrics := []string{"kubernetes_feature_enabled"}
+	expectedOutput := `
+		# HELP kubernetes_feature_enabled [BETA] This metric records the data about the stage and enablement of a k8s feature.
+        # TYPE kubernetes_feature_enabled gauge
+        kubernetes_feature_enabled{name="TestAlpha",stage="ALPHA"} 0
+        kubernetes_feature_enabled{name="TestBeta",stage="BETA"} 1
+		kubernetes_feature_enabled{name="TestAlphaEnabled",stage="ALPHA"} 1
+        kubernetes_feature_enabled{name="AllAlpha",stage="ALPHA"} 0
+        kubernetes_feature_enabled{name="AllBeta",stage="BETA"} 0
+		kubernetes_feature_enabled{name="TestBetaDisabled",stage="BETA"} 0
+`
+
+	f := NewVersionedFeatureGate(version.MustParse("1.29"))
+	require.NoError(t, f.SetEmulationVersion(version.MustParse("1.28")))
+	err := f.AddVersioned(map[Feature]VersionedSpecs{
+		testAlphaGate: VersionedSpecs{
+			{Version: version.MustParse("1.28"), Default: false, PreRelease: Alpha},
+			{Version: version.MustParse("1.29"), Default: true, PreRelease: Beta},
+		},
+		testAlphaEnabled: VersionedSpecs{
+			{Version: version.MustParse("1.28"), Default: false, PreRelease: Alpha},
+			{Version: version.MustParse("1.29"), Default: true, PreRelease: Beta},
+		},
+		testBetaGate: VersionedSpecs{
+			{Version: version.MustParse("1.28"), Default: true, PreRelease: Beta},
+			{Version: version.MustParse("1.27"), Default: false, PreRelease: Alpha},
+		},
+		testBetaDisabled: VersionedSpecs{
+			{Version: version.MustParse("1.28"), Default: true, PreRelease: Beta},
+			{Version: version.MustParse("1.27"), Default: false, PreRelease: Alpha},
+		},
+	})
+	require.NoError(t, err)
+
+	f.SetFromMap(map[string]bool{"TestAlphaEnabled": true, "TestBetaDisabled": false})
+	f.AddMetrics()
+	if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(expectedOutput), testedMetrics...); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestVersionedFeatureGateOverrideDefault(t *testing.T) {
+	t.Run("overrides take effect", func(t *testing.T) {
+		f := NewVersionedFeatureGate(version.MustParse("1.29"))
+		require.NoError(t, f.SetEmulationVersion(version.MustParse("1.28")))
+		if err := f.AddVersioned(map[Feature]VersionedSpecs{
+			"TestFeature1": VersionedSpecs{
+				{Version: version.MustParse("1.28"), Default: true},
+			},
+			"TestFeature2": VersionedSpecs{
+				{Version: version.MustParse("1.26"), Default: false},
+				{Version: version.MustParse("1.29"), Default: true},
+			},
+		}); err != nil {
+			t.Fatal(err)
+		}
+		require.NoError(t, f.OverrideDefault("TestFeature1", false))
+		require.NoError(t, f.OverrideDefault("TestFeature2", true))
+		if f.Enabled("TestFeature1") {
+			t.Error("expected TestFeature1 to have effective default of false")
+		}
+		if !f.Enabled("TestFeature2") {
+			t.Error("expected TestFeature2 to have effective default of true")
+		}
+	})
+
+	t.Run("overrides are preserved across deep copies", func(t *testing.T) {
+		f := NewVersionedFeatureGate(version.MustParse("1.29"))
+		require.NoError(t, f.SetEmulationVersion(version.MustParse("1.28")))
+		if err := f.AddVersioned(map[Feature]VersionedSpecs{
+			"TestFeature": VersionedSpecs{
+				{Version: version.MustParse("1.28"), Default: false},
+				{Version: version.MustParse("1.29"), Default: true},
+			},
+		}); err != nil {
+			t.Fatal(err)
+		}
+		require.NoError(t, f.OverrideDefault("TestFeature", true))
+		fcopy := f.DeepCopy()
+		if !fcopy.Enabled("TestFeature") {
+			t.Error("default override was not preserved by deep copy")
+		}
+	})
+
+	t.Run("reflected in known features", func(t *testing.T) {
+		f := NewVersionedFeatureGate(version.MustParse("1.29"))
+		require.NoError(t, f.SetEmulationVersion(version.MustParse("1.28")))
+		if err := f.AddVersioned(map[Feature]VersionedSpecs{
+			"TestFeature": VersionedSpecs{
+				{Version: version.MustParse("1.28"), Default: false, PreRelease: Alpha},
+				{Version: version.MustParse("1.29"), Default: true, PreRelease: Beta},
+			},
+		}); err != nil {
+			t.Fatal(err)
+		}
+		require.NoError(t, f.OverrideDefault("TestFeature", true))
+		var found bool
+		for _, s := range f.KnownFeatures() {
+			if !strings.Contains(s, "TestFeature") {
+				continue
+			}
+			found = true
+			if !strings.Contains(s, "default=true") {
+				t.Errorf("expected override of default to be reflected in known feature description %q", s)
+			}
+		}
+		if !found {
+			t.Error("found no entry for TestFeature in known features")
+		}
+	})
+
+	t.Run("may not change default for specs with locked defaults", func(t *testing.T) {
+		f := NewVersionedFeatureGate(version.MustParse("1.29"))
+		require.NoError(t, f.SetEmulationVersion(version.MustParse("1.28")))
+		if err := f.AddVersioned(map[Feature]VersionedSpecs{
+			"LockedFeature": VersionedSpecs{
+				{Version: version.MustParse("1.28"), Default: true, LockToDefault: true},
+			},
+		}); err != nil {
+			t.Fatal(err)
+		}
+		if f.OverrideDefault("LockedFeature", false) == nil {
+			t.Error("expected error when attempting to override the default for a feature with a locked default")
+		}
+		if f.OverrideDefault("LockedFeature", true) == nil {
+			t.Error("expected error when attempting to override the default for a feature with a locked default")
+		}
+	})
+
+	t.Run("can change default for specs without locked defaults for emulation version", func(t *testing.T) {
+		f := NewVersionedFeatureGate(version.MustParse("1.29"))
+		require.NoError(t, f.SetEmulationVersion(version.MustParse("1.28")))
+		if err := f.AddVersioned(map[Feature]VersionedSpecs{
+			"LockedFeature": VersionedSpecs{
+				{Version: version.MustParse("1.28"), Default: true},
+				{Version: version.MustParse("1.29"), Default: true, LockToDefault: true},
+			},
+		}); err != nil {
+			t.Fatal(err)
+		}
+		require.NoError(t, f.OverrideDefault("LockedFeature", false))
+		if f.Enabled("LockedFeature") {
+			t.Error("expected LockedFeature to have effective default of false")
+		}
+	})
+
+	t.Run("does not supersede explicitly-set value", func(t *testing.T) {
+		f := NewVersionedFeatureGate(version.MustParse("1.29"))
+		require.NoError(t, f.SetEmulationVersion(version.MustParse("1.28")))
+		if err := f.AddVersioned(map[Feature]VersionedSpecs{
+			"TestFeature": VersionedSpecs{
+				{Version: version.MustParse("1.28"), Default: true},
+			},
+		}); err != nil {
+			t.Fatal(err)
+		}
+		require.NoError(t, f.OverrideDefault("TestFeature", false))
+		require.NoError(t, f.SetFromMap(map[string]bool{"TestFeature": true}))
+		if !f.Enabled("TestFeature") {
+			t.Error("expected feature to be effectively enabled despite default override")
+		}
+	})
+
+	t.Run("prevents re-registration of feature spec after overriding default", func(t *testing.T) {
+		f := NewVersionedFeatureGate(version.MustParse("1.29"))
+		require.NoError(t, f.SetEmulationVersion(version.MustParse("1.28")))
+		if err := f.AddVersioned(map[Feature]VersionedSpecs{
+			"TestFeature": VersionedSpecs{
+				{Version: version.MustParse("1.28"), Default: true, PreRelease: Alpha},
+			},
+		}); err != nil {
+			t.Fatal(err)
+		}
+		require.NoError(t, f.OverrideDefault("TestFeature", false))
+		if err := f.Add(map[Feature]FeatureSpec{
+			"TestFeature": {
+				Default:    true,
+				PreRelease: Alpha,
+			},
+		}); err == nil {
+			t.Error("expected re-registration to return a non-nil error after overriding its default")
+		}
+	})
+
+	t.Run("does not allow override for a feature added after emulation version", func(t *testing.T) {
+		f := NewVersionedFeatureGate(version.MustParse("1.29"))
+		require.NoError(t, f.SetEmulationVersion(version.MustParse("1.28")))
+		if err := f.AddVersioned(map[Feature]VersionedSpecs{
+			"TestFeature": VersionedSpecs{
+				{Version: version.MustParse("1.29"), Default: false},
+			},
+		}); err != nil {
+			t.Fatal(err)
+		}
+		if err := f.OverrideDefault("TestFeature", true); err == nil {
+			t.Error("expected an error to be returned in attempt to override default for a feature added after emulation version")
+		}
+	})
+
+	t.Run("does not allow override for an unknown feature", func(t *testing.T) {
+		f := NewVersionedFeatureGate(version.MustParse("1.29"))
+		require.NoError(t, f.SetEmulationVersion(version.MustParse("1.28")))
+		if err := f.OverrideDefault("TestFeature", true); err == nil {
+			t.Error("expected an error to be returned in attempt to override default for unregistered feature")
+		}
+	})
+
+	t.Run("returns error if already added to flag set", func(t *testing.T) {
+		f := NewVersionedFeatureGate(version.MustParse("1.29"))
+		require.NoError(t, f.SetEmulationVersion(version.MustParse("1.28")))
+		fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+		f.AddFlag(fs)
+
+		if err := f.OverrideDefault("TestFeature", true); err == nil {
+			t.Error("expected a non-nil error to be returned")
+		}
+	})
+}
+
+func TestGetCurrentVersion(t *testing.T) {
+	specs := VersionedSpecs{{Version: version.MustParse("1.29"), Default: true, PreRelease: GA},
+		{Version: version.MustParse("1.28"), Default: false, PreRelease: Beta},
+		{Version: version.MustParse("1.25"), Default: false, PreRelease: Alpha},
+	}
+	sort.Sort(specs)
+	tests := []struct {
+		cVersion string
+		expect   FeatureSpec
+	}{
+		{
+			cVersion: "1.30",
+			expect:   FeatureSpec{Version: version.MustParse("1.29"), Default: true, PreRelease: GA},
+		},
+		{
+			cVersion: "1.29",
+			expect:   FeatureSpec{Version: version.MustParse("1.29"), Default: true, PreRelease: GA},
+		},
+		{
+			cVersion: "1.28",
+			expect:   FeatureSpec{Version: version.MustParse("1.28"), Default: false, PreRelease: Beta},
+		},
+		{
+			cVersion: "1.27",
+			expect:   FeatureSpec{Version: version.MustParse("1.25"), Default: false, PreRelease: Alpha},
+		},
+		{
+			cVersion: "1.25",
+			expect:   FeatureSpec{Version: version.MustParse("1.25"), Default: false, PreRelease: Alpha},
+		},
+		{
+			cVersion: "1.24",
+			expect:   FeatureSpec{Version: version.MajorMinor(0, 0), Default: false, PreRelease: PreAlpha},
+		},
+	}
+	for i, test := range tests {
+		t.Run(fmt.Sprintf("getCurrentVersion for emulationVersion %s", test.cVersion), func(t *testing.T) {
+			result := getCurrentVersion(specs, version.MustParse(test.cVersion))
+			if !reflect.DeepEqual(*result, test.expect) {
+				t.Errorf("%d: getCurrentVersion(, %s) Expected %v, Got %v", i, test.cVersion, test.expect, result)
+			}
+		})
+	}
 }

--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/apiserver.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/apiserver.go
@@ -606,8 +606,8 @@ func (s *APIAggregator) RemoveAPIService(apiServiceName string) {
 }
 
 // DefaultAPIResourceConfigSource returns default configuration for an APIResource.
-func DefaultAPIResourceConfigSource() *serverstorage.ResourceConfig {
-	ret := serverstorage.NewResourceConfig()
+func DefaultAPIResourceConfigSource(registry serverstorage.GroupVersionRegistry) *serverstorage.ResourceConfig {
+	ret := serverstorage.NewResourceConfig(registry)
 	// NOTE: GroupVersions listed here will be enabled by default. Don't put alpha versions in the list.
 	ret.EnableVersions(
 		v1.SchemeGroupVersion,

--- a/staging/src/k8s.io/kube-aggregator/pkg/cmd/server/start.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/cmd/server/start.go
@@ -27,9 +27,12 @@ import (
 
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
+	genericfeatures "k8s.io/apiserver/pkg/features"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/apiserver/pkg/server/filters"
 	genericoptions "k8s.io/apiserver/pkg/server/options"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	serverversion "k8s.io/apiserver/pkg/util/version"
 	"k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1"
 	"k8s.io/kube-aggregator/pkg/apiserver"
 	aggregatorscheme "k8s.io/kube-aggregator/pkg/apiserver/scheme"
@@ -115,6 +118,10 @@ func (o AggregatorOptions) Validate(args []string) error {
 
 // Complete fills in missing Options.
 func (o *AggregatorOptions) Complete() error {
+	// set feature gate emulation version before Validate().
+	if utilfeature.DefaultFeatureGate.Enabled(genericfeatures.EmulationVersion) {
+		return utilfeature.DefaultMutableVersionedFeatureGate.SetEmulationVersion(serverversion.Effective.EmulationVersion())
+	}
 	return nil
 }
 

--- a/staging/src/k8s.io/kube-aggregator/pkg/cmd/server/start.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/cmd/server/start.go
@@ -133,7 +133,7 @@ func (o AggregatorOptions) RunAggregator(stopCh <-chan struct{}) error {
 	if err := o.RecommendedOptions.ApplyTo(serverConfig); err != nil {
 		return err
 	}
-	if err := o.APIEnablement.ApplyTo(&serverConfig.Config, apiserver.DefaultAPIResourceConfigSource(), aggregatorscheme.Scheme); err != nil {
+	if err := o.APIEnablement.ApplyTo(&serverConfig.Config, apiserver.DefaultAPIResourceConfigSource(aggregatorscheme.Scheme)); err != nil {
 		return err
 	}
 	serverConfig.LongRunningFunc = filters.BasicLongRunningRequestCheck(

--- a/test/integration/apiserver/apiserver_test.go
+++ b/test/integration/apiserver/apiserver_test.go
@@ -2937,8 +2937,8 @@ func TestDedupOwnerReferences(t *testing.T) {
 }
 
 func TestEnableEmulationVersion(t *testing.T) {
-	t.Cleanup(utilversion.Effective.SetBinaryVersionForTests(apimachineryversion.MustParse("v1.26.0")))
-	server := kubeapiservertesting.StartTestServerOrDie(t, nil, []string{"--emulation-version=v1.25.0", "--feature-gates=EmulationVersion=true"}, framework.SharedEtcd())
+	t.Cleanup(utilversion.Effective.SetBinaryVersionForTests(apimachineryversion.MustParse("v1.31.0")))
+	server := kubeapiservertesting.StartTestServerOrDie(t, nil, []string{"--emulated-version=1.30", "--feature-gates=EmulationVersion=true"}, framework.SharedEtcd())
 	defer server.TearDownFn()
 
 	rt, err := restclient.TransportFor(server.ClientConfig)
@@ -2960,15 +2960,15 @@ func TestEnableEmulationVersion(t *testing.T) {
 		},
 		{
 			path:               "/apis/flowcontrol.apiserver.k8s.io/v1beta1/flowschemas", // introduced at 1.20, removed at 1.26
-			expectedStatusCode: 200,
+			expectedStatusCode: 404,
 		},
 		{
 			path:               "/apis/flowcontrol.apiserver.k8s.io/v1beta2/flowschemas", // introduced at 1.23, removed at 1.29
-			expectedStatusCode: 200,
+			expectedStatusCode: 404,
 		},
 		{
 			path:               "/apis/flowcontrol.apiserver.k8s.io/v1beta3/flowschemas", // introduced at 1.26, removed at 1.32
-			expectedStatusCode: 404,
+			expectedStatusCode: 200,
 		},
 	}
 
@@ -2991,8 +2991,8 @@ func TestEnableEmulationVersion(t *testing.T) {
 }
 
 func TestDisableEmulationVersion(t *testing.T) {
-	t.Cleanup(utilversion.Effective.SetBinaryVersionForTests(apimachineryversion.MustParse("v1.28.0")))
-	server := kubeapiservertesting.StartTestServerOrDie(t, nil, []string{"--emulation-version=v1.28.0", "--feature-gates=EmulationVersion=false"}, framework.SharedEtcd())
+	t.Cleanup(utilversion.Effective.SetBinaryVersionForTests(apimachineryversion.MustParse("v1.30.0")))
+	server := kubeapiservertesting.StartTestServerOrDie(t, nil, []string{"--emulated-version=1.30", "--feature-gates=EmulationVersion=false"}, framework.SharedEtcd())
 	defer server.TearDownFn()
 
 	rt, err := restclient.TransportFor(server.ClientConfig)

--- a/test/integration/apiserver/apiserver_test.go
+++ b/test/integration/apiserver/apiserver_test.go
@@ -51,10 +51,12 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer/streaming"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/uuid"
+	apimachineryversion "k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/apiserver/pkg/endpoints/handlers"
 	"k8s.io/apiserver/pkg/storage/storagebackend"
+	utilversion "k8s.io/apiserver/pkg/util/version"
 	"k8s.io/client-go/dynamic"
 	clientset "k8s.io/client-go/kubernetes"
 	appsv1 "k8s.io/client-go/kubernetes/typed/apps/v1"
@@ -2931,6 +2933,114 @@ func TestDedupOwnerReferences(t *testing.T) {
 	// cleanup
 	if err := client.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{}); err != nil {
 		t.Fatalf("failed to delete test ns: %v", err)
+	}
+}
+
+func TestEnableEmulationVersion(t *testing.T) {
+	t.Cleanup(utilversion.Effective.SetBinaryVersionForTests(apimachineryversion.MustParse("v1.26.0")))
+	server := kubeapiservertesting.StartTestServerOrDie(t, nil, []string{"--emulation-version=v1.25.0", "--feature-gates=EmulationVersion=true"}, framework.SharedEtcd())
+	defer server.TearDownFn()
+
+	rt, err := restclient.TransportFor(server.ClientConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tcs := []struct {
+		path               string
+		expectedStatusCode int
+	}{
+		{
+			path:               "/",
+			expectedStatusCode: 200,
+		},
+		{
+			path:               "/apis/apps/v1/deployments",
+			expectedStatusCode: 200,
+		},
+		{
+			path:               "/apis/flowcontrol.apiserver.k8s.io/v1beta1/flowschemas", // introduced at 1.20, removed at 1.26
+			expectedStatusCode: 200,
+		},
+		{
+			path:               "/apis/flowcontrol.apiserver.k8s.io/v1beta2/flowschemas", // introduced at 1.23, removed at 1.29
+			expectedStatusCode: 200,
+		},
+		{
+			path:               "/apis/flowcontrol.apiserver.k8s.io/v1beta3/flowschemas", // introduced at 1.26, removed at 1.32
+			expectedStatusCode: 404,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.path, func(t *testing.T) {
+			req, err := http.NewRequest("GET", server.ClientConfig.Host+tc.path, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			resp, err := rt.RoundTrip(req)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if resp.StatusCode != tc.expectedStatusCode {
+				t.Errorf("expect status code: %d, got : %d\n", tc.expectedStatusCode, resp.StatusCode)
+			}
+			defer resp.Body.Close()
+		})
+	}
+}
+
+func TestDisableEmulationVersion(t *testing.T) {
+	t.Cleanup(utilversion.Effective.SetBinaryVersionForTests(apimachineryversion.MustParse("v1.28.0")))
+	server := kubeapiservertesting.StartTestServerOrDie(t, nil, []string{"--emulation-version=v1.28.0", "--feature-gates=EmulationVersion=false"}, framework.SharedEtcd())
+	defer server.TearDownFn()
+
+	rt, err := restclient.TransportFor(server.ClientConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tcs := []struct {
+		path               string
+		expectedStatusCode int
+	}{
+		{
+			path:               "/",
+			expectedStatusCode: 200,
+		},
+		{
+			path:               "/apis/apps/v1/deployments",
+			expectedStatusCode: 200,
+		},
+		{
+			path:               "/apis/flowcontrol.apiserver.k8s.io/v1beta1/flowschemas", // introduced at 1.20, removed at 1.26
+			expectedStatusCode: 200,
+		},
+		{
+			path:               "/apis/flowcontrol.apiserver.k8s.io/v1beta2/flowschemas", // introduced at 1.23, removed at 1.29
+			expectedStatusCode: 200,
+		},
+		{
+			path:               "/apis/flowcontrol.apiserver.k8s.io/v1beta3/flowschemas", // introduced at 1.26, removed at 1.32
+			expectedStatusCode: 200,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.path, func(t *testing.T) {
+			req, err := http.NewRequest("GET", server.ClientConfig.Host+tc.path, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			resp, err := rt.RoundTrip(req)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if resp.StatusCode != tc.expectedStatusCode {
+				t.Errorf("expect status code: %d, got : %d\n", tc.expectedStatusCode, resp.StatusCode)
+			}
+			defer resp.Body.Close()
+		})
 	}
 }
 

--- a/test/integration/apiserver/apiserver_test.go
+++ b/test/integration/apiserver/apiserver_test.go
@@ -82,7 +82,7 @@ func setupWithResources(t *testing.T, groupVersions []schema.GroupVersion, resou
 	client, config, teardown := framework.StartTestServer(ctx, t, framework.TestServerSetup{
 		ModifyServerConfig: func(config *controlplane.Config) {
 			if len(groupVersions) > 0 || len(resources) > 0 {
-				resourceConfig := controlplane.DefaultAPIResourceConfigSource()
+				resourceConfig := controlplane.DefaultAPIResourceConfigSource(nil)
 				resourceConfig.EnableVersions(groupVersions...)
 				resourceConfig.EnableResources(resources...)
 				config.ExtraConfig.APIResourceConfigSource = resourceConfig

--- a/test/integration/controlplane/transformation/kms_transformation_test.go
+++ b/test/integration/controlplane/transformation/kms_transformation_test.go
@@ -642,6 +642,12 @@ resources:
 		client := dynamic.NewForConfigOrDie(test.kubeAPIServer.ClientConfig)
 
 		etcdStorageData := etcd.GetEtcdStorageDataForNamespace(testNamespace)
+		// Remove resources removed before test binary version 1.30
+		delete(etcdStorageData, gvr("flowcontrol.apiserver.k8s.io", "v1beta1", "flowschemas"))
+		delete(etcdStorageData, gvr("flowcontrol.apiserver.k8s.io", "v1beta1", "prioritylevelconfigurations"))
+		delete(etcdStorageData, gvr("flowcontrol.apiserver.k8s.io", "v1beta2", "flowschemas"))
+		delete(etcdStorageData, gvr("flowcontrol.apiserver.k8s.io", "v1beta2", "prioritylevelconfigurations"))
+
 		restResourceSet := sets.New[schema.GroupVersionResource]()
 		stubResourceSet := sets.New[schema.GroupVersionResource]()
 		for _, resource := range resources {

--- a/test/integration/controlplane/transformation/kmsv2_transformation_test.go
+++ b/test/integration/controlplane/transformation/kmsv2_transformation_test.go
@@ -1188,9 +1188,9 @@ func getRESTOptionsGetterForSecrets(t testing.TB, test *transformTest) generic.R
 
 	genericConfig := genericapiserver.NewConfig(legacyscheme.Codecs)
 
-	genericConfig.MergedResourceConfig = controlplane.DefaultAPIResourceConfigSource()
+	genericConfig.MergedResourceConfig = controlplane.DefaultAPIResourceConfigSource(legacyscheme.Scheme)
 
-	if err := s.APIEnablement.ApplyTo(genericConfig, controlplane.DefaultAPIResourceConfigSource(), legacyscheme.Scheme); err != nil {
+	if err := s.APIEnablement.ApplyTo(genericConfig, controlplane.DefaultAPIResourceConfigSource(legacyscheme.Scheme)); err != nil {
 		t.Fatal(err)
 	}
 

--- a/test/integration/etcd/etcd_storage_path_test.go
+++ b/test/integration/etcd/etcd_storage_path_test.go
@@ -86,6 +86,11 @@ func TestEtcdStoragePath(t *testing.T) {
 	}
 
 	etcdStorageData := GetEtcdStorageData()
+	// Remove resources removed before test binary version 1.30
+	delete(etcdStorageData, gvr("flowcontrol.apiserver.k8s.io", "v1beta1", "flowschemas"))
+	delete(etcdStorageData, gvr("flowcontrol.apiserver.k8s.io", "v1beta1", "prioritylevelconfigurations"))
+	delete(etcdStorageData, gvr("flowcontrol.apiserver.k8s.io", "v1beta2", "flowschemas"))
+	delete(etcdStorageData, gvr("flowcontrol.apiserver.k8s.io", "v1beta2", "prioritylevelconfigurations"))
 
 	kindSeen := sets.NewString()
 	pathSeen := map[string][]schema.GroupVersionResource{}

--- a/test/integration/etcd/server.go
+++ b/test/integration/etcd/server.go
@@ -40,7 +40,6 @@ import (
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/wait"
 	genericapiserveroptions "k8s.io/apiserver/pkg/server/options"
-	utilversion "k8s.io/apiserver/pkg/util/version"
 	cacheddiscovery "k8s.io/client-go/discovery/cached/memory"
 	"k8s.io/client-go/dynamic"
 	clientset "k8s.io/client-go/kubernetes"
@@ -101,7 +100,6 @@ func StartRealAPIServerOrDie(t *testing.T, configFuncs ...func(*options.ServerRu
 	opts.Options.Authentication.ServiceAccounts.KeyFiles = []string{saSigningKeyFile.Name()}
 	opts.Options.Authorization.Modes = []string{"RBAC"}
 	opts.Options.Admission.GenericAdmission.DisablePlugins = []string{"ServiceAccount"}
-	opts.Options.APIEnablement.EmulationVersion = utilversion.Effective.BinaryVersion().String()
 	opts.Options.APIEnablement.RuntimeConfig["api/all"] = "true"
 	for _, f := range configFuncs {
 		f(opts)

--- a/test/integration/etcd/server.go
+++ b/test/integration/etcd/server.go
@@ -40,6 +40,7 @@ import (
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/wait"
 	genericapiserveroptions "k8s.io/apiserver/pkg/server/options"
+	utilversion "k8s.io/apiserver/pkg/util/version"
 	cacheddiscovery "k8s.io/client-go/discovery/cached/memory"
 	"k8s.io/client-go/dynamic"
 	clientset "k8s.io/client-go/kubernetes"
@@ -100,6 +101,7 @@ func StartRealAPIServerOrDie(t *testing.T, configFuncs ...func(*options.ServerRu
 	opts.Options.Authentication.ServiceAccounts.KeyFiles = []string{saSigningKeyFile.Name()}
 	opts.Options.Authorization.Modes = []string{"RBAC"}
 	opts.Options.Admission.GenericAdmission.DisablePlugins = []string{"ServiceAccount"}
+	opts.Options.APIEnablement.EmulationVersion = utilversion.Effective.BinaryVersion().String()
 	opts.Options.APIEnablement.RuntimeConfig["api/all"] = "true"
 	for _, f := range configFuncs {
 		f(opts)


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This change is intended to make the version used for encoding in etcd configurable by a `compatibility-version` flag. The used storage versions will be looked up from a table that takes into account K8s versions each resource was introduced, and version skew. This is intended to make for smoother upgrades.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

ATM this is just some basic planning for wiring. Posting as a WIP to source some early feedback and comments about the approach.

/cc @logicalhan @jpbetz  @liggitt 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
TBD
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
