### PR TITLE
Support overrides for registered feature defaults.

### DIFF
--- a/staging/src/k8s.io/component-base/featuregate/feature_gate.go
+++ b/staging/src/k8s.io/component-base/featuregate/feature_gate.go
@@ -115,6 +115,17 @@ type MutableFeatureGate interface {
 	GetAll() map[Feature]FeatureSpec
 	// AddMetrics adds feature enablement metrics
 	AddMetrics()
+	// OverrideDefault sets a local override for the registered default value of a named
+	// feature. If the feature has not been previously registered (e.g. by a call to Add), has a
+	// locked default, or if the gate has already registered itself with a FlagSet, a non-nil
+	// error is returned.
+	//
+	// When two or more components consume a common feature, one component can override its
+	// default at runtime in order to adopt new defaults before or after the other
+	// components. For example, a new feature can be evaluated with a limited blast radius by
+	// overriding its default to true for a limited number of components without simultaneously
+	// changing its default for all consuming components.
+	OverrideDefault(name Feature, override bool) error
 }
 
 // featureGate implements FeatureGate as well as pflag.Value for flag parsing.
@@ -291,6 +302,38 @@ func (f *featureGate) Add(features map[Feature]FeatureSpec) error {
 	}
 
 	// Persist updated state
+	f.known.Store(known)
+
+	return nil
+}
+
+func (f *featureGate) OverrideDefault(name Feature, override bool) error {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+
+	if f.closed {
+		return fmt.Errorf("cannot override default for feature %q: gates already added to a flag set", name)
+	}
+
+	known := map[Feature]FeatureSpec{}
+	for name, spec := range f.known.Load().(map[Feature]FeatureSpec) {
+		known[name] = spec
+	}
+
+	spec, ok := known[name]
+	switch {
+	case !ok:
+		return fmt.Errorf("cannot override default: feature %q is not registered", name)
+	case spec.LockToDefault:
+		return fmt.Errorf("cannot override default: feature %q default is locked to %t", name, spec.Default)
+	case spec.PreRelease == Deprecated:
+		klog.Warningf("Overriding default of deprecated feature gate %s=%t. It will be removed in a future release.", name, override)
+	case spec.PreRelease == GA:
+		klog.Warningf("Overriding default of GA feature gate %s=%t. It will be removed in a future release.", name, override)
+	}
+
+	spec.Default = override
+	known[name] = spec
 	f.known.Store(known)
 
 	return nil

--- a/staging/src/k8s.io/component-base/featuregate/feature_gate_test.go
+++ b/staging/src/k8s.io/component-base/featuregate/feature_gate_test.go
@@ -508,3 +508,141 @@ func TestFeatureGateString(t *testing.T) {
 		})
 	}
 }
+
+func TestFeatureGateOverrideDefault(t *testing.T) {
+	t.Run("overrides take effect", func(t *testing.T) {
+		f := NewFeatureGate()
+		if err := f.Add(map[Feature]FeatureSpec{
+			"TestFeature1": {Default: true},
+			"TestFeature2": {Default: false},
+		}); err != nil {
+			t.Fatal(err)
+		}
+		if err := f.OverrideDefault("TestFeature1", false); err != nil {
+			t.Fatal(err)
+		}
+		if err := f.OverrideDefault("TestFeature2", true); err != nil {
+			t.Fatal(err)
+		}
+		if f.Enabled("TestFeature1") {
+			t.Error("expected TestFeature1 to have effective default of false")
+		}
+		if !f.Enabled("TestFeature2") {
+			t.Error("expected TestFeature2 to have effective default of true")
+		}
+	})
+
+	t.Run("overrides are preserved across deep copies", func(t *testing.T) {
+		f := NewFeatureGate()
+		if err := f.Add(map[Feature]FeatureSpec{"TestFeature": {Default: false}}); err != nil {
+			t.Fatal(err)
+		}
+		if err := f.OverrideDefault("TestFeature", true); err != nil {
+			t.Fatal(err)
+		}
+		fcopy := f.DeepCopy()
+		if !fcopy.Enabled("TestFeature") {
+			t.Error("default override was not preserved by deep copy")
+		}
+	})
+
+	t.Run("reflected in known features", func(t *testing.T) {
+		f := NewFeatureGate()
+		if err := f.Add(map[Feature]FeatureSpec{"TestFeature": {
+			Default:    false,
+			PreRelease: Alpha,
+		}}); err != nil {
+			t.Fatal(err)
+		}
+		if err := f.OverrideDefault("TestFeature", true); err != nil {
+			t.Fatal(err)
+		}
+		var found bool
+		for _, s := range f.KnownFeatures() {
+			if !strings.Contains(s, "TestFeature") {
+				continue
+			}
+			found = true
+			if !strings.Contains(s, "default=true") {
+				t.Errorf("expected override of default to be reflected in known feature description %q", s)
+			}
+		}
+		if !found {
+			t.Error("found no entry for TestFeature in known features")
+		}
+	})
+
+	t.Run("may not change default for specs with locked defaults", func(t *testing.T) {
+		f := NewFeatureGate()
+		if err := f.Add(map[Feature]FeatureSpec{
+			"LockedFeature": {
+				Default:       true,
+				LockToDefault: true,
+			},
+		}); err != nil {
+			t.Fatal(err)
+		}
+		if f.OverrideDefault("LockedFeature", false) == nil {
+			t.Error("expected error when attempting to override the default for a feature with a locked default")
+		}
+		if f.OverrideDefault("LockedFeature", true) == nil {
+			t.Error("expected error when attempting to override the default for a feature with a locked default")
+		}
+	})
+
+	t.Run("does not supersede explicitly-set value", func(t *testing.T) {
+		f := NewFeatureGate()
+		if err := f.Add(map[Feature]FeatureSpec{"TestFeature": {Default: true}}); err != nil {
+			t.Fatal(err)
+		}
+		if err := f.OverrideDefault("TestFeature", false); err != nil {
+			t.Fatal(err)
+		}
+		if err := f.SetFromMap(map[string]bool{"TestFeature": true}); err != nil {
+			t.Fatal(err)
+		}
+		if !f.Enabled("TestFeature") {
+			t.Error("expected feature to be effectively enabled despite default override")
+		}
+	})
+
+	t.Run("prevents re-registration of feature spec after overriding default", func(t *testing.T) {
+		f := NewFeatureGate()
+		if err := f.Add(map[Feature]FeatureSpec{
+			"TestFeature": {
+				Default:    true,
+				PreRelease: Alpha,
+			},
+		}); err != nil {
+			t.Fatal(err)
+		}
+		if err := f.OverrideDefault("TestFeature", false); err != nil {
+			t.Fatal(err)
+		}
+		if err := f.Add(map[Feature]FeatureSpec{
+			"TestFeature": {
+				Default:    true,
+				PreRelease: Alpha,
+			},
+		}); err == nil {
+			t.Error("expected re-registration to return a non-nil error after overriding its default")
+		}
+	})
+
+	t.Run("does not allow override for an unknown feature", func(t *testing.T) {
+		f := NewFeatureGate()
+		if err := f.OverrideDefault("TestFeature", true); err == nil {
+			t.Error("expected an error to be returned in attempt to override default for unregistered feature")
+		}
+	})
+
+	t.Run("returns error if already added to flag set", func(t *testing.T) {
+		f := NewFeatureGate()
+		fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+		f.AddFlag(fs)
+
+		if err := f.OverrideDefault("TestFeature", true); err == nil {
+			t.Error("expected a non-nil error to be returned")
+		}
+	})
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

#### What this PR does / why we need it:

This is to support the goal of enabling a feature by default for a single component only when the feature in question is consumed by multiple components.

Overriden defaults are reflected in KnownFeatures and registered flag text.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

For beta, [KEP 3157](https://github.com/kubernetes/enhancements/blob/1306aa9202dd6792b4ee60fca7a1dd69d1f589ae/keps/sig-api-machinery/3157-watch-list/README.md#how-can-a-rollout-or-rollback-fail-can-it-impact-already-running-workloads) proposes to enable a client-side feature gate by default in kube-controller-manager only.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added to MutableFeatureGate the ability to override the default setting of feature gates, to allow default-enabling a feature on a component-by-component basis instead of for all affected components simultaneously.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [Proposal]: https://docs.google.com/document/d/1g9BGCRw-7ucUxO6OtCWbb3lfzUGA_uU9178wLdXAIfs/edit#heading=h.ookhkzz1jrsp
```
