### PR TITLE
Put NPD e2e test behind a feature gate

### DIFF
--- a/test/e2e/feature/feature.go
+++ b/test/e2e/feature/feature.go
@@ -86,6 +86,7 @@ var (
 	NodeAuthorizer                          = framework.WithFeature(framework.ValidFeatures.Add("NodeAuthorizer"))
 	NodeLogQuery                            = framework.WithFeature(framework.ValidFeatures.Add("NodeLogQuery"))
 	NodeOutOfServiceVolumeDetach            = framework.WithFeature(framework.ValidFeatures.Add("NodeOutOfServiceVolumeDetach"))
+	NodeProblemDetector                     = framework.WithFeature(framework.ValidFeatures.Add("NodeProblemDetector"))
 	NoSNAT                                  = framework.WithFeature(framework.ValidFeatures.Add("NoSNAT"))
 	PersistentVolumeLastPhaseTransitionTime = framework.WithFeature(framework.ValidFeatures.Add("PersistentVolumeLastPhaseTransitionTime"))
 	PerformanceDNS                          = framework.WithFeature(framework.ValidFeatures.Add("PerformanceDNS"))

--- a/test/e2e/node/node_problem_detector.go
+++ b/test/e2e/node/node_problem_detector.go
@@ -28,6 +28,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/kubernetes/test/e2e/feature"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2ekubelet "k8s.io/kubernetes/test/e2e/framework/kubelet"
 	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
@@ -42,7 +43,7 @@ import (
 
 // This test checks if node-problem-detector (NPD) runs fine without error on
 // the up to 10 nodes in the cluster. NPD's functionality is tested in e2e_node tests.
-var _ = SIGDescribe("NodeProblemDetector", func() {
+var _ = SIGDescribe(feature.NodeProblemDetector, func() {
 	const (
 		pollInterval      = 1 * time.Second
 		pollTimeout       = 1 * time.Minute


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

NPD test should have a feature tag so it doesn't run by default as it requires a cluster provisioner to install npd. We have dedicated CI job for this feature so we shouldn't lose coverage from this change.

https://testgrid.k8s.io/sig-node-node-problem-detector#ci-npd-e2e-kubernetes-gce-ubuntu

Reason for this change: https://github.com/kubernetes/kops/pull/16176#discussion_r1434141503

Personally, this test should live in the NPD repo.

This is now an issue for kops because kops sets `node-os-distro` ginkgo flag and we have a very long list of skips that are specific to optional non k/k features.

https://github.com/kubernetes/kops/blob/0300a3b858bf389f75d408b5ab9b12744139814c/tests/e2e/pkg/tester/skip_regex.go#L4

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of https://github.com/kubernetes/kubernetes/issues/120989

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
