### PR TITLE
Fixed Inappropriate Logical Expression

### DIFF
--- a/staging/src/k8s.io/dynamic-resource-allocation/kubeletplugin/nonblockinggrpcserver.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/kubeletplugin/nonblockinggrpcserver.go
@@ -84,9 +84,7 @@ func startGRPCServer(logger klog.Logger, grpcVerbosity int, interceptors []grpc.
 		finalInterceptors = append(finalInterceptors, s.interceptor)
 	}
 	finalInterceptors = append(finalInterceptors, interceptors...)
-	if len(finalInterceptors) >= 0 {
-		opts = append(opts, grpc.ChainUnaryInterceptor(finalInterceptors...))
-	}
+	opts = append(opts, grpc.ChainUnaryInterceptor(finalInterceptors...))
 	s.server = grpc.NewServer(opts...)
 	for _, service := range services {
 		service(s.server)


### PR DESCRIPTION
The length of `finalInterceptors` will always be a non-negative value. In that case, the comparison will always return a True value, making the comparison meaningless.


#### What type of PR is this?
/kind bug


#### What this PR does / why we need it:
This PR removes an unnecessary comparison that always results in True value.


#### Which issue(s) this PR fixes:
None


#### Does this PR introduce a user-facing change?
```release-note
NONE
```


### CLA Requirements
*This section is only relevant if your project requires contributors to sign a Contributor License Agreement (CLA) for external contributions.*

All contributed commits are already automatically signed off.

> The meaning of a signoff depends on the project, but it typically certifies that committer has the rights to submit this work under the same license and agrees to a Developer Certificate of Origin (see [https://developercertificate.org/](https://developercertificate.org/) for more information).
>
> \- [Git Commit SignOff documentation](https://developercertificate.org/)


### Sponsorship and Support
This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.