### PR TITLE
kubelet: make log more clearer for not create a mirror pod

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1900,7 +1900,9 @@ func (kl *Kubelet) SyncPod(ctx context.Context, updateType kubetypes.SyncPodType
 		}
 		if mirrorPod == nil || deleted {
 			node, err := kl.GetNode()
-			if err != nil || node.DeletionTimestamp != nil {
+			if err != nil {
+				klog.V(4).ErrorS(err, "No need to create a mirror pod, since failed to get node info from the cluster", "node", klog.KRef("", string(kl.nodeName)))
+			} else if node.DeletionTimestamp != nil {
 				klog.V(4).InfoS("No need to create a mirror pod, since node has been removed from the cluster", "node", klog.KRef("", string(kl.nodeName)))
 			} else {
 				klog.V(4).InfoS("Creating a mirror pod for static pod", "pod", klog.KObj(pod))


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This happens in almost all CI. 

> Jan 14 20:40:18 kind-control-plane kubelet[248]: I0114 20:40:18.042753     248 kubelet.go:1904] "No need to create a mirror pod, since node has been removed from the cluster" node="kind-control-plane"

When we install a cluster using staticpods to start etcd/apiserver, at the beginning, we will see logs like above.

It shows that the node is removed, but this is not the truth. 

https://storage.googleapis.com/kubernetes-jenkins/logs/ci-kubernetes-e2e-kind-beta-features/1746629504689770496/artifacts/kind-control-plane/kubelet.log is an example. 

#### Which issue(s) this PR fixes:
Fixes None

#### Special notes for your reviewer:
This change is just a log improvement.

#### Does this PR introduce a user-facing change?

```release-note
None
```

/sig node
/priority backlog