### PR TITLE
fix: blank window when updating ClusterRole with AggregationRule

### DIFF
--- a/pkg/registry/rbac/clusterrole/strategy.go
+++ b/pkg/registry/rbac/clusterrole/strategy.go
@@ -62,11 +62,18 @@ func (strategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
 }
 
 // PrepareForUpdate clears fields that are not allowed to be set by end users on update.
-func (strategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object) {
+func (s strategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object) {
 	newClusterRole := obj.(*rbac.ClusterRole)
 	oldClusterRole := old.(*rbac.ClusterRole)
 
 	_, _ = newClusterRole, oldClusterRole
+	s.updateRulesForAggregation(oldClusterRole, newClusterRole)
+}
+
+func (s strategy) updateRulesForAggregation(oldClusterRole, newClusterRole *rbac.ClusterRole) {
+	if oldClusterRole.AggregationRule != nil && newClusterRole.AggregationRule != nil && newClusterRole.Rules == nil {
+		newClusterRole.Rules = append([]rbac.PolicyRule{}, oldClusterRole.Rules...)
+	}
 }
 
 // Validate validates a new ClusterRole. Validation must check for a correct signature.

--- a/pkg/registry/rbac/clusterrole/strategy_test.go
+++ b/pkg/registry/rbac/clusterrole/strategy_test.go
@@ -1,0 +1,225 @@
+package clusterrole
+
+import (
+	"testing"
+
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/pkg/apis/rbac"
+)
+
+func TestUpdateRulesForAggregation(t *testing.T) {
+	s := strategy{}
+
+	testCases := []struct {
+		name            string
+		oldClusterRole  *rbac.ClusterRole
+		newClusterRole  *rbac.ClusterRole
+		expectSameAsOld bool
+		expectSameAsNew bool
+	}{
+		{
+			name: "no change",
+			oldClusterRole: &rbac.ClusterRole{
+				AggregationRule: &rbac.AggregationRule{
+					ClusterRoleSelectors: []metav1.LabelSelector{
+						{
+							MatchLabels: map[string]string{
+								"foo": "bar",
+							},
+						},
+					},
+				},
+			},
+			newClusterRole: &rbac.ClusterRole{
+				AggregationRule: &rbac.AggregationRule{
+					ClusterRoleSelectors: []metav1.LabelSelector{
+						{
+							MatchLabels: map[string]string{
+								"foo": "bar",
+							},
+						},
+					},
+				},
+			},
+			expectSameAsOld: true,
+			expectSameAsNew: true,
+		},
+		{
+			name: "no change with rules",
+			oldClusterRole: &rbac.ClusterRole{
+				AggregationRule: &rbac.AggregationRule{
+					ClusterRoleSelectors: []metav1.LabelSelector{
+						{
+							MatchLabels: map[string]string{
+								"foo": "bar",
+							},
+						},
+					},
+				},
+				Rules: []rbac.PolicyRule{
+					{
+						Verbs:     []string{"get"},
+						APIGroups: []string{"*"},
+						Resources: []string{"pods"},
+					},
+				},
+			},
+			newClusterRole: &rbac.ClusterRole{
+				AggregationRule: &rbac.AggregationRule{
+					ClusterRoleSelectors: []metav1.LabelSelector{
+						{
+							MatchLabels: map[string]string{
+								"foo": "bar",
+							},
+						},
+					},
+				},
+				Rules: []rbac.PolicyRule{
+					{
+						Verbs:     []string{"get"},
+						APIGroups: []string{"*"},
+						Resources: []string{"pods"},
+					},
+				},
+			},
+			expectSameAsOld: true,
+			expectSameAsNew: true,
+		},
+		{
+			name: "no change with rules and aggregation rule nil",
+			oldClusterRole: &rbac.ClusterRole{
+				Rules: []rbac.PolicyRule{
+					{
+						Verbs:     []string{"get"},
+						APIGroups: []string{"*"},
+						Resources: []string{"pods"},
+					},
+				},
+			},
+			newClusterRole: &rbac.ClusterRole{
+				Rules: []rbac.PolicyRule{
+					{
+						Verbs:     []string{"get"},
+						APIGroups: []string{"*"},
+						Resources: []string{"pods"},
+					},
+				},
+			},
+			expectSameAsOld: true,
+			expectSameAsNew: true,
+		},
+		{
+			name: "change rules when aggregation rule nil",
+			oldClusterRole: &rbac.ClusterRole{
+				Rules: []rbac.PolicyRule{
+					{
+						Verbs:     []string{"get"},
+						APIGroups: []string{"*"},
+						Resources: []string{"pods"},
+					},
+				},
+			},
+			newClusterRole: &rbac.ClusterRole{
+				Rules: []rbac.PolicyRule{},
+			},
+			expectSameAsOld: false,
+			expectSameAsNew: true,
+		},
+		{
+			name: "no change rules when new rules is nil",
+			oldClusterRole: &rbac.ClusterRole{
+				AggregationRule: &rbac.AggregationRule{
+					ClusterRoleSelectors: []metav1.LabelSelector{
+						{
+							MatchLabels: map[string]string{
+								"foo": "bar",
+							},
+						},
+					},
+				},
+				Rules: []rbac.PolicyRule{
+					{
+						Verbs:     []string{"get"},
+						APIGroups: []string{"*"},
+						Resources: []string{"pods"},
+					},
+				},
+			},
+			newClusterRole: &rbac.ClusterRole{
+				AggregationRule: &rbac.AggregationRule{
+					ClusterRoleSelectors: []metav1.LabelSelector{
+						{
+							MatchLabels: map[string]string{
+								"foo": "bar",
+							},
+						},
+					},
+				},
+				Rules: nil,
+			},
+			expectSameAsOld: true,
+			expectSameAsNew: false,
+		},
+		{
+			name: "change rules when new rules is defined with 0 item",
+			oldClusterRole: &rbac.ClusterRole{
+				Rules: []rbac.PolicyRule{
+					{
+						Verbs:     []string{"get"},
+						APIGroups: []string{"*"},
+						Resources: []string{"pods"},
+					},
+				},
+			},
+			newClusterRole: &rbac.ClusterRole{
+				Rules: []rbac.PolicyRule{},
+			},
+			expectSameAsOld: false,
+			expectSameAsNew: true,
+		},
+		{
+			name: "change rules when new rules is defined with items",
+			oldClusterRole: &rbac.ClusterRole{
+				Rules: []rbac.PolicyRule{
+					{
+						Verbs:     []string{"get"},
+						APIGroups: []string{"*"},
+						Resources: []string{"pods"},
+					},
+				},
+			},
+			newClusterRole: &rbac.ClusterRole{
+				Rules: []rbac.PolicyRule{
+					{
+						Verbs:     []string{"get"},
+						APIGroups: []string{"*"},
+						Resources: []string{"pods"},
+					},
+					{
+						Verbs:     []string{"list"},
+						APIGroups: []string{"*"},
+						Resources: []string{"pods"},
+					},
+				},
+			},
+			expectSameAsOld: false,
+			expectSameAsNew: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			originOld, originNew := tc.oldClusterRole.DeepCopy(), tc.newClusterRole.DeepCopy()
+			s.updateRulesForAggregation(tc.oldClusterRole, tc.newClusterRole)
+
+			if tc.expectSameAsOld && !apiequality.Semantic.DeepEqual(originOld.Rules, tc.newClusterRole.Rules) {
+				t.Errorf("Expected same as old[%+v], but got[%+v]", originOld.Rules, tc.newClusterRole.Rules)
+			}
+
+			if tc.expectSameAsNew && !apiequality.Semantic.DeepEqual(originNew.Rules, tc.newClusterRole.Rules) {
+				t.Errorf("Expected same as new[%+v], but got [%v]", originNew.Rules, tc.newClusterRole.Rules)
+			}
+		})
+	}
+}


### PR DESCRIPTION
reset the rules of clusterrole as the old when aggregation is not nil

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

blank window when applying the clusterrole with aggregation results in rejections.

#### Which issue(s) this PR fixes:

Fixes # https://github.com/kubernetes/kubernetes/issues/118648

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
none
```

