### PR TITLE
[master] Update `multiprotocol-test` `containerPort := 100`, avoid conflict with internal HTTP_PROXY

### DIFF
--- a/test/e2e/network/service.go
+++ b/test/e2e/network/service.go
@@ -3650,17 +3650,17 @@ var _ = common.SIGDescribe("Services", func() {
 		serviceName := "multiprotocol-test"
 		testLabels := map[string]string{"app": "multiport"}
 		ns := f.Namespace.Name
-		containerPort := 80
+		containerPort := 100
 
 		svcTCPport := v1.ServicePort{
 			Name:       "tcp-port",
-			Port:       80,
+			Port:       100,
 			TargetPort: intstr.FromInt(containerPort),
 			Protocol:   v1.ProtocolTCP,
 		}
 		svcUDPport := v1.ServicePort{
 			Name:       "udp-port",
-			Port:       80,
+			Port:       100,
 			TargetPort: intstr.FromInt(containerPort),
 			Protocol:   v1.ProtocolUDP,
 		}
@@ -3697,11 +3697,11 @@ var _ = common.SIGDescribe("Services", func() {
 
 		ginkgo.By("Checking if the Service forwards traffic to the TCP and UDP port")
 		execPod := e2epod.CreateExecPodOrFail(ctx, cs, ns, "execpod", nil)
-		err = testEndpointReachability(ctx, service.Spec.ClusterIP, 80, v1.ProtocolTCP, execPod, 30*time.Second)
+		err = testEndpointReachability(ctx, service.Spec.ClusterIP, 100, v1.ProtocolTCP, execPod, 30*time.Second)
 		if err != nil {
 			framework.Failf("Failed to connect to Service TCP port: %v", err)
 		}
-		err = testEndpointReachability(ctx, service.Spec.ClusterIP, 80, v1.ProtocolUDP, execPod, 30*time.Second)
+		err = testEndpointReachability(ctx, service.Spec.ClusterIP, 100, v1.ProtocolUDP, execPod, 30*time.Second)
 		if err != nil {
 			framework.Failf("Failed to connect to Service UDP port: %v", err)
 		}
@@ -3718,7 +3718,7 @@ var _ = common.SIGDescribe("Services", func() {
 		}
 
 		// test reachability
-		err = testEndpointReachability(ctx, service.Spec.ClusterIP, 80, v1.ProtocolTCP, execPod, 30*time.Second)
+		err = testEndpointReachability(ctx, service.Spec.ClusterIP, 100, v1.ProtocolTCP, execPod, 30*time.Second)
 		if err != nil {
 			framework.Failf("Failed to connect to Service TCP port: %v", err)
 		}
@@ -3726,7 +3726,7 @@ var _ = common.SIGDescribe("Services", func() {
 		// testEndpointReachability tries 3 times every 3 second
 		// we retry again during 30 seconds to check if the port stops forwarding
 		gomega.Eventually(ctx, func() error {
-			return testEndpointReachability(ctx, service.Spec.ClusterIP, 80, v1.ProtocolUDP, execPod, 6*time.Second)
+			return testEndpointReachability(ctx, service.Spec.ClusterIP, 100, v1.ProtocolUDP, execPod, 6*time.Second)
 		}).WithTimeout(30 * time.Second).WithPolling(5 * time.Second).ShouldNot(gomega.BeNil())
 
 		ginkgo.By("Checking if the Service forwards traffic to UDP only")
@@ -3741,7 +3741,7 @@ var _ = common.SIGDescribe("Services", func() {
 		}
 
 		// test reachability
-		err = testEndpointReachability(ctx, service.Spec.ClusterIP, 80, v1.ProtocolUDP, execPod, 30*time.Second)
+		err = testEndpointReachability(ctx, service.Spec.ClusterIP, 100, v1.ProtocolUDP, execPod, 30*time.Second)
 		if err != nil {
 			framework.Failf("Failed to connect to Service UDP port: %v", err)
 		}
@@ -3749,7 +3749,7 @@ var _ = common.SIGDescribe("Services", func() {
 		// testEndpointReachability tries 3 times every 3 second
 		// we retry again during 30 seconds to check if the port stops forwarding
 		gomega.Eventually(ctx, func() error {
-			return testEndpointReachability(ctx, service.Spec.ClusterIP, 80, v1.ProtocolTCP, execPod, 6*time.Second)
+			return testEndpointReachability(ctx, service.Spec.ClusterIP, 100, v1.ProtocolTCP, execPod, 6*time.Second)
 		}).WithTimeout(30 * time.Second).WithPolling(5 * time.Second).ShouldNot(gomega.BeNil())
 	})
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
/kind failing-test

#### What this PR does / why we need it:

https://github.com/kubernetes/kubernetes/pull/120069 promote the Service multiprotocol tests to conformance, which was newly introduced for v1.29.0.

BTW, the test choose port TCP/80 and UDP/80 when creating service, which block my conformance test submissions:
* https://github.com/cncf/k8s-conformance/pull/2937
* https://github.com/cncf/k8s-conformance/pull/2938

The reason here is because I have an OpenWRT router named `gw2.lan` with Squid transparency outgoing HTTP_PROXY enabled. Such testing traffic is captured by the firewall rules and so forwarded to Squid. Now the test failed with following error log:
```
  Dec 16 16:20:46.732: INFO: Running '/usr/local/bin/kubectl --kubeconfig=/tmp/kubeconfig-2989162759 --namespace=services-951 exec execpodxztrq -- /bin/sh -x -c echo hostName | nc -v -t -w 2 10.233.15.240 80'
  Dec 16 16:20:47.047: INFO: stderr: "+ echo hostName\n+ nc -v -t -w 2 10.233.15.240 80\nConnection to 10.233.15.240 80 port [tcp/http] succeeded!\n"
  Dec 16 16:20:47.048: INFO: stdout: "HTTP/1.1 400 Bad Request\r\nServer: squid/5.7\r\nMime-Version: 1.0\r\nDate: Sat, 16 Dec 2023 16:20:47 GMT\r\nContent-Type: text/html;charset=utf-8\r\nContent-Length: 3326\r\nX-Squid-Error: ERR_PROTOCOL_UNKNOWN 0\r\nContent-Language: en\r\nX-Cache: MISS from gw2.lan\r\nX-Cache-Lookup: NONE from gw2.lan:3128\r\nVia: 1.1 gw2.lan (squid/5.7)\r\nConnection: close\r\n\r\n<!DOCTYPE html PUBLIC \"-//W3C//DTD HTML 4.01//EN\" \"http://www.w3.org/TR/html4/strict.dtd\">\n<html><head>\n<meta type=\"copyright\" content=\"Copyright (C) 1996-2022 The Squid Software Foundation and contributors\">\n<meta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\">\n<title>ERROR: The requested URL could not be retrieved</title>\n<style type=\"text/css\"><!-- \n /*\n * Copyright (C) 1996-2022 The Squid Software Foundation and contributors\n *\n * Squid software is distributed under GPLv2+ license and includes\n * contributions from numerous individuals and organizations.\n * Please see the COPYING and CONTRIBUTORS files for details.\n */\n\n/*\n Stylesheet for Squid Error pages\n Adapted from design by Free CSS Templates\n http://www.freecsstemplates.org\n Released for free under a Creative Commons Attribution 2.5 License\n*/\n\n/* Page basics */\n* {\n\tfont-family: verdana, sans-serif;\n}\n\nhtml body {\n\tmargin: 0;\n\tpadding: 0;\n\tbackground: #efefef;\n\tfont-size: 12px;\n\tcolor: #1e1e1e;\n}\n\n/* Page displayed title area */\n#titles {\n\tmargin-left: 15px;\n\tpadding: 10px;\n\tpadding-left: 100px;\n\tbackground: url('/squid-internal-static/icons/SN.png') no-repeat left;\n}\n\n/* initial title */\n#titles h1 {\n\tcolor: #000000;\n}\n#titles h2 {\n\tcolor: #000000;\n}\n\n/* special event: FTP success page titles */\n#titles ftpsuccess {\n\tbackground-color:#00ff00;\n\twidth:100%;\n}\n\n/* Page displayed body content area */\n#content {\n\tpadding: 10px;\n\tbackground: #ffffff;\n}\n\n/* General text */\np {\n}\n\n/* error brief description */\n#error p {\n}\n\n/* some data which may have caused the problem */\n#data {\n}\n\n/* the error message received from the system or other software */\n#sysmsg {\n}\n\npre {\n}\n\n/* special event: FTP / Gopher directory listing */\n#dirmsg {\n    font-family: courier, monospace;\n    color: black;\n    font-size: 10pt;\n}\n#dirlisting {\n    margin-left: 2%;\n    margin-right: 2%;\n}\n#dirlisting tr.entry td.icon,td.filename,td.size,td.date {\n    border-bottom: groove;\n}\n#dirlisting td.size {\n    width: 50px;\n    text-align: right;\n    padding-right: 5px;\n}\n\n/* horizontal lines */\nhr {\n\tmargin: 0;\n}\n\n/* page displayed footer area */\n#footer {\n\tfont-size: 9px;\n\tpadding-left: 10px;\n}\n\n\nbody\n:lang(fa) { direction: rtl; font-size: 100%; font-family: Tahoma, Roya, sans-serif; float: right; }\n:lang(he) { direction: rtl; }\n --></style>\n</head><body id=ERR_PROTOCOL_UNKNOWN>\n<div id=\"titles\">\n<h1>ERROR</h1>\n<h2>The requested URL could not be retrieved</h2>\n</div>\n<hr>\n\n<div id=\"content\">\n<p>The following error was encountered while trying to retrieve the URL: <a href=\"error:invalid-request\">error:invalid-request</a></p>\n\n<blockquote id=\"error\">\n<p><b>Unsupported Protocol</b></p>\n</blockquote>\n\n<p>Squid does not support some access protocols. For example, the SSH protocol is currently not supported.</p>\n\n<p>Your cache administrator is <a href=\"mailto:webmaster?subject=CacheErrorInfo%20-%20ERR_PROTOCOL_UNKNOWN&amp;body=CacheHost%3A%20gw2.lan%0D%0AErrPage%3A%20ERR_PROTOCOL_UNKNOWN%0D%0AErr%3A%20%5Bnone%5D%0D%0ATimeStamp%3A%20Sat,%2016%20Dec%202023%2016%3A20%3A47%20GMT%0D%0A%0D%0AClientIP%3A%20172.23.100.12%0D%0A%0D%0AHTTP%20Request%3A%0D%0A%0D%0A%0D%0A\">webmaster</a>.</p>\n<br>\n</div>\n\n<hr>\n<div id=\"footer\">\n<p>Generated Sat, 16 Dec 2023 16:20:47 GMT by gw2.lan (squid/5.7)</p>\n<!-- ERR_PROTOCOL_UNKNOWN -->\n</div>\n</body></html>\n"
```

This could be avoided by NOT using port 80 for testing, e.g. using [`containerPort := 100`](https://github.com/kubernetes/kubernetes/blob/42ab3b7b40c34e91b63589ae905ed918752a4a36/test/e2e/network/service.go#L3793)

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Fixes  https://github.com/cncf/k8s-conformance/pull/2937
Fixes  https://github.com/cncf/k8s-conformance/pull/2938

#### Special notes for your reviewer:

I had tried for both CNI with Flannel or Cilium (without kube-proxy replacement), both forward the traffic to my internal OpenWRT due to using port 80. After switching it to 100 the conformance test now get passed.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
