### PR TITLE
kubeadm: remove code to be removed in 1.30

### DIFF
--- a/cmd/kubeadm/app/phases/certs/renewal/manager.go
+++ b/cmd/kubeadm/app/phases/certs/renewal/manager.go
@@ -423,48 +423,5 @@ func certToConfig(cert *x509.Certificate) certutil.Config {
 }
 
 func loadCertConfigMutators(certBaseName string) []certConfigMutatorFunc {
-	// TODO: Remove these mutators after the organization migration is complete in a future release
-	// https://github.com/kubernetes/kubeadm/issues/2414
-	switch certBaseName {
-	case kubeadmconstants.EtcdHealthcheckClientCertAndKeyBaseName,
-		kubeadmconstants.APIServerEtcdClientCertAndKeyBaseName:
-		return []certConfigMutatorFunc{
-			removeSystemPrivilegedGroupMutator(),
-		}
-	case kubeadmconstants.APIServerKubeletClientCertAndKeyBaseName:
-		return []certConfigMutatorFunc{
-			removeSystemPrivilegedGroupMutator(),
-			addClusterAdminsGroupMutator(),
-		}
-	}
 	return nil
-}
-
-func removeSystemPrivilegedGroupMutator() certConfigMutatorFunc {
-	return func(c *certutil.Config) error {
-		organizations := make([]string, 0, len(c.Organization))
-		for _, org := range c.Organization {
-			if org != kubeadmconstants.SystemPrivilegedGroup {
-				organizations = append(organizations, org)
-			}
-		}
-		c.Organization = organizations
-		return nil
-	}
-}
-
-func addClusterAdminsGroupMutator() certConfigMutatorFunc {
-	return func(c *certutil.Config) error {
-		found := false
-		for _, org := range c.Organization {
-			if org == kubeadmconstants.ClusterAdminsGroupAndClusterRoleBinding {
-				found = true
-				break
-			}
-		}
-		if !found {
-			c.Organization = append(c.Organization, kubeadmconstants.ClusterAdminsGroupAndClusterRoleBinding)
-		}
-		return nil
-	}
 }

--- a/cmd/kubeadm/app/phases/certs/renewal/manager_test.go
+++ b/cmd/kubeadm/app/phases/certs/renewal/manager_test.go
@@ -30,7 +30,6 @@ import (
 	netutils "k8s.io/utils/net"
 
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
-	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	certtestutil "k8s.io/kubernetes/cmd/kubeadm/app/util/certs"
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/pkiutil"
 	testutil "k8s.io/kubernetes/cmd/kubeadm/test"
@@ -126,22 +125,6 @@ func TestRenewUsingLocalCA(t *testing.T) {
 				return writeTestKubeconfig(t, dir, "admin.conf", testCACert, testCAKey)
 			},
 			expectedOrganization: testCertOrganization,
-		},
-		{
-			name:     "apiserver-etcd-client cert should not contain SystemPrivilegedGroup after renewal",
-			certName: "apiserver-etcd-client",
-			createCertFunc: func() *x509.Certificate {
-				return writeTestCertificate(t, dir, "apiserver-etcd-client", testCACert, testCAKey, []string{kubeadmconstants.SystemPrivilegedGroup})
-			},
-			expectedOrganization: []string{},
-		},
-		{
-			name:     "apiserver-kubelet-client cert should replace SystemPrivilegedGroup with ClusterAdminsGroup after renewal",
-			certName: "apiserver-kubelet-client",
-			createCertFunc: func() *x509.Certificate {
-				return writeTestCertificate(t, dir, "apiserver-kubelet-client", testCACert, testCAKey, []string{kubeadmconstants.SystemPrivilegedGroup})
-			},
-			expectedOrganization: []string{kubeadmconstants.ClusterAdminsGroupAndClusterRoleBinding},
 		},
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
According to the comments, we don't need this code in 1.30
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
part of [#2414](https://github.com/kubernetes/kubeadm/issues/2414)

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://git.k8s.io/enhancements/keps/sig-cluster-lifecycle/kubeadm/4214-separate-super-user-kubeconfig
```
