### PR TITLE
kubelet: delete channel from the terminated after closing it

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_termination_order.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_termination_order.go
@@ -17,6 +17,7 @@ limitations under the License.
 package kuberuntime
 
 import (
+	"sync"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -34,6 +35,8 @@ type terminationOrdering struct {
 	// prereqs is a map from container name to a list of channel that the container
 	// must wait on to ensure termination ordering
 	prereqs map[string][]chan struct{}
+
+	lock sync.Mutex
 }
 
 // newTerminationOrdering constructs a terminationOrdering based on the pod spec and the currently running containers.
@@ -106,9 +109,12 @@ func (o *terminationOrdering) waitForTurn(name string, gracePeriod int64) float6
 	return time.Since(start).Seconds()
 }
 
-// containerTerminated should be called once the container with the speecified name has exited.
+// containerTerminated should be called once the container with the specified name has exited.
 func (o *terminationOrdering) containerTerminated(name string) {
+	o.lock.Lock()
+	defer o.lock.Unlock()
 	if ch, ok := o.terminated[name]; ok {
 		close(ch)
+		delete(o.terminated, name)
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind cleanup

#### What this PR does / why we need it:
https://github.com/kubernetes/kubernetes/commit/55cf7fef8e9080694740ea90ee80673a09aea1e6 fixed a panic of close channel in CI (newly found)

This is found in a flake run of kind e2e. 
```
Jan 09 15:23:43 kind-worker kubelet[245]: I0109 15:23:43.092705     245 kuberuntime_container.go:779] "Container exited normally" pod="disruption-7238/pod-0" podUID="faa3c238-288f-4026-ad1d-39c9f3a6d26e" containerName="donothing" containerID="containerd://7b8a789c36456e0bab677311438a66e68893a28d7c8a2e578997b25e06b5aa94"
Jan 09 15:23:43 kind-worker kubelet[245]: E0109 15:23:43.092849     245 runtime.go:79] Observed a panic: "close of closed channel" (close of closed channel)
Jan 09 15:23:43 kind-worker kubelet[245]: goroutine 1403 [running]:
Jan 09 15:23:43 kind-worker kubelet[245]: k8s.io/apimachinery/pkg/util/runtime.logPanic({0x3c8e720?, 0x4c26dc0})
Jan 09 15:23:43 kind-worker kubelet[245]:         k8s.io/apimachinery@v0.0.0/pkg/util/runtime/runtime.go:75 +0x85
Jan 09 15:23:43 kind-worker kubelet[245]: k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x0, 0x0, 0x6e09fa0?})
Jan 09 15:23:43 kind-worker kubelet[245]:         k8s.io/apimachinery@v0.0.0/pkg/util/runtime/runtime.go:49 +0x6b
Jan 09 15:23:43 kind-worker kubelet[245]: panic({0x3c8e720?, 0x4c26dc0?})
Jan 09 15:23:43 kind-worker kubelet[245]:         runtime/panic.go:914 +0x21f
Jan 09 15:23:43 kind-worker kubelet[245]: k8s.io/kubernetes/pkg/kubelet/kuberuntime.(*terminationOrdering).containerTerminated(...)
Jan 09 15:23:43 kind-worker kubelet[245]:         k8s.io/kubernetes/pkg/kubelet/kuberuntime/kuberuntime_termination_order.go:112
Jan 09 15:23:43 kind-worker kubelet[245]: k8s.io/kubernetes/pkg/kubelet/kuberuntime.(*kubeGenericRuntimeManager).killContainer(0xc000b44180, {0x4c606f0, 0xc00123b410}, 0xc0018e8000?, {{0xc0006ccfe0, 0xa}, {0xc000d57800, 0x40}}, {0xc00185e250, 0x9}, ...)
Jan 09 15:23:43 kind-worker kubelet[245]:         k8s.io/kubernetes/pkg/kubelet/kuberuntime/kuberuntime_container.go:783 +0x12d6
Jan 09 15:23:43 kind-worker kubelet[245]: k8s.io/kubernetes/pkg/kubelet/kuberuntime.(*kubeGenericRuntimeManager).killContainersWithSyncResult.func1(0xc001a3b500)
Jan 09 15:23:43 kind-worker kubelet[245]:         k8s.io/kubernetes/pkg/kubelet/kuberuntime/kuberuntime_container.go:810 +0x1e5
Jan 09 15:23:43 kind-worker kubelet[245]: created by k8s.io/kubernetes/pkg/kubelet/kuberuntime.(*kubeGenericRuntimeManager).killContainersWithSyncResult in goroutine 846
Jan 09 15:23:43 kind-worker kubelet[245]:         k8s.io/kubernetes/pkg/kubelet/kuberuntime/kuberuntime_container.go:805 +0x125
Jan 09 15:23:43 kind-worker kubelet[245]: panic: close of closed channel [recovered]
Jan 09 15:23:43 kind-worker kubelet[245]:         panic: close of closed channel
Jan 09 15:23:43 kind-worker kubelet[245]: goroutine 1403 [running]:
Jan 09 15:23:43 kind-worker kubelet[245]: k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x0, 0x0, 0x6e09fa0?})
Jan 09 15:23:43 kind-worker kubelet[245]:         k8s.io/apimachinery@v0.0.0/pkg/util/runtime/runtime.go:56 +0xcd
Jan 09 15:23:43 kind-worker kubelet[245]: panic({0x3c8e720?, 0x4c26dc0?})
Jan 09 15:23:43 kind-worker kubelet[245]:         runtime/panic.go:914 +0x21f
Jan 09 15:23:43 kind-worker kubelet[245]: k8s.io/kubernetes/pkg/kubelet/kuberuntime.(*terminationOrdering).containerTerminated(...)
Jan 09 15:23:43 kind-worker kubelet[245]:         k8s.io/kubernetes/pkg/kubelet/kuberuntime/kuberuntime_termination_order.go:112
Jan 09 15:23:43 kind-worker kubelet[245]: k8s.io/kubernetes/pkg/kubelet/kuberuntime.(*kubeGenericRuntimeManager).killContainer(0xc000b44180, {0x4c606f0, 0xc00123b410}, 0xc0018e8000?, {{0xc0006ccfe0, 0xa}, {0xc000d57800, 0x40}}, {0xc00185e250, 0x9}, ...)
Jan 09 15:23:43 kind-worker kubelet[245]:         k8s.io/kubernetes/pkg/kubelet/kuberuntime/kuberuntime_container.go:783 +0x12d6
Jan 09 15:23:43 kind-worker kubelet[245]: k8s.io/kubernetes/pkg/kubelet/kuberuntime.(*kubeGenericRuntimeManager).killContainersWithSyncResult.func1(0xc001a3b500)
Jan 09 15:23:43 kind-worker kubelet[245]:         k8s.io/kubernetes/pkg/kubelet/kuberuntime/kuberuntime_container.go:810 +0x1e5
Jan 09 15:23:43 kind-worker kubelet[245]: created by k8s.io/kubernetes/pkg/kubelet/kuberuntime.(*kubeGenericRuntimeManager).killContainersWithSyncResult in goroutine 846
Jan 09 15:23:43 kind-worker kubelet[245]:         k8s.io/kubernetes/pkg/kubelet/kuberuntime/kuberuntime_container.go:805 +0x125
Jan 09 15:23:43 kind-worker systemd[1]: kubelet.service: Main process exited, code=exited, status=2/INVALIDARGUMENT
Jan 09 15:23:43 kind-worker systemd[1]: kubelet.service: Failed with result 'exit-code'.
Jan 09 15:23:43 kind-worker systemd[1]: kubelet.service: Consumed 3.051s CPU time.
Jan 09 15:23:44 kind-worker systemd[1]: kubelet.service: Scheduled restart job, restart counter is at 1.
Jan 09 15:23:44 kind-worker systemd[1]: Stopped kubelet: The Kubernetes Node Agent.
Jan 09 15:23:44 kind-worker systemd[1]: kubelet.service: Consumed 3.051s CPU time.
Jan 09 15:23:44 kind-worker systemd[1]: Starting kubelet: The Kubernetes Node Agent
```

#### Which issue(s) this PR fixes:

Fixes None

This commit is original one commit from #122763, and I am not sure the progress of it. So I open a panic-fix only PR here to fix it separately. It is more clear. And I will drop the commit from #122763 after this is merged.

#### Special notes for your reviewer:
more details can be found in https://github.com/kubernetes/kubernetes/pull/122124#issuecomment-1884140544.

#### Does this PR introduce a user-facing change?

```release-note
None
```
/priority important-longterm
/sig node