### PR TITLE
[DO-NOT-MERGE] POC injecting feature gate under build tag

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/features/compatibility_test_features_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/features/compatibility_test_features_test.go
@@ -1,0 +1,16 @@
+//go:build compatibility_testing
+
+package features_test
+
+import (
+	"testing"
+
+	features "k8s.io/apiserver/pkg/features"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
+)
+
+func TestCompatibilityFeatures(t *testing.T) {
+	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.CompatibilityTestingAlphaFeature, true)()
+
+}

--- a/staging/src/k8s.io/apiserver/pkg/features/compatiility_test_features.go
+++ b/staging/src/k8s.io/apiserver/pkg/features/compatiility_test_features.go
@@ -1,0 +1,45 @@
+//go:build compatibility_testing
+
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package features
+
+import (
+	"k8s.io/apimachinery/pkg/util/runtime"
+
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/component-base/featuregate"
+)
+
+func init() {
+	runtime.Must(utilfeature.DefaultMutableFeatureGate.Add(compatibilitytestingKubernetesFeatureGates))
+}
+
+const (
+	CompatibilityTestingAlphaFeature featuregate.Feature = "CompatibilityTestingAlphaFeature"
+	CompatibilityTestingBetaFeature  featuregate.Feature = "CompatibilityTestingBetaFeature"
+	CompatibilityTestingGAFeature    featuregate.Feature = "CompatibilityTestingGAFeature"
+)
+
+// defaultKubernetesFeatureGates consists of all known Kubernetes-specific feature keys.
+// To add a new feature, define a key for it above and add it here. The features will be
+// available throughout Kubernetes binaries.
+var compatibilitytestingKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
+	CompatibilityTestingAlphaFeature: {Default: false, PreRelease: featuregate.Alpha},
+	CompatibilityTestingBetaFeature:  {Default: true, PreRelease: featuregate.Beta},
+	CompatibilityTestingGAFeature:    {Default: true, PreRelease: featuregate.GA},
+}


### PR DESCRIPTION
Proof of concept shows that a feature gate can be injected by adding a single file to the build directory. Manual testing of a build with no extra build tags gives the error for `--feature-gates` cli flag on APIServer:

```
Error: invalid argument "CompatibilityTestingAlphaFeature=true" for "--feature-gates" flag: unrecognized feature gate: CompatibilityTestingAlphaFeature
```


Building with `--tags=compatibility_testing` allows the server to startup, since the flag exists

The build tag should be added to any integration test files seeking to use the test features

/cc @jpbetz