### PR TITLE
kube-proxy: canonicalize external IPs

### DIFF
--- a/pkg/proxy/serviceport.go
+++ b/pkg/proxy/serviceport.go
@@ -253,7 +253,7 @@ func newBaseServiceInfo(service *v1.Service, ipFamily v1.IPFamily, port *v1.Serv
 		// kube-proxy does not implement IP family translation, skip addresses with
 		// different IP family
 		if ingFamily := proxyutil.GetIPFamilyFromIP(ing.IP); ingFamily == ipFamily {
-			info.loadBalancerVIPs = append(info.loadBalancerVIPs, ing.IP)
+			info.loadBalancerVIPs = append(info.loadBalancerVIPs, netutils.ParseIPSloppy(ing.IP).String())
 		} else {
 			invalidIPs = append(invalidIPs, ing.IP)
 		}

--- a/pkg/proxy/util/utils.go
+++ b/pkg/proxy/util/utils.go
@@ -185,7 +185,7 @@ func MapIPsByIPFamily(ipStrings []string) map[v1.IPFamily][]string {
 	for _, ip := range ipStrings {
 		// Handle only the valid IPs
 		if ipFamily := GetIPFamilyFromIP(ip); ipFamily != v1.IPFamilyUnknown {
-			ipFamilyMap[ipFamily] = append(ipFamilyMap[ipFamily], ip)
+			ipFamilyMap[ipFamily] = append(ipFamilyMap[ipFamily], netutils.ParseIPSloppy(ip).String())
 		} else {
 			// this function is called in multiple places. All of which
 			// have sanitized data. Except the case of ExternalIPs which is


### PR DESCRIPTION
ExternalIPs and loadBalancerIPs are canonicalized before passing them to the proxier. 

#### What type of PR is this?

/kind bug
/sig network
/area kube-proxy

#### What this PR does / why we need it:

The "nft" utility used by proxy-mode=nftables can't handle addresses like "fd00::10.0.0.1"

#### Which issue(s) this PR fixes:

Fixes #122611

#### Special notes for your reviewer:

Since this can be done in many ways, I would like to get review feedback before I write any unit tests.

Tested for proxy-mode=nftables with loadBalancerIPs and externalIPs.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

N/A