### PR TITLE
Automated cherry pick of #122261: Add unit test for Job Controller for panic when PodFailurePolicy is used

### DIFF
--- a/pkg/controller/job/job_controller_test.go
+++ b/pkg/controller/job/job_controller_test.go
@@ -256,6 +256,7 @@ func TestControllerSyncJob(t *testing.T) {
 		wasSuspended         bool
 		suspend              bool
 		podReplacementPolicy *batch.PodReplacementPolicy
+		podFailurePolicy     *batch.PodFailurePolicy
 		initialStatus        *jobInitialStatus
 		backoffRecord        *backoffRecord
 		controllerTime       *time.Time
@@ -293,6 +294,7 @@ func TestControllerSyncJob(t *testing.T) {
 		// features
 		podIndexLabelDisabled   bool
 		jobPodReplacementPolicy bool
+		jobPodFailurePolicy     bool
 	}{
 		"job start": {
 			parallelism:       2,
@@ -406,6 +408,22 @@ func TestControllerSyncJob(t *testing.T) {
 			expectedActive:          1,
 			expectedDeletions:       1,
 			expectedPodPatches:      1,
+		},
+		"more terminating pods than parallelism; PodFailurePolicy used": {
+			// Repro for https://github.com/kubernetes/kubernetes/issues/122235
+			parallelism:         1,
+			completions:         1,
+			backoffLimit:        6,
+			activePods:          2,
+			failedPods:          0,
+			terminatingPods:     4,
+			jobPodFailurePolicy: true,
+			podFailurePolicy:    &batch.PodFailurePolicy{},
+			expectedTerminating: nil,
+			expectedReady:       ptr.To[int32](0),
+			expectedActive:      1,
+			expectedDeletions:   1,
+			expectedPodPatches:  1,
 		},
 		"too few active pods and active back-off": {
 			parallelism:  1,
@@ -935,6 +953,7 @@ func TestControllerSyncJob(t *testing.T) {
 			logger, _ := ktesting.NewTestContext(t)
 			defer featuregatetesting.SetFeatureGateDuringTest(t, feature.DefaultFeatureGate, features.PodIndexLabel, !tc.podIndexLabelDisabled)()
 			defer featuregatetesting.SetFeatureGateDuringTest(t, feature.DefaultFeatureGate, features.JobPodReplacementPolicy, tc.jobPodReplacementPolicy)()
+			defer featuregatetesting.SetFeatureGateDuringTest(t, feature.DefaultFeatureGate, features.JobPodFailurePolicy, tc.jobPodFailurePolicy)()
 			// job manager setup
 			clientSet := clientset.NewForConfigOrDie(&restclient.Config{Host: "", ContentConfig: restclient.ContentConfig{GroupVersion: &schema.GroupVersion{Group: "", Version: "v1"}}})
 
@@ -956,6 +975,9 @@ func TestControllerSyncJob(t *testing.T) {
 			job.Spec.Suspend = ptr.To(tc.suspend)
 			if tc.jobPodReplacementPolicy {
 				job.Spec.PodReplacementPolicy = tc.podReplacementPolicy
+			}
+			if tc.jobPodFailurePolicy {
+				job.Spec.PodFailurePolicy = tc.podFailurePolicy
 			}
 			if tc.initialStatus != nil {
 				startTime := metav1.Now()


### PR DESCRIPTION
Cherry pick of #122261 on release-1.29.

#122261: Add unit test for Job Controller for panic when PodFailurePolicy is used

**Motivation**:

I consider it an important unit test to cherry-pick because it should go in tandem with the fix in
https://github.com/kubernetes/kubernetes/pull/121147, which is now cherry-picked
to 1.28: https://github.com/kubernetes/kubernetes/pull/122267.

This scenario was not initially attributed to the fix, but it turns out it causes Job controller
panics on 1.28: https://github.com/kubernetes/kubernetes/issues/122235.

```release-note

```