### PR TITLE
Automated cherry pick of #121894: build: use -trimpath in non-DBG mode

### DIFF
--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -773,7 +773,7 @@ kube::golang::build_binaries_for_platform() {
   done
 
   V=2 kube::log::info "Env for ${platform}: GOOS=${GOOS-} GOARCH=${GOARCH-} GOROOT=${GOROOT-} CGO_ENABLED=${CGO_ENABLED-} CC=${CC-}"
-  V=3 kube::log::info "Building binaries with GCFLAGS=${gogcflags} ASMFLAGS=${goasmflags} LDFLAGS=${goldflags}"
+  V=3 kube::log::info "Building binaries with GCFLAGS=${gogcflags} LDFLAGS=${goldflags}"
 
   local -a build_args
   if [[ "${#statics[@]}" != 0 ]]; then
@@ -781,7 +781,6 @@ kube::golang::build_binaries_for_platform() {
       -installsuffix=static
       ${goflags:+"${goflags[@]}"}
       -gcflags="${gogcflags}"
-      -asmflags="${goasmflags}"
       -ldflags="${goldflags}"
       -tags="${gotags:-}"
     )
@@ -792,7 +791,6 @@ kube::golang::build_binaries_for_platform() {
     build_args=(
       ${goflags:+"${goflags[@]}"}
       -gcflags="${gogcflags}"
-      -asmflags="${goasmflags}"
       -ldflags="${goldflags}"
       -tags="${gotags:-}"
     )
@@ -808,7 +806,6 @@ kube::golang::build_binaries_for_platform() {
     go test -c \
       ${goflags:+"${goflags[@]}"} \
       -gcflags="${gogcflags}" \
-      -asmflags="${goasmflags}" \
       -ldflags="${goldflags}" \
       -tags="${gotags:-}" \
       -o "${outfile}" \
@@ -865,26 +862,19 @@ kube::golang::build_binaries() {
     # These are "local" but are visible to and relied on by functions this
     # function calls.  They are effectively part of the calling API to
     # build_binaries_for_platform.
-    local goflags goldflags goasmflags gogcflags gotags
+    local goflags goldflags gogcflags gotags
 
-    # This is $(pwd) because we use run-in-gopath to build.  Once that is
-    # excised, this can become ${KUBE_ROOT}.
-    local trimroot # two lines to appease shellcheck SC2155
-    trimroot=$(pwd)
+    goflags=()
+    gogcflags="${GOGCFLAGS:-}"
+    goldflags="all=$(kube::version::ldflags) ${GOLDFLAGS:-}"
 
-    goasmflags="all=-trimpath=${trimroot}"
-
-    gogcflags="all=-trimpath=${trimroot} ${GOGCFLAGS:-}"
     if [[ "${DBG:-}" == 1 ]]; then
         # Debugging - disable optimizations and inlining and trimPath
-        gogcflags="${GOGCFLAGS:-} all=-N -l"
-        goasmflags=""
-    fi
-
-    goldflags="all=$(kube::version::ldflags) ${GOLDFLAGS:-}"
-    if [[ "${DBG:-}" != 1 ]]; then
-        # Not debugging - disable symbols and DWARF.
+        gogcflags="${gogcflags} all=-N -l"
+    else
+        # Not debugging - disable symbols and DWARF, trim embedded paths
         goldflags="${goldflags} -s -w"
+        goflags+=("-trimpath")
     fi
 
     # Extract tags if any specified in GOFLAGS

--- a/test/conformance/gen-specsummaries.sh
+++ b/test/conformance/gen-specsummaries.sh
@@ -23,7 +23,12 @@ KUBE_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")"/../.. && pwd -P)
 cd "${KUBE_ROOT}"
 
 # build ginkgo and e2e.test
-hack/make-rules/build.sh github.com/onsi/ginkgo/v2/ginkgo test/e2e/e2e.test
+#
+# Set DBG=1 to build with embedded filenames as filenames rather than
+# module-relative names (e.g. /src/kube/foo/bar.go vs.
+# k8s.io/kubernetes/foo/bar.go).  These names are used by gingko in
+# `--spec-dump` which is consumed later in conformance verification. 
+DBG=1 hack/make-rules/build.sh github.com/onsi/ginkgo/v2/ginkgo test/e2e/e2e.test
 
 # dump spec
 ./_output/bin/ginkgo --dry-run=true --focus='[Conformance]' ./_output/bin/e2e.test -- --spec-dump "${KUBE_ROOT}/_output/specsummaries.json" > /dev/null


### PR DESCRIPTION
Cherry pick of #121894 on release-1.29.

#121894: build: use -trimpath in non-DBG mode

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```