### PR TITLE
client-go/testing: support for finalizer

### DIFF
--- a/pkg/controller/resourceclaim/controller_test.go
+++ b/pkg/controller/resourceclaim/controller_test.go
@@ -327,11 +327,7 @@ func TestSyncHandler(t *testing.T) {
 				return []*resourceapi.ResourceClaim{claim}
 			}(),
 			expectedClaims: func() []resourceapi.ResourceClaim {
-				claim := structuredParameters(testClaimAllocated.DeepCopy())
-				claim.DeletionTimestamp = &metav1.Time{}
-				claim.Finalizers = []string{}
-				claim.Status.Allocation = nil
-				return []resourceapi.ResourceClaim{*claim}
+				return nil // finalizer got removed
 			}(),
 			expectedMetrics: expectedMetrics{0, 0},
 		},
@@ -345,11 +341,7 @@ func TestSyncHandler(t *testing.T) {
 				return []*resourceapi.ResourceClaim{claim}
 			}(),
 			expectedClaims: func() []resourceapi.ResourceClaim {
-				claim := structuredParameters(testClaimAllocated.DeepCopy())
-				claim.DeletionTimestamp = &metav1.Time{}
-				claim.Finalizers = []string{}
-				claim.Status.Allocation = nil
-				return []resourceapi.ResourceClaim{*claim}
+				return nil // finalizer got removed
 			}(),
 			expectedMetrics: expectedMetrics{0, 0},
 		},
@@ -649,7 +641,9 @@ func normalizeScheduling(scheduling []resourceapi.PodSchedulingContext) []resour
 }
 
 func createTestClient(objects ...runtime.Object) *fake.Clientset {
-	fakeClient := fake.NewSimpleClientset(objects...)
+	fakeClient := fake.NewClientsetWithOptions(fake.ClientsetOptions{
+		SupportsFinalizer: true,
+	}, objects...)
 	fakeClient.PrependReactor("create", "resourceclaims", createResourceClaimReactor())
 	return fakeClient
 }

--- a/staging/publishing/import-restrictions.yaml
+++ b/staging/publishing/import-restrictions.yaml
@@ -161,7 +161,7 @@
   - k8s.io/component-base
   - k8s.io/kube-openapi
   - k8s.io/sample-apiserver
-  - k8s.io/utils/net
+  - k8s.io/utils
   - k8s.io/klog
 
 - baseImportPath: "./staging/src/k8s.io/apiextensions-apiserver"

--- a/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/clientset/versioned/fake/clientset_generated.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/clientset/versioned/fake/clientset_generated.go
@@ -24,10 +24,12 @@ import (
 	crv1 "k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/clientset/versioned/typed/cr/v1"
 	fakecrv1 "k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/clientset/versioned/typed/cr/v1/fake"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/managedfields"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/discovery"
 	fakediscovery "k8s.io/client-go/discovery/fake"
 	"k8s.io/client-go/testing"
+	"k8s.io/utils/clock"
 )
 
 // NewSimpleClientset returns a clientset that will respond with the provided objects.
@@ -79,15 +81,29 @@ func (c *Clientset) Tracker() testing.ObjectTracker {
 	return c.tracker
 }
 
-// NewClientset returns a clientset that will respond with the provided objects.
-// It's backed by a very simple object tracker that processes creates, updates and deletions as-is,
-// without applying any validations and/or defaults. It shouldn't be considered a replacement
-// for a real clientset and is mostly useful in simple unit tests.
-func NewClientset(objects ...runtime.Object) *Clientset {
-	o := testing.NewFieldManagedObjectTracker(
+type ClientsetOptions struct {
+	// Whether to block deletion when the object has finalizers, and delete the object if the finalizers are removed.
+	SupportsFinalizer bool
+	// Support field management to improve server side apply testing
+	ManagedFields bool
+
+	Clock clock.PassiveClock
+}
+
+// NewClientsetWithOptions likes NewClientset but takes additional options.
+func NewClientsetWithOptions(options ClientsetOptions, objects ...runtime.Object) *Clientset {
+	var typeConverter managedfields.TypeConverter
+	if options.ManagedFields {
+		typeConverter = applyconfiguration.NewTypeConverter(scheme)
+	}
+	o := testing.NewObjectTrackerWithOptions(
 		scheme,
 		codecs.UniversalDecoder(),
-		applyconfiguration.NewTypeConverter(scheme),
+		testing.ObjectTrackerOptions{
+			Clock:             options.Clock,
+			SupportsFinalizer: options.SupportsFinalizer,
+			TypeConverter:     typeConverter,
+		},
 	)
 	for _, obj := range objects {
 		if err := o.Add(obj); err != nil {
@@ -109,6 +125,16 @@ func NewClientset(objects ...runtime.Object) *Clientset {
 	})
 
 	return cs
+}
+
+// NewClientset returns a clientset that will respond with the provided objects.
+// It's backed by a very simple object tracker that processes creates, updates and deletions as-is,
+// without applying any validations and/or defaults. It shouldn't be considered a replacement
+// for a real clientset and is mostly useful in simple unit tests.
+func NewClientset(objects ...runtime.Object) *Clientset {
+	return NewClientsetWithOptions(ClientsetOptions{
+		ManagedFields: true,
+	}, objects...)
 }
 
 var (

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake/clientset_generated.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake/clientset_generated.go
@@ -26,10 +26,12 @@ import (
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1"
 	fakeapiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1/fake"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/managedfields"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/discovery"
 	fakediscovery "k8s.io/client-go/discovery/fake"
 	"k8s.io/client-go/testing"
+	"k8s.io/utils/clock"
 )
 
 // NewSimpleClientset returns a clientset that will respond with the provided objects.
@@ -81,15 +83,29 @@ func (c *Clientset) Tracker() testing.ObjectTracker {
 	return c.tracker
 }
 
-// NewClientset returns a clientset that will respond with the provided objects.
-// It's backed by a very simple object tracker that processes creates, updates and deletions as-is,
-// without applying any validations and/or defaults. It shouldn't be considered a replacement
-// for a real clientset and is mostly useful in simple unit tests.
-func NewClientset(objects ...runtime.Object) *Clientset {
-	o := testing.NewFieldManagedObjectTracker(
+type ClientsetOptions struct {
+	// Whether to block deletion when the object has finalizers, and delete the object if the finalizers are removed.
+	SupportsFinalizer bool
+	// Support field management to improve server side apply testing
+	ManagedFields bool
+
+	Clock clock.PassiveClock
+}
+
+// NewClientsetWithOptions likes NewClientset but takes additional options.
+func NewClientsetWithOptions(options ClientsetOptions, objects ...runtime.Object) *Clientset {
+	var typeConverter managedfields.TypeConverter
+	if options.ManagedFields {
+		typeConverter = applyconfiguration.NewTypeConverter(scheme)
+	}
+	o := testing.NewObjectTrackerWithOptions(
 		scheme,
 		codecs.UniversalDecoder(),
-		applyconfiguration.NewTypeConverter(scheme),
+		testing.ObjectTrackerOptions{
+			Clock:             options.Clock,
+			SupportsFinalizer: options.SupportsFinalizer,
+			TypeConverter:     typeConverter,
+		},
 	)
 	for _, obj := range objects {
 		if err := o.Add(obj); err != nil {
@@ -111,6 +127,16 @@ func NewClientset(objects ...runtime.Object) *Clientset {
 	})
 
 	return cs
+}
+
+// NewClientset returns a clientset that will respond with the provided objects.
+// It's backed by a very simple object tracker that processes creates, updates and deletions as-is,
+// without applying any validations and/or defaults. It shouldn't be considered a replacement
+// for a real clientset and is mostly useful in simple unit tests.
+func NewClientset(objects ...runtime.Object) *Clientset {
+	return NewClientsetWithOptions(ClientsetOptions{
+		ManagedFields: true,
+	}, objects...)
 }
 
 var (

--- a/staging/src/k8s.io/client-go/kubernetes/fake/clientset_generated.go
+++ b/staging/src/k8s.io/client-go/kubernetes/fake/clientset_generated.go
@@ -20,6 +20,7 @@ package fake
 
 import (
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/managedfields"
 	"k8s.io/apimachinery/pkg/watch"
 	applyconfigurations "k8s.io/client-go/applyconfigurations"
 	"k8s.io/client-go/discovery"
@@ -132,6 +133,7 @@ import (
 	storagemigrationv1alpha1 "k8s.io/client-go/kubernetes/typed/storagemigration/v1alpha1"
 	fakestoragemigrationv1alpha1 "k8s.io/client-go/kubernetes/typed/storagemigration/v1alpha1/fake"
 	"k8s.io/client-go/testing"
+	"k8s.io/utils/clock"
 )
 
 // NewSimpleClientset returns a clientset that will respond with the provided objects.
@@ -183,15 +185,29 @@ func (c *Clientset) Tracker() testing.ObjectTracker {
 	return c.tracker
 }
 
-// NewClientset returns a clientset that will respond with the provided objects.
-// It's backed by a very simple object tracker that processes creates, updates and deletions as-is,
-// without applying any validations and/or defaults. It shouldn't be considered a replacement
-// for a real clientset and is mostly useful in simple unit tests.
-func NewClientset(objects ...runtime.Object) *Clientset {
-	o := testing.NewFieldManagedObjectTracker(
+type ClientsetOptions struct {
+	// Whether to block deletion when the object has finalizers, and delete the object if the finalizers are removed.
+	SupportsFinalizer bool
+	// Support field management to improve server side apply testing
+	ManagedFields bool
+
+	Clock clock.PassiveClock
+}
+
+// NewClientsetWithOptions likes NewClientset but takes additional options.
+func NewClientsetWithOptions(options ClientsetOptions, objects ...runtime.Object) *Clientset {
+	var typeConverter managedfields.TypeConverter
+	if options.ManagedFields {
+		typeConverter = applyconfigurations.NewTypeConverter(scheme)
+	}
+	o := testing.NewObjectTrackerWithOptions(
 		scheme,
 		codecs.UniversalDecoder(),
-		applyconfigurations.NewTypeConverter(scheme),
+		testing.ObjectTrackerOptions{
+			Clock:             options.Clock,
+			SupportsFinalizer: options.SupportsFinalizer,
+			TypeConverter:     typeConverter,
+		},
 	)
 	for _, obj := range objects {
 		if err := o.Add(obj); err != nil {
@@ -213,6 +229,16 @@ func NewClientset(objects ...runtime.Object) *Clientset {
 	})
 
 	return cs
+}
+
+// NewClientset returns a clientset that will respond with the provided objects.
+// It's backed by a very simple object tracker that processes creates, updates and deletions as-is,
+// without applying any validations and/or defaults. It shouldn't be considered a replacement
+// for a real clientset and is mostly useful in simple unit tests.
+func NewClientset(objects ...runtime.Object) *Clientset {
+	return NewClientsetWithOptions(ClientsetOptions{
+		ManagedFields: true,
+	}, objects...)
 }
 
 var (

--- a/staging/src/k8s.io/client-go/testing/fixture_test.go
+++ b/staging/src/k8s.io/client-go/testing/fixture_test.go
@@ -646,7 +646,9 @@ func TestDeleteWithFinalizer(t *testing.T) {
 	scheme := runtime.NewScheme()
 	codecs := serializer.NewCodecFactory(scheme)
 
-	o := NewObjectTracker(scheme, codecs.UniversalDecoder())
+	o := NewObjectTrackerWithOptions(scheme, codecs.UniversalDecoder(), ObjectTrackerOptions{
+		SupportsFinalizer: true,
+	})
 	gvr := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "PersistentVolumeClaim"}
 	pvc := getArbitraryResource(gvr, "pvc", "test-ns")
 	require.NoError(t, o.Add(pvc))

--- a/staging/src/k8s.io/code-generator/examples/MixedCase/clientset/versioned/fake/clientset_generated.go
+++ b/staging/src/k8s.io/code-generator/examples/MixedCase/clientset/versioned/fake/clientset_generated.go
@@ -20,6 +20,7 @@ package fake
 
 import (
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/managedfields"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/discovery"
 	fakediscovery "k8s.io/client-go/discovery/fake"
@@ -28,6 +29,7 @@ import (
 	clientset "k8s.io/code-generator/examples/MixedCase/clientset/versioned"
 	examplev1 "k8s.io/code-generator/examples/MixedCase/clientset/versioned/typed/example/v1"
 	fakeexamplev1 "k8s.io/code-generator/examples/MixedCase/clientset/versioned/typed/example/v1/fake"
+	"k8s.io/utils/clock"
 )
 
 // NewSimpleClientset returns a clientset that will respond with the provided objects.
@@ -79,15 +81,29 @@ func (c *Clientset) Tracker() testing.ObjectTracker {
 	return c.tracker
 }
 
-// NewClientset returns a clientset that will respond with the provided objects.
-// It's backed by a very simple object tracker that processes creates, updates and deletions as-is,
-// without applying any validations and/or defaults. It shouldn't be considered a replacement
-// for a real clientset and is mostly useful in simple unit tests.
-func NewClientset(objects ...runtime.Object) *Clientset {
-	o := testing.NewFieldManagedObjectTracker(
+type ClientsetOptions struct {
+	// Whether to block deletion when the object has finalizers, and delete the object if the finalizers are removed.
+	SupportsFinalizer bool
+	// Support field management to improve server side apply testing
+	ManagedFields bool
+
+	Clock clock.PassiveClock
+}
+
+// NewClientsetWithOptions likes NewClientset but takes additional options.
+func NewClientsetWithOptions(options ClientsetOptions, objects ...runtime.Object) *Clientset {
+	var typeConverter managedfields.TypeConverter
+	if options.ManagedFields {
+		typeConverter = applyconfiguration.NewTypeConverter(scheme)
+	}
+	o := testing.NewObjectTrackerWithOptions(
 		scheme,
 		codecs.UniversalDecoder(),
-		applyconfiguration.NewTypeConverter(scheme),
+		testing.ObjectTrackerOptions{
+			Clock:             options.Clock,
+			SupportsFinalizer: options.SupportsFinalizer,
+			TypeConverter:     typeConverter,
+		},
 	)
 	for _, obj := range objects {
 		if err := o.Add(obj); err != nil {
@@ -109,6 +125,16 @@ func NewClientset(objects ...runtime.Object) *Clientset {
 	})
 
 	return cs
+}
+
+// NewClientset returns a clientset that will respond with the provided objects.
+// It's backed by a very simple object tracker that processes creates, updates and deletions as-is,
+// without applying any validations and/or defaults. It shouldn't be considered a replacement
+// for a real clientset and is mostly useful in simple unit tests.
+func NewClientset(objects ...runtime.Object) *Clientset {
+	return NewClientsetWithOptions(ClientsetOptions{
+		ManagedFields: true,
+	}, objects...)
 }
 
 var (

--- a/staging/src/k8s.io/code-generator/examples/crd/clientset/versioned/fake/clientset_generated.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/clientset/versioned/fake/clientset_generated.go
@@ -20,6 +20,7 @@ package fake
 
 import (
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/managedfields"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/discovery"
 	fakediscovery "k8s.io/client-go/discovery/fake"
@@ -30,6 +31,7 @@ import (
 	fakeexamplev1 "k8s.io/code-generator/examples/crd/clientset/versioned/typed/example/v1/fake"
 	secondexamplev1 "k8s.io/code-generator/examples/crd/clientset/versioned/typed/example2/v1"
 	fakesecondexamplev1 "k8s.io/code-generator/examples/crd/clientset/versioned/typed/example2/v1/fake"
+	"k8s.io/utils/clock"
 )
 
 // NewSimpleClientset returns a clientset that will respond with the provided objects.
@@ -81,15 +83,29 @@ func (c *Clientset) Tracker() testing.ObjectTracker {
 	return c.tracker
 }
 
-// NewClientset returns a clientset that will respond with the provided objects.
-// It's backed by a very simple object tracker that processes creates, updates and deletions as-is,
-// without applying any validations and/or defaults. It shouldn't be considered a replacement
-// for a real clientset and is mostly useful in simple unit tests.
-func NewClientset(objects ...runtime.Object) *Clientset {
-	o := testing.NewFieldManagedObjectTracker(
+type ClientsetOptions struct {
+	// Whether to block deletion when the object has finalizers, and delete the object if the finalizers are removed.
+	SupportsFinalizer bool
+	// Support field management to improve server side apply testing
+	ManagedFields bool
+
+	Clock clock.PassiveClock
+}
+
+// NewClientsetWithOptions likes NewClientset but takes additional options.
+func NewClientsetWithOptions(options ClientsetOptions, objects ...runtime.Object) *Clientset {
+	var typeConverter managedfields.TypeConverter
+	if options.ManagedFields {
+		typeConverter = applyconfiguration.NewTypeConverter(scheme)
+	}
+	o := testing.NewObjectTrackerWithOptions(
 		scheme,
 		codecs.UniversalDecoder(),
-		applyconfiguration.NewTypeConverter(scheme),
+		testing.ObjectTrackerOptions{
+			Clock:             options.Clock,
+			SupportsFinalizer: options.SupportsFinalizer,
+			TypeConverter:     typeConverter,
+		},
 	)
 	for _, obj := range objects {
 		if err := o.Add(obj); err != nil {
@@ -111,6 +127,16 @@ func NewClientset(objects ...runtime.Object) *Clientset {
 	})
 
 	return cs
+}
+
+// NewClientset returns a clientset that will respond with the provided objects.
+// It's backed by a very simple object tracker that processes creates, updates and deletions as-is,
+// without applying any validations and/or defaults. It shouldn't be considered a replacement
+// for a real clientset and is mostly useful in simple unit tests.
+func NewClientset(objects ...runtime.Object) *Clientset {
+	return NewClientsetWithOptions(ClientsetOptions{
+		ManagedFields: true,
+	}, objects...)
 }
 
 var (

--- a/staging/src/k8s.io/code-generator/examples/go.mod
+++ b/staging/src/k8s.io/code-generator/examples/go.mod
@@ -9,6 +9,7 @@ require (
 	k8s.io/apimachinery v0.0.0
 	k8s.io/client-go v0.0.0
 	k8s.io/kube-openapi v0.0.0-20240827152857-f7e401e7b4c2
+	k8s.io/utils v0.0.0-20240711033017-18e509b52bc8
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1
 )
 
@@ -46,7 +47,6 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
-	k8s.io/utils v0.0.0-20240711033017-18e509b52bc8 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )

--- a/staging/src/k8s.io/code-generator/examples/single/clientset/versioned/fake/clientset_generated.go
+++ b/staging/src/k8s.io/code-generator/examples/single/clientset/versioned/fake/clientset_generated.go
@@ -20,6 +20,7 @@ package fake
 
 import (
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/managedfields"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/discovery"
 	fakediscovery "k8s.io/client-go/discovery/fake"
@@ -28,6 +29,7 @@ import (
 	clientset "k8s.io/code-generator/examples/single/clientset/versioned"
 	examplev1 "k8s.io/code-generator/examples/single/clientset/versioned/typed/api/v1"
 	fakeexamplev1 "k8s.io/code-generator/examples/single/clientset/versioned/typed/api/v1/fake"
+	"k8s.io/utils/clock"
 )
 
 // NewSimpleClientset returns a clientset that will respond with the provided objects.
@@ -79,15 +81,29 @@ func (c *Clientset) Tracker() testing.ObjectTracker {
 	return c.tracker
 }
 
-// NewClientset returns a clientset that will respond with the provided objects.
-// It's backed by a very simple object tracker that processes creates, updates and deletions as-is,
-// without applying any validations and/or defaults. It shouldn't be considered a replacement
-// for a real clientset and is mostly useful in simple unit tests.
-func NewClientset(objects ...runtime.Object) *Clientset {
-	o := testing.NewFieldManagedObjectTracker(
+type ClientsetOptions struct {
+	// Whether to block deletion when the object has finalizers, and delete the object if the finalizers are removed.
+	SupportsFinalizer bool
+	// Support field management to improve server side apply testing
+	ManagedFields bool
+
+	Clock clock.PassiveClock
+}
+
+// NewClientsetWithOptions likes NewClientset but takes additional options.
+func NewClientsetWithOptions(options ClientsetOptions, objects ...runtime.Object) *Clientset {
+	var typeConverter managedfields.TypeConverter
+	if options.ManagedFields {
+		typeConverter = applyconfiguration.NewTypeConverter(scheme)
+	}
+	o := testing.NewObjectTrackerWithOptions(
 		scheme,
 		codecs.UniversalDecoder(),
-		applyconfiguration.NewTypeConverter(scheme),
+		testing.ObjectTrackerOptions{
+			Clock:             options.Clock,
+			SupportsFinalizer: options.SupportsFinalizer,
+			TypeConverter:     typeConverter,
+		},
 	)
 	for _, obj := range objects {
 		if err := o.Add(obj); err != nil {
@@ -109,6 +125,16 @@ func NewClientset(objects ...runtime.Object) *Clientset {
 	})
 
 	return cs
+}
+
+// NewClientset returns a clientset that will respond with the provided objects.
+// It's backed by a very simple object tracker that processes creates, updates and deletions as-is,
+// without applying any validations and/or defaults. It shouldn't be considered a replacement
+// for a real clientset and is mostly useful in simple unit tests.
+func NewClientset(objects ...runtime.Object) *Clientset {
+	return NewClientsetWithOptions(ClientsetOptions{
+		ManagedFields: true,
+	}, objects...)
 }
 
 var (

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/fake/clientset_generated.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/fake/clientset_generated.go
@@ -20,6 +20,7 @@ package fake
 
 import (
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/managedfields"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/discovery"
 	fakediscovery "k8s.io/client-go/discovery/fake"
@@ -30,6 +31,7 @@ import (
 	fakewardlev1alpha1 "k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1alpha1/fake"
 	wardlev1beta1 "k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1beta1"
 	fakewardlev1beta1 "k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1beta1/fake"
+	"k8s.io/utils/clock"
 )
 
 // NewSimpleClientset returns a clientset that will respond with the provided objects.
@@ -81,15 +83,29 @@ func (c *Clientset) Tracker() testing.ObjectTracker {
 	return c.tracker
 }
 
-// NewClientset returns a clientset that will respond with the provided objects.
-// It's backed by a very simple object tracker that processes creates, updates and deletions as-is,
-// without applying any validations and/or defaults. It shouldn't be considered a replacement
-// for a real clientset and is mostly useful in simple unit tests.
-func NewClientset(objects ...runtime.Object) *Clientset {
-	o := testing.NewFieldManagedObjectTracker(
+type ClientsetOptions struct {
+	// Whether to block deletion when the object has finalizers, and delete the object if the finalizers are removed.
+	SupportsFinalizer bool
+	// Support field management to improve server side apply testing
+	ManagedFields bool
+
+	Clock clock.PassiveClock
+}
+
+// NewClientsetWithOptions likes NewClientset but takes additional options.
+func NewClientsetWithOptions(options ClientsetOptions, objects ...runtime.Object) *Clientset {
+	var typeConverter managedfields.TypeConverter
+	if options.ManagedFields {
+		typeConverter = applyconfiguration.NewTypeConverter(scheme)
+	}
+	o := testing.NewObjectTrackerWithOptions(
 		scheme,
 		codecs.UniversalDecoder(),
-		applyconfiguration.NewTypeConverter(scheme),
+		testing.ObjectTrackerOptions{
+			Clock:             options.Clock,
+			SupportsFinalizer: options.SupportsFinalizer,
+			TypeConverter:     typeConverter,
+		},
 	)
 	for _, obj := range objects {
 		if err := o.Add(obj); err != nil {
@@ -111,6 +127,16 @@ func NewClientset(objects ...runtime.Object) *Clientset {
 	})
 
 	return cs
+}
+
+// NewClientset returns a clientset that will respond with the provided objects.
+// It's backed by a very simple object tracker that processes creates, updates and deletions as-is,
+// without applying any validations and/or defaults. It shouldn't be considered a replacement
+// for a real clientset and is mostly useful in simple unit tests.
+func NewClientset(objects ...runtime.Object) *Clientset {
+	return NewClientsetWithOptions(ClientsetOptions{
+		ManagedFields: true,
+	}, objects...)
 }
 
 var (


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

* Set DeletionTimestamp if an object is deleted with finalizer present.
* Delete object if DeletionTimestamp is present and finalizer is cleared.

Note that DeletionGracePeriodSeconds is still not supported, and is always treated as zero.

The fake clientsets gain a new func to pass in additional options. So that we can enable finalizer support for each test separately.

To avoid leaving unused code, I've adopted resource claim controller tests to use this new feature.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:

~~This may break existing tests. But I think breaking tests is fine.~~
This is not a breaking change now.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
client-go: fake client now supports finalizer. New `NewClientsetWithOptions` func is introduced to the fake clientset.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
