### PR TITLE
kubeadm: increase ut coverage fo phases/kubeconfig

### DIFF
--- a/cmd/kubeadm/app/phases/kubeconfig/kubeconfig_test.go
+++ b/cmd/kubeadm/app/phases/kubeconfig/kubeconfig_test.go
@@ -944,3 +944,202 @@ func TestEnsureAdminClusterRoleBindingImpl(t *testing.T) {
 		})
 	}
 }
+
+func TestCreateKubeConfigAndCSR(t *testing.T) {
+	tmpDir := testutil.SetupTempDir(t)
+	testutil.SetupEmptyFiles(t, tmpDir, "testfile", "bar.csr", "bar.key")
+	defer func() {
+		if err := os.RemoveAll(tmpDir); err != nil {
+			t.Error(err)
+		}
+	}()
+	caCert, caKey := certstestutil.SetupCertificateAuthority(t)
+
+	type args struct {
+		kubeConfigDir string
+		kubeadmConfig *kubeadmapi.InitConfiguration
+		name          string
+		spec          *kubeConfigSpec
+	}
+	tests := []struct {
+		name          string
+		args          args
+		expectedError bool
+	}{
+		{
+			name: "kubeadmConfig is nil",
+			args: args{
+				kubeConfigDir: tmpDir,
+				kubeadmConfig: nil,
+				name:          "foo",
+				spec: &kubeConfigSpec{
+					CACert:         caCert,
+					APIServer:      "10.0.0.1",
+					ClientName:     "foo",
+					TokenAuth:      &tokenAuth{Token: "test"},
+					ClientCertAuth: &clientCertAuth{CAKey: caKey},
+				},
+			},
+			expectedError: true,
+		},
+		{
+			name: "The kubeConfigDir is empty",
+			args: args{
+				kubeConfigDir: "",
+				kubeadmConfig: &kubeadmapi.InitConfiguration{},
+				name:          "foo",
+				spec: &kubeConfigSpec{
+					CACert:         caCert,
+					APIServer:      "10.0.0.1",
+					ClientName:     "foo",
+					TokenAuth:      &tokenAuth{Token: "test"},
+					ClientCertAuth: &clientCertAuth{CAKey: caKey},
+				},
+			},
+			expectedError: true,
+		},
+		{
+			name: "The name is empty",
+			args: args{
+				kubeConfigDir: tmpDir,
+				kubeadmConfig: &kubeadmapi.InitConfiguration{},
+				name:          "",
+				spec: &kubeConfigSpec{
+					CACert:         caCert,
+					APIServer:      "10.0.0.1",
+					ClientName:     "foo",
+					TokenAuth:      &tokenAuth{Token: "test"},
+					ClientCertAuth: &clientCertAuth{CAKey: caKey},
+				},
+			},
+			expectedError: true,
+		},
+		{
+			name: "The spec is empty",
+			args: args{
+				kubeConfigDir: tmpDir,
+				kubeadmConfig: &kubeadmapi.InitConfiguration{},
+				name:          "foo",
+				spec:          nil,
+			},
+			expectedError: true,
+		},
+		{
+			name: "The kubeconfig file already exists",
+			args: args{
+				kubeConfigDir: tmpDir,
+				kubeadmConfig: &kubeadmapi.InitConfiguration{},
+				name:          "testfile",
+				spec: &kubeConfigSpec{
+					CACert:         caCert,
+					APIServer:      "10.0.0.1",
+					ClientName:     "foo",
+					TokenAuth:      &tokenAuth{Token: "test"},
+					ClientCertAuth: &clientCertAuth{CAKey: caKey},
+				},
+			},
+			expectedError: true,
+		},
+		{
+			name: "The CSR or key files already exists",
+			args: args{
+				kubeConfigDir: tmpDir,
+				kubeadmConfig: &kubeadmapi.InitConfiguration{},
+				name:          "bar",
+				spec: &kubeConfigSpec{
+					CACert:         caCert,
+					APIServer:      "10.0.0.1",
+					ClientName:     "foo",
+					TokenAuth:      &tokenAuth{Token: "test"},
+					ClientCertAuth: &clientCertAuth{CAKey: caKey},
+				},
+			},
+			expectedError: true,
+		},
+		{
+			name: "configuration is valid, expect no errors",
+			args: args{
+				kubeConfigDir: tmpDir,
+				kubeadmConfig: &kubeadmapi.InitConfiguration{},
+				name:          "test",
+				spec: &kubeConfigSpec{
+					CACert:         caCert,
+					APIServer:      "10.0.0.1",
+					ClientName:     "foo",
+					TokenAuth:      &tokenAuth{Token: "test"},
+					ClientCertAuth: &clientCertAuth{CAKey: caKey},
+				},
+			},
+			expectedError: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := createKubeConfigAndCSR(tc.args.kubeConfigDir, tc.args.kubeadmConfig, tc.args.name, tc.args.spec); (err != nil) != tc.expectedError {
+				t.Errorf("createKubeConfigAndCSR() error = %v, wantErr %v", err, tc.expectedError)
+			}
+		})
+	}
+}
+
+func TestCreateDefaultKubeConfigsAndCSRFiles(t *testing.T) {
+	tmpDir := testutil.SetupTempDir(t)
+	defer func() {
+		if err := os.RemoveAll(tmpDir); err != nil {
+			t.Error(err)
+		}
+	}()
+	type args struct {
+		kubeConfigDir string
+		kubeadmConfig *kubeadmapi.InitConfiguration
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "kubeadmConfig is empty",
+			args: args{
+				kubeConfigDir: tmpDir,
+				kubeadmConfig: &kubeadmapi.InitConfiguration{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "The APIEndpoint is invalid",
+			args: args{
+				kubeConfigDir: tmpDir,
+				kubeadmConfig: &kubeadmapi.InitConfiguration{
+					LocalAPIEndpoint: kubeadmapi.APIEndpoint{
+						AdvertiseAddress: "x.12.FOo.1",
+						BindPort:         6443,
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "The APIEndpoint is valid",
+			args: args{
+				kubeConfigDir: tmpDir,
+				kubeadmConfig: &kubeadmapi.InitConfiguration{
+					LocalAPIEndpoint: kubeadmapi.APIEndpoint{
+						AdvertiseAddress: "127.0.0.1",
+						BindPort:         6443,
+					},
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			out := &bytes.Buffer{}
+			if err := CreateDefaultKubeConfigsAndCSRFiles(out, tc.args.kubeConfigDir, tc.args.kubeadmConfig); (err != nil) != tc.wantErr {
+				t.Errorf("CreateDefaultKubeConfigsAndCSRFiles() error = %v, wantErr %v", err, tc.wantErr)
+				return
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Increase ut coverage fo phases/kubeconfig

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
