### PR TITLE
Revert "Graduate Evented PLEG to Beta"

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -243,7 +243,6 @@ const (
 	// owner: @harche
 	// kep: http://kep.k8s.io/3386
 	// alpha: v1.25
-	// beta: v1.27
 	//
 	// Allows using event-driven PLEG (pod lifecycle event generator) through kubelet
 	// which avoids frequent relisting of containers which helps optimize performance.
@@ -970,7 +969,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 
 	DynamicResourceAllocation: {Default: false, PreRelease: featuregate.Alpha},
 
-	EventedPLEG: {Default: false, PreRelease: featuregate.Beta}, // off by default, requires CRI Runtime support
+	EventedPLEG: {Default: false, PreRelease: featuregate.Alpha},
 
 	ExecProbeTimeout: {Default: true, PreRelease: featuregate.GA}, // lock to default and remove after v1.22 based on KEP #1972 update
 


### PR DESCRIPTION
This reverts commit d971809b491eb7aa1df924eb898185ab1f57f66f.

#### What type of PR is this?
/kind bug
/kind cleanup

#### What this PR does / why we need it:

https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/121345/pull-kubernetes-e2e-kind-beta-features/1745324395255042048 first pass of this job with disabling this FG EventedPLEG. See #121345 for more detailed CI status.


#### Which issue(s) this PR fixes:
revert as  there is a known issue https://github.com/kubernetes/kubernetes/issues/121349 that will make static pod failed to start.
- We are working to fix the issue in #121349.

It also makes the https://testgrid.k8s.io/sig-testing-kind#kind-master-beta failing for cluster init.
- and also https://prow.k8s.io/job-history/gs/kubernetes-jenkins/pr-logs/directory/pull-kubernetes-e2e-kind-beta-features 

#### Special notes for your reviewer:

- https://github.com/kubernetes/enhancements/issues/3386
- https://github.com/kubernetes/kubernetes/pull/115967 (1.27 promoted to beta but default false.)

#### Does this PR introduce a user-facing change?
```release-note
Reverts the EventedPLEG feature (beta, but disabled by default) back to alpha for a known issue
```
