### PR TITLE
WIP: e2e: restrict permitted images to known images list

### DIFF
--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -45,6 +45,7 @@ import (
 	"k8s.io/klog/v2"
 
 	"k8s.io/kubernetes/test/e2e/framework/internal/junit"
+	"k8s.io/kubernetes/test/images"
 	"k8s.io/kubernetes/test/utils/image"
 	"k8s.io/kubernetes/test/utils/kubeconfig"
 )
@@ -500,6 +501,17 @@ func AfterReadingAllFlags(t *TestContextType) {
 	fs.Set("stderrthreshold", "10" /* higher than any of the severities -> none pass the threshold */)
 	klog.SetOutput(ginkgo.GinkgoWriter)
 
+	var usedImages []string
+	for _, v := range image.GetImageConfigs() {
+		usedImages = append(usedImages, v.GetE2EImage())
+	}
+	if err := images.VerifyImages(usedImages...); err != nil {
+		RecordBug(Bug{
+			FileName:   err.File,
+			LineNumber: err.Line,
+			Message:    err.Error(),
+		})
+	}
 	if t.ListImages {
 		for _, v := range image.GetImageConfigs() {
 			fmt.Println(v.GetE2EImage())

--- a/test/images/permitted.go
+++ b/test/images/permitted.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package images
+
+import (
+	"errors"
+	"fmt"
+	"runtime"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+// NOTE: Please do NOT add any to this list!!
+//
+// We are aiming to consolidate on: registry.k8s.io/e2e-test-images/agnhost
+// The sources for which are in test/images/agnhost.
+// If agnhost is missing functionality for your tests, please reach out to SIG Testing.
+var _, file, line, _ = runtime.Caller(0)
+var PermittedImages = sets.New(
+	"gcr.io/authenticated-image-pulling/alpine",
+	"gcr.io/authenticated-image-pulling/windows-nanoserver",
+	"gcr.io/k8s-authenticated-test/agnhost",
+	"invalid.registry.k8s.io/invalid/alpine",
+	"registry.k8s.io/build-image/distroless-iptables",
+	"registry.k8s.io/cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver",
+	"registry.k8s.io/e2e-test-images/agnhost",
+	"registry.k8s.io/e2e-test-images/apparmor-loader",
+	"registry.k8s.io/e2e-test-images/busybox",
+	"registry.k8s.io/e2e-test-images/cuda-vector-add",
+	"registry.k8s.io/e2e-test-images/httpd",
+	"registry.k8s.io/e2e-test-images/ipc-utils",
+	"registry.k8s.io/e2e-test-images/jessie-dnsutils",
+	"registry.k8s.io/e2e-test-images/kitten",
+	"registry.k8s.io/e2e-test-images/nautilus",
+	"registry.k8s.io/e2e-test-images/nginx",
+	"registry.k8s.io/e2e-test-images/node-perf/npb-ep",
+	"registry.k8s.io/e2e-test-images/node-perf/npb-is",
+	"registry.k8s.io/e2e-test-images/node-perf/tf-wide-deep",
+	"registry.k8s.io/e2e-test-images/nonewprivs",
+	"registry.k8s.io/e2e-test-images/nonroot",
+	"registry.k8s.io/e2e-test-images/perl",
+	"registry.k8s.io/e2e-test-images/redis",
+	"registry.k8s.io/e2e-test-images/regression-issue-74839",
+	"registry.k8s.io/e2e-test-images/resource-consumer",
+	"registry.k8s.io/e2e-test-images/sample-apiserver",
+	"registry.k8s.io/e2e-test-images/volume/iscsi",
+	"registry.k8s.io/e2e-test-images/volume/nfs",
+	"registry.k8s.io/e2e-test-images/volume/rbd",
+	"registry.k8s.io/etcd",
+	"registry.k8s.io/pause",
+	"registry.k8s.io/prometheus-dummy-exporter",
+	"registry.k8s.io/prometheus-to-sd",
+	"registry.k8s.io/sd-dummy-exporter",
+	"registry.k8s.io/sig-storage/csi-attacher",
+	"registry.k8s.io/sig-storage/csi-external-health-monitor-controller",
+	"registry.k8s.io/sig-storage/csi-node-driver-registrar",
+	"registry.k8s.io/sig-storage/csi-provisioner",
+	"registry.k8s.io/sig-storage/csi-resizer",
+	"registry.k8s.io/sig-storage/csi-snapshotter",
+	"registry.k8s.io/sig-storage/hello-populator",
+	"registry.k8s.io/sig-storage/hostpathplugin",
+	"registry.k8s.io/sig-storage/livenessprobe",
+	"registry.k8s.io/sig-storage/nfs-provisioner",
+	"registry.k8s.io/sig-storage/volume-data-source-validator",
+)
+
+func VerifyImages(images ...string) *ImageError {
+	var errs []error
+
+	for _, image := range images {
+		baseImage := strings.Split(image, ":")[0]
+		if !PermittedImages.Has(baseImage) {
+			errs = append(errs, fmt.Errorf("usage of base image %s from %s is not permitted", baseImage, image))
+		}
+	}
+	if len(errs) > 0 {
+		return &ImageError{
+			error: errors.Join(errs...),
+			File:  file,
+			Line:  line,
+		}
+	}
+
+	// TODO: generate error when PermittedImages contains unused entries.
+
+	return nil
+}
+
+// ImageError is an error with source code information.
+type ImageError struct {
+	error
+	File string
+	Line int
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:

Allows tag bumps, but prevents adding new images to e2e without test/images approval. Adds a pointer to agnhost as preferred before adding new images.

This gets checked for each invocation of an E2E suite, so developers get immediate feedback when adding a new test with an image that is not permitted.

When one image is intentionally not listed, it fails like this:

    $ hack/verify-e2e-suites.sh
    ERROR: E2E test suite invocation failed for test/e2e.
        ERROR: E2E suite initialization was faulty, these errors must be fixed:
        ERROR: test/images/permitted.go:33: usage of base image registry.k8s.io/sig-storage/livenessprobe from registry.k8s.io/sig-storage/livenessprobe:v2.7.0 is not permitted
    [same for the other suites]
    
    $ _output/bin/ginkgo -focus=foobar ./test/e2e
    ERROR: E2E suite initialization was faulty, these errors must be fixed:
    ERROR: ../images/permitted.go:33: usage of base image registry.k8s.io/sig-storage/livenessprobe from registry.k8s.io/sig-storage/livenessprobe:v2.7.0 is not permitted
    
     Ginkgo ran 1 suite in 12.866638777s
     
     Test Suite Failed

#### Special notes for your reviewer:

This is an alternative for https://github.com/kubernetes/kubernetes/pull/122751

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/cc @dims @aojea @BenTheElder 