### PR TITLE
dra scheduler: fix incorrect tracking of claim candidates for reallocation

### DIFF
--- a/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources.go
@@ -754,7 +754,7 @@ func (pl *dynamicResources) Filter(ctx context.Context, cs *framework.CycleState
 			// would just get allocated again for a random node,
 			// which is unlikely to help the pod.
 			if claim.Spec.AllocationMode == resourcev1alpha2.AllocationModeWaitForFirstConsumer {
-				state.unavailableClaims.Insert(unavailableClaims...)
+				state.unavailableClaims.Insert(index)
 			}
 		}
 		return statusUnschedulable(logger, "resourceclaim not available on the node", "pod", klog.KObj(pod))


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When dealing with unschedulable pods, the intent was to deallocate only claims which are allocated and use delayed allocation. That if check wasn't handled correctly, causing also claims with immediate allocation to be considered as candidates.

#### Special notes for your reviewer:

Found during code reading, probably has never occurred in practice yet.

#### Does this PR introduce a user-facing change?
```release-note
When using a claim with immediate allocation and a pod referencing that claim couldn't get scheduled, the scheduler incorrectly may have tried to deallocate that claim.
```
