### PR TITLE
Automated cherry pick of #121834: Added Imagefs inodes in default Eviction Hard

### DIFF
--- a/pkg/kubelet/eviction/defaults_linux.go
+++ b/pkg/kubelet/eviction/defaults_linux.go
@@ -25,4 +25,5 @@ var DefaultEvictionHard = map[string]string{
 	"nodefs.available":  "10%",
 	"nodefs.inodesFree": "5%",
 	"imagefs.available": "15%",
+	"imagefs.inodesFree": "5%",
 }

--- a/pkg/kubelet/eviction/defaults_linux.go
+++ b/pkg/kubelet/eviction/defaults_linux.go
@@ -21,9 +21,9 @@ package eviction
 
 // DefaultEvictionHard includes default options for hard eviction.
 var DefaultEvictionHard = map[string]string{
-	"memory.available":  "100Mi",
-	"nodefs.available":  "10%",
-	"nodefs.inodesFree": "5%",
-	"imagefs.available": "15%",
+	"memory.available":   "100Mi",
+	"nodefs.available":   "10%",
+	"nodefs.inodesFree":  "5%",
+	"imagefs.available":  "15%",
 	"imagefs.inodesFree": "5%",
 }


### PR DESCRIPTION
Cherry pick of #121834 on release-1.29.

#121834: Added Imagefs inodes in default Eviction Hard

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```