### PR TITLE
DisableServiceLinks admission controller

### DIFF
--- a/pkg/kubeapiserver/options/plugins.go
+++ b/pkg/kubeapiserver/options/plugins.go
@@ -31,6 +31,7 @@ import (
 	certsubjectrestriction "k8s.io/kubernetes/plugin/pkg/admission/certificates/subjectrestriction"
 	"k8s.io/kubernetes/plugin/pkg/admission/defaulttolerationseconds"
 	"k8s.io/kubernetes/plugin/pkg/admission/deny"
+	"k8s.io/kubernetes/plugin/pkg/admission/disableservicelinks"
 	"k8s.io/kubernetes/plugin/pkg/admission/eventratelimit"
 	"k8s.io/kubernetes/plugin/pkg/admission/extendedresourcetoleration"
 	"k8s.io/kubernetes/plugin/pkg/admission/gc"
@@ -93,6 +94,7 @@ var AllOrderedPlugins = []string{
 	certsubjectrestriction.PluginName,       // CertificateSubjectRestriction
 	defaultingressclass.PluginName,          // DefaultIngressClass
 	denyserviceexternalips.PluginName,       // DenyServiceExternalIPs
+	disableservicelinks.PluginName,          // DisableServiceLinks
 
 	// new admission plugins should generally be inserted above here
 	// webhook, resourcequota, and deny plugins must go at the end
@@ -114,6 +116,7 @@ func RegisterAllAdmissionPlugins(plugins *admission.Plugins) {
 	defaultingressclass.Register(plugins)
 	denyserviceexternalips.Register(plugins)
 	deny.Register(plugins) // DEPRECATED as no real meaning
+	disableservicelinks.Register(plugins)
 	eventratelimit.Register(plugins)
 	extendedresourcetoleration.Register(plugins)
 	gc.Register(plugins)

--- a/plugin/pkg/admission/disableservicelinks/admission.go
+++ b/plugin/pkg/admission/disableservicelinks/admission.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package disableservicelinks
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/kubernetes/pkg/apis/core"
+	"k8s.io/utils/ptr"
+)
+
+// PluginName indicates name of admission plugin.
+const PluginName = "DisableServiceLinks"
+
+// Register is called by the apiserver to register the plugin factory.
+func Register(plugins *admission.Plugins) {
+	plugins.Register(PluginName, func(config io.Reader) (admission.Interface, error) {
+		return newDisableServiceLinks(), nil
+	})
+}
+
+// newDisableServiceLinks creates a new instance of the DisableServiceLinks admission controller.
+func newDisableServiceLinks() *plugin {
+	return &plugin{
+		Handler: admission.NewHandler(admission.Create, admission.Update),
+	}
+}
+
+// Make sure we are implementing the interface.
+var _ admission.MutationInterface = &plugin{}
+
+type plugin struct {
+	*admission.Handler
+}
+
+// Admit updates the EnableServiceLinks of a pod and set it to false.
+func (p *plugin) Admit(ctx context.Context, attributes admission.Attributes, o admission.ObjectInterfaces) error {
+	op := attributes.GetOperation()
+
+	// noop admission.Update for future support
+	if op == admission.Update {
+		return nil
+	}
+
+	// Ignore all calls to subresources or resources other than pods.
+	if len(attributes.GetSubresource()) != 0 || attributes.GetResource().GroupResource() != core.Resource("pods") {
+		return nil
+	}
+
+	pod, ok := attributes.GetObject().(*core.Pod)
+	if !ok {
+		return errors.NewBadRequest(fmt.Sprintf("expected *core.Pod but got %T", attributes.GetObject()))
+	}
+
+	pod.Spec.EnableServiceLinks = ptr.To(false)
+
+	return nil
+}

--- a/plugin/pkg/admission/disableservicelinks/admission_test.go
+++ b/plugin/pkg/admission/disableservicelinks/admission_test.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package disableservicelinks
+
+import (
+	"context"
+	"testing"
+
+	"k8s.io/apiserver/pkg/admission"
+	admissiontesting "k8s.io/apiserver/pkg/admission/testing"
+	"k8s.io/kubernetes/pkg/apis/core"
+	"k8s.io/kubernetes/pkg/apis/core/helper"
+	"k8s.io/utils/ptr"
+)
+
+func TestAdmit(t *testing.T) {
+
+	plugin := admissiontesting.WithReinvocationTesting(t, newDisableServiceLinks())
+
+	tests := []struct {
+		description  string
+		requestedPod core.Pod
+		expectedPod  core.Pod
+		operation    admission.Operation
+	}{
+		{
+			description: "Create empty pod with default value of Spec.EnableServiceLinks",
+			requestedPod: core.Pod{
+				Spec: core.PodSpec{},
+			},
+			expectedPod: core.Pod{
+				Spec: core.PodSpec{EnableServiceLinks: ptr.To(false)},
+			},
+			operation: admission.Create,
+		},
+		{
+			description: "Create empty pod with Spec.EnableServiceLinks set to true",
+			requestedPod: core.Pod{
+				Spec: core.PodSpec{EnableServiceLinks: ptr.To(true)},
+			},
+			expectedPod: core.Pod{
+				Spec: core.PodSpec{EnableServiceLinks: ptr.To(false)},
+			},
+			operation: admission.Create,
+		},
+		{
+			description: "Update empty pod with Spec.EnableServiceLinks set to true",
+			requestedPod: core.Pod{
+				Spec: core.PodSpec{EnableServiceLinks: ptr.To(true)},
+			},
+			expectedPod: core.Pod{
+				Spec: core.PodSpec{EnableServiceLinks: ptr.To(true)},
+			},
+			operation: admission.Update,
+		},
+	}
+	for i, test := range tests {
+		err := plugin.Admit(context.TODO(), admission.NewAttributesRecord(&test.requestedPod, nil,
+			core.Kind("Pod").WithVersion("version"), "foo", "name",
+			core.Resource("pods").WithVersion("version"), "", test.operation,
+			nil, false, nil), nil)
+
+		if err != nil {
+			t.Errorf("[%d: %s] unexpected error %v for pod %+v", i, test.description, err, test.requestedPod)
+		}
+
+		if !helper.Semantic.DeepEqual(test.expectedPod.Spec, test.requestedPod.Spec) {
+			t.Errorf("[%d: %s] expected %t got %t", i, test.description, *test.expectedPod.Spec.EnableServiceLinks, *test.requestedPod.Spec.EnableServiceLinks)
+		}
+	}
+}
+
+func TestHandles(t *testing.T) {
+	plugin := newDisableServiceLinks()
+	tests := map[admission.Operation]bool{
+		admission.Create:  true,
+		admission.Update:  true,
+		admission.Delete:  false,
+		admission.Connect: false,
+	}
+	for op, expected := range tests {
+		result := plugin.Handles(op)
+		if result != expected {
+			t.Errorf("Unexpected result for operation %s: %v\n", op, result)
+		}
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature


<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Adds an optional admission controller to disable EnableServiceLinks for new Pods without the need for a third-party mutating webhook.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # https://github.com/kubernetes/kubernetes/issues/121787

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

Thios PR was reverted in #125002.

The original relnote, for posterity: Added `DisableServiceLinks` admission controller: An optional mutating controller that will set `Spec.EnableServiceLinks: False` for all pods manifests in the cluster before scheduling. 

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

Agreement to solve this issue with an optional admission controller.
REF: https://github.com/kubernetes/kubernetes/issues/121787#issuecomment-1863694095

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
