### PR TITLE
Automated cherry pick of #122447: Initialize default attach func regardless of the value of

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go
@@ -213,14 +213,15 @@ func (o *DebugOptions) Complete(restClientGetter genericclioptions.RESTClientGet
 	attachFlag := cmd.Flags().Lookup("attach")
 	if !attachFlag.Changed && o.Interactive {
 		o.Attach = true
-		// Downstream tools may want to use their own customized
-		// attach function to do extra work or use attach command
-		// with different flags instead of the static one defined in
-		// handleAttachPod. But if this function is not set explicitly,
-		// we fall back to default.
-		if o.AttachFunc == nil {
-			o.AttachFunc = o.handleAttachPod
-		}
+	}
+
+	// Downstream tools may want to use their own customized
+	// attach function to do extra work or use attach command
+	// with different flags instead of the static one defined in
+	// handleAttachPod. But if this function is not set explicitly,
+	// we fall back to default.
+	if o.AttachFunc == nil {
+		o.AttachFunc = o.handleAttachPod
 	}
 
 	// Environment


### PR DESCRIPTION
Cherry pick of #122447 on release-1.29.

#122447: Initialize default attach func regardless of the value of

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fixes a 1.29.0 regression in kubectl that did not honor the --attach flag.
```