### PR TITLE
Fix evented pleg mirror pod & use IsEventedPLEGInUse instead of FG status check

### DIFF
--- a/pkg/kubelet/container/cache.go
+++ b/pkg/kubelet/container/cache.go
@@ -21,8 +21,6 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/types"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
-	"k8s.io/kubernetes/pkg/features"
 )
 
 // Cache stores the PodStatus for the pods. It represents *all* the visible
@@ -102,14 +100,6 @@ func (c *cache) GetNewerThan(id types.UID, minTime time.Time) (*PodStatus, error
 func (c *cache) Set(id types.UID, status *PodStatus, err error, timestamp time.Time) (updated bool) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
-
-	if utilfeature.DefaultFeatureGate.Enabled(features.EventedPLEG) {
-		// Set the value in the cache only if it's not present already
-		// or the timestamp in the cache is older than the current update timestamp
-		if cachedVal, ok := c.pods[id]; ok && cachedVal.modified.After(timestamp) {
-			return false
-		}
-	}
 
 	c.pods[id] = &data{status: status, err: err, modified: timestamp}
 	c.notify(id, timestamp)

--- a/pkg/kubelet/container/helpers.go
+++ b/pkg/kubelet/container/helpers.go
@@ -94,6 +94,7 @@ func ShouldContainerBeRestarted(container *v1.Container, pod *v1.Pod, podStatus 
 		return true
 	}
 	if status.State == ContainerStateCreated {
+		klog.V(4).InfoS("Container state is Created, and it will be decided whether to restart based on the specific situation.", "pod", klog.KObj(pod), "containerName", container.Name, "restartOnCreatedState", restartOnCreatedState)
 		// we don't retart the container directly as the CREATED event will always be triggered
 		// but for next syncpod, we should handle the containers failed to be started which is in CREATED state.
 		return restartOnCreatedState

--- a/pkg/kubelet/container/helpers.go
+++ b/pkg/kubelet/container/helpers.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"hash/fnv"
 	"strings"
+	"time"
 
 	"k8s.io/klog/v2"
 
@@ -73,7 +74,7 @@ type RuntimeHelper interface {
 
 // ShouldContainerBeRestarted checks whether a container needs to be restarted.
 // TODO(yifan): Think about how to refactor this.
-func ShouldContainerBeRestarted(container *v1.Container, pod *v1.Pod, podStatus *PodStatus, restartOnCreatedState bool) bool {
+func ShouldContainerBeRestarted(container *v1.Container, pod *v1.Pod, podStatus *PodStatus, restartOnCreatedStateImediately bool) bool {
 	// Once a pod has been marked deleted, it should not be restarted
 	if pod.DeletionTimestamp != nil {
 		return false
@@ -94,10 +95,11 @@ func ShouldContainerBeRestarted(container *v1.Container, pod *v1.Pod, podStatus 
 		return true
 	}
 	if status.State == ContainerStateCreated {
-		klog.V(4).InfoS("Container state is Created, and it will be decided whether to restart based on the specific situation.", "pod", klog.KObj(pod), "containerName", container.Name, "restartOnCreatedState", restartOnCreatedState)
+		klog.V(4).InfoS("Container state is Created, and it will be decided whether to restart based on the specific situation.", "pod", klog.KObj(pod), "containerName", container.Name, "restartOnCreatedStateImediately", restartOnCreatedStateImediately)
 		// we don't retart the container directly as the CREATED event will always be triggered
 		// but for next syncpod, we should handle the containers failed to be started which is in CREATED state.
-		return restartOnCreatedState
+		// If a pod hangs for more than 1m, we should trigger the restart then.
+		return restartOnCreatedStateImediately || time.Since(status.CreatedAt).Seconds() > 60
 	}
 
 	// Check RestartPolicy for dead container

--- a/pkg/kubelet/container/helpers.go
+++ b/pkg/kubelet/container/helpers.go
@@ -73,7 +73,7 @@ type RuntimeHelper interface {
 
 // ShouldContainerBeRestarted checks whether a container needs to be restarted.
 // TODO(yifan): Think about how to refactor this.
-func ShouldContainerBeRestarted(container *v1.Container, pod *v1.Pod, podStatus *PodStatus) bool {
+func ShouldContainerBeRestarted(container *v1.Container, pod *v1.Pod, podStatus *PodStatus, restartOnCreatedState bool) bool {
 	// Once a pod has been marked deleted, it should not be restarted
 	if pod.DeletionTimestamp != nil {
 		return false
@@ -89,10 +89,16 @@ func ShouldContainerBeRestarted(container *v1.Container, pod *v1.Pod, podStatus 
 	if status.State == ContainerStateRunning {
 		return false
 	}
-	// Always restart container in the unknown, or in the created state.
-	if status.State == ContainerStateUnknown || status.State == ContainerStateCreated {
+	// Always restart container in the unknown state
+	if status.State == ContainerStateUnknown {
 		return true
 	}
+	if status.State == ContainerStateCreated {
+		// we don't retart the container directly as the CREATED event will always be triggered
+		// but for next syncpod, we should handle the containers failed to be started which is in CREATED state.
+		return restartOnCreatedState
+	}
+
 	// Check RestartPolicy for dead container
 	if pod.Spec.RestartPolicy == v1.RestartPolicyNever {
 		klog.V(4).InfoS("Already ran container, do nothing", "pod", klog.KObj(pod), "containerName", container.Name)

--- a/pkg/kubelet/container/helpers_test.go
+++ b/pkg/kubelet/container/helpers_test.go
@@ -460,7 +460,7 @@ func TestShouldContainerBeRestarted(t *testing.T) {
 		for i, policy := range policies {
 			pod.Spec.RestartPolicy = policy
 			e := expected[c.Name][i]
-			r := ShouldContainerBeRestarted(&c, pod, podStatus)
+			r := ShouldContainerBeRestarted(&c, pod, podStatus, true)
 			if r != e {
 				t.Errorf("Restart for container %q with restart policy %q expected %t, got %t",
 					c.Name, policy, e, r)
@@ -481,7 +481,7 @@ func TestShouldContainerBeRestarted(t *testing.T) {
 		for i, policy := range policies {
 			pod.Spec.RestartPolicy = policy
 			e := expected[c.Name][i]
-			r := ShouldContainerBeRestarted(&c, pod, podStatus)
+			r := ShouldContainerBeRestarted(&c, pod, podStatus, true)
 			if r != e {
 				t.Errorf("Restart for container %q with restart policy %q expected %t, got %t",
 					c.Name, policy, e, r)

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -2382,7 +2382,7 @@ func (kl *Kubelet) convertToAPIContainerStatuses(pod *v1.Pod, podStatus *kubecon
 			}
 		}
 		// If a container should be restarted in next syncpod, it is *Waiting*.
-		if !kubecontainer.ShouldContainerBeRestarted(&container, pod, podStatus) {
+		if !kubecontainer.ShouldContainerBeRestarted(&container, pod, podStatus, true) {
 			continue
 		}
 		status := statuses[container.Name]

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -1033,7 +1033,9 @@ func (m *kubeGenericRuntimeManager) computePodActions(ctx context.Context, pod *
 		// If container does not exist, or is not running, check whether we
 		// need to restart it.
 		if containerStatus == nil || containerStatus.State != kubecontainer.ContainerStateRunning {
-			if kubecontainer.ShouldContainerBeRestarted(&container, pod, podStatus, false) {
+			// when Evented PLEG is in use, don't restart
+			// for Generic PLEG, restart as is
+			if kubecontainer.ShouldContainerBeRestarted(&container, pod, podStatus, !pleg.IsEventedPLEGInUse()) {
 				klog.V(3).InfoS("Container of pod is not in the desired state and shall be started", "containerName", container.Name, "pod", klog.KObj(pod))
 				changes.ContainersToStart = append(changes.ContainersToStart, idx)
 				if containerStatus != nil && containerStatus.State == kubecontainer.ContainerStateUnknown {
@@ -1048,9 +1050,9 @@ func (m *kubeGenericRuntimeManager) computePodActions(ctx context.Context, pod *
 						reason: reasonUnknown,
 					}
 				}
-			} else if containerStatus.State == kubecontainer.ContainerStateCreated {
-				// keep CREATED container
-				keepCount ++
+			} else if pleg.IsEventedPLEGInUse() && containerStatus.State == kubecontainer.ContainerStateCreated {
+				// keep CREATED container when evented PLEG is in use
+				keepCount++
 			}
 			continue
 		}
@@ -1634,7 +1636,7 @@ func (m *kubeGenericRuntimeManager) GetPodStatus(ctx context.Context, uid kubety
 			podIPs = m.determinePodSandboxIPs(namespace, name, resp.Status)
 		}
 
-		if idx == 0 && utilfeature.DefaultFeatureGate.Enabled(features.EventedPLEG) {
+		if idx == 0 && pleg.IsEventedPLEGInUse() {
 			if resp.Timestamp == 0 {
 				// If the Evented PLEG is enabled in the kubelet, but not in the runtime
 				// then the pod status we get will not have the timestamp set.
@@ -1661,7 +1663,7 @@ func (m *kubeGenericRuntimeManager) GetPodStatus(ctx context.Context, uid kubety
 		}
 	}
 
-	if !utilfeature.DefaultFeatureGate.Enabled(features.EventedPLEG) {
+	if !pleg.IsEventedPLEGInUse() {
 		// Get statuses of all containers visible in the pod.
 		containerStatuses, err = m.getPodContainerStatuses(ctx, uid, name, namespace)
 		if err != nil {

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -1033,7 +1033,7 @@ func (m *kubeGenericRuntimeManager) computePodActions(ctx context.Context, pod *
 		// If container does not exist, or is not running, check whether we
 		// need to restart it.
 		if containerStatus == nil || containerStatus.State != kubecontainer.ContainerStateRunning {
-			// when Evented PLEG is in use, don't restart
+			// when Evented PLEG is in use, don't restart immediately
 			// for Generic PLEG, restart as is
 			if kubecontainer.ShouldContainerBeRestarted(&container, pod, podStatus, !pleg.IsEventedPLEGInUse()) {
 				klog.V(3).InfoS("Container of pod is not in the desired state and shall be started", "containerName", container.Name, "pod", klog.KObj(pod))

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -1022,8 +1022,8 @@ func (m *kubeGenericRuntimeManager) computePodActions(ctx context.Context, pod *
 
 		// Call internal container post-stop lifecycle hook for any non-running container so that any
 		// allocated cpus are released immediately. If the container is restarted, cpus will be re-allocated
-		// to it.
-		if containerStatus != nil && containerStatus.State != kubecontainer.ContainerStateRunning {
+		// to it. Don't remove/stop CREATED container.
+		if containerStatus != nil && containerStatus.State != kubecontainer.ContainerStateRunning && containerStatus.State != kubecontainer.ContainerStateCreated {
 			if err := m.internalLifecycle.PostStopContainer(containerStatus.ID.ID); err != nil {
 				klog.ErrorS(err, "Internal container post-stop lifecycle hook failed for container in pod with error",
 					"containerName", container.Name, "pod", klog.KObj(pod))
@@ -1033,7 +1033,7 @@ func (m *kubeGenericRuntimeManager) computePodActions(ctx context.Context, pod *
 		// If container does not exist, or is not running, check whether we
 		// need to restart it.
 		if containerStatus == nil || containerStatus.State != kubecontainer.ContainerStateRunning {
-			if kubecontainer.ShouldContainerBeRestarted(&container, pod, podStatus) {
+			if kubecontainer.ShouldContainerBeRestarted(&container, pod, podStatus, false) {
 				klog.V(3).InfoS("Container of pod is not in the desired state and shall be started", "containerName", container.Name, "pod", klog.KObj(pod))
 				changes.ContainersToStart = append(changes.ContainersToStart, idx)
 				if containerStatus != nil && containerStatus.State == kubecontainer.ContainerStateUnknown {
@@ -1048,6 +1048,9 @@ func (m *kubeGenericRuntimeManager) computePodActions(ctx context.Context, pod *
 						reason: reasonUnknown,
 					}
 				}
+			} else if containerStatus.State == kubecontainer.ContainerStateCreated {
+				// keep CREATED container
+				keepCount ++
 			}
 			continue
 		}

--- a/pkg/kubelet/pleg/evented.go
+++ b/pkg/kubelet/pleg/evented.go
@@ -42,11 +42,11 @@ var (
 	eventedPLEGUsageMu = sync.RWMutex{}
 )
 
-// isEventedPLEGInUse indicates whether Evented PLEG is in use. Even after enabling
+// IsEventedPLEGInUse indicates whether Evented PLEG is in use. Even after enabling
 // the Evented PLEG feature gate, there could be several reasons it may not be in use.
 // e.g. Streaming data issues from the runtime or the runtime does not implement the
 // container events stream.
-func isEventedPLEGInUse() bool {
+func IsEventedPLEGInUse() bool {
 	eventedPLEGUsageMu.RLock()
 	defer eventedPLEGUsageMu.RUnlock()
 	return eventedPLEGUsage
@@ -122,7 +122,7 @@ func (e *EventedPLEG) Relist() {
 func (e *EventedPLEG) Start() {
 	e.runningMu.Lock()
 	defer e.runningMu.Unlock()
-	if isEventedPLEGInUse() {
+	if IsEventedPLEGInUse() {
 		return
 	}
 	setEventedPLEGUsage(true)
@@ -136,7 +136,7 @@ func (e *EventedPLEG) Start() {
 func (e *EventedPLEG) Stop() {
 	e.runningMu.Lock()
 	defer e.runningMu.Unlock()
-	if !isEventedPLEGInUse() {
+	if !IsEventedPLEGInUse() {
 		return
 	}
 	setEventedPLEGUsage(false)
@@ -185,7 +185,7 @@ func (e *EventedPLEG) watchEventsChannel() {
 		numAttempts := 0
 		for {
 			if numAttempts >= e.eventedPlegMaxStreamRetries {
-				if isEventedPLEGInUse() {
+				if IsEventedPLEGInUse() {
 					// Fall back to Generic PLEG relisting since Evented PLEG is not working.
 					e.logger.V(4).Info("Fall back to Generic PLEG relisting since Evented PLEG is not working")
 					e.Stop()
@@ -208,7 +208,7 @@ func (e *EventedPLEG) watchEventsChannel() {
 		}
 	}()
 
-	if isEventedPLEGInUse() {
+	if IsEventedPLEGInUse() {
 		e.processCRIEvents(containerEventsResponseCh)
 	}
 }

--- a/pkg/kubelet/pleg/generic.go
+++ b/pkg/kubelet/pleg/generic.go
@@ -26,10 +26,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/klog/v2"
-	"k8s.io/kubernetes/pkg/features"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/kubelet/metrics"
 	"k8s.io/utils/clock"
@@ -305,7 +303,7 @@ func (g *GenericPLEG) Relist() {
 			needsReinspection[pid] = pod
 
 			continue
-		} else if utilfeature.DefaultFeatureGate.Enabled(features.EventedPLEG) {
+		} else if IsEventedPLEGInUse() {
 			if !updated {
 				continue
 			}
@@ -481,7 +479,7 @@ func (g *GenericPLEG) updateCache(ctx context.Context, pod *kubecontainer.Pod, p
 	// Evented PLEG after the event has been received by the Kubelet.
 	// For more details refer to:
 	// https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/3386-kubelet-evented-pleg#timestamp-of-the-pod-status
-	if utilfeature.DefaultFeatureGate.Enabled(features.EventedPLEG) && isEventedPLEGInUse() && status != nil {
+	if IsEventedPLEGInUse() && status != nil {
 		timestamp = status.TimeStamp
 	}
 

--- a/test/e2e/common/node/init_container.go
+++ b/test/e2e/common/node/init_container.go
@@ -530,7 +530,7 @@ var _ = SIGDescribe("InitContainer", framework.WithNodeConformance(), func() {
 						}
 						status := t.Status.InitContainerStatuses[0]
 						if status.State.Terminated == nil {
-							if status.State.Waiting != nil && status.State.Waiting.Reason != "PodInitializing" {
+							if status.State.Waiting != nil && status.State.Waiting.Reason != "" && status.State.Waiting.Reason != "PodInitializing" {
 								return false, fmt.Errorf("second init container should have reason PodInitializing: %s", toDebugJSON(status))
 							}
 							return false, nil


### PR DESCRIPTION
This PR is based on #122763, and we use `IsEventedPLEGInUse()` instead of `utilfeature.DefaultFeatureGate.Enabled(features.EventedPLEG)`.

- This PR also includes #127954 which can fix init container problem.

Fixes #123087

Context can be found in #122763.

```release-note
kubelet: fix a static pod startup bug with Evented PLEG
``` 