### PR TITLE
Inject feature gate instance into client-go for kube components.

### DIFF
--- a/pkg/features/client_adapter.go
+++ b/pkg/features/client_adapter.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package features
+
+import (
+	"fmt"
+
+	clientfeatures "k8s.io/client-go/features"
+	"k8s.io/component-base/featuregate"
+)
+
+// clientAdapter adapts a k8s.io/component-base/featuregate.MutableFeatureGate to client-go's
+// feature Gate and Registry interfaces. The component-base types Feature, FeatureSpec, and
+// prerelease, and the component-base prerelease constants, are duplicated by parallel types and
+// constants in client-go. The parallel types exist to allow the feature gate mechanism to be used
+// for client-go features without introducing a circular dependency between component-base and
+// client-go.
+type clientAdapter struct {
+	mfg featuregate.MutableFeatureGate
+}
+
+var _ clientfeatures.Gates = &clientAdapter{}
+
+func (a *clientAdapter) Enabled(name clientfeatures.Feature) bool {
+	return a.mfg.Enabled(featuregate.Feature(name))
+}
+
+var _ clientfeatures.Registry = &clientAdapter{}
+
+func (a *clientAdapter) Add(in map[clientfeatures.Feature]clientfeatures.FeatureSpec) error {
+	out := map[featuregate.Feature]featuregate.FeatureSpec{}
+	for name, spec := range in {
+		converted := featuregate.FeatureSpec{
+			Default:       spec.Default,
+			LockToDefault: spec.LockToDefault,
+		}
+		switch spec.PreRelease {
+		case clientfeatures.Alpha:
+			converted.PreRelease = featuregate.Alpha
+		case clientfeatures.Beta:
+			converted.PreRelease = featuregate.Beta
+		case clientfeatures.GA:
+			converted.PreRelease = featuregate.GA
+		case clientfeatures.Deprecated:
+			converted.PreRelease = featuregate.Deprecated
+		default:
+			// The default case implies programmer error.  The same set of prerelease
+			// constants must exist in both component-base and client-go, and each one
+			// must have a case here.
+			panic(fmt.Sprintf("unrecognized prerelease %q of feature %q", spec.PreRelease, name))
+		}
+		out[featuregate.Feature(name)] = converted
+	}
+	return a.mfg.Add(out)
+}

--- a/pkg/features/client_adapter_test.go
+++ b/pkg/features/client_adapter_test.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package features
+
+import (
+	"testing"
+
+	clientfeatures "k8s.io/client-go/features"
+	"k8s.io/component-base/featuregate"
+)
+
+func TestClientAdapterEnabled(t *testing.T) {
+	fg := featuregate.NewFeatureGate()
+	if err := fg.Add(map[featuregate.Feature]featuregate.FeatureSpec{
+		"Foo": {Default: true},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	a := &clientAdapter{fg}
+	if !a.Enabled("Foo") {
+		t.Error("expected Enabled(\"Foo\") to return true")
+	}
+	var r interface{}
+	func() {
+		defer func() {
+			r = recover()
+		}()
+		a.Enabled("Bar")
+	}()
+	if r == nil {
+		t.Error("expected Enabled(\"Bar\") to panic due to unknown feature name")
+	}
+}
+
+func TestClientAdapterAdd(t *testing.T) {
+	fg := featuregate.NewFeatureGate()
+	a := &clientAdapter{fg}
+	defaults := fg.GetAll()
+	if err := a.Add(map[clientfeatures.Feature]clientfeatures.FeatureSpec{
+		"FeatureAlpha":      {PreRelease: clientfeatures.Alpha, Default: true},
+		"FeatureBeta":       {PreRelease: clientfeatures.Beta, Default: false},
+		"FeatureGA":         {PreRelease: clientfeatures.GA, Default: true, LockToDefault: true},
+		"FeatureDeprecated": {PreRelease: clientfeatures.Deprecated, Default: false, LockToDefault: true},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	all := fg.GetAll()
+	allexpected := map[featuregate.Feature]featuregate.FeatureSpec{
+		"FeatureAlpha":      {PreRelease: featuregate.Alpha, Default: true},
+		"FeatureBeta":       {PreRelease: featuregate.Beta, Default: false},
+		"FeatureGA":         {PreRelease: featuregate.GA, Default: true, LockToDefault: true},
+		"FeatureDeprecated": {PreRelease: featuregate.Deprecated, Default: false, LockToDefault: true},
+	}
+	for name, spec := range defaults {
+		allexpected[name] = spec
+	}
+	if len(all) != len(allexpected) {
+		t.Errorf("expected %d registered features, got %d", len(allexpected), len(all))
+	}
+	for name, expected := range allexpected {
+		actual, ok := all[name]
+		if !ok {
+			t.Errorf("expected feature %q not found", name)
+			continue
+		}
+
+		if actual != expected {
+			t.Errorf("expected feature %q spec %#v, got spec %#v", name, expected, actual)
+		}
+	}
+
+	var r interface{}
+	func() {
+		defer func() {
+			r = recover()
+		}()
+		_ = a.Add(map[clientfeatures.Feature]clientfeatures.FeatureSpec{
+			"FeatureAlpha": {PreRelease: "foobar"},
+		})
+	}()
+	if r == nil {
+		t.Error("expected panic when adding feature with unknown prerelease")
+	}
+}

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/runtime"
 	genericfeatures "k8s.io/apiserver/pkg/features"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	clientfeatures "k8s.io/client-go/features"
 	"k8s.io/component-base/featuregate"
 )
 
@@ -904,6 +905,15 @@ const (
 
 func init() {
 	runtime.Must(utilfeature.DefaultMutableFeatureGate.Add(defaultKubernetesFeatureGates))
+
+	// Register all client-go features with kube's feature gate instance and make all client-go
+	// feature checks use kube's instance. The effect is that for kube binaries, client-go
+	// features are wired to the existing --feature-gates flag just as all other features
+	// are. Further, client-go features automatically support the existing mechanisms for
+	// feature enablement metrics and test overrides.
+	ca := &clientAdapter{utilfeature.DefaultMutableFeatureGate}
+	runtime.Must(clientfeatures.AddFeaturesToExistingFeatureGates(ca))
+	clientfeatures.ReplaceFeatureGates(ca)
 }
 
 // defaultKubernetesFeatureGates consists of all known Kubernetes-specific feature keys.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1688,6 +1688,7 @@ k8s.io/client-go/dynamic
 k8s.io/client-go/dynamic/dynamicinformer
 k8s.io/client-go/dynamic/dynamiclister
 k8s.io/client-go/dynamic/fake
+k8s.io/client-go/features
 k8s.io/client-go/informers
 k8s.io/client-go/informers/admissionregistration
 k8s.io/client-go/informers/admissionregistration/v1


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature
/sig api-machinery

#### What this PR does / why we need it:

Registers all client-go features with the DefaultFeatureGate instance and wires client-go to perform feature checks using the same instance used for kube feature checks. For kube components, this means that client features will be exposed in the existing `--feature-gates` flag.

In order to avoid a dependency cycle between component-base and client-go, client-go maintains parallel definitions of component-base's feature types and constants. Passing kube's default feature gate instance to client-go requires an adapter.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [Proposal]: https://docs.google.com/document/d/1g9BGCRw-7ucUxO6OtCWbb3lfzUGA_uU9178wLdXAIfs/edit#heading=h.ookhkzz1jrsp
```
