### PR TITLE
Make logs info keep the same style in kubelet_node_status

### DIFF
--- a/pkg/kubelet/kubelet_node_status.go
+++ b/pkg/kubelet/kubelet_node_status.go
@@ -401,7 +401,7 @@ func (kl *Kubelet) initialNode(ctx context.Context) (*v1.Node, error) {
 			return nil, err
 		}
 		if instanceType != "" {
-			klog.InfoS("Adding label from cloud provider", "labelKey", v1.LabelInstanceType, "labelValue", instanceType)
+			klog.InfoS("Adding node label from cloud provider", "labelKey", v1.LabelInstanceType, "labelValue", instanceType)
 			node.ObjectMeta.Labels[v1.LabelInstanceType] = instanceType
 			klog.InfoS("Adding node label from cloud provider", "labelKey", v1.LabelInstanceTypeStable, "labelValue", instanceType)
 			node.ObjectMeta.Labels[v1.LabelInstanceTypeStable] = instanceType


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Make logs info keep the same style in kubelet_node_status

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

