### PR TITLE
kubeadm: swap deprecated wait.Poll() and wait.PollImmediate()

### DIFF
--- a/cmd/kubeadm/app/cmd/phases/join/kubelet.go
+++ b/cmd/kubeadm/app/cmd/phases/join/kubelet.go
@@ -236,11 +236,13 @@ func waitForTLSBootstrappedClient() error {
 	fmt.Println("[kubelet-start] Waiting for the kubelet to perform the TLS Bootstrap")
 
 	// Loop on every falsy return. Return with an error if raised. Exit successfully if true is returned.
-	return wait.PollImmediate(kubeadmconstants.TLSBootstrapRetryInterval, kubeadmconstants.TLSBootstrapTimeout, func() (bool, error) {
-		// Check that we can create a client set out of the kubelet kubeconfig. This ensures not
-		// only that the kubeconfig file exists, but that other files required by it also exist (like
-		// client certificate and key)
-		_, err := kubeconfigutil.ClientSetFromFile(kubeadmconstants.GetKubeletKubeConfigPath())
-		return (err == nil), nil
-	})
+	return wait.PollUntilContextTimeout(context.Background(),
+		kubeadmconstants.TLSBootstrapRetryInterval, kubeadmconstants.TLSBootstrapTimeout,
+		true, func(_ context.Context) (bool, error) {
+			// Check that we can create a client set out of the kubelet kubeconfig. This ensures not
+			// only that the kubeconfig file exists, but that other files required by it also exist (like
+			// client certificate and key)
+			_, err := kubeconfigutil.ClientSetFromFile(kubeadmconstants.GetKubeletKubeConfigPath())
+			return (err == nil), nil
+		})
 }

--- a/cmd/kubeadm/app/util/apiclient/idempotency.go
+++ b/cmd/kubeadm/app/util/apiclient/idempotency.go
@@ -61,17 +61,19 @@ func CreateOrUpdateConfigMap(client clientset.Interface, cm *v1.ConfigMap) error
 // taking place)
 func CreateOrMutateConfigMap(client clientset.Interface, cm *v1.ConfigMap, mutator ConfigMapMutator) error {
 	var lastError error
-	err := wait.PollImmediate(constants.APICallRetryInterval, constants.APICallWithWriteTimeout, func() (bool, error) {
-		if _, err := client.CoreV1().ConfigMaps(cm.ObjectMeta.Namespace).Create(context.TODO(), cm, metav1.CreateOptions{}); err != nil {
-			lastError = err
-			if apierrors.IsAlreadyExists(err) {
-				lastError = MutateConfigMap(client, metav1.ObjectMeta{Namespace: cm.ObjectMeta.Namespace, Name: cm.ObjectMeta.Name}, mutator)
-				return lastError == nil, nil
+	err := wait.PollUntilContextTimeout(context.Background(),
+		constants.APICallRetryInterval, constants.APICallWithWriteTimeout,
+		true, func(_ context.Context) (bool, error) {
+			if _, err := client.CoreV1().ConfigMaps(cm.ObjectMeta.Namespace).Create(context.TODO(), cm, metav1.CreateOptions{}); err != nil {
+				lastError = err
+				if apierrors.IsAlreadyExists(err) {
+					lastError = MutateConfigMap(client, metav1.ObjectMeta{Namespace: cm.ObjectMeta.Namespace, Name: cm.ObjectMeta.Name}, mutator)
+					return lastError == nil, nil
+				}
+				return false, nil
 			}
-			return false, nil
-		}
-		return true, nil
-	})
+			return true, nil
+		})
 	if err == nil {
 		return nil
 	}
@@ -84,19 +86,21 @@ func CreateOrMutateConfigMap(client clientset.Interface, cm *v1.ConfigMap, mutat
 // taking place).
 func MutateConfigMap(client clientset.Interface, meta metav1.ObjectMeta, mutator ConfigMapMutator) error {
 	var lastError error
-	err := wait.PollImmediate(constants.APICallRetryInterval, constants.APICallWithWriteTimeout, func() (bool, error) {
-		configMap, err := client.CoreV1().ConfigMaps(meta.Namespace).Get(context.TODO(), meta.Name, metav1.GetOptions{})
-		if err != nil {
-			lastError = err
-			return false, nil
-		}
-		if err = mutator(configMap); err != nil {
-			lastError = errors.Wrap(err, "unable to mutate ConfigMap")
-			return false, nil
-		}
-		_, lastError = client.CoreV1().ConfigMaps(configMap.ObjectMeta.Namespace).Update(context.TODO(), configMap, metav1.UpdateOptions{})
-		return lastError == nil, nil
-	})
+	err := wait.PollUntilContextTimeout(context.Background(),
+		constants.APICallRetryInterval, constants.APICallWithWriteTimeout,
+		true, func(_ context.Context) (bool, error) {
+			configMap, err := client.CoreV1().ConfigMaps(meta.Namespace).Get(context.TODO(), meta.Name, metav1.GetOptions{})
+			if err != nil {
+				lastError = err
+				return false, nil
+			}
+			if err = mutator(configMap); err != nil {
+				lastError = errors.Wrap(err, "unable to mutate ConfigMap")
+				return false, nil
+			}
+			_, lastError = client.CoreV1().ConfigMaps(configMap.ObjectMeta.Namespace).Update(context.TODO(), configMap, metav1.UpdateOptions{})
+			return lastError == nil, nil
+		})
 	if err == nil {
 		return nil
 	}
@@ -190,20 +194,22 @@ func CreateOrUpdateDaemonSet(client clientset.Interface, ds *apps.DaemonSet) err
 // CreateOrUpdateRole creates a Role if the target resource doesn't exist. If the resource exists already, this function will update the resource instead.
 func CreateOrUpdateRole(client clientset.Interface, role *rbac.Role) error {
 	var lastError error
-	err := wait.PollImmediate(constants.APICallRetryInterval, constants.APICallWithWriteTimeout, func() (bool, error) {
-		if _, err := client.RbacV1().Roles(role.ObjectMeta.Namespace).Create(context.TODO(), role, metav1.CreateOptions{}); err != nil {
-			if !apierrors.IsAlreadyExists(err) {
-				lastError = errors.Wrap(err, "unable to create RBAC role")
-				return false, nil
-			}
+	err := wait.PollUntilContextTimeout(context.Background(),
+		constants.APICallRetryInterval, constants.APICallWithWriteTimeout,
+		true, func(_ context.Context) (bool, error) {
+			if _, err := client.RbacV1().Roles(role.ObjectMeta.Namespace).Create(context.TODO(), role, metav1.CreateOptions{}); err != nil {
+				if !apierrors.IsAlreadyExists(err) {
+					lastError = errors.Wrap(err, "unable to create RBAC role")
+					return false, nil
+				}
 
-			if _, err := client.RbacV1().Roles(role.ObjectMeta.Namespace).Update(context.TODO(), role, metav1.UpdateOptions{}); err != nil {
-				lastError = errors.Wrap(err, "unable to update RBAC role")
-				return false, nil
+				if _, err := client.RbacV1().Roles(role.ObjectMeta.Namespace).Update(context.TODO(), role, metav1.UpdateOptions{}); err != nil {
+					lastError = errors.Wrap(err, "unable to update RBAC role")
+					return false, nil
+				}
 			}
-		}
-		return true, nil
-	})
+			return true, nil
+		})
 	if err == nil {
 		return nil
 	}
@@ -213,20 +219,22 @@ func CreateOrUpdateRole(client clientset.Interface, role *rbac.Role) error {
 // CreateOrUpdateRoleBinding creates a RoleBinding if the target resource doesn't exist. If the resource exists already, this function will update the resource instead.
 func CreateOrUpdateRoleBinding(client clientset.Interface, roleBinding *rbac.RoleBinding) error {
 	var lastError error
-	err := wait.PollImmediate(constants.APICallRetryInterval, constants.APICallWithWriteTimeout, func() (bool, error) {
-		if _, err := client.RbacV1().RoleBindings(roleBinding.ObjectMeta.Namespace).Create(context.TODO(), roleBinding, metav1.CreateOptions{}); err != nil {
-			if !apierrors.IsAlreadyExists(err) {
-				lastError = errors.Wrap(err, "unable to create RBAC rolebinding")
-				return false, nil
-			}
+	err := wait.PollUntilContextTimeout(context.Background(),
+		constants.APICallRetryInterval, constants.APICallWithWriteTimeout,
+		true, func(_ context.Context) (bool, error) {
+			if _, err := client.RbacV1().RoleBindings(roleBinding.ObjectMeta.Namespace).Create(context.TODO(), roleBinding, metav1.CreateOptions{}); err != nil {
+				if !apierrors.IsAlreadyExists(err) {
+					lastError = errors.Wrap(err, "unable to create RBAC rolebinding")
+					return false, nil
+				}
 
-			if _, err := client.RbacV1().RoleBindings(roleBinding.ObjectMeta.Namespace).Update(context.TODO(), roleBinding, metav1.UpdateOptions{}); err != nil {
-				lastError = errors.Wrap(err, "unable to update RBAC rolebinding")
-				return false, nil
+				if _, err := client.RbacV1().RoleBindings(roleBinding.ObjectMeta.Namespace).Update(context.TODO(), roleBinding, metav1.UpdateOptions{}); err != nil {
+					lastError = errors.Wrap(err, "unable to update RBAC rolebinding")
+					return false, nil
+				}
 			}
-		}
-		return true, nil
-	})
+			return true, nil
+		})
 	if err == nil {
 		return nil
 	}
@@ -262,11 +270,8 @@ func CreateOrUpdateClusterRoleBinding(client clientset.Interface, clusterRoleBin
 }
 
 // PatchNodeOnce executes patchFn on the node object found by the node name.
-// This is a condition function meant to be used with wait.Poll. false, nil
-// implies it is safe to try again, an error indicates no more tries should be
-// made and true indicates success.
-func PatchNodeOnce(client clientset.Interface, nodeName string, patchFn func(*v1.Node), lastError *error) func() (bool, error) {
-	return func() (bool, error) {
+func PatchNodeOnce(client clientset.Interface, nodeName string, patchFn func(*v1.Node), lastError *error) func(context.Context) (bool, error) {
+	return func(_ context.Context) (bool, error) {
 		// First get the node object
 		n, err := client.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
 		if err != nil {
@@ -317,10 +322,9 @@ func PatchNodeOnce(client clientset.Interface, nodeName string, patchFn func(*v1
 // Retries are provided by the wait package.
 func PatchNode(client clientset.Interface, nodeName string, patchFn func(*v1.Node)) error {
 	var lastError error
-	// wait.Poll will rerun the condition function every interval function if
-	// the function returns false. If the condition function returns an error
-	// then the retries end and the error is returned.
-	err := wait.Poll(constants.APICallRetryInterval, constants.PatchNodeTimeout, PatchNodeOnce(client, nodeName, patchFn, &lastError))
+	err := wait.PollUntilContextTimeout(context.Background(),
+		constants.APICallRetryInterval, constants.PatchNodeTimeout,
+		true, PatchNodeOnce(client, nodeName, patchFn, &lastError))
 	if err == nil {
 		return nil
 	}

--- a/cmd/kubeadm/app/util/apiclient/idempotency_test.go
+++ b/cmd/kubeadm/app/util/apiclient/idempotency_test.go
@@ -135,7 +135,7 @@ func TestPatchNode(t *testing.T) {
 					"updatedBy": "test",
 				}
 			}, &lastError)
-			success, err := conditionFunction()
+			success, err := conditionFunction(context.Background())
 			if err != nil {
 				t.Fatalf("did not expect error: %v", err)
 			}

--- a/cmd/kubeadm/app/util/apiclient/wait.go
+++ b/cmd/kubeadm/app/util/apiclient/wait.go
@@ -103,43 +103,47 @@ func (w *KubeWaiter) WaitForAPI() error {
 func (w *KubeWaiter) WaitForPodsWithLabel(kvLabel string) error {
 
 	lastKnownPodNumber := -1
-	return wait.PollImmediate(kubeadmconstants.APICallRetryInterval, w.timeout, func() (bool, error) {
-		listOpts := metav1.ListOptions{LabelSelector: kvLabel}
-		pods, err := w.client.CoreV1().Pods(metav1.NamespaceSystem).List(context.TODO(), listOpts)
-		if err != nil {
-			fmt.Fprintf(w.writer, "[apiclient] Error getting Pods with label selector %q [%v]\n", kvLabel, err)
-			return false, nil
-		}
-
-		if lastKnownPodNumber != len(pods.Items) {
-			fmt.Fprintf(w.writer, "[apiclient] Found %d Pods for label selector %s\n", len(pods.Items), kvLabel)
-			lastKnownPodNumber = len(pods.Items)
-		}
-
-		if len(pods.Items) == 0 {
-			return false, nil
-		}
-
-		for _, pod := range pods.Items {
-			if pod.Status.Phase != v1.PodRunning {
+	return wait.PollUntilContextTimeout(context.Background(),
+		kubeadmconstants.APICallRetryInterval, w.timeout,
+		true, func(_ context.Context) (bool, error) {
+			listOpts := metav1.ListOptions{LabelSelector: kvLabel}
+			pods, err := w.client.CoreV1().Pods(metav1.NamespaceSystem).List(context.TODO(), listOpts)
+			if err != nil {
+				fmt.Fprintf(w.writer, "[apiclient] Error getting Pods with label selector %q [%v]\n", kvLabel, err)
 				return false, nil
 			}
-		}
 
-		return true, nil
-	})
+			if lastKnownPodNumber != len(pods.Items) {
+				fmt.Fprintf(w.writer, "[apiclient] Found %d Pods for label selector %s\n", len(pods.Items), kvLabel)
+				lastKnownPodNumber = len(pods.Items)
+			}
+
+			if len(pods.Items) == 0 {
+				return false, nil
+			}
+
+			for _, pod := range pods.Items {
+				if pod.Status.Phase != v1.PodRunning {
+					return false, nil
+				}
+			}
+
+			return true, nil
+		})
 }
 
 // WaitForPodToDisappear blocks until it timeouts or gets a "NotFound" response from the API Server when getting the Static Pod in question
 func (w *KubeWaiter) WaitForPodToDisappear(podName string) error {
-	return wait.PollImmediate(kubeadmconstants.APICallRetryInterval, w.timeout, func() (bool, error) {
-		_, err := w.client.CoreV1().Pods(metav1.NamespaceSystem).Get(context.TODO(), podName, metav1.GetOptions{})
-		if err != nil && apierrors.IsNotFound(err) {
-			fmt.Printf("[apiclient] The old Pod %q is now removed (which is desired)\n", podName)
-			return true, nil
-		}
-		return false, nil
-	})
+	return wait.PollUntilContextTimeout(context.Background(),
+		kubeadmconstants.APICallRetryInterval, w.timeout,
+		true, func(_ context.Context) (bool, error) {
+			_, err := w.client.CoreV1().Pods(metav1.NamespaceSystem).Get(context.TODO(), podName, metav1.GetOptions{})
+			if err != nil && apierrors.IsNotFound(err) {
+				fmt.Printf("[apiclient] The old Pod %q is now removed (which is desired)\n", podName)
+				return true, nil
+			}
+			return false, nil
+		})
 }
 
 // WaitForKubelet blocks until the kubelet /healthz endpoint returns 'ok'.
@@ -204,14 +208,16 @@ func (w *KubeWaiter) WaitForStaticPodControlPlaneHashes(nodeName string) (map[st
 	var err, lastErr error
 	mirrorPodHashes := map[string]string{}
 	for _, component := range kubeadmconstants.ControlPlaneComponents {
-		err = wait.PollImmediate(kubeadmconstants.APICallRetryInterval, w.timeout, func() (bool, error) {
-			componentHash, err = getStaticPodSingleHash(w.client, nodeName, component)
-			if err != nil {
-				lastErr = err
-				return false, nil
-			}
-			return true, nil
-		})
+		err = wait.PollUntilContextTimeout(context.Background(),
+			kubeadmconstants.APICallRetryInterval, w.timeout,
+			true, func(_ context.Context) (bool, error) {
+				componentHash, err = getStaticPodSingleHash(w.client, nodeName, component)
+				if err != nil {
+					lastErr = err
+					return false, nil
+				}
+				return true, nil
+			})
 		if err != nil {
 			return nil, lastErr
 		}
@@ -226,14 +232,16 @@ func (w *KubeWaiter) WaitForStaticPodSingleHash(nodeName string, component strin
 
 	componentPodHash := ""
 	var err, lastErr error
-	err = wait.PollImmediate(kubeadmconstants.APICallRetryInterval, w.timeout, func() (bool, error) {
-		componentPodHash, err = getStaticPodSingleHash(w.client, nodeName, component)
-		if err != nil {
-			lastErr = err
-			return false, nil
-		}
-		return true, nil
-	})
+	err = wait.PollUntilContextTimeout(context.Background(),
+		kubeadmconstants.APICallRetryInterval, w.timeout,
+		true, func(_ context.Context) (bool, error) {
+			componentPodHash, err = getStaticPodSingleHash(w.client, nodeName, component)
+			if err != nil {
+				lastErr = err
+				return false, nil
+			}
+			return true, nil
+		})
 
 	if err != nil {
 		err = lastErr
@@ -245,21 +253,23 @@ func (w *KubeWaiter) WaitForStaticPodSingleHash(nodeName string, component strin
 // This implicitly means this function blocks until the kubelet has restarted the Static Pod in question
 func (w *KubeWaiter) WaitForStaticPodHashChange(nodeName, component, previousHash string) error {
 	var err, lastErr error
-	err = wait.PollImmediate(kubeadmconstants.APICallRetryInterval, w.timeout, func() (bool, error) {
-		hash, err := getStaticPodSingleHash(w.client, nodeName, component)
-		if err != nil {
-			lastErr = err
-			return false, nil
-		}
-		// Set lastErr to nil to be able to later distinguish between getStaticPodSingleHash() and timeout errors
-		lastErr = nil
-		// We should continue polling until the UID changes
-		if hash == previousHash {
-			return false, nil
-		}
+	err = wait.PollUntilContextTimeout(context.Background(),
+		kubeadmconstants.APICallRetryInterval, w.timeout,
+		true, func(_ context.Context) (bool, error) {
+			hash, err := getStaticPodSingleHash(w.client, nodeName, component)
+			if err != nil {
+				lastErr = err
+				return false, nil
+			}
+			// Set lastErr to nil to be able to later distinguish between getStaticPodSingleHash() and timeout errors
+			lastErr = nil
+			// We should continue polling until the UID changes
+			if hash == previousHash {
+				return false, nil
+			}
 
-		return true, nil
-	})
+			return true, nil
+		})
 
 	// If lastError is not nil, this must be a getStaticPodSingleHash() error, else if err is not nil there was a poll timeout
 	if lastErr != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Swap the usage of these deprecated functions with
wait.PollUntilContextTimeout(). Since we don't have piping of context around kubeadm, use context.Background() everywhere.

wait.ExponentialBackoff and wait.JitterUntil are not deprecated.

Some wait.Poll() functions were converted to "immediate" as there is no point for them to not be. This is done for consistency.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
NONE

#### Special notes for your reviewer:
NONE

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
