### PR TITLE
revert part of #122529 to allow a client may fail

### DIFF
--- a/cmd/kubeadm/app/util/apiclient/idempotency.go
+++ b/cmd/kubeadm/app/util/apiclient/idempotency.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
+	clientsetretry "k8s.io/client-go/util/retry"
 
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
@@ -336,17 +337,15 @@ func PatchNode(client clientset.Interface, nodeName string, patchFn func(*v1.Nod
 func GetConfigMapWithRetry(client clientset.Interface, namespace, name string) (*v1.ConfigMap, error) {
 	var cm *v1.ConfigMap
 	var lastError error
-	err := wait.PollUntilContextTimeout(context.Background(),
-		constants.KubernetesAPICallRetryInterval, kubeadmapi.GetActiveTimeouts().KubernetesAPICall.Duration,
-		true, func(ctx context.Context) (bool, error) {
-			var err error
-			cm, err = client.CoreV1().ConfigMaps(namespace).Get(ctx, name, metav1.GetOptions{})
-			if err == nil {
-				return true, nil
-			}
-			lastError = err
-			return false, nil
-		})
+	err := wait.ExponentialBackoff(clientsetretry.DefaultBackoff, func() (bool, error) {
+		var err error
+		cm, err = client.CoreV1().ConfigMaps(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+		if err == nil {
+			return true, nil
+		}
+		lastError = err
+		return false, nil
+	})
 	if err == nil {
 		return cm, nil
 	}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
In the failing test, `kubeadm  certs renew super-admin.conf` and other renew will use the new timeout.

Each renew will be more than 1m.

#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes/kubeadm/issues/2995

#### Special notes for your reviewer:

https://github.com/kubernetes/kubernetes/blob/ebb79e5cf9a404d801841a8e0d60242a617e75cb/staging/src/k8s.io/client-go/util/retry/util.go#L35-L43

#### Does this PR introduce a user-facing change?
```release-note
None
```
