### PR TITLE
e2e: forbid usage of gomega.BeTrue/False

### DIFF
--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -150,6 +150,12 @@ linters-settings: # please keep this alphabetized
     - p: \.Extract
       pkg: ^k8s\.io/client-go/applyconfigurations/
       msg: should not be used because managedFields was removed
+    - p: ^gomega\.BeTrue$
+      pkg: ^github.com/onsi/gomega$
+      msg: "it does not produce a good failure message - use BeTrueBecause with an explicit printf-style failure message instead, or plain Go: if ... { ginkgo.Fail(...) }"
+    - p: ^gomega\.BeFalse$
+      pkg: ^github.com/onsi/gomega$
+      msg: "it does not produce a good failure message - use BeFalseBecause with an explicit printf-style failure message instead, or plain Go: if ... { ginkgo.Fail(...) }"
   revive:
     # Only these rules are enabled.
     rules:

--- a/hack/golangci.yaml.in
+++ b/hack/golangci.yaml.in
@@ -171,6 +171,14 @@ linters-settings: # please keep this alphabetized
     - p: \.Extract
       pkg: ^k8s\.io/client-go/applyconfigurations/
       msg: should not be used because managedFields was removed
+    {{- if .Hints}}
+    - p: ^gomega\.BeTrue$
+      pkg: ^github.com/onsi/gomega$
+      msg: "it does not produce a good failure message - use BeTrueBecause with an explicit printf-style failure message instead, or plain Go: if ... { ginkgo.Fail(...) }"
+    - p: ^gomega\.BeFalse$
+      pkg: ^github.com/onsi/gomega$
+      msg: "it does not produce a good failure message - use BeFalseBecause with an explicit printf-style failure message instead, or plain Go: if ... { ginkgo.Fail(...) }"
+    {{- end}}
   {{- if .Base }}
   gocritic:
     enabled-checks:


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

`BeTrue` without explanation in `Should` just prints "false is not true", which isn't a useful failure message. Even with an explanation that message is still printed, which is just noise. The new `Be[True/False]Because` avoid that by requiring that an explanation is provided and using that instead of "false is not true".

In Kubernetes, we can enforce the usage of those better alternatives or the if+Fail combination via forbidigo. Because we have existing code which still needs to be updated, this can only be a hint for now.

Some examples found with this:
```
ERROR: test/e2e/apimachinery/protocol.go:75:20: use of `o.BeTrue` forbidden because "it does not produce a good failure message, use BeTrueBecause with an explicit printf-style failure message instead or plain Go: if ... { ginkgo.Fail(...) }" (forbidigo)
ERROR: 			o.Expect(ok).To(o.BeTrue())
ERROR: 			                ^

ERROR: test/e2e_node/unknown_pods_test.go:163:52: use of `gomega.BeTrue` forbidden because "it does not produce a good failure message, use BeTrueBecause with an explicit printf-style failure message instead or plain Go: if ... { ginkgo.Fail(...) }" (forbidigo)
ERROR: 			}, f.Timeouts.PodStart, f.Timeouts.Poll).Should(gomega.BeTrue())
ERROR: 			                                                ^
```

The solution might also be to write a custom matcher, but that is a bit hard to explain in the forbidigo message.

#### Which issue(s) this PR fixes:

Related-To: https://github.com/kubernetes/kubernetes/issues/105678

#### Special notes for your reviewer:

Work is under way in the issue to fix existing code. Then this can be promoted from hint to enforced linter check.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/assign @thockin 
