### PR TITLE
Type=notify in kubelet.service

### DIFF
--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -1656,6 +1656,7 @@ Requires=network-online.target
 After=network-online.target
 
 [Service]
+Type=notify
 Restart=always
 RestartSec=10
 EnvironmentFile=${kubelet_env_file}


### PR DESCRIPTION

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Using `Type=notify` is more precisely indicating `kubelet`'s start progress compared to the default (see [doc](https://www.freedesktop.org/software/systemd/man/latest/systemd.service.html#Options))

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

After https://github.com/kubernetes/kubernetes/pull/60654, kubelet did support notifying systemd with its startup signal

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
