### PR TITLE
[WIP]Revert "Fix issue in enabling evented pleg feature gate"

### DIFF
--- a/pkg/kubelet/container/cache.go
+++ b/pkg/kubelet/container/cache.go
@@ -157,6 +157,29 @@ func (c *cache) get(id types.UID) *data {
 // Otherwise, it returns nil. The caller should acquire the lock.
 func (c *cache) getIfNewerThan(id types.UID, minTime time.Time) *data {
 	d, ok := c.pods[id]
+	if utilfeature.DefaultFeatureGate.Enabled(features.EventedPLEG) {
+		// Evented PLEG has CREATED, STARTED, STOPPED and DELETED events
+		// However if the container creation fails for some reason there is no
+		// CRI event received by the kubelet and that pod will get stuck a
+		// GetNewerThan call in the pod workers. This is reproducible with
+		// the node e2e test,
+		// https://github.com/kubernetes/kubernetes/blob/83415e5c9e6e59a3d60a148160490560af2178a1/test/e2e_node/pod_hostnamefqdn_test.go#L161
+		// which forces failure during pod creation. This issue also exists in
+		// Generic PLEG but since it updates global timestamp periodically
+		// the GetNewerThan call gets unstuck.
+
+		// During node e2e tests, it was observed this change does not have any
+		// adverse impact on the behaviour of the Generic PLEG as well.
+		switch {
+		case !ok:
+			return makeDefaultData(id)
+		case ok && (d.modified.After(minTime) || (c.timestamp != nil && c.timestamp.After(minTime))):
+			return d
+		default:
+			return nil
+		}
+	}
+
 	globalTimestampIsNewer := (c.timestamp != nil && c.timestamp.After(minTime))
 	if !ok && globalTimestampIsNewer {
 		// Status is not cached, but the global timestamp is newer than

--- a/pkg/kubelet/cri/remote/remote_runtime.go
+++ b/pkg/kubelet/cri/remote/remote_runtime.go
@@ -38,10 +38,8 @@ import (
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/features"
-	"k8s.io/kubernetes/pkg/kubelet/metrics"
 	"k8s.io/kubernetes/pkg/kubelet/util"
 	"k8s.io/kubernetes/pkg/probe/exec"
-
 	utilexec "k8s.io/utils/exec"
 )
 
@@ -813,9 +811,6 @@ func (r *remoteRuntimeService) GetContainerEvents(containerEventsCh chan *runtim
 		klog.ErrorS(err, "GetContainerEvents failed to get streaming client")
 		return err
 	}
-
-	// The connection is successfully established and we have a streaming client ready for use.
-	metrics.EventedPLEGConn.Inc()
 
 	for {
 		resp, err := containerEventsStreamingClient.Recv()

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -726,11 +726,8 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 			RelistPeriod:    genericPlegRelistPeriod,
 			RelistThreshold: genericPlegRelistThreshold,
 		}
-		klet.eventedPleg, err = pleg.NewEventedPLEG(klet.containerRuntime, klet.runtimeService, eventChannel,
+		klet.eventedPleg = pleg.NewEventedPLEG(klet.containerRuntime, klet.runtimeService, eventChannel,
 			klet.podCache, klet.pleg, eventedPlegMaxStreamRetries, eventedRelistDuration, clock.RealClock{})
-		if err != nil {
-			return nil, err
-		}
 	} else {
 		genericRelistDuration := &pleg.RelistDuration{
 			RelistPeriod:    genericPlegRelistPeriod,

--- a/pkg/kubelet/metrics/metrics.go
+++ b/pkg/kubelet/metrics/metrics.go
@@ -49,9 +49,6 @@ const (
 	PLEGDiscardEventsKey               = "pleg_discard_events"
 	PLEGRelistIntervalKey              = "pleg_relist_interval_seconds"
 	PLEGLastSeenKey                    = "pleg_last_seen_seconds"
-	EventedPLEGConnErrKey              = "evented_pleg_connection_error_count"
-	EventedPLEGConnKey                 = "evented_pleg_connection_success_count"
-	EventedPLEGConnLatencyKey          = "evented_pleg_connection_latency_seconds"
 	EvictionsKey                       = "evictions"
 	EvictionStatsAgeKey                = "eviction_stats_age_seconds"
 	PreemptionsKey                     = "preemptions"
@@ -287,41 +284,6 @@ var (
 			StabilityLevel: metrics.ALPHA,
 		},
 	)
-
-	// EventedPLEGConnErr is a Counter that tracks the number of errors encountered during
-	// the establishment of streaming connection with the CRI runtime.
-	EventedPLEGConnErr = metrics.NewCounter(
-		&metrics.CounterOpts{
-			Subsystem:      KubeletSubsystem,
-			Name:           EventedPLEGConnErrKey,
-			Help:           "The number of errors encountered during the establishment of streaming connection with the CRI runtime.",
-			StabilityLevel: metrics.ALPHA,
-		},
-	)
-
-	// EventedPLEGConn is a Counter that tracks the number of times a streaming client
-	// was obtained to receive CRI Events.
-	EventedPLEGConn = metrics.NewCounter(
-		&metrics.CounterOpts{
-			Subsystem:      KubeletSubsystem,
-			Name:           EventedPLEGConnKey,
-			Help:           "The number of times a streaming client was obtained to receive CRI Events.",
-			StabilityLevel: metrics.ALPHA,
-		},
-	)
-
-	// EventedPLEGConnLatency is a Histogram that tracks the latency of streaming connection
-	// with the CRI runtime, measured in seconds.
-	EventedPLEGConnLatency = metrics.NewHistogram(
-		&metrics.HistogramOpts{
-			Subsystem:      KubeletSubsystem,
-			Name:           EventedPLEGConnLatencyKey,
-			Help:           "The latency of streaming connection with the CRI runtime, measured in seconds.",
-			Buckets:        metrics.DefBuckets,
-			StabilityLevel: metrics.ALPHA,
-		},
-	)
-
 	// RuntimeOperations is a Counter that tracks the cumulative number of remote runtime operations.
 	// Broken down by operation type.
 	RuntimeOperations = metrics.NewCounterVec(
@@ -848,9 +810,6 @@ func Register(collectors ...metrics.StableCollector) {
 		legacyregistry.MustRegister(PLEGDiscardEvents)
 		legacyregistry.MustRegister(PLEGRelistInterval)
 		legacyregistry.MustRegister(PLEGLastSeen)
-		legacyregistry.MustRegister(EventedPLEGConnErr)
-		legacyregistry.MustRegister(EventedPLEGConn)
-		legacyregistry.MustRegister(EventedPLEGConnLatency)
 		legacyregistry.MustRegister(RuntimeOperations)
 		legacyregistry.MustRegister(RuntimeOperationsDuration)
 		legacyregistry.MustRegister(RuntimeOperationsErrors)

--- a/pkg/kubelet/pleg/evented.go
+++ b/pkg/kubelet/pleg/evented.go
@@ -204,19 +204,6 @@ func (e *EventedPLEG) watchEventsChannel() {
 
 func (e *EventedPLEG) processCRIEvents(containerEventsResponseCh chan *runtimeapi.ContainerEventResponse) {
 	for event := range containerEventsResponseCh {
-		// Ignore the event if PodSandboxStatus is nil.
-		// This might happen under some race condition where the podSandbox has
-		// been deleted, and therefore container runtime couldn't find the
-		// podSandbox for the container when generating the event.
-		// It is safe to ignore because
-		// a) a event would have been received for the sandbox deletion,
-		// b) in worst case, a relist will eventually sync the pod status.
-		// TODO(#114371): Figure out a way to handle this case instead of ignoring.
-		if event.PodSandboxStatus == nil || event.PodSandboxStatus.Metadata == nil {
-			klog.ErrorS(nil, "Evented PLEG: received ContainerEventResponse with nil PodSandboxStatus or PodSandboxStatus.Metadata", "containerEventResponse", event)
-			continue
-		}
-
 		podID := types.UID(event.PodSandboxStatus.Metadata.Uid)
 		shouldSendPLEGEvent := false
 

--- a/pkg/kubelet/pleg/evented.go
+++ b/pkg/kubelet/pleg/evented.go
@@ -71,7 +71,7 @@ type EventedPLEG struct {
 	// For testability.
 	clock clock.Clock
 	// GenericPLEG is used to force relist when required.
-	genericPleg podLifecycleEventGeneratorHandler
+	genericPleg PodLifecycleEventGenerator
 	// The maximum number of retries when getting container events from the runtime.
 	eventedPlegMaxStreamRetries int
 	// Indicates relisting related parameters
@@ -87,21 +87,17 @@ type EventedPLEG struct {
 // NewEventedPLEG instantiates a new EventedPLEG object and return it.
 func NewEventedPLEG(runtime kubecontainer.Runtime, runtimeService internalapi.RuntimeService, eventChannel chan *PodLifecycleEvent,
 	cache kubecontainer.Cache, genericPleg PodLifecycleEventGenerator, eventedPlegMaxStreamRetries int,
-	relistDuration *RelistDuration, clock clock.Clock) (PodLifecycleEventGenerator, error) {
-	handler, ok := genericPleg.(podLifecycleEventGeneratorHandler)
-	if !ok {
-		return nil, fmt.Errorf("%v doesn't implement podLifecycleEventGeneratorHandler interface", genericPleg)
-	}
+	relistDuration *RelistDuration, clock clock.Clock) PodLifecycleEventGenerator {
 	return &EventedPLEG{
 		runtime:                     runtime,
 		runtimeService:              runtimeService,
 		eventChannel:                eventChannel,
 		cache:                       cache,
-		genericPleg:                 handler,
+		genericPleg:                 genericPleg,
 		eventedPlegMaxStreamRetries: eventedPlegMaxStreamRetries,
 		relistDuration:              relistDuration,
 		clock:                       clock,
-	}, nil
+	}
 }
 
 // Watch returns a channel from which the subscriber can receive PodLifecycleEvent events.

--- a/pkg/kubelet/pleg/evented.go
+++ b/pkg/kubelet/pleg/evented.go
@@ -46,16 +46,16 @@ var (
 // e.g. Streaming data issues from the runtime or the runtime does not implement the
 // container events stream.
 func isEventedPLEGInUse() bool {
-	eventedPLEGUsageMu.RLock()
-	defer eventedPLEGUsageMu.RUnlock()
+	eventedPLEGUsageMu.Lock()
+	defer eventedPLEGUsageMu.Unlock()
 	return eventedPLEGUsage
 }
 
 // setEventedPLEGUsage should only be accessed from
 // Start/Stop of Evented PLEG.
 func setEventedPLEGUsage(enable bool) {
-	eventedPLEGUsageMu.Lock()
-	defer eventedPLEGUsageMu.Unlock()
+	eventedPLEGUsageMu.RLock()
+	defer eventedPLEGUsageMu.RUnlock()
 	eventedPLEGUsage = enable
 }
 

--- a/pkg/kubelet/pleg/evented.go
+++ b/pkg/kubelet/pleg/evented.go
@@ -190,7 +190,6 @@ func (e *EventedPLEG) watchEventsChannel() {
 
 			err := e.runtimeService.GetContainerEvents(containerEventsResponseCh)
 			if err != nil {
-				metrics.EventedPLEGConnErr.Inc()
 				numAttempts++
 				e.Relist() // Force a relist to get the latest container and pods running metric.
 				klog.V(4).InfoS("Evented PLEG: Failed to get container events, retrying: ", "err", err)
@@ -246,7 +245,6 @@ func (e *EventedPLEG) processCRIEvents(containerEventsResponseCh chan *runtimeap
 
 		e.updateRunningPodMetric(status)
 		e.updateRunningContainerMetric(status)
-		e.updateLatencyMetric(event)
 
 		if event.ContainerEventType == runtimeapi.ContainerEventType_CONTAINER_DELETED_EVENT {
 			for _, sandbox := range status.SandboxStatuses {
@@ -410,11 +408,6 @@ func (e *EventedPLEG) updateRunningContainerMetric(podStatus *kubecontainer.PodS
 			metrics.RunningContainerCount.WithLabelValues(string(state)).Add(float64(diff))
 		}
 	}
-}
-
-func (e *EventedPLEG) updateLatencyMetric(event *runtimeapi.ContainerEventResponse) {
-	duration := time.Duration(time.Now().UnixNano()-event.CreatedAt) * time.Nanosecond
-	metrics.EventedPLEGConnLatency.Observe(duration.Seconds())
 }
 
 func (e *EventedPLEG) UpdateCache(pod *kubecontainer.Pod, pid types.UID) (error, bool) {

--- a/pkg/kubelet/pleg/evented.go
+++ b/pkg/kubelet/pleg/evented.go
@@ -215,7 +215,7 @@ func (e *EventedPLEG) processCRIEvents(containerEventsResponseCh chan *runtimeap
 			if klog.V(6).Enabled() {
 				klog.ErrorS(err, "Evented PLEG: error generating pod status from the received event", "podUID", podID, "podStatus", status)
 			} else {
-				klog.ErrorS(err, "Evented PLEG: error generating pod status from the received event", "podUID", podID)
+				klog.ErrorS(err, "Evented PLEG: error generating pod status from the received event", "podUID", podID, "podStatus", status)
 			}
 		} else {
 			if klogV := klog.V(6); klogV.Enabled() {

--- a/pkg/kubelet/pleg/pleg.go
+++ b/pkg/kubelet/pleg/pleg.go
@@ -64,16 +64,10 @@ type PodLifecycleEvent struct {
 // PodLifecycleEventGenerator contains functions for generating pod life cycle events.
 type PodLifecycleEventGenerator interface {
 	Start()
-	Watch() chan *PodLifecycleEvent
-	Healthy() (bool, error)
-	UpdateCache(*kubecontainer.Pod, types.UID) (error, bool)
-}
-
-// podLifecycleEventGeneratorHandler contains functions that are useful for different PLEGs
-// and need not be exposed to rest of the kubelet
-type podLifecycleEventGeneratorHandler interface {
-	PodLifecycleEventGenerator
 	Stop()
 	Update(relistDuration *RelistDuration)
+	Watch() chan *PodLifecycleEvent
+	Healthy() (bool, error)
 	Relist()
+	UpdateCache(*kubecontainer.Pod, types.UID) (error, bool)
 }


### PR DESCRIPTION
Test only with revert evented recent changes

- [x] revert #120942: beta features CI still failed for SynchronizedBeforeSuite https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/122700/pull-kubernetes-e2e-kind-beta-features/1745357214949838848
- [x] revert #120942 and #113825 : beta features CI still failed for other e2e tests. 
- [x] revert #120942 and #113825 and #117523 :beta features CI still failed for SynchronizedBeforeSuite https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/122700/pull-kubernetes-e2e-kind-alpha-beta-features/1745385607430934528
- [ ] 


To confirm if this caused the failure of beta features.