### PR TITLE
Add process_start_time_seconds to metrics/slis endpoint for all components

### DIFF
--- a/staging/src/k8s.io/component-base/metrics/prometheus/slis/metrics.go
+++ b/staging/src/k8s.io/component-base/metrics/prometheus/slis/metrics.go
@@ -55,6 +55,7 @@ var (
 func Register(registry k8smetrics.KubeRegistry) {
 	registry.Register(healthcheck)
 	registry.Register(healthchecksTotal)
+	_ = k8smetrics.RegisterProcessStartTime(registry.Register)
 }
 
 func ResetHealthMetrics() {


### PR DESCRIPTION
Fixes #122520

#### Special notes for your reviewer:


```release-note
Add process_start_time_seconds to /metrics/slis endpoint of all components
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
# HELP process_start_time_seconds [ALPHA] Start time of the process since unix epoch in seconds.
# TYPE process_start_time_seconds gauge
process_start_time_seconds 1.70509226673e+09

```
