### PR TITLE
[KEP - 4191]: Use Cadvisor labels rather than hard coding them into kubelet

### DIFF
--- a/pkg/kubelet/cadvisor/cadvisor_linux_test.go
+++ b/pkg/kubelet/cadvisor/cadvisor_linux_test.go
@@ -68,7 +68,7 @@ func TestContainerFsInfoLabel(t *testing.T) {
 	}{{
 		description:     "LabelCrioWriteableImages should be returned",
 		runtimeEndpoint: crio.CrioSocket,
-		expectedLabel:   LabelCrioContainers,
+		expectedLabel:   cadvisorfs.LabelCrioContainers,
 		expectedError:   nil,
 	}, {
 		description:     "Cannot find valid imagefs label",

--- a/pkg/kubelet/cadvisor/helpers_linux.go
+++ b/pkg/kubelet/cadvisor/helpers_linux.go
@@ -26,11 +26,6 @@ import (
 	cadvisorfs "github.com/google/cadvisor/fs"
 )
 
-// LabelCrioContainers is a label to allow for cadvisor to track writeable layers
-// separately from read-only layers.
-// Once CAdvisor upstream changes are merged, we should remove this constant
-const LabelCrioContainers string = "crio-containers"
-
 // imageFsInfoProvider knows how to translate the configured runtime
 // to its file system label for images.
 type imageFsInfoProvider struct {
@@ -50,7 +45,7 @@ func (i *imageFsInfoProvider) ImageFsInfoLabel() (string, error) {
 // For remote runtimes, it handles addition runtimes natively understood by cAdvisor.
 func (i *imageFsInfoProvider) ContainerFsInfoLabel() (string, error) {
 	if detectCrioWorkaround(i) {
-		return LabelCrioContainers, nil
+		return cadvisorfs.LabelCrioContainers, nil
 	}
 	return "", fmt.Errorf("no containerfs label for configured runtime")
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
We added a label for the read-only and writeable layers for crio on cadvisor side.

This PR uses the cadvisor constants rather than hardcoding them into kubelet.
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Use cadvisor constants rather than the ones in kubelet.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
