### PR TITLE
Make EndpointSlice API e2e test faster

### DIFF
--- a/test/e2e/network/endpointslice.go
+++ b/test/e2e/network/endpointslice.go
@@ -307,7 +307,7 @@ var _ = common.SIGDescribe("EndpointSlice", func() {
 			},
 		})
 
-		err := wait.Poll(5*time.Second, 3*time.Minute, func() (bool, error) {
+		err := wait.PollUntilContextTimeout(ctx, 2*time.Second, 3*time.Minute, true, func(ctx context.Context) (bool, error) {
 			var err error
 			pod1, err = podClient.Get(ctx, pod1.Name, metav1.GetOptions{})
 			if err != nil {
@@ -740,7 +740,7 @@ var _ = common.SIGDescribe("EndpointSlice", func() {
 // the only caller of this function.
 func expectEndpointsAndSlices(ctx context.Context, cs clientset.Interface, ns string, svc *v1.Service, pods []*v1.Pod, numSubsets, numSlices int, namedPort bool) {
 	endpointSlices := []discoveryv1.EndpointSlice{}
-	if err := wait.PollUntilContextTimeout(ctx, 5*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
+	if err := wait.PollUntilContextTimeout(ctx, 2*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
 		endpointSlicesFound, hasMatchingSlices := hasMatchingEndpointSlices(ctx, cs, ns, svc.Name, len(pods), numSlices)
 		if !hasMatchingSlices {
 			return false, nil
@@ -752,7 +752,7 @@ func expectEndpointsAndSlices(ctx context.Context, cs clientset.Interface, ns st
 	}
 
 	endpoints := &v1.Endpoints{}
-	if err := wait.PollWithContext(ctx, 5*time.Second, 2*time.Minute, func(ctx context.Context) (bool, error) {
+	if err := wait.PollUntilContextTimeout(ctx, 2*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
 		endpointsFound, hasMatchingEndpoints := hasMatchingEndpoints(ctx, cs, ns, svc.Name, len(pods), numSubsets)
 		if !hasMatchingEndpoints {
 			framework.Logf("Matching Endpoints not found")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

EndpointSlices and Endpoints usually become ready pretty fast, but the test always waited 5s before performing every check and it performed the check 4 times in total, so unnecessarily extends the test 20s.

The commit changes the poll function to perform a check before waiting, and reduces the interval to 2 seconds to align with other EndpointSlice tests. It reduces the test duration from 30s to 4s.

Before the commit:
```
[sig-network] EndpointSlice should create Endpoints and EndpointSlices for Pods matching a Service [Conformance] [sig-network, Conformance]
test/e2e/network/endpointslice.go:208
  STEP: Creating a kubernetes client @ 01/05/24 10:24:27.373
  Jan  5 10:24:27.373: INFO: >>> kubeConfig: /root/.kube/config
  STEP: Building a namespace api object, basename endpointslice @ 01/05/24 10:24:27.375
  STEP: Waiting for a default service account to be provisioned in namespace @ 01/05/24 10:24:27.387
  STEP: Waiting for kube-root-ca.crt to be provisioned in namespace @ 01/05/24 10:24:27.39
  STEP: referencing a single matching pod @ 01/05/24 10:24:32.445
  STEP: referencing matching pods with named port @ 01/05/24 10:24:37.456
  STEP: creating empty Endpoints and EndpointSlices for no matching Pods @ 01/05/24 10:24:42.466
  STEP: recreating EndpointSlices after they've been deleted @ 01/05/24 10:24:47.476
  Jan  5 10:24:47.499: INFO: EndpointSlice for Service endpointslice-2731/example-named-port not found
  Jan  5 10:24:57.507: INFO: Waiting up to 7m0s for all (but 0) nodes to be ready
  STEP: Destroying namespace "endpointslice-2731" for this suite. @ 01/05/24 10:24:57.513
• [30.147 seconds]
```

After the commit:
```
[sig-network] EndpointSlice should create Endpoints and EndpointSlices for Pods matching a Service [Conformance] [sig-network, Conformance]
test/e2e/network/endpointslice.go:208
  STEP: Creating a kubernetes client @ 01/05/24 10:30:56.878
  Jan  5 10:30:56.878: INFO: >>> kubeConfig: /root/.kube/config
  STEP: Building a namespace api object, basename endpointslice @ 01/05/24 10:30:56.88
  STEP: Waiting for a default service account to be provisioned in namespace @ 01/05/24 10:30:56.895
  STEP: Waiting for kube-root-ca.crt to be provisioned in namespace @ 01/05/24 10:30:56.899
  STEP: referencing a single matching pod @ 01/05/24 10:30:58.95
  STEP: referencing matching pods with named port @ 01/05/24 10:30:58.959
  STEP: creating empty Endpoints and EndpointSlices for no matching Pods @ 01/05/24 10:30:58.966
  STEP: recreating EndpointSlices after they've been deleted @ 01/05/24 10:30:58.973
  Jan  5 10:30:58.995: INFO: EndpointSlice for Service endpointslice-9287/example-named-port not found
  Jan  5 10:31:01.001: INFO: Waiting up to 7m0s for all (but 0) nodes to be ready
  STEP: Destroying namespace "endpointslice-9287" for this suite. @ 01/05/24 10:31:01.007
• [4.136 seconds]
```
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
