### PR TITLE
Automated cherry pick of #120750: e2e framework: adapt unit test to Go 1.22

### DIFF
--- a/test/e2e/framework/internal/output/output.go
+++ b/test/e2e/framework/internal/output/output.go
@@ -110,6 +110,7 @@ func simplify(in string, expected TestResult) string {
 	out := normalizeLocation(in)
 	out = stripTimes(out)
 	out = stripAddresses(out)
+	out = normalizeInitFunctions(out)
 	if expected.NormalizeOutput != nil {
 		out = expected.NormalizeOutput(out)
 	}
@@ -176,5 +177,14 @@ func normalizeLocation(in string) string {
 	out = functionArgs.ReplaceAllString(out, "$1()")
 	out = testFailureOutput.ReplaceAllString(out, "")
 	out = klogPrefix.ReplaceAllString(out, "<klog> ")
+	return out
+}
+
+var initFunc = regexp.MustCompile(`(init\.+func|glob\.+func)`)
+
+// normalizeInitFunctions maps both init.func (used by Go >= 1.22) and
+// glob..func (used by Go < 1.22) to <init.func>.
+func normalizeInitFunctions(in string) string {
+	out := initFunc.ReplaceAllString(in, "<init.func>")
 	return out
 }


### PR DESCRIPTION
Cherry pick of #120750 on release-1.27.

#120750: e2e framework: adapt unit test to Go 1.22

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```