### PR TITLE
swap originalPod and modifiedPod to match the comments

### DIFF
--- a/pkg/scheduler/framework/plugins/podtopologyspread/plugin.go
+++ b/pkg/scheduler/framework/plugins/podtopologyspread/plugin.go
@@ -196,25 +196,25 @@ func (pl *PodTopologySpread) isSchedulableAfterPodChange(logger klog.Logger, pod
 	}
 
 	// Pod is added. Return Queue when the added Pod has a label that matches with topologySpread's selector.
-	if originalPod != nil {
-		if podLabelsMatchSpreadConstraints(constraints, originalPod.Labels) {
+	if modifiedPod != nil {
+		if podLabelsMatchSpreadConstraints(constraints, modifiedPod.Labels) {
 			logger.V(5).Info("a scheduled pod was created and it matches with the pod's topology spread constraints",
-				"pod", klog.KObj(pod), "createdPod", klog.KObj(originalPod))
+				"pod", klog.KObj(pod), "createdPod", klog.KObj(modifiedPod))
 			return framework.Queue, nil
 		}
 		logger.V(5).Info("a scheduled pod was created, but it doesn't matches with the pod's topology spread constraints",
-			"pod", klog.KObj(pod), "createdPod", klog.KObj(originalPod))
+			"pod", klog.KObj(pod), "createdPod", klog.KObj(modifiedPod))
 		return framework.QueueSkip, nil
 	}
 
 	// Pod is deleted. Return Queue when the deleted Pod has a label that matches with topologySpread's selector.
-	if podLabelsMatchSpreadConstraints(constraints, modifiedPod.Labels) {
+	if podLabelsMatchSpreadConstraints(constraints, originalPod.Labels) {
 		logger.V(5).Info("a scheduled pod which matches with the pod's topology spread constraints was deleted, and the pod may be schedulable now",
-			"pod", klog.KObj(pod), "deletedPod", klog.KObj(modifiedPod))
+			"pod", klog.KObj(pod), "deletedPod", klog.KObj(originalPod))
 		return framework.Queue, nil
 	}
 	logger.V(5).Info("a scheduled pod was deleted, but it's unrelated to the pod's topology spread constraints",
-		"pod", klog.KObj(pod), "deletedPod", klog.KObj(modifiedPod))
+		"pod", klog.KObj(pod), "deletedPod", klog.KObj(originalPod))
 
 	return framework.QueueSkip, nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
The code doesn't match the comment.  Swaping `originalPod` and `modifiedPod` is a easier way to to implement it.
https://github.com/kubernetes/kubernetes/blob/e45f5b089f770b1c8a1583f2792176bfe450bb47/pkg/scheduler/framework/plugins/podtopologyspread/plugin.go#L198-L199

https://github.com/kubernetes/kubernetes/blob/e45f5b089f770b1c8a1583f2792176bfe450bb47/pkg/scheduler/framework/plugins/podtopologyspread/plugin.go#L210-L211
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
