### PR TITLE
Refactor metric function names for clarity

### DIFF
--- a/pkg/scheduler/internal/queue/scheduling_queue_test.go
+++ b/pkg/scheduler/internal/queue/scheduling_queue_test.go
@@ -2825,10 +2825,10 @@ scheduler_plugin_execution_duration_seconds_count{extension_point="PreEnqueue",p
 	}
 
 	resetMetrics := func() {
-		metrics.ActivePods().Set(0)
-		metrics.BackoffPods().Set(0)
-		metrics.UnschedulablePods().Set(0)
-		metrics.GatedPods().Set(0)
+		metrics.ActivePendingPods().Set(0)
+		metrics.BackoffPendingPods().Set(0)
+		metrics.UnschedulablePendingPods().Set(0)
+		metrics.GatedPendingPods().Set(0)
 		metrics.PluginExecutionDuration.Reset()
 	}
 

--- a/pkg/scheduler/metrics/metric_recorder.go
+++ b/pkg/scheduler/metrics/metric_recorder.go
@@ -40,28 +40,28 @@ type PendingPodsRecorder struct {
 // NewActivePodsRecorder returns ActivePods in a Prometheus metric fashion
 func NewActivePodsRecorder() *PendingPodsRecorder {
 	return &PendingPodsRecorder{
-		recorder: ActivePods(),
+		recorder: ActivePendingPods(),
 	}
 }
 
 // NewUnschedulablePodsRecorder returns UnschedulablePods in a Prometheus metric fashion
 func NewUnschedulablePodsRecorder() *PendingPodsRecorder {
 	return &PendingPodsRecorder{
-		recorder: UnschedulablePods(),
+		recorder: UnschedulablePendingPods(),
 	}
 }
 
 // NewBackoffPodsRecorder returns BackoffPods in a Prometheus metric fashion
 func NewBackoffPodsRecorder() *PendingPodsRecorder {
 	return &PendingPodsRecorder{
-		recorder: BackoffPods(),
+		recorder: BackoffPendingPods(),
 	}
 }
 
 // NewGatedPodsRecorder returns GatedPods in a Prometheus metric fashion
 func NewGatedPodsRecorder() *PendingPodsRecorder {
 	return &PendingPodsRecorder{
-		recorder: GatedPods(),
+		recorder: GatedPendingPods(),
 	}
 }
 

--- a/pkg/scheduler/metrics/metrics.go
+++ b/pkg/scheduler/metrics/metrics.go
@@ -258,23 +258,23 @@ func GetGather() metrics.Gatherer {
 	return legacyregistry.DefaultGatherer
 }
 
-// ActivePods returns the pending pods metrics with the label active
-func ActivePods() metrics.GaugeMetric {
+// ActivePendingPods returns the pending pods metrics with the label active
+func ActivePendingPods() metrics.GaugeMetric {
 	return pendingPods.With(metrics.Labels{"queue": "active"})
 }
 
-// BackoffPods returns the pending pods metrics with the label backoff
-func BackoffPods() metrics.GaugeMetric {
+// BackoffPendingPods returns the pending pods metrics with the label backoff
+func BackoffPendingPods() metrics.GaugeMetric {
 	return pendingPods.With(metrics.Labels{"queue": "backoff"})
 }
 
-// UnschedulablePods returns the pending pods metrics with the label unschedulable
-func UnschedulablePods() metrics.GaugeMetric {
+// UnschedulablePendingPods returns the pending pods metrics with the label unschedulable
+func UnschedulablePendingPods() metrics.GaugeMetric {
 	return pendingPods.With(metrics.Labels{"queue": "unschedulable"})
 }
 
-// GatedPods returns the pending pods metrics with the label gated
-func GatedPods() metrics.GaugeMetric {
+// GatedPendingPods returns the pending pods metrics with the label gated
+func GatedPendingPods() metrics.GaugeMetric {
 	return pendingPods.With(metrics.Labels{"queue": "gated"})
 }
 


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:

I was confused about whether is was PendingPod or IncomingPod, so I'll clear it up.

- Rename ActivePods to ActivePendingPods
- Rename BackoffPods to BackoffPendingPods
- Rename UnschedulablePods to UnschedulablePendingPods
- Rename GatedPods to GatedPendingPods

This change makes it clearer that the metrics track the state of pending pods.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
