### PR TITLE
Automated cherry pick of #122636: fix null lastTransitionTime in pod condition when setting

### DIFF
--- a/pkg/registry/core/pod/strategy.go
+++ b/pkg/registry/core/pod/strategy.go
@@ -673,7 +673,7 @@ func applyWaitingForSchedulingGatesCondition(pod *api.Pod) {
 		}
 	}
 
-	pod.Status.Conditions = append(pod.Status.Conditions, api.PodCondition{
+	podutil.UpdatePodCondition(&pod.Status, &api.PodCondition{
 		Type:    api.PodScheduled,
 		Status:  api.ConditionFalse,
 		Reason:  api.PodReasonSchedulingGated,

--- a/pkg/registry/core/pod/strategy_test.go
+++ b/pkg/registry/core/pod/strategy_test.go
@@ -323,7 +323,10 @@ func TestWaitingForGatesCondition(t *testing.T) {
 				}
 			}
 
-			if diff := cmp.Diff(tt.want, got); diff != "" {
+			if got.LastTransitionTime.IsZero() && got.Type != "" {
+				t.Errorf("unexpected empty LastTransitionTime in condition")
+			}
+			if diff := cmp.Diff(tt.want, got, cmpopts.IgnoreFields(api.PodCondition{}, "LastTransitionTime")); diff != "" {
 				t.Errorf("unexpected field errors (-want, +got):\n%s", diff)
 			}
 		})


### PR DESCRIPTION
Cherry pick of #122636 on release-1.27.

#122636: fix null lastTransitionTime in pod condition when setting

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```