### PR TITLE
kubeadm: hide unwanted global klog flags

### DIFF
--- a/cmd/kubeadm/app/kubeadm.go
+++ b/cmd/kubeadm/app/kubeadm.go
@@ -41,10 +41,10 @@ func Run() error {
 	pflag.CommandLine.MarkHidden("log-backtrace-at")
 	pflag.CommandLine.MarkHidden("log-dir")
 	pflag.CommandLine.MarkHidden("logtostderr")
-	pflag.CommandLine.MarkHidden("log-file")
-	pflag.CommandLine.MarkHidden("log-file-max-size")
-	pflag.CommandLine.MarkHidden("one-output")
-	pflag.CommandLine.MarkHidden("skip-log-headers")
+	pflag.CommandLine.MarkHidden("log-file")          //nolint:errcheck
+	pflag.CommandLine.MarkHidden("log-file-max-size") //nolint:errcheck
+	pflag.CommandLine.MarkHidden("one-output")        //nolint:errcheck
+	pflag.CommandLine.MarkHidden("skip-log-headers")  //nolint:errcheck
 	pflag.CommandLine.MarkHidden("stderrthreshold")
 	pflag.CommandLine.MarkHidden("vmodule")
 

--- a/cmd/kubeadm/app/kubeadm.go
+++ b/cmd/kubeadm/app/kubeadm.go
@@ -37,12 +37,14 @@ func Run() error {
 	pflag.Set("logtostderr", "true")
 	// We do not want these flags to show up in --help
 	// These MarkHidden calls must be after the lines above
-	pflag.CommandLine.MarkHidden("version")
-	pflag.CommandLine.MarkHidden("log-flush-frequency")
 	pflag.CommandLine.MarkHidden("alsologtostderr")
 	pflag.CommandLine.MarkHidden("log-backtrace-at")
 	pflag.CommandLine.MarkHidden("log-dir")
 	pflag.CommandLine.MarkHidden("logtostderr")
+	pflag.CommandLine.MarkHidden("log-file")
+	pflag.CommandLine.MarkHidden("log-file-max-size")
+	pflag.CommandLine.MarkHidden("one-output")
+	pflag.CommandLine.MarkHidden("skip-log-headers")
 	pflag.CommandLine.MarkHidden("stderrthreshold")
 	pflag.CommandLine.MarkHidden("vmodule")
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
kubeadm: hide unwanted global klog flags

- --version: no registration at all, no hiding
- --log-flush-frequency: no registration at all, no hiding
- --log-file: no effect when -logtostderr=true, hiding
- --log-file-max-size: no effect when -logtostderr=true, hiding
- --one-output: no effect when -logtostderr=true, hiding
- --skip-log-headers: no effect when -logtostderr=true, hiding

Before
```sh
$ kubeadm -h
...
Flags:
      --add-dir-header           If true, adds the file directory to the header of the log messages
  -h, --help                     help for kubeadm
      --log-file string          If non-empty, use this log file (no effect when -logtostderr=true)
      --log-file-max-size uint   Defines the maximum size a log file can grow to (no effect when -logtostderr=true). Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
      --one-output               If true, only write logs to their native severity level (vs also writing to each lower severity level; no effect when -logtostderr=true)
      --rootfs string            [EXPERIMENTAL] The path to the 'real' host root filesystem.
      --skip-headers             If true, avoid header prefixes in the log messages
      --skip-log-headers         If true, avoid headers when opening log files (no effect when -logtostderr=true)
  -v, --v Level                  number for the log level verbosity
```

After
```sh
$ kubeadm -h
...
Flags:
      --add-dir-header   If true, adds the file directory to the header of the log messages
  -h, --help             help for kubeadm
      --rootfs string    [EXPERIMENTAL] The path to the 'real' host root filesystem.
      --skip-headers     If true, avoid header prefixes in the log messages
  -v, --v Level          number for the log level verbosity
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
