### PR TITLE
fix nil pointer dereference when EventedPLEG is enabled

### DIFF
--- a/pkg/kubelet/pleg/generic.go
+++ b/pkg/kubelet/pleg/generic.go
@@ -475,7 +475,7 @@ func (g *GenericPLEG) updateCache(ctx context.Context, pod *kubecontainer.Pod, p
 	// Evented PLEG after the event has been received by the Kubelet.
 	// For more details refer to:
 	// https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/3386-kubelet-evented-pleg#timestamp-of-the-pod-status
-	if utilfeature.DefaultFeatureGate.Enabled(features.EventedPLEG) && isEventedPLEGInUse() {
+	if utilfeature.DefaultFeatureGate.Enabled(features.EventedPLEG) && isEventedPLEGInUse() && status != nil {
 		timestamp = status.TimeStamp
 	}
 


### PR DESCRIPTION
#### What type of PR is this?
/kind bug


#### What this PR does / why we need it:

My test ENV is v1.29.0 with `AllBeta: true` including evented PLEG.
```
featureGates:
  AllBeta: true
  EventedPLEG: true
```
Log panic
```
12月 25 16:02:37 daocloud kubelet[22154]: E1225 16:02:37.233805   22154 kuberuntime_manager.go:1456] "PodSandboxStatus of sandbox for pod" err="rpc error: code = Unknown desc = failed to get sandbox ip: check network namespace closed: remove netns: unlinkat /var/run/netns/cni-69bc2682-2d1a-694c-2a43-276d3e693ea6: device or resource busy" podSandboxID="313ce8e172c9d0de6da0c25a9a05e4b4703445ee30159237d6c07ac577cdb03e" pod="calico-system/calico-kube-controllers-57c5f9d79c-nqdxx"
12月 25 16:02:37 daocloud kubelet[22154]: E1225 16:02:37.233866   22154 generic.go:453] "PLEG: Write status" err="rpc error: code = Unknown desc = failed to get sandbox ip: check network namespace closed: remove netns: unlinkat /var/run/netns/cni-69bc2682-2d1a-694c-2a43-276d3e693ea6: device or resource busy" pod="calico-system/calico-kube-controllers-57c5f9d79c-nqdxx"
12月 25 16:02:37 daocloud kubelet[22154]: E1225 16:02:37.234031   22154 runtime.go:79] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
12月 25 16:02:37 daocloud kubelet[22154]: goroutine 419 [running]:
12月 25 16:02:37 daocloud kubelet[22154]: k8s.io/apimachinery/pkg/util/runtime.logPanic({0x3c742e0?, 0x6e6ad40})
12月 25 16:02:37 daocloud kubelet[22154]:         vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:75 +0x85
12月 25 16:02:37 daocloud kubelet[22154]: k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x0, 0x0, 0x6eb7920?})
12月 25 16:02:37 daocloud kubelet[22154]:         vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:49 +0x6b
12月 25 16:02:37 daocloud kubelet[22154]: panic({0x3c742e0?, 0x6e6ad40?})
12月 25 16:02:37 daocloud kubelet[22154]:         /usr/local/go/src/runtime/panic.go:914 +0x21f
12月 25 16:02:37 daocloud kubelet[22154]: k8s.io/kubernetes/pkg/kubelet/pleg.(*GenericPLEG).updateCache(0xc000a86750, {0x4c40048, 0x6ee85c0}, 0xc0006c6380, {0xc00141e330, 0x24})
12月 25 16:02:37 daocloud kubelet[22154]:         pkg/kubelet/pleg/generic.go:479 +0x7ac
12月 25 16:02:37 daocloud kubelet[22154]: k8s.io/kubernetes/pkg/kubelet/pleg.(*GenericPLEG).Relist(0xc000a86750)
12月 25 16:02:37 daocloud kubelet[22154]:         pkg/kubelet/pleg/generic.go:283 +0x815
12月 25 16:02:37 daocloud kubelet[22154]: k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0x30?)
12月 25 16:02:37 daocloud kubelet[22154]:         vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:226 +0x33
12月 25 16:02:37 daocloud kubelet[22154]: k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0x0?, {0x4c0f620, 0xc000fd5b90}, 0x1, 0xc00020cfc0)
12月 25 16:02:37 daocloud kubelet[22154]:         vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:227 +0xaf
12月 25 16:02:37 daocloud kubelet[22154]: k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc000095fb0?, 0x45d964b800, 0x0, 0x0?, 0x4475bc?)
12月 25 16:02:37 daocloud kubelet[22154]:         vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:204 +0x7f
12月 25 16:02:37 daocloud kubelet[22154]: k8s.io/apimachinery/pkg/util/wait.Until(0xa946c5?, 0xa8f505?, 0xc000b11390?)
12月 25 16:02:37 daocloud kubelet[22154]:         vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:161 +0x1e
12月 25 16:02:37 daocloud kubelet[22154]: created by k8s.io/kubernetes/pkg/kubelet/pleg.(*GenericPLEG).Start in goroutine 234
12月 25 16:02:37 daocloud kubelet[22154]:         pkg/kubelet/pleg/generic.go:146 +0x185
12月 25 16:02:37 daocloud kubelet[22154]: panic: runtime error: invalid memory address or nil pointer dereference [recovered]
12月 25 16:02:37 daocloud kubelet[22154]:         panic: runtime error: invalid memory address or nil pointer dereference
12月 25 16:02:37 daocloud kubelet[22154]: [signal SIGSEGV: segmentation violation code=0x1 addr=0x78 pc=0x350b6ec]
12月 25 16:02:37 daocloud kubelet[22154]: goroutine 419 [running]:
12月 25 16:02:37 daocloud kubelet[22154]: k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x0, 0x0, 0x6eb7920?})
12月 25 16:02:37 daocloud kubelet[22154]:         vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:56 +0xcd
12月 25 16:02:37 daocloud kubelet[22154]: panic({0x3c742e0?, 0x6e6ad40?})
12月 25 16:02:37 daocloud kubelet[22154]:         /usr/local/go/src/runtime/panic.go:914 +0x21f
12月 25 16:02:37 daocloud kubelet[22154]: k8s.io/kubernetes/pkg/kubelet/pleg.(*GenericPLEG).updateCache(0xc000a86750, {0x4c40048, 0x6ee85c0}, 0xc0006c6380, {0xc00141e330, 0x24})
12月 25 16:02:37 daocloud kubelet[22154]:         pkg/kubelet/pleg/generic.go:479 +0x7ac
12月 25 16:02:37 daocloud kubelet[22154]: k8s.io/kubernetes/pkg/kubelet/pleg.(*GenericPLEG).Relist(0xc000a86750)
12月 25 16:02:37 daocloud kubelet[22154]:         pkg/kubelet/pleg/generic.go:283 +0x815
12月 25 16:02:37 daocloud kubelet[22154]: k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0x30?)
12月 25 16:02:37 daocloud kubelet[22154]:         vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:226 +0x33
12月 25 16:02:37 daocloud kubelet[22154]: k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0x0?, {0x4c0f620, 0xc000fd5b90}, 0x1, 0xc00020cfc0)
12月 25 16:02:37 daocloud kubelet[22154]:         vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:227 +0xaf
12月 25 16:02:37 daocloud kubelet[22154]: k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc000095fb0?, 0x45d964b800, 0x0, 0x0?, 0x4475bc?)
12月 25 16:02:37 daocloud kubelet[22154]:         vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:204 +0x7f
12月 25 16:02:37 daocloud kubelet[22154]: k8s.io/apimachinery/pkg/util/wait.Until(0xa946c5?, 0xa8f505?, 0xc000b11390?)
12月 25 16:02:37 daocloud kubelet[22154]:         vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:161 +0x1e
12月 25 16:02:37 daocloud kubelet[22154]: created by k8s.io/kubernetes/pkg/kubelet/pleg.(*GenericPLEG).Start in goroutine 234
12月 25 16:02:37 daocloud systemd[1]: kubelet.service: Main process exited, code=exited, status=2/INVALIDARGUMENT
12月 25 16:02:37 daocloud kubelet[22154]:         pkg/kubelet/pleg/generic.go:146 +0x185
12月 25 16:02:37 daocloud systemd[1]: kubelet.service: Unit entered failed state.
12月 25 16:02:37 daocloud systemd[1]: kubelet.service: Failed with result 'exit-code'.
```


#### Which issue(s) this PR fixes:

Fixes None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
fix panic of Evented PLEG during kubelet start-up
```
