### PR TITLE
WIP: scheduler_perf: add support for CRDs

### DIFF
--- a/test/integration/scheduler_perf/create.go
+++ b/test/integration/scheduler_perf/create.go
@@ -21,7 +21,10 @@ import (
 	"fmt"
 	"testing"
 
+	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
 	clientset "k8s.io/client-go/kubernetes"
 )
 
@@ -69,7 +72,7 @@ func (cro *createOp[T, P]) requiredNamespaces() []string {
 	return []string{cro.Namespace}
 }
 
-func (cro *createOp[T, P]) run(ctx context.Context, tb testing.TB, client clientset.Interface) {
+func (cro *createOp[T, P]) run(ctx context.Context, tb testing.TB, client kubernetes.Interface, dynClient dynamic.Interface, apiClient apiextensionsclient.Interface) {
 	var obj *T
 	var p P
 	if err := getSpecFromFile(&cro.TemplatePath, &obj); err != nil {

--- a/test/integration/scheduler_perf/dra.go
+++ b/test/integration/scheduler_perf/dra.go
@@ -24,7 +24,10 @@ import (
 	"testing"
 
 	resourcev1alpha2 "k8s.io/api/resource/v1alpha2"
+	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
@@ -82,7 +85,7 @@ func (op *createResourceClaimsOp) requiredNamespaces() []string {
 	return []string{op.Namespace}
 }
 
-func (op *createResourceClaimsOp) run(ctx context.Context, tb testing.TB, clientset clientset.Interface) {
+func (op *createResourceClaimsOp) run(ctx context.Context, tb testing.TB, client kubernetes.Interface, dynClient dynamic.Interface, apiClient apiextensionsclient.Interface) {
 	tb.Logf("creating %d claims in namespace %q", op.Count, op.Namespace)
 
 	var claimTemplate *resourcev1alpha2.ResourceClaim
@@ -93,7 +96,7 @@ func (op *createResourceClaimsOp) run(ctx context.Context, tb testing.TB, client
 	var mutex sync.Mutex
 	create := func(i int) {
 		err := func() error {
-			if _, err := clientset.ResourceV1alpha2().ResourceClaims(op.Namespace).Create(ctx, claimTemplate.DeepCopy(), metav1.CreateOptions{}); err != nil {
+			if _, err := client.ResourceV1alpha2().ResourceClaims(op.Namespace).Create(ctx, claimTemplate.DeepCopy(), metav1.CreateOptions{}); err != nil {
 				return fmt.Errorf("create claim: %v", err)
 			}
 			return nil
@@ -186,7 +189,7 @@ func (op *createResourceDriverOp) patchParams(w *workload) (realOp, error) {
 
 func (op *createResourceDriverOp) requiredNamespaces() []string { return nil }
 
-func (op *createResourceDriverOp) run(ctx context.Context, tb testing.TB, clientset clientset.Interface) {
+func (op *createResourceDriverOp) run(ctx context.Context, tb testing.TB, client kubernetes.Interface, dynClient dynamic.Interface, apiClient apiextensionsclient.Interface) {
 	tb.Logf("creating resource driver %q for nodes matching %q", op.DriverName, op.Nodes)
 
 	// Start the controller side of the DRA test driver such that it simulates
@@ -197,7 +200,7 @@ func (op *createResourceDriverOp) run(ctx context.Context, tb testing.TB, client
 		MaxAllocations: op.MaxClaimsPerNode,
 	}
 
-	nodes, err := clientset.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	nodes, err := client.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
 	if err != nil {
 		tb.Fatalf("list nodes: %v", err)
 	}
@@ -211,7 +214,7 @@ func (op *createResourceDriverOp) run(ctx context.Context, tb testing.TB, client
 		}
 	}
 
-	controller := draapp.NewController(clientset, resources)
+	controller := draapp.NewController(client, resources)
 	ctx, cancel := context.WithCancel(ctx)
 	var wg sync.WaitGroup
 	wg.Add(1)

--- a/test/integration/scheduler_perf/scheduler_test.go
+++ b/test/integration/scheduler_perf/scheduler_test.go
@@ -79,7 +79,7 @@ func TestScheduling(t *testing.T) {
 			for feature, flag := range config.featureGates {
 				defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, feature, flag)()
 			}
-			informerFactory, client, dynClient := setupClusterForWorkload(ctx, t, config.schedulerConfigPath, config.featureGates, nil)
+			informerFactory, client, dynClient, apiClient := setupClusterForWorkload(ctx, t, config.schedulerConfigPath, config.featureGates, nil)
 
 			for _, tc := range testCases {
 				if !config.equals(tc) {
@@ -94,7 +94,7 @@ func TestScheduling(t *testing.T) {
 								t.Skipf("disabled by label filter %q", *testSchedulingLabelFilter)
 							}
 							_, ctx := ktesting.NewTestContext(t)
-							runWorkload(ctx, t, tc, w, informerFactory, client, dynClient, true)
+							runWorkload(ctx, t, tc, w, informerFactory, client, dynClient, apiClient, true)
 						})
 					}
 				})


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The ability to create a CRD via the apiextensions client will be useful for DRA and might also be useful elsewhere.

Support for CRDs depends on starting the apiserver via k8s.io/kubernetes/cmd/kube-apiserver/app/testing because only that enables the CRD extensions. As discussed [on Slack](https://kubernetes.slack.com/archives/C0EG7JC6T/p1702906476590319), the long-term goal is to replace the in-tree StartTestServer with the one in staging, so this is going in the right direction.

#### Special notes for your reviewer:

Instead of passing around yet another client Interface, all such interfaces get combined in a single interface.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
