### PR TITLE
client-go/features: warn when ordering initialization issue

### DIFF
--- a/staging/src/k8s.io/client-go/features/OWNERS
+++ b/staging/src/k8s.io/client-go/features/OWNERS
@@ -1,0 +1,4 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - feature-approvers

--- a/staging/src/k8s.io/client-go/features/envvar.go
+++ b/staging/src/k8s.io/client-go/features/envvar.go
@@ -1,0 +1,131 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package features
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"sync"
+	"sync/atomic"
+
+	"k8s.io/apimachinery/pkg/util/naming"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/klog/v2"
+)
+
+// internalPackages are packages that ignored when creating a name for featureGates. These packages are in the common
+// call chains, so they'd be unhelpful as names.
+var internalPackages = []string{"k8s.io/client-go/features/envvar.go"}
+
+var _ Gates = &envVarFeatureGates{}
+
+// newEnvVarFeatureGates creates a feature gate that allows for registration
+// of features and checking if the features are enabled.
+//
+// On the first call to Enabled, the effective state of all known features is loaded from
+// environment variables. The environment variable read for a given feature is formed by
+// concatenating the prefix "KUBE_FEATURE_" with the feature's name.
+//
+// For example, if you have a feature named "MyFeature"
+// setting an environmental variable "KUBE_FEATURE_MyFeature"
+// will allow you to configure the state of that feature.
+//
+// Please note that environmental variables can only be set to the boolean value.
+// Incorrect values will be ignored and logged.
+func newEnvVarFeatureGates(features map[Feature]FeatureSpec) *envVarFeatureGates {
+	enabled := map[Feature]bool{}
+	enabledValue := &atomic.Value{}
+	enabledValue.Store(enabled)
+
+	known := map[Feature]FeatureSpec{}
+	for name, spec := range features {
+		known[name] = spec
+	}
+
+	return &envVarFeatureGates{
+		callSiteName: naming.GetNameFromCallsite(internalPackages...),
+		known:        known,
+		enabled:      enabledValue,
+	}
+}
+
+// envVarFeatureGates implements Gates and allows for feature registration.
+type envVarFeatureGates struct {
+	// callSiteName holds the name of the file
+	// that created this instance
+	callSiteName string
+
+	// readEnvVarsOnce guards reading environmental variables
+	readEnvVarsOnce sync.Once
+
+	// known holds known feature gates
+	known map[Feature]FeatureSpec
+
+	// enabled holds a map[Feature]bool
+	// with values explicitly set via env var
+	enabled *atomic.Value
+}
+
+// Enabled returns true if the key is enabled.  If the key is not known, this call will panic.
+func (f *envVarFeatureGates) Enabled(key Feature) bool {
+	if v, ok := f.getEnabledMapFromEnvVar()[key]; ok {
+		return v
+	}
+	if v, ok := f.known[key]; ok {
+		return v.Default
+	}
+	panic(fmt.Errorf("feature %q is not registered in FeatureGates %q", key, f.callSiteName))
+}
+
+// getEnabledMapFromEnvVar will fill the enabled map on the first call.
+// This is the only time a known feature can be set to a value
+// read from the corresponding environmental variable.
+func (f *envVarFeatureGates) getEnabledMapFromEnvVar() map[Feature]bool {
+	f.readEnvVarsOnce.Do(func() {
+		featureGatesState := map[Feature]bool{}
+		for feature, featureSpec := range f.known {
+			featureState, featureStateSet := os.LookupEnv(fmt.Sprintf("KUBE_FEATURE_%s", feature))
+			if !featureStateSet {
+				continue
+			}
+			boolVal, boolErr := strconv.ParseBool(featureState)
+			switch {
+			case boolErr != nil:
+				utilruntime.HandleError(fmt.Errorf("cannot set feature gate %q to %q, due to %v", feature, featureState, boolErr))
+			case featureSpec.LockToDefault:
+				if boolVal != featureSpec.Default {
+					utilruntime.HandleError(fmt.Errorf("cannot set feature gate %q to %q, feature is locked to %v", feature, featureState, featureSpec.Default))
+					break
+				}
+				featureGatesState[feature] = featureSpec.Default
+			default:
+				featureGatesState[feature] = boolVal
+			}
+		}
+		f.enabled.Store(featureGatesState)
+
+		for feature, featureSpec := range f.known {
+			if featureState, ok := featureGatesState[feature]; ok {
+				klog.V(1).InfoS("Feature gate updated state", "feature", feature, "enabled", featureState)
+				continue
+			}
+			klog.V(1).InfoS("Feature gate default state", "feature", feature, "enabled", featureSpec.Default)
+		}
+	})
+	return f.enabled.Load().(map[Feature]bool)
+}

--- a/staging/src/k8s.io/client-go/features/envvar_test.go
+++ b/staging/src/k8s.io/client-go/features/envvar_test.go
@@ -1,0 +1,148 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package features
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnvVarFeatureGates(t *testing.T) {
+	defaultTestFeatures := map[Feature]FeatureSpec{
+		"TestAlpha": {
+			Default:       false,
+			LockToDefault: false,
+			PreRelease:    "Alpha",
+		},
+		"TestBeta": {
+			Default:       true,
+			LockToDefault: false,
+			PreRelease:    "Beta",
+		},
+	}
+	expectedDefaultFeaturesState := map[Feature]bool{"TestAlpha": false, "TestBeta": true}
+
+	copyExpectedStateMap := func(toCopy map[Feature]bool) map[Feature]bool {
+		m := map[Feature]bool{}
+		for k, v := range toCopy {
+			m[k] = v
+		}
+		return m
+	}
+
+	scenarios := []struct {
+		name                                string
+		features                            map[Feature]FeatureSpec
+		envVariables                        map[string]string
+		expectedFeaturesState               map[Feature]bool
+		expectedInternalEnabledFeatureState map[Feature]bool
+	}{
+		{
+			name: "can add empty features",
+		},
+		{
+			name:                  "no env var, features get Defaults assigned",
+			features:              defaultTestFeatures,
+			expectedFeaturesState: expectedDefaultFeaturesState,
+		},
+		{
+			name:                  "incorrect env var, feature gets Default assigned",
+			features:              defaultTestFeatures,
+			envVariables:          map[string]string{"TestAlpha": "true"},
+			expectedFeaturesState: expectedDefaultFeaturesState,
+		},
+		{
+			name:         "correct env var changes the feature gets state",
+			features:     defaultTestFeatures,
+			envVariables: map[string]string{"KUBE_FEATURE_TestAlpha": "true"},
+			expectedFeaturesState: func() map[Feature]bool {
+				expectedDefaultFeaturesStateCopy := copyExpectedStateMap(expectedDefaultFeaturesState)
+				expectedDefaultFeaturesStateCopy["TestAlpha"] = true
+				return expectedDefaultFeaturesStateCopy
+			}(),
+			expectedInternalEnabledFeatureState: map[Feature]bool{"TestAlpha": true},
+		},
+		{
+			name:                  "incorrect env var value gets ignored",
+			features:              defaultTestFeatures,
+			envVariables:          map[string]string{"KUBE_FEATURE_TestAlpha": "TrueFalse"},
+			expectedFeaturesState: expectedDefaultFeaturesState,
+		},
+		{
+			name:                  "empty env var value gets ignored",
+			features:              defaultTestFeatures,
+			envVariables:          map[string]string{"KUBE_FEATURE_TestAlpha": ""},
+			expectedFeaturesState: expectedDefaultFeaturesState,
+		},
+		{
+			name: "a feature LockToDefault wins",
+			features: map[Feature]FeatureSpec{
+				"TestAlpha": {
+					Default:       true,
+					LockToDefault: true,
+					PreRelease:    "Alpha",
+				},
+			},
+			envVariables:          map[string]string{"KUBE_FEATURE_TestAlpha": "False"},
+			expectedFeaturesState: map[Feature]bool{"TestAlpha": true},
+		},
+		{
+			name: "setting a feature to LockToDefault changes the internal state",
+			features: map[Feature]FeatureSpec{
+				"TestAlpha": {
+					Default:       true,
+					LockToDefault: true,
+					PreRelease:    "Alpha",
+				},
+			},
+			envVariables:                        map[string]string{"KUBE_FEATURE_TestAlpha": "True"},
+			expectedFeaturesState:               map[Feature]bool{"TestAlpha": true},
+			expectedInternalEnabledFeatureState: map[Feature]bool{"TestAlpha": true},
+		},
+	}
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			for k, v := range scenario.envVariables {
+				t.Setenv(k, v)
+			}
+			target := newEnvVarFeatureGates(scenario.features)
+
+			for expectedFeature, expectedValue := range scenario.expectedFeaturesState {
+				actualValue := target.Enabled(expectedFeature)
+				require.Equal(t, actualValue, expectedValue, "expected feature=%v, to be=%v, not=%v", expectedFeature, expectedValue, actualValue)
+			}
+
+			enabledInternalMap := target.enabled.Load().(map[Feature]bool)
+			require.Len(t, enabledInternalMap, len(scenario.expectedInternalEnabledFeatureState))
+
+			for expectedFeature, expectedInternalPresence := range scenario.expectedInternalEnabledFeatureState {
+				featureInternalValue, featureSet := enabledInternalMap[expectedFeature]
+				require.Equal(t, expectedInternalPresence, featureSet, "feature %v present = %v, expected = %v", expectedFeature, featureSet, expectedInternalPresence)
+
+				expectedFeatureInternalValue := scenario.expectedFeaturesState[expectedFeature]
+				require.Equal(t, expectedFeatureInternalValue, featureInternalValue)
+			}
+		})
+	}
+}
+
+func TestEnvVarFeatureGatesEnabledPanic(t *testing.T) {
+	target := newEnvVarFeatureGates(nil)
+	require.PanicsWithError(t, fmt.Errorf("feature %q is not registered in FeatureGates %q", "UnknownFeature", target.callSiteName).Error(), func() { target.Enabled("UnknownFeature") })
+}

--- a/staging/src/k8s.io/client-go/features/envvar_test.go
+++ b/staging/src/k8s.io/client-go/features/envvar_test.go
@@ -142,7 +142,15 @@ func TestEnvVarFeatureGates(t *testing.T) {
 	}
 }
 
-func TestEnvVarFeatureGatesEnabledPanic(t *testing.T) {
+func TestEnabledPanic(t *testing.T) {
 	target := newEnvVarFeatureGates(nil)
 	require.PanicsWithError(t, fmt.Errorf("feature %q is not registered in FeatureGates %q", "UnknownFeature", target.callSiteName).Error(), func() { target.Enabled("UnknownFeature") })
+}
+
+func TestHasAlreadyReadEnvVar(t *testing.T) {
+	target := newEnvVarFeatureGates(nil)
+	require.False(t, target.hasAlreadyReadEnvVar())
+
+	_ = target.getEnabledMapFromEnvVar()
+	require.True(t, target.hasAlreadyReadEnvVar())
 }

--- a/staging/src/k8s.io/client-go/features/features.go
+++ b/staging/src/k8s.io/client-go/features/features.go
@@ -1,0 +1,131 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package features
+
+import (
+	"sync/atomic"
+)
+
+// NOTE: types Feature, FeatureSpec, prerelease (and its values)
+// were duplicated from the component-base repository
+//
+// for more information please refer to https://docs.google.com/document/d/1g9BGCRw-7ucUxO6OtCWbb3lfzUGA_uU9178wLdXAIfs
+
+const (
+	// Values for PreRelease.
+	Alpha = prerelease("ALPHA")
+	Beta  = prerelease("BETA")
+	GA    = prerelease("")
+
+	// Deprecated
+	Deprecated = prerelease("DEPRECATED")
+)
+
+type prerelease string
+
+type Feature string
+
+type FeatureSpec struct {
+	// Default is the default enablement state for the feature
+	Default bool
+	// LockToDefault indicates that the feature is locked to its default and cannot be changed
+	LockToDefault bool
+	// PreRelease indicates the maturity level of the feature
+	PreRelease prerelease
+}
+
+// Gates indicates whether a given feature is enabled or not.
+type Gates interface {
+	// Enabled returns true if the key is enabled.
+	Enabled(key Feature) bool
+}
+
+// Registry represents an external feature gates registry.
+type Registry interface {
+	// Add adds existing feature gates to the provided registry.
+	//
+	// As of today, this method is used by AddFeaturesToExistingFeatureGates and
+	// SetFeatureGates to take control of the features exposed by this library.
+	Add(map[Feature]FeatureSpec) error
+}
+
+// FeatureGates returns the feature gates exposed by this library.
+//
+// By default, only the default features gates will be returned.
+// The default implementation allows controlling the features
+// via environmental variables.
+// For example, if you have a feature named "MyFeature"
+// setting an environmental variable "KUBE_FEATURE_MyFeature"
+// will allow you to configure the state of that feature.
+//
+// Please note that the actual set of the feature gates
+// might be overwritten by calling SetFeatureGates method.
+func FeatureGates() Gates {
+	return featureGates.Load().(*featureGatesWrapper).Gates
+}
+
+// AddFeaturesToExistingFeatureGates adds the default feature gates to the provided registry.
+// Usually this function is combined with SetFeatureGates to take control of the
+// features exposed by this library.
+func AddFeaturesToExistingFeatureGates(registry Registry) error {
+	return registry.Add(defaultKubernetesFeatureGates)
+}
+
+// SetFeatureGates overwrites the default implementation of the feature gates
+// used by this library.
+//
+// Useful for binaries that would like to have full control of the features
+// exposed by this library, such as allowing consumers of a binary
+// to interact with the features via a command line flag.
+//
+// For example:
+//
+//	// first, register client-go's features to your registry.
+//	clientgofeaturegate.AddFeaturesToExistingFeatureGates(utilfeature.DefaultMutableFeatureGate)
+//	// then replace client-go's feature gates implementation with your implementation
+//	clientgofeaturegate.SetFeatureGates(utilfeature.DefaultMutableFeatureGate)
+func SetFeatureGates(newFeatureGates Gates) {
+	wrappedFeatureGates := &featureGatesWrapper{newFeatureGates}
+	featureGates.Store(wrappedFeatureGates)
+}
+
+func init() {
+	envVarGates := newEnvVarFeatureGates(defaultKubernetesFeatureGates)
+
+	wrappedFeatureGates := &featureGatesWrapper{envVarGates}
+	featureGates.Store(wrappedFeatureGates)
+}
+
+// featureGatesWrapper a thin wrapper to satisfy featureGates variable (atomic.Value).
+// That is, all calls to Store for a given Value must use values of the same concrete type.
+type featureGatesWrapper struct {
+	Gates
+}
+
+var (
+	// featureGates is a shared global FeatureGates.
+	//
+	// Top-level commands/options setup that needs to modify this feature gates
+	// should use AddFeaturesToExistingFeatureGates followed by SetFeatureGates.
+	featureGates = &atomic.Value{}
+)
+
+// defaultKubernetesFeatureGates consists of all known Kubernetes-specific feature keys.
+//
+// To add a new feature, define a key for it above and add it here. The features will be
+// available throughout Kubernetes binaries.
+var defaultKubernetesFeatureGates = map[Feature]FeatureSpec{}

--- a/staging/src/k8s.io/client-go/features/features_test.go
+++ b/staging/src/k8s.io/client-go/features/features_test.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package features
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestAddFeaturesToExistingFeatureGates ensures that
+// the defaultKubernetesFeatureGates are added to a test feature gates registry.
+func TestAddFeaturesToExistingFeatureGates(t *testing.T) {
+	fakeFeatureGates := &fakeRegistry{}
+	require.NoError(t, AddFeaturesToExistingFeatureGates(fakeFeatureGates))
+	require.Equal(t, defaultKubernetesFeatureGates, fakeFeatureGates.specs)
+}
+
+type fakeRegistry struct {
+	specs map[Feature]FeatureSpec
+}
+
+func (f *fakeRegistry) Add(specs map[Feature]FeatureSpec) error {
+	f.specs = specs
+	return nil
+}

--- a/staging/src/k8s.io/client-go/features/features_test.go
+++ b/staging/src/k8s.io/client-go/features/features_test.go
@@ -30,6 +30,23 @@ func TestAddFeaturesToExistingFeatureGates(t *testing.T) {
 	require.Equal(t, defaultKubernetesFeatureGates, fakeFeatureGates.specs)
 }
 
+func TestSetFeatureGatesWithWarningIndicator(t *testing.T) {
+	fakeFeatureGates := &alwaysEnabledFakeGates{}
+	require.False(t, setFeatureGatesWithWarningIndicator(fakeFeatureGates))
+
+	defaultEnvVarGates := newEnvVarFeatureGates(nil)
+	require.False(t, setFeatureGatesWithWarningIndicator(defaultEnvVarGates))
+
+	_ = defaultEnvVarGates.getEnabledMapFromEnvVar()
+	require.True(t, setFeatureGatesWithWarningIndicator(fakeFeatureGates))
+}
+
+type alwaysEnabledFakeGates struct{}
+
+func (f *alwaysEnabledFakeGates) Enabled(Feature) bool {
+	return true
+}
+
 type fakeRegistry struct {
 	specs map[Feature]FeatureSpec
 }

--- a/staging/src/k8s.io/client-go/features/testing/features_init_test.go
+++ b/staging/src/k8s.io/client-go/features/testing/features_init_test.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"k8s.io/client-go/features"
+)
+
+func TestDriveInitDefaultFeatureGates(t *testing.T) {
+	featureGates := features.FeatureGates()
+	assertFunctionPanicsWithMessage(t, func() { featureGates.Enabled("FakeFeatureGate") }, "features.FeatureGates().Enabled", fmt.Sprintf("feature %q is not registered in FeatureGate", "FakeFeatureGate"))
+
+	fakeFeatureGates := &alwaysEnabledFakeGates{}
+	require.True(t, fakeFeatureGates.Enabled("FakeFeatureGate"))
+
+	features.SetFeatureGates(fakeFeatureGates)
+	featureGates = features.FeatureGates()
+
+	assertFeatureGatesType(t, featureGates)
+	require.True(t, featureGates.Enabled("FakeFeatureGate"))
+}
+
+type alwaysEnabledFakeGates struct{}
+
+func (f *alwaysEnabledFakeGates) Enabled(features.Feature) bool {
+	return true
+}
+
+func assertFeatureGatesType(t *testing.T, fg features.Gates) {
+	_, ok := fg.(*alwaysEnabledFakeGates)
+	if !ok {
+		t.Fatalf("passed features.FeatureGates() is NOT of type *alwaysEnabledFakeGates, it is of type = %T", fg)
+	}
+}
+
+func assertFunctionPanicsWithMessage(t *testing.T, f func(), fName, errMessage string) {
+	didPanic, panicMessage := didFunctionPanic(f)
+	if !didPanic {
+		t.Fatalf("function %q did not panicked", fName)
+	}
+
+	panicError, ok := panicMessage.(error)
+	if !ok || !strings.Contains(panicError.Error(), errMessage) {
+		t.Fatalf("func %q should panic with error message:\t%#v\n\tPanic value:\t%#v\n", fName, errMessage, panicMessage)
+	}
+}
+
+func didFunctionPanic(f func()) (didPanic bool, panicMessage interface{}) {
+	didPanic = true
+
+	defer func() {
+		panicMessage = recover()
+	}()
+
+	f()
+	didPanic = false
+
+	return
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
SetFeatureGates logs a warning when the default env var
implementation has been already used.
Such a situation indicates a potential ordering issue and usually is unwanted.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
requires https://github.com/kubernetes/kubernetes/pull/122555
please review only the second commit

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
