### PR TITLE
If a pvc has an empty storageclass name, don't try to assign a default StorageClass

### DIFF
--- a/pkg/controller/volume/persistentvolume/pv_controller.go
+++ b/pkg/controller/volume/persistentvolume/pv_controller.go
@@ -948,7 +948,8 @@ func (ctrl *PersistentVolumeController) updateVolumePhaseWithEvent(ctx context.C
 func (ctrl *PersistentVolumeController) assignDefaultStorageClass(ctx context.Context, claim *v1.PersistentVolumeClaim) (bool, error) {
 	logger := klog.FromContext(ctx)
 
-	if storagehelpers.GetPersistentVolumeClaimClass(claim) != "" {
+	if storagehelpers.PersistentVolumeClaimHasClass(claim) {
+		// The user asked for a class.
 		return false, nil
 	}
 

--- a/staging/src/k8s.io/component-helpers/storage/volume/helpers.go
+++ b/staging/src/k8s.io/component-helpers/storage/volume/helpers.go
@@ -24,6 +24,20 @@ import (
 	"k8s.io/component-helpers/scheduling/corev1"
 )
 
+// PersistentVolumeClaimHasClass returns true if given claim has set StorageClassName field.
+func PersistentVolumeClaimHasClass(claim *v1.PersistentVolumeClaim) bool {
+	// Use beta annotation first
+	if _, found := claim.Annotations[v1.BetaStorageClassAnnotation]; found {
+		return true
+	}
+
+	if claim.Spec.StorageClassName != nil {
+		return true
+	}
+
+	return false
+}
+
 // GetPersistentVolumeClaimClass returns StorageClassName. If no storage class was
 // requested, it returns "".
 func GetPersistentVolumeClaimClass(claim *v1.PersistentVolumeClaim) string {

--- a/staging/src/k8s.io/component-helpers/storage/volume/helpers_test.go
+++ b/staging/src/k8s.io/component-helpers/storage/volume/helpers_test.go
@@ -21,6 +21,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 )
 
 var nodeLabels = map[string]string{
@@ -212,5 +213,49 @@ func testVolumeWithNodeAffinity(t *testing.T, affinity *v1.VolumeNodeAffinity) *
 		Spec: v1.PersistentVolumeSpec{
 			NodeAffinity: affinity,
 		},
+	}
+}
+
+func TestPersistentVolumeClaimHasClass(t *testing.T) {
+	testCases := []struct {
+		name string
+		pvc  *v1.PersistentVolumeClaim
+		want bool
+	}{
+		{
+			name: "no storage class",
+			pvc:  &v1.PersistentVolumeClaim{},
+			want: false,
+		},
+		{
+			name: "storage class set on annotation",
+			pvc: &v1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						v1.BetaStorageClassAnnotation: "",
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "storage class set on spec",
+			pvc: &v1.PersistentVolumeClaim{
+				Spec: v1.PersistentVolumeClaimSpec{
+					StorageClassName: ptr.To(""),
+				},
+			},
+			want: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got := PersistentVolumeClaimHasClass(tc.pvc)
+			if got != tc.want {
+				t.Errorf("PersistentVolumeClaimHasClass() = %v, want %v", got, tc.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

kube-controller-manager log is https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/121895/pull-kubernetes-e2e-kind-alpha-features/1745322068624281600/artifacts/kind-control-plane/pods/kube-system_kube-controller-manager-kind-control-plane_adb1f34692d5d1ca5fb847c6cb9a07eb/kube-controller-manager/0.log.20240111-061905

```log
 2024-01-11T06:16:46.650889123Z stderr F E0111 06:16:46.650788       1 pv_controller_base.go:270] "Could not sync volume" err=<
 2024-01-11T06:16:46.650919219Z stderr F     can't update PersistentVolumeClaim["volume-attributes-class-3934/test-claim-1"]: PersistentVolumeClaim "test-claim-1" is invalid: spec: Forbidden: spec is immutable after creation except resources.requests and volumeAttributesClassName for bound claims
 2024-01-11T06:16:46.650924249Z stderr F       core.PersistentVolumeClaimSpec{
 2024-01-11T06:16:46.650928921Z stderr F         ... // 2 identical fields
 2024-01-11T06:16:46.650933072Z stderr F         Resources:        {Requests: {s"storage": {i: {...}, s: "1Gi", Format: "BinarySI"}}},
 2024-01-11T06:16:46.650937575Z stderr F         VolumeName:       "",
 2024-01-11T06:16:46.650941831Z stderr F     -   StorageClassName: &"",
 2024-01-11T06:16:46.650946361Z stderr F     +   StorageClassName: &"standard",
 2024-01-11T06:16:46.650950419Z stderr F         VolumeMode:       &"Filesystem",
 2024-01-11T06:16:46.650954604Z stderr F         DataSource:       nil,
 2024-01-11T06:16:46.650958639Z stderr F         ... // 2 identical fields
 2024-01-11T06:16:46.650962711Z stderr F       }
 2024-01-11T06:16:46.650966976Z stderr F  > logger="persistentvolume-binder-controller" PVC="volume-attributes-class-3934/test-claim-1"
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixes a regression in 1.26+ default configurations: If a pvc has an empty storageClassName, persistentvolume controller won't try to assign a default StorageClass
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/3333
```
