### PR TITLE
Fix hpa controller metrics utils func.

### DIFF
--- a/pkg/controller/podautoscaler/config/types.go
+++ b/pkg/controller/podautoscaler/config/types.go
@@ -32,7 +32,7 @@ type HPAControllerConfiguration struct {
 	HorizontalPodAutoscalerUpscaleForbiddenWindow metav1.Duration
 	// horizontalPodAutoscalerDownscaleForbiddenWindow is a period after which next downscale allowed.
 	HorizontalPodAutoscalerDownscaleForbiddenWindow metav1.Duration
-	// HorizontalPodAutoscalerDowncaleStabilizationWindow is a period for which autoscaler will look
+	// horizontalPodAutoscalerDownscaleStabilizationWindow is a period for which autoscaler will look
 	// backwards and not scale down below any recommendation it made during that period.
 	HorizontalPodAutoscalerDownscaleStabilizationWindow metav1.Duration
 	// horizontalPodAutoscalerTolerance is the tolerance for when

--- a/pkg/controller/podautoscaler/metrics/utilization.go
+++ b/pkg/controller/podautoscaler/metrics/utilization.go
@@ -55,6 +55,10 @@ func GetResourceUtilizationRatio(metrics PodMetricsInfo, requests map[string]int
 // and calculates the ratio of desired to actual usage
 // (returning that and the actual usage)
 func GetMetricUsageRatio(metrics PodMetricsInfo, targetUsage int64) (usageRatio float64, currentUsage int64) {
+	if len(metrics) == 0 || targetUsage == 0 {
+		return 0, 0
+	}
+
 	metricsTotal := int64(0)
 	for _, metric := range metrics {
 		metricsTotal += metric.Value

--- a/pkg/controller/podautoscaler/metrics/utilization_test.go
+++ b/pkg/controller/podautoscaler/metrics/utilization_test.go
@@ -144,6 +144,32 @@ func TestGetMetricUsageRatioBaseCase(t *testing.T) {
 		expectedUsageRatio:   .75,
 		expectedCurrentUsage: 7500,
 	}
-
 	tc.runTest(t)
+
+	tc = metricUsageRatioTestCase{
+		metrics:              nil,
+		targetUsage:          10000,
+		expectedUsageRatio:   0,
+		expectedCurrentUsage: 0,
+	}
+	tc.runTest(t)
+
+	tc = metricUsageRatioTestCase{
+		metrics: PodMetricsInfo{
+			"test-pod-0": {Value: 5000}, "test-pod-1": {Value: 10000},
+		},
+		targetUsage:          0,
+		expectedUsageRatio:   0,
+		expectedCurrentUsage: 0,
+	}
+	tc.runTest(t)
+
+	tc = metricUsageRatioTestCase{
+		metrics:              nil,
+		targetUsage:          0,
+		expectedUsageRatio:   0,
+		expectedCurrentUsage: 0,
+	}
+	tc.runTest(t)
+
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
1 Fix potential panic when call ```GetMetricUsageRatio```.
Even though it is judge in logic: 
```
k8s/pkg/controller/podautoscaler/replica_calculator.go
if len(metrics) == 0 {
		return 0, 0, fmt.Errorf("did not receive metrics for targeted pods (pods might be unready)")
	}
usageRatio, usage := metricsclient.GetMetricUsageRatio(metrics, targetUsage)

```
But i still think it is should be nil check in function itsself. Because it is a public function. 

2 fix typos HorizontalPodAutoscalerDowncaleStabilizationWindow in ```pkg/controller/podautoscaler/config/types.go```.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
None
```

