### PR TITLE
kubeadm: fix a regression in "kubeadm init" where --kubeconfig is ignored

### DIFF
--- a/cmd/kubeadm/app/cmd/init_test.go
+++ b/cmd/kubeadm/app/cmd/init_test.go
@@ -17,7 +17,10 @@ limitations under the License.
 package cmd
 
 import (
+	"context"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
@@ -53,6 +56,20 @@ apiVersion: %[1]s
 kind: ClusterConfiguration
 controlPlaneEndpoint: "3.4.5.6"
 `, kubeadmapiv1.SchemeGroupVersion.String(), expectedCRISocket)
+
+const testKubeconfigDataFormat = `---
+apiVersion: v1
+clusters:
+- name: foo-cluster
+  cluster:
+    server: %s
+contexts:
+- name: foo-context
+  context:
+    cluster: foo-cluster
+current-context: foo-context
+kind: Config
+`
 
 func TestNewInitData(t *testing.T) {
 	// create temp directory
@@ -347,5 +364,40 @@ func expectedInitIgnorePreflightErrors(expectedItems ...string) func(t *testing.
 		if !expected.HasAll(data.cfg.NodeRegistration.IgnorePreflightErrors...) {
 			t.Errorf("Invalid ignore preflight errors in InitConfiguration. Expected: %v. Actual: %v", sets.List(expected), data.cfg.NodeRegistration.IgnorePreflightErrors)
 		}
+	}
+}
+
+func TestInitDataClientWithNonDefaultKubeconfig(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodHead {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	defer ts.Close()
+
+	kubeconfigPath := filepath.Join(t.TempDir(), "custom.conf")
+	if err := os.WriteFile(kubeconfigPath, []byte(fmt.Sprintf(testKubeconfigDataFormat, ts.URL)), 0o600); err != nil {
+		t.Fatalf("os.WriteFile returned unexpected error: %v", err)
+	}
+
+	// initialize an external init option and inject it to the init cmd
+	initOptions := newInitOptions()
+	initOptions.skipCRIDetect = true // avoid CRI detection in unit tests
+	initOptions.kubeconfigPath = kubeconfigPath
+	cmd := newCmdInit(nil, initOptions)
+
+	data, err := newInitData(cmd, nil, initOptions, nil)
+	if err != nil {
+		t.Fatalf("newInitData returned unexpected error: %v", err)
+	}
+
+	client, err := data.Client()
+	if err != nil {
+		t.Fatalf("data.Client returned unexpected error: %v", err)
+	}
+
+	result := client.Discovery().RESTClient().Verb("HEAD").Do(context.Background())
+	if err := result.Error(); err != nil {
+		t.Fatalf("REST client request returned unexpected error: %v", err)
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind regression

#### What this PR does / why we need it:

Don't create admin rolebindings when `--kubeconfig` is set to a non-default value.
This allows `kubeadm init` to be invoked with a custom kubeconfig again.

#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes/kubeadm/issues/2992

#### Special notes for your reviewer:

I built and tested the kubeadm binary.

@neolit123 

#### Does this PR introduce a user-facing change?

```release-note
fixes a 1.29 regression in "kubeadm init" that caused a user-specified --kubeconfig file to be ignored.
```