### PR TITLE
cluster/gce: upgrade cos-97-lts -> cos-109-lts

### DIFF
--- a/cluster/gce/config-default.sh
+++ b/cluster/gce/config-default.sh
@@ -90,7 +90,7 @@ fi
 # By default, the latest image from the image family will be used unless an
 # explicit image will be set.
 GCI_VERSION=${KUBE_GCI_VERSION:-}
-IMAGE_FAMILY=${KUBE_IMAGE_FAMILY:-cos-97-lts}
+IMAGE_FAMILY=${KUBE_IMAGE_FAMILY:-cos-109-lts}
 export MASTER_IMAGE=${KUBE_GCE_MASTER_IMAGE:-}
 export MASTER_IMAGE_FAMILY=${KUBE_GCE_MASTER_IMAGE_FAMILY:-${IMAGE_FAMILY}}
 export MASTER_IMAGE_PROJECT=${KUBE_GCE_MASTER_PROJECT:-cos-cloud}

--- a/cluster/gce/config-test.sh
+++ b/cluster/gce/config-test.sh
@@ -103,7 +103,7 @@ ALLOWED_NOTREADY_NODES=${ALLOWED_NOTREADY_NODES:-$(($(get-num-nodes) / 100))}
 # By default, the latest image from the image family will be used unless an
 # explicit image will be set.
 GCI_VERSION=${KUBE_GCI_VERSION:-}
-IMAGE_FAMILY=${KUBE_IMAGE_FAMILY:-cos-97-lts}
+IMAGE_FAMILY=${KUBE_IMAGE_FAMILY:-cos-109-lts}
 export MASTER_IMAGE=${KUBE_GCE_MASTER_IMAGE:-}
 export MASTER_IMAGE_FAMILY=${KUBE_GCE_MASTER_IMAGE_FAMILY:-${IMAGE_FAMILY}}
 export MASTER_IMAGE_PROJECT=${KUBE_GCE_MASTER_PROJECT:-cos-cloud}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind failing-test

#### What this PR does / why we need it:

This is an upgrade of cos image family to the resent -lts milestone.

Using old COS images caused issues with old GLBC for a recent containerd binaries, e.g. [ci-cos-cgroupv1-inplace-pod-resize-containerd-main-e2e-gce-serial](https://storage.googleapis.com/kubernetes-jenkins/logs/ci-cos-cgroupv1-inplace-pod-resize-containerd-main-e2e-gce-serial/1736116674186186752/artifacts/bootstrap-e2e-master/containerd.log). Containerd binaries require newer libc version and produced `/home/containerd/usr/local/bin/containerd: /lib64/libc.so.6: version 'GLIBC_2.34' not found (required by /home/containerd/usr/local/bin/containerd)`

Around 5 different  jobs were failing due to this issue. 


#### Which issue(s) this PR fixes:
Fixes #121309

#### Special notes for your reviewer:


#### Does this PR introduce a user-facing change?
```release-note
NONE
```