### PR TITLE
kubeadm: increase ut coverage for util/etcd

### DIFF
--- a/cmd/kubeadm/app/util/etcd/etcd.go
+++ b/cmd/kubeadm/app/util/etcd/etcd.go
@@ -104,6 +104,8 @@ type Client struct {
 	Endpoints []string
 
 	newEtcdClient func(endpoints []string) (etcdClient, error)
+
+	listMembersFunc func(backoff *wait.Backoff) (*clientv3.MemberListResponse, error)
 }
 
 // New creates a new EtcdCluster client
@@ -134,6 +136,8 @@ func New(endpoints []string, ca, cert, key string) (*Client, error) {
 			TLS: tlsConfig,
 		})
 	}
+
+	client.listMembersFunc = client.listMembers
 
 	return &client, nil
 }
@@ -274,11 +278,14 @@ type Member struct {
 	PeerURL string
 }
 
-func (c *Client) listMembers() (*clientv3.MemberListResponse, error) {
+func (c *Client) listMembers(backoff *wait.Backoff) (*clientv3.MemberListResponse, error) {
 	// Gets the member list
 	var lastError error
 	var resp *clientv3.MemberListResponse
-	err := wait.ExponentialBackoff(etcdBackoff, func() (bool, error) {
+	if backoff == nil {
+		backoff = &etcdBackoff
+	}
+	err := wait.ExponentialBackoff(*backoff, func() (bool, error) {
 		cli, err := c.newEtcdClient(c.Endpoints)
 		if err != nil {
 			lastError = err
@@ -304,7 +311,7 @@ func (c *Client) listMembers() (*clientv3.MemberListResponse, error) {
 
 // GetMemberID returns the member ID of the given peer URL
 func (c *Client) GetMemberID(peerURL string) (uint64, error) {
-	resp, err := c.listMembers()
+	resp, err := c.listMembersFunc(nil)
 	if err != nil {
 		return 0, err
 	}
@@ -319,7 +326,7 @@ func (c *Client) GetMemberID(peerURL string) (uint64, error) {
 
 // ListMembers returns the member list.
 func (c *Client) ListMembers() ([]Member, error) {
-	resp, err := c.listMembers()
+	resp, err := c.listMembersFunc(nil)
 	if err != nil {
 		return nil, err
 	}
@@ -480,7 +487,7 @@ func (c *Client) addMember(name string, peerAddrs string, isLearner bool) ([]Mem
 
 // isLearner returns true if the given member ID is a learner.
 func (c *Client) isLearner(memberID uint64) (bool, error) {
-	resp, err := c.listMembers()
+	resp, err := c.listMembersFunc(nil)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

kubeadm: increase ut coverage for util/etcd

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
 NONE
```
