### PR TITLE
promote contextual logging to beta, enabled by default

### DIFF
--- a/staging/src/k8s.io/component-base/logs/api/v1/kube_features.go
+++ b/staging/src/k8s.io/component-base/logs/api/v1/kube_features.go
@@ -24,15 +24,17 @@ const (
 	// owner: @pohly
 	// kep: https://kep.k8s.io/3077
 	// alpha: v1.24
+	// beta: v1.30
 	//
 	// Enables looking up a logger from a context.Context instead of using
 	// the global fallback logger and manipulating the logger that is
 	// used by a call chain.
 	ContextualLogging featuregate.Feature = "ContextualLogging"
 
-	// contextualLoggingDefault must remain false while in alpha. It can
-	// become true in beta.
-	contextualLoggingDefault = false
+	// contextualLoggingDefault is now true because the feature reached beta
+	// and performance comparisons showed no relevant degradation when
+	// enabling it.
+	contextualLoggingDefault = true
 
 	// Allow fine-tuning of experimental, alpha-quality logging options.
 	//
@@ -57,7 +59,7 @@ const (
 
 func featureGates() map[featuregate.Feature]featuregate.FeatureSpec {
 	return map[featuregate.Feature]featuregate.FeatureSpec{
-		ContextualLogging: {Default: contextualLoggingDefault, PreRelease: featuregate.Alpha},
+		ContextualLogging: {Default: contextualLoggingDefault, PreRelease: featuregate.Beta},
 
 		LoggingAlphaOptions: {Default: false, PreRelease: featuregate.Alpha},
 		LoggingBetaOptions:  {Default: true, PreRelease: featuregate.Beta},


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Enabling the feature by default ensures that log output becomes better regardless whether users know and remember to enable it.

#### Which issue(s) this PR fixes:
Related-to https://github.com/kubernetes/enhancements/issues/3077

#### Special notes for your reviewer:

As discussed in
https://github.com/kubernetes/enhancements/pull/4219#issuecomment-1807811995 benchstat reports no significant difference in most test cases for scheduler_perf for -v3. At -v5, there is some slowdown, but that is justified because the output becomes more useful for debugging.

#### Does this PR introduce a user-facing change?
```release-note
Contextual logging is now beta and enabled by default.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/3077
- [Usage]: https://kubernetes.io/docs/concepts/cluster-administration/system-logs/#contextual-logging
```
