### PR TITLE
Fix typos in description and comments

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -15391,7 +15391,7 @@
       ]
     },
     "io.k8s.api.storage.v1.VolumeAttachmentSource": {
-      "description": "VolumeAttachmentSource represents a volume that should be attached. Right now only PersistenVolumes can be attached via external attacher, in future we may allow also inline volumes in pods. Exactly one member can be set.",
+      "description": "VolumeAttachmentSource represents a volume that should be attached. Right now only PersistentVolumes can be attached via external attacher, in future we may allow also inline volumes in pods. Exactly one member can be set.",
       "properties": {
         "inlineVolumeSpec": {
           "$ref": "#/definitions/io.k8s.api.core.v1.PersistentVolumeSpec",

--- a/api/openapi-spec/v3/apis__storage.k8s.io__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__storage.k8s.io__v1_openapi.json
@@ -1824,7 +1824,7 @@
         ]
       },
       "io.k8s.api.storage.v1.VolumeAttachmentSource": {
-        "description": "VolumeAttachmentSource represents a volume that should be attached. Right now only PersistenVolumes can be attached via external attacher, in future we may allow also inline volumes in pods. Exactly one member can be set.",
+        "description": "VolumeAttachmentSource represents a volume that should be attached. Right now only PersistentVolumes can be attached via external attacher, in future we may allow also inline volumes in pods. Exactly one member can be set.",
         "properties": {
           "inlineVolumeSpec": {
             "allOf": [

--- a/pkg/controller/volume/ephemeral/metrics/metrics.go
+++ b/pkg/controller/volume/ephemeral/metrics/metrics.go
@@ -33,7 +33,7 @@ var (
 		&metrics.CounterOpts{
 			Subsystem:      EphemeralVolumeSubsystem,
 			Name:           "create_total",
-			Help:           "Number of PersistenVolumeClaims creation requests",
+			Help:           "Number of PersistentVolumeClaims creation requests",
 			StabilityLevel: metrics.ALPHA,
 		})
 	// EphemeralVolumeCreateFailures tracks the number of unsuccessful
@@ -42,7 +42,7 @@ var (
 		&metrics.CounterOpts{
 			Subsystem:      EphemeralVolumeSubsystem,
 			Name:           "create_failures_total",
-			Help:           "Number of PersistenVolumeClaims creation requests",
+			Help:           "Number of PersistentVolumeClaims creation requests",
 			StabilityLevel: metrics.ALPHA,
 		})
 )

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -45361,7 +45361,7 @@ func schema_k8sio_api_storage_v1_VolumeAttachmentSource(ref common.ReferenceCall
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "VolumeAttachmentSource represents a volume that should be attached. Right now only PersistenVolumes can be attached via external attacher, in future we may allow also inline volumes in pods. Exactly one member can be set.",
+				Description: "VolumeAttachmentSource represents a volume that should be attached. Right now only PersistentVolumes can be attached via external attacher, in future we may allow also inline volumes in pods. Exactly one member can be set.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"persistentVolumeName": {
@@ -45744,7 +45744,7 @@ func schema_k8sio_api_storage_v1alpha1_VolumeAttachmentSource(ref common.Referen
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "VolumeAttachmentSource represents a volume that should be attached. Right now only PersistenVolumes can be attached via external attacher, in future we may allow also inline volumes in pods. Exactly one member can be set.",
+				Description: "VolumeAttachmentSource represents a volume that should be attached. Right now only PersistentVolumes can be attached via external attacher, in future we may allow also inline volumes in pods. Exactly one member can be set.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"persistentVolumeName": {
@@ -46805,7 +46805,7 @@ func schema_k8sio_api_storage_v1beta1_VolumeAttachmentSource(ref common.Referenc
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "VolumeAttachmentSource represents a volume that should be attached. Right now only PersistenVolumes can be attached via external attacher, in future we may allow also inline volumes in pods. Exactly one member can be set.",
+				Description: "VolumeAttachmentSource represents a volume that should be attached. Right now only PersistentVolumes can be attached via external attacher, in future we may allow also inline volumes in pods. Exactly one member can be set.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"persistentVolumeName": {
@@ -52919,7 +52919,7 @@ func schema_pkg_apis_audit_v1_Policy(ref common.ReferenceCallback) common.OpenAP
 					},
 					"omitManagedFields": {
 						SchemaProps: spec.SchemaProps{
-							Description: "OmitManagedFields indicates whether to omit the managed fields of the request and response bodies from being written to the API audit log. This is used as a global default - a value of 'true' will omit the managed fileds, otherwise the managed fields will be included in the API audit log. Note that this can also be specified per rule in which case the value specified in a rule will override the global default.",
+							Description: "OmitManagedFields indicates whether to omit the managed fields of the request and response bodies from being written to the API audit log. This is used as a global default - a value of 'true' will omit the managed fields, otherwise the managed fields will be included in the API audit log. Note that this can also be specified per rule in which case the value specified in a rule will override the global default.",
 							Type:        []string{"boolean"},
 							Format:      "",
 						},
@@ -53138,7 +53138,7 @@ func schema_pkg_apis_audit_v1_PolicyRule(ref common.ReferenceCallback) common.Op
 					},
 					"omitManagedFields": {
 						SchemaProps: spec.SchemaProps{
-							Description: "OmitManagedFields indicates whether to omit the managed fields of the request and response bodies from being written to the API audit log. - a value of 'true' will drop the managed fields from the API audit log - a value of 'false' indicates that the managed fileds should be included\n  in the API audit log\nNote that the value, if specified, in this rule will override the global default If a value is not specified then the global default specified in Policy.OmitManagedFields will stand.",
+							Description: "OmitManagedFields indicates whether to omit the managed fields of the request and response bodies from being written to the API audit log. - a value of 'true' will drop the managed fields from the API audit log - a value of 'false' indicates that the managed fields should be included\n  in the API audit log\nNote that the value, if specified, in this rule will override the global default If a value is not specified then the global default specified in Policy.OmitManagedFields will stand.",
 							Type:        []string{"boolean"},
 							Format:      "",
 						},

--- a/staging/src/k8s.io/api/storage/v1/generated.proto
+++ b/staging/src/k8s.io/api/storage/v1/generated.proto
@@ -491,7 +491,7 @@ message VolumeAttachmentList {
 }
 
 // VolumeAttachmentSource represents a volume that should be attached.
-// Right now only PersistenVolumes can be attached via external attacher,
+// Right now only PersistentVolumes can be attached via external attacher,
 // in future we may allow also inline volumes in pods.
 // Exactly one member can be set.
 message VolumeAttachmentSource {

--- a/staging/src/k8s.io/api/storage/v1/types.go
+++ b/staging/src/k8s.io/api/storage/v1/types.go
@@ -165,7 +165,7 @@ type VolumeAttachmentSpec struct {
 }
 
 // VolumeAttachmentSource represents a volume that should be attached.
-// Right now only PersistenVolumes can be attached via external attacher,
+// Right now only PersistentVolumes can be attached via external attacher,
 // in future we may allow also inline volumes in pods.
 // Exactly one member can be set.
 type VolumeAttachmentSource struct {

--- a/staging/src/k8s.io/api/storage/v1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/storage/v1/types_swagger_doc_generated.go
@@ -185,7 +185,7 @@ func (VolumeAttachmentList) SwaggerDoc() map[string]string {
 }
 
 var map_VolumeAttachmentSource = map[string]string{
-	"":                     "VolumeAttachmentSource represents a volume that should be attached. Right now only PersistenVolumes can be attached via external attacher, in future we may allow also inline volumes in pods. Exactly one member can be set.",
+	"":                     "VolumeAttachmentSource represents a volume that should be attached. Right now only PersistentVolumes can be attached via external attacher, in future we may allow also inline volumes in pods. Exactly one member can be set.",
 	"persistentVolumeName": "persistentVolumeName represents the name of the persistent volume to attach.",
 }
 

--- a/staging/src/k8s.io/api/storage/v1alpha1/generated.proto
+++ b/staging/src/k8s.io/api/storage/v1alpha1/generated.proto
@@ -155,7 +155,7 @@ message VolumeAttachmentList {
 }
 
 // VolumeAttachmentSource represents a volume that should be attached.
-// Right now only PersistenVolumes can be attached via external attacher,
+// Right now only PersistentVolumes can be attached via external attacher,
 // in future we may allow also inline volumes in pods.
 // Exactly one member can be set.
 message VolumeAttachmentSource {

--- a/staging/src/k8s.io/api/storage/v1alpha1/types.go
+++ b/staging/src/k8s.io/api/storage/v1alpha1/types.go
@@ -84,7 +84,7 @@ type VolumeAttachmentSpec struct {
 }
 
 // VolumeAttachmentSource represents a volume that should be attached.
-// Right now only PersistenVolumes can be attached via external attacher,
+// Right now only PersistentVolumes can be attached via external attacher,
 // in future we may allow also inline volumes in pods.
 // Exactly one member can be set.
 type VolumeAttachmentSource struct {

--- a/staging/src/k8s.io/api/storage/v1alpha1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/storage/v1alpha1/types_swagger_doc_generated.go
@@ -72,7 +72,7 @@ func (VolumeAttachmentList) SwaggerDoc() map[string]string {
 }
 
 var map_VolumeAttachmentSource = map[string]string{
-	"":                     "VolumeAttachmentSource represents a volume that should be attached. Right now only PersistenVolumes can be attached via external attacher, in future we may allow also inline volumes in pods. Exactly one member can be set.",
+	"":                     "VolumeAttachmentSource represents a volume that should be attached. Right now only PersistentVolumes can be attached via external attacher, in future we may allow also inline volumes in pods. Exactly one member can be set.",
 	"persistentVolumeName": "persistentVolumeName represents the name of the persistent volume to attach.",
 }
 

--- a/staging/src/k8s.io/api/storage/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/storage/v1beta1/generated.proto
@@ -493,7 +493,7 @@ message VolumeAttachmentList {
 }
 
 // VolumeAttachmentSource represents a volume that should be attached.
-// Right now only PersistenVolumes can be attached via external attacher,
+// Right now only PersistentVolumes can be attached via external attacher,
 // in future we may allow also inline volumes in pods.
 // Exactly one member can be set.
 message VolumeAttachmentSource {

--- a/staging/src/k8s.io/api/storage/v1beta1/types.go
+++ b/staging/src/k8s.io/api/storage/v1beta1/types.go
@@ -176,7 +176,7 @@ type VolumeAttachmentSpec struct {
 }
 
 // VolumeAttachmentSource represents a volume that should be attached.
-// Right now only PersistenVolumes can be attached via external attacher,
+// Right now only PersistentVolumes can be attached via external attacher,
 // in future we may allow also inline volumes in pods.
 // Exactly one member can be set.
 type VolumeAttachmentSource struct {

--- a/staging/src/k8s.io/api/storage/v1beta1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/storage/v1beta1/types_swagger_doc_generated.go
@@ -185,7 +185,7 @@ func (VolumeAttachmentList) SwaggerDoc() map[string]string {
 }
 
 var map_VolumeAttachmentSource = map[string]string{
-	"":                     "VolumeAttachmentSource represents a volume that should be attached. Right now only PersistenVolumes can be attached via external attacher, in future we may allow also inline volumes in pods. Exactly one member can be set.",
+	"":                     "VolumeAttachmentSource represents a volume that should be attached. Right now only PersistentVolumes can be attached via external attacher, in future we may allow also inline volumes in pods. Exactly one member can be set.",
 	"persistentVolumeName": "persistentVolumeName represents the name of the persistent volume to attach.",
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/apis/audit/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/audit/types.go
@@ -181,7 +181,7 @@ type Policy struct {
 
 	// OmitManagedFields indicates whether to omit the managed fields of the request
 	// and response bodies from being written to the API audit log.
-	// This is used as a global default - a value of 'true' will omit the managed fileds,
+	// This is used as a global default - a value of 'true' will omit the managed fields,
 	// otherwise the managed fields will be included in the API audit log.
 	// Note that this can also be specified per rule in which case the value specified
 	// in a rule will override the global default.
@@ -251,7 +251,7 @@ type PolicyRule struct {
 	// OmitManagedFields indicates whether to omit the managed fields of the request
 	// and response bodies from being written to the API audit log.
 	// - a value of 'true' will drop the managed fields from the API audit log
-	// - a value of 'false' indicates that the managed fileds should be included
+	// - a value of 'false' indicates that the managed fields should be included
 	//   in the API audit log
 	// Note that the value, if specified, in this rule will override the global default
 	// If a value is not specified then the global default specified in

--- a/staging/src/k8s.io/apiserver/pkg/apis/audit/v1/generated.proto
+++ b/staging/src/k8s.io/apiserver/pkg/apis/audit/v1/generated.proto
@@ -204,7 +204,7 @@ message Policy {
 
   // OmitManagedFields indicates whether to omit the managed fields of the request
   // and response bodies from being written to the API audit log.
-  // This is used as a global default - a value of 'true' will omit the managed fileds,
+  // This is used as a global default - a value of 'true' will omit the managed fields,
   // otherwise the managed fields will be included in the API audit log.
   // Note that this can also be specified per rule in which case the value specified
   // in a rule will override the global default.
@@ -276,7 +276,7 @@ message PolicyRule {
   // OmitManagedFields indicates whether to omit the managed fields of the request
   // and response bodies from being written to the API audit log.
   // - a value of 'true' will drop the managed fields from the API audit log
-  // - a value of 'false' indicates that the managed fileds should be included
+  // - a value of 'false' indicates that the managed fields should be included
   //   in the API audit log
   // Note that the value, if specified, in this rule will override the global default
   // If a value is not specified then the global default specified in

--- a/staging/src/k8s.io/apiserver/pkg/apis/audit/v1/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/audit/v1/types.go
@@ -178,7 +178,7 @@ type Policy struct {
 
 	// OmitManagedFields indicates whether to omit the managed fields of the request
 	// and response bodies from being written to the API audit log.
-	// This is used as a global default - a value of 'true' will omit the managed fileds,
+	// This is used as a global default - a value of 'true' will omit the managed fields,
 	// otherwise the managed fields will be included in the API audit log.
 	// Note that this can also be specified per rule in which case the value specified
 	// in a rule will override the global default.
@@ -255,7 +255,7 @@ type PolicyRule struct {
 	// OmitManagedFields indicates whether to omit the managed fields of the request
 	// and response bodies from being written to the API audit log.
 	// - a value of 'true' will drop the managed fields from the API audit log
-	// - a value of 'false' indicates that the managed fileds should be included
+	// - a value of 'false' indicates that the managed fields should be included
 	//   in the API audit log
 	// Note that the value, if specified, in this rule will override the global default
 	// If a value is not specified then the global default specified in

--- a/staging/src/k8s.io/cli-runtime/artifacts/openapi/swagger-with-shared-parameters.json
+++ b/staging/src/k8s.io/cli-runtime/artifacts/openapi/swagger-with-shared-parameters.json
@@ -14526,7 +14526,7 @@
       ]
     },
     "io.k8s.api.storage.v1.VolumeAttachmentSource": {
-      "description": "VolumeAttachmentSource represents a volume that should be attached. Right now only PersistenVolumes can be attached via external attacher, in future we may allow also inline volumes in pods. Exactly one member can be set.",
+      "description": "VolumeAttachmentSource represents a volume that should be attached. Right now only PersistentVolumes can be attached via external attacher, in future we may allow also inline volumes in pods. Exactly one member can be set.",
       "properties": {
         "inlineVolumeSpec": {
           "$ref": "#/definitions/io.k8s.api.core.v1.PersistentVolumeSpec",

--- a/test/instrumentation/documentation/documentation-list.yaml
+++ b/test/instrumentation/documentation/documentation-list.yaml
@@ -561,12 +561,12 @@
   - state
 - name: create_failures_total
   subsystem: ephemeral_volume_controller
-  help: Number of PersistenVolumeClaims creation requests
+  help: Number of PersistentVolumeClaims creation requests
   type: Counter
   stabilityLevel: ALPHA
 - name: create_total
   subsystem: ephemeral_volume_controller
-  help: Number of PersistenVolumeClaims creation requests
+  help: Number of PersistentVolumeClaims creation requests
   type: Counter
   stabilityLevel: ALPHA
 - name: client_expiration_renew_errors

--- a/test/instrumentation/documentation/documentation.md
+++ b/test/instrumentation/documentation/documentation.md
@@ -1482,14 +1482,14 @@ Alpha metrics do not have any API guarantees. These metrics must be used at your
 	</ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">ephemeral_volume_controller_create_failures_total</div>
-	<div class="metric_help">Number of PersistenVolumeClaims creation requests</div>
+	<div class="metric_help">Number of PersistentVolumeClaims creation requests</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
 	</ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">ephemeral_volume_controller_create_total</div>
-	<div class="metric_help">Number of PersistenVolumeClaims creation requests</div>
+	<div class="metric_help">Number of PersistentVolumeClaims creation requests</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>


### PR DESCRIPTION
/kind cleanup
/kind documentation

Fix two typos:

- PersistenVolumeClaims to PersistentVolumeClaims
- fileds to fields

#### Does this PR introduce a user-facing change?

```release-note
NONE
```