### PR TITLE
Add link to KEP project and mention feature requests in .github/ISSUE…

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yaml
@@ -1,5 +1,5 @@
 name: Bug Report
-description: Report a bug encountered while operating Kubernetes
+description: Report a bug encountered while operating Kubernetes or feature request
 labels: kind/bug
 body:
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,3 +2,6 @@ contact_links:
   - name: Support Request
     url: https://discuss.kubernetes.io
     about: Support request or question relating to Kubernetes
+  - name: Kubernetes Enhancement Processes (KEP)
+    url: https://github.com/kubernetes/enhancements
+    about: check https://github.com/kubernetes/enhancements#is-my-thing-an-enhancement


### PR DESCRIPTION
#### What type of PR is this?
/kind documentation

#### What this PR does / why we need it:
It was unclear to me whether this is the right spot to open feature requests that are not KEPs. This improves the overview when opening an issue, I hope. I have been asking on https://discuss.kubernetes.io/t/where-to-report-feature-requests/26470.

#### Which issue(s) this PR fixes:
./.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
no

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
./.
