### PR TITLE
Bug fix: Enable CRD field dropping for validation ratcheting

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresourcedefinition/strategy.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresourcedefinition/strategy.go
@@ -80,6 +80,7 @@ func (strategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
 			break
 		}
 	}
+	dropDisabledFields(crd, nil)
 }
 
 // PrepareForUpdate clears fields that are not allowed to be set by end users on update.
@@ -108,6 +109,7 @@ func (strategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object) {
 			break
 		}
 	}
+	dropDisabledFields(newCRD, oldCRD)
 }
 
 // Validate validates a new CustomResourceDefinition.


### PR DESCRIPTION
/kind bug
/kind api-change


#### What this PR does / why we need it:

CRD field dropping was added to [CRD validation ratcheting](https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/4008-crd-ratcheting) and carefully unit tested, but never got fully wired in.

#### Which issue(s) this PR fixes:


#### Special notes for your reviewer:

This should be cherry picked to 1.29  (https://github.com/kubernetes/kubernetes/pull/121034 was introduced in 1.29)

#### Does this PR introduce a user-facing change?

```release-note
Fixes accidental enablement of the new alpha `optionalOldSelf` API field in CustomResourceDefinition validation rules, which should only be allowed to be set when the CRDValidationRatcheting feature gate is enabled.
```
