### PR TITLE
apiserver/storage: improve RunWatchSemanticInitialEventsExtended test

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/testing/watcher_tests.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/testing/watcher_tests.go
@@ -1513,31 +1513,36 @@ func RunWatchSemantics(ctx context.Context, t *testing.T, store storage.Interfac
 // by adding the pod to a different ns to advance the global RV
 func RunWatchSemanticInitialEventsExtended(ctx context.Context, t *testing.T, store storage.Interface) {
 	trueVal := true
-	expectedInitialEventsInStrictOrder := func(firstPod, secondPod *example.Pod) []watch.Event {
-		return []watch.Event{
-			{Type: watch.Added, Object: firstPod},
-			{Type: watch.Bookmark, Object: &example.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					ResourceVersion: secondPod.ResourceVersion,
-					Annotations:     map[string]string{"k8s.io/initial-events-end": "true"},
-				},
-			}},
+	expectedInitialEventsInStrictOrder := func(initialPods []*example.Pod, globalResourceVersion string) []watch.Event {
+		watchEvents := []watch.Event{}
+		for _, initialPod := range initialPods {
+			watchEvents = append(watchEvents, watch.Event{Type: watch.Added, Object: initialPod})
 		}
+		watchEvents = append(watchEvents, watch.Event{Type: watch.Bookmark, Object: &example.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				ResourceVersion: globalResourceVersion,
+				Annotations:     map[string]string{"k8s.io/initial-events-end": "true"},
+			},
+		}})
+		return watchEvents
 	}
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.WatchList, true)()
 
+	initialPods := []*example.Pod{}
 	ns := "ns-foo"
-	pod := makePod("1")
-	pod.Namespace = ns
-	firstPod := &example.Pod{}
-	err := store.Create(ctx, computePodKey(pod), pod, firstPod, 0)
-	require.NoError(t, err, "failed to add a pod: %v")
+	for _, initialPod := range []*example.Pod{makePod("1"), makePod("2"), makePod("3"), makePod("4"), makePod("5")} {
+		initialPod.Namespace = ns
+		out := &example.Pod{}
+		err := store.Create(ctx, computePodKey(initialPod), initialPod, out, 0)
+		require.NoError(t, err, "failed to add a pod: %v")
+		initialPods = append(initialPods, out)
+	}
 
 	// add the pod to a different ns to advance the global RV
-	pod = makePod("2")
+	pod := makePod("1")
 	pod.Namespace = "other-ns-foo"
-	secondPod := &example.Pod{}
-	err = store.Create(ctx, computePodKey(pod), pod, secondPod, 0)
+	otherNsPod := &example.Pod{}
+	err := store.Create(ctx, computePodKey(pod), pod, otherNsPod, 0)
 	require.NoError(t, err, "failed to add a pod: %v")
 
 	opts := storage.ListOptions{Predicate: storage.Everything, Recursive: true}
@@ -1550,7 +1555,7 @@ func RunWatchSemanticInitialEventsExtended(ctx context.Context, t *testing.T, st
 
 	// make sure we only get initial events from the first ns
 	// followed by the bookmark with the global RV
-	testCheckResultsInStrictOrder(t, w, expectedInitialEventsInStrictOrder(firstPod, secondPod))
+	testCheckResultsInStrictOrder(t, w, expectedInitialEventsInStrictOrder(initialPods, otherNsPod.ResourceVersion))
 	testCheckNoMoreResults(t, w)
 }
 


### PR DESCRIPTION
changes the test to populate the underlying data store with more data to trigger potential ordering issues.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
changes the `RunWatchSemanticInitialEventsExtended` test to populate the underlying data store with
more data to trigger potential ordering issues.


As of today the test is run for `etcd` and `cache` implementations and shows inconsistencies between the implementations. 

The `etcd` implementation sorts the results and the test passes.

```
❯ go run -mod=mod golang.org/x/tools/cmd/stress ./etcd3.test -test.run TestEtcdWatchSemanticInitialEventsExtended
5s: 11 runs so far, 0 failures
10s: 31 runs so far, 0 failures
15s: 50 runs so far, 0 failures
20s: 70 runs so far, 0 failures
25s: 87 runs so far, 0 failures
30s: 105 runs so far, 0 failures
35s: 124 runs so far, 0 failures
40s: 143 runs so far, 0 failures
45s: 162 runs so far, 0 failures
50s: 180 runs so far, 0 failures
55s: 199 runs so far, 0 failures
1m0s: 217 runs so far, 0 failures
1m5s: 236 runs so far, 0 failures
1m10s: 253 runs so far, 0 failures
1m15s: 271 runs so far, 0 failures
1m20s: 290 runs so far, 0 failures
1m25s: 311 runs so far, 0 failures
1m30s: 325 runs so far, 0 failures
1m35s: 346 runs so far, 0 failures
1m40s: 364 runs so far, 0 failures
1m45s: 382 runs so far, 0 failures
1m50s: 400 runs so far, 0 failures
1m55s: 421 runs so far, 0 failures
2m0s: 439 runs so far, 0 failures
2m5s: 458 runs so far, 0 failures
2m10s: 478 runs so far, 0 failures
```

The `cache` implementation fails immediately with ordering issues and the test fails.

```
--- FAIL: TestCacherWatchSemanticInitialEventsExtended (4.21s)
    utils.go:155: incorrect event:   watch.Event{
          	Type: "ADDED",
          	Object: &example.Pod{
          		TypeMeta: {},
          		ObjectMeta: v1.ObjectMeta{
        - 			Name:              "pod-1",
        + 			Name:              "pod-2",
          			GenerateName:      "",
          			Namespace:         "ns-foo",
          			SelfLink:          "",
          			UID:               "",
        - 			ResourceVersion:   "2",
        + 			ResourceVersion:   "3",
          			Generation:        0,
          			CreationTimestamp: {},
          			... // 7 identical fields
          		},
          		Spec:   {},
          		Status: {},
          	},
          }
    utils.go:155: incorrect event:   watch.Event{
          	Type: "ADDED",
          	Object: &example.Pod{
          		TypeMeta: {},
          		ObjectMeta: v1.ObjectMeta{
        - 			Name:              "pod-2",
        + 			Name:              "pod-3",
          			GenerateName:      "",
          			Namespace:         "ns-foo",
          			SelfLink:          "",
          			UID:               "",
        - 			ResourceVersion:   "3",
        + 			ResourceVersion:   "4",
          			Generation:        0,
          			CreationTimestamp: {},
          			... // 7 identical fields
          		},
          		Spec:   {},
          		Status: {},

…
5s: 6 runs so far, 6 failures (100.00%)
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
