### PR TITLE
WIP: Do not close http2 connections authenticated by a front proxy

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/authentication/authenticator/interfaces.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/authenticator/interfaces.go
@@ -62,4 +62,14 @@ type Response struct {
 	Audiences Audiences
 	// User is the UserInfo associated with the authentication context.
 	User user.Info
+	// IsProxiedAuthentication is set to true by authenticators that rely on a
+	// layer 7 reverse proxy in front of the API server to perform authentication.
+	// This means that the API server is not directly connected to the real client,
+	// and must delegate any connection level protections to the authenticating proxy.
+	// From this API server's perspective, when a protocol like HTTP/2 is used,
+	// the client is a proxy multiplexing many concurrent operations, including
+	// long-running ones, into one HTTP/2 connection into this API server.  Therefore,
+	// it is not possible for this API server to safely make decisions about individual
+	// requests since they may share the same underling HTTP/2 connection.
+	IsProxiedAuthentication bool
 }

--- a/staging/src/k8s.io/apiserver/pkg/authentication/request/headerrequest/requestheader.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/request/headerrequest/requestheader.go
@@ -171,6 +171,7 @@ func (a *requestHeaderAuthRequestHandler) AuthenticateRequest(req *http.Request)
 			Groups: groups,
 			Extra:  extra,
 		},
+		IsProxiedAuthentication: true,
 	}, true, nil
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/authentication.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/authentication.go
@@ -109,7 +109,7 @@ func withAuthentication(handler http.Handler, auth authenticator.Request, failed
 		// Do not allow unauthenticated clients to keep these
 		// connections open (i.e. basically degrade them to the
 		// performance of http1 with keep-alive disabled).
-		if utilfeature.DefaultFeatureGate.Enabled(genericfeatures.UnauthenticatedHTTP2DOSMitigation) && req.ProtoMajor == 2 && isAnonymousUser(resp.User) {
+		if shouldCloseAnonymousHTTP2Request(req, resp) {
 			// limit this connection to just this request,
 			// and then send a GOAWAY and tear down the TCP connection
 			// https://github.com/golang/net/commit/97aa3a539ec716117a9d15a4659a911f50d13c3c
@@ -152,6 +152,13 @@ func audiencesAreAcceptable(apiAuds, responseAudiences authenticator.Audiences) 
 	}
 
 	return len(apiAuds.Intersect(responseAudiences)) > 0
+}
+
+func shouldCloseAnonymousHTTP2Request(req *http.Request, resp *authenticator.Response) bool {
+	return utilfeature.DefaultFeatureGate.Enabled(genericfeatures.UnauthenticatedHTTP2DOSMitigation) &&
+		req.ProtoMajor == 2 &&
+		!resp.IsProxiedAuthentication &&
+		isAnonymousUser(resp.User)
 }
 
 func isAnonymousUser(u user.Info) bool {


### PR DESCRIPTION
/kind bug
/kind regression
/assign @liggitt @aojea 

Fixes #122308

```release-note
TODO
```

Remaining items:
- [ ] Confirm that it makes sense to always skip the DOS mitigation for request header authn (i.e. does it make sense for both proxy->KAS and KAS->aggregated API server)
- [ ] See if there is any other way to fix this issue
- [ ] Add test that shows this fixes the issue

cc @benjaminapetersen @cfryanr