### PR TITLE
Remove Incorrect Use of 'a the' and `the a` in code comments

### DIFF
--- a/pkg/controller/statefulset/stateful_set_utils.go
+++ b/pkg/controller/statefulset/stateful_set_utils.go
@@ -332,7 +332,7 @@ func removeOwnerRef(target, owner metav1.Object) bool {
 }
 
 // getPersistentVolumeClaims gets a map of PersistentVolumeClaims to their template names, as defined in set. The
-// returned PersistentVolumeClaims are each constructed with a the name specific to the Pod. This name is determined
+// returned PersistentVolumeClaims are each constructed with a name specific to the Pod. This name is determined
 // by getPersistentVolumeClaimName.
 func getPersistentVolumeClaims(set *apps.StatefulSet, pod *v1.Pod) map[string]v1.PersistentVolumeClaim {
 	ordinal := getOrdinal(pod)

--- a/pkg/controller/volume/attachdetach/reconciler/reconciler_test.go
+++ b/pkg/controller/volume/attachdetach/reconciler/reconciler_test.go
@@ -567,7 +567,7 @@ func Test_Run_OneVolumeAttachAndDetachMultipleNodesWithReadWriteOnce(t *testing.
 }
 
 // Creates a volume with accessMode ReadWriteOnce
-// First create a pod which will try to attach the volume to the a node named "uncertain-node". The attach call for this node will
+// First create a pod which will try to attach the volume to a node named "uncertain-node". The attach call for this node will
 // fail for timeout, but the volume will be actually attached to the node after the call.
 // Secondly, delete this pod.
 // Lastly, create a pod scheduled to a normal node which will trigger attach volume to the node. The attach should return successfully.
@@ -773,7 +773,7 @@ func Test_Run_OneVolumeDetachFailNodeWithReadWriteOnce(t *testing.T) {
 }
 
 // Creates a volume with accessMode ReadWriteOnce
-// First create a pod which will try to attach the volume to the a node named "timeout-node". The attach call for this node will
+// First create a pod which will try to attach the volume to a node named "timeout-node". The attach call for this node will
 // fail for timeout, but the volume will be actually attached to the node after the call.
 // Secondly, delete the this pod.
 // Lastly, create a pod scheduled to a normal node which will trigger attach volume to the node. The attach should return successfully.

--- a/pkg/scheduler/internal/heap/heap.go
+++ b/pkg/scheduler/internal/heap/heap.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Below is the implementation of the a heap. The logic is pretty much the same
+// Below is the implementation of a heap. The logic is pretty much the same
 // as cache.heap, however, this heap does not perform synchronization. It leaves
 // synchronization to the SchedulingQueue.
 

--- a/pkg/util/goroutinemap/goroutinemap.go
+++ b/pkg/util/goroutinemap/goroutinemap.go
@@ -32,7 +32,7 @@ import (
 
 // GoRoutineMap defines a type that can run named goroutines and track their
 // state.  It prevents the creation of multiple goroutines with the same name
-// and may prevent recreation of a goroutine until after the a backoff time
+// and may prevent recreation of a goroutine until after a backoff time
 // has elapsed after the last goroutine with that name finished.
 type GoRoutineMap interface {
 	// Run adds operation name to the list of running operations and spawns a

--- a/staging/src/k8s.io/apiserver/pkg/cel/library/cidr.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/library/cidr.go
@@ -64,11 +64,11 @@ import (
 //
 // containsIP / containerCIDR / ip / masked / prefixLength
 //
-// - containsIP: Returns true if a the CIDR contains the given IP address.
+// - containsIP: Returns true if the CIDR contains the given IP address.
 // The IP address must be an IPv4 or IPv6 address.
 // May take either a string or IP address as an argument.
 //
-// - containsCIDR: Returns true if a the CIDR contains the given CIDR.
+// - containsCIDR: Returns true if the CIDR contains the given CIDR.
 // The CIDR must be an IPv4 or IPv6 subnet address with a mask.
 // May take either a string or CIDR as an argument.
 //

--- a/staging/src/k8s.io/apiserver/pkg/storage/interfaces.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/interfaces.go
@@ -237,7 +237,7 @@ type Interface interface {
 	// Count returns number of different entries under the key (generally being path prefix).
 	Count(key string) (int64, error)
 
-	// RequestWatchProgress requests the a watch stream progress status be sent in the
+	// RequestWatchProgress requests a watch stream progress status be sent in the
 	// watch response stream as soon as possible.
 	// Used for monitor watch progress even if watching resources with no changes.
 	//

--- a/test/e2e/framework/providers/gce/ingress.go
+++ b/test/e2e/framework/providers/gce/ingress.go
@@ -525,7 +525,7 @@ func (cont *IngressController) verifyBackendMode(svcPorts map[string]v1.ServiceP
 	for svcName, sp := range svcPorts {
 		match := false
 		bsMatch := &compute.BackendService{}
-		// NEG BackendServices' names contain the a sha256 hash of a string.
+		// NEG BackendServices' names contain a sha256 hash of a string.
 		// This logic is copied from the ingress-gce namer.
 		// WARNING: This needs to adapt if the naming convention changed.
 		negString := strings.Join([]string{uid, cont.Ns, svcName, fmt.Sprintf("%v", sp.Port)}, ";")
@@ -539,7 +539,7 @@ func (cont *IngressController) verifyBackendMode(svcPorts map[string]v1.ServiceP
 				break
 			}
 
-			// NEG BackendServices' names contain the a sha256 hash of a string.
+			// NEG BackendServices' names contain a sha256 hash of a string.
 			if backendType == negBackend && strings.Contains(bs.Name, negHash) {
 				match = true
 				bsMatch = bs

--- a/test/integration/etcd/etcd_storage_path_test.go
+++ b/test/integration/etcd/etcd_storage_path_test.go
@@ -272,7 +272,7 @@ func addGVKToEtcdBucket(cohabitatingResources map[string]map[schema.GroupVersion
 
 // getEtcdBucket assumes the last segment of the given etcd path is the name of the object.
 // Thus it strips that segment to extract the object's storage "bucket" in etcd. We expect
-// all objects that share the a bucket (cohabitating resources) to be stored as the same GVK.
+// all objects that share a bucket (cohabitating resources) to be stored as the same GVK.
 func getEtcdBucket(path string) string {
 	idx := strings.LastIndex(path, "/")
 	if idx == -1 {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR addresses a minor but widespread documentation issue where the phrase:

- 'a the'  (Ex:The returned PersistentVolumeClaims are each constructed with a the name specific to the Pod. This name is determined)
- 'the a'  (Ex: First create a pod which will try to attach the volume to the a node named "uncertain-node")

was incorrectly used in various comments throughout the code. This typo can potentially confuse readers and detract from the professionalism of the documentation.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
