### PR TITLE
fix version typo of pod namespace indexer

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -896,7 +896,7 @@ const (
 	UserNamespacesPodSecurityStandards featuregate.Feature = "UserNamespacesPodSecurityStandards"
 
 	// owner: @ahutsunshine
-	// beta: v1.29
+	// beta: v1.30
 	//
 	// Allows namespace indexer for namespace scope resources in apiserver cache to accelerate list operations.
 	StorageNamespaceIndex featuregate.Feature = "StorageNamespaceIndex"


### PR DESCRIPTION
What type of PR is this?
/kind documentation

What this PR does / why we need it:
Fix version document typo which is token in pod namespace indexer feature.

Which issue(s) this PR fixes:
https://github.com/kubernetes/kubernetes/pull/121906 