### PR TITLE
remove scheduled-pod filtering from QueueingHints for pod/deleted

### DIFF
--- a/pkg/scheduler/framework/plugins/nodeports/node_ports.go
+++ b/pkg/scheduler/framework/plugins/nodeports/node_ports.go
@@ -127,16 +127,14 @@ func (pl *NodePorts) EventsToRegister() []framework.ClusterEventWithHint {
 
 // isSchedulableAfterPodDeleted is invoked whenever a pod deleted. It checks whether
 // that change made a previously unschedulable pod schedulable.
+//
+// Note that, we intentionally don't check whether the deleted pod was scheduled or not.
+// If we want to do so, it'd be complicated because we have to take assume Pods into consideration.
+// See: https://github.com/kubernetes/kubernetes/issues/122444
 func (pl *NodePorts) isSchedulableAfterPodDeleted(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (framework.QueueingHint, error) {
 	deletedPod, _, err := util.As[*v1.Pod](oldObj, nil)
 	if err != nil {
 		return framework.Queue, err
-	}
-
-	// If the deleted pod is unscheduled, it doesn't make the target pod schedulable.
-	if deletedPod.Spec.NodeName == "" {
-		logger.V(4).Info("the deleted pod is unscheduled and it doesn't make the target pod schedulable", "pod", pod, "deletedPod", deletedPod)
-		return framework.QueueSkip, nil
 	}
 
 	// Get the used host ports of the deleted pod.

--- a/pkg/scheduler/framework/plugins/nodeports/node_ports_test.go
+++ b/pkg/scheduler/framework/plugins/nodeports/node_ports_test.go
@@ -310,30 +310,30 @@ func Test_isSchedulableAfterPodDeleted(t *testing.T) {
 		expectedHint framework.QueueingHint
 		expectedErr  bool
 	}{
-		"backoff-wrong-old-object": {
+		"return error the object is not Pod": {
 			pod:          podWithHostPort.Obj(),
 			oldObj:       "not-a-pod",
 			expectedHint: framework.Queue,
 			expectedErr:  true,
 		},
-		"skip-queue-on-unscheduled": {
-			pod:          podWithHostPort.Obj(),
-			oldObj:       st.MakePod().Obj(),
-			expectedHint: framework.QueueSkip,
-		},
-		"skip-queue-on-non-hostport": {
+		"return skip when deleted Pod has no hostport": {
 			pod:          podWithHostPort.Obj(),
 			oldObj:       st.MakePod().Node("fake-node").Obj(),
 			expectedHint: framework.QueueSkip,
 		},
-		"skip-queue-on-unrelated-hostport": {
+		"return skip when deleted Pod has different hostport from unscheduled Pod": {
 			pod:          podWithHostPort.Obj(),
 			oldObj:       st.MakePod().Node("fake-node").HostPort(8081).Obj(),
 			expectedHint: framework.QueueSkip,
 		},
-		"queue-on-released-hostport": {
+		"return queue when deleted Pod has the same hostport as unscheduled Pod": {
 			pod:          podWithHostPort.Obj(),
 			oldObj:       st.MakePod().Node("fake-node").HostPort(8080).Obj(),
+			expectedHint: framework.Queue,
+		},
+		"return queue even when a deleted Pod was unscheduled": {
+			pod:          podWithHostPort.Obj(),
+			oldObj:       st.MakePod().HostPort(8080).Obj(),
 			expectedHint: framework.Queue,
 		},
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Currently, we have a problem on pod/deleted like in this kind of scenarios:
1. Only one Node which can accomodate only one Pod exists.
2. Pod-a is assumed to the Node. (but not yet actually bound)
3. Pod-b is rejected because the scheduler assumes Pod-a.
4. Pod-a is somehow unassumed. It's treated as Pod/delete event.
5. Pod-a goes to the scheduling queue. Now, the Node has a free space though, will Pod-b be retried? Well, it's depending on the implementation of QHints of Pod/delete...

This PR makes QueueingHints return `Queue` even when the deleted Pod was un-scheduled so that they take assumed Pods into consideration.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #122444

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed a problem on QueueingHints in NodeResourceFit and NodePorts which could result in Pod pending in the scheduling queue unnecessarily for 5 min in a scenario where assumed Pods are involved in.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
