### PR TITLE
add single-request to default DNS options for clusterFirst DNS policy

### DIFF
--- a/pkg/kubelet/network/dns/dns.go
+++ b/pkg/kubelet/network/dns/dns.go
@@ -40,7 +40,7 @@ import (
 
 var (
 	// The default dns opt strings.
-	defaultDNSOptions = []string{"ndots:5"}
+	defaultDNSOptions = []string{"ndots:5", "single-request"}
 )
 
 type podDNSType int


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:

There is a issue when glibc do ipv4 and ipv6 dns query at the same time with same UDP port. Kube-dns service with IPVS will not work correctly sometime.

Althrough there some PR try to fix are not merged. But it still a issue for kube-dns. If we don't has good idea to fix it. I think add a default option is a quick fix. When search 'k8s dns 5s' on google, there are many issues.

Refs:
1. https://www.weave.works/blog/racy-conntrack-and-dns-lookup-timeouts
2. https://man7.org/linux/man-pages/man5/resolv.conf.5.html

And there are fixes. But not accepted.
PRs: 
1. https://github.com/kubernetes/kubernetes/pull/68932


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
https://github.com/kubernetes/kubernetes/issues/59031
https://github.com/kubernetes/kubernetes/issues/56903 DNS intermittent delays of 5s



#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Add `single-request` option to default DNS options for clusterFirst DNS policy
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
doc for single-request: https://man7.org/linux/man-pages/man5/resolv.conf.5.html
        single-request (since glibc 2.10)
                     Sets RES_SNGLKUP in _res.options.  By default,
                     glibc performs IPv4 and IPv6 lookups in parallel
                     since glibc 2.9.  Some appliance DNS servers cannot
                     handle these queries properly and make the requests
                     time out.  This option disables the behavior and
                     makes glibc perform the IPv6 and IPv4 requests
                     sequentially (at the cost of some slowdown of the
                     resolving process).

```
