### PR TITLE
Tighten IP/CIDR validation

### DIFF
--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -20725,7 +20725,7 @@ func TestValidateEndpointsCreate(t *testing.T) {
 				}},
 			},
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("subsets[0].addresses[0].ip"), nil, "").WithOrigin("format=non-special-ip"),
+				field.Invalid(field.NewPath("subsets[0].addresses[0].ip"), nil, "").WithOrigin("format=endpoint-ip"),
 			},
 		},
 		"Address is link-local": {
@@ -20737,7 +20737,7 @@ func TestValidateEndpointsCreate(t *testing.T) {
 				}},
 			},
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("subsets[0].addresses[0].ip"), nil, "").WithOrigin("format=non-special-ip"),
+				field.Invalid(field.NewPath("subsets[0].addresses[0].ip"), nil, "").WithOrigin("format=endpoint-ip"),
 			},
 		},
 		"Address is link-local multicast": {
@@ -20749,7 +20749,7 @@ func TestValidateEndpointsCreate(t *testing.T) {
 				}},
 			},
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("subsets[0].addresses[0].ip"), nil, "").WithOrigin("format=non-special-ip"),
+				field.Invalid(field.NewPath("subsets[0].addresses[0].ip"), nil, "").WithOrigin("format=endpoint-ip"),
 			},
 		},
 		"Invalid AppProtocol": {
@@ -23641,7 +23641,7 @@ func TestValidateResourceRequirements(t *testing.T) {
 	}
 }
 
-func TestValidateNonSpecialIP(t *testing.T) {
+func TestValidateEndpointIP(t *testing.T) {
 	fp := field.NewPath("ip")
 
 	// Valid values.
@@ -23652,11 +23652,15 @@ func TestValidateNonSpecialIP(t *testing.T) {
 		{"ipv4", "10.1.2.3"},
 		{"ipv4 class E", "244.1.2.3"},
 		{"ipv6", "2000::1"},
+
+		// These probably should not have been allowed, but they are
+		{"ipv4 multicast", "239.255.255.253"},
+		{"ipv6 multicast", "ff05::1:3"},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
-			errs := ValidateNonSpecialIP(tc.ip, fp)
+			errs := ValidateEndpointIP(tc.ip, fp)
 			if len(errs) != 0 {
-				t.Errorf("ValidateNonSpecialIP(%q, ...) = %v; want nil", tc.ip, errs)
+				t.Errorf("ValidateEndpointIP(%q, ...) = %v; want nil", tc.ip, errs)
 			}
 		})
 	}
@@ -23670,13 +23674,15 @@ func TestValidateNonSpecialIP(t *testing.T) {
 		{"ipv4 localhost", "127.0.0.0"},
 		{"ipv4 localhost", "127.255.255.255"},
 		{"ipv6 localhost", "::1"},
+		{"ipv4 link local", "169.254.169.254"},
 		{"ipv6 link local", "fe80::"},
+		{"ipv4 local multicast", "224.0.0.251"},
 		{"ipv6 local multicast", "ff02::"},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
-			errs := ValidateNonSpecialIP(tc.ip, fp)
+			errs := ValidateEndpointIP(tc.ip, fp)
 			if len(errs) == 0 {
-				t.Errorf("ValidateNonSpecialIP(%q, ...) = nil; want non-nil (errors)", tc.ip)
+				t.Errorf("ValidateEndpointIP(%q, ...) = nil; want non-nil (errors)", tc.ip)
 			}
 		})
 	}

--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -9951,16 +9951,18 @@ func TestValidatePodDNSConfig(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		if tc.dnsPolicy == nil {
-			tc.dnsPolicy = &testDNSClusterFirst
-		}
+		t.Run("", func(t *testing.T) {
+			if tc.dnsPolicy == nil {
+				tc.dnsPolicy = &testDNSClusterFirst
+			}
 
-		errs := validatePodDNSConfig(tc.dnsConfig, tc.dnsPolicy, field.NewPath("dnsConfig"), tc.opts)
-		if len(errs) != 0 && !tc.expectedError {
-			t.Errorf("%v: validatePodDNSConfig(%v) = %v, want nil", tc.desc, tc.dnsConfig, errs)
-		} else if len(errs) == 0 && tc.expectedError {
-			t.Errorf("%v: validatePodDNSConfig(%v) = nil, want error", tc.desc, tc.dnsConfig)
-		}
+			errs := validatePodDNSConfig(tc.dnsConfig, tc.dnsPolicy, field.NewPath("dnsConfig"), tc.opts)
+			if len(errs) != 0 && !tc.expectedError {
+				t.Errorf("%v: validatePodDNSConfig(%v) = %v, want nil", tc.desc, tc.dnsConfig, errs)
+			} else if len(errs) == 0 && tc.expectedError {
+				t.Errorf("%v: validatePodDNSConfig(%v) = nil, want error", tc.desc, tc.dnsConfig)
+			}
+		})
 	}
 }
 
@@ -10304,12 +10306,14 @@ func TestValidatePodSpec(t *testing.T) {
 		),
 	}
 	for k, v := range failureCases {
-		opts := PodValidationOptions{
-			ResourceIsPod: true,
-		}
-		if errs := ValidatePodSpec(&v.Spec, nil, field.NewPath("field"), opts); len(errs) == 0 {
-			t.Errorf("expected failure for %q", k)
-		}
+		t.Run(k, func(t *testing.T) {
+			opts := PodValidationOptions{
+				ResourceIsPod: true,
+			}
+			if errs := ValidatePodSpec(&v.Spec, nil, field.NewPath("field"), opts); len(errs) == 0 {
+				t.Errorf("expected failure")
+			}
+		})
 	}
 }
 
@@ -15302,35 +15306,35 @@ func TestValidateServiceCreate(t *testing.T) {
 		// numErrs: 1,
 		numErrs: 0,
 	}, {
-		name: "invalid publicIPs localhost",
+		name: "invalid externalIPs localhost",
 		tweakSvc: func(s *core.Service) {
 			s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
 			s.Spec.ExternalIPs = []string{"127.0.0.1"}
 		},
 		numErrs: 1,
 	}, {
-		name: "invalid publicIPs unspecified",
+		name: "invalid externalIPs unspecified",
 		tweakSvc: func(s *core.Service) {
 			s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
 			s.Spec.ExternalIPs = []string{"0.0.0.0"}
 		},
 		numErrs: 1,
 	}, {
-		name: "invalid publicIPs loopback",
+		name: "invalid externalIPs loopback",
 		tweakSvc: func(s *core.Service) {
 			s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
 			s.Spec.ExternalIPs = []string{"127.0.0.1"}
 		},
 		numErrs: 1,
 	}, {
-		name: "invalid publicIPs host",
+		name: "invalid externalIPs host",
 		tweakSvc: func(s *core.Service) {
 			s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
 			s.Spec.ExternalIPs = []string{"myhost.mydomain"}
 		},
 		numErrs: 1,
 	}, {
-		name: "valid publicIPs",
+		name: "valid externalIPs",
 		tweakSvc: func(s *core.Service) {
 			s.Spec.ExternalTrafficPolicy = core.ServiceExternalTrafficPolicyCluster
 			s.Spec.ExternalIPs = []string{"1.2.3.4"}
@@ -16989,9 +16993,11 @@ func TestValidateNode(t *testing.T) {
 	},
 	}
 	for _, successCase := range successCases {
-		if errs := ValidateNode(&successCase); len(errs) != 0 {
-			t.Errorf("expected success: %v", errs)
-		}
+		t.Run("", func(t *testing.T) {
+			if errs := ValidateNode(&successCase); len(errs) != 0 {
+				t.Errorf("expected success: %v", errs)
+			}
+		})
 	}
 
 	errorCases := map[string]core.Node{
@@ -17195,30 +17201,32 @@ func TestValidateNode(t *testing.T) {
 		},
 	}
 	for k, v := range errorCases {
-		errs := ValidateNode(&v)
-		if len(errs) == 0 {
-			t.Errorf("expected failure for %s", k)
-		}
-		for i := range errs {
-			field := errs[i].Field
-			expectedFields := map[string]bool{
-				"metadata.name":         true,
-				"metadata.labels":       true,
-				"metadata.annotations":  true,
-				"metadata.namespace":    true,
-				"spec.externalID":       true,
-				"spec.taints[0].key":    true,
-				"spec.taints[0].value":  true,
-				"spec.taints[0].effect": true,
-				"metadata.annotations.scheduler.alpha.kubernetes.io/preferAvoidPods[0].PodSignature":                          true,
-				"metadata.annotations.scheduler.alpha.kubernetes.io/preferAvoidPods[0].PodSignature.PodController.Controller": true,
+		t.Run(k, func(t *testing.T) {
+			errs := ValidateNode(&v)
+			if len(errs) == 0 {
+				t.Errorf("expected failure")
 			}
-			if val, ok := expectedFields[field]; ok {
-				if !val {
-					t.Errorf("%s: missing prefix for: %v", k, errs[i])
+			for i := range errs {
+				field := errs[i].Field
+				expectedFields := map[string]bool{
+					"metadata.name":         true,
+					"metadata.labels":       true,
+					"metadata.annotations":  true,
+					"metadata.namespace":    true,
+					"spec.externalID":       true,
+					"spec.taints[0].key":    true,
+					"spec.taints[0].value":  true,
+					"spec.taints[0].effect": true,
+					"metadata.annotations.scheduler.alpha.kubernetes.io/preferAvoidPods[0].PodSignature":                          true,
+					"metadata.annotations.scheduler.alpha.kubernetes.io/preferAvoidPods[0].PodSignature.PodController.Controller": true,
+				}
+				if val, ok := expectedFields[field]; ok {
+					if !val {
+						t.Errorf("missing prefix for: %v", errs[i])
+					}
 				}
 			}
-		}
+		})
 	}
 }
 
@@ -22825,28 +22833,32 @@ func makePod(podName string, podNamespace string, podIPs []core.PodIP) core.Pod 
 	}
 }
 func TestPodIPsValidation(t *testing.T) {
+	// We test updating every pod in testCases to every other pod in testCases.
+	// expectError is true if we expect an error when updating *to* that pod.
+
 	testCases := []struct {
 		pod         core.Pod
 		expectError bool
-	}{{
-		expectError: false,
-		pod:         makePod("nil-ips", "ns", nil),
-	}, {
-		expectError: false,
-		pod:         makePod("empty-podips-list", "ns", []core.PodIP{}),
-	}, {
-		expectError: false,
-		pod:         makePod("single-ip-family-6", "ns", []core.PodIP{{IP: "::1"}}),
-	}, {
-		expectError: false,
-		pod:         makePod("single-ip-family-4", "ns", []core.PodIP{{IP: "1.1.1.1"}}),
-	}, {
-		expectError: false,
-		pod:         makePod("dual-stack-4-6", "ns", []core.PodIP{{IP: "1.1.1.1"}, {IP: "::1"}}),
-	}, {
-		expectError: false,
-		pod:         makePod("dual-stack-6-4", "ns", []core.PodIP{{IP: "::1"}, {IP: "1.1.1.1"}}),
-	},
+	}{
+		{
+			expectError: false,
+			pod:         makePod("nil-ips", "ns", nil),
+		}, {
+			expectError: false,
+			pod:         makePod("empty-podips-list", "ns", []core.PodIP{}),
+		}, {
+			expectError: false,
+			pod:         makePod("single-ip-family-6", "ns", []core.PodIP{{IP: "::1"}}),
+		}, {
+			expectError: false,
+			pod:         makePod("single-ip-family-4", "ns", []core.PodIP{{IP: "1.1.1.1"}}),
+		}, {
+			expectError: false,
+			pod:         makePod("dual-stack-4-6", "ns", []core.PodIP{{IP: "1.1.1.1"}, {IP: "::1"}}),
+		}, {
+			expectError: false,
+			pod:         makePod("dual-stack-6-4", "ns", []core.PodIP{{IP: "::1"}, {IP: "1.1.1.1"}}),
+		},
 		/* failure cases start here */
 		{
 			expectError: true,
@@ -22887,10 +22899,10 @@ func TestPodIPsValidation(t *testing.T) {
 				errs := ValidatePodStatusUpdate(newPod, oldPod, PodValidationOptions{})
 
 				if len(errs) == 0 && testCase.expectError {
-					t.Fatalf("expected failure for %s, but there were none", testCase.pod.Name)
+					t.Fatalf("expected failure updating from %s, but there were none", oldTestCase.pod.Name)
 				}
 				if len(errs) != 0 && !testCase.expectError {
-					t.Fatalf("expected success for %s, but there were errors: %v", testCase.pod.Name, errs)
+					t.Fatalf("expected success updating from %s, but there were errors: %v", oldTestCase.pod.Name, errs)
 				}
 			}
 		})
@@ -22921,6 +22933,9 @@ func makePodWithHostIPs(podName string, podNamespace string, hostIPs []core.Host
 }
 
 func TestHostIPsValidation(t *testing.T) {
+	// We test updating every pod in testCases to every other pod in testCases.
+	// expectError is true if we expect an error when updating *to* that pod.
+
 	testCases := []struct {
 		pod         core.Pod
 		expectError bool
@@ -22952,7 +22967,7 @@ func TestHostIPsValidation(t *testing.T) {
 		/* failure cases start here */
 		{
 			expectError: true,
-			pod:         makePodWithHostIPs("invalid-pod-ip", "ns", []core.HostIP{{IP: "this-is-not-an-ip"}}),
+			pod:         makePodWithHostIPs("invalid-host-ip", "ns", []core.HostIP{{IP: "this-is-not-an-ip"}}),
 		},
 		{
 			expectError: true,
@@ -22994,10 +23009,10 @@ func TestHostIPsValidation(t *testing.T) {
 				errs := ValidatePodStatusUpdate(newPod, oldPod, PodValidationOptions{})
 
 				if len(errs) == 0 && testCase.expectError {
-					t.Fatalf("expected failure for %s, but there were none", testCase.pod.Name)
+					t.Fatalf("expected failure updating from %s, but there were none", oldTestCase.pod.Name)
 				}
 				if len(errs) != 0 && !testCase.expectError {
-					t.Fatalf("expected success for %s, but there were errors: %v", testCase.pod.Name, errs)
+					t.Fatalf("expected success updating from %s, but there were errors: %v", oldTestCase.pod.Name, errs)
 				}
 			}
 		})

--- a/pkg/apis/discovery/validation/validation.go
+++ b/pkg/apis/discovery/validation/validation.go
@@ -100,10 +100,10 @@ func validateEndpoints(endpoints []discovery.Endpoint, addrType discovery.Addres
 			switch addrType {
 			case discovery.AddressTypeIPv4:
 				allErrs = append(allErrs, validation.IsValidIPv4Address(addressPath.Index(i), address)...)
-				allErrs = append(allErrs, apivalidation.ValidateNonSpecialIP(address, addressPath.Index(i))...)
+				allErrs = append(allErrs, apivalidation.ValidateEndpointIP(address, addressPath.Index(i))...)
 			case discovery.AddressTypeIPv6:
 				allErrs = append(allErrs, validation.IsValidIPv6Address(addressPath.Index(i), address)...)
-				allErrs = append(allErrs, apivalidation.ValidateNonSpecialIP(address, addressPath.Index(i))...)
+				allErrs = append(allErrs, apivalidation.ValidateEndpointIP(address, addressPath.Index(i))...)
 			case discovery.AddressTypeFQDN:
 				allErrs = append(allErrs, validation.IsFullyQualifiedDomainName(addressPath.Index(i), address)...)
 			}

--- a/pkg/apis/discovery/validation/validation.go
+++ b/pkg/apis/discovery/validation/validation.go
@@ -100,7 +100,7 @@ func validateEndpoints(endpoints []discovery.Endpoint, addrType discovery.Addres
 			// and do not get validated.
 			switch addrType {
 			case discovery.AddressTypeIPv4:
-				ipErrs := validation.IsValidIP(addressPath.Index(i), address)
+				ipErrs := apivalidation.IsValidIPForLegacyField(addressPath.Index(i), address)
 				if len(ipErrs) > 0 {
 					allErrs = append(allErrs, ipErrs...)
 				} else {

--- a/pkg/apis/discovery/validation/validation.go
+++ b/pkg/apis/discovery/validation/validation.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apimachineryvalidation "k8s.io/apimachinery/pkg/api/validation"
 	metavalidation "k8s.io/apimachinery/pkg/apis/meta/v1/validation"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -55,23 +56,34 @@ var (
 var ValidateEndpointSliceName = apimachineryvalidation.NameIsDNSSubdomain
 
 // ValidateEndpointSlice validates an EndpointSlice.
-func ValidateEndpointSlice(endpointSlice *discovery.EndpointSlice) field.ErrorList {
+func ValidateEndpointSlice(endpointSlice, oldEndpointSlice *discovery.EndpointSlice) field.ErrorList {
 	allErrs := apivalidation.ValidateObjectMeta(&endpointSlice.ObjectMeta, true, ValidateEndpointSliceName, field.NewPath("metadata"))
 	allErrs = append(allErrs, validateAddressType(endpointSlice.AddressType)...)
-	allErrs = append(allErrs, validateEndpoints(endpointSlice.Endpoints, endpointSlice.AddressType, field.NewPath("endpoints"))...)
 	allErrs = append(allErrs, validatePorts(endpointSlice.Ports, field.NewPath("ports"))...)
+
+	endpointsErrs := validateEndpoints(endpointSlice.Endpoints, endpointSlice.AddressType, field.NewPath("endpoints"))
+	if len(endpointsErrs) != 0 {
+		// If this is an update, and Endpoints was unchanged, then ignore the
+		// validation errors, since apparently older versions of Kubernetes
+		// considered the data valid. (We only check this after getting a
+		// validation error since Endpoints may be large and DeepEqual is slow.)
+		if oldEndpointSlice != nil && apiequality.Semantic.DeepEqual(oldEndpointSlice.Endpoints, endpointSlice.Endpoints) {
+			endpointsErrs = nil
+		}
+	}
+	allErrs = append(allErrs, endpointsErrs...)
 
 	return allErrs
 }
 
 // ValidateEndpointSliceCreate validates an EndpointSlice when it is created.
 func ValidateEndpointSliceCreate(endpointSlice *discovery.EndpointSlice) field.ErrorList {
-	return ValidateEndpointSlice(endpointSlice)
+	return ValidateEndpointSlice(endpointSlice, nil)
 }
 
 // ValidateEndpointSliceUpdate validates an EndpointSlice when it is updated.
 func ValidateEndpointSliceUpdate(newEndpointSlice, oldEndpointSlice *discovery.EndpointSlice) field.ErrorList {
-	allErrs := ValidateEndpointSlice(newEndpointSlice)
+	allErrs := ValidateEndpointSlice(newEndpointSlice, oldEndpointSlice)
 	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newEndpointSlice.AddressType, oldEndpointSlice.AddressType, field.NewPath("addressType"))...)
 
 	return allErrs
@@ -100,7 +112,7 @@ func validateEndpoints(endpoints []discovery.Endpoint, addrType discovery.Addres
 			// and do not get validated.
 			switch addrType {
 			case discovery.AddressTypeIPv4:
-				ipErrs := apivalidation.IsValidIPForLegacyField(addressPath.Index(i), address)
+				ipErrs := apivalidation.IsValidIPForLegacyField(addressPath.Index(i), address, nil)
 				if len(ipErrs) > 0 {
 					allErrs = append(allErrs, ipErrs...)
 				} else {

--- a/pkg/apis/discovery/validation/validation_test.go
+++ b/pkg/apis/discovery/validation/validation_test.go
@@ -408,7 +408,7 @@ func TestValidateEndpointSlice(t *testing.T) {
 			},
 		},
 		"bad-ip": {
-			expectedErrors: 2,
+			expectedErrors: 1,
 			endpointSlice: &discovery.EndpointSlice{
 				ObjectMeta:  standardMeta,
 				AddressType: discovery.AddressTypeIPv4,
@@ -423,7 +423,7 @@ func TestValidateEndpointSlice(t *testing.T) {
 			},
 		},
 		"bad-ipv4": {
-			expectedErrors: 3,
+			expectedErrors: 2,
 			endpointSlice: &discovery.EndpointSlice{
 				ObjectMeta:  standardMeta,
 				AddressType: discovery.AddressTypeIPv4,
@@ -438,7 +438,7 @@ func TestValidateEndpointSlice(t *testing.T) {
 			},
 		},
 		"bad-ipv6": {
-			expectedErrors: 4,
+			expectedErrors: 2,
 			endpointSlice: &discovery.EndpointSlice{
 				ObjectMeta:  standardMeta,
 				AddressType: discovery.AddressTypeIPv6,

--- a/pkg/apis/discovery/validation/validation_test.go
+++ b/pkg/apis/discovery/validation/validation_test.go
@@ -23,8 +23,11 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/apis/discovery"
+	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/utils/ptr"
 )
 
@@ -36,6 +39,7 @@ func TestValidateEndpointSlice(t *testing.T) {
 
 	testCases := map[string]struct {
 		expectedErrors int
+		legacyIPs      bool
 		endpointSlice  *discovery.EndpointSlice
 	}{
 		"good-slice": {
@@ -235,6 +239,22 @@ func TestValidateEndpointSlice(t *testing.T) {
 				}},
 			},
 		},
+		"legacy-ip-with-legacy-validation": {
+			expectedErrors: 0,
+			legacyIPs:      true,
+			endpointSlice: &discovery.EndpointSlice{
+				ObjectMeta:  standardMeta,
+				AddressType: discovery.AddressTypeIPv4,
+				Ports: []discovery.EndpointPort{{
+					Name:     ptr.To("http"),
+					Protocol: ptr.To(api.ProtocolTCP),
+				}},
+				Endpoints: []discovery.Endpoint{{
+					Addresses: []string{"012.034.056.078"},
+					Hostname:  ptr.To("valid-123"),
+				}},
+			},
+		},
 
 		// expected failures
 		"duplicate-port-name": {
@@ -422,6 +442,21 @@ func TestValidateEndpointSlice(t *testing.T) {
 				}},
 			},
 		},
+		"legacy-ip-with-strict-validation": {
+			expectedErrors: 1,
+			endpointSlice: &discovery.EndpointSlice{
+				ObjectMeta:  standardMeta,
+				AddressType: discovery.AddressTypeIPv4,
+				Ports: []discovery.EndpointPort{{
+					Name:     ptr.To("http"),
+					Protocol: ptr.To(api.ProtocolTCP),
+				}},
+				Endpoints: []discovery.Endpoint{{
+					Addresses: []string{"012.034.056.078"},
+					Hostname:  ptr.To("valid-123"),
+				}},
+			},
+		},
 		"bad-ipv4": {
 			expectedErrors: 2,
 			endpointSlice: &discovery.EndpointSlice{
@@ -601,6 +636,7 @@ func TestValidateEndpointSlice(t *testing.T) {
 
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.StrictIPCIDRValidation, !testCase.legacyIPs)
 			errs := ValidateEndpointSlice(testCase.endpointSlice)
 			if len(errs) != testCase.expectedErrors {
 				t.Errorf("Expected %d errors, got %d errors: %v", testCase.expectedErrors, len(errs), errs)

--- a/pkg/apis/networking/validation/validation_test.go
+++ b/pkg/apis/networking/validation/validation_test.go
@@ -249,10 +249,12 @@ func TestValidateNetworkPolicy(t *testing.T) {
 
 	// Success cases are expected to pass validation.
 
-	for k, v := range successCases {
-		if errs := ValidateNetworkPolicy(v, NetworkPolicyValidationOptions{AllowInvalidLabelValueInSelector: true}); len(errs) != 0 {
-			t.Errorf("Expected success for the success validation test number %d, got %v", k, errs)
-		}
+	for _, v := range successCases {
+		t.Run("", func(t *testing.T) {
+			if errs := ValidateNetworkPolicy(v, NetworkPolicyValidationOptions{AllowInvalidLabelValueInSelector: true}); len(errs) != 0 {
+				t.Errorf("Expected success, got %v", errs)
+			}
+		})
 	}
 
 	invalidSelector := map[string]string{"NoUppercaseOrSpecialCharsLike=Equals": "b"}
@@ -367,9 +369,11 @@ func TestValidateNetworkPolicy(t *testing.T) {
 
 	// Error cases are not expected to pass validation.
 	for testName, networkPolicy := range errorCases {
-		if errs := ValidateNetworkPolicy(networkPolicy, NetworkPolicyValidationOptions{AllowInvalidLabelValueInSelector: true}); len(errs) == 0 {
-			t.Errorf("Expected failure for test: %s", testName)
-		}
+		t.Run(testName, func(t *testing.T) {
+			if errs := ValidateNetworkPolicy(networkPolicy, NetworkPolicyValidationOptions{AllowInvalidLabelValueInSelector: true}); len(errs) == 0 {
+				t.Errorf("Expected failure")
+			}
+		})
 	}
 }
 
@@ -420,11 +424,13 @@ func TestValidateNetworkPolicyUpdate(t *testing.T) {
 	}
 
 	for testName, successCase := range successCases {
-		successCase.old.ObjectMeta.ResourceVersion = "1"
-		successCase.update.ObjectMeta.ResourceVersion = "1"
-		if errs := ValidateNetworkPolicyUpdate(&successCase.update, &successCase.old, NetworkPolicyValidationOptions{false}); len(errs) != 0 {
-			t.Errorf("expected success (%s): %v", testName, errs)
-		}
+		t.Run(testName, func(t *testing.T) {
+			successCase.old.ObjectMeta.ResourceVersion = "1"
+			successCase.update.ObjectMeta.ResourceVersion = "1"
+			if errs := ValidateNetworkPolicyUpdate(&successCase.update, &successCase.old, NetworkPolicyValidationOptions{false}); len(errs) != 0 {
+				t.Errorf("expected success, but got %v", errs)
+			}
+		})
 	}
 
 	errorCases := map[string]npUpdateTest{
@@ -447,11 +453,13 @@ func TestValidateNetworkPolicyUpdate(t *testing.T) {
 	}
 
 	for testName, errorCase := range errorCases {
-		errorCase.old.ObjectMeta.ResourceVersion = "1"
-		errorCase.update.ObjectMeta.ResourceVersion = "1"
-		if errs := ValidateNetworkPolicyUpdate(&errorCase.update, &errorCase.old, NetworkPolicyValidationOptions{false}); len(errs) == 0 {
-			t.Errorf("expected failure: %s", testName)
-		}
+		t.Run(testName, func(t *testing.T) {
+			errorCase.old.ObjectMeta.ResourceVersion = "1"
+			errorCase.update.ObjectMeta.ResourceVersion = "1"
+			if errs := ValidateNetworkPolicyUpdate(&errorCase.update, &errorCase.old, NetworkPolicyValidationOptions{false}); len(errs) == 0 {
+				t.Errorf("expected failure")
+			}
+		})
 	}
 }
 
@@ -1824,16 +1832,18 @@ func TestValidateIngressStatusUpdate(t *testing.T) {
 		"status.loadBalancer.ingress[0].hostname: Invalid value": invalidHostname,
 	}
 	for k, v := range errorCases {
-		errs := ValidateIngressStatusUpdate(&v, &oldValue)
-		if len(errs) == 0 {
-			t.Errorf("expected failure for %s", k)
-		} else {
-			s := strings.Split(k, ":")
-			err := errs[0]
-			if err.Field != s[0] || !strings.Contains(err.Error(), s[1]) {
-				t.Errorf("unexpected error: %q, expected: %q", err, k)
+		t.Run(k, func(t *testing.T) {
+			errs := ValidateIngressStatusUpdate(&v, &oldValue)
+			if len(errs) == 0 {
+				t.Errorf("expected failure")
+			} else {
+				s := strings.Split(k, ":")
+				err := errs[0]
+				if err.Field != s[0] || !strings.Contains(err.Error(), s[1]) {
+					t.Errorf("unexpected error: %q, expected: %q", err, k)
+				}
 			}
-		}
+		})
 	}
 }
 

--- a/pkg/apis/resource/validation/validation_resourceclaim_test.go
+++ b/pkg/apis/resource/validation/validation_resourceclaim_test.go
@@ -1257,9 +1257,9 @@ func TestValidateClaimStatusUpdate(t *testing.T) {
 			wantFailures: field.ErrorList{
 				field.TooLong(field.NewPath("status", "devices").Index(0).Child("networkData", "interfaceName"), "", resource.NetworkDeviceDataInterfaceNameMaxLength),
 				field.TooLong(field.NewPath("status", "devices").Index(0).Child("networkData", "hardwareAddress"), "", resource.NetworkDeviceDataHardwareAddressMaxLength),
-				field.Invalid(field.NewPath("status", "devices").Index(0).Child("networkData", "ips").Index(0), "300.9.8.0/24", "must be a valid CIDR value, (e.g. 10.9.8.0/24 or 2001:db8::/64)"),
-				field.Invalid(field.NewPath("status", "devices").Index(0).Child("networkData", "ips").Index(1), "010.009.008.000/24", "must be in canonical form (10.9.8.0/24)"),
-				field.Invalid(field.NewPath("status", "devices").Index(0).Child("networkData", "ips").Index(2), "2001:0db8::1/64", "must be in canonical form (2001:db8::1/64)"),
+				field.Invalid(field.NewPath("status", "devices").Index(0).Child("networkData", "ips").Index(0), "300.9.8.0/24", "must be a valid address in CIDR form, (e.g. 10.9.8.7/24 or 2001:db8::1/64)"),
+				field.Invalid(field.NewPath("status", "devices").Index(0).Child("networkData", "ips").Index(1), "010.009.008.000/24", "must be in canonical form (\"10.9.8.0/24\")"),
+				field.Invalid(field.NewPath("status", "devices").Index(0).Child("networkData", "ips").Index(2), "2001:0db8::1/64", "must be in canonical form (\"2001:db8::1/64\")"),
 			},
 			oldClaim: func() *resource.ResourceClaim { return validAllocatedClaim }(),
 			update: func(claim *resource.ResourceClaim) *resource.ResourceClaim {
@@ -1390,7 +1390,7 @@ func TestValidateClaimStatusUpdate(t *testing.T) {
 			wantFailures: field.ErrorList{
 				field.TooLong(field.NewPath("status", "devices").Index(0).Child("networkData", "interfaceName"), "", resource.NetworkDeviceDataInterfaceNameMaxLength),
 				field.TooLong(field.NewPath("status", "devices").Index(0).Child("networkData", "hardwareAddress"), "", resource.NetworkDeviceDataHardwareAddressMaxLength),
-				field.Invalid(field.NewPath("status", "devices").Index(0).Child("networkData", "ips").Index(0), "300.9.8.0/24", "must be a valid CIDR value, (e.g. 10.9.8.0/24 or 2001:db8::/64)"),
+				field.Invalid(field.NewPath("status", "devices").Index(0).Child("networkData", "ips").Index(0), "300.9.8.0/24", "must be a valid address in CIDR form, (e.g. 10.9.8.7/24 or 2001:db8::1/64)"),
 			},
 			oldClaim: func() *resource.ResourceClaim { return validAllocatedClaim }(),
 			update: func(claim *resource.ResourceClaim) *resource.ResourceClaim {

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -715,6 +715,12 @@ const (
 	// Allow API server Protobuf encoder to encode collections item by item, instead of all at once.
 	StreamingCollectionEncodingToProtobuf featuregate.Feature = "StreamingCollectionEncodingToProtobuf"
 
+	// owner: @danwinship
+	// kep: https://kep.k8s.io/4858
+	//
+	// Requires stricter validation of IP addresses and CIDR values in API objects.
+	StrictIPCIDRValidation featuregate.Feature = "StrictIPCIDRValidation"
+
 	// owner: @robscott
 	// kep: https://kep.k8s.io/2433
 	//

--- a/pkg/features/versioned_kube_features.go
+++ b/pkg/features/versioned_kube_features.go
@@ -763,6 +763,10 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 		{Version: version.MustParse("1.32"), Default: true, PreRelease: featuregate.Beta},
 	},
 
+	StrictIPCIDRValidation: {
+		{Version: version.MustParse("1.33"), Default: false, PreRelease: featuregate.Alpha},
+	},
+
 	TopologyAwareHints: {
 		{Version: version.MustParse("1.21"), Default: false, PreRelease: featuregate.Alpha},
 		{Version: version.MustParse("1.23"), Default: false, PreRelease: featuregate.Beta},

--- a/pkg/registry/core/service/storage/alloc.go
+++ b/pkg/registry/core/service/storage/alloc.go
@@ -151,9 +151,7 @@ func (al *Allocators) initIPFamilyFields(after After, before Before) error {
 
 	// Do some loose pre-validation of the input.  This makes it easier in the
 	// rest of allocation code to not have to consider corner cases.
-	// TODO(thockin): when we tighten validation (e.g. to require IPs) we will
-	// need a "strict" and a "loose" form of this.
-	if el := validation.ValidateServiceClusterIPsRelatedFields(service); len(el) != 0 {
+	if el := validation.ValidateServiceClusterIPsRelatedFields(service, oldService); len(el) != 0 {
 		return errors.NewInvalid(api.Kind("Service"), service.Name, el)
 	}
 

--- a/staging/src/k8s.io/apimachinery/pkg/util/validation/ip.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/validation/ip.go
@@ -65,26 +65,6 @@ func GetWarningsForIP(fldPath *field.Path, value string) []string {
 	return nil
 }
 
-// IsValidIPv4Address tests that the argument is a valid IPv4 address.
-func IsValidIPv4Address(fldPath *field.Path, value string) field.ErrorList {
-	var allErrors field.ErrorList
-	ip := netutils.ParseIPSloppy(value)
-	if ip == nil || ip.To4() == nil {
-		allErrors = append(allErrors, field.Invalid(fldPath, value, "must be a valid IPv4 address"))
-	}
-	return allErrors
-}
-
-// IsValidIPv6Address tests that the argument is a valid IPv6 address.
-func IsValidIPv6Address(fldPath *field.Path, value string) field.ErrorList {
-	var allErrors field.ErrorList
-	ip := netutils.ParseIPSloppy(value)
-	if ip == nil || ip.To4() != nil {
-		allErrors = append(allErrors, field.Invalid(fldPath, value, "must be a valid IPv6 address"))
-	}
-	return allErrors
-}
-
 // IsValidCIDR tests that the argument is a valid CIDR value.
 func IsValidCIDR(fldPath *field.Path, value string) field.ErrorList {
 	var allErrors field.ErrorList

--- a/staging/src/k8s.io/apimachinery/pkg/util/validation/ip.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/validation/ip.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"net"
 	"net/netip"
+	"slices"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/klog/v2"
@@ -70,10 +71,17 @@ func parseIP(fldPath *field.Path, value string, strictValidation bool) (net.IP, 
 //     netip.ParseAddr both allow these, but there are no use cases for representing IPv4
 //     addresses as IPv4-mapped IPv6 addresses in Kubernetes.)
 //
+// Alternatively, when validating an update to an existing field, you can pass a list of
+// IP values from the old object that should be accepted if they appear in the new object
+// even if they are not valid.
+//
 // This function should only be used to validate the existing fields that were
 // historically validated in this way, and strictValidation should be true unless the
 // StrictIPCIDRValidation feature gate is disabled. Use IsValidIP for parsing new fields.
-func IsValidIPForLegacyField(fldPath *field.Path, value string, strictValidation bool) field.ErrorList {
+func IsValidIPForLegacyField(fldPath *field.Path, value string, strictValidation bool, validOldIPs []string) field.ErrorList {
+	if slices.Contains(validOldIPs, value) {
+		return nil
+	}
 	_, allErrors := parseIP(fldPath, value, strictValidation)
 	return allErrors.WithOrigin("format=ip-sloppy")
 }
@@ -165,11 +173,19 @@ func parseCIDR(fldPath *field.Path, value string, strictValidation bool) (*net.I
 //
 //  3. The prefix length is allowed to have leading 0s.
 //
+// Alternatively, when validating an update to an existing field, you can pass a list of
+// CIDR values from the old object that should be accepted if they appear in the new
+// object even if they are not valid.
+//
 // This function should only be used to validate the existing fields that were
 // historically validated in this way, and strictValidation should be true unless the
 // StrictIPCIDRValidation feature gate is disabled. Use IsValidCIDR or
 // IsValidInterfaceAddress for parsing new fields.
-func IsValidCIDRForLegacyField(fldPath *field.Path, value string, strictValidation bool) field.ErrorList {
+func IsValidCIDRForLegacyField(fldPath *field.Path, value string, strictValidation bool, validOldCIDRs []string) field.ErrorList {
+	if slices.Contains(validOldCIDRs, value) {
+		return nil
+	}
+
 	_, allErrors := parseCIDR(fldPath, value, strictValidation)
 	return allErrors
 }

--- a/staging/src/k8s.io/apimachinery/pkg/util/validation/ip_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/validation/ip_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func TestIsValidIP(t *testing.T) {
-	for _, tc := range []struct {
+	testCases := []struct {
 		name string
 		in   string
 
@@ -202,7 +202,16 @@ func TestIsValidIP(t *testing.T) {
 			legacyErr:       "must be a valid IP address",
 			legacyStrictErr: "must be a valid IP address",
 		},
-	} {
+	}
+
+	var badIPs []string
+	for _, tc := range testCases {
+		if tc.legacyStrictErr != "" {
+			badIPs = append(badIPs, tc.in)
+		}
+	}
+
+	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			errs := IsValidIP(field.NewPath(""), tc.in)
 			if tc.err == "" {
@@ -217,7 +226,7 @@ func TestIsValidIP(t *testing.T) {
 				}
 			}
 
-			errs = IsValidIPForLegacyField(field.NewPath(""), tc.in, false)
+			errs = IsValidIPForLegacyField(field.NewPath(""), tc.in, false, nil)
 			if tc.legacyErr == "" {
 				if len(errs) != 0 {
 					t.Errorf("expected %q to be valid according to IsValidIPForLegacyField but got: %v", tc.in, errs)
@@ -230,7 +239,7 @@ func TestIsValidIP(t *testing.T) {
 				}
 			}
 
-			errs = IsValidIPForLegacyField(field.NewPath(""), tc.in, true)
+			errs = IsValidIPForLegacyField(field.NewPath(""), tc.in, true, nil)
 			if tc.legacyStrictErr == "" {
 				if len(errs) != 0 {
 					t.Errorf("expected %q to be valid according to IsValidIPForLegacyField with strict validation, but got: %v", tc.in, errs)
@@ -241,6 +250,11 @@ func TestIsValidIP(t *testing.T) {
 				} else if !strings.Contains(errs[0].Detail, tc.legacyStrictErr) {
 					t.Errorf("expected error from IsValidIPForLegacyField with strict validation for %q to contain %q but got: %q", tc.in, tc.legacyStrictErr, errs[0].Detail)
 				}
+			}
+
+			errs = IsValidIPForLegacyField(field.NewPath(""), tc.in, true, badIPs)
+			if len(errs) != 0 {
+				t.Errorf("expected %q to be accepted when using validOldIPs, but got: %v", tc.in, errs)
 			}
 		})
 	}
@@ -300,7 +314,7 @@ func TestGetWarningsForIP(t *testing.T) {
 }
 
 func TestIsValidCIDR(t *testing.T) {
-	for _, tc := range []struct {
+	testCases := []struct {
 		name string
 		in   string
 
@@ -455,7 +469,16 @@ func TestIsValidCIDR(t *testing.T) {
 			legacyErr:       "must be a valid CIDR value",
 			legacyStrictErr: "must be a valid CIDR value",
 		},
-	} {
+	}
+
+	var badCIDRs []string
+	for _, tc := range testCases {
+		if tc.legacyStrictErr != "" {
+			badCIDRs = append(badCIDRs, tc.in)
+		}
+	}
+
+	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			errs := IsValidCIDR(field.NewPath(""), tc.in)
 			if tc.err == "" {
@@ -470,7 +493,7 @@ func TestIsValidCIDR(t *testing.T) {
 				}
 			}
 
-			errs = IsValidCIDRForLegacyField(field.NewPath(""), tc.in, false)
+			errs = IsValidCIDRForLegacyField(field.NewPath(""), tc.in, false, nil)
 			if tc.legacyErr == "" {
 				if len(errs) != 0 {
 					t.Errorf("expected %q to be valid according to IsValidCIDRForLegacyField but got: %v", tc.in, errs)
@@ -483,7 +506,7 @@ func TestIsValidCIDR(t *testing.T) {
 				}
 			}
 
-			errs = IsValidCIDRForLegacyField(field.NewPath(""), tc.in, true)
+			errs = IsValidCIDRForLegacyField(field.NewPath(""), tc.in, true, nil)
 			if tc.legacyStrictErr == "" {
 				if len(errs) != 0 {
 					t.Errorf("expected %q to be valid according to IsValidCIDRForLegacyField with strict validation but got: %v", tc.in, errs)
@@ -494,6 +517,11 @@ func TestIsValidCIDR(t *testing.T) {
 				} else if !strings.Contains(errs[0].Detail, tc.legacyStrictErr) {
 					t.Errorf("expected error for %q from IsValidCIDRForLegacyField with strict validation to contain %q but got: %q", tc.in, tc.legacyStrictErr, errs[0].Detail)
 				}
+			}
+
+			errs = IsValidCIDRForLegacyField(field.NewPath(""), tc.in, true, badCIDRs)
+			if len(errs) != 0 {
+				t.Errorf("expected %q to be accepted when using validOldCIDRs, but got: %v", tc.in, errs)
 			}
 		})
 	}

--- a/staging/src/k8s.io/apimachinery/pkg/util/validation/ip_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/validation/ip_test.go
@@ -26,70 +26,58 @@ import (
 
 func TestIsValidIP(t *testing.T) {
 	for _, tc := range []struct {
-		name   string
-		in     string
-		family int
-		err    string
+		name string
+		in   string
+		err  string
 	}{
 		// GOOD VALUES
 		{
-			name:   "ipv4",
-			in:     "1.2.3.4",
-			family: 4,
+			name: "ipv4",
+			in:   "1.2.3.4",
 		},
 		{
-			name:   "ipv4, all zeros",
-			in:     "0.0.0.0",
-			family: 4,
+			name: "ipv4, all zeros",
+			in:   "0.0.0.0",
 		},
 		{
-			name:   "ipv4, max",
-			in:     "255.255.255.255",
-			family: 4,
+			name: "ipv4, max",
+			in:   "255.255.255.255",
 		},
 		{
-			name:   "ipv6",
-			in:     "1234::abcd",
-			family: 6,
+			name: "ipv6",
+			in:   "1234::abcd",
 		},
 		{
-			name:   "ipv6, all zeros, collapsed",
-			in:     "::",
-			family: 6,
+			name: "ipv6, all zeros, collapsed",
+			in:   "::",
 		},
 		{
-			name:   "ipv6, max",
-			in:     "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
-			family: 6,
+			name: "ipv6, max",
+			in:   "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
 		},
 
 		// GOOD, THOUGH NON-CANONICAL, VALUES
 		{
-			name:   "ipv6, all zeros, expanded (non-canonical)",
-			in:     "0:0:0:0:0:0:0:0",
-			family: 6,
+			name: "ipv6, all zeros, expanded (non-canonical)",
+			in:   "0:0:0:0:0:0:0:0",
 		},
 		{
-			name:   "ipv6, leading 0s (non-canonical)",
-			in:     "0001:002:03:4::",
-			family: 6,
+			name: "ipv6, leading 0s (non-canonical)",
+			in:   "0001:002:03:4::",
 		},
 		{
-			name:   "ipv6, capital letters (non-canonical)",
-			in:     "1234::ABCD",
-			family: 6,
+			name: "ipv6, capital letters (non-canonical)",
+			in:   "1234::ABCD",
 		},
 
 		// BAD VALUES WE CURRENTLY CONSIDER GOOD
 		{
-			name:   "ipv4 with leading 0s",
-			in:     "1.1.1.01",
-			family: 4,
+			name: "ipv4 with leading 0s",
+			in:   "1.1.1.01",
 		},
 		{
-			name:   "ipv4-in-ipv6 value",
-			in:     "::ffff:1.1.1.1",
-			family: 4,
+			name: "ipv4-in-ipv6 value",
+			in:   "::ffff:1.1.1.1",
 		},
 
 		// BAD VALUES
@@ -170,28 +158,6 @@ func TestIsValidIP(t *testing.T) {
 					t.Errorf("expected %q to have 1 error but got: %v", tc.in, errs)
 				} else if !strings.Contains(errs[0].Detail, tc.err) {
 					t.Errorf("expected error for %q to contain %q but got: %q", tc.in, tc.err, errs[0].Detail)
-				}
-			}
-
-			errs = IsValidIPv4Address(field.NewPath(""), tc.in)
-			if tc.family == 4 {
-				if len(errs) != 0 {
-					t.Errorf("expected %q to pass IsValidIPv4Address but got: %v", tc.in, errs)
-				}
-			} else {
-				if len(errs) == 0 {
-					t.Errorf("expected %q to fail IsValidIPv4Address", tc.in)
-				}
-			}
-
-			errs = IsValidIPv6Address(field.NewPath(""), tc.in)
-			if tc.family == 6 {
-				if len(errs) != 0 {
-					t.Errorf("expected %q to pass IsValidIPv6Address but got: %v", tc.in, errs)
-				}
-			} else {
-				if len(errs) == 0 {
-					t.Errorf("expected %q to fail IsValidIPv6Address", tc.in)
 				}
 			}
 		})

--- a/test/featuregates_linter/test_data/versioned_feature_list.yaml
+++ b/test/featuregates_linter/test_data/versioned_feature_list.yaml
@@ -1376,6 +1376,12 @@
     lockToDefault: true
     preRelease: GA
     version: "1.32"
+- name: StrictIPCIDRValidation
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.33"
 - name: StructuredAuthenticationConfiguration
   versionedSpecs:
   - default: false


### PR DESCRIPTION
#### What this PR does / why we need it:
Belatedly continues the plan from #108074 to deal with the fallout from golang 1.17 changing the behavior of `net.ParseIP`/`net.ParseCIDR` to prevent CVEs.

The approach here is:
1. Make sure every IP-valued field is being validated with `validation.IsValidIP` (merged as https://github.com/kubernetes/kubernetes/pull/122931), and every CIDR-valued field is being validated with `validation.IsValidCIDR` (merged as https://github.com/kubernetes/kubernetes/pull/123174)
2. Tighten up the validation performed by those functions (see the changes to `staging/src/k8s.io/apimachinery/pkg/util/validation/ip.go` in the commit `"Tighten up IP/CIDR validation"` for details.). This also tightens up the behavior of `IsValidNonSpecialIP` (formerly `ValidateNonSpecialIP`) to reject two cases that it missed before (broadcast and global multicast).
3. Fix up `pkg/apis/*/validation/` to not revalidate unchanged IPs/CIDRs on updates, so that existing objects with "bad" IPs/CIDRs can still receive unrelated updates.
4. Fix up `pkg/apis/*/validation/` to allow fixing otherwise-immutable IP/CIDR fields by replacing "bad" IPs/CIDRs with equivalent good ones.

(Logically, step 3 should have come before step 2, but the code in step 3 can't be fully unit tested until there exists a concept of "formerly valid but now invalid IPs". E.g., you can't test "it's possible to upgrade a service with an invalid ClusterIP from single-stack to dual-stack without having to fix the existing invalid IP" unless there are IPs that will pass `IsDualStackIPs()` but fail `IsValidIP()`.)

See also  #122549 which works on replacing the "sloppy" IP/CIDR parsers with a better API.

#### Which issue(s) this PR fixes:
Maybe "Fixes #108074" but there is at least additional code cleanup required...

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
When the `StrictIPCIDRValidation` feature gate is enabled, Kubernetes will be
slightly stricter about what values will be accepted as IP addresses and network
address ranges (“CIDR blocks”).

In particular, octets within IPv4 addresses are not allowed to have any leading
`0`s, and IPv4-mapped IPv6 values (e.g. `::ffff:192.168.0.1`) are forbidden.
These sorts of values can potentially cause security problems when different
components interpret the same string as referring to different IP addresses
(as in CVE-2021-29923).

This tightening applies only to fields in build-in API kinds, and not to
custom resource kinds, values in Kubernetes configuration files, or
command-line arguments.

(When the feature gate is disabled, creating an object with such an invalid
IP or CIDR value will result in a warning from the API server about the fact
that it will be rejected in the future.)
```

/kind cleanup
/kind feature
/kind api-change
/priority important-soon
/sig network
/sig apimachinery