### PR TITLE
Fix resource deletion failure caused by quota calculation error when InPlacePodVerticalScaling is turned on

### DIFF
--- a/plugin/pkg/admission/resourcequota/admission_test.go
+++ b/plugin/pkg/admission/resourcequota/admission_test.go
@@ -31,15 +31,12 @@ import (
 	genericadmissioninitializer "k8s.io/apiserver/pkg/admission/initializer"
 	"k8s.io/apiserver/pkg/admission/plugin/resourcequota"
 	resourcequotaapi "k8s.io/apiserver/pkg/admission/plugin/resourcequota/apis/resourcequota"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 	testcore "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
-	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	api "k8s.io/kubernetes/pkg/apis/core"
-	"k8s.io/kubernetes/pkg/features"
 	kubeapiserveradmission "k8s.io/kubernetes/pkg/kubeapiserver/admission"
 	"k8s.io/kubernetes/pkg/quota/v1/install"
 )
@@ -2113,114 +2110,5 @@ func TestAdmitAllowDecreaseUsageWithoutCoveringQuota(t *testing.T) {
 
 	if err != nil {
 		t.Errorf("Expected no error for decreasing a limited resource without quota, got %v", err)
-	}
-}
-
-func TestPodResourcesResizeWithResourceQuota(t *testing.T) {
-	stopCh := make(chan struct{})
-	defer close(stopCh)
-
-	resourceQuota := &corev1.ResourceQuota{
-		ObjectMeta: metav1.ObjectMeta{Name: "quota", Namespace: "test", ResourceVersion: "124"},
-		Status: corev1.ResourceQuotaStatus{
-			Hard: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("1000m"),
-				corev1.ResourceMemory: resource.MustParse("1000Mi"),
-				corev1.ResourcePods:   resource.MustParse("5"),
-			},
-			Used: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("500m"),
-				corev1.ResourceMemory: resource.MustParse("500Mi"),
-				corev1.ResourcePods:   resource.MustParse("1"),
-			},
-		},
-	}
-
-	currentPod := validPod("testpod", 1, getResourceRequirements(getResourceList("500m", "500Mi"), getResourceList("500m", "500Mi")))
-	currentPod.ResourceVersion = "1"
-
-	type testCase struct {
-		newPod        *api.Pod
-		fgEnabled     bool
-		expectError   string
-		expectActions sets.String
-	}
-	testCases := map[string]testCase{
-		"pod resize featuregate enabled, increase CPU within quota": {
-			newPod:        validPod("testpod", 1, getResourceRequirements(getResourceList("990m", "500Mi"), getResourceList("990m", "500Mi"))),
-			fgEnabled:     true,
-			expectError:   "",
-			expectActions: sets.NewString(strings.Join([]string{"update", "resourcequotas", "status"}, "-")),
-		},
-		"pod resize featuregate enabled, increase memory beyond quota": {
-			newPod:        validPod("testpod", 1, getResourceRequirements(getResourceList("500m", "1100Mi"), getResourceList("500m", "1100Mi"))),
-			fgEnabled:     true,
-			expectError:   "forbidden: exceeded quota: quota, requested: memory=600Mi, used: memory=500Mi, limited: memory=1000Mi",
-			expectActions: sets.NewString(strings.Join([]string{"update", "resourcequotas", "status"}, "-")),
-		},
-		"pod resize featuregate enabled, decrease CPU within quota": {
-			newPod:        validPod("testpod", 1, getResourceRequirements(getResourceList("300m", "500Mi"), getResourceList("300m", "500Mi"))),
-			fgEnabled:     true,
-			expectError:   "",
-			expectActions: sets.NewString(strings.Join([]string{"update", "resourcequotas", "status"}, "-")),
-		},
-		"pod resize featuregate disabled, decrease memory within quota": {
-			newPod:        validPod("testpod", 1, getResourceRequirements(getResourceList("500m", "400Mi"), getResourceList("500m", "400Mi"))),
-			fgEnabled:     false,
-			expectError:   "",
-			expectActions: nil,
-		},
-		"pod resize featuregate disabled, increase CPU beyond quota": {
-			newPod:        validPod("testpod", 1, getResourceRequirements(getResourceList("1010m", "500Mi"), getResourceList("1010m", "500Mi"))),
-			fgEnabled:     false,
-			expectError:   "",
-			expectActions: nil,
-		},
-	}
-
-	for desc, tc := range testCases {
-		t.Run(desc, func(t *testing.T) {
-			defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.InPlacePodVerticalScaling, tc.fgEnabled)()
-			kubeClient := fake.NewSimpleClientset(resourceQuota)
-			informerFactory := informers.NewSharedInformerFactory(kubeClient, 0)
-			handler, err := createHandler(kubeClient, informerFactory, stopCh)
-			if err != nil {
-				t.Errorf("Error occurred while creating admission plugin: %v", err)
-			}
-			informerFactory.Core().V1().ResourceQuotas().Informer().GetIndexer().Add(resourceQuota)
-
-			tc.newPod.ResourceVersion = "2"
-			err = handler.Validate(context.TODO(), admission.NewAttributesRecord(tc.newPod, currentPod,
-				api.Kind("Pod").WithVersion("version"), tc.newPod.Namespace, tc.newPod.Name,
-				corev1.Resource("pods").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{},
-				false, nil), nil)
-			if tc.expectError == "" {
-				if err != nil {
-					t.Errorf("Unexpected error: %v", err)
-				}
-				if tc.expectActions != nil {
-					if len(kubeClient.Actions()) == 0 {
-						t.Errorf("Expected a client action")
-					}
-				} else {
-					if len(kubeClient.Actions()) > 0 {
-						t.Errorf("Got client action(s) when not expected")
-					}
-				}
-				actionSet := sets.NewString()
-				for _, action := range kubeClient.Actions() {
-					actionSet.Insert(strings.Join([]string{action.GetVerb(), action.GetResource().Resource,
-						action.GetSubresource()}, "-"))
-				}
-				if !actionSet.HasAll(tc.expectActions.List()...) {
-					t.Errorf("Expected actions:\n%v\n but got:\n%v\nDifference:\n%v", tc.expectActions,
-						actionSet, tc.expectActions.Difference(actionSet))
-				}
-			} else {
-				if err == nil || !strings.Contains(err.Error(), tc.expectError) {
-					t.Errorf("Expected error containing '%s' got err: '%v'", tc.expectError, err)
-				}
-			}
-		})
 	}
 }

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/resourcequota/controller.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/resourcequota/controller.go
@@ -35,10 +35,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apiserver/pkg/admission"
 	resourcequotaapi "k8s.io/apiserver/pkg/admission/plugin/resourcequota/apis/resourcequota"
-	"k8s.io/apiserver/pkg/features"
 	quota "k8s.io/apiserver/pkg/quota/v1"
 	"k8s.io/apiserver/pkg/quota/v1/generic"
-	"k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/util/workqueue"
 )
 
@@ -518,14 +516,7 @@ func CheckRequest(quotas []corev1.ResourceQuota, a admission.Attributes, evaluat
 			if innerErr != nil {
 				return quotas, innerErr
 			}
-			if feature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScaling) {
-				// allow negative usage for pods as pod resources can increase or decrease
-				if a.GetResource().GroupResource() == corev1.Resource("pods") {
-					deltaUsage = quota.Subtract(deltaUsage, prevUsage)
-				}
-			} else {
-				deltaUsage = quota.SubtractWithNonNegativeResult(deltaUsage, prevUsage)
-			}
+			deltaUsage = quota.SubtractWithNonNegativeResult(deltaUsage, prevUsage)
 		}
 	}
 


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

e2e test log is https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/121895/pull-kubernetes-e2e-kind-alpha-features/1745322068624281600#1:build-log.txt%3A749

kube-controller-manager log is https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/121895/pull-kubernetes-e2e-kind-alpha-features/1745322068624281600/artifacts/kind-control-plane/pods/kube-system_kube-controller-manager-kind-control-plane_adb1f34692d5d1ca5fb847c6cb9a07eb/kube-controller-manager/0.log.20240111-061905

```log
2024-01-11T06:16:48.651436802Z stderr F I0111 06:16:48.651097       1 pvc_protection_controller.go:335] "Got event on PVC" logger="persistentvolumeclaim-protection-controller" pvc="volume-attributes-class-3934/test-claim-1"
2024-01-11T06:16:49.02831192Z stderr F I0111 06:16:49.028163       1 pvc_protection_controller.go:273] "PVC is unused" logger="persistentvolumeclaim-protection-controller" PVC="volume-attributes-class-3934/test-claim-1"
2024-01-11T06:16:49.032005252Z stderr F E0111 06:16:49.031898       1 pvc_protection_controller.go:206] "Error removing protection finalizer from PVC" err="persistentvolumeclaims \"test-claim-1\" is forbidden: exceeded quota: test-quota, requested: gold. volumeattributesclass.storage.k8s.io/persistentvolumeclaims=1, used: gold.volumeattributesclass.storage.k8s.io/persistentvolumeclaims=1, limited: gold.volumeattributesclass.storage.k8s.io/persistentvolumeclaims=1" logger="persistentvolumeclaim-   protection-controller" PVC="volume-attributes-class-3934/test-claim-1"
```

/cc @vinaykul

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix resource deletion failure caused by quota calculation error when InPlacePodVerticalScaling is turned on
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/1287
```
