### PR TITLE
Fix evented pleg mirror pod

### DIFF
--- a/pkg/kubelet/container/helpers.go
+++ b/pkg/kubelet/container/helpers.go
@@ -91,6 +91,7 @@ func ShouldContainerBeRestarted(container *v1.Container, pod *v1.Pod, podStatus 
 		return true
 	}
 	if status.State == ContainerStateCreated {
+		klog.V(4).InfoS("Container state is Created, and it will be decided whether to restart based on the specific situation.", "pod", klog.KObj(pod), "containerName", container.Name, "restartOnCreatedState", restartOnCreatedState)
 		// we don't retart the container directly as the CREATED event will always be triggered
 		// but for next syncpod, we should handle the containers failed to be started which is in CREATED state.
 		return restartOnCreatedState

--- a/pkg/kubelet/container/helpers_test.go
+++ b/pkg/kubelet/container/helpers_test.go
@@ -460,7 +460,7 @@ func TestShouldContainerBeRestarted(t *testing.T) {
 		for i, policy := range policies {
 			pod.Spec.RestartPolicy = policy
 			e := expected[c.Name][i]
-			r := ShouldContainerBeRestarted(&c, pod, podStatus)
+			r := ShouldContainerBeRestarted(&c, pod, podStatus, true)
 			if r != e {
 				t.Errorf("Restart for container %q with restart policy %q expected %t, got %t",
 					c.Name, policy, e, r)
@@ -481,7 +481,7 @@ func TestShouldContainerBeRestarted(t *testing.T) {
 		for i, policy := range policies {
 			pod.Spec.RestartPolicy = policy
 			e := expected[c.Name][i]
-			r := ShouldContainerBeRestarted(&c, pod, podStatus)
+			r := ShouldContainerBeRestarted(&c, pod, podStatus, true)
 			if r != e {
 				t.Errorf("Restart for container %q with restart policy %q expected %t, got %t",
 					c.Name, policy, e, r)

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -2169,7 +2169,7 @@ func (kl *Kubelet) convertToAPIContainerStatuses(pod *v1.Pod, podStatus *kubecon
 			}
 		}
 		// If a container should be restarted in next syncpod, it is *Waiting*.
-		if !kubecontainer.ShouldContainerBeRestarted(&container, pod, podStatus) {
+		if !kubecontainer.ShouldContainerBeRestarted(&container, pod, podStatus, true) {
 			continue
 		}
 		status := statuses[container.Name]

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -954,8 +954,8 @@ func (m *kubeGenericRuntimeManager) computePodActions(ctx context.Context, pod *
 
 		// Call internal container post-stop lifecycle hook for any non-running container so that any
 		// allocated cpus are released immediately. If the container is restarted, cpus will be re-allocated
-		// to it.
-		if containerStatus != nil && containerStatus.State != kubecontainer.ContainerStateRunning {
+		// to it. Don't remove/stop CREATED container.
+		if containerStatus != nil && containerStatus.State != kubecontainer.ContainerStateRunning && containerStatus.State != kubecontainer.ContainerStateCreated {
 			if err := m.internalLifecycle.PostStopContainer(containerStatus.ID.ID); err != nil {
 				klog.ErrorS(err, "Internal container post-stop lifecycle hook failed for container in pod with error",
 					"containerName", container.Name, "pod", klog.KObj(pod))
@@ -965,7 +965,7 @@ func (m *kubeGenericRuntimeManager) computePodActions(ctx context.Context, pod *
 		// If container does not exist, or is not running, check whether we
 		// need to restart it.
 		if containerStatus == nil || containerStatus.State != kubecontainer.ContainerStateRunning {
-			if kubecontainer.ShouldContainerBeRestarted(&container, pod, podStatus) {
+			if kubecontainer.ShouldContainerBeRestarted(&container, pod, podStatus, false) {
 				klog.V(3).InfoS("Container of pod is not in the desired state and shall be started", "containerName", container.Name, "pod", klog.KObj(pod))
 				changes.ContainersToStart = append(changes.ContainersToStart, idx)
 				if containerStatus != nil && containerStatus.State == kubecontainer.ContainerStateUnknown {
@@ -980,6 +980,9 @@ func (m *kubeGenericRuntimeManager) computePodActions(ctx context.Context, pod *
 						reason: reasonUnknown,
 					}
 				}
+			} else if containerStatus.State == kubecontainer.ContainerStateCreated {
+				// keep CREATED container
+				keepCount++
 			}
 			continue
 		}

--- a/pkg/kubelet/kuberuntime/kuberuntime_termination_order.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_termination_order.go
@@ -17,6 +17,7 @@ limitations under the License.
 package kuberuntime
 
 import (
+	"sync"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -34,6 +35,8 @@ type terminationOrdering struct {
 	// prereqs is a map from container name to a list of channel that the container
 	// must wait on to ensure termination ordering
 	prereqs map[string][]chan struct{}
+
+	lock sync.Mutex
 }
 
 // newTerminationOrdering constructs a terminationOrdering based on the pod spec and the currently running containers.
@@ -108,7 +111,10 @@ func (o *terminationOrdering) waitForTurn(name string, gracePeriod int64) float6
 
 // containerTerminated should be called once the container with the speecified name has exited.
 func (o *terminationOrdering) containerTerminated(name string) {
+	o.lock.Lock()
+	defer o.lock.Unlock()
 	if ch, ok := o.terminated[name]; ok {
 		close(ch)
+		delete(o.terminated, name)
 	}
 }

--- a/test/e2e/common/node/init_container.go
+++ b/test/e2e/common/node/init_container.go
@@ -530,7 +530,7 @@ var _ = SIGDescribe("InitContainer", framework.WithNodeConformance(), func() {
 						}
 						status := t.Status.InitContainerStatuses[0]
 						if status.State.Terminated == nil {
-							if status.State.Waiting != nil && status.State.Waiting.Reason != "PodInitializing" {
+							if status.State.Waiting != nil && status.State.Waiting.Reason != "" && status.State.Waiting.Reason != "PodInitializing" {
 								return false, fmt.Errorf("second init container should have reason PodInitializing: %s", toDebugJSON(status))
 							}
 							return false, nil


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
kind regression ?

- https://github.com/kubernetes/enhancements/issues/3386

This fix is following #122124  and there are some discussions in #122124  and https://kubernetes.slack.com/archives/C09QZ4DQB/p1704957019603369?thread_ts=1704859442.079249&cid=C09QZ4DQB on slack, and then we revert it to alpha in  #122697. 

#### What this PR does / why we need it:
- [ ] TODO, this should be cherry-picked to releases before as well
- [ ] revert https://github.com/kubernetes/test-infra/pull/31647 to enable evented pleg in those presubmittion CIs.

#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes/kubernetes/issues/123087
- original https://github.com/kubernetes/kubernetes/issues/122721

#### Special notes for your reviewer:

try to avoid using the FG in the fix like #122124 
1.  https://github.com/kubernetes/kubernetes/pull/122763/commits/4397f1ed8fcb14a85356dea51a95e9c7209249f6 key part of the fix, for handling `ContainerCreatedState`: with evented pleg, kubelet can catche the middle state after container is created and before container is started, the container is in `Created` state. For generic PLEG, a Created State always means the container cannot be started, so Generic Container will start a new one when this happens. 
2. https://github.com/kubernetes/kubernetes/pull/122763/commits/55cf7fef8e9080694740ea90ee80673a09aea1e6 fixed a panic of close channel in CI (newly found)
3. https://github.com/kubernetes/kubernetes/pull/122763/commits/f6baea531560b19be72fad8f7c4c2b1dc7848151 fix a flake in initcontainers after enabling EventedPLEG. Flake in https://prow.k8s.io/job-history/gs/kubernetes-jenkins/logs/ci-crio-cgroupv1-evented-pleg.
4. https://github.com/kubernetes/kubernetes/pull/122763/commits/04b11efca2f69b30ebfbb3b1042f74f8faf8c25c Add a log for debugging.

#### Does this PR introduce a user-facing change?

```release-note
Fix Evented PLEG bug when starting static pods: multi containers will be created for a container
```

Current Problems with this PR:
- [ ] https://github.com/kubernetes/kubernetes/pull/122763#issuecomment-1890913659 `Kubernetes e2e suite: [It] [sig-node] Probing container should mark readiness on pods to false and disable liveness probes while pod is in progress of terminating`
- [x] Failure: https://github.com/kubernetes/kubernetes/pull/122763#issuecomment-1890952433 in https://prow.k8s.io/pr-history/?org=kubernetes&repo=kubernetes&pr=122778, all run are passed. I fixed it.