### PR TITLE
[StructuredAuthnConfig] add comment for extra keys unique requirement

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1alpha1/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1alpha1/types.go
@@ -376,6 +376,7 @@ type ExtraMapping struct {
 	// subdomain as defined by RFC 1123. All characters trailing the first "/" must
 	// be valid HTTP Path characters as defined by RFC 3986.
 	// key must be lowercase.
+	// Required to be unique.
 	// +required
 	Key string `json:"key"`
 


### PR DESCRIPTION
- Add a comment in the API types for the extra keys needed to be unique.

part of https://github.com/kubernetes/kubernetes/issues/121553

/kind cleanup
/sig auth
/triage accepted
/milestone v1.30
/priority important-soon

```release-note
NONE
```

```docs
[KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-auth/3331-structured-authentication-configuration
```
