### PR TITLE
flowcontrol: set the serialization version to v1

### DIFF
--- a/api/discovery/apis__flowcontrol.apiserver.k8s.io__v1.json
+++ b/api/discovery/apis__flowcontrol.apiserver.k8s.io__v1.json
@@ -8,7 +8,7 @@
       "name": "flowschemas",
       "namespaced": false,
       "singularName": "flowschema",
-      "storageVersionHash": "9NnFrw7ZEmA=",
+      "storageVersionHash": "GJVAJZSZBIw=",
       "verbs": [
         "create",
         "delete",
@@ -36,7 +36,7 @@
       "name": "prioritylevelconfigurations",
       "namespaced": false,
       "singularName": "prioritylevelconfiguration",
-      "storageVersionHash": "+CwSrEWTDhc=",
+      "storageVersionHash": "Kir5PVfvNeI=",
       "verbs": [
         "create",
         "delete",

--- a/api/discovery/apis__flowcontrol.apiserver.k8s.io__v1beta3.json
+++ b/api/discovery/apis__flowcontrol.apiserver.k8s.io__v1beta3.json
@@ -8,7 +8,7 @@
       "name": "flowschemas",
       "namespaced": false,
       "singularName": "flowschema",
-      "storageVersionHash": "9NnFrw7ZEmA=",
+      "storageVersionHash": "GJVAJZSZBIw=",
       "verbs": [
         "create",
         "delete",
@@ -36,7 +36,7 @@
       "name": "prioritylevelconfigurations",
       "namespaced": false,
       "singularName": "prioritylevelconfiguration",
-      "storageVersionHash": "+CwSrEWTDhc=",
+      "storageVersionHash": "Kir5PVfvNeI=",
       "verbs": [
         "create",
         "delete",

--- a/pkg/apis/flowcontrol/install/install.go
+++ b/pkg/apis/flowcontrol/install/install.go
@@ -41,9 +41,6 @@ func Install(scheme *runtime.Scheme) {
 	utilruntime.Must(flowcontrolv1beta3.AddToScheme(scheme))
 	utilruntime.Must(flowcontrolv1.AddToScheme(scheme))
 
-	// TODO(#121119): This controls serialization order, for 1.29, we continue
-	//  to use v1beta3 as the serialization version because vN-1 understands that
-	//  level. In 1.30, we should set the serialization version to v1.
-	utilruntime.Must(scheme.SetVersionPriority(flowcontrolv1beta3.SchemeGroupVersion, flowcontrolv1.SchemeGroupVersion,
+	utilruntime.Must(scheme.SetVersionPriority(flowcontrolv1.SchemeGroupVersion, flowcontrolv1beta3.SchemeGroupVersion,
 		flowcontrolv1beta2.SchemeGroupVersion, flowcontrolv1beta1.SchemeGroupVersion))
 }

--- a/pkg/controlplane/storageversionhashdata/data.go
+++ b/pkg/controlplane/storageversionhashdata/data.go
@@ -82,8 +82,8 @@ var GVRToStorageVersionHash = map[string]string{
 	"admissionregistration.k8s.io/v1/mutatingwebhookconfigurations":    "Sqi0GUgDaX0=",
 	"admissionregistration.k8s.io/v1/validatingwebhookconfigurations":  "B0wHjQmsGNk=",
 	"events.k8s.io/v1/events":                                          "r2yiGXH7wu8=",
-	"flowcontrol.apiserver.k8s.io/v1beta3/flowschemas":                 "9NnFrw7ZEmA=",
-	"flowcontrol.apiserver.k8s.io/v1beta3/prioritylevelconfigurations": "+CwSrEWTDhc=",
-	"flowcontrol.apiserver.k8s.io/v1/flowschemas":                      "9NnFrw7ZEmA=",
-	"flowcontrol.apiserver.k8s.io/v1/prioritylevelconfigurations":      "+CwSrEWTDhc=",
+	"flowcontrol.apiserver.k8s.io/v1beta3/flowschemas":                 "GJVAJZSZBIw=",
+	"flowcontrol.apiserver.k8s.io/v1beta3/prioritylevelconfigurations": "Kir5PVfvNeI=",
+	"flowcontrol.apiserver.k8s.io/v1/flowschemas":                      "GJVAJZSZBIw=",
+	"flowcontrol.apiserver.k8s.io/v1/prioritylevelconfigurations":      "Kir5PVfvNeI=",
 }

--- a/test/integration/etcd/data.go
+++ b/test/integration/etcd/data.go
@@ -228,7 +228,7 @@ func GetEtcdStorageDataForNamespace(namespace string) map[schema.GroupVersionRes
 		gvr("flowcontrol.apiserver.k8s.io", "v1beta1", "flowschemas"): {
 			Stub:             `{"metadata": {"name": "va2"}, "spec": {"priorityLevelConfiguration": {"name": "name1"}}}`,
 			ExpectedEtcdPath: "/registry/flowschemas/va2",
-			ExpectedGVK:      gvkP("flowcontrol.apiserver.k8s.io", "v1beta3", "FlowSchema"),
+			ExpectedGVK:      gvkP("flowcontrol.apiserver.k8s.io", "v1", "FlowSchema"),
 		},
 		// --
 
@@ -236,7 +236,7 @@ func GetEtcdStorageDataForNamespace(namespace string) map[schema.GroupVersionRes
 		gvr("flowcontrol.apiserver.k8s.io", "v1beta1", "prioritylevelconfigurations"): {
 			Stub:             `{"metadata": {"name": "conf2"}, "spec": {"type": "Limited", "limited": {"assuredConcurrencyShares":3, "limitResponse": {"type": "Reject"}}}}`,
 			ExpectedEtcdPath: "/registry/prioritylevelconfigurations/conf2",
-			ExpectedGVK:      gvkP("flowcontrol.apiserver.k8s.io", "v1beta3", "PriorityLevelConfiguration"),
+			ExpectedGVK:      gvkP("flowcontrol.apiserver.k8s.io", "v1", "PriorityLevelConfiguration"),
 		},
 		// --
 
@@ -244,7 +244,7 @@ func GetEtcdStorageDataForNamespace(namespace string) map[schema.GroupVersionRes
 		gvr("flowcontrol.apiserver.k8s.io", "v1beta2", "flowschemas"): {
 			Stub:             `{"metadata": {"name": "fs-1"}, "spec": {"priorityLevelConfiguration": {"name": "name1"}}}`,
 			ExpectedEtcdPath: "/registry/flowschemas/fs-1",
-			ExpectedGVK:      gvkP("flowcontrol.apiserver.k8s.io", "v1beta3", "FlowSchema"),
+			ExpectedGVK:      gvkP("flowcontrol.apiserver.k8s.io", "v1", "FlowSchema"),
 		},
 		// --
 
@@ -252,7 +252,7 @@ func GetEtcdStorageDataForNamespace(namespace string) map[schema.GroupVersionRes
 		gvr("flowcontrol.apiserver.k8s.io", "v1beta2", "prioritylevelconfigurations"): {
 			Stub:             `{"metadata": {"name": "conf3"}, "spec": {"type": "Limited", "limited": {"assuredConcurrencyShares":3, "limitResponse": {"type": "Reject"}}}}`,
 			ExpectedEtcdPath: "/registry/prioritylevelconfigurations/conf3",
-			ExpectedGVK:      gvkP("flowcontrol.apiserver.k8s.io", "v1beta3", "PriorityLevelConfiguration"),
+			ExpectedGVK:      gvkP("flowcontrol.apiserver.k8s.io", "v1", "PriorityLevelConfiguration"),
 		},
 		// --
 
@@ -260,6 +260,7 @@ func GetEtcdStorageDataForNamespace(namespace string) map[schema.GroupVersionRes
 		gvr("flowcontrol.apiserver.k8s.io", "v1beta3", "flowschemas"): {
 			Stub:             `{"metadata": {"name": "fs-2"}, "spec": {"priorityLevelConfiguration": {"name": "name1"}}}`,
 			ExpectedEtcdPath: "/registry/flowschemas/fs-2",
+			ExpectedGVK:      gvkP("flowcontrol.apiserver.k8s.io", "v1", "FlowSchema"),
 		},
 		// --
 
@@ -267,6 +268,7 @@ func GetEtcdStorageDataForNamespace(namespace string) map[schema.GroupVersionRes
 		gvr("flowcontrol.apiserver.k8s.io", "v1beta3", "prioritylevelconfigurations"): {
 			Stub:             `{"metadata": {"name": "conf4"}, "spec": {"type": "Limited", "limited": {"nominalConcurrencyShares":3, "limitResponse": {"type": "Reject"}}}}`,
 			ExpectedEtcdPath: "/registry/prioritylevelconfigurations/conf4",
+			ExpectedGVK:      gvkP("flowcontrol.apiserver.k8s.io", "v1", "PriorityLevelConfiguration"),
 		},
 		// --
 
@@ -274,7 +276,6 @@ func GetEtcdStorageDataForNamespace(namespace string) map[schema.GroupVersionRes
 		gvr("flowcontrol.apiserver.k8s.io", "v1", "flowschemas"): {
 			Stub:             `{"metadata": {"name": "fs-3"}, "spec": {"priorityLevelConfiguration": {"name": "name1"}}}`,
 			ExpectedEtcdPath: "/registry/flowschemas/fs-3",
-			ExpectedGVK:      gvkP("flowcontrol.apiserver.k8s.io", "v1beta3", "FlowSchema"),
 		},
 		// --
 
@@ -282,7 +283,6 @@ func GetEtcdStorageDataForNamespace(namespace string) map[schema.GroupVersionRes
 		gvr("flowcontrol.apiserver.k8s.io", "v1", "prioritylevelconfigurations"): {
 			Stub:             `{"metadata": {"name": "conf5"}, "spec": {"type": "Limited", "limited": {"nominalConcurrencyShares":3, "limitResponse": {"type": "Reject"}}}}`,
 			ExpectedEtcdPath: "/registry/prioritylevelconfigurations/conf5",
-			ExpectedGVK:      gvkP("flowcontrol.apiserver.k8s.io", "v1beta3", "PriorityLevelConfiguration"),
 		},
 		// --
 


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
```
	// TODO(#121119): This controls serialization order, for 1.29, we continue
	//  to use v1beta3 as the serialization version because vN-1 understands that
	//  level. In 1.30, we should set the serialization version to v1.
```	

#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/kubernetes/issues/121119

#### Special notes for your reviewer:
follow up of https://github.com/kubernetes/kubernetes/pull/121089

#### Does this PR introduce a user-facing change?
```release-note
None
```
