### PR TITLE
Automated cherry pick of #121624: use context for lazy evaluation.

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/cel/composition.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/cel/composition.go
@@ -177,7 +177,7 @@ func (a *variableAccessor) Callback(_ *lazy.MapValue) ref.Val {
 		return types.NewErr("composited variable %q fails to compile: %v", a.name, a.result.Error)
 	}
 
-	v, details, err := a.result.Program.Eval(a.activation)
+	v, details, err := a.result.Program.ContextEval(a.context, a.activation)
 	if details == nil {
 		return types.NewErr("unable to get evaluation details of variable %q", a.name)
 	}


### PR DESCRIPTION
Cherry pick of #121624 on release-1.28.

#121624: use context for lazy evaluation.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```