### PR TITLE
WIP: ktesting: enable usage in test/e2e, consolidate "create from YAML manifest"

### DIFF
--- a/test/e2e/framework/pod/get.go
+++ b/test/e2e/framework/pod/get.go
@@ -21,11 +21,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
+	"k8s.io/kubernetes/test/utils/ktesting/kobject"
 )
 
 // Get creates a function which retrieves the pod anew each time the function
 // is called. Fatal errors are detected by framework.GetObject and cause
 // polling to stop.
-func Get(c clientset.Interface, pod framework.NamedObject) framework.GetFunc[*v1.Pod] {
+func Get(c clientset.Interface, pod kobject.Object) framework.GetFunc[*v1.Pod] {
 	return framework.GetObject(c.CoreV1().Pods(pod.GetNamespace()).Get, pod.GetName(), metav1.GetOptions{})
 }

--- a/test/e2e/framework/testfiles/testfiles_test.go
+++ b/test/e2e/framework/testfiles/testfiles_test.go
@@ -18,6 +18,7 @@ package testfiles
 
 import (
 	"embed"
+	"io"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -48,16 +49,17 @@ func TestEmbeddedFileSource(t *testing.T) {
 	s := getTestEmbeddedSource()
 
 	// read a file which exists and compare the contents
-	b, err := s.ReadTestFile(fooPath)
-
+	f, err := s.OpenTestFile(fooPath)
+	require.NoError(t, err)
+	b, err := io.ReadAll(f)
 	require.NoError(t, err)
 	assert.Equal(t, fooContents, string(b))
 
-	// read a non-existent file and ensure that the returned value is empty and error is nil
+	// read a non-existent file and ensure that the returned value is nil and error is nil
 	// Note: this is done so that the next file source can be tried by the caller
-	b, err = s.ReadTestFile(notExistsPath)
+	f, err = s.OpenTestFile(notExistsPath)
 	require.NoError(t, err)
-	assert.Empty(t, b)
+	assert.Empty(t, f)
 
 	// describing the test filesystem should list down all files
 	assert.Equal(t, expectedDescription, s.DescribeFiles())

--- a/test/e2e/storage/csimock/base.go
+++ b/test/e2e/storage/csimock/base.go
@@ -48,6 +48,7 @@ import (
 	"k8s.io/kubernetes/test/e2e/storage/utils"
 	"k8s.io/kubernetes/test/utils/format"
 	imageutils "k8s.io/kubernetes/test/utils/image"
+	"k8s.io/kubernetes/test/utils/ktesting"
 	"k8s.io/utils/ptr"
 )
 
@@ -265,14 +266,14 @@ func (m *mockDriverSetup) cleanup(ctx context.Context) {
 	framework.ExpectNoError(err, "while cleaning up after test")
 }
 
-func (m *mockDriverSetup) update(o utils.PatchCSIOptions) {
-	item, err := m.cs.StorageV1().CSIDrivers().Get(context.TODO(), m.config.GetUniqueDriverName(), metav1.GetOptions{})
+func (m *mockDriverSetup) update(tCtx ktesting.TContext, o utils.PatchCSIOptions) {
+	item, err := m.cs.StorageV1().CSIDrivers().Get(tCtx, m.config.GetUniqueDriverName(), metav1.GetOptions{})
 	framework.ExpectNoError(err, "Failed to get CSIDriver %v", m.config.GetUniqueDriverName())
 
-	err = utils.PatchCSIDeployment(nil, o, item)
+	utils.PatchCSIDeployment(tCtx, o, item)
 	framework.ExpectNoError(err, "Failed to apply %v to CSIDriver object %v", o, m.config.GetUniqueDriverName())
 
-	_, err = m.cs.StorageV1().CSIDrivers().Update(context.TODO(), item, metav1.UpdateOptions{})
+	_, err = m.cs.StorageV1().CSIDrivers().Update(tCtx, item, metav1.UpdateOptions{})
 	framework.ExpectNoError(err, "Failed to update CSIDriver %v", m.config.GetUniqueDriverName())
 }
 

--- a/test/e2e/storage/csimock/csi_fsgroup_policy.go
+++ b/test/e2e/storage/csimock/csi_fsgroup_policy.go
@@ -133,7 +133,7 @@ var _ = utils.SIGDescribe("CSI Mock volume fsgroup policies", func() {
 				ginkgo.DeferCleanup(m.cleanup)
 
 				waitUtilFSGroupInPod(ctx, m, test.oldFSGroupPolicy != storagev1.NoneFSGroupPolicy)
-				m.update(utils.PatchCSIOptions{FSGroupPolicy: &test.newFSGroupPolicy})
+				m.update(f.TContext(ctx), utils.PatchCSIOptions{FSGroupPolicy: &test.newFSGroupPolicy})
 				waitUtilFSGroupInPod(ctx, m, test.newFSGroupPolicy != storagev1.NoneFSGroupPolicy)
 
 				// The created resources will be removed by the cleanup() function,

--- a/test/e2e/storage/csimock/csi_workload.go
+++ b/test/e2e/storage/csimock/csi_workload.go
@@ -111,7 +111,7 @@ var _ = utils.SIGDescribe("CSI Mock workload info", func() {
 				ginkgo.DeferCleanup(m.cleanup)
 
 				waitUntilPodInfoInLog(ctx, m, test.oldPodInfoOnMount, false)
-				m.update(utils.PatchCSIOptions{PodInfo: &test.newPodInfoOnMount})
+				m.update(f.TContext(ctx), utils.PatchCSIOptions{PodInfo: &test.newPodInfoOnMount})
 				waitUntilPodInfoInLog(ctx, m, test.newPodInfoOnMount, false)
 			})
 		}

--- a/test/e2e/storage/utils/create.go
+++ b/test/e2e/storage/utils/create.go
@@ -17,13 +17,7 @@ limitations under the License.
 package utils
 
 import (
-	"bytes"
-	"context"
-	"encoding/json"
-	"errors"
 	"fmt"
-
-	"github.com/onsi/ginkgo/v2"
 
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
@@ -32,82 +26,30 @@ import (
 	storagev1beta1 "k8s.io/api/storage/v1beta1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/tools/cache"
-	"k8s.io/kubernetes/test/e2e/framework"
 	e2etestfiles "k8s.io/kubernetes/test/e2e/framework/testfiles"
 	imageutils "k8s.io/kubernetes/test/utils/image"
+	"k8s.io/kubernetes/test/utils/ktesting"
+	"k8s.io/kubernetes/test/utils/ktesting/kobject"
 )
 
-// LoadFromManifests loads .yaml or .json manifest files and returns
-// all items that it finds in them. It supports all items for which
-// there is a factory registered in factories and .yaml files with
-// multiple items separated by "---". Files are accessed via the
-// "testfiles" package, which means they can come from a file system
+// LoadFromManifests is a wrapper around [kobject.LoadFromManifests].
+// It opens files by name via the "testfiles" package, which means they can come from a file system
 // or be built into the binary.
-//
-// LoadFromManifests has some limitations:
-//   - aliases are not supported (i.e. use serviceAccountName instead of the deprecated serviceAccount,
-//     https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1)
-//     and silently ignored
-//   - the latest stable API version for each item is used, regardless of what
-//     is specified in the manifest files
-func LoadFromManifests(files ...string) ([]interface{}, error) {
-	var items []interface{}
-	err := visitManifests(func(data []byte) error {
-		// Ignore any additional fields for now, just determine what we have.
-		var what What
-		if err := runtime.DecodeInto(scheme.Codecs.UniversalDecoder(), data, &what); err != nil {
-			return fmt.Errorf("decode TypeMeta: %w", err)
-		}
-		// Ignore empty documents.
-		if what.Kind == "" {
+func LoadFromManifests(tCtx ktesting.TContext, fileNames ...string) []runtime.Object {
+	tCtx.Helper()
+	var files []kobject.NamedReader
+	for _, fileName := range fileNames {
+		file, err := e2etestfiles.Open(fileName)
+		if err != nil {
 			return nil
 		}
-
-		factory := factories[what]
-		if factory == nil {
-			return fmt.Errorf("item of type %+v not supported", what)
-		}
-
-		object := factory.New()
-		if err := runtime.DecodeInto(scheme.Codecs.UniversalDecoder(), data, object); err != nil {
-			return fmt.Errorf("decode %+v: %w", what, err)
-		}
-		items = append(items, object)
-		return nil
-	}, files...)
-
-	return items, err
-}
-
-func visitManifests(cb func([]byte) error, files ...string) error {
-	for _, fileName := range files {
-		data, err := e2etestfiles.Read(fileName)
-		if err != nil {
-			framework.Failf("reading manifest file: %v", err)
-		}
-
-		// Split at the "---" separator before working on
-		// individual item. Only works for .yaml.
-		//
-		// We need to split ourselves because we need access
-		// to each original chunk of data for
-		// runtime.DecodeInto. kubectl has its own
-		// infrastructure for this, but that is a lot of code
-		// with many dependencies.
-		items := bytes.Split(data, []byte("\n---"))
-
-		for _, item := range items {
-			if err := cb(item); err != nil {
-				return fmt.Errorf("%s: %w", fileName, err)
-			}
-		}
+		defer func() {
+			_ = file.Close()
+		}()
+		files = append(files, file)
 	}
-	return nil
+	return kobject.LoadFromManifests(tCtx, nil, files...)
 }
 
 // PatchItems modifies the given items in place such that each test
@@ -121,618 +63,122 @@ func visitManifests(cb func([]byte) error, files ...string) error {
 // PatchItems has some limitations:
 // - only some common items are supported, unknown ones trigger an error
 // - only the latest stable API version for each item is supported
-func PatchItems(f *framework.Framework, driverNamespace *v1.Namespace, items ...interface{}) error {
-	for _, item := range items {
+func PatchItems(tCtx ktesting.TContext, objs ...runtime.Object) {
+	tCtx.Helper()
+	for _, obj := range objs {
 		// Uncomment when debugging the loading and patching of items.
 		// Logf("patching original content of %T:\n%s", item, PrettyPrint(item))
-		if err := patchItemRecursively(f, driverNamespace, item); err != nil {
-			return err
-		}
+		patchItemRecursively(tCtx, obj)
 	}
-	return nil
 }
 
-// CreateItems creates the items. Each of them must be an API object
-// of a type that is registered in Factory.
+// CreateItems creates the objects in the namespace associated with
+// the context.
 //
-// It returns either a cleanup function or an error, but never both.
+// Errors are treated as test failures.
 //
-// Cleaning up after a test can be triggered in two ways:
-//   - the test invokes the returned cleanup function,
-//     usually in an AfterEach
-//   - the test suite terminates, potentially after
-//     skipping the test's AfterEach (https://github.com/onsi/ginkgo/issues/222)
-//
-// PatchItems has the some limitations as LoadFromManifests:
-// - only some common items are supported, unknown ones trigger an error
-// - only the latest stable API version for each item is supported
-func CreateItems(ctx context.Context, f *framework.Framework, ns *v1.Namespace, items ...interface{}) error {
-	var result error
-	for _, item := range items {
-		// Each factory knows which item(s) it supports, so try each one.
-		done := false
-		description := describeItem(item)
-		// Uncomment this line to get a full dump of the entire item.
-		// description = fmt.Sprintf("%s:\n%s", description, PrettyPrint(item))
-		framework.Logf("creating %s", description)
-		for _, factory := range factories {
-			destructor, err := factory.Create(ctx, f, ns, item)
-			if destructor != nil {
-				ginkgo.DeferCleanup(framework.IgnoreNotFound(destructor), framework.AnnotatedLocation(fmt.Sprintf("deleting %s", description)))
-			}
-			if err == nil {
-				done = true
-				break
-			} else if !errors.Is(err, errorItemNotSupported) {
-				result = err
-				break
-			}
-		}
-		if result == nil && !done {
-			result = fmt.Errorf("item of type %T not supported", item)
-			break
-		}
-	}
+// All items are deleted automatically when the test is done.
+func CreateItems(tCtx ktesting.TContext, objs ...runtime.Object) {
+	tCtx.Helper()
 
-	return result
+	for _, obj := range objs {
+		_, err := kobject.Create(tCtx, obj, metav1.CreateOptions{})
+		tCtx.ExpectNoError(err, "create object")
+	}
 }
 
 // CreateFromManifests is a combination of LoadFromManifests,
 // PatchItems, patching with an optional custom function,
 // and CreateItems.
-func CreateFromManifests(ctx context.Context, f *framework.Framework, driverNamespace *v1.Namespace, patch func(item interface{}) error, files ...string) error {
-	items, err := LoadFromManifests(files...)
-	if err != nil {
-		return fmt.Errorf("CreateFromManifests: %w", err)
-	}
-	if err := PatchItems(f, driverNamespace, items...); err != nil {
-		return err
-	}
+func CreateFromManifests(tCtx ktesting.TContext, patch func(ktesting.TContext, runtime.Object), files ...string) {
+	tCtx.Helper()
+	objs := LoadFromManifests(ktesting.WithStep(tCtx, "load manifests"), files...)
+	PatchItems(ktesting.WithStep(tCtx, "patch items"), objs...)
 	if patch != nil {
-		for _, item := range items {
-			if err := patch(item); err != nil {
-				return err
-			}
+		for _, obj := range objs {
+			patch(tCtx, obj)
 		}
 	}
-	return CreateItems(ctx, f, driverNamespace, items...)
+	CreateItems(ktesting.WithStep(tCtx, "create items"), objs...)
 }
 
-// What is a subset of metav1.TypeMeta which (in contrast to
-// metav1.TypeMeta itself) satisfies the runtime.Object interface.
-type What struct {
-	Kind string `json:"kind"`
-}
-
-// DeepCopy is an autogenerated deepcopy function, copying the receiver, creating a new What.
-func (in *What) DeepCopy() *What {
-	return &What{Kind: in.Kind}
-}
-
-// DeepCopyInto is an autogenerated deepcopy function, copying the receiver, writing into out.
-func (in *What) DeepCopyInto(out *What) {
-	out.Kind = in.Kind
-}
-
-// DeepCopyObject is an autogenerated deepcopy function, copying the receiver, creating a new runtime.Object.
-func (in *What) DeepCopyObject() runtime.Object {
-	return &What{Kind: in.Kind}
-}
-
-// GetObjectKind returns the ObjectKind schema
-func (in *What) GetObjectKind() schema.ObjectKind {
-	return nil
-}
-
-// ItemFactory provides support for creating one particular item.
-// The type gets exported because other packages might want to
-// extend the set of pre-defined factories.
-type ItemFactory interface {
-	// New returns a new empty item.
-	New() runtime.Object
-
-	// Create is responsible for creating the item. It returns an
-	// error or a cleanup function for the created item.
-	// If the item is of an unsupported type, it must return
-	// an error that has errorItemNotSupported as cause.
-	Create(ctx context.Context, f *framework.Framework, ns *v1.Namespace, item interface{}) (func(ctx context.Context) error, error)
-}
-
-// describeItem always returns a string that describes the item,
-// usually by calling out to cache.MetaNamespaceKeyFunc which
-// concatenates namespace (if set) and name. If that fails, the entire
-// item gets converted to a string.
-func describeItem(item interface{}) string {
-	key, err := cache.MetaNamespaceKeyFunc(item)
-	if err == nil && key != "" {
-		return fmt.Sprintf("%T: %s", item, key)
-	}
-	return fmt.Sprintf("%T: %s", item, item)
-}
-
-// errorItemNotSupported is the error that Create methods
-// must return or wrap when they don't support the given item.
-var errorItemNotSupported = errors.New("not supported")
-
-var factories = map[What]ItemFactory{
-	{"ClusterRole"}:              &clusterRoleFactory{},
-	{"ClusterRoleBinding"}:       &clusterRoleBindingFactory{},
-	{"CSIDriver"}:                &csiDriverFactory{},
-	{"DaemonSet"}:                &daemonSetFactory{},
-	{"ReplicaSet"}:               &replicaSetFactory{},
-	{"Role"}:                     &roleFactory{},
-	{"RoleBinding"}:              &roleBindingFactory{},
-	{"Secret"}:                   &secretFactory{},
-	{"Service"}:                  &serviceFactory{},
-	{"ServiceAccount"}:           &serviceAccountFactory{},
-	{"StatefulSet"}:              &statefulSetFactory{},
-	{"Deployment"}:               &deploymentFactory{},
-	{"StorageClass"}:             &storageClassFactory{},
-	{"VolumeAttributesClass"}:    &volumeAttributesClassFactory{},
-	{"CustomResourceDefinition"}: &customResourceDefinitionFactory{},
-}
-
-// PatchName makes the name of some item unique by appending the
-// generated unique name.
-func PatchName(f *framework.Framework, item *string) {
-	if *item != "" {
-		*item = *item + "-" + f.UniqueName
-	}
-}
-
-// PatchNamespace moves the item into the test's namespace.  Not
-// all items can be namespaced. For those, the name also needs to be
-// patched.
-func PatchNamespace(f *framework.Framework, driverNamespace *v1.Namespace, item *string) {
-	if driverNamespace != nil {
-		*item = driverNamespace.GetName()
-		return
-	}
-
-	if f.Namespace != nil {
-		*item = f.Namespace.GetName()
-	}
-}
-
-func patchItemRecursively(f *framework.Framework, driverNamespace *v1.Namespace, item interface{}) error {
+func patchItemRecursively(tCtx ktesting.TContext, item interface{}) {
+	tCtx.Helper()
+	tCtx = ktesting.WithStep(tCtx, fmt.Sprintf("patching %T", item))
+	namespace := tCtx.Namespace()
 	switch item := item.(type) {
 	case *rbacv1.Subject:
-		PatchNamespace(f, driverNamespace, &item.Namespace)
+		item.Namespace = namespace
 	case *rbacv1.RoleRef:
 		// TODO: avoid hard-coding this special name. Perhaps add a Framework.PredefinedRoles
 		// which contains all role names that are defined cluster-wide before the test starts?
 		// All those names are exempt from renaming. That list could be populated by querying
 		// and get extended by tests.
 		if item.Name != "e2e-test-privileged-psp" {
-			PatchName(f, &item.Name)
+			item.Name += "-" + namespace
 		}
 	case *rbacv1.ClusterRole:
-		PatchName(f, &item.Name)
+		item.Name += "-" + namespace
 	case *rbacv1.Role:
-		PatchNamespace(f, driverNamespace, &item.Namespace)
+		item.Namespace = namespace
 		// Roles are namespaced, but because for RoleRef above we don't
 		// know whether the referenced role is a ClusterRole or Role
 		// and therefore always renames, we have to do the same here.
-		PatchName(f, &item.Name)
+		item.Name += "-" + namespace
 	case *storagev1.StorageClass:
-		PatchName(f, &item.Name)
+		item.Name += "-" + namespace
 	case *storagev1beta1.VolumeAttributesClass:
-		PatchName(f, &item.Name)
+		item.Name += "-" + namespace
 	case *storagev1.CSIDriver:
-		PatchName(f, &item.Name)
+		item.Name += "-" + namespace
 	case *v1.ServiceAccount:
-		PatchNamespace(f, driverNamespace, &item.ObjectMeta.Namespace)
+		item.ObjectMeta.Namespace = namespace
 	case *v1.Secret:
-		PatchNamespace(f, driverNamespace, &item.ObjectMeta.Namespace)
+		item.ObjectMeta.Namespace = namespace
 	case *rbacv1.ClusterRoleBinding:
-		PatchName(f, &item.Name)
+		item.Name += "-" + namespace
 		for i := range item.Subjects {
-			if err := patchItemRecursively(f, driverNamespace, &item.Subjects[i]); err != nil {
-				return fmt.Errorf("%T: %w", f, err)
-			}
+			patchItemRecursively(tCtx, &item.Subjects[i])
 		}
-		if err := patchItemRecursively(f, driverNamespace, &item.RoleRef); err != nil {
-			return fmt.Errorf("%T: %w", f, err)
-		}
+		patchItemRecursively(tCtx, &item.RoleRef)
 	case *rbacv1.RoleBinding:
-		PatchNamespace(f, driverNamespace, &item.Namespace)
+		item.Namespace = namespace
 		for i := range item.Subjects {
-			if err := patchItemRecursively(f, driverNamespace, &item.Subjects[i]); err != nil {
-				return fmt.Errorf("%T: %w", f, err)
-			}
+			patchItemRecursively(tCtx, &item.Subjects[i])
 		}
-		if err := patchItemRecursively(f, driverNamespace, &item.RoleRef); err != nil {
-			return fmt.Errorf("%T: %w", f, err)
-		}
+		patchItemRecursively(tCtx, &item.RoleRef)
 	case *v1.Service:
-		PatchNamespace(f, driverNamespace, &item.ObjectMeta.Namespace)
+		item.ObjectMeta.Namespace = namespace
 	case *appsv1.StatefulSet:
-		PatchNamespace(f, driverNamespace, &item.ObjectMeta.Namespace)
-		if err := patchContainerImages(item.Spec.Template.Spec.Containers); err != nil {
-			return err
-		}
-		if err := patchContainerImages(item.Spec.Template.Spec.InitContainers); err != nil {
-			return err
-		}
+		item.ObjectMeta.Namespace = namespace
+		patchItemRecursively(tCtx, &item.Spec.Template.Spec)
 	case *appsv1.Deployment:
-		PatchNamespace(f, driverNamespace, &item.ObjectMeta.Namespace)
-		if err := patchContainerImages(item.Spec.Template.Spec.Containers); err != nil {
-			return err
-		}
-		if err := patchContainerImages(item.Spec.Template.Spec.InitContainers); err != nil {
-			return err
-		}
+		item.ObjectMeta.Namespace = namespace
+		patchItemRecursively(tCtx, &item.Spec.Template.Spec)
 	case *appsv1.DaemonSet:
-		PatchNamespace(f, driverNamespace, &item.ObjectMeta.Namespace)
-		if err := patchContainerImages(item.Spec.Template.Spec.Containers); err != nil {
-			return err
-		}
-		if err := patchContainerImages(item.Spec.Template.Spec.InitContainers); err != nil {
-			return err
-		}
+		item.ObjectMeta.Namespace = namespace
+		patchItemRecursively(tCtx, &item.Spec.Template.Spec)
 	case *appsv1.ReplicaSet:
-		PatchNamespace(f, driverNamespace, &item.ObjectMeta.Namespace)
-		if err := patchContainerImages(item.Spec.Template.Spec.Containers); err != nil {
-			return err
-		}
-		if err := patchContainerImages(item.Spec.Template.Spec.InitContainers); err != nil {
-			return err
-		}
+		item.ObjectMeta.Namespace = namespace
+		patchItemRecursively(tCtx, &item.Spec.Template.Spec)
+	case *v1.PodSpec:
+		patchContainerImages(ktesting.WithStep(tCtx, "containers"), item.Containers)
+		patchContainerImages(ktesting.WithStep(tCtx, "initContainers"), item.InitContainers)
 	case *apiextensionsv1.CustomResourceDefinition:
 		// Do nothing. Patching name to all CRDs won't always be the expected behavior.
 	default:
-		return fmt.Errorf("missing support for patching item of type %T", item)
+		// WithStep provides the necessary context for how we got here.
+		tCtx.Fatal("missing support for patching item")
 	}
-	return nil
-}
-
-// The individual factories all follow the same template, but with
-// enough differences in types and functions that copy-and-paste
-// looked like the least dirty approach. Perhaps one day Go will have
-// generics.
-
-type serviceAccountFactory struct{}
-
-func (f *serviceAccountFactory) New() runtime.Object {
-	return &v1.ServiceAccount{}
-}
-
-func (*serviceAccountFactory) Create(ctx context.Context, f *framework.Framework, ns *v1.Namespace, i interface{}) (func(ctx context.Context) error, error) {
-	item, ok := i.(*v1.ServiceAccount)
-	if !ok {
-		return nil, errorItemNotSupported
-	}
-	client := f.ClientSet.CoreV1().ServiceAccounts(ns.Name)
-	if _, err := client.Create(ctx, item, metav1.CreateOptions{}); err != nil {
-		return nil, fmt.Errorf("create ServiceAccount: %w", err)
-	}
-	return func(ctx context.Context) error {
-		return client.Delete(ctx, item.GetName(), metav1.DeleteOptions{})
-	}, nil
-}
-
-type clusterRoleFactory struct{}
-
-func (f *clusterRoleFactory) New() runtime.Object {
-	return &rbacv1.ClusterRole{}
-}
-
-func (*clusterRoleFactory) Create(ctx context.Context, f *framework.Framework, ns *v1.Namespace, i interface{}) (func(ctx context.Context) error, error) {
-	item, ok := i.(*rbacv1.ClusterRole)
-	if !ok {
-		return nil, errorItemNotSupported
-	}
-
-	framework.Logf("Define cluster role %v", item.GetName())
-	client := f.ClientSet.RbacV1().ClusterRoles()
-	if _, err := client.Create(ctx, item, metav1.CreateOptions{}); err != nil {
-		return nil, fmt.Errorf("create ClusterRole: %w", err)
-	}
-	return func(ctx context.Context) error {
-		return client.Delete(ctx, item.GetName(), metav1.DeleteOptions{})
-	}, nil
-}
-
-type clusterRoleBindingFactory struct{}
-
-func (f *clusterRoleBindingFactory) New() runtime.Object {
-	return &rbacv1.ClusterRoleBinding{}
-}
-
-func (*clusterRoleBindingFactory) Create(ctx context.Context, f *framework.Framework, ns *v1.Namespace, i interface{}) (func(ctx context.Context) error, error) {
-	item, ok := i.(*rbacv1.ClusterRoleBinding)
-	if !ok {
-		return nil, errorItemNotSupported
-	}
-
-	client := f.ClientSet.RbacV1().ClusterRoleBindings()
-	if _, err := client.Create(ctx, item, metav1.CreateOptions{}); err != nil {
-		return nil, fmt.Errorf("create ClusterRoleBinding: %w", err)
-	}
-	return func(ctx context.Context) error {
-		return client.Delete(ctx, item.GetName(), metav1.DeleteOptions{})
-	}, nil
-}
-
-type roleFactory struct{}
-
-func (f *roleFactory) New() runtime.Object {
-	return &rbacv1.Role{}
-}
-
-func (*roleFactory) Create(ctx context.Context, f *framework.Framework, ns *v1.Namespace, i interface{}) (func(ctx context.Context) error, error) {
-	item, ok := i.(*rbacv1.Role)
-	if !ok {
-		return nil, errorItemNotSupported
-	}
-
-	client := f.ClientSet.RbacV1().Roles(ns.Name)
-	if _, err := client.Create(ctx, item, metav1.CreateOptions{}); err != nil {
-		return nil, fmt.Errorf("create Role: %w", err)
-	}
-	return func(ctx context.Context) error {
-		return client.Delete(ctx, item.GetName(), metav1.DeleteOptions{})
-	}, nil
-}
-
-type roleBindingFactory struct{}
-
-func (f *roleBindingFactory) New() runtime.Object {
-	return &rbacv1.RoleBinding{}
-}
-
-func (*roleBindingFactory) Create(ctx context.Context, f *framework.Framework, ns *v1.Namespace, i interface{}) (func(ctx context.Context) error, error) {
-	item, ok := i.(*rbacv1.RoleBinding)
-	if !ok {
-		return nil, errorItemNotSupported
-	}
-
-	client := f.ClientSet.RbacV1().RoleBindings(ns.Name)
-	if _, err := client.Create(ctx, item, metav1.CreateOptions{}); err != nil {
-		return nil, fmt.Errorf("create RoleBinding: %w", err)
-	}
-	return func(ctx context.Context) error {
-		return client.Delete(ctx, item.GetName(), metav1.DeleteOptions{})
-	}, nil
-}
-
-type serviceFactory struct{}
-
-func (f *serviceFactory) New() runtime.Object {
-	return &v1.Service{}
-}
-
-func (*serviceFactory) Create(ctx context.Context, f *framework.Framework, ns *v1.Namespace, i interface{}) (func(ctx context.Context) error, error) {
-	item, ok := i.(*v1.Service)
-	if !ok {
-		return nil, errorItemNotSupported
-	}
-
-	client := f.ClientSet.CoreV1().Services(ns.Name)
-	if _, err := client.Create(ctx, item, metav1.CreateOptions{}); err != nil {
-		return nil, fmt.Errorf("create Service: %w", err)
-	}
-	return func(ctx context.Context) error {
-		return client.Delete(ctx, item.GetName(), metav1.DeleteOptions{})
-	}, nil
-}
-
-type statefulSetFactory struct{}
-
-func (f *statefulSetFactory) New() runtime.Object {
-	return &appsv1.StatefulSet{}
-}
-
-func (*statefulSetFactory) Create(ctx context.Context, f *framework.Framework, ns *v1.Namespace, i interface{}) (func(ctx context.Context) error, error) {
-	item, ok := i.(*appsv1.StatefulSet)
-	if !ok {
-		return nil, errorItemNotSupported
-	}
-
-	client := f.ClientSet.AppsV1().StatefulSets(ns.Name)
-	if _, err := client.Create(ctx, item, metav1.CreateOptions{}); err != nil {
-		return nil, fmt.Errorf("create StatefulSet: %w", err)
-	}
-	return func(ctx context.Context) error {
-		return client.Delete(ctx, item.GetName(), metav1.DeleteOptions{})
-	}, nil
-}
-
-type deploymentFactory struct{}
-
-func (f *deploymentFactory) New() runtime.Object {
-	return &appsv1.Deployment{}
-}
-
-func (*deploymentFactory) Create(ctx context.Context, f *framework.Framework, ns *v1.Namespace, i interface{}) (func(ctx context.Context) error, error) {
-	item, ok := i.(*appsv1.Deployment)
-	if !ok {
-		return nil, errorItemNotSupported
-	}
-
-	client := f.ClientSet.AppsV1().Deployments(ns.Name)
-	if _, err := client.Create(ctx, item, metav1.CreateOptions{}); err != nil {
-		return nil, fmt.Errorf("create Deployment: %w", err)
-	}
-	return func(ctx context.Context) error {
-		return client.Delete(ctx, item.GetName(), metav1.DeleteOptions{})
-	}, nil
-}
-
-type daemonSetFactory struct{}
-
-func (f *daemonSetFactory) New() runtime.Object {
-	return &appsv1.DaemonSet{}
-}
-
-func (*daemonSetFactory) Create(ctx context.Context, f *framework.Framework, ns *v1.Namespace, i interface{}) (func(ctx context.Context) error, error) {
-	item, ok := i.(*appsv1.DaemonSet)
-	if !ok {
-		return nil, errorItemNotSupported
-	}
-
-	client := f.ClientSet.AppsV1().DaemonSets(ns.Name)
-	if _, err := client.Create(ctx, item, metav1.CreateOptions{}); err != nil {
-		return nil, fmt.Errorf("create DaemonSet: %w", err)
-	}
-	return func(ctx context.Context) error {
-		return client.Delete(ctx, item.GetName(), metav1.DeleteOptions{})
-	}, nil
-}
-
-type replicaSetFactory struct{}
-
-func (f *replicaSetFactory) New() runtime.Object {
-	return &appsv1.ReplicaSet{}
-}
-
-func (*replicaSetFactory) Create(ctx context.Context, f *framework.Framework, ns *v1.Namespace, i interface{}) (func(ctx context.Context) error, error) {
-	item, ok := i.(*appsv1.ReplicaSet)
-	if !ok {
-		return nil, errorItemNotSupported
-	}
-
-	client := f.ClientSet.AppsV1().ReplicaSets(ns.Name)
-	if _, err := client.Create(ctx, item, metav1.CreateOptions{}); err != nil {
-		return nil, fmt.Errorf("create ReplicaSet: %w", err)
-	}
-	return func(ctx context.Context) error {
-		return client.Delete(ctx, item.GetName(), metav1.DeleteOptions{})
-	}, nil
-}
-
-type storageClassFactory struct{}
-
-func (f *storageClassFactory) New() runtime.Object {
-	return &storagev1.StorageClass{}
-}
-
-func (*storageClassFactory) Create(ctx context.Context, f *framework.Framework, ns *v1.Namespace, i interface{}) (func(ctx context.Context) error, error) {
-	item, ok := i.(*storagev1.StorageClass)
-	if !ok {
-		return nil, errorItemNotSupported
-	}
-
-	client := f.ClientSet.StorageV1().StorageClasses()
-	if _, err := client.Create(ctx, item, metav1.CreateOptions{}); err != nil {
-		return nil, fmt.Errorf("create StorageClass: %w", err)
-	}
-	return func(ctx context.Context) error {
-		return client.Delete(ctx, item.GetName(), metav1.DeleteOptions{})
-	}, nil
-}
-
-type volumeAttributesClassFactory struct{}
-
-func (f *volumeAttributesClassFactory) New() runtime.Object {
-	return &storagev1beta1.VolumeAttributesClass{}
-}
-
-func (*volumeAttributesClassFactory) Create(ctx context.Context, f *framework.Framework, ns *v1.Namespace, i interface{}) (func(ctx context.Context) error, error) {
-	item, ok := i.(*storagev1beta1.VolumeAttributesClass)
-	if !ok {
-		return nil, errorItemNotSupported
-	}
-
-	client := f.ClientSet.StorageV1beta1().VolumeAttributesClasses()
-	if _, err := client.Create(ctx, item, metav1.CreateOptions{}); err != nil {
-		return nil, fmt.Errorf("create VolumeAttributesClass: %w", err)
-	}
-	return func(ctx context.Context) error {
-		return client.Delete(ctx, item.GetName(), metav1.DeleteOptions{})
-	}, nil
-}
-
-type csiDriverFactory struct{}
-
-func (f *csiDriverFactory) New() runtime.Object {
-	return &storagev1.CSIDriver{}
-}
-
-func (*csiDriverFactory) Create(ctx context.Context, f *framework.Framework, ns *v1.Namespace, i interface{}) (func(ctx context.Context) error, error) {
-	item, ok := i.(*storagev1.CSIDriver)
-	if !ok {
-		return nil, errorItemNotSupported
-	}
-
-	client := f.ClientSet.StorageV1().CSIDrivers()
-	if _, err := client.Create(ctx, item, metav1.CreateOptions{}); err != nil {
-		return nil, fmt.Errorf("create CSIDriver: %w", err)
-	}
-	return func(ctx context.Context) error {
-		return client.Delete(ctx, item.GetName(), metav1.DeleteOptions{})
-	}, nil
-}
-
-type secretFactory struct{}
-
-func (f *secretFactory) New() runtime.Object {
-	return &v1.Secret{}
-}
-
-func (*secretFactory) Create(ctx context.Context, f *framework.Framework, ns *v1.Namespace, i interface{}) (func(ctx context.Context) error, error) {
-	item, ok := i.(*v1.Secret)
-	if !ok {
-		return nil, errorItemNotSupported
-	}
-
-	client := f.ClientSet.CoreV1().Secrets(ns.Name)
-	if _, err := client.Create(ctx, item, metav1.CreateOptions{}); err != nil {
-		return nil, fmt.Errorf("create Secret: %w", err)
-	}
-	return func(ctx context.Context) error {
-		return client.Delete(ctx, item.GetName(), metav1.DeleteOptions{})
-	}, nil
-}
-
-type customResourceDefinitionFactory struct{}
-
-func (f *customResourceDefinitionFactory) New() runtime.Object {
-	return &apiextensionsv1.CustomResourceDefinition{}
-}
-
-func (*customResourceDefinitionFactory) Create(ctx context.Context, f *framework.Framework, ns *v1.Namespace, i interface{}) (func(ctx context.Context) error, error) {
-	var err error
-	unstructCRD := &unstructured.Unstructured{}
-	gvr := schema.GroupVersionResource{Group: "apiextensions.k8s.io", Version: "v1", Resource: "customresourcedefinitions"}
-
-	item, ok := i.(*apiextensionsv1.CustomResourceDefinition)
-	if !ok {
-		return nil, errorItemNotSupported
-	}
-
-	unstructCRD.Object, err = runtime.DefaultUnstructuredConverter.ToUnstructured(i)
-	if err != nil {
-		return nil, err
-	}
-
-	if _, err = f.DynamicClient.Resource(gvr).Create(ctx, unstructCRD, metav1.CreateOptions{}); err != nil {
-		return nil, fmt.Errorf("create CustomResourceDefinition: %w", err)
-	}
-	return func(ctx context.Context) error {
-		return f.DynamicClient.Resource(gvr).Delete(ctx, item.GetName(), metav1.DeleteOptions{})
-	}, nil
-}
-
-// PrettyPrint returns a human-readable representation of an item.
-func PrettyPrint(item interface{}) string {
-	data, err := json.MarshalIndent(item, "", "  ")
-	if err == nil {
-		return string(data)
-	}
-	return fmt.Sprintf("%+v", item)
 }
 
 // patchContainerImages replaces the specified Container Registry with a custom
 // one provided via the KUBE_TEST_REPO_LIST env variable
-func patchContainerImages(containers []v1.Container) error {
+func patchContainerImages(tCtx ktesting.TContext, containers []v1.Container) {
+	tCtx.Helper()
 	var err error
 	for i, c := range containers {
 		containers[i].Image, err = imageutils.ReplaceRegistryInImageURL(c.Image)
-		if err != nil {
-			return err
-		}
+		tCtx.ExpectNoError(err, fmt.Sprintf("patching container image %s", c.Image))
 	}
-
-	return nil
 }

--- a/test/e2e/storage/utils/deployment.go
+++ b/test/e2e/storage/utils/deployment.go
@@ -24,8 +24,10 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	e2eframework "k8s.io/kubernetes/test/e2e/framework"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
+	"k8s.io/kubernetes/test/utils/ktesting"
 )
 
 // PatchCSIDeployment modifies the CSI driver deployment:
@@ -49,7 +51,7 @@ import (
 //
 // Driver deployments that are different will have to do the patching
 // without this function, or skip patching entirely.
-func PatchCSIDeployment(f *e2eframework.Framework, o PatchCSIOptions, object interface{}) error {
+func PatchCSIDeployment(tCtx ktesting.TContext, o PatchCSIOptions, object runtime.Object) {
 	rename := o.OldDriverName != "" && o.NewDriverName != "" &&
 		o.OldDriverName != o.NewDriverName
 
@@ -162,8 +164,6 @@ func PatchCSIDeployment(f *e2eframework.Framework, o PatchCSIOptions, object int
 			object.Spec.SELinuxMount = o.SELinuxMount
 		}
 	}
-
-	return nil
 }
 
 // PatchCSIOptions controls how PatchCSIDeployment patches the objects.

--- a/test/utils/ktesting/examples/ginkgo/doc.go
+++ b/test/utils/ktesting/examples/ginkgo/doc.go
@@ -1,0 +1,20 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// The tests will fail and therefore are excluded from normal "make test" via
+// the "example" build tag. To run the tests and check the output, use "go test
+// -tags example ."
+package ginkgo_test

--- a/test/utils/ktesting/examples/ginkgo/example_test.go
+++ b/test/utils/ktesting/examples/ginkgo/example_test.go
@@ -1,0 +1,71 @@
+//go:build example
+// +build example
+
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ginkgo_test
+
+import (
+	"context"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	"github.com/stretchr/testify/require"
+	"k8s.io/kubernetes/test/utils/ktesting"
+)
+
+var _ = ginkgo.Describe("something", func() {
+	ginkgo.It("fails", func(ctx context.Context) {
+		tCtx := ktesting.InitCtx(ctx, ginkgo.GinkgoT(1))
+		doSomething(ktesting.WithStep(tCtx, "trying something"))
+	})
+
+	// Ginkgo produces its own [TIMEDOUT] failure in this case.
+	// The step gets injected by stepReporter.AttachProgressReporter.
+	ginkgo.It("spec timeout", func(ctx context.Context) {
+		tCtx := ktesting.InitCtx(ctx, ginkgo.GinkgoT(1))
+		timeout(ktesting.WithStep(tCtx, "trying something"))
+	}, ginkgo.SpecTimeout(30*time.Second))
+
+	// Here Gomega produces the failure.
+	// The step gets injected by stepContext.Fatal.
+	ginkgo.It("canceled", func(ctx context.Context) {
+		tCtx := ktesting.InitCtx(ctx, ginkgo.GinkgoT(1))
+		tCtx = ktesting.WithTimeout(tCtx, 30*time.Second, "test timeout")
+		timeout(ktesting.WithStep(tCtx, "trying something"))
+	})
+})
+
+func doSomething(tCtx ktesting.TContext) {
+	tCtx.Helper() // Failures are recorded for the caller.
+	tCtx.Log("Log()")
+	tCtx.Logger().Info("Logger().Info()")
+	tCtx.Fatal("this failure is intentional")
+	require.Equal(tCtx, 1, 2) // not reached
+}
+
+func timeout(tCtx ktesting.TContext) {
+	tCtx.Helper() // Failures are recorded for the caller.
+	ktesting.Eventually(tCtx, func(tCtx ktesting.TContext) int {
+		select {
+		case <-tCtx.Done():
+		case <-time.After(time.Second):
+		}
+		return 42
+	}).Should(gomega.Equal(1))
+}

--- a/test/utils/ktesting/examples/ginkgo/ginkgo_suite_test.go
+++ b/test/utils/ktesting/examples/ginkgo/ginkgo_suite_test.go
@@ -1,0 +1,61 @@
+//go:build example
+// +build example
+
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ginkgo_test
+
+import (
+	"testing"
+
+	"github.com/onsi/ginkgo/v2"
+	ginkgotypes "github.com/onsi/ginkgo/v2/types"
+	"github.com/onsi/gomega"
+
+	"k8s.io/klog/v2"
+	"k8s.io/klog/v2/textlogger"
+)
+
+// Initialize klog to log through Ginkgo. The textlogger supports
+// delegating stack unwinding to Ginkgo, therefore it gets used here.
+func init() {
+	config := textlogger.NewConfig(
+		textlogger.Output(ginkgo.GinkgoWriter),
+		textlogger.Backtrace(unwind),
+	)
+	logger := textlogger.NewLogger(config)
+	writer, _ := logger.GetSink().(textlogger.KlogBufferWriter)
+	opts := []klog.LoggerOption{
+		klog.ContextualLogger(true),
+		klog.WriteKlogBuffer(writer.WriteKlogBuffer),
+	}
+	klog.SetLoggerWithOptions(logger, opts...)
+
+	// No command line flags, ktesting already added them
+	// for klog. This can be solved, but isn't needed
+	// for this simple example.
+}
+
+func unwind(skip int) (string, int) {
+	location := ginkgotypes.NewCodeLocation(skip + 1)
+	return location.FileName, location.LineNumber
+}
+
+func TestGinkgo(t *testing.T) {
+	gomega.RegisterFailHandler(ginkgo.Fail)
+	ginkgo.RunSpecs(t, "Ginkgo Suite")
+}

--- a/test/utils/ktesting/kobject/encoding.go
+++ b/test/utils/ktesting/kobject/encoding.go
@@ -1,0 +1,148 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kobject
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+
+	apiextensionsscheme "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/scheme"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	cgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/kubernetes/test/utils/ktesting"
+	"sigs.k8s.io/yaml"
+)
+
+var scheme = runtime.NewScheme()
+var decoder = serializer.NewCodecFactory(scheme).UniversalDeserializer() // no defaulting (not registered anyway), no conversion (= return exactly what is in the input)
+
+func init() {
+	metav1.AddToGroupVersion(scheme, schema.GroupVersion{Version: "v1"})
+	utilruntime.Must(cgoscheme.AddToScheme(scheme))
+	utilruntime.Must(apiextensionsscheme.AddToScheme(scheme))
+}
+
+// NamedReader is a reader which can also name what it is reading from
+// for error messages. Implemented by os.File.
+type NamedReader interface {
+	io.Reader
+	Name() string
+}
+
+var _ NamedReader = &os.File{}
+
+// NamedReadCloser is a [NamedReader] which also supports closing itself.
+type NamedReadCloser interface {
+	NamedReader
+	Close() error
+}
+
+// NameReader associates a name with a reader which itself doesn't have one.
+func NameReader(r io.Reader, name string) NamedReader {
+	return namedReader{
+		Reader: r,
+		name:   name,
+	}
+}
+
+type namedReader struct {
+	io.Reader
+	name string
+}
+
+func (n namedReader) Name() string {
+	return n.name
+}
+
+// LoadFromManifests loads .yaml or .json manifest files and returns all items
+// that it finds in them. It creates native types for everyting that the typed
+// clients supported by ktesting support (like Pod, CustomResourceDefinition,
+// etc.). Everything else gets decoded into an [unstructured.Unstructured].
+//
+// YAML files may contain multiple items separated by "---". Empty items (only
+// comments) are ignored.
+//
+// Each item may get patches before parsing. The patch callback may be empty.
+func LoadFromManifests(tCtx ktesting.TContext, patch func(ktesting.TContext, []byte) []byte, files ...NamedReader) []runtime.Object {
+	tCtx.Helper()
+
+	var objs []runtime.Object
+	parse := func(tCtx ktesting.TContext, data []byte) {
+		if patch != nil {
+			data = patch(ktesting.WithStep(tCtx, "patch"), data)
+		}
+		obj, err := runtime.Decode(decoder, data)
+
+		if runtime.IsNotRegisteredError(err) {
+			var anyObj unstructured.Unstructured
+			tCtx.ExpectNoError(runtime.DecodeInto(decoder, data, &anyObj), "decoding into unstructured.Unstructured failed")
+			if len(anyObj.Object) > 0 {
+				objs = append(objs, &anyObj)
+				return
+			}
+			// Fall through...
+		}
+
+		if runtime.IsMissingVersion(err) || runtime.IsMissingKind(err) {
+			// Could be an empty item (= only comments).
+			// Parse as YAML and if that confirms that hypothesis, then ignore the item.
+			var anyObj map[string]any
+			tCtx.ExpectNoError(yaml.Unmarshal(data, &anyObj), "decoding as YAML")
+			if len(anyObj) == 0 {
+				return
+			}
+			// Fall through...
+		}
+
+		tCtx.ExpectNoError(err, "decoding failed")
+		objs = append(objs, obj)
+	}
+
+	for _, file := range files {
+		visitManifest(ktesting.WithStep(tCtx, file.Name()), parse, file)
+	}
+
+	return objs
+}
+
+func visitManifest(tCtx ktesting.TContext, cb func(ktesting.TContext, []byte), file NamedReader) {
+	tCtx.Helper()
+	data, err := io.ReadAll(file)
+	tCtx.ExpectNoError(err, "reading manifest")
+
+	// Split at the "---" separator before working on
+	// individual item. Only works for .yaml.
+	//
+	// We need to split ourselves because we need access
+	// to each original chunk of data for
+	// runtime.Decode. kubectl has its own
+	// infrastructure for this, but that is a lot of code
+	// with many dependencies.
+	items := bytes.Split(data, []byte("\n---"))
+
+	for i, item := range items {
+		itemCtx := ktesting.WithStep(tCtx, fmt.Sprintf("item #%d", i))
+		cb(itemCtx, item)
+	}
+}

--- a/test/utils/ktesting/kobject/kobject.go
+++ b/test/utils/ktesting/kobject/kobject.go
@@ -1,0 +1,218 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kobject
+
+import (
+	"errors"
+	"fmt"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/klog/v2"
+	"k8s.io/kubernetes/test/utils/ktesting"
+)
+
+// This package works by converting to/from unstructured.Unstructured and then
+// calling the dynamic client with a group/version/resource determined via
+// the REST mapper.
+//
+// We could avoid double conversion by replicating the code of the dynamic client
+// and decoding the response directly into the right type. Better for performance,
+// but more code to maintain, so not worth it?
+
+func Get[T runtime.Object](tCtx ktesting.TContext, what Object, options metav1.GetOptions) (T, error) {
+	tCtx.Helper()
+
+	var object T
+	gvk, err := getGVK(tCtx, object)
+	if err != nil {
+		return object, err
+	}
+	mapping, err := tCtx.RESTMapper().RESTMapping(gvk.GroupKind(), gvk.Version)
+	if err != nil {
+		// Try again once after resetting the mapping. The information
+		// might have been stale.
+		tCtx.RESTMapper().Reset()
+		mapping, err = tCtx.RESTMapper().RESTMapping(gvk.GroupKind(), gvk.Version)
+	}
+	if err != nil {
+		return object, fmt.Errorf("not resource found for %T: %w", object, err)
+	}
+
+	var client dynamic.ResourceInterface
+	if mapping.Scope.Name() == meta.RESTScopeNameNamespace {
+		client = tCtx.Dynamic().Resource(mapping.Resource).Namespace(what.GetNamespace())
+	} else {
+		client = tCtx.Dynamic().Resource(mapping.Resource)
+	}
+	obj, err := client.Get(tCtx, what.GetName(), options)
+	if err != nil {
+		return object, fmt.Errorf("get failed: %w", err)
+	}
+	if err := scheme.Convert(obj, object, nil); err != nil {
+		return object, fmt.Errorf("conversion from %s to %T failed: %w", gvk, object, err)
+	}
+
+	return object, nil
+}
+
+// Create creates an object. If the corresponding resource is namespaced, then
+// the namespace in the object is used or, if that is unset, the default
+// namespace in the context (see [WithNamespace]).
+//
+// Supported object types are [unstructured.Unstructured] and any of the API
+// types that the typed clients supported by ktesting support (like Pod,
+// CustomResourceDefinition, etc.)
+//
+// The object will get removed during test cleanup automatically. This can be
+// disabled via [WithCleanup].
+//
+// A message gets logged about creating and (if that is enabled) deleting the
+// object at V(0). Use [ktesting.WithLogger] and a logger with higher verbosity
+// reduce log output.
+//
+// API calls get retried automatically if the apiserver's response indicates
+// that the error was transient.
+func Create[T runtime.Object](tCtx ktesting.TContext, object T, options metav1.CreateOptions) (T, error) {
+	tCtx.Helper()
+
+	var result T
+	gvk := object.GetObjectKind().GroupVersionKind()
+
+	// gvk might be unset, for example when T is *v1.Pod.
+	// In that case we have to look it up.
+	//
+	// For unstructured.Unstructured it has to be set because
+	// there is no way to guess it.
+	var emptyGVK schema.GroupVersionKind
+	if gvk == emptyGVK {
+		objGVK, err := getGVK(tCtx, object)
+		if err != nil {
+			return result, err
+		}
+		gvk = objGVK
+	}
+
+	mapping, err := tCtx.RESTMapper().RESTMapping(gvk.GroupKind(), gvk.Version)
+	if err != nil {
+		// Try again once after resetting the mapping. The information
+		// might have been stale.
+		tCtx.RESTMapper().Reset()
+		mapping, err = tCtx.RESTMapper().RESTMapping(gvk.GroupKind(), gvk.Version)
+	}
+	if err != nil {
+		return result, fmt.Errorf("not resource found for %T: %w", result, err)
+	}
+
+	accessor, err := meta.Accessor(object)
+	if err != nil {
+		return result, fmt.Errorf("cannot access meta data of %T: %w", object, err)
+	}
+	named := NamespacedName{
+		Name: accessor.GetName(),
+	}
+	var client dynamic.ResourceInterface
+	if mapping.Scope.Name() == meta.RESTScopeNameNamespace {
+		namespace := accessor.GetNamespace()
+		if namespace == "" {
+			namespace = tCtx.Namespace()
+		}
+		if namespace == "" {
+			return result, fmt.Errorf("%T is namespaced, but namespace in object and context are unset", object)
+		}
+		named.Namespace = namespace
+		client = tCtx.Dynamic().Resource(mapping.Resource).Namespace(namespace)
+	} else {
+		client = tCtx.Dynamic().Resource(mapping.Resource)
+	}
+
+	tCtx.Logger().Info("Creating object", "gvk", gvk, "object", klog.KObj(named))
+	tCtx.Logf("Creating %q %s", gvk, named)
+
+	// This is where generics in Go stop being useful:
+	// we need to handle API types and unstructured.Unstructured differently,
+	// but can only do so via runtime reflection.
+	out, err := create(tCtx, client, gvk, object, options)
+	if err != nil {
+		return result, err
+	}
+
+	tCtx.CleanupCtx(func(tCtx ktesting.TContext) {
+		tCtx.Logger().Info("Cleaning up object", "gvk", gvk, "object", klog.KObj(named))
+		err := client.Delete(tCtx, named.Name, metav1.DeleteOptions{})
+		if err == nil || apierrors.IsNotFound(err) {
+			return
+		}
+		tCtx.Errorf("Deleting %s %s failed: %v", gvk, named, err)
+	})
+
+	return out.(T), nil
+}
+
+func create(tCtx ktesting.TContext, client dynamic.ResourceInterface, gvk schema.GroupVersionKind, object any, options metav1.CreateOptions) (any, error) {
+	tCtx.Helper()
+
+	if object, ok := object.(*unstructured.Unstructured); ok {
+		return client.Create(tCtx, object, options)
+	}
+
+	var out unstructured.Unstructured
+	if err := scheme.Convert(object, &out, nil); err != nil {
+		return nil, fmt.Errorf("conversion from %T to unstructured %s failed: %w", object, gvk, err)
+	}
+	in, err := client.Create(tCtx, &out, options)
+	if err != nil {
+		return nil, err
+	}
+	result, err := scheme.New(gvk)
+	if err != nil {
+		return nil, fmt.Errorf("cannot create new object of type %T from %s: %w", object, gvk, err)
+	}
+	if err := scheme.Convert(in, result, nil); err != nil {
+		return result, fmt.Errorf("conversion from unstructured %s to %T failed: %w", gvk, result, err)
+	}
+
+	return result, nil
+}
+
+func getGVK(tCtx ktesting.TContext, object runtime.Object) (gvk schema.GroupVersionKind, finalErr error) {
+	defer func() {
+		if finalErr != nil {
+			finalErr = fmt.Errorf("look up group/version/kind for %T: %w", object, finalErr)
+		}
+	}()
+
+	gvks, unversioned, err := scheme.ObjectKinds(object)
+	if err != nil {
+		return gvk, err
+	}
+	if unversioned {
+		return gvk, errors.New("not versioned")
+	}
+	if len(gvks) == 0 {
+		return gvk, errors.New("no type information")
+	}
+	if len(gvks) > 1 {
+		return gvk, fmt.Errorf("type is ambiguous (%v)", gvks)
+	}
+	return gvks[0], nil
+}

--- a/test/utils/ktesting/kobject/object.go
+++ b/test/utils/ktesting/kobject/object.go
@@ -14,36 +14,39 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package framework
+package kobject
 
-// NamespacedName comprises a resource name, with a mandatory namespace,
-// rendered as "<namespace>/<name>". It implements NamedObject and thus can be
+// Object is a subset of metav1.Object which provides read-only access
+// to name and namespace of an object. The namespace is optional.
+type Object interface {
+	GetNamespace() string
+	GetName() string
+}
+
+// NamespacedName combines a resource name with an optional namespace,
+// rendered as "[<namespace>/]<name>". It Object and thus can be
 // used as function parameter instead of a full API object.
 type NamespacedName struct {
 	Namespace string
 	Name      string
 }
 
-var _ NamedObject = NamespacedName{}
+var _ Object = NamespacedName{}
 
-// NamedObject is a subset of metav1.Object which provides read-only access
-// to name and namespace of an object.
-type NamedObject interface {
-	GetNamespace() string
-	GetName() string
-}
-
-// GetNamespace implements NamedObject.
+// GetNamespace implements [Object.GetNamespace].
 func (n NamespacedName) GetNamespace() string {
 	return n.Namespace
 }
 
-// GetName implements NamedObject.
+// GetName implements [Object.GetName].
 func (n NamespacedName) GetName() string {
 	return n.Name
 }
 
 // String returns the general purpose string representation
 func (n NamespacedName) String() string {
-	return n.Namespace + "/" + n.Name
+	if n.Namespace != "" {
+		return n.Namespace + "/" + n.Name
+	}
+	return n.Name
 }

--- a/test/utils/ktesting/namespacecontext.go
+++ b/test/utils/ktesting/namespacecontext.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ktesting
+
+// WithNamespace add a default namespace name for operations using the context.
+func WithNamespace(tCtx TContext, namespace string) TContext {
+	return namespaceContext{TContext: tCtx, namespace: namespace}
+}
+
+type namespaceContext struct {
+	TContext
+
+	namespace string
+}
+
+func (nCtx namespaceContext) Namespace() string {
+	return nCtx.namespace
+}

--- a/test/utils/ktesting/namespacecontext_test.go
+++ b/test/utils/ktesting/namespacecontext_test.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ktesting
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWithNamespace(t *testing.T) {
+	tCtx := Init(t)
+	assert.Equal(tCtx, "", tCtx.Namespace(), "not set yet")
+
+	tCtx = WithNamespace(tCtx, "foo")
+	assert.Equal(tCtx, "foo", tCtx.Namespace(), "namespace from tCtx")
+}

--- a/test/utils/ktesting/run.go
+++ b/test/utils/ktesting/run.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ktesting
+
+import (
+	"testing"
+	"time"
+)
+
+// RunB runs f as a subbenchmark of tCtx called name.
+// tCtx must be based on *testing.B, otherwise
+// RunB fails the parent benchmark.
+func RunB(tCtx TContext, name string, f func(bCtx BContext)) {
+	tb := tCtx.TB()
+	b, ok := tb.(*testing.B)
+	if !ok {
+		tCtx.Helper()
+		tCtx.Errorf("ktesting.RunB is only supported for a TContext based on *testing.B, got instead: %T", tb)
+	}
+	b.Run(name, func(b *testing.B) {
+		tCtx := WithTB(tCtx, b)
+		f(BContext{N: b.N, TContext: tCtx, b: b})
+	})
+}
+
+// BContext is a variant of TContext which exposes the additional API normally
+// associated with a testing.B (N field, methods for controlling benchmarks).
+type BContext struct {
+	TContext
+	N int
+	b *testing.B
+}
+
+func (bCtx BContext) Elapsed() time.Duration {
+	return bCtx.b.Elapsed()
+}
+
+func (bCtx BContext) ReportAllocs() {
+	bCtx.b.ReportAllocs()
+}
+
+func (bCtx BContext) ReportMetric(n float64, unit string) {
+	bCtx.b.ReportMetric(n, unit)
+}
+
+func (bCtx BContext) ResetTimer() {
+	bCtx.b.ResetTimer()
+}
+
+func (bCtx BContext) SetBytes(n int64) {
+	bCtx.b.SetBytes(n)
+}
+
+func (bCtx BContext) StartTimer() {
+	bCtx.b.StartTimer()
+}
+
+func (bCtx BContext) StopTimer() {
+	bCtx.b.StopTimer()
+}
+
+// RunT runs f as a subtest of tCtx called name.
+// tCtx must be based on *testing.T, otherwise
+// RunT fails the parent test.
+func RunT(tCtx TContext, name string, f func(tCtx TContext)) {
+	tb := tCtx.TB()
+	t, ok := tb.(*testing.T)
+	if !ok {
+		tCtx.Helper()
+		tCtx.Errorf("ktesting.RunT is only supported for a TContext based on *testing.T, got instead: %T", tb)
+	}
+	t.Run(name, func(t *testing.T) {
+		tCtx := WithTB(tCtx, t)
+		f(tCtx)
+	})
+}

--- a/test/utils/ktesting/tcontext.go
+++ b/test/utils/ktesting/tcontext.go
@@ -159,6 +159,10 @@ type TContext interface {
 	Dynamic() dynamic.Interface
 	APIExtensions() apiextensions.Interface
 
+	// Namespace returns the Kubernetes namespace associated with the context.
+	// May be empty if there is none.
+	Namespace() string
+
 	// The following methods must be implemented by every implementation
 	// of TContext to ensure that the leaf TContext is used, not some
 	// embedded TContext:
@@ -482,4 +486,8 @@ func (tCtx tContext) Dynamic() dynamic.Interface {
 
 func (tCtx tContext) APIExtensions() apiextensions.Interface {
 	return nil
+}
+
+func (tCtx tContext) Namespace() string {
+	return ""
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Both scheduler_perf and storage+DRA E2E tests create objects from YAML files. This common functionality is now provided by ktesting. Instead of manually written code as in the storage helper, discovery and a generic client are used, so arbitrary types are supported.

Running TContext on top of Go unit tests was added earlier. Running it on top of Ginkgo in an E2E test gets added here.

The error handling philosophy is a bit different than before: instead of returning errors, helper functions mark themselves as helper and raise a test failure directly on errors. The source code location then is their caller. `WithStep` is used to provide the "bread crumbs" that normally would be in the wrapper error.

#### Special notes for your reviewer:

This PR started as a playground for exploring the idea of a common base for Go test and E2E tests. Most of the changes were already merged earlier. What's left is what I still had pending in the branch.

This replaces https://github.com/kubernetes/kubernetes/pull/122391.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/assign @kerthcet @aojea