### PR TITLE
codegen: Use long flag names for clarity

### DIFF
--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -185,8 +185,8 @@ function codegen::deepcopy() {
     ./hack/run-in-gopath.sh "${gen_deepcopy_bin}" \
         --v "${KUBE_VERBOSE}" \
         --logtostderr \
-        -h "${BOILERPLATE_FILENAME}" \
-        -O "${output_file}" \
+        --go-header-file "${BOILERPLATE_FILENAME}" \
+        --output-file-base "${output_file}" \
         --bounding-dirs "${PRJ_SRC_PATH},k8s.io/api" \
         $(printf -- " -i %s" "${tag_pkgs[@]}") \
         "$@"
@@ -318,8 +318,8 @@ function codegen::prerelease() {
     ./hack/run-in-gopath.sh "${gen_prerelease_bin}" \
         --v "${KUBE_VERBOSE}" \
         --logtostderr \
-        -h "${BOILERPLATE_FILENAME}" \
-        -O "${output_file}" \
+        --go-header-file "${BOILERPLATE_FILENAME}" \
+        --output-file-base "${output_file}" \
         $(printf -- " -i %s" "${tag_pkgs[@]}") \
         "$@"
 
@@ -387,8 +387,8 @@ function codegen::defaults() {
     ./hack/run-in-gopath.sh "${gen_defaulter_bin}" \
         --v "${KUBE_VERBOSE}" \
         --logtostderr \
-        -h "${BOILERPLATE_FILENAME}" \
-        -O "${output_file}" \
+        --go-header-file "${BOILERPLATE_FILENAME}" \
+        --output-file-base "${output_file}" \
         $(printf -- " --extra-peer-dirs %s" "${tag_pkgs[@]}") \
         $(printf -- " -i %s" "${tag_pkgs[@]}") \
         "$@"
@@ -468,8 +468,8 @@ function codegen::conversions() {
     ./hack/run-in-gopath.sh "${gen_conversion_bin}" \
         --v "${KUBE_VERBOSE}" \
         --logtostderr \
-        -h "${BOILERPLATE_FILENAME}" \
-        -O "${output_file}" \
+        --go-header-file "${BOILERPLATE_FILENAME}" \
+        --output-file-base "${output_file}" \
         $(printf -- " --extra-peer-dirs %s" "${extra_peer_pkgs[@]}") \
         $(printf -- " --extra-dirs %s" "${tag_pkgs[@]}") \
         $(printf -- " -i %s" "${tag_pkgs[@]}") \
@@ -564,10 +564,10 @@ function codegen::openapi() {
     ./hack/run-in-gopath.sh "${gen_openapi_bin}" \
         --v "${KUBE_VERBOSE}" \
         --logtostderr \
-        -h "${BOILERPLATE_FILENAME}" \
-        -O "${output_file}" \
-        -p "${PRJ_SRC_PATH}/${output_dir}" \
-        -r "${report_file}" \
+        --go-header-file "${BOILERPLATE_FILENAME}" \
+        --output-file-base "${output_file}" \
+        --output-package "${PRJ_SRC_PATH}/${output_dir}" \
+        --report-filename "${report_file}" \
         $(printf -- " -i %s" "${tag_pkgs[@]}") \
         "$@"
 

--- a/staging/src/k8s.io/code-generator/kube_codegen.sh
+++ b/staging/src/k8s.io/code-generator/kube_codegen.sh
@@ -143,7 +143,7 @@ function kube::codegen::gen_helpers() {
         done
         "${gobin}/deepcopy-gen" \
             -v "${v}" \
-            -O zz_generated.deepcopy \
+            --output-file-base zz_generated.deepcopy \
             --go-header-file "${boilerplate}" \
             --output-base "${out_base}" \
             "${input_args[@]}"
@@ -177,7 +177,7 @@ function kube::codegen::gen_helpers() {
         done
         "${gobin}/defaulter-gen" \
             -v "${v}" \
-            -O zz_generated.defaults \
+            --output-file-base zz_generated.defaults \
             --go-header-file "${boilerplate}" \
             --output-base "${out_base}" \
             "${input_args[@]}"
@@ -215,7 +215,7 @@ function kube::codegen::gen_helpers() {
         done
         "${gobin}/conversion-gen" \
             -v "${v}" \
-            -O zz_generated.conversion \
+            --output-file-base zz_generated.conversion \
             --go-header-file "${boilerplate}" \
             --output-base "${out_base}" \
             "${extra_peer_args[@]:+"${extra_peer_args[@]}"}" \
@@ -372,7 +372,7 @@ function kube::codegen::gen_openapi() {
         done
         "${gobin}/openapi-gen" \
             -v "${v}" \
-            -O zz_generated.openapi \
+            --output-file-base zz_generated.openapi \
             --go-header-file "${boilerplate}" \
             --output-base "${out_base}" \
             --output-package "${out_pkg_root}/${openapi_subdir}" \


### PR DESCRIPTION
/kind cleanup
/sig api-machinery

Inclusive of #122775 

```release-note
NONE
```
