### PR TITLE
Use v1beta1 endpoints when cleaning up ValidatingAdmissionPolicies

### DIFF
--- a/test/e2e/apimachinery/validatingadmissionpolicy.go
+++ b/test/e2e/apimachinery/validatingadmissionpolicy.go
@@ -297,7 +297,7 @@ var _ = SIGDescribe("ValidatingAdmissionPolicy [Privileged:ClusterAdmin]", frame
 			policy, err := client.AdmissionregistrationV1beta1().ValidatingAdmissionPolicies().Create(ctx, policy, metav1.CreateOptions{})
 			framework.ExpectNoError(err, "create policy")
 			ginkgo.DeferCleanup(func(ctx context.Context, name string) error {
-				return client.AdmissionregistrationV1alpha1().ValidatingAdmissionPolicies().Delete(ctx, name, metav1.DeleteOptions{})
+				return client.AdmissionregistrationV1beta1().ValidatingAdmissionPolicies().Delete(ctx, name, metav1.DeleteOptions{})
 			}, policy.Name)
 		})
 		ginkgo.By("waiting for the type check to finish without warnings", func() {
@@ -330,7 +330,7 @@ var _ = SIGDescribe("ValidatingAdmissionPolicy [Privileged:ClusterAdmin]", frame
 			policy, err := client.AdmissionregistrationV1beta1().ValidatingAdmissionPolicies().Create(ctx, policy, metav1.CreateOptions{})
 			framework.ExpectNoError(err, "create policy")
 			ginkgo.DeferCleanup(func(ctx context.Context, name string) error {
-				return client.AdmissionregistrationV1alpha1().ValidatingAdmissionPolicies().Delete(ctx, name, metav1.DeleteOptions{})
+				return client.AdmissionregistrationV1beta1().ValidatingAdmissionPolicies().Delete(ctx, name, metav1.DeleteOptions{})
 			}, policy.Name)
 		})
 		ginkgo.By("waiting for the type check to finish with warnings", func() {


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/sig testing
/sig api-machinery 

#### What this PR does / why we need it:
https://github.com/kubernetes/kubernetes/pull/119109 adds tests for ValidatingAdmissionPolicies, for creation this is using v1beta1 api, but cleaning up uses v1alpha1. We should use the former where possible for consistency on clusters with only one of the API available 

#### Which issue(s) this PR fixes:
Found this in a tech-preview job in openshift (https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/openshift-origin-28473-ci-4.16-e2e-azure-sdn-techpreview/1744826675490721792) where we explicitly enable `admissionregistration.k8s.io/v1beta1`

#### Special notes for your reviewer:
/assign @deads2k 

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
