### PR TITLE
Kube codegen tool now ignore the vendor folder by default on code generation

### DIFF
--- a/staging/src/k8s.io/code-generator/kube_codegen.sh
+++ b/staging/src/k8s.io/code-generator/kube_codegen.sh
@@ -33,7 +33,7 @@ function kube::codegen::internal::git_find() {
 function kube::codegen::internal::git_grep() {
     # We want to include modified and untracked files because this might be
     # running against code which is not tracked by git yet.
-    git grep --untracked "$@"
+    git grep --untracked "$@" ":(exclude)vendor/"
 }
 
 # Generate tagged helper code: conversions, deepcopy, and defaults


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

During the client code generation, the vendor folder now could be ignored, passing the new flag --ignore-vendor

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Adds a rule on the kube_codegen tool to ignore vendor folder during the code generation.
```

The change is more for developers using the codegen tool, so I don't think it's necessary a release-note at all.
