### PR TITLE
Migrate client-go/rest to contextual logging

### DIFF
--- a/staging/src/k8s.io/client-go/rest/plugin.go
+++ b/staging/src/k8s.io/client-go/rest/plugin.go
@@ -21,9 +21,8 @@ import (
 	"net/http"
 	"sync"
 
-	"k8s.io/klog/v2"
-
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	"k8s.io/klog/v2"
 )
 
 type AuthProvider interface {
@@ -65,7 +64,8 @@ func RegisterAuthProviderPlugin(name string, plugin Factory) error {
 	if _, found := plugins[name]; found {
 		return fmt.Errorf("auth Provider Plugin %q was registered twice", name)
 	}
-	klog.V(4).Infof("Registered Auth Provider Plugin %q", name)
+	//nolint:logchck // For development and debugging only
+	klog.Background().V(4).Info("Registered Auth Provider Plugin", "plugin-name", name)
 	plugins[name] = plugin
 	return nil
 }

--- a/staging/src/k8s.io/client-go/rest/urlbackoff.go
+++ b/staging/src/k8s.io/client-go/rest/urlbackoff.go
@@ -17,6 +17,7 @@ limitations under the License.
 package rest
 
 import (
+	"context"
 	"net/url"
 	"time"
 
@@ -33,8 +34,16 @@ var serverIsOverloadedSet = sets.NewInt(429)
 var maxResponseCode = 499
 
 type BackoffManager interface {
+	//logcheck:context // Use UpdateBackoffWithContext instead in code which supports contextual logging.
 	UpdateBackoff(actualUrl *url.URL, err error, responseCode int)
+
+	UpdateBackoffWithContext(ctx context.Context, actualUrl *url.URL, err error, responseCode int)
+
+	//logcheck:context // Use CalculateBackoffWithContext instead in code which supports contextual logging.
 	CalculateBackoff(actualUrl *url.URL) time.Duration
+
+	CalculateBackoffWithContext(ctx context.Context, actualUrl *url.URL) time.Duration
+
 	Sleep(d time.Duration)
 }
 
@@ -45,15 +54,32 @@ type URLBackoff struct {
 	Backoff *flowcontrol.Backoff
 }
 
+// NewURLBackoff creates a new URLBackoff pointer instance.
+func NewURLBackoff(backoff *flowcontrol.Backoff) *URLBackoff {
+	return &URLBackoff{
+		Backoff: backoff,
+	}
+}
+
 // NoBackoff is a stub implementation, can be used for mocking or else as a default.
 type NoBackoff struct {
 }
 
+//logcheck:context // Use UpdateBackoffWithContext instead in code which supports contextual logging.
 func (n *NoBackoff) UpdateBackoff(actualUrl *url.URL, err error, responseCode int) {
+	n.UpdateBackoffWithContext(context.Background(), actualUrl, err, responseCode)
+}
+
+func (n *NoBackoff) UpdateBackoffWithContext(ctx context.Context, actualUrl *url.URL, err error, responseCode int) {
 	// do nothing.
 }
 
+//logcheck:context // Use CalculateBackoffWithContext instead in code which supports contextual logging.
 func (n *NoBackoff) CalculateBackoff(actualUrl *url.URL) time.Duration {
+	return n.CalculateBackoffWithContext(context.Background(), actualUrl)
+}
+
+func (n *NoBackoff) CalculateBackoffWithContext(ctx context.Context, actualUrl *url.URL) time.Duration {
 	return 0 * time.Second
 }
 
@@ -63,43 +89,60 @@ func (n *NoBackoff) Sleep(d time.Duration) {
 
 // Disable makes the backoff trivial, i.e., sets it to zero.  This might be used
 // by tests which want to run 1000s of mock requests without slowing down.
-func (b *URLBackoff) Disable() {
-	klog.V(4).Infof("Disabling backoff strategy")
+func (b *URLBackoff) Disable(ctx context.Context) {
+	logger := klog.FromContext(ctx)
+	logger.V(4).Info("disabling backoff strategy")
 	b.Backoff = flowcontrol.NewBackOff(0*time.Second, 0*time.Second)
 }
 
 // baseUrlKey returns the key which urls will be mapped to.
 // For example, 127.0.0.1:8080/api/v2/abcde -> 127.0.0.1:8080.
-func (b *URLBackoff) baseUrlKey(rawurl *url.URL) string {
+func (b *URLBackoff) baseUrlKey(rawurl *url.URL, logger klog.Logger) string {
 	// Simple implementation for now, just the host.
 	// We may backoff specific paths (i.e. "pods") differentially
 	// in the future.
 	host, err := url.Parse(rawurl.String())
 	if err != nil {
-		klog.V(4).Infof("Error extracting url: %v", rawurl)
+		logger.V(4).Error(err, "error extracting url", "rawurl", rawurl)
 		panic("bad url!")
 	}
 	return host.Host
 }
 
 // UpdateBackoff updates backoff metadata
+//
+//logcheck:context // Use UpdateBackoffWithContext instead in code which supports contextual logging.
 func (b *URLBackoff) UpdateBackoff(actualUrl *url.URL, err error, responseCode int) {
+	b.UpdateBackoffWithContext(context.Background(), actualUrl, err, responseCode)
+}
+
+// UpdateBackoffWithContext updates backoff metadata and supports contextual logging
+func (b *URLBackoff) UpdateBackoffWithContext(ctx context.Context, actualUrl *url.URL, err error, responseCode int) {
+	logger := klog.FromContext(ctx)
 	// range for retry counts that we store is [0,13]
 	if responseCode > maxResponseCode || serverIsOverloadedSet.Has(responseCode) {
-		b.Backoff.Next(b.baseUrlKey(actualUrl), b.Backoff.Clock.Now())
+		b.Backoff.Next(b.baseUrlKey(actualUrl, logger), b.Backoff.Clock.Now())
 		return
 	} else if responseCode >= 300 || err != nil {
-		klog.V(4).Infof("Client is returning errors: code %v, error %v", responseCode, err)
+		logger.V(4).Info("client is returning errors", "code", responseCode, "err", err)
 	}
 
 	//If we got this far, there is no backoff required for this URL anymore.
-	b.Backoff.Reset(b.baseUrlKey(actualUrl))
+	b.Backoff.Reset(b.baseUrlKey(actualUrl, logger))
 }
 
-// CalculateBackoff takes a url and back's off exponentially,
-// based on its knowledge of existing failures.
+// CalculateBackoff takes a url and back's off exponentially, based on its knowledge of existing failures.
+//
+//logcheck:context // Use CalculateBackoffWithContext instead in code which supports contextual logging.
 func (b *URLBackoff) CalculateBackoff(actualUrl *url.URL) time.Duration {
-	return b.Backoff.Get(b.baseUrlKey(actualUrl))
+	return b.CalculateBackoffWithContext(context.Background(), actualUrl)
+}
+
+// CalculateBackoff takes a url and back's off exponentially, based on its knowledge of existing failures.
+// This method supports contextual logging.
+func (b *URLBackoff) CalculateBackoffWithContext(ctx context.Context, actualUrl *url.URL) time.Duration {
+	logger := klog.FromContext(ctx)
+	return b.Backoff.Get(b.baseUrlKey(actualUrl, logger))
 }
 
 func (b *URLBackoff) Sleep(d time.Duration) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Migrate client-go/rest to contextual logging

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes [[#3077 ]()](https://github.com/kubernetes/enhancements/issues/3077)

#### Special notes for your reviewer:

Check result of logcheck:
```
# echo "Component | Non-Structured Logging | Non-Contextual Logging | Owner " && echo "------ | ------- |  ------- | ------" && for i in $(find staging/src/k8s.io/client-go/rest  -maxdepth 0 -type d | sort); do      echo "$i | $(cd $i; ${GOPATH}/bin/logcheck -check-structured -check-deprecations=false 2>&1 ./... | wc -l ) | $(cd $i; ${GOPATH}/bin/logcheck -check-structured -check-deprecations=false -check-contextual ./... 2>&1 | wc -l ) |" | grep -v '| 0 | 0 |'; done
Component | Non-Structured Logging | Non-Contextual Logging | Owner
------ | ------- |  ------- | ------
staging/src/k8s.io/client-go/rest |        0 |        0 |
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Migrate client-go/rest to contextual logging
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/42bb993e369d166142b7181e90882066ad6c7651/keps/sig-instrumentation/3077-contextual-logging
```
