### PR TITLE
Multiple kube-proxy instances

### DIFF
--- a/cmd/kube-proxy/app/server.go
+++ b/cmd/kube-proxy/app/server.go
@@ -191,7 +191,7 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.DurationVar(&o.config.IPVS.TCPTimeout.Duration, "ipvs-tcp-timeout", o.config.IPVS.TCPTimeout.Duration, "The timeout for idle IPVS TCP connections, 0 to leave as-is. (e.g. '5s', '1m', '2h22m').")
 	fs.DurationVar(&o.config.IPVS.TCPFinTimeout.Duration, "ipvs-tcpfin-timeout", o.config.IPVS.TCPFinTimeout.Duration, "The timeout for IPVS TCP connections after receiving a FIN packet, 0 to leave as-is. (e.g. '5s', '1m', '2h22m').")
 	fs.DurationVar(&o.config.IPVS.UDPTimeout.Duration, "ipvs-udp-timeout", o.config.IPVS.UDPTimeout.Duration, "The timeout for IPVS UDP packets, 0 to leave as-is. (e.g. '5s', '1m', '2h22m').")
-
+	fs.StringVar(&o.config.NFTables.TableName, "nftables-table-name", o.config.NFTables.TableName, "The table name for ip and ip6. Will use \"kube-proxy\" if empty")
 	fs.Var(&o.config.DetectLocalMode, "detect-local-mode", "Mode to use to detect local traffic. This parameter is ignored if a config file is specified by --config.")
 	fs.StringVar(&o.config.DetectLocal.BridgeInterface, "pod-bridge-interface", o.config.DetectLocal.BridgeInterface, "A bridge interface name. When --detect-local-mode is set to BridgeInterface, kube-proxy will consider traffic to be local if it originates from this bridge.")
 	fs.StringVar(&o.config.DetectLocal.InterfaceNamePrefix, "pod-interface-name-prefix", o.config.DetectLocal.InterfaceNamePrefix, "An interface name prefix. When --detect-local-mode is set to InterfaceNamePrefix, kube-proxy will consider traffic to be local if it originates from any interface whose name begins with this prefix.")

--- a/cmd/kube-proxy/app/server_linux.go
+++ b/cmd/kube-proxy/app/server_linux.go
@@ -306,6 +306,7 @@ func (s *ProxyServer) createProxier(ctx context.Context, config *proxyconfigapi.
 				s.Recorder,
 				s.HealthzServer,
 				config.NodePortAddresses,
+				config.NFTables.TableName,
 				initOnly,
 			)
 		} else {
@@ -325,6 +326,7 @@ func (s *ProxyServer) createProxier(ctx context.Context, config *proxyconfigapi.
 				s.Recorder,
 				s.HealthzServer,
 				config.NodePortAddresses,
+				config.NFTables.TableName,
 				initOnly,
 			)
 		}

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -58989,6 +58989,13 @@ func schema_k8sio_kube_proxy_config_v1alpha1_KubeProxyConfiguration(ref common.R
 							Format:      "",
 						},
 					},
+					"serviceProxyName": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The value for the \"service.kubernetes.io/service-proxy-name\" label that this kube-proxy instance shall handle. If unset (default), kube-proxy will handle any service that has NOT set this label.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"mode": {
 						SchemaProps: spec.SchemaProps{
 							Description: "mode specifies which proxy mode to use.",

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -59330,6 +59330,13 @@ func schema_k8sio_kube_proxy_config_v1alpha1_KubeProxyNFTablesConfiguration(ref 
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Duration"),
 						},
 					},
+					"tableName": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The name of the tables (ip and ip6) that this instance of kube-proxy will use",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 				Required: []string{"masqueradeBit", "masqueradeAll", "syncPeriod", "minSyncPeriod"},
 			},

--- a/pkg/proxy/apis/config/types.go
+++ b/pkg/proxy/apis/config/types.go
@@ -94,6 +94,8 @@ type KubeProxyNFTablesConfiguration struct {
 	// '1m', '2h22m'). A value of 0 means every Service or EndpointSlice change will
 	// result in an immediate iptables resync.
 	MinSyncPeriod metav1.Duration
+	// The name of the tables (ip and ip6) that this instance of kube-proxy will use
+	TableName string
 }
 
 // KubeProxyConntrackConfiguration contains conntrack settings for

--- a/pkg/proxy/apis/config/types.go
+++ b/pkg/proxy/apis/config/types.go
@@ -201,6 +201,10 @@ type KubeProxyConfiguration struct {
 	EnableProfiling bool
 	// showHiddenMetricsForVersion is the version for which you want to show hidden metrics.
 	ShowHiddenMetricsForVersion string
+	// The value for the "service.kubernetes.io/service-proxy-name" label that this
+	// kube-proxy instance shall handle. If unset (default), kube-proxy will handle
+	// any service that has NOT set this label.
+	ServiceProxyName string
 
 	// mode specifies which proxy mode to use.
 	Mode ProxyMode

--- a/pkg/proxy/apis/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/proxy/apis/config/v1alpha1/zz_generated.conversion.go
@@ -147,6 +147,7 @@ func autoConvert_v1alpha1_KubeProxyConfiguration_To_config_KubeProxyConfiguratio
 	out.BindAddressHardFail = in.BindAddressHardFail
 	out.EnableProfiling = in.EnableProfiling
 	out.ShowHiddenMetricsForVersion = in.ShowHiddenMetricsForVersion
+	out.ServiceProxyName = in.ServiceProxyName
 	out.Mode = config.ProxyMode(in.Mode)
 	if err := Convert_v1alpha1_KubeProxyIPTablesConfiguration_To_config_KubeProxyIPTablesConfiguration(&in.IPTables, &out.IPTables, s); err != nil {
 		return err
@@ -193,6 +194,7 @@ func autoConvert_config_KubeProxyConfiguration_To_v1alpha1_KubeProxyConfiguratio
 	out.BindAddressHardFail = in.BindAddressHardFail
 	out.EnableProfiling = in.EnableProfiling
 	out.ShowHiddenMetricsForVersion = in.ShowHiddenMetricsForVersion
+	out.ServiceProxyName = in.ServiceProxyName
 	out.Mode = v1alpha1.ProxyMode(in.Mode)
 	if err := Convert_config_KubeProxyIPTablesConfiguration_To_v1alpha1_KubeProxyIPTablesConfiguration(&in.IPTables, &out.IPTables, s); err != nil {
 		return err

--- a/pkg/proxy/apis/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/proxy/apis/config/v1alpha1/zz_generated.conversion.go
@@ -327,6 +327,7 @@ func autoConvert_v1alpha1_KubeProxyNFTablesConfiguration_To_config_KubeProxyNFTa
 	out.MasqueradeAll = in.MasqueradeAll
 	out.SyncPeriod = in.SyncPeriod
 	out.MinSyncPeriod = in.MinSyncPeriod
+	out.TableName = in.TableName
 	return nil
 }
 
@@ -340,6 +341,7 @@ func autoConvert_config_KubeProxyNFTablesConfiguration_To_v1alpha1_KubeProxyNFTa
 	out.MasqueradeAll = in.MasqueradeAll
 	out.SyncPeriod = in.SyncPeriod
 	out.MinSyncPeriod = in.MinSyncPeriod
+	out.TableName = in.TableName
 	return nil
 }
 

--- a/staging/src/k8s.io/kube-proxy/config/v1alpha1/types.go
+++ b/staging/src/k8s.io/kube-proxy/config/v1alpha1/types.go
@@ -201,6 +201,10 @@ type KubeProxyConfiguration struct {
 	EnableProfiling bool `json:"enableProfiling"`
 	// showHiddenMetricsForVersion is the version for which you want to show hidden metrics.
 	ShowHiddenMetricsForVersion string `json:"showHiddenMetricsForVersion"`
+	// The value for the "service.kubernetes.io/service-proxy-name" label that this
+	// kube-proxy instance shall handle. If unset (default), kube-proxy will handle
+	// any service that has NOT set this label.
+	ServiceProxyName string `json:"serviceProxyName,omitempty"`
 
 	// mode specifies which proxy mode to use.
 	Mode ProxyMode `json:"mode"`

--- a/staging/src/k8s.io/kube-proxy/config/v1alpha1/types.go
+++ b/staging/src/k8s.io/kube-proxy/config/v1alpha1/types.go
@@ -94,6 +94,8 @@ type KubeProxyNFTablesConfiguration struct {
 	// '1m', '2h22m'). A value of 0 means every Service or EndpointSlice change will
 	// result in an immediate iptables resync.
 	MinSyncPeriod metav1.Duration `json:"minSyncPeriod"`
+	// The name of the tables (ip and ip6) that this instance of kube-proxy will use
+	TableName string `json:"tableName,omitempty"`
 }
 
 // KubeProxyConntrackConfiguration contains conntrack settings for


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/kind bug
/sig network
/area kube-proxy

#### What this PR does / why we need it:

The [well known](https://kubernetes.io/docs/reference/labels-annotations-taints/#servicekubernetesioservice-proxy-name) label `service.kubernetes.io/service-proxy-name` is honored by the regular `kube-proxy`.

So far this label has been used to ask `kube-proxy` to ignore services that are handled by some specialized proxy, e.g. [kpng](https://kubernetes.io/blog/2021/10/18/use-kpng-to-write-specialized-kube-proxiers/). With the introduction of proxy-mode `nftables` it is possible to create kube-proxy instances that don't interfere with each other. This can be useful for secondary networks that have use for load balancing.

A new instance of kube-proxy must have a separate configuration like:
```yaml
apiVersion: kubeproxy.config.k8s.io/v1alpha1
kind: KubeProxyConfiguration
featureGates:
  NFTablesProxyMode: true
serviceProxyName: "kube-proxy-nftables2"
mode: "nftables"
  tableName: "kube-proxy-nftables2"
# (the rest of the config is omitted ...)
```
Now new tables (for ipv4 and ipv6) are created by kube-proxy in nftables mode:
```
# nft list tables
table ip kube-proxy
table ip6 kube-proxy
table ip kube-proxy-nftables2
table ip6 kube-proxy-nftables2
```
A service that should be handled by the second `kube-proxy` must set the label:
```yaml
apiVersion: v1
kind: Service
metadata:
  name: tserver-nftables2
  labels:
    service.kubernetes.io/service-proxy-name: kube-proxy-nftables2
spec:
  selector:
    app: tserver
  ports:
  - port: 5001
    name: mconnect
```

For this to be useful for secondary networks the "selector" can't be used since endpointslices would be created for addresses on the main network. Instead the selector can be omitted an an annotation can be used:
```yaml
apiVersion: v1
kind: Service
metadata:
  name: tserver-nftables2
  labels:
    service.kubernetes.io/service-proxy-name: kube-proxy-nftables2
  annotations:
    kube-proxy-nftables2-selector: app=tserver
spec:
  ports:
  - port: 5001
    name: mconnect
```
The endpointslices can then be created manually, or by a controller.


#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

This is a PoC. Kube-proxy should honor `ServiceProxyName` in any case, but the configurable table-name will become useful when(if) K8s multi-networking is supported.

#### Does this PR introduce a user-facing change?

```release-note
Kube-proxy can be configured to handle services with a specified `service.kubernetes.io/service-proxy-name` label only.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
