### PR TITLE
Fix flaking test: CSI Mock workload info CSI PodInfoOnMount Update

### DIFF
--- a/test/e2e/storage/csi_mock/base.go
+++ b/test/e2e/storage/csi_mock/base.go
@@ -46,6 +46,7 @@ import (
 	storageframework "k8s.io/kubernetes/test/e2e/storage/framework"
 	"k8s.io/kubernetes/test/e2e/storage/testsuites"
 	"k8s.io/kubernetes/test/e2e/storage/utils"
+	"k8s.io/kubernetes/test/utils/format"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 )
 
@@ -702,63 +703,81 @@ func startPausePodWithSELinuxOptions(cs clientset.Interface, pvc *v1.PersistentV
 	return cs.CoreV1().Pods(ns).Create(context.TODO(), pod, metav1.CreateOptions{})
 }
 
-func checkPodLogs(ctx context.Context, getCalls func(ctx context.Context) ([]drivers.MockCSICall, error), pod *v1.Pod, expectPodInfo, ephemeralVolume, csiInlineVolumesEnabled, csiServiceAccountTokenEnabled bool, expectedNumNodePublish int) error {
+// checkNodePublishVolume goes through all calls to the mock driver and checks that at least one NodePublishVolume call had expected attributes.
+// If a matched call is found but it has unexpected attributes, checkNodePublishVolume skips it and continues searching.
+func checkNodePublishVolume(ctx context.Context, getCalls func(ctx context.Context) ([]drivers.MockCSICall, error), pod *v1.Pod, expectPodInfo, ephemeralVolume, csiInlineVolumesEnabled, csiServiceAccountTokenEnabled bool) error {
 	expectedAttributes := map[string]string{}
+	unexpectedAttributeKeys := sets.New[string]()
 	if expectPodInfo {
 		expectedAttributes["csi.storage.k8s.io/pod.name"] = pod.Name
 		expectedAttributes["csi.storage.k8s.io/pod.namespace"] = pod.Namespace
 		expectedAttributes["csi.storage.k8s.io/pod.uid"] = string(pod.UID)
 		expectedAttributes["csi.storage.k8s.io/serviceAccount.name"] = "default"
-
+	} else {
+		unexpectedAttributeKeys.Insert("csi.storage.k8s.io/pod.name")
+		unexpectedAttributeKeys.Insert("csi.storage.k8s.io/pod.namespace")
+		unexpectedAttributeKeys.Insert("csi.storage.k8s.io/pod.uid")
+		unexpectedAttributeKeys.Insert("csi.storage.k8s.io/serviceAccount.name")
 	}
 	if csiInlineVolumesEnabled {
 		// This is only passed in 1.15 when the CSIInlineVolume feature gate is set.
 		expectedAttributes["csi.storage.k8s.io/ephemeral"] = strconv.FormatBool(ephemeralVolume)
+	} else {
+		unexpectedAttributeKeys.Insert("csi.storage.k8s.io/ephemeral")
 	}
 
 	if csiServiceAccountTokenEnabled {
 		expectedAttributes["csi.storage.k8s.io/serviceAccount.tokens"] = "<nonempty>"
+	} else {
+		unexpectedAttributeKeys.Insert("csi.storage.k8s.io/serviceAccount.tokens")
 	}
 
-	// Find NodePublish in the GRPC calls.
-	foundAttributes := sets.NewString()
-	numNodePublishVolume := 0
-	numNodeUnpublishVolume := 0
 	calls, err := getCalls(ctx)
 	if err != nil {
 		return err
 	}
 
+	var volumeContexts []map[string]string
 	for _, call := range calls {
-		switch call.Method {
-		case "NodePublishVolume":
-			numNodePublishVolume++
-			if numNodePublishVolume == expectedNumNodePublish {
-				// Check that NodePublish had expected attributes for last of expected volume
-				for k, v := range expectedAttributes {
-					vv, found := call.Request.VolumeContext[k]
-					if found && (v == vv || (v == "<nonempty>" && len(vv) != 0)) {
-						foundAttributes.Insert(k)
-						framework.Logf("Found volume attribute %s: %s", k, vv)
-					}
-				}
-			}
-		case "NodeUnpublishVolume":
-			framework.Logf("Found NodeUnpublishVolume: %+v", call)
-			numNodeUnpublishVolume++
+		if call.Method != "NodePublishVolume" {
+			continue
 		}
-	}
-	if numNodePublishVolume < expectedNumNodePublish {
-		return fmt.Errorf("NodePublish should be called at least %d", expectedNumNodePublish)
+
+		volumeCtx := call.Request.VolumeContext
+
+		// Check that NodePublish had expected attributes
+		foundAttributes := sets.NewString()
+		for k, v := range expectedAttributes {
+			vv, found := volumeCtx[k]
+			if found && (v == vv || (v == "<nonempty>" && len(vv) != 0)) {
+				foundAttributes.Insert(k)
+			}
+		}
+		if foundAttributes.Len() != len(expectedAttributes) {
+			framework.Logf("Skipping the NodePublishVolume call: expected attribute %+v, got %+v", format.Object(expectedAttributes, 1), format.Object(volumeCtx, 1))
+			continue
+		}
+
+		// Check that NodePublish had no unexpected attributes
+		unexpectedAttributes := make(map[string]string)
+		for k := range volumeCtx {
+			if unexpectedAttributeKeys.Has(k) {
+				unexpectedAttributes[k] = volumeCtx[k]
+			}
+		}
+		if len(unexpectedAttributes) != 0 {
+			framework.Logf("Skipping the NodePublishVolume call because it contains unexpected attributes %+v", format.Object(unexpectedAttributes, 1))
+			continue
+		}
+
+		return nil
 	}
 
-	if numNodeUnpublishVolume == 0 {
-		return fmt.Errorf("NodeUnpublish was never called")
+	if len(volumeContexts) == 0 {
+		return fmt.Errorf("NodePublishVolume was never called")
 	}
-	if foundAttributes.Len() != len(expectedAttributes) {
-		return fmt.Errorf("number of found volume attributes does not match, expected %d, got %d", len(expectedAttributes), foundAttributes.Len())
-	}
-	return nil
+
+	return fmt.Errorf("NodePublishVolume was called %d times, but no call had expected attributes %s or calls have unwanted attributes key %+v", len(volumeContexts), format.Object(expectedAttributes, 1), unexpectedAttributeKeys.UnsortedList())
 }
 
 // createFSGroupRequestPreHook creates a hook that records the fsGroup passed in

--- a/test/e2e/storage/csi_mock/csi_service_account_token.go
+++ b/test/e2e/storage/csi_mock/csi_service_account_token.go
@@ -79,10 +79,8 @@ var _ = utils.SIGDescribe("CSI Mock volume service account token", func() {
 				framework.ExpectNoError(err, "Failed to start pod: %v", err)
 
 				// sleep to make sure RequiresRepublish triggers more than 1 NodePublishVolume
-				numNodePublishVolume := 1
 				if test.deployCSIDriverObject && csiServiceAccountTokenEnabled {
 					time.Sleep(5 * time.Second)
-					numNodePublishVolume = 2
 				}
 
 				ginkgo.By("Deleting the previously created pod")
@@ -90,7 +88,7 @@ var _ = utils.SIGDescribe("CSI Mock volume service account token", func() {
 				framework.ExpectNoError(err, "while deleting")
 
 				ginkgo.By("Checking CSI driver logs")
-				err = checkPodLogs(ctx, m.driver.GetCalls, pod, false, false, false, test.deployCSIDriverObject && csiServiceAccountTokenEnabled, numNodePublishVolume)
+				err = checkNodePublishVolume(ctx, m.driver.GetCalls, pod, false, false, false, test.deployCSIDriverObject && csiServiceAccountTokenEnabled)
 				framework.ExpectNoError(err)
 			})
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind failing-test
/kind flake

#### What this PR does / why we need it:

please see https://github.com/kubernetes/kubernetes/issues/122376#issuecomment-1884797879

test result:

```console
(⎈|kind-kind:N/A)➜  kubernetes git:(fix-122376) ✗ ginkgo --focus "CSI Mock workload info|CSI Mock volume service account token" -v test/e2e

Ran 9 of 7415 Specs in 380.930 seconds
SUCCESS! -- 9 Passed | 0 Failed | 0 Pending | 7406 Skipped
PASS
You're using deprecated Ginkgo functionality:
=============================================
  --ginkgo.slow-spec-threshold is deprecated --slow-spec-threshold has been deprecated and will be removed in a future version of Ginkgo.  This feature has proved to be more noisy than useful.  You can use --poll-progress-after, instead, to get more actionable feedback about potentially slow specs and understand where they might be getting stuck.
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #122376

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
