### PR TITLE
[WIP] use hcn package directly instead of hcsshim

### DIFF
--- a/pkg/kubelet/stats/cri_stats_provider_windows.go
+++ b/pkg/kubelet/stats/cri_stats_provider_windows.go
@@ -42,11 +42,11 @@ type windowsNetworkStatsProvider interface {
 type networkStats struct{}
 
 func (s networkStats) HNSListEndpointRequest() ([]hcsshim.HNSEndpoint, error) {
-	return hcsshim.HNSListEndpointRequest()
+	return hns.HNSListEndpointRequest()
 }
 
 func (s networkStats) GetHNSEndpointStats(endpointName string) (*hcsshim.HNSEndpointStats, error) {
-	return hcsshim.GetHNSEndpointStats(endpointName)
+	return hns.GetHNSEndpointStats(endpointName)
 }
 
 // listContainerNetworkStats returns the network stats of all the running containers.

--- a/pkg/proxy/winkernel/hcnutils.go
+++ b/pkg/proxy/winkernel/hcnutils.go
@@ -20,7 +20,6 @@ limitations under the License.
 package winkernel
 
 import (
-	"github.com/Microsoft/hcsshim"
 	"github.com/Microsoft/hcsshim/hcn"
 	"k8s.io/klog/v2"
 )
@@ -121,7 +120,7 @@ func (hcnObj hcnImpl) DsrSupported() error {
 }
 
 func (hcnObj hcnImpl) DeleteAllHnsLoadBalancerPolicy() {
-	plists, err := hcsshim.HNSListPolicyListRequest()
+	plists, err := hns.HNSListPolicyListRequest()
 	if err != nil {
 		return
 	}

--- a/pkg/proxy/winkernel/proxier.go
+++ b/pkg/proxy/winkernel/proxier.go
@@ -73,7 +73,7 @@ type WindowsKernelCompatTester struct{}
 
 // IsCompatible returns true if winkernel can support this mode of proxy
 func (lkct WindowsKernelCompatTester) IsCompatible() error {
-	_, err := hcsshim.HNSListPolicyListRequest()
+	_, err := hns.HNSListPolicyListRequest()
 	if err != nil {
 		return fmt.Errorf("Windows kernel is not compatible for Kernel mode")
 	}


### PR DESCRIPTION
We use an older version of hcsshim which is perfectly fine, but newer hcsshim is running into trouble on a few fronts, see thread https://kubernetes.slack.com/archives/CHGFYJVAN/p1704808840624469

While looking at the dependency and how it is used in our repository, realized that some of the methods we use in the `hcsshim` package are just wrappers into another public package `hcsshim/hcn`, So in this PR, just making sure all our uses of `hcsshim` module is limited to `hcsshim/hcn` package. So if/when we are updating `hcsshim` we know we don't really need everything and we just depend on `hcs`.

Implicitly, this is also a request to `hcsshim` folks to ensure that hard and transitive dependencies for our use here are as small as possible. (if you see links in thread above, you will see newer hcsshim pulls in a bunch of things which are not needed for our use case).

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
