### PR TITLE
Automated cherry pick of #120090: Handle edge cases in seat demand stats

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/apf_controller.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/apf_controller.go
@@ -264,9 +264,15 @@ type seatDemandStats struct {
 }
 
 func (stats *seatDemandStats) update(obs fq.IntegratorResults) {
+	stats.highWatermark = obs.Max
+	if obs.Duration <= 0 {
+		return
+	}
+	if math.IsNaN(obs.Deviation) {
+		obs.Deviation = 0
+	}
 	stats.avg = obs.Average
 	stats.stdDev = obs.Deviation
-	stats.highWatermark = obs.Max
 	envelope := obs.Average + obs.Deviation
 	stats.smoothed = math.Max(envelope, seatDemandSmoothingCoefficient*stats.smoothed+(1-seatDemandSmoothingCoefficient)*envelope)
 }


### PR DESCRIPTION
kind/bug

Cherry pick of #120090 on release-1.27.

#120090: Handle edge cases in seat demand stats

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```