### PR TITLE
Fix dry-run flag in go-runner and run_e2e.sh scripts

### DIFF
--- a/test/conformance/image/go-runner/cmd.go
+++ b/test/conformance/image/go-runner/cmd.go
@@ -70,7 +70,7 @@ func getCmd(env Getenver, w io.Writer) *exec.Cmd {
 	}
 
 	if len(env.Getenv(dryRunEnvKey)) > 0 {
-		ginkgoArgs = append(ginkgoArgs, "--dryRun=true")
+		ginkgoArgs = append(ginkgoArgs, "--dry-run=true")
 	}
 	// NOTE: Ginkgo's default timeout has been reduced from 24h to 1h in V2, set it as "24h" for backward compatibility
 	// if this is not set by env of extraGinkgoArgsEnvKey.

--- a/test/conformance/image/run_e2e.sh
+++ b/test/conformance/image/run_e2e.sh
@@ -49,7 +49,7 @@ trap shutdown TERM
 
 ginkgo_args=()
 if [[ -n ${E2E_DRYRUN:-} ]]; then
-    ginkgo_args+=("--dryRun=true")
+    ginkgo_args+=("--dry-run=true")
 fi
 
 # NOTE: Ginkgo's default timeout has been reduced from 24h to 1h in V2, set it manually here as "24h"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
In Ginkgo v2 the `--dryRun` flag was deprecated in favor of `--dry-run`. This PR updates our conformance container to reference the correct flag. 

ref: https://github.com/onsi/ginkgo/blob/master/types/config.go#L278

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

xref: https://github.com/dims/hydrophone/pull/48