### PR TITLE
Initialize default attach func regardless of the value of flag

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go
@@ -213,14 +213,15 @@ func (o *DebugOptions) Complete(restClientGetter genericclioptions.RESTClientGet
 	attachFlag := cmd.Flags().Lookup("attach")
 	if !attachFlag.Changed && o.Interactive {
 		o.Attach = true
-		// Downstream tools may want to use their own customized
-		// attach function to do extra work or use attach command
-		// with different flags instead of the static one defined in
-		// handleAttachPod. But if this function is not set explicitly,
-		// we fall back to default.
-		if o.AttachFunc == nil {
-			o.AttachFunc = o.handleAttachPod
-		}
+	}
+
+	// Downstream tools may want to use their own customized
+	// attach function to do extra work or use attach command
+	// with different flags instead of the static one defined in
+	// handleAttachPod. But if this function is not set explicitly,
+	// we fall back to default.
+	if o.AttachFunc == nil {
+		o.AttachFunc = o.handleAttachPod
 	}
 
 	// Environment


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
This PR https://github.com/kubernetes/kubernetes/pull/119537 has made `attachFunc`
customizable. However, it has brought about a bug that when user passes `--attach` flag, 
it skips the initialization of the function and does not attach.

This PR initializes attachFunc regardless of the value of attach flag.

#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/kubectl/issues/1539

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Fixes a 1.29.0 regression in kubectl that did not honor the --attach flag.
```
