### PR TITLE
codegen: don't use xargs w/ maybe-empty input

### DIFF
--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -107,7 +107,7 @@ function codegen::protobuf() {
             -e '// +k8s:protobuf-gen=package' \
             -- \
             cmd pkg staging \
-            | xargs -0 -n1 dirname \
+            | while read -r -d $'\0' F; do dirname "${F}"; done \
             | sed 's|^|k8s.io/kubernetes/|;s|k8s.io/kubernetes/staging/src/||' \
             | sort -u)
 
@@ -161,7 +161,7 @@ function codegen::deepcopy() {
     local tag_dirs=()
     kube::util::read-array tag_dirs < <( \
         grep -l --null '+k8s:deepcopy-gen=' "${ALL_K8S_TAG_FILES[@]}" \
-            | xargs -0 -n1 dirname \
+            | while read -r -d $'\0' F; do dirname "${F}"; done \
             | sort -u)
     if [[ "${DBG_CODEGEN}" == 1 ]]; then
         kube::log::status "DBG: found ${#tag_dirs[@]} +k8s:deepcopy-gen tagged dirs"
@@ -294,7 +294,7 @@ function codegen::prerelease() {
     local tag_dirs=()
     kube::util::read-array tag_dirs < <( \
         grep -l --null '+k8s:prerelease-lifecycle-gen=true' "${ALL_K8S_TAG_FILES[@]}" \
-            | xargs -0 -n1 dirname \
+            | while read -r -d $'\0' F; do dirname "${F}"; done \
             | sort -u)
     if [[ "${DBG_CODEGEN}" == 1 ]]; then
         kube::log::status "DBG: found ${#tag_dirs[@]} +k8s:prerelease-lifecycle-gen tagged dirs"
@@ -363,7 +363,7 @@ function codegen::defaults() {
     local tag_dirs=()
     kube::util::read-array tag_dirs < <( \
         grep -l --null '+k8s:defaulter-gen=' "${ALL_K8S_TAG_FILES[@]}" \
-            | xargs -0 -n1 dirname \
+            | while read -r -d $'\0' F; do dirname "${F}"; done \
             | sort -u)
     if [[ "${DBG_CODEGEN}" == 1 ]]; then
         kube::log::status "DBG: found ${#tag_dirs[@]} +k8s:defaulter-gen tagged dirs"
@@ -438,7 +438,7 @@ function codegen::conversions() {
     local tag_dirs=()
     kube::util::read-array tag_dirs < <(\
         grep -l --null '^// *+k8s:conversion-gen=' "${ALL_K8S_TAG_FILES[@]}" \
-            | xargs -0 -n1 dirname \
+            | while read -r -d $'\0' F; do dirname "${F}"; done \
             | sort -u)
     if [[ "${DBG_CODEGEN}" == 1 ]]; then
         kube::log::status "DBG: found ${#tag_dirs[@]} +k8s:conversion-gen tagged dirs"
@@ -539,7 +539,7 @@ function codegen::openapi() {
     local tag_dirs=()
     kube::util::read-array tag_dirs < <(
         grep -l --null '+k8s:openapi-gen=' "${tag_files[@]}" \
-            | xargs -0 -n1 dirname \
+            | while read -r -d $'\0' F; do dirname "${F}"; done \
             | sort -u)
 
     if [[ "${DBG_CODEGEN}" == 1 ]]; then
@@ -598,7 +598,7 @@ function codegen::applyconfigs() {
     kube::util::read-array ext_apis < <(
         cd "${KUBE_ROOT}/staging/src"
         git_find -z ':(glob)k8s.io/api/**/types.go' \
-            | xargs -0 -n1 dirname \
+            | while read -r -d $'\0' F; do dirname "${F}"; done \
             | sort -u)
     ext_apis+=("k8s.io/apimachinery/pkg/apis/meta/v1")
 
@@ -696,7 +696,7 @@ function codegen::listers() {
     kube::util::read-array ext_apis < <(
         cd "${KUBE_ROOT}/staging/src"
         git_find -z ':(glob)k8s.io/api/**/types.go' \
-            | xargs -0 -n1 dirname \
+            | while read -r -d $'\0' F; do dirname "${F}"; done \
             | sort -u)
 
     kube::log::status "Generating lister code for ${#ext_apis[@]} targets"
@@ -737,7 +737,7 @@ function codegen::informers() {
     kube::util::read-array ext_apis < <(
         cd "${KUBE_ROOT}/staging/src"
         git_find -z ':(glob)k8s.io/api/**/types.go' \
-            | xargs -0 -n1 dirname \
+            | while read -r -d $'\0' F; do dirname "${F}"; done \
             | sort -u)
 
     kube::log::status "Generating informer code for ${#ext_apis[@]} targets"

--- a/staging/src/k8s.io/code-generator/kube_codegen.sh
+++ b/staging/src/k8s.io/code-generator/kube_codegen.sh
@@ -126,7 +126,7 @@ function kube::codegen::gen_helpers() {
             -e '+k8s:deepcopy-gen=' \
             ":(glob)${root}"/'**/*.go' \
             || true \
-        ) | xargs -0 -n1 dirname \
+        ) | while read -r -d $'\0' F; do dirname "${F}"; done \
           | LC_ALL=C sort -u
     )
 
@@ -160,7 +160,7 @@ function kube::codegen::gen_helpers() {
             -e '+k8s:defaulter-gen=' \
             ":(glob)${root}"/'**/*.go' \
             || true \
-        ) | xargs -0 -n1 dirname \
+        ) | while read -r -d $'\0' F; do dirname "${F}"; done \
           | LC_ALL=C sort -u
     )
 
@@ -194,7 +194,7 @@ function kube::codegen::gen_helpers() {
             -e '+k8s:conversion-gen=' \
             ":(glob)${root}"/'**/*.go' \
             || true \
-        ) | xargs -0 -n1 dirname \
+        ) | while read -r -d $'\0' F; do dirname "${F}"; done \
           | LC_ALL=C sort -u
     )
 
@@ -355,7 +355,7 @@ function kube::codegen::gen_openapi() {
             -e '+k8s:openapi-gen=' \
             ":(glob)${root}"/'**/*.go' \
             || true \
-        ) | xargs -0 -n1 dirname \
+        ) | while read -r -d $'\0' F; do dirname "${F}"; done \
           | LC_ALL=C sort -u
     )
 
@@ -563,7 +563,7 @@ function kube::codegen::gen_client() {
             -e '+genclient' \
             ":(glob)${in_root}${one_input_api}"/'**/*.go' \
             || true \
-        ) | xargs -0 -n1 dirname \
+        ) | while read -r -d $'\0' F; do dirname "${F}"; done \
           | LC_ALL=C sort -u
     )
 


### PR DESCRIPTION
GNU xargs has a `-r, --no-run-if-empty` option but I don't think we want to depend on GNU (thanks, MacOS).

Why?  Sometimes, when you are messing with codegens, you end up with an empty input and then it just hangs.

/kind cleanup
/sig architecture
/sig api-machinery


```release-note
NONE
```
