### PR TITLE
Add a throttle logger to avoid log spam in the Attach/Detach controller

### DIFF
--- a/cmd/kube-controller-manager/app/core.go
+++ b/cmd/kube-controller-manager/app/core.go
@@ -27,8 +27,6 @@ import (
 	"strings"
 	"time"
 
-	"k8s.io/klog/v2"
-
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	genericfeatures "k8s.io/apiserver/pkg/features"
@@ -63,6 +61,7 @@ import (
 	ttlcontroller "k8s.io/kubernetes/pkg/controller/ttl"
 	"k8s.io/kubernetes/pkg/controller/ttlafterfinished"
 	"k8s.io/kubernetes/pkg/controller/volume/attachdetach"
+	"k8s.io/kubernetes/pkg/controller/volume/attachdetach/util"
 	"k8s.io/kubernetes/pkg/controller/volume/ephemeral"
 	"k8s.io/kubernetes/pkg/controller/volume/expand"
 	persistentvolumecontroller "k8s.io/kubernetes/pkg/controller/volume/persistentvolume"
@@ -390,6 +389,7 @@ func startPersistentVolumeAttachDetachController(ctx context.Context, controller
 			controllerContext.ComponentConfig.AttachDetachController.DisableAttachDetachReconcilerSync,
 			controllerContext.ComponentConfig.AttachDetachController.ReconcilerSyncLoopPeriod.Duration,
 			controllerContext.ComponentConfig.AttachDetachController.DisableForceDetachOnTimeout,
+			util.NewThrottleLogger(ctx, logger, util.WithInterval(controllerContext.ComponentConfig.AttachDetachController.ErrorLogInterval.Duration)),
 			attachdetach.DefaultTimerConfig,
 		)
 	if attachDetachControllerErr != nil {

--- a/cmd/kube-controller-manager/app/options/attachdetachcontroller.go
+++ b/cmd/kube-controller-manager/app/options/attachdetachcontroller.go
@@ -38,6 +38,7 @@ func (o *AttachDetachControllerOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&o.DisableAttachDetachReconcilerSync, "disable-attach-detach-reconcile-sync", false, "Disable volume attach detach reconciler sync. Disabling this may cause volumes to be mismatched with pods. Use wisely.")
 	fs.DurationVar(&o.ReconcilerSyncLoopPeriod.Duration, "attach-detach-reconcile-sync-period", o.ReconcilerSyncLoopPeriod.Duration, "The reconciler sync wait time between volume attach detach. This duration must be larger than one second, and increasing this value from the default may allow for volumes to be mismatched with pods.")
 	fs.BoolVar(&o.DisableForceDetachOnTimeout, "disable-force-detach-on-timeout", false, "Prevent force detaching volumes based on maximum unmount time and node status. If this flag is set to true, the non-graceful node shutdown feature must be used to recover from node failure. See https://k8s.io/docs/storage-disable-force-detach-on-timeout/.")
+	fs.DurationVar(&o.ErrorLogInterval.Duration, "attach-detach-err-log-interval", o.ErrorLogInterval.Duration, "The interval of logging errors for the same volume.")
 }
 
 // ApplyTo fills up AttachDetachController config with options.
@@ -49,6 +50,7 @@ func (o *AttachDetachControllerOptions) ApplyTo(cfg *attachdetachconfig.AttachDe
 	cfg.DisableAttachDetachReconcilerSync = o.DisableAttachDetachReconcilerSync
 	cfg.ReconcilerSyncLoopPeriod = o.ReconcilerSyncLoopPeriod
 	cfg.DisableForceDetachOnTimeout = o.DisableForceDetachOnTimeout
+	cfg.ErrorLogInterval = o.ErrorLogInterval
 
 	return nil
 }

--- a/pkg/controller/volume/attachdetach/attach_detach_controller_test.go
+++ b/pkg/controller/volume/attachdetach/attach_detach_controller_test.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/kubernetes/pkg/controller"
 	"k8s.io/kubernetes/pkg/controller/volume/attachdetach/cache"
 	controllervolumetesting "k8s.io/kubernetes/pkg/controller/volume/attachdetach/testing"
+	attachdetachutil "k8s.io/kubernetes/pkg/controller/volume/attachdetach/util"
 	"k8s.io/kubernetes/pkg/volume"
 	"k8s.io/kubernetes/pkg/volume/csi"
 	"k8s.io/kubernetes/pkg/volume/util"
@@ -51,6 +52,7 @@ func Test_NewAttachDetachController_Positive(t *testing.T) {
 
 	// Act
 	tCtx := ktesting.Init(t)
+	logger, _ := ktesting.NewTestContext(t)
 	_, err := NewAttachDetachController(
 		tCtx,
 		fakeKubeClient,
@@ -67,6 +69,7 @@ func Test_NewAttachDetachController_Positive(t *testing.T) {
 		false,
 		5*time.Second,
 		false,
+		attachdetachutil.NewThrottleLogger(tCtx, logger),
 		DefaultTimerConfig,
 	)
 
@@ -280,6 +283,7 @@ func attachDetachRecoveryTestCase(t *testing.T, extraPods1 []*v1.Pod, extraPods2
 		false,
 		1*time.Second,
 		false,
+		attachdetachutil.NewThrottleLogger(ctx, logger),
 		DefaultTimerConfig,
 	)
 
@@ -544,6 +548,7 @@ func volumeAttachmentRecoveryTestCase(t *testing.T, tc vaTest) {
 		false,
 		1*time.Second,
 		false,
+		attachdetachutil.NewThrottleLogger(ctx, logger),
 		DefaultTimerConfig,
 	)
 	if err != nil {

--- a/pkg/controller/volume/attachdetach/config/types.go
+++ b/pkg/controller/volume/attachdetach/config/types.go
@@ -33,4 +33,7 @@ type AttachDetachControllerConfiguration struct {
 	// time is exceeded. Is false by default, and thus force detach on unmount is
 	// enabled.
 	DisableForceDetachOnTimeout bool
+	// ErrorLogInterval is the amount of time between logging errors for the same volume.
+	// Is set to 1 min by default.
+	ErrorLogInterval metav1.Duration
 }

--- a/pkg/controller/volume/attachdetach/populator/desired_state_of_world_populator.go
+++ b/pkg/controller/volume/attachdetach/populator/desired_state_of_world_populator.go
@@ -64,7 +64,8 @@ func NewDesiredStateOfWorldPopulator(
 	pvcLister corelisters.PersistentVolumeClaimLister,
 	pvLister corelisters.PersistentVolumeLister,
 	csiMigratedPluginManager csimigration.PluginManager,
-	intreeToCSITranslator csimigration.InTreeToCSITranslator) DesiredStateOfWorldPopulator {
+	intreeToCSITranslator csimigration.InTreeToCSITranslator,
+	throttleLogger *util.ThrottleLogger) DesiredStateOfWorldPopulator {
 	return &desiredStateOfWorldPopulator{
 		loopSleepDuration:        loopSleepDuration,
 		listPodsRetryDuration:    listPodsRetryDuration,
@@ -75,6 +76,7 @@ func NewDesiredStateOfWorldPopulator(
 		pvLister:                 pvLister,
 		csiMigratedPluginManager: csiMigratedPluginManager,
 		intreeToCSITranslator:    intreeToCSITranslator,
+		throttleLogger:           throttleLogger,
 	}
 }
 
@@ -89,6 +91,7 @@ type desiredStateOfWorldPopulator struct {
 	timeOfLastListPods       time.Time
 	csiMigratedPluginManager csimigration.PluginManager
 	intreeToCSITranslator    csimigration.InTreeToCSITranslator
+	throttleLogger           *util.ThrottleLogger
 }
 
 func (dswp *desiredStateOfWorldPopulator) Run(ctx context.Context) {
@@ -190,8 +193,7 @@ func (dswp *desiredStateOfWorldPopulator) findAndAddActivePods(logger klog.Logge
 			continue
 		}
 		util.ProcessPodVolumes(logger, pod, true,
-			dswp.desiredStateOfWorld, dswp.volumePluginMgr, dswp.pvcLister, dswp.pvLister, dswp.csiMigratedPluginManager, dswp.intreeToCSITranslator)
-
+			dswp.desiredStateOfWorld, dswp.volumePluginMgr, dswp.pvcLister, dswp.pvLister, dswp.csiMigratedPluginManager, dswp.intreeToCSITranslator, dswp.throttleLogger)
 	}
 
 }

--- a/pkg/controller/volume/attachdetach/util/throttle_logger.go
+++ b/pkg/controller/volume/attachdetach/util/throttle_logger.go
@@ -1,0 +1,104 @@
+package util
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog/v2"
+	"k8s.io/utils/pointer"
+)
+
+const defaultInterval = 1 * time.Minute
+
+// ThrottleLogger provides throttling functionality and rate control to the logging output.
+// It limits the log repetition for same key in specific time duration.
+type ThrottleLogger struct {
+	// logger is the underlying logger that messages are written to.
+	logger klog.Logger
+	// lastLogTimes maps unique keys to the last time a message was logged.
+	lastLogTimes map[string]time.Time
+	// logInterval is the minimum time between log messages for a given key.
+	logInterval time.Duration
+	// expireDuration is the maximum time an item of the lastLogTimes map can be idle before it is deleted.
+	expireDuration *time.Duration
+	// gcPeriod is the time between garbage collection runs.
+	gcPeriod *time.Duration
+	// mutex locks access to the lastLogTimes map.
+	mutex sync.Mutex
+}
+
+// Log logs only if the key has not been logged or the gap since last log is more than logInterval.
+func (t *ThrottleLogger) Log(level int, uniqueName, msg string, keysAndValues ...interface{}) {
+	t.mutex.Lock()
+	defer t.mutex.Unlock()
+
+	// Log the message if uniqueName log entry does not exist or if it has not been logged within the logInterval.
+	if lastLogTime, ok := t.lastLogTimes[uniqueName]; !ok || time.Since(lastLogTime) > t.logInterval {
+		t.logger.V(level).Info(msg, keysAndValues...)
+		t.lastLogTimes[uniqueName] = time.Now()
+	}
+}
+
+// garbageCollectFunc checks and cleans up stale entries in lastLogTimes map.
+// If any log key has last log time older than expireDuration then that the entry is removed from map.
+func (t *ThrottleLogger) garbageCollectFunc() func(ctx context.Context) {
+	return func(ctx context.Context) {
+		t.mutex.Lock()
+		defer t.mutex.Unlock()
+
+		for key, lastLogTime := range t.lastLogTimes {
+			if time.Since(lastLogTime) > t.logInterval {
+				delete(t.lastLogTimes, key)
+			}
+		}
+	}
+}
+
+// Option is a function that sets some option for ThrottleLogger.
+type Option func(*ThrottleLogger)
+
+func WithInterval(interval time.Duration) Option {
+	return func(t *ThrottleLogger) {
+		t.logInterval = interval
+	}
+}
+
+func WithExpireDuration(expireDuration time.Duration) Option {
+	return func(t *ThrottleLogger) {
+		t.expireDuration = pointer.Duration(expireDuration)
+	}
+}
+
+func WithGCPeriod(gcPeriod time.Duration) Option {
+	return func(t *ThrottleLogger) {
+		t.gcPeriod = pointer.Duration(gcPeriod)
+	}
+}
+
+// NewThrottleLogger creates a new ThrottleLogger instance.
+// It also starts a separate goroutine to call `garbageCollectFunc` every `gcPeriod` time.
+func NewThrottleLogger(ctx context.Context, logger klog.Logger, opts ...Option) *ThrottleLogger {
+	tl := &ThrottleLogger{
+		logger:       logger,
+		lastLogTimes: make(map[string]time.Time),
+		logInterval:  defaultInterval,
+		mutex:        sync.Mutex{},
+	}
+
+	for _, opt := range opts {
+		opt(tl)
+	}
+
+	// Set default values if not provided.
+	if tl.expireDuration == nil {
+		tl.expireDuration = pointer.Duration(tl.logInterval * 2)
+	}
+	if tl.gcPeriod == nil {
+		tl.gcPeriod = pointer.Duration(tl.logInterval)
+	}
+
+	go wait.UntilWithContext(ctx, tl.garbageCollectFunc(), *tl.gcPeriod)
+	return tl
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

We have some errors that are logged at level 10 because the ADC reconciler runs very frequently and would cause log spam.

This PR introduces a throttle logger to log errors with a configurable interval.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #120088 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Add a throttle logger to avoid log spam in the Attach/Detach controller
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
