### PR TITLE
Automated cherry pick of #122346: Make OpenAPIGetter tolerant of nil

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/patcher.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/patcher.go
@@ -156,7 +156,7 @@ func (p *Patcher) patchSimple(obj runtime.Object, modified []byte, namespace, na
 		}
 	}
 
-	if patch == nil {
+	if patch == nil && p.OpenAPIGetter != nil {
 		if openAPISchema, err := p.OpenAPIGetter.OpenAPISchema(); err == nil && openAPISchema != nil {
 			// if openapischema is used, we'll try to get required patch type for this GVK from Open API.
 			// if it fails or could not find any patch type, fall back to baked-in patch type determination.


### PR DESCRIPTION
Cherry pick of #122346 on release-1.29.

#122346: Make OpenAPIGetter tolerant of nil

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fix an issue where kubectl apply could panic when imported as a library
```