### PR TITLE
Fix the minor typo in the comment of the checkQuotas method.

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/resourcequota/controller.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/resourcequota/controller.go
@@ -314,10 +314,10 @@ func (e *quotaEvaluator) checkQuotas(quotas []corev1.ResourceQuota, admissionAtt
 		return
 	}
 
-	// this retry logic has the same bug that its possible to be checking against quota in a state that never actually exists where
-	// you've added a new documented, then updated an old one, your resource matches both and you're only checking one
-	// updates for these quota names failed.  Get the current quotas in the namespace, compare by name, check to see if the
-	// resource versions have changed.  If not, we're going to fall through an fail everything.  If they all have, then we can try again
+	// this retry logic has the same bug: it's possible to be checking against quota in a state that never actually exists where
+	// you've added a new document, then updated an old one. Your resource matches both, and you're only checking one.
+	// Updates for these quota names failed. Get the current quotas in the namespace, compare by name, check to see if the
+	// resource versions have changed. If not, we're going to fall through and fail everything. If they all have, then we can try again.
 	newQuotas, err := e.quotaAccessor.GetQuotas(quotas[0].Namespace)
 	if err != nil {
 		// this means that updates failed.  Anything with a default deny error has failed and we need to let them know

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/resourcequota/controller.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/resourcequota/controller.go
@@ -219,9 +219,9 @@ func (e *quotaEvaluator) checkAttributes(ns string, admissionAttributes []*admis
 // AFTER it has checked all the admissionAttributes.  The method breaks down into phase like this:
 //  0. make a copy of the quotas to act as a "running" quota so we know what we need to update and can still compare against the
 //     originals
-//  1. check each admission attribute to see if it fits within *all* the quotas.  If it doesn't fit, mark the waiter as failed
-//     and the running quota don't change.  If it did fit, check to see if any quota was changed.  It there was no quota change
-//     mark the waiter as succeeded.  If some quota did change, update the running quotas
+//  1. check each admission attribute to see if it fits within *all* the quotas.  If it didn't fit, mark the waiter as failed
+//     and the running quota doesn't change.  If it did fit, check to see if any quota was changed.  If there was no quota change
+//     mark the waiter as succeeded.  If some quota did change, update the running quotas.
 //  2. If no running quota was changed, return now since no updates are needed.
 //  3. for each quota that has changed, attempt an update.  If all updates succeeded, update all unset waiters to success status and return.  If the some
 //     updates failed on conflict errors and we have retries left, re-get the failed quota from our cache for the latest version


### PR DESCRIPTION
Fix the syntax error in the comment of the checkQuotas method. From "It there was no quota change mark the waiter as succeeded." to "If there was no quota change mark the waiter as succeeded." also fixed some grammatically incorrect words.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind documentation
#### What this PR does / why we need it:
Fix the syntax error in the comment of the checkQuotas method.
From "It there was no quota change mark the waiter as succeeded." to "If there was no quota change mark the waiter as succeeded."
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #https://github.com/kubernetes/kubernetes/issues/121427

#### Special notes for your reviewer:
Fix the syntax error in the comment of the checkQuotas method.
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
