### PR TITLE
kube-proxy: clear blackholing conntrack entry more precisely

### DIFF
--- a/pkg/proxy/conntrack/conntrack_test.go
+++ b/pkg/proxy/conntrack/conntrack_test.go
@@ -164,11 +164,11 @@ func TestClearUDPConntrackForPort(t *testing.T) {
 	}
 	svcCount := 0
 	for _, tc := range testCases {
-		err := ClearEntriesForPort(fexec, tc.port, tc.isIPv6, v1.ProtocolUDP)
+		err := ClearEntriesForPortNoNAT(fexec, tc.port, tc.isIPv6, v1.ProtocolUDP)
 		if err != nil {
 			t.Errorf("%s test case: Unexpected error: %v", tc.name, err)
 		}
-		expectCommand := fmt.Sprintf("conntrack -D -p udp --dport %d", tc.port) + familyParamStr(tc.isIPv6)
+		expectCommand := fmt.Sprintf("conntrack -D -p udp --dport %d --reply-port-src %d", tc.port, tc.port) + familyParamStr(tc.isIPv6)
 		execCommand := strings.Join(fcmd.CombinedOutputLog[svcCount], " ")
 		if expectCommand != execCommand {
 			t.Errorf("%s test case: Expect command: %s, but executed %s", tc.name, expectCommand, execCommand)

--- a/pkg/proxy/iptables/proxier_test.go
+++ b/pkg/proxy/iptables/proxier_test.go
@@ -237,7 +237,7 @@ func TestDeleteEndpointConnections(t *testing.T) {
 
 				// First clear conntrack entries for the clusterIP when the
 				// endpoint is first added.
-				expectCommand := fmt.Sprintf("conntrack -D --orig-dst %s -p udp", tc.svcIP)
+				expectCommand := fmt.Sprintf("conntrack -D --orig-dst %s --reply-src %s -p udp", tc.svcIP, tc.svcIP)
 				if isIPv6 {
 					expectCommand += " -f ipv6"
 				}
@@ -4448,13 +4448,13 @@ func TestProxierDeleteNodePortStaleUDP(t *testing.T) {
 	// the order is not guaranteed so we have to compare the strings in any order
 	expectedCommands := []string{
 		// Delete ClusterIP Conntrack entries
-		fmt.Sprintf("conntrack -D --orig-dst %s -p %s", svcIP, strings.ToLower(string((v1.ProtocolUDP)))),
+		fmt.Sprintf("conntrack -D --orig-dst %s --reply-src %s -p %s", svcIP, svcIP, strings.ToLower(string((v1.ProtocolUDP)))),
 		// Delete ExternalIP Conntrack entries
-		fmt.Sprintf("conntrack -D --orig-dst %s -p %s", extIP, strings.ToLower(string((v1.ProtocolUDP)))),
+		fmt.Sprintf("conntrack -D --orig-dst %s --reply-src %s -p %s", extIP, extIP, strings.ToLower(string((v1.ProtocolUDP)))),
 		// Delete LoadBalancerIP Conntrack entries
-		fmt.Sprintf("conntrack -D --orig-dst %s -p %s", lbIngressIP, strings.ToLower(string((v1.ProtocolUDP)))),
+		fmt.Sprintf("conntrack -D --orig-dst %s --reply-src %s -p %s", lbIngressIP, lbIngressIP, strings.ToLower(string((v1.ProtocolUDP)))),
 		// Delete NodePort Conntrack entrie
-		fmt.Sprintf("conntrack -D -p %s --dport %d", strings.ToLower(string((v1.ProtocolUDP))), nodePort),
+		fmt.Sprintf("conntrack -D -p %s --dport %d --reply-port-src %d", strings.ToLower(string((v1.ProtocolUDP))), nodePort, nodePort),
 	}
 	actualCommands := []string{
 		strings.Join(fcmd.CombinedOutputLog[0], " "),

--- a/pkg/proxy/nftables/proxier_test.go
+++ b/pkg/proxy/nftables/proxier_test.go
@@ -221,7 +221,7 @@ func TestDeleteEndpointConnections(t *testing.T) {
 
 				// First clear conntrack entries for the clusterIP when the
 				// endpoint is first added.
-				expectCommand := fmt.Sprintf("conntrack -D --orig-dst %s -p udp", tc.svcIP)
+				expectCommand := fmt.Sprintf("conntrack -D --orig-dst %s --reply-src %s -p udp", tc.svcIP, tc.svcIP)
 				if fp.ipFamily == v1.IPv6Protocol {
 					expectCommand += " -f ipv6"
 				}
@@ -2867,13 +2867,13 @@ func TestProxierDeleteNodePortStaleUDP(t *testing.T) {
 	// the order is not guaranteed so we have to compare the strings in any order
 	expectedCommands := []string{
 		// Delete ClusterIP Conntrack entries
-		fmt.Sprintf("conntrack -D --orig-dst %s -p %s", svcIP, strings.ToLower(string((v1.ProtocolUDP)))),
+		fmt.Sprintf("conntrack -D --orig-dst %s --reply-src %s -p %s", svcIP, svcIP, strings.ToLower(string((v1.ProtocolUDP)))),
 		// Delete ExternalIP Conntrack entries
-		fmt.Sprintf("conntrack -D --orig-dst %s -p %s", extIP, strings.ToLower(string((v1.ProtocolUDP)))),
+		fmt.Sprintf("conntrack -D --orig-dst %s --reply-src %s -p %s", extIP, extIP, strings.ToLower(string((v1.ProtocolUDP)))),
 		// Delete LoadBalancerIP Conntrack entries
-		fmt.Sprintf("conntrack -D --orig-dst %s -p %s", lbIngressIP, strings.ToLower(string((v1.ProtocolUDP)))),
+		fmt.Sprintf("conntrack -D --orig-dst %s --reply-src %s -p %s", lbIngressIP, lbIngressIP, strings.ToLower(string((v1.ProtocolUDP)))),
 		// Delete NodePort Conntrack entrie
-		fmt.Sprintf("conntrack -D -p %s --dport %d", strings.ToLower(string((v1.ProtocolUDP))), nodePort),
+		fmt.Sprintf("conntrack -D -p %s --dport %d --reply-port-src %d", strings.ToLower(string((v1.ProtocolUDP))), nodePort, nodePort),
 	}
 	actualCommands := []string{
 		strings.Join(fcmd.CombinedOutputLog[0], " "),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When kube-proxy restarts, in the first sync, all services will be treated as newly active services, all UDP conntrack entries of services were deleted unnecessarily, which may disrupt connections for some protocols built on UDP, e.g. QUIC.

The actual blackholing conntrack entry should be the ones with no destination IP translation. The commit makes sure it doesn't delete service connections established with endpoints by limiting the reply source address to service IP or the reply source port to NodePort.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #122740

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kube-proxy: fixed UDP connections of Services not preserved after restarting kube-proxy
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
