### PR TITLE
kube-scheduler: fix empty lastTransitionTime in pod condition

### DIFF
--- a/pkg/registry/core/pod/strategy.go
+++ b/pkg/registry/core/pod/strategy.go
@@ -752,7 +752,7 @@ func applyWaitingForSchedulingGatesCondition(pod *api.Pod) {
 		}
 	}
 
-	pod.Status.Conditions = append(pod.Status.Conditions, api.PodCondition{
+	podutil.UpdatePodCondition(&pod.Status, &api.PodCondition{
 		Type:    api.PodScheduled,
 		Status:  api.ConditionFalse,
 		Reason:  apiv1.PodReasonSchedulingGated,

--- a/pkg/registry/core/pod/strategy_test.go
+++ b/pkg/registry/core/pod/strategy_test.go
@@ -371,7 +371,10 @@ func TestWaitingForGatesCondition(t *testing.T) {
 				}
 			}
 
-			if diff := cmp.Diff(tt.want, got); diff != "" {
+			if got.LastTransitionTime.IsZero() && got.Type != "" {
+				t.Errorf("unexpected empty LastTransitionTime in condition")
+			}
+			if diff := cmp.Diff(tt.want, got, cmpopts.IgnoreFields(api.PodCondition{}, "LastTransitionTime")); diff != "" {
 				t.Errorf("unexpected field errors (-want, +got):\n%s", diff)
 			}
 		})


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Fix null lastTransitionTime in pod condition when setting scheduling gate

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #122164

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix null lastTransitionTime in Pod condition when setting scheduling gate.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
