### PR TITLE
Removing Windows image from e2e test image utils

### DIFF
--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -41,7 +41,6 @@ type RegistryList struct {
 	GcRegistry               string `yaml:"gcRegistry"`
 	SigStorageRegistry       string `yaml:"sigStorageRegistry"`
 	PrivateRegistry          string `yaml:"privateRegistry"`
-	MicrosoftRegistry        string `yaml:"microsoftRegistry"`
 	DockerLibraryRegistry    string `yaml:"dockerLibraryRegistry"`
 	CloudProviderGcpRegistry string `yaml:"cloudProviderGcpRegistry"`
 }
@@ -138,7 +137,6 @@ var (
 		GcRegistry:               "registry.k8s.io",
 		SigStorageRegistry:       "registry.k8s.io/sig-storage",
 		PrivateRegistry:          "gcr.io/k8s-authenticated-test",
-		MicrosoftRegistry:        "mcr.microsoft.com",
 		DockerLibraryRegistry:    "docker.io/library",
 		CloudProviderGcpRegistry: "registry.k8s.io/cloud-provider-gcp",
 	}
@@ -226,8 +224,6 @@ const (
 	VolumeISCSIServer
 	// VolumeRBDServer image
 	VolumeRBDServer
-	// WindowsServer image
-	WindowsServer
 )
 
 func initImageConfigs(list RegistryList) (map[ImageID]Config, map[ImageID]Config) {
@@ -270,7 +266,6 @@ func initImageConfigs(list RegistryList) (map[ImageID]Config, map[ImageID]Config
 	configs[VolumeNFSServer] = Config{list.PromoterE2eRegistry, "volume/nfs", "1.3"}
 	configs[VolumeISCSIServer] = Config{list.PromoterE2eRegistry, "volume/iscsi", "2.6"}
 	configs[VolumeRBDServer] = Config{list.PromoterE2eRegistry, "volume/rbd", "1.0.6"}
-	configs[WindowsServer] = Config{list.MicrosoftRegistry, "windows", "1809"}
 
 	// This adds more config entries. Those have no pre-defined ImageID number,
 	// but will be used via ReplaceRegistryInImageURL when deploying
@@ -420,8 +415,6 @@ func replaceRegistryInImageURLWithList(imageURL string, reg RegistryList) (strin
 		registryAndUser = reg.PrivateRegistry
 	case initRegistry.InvalidRegistry:
 		registryAndUser = reg.InvalidRegistry
-	case initRegistry.MicrosoftRegistry:
-		registryAndUser = reg.MicrosoftRegistry
 	case initRegistry.PromoterE2eRegistry:
 		registryAndUser = reg.PromoterE2eRegistry
 	case initRegistry.BuildImageRegistry:

--- a/test/utils/image/manifest_test.go
+++ b/test/utils/image/manifest_test.go
@@ -51,9 +51,6 @@ func BenchmarkReplaceRegistryInImageURL(b *testing.B) {
 			in:  "invalid.registry.k8s.io/invalid/test:latest",
 			out: "test.io/invalid/test:latest",
 		}, {
-			in:  "mcr.microsoft.com/test:latest",
-			out: "test.io/microsoft/test:latest",
-		}, {
 			in:  "registry.k8s.io/e2e-test-images/test:latest",
 			out: "test.io/promoter/test:latest",
 		}, {
@@ -70,7 +67,6 @@ func BenchmarkReplaceRegistryInImageURL(b *testing.B) {
 		PrivateRegistry:         "test.io/k8s-authenticated-test",
 		SigStorageRegistry:      "test.io/sig-storage",
 		InvalidRegistry:         "test.io/invalid",
-		MicrosoftRegistry:       "test.io/microsoft",
 		PromoterE2eRegistry:     "test.io/promoter",
 		BuildImageRegistry:      "test.io/build",
 		GcAuthenticatedRegistry: "test.io/gcAuth",
@@ -112,9 +108,6 @@ func TestReplaceRegistryInImageURL(t *testing.T) {
 			in:  "invalid.registry.k8s.io/invalid/test:latest",
 			out: "test.io/invalid/test:latest",
 		}, {
-			in:  "mcr.microsoft.com/test:latest",
-			out: "test.io/microsoft/test:latest",
-		}, {
 			in:  "registry.k8s.io/e2e-test-images/test:latest",
 			out: "test.io/promoter/test:latest",
 		}, {
@@ -136,7 +129,6 @@ func TestReplaceRegistryInImageURL(t *testing.T) {
 		PrivateRegistry:         "test.io/k8s-authenticated-test",
 		SigStorageRegistry:      "test.io/sig-storage",
 		InvalidRegistry:         "test.io/invalid",
-		MicrosoftRegistry:       "test.io/microsoft",
 		PromoterE2eRegistry:     "test.io/promoter",
 		BuildImageRegistry:      "test.io/build",
 		GcAuthenticatedRegistry: "test.io/gcAuth",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup
This PR is similar to https://github.com/kubernetes/kubernetes/pull/122556 and removes `mcr.microsoft.com/windows` images from the output of `e2e.test --list-images`.

Although this image is used by a single e2e test - the image is very large and the test that uses the image requires a lot of additional setup and custom specialized hardware so we will instead hardcode the path the full windows image in the single test that uses it (also the image doesn't change)

<!--
Add one of the following kinds:
/kind bug

/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/sig windows
/area test
/assign @dims @jsturtevant 