### PR TITLE
Refactor Code to Use `PollUntilContextTimeout` Replacing Deprecated `PolImmediate`

### DIFF
--- a/pkg/controller/daemon/daemon_controller_test.go
+++ b/pkg/controller/daemon/daemon_controller_test.go
@@ -513,21 +513,22 @@ func TestExpectationsOnRecreate(t *testing.T) {
 	waitForQueueLength := func(expected int, msg string) {
 		t.Helper()
 		i := 0
-		err = wait.PollImmediate(100*time.Millisecond, informerSyncTimeout, func() (bool, error) {
-			current := dsc.queue.Len()
-			switch {
-			case current == expected:
-				return true, nil
-			case current > expected:
-				return false, fmt.Errorf("queue length %d exceeded expected length %d", current, expected)
-			default:
-				i++
-				if i > 1 {
-					t.Logf("Waiting for queue to have %d item, currently has: %d", expected, current)
+		err = wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, informerSyncTimeout, true,
+			func(ctx context.Context) (bool, error) {
+				current := dsc.queue.Len()
+				switch {
+				case current == expected:
+					return true, nil
+				case current > expected:
+					return false, fmt.Errorf("queue length %d exceeded expected length %d", current, expected)
+				default:
+					i++
+					if i > 1 {
+						t.Logf("Waiting for queue to have %d item, currently has: %d", expected, current)
+					}
+					return false, nil
 				}
-				return false, nil
-			}
-		})
+			})
 		if err != nil {
 			t.Fatalf("%s: %v", msg, err)
 		}

--- a/pkg/controller/endpoint/endpoints_controller_test.go
+++ b/pkg/controller/endpoint/endpoints_controller_test.go
@@ -1015,9 +1015,10 @@ func TestWaitsForAllInformersToBeSynced2(t *testing.T) {
 			time.Sleep(150 * time.Millisecond)
 			if test.shouldUpdateEndpoints {
 				// Ensure the work queue has been processed by looping for up to a second to prevent flakes.
-				wait.PollImmediate(50*time.Millisecond, 1*time.Second, func() (bool, error) {
-					return endpoints.queue.Len() == 0, nil
-				})
+				wait.PollUntilContextTimeout(context.Background(), 50*time.Millisecond, 1*time.Second, true,
+					func(ctx context.Context) (bool, error) {
+						return endpoints.queue.Len() == 0, nil
+					})
 				endpointsHandler.ValidateRequestCount(t, 1)
 			} else {
 				endpointsHandler.ValidateRequestCount(t, 0)
@@ -2279,9 +2280,10 @@ func TestMultipleServiceChanges(t *testing.T) {
 	controller.onServiceUpdate(svc)
 
 	// Ensure the work queue has been processed by looping for up to a second to prevent flakes.
-	wait.PollImmediate(50*time.Millisecond, 1*time.Second, func() (bool, error) {
-		return controller.queue.Len() == 0, nil
-	})
+	wait.PollUntilContextTimeout(context.Background(), 50*time.Millisecond, 1*time.Second, true,
+		func(ctx context.Context) (bool, error) {
+			return controller.queue.Len() == 0, nil
+		})
 
 	// Cause test server to delete endpoints
 	close(blockDelete)

--- a/pkg/controller/endpointslice/endpointslice_controller_test.go
+++ b/pkg/controller/endpointslice/endpointslice_controller_test.go
@@ -541,12 +541,13 @@ func TestOnEndpointSliceUpdate(t *testing.T) {
 
 	assert.Equal(t, 0, esController.queue.Len())
 	esController.onEndpointSliceUpdate(logger, epSlice1, epSlice2)
-	err := wait.PollImmediate(100*time.Millisecond, 3*time.Second, func() (bool, error) {
-		if esController.queue.Len() > 0 {
-			return true, nil
-		}
-		return false, nil
-	})
+	err := wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 3*time.Second, true,
+		func(ctx context.Context) (bool, error) {
+			if esController.queue.Len() > 0 {
+				return true, nil
+			}
+			return false, nil
+		})
 	if err != nil {
 		t.Fatalf("unexpected error waiting for add to queue")
 	}

--- a/pkg/controller/endpointslicemirroring/endpointslicemirroring_controller_test.go
+++ b/pkg/controller/endpointslicemirroring/endpointslicemirroring_controller_test.go
@@ -253,15 +253,16 @@ func TestSyncEndpoints(t *testing.T) {
 
 			numInitialActions := len(tc.endpointSlices)
 			// Wait for the expected event show up in test "Endpoints with 1001 addresses - 1 should not be mirrored"
-			err = wait.PollImmediate(time.Millisecond*100, wait.ForeverTestTimeout, func() (done bool, err error) {
-				actions := client.Actions()
-				numExtraActions := len(actions) - numInitialActions
-				if numExtraActions != tc.expectedNumActions {
-					t.Logf("Expected %d additional client actions, got %d: %#v. Will retry", tc.expectedNumActions, numExtraActions, actions[numInitialActions:])
-					return false, nil
-				}
-				return true, nil
-			})
+			err = wait.PollUntilContextTimeout(context.Background(), time.Millisecond*100, wait.ForeverTestTimeout, true,
+				func(ctx context.Context) (done bool, err error) {
+					actions := client.Actions()
+					numExtraActions := len(actions) - numInitialActions
+					if numExtraActions != tc.expectedNumActions {
+						t.Logf("Expected %d additional client actions, got %d: %#v. Will retry", tc.expectedNumActions, numExtraActions, actions[numInitialActions:])
+						return false, nil
+					}
+					return true, nil
+				})
 			if err != nil {
 				t.Fatal("Timed out waiting for expected actions")
 			}

--- a/pkg/controller/replicaset/replica_set_test.go
+++ b/pkg/controller/replicaset/replica_set_test.go
@@ -1218,10 +1218,11 @@ func TestExpectationsOnRecreate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = wait.PollImmediate(100*time.Millisecond, informerSyncTimeout, func() (bool, error) {
-		logger.V(8).Info("Waiting for queue to have 1 item", "length", manager.queue.Len())
-		return manager.queue.Len() == 1, nil
-	})
+	err = wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, informerSyncTimeout, true,
+		func(ctx context.Context) (bool, error) {
+			logger.V(8).Info("Waiting for queue to have 1 item", "length", manager.queue.Len())
+			return manager.queue.Len() == 1, nil
+		})
 	if err != nil {
 		t.Fatalf("initial RS didn't result in new item in the queue: %v", err)
 	}
@@ -1262,10 +1263,11 @@ func TestExpectationsOnRecreate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = wait.PollImmediate(100*time.Millisecond, informerSyncTimeout, func() (bool, error) {
-		logger.V(8).Info("Waiting for queue to have 1 item", "length", manager.queue.Len())
-		return manager.queue.Len() == 1, nil
-	})
+	err = wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, informerSyncTimeout, true,
+		func(ctx context.Context) (bool, error) {
+			logger.V(8).Info("Waiting for queue to have 1 item", "length", manager.queue.Len())
+			return manager.queue.Len() == 1, nil
+		})
 	if err != nil {
 		t.Fatalf("Deleting RS didn't result in new item in the queue: %v", err)
 	}
@@ -1304,10 +1306,11 @@ func TestExpectationsOnRecreate(t *testing.T) {
 		t.Fatal("New RS has the same UID as the old one!")
 	}
 
-	err = wait.PollImmediate(100*time.Millisecond, informerSyncTimeout, func() (bool, error) {
-		logger.V(8).Info("Waiting for queue to have 1 item", "length", manager.queue.Len())
-		return manager.queue.Len() == 1, nil
-	})
+	err = wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, informerSyncTimeout, true,
+		func(ctx context.Context) (bool, error) {
+			logger.V(8).Info("Waiting for queue to have 1 item", "length", manager.queue.Len())
+			return manager.queue.Len() == 1, nil
+		})
 	if err != nil {
 		t.Fatalf("Re-creating RS didn't result in new item in the queue: %v", err)
 	}

--- a/pkg/controller/tainteviction/taint_eviction_test.go
+++ b/pkg/controller/tainteviction/taint_eviction_test.go
@@ -314,10 +314,11 @@ func TestUpdatePod(t *testing.T) {
 
 			if item.awaitForScheduledEviction {
 				nsName := types.NamespacedName{Namespace: item.prevPod.Namespace, Name: item.prevPod.Name}
-				err := wait.PollImmediate(time.Millisecond*10, time.Second, func() (bool, error) {
-					scheduledEviction := controller.taintEvictionQueue.GetWorkerUnsafe(nsName.String())
-					return scheduledEviction != nil, nil
-				})
+				err := wait.PollUntilContextTimeout(context.Background(), time.Millisecond*10, time.Second, true,
+					func(ctx context.Context) (bool, error) {
+						scheduledEviction := controller.taintEvictionQueue.GetWorkerUnsafe(nsName.String())
+						return scheduledEviction != nil, nil
+					})
 				if err != nil {
 					t.Fatalf("Failed to await for scheduled eviction: %q", err)
 				}
@@ -396,12 +397,13 @@ func TestDeleteNode(t *testing.T) {
 	controller.NodeUpdated(testutil.NewNode("node1"), nil)
 
 	// await until controller.taintedNodes is empty
-	err := wait.PollImmediate(10*time.Millisecond, time.Second, func() (bool, error) {
-		controller.taintedNodesLock.Lock()
-		defer controller.taintedNodesLock.Unlock()
-		_, ok := controller.taintedNodes["node1"]
-		return !ok, nil
-	})
+	err := wait.PollUntilContextTimeout(context.Background(), 10*time.Millisecond, time.Second, true,
+		func(ctx context.Context) (bool, error) {
+			controller.taintedNodesLock.Lock()
+			defer controller.taintedNodesLock.Unlock()
+			_, ok := controller.taintedNodes["node1"]
+			return !ok, nil
+		})
 	if err != nil {
 		t.Errorf("Failed to await for processing node deleted: %q", err)
 	}

--- a/pkg/controller/volume/persistentvolume/pv_controller_test.go
+++ b/pkg/controller/volume/persistentvolume/pv_controller_test.go
@@ -191,14 +191,15 @@ func TestControllerSync(t *testing.T) {
 					return err
 				}
 				// wait for volume delete operation to appear once volumeWorker() runs
-				return wait.PollImmediate(10*time.Millisecond, wait.ForeverTestTimeout, func() (bool, error) {
-					// make sure the operation timestamp cache is NOT empty
-					if ctrl.operationTimestamps.Has("volume5-6") {
-						return true, nil
-					}
-					t.Logf("missing volume5-6 from timestamp cache, will retry")
-					return false, nil
-				})
+				return wait.PollUntilContextTimeout(context.Background(), 10*time.Millisecond, wait.ForeverTestTimeout, true,
+					func(ctx context.Context) (bool, error) {
+						// make sure the operation timestamp cache is NOT empty
+						if ctrl.operationTimestamps.Has("volume5-6") {
+							return true, nil
+						}
+						t.Logf("missing volume5-6 from timestamp cache, will retry")
+						return false, nil
+					})
 			},
 		},
 		{

--- a/pkg/kubelet/certificate/transport_test.go
+++ b/pkg/kubelet/certificate/transport_test.go
@@ -209,15 +209,16 @@ func TestRotateShutsDownConnections(t *testing.T) {
 	// its connections to the server.
 	m.setCurrent(client2CertData.certificate)
 
-	err = wait.PollImmediate(time.Millisecond*50, wait.ForeverTestTimeout, func() (done bool, err error) {
-		client.Get().Do(context.TODO())
-		if firstCertSerial.Cmp(lastSerialNumber()) != 0 {
-			// The certificate changed!
-			return true, nil
-		}
-		t.Logf("Certificate not changed, will retry.")
-		return false, nil
-	})
+	err = wait.PollUntilContextTimeout(context.Background(), 50*time.Millisecond, wait.ForeverTestTimeout, true,
+		func(ctx context.Context) (done bool, err error) {
+			client.Get().Do(context.TODO())
+			if firstCertSerial.Cmp(lastSerialNumber()) != 0 {
+				// The certificate changed!
+				return true, nil
+			}
+			t.Logf("Certificate not changed, will retry.")
+			return false, nil
+		})
 	if err != nil {
 		t.Fatal("certificate rotated but client never reconnected with new cert")
 	}

--- a/pkg/kubelet/cm/devicemanager/plugin/v1beta1/stub.go
+++ b/pkg/kubelet/cm/devicemanager/plugin/v1beta1/stub.go
@@ -160,15 +160,20 @@ func (m *Stub) Start() error {
 	}()
 
 	var lastDialErr error
-	wait.PollImmediate(1*time.Second, 10*time.Second, func() (bool, error) {
-		var conn *grpc.ClientConn
-		_, conn, lastDialErr = dial(m.socket)
-		if lastDialErr != nil {
-			return false, nil
-		}
-		conn.Close()
-		return true, nil
-	})
+	err = wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 10*time.Second, true,
+		func(ctx context.Context) (bool, error) {
+			var conn *grpc.ClientConn
+			_, conn, lastDialErr = dial(m.socket)
+			if lastDialErr != nil {
+				return false, nil
+			}
+			conn.Close()
+			return true, nil
+		})
+
+	if err != nil {
+		return err
+	}
 	if lastDialErr != nil {
 		return lastDialErr
 	}

--- a/pkg/kubelet/util/manager/watch_based_manager.go
+++ b/pkg/kubelet/util/manager/watch_based_manager.go
@@ -17,6 +17,7 @@ limitations under the License.
 package manager
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"time"
@@ -315,7 +316,10 @@ func (c *objectCache) Get(namespace, name string) (runtime.Object, error) {
 	if !c.isStopped() {
 		item.restartReflectorIfNeeded()
 	}
-	if err := wait.PollImmediate(10*time.Millisecond, time.Second, item.hasSynced); err != nil {
+	if err := wait.PollUntilContextTimeout(context.Background(), 10*time.Millisecond, time.Second, true,
+		func(ctx context.Context) (done bool, err error) {
+			return item.hasSynced()
+		}); err != nil {
 		return nil, fmt.Errorf("failed to sync %s cache: %v", c.groupResource.String(), err)
 	}
 	obj, exists, err := item.store.GetByKey(c.key(namespace, name))

--- a/pkg/kubelet/util/manager/watch_based_manager_test.go
+++ b/pkg/kubelet/util/manager/watch_based_manager_test.go
@@ -105,7 +105,7 @@ func TestSecretCache(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "name", Namespace: "ns", ResourceVersion: "125"},
 	}
 	fakeWatch.Add(secret)
-	getFn := func() (bool, error) {
+	getFn := func(ctx context.Context) (bool, error) {
 		object, err := store.Get("ns", "name")
 		if err != nil {
 			if apierrors.IsNotFound(err) {
@@ -119,14 +119,14 @@ func TestSecretCache(t *testing.T) {
 		}
 		return true, nil
 	}
-	if err := wait.PollImmediate(10*time.Millisecond, time.Second, getFn); err != nil {
+	if err := wait.PollUntilContextTimeout(context.Background(), 10*time.Millisecond, time.Second, true, getFn); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 
-	// Eventually we should observer secret deletion.
+	// Eventually we should observe secret deletion.
 	fakeWatch.Delete(secret)
-	getFn = func() (bool, error) {
-		_, err := store.Get("ns", "name")
+	getFn = func(ctx context.Context) (bool, error) {
+		_, err = store.Get("ns", "name")
 		if err != nil {
 			if apierrors.IsNotFound(err) {
 				return true, nil
@@ -135,7 +135,7 @@ func TestSecretCache(t *testing.T) {
 		}
 		return false, nil
 	}
-	if err := wait.PollImmediate(10*time.Millisecond, time.Second, getFn); err != nil {
+	if err = wait.PollUntilContextTimeout(context.Background(), 10*time.Millisecond, time.Second, true, getFn); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 
@@ -166,7 +166,7 @@ func TestSecretCacheMultipleRegistrations(t *testing.T) {
 
 	store.AddReference("ns", "name", "pod")
 	// This should trigger List and Watch actions eventually.
-	actionsFn := func() (bool, error) {
+	actionsFn := func(ctx context.Context) (bool, error) {
 		actions := fakeClient.Actions()
 		if len(actions) > 2 {
 			return false, fmt.Errorf("too many actions: %v", actions)
@@ -179,7 +179,7 @@ func TestSecretCacheMultipleRegistrations(t *testing.T) {
 		}
 		return true, nil
 	}
-	if err := wait.PollImmediate(10*time.Millisecond, time.Second, actionsFn); err != nil {
+	if err := wait.PollUntilContextTimeout(context.Background(), 10*time.Millisecond, time.Second, true, actionsFn); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 
@@ -309,7 +309,7 @@ func TestImmutableSecretStopsTheReflector(t *testing.T) {
 			fakeWatch.Add(tc.eventual)
 
 			// Eventually Get should return that secret.
-			getFn := func() (bool, error) {
+			getFn := func(ctx context.Context) (bool, error) {
 				object, err := store.Get("ns", "name")
 				if err != nil {
 					if apierrors.IsNotFound(err) {
@@ -320,7 +320,7 @@ func TestImmutableSecretStopsTheReflector(t *testing.T) {
 				secret := object.(*v1.Secret)
 				return apiequality.Semantic.DeepEqual(tc.eventual, secret), nil
 			}
-			if err := wait.PollImmediate(10*time.Millisecond, time.Second, getFn); err != nil {
+			if err := wait.PollUntilContextTimeout(context.Background(), 10*time.Millisecond, time.Second, true, getFn); err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}
 

--- a/pkg/proxy/config/api_test.go
+++ b/pkg/proxy/config/api_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package config
 
 import (
+	"context"
 	"reflect"
 	"testing"
 	"time"
@@ -203,26 +204,28 @@ func TestInitialSync(t *testing.T) {
 	defer close(stopCh)
 	sharedInformers.Start(stopCh)
 
-	err := wait.PollImmediate(time.Millisecond*10, wait.ForeverTestTimeout, func() (bool, error) {
-		svcHandler.lock.Lock()
-		defer svcHandler.lock.Unlock()
-		if reflect.DeepEqual(svcHandler.state, expectedSvcState) {
-			return true, nil
-		}
-		return false, nil
-	})
+	err := wait.PollUntilContextTimeout(context.Background(), time.Millisecond*10, wait.ForeverTestTimeout, true,
+		func(ctx context.Context) (bool, error) {
+			svcHandler.lock.Lock()
+			defer svcHandler.lock.Unlock()
+			if reflect.DeepEqual(svcHandler.state, expectedSvcState) {
+				return true, nil
+			}
+			return false, nil
+		})
 	if err != nil {
 		t.Fatal("Timed out waiting for the completion of handler `OnServiceAdd`")
 	}
 
-	err = wait.PollImmediate(time.Millisecond*10, wait.ForeverTestTimeout, func() (bool, error) {
-		epsHandler.lock.Lock()
-		defer epsHandler.lock.Unlock()
-		if reflect.DeepEqual(epsHandler.state, expectedEpsState) {
-			return true, nil
-		}
-		return false, nil
-	})
+	err = wait.PollUntilContextTimeout(context.Background(), time.Millisecond*10, wait.ForeverTestTimeout, true,
+		func(ctx context.Context) (bool, error) {
+			epsHandler.lock.Lock()
+			defer epsHandler.lock.Unlock()
+			if reflect.DeepEqual(epsHandler.state, expectedEpsState) {
+				return true, nil
+			}
+			return false, nil
+		})
 	if err != nil {
 		t.Fatal("Timed out waiting for the completion of handler `OnEndpointsAdd`")
 	}

--- a/pkg/registry/core/service/portallocator/controller/repair.go
+++ b/pkg/registry/core/service/portallocator/controller/repair.go
@@ -113,11 +113,12 @@ func (c *Repair) doRunOnce() error {
 	// important when we start apiserver and etcd at the same time.
 	var snapshot *api.RangeAllocation
 
-	err := wait.PollImmediate(time.Second, 10*time.Second, func() (bool, error) {
-		var err error
-		snapshot, err = c.alloc.Get()
-		return err == nil, err
-	})
+	err := wait.PollUntilContextTimeout(context.Background(), time.Second, 10*time.Second, true,
+		func(ctx context.Context) (bool, error) {
+			var err error
+			snapshot, err = c.alloc.Get()
+			return err == nil, err
+		})
 	if err != nil {
 		return fmt.Errorf("unable to refresh the port allocations: %v", err)
 	}

--- a/pkg/util/iptables/iptables_linux.go
+++ b/pkg/util/iptables/iptables_linux.go
@@ -20,6 +20,7 @@ limitations under the License.
 package iptables
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"os"
@@ -72,23 +73,25 @@ func grabIptablesLocks(lockfilePath14x, lockfilePath16x string) (iptablesLocker,
 		return nil, fmt.Errorf("failed to open iptables lock %s: %v", lockfilePath16x, err)
 	}
 
-	if err := wait.PollImmediate(200*time.Millisecond, 2*time.Second, func() (bool, error) {
-		if err := grabIptablesFileLock(l.lock16); err != nil {
-			return false, nil
-		}
-		return true, nil
-	}); err != nil {
+	if err := wait.PollUntilContextTimeout(context.Background(), 200*time.Millisecond, 2*time.Second, true,
+		func(ctx context.Context) (bool, error) {
+			if err := grabIptablesFileLock(l.lock16); err != nil {
+				return false, nil
+			}
+			return true, nil
+		}); err != nil {
 		return nil, fmt.Errorf("failed to acquire new iptables lock: %v", err)
 	}
 
 	// Roughly duplicate iptables 1.4.x xtables_lock() function.
-	if err := wait.PollImmediate(200*time.Millisecond, 2*time.Second, func() (bool, error) {
-		l.lock14, err = net.ListenUnix("unix", &net.UnixAddr{Name: lockfilePath14x, Net: "unix"})
-		if err != nil {
-			return false, nil
-		}
-		return true, nil
-	}); err != nil {
+	if err := wait.PollUntilContextTimeout(context.Background(), 200*time.Millisecond, 2*time.Second, true,
+		func(ctx context.Context) (bool, error) {
+			l.lock14, err = net.ListenUnix("unix", &net.UnixAddr{Name: lockfilePath14x, Net: "unix"})
+			if err != nil {
+				return false, nil
+			}
+			return true, nil
+		}); err != nil {
 		return nil, fmt.Errorf("failed to acquire old iptables lock: %v", err)
 	}
 

--- a/pkg/volume/testing/volume_host.go
+++ b/pkg/volume/testing/volume_host.go
@@ -244,11 +244,12 @@ func (f *fakeVolumeHost) ScriptCommands(scripts []CommandScript) {
 }
 
 func (f *fakeVolumeHost) WaitForKubeletErrNil() error {
-	return wait.PollImmediate(10*time.Millisecond, 10*time.Second, func() (bool, error) {
-		f.mux.Lock()
-		defer f.mux.Unlock()
-		return f.kubeletErr == nil, nil
-	})
+	return wait.PollUntilContextTimeout(context.Background(), 10*time.Millisecond, 10*time.Second, true,
+		func(ctx context.Context) (bool, error) {
+			f.mux.Lock()
+			defer f.mux.Unlock()
+			return f.kubeletErr == nil, nil
+		})
 }
 
 type fakeAttachDetachVolumeHost struct {

--- a/pkg/volume/util/util.go
+++ b/pkg/volume/util/util.go
@@ -797,18 +797,19 @@ func IsDeviceMountableVolume(volumeSpec *volume.Spec, volumePluginMgr *volume.Vo
 func GetReliableMountRefs(mounter mount.Interface, mountPath string) ([]string, error) {
 	var paths []string
 	var lastErr error
-	err := wait.PollImmediate(10*time.Millisecond, time.Minute, func() (bool, error) {
-		var err error
-		paths, err = mounter.GetMountRefs(mountPath)
-		if io.IsInconsistentReadError(err) {
-			lastErr = err
-			return false, nil
-		}
-		if err != nil {
-			return false, err
-		}
-		return true, nil
-	})
+	err := wait.PollUntilContextTimeout(context.Background(), 10*time.Millisecond, time.Minute, true,
+		func(ctx context.Context) (bool, error) {
+			var err error
+			paths, err = mounter.GetMountRefs(mountPath)
+			if io.IsInconsistentReadError(err) {
+				lastErr = err
+				return false, nil
+			}
+			if err != nil {
+				return false, err
+			}
+			return true, nil
+		})
 	if err == wait.ErrWaitTimeout {
 		return nil, lastErr
 	}

--- a/test/e2e/apimachinery/custom_resource_definition.go
+++ b/test/e2e/apimachinery/custom_resource_definition.go
@@ -312,23 +312,24 @@ var _ = SIGDescribe("CustomResourceDefinition resources [Privileged:ClusterAdmin
 		]`), metav1.PatchOptions{})
 		framework.ExpectNoError(err, "setting default for a to \"A\" in schema")
 
-		err = wait.PollImmediate(time.Millisecond*100, wait.ForeverTestTimeout, func() (bool, error) {
-			u1, err := crClient.Get(ctx, name1, metav1.GetOptions{})
-			if err != nil {
-				return false, err
-			}
-			a, found, err := unstructured.NestedFieldNoCopy(u1.Object, "a")
-			if err != nil {
-				return false, err
-			}
-			if !found {
-				return false, nil
-			}
-			if a != "A" {
-				return false, fmt.Errorf("expected a:\"A\", but got a:%q", a)
-			}
-			return true, nil
-		})
+		err = wait.PollUntilContextTimeout(context.Background(), time.Millisecond*100, wait.ForeverTestTimeout, true,
+			func(ctx context.Context) (bool, error) {
+				u1, err := crClient.Get(ctx, name1, metav1.GetOptions{})
+				if err != nil {
+					return false, err
+				}
+				a, found, err := unstructured.NestedFieldNoCopy(u1.Object, "a")
+				if err != nil {
+					return false, err
+				}
+				if !found {
+					return false, nil
+				}
+				if a != "A" {
+					return false, fmt.Errorf("expected a:\"A\", but got a:%q", a)
+				}
+				return true, nil
+			})
 		framework.ExpectNoError(err, "waiting for CR to be defaulted on read")
 
 		// create CR with default in storage
@@ -354,33 +355,34 @@ var _ = SIGDescribe("CustomResourceDefinition resources [Privileged:ClusterAdmin
 		]`), metav1.PatchOptions{})
 		framework.ExpectNoError(err, "setting default for b to \"B\" and remove default for a")
 
-		err = wait.PollImmediate(time.Millisecond*100, wait.ForeverTestTimeout, func() (bool, error) {
-			u2, err := crClient.Get(ctx, name2, metav1.GetOptions{})
-			if err != nil {
-				return false, err
-			}
-			b, found, err := unstructured.NestedFieldNoCopy(u2.Object, "b")
-			if err != nil {
-				return false, err
-			}
-			if !found {
-				return false, nil
-			}
-			if b != "B" {
-				return false, fmt.Errorf("expected b:\"B\", but got b:%q", b)
-			}
-			a, found, err := unstructured.NestedFieldNoCopy(u2.Object, "a")
-			if err != nil {
-				return false, err
-			}
-			if !found {
-				return false, fmt.Errorf("expected a:\"A\" to be unchanged, but it was removed")
-			}
-			if a != "A" {
-				return false, fmt.Errorf("expected a:\"A\" to be unchanged, but it changed to %q", a)
-			}
-			return true, nil
-		})
+		err = wait.PollUntilContextTimeout(context.Background(), time.Millisecond*100, wait.ForeverTestTimeout, true,
+			func(ctx context.Context) (bool, error) {
+				u2, err := crClient.Get(ctx, name2, metav1.GetOptions{})
+				if err != nil {
+					return false, err
+				}
+				b, found, err := unstructured.NestedFieldNoCopy(u2.Object, "b")
+				if err != nil {
+					return false, err
+				}
+				if !found {
+					return false, nil
+				}
+				if b != "B" {
+					return false, fmt.Errorf("expected b:\"B\", but got b:%q", b)
+				}
+				a, found, err := unstructured.NestedFieldNoCopy(u2.Object, "a")
+				if err != nil {
+					return false, err
+				}
+				if !found {
+					return false, fmt.Errorf("expected a:\"A\" to be unchanged, but it was removed")
+				}
+				if a != "A" {
+					return false, fmt.Errorf("expected a:\"A\" to be unchanged, but it changed to %q", a)
+				}
+				return true, nil
+			})
 		framework.ExpectNoError(err, "waiting for CR to be defaulted on read for b and a staying the same")
 	})
 

--- a/test/e2e/apimachinery/storage_version.go
+++ b/test/e2e/apimachinery/storage_version.go
@@ -69,18 +69,19 @@ var _ = SIGDescribe("StorageVersion resources", feature.StorageVersionAPI, func(
 
 		// wait for sv to be GC'ed
 		framework.Logf("Waiting for storage version %v to be garbage collected", createdSV.Name)
-		err = wait.PollImmediate(100*time.Millisecond, wait.ForeverTestTimeout, func() (bool, error) {
-			_, err := client.InternalV1alpha1().StorageVersions().Get(
-				ctx, createdSV.Name, metav1.GetOptions{})
-			if apierrors.IsNotFound(err) {
-				return true, nil
-			}
-			if err != nil {
-				return false, err
-			}
-			framework.Logf("The storage version %v hasn't been garbage collected yet. Retrying", createdSV.Name)
-			return false, nil
-		})
+		err = wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, wait.ForeverTestTimeout, true,
+			func(ctx context.Context) (bool, error) {
+				_, err := client.InternalV1alpha1().StorageVersions().Get(
+					ctx, createdSV.Name, metav1.GetOptions{})
+				if apierrors.IsNotFound(err) {
+					return true, nil
+				}
+				if err != nil {
+					return false, err
+				}
+				framework.Logf("The storage version %v hasn't been garbage collected yet. Retrying", createdSV.Name)
+				return false, nil
+			})
 		framework.ExpectNoError(err, "garbage-collecting storage version")
 	})
 })

--- a/test/e2e/apps/deployment.go
+++ b/test/e2e/apps/deployment.go
@@ -694,17 +694,18 @@ func stopDeployment(ctx context.Context, c clientset.Interface, ns, deploymentNa
 	gomega.Expect(rss.Items).Should(gomega.BeEmpty())
 	framework.Logf("Ensuring deployment %s's Pods were deleted", deploymentName)
 	var pods *v1.PodList
-	if err := wait.PollImmediate(time.Second, timeout, func() (bool, error) {
-		pods, err = c.CoreV1().Pods(ns).List(ctx, options)
-		if err != nil {
-			return false, err
-		}
-		// Pods may be created by overlapping deployments right after this deployment is deleted, ignore them
-		if len(pods.Items) == 0 {
-			return true, nil
-		}
-		return false, nil
-	}); err != nil {
+	if err = wait.PollUntilContextTimeout(context.Background(), time.Second, timeout, true,
+		func(ctx context.Context) (bool, error) {
+			pods, err = c.CoreV1().Pods(ns).List(ctx, options)
+			if err != nil {
+				return false, err
+			}
+			// Pods may be created by overlapping deployments right after this deployment is deleted, ignore them
+			if len(pods.Items) == 0 {
+				return true, nil
+			}
+			return false, nil
+		}); err != nil {
 		framework.Failf("Err : %s\n. Failed to remove deployment %s pods : %+v", err, deploymentName, pods)
 	}
 }
@@ -1561,19 +1562,20 @@ func waitForDeploymentOldRSsNum(ctx context.Context, c clientset.Interface, ns, 
 	var oldRSs []*appsv1.ReplicaSet
 	var d *appsv1.Deployment
 
-	pollErr := wait.PollImmediate(poll, 5*time.Minute, func() (bool, error) {
-		deployment, err := c.AppsV1().Deployments(ns).Get(ctx, deploymentName, metav1.GetOptions{})
-		if err != nil {
-			return false, err
-		}
-		d = deployment
+	pollErr := wait.PollUntilContextTimeout(context.Background(), poll, 5*time.Minute, true,
+		func(ctx context.Context) (bool, error) {
+			deployment, err := c.AppsV1().Deployments(ns).Get(ctx, deploymentName, metav1.GetOptions{})
+			if err != nil {
+				return false, err
+			}
+			d = deployment
 
-		_, oldRSs, err = testutil.GetOldReplicaSets(deployment, c)
-		if err != nil {
-			return false, err
-		}
-		return len(oldRSs) == desiredRSNum, nil
-	})
+			_, oldRSs, err = testutil.GetOldReplicaSets(deployment, c)
+			if err != nil {
+				return false, err
+			}
+			return len(oldRSs) == desiredRSNum, nil
+		})
 	if wait.Interrupted(pollErr) {
 		pollErr = fmt.Errorf("%d old replica sets were not cleaned up for deployment %q", len(oldRSs)-desiredRSNum, deploymentName)
 		testutil.LogReplicaSetsOfDeployment(d, oldRSs, nil, framework.Logf)

--- a/test/e2e/apps/replica_set.go
+++ b/test/e2e/apps/replica_set.go
@@ -243,15 +243,16 @@ func testReplicaSetConditionCheck(ctx context.Context, f *framework.Framework) {
 	_, err := c.CoreV1().ResourceQuotas(namespace).Create(ctx, quota, metav1.CreateOptions{})
 	framework.ExpectNoError(err)
 
-	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
-		quota, err = c.CoreV1().ResourceQuotas(namespace).Get(ctx, name, metav1.GetOptions{})
-		if err != nil {
-			return false, err
-		}
-		quantity := resource.MustParse("2")
-		podQuota := quota.Status.Hard[v1.ResourcePods]
-		return (&podQuota).Cmp(quantity) == 0, nil
-	})
+	err = wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 1*time.Minute, true,
+		func(ctx context.Context) (bool, error) {
+			quota, err = c.CoreV1().ResourceQuotas(namespace).Get(ctx, name, metav1.GetOptions{})
+			if err != nil {
+				return false, err
+			}
+			quantity := resource.MustParse("2")
+			podQuota := quota.Status.Hard[v1.ResourcePods]
+			return (&podQuota).Cmp(quantity) == 0, nil
+		})
 	if wait.Interrupted(err) {
 		err = fmt.Errorf("resource quota %q never synced", name)
 	}
@@ -265,21 +266,21 @@ func testReplicaSetConditionCheck(ctx context.Context, f *framework.Framework) {
 	ginkgo.By(fmt.Sprintf("Checking replica set %q has the desired failure condition set", name))
 	generation := rs.Generation
 	conditions := rs.Status.Conditions
-	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
-		rs, err = c.AppsV1().ReplicaSets(namespace).Get(ctx, name, metav1.GetOptions{})
-		if err != nil {
-			return false, err
-		}
+	err = wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 1*time.Minute, true,
+		func(ctx context.Context) (bool, error) {
+			rs, err = c.AppsV1().ReplicaSets(namespace).Get(ctx, name, metav1.GetOptions{})
+			if err != nil {
+				return false, err
+			}
 
-		if generation > rs.Status.ObservedGeneration {
-			return false, nil
-		}
-		conditions = rs.Status.Conditions
+			if generation > rs.Status.ObservedGeneration {
+				return false, nil
+			}
+			conditions = rs.Status.Conditions
 
-		cond := replicaset.GetCondition(rs.Status, appsv1.ReplicaSetReplicaFailure)
-		return cond != nil, nil
-
-	})
+			cond := replicaset.GetCondition(rs.Status, appsv1.ReplicaSetReplicaFailure)
+			return cond != nil, nil
+		})
 	if wait.Interrupted(err) {
 		err = fmt.Errorf("rs controller never added the failure condition for replica set %q: %#v", name, conditions)
 	}
@@ -295,20 +296,21 @@ func testReplicaSetConditionCheck(ctx context.Context, f *framework.Framework) {
 	ginkgo.By(fmt.Sprintf("Checking replica set %q has no failure condition set", name))
 	generation = rs.Generation
 	conditions = rs.Status.Conditions
-	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
-		rs, err = c.AppsV1().ReplicaSets(namespace).Get(ctx, name, metav1.GetOptions{})
-		if err != nil {
-			return false, err
-		}
+	err = wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 1*time.Minute, true,
+		func(ctx context.Context) (bool, error) {
+			rs, err = c.AppsV1().ReplicaSets(namespace).Get(ctx, name, metav1.GetOptions{})
+			if err != nil {
+				return false, err
+			}
 
-		if generation > rs.Status.ObservedGeneration {
-			return false, nil
-		}
-		conditions = rs.Status.Conditions
+			if generation > rs.Status.ObservedGeneration {
+				return false, nil
+			}
+			conditions = rs.Status.Conditions
 
-		cond := replicaset.GetCondition(rs.Status, appsv1.ReplicaSetReplicaFailure)
-		return cond == nil, nil
-	})
+			cond := replicaset.GetCondition(rs.Status, appsv1.ReplicaSetReplicaFailure)
+			return cond == nil, nil
+		})
 	if wait.Interrupted(err) {
 		err = fmt.Errorf("rs controller never removed the failure condition for rs %q: %#v", name, conditions)
 	}
@@ -343,22 +345,23 @@ func testRSAdoptMatchingAndReleaseNotMatching(ctx context.Context, f *framework.
 	framework.ExpectNoError(err)
 
 	ginkgo.By("Then the orphan pod is adopted")
-	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
-		p2, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(ctx, p.Name, metav1.GetOptions{})
-		// The Pod p should either be adopted or deleted by the ReplicaSet
-		if apierrors.IsNotFound(err) {
-			return true, nil
-		}
-		framework.ExpectNoError(err)
-		for _, owner := range p2.OwnerReferences {
-			if *owner.Controller && owner.UID == rs.UID {
-				// pod adopted
+	err = wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 1*time.Minute, true,
+		func(ctx context.Context) (bool, error) {
+			p2, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(ctx, p.Name, metav1.GetOptions{})
+			// The Pod p should either be adopted or deleted by the ReplicaSet
+			if apierrors.IsNotFound(err) {
 				return true, nil
 			}
-		}
-		// pod still not adopted
-		return false, nil
-	})
+			framework.ExpectNoError(err)
+			for _, owner := range p2.OwnerReferences {
+				if *owner.Controller && owner.UID == rs.UID {
+					// pod adopted
+					return true, nil
+				}
+			}
+			// pod still not adopted
+			return false, nil
+		})
 	framework.ExpectNoError(err)
 
 	ginkgo.By("When the matched label of one of its pods change")
@@ -366,35 +369,37 @@ func testRSAdoptMatchingAndReleaseNotMatching(ctx context.Context, f *framework.
 	framework.ExpectNoError(err)
 
 	p = &pods.Items[0]
-	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
-		pod, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(ctx, p.Name, metav1.GetOptions{})
-		framework.ExpectNoError(err)
+	err = wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 1*time.Minute, true,
+		func(ctx context.Context) (bool, error) {
+			pod, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(ctx, p.Name, metav1.GetOptions{})
+			framework.ExpectNoError(err)
 
-		pod.Labels = map[string]string{"name": "not-matching-name"}
-		_, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Update(ctx, pod, metav1.UpdateOptions{})
-		if err != nil && apierrors.IsConflict(err) {
-			return false, nil
-		}
-		if err != nil {
-			return false, err
-		}
-		return true, nil
-	})
+			pod.Labels = map[string]string{"name": "not-matching-name"}
+			_, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Update(ctx, pod, metav1.UpdateOptions{})
+			if err != nil && apierrors.IsConflict(err) {
+				return false, nil
+			}
+			if err != nil {
+				return false, err
+			}
+			return true, nil
+		})
 	framework.ExpectNoError(err)
 
 	ginkgo.By("Then the pod is released")
-	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
-		p2, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(ctx, p.Name, metav1.GetOptions{})
-		framework.ExpectNoError(err)
-		for _, owner := range p2.OwnerReferences {
-			if *owner.Controller && owner.UID == rs.UID {
-				// pod still belonging to the replicaset
-				return false, nil
+	err = wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 1*time.Minute, true,
+		func(ctx context.Context) (bool, error) {
+			p2, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(ctx, p.Name, metav1.GetOptions{})
+			framework.ExpectNoError(err)
+			for _, owner := range p2.OwnerReferences {
+				if *owner.Controller && owner.UID == rs.UID {
+					// pod still belonging to the replicaset
+					return false, nil
+				}
 			}
-		}
-		// pod already released
-		return true, nil
-	})
+			// pod already released
+			return true, nil
+		})
 	framework.ExpectNoError(err)
 }
 

--- a/test/e2e/auth/service_accounts.go
+++ b/test/e2e/auth/service_accounts.go
@@ -740,17 +740,18 @@ var _ = SIGDescribe("ServiceAccounts", func() {
 			3. Reconciled if modified
 	*/
 	framework.ConformanceIt("should guarantee kube-root-ca.crt exist in any namespace", func(ctx context.Context) {
-		framework.ExpectNoError(wait.PollImmediate(500*time.Millisecond, wait.ForeverTestTimeout, func() (bool, error) {
-			_, err := f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Get(ctx, rootCAConfigMapName, metav1.GetOptions{})
-			if err == nil {
-				return true, nil
-			}
-			if apierrors.IsNotFound(err) {
-				ginkgo.By("root ca configmap not found, retrying")
-				return false, nil
-			}
-			return false, err
-		}))
+		framework.ExpectNoError(wait.PollUntilContextTimeout(context.Background(), 500*time.Millisecond, wait.ForeverTestTimeout, true,
+			func(ctx context.Context) (bool, error) {
+				_, err := f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Get(ctx, rootCAConfigMapName, metav1.GetOptions{})
+				if err == nil {
+					return true, nil
+				}
+				if apierrors.IsNotFound(err) {
+					ginkgo.By("root ca configmap not found, retrying")
+					return false, nil
+				}
+				return false, err
+			}))
 		framework.Logf("Got root ca configmap in namespace %q", f.Namespace.Name)
 
 		framework.ExpectNoError(f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Delete(ctx, rootCAConfigMapName, metav1.DeleteOptions{GracePeriodSeconds: utilptr.Int64Ptr(0)}))

--- a/test/e2e/autoscaling/cluster_size_autoscaling.go
+++ b/test/e2e/autoscaling/cluster_size_autoscaling.go
@@ -1712,13 +1712,14 @@ func runReplicatedPodOnEachNode(ctx context.Context, f *framework.Framework, nod
 			}
 		}
 
-		err = wait.PollImmediate(5*time.Second, podTimeout, func() (bool, error) {
-			rc, err = f.ClientSet.CoreV1().ReplicationControllers(namespace).Get(ctx, id, metav1.GetOptions{})
-			if err != nil || rc.Status.ReadyReplicas < int32((i+1)*podsPerNode) {
-				return false, nil
-			}
-			return true, nil
-		})
+		err = wait.PollUntilContextTimeout(context.Background(), 5*time.Second, podTimeout, true,
+			func(ctx context.Context) (bool, error) {
+				rc, err = f.ClientSet.CoreV1().ReplicationControllers(namespace).Get(ctx, id, metav1.GetOptions{})
+				if err != nil || rc.Status.ReadyReplicas < int32((i+1)*podsPerNode) {
+					return false, nil
+				}
+				return true, nil
+			})
 		if err != nil {
 			return fmt.Errorf("failed to coerce RC into spawning a pod on node %s within timeout", node.Name)
 		}

--- a/test/e2e/framework/job/wait.go
+++ b/test/e2e/framework/job/wait.go
@@ -102,14 +102,15 @@ func WaitForJobSuspend(ctx context.Context, c clientset.Interface, ns, jobName s
 
 // WaitForJobFailed uses c to wait for the Job jobName in namespace ns to fail
 func WaitForJobFailed(c clientset.Interface, ns, jobName string) error {
-	return wait.PollImmediate(framework.Poll, JobTimeout, func() (bool, error) {
-		curr, err := c.BatchV1().Jobs(ns).Get(context.TODO(), jobName, metav1.GetOptions{})
-		if err != nil {
-			return false, err
-		}
+	return wait.PollUntilContextTimeout(context.Background(), framework.Poll, JobTimeout, true,
+		func(ctx context.Context) (bool, error) {
+			curr, err := c.BatchV1().Jobs(ns).Get(context.TODO(), jobName, metav1.GetOptions{})
+			if err != nil {
+				return false, err
+			}
 
-		return isJobFailed(curr), nil
-	})
+			return isJobFailed(curr), nil
+		})
 }
 
 func isJobFailed(j *batchv1.Job) bool {

--- a/test/e2e/kubectl/kubectl.go
+++ b/test/e2e/kubectl/kubectl.go
@@ -210,7 +210,7 @@ func cleanupKubectlInputs(fileContents string, ns string, selectors ...string) {
 // assertCleanup asserts that cleanup of a namespace wrt selectors occurred.
 func assertCleanup(ns string, selectors ...string) {
 	var e error
-	verifyCleanupFunc := func() (bool, error) {
+	verifyCleanupFunc := func(ctx context.Context) (bool, error) {
 		e = nil
 		for _, selector := range selectors {
 			resources := e2ekubectl.RunKubectlOrDie(ns, "get", "rc,svc", "-l", selector, "--no-headers")
@@ -226,7 +226,7 @@ func assertCleanup(ns string, selectors ...string) {
 		}
 		return true, nil
 	}
-	err := wait.PollImmediate(500*time.Millisecond, 1*time.Minute, verifyCleanupFunc)
+	err := wait.PollUntilContextTimeout(context.Background(), 500*time.Millisecond, 1*time.Minute, true, verifyCleanupFunc)
 	if err != nil {
 		framework.Failf(e.Error())
 	}

--- a/test/e2e/network/dual_stack.go
+++ b/test/e2e/network/dual_stack.go
@@ -272,15 +272,16 @@ var _ = common.SIGDescribe(feature.IPv6DualStack, func() {
 		validateServiceAndClusterIPFamily(svc, expectedFamilies, &expectedPolicy)
 
 		// ensure endpoint belong to same ipfamily as service
-		if err := wait.PollImmediate(500*time.Millisecond, 10*time.Second, func() (bool, error) {
-			endpoint, err := cs.CoreV1().Endpoints(svc.Namespace).Get(ctx, svc.Name, metav1.GetOptions{})
-			if err != nil {
-				return false, nil
-			}
-			validateEndpointsBelongToIPFamily(svc, endpoint, expectedFamilies[0] /*endpoint controller works on primary ip*/)
+		if err := wait.PollUntilContextTimeout(context.Background(), 500*time.Millisecond, 10*time.Second, true,
+			func(ctx context.Context) (bool, error) {
+				endpoint, err := cs.CoreV1().Endpoints(svc.Namespace).Get(ctx, svc.Name, metav1.GetOptions{})
+				if err != nil {
+					return false, nil
+				}
+				validateEndpointsBelongToIPFamily(svc, endpoint, expectedFamilies[0] /*endpoint controller works on primary ip*/)
 
-			return true, nil
-		}); err != nil {
+				return true, nil
+			}); err != nil {
 			framework.Failf("Get endpoints for service %s/%s failed (%s)", svc.Namespace, svc.Name, err)
 		}
 	})
@@ -318,14 +319,15 @@ var _ = common.SIGDescribe(feature.IPv6DualStack, func() {
 		validateServiceAndClusterIPFamily(svc, expectedFamilies, &expectedPolicy)
 
 		// ensure endpoints belong to same ipfamily as service
-		if err := wait.PollImmediate(500*time.Millisecond, 10*time.Second, func() (bool, error) {
-			endpoint, err := cs.CoreV1().Endpoints(svc.Namespace).Get(ctx, svc.Name, metav1.GetOptions{})
-			if err != nil {
-				return false, nil
-			}
-			validateEndpointsBelongToIPFamily(svc, endpoint, expectedFamilies[0] /* endpoint controller operates on primary ip */)
-			return true, nil
-		}); err != nil {
+		if err := wait.PollUntilContextTimeout(context.Background(), 500*time.Millisecond, 10*time.Second, true,
+			func(ctx context.Context) (bool, error) {
+				endpoint, err := cs.CoreV1().Endpoints(svc.Namespace).Get(ctx, svc.Name, metav1.GetOptions{})
+				if err != nil {
+					return false, nil
+				}
+				validateEndpointsBelongToIPFamily(svc, endpoint, expectedFamilies[0] /* endpoint controller operates on primary ip */)
+				return true, nil
+			}); err != nil {
 			framework.Failf("Get endpoints for service %s/%s failed (%s)", svc.Namespace, svc.Name, err)
 		}
 	})
@@ -363,14 +365,15 @@ var _ = common.SIGDescribe(feature.IPv6DualStack, func() {
 		validateServiceAndClusterIPFamily(svc, expectedFamilies, &expectedPolicy)
 
 		// ensure endpoints belong to same ipfamily as service
-		if err := wait.PollImmediate(500*time.Millisecond, 10*time.Second, func() (bool, error) {
-			endpoint, err := cs.CoreV1().Endpoints(svc.Namespace).Get(ctx, svc.Name, metav1.GetOptions{})
-			if err != nil {
-				return false, nil
-			}
-			validateEndpointsBelongToIPFamily(svc, endpoint, ipv6)
-			return true, nil
-		}); err != nil {
+		if err := wait.PollUntilContextTimeout(context.Background(), 500*time.Millisecond, 10*time.Second, true,
+			func(ctx context.Context) (bool, error) {
+				endpoint, err := cs.CoreV1().Endpoints(svc.Namespace).Get(ctx, svc.Name, metav1.GetOptions{})
+				if err != nil {
+					return false, nil
+				}
+				validateEndpointsBelongToIPFamily(svc, endpoint, ipv6)
+				return true, nil
+			}); err != nil {
 			framework.Failf("Get endpoints for service %s/%s failed (%s)", svc.Namespace, svc.Name, err)
 		}
 	})
@@ -408,14 +411,15 @@ var _ = common.SIGDescribe(feature.IPv6DualStack, func() {
 		validateServiceAndClusterIPFamily(svc, expectedFamilies, &expectedPolicy)
 
 		// ensure endpoints belong to same ipfamily as service
-		if err := wait.PollImmediate(500*time.Millisecond, 10*time.Second, func() (bool, error) {
-			endpoint, err := cs.CoreV1().Endpoints(svc.Namespace).Get(ctx, svc.Name, metav1.GetOptions{})
-			if err != nil {
-				return false, nil
-			}
-			validateEndpointsBelongToIPFamily(svc, endpoint, expectedFamilies[0] /* endpoint controller operates on primary ip */)
-			return true, nil
-		}); err != nil {
+		if err := wait.PollUntilContextTimeout(context.Background(), 500*time.Millisecond, 10*time.Second, true,
+			func(ctx context.Context) (bool, error) {
+				endpoint, err := cs.CoreV1().Endpoints(svc.Namespace).Get(ctx, svc.Name, metav1.GetOptions{})
+				if err != nil {
+					return false, nil
+				}
+				validateEndpointsBelongToIPFamily(svc, endpoint, expectedFamilies[0] /* endpoint controller operates on primary ip */)
+				return true, nil
+			}); err != nil {
 			framework.Failf("Get endpoints for service %s/%s failed (%s)", svc.Namespace, svc.Name, err)
 		}
 	})
@@ -453,14 +457,15 @@ var _ = common.SIGDescribe(feature.IPv6DualStack, func() {
 		validateServiceAndClusterIPFamily(svc, expectedFamilies, &expectedPolicy)
 
 		// ensure endpoints belong to same ipfamily as service
-		if err := wait.PollImmediate(500*time.Millisecond, 10*time.Second, func() (bool, error) {
-			endpoint, err := cs.CoreV1().Endpoints(svc.Namespace).Get(ctx, svc.Name, metav1.GetOptions{})
-			if err != nil {
-				return false, nil
-			}
-			validateEndpointsBelongToIPFamily(svc, endpoint, expectedFamilies[0] /* endpoint controller operates on primary ip */)
-			return true, nil
-		}); err != nil {
+		if err := wait.PollUntilContextTimeout(context.Background(), 500*time.Millisecond, 10*time.Second, true,
+			func(ctx context.Context) (bool, error) {
+				endpoint, err := cs.CoreV1().Endpoints(svc.Namespace).Get(ctx, svc.Name, metav1.GetOptions{})
+				if err != nil {
+					return false, nil
+				}
+				validateEndpointsBelongToIPFamily(svc, endpoint, expectedFamilies[0] /* endpoint controller operates on primary ip */)
+				return true, nil
+			}); err != nil {
 			framework.Failf("Get endpoints for service %s/%s failed (%s)", svc.Namespace, svc.Name, err)
 		}
 	})

--- a/test/e2e/network/service.go
+++ b/test/e2e/network/service.go
@@ -192,27 +192,28 @@ func checkAffinity(ctx context.Context, cs clientset.Interface, execPod *v1.Pod,
 	}
 
 	var tracker affinityTracker
-	if pollErr := wait.PollImmediate(interval, timeout, func() (bool, error) {
-		hosts := getHosts()
-		for _, host := range hosts {
-			if len(host) > 0 {
-				tracker.recordHost(strings.TrimSpace(host))
+	if pollErr := wait.PollUntilContextTimeout(context.Background(), interval, timeout, true,
+		func(ctx context.Context) (bool, error) {
+			hosts := getHosts()
+			for _, host := range hosts {
+				if len(host) > 0 {
+					tracker.recordHost(strings.TrimSpace(host))
+				}
 			}
-		}
 
-		trackerFulfilled, affinityHolds := tracker.checkHostTrace(AffinityConfirmCount)
-		if !trackerFulfilled {
+			trackerFulfilled, affinityHolds := tracker.checkHostTrace(AffinityConfirmCount)
+			if !trackerFulfilled {
+				return false, nil
+			}
+
+			if !shouldHold && !affinityHolds {
+				return true, nil
+			}
+			if shouldHold && affinityHolds {
+				return true, nil
+			}
 			return false, nil
-		}
-
-		if !shouldHold && !affinityHolds {
-			return true, nil
-		}
-		if shouldHold && affinityHolds {
-			return true, nil
-		}
-		return false, nil
-	}); pollErr != nil {
+		}); pollErr != nil {
 		trackerFulfilled, _ := tracker.checkHostTrace(AffinityConfirmCount)
 		if !wait.Interrupted(pollErr) {
 			checkAffinityFailed(tracker, pollErr.Error())
@@ -429,9 +430,9 @@ func verifyServeHostnameServiceDown(ctx context.Context, c clientset.Interface, 
 	return fmt.Errorf("waiting for service to be down timed out")
 }
 
-// testNotReachableHTTP tests that a HTTP request doesn't connect to the given host and port.
+// testNotReachableHTTP tests that an HTTP request doesn't connect to the given host and port.
 func testNotReachableHTTP(host string, port int, timeout time.Duration) {
-	pollfn := func() (bool, error) {
+	pollfn := func(ctx context.Context) (bool, error) {
 		result := e2enetwork.PokeHTTP(host, port, "/", nil)
 		if result.Code == 0 {
 			return true, nil
@@ -439,14 +440,14 @@ func testNotReachableHTTP(host string, port int, timeout time.Duration) {
 		return false, nil // caller can retry
 	}
 
-	if err := wait.PollImmediate(framework.Poll, timeout, pollfn); err != nil {
+	if err := wait.PollUntilContextTimeout(context.Background(), framework.Poll, timeout, true, pollfn); err != nil {
 		framework.Failf("HTTP service %v:%v reachable after %v: %v", host, port, timeout, err)
 	}
 }
 
-// testRejectedHTTP tests that the given host rejects a HTTP request on the given port.
+// testRejectedHTTP tests that the given host rejects an HTTP request on the given port.
 func testRejectedHTTP(host string, port int, timeout time.Duration) {
-	pollfn := func() (bool, error) {
+	pollfn := func(ctx context.Context) (bool, error) {
 		result := e2enetwork.PokeHTTP(host, port, "/", nil)
 		if result.Status == e2enetwork.HTTPRefused {
 			return true, nil
@@ -454,7 +455,7 @@ func testRejectedHTTP(host string, port int, timeout time.Duration) {
 		return false, nil // caller can retry
 	}
 
-	if err := wait.PollImmediate(framework.Poll, timeout, pollfn); err != nil {
+	if err := wait.PollUntilContextTimeout(context.Background(), framework.Poll, timeout, true, pollfn); err != nil {
 		framework.Failf("HTTP service %v:%v not rejected: %v", host, port, err)
 	}
 }
@@ -591,7 +592,7 @@ func pokeUDP(host string, port int, request string, params *UDPPokeParams) UDPPo
 
 // testReachableUDP tests that the given host serves UDP on the given port.
 func testReachableUDP(host string, port int, timeout time.Duration) {
-	pollfn := func() (bool, error) {
+	pollfn := func(ctx context.Context) (bool, error) {
 		result := pokeUDP(host, port, "echo hello", &UDPPokeParams{
 			Timeout:  3 * time.Second,
 			Response: "hello",
@@ -602,43 +603,43 @@ func testReachableUDP(host string, port int, timeout time.Duration) {
 		return false, nil // caller can retry
 	}
 
-	if err := wait.PollImmediate(framework.Poll, timeout, pollfn); err != nil {
+	if err := wait.PollUntilContextTimeout(context.Background(), framework.Poll, timeout, true, pollfn); err != nil {
 		framework.Failf("Could not reach UDP service through %v:%v after %v: %v", host, port, timeout, err)
 	}
 }
 
 // testNotReachableUDP tests that the given host doesn't serve UDP on the given port.
 func testNotReachableUDP(host string, port int, timeout time.Duration) {
-	pollfn := func() (bool, error) {
+	pollfn := func(ctx context.Context) (bool, error) {
 		result := pokeUDP(host, port, "echo hello", &UDPPokeParams{Timeout: 3 * time.Second})
 		if result.Status != UDPSuccess && result.Status != UDPError {
 			return true, nil
 		}
 		return false, nil // caller can retry
 	}
-	if err := wait.PollImmediate(framework.Poll, timeout, pollfn); err != nil {
+	if err := wait.PollUntilContextTimeout(context.Background(), framework.Poll, timeout, true, pollfn); err != nil {
 		framework.Failf("UDP service %v:%v reachable after %v: %v", host, port, timeout, err)
 	}
 }
 
 // testRejectedUDP tests that the given host rejects a UDP request on the given port.
 func testRejectedUDP(host string, port int, timeout time.Duration) {
-	pollfn := func() (bool, error) {
+	pollfn := func(ctx context.Context) (bool, error) {
 		result := pokeUDP(host, port, "echo hello", &UDPPokeParams{Timeout: 3 * time.Second})
 		if result.Status == UDPRefused {
 			return true, nil
 		}
 		return false, nil // caller can retry
 	}
-	if err := wait.PollImmediate(framework.Poll, timeout, pollfn); err != nil {
+	if err := wait.PollUntilContextTimeout(context.Background(), framework.Poll, timeout, true, pollfn); err != nil {
 		framework.Failf("UDP service %v:%v not rejected: %v", host, port, err)
 	}
 }
 
-// TestHTTPHealthCheckNodePort tests a HTTP connection by the given request to the given host and port.
+// TestHTTPHealthCheckNodePort tests an HTTP connection by the given request to the given host and port.
 func TestHTTPHealthCheckNodePort(host string, port int, request string, timeout time.Duration, expectSucceed bool, threshold int) error {
 	count := 0
-	condition := func() (bool, error) {
+	condition := func(ctx context.Context) (bool, error) {
 		success, _ := testHTTPHealthCheckNodePort(host, port, request)
 		if success && expectSucceed ||
 			!success && !expectSucceed {
@@ -650,7 +651,7 @@ func TestHTTPHealthCheckNodePort(host string, port int, request string, timeout 
 		return false, nil
 	}
 
-	if err := wait.PollImmediate(time.Second, timeout, condition); err != nil {
+	if err := wait.PollUntilContextTimeout(context.Background(), time.Second, timeout, true, condition); err != nil {
 		return fmt.Errorf("error waiting for healthCheckNodePort: expected at least %d succeed=%v on %v%v, got %d", threshold, expectSucceed, host, port, count)
 	}
 	return nil
@@ -687,7 +688,7 @@ func testHTTPHealthCheckNodePort(ip string, port int, request string) (bool, err
 
 func testHTTPHealthCheckNodePortFromTestContainer(ctx context.Context, config *e2enetwork.NetworkingTestConfig, host string, port int, timeout time.Duration, expectSucceed bool, threshold int) error {
 	count := 0
-	pollFn := func() (bool, error) {
+	pollFn := func(ctx context.Context) (bool, error) {
 		statusCode, err := config.GetHTTPCodeFromTestContainer(ctx,
 			"/healthz",
 			host,
@@ -704,7 +705,7 @@ func testHTTPHealthCheckNodePortFromTestContainer(ctx context.Context, config *e
 		}
 		return count >= threshold, nil
 	}
-	err := wait.PollImmediate(time.Second, timeout, pollFn)
+	err := wait.PollUntilContextTimeout(context.Background(), time.Second, timeout, true, pollFn)
 	if err != nil {
 		return fmt.Errorf("error waiting for healthCheckNodePort: expected at least %d succeed=%v on %v:%v/healthz, got %d", threshold, expectSucceed, host, port, count)
 	}
@@ -1178,18 +1179,19 @@ var _ = common.SIGDescribe("Services", func() {
 		framework.ExpectNoError(err)
 
 		ginkgo.By("Waiting for the service " + serviceName + " in namespace " + ns + " to disappear")
-		if pollErr := wait.PollImmediate(framework.Poll, e2eservice.RespondingTimeout, func() (bool, error) {
-			_, err := cs.CoreV1().Services(ns).Get(ctx, serviceName, metav1.GetOptions{})
-			if err != nil {
-				if apierrors.IsNotFound(err) {
-					framework.Logf("Service %s/%s is gone.", ns, serviceName)
-					return true, nil
+		if pollErr := wait.PollUntilContextTimeout(context.Background(), framework.Poll, e2eservice.RespondingTimeout, true,
+			func(ctx context.Context) (bool, error) {
+				_, err := cs.CoreV1().Services(ns).Get(ctx, serviceName, metav1.GetOptions{})
+				if err != nil {
+					if apierrors.IsNotFound(err) {
+						framework.Logf("Service %s/%s is gone.", ns, serviceName)
+						return true, nil
+					}
+					return false, err
 				}
-				return false, err
-			}
-			framework.Logf("Service %s/%s still exists", ns, serviceName)
-			return false, nil
-		}); pollErr != nil {
+				framework.Logf("Service %s/%s still exists", ns, serviceName)
+				return false, nil
+			}); pollErr != nil {
 			framework.Failf("Failed to wait for service to disappear: %v", pollErr)
 		}
 
@@ -1733,15 +1735,15 @@ var _ = common.SIGDescribe("Services", func() {
 		hostExec := launchHostExecPod(ctx, f.ClientSet, f.Namespace.Name, "hostexec")
 		cmd := fmt.Sprintf(`! ss -ant46 'sport = :%d' | tail -n +2 | grep LISTEN`, nodePort)
 		var stdout string
-		if pollErr := wait.PollImmediate(framework.Poll, e2eservice.KubeProxyLagTimeout, func() (bool, error) {
-			var err error
-			stdout, err = e2eoutput.RunHostCmd(hostExec.Namespace, hostExec.Name, cmd)
-			if err != nil {
-				framework.Logf("expected node port (%d) to not be in use, stdout: %v", nodePort, stdout)
-				return false, nil
-			}
-			return true, nil
-		}); pollErr != nil {
+		if pollErr := wait.PollUntilContextTimeout(context.Background(), framework.Poll, e2eservice.KubeProxyLagTimeout, true,
+			func(ctx context.Context) (bool, error) {
+				stdout, err = e2eoutput.RunHostCmd(hostExec.Namespace, hostExec.Name, cmd)
+				if err != nil {
+					framework.Logf("expected node port (%d) to not be in use, stdout: %v", nodePort, stdout)
+					return false, nil
+				}
+				return true, nil
+			}); pollErr != nil {
 			framework.Failf("expected node port (%d) to not be in use in %v, stdout: %v", nodePort, e2eservice.KubeProxyLagTimeout, stdout)
 		}
 
@@ -1849,15 +1851,15 @@ var _ = common.SIGDescribe("Services", func() {
 
 		ginkgo.By("Check if pod is unreachable")
 		cmd = fmt.Sprintf("curl -q -s --connect-timeout 2 http://%s:%d/; test \"$?\" -ne \"0\"", svcName, port)
-		if pollErr := wait.PollImmediate(framework.Poll, e2eservice.KubeProxyLagTimeout, func() (bool, error) {
-			var err error
-			stdout, err = e2eoutput.RunHostCmd(f.Namespace.Name, execPodName, cmd)
-			if err != nil {
-				framework.Logf("expected un-ready endpoint for Service %v, stdout: %v, err %v", t.Name, stdout, err)
-				return false, nil
-			}
-			return true, nil
-		}); pollErr != nil {
+		if pollErr := wait.PollUntilContextTimeout(context.Background(), framework.Poll, e2eservice.KubeProxyLagTimeout, true,
+			func(ctx context.Context) (bool, error) {
+				stdout, err = e2eoutput.RunHostCmd(f.Namespace.Name, execPodName, cmd)
+				if err != nil {
+					framework.Logf("expected un-ready endpoint for Service %v, stdout: %v, err %v", t.Name, stdout, err)
+					return false, nil
+				}
+				return true, nil
+			}); pollErr != nil {
 			framework.Failf("expected un-ready endpoint for Service %v within %v, stdout: %v", t.Name, e2eservice.KubeProxyLagTimeout, stdout)
 		}
 
@@ -1869,15 +1871,15 @@ var _ = common.SIGDescribe("Services", func() {
 
 		ginkgo.By("Check if terminating pod is available through service")
 		cmd = fmt.Sprintf("curl -q -s --connect-timeout 2 http://%s:%d/", svcName, port)
-		if pollErr := wait.PollImmediate(framework.Poll, e2eservice.KubeProxyLagTimeout, func() (bool, error) {
-			var err error
-			stdout, err = e2eoutput.RunHostCmd(f.Namespace.Name, execPodName, cmd)
-			if err != nil {
-				framework.Logf("expected un-ready endpoint for Service %v, stdout: %v, err %v", t.Name, stdout, err)
-				return false, nil
-			}
-			return true, nil
-		}); pollErr != nil {
+		if pollErr := wait.PollUntilContextTimeout(context.Background(), framework.Poll, e2eservice.KubeProxyLagTimeout, true,
+			func(ctx context.Context) (bool, error) {
+				stdout, err = e2eoutput.RunHostCmd(f.Namespace.Name, execPodName, cmd)
+				if err != nil {
+					framework.Logf("expected un-ready endpoint for Service %v, stdout: %v, err %v", t.Name, stdout, err)
+					return false, nil
+				}
+				return true, nil
+			}); pollErr != nil {
 			framework.Failf("expected un-ready endpoint for Service %v within %v, stdout: %v", t.Name, e2eservice.KubeProxyLagTimeout, stdout)
 		}
 
@@ -2307,7 +2309,7 @@ var _ = common.SIGDescribe("Services", func() {
 		ginkgo.By("creating service-headless in namespace " + ns)
 		svcHeadless := getServeHostnameService("service-headless")
 		svcHeadless.ObjectMeta.Labels = serviceHeadlessLabels
-		// This should be improved, as we do not want a Headlesss Service to contain an IP...
+		// This should be improved, as we do not want an Headlesss Service to contain an IP...
 		_, svcHeadlessIP, err := StartServeHostnameService(ctx, cs, svcHeadless, ns, numPods)
 		framework.ExpectNoError(err, "failed to create replication controller with headless service: %s in the namespace: %s", svcHeadlessIP, ns)
 
@@ -2373,19 +2375,20 @@ var _ = common.SIGDescribe("Services", func() {
 
 		ginkgo.By(fmt.Sprintf("hitting service %v from pod %v on node %v", serviceAddress, podName, nodeName))
 		expectedErr := "REFUSED"
-		if pollErr := wait.PollImmediate(framework.Poll, e2eservice.KubeProxyEndpointLagTimeout, func() (bool, error) {
-			_, err := e2eoutput.RunHostCmd(execPod.Namespace, execPod.Name, cmd)
+		if pollErr := wait.PollUntilContextTimeout(context.Background(), framework.Poll, e2eservice.KubeProxyEndpointLagTimeout, true,
+			func(ctx context.Context) (bool, error) {
+				_, err := e2eoutput.RunHostCmd(execPod.Namespace, execPod.Name, cmd)
 
-			if err != nil {
-				if strings.Contains(err.Error(), expectedErr) {
-					framework.Logf("error contained '%s', as expected: %s", expectedErr, err.Error())
-					return true, nil
+				if err != nil {
+					if strings.Contains(err.Error(), expectedErr) {
+						framework.Logf("error contained '%s', as expected: %s", expectedErr, err.Error())
+						return true, nil
+					}
+					framework.Logf("error didn't contain '%s', keep trying: %s", expectedErr, err.Error())
+					return false, nil
 				}
-				framework.Logf("error didn't contain '%s', keep trying: %s", expectedErr, err.Error())
-				return false, nil
-			}
-			return true, errors.New("expected connect call to fail")
-		}); pollErr != nil {
+				return true, errors.New("expected connect call to fail")
+			}); pollErr != nil {
 			framework.ExpectNoError(pollErr)
 		}
 	})
@@ -2429,32 +2432,33 @@ var _ = common.SIGDescribe("Services", func() {
 			e2epod.SetNodeSelection(&pod.Spec, nodeSelection)
 		})
 
-		if epErr := wait.PollImmediate(framework.Poll, e2eservice.ServiceEndpointsTimeout, func() (bool, error) {
-			endpoints, err := cs.CoreV1().Endpoints(namespace).Get(ctx, serviceName, metav1.GetOptions{})
-			if err != nil {
-				framework.Logf("error fetching '%s/%s' Endpoints: %s", namespace, serviceName, err.Error())
-				return false, err
-			}
-			if len(endpoints.Subsets) > 0 {
-				framework.Logf("expected '%s/%s' Endpoints to be empty, got: %v", namespace, serviceName, endpoints.Subsets)
-				return false, nil
-			}
-			epsList, err := cs.DiscoveryV1().EndpointSlices(namespace).List(ctx, metav1.ListOptions{LabelSelector: fmt.Sprintf("%s=%s", discoveryv1.LabelServiceName, serviceName)})
-			if err != nil {
-				framework.Logf("error fetching '%s/%s' EndpointSlices: %s", namespace, serviceName, err.Error())
-				return false, err
-			}
-			if len(epsList.Items) != 1 {
-				framework.Logf("expected exactly 1 EndpointSlice, got: %d", len(epsList.Items))
-				return false, nil
-			}
-			endpointSlice := epsList.Items[0]
-			if len(endpointSlice.Endpoints) > 0 {
-				framework.Logf("expected EndpointSlice to be empty, got %d endpoints", len(endpointSlice.Endpoints))
-				return false, nil
-			}
-			return true, nil
-		}); epErr != nil {
+		if epErr := wait.PollUntilContextTimeout(context.Background(), framework.Poll, e2eservice.ServiceEndpointsTimeout, true,
+			func(ctx context.Context) (bool, error) {
+				endpoints, err := cs.CoreV1().Endpoints(namespace).Get(ctx, serviceName, metav1.GetOptions{})
+				if err != nil {
+					framework.Logf("error fetching '%s/%s' Endpoints: %s", namespace, serviceName, err.Error())
+					return false, err
+				}
+				if len(endpoints.Subsets) > 0 {
+					framework.Logf("expected '%s/%s' Endpoints to be empty, got: %v", namespace, serviceName, endpoints.Subsets)
+					return false, nil
+				}
+				epsList, err := cs.DiscoveryV1().EndpointSlices(namespace).List(ctx, metav1.ListOptions{LabelSelector: fmt.Sprintf("%s=%s", discoveryv1.LabelServiceName, serviceName)})
+				if err != nil {
+					framework.Logf("error fetching '%s/%s' EndpointSlices: %s", namespace, serviceName, err.Error())
+					return false, err
+				}
+				if len(epsList.Items) != 1 {
+					framework.Logf("expected exactly 1 EndpointSlice, got: %d", len(epsList.Items))
+					return false, nil
+				}
+				endpointSlice := epsList.Items[0]
+				if len(endpointSlice.Endpoints) > 0 {
+					framework.Logf("expected EndpointSlice to be empty, got %d endpoints", len(endpointSlice.Endpoints))
+					return false, nil
+				}
+				return true, nil
+			}); epErr != nil {
 			framework.ExpectNoError(epErr)
 		}
 
@@ -2464,19 +2468,20 @@ var _ = common.SIGDescribe("Services", func() {
 
 		ginkgo.By(fmt.Sprintf("hitting service %v from pod %v on node %v expected to be refused", serviceAddress, podName, nodeName))
 		expectedErr := "REFUSED"
-		if pollErr := wait.PollImmediate(framework.Poll, e2eservice.KubeProxyEndpointLagTimeout, func() (bool, error) {
-			_, err := e2eoutput.RunHostCmd(execPod.Namespace, execPod.Name, cmd)
+		if pollErr := wait.PollUntilContextTimeout(context.Background(), framework.Poll, e2eservice.KubeProxyEndpointLagTimeout, true,
+			func(ctx context.Context) (bool, error) {
+				_, err := e2eoutput.RunHostCmd(execPod.Namespace, execPod.Name, cmd)
 
-			if err != nil {
-				if strings.Contains(err.Error(), expectedErr) {
-					framework.Logf("error contained '%s', as expected: %s", expectedErr, err.Error())
-					return true, nil
+				if err != nil {
+					if strings.Contains(err.Error(), expectedErr) {
+						framework.Logf("error contained '%s', as expected: %s", expectedErr, err.Error())
+						return true, nil
+					}
+					framework.Logf("error didn't contain '%s', keep trying: %s", expectedErr, err.Error())
+					return false, nil
 				}
-				framework.Logf("error didn't contain '%s', keep trying: %s", expectedErr, err.Error())
-				return false, nil
-			}
-			return true, errors.New("expected connect call to fail")
-		}); pollErr != nil {
+				return true, errors.New("expected connect call to fail")
+			}); pollErr != nil {
 			framework.ExpectNoError(pollErr)
 		}
 	})
@@ -2769,21 +2774,22 @@ var _ = common.SIGDescribe("Services", func() {
 		nodeIPs := e2enode.GetAddresses(&node0, v1.NodeInternalIP)
 		healthCheckNodePortAddr := net.JoinHostPort(nodeIPs[0], strconv.Itoa(int(svc.Spec.HealthCheckNodePort)))
 		// validate that the health check node port from kube-proxy returns 200 when there are ready endpoints
-		err = wait.PollImmediate(time.Second, time.Minute, func() (bool, error) {
-			cmd := fmt.Sprintf(`curl -s -o /dev/null -w "%%{http_code}" --max-time 5 http://%s/healthz`, healthCheckNodePortAddr)
-			out, err := e2eoutput.RunHostCmd(pausePod0.Namespace, pausePod0.Name, cmd)
-			if err != nil {
-				framework.Logf("unexpected error trying to connect to nodeport %d : %v", healthCheckNodePortAddr, err)
-				return false, nil
-			}
+		err = wait.PollUntilContextTimeout(context.Background(), time.Second, time.Minute, true,
+			func(ctx context.Context) (bool, error) {
+				cmd := fmt.Sprintf(`curl -s -o /dev/null -w "%%{http_code}" --max-time 5 http://%s/healthz`, healthCheckNodePortAddr)
+				out, err := e2eoutput.RunHostCmd(pausePod0.Namespace, pausePod0.Name, cmd)
+				if err != nil {
+					framework.Logf("unexpected error trying to connect to nodeport %d : %v", healthCheckNodePortAddr, err)
+					return false, nil
+				}
 
-			expectedOut := "200"
-			if out != expectedOut {
-				framework.Logf("expected output: %s , got %s", expectedOut, out)
-				return false, nil
-			}
-			return true, nil
-		})
+				expectedOut := "200"
+				if out != expectedOut {
+					framework.Logf("expected output: %s , got %s", expectedOut, out)
+					return false, nil
+				}
+				return true, nil
+			})
 		framework.ExpectNoError(err)
 
 		// webserver should continue to serve traffic through the Service after deletion, even though the health check node port should return 503
@@ -2792,21 +2798,22 @@ var _ = common.SIGDescribe("Services", func() {
 		framework.ExpectNoError(err)
 
 		// validate that the health check node port from kube-proxy returns 503 when there are no ready endpoints
-		err = wait.PollImmediate(time.Second, time.Minute, func() (bool, error) {
-			cmd := fmt.Sprintf(`curl -s -o /dev/null -w "%%{http_code}" --max-time 5 http://%s/healthz`, healthCheckNodePortAddr)
-			out, err := e2eoutput.RunHostCmd(pausePod0.Namespace, pausePod0.Name, cmd)
-			if err != nil {
-				framework.Logf("unexpected error trying to connect to nodeport %d : %v", healthCheckNodePortAddr, err)
-				return false, nil
-			}
+		err = wait.PollUntilContextTimeout(context.Background(), time.Second, time.Minute, true,
+			func(ctx context.Context) (bool, error) {
+				cmd := fmt.Sprintf(`curl -s -o /dev/null -w "%%{http_code}" --max-time 5 http://%s/healthz`, healthCheckNodePortAddr)
+				out, err := e2eoutput.RunHostCmd(pausePod0.Namespace, pausePod0.Name, cmd)
+				if err != nil {
+					framework.Logf("unexpected error trying to connect to nodeport %d : %v", healthCheckNodePortAddr, err)
+					return false, nil
+				}
 
-			expectedOut := "503"
-			if out != expectedOut {
-				framework.Logf("expected output: %s , got %s", expectedOut, out)
-				return false, nil
-			}
-			return true, nil
-		})
+				expectedOut := "503"
+				if out != expectedOut {
+					framework.Logf("expected output: %s , got %s", expectedOut, out)
+					return false, nil
+				}
+				return true, nil
+			})
 		framework.ExpectNoError(err)
 
 		// also verify that while health check node port indicates 0 endpoints and returns 503, the endpoint still serves traffic.
@@ -4148,19 +4155,20 @@ func launchHostExecPod(ctx context.Context, client clientset.Interface, ns, name
 // checkReachabilityFromPod checks reachability from the specified pod.
 func checkReachabilityFromPod(expectToBeReachable bool, timeout time.Duration, namespace, pod, target string) {
 	cmd := fmt.Sprintf("wget -T 5 -qO- %q", target)
-	err := wait.PollImmediate(framework.Poll, timeout, func() (bool, error) {
-		_, err := e2eoutput.RunHostCmd(namespace, pod, cmd)
-		if expectToBeReachable && err != nil {
-			framework.Logf("Expect target to be reachable. But got err: %v. Retry until timeout", err)
-			return false, nil
-		}
+	err := wait.PollUntilContextTimeout(context.Background(), framework.Poll, timeout, true,
+		func(ctx context.Context) (bool, error) {
+			_, err := e2eoutput.RunHostCmd(namespace, pod, cmd)
+			if expectToBeReachable && err != nil {
+				framework.Logf("Expect target to be reachable. But got err: %v. Retry until timeout", err)
+				return false, nil
+			}
 
-		if !expectToBeReachable && err == nil {
-			framework.Logf("Expect target NOT to be reachable. But it is reachable. Retry until timeout")
-			return false, nil
-		}
-		return true, nil
-	})
+			if !expectToBeReachable && err == nil {
+				framework.Logf("Expect target NOT to be reachable. But it is reachable. Retry until timeout")
+				return false, nil
+			}
+			return true, nil
+		})
 	framework.ExpectNoError(err)
 }
 
@@ -4215,47 +4223,48 @@ func validateEndpointsPortsOrFail(ctx context.Context, c clientset.Interface, na
 		pollErr error
 		i       = 0
 	)
-	if pollErr = wait.PollImmediate(time.Second, framework.ServiceStartTimeout, func() (bool, error) {
-		i++
+	if pollErr = wait.PollUntilContextTimeout(context.Background(), time.Second, framework.ServiceStartTimeout, true,
+		func(ctx context.Context) (bool, error) {
+			i++
 
-		ep, err := c.CoreV1().Endpoints(namespace).Get(ctx, serviceName, metav1.GetOptions{})
-		if err != nil {
-			framework.Logf("Failed go get Endpoints object: %v", err)
-			// Retry the error
-			return false, nil
-		}
-		portsByUID := portsByPodUID(e2eendpoints.GetContainerPortsByPodUID(ep))
-		if err := validatePorts(portsByUID, expectedPortsByPodUID); err != nil {
-			if i%5 == 0 {
-				framework.Logf("Unexpected endpoints: found %v, expected %v, will retry", portsByUID, expectedEndpoints)
-			}
-			return false, nil
-		}
-
-		// If EndpointSlice API is enabled, then validate if appropriate EndpointSlice objects
-		// were also create/updated/deleted.
-		if _, err := c.Discovery().ServerResourcesForGroupVersion(discoveryv1.SchemeGroupVersion.String()); err == nil {
-			opts := metav1.ListOptions{
-				LabelSelector: "kubernetes.io/service-name=" + serviceName,
-			}
-			es, err := c.DiscoveryV1().EndpointSlices(namespace).List(ctx, opts)
+			ep, err := c.CoreV1().Endpoints(namespace).Get(ctx, serviceName, metav1.GetOptions{})
 			if err != nil {
-				framework.Logf("Failed go list EndpointSlice objects: %v", err)
+				framework.Logf("Failed go get Endpoints object: %v", err)
 				// Retry the error
 				return false, nil
 			}
-			portsByUID = portsByPodUID(e2eendpointslice.GetContainerPortsByPodUID(es.Items))
-			if err := validatePorts(portsByUID, expectedPortsByPodUID); err != nil {
+			portsByUID := portsByPodUID(e2eendpoints.GetContainerPortsByPodUID(ep))
+			if err = validatePorts(portsByUID, expectedPortsByPodUID); err != nil {
 				if i%5 == 0 {
-					framework.Logf("Unexpected endpoint slices: found %v, expected %v, will retry", portsByUID, expectedEndpoints)
+					framework.Logf("Unexpected endpoints: found %v, expected %v, will retry", portsByUID, expectedEndpoints)
 				}
 				return false, nil
 			}
-		}
-		framework.Logf("successfully validated that service %s in namespace %s exposes endpoints %v",
-			serviceName, namespace, expectedEndpoints)
-		return true, nil
-	}); pollErr != nil {
+
+			// If EndpointSlice API is enabled, then validate if appropriate EndpointSlice objects
+			// were also create/updated/deleted.
+			if _, err = c.Discovery().ServerResourcesForGroupVersion(discoveryv1.SchemeGroupVersion.String()); err == nil {
+				opts := metav1.ListOptions{
+					LabelSelector: "kubernetes.io/service-name=" + serviceName,
+				}
+				es, err := c.DiscoveryV1().EndpointSlices(namespace).List(ctx, opts)
+				if err != nil {
+					framework.Logf("Failed go list EndpointSlice objects: %v", err)
+					// Retry the error
+					return false, nil
+				}
+				portsByUID = portsByPodUID(e2eendpointslice.GetContainerPortsByPodUID(es.Items))
+				if err := validatePorts(portsByUID, expectedPortsByPodUID); err != nil {
+					if i%5 == 0 {
+						framework.Logf("Unexpected endpoint slices: found %v, expected %v, will retry", portsByUID, expectedEndpoints)
+					}
+					return false, nil
+				}
+			}
+			framework.Logf("successfully validated that service %s in namespace %s exposes endpoints %v",
+				serviceName, namespace, expectedEndpoints)
+			return true, nil
+		}); pollErr != nil {
 		if pods, err := c.CoreV1().Pods(metav1.NamespaceAll).List(ctx, metav1.ListOptions{}); err == nil {
 			for _, pod := range pods.Items {
 				framework.Logf("Pod %s\t%s\t%s\t%s", pod.Namespace, pod.Name, pod.Spec.NodeName, pod.DeletionTimestamp)
@@ -4308,47 +4317,48 @@ func validateEndpointsPortsWithProtocolsOrFail(c clientset.Interface, namespace,
 		pollErr error
 		i       = 0
 	)
-	if pollErr = wait.PollImmediate(time.Second, framework.ServiceStartTimeout, func() (bool, error) {
-		i++
+	if pollErr = wait.PollUntilContextTimeout(context.Background(), time.Second, framework.ServiceStartTimeout, true,
+		func(ctx context.Context) (bool, error) {
+			i++
 
-		ep, err := c.CoreV1().Endpoints(namespace).Get(context.TODO(), serviceName, metav1.GetOptions{})
-		if err != nil {
-			framework.Logf("Failed go get Endpoints object: %v", err)
-			// Retry the error
-			return false, nil
-		}
-		portsByUID := fullPortsByPodUID(e2eendpoints.GetFullContainerPortsByPodUID(ep))
-		if err := validatePortsAndProtocols(portsByUID, expectedPortsByPodUID); err != nil {
-			if i%5 == 0 {
-				framework.Logf("Unexpected endpoints: found %v, expected %v, will retry", portsByUID, expectedEndpoints)
-			}
-			return false, nil
-		}
-
-		// If EndpointSlice API is enabled, then validate if appropriate EndpointSlice objects
-		// were also create/updated/deleted.
-		if _, err := c.Discovery().ServerResourcesForGroupVersion(discoveryv1.SchemeGroupVersion.String()); err == nil {
-			opts := metav1.ListOptions{
-				LabelSelector: "kubernetes.io/service-name=" + serviceName,
-			}
-			es, err := c.DiscoveryV1().EndpointSlices(namespace).List(context.TODO(), opts)
+			ep, err := c.CoreV1().Endpoints(namespace).Get(context.TODO(), serviceName, metav1.GetOptions{})
 			if err != nil {
-				framework.Logf("Failed go list EndpointSlice objects: %v", err)
+				framework.Logf("Failed go get Endpoints object: %v", err)
 				// Retry the error
 				return false, nil
 			}
-			portsByUID = fullPortsByPodUID(e2eendpointslice.GetFullContainerPortsByPodUID(es.Items))
+			portsByUID := fullPortsByPodUID(e2eendpoints.GetFullContainerPortsByPodUID(ep))
 			if err := validatePortsAndProtocols(portsByUID, expectedPortsByPodUID); err != nil {
 				if i%5 == 0 {
-					framework.Logf("Unexpected endpoint slices: found %v, expected %v, will retry", portsByUID, expectedEndpoints)
+					framework.Logf("Unexpected endpoints: found %v, expected %v, will retry", portsByUID, expectedEndpoints)
 				}
 				return false, nil
 			}
-		}
-		framework.Logf("successfully validated that service %s in namespace %s exposes endpoints %v",
-			serviceName, namespace, expectedEndpoints)
-		return true, nil
-	}); pollErr != nil {
+
+			// If EndpointSlice API is enabled, then validate if appropriate EndpointSlice objects
+			// were also create/updated/deleted.
+			if _, err := c.Discovery().ServerResourcesForGroupVersion(discoveryv1.SchemeGroupVersion.String()); err == nil {
+				opts := metav1.ListOptions{
+					LabelSelector: "kubernetes.io/service-name=" + serviceName,
+				}
+				es, err := c.DiscoveryV1().EndpointSlices(namespace).List(context.TODO(), opts)
+				if err != nil {
+					framework.Logf("Failed go list EndpointSlice objects: %v", err)
+					// Retry the error
+					return false, nil
+				}
+				portsByUID = fullPortsByPodUID(e2eendpointslice.GetFullContainerPortsByPodUID(es.Items))
+				if err := validatePortsAndProtocols(portsByUID, expectedPortsByPodUID); err != nil {
+					if i%5 == 0 {
+						framework.Logf("Unexpected endpoint slices: found %v, expected %v, will retry", portsByUID, expectedEndpoints)
+					}
+					return false, nil
+				}
+			}
+			framework.Logf("successfully validated that service %s in namespace %s exposes endpoints %v",
+				serviceName, namespace, expectedEndpoints)
+			return true, nil
+		}); pollErr != nil {
 		if pods, err := c.CoreV1().Pods(metav1.NamespaceAll).List(context.TODO(), metav1.ListOptions{}); err == nil {
 			for _, pod := range pods.Items {
 				framework.Logf("Pod %s\t%s\t%s\t%s", pod.Namespace, pod.Name, pod.Spec.NodeName, pod.DeletionTimestamp)

--- a/test/e2e/upgrades/network/kube_proxy_migration.go
+++ b/test/e2e/upgrades/network/kube_proxy_migration.go
@@ -174,7 +174,7 @@ func waitForKubeProxyStaticPodsDisappear(ctx context.Context, c clientset.Interf
 func waitForKubeProxyDaemonSetRunning(ctx context.Context, f *framework.Framework, c clientset.Interface) error {
 	framework.Logf("Waiting up to %v for kube-proxy DaemonSet running", defaultTestTimeout)
 
-	condition := func() (bool, error) {
+	condition := func(ctx context.Context) (bool, error) {
 		daemonSets, err := getKubeProxyDaemonSet(ctx, c)
 		if err != nil {
 			framework.Logf("Failed to get kube-proxy DaemonSet: %v", err)
@@ -189,7 +189,7 @@ func waitForKubeProxyDaemonSetRunning(ctx context.Context, f *framework.Framewor
 		return e2edaemonset.CheckRunningOnAllNodes(ctx, f, &daemonSets.Items[0])
 	}
 
-	if err := wait.PollImmediate(5*time.Second, defaultTestTimeout, condition); err != nil {
+	if err := wait.PollUntilContextTimeout(context.Background(), 5*time.Second, defaultTestTimeout, true, condition); err != nil {
 		return fmt.Errorf("error waiting for kube-proxy DaemonSet running: %w", err)
 	}
 	return nil
@@ -198,7 +198,7 @@ func waitForKubeProxyDaemonSetRunning(ctx context.Context, f *framework.Framewor
 func waitForKubeProxyDaemonSetDisappear(ctx context.Context, c clientset.Interface) error {
 	framework.Logf("Waiting up to %v for kube-proxy DaemonSet disappear", defaultTestTimeout)
 
-	condition := func() (bool, error) {
+	condition := func(ctx context.Context) (bool, error) {
 		daemonSets, err := getKubeProxyDaemonSet(ctx, c)
 		if err != nil {
 			framework.Logf("Failed to get kube-proxy DaemonSet: %v", err)
@@ -212,7 +212,7 @@ func waitForKubeProxyDaemonSetDisappear(ctx context.Context, c clientset.Interfa
 		return true, nil
 	}
 
-	if err := wait.PollImmediate(5*time.Second, defaultTestTimeout, condition); err != nil {
+	if err := wait.PollUntilContextTimeout(context.Background(), 5*time.Second, defaultTestTimeout, true, condition); err != nil {
 		return fmt.Errorf("error waiting for kube-proxy DaemonSet disappear: %w", err)
 	}
 	return nil

--- a/test/images/agnhost/openidmetadata/openidmetadata.go
+++ b/test/images/agnhost/openidmetadata/openidmetadata.go
@@ -210,13 +210,14 @@ func ensureWindowsDNSAvailability(issuer string) error {
 		return err
 	}
 
-	return wait.PollImmediate(5*time.Second, 20*time.Second, func() (bool, error) {
-		ips, err := net.LookupHost(u.Host)
-		if err != nil {
-			log.Println(err)
-			return false, nil
-		}
-		log.Printf("OK: Resolved host %s: %v", u.Host, ips)
-		return true, nil
-	})
+	return wait.PollUntilContextTimeout(context.Background(), 5*time.Second, 20*time.Second, true,
+		func(ctx context.Context) (bool, error) {
+			ips, err := net.LookupHost(u.Host)
+			if err != nil {
+				log.Println(err)
+				return false, nil
+			}
+			log.Printf("OK: Resolved host %s: %v", u.Host, ips)
+			return true, nil
+		})
 }

--- a/test/integration/utils.go
+++ b/test/integration/utils.go
@@ -55,16 +55,17 @@ var (
 
 // WaitForPodToDisappear polls the API server if the pod has been deleted.
 func WaitForPodToDisappear(podClient coreclient.PodInterface, podName string, interval, timeout time.Duration) error {
-	return wait.PollImmediate(interval, timeout, func() (bool, error) {
-		_, err := podClient.Get(context.TODO(), podName, metav1.GetOptions{})
-		if err == nil {
-			return false, nil
-		}
-		if apierrors.IsNotFound(err) {
-			return true, nil
-		}
-		return false, err
-	})
+	return wait.PollUntilContextTimeout(context.Background(), interval, timeout, true,
+		func(ctx context.Context) (bool, error) {
+			_, err := podClient.Get(context.TODO(), podName, metav1.GetOptions{})
+			if err == nil {
+				return false, nil
+			}
+			if apierrors.IsNotFound(err) {
+				return true, nil
+			}
+			return false, err
+		})
 }
 
 // GetEtcdClients returns an initialized  clientv3.Client and clientv3.KV.


### PR DESCRIPTION
Looking forward to your feedback to continue with the rest of the updates.
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Refactor code to use `PollUntilContextTimeout` replacing deprecated `PolImmediate`.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

N/A

#### Special notes for your reviewer:

Completely updating all the deprecated `PollImmediate` to `PollUntilContextTimeout` is a big task. It took me quite a while, and I have changed about half of them.

However, I have noticed that the number of files modified in the current update is already quite substantial. If I were to continue with this update task, it might require modifying dozens more files, which could pose some difficulties for the review process. 
Therefore, I have decided to submit a PR now. The remaining update work can be completed in a separate PR later on.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
