### PR TITLE
Automated cherry pick of #122204: Fix race condition in iptables partial sync handling

### DIFF
--- a/pkg/proxy/endpoints.go
+++ b/pkg/proxy/endpoints.go
@@ -229,16 +229,9 @@ func (ect *EndpointChangeTracker) EndpointSliceUpdate(endpointSlice *discovery.E
 	return changeNeeded
 }
 
-// PendingChanges returns a set whose keys are the names of the services whose endpoints
-// have changed since the last time ect was used to update an EndpointsMap. (You must call
-// this _before_ calling em.Update(ect).)
-func (ect *EndpointChangeTracker) PendingChanges() sets.String {
-	return ect.endpointSliceCache.pendingChanges()
-}
-
-// checkoutChanges returns a list of pending endpointsChanges and marks them as
+// checkoutChanges returns a map of pending endpointsChanges and marks them as
 // applied.
-func (ect *EndpointChangeTracker) checkoutChanges() []*endpointsChange {
+func (ect *EndpointChangeTracker) checkoutChanges() map[types.NamespacedName]*endpointsChange {
 	metrics.EndpointChangesPending.Set(0)
 
 	return ect.endpointSliceCache.checkoutChanges()
@@ -293,6 +286,10 @@ type endpointsChange struct {
 
 // UpdateEndpointMapResult is the updated results after applying endpoints changes.
 type UpdateEndpointMapResult struct {
+	// UpdatedServices lists the names of all services with added/updated/deleted
+	// endpoints since the last Update.
+	UpdatedServices sets.Set[types.NamespacedName]
+
 	// DeletedUDPEndpoints identifies UDP endpoints that have just been deleted.
 	// Existing conntrack NAT entries pointing to these endpoints must be deleted to
 	// ensure that no further traffic for the Service gets delivered to them.
@@ -318,6 +315,7 @@ type EndpointsMap map[ServicePortName][]Endpoint
 // changes map.
 func (em EndpointsMap) Update(ect *EndpointChangeTracker) UpdateEndpointMapResult {
 	result := UpdateEndpointMapResult{
+		UpdatedServices:        sets.New[types.NamespacedName](),
 		DeletedUDPEndpoints:    make([]ServiceEndpoint, 0),
 		NewlyActiveUDPServices: make([]ServicePortName, 0),
 		LastChangeTriggerTimes: make(map[types.NamespacedName][]time.Time),
@@ -327,10 +325,12 @@ func (em EndpointsMap) Update(ect *EndpointChangeTracker) UpdateEndpointMapResul
 	}
 
 	changes := ect.checkoutChanges()
-	for _, change := range changes {
+	for nn, change := range changes {
 		if ect.processEndpointsMapChange != nil {
 			ect.processEndpointsMapChange(change.previous, change.current)
 		}
+		result.UpdatedServices.Insert(nn)
+
 		em.unmerge(change.previous)
 		em.merge(change.current)
 		detectStaleConntrackEntries(change.previous, change.current, &result.DeletedUDPEndpoints, &result.NewlyActiveUDPServices)

--- a/pkg/proxy/endpoints.go
+++ b/pkg/proxy/endpoints.go
@@ -310,28 +310,20 @@ type UpdateEndpointMapResult struct {
 	LastChangeTriggerTimes map[types.NamespacedName][]time.Time
 }
 
-// Update updates endpointsMap base on the given changes.
-func (em EndpointsMap) Update(changes *EndpointChangeTracker) (result UpdateEndpointMapResult) {
-	result.DeletedUDPEndpoints = make([]ServiceEndpoint, 0)
-	result.NewlyActiveUDPServices = make([]ServicePortName, 0)
-	result.LastChangeTriggerTimes = make(map[types.NamespacedName][]time.Time)
-
-	em.apply(changes, &result.DeletedUDPEndpoints, &result.NewlyActiveUDPServices, &result.LastChangeTriggerTimes)
-
-	return result
-}
-
 // EndpointsMap maps a service name to a list of all its Endpoints.
 type EndpointsMap map[ServicePortName][]Endpoint
 
-// apply the changes to EndpointsMap, update the passed-in stale-conntrack-entry arrays,
-// and clear the changes map. In addition it returns (via argument) and resets the
-// lastChangeTriggerTimes for all endpoints that were changed and will result in syncing
-// the proxy rules. apply triggers processEndpointsMapChange on every change.
-func (em EndpointsMap) apply(ect *EndpointChangeTracker, deletedUDPEndpoints *[]ServiceEndpoint,
-	newlyActiveUDPServices *[]ServicePortName, lastChangeTriggerTimes *map[types.NamespacedName][]time.Time) {
+// Update updates em based on the changes in ect, returns information about the diff since
+// the last Update, triggers processEndpointsMapChange on every change, and clears the
+// changes map.
+func (em EndpointsMap) Update(ect *EndpointChangeTracker) UpdateEndpointMapResult {
+	result := UpdateEndpointMapResult{
+		DeletedUDPEndpoints:    make([]ServiceEndpoint, 0),
+		NewlyActiveUDPServices: make([]ServicePortName, 0),
+		LastChangeTriggerTimes: make(map[types.NamespacedName][]time.Time),
+	}
 	if ect == nil {
-		return
+		return result
 	}
 
 	changes := ect.checkoutChanges()
@@ -341,9 +333,11 @@ func (em EndpointsMap) apply(ect *EndpointChangeTracker, deletedUDPEndpoints *[]
 		}
 		em.unmerge(change.previous)
 		em.merge(change.current)
-		detectStaleConntrackEntries(change.previous, change.current, deletedUDPEndpoints, newlyActiveUDPServices)
+		detectStaleConntrackEntries(change.previous, change.current, &result.DeletedUDPEndpoints, &result.NewlyActiveUDPServices)
 	}
-	ect.checkoutTriggerTimes(lastChangeTriggerTimes)
+	ect.checkoutTriggerTimes(&result.LastChangeTriggerTimes)
+
+	return result
 }
 
 // Merge ensures that the current EndpointsMap contains all <service, endpoints> pairs from the EndpointsMap passed in.

--- a/pkg/proxy/endpoints_test.go
+++ b/pkg/proxy/endpoints_test.go
@@ -506,7 +506,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		expectedDeletedUDPEndpoints    []ServiceEndpoint
 		expectedNewlyActiveUDPServices map[ServicePortName]bool
 		expectedLocalEndpoints         map[types.NamespacedName]int
-		expectedChangedEndpoints       sets.String
+		expectedChangedEndpoints       sets.Set[types.NamespacedName]
 	}{{
 		name:                           "empty",
 		oldEndpoints:                   map[ServicePortName][]*BaseEndpointInfo{},
@@ -514,7 +514,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		expectedDeletedUDPEndpoints:    []ServiceEndpoint{},
 		expectedNewlyActiveUDPServices: map[ServicePortName]bool{},
 		expectedLocalEndpoints:         map[types.NamespacedName]int{},
-		expectedChangedEndpoints:       sets.NewString(),
+		expectedChangedEndpoints:       sets.New[types.NamespacedName](),
 	}, {
 		name: "no change, unnamed port",
 		previousEndpoints: []*discovery.EndpointSlice{
@@ -536,7 +536,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		expectedDeletedUDPEndpoints:    []ServiceEndpoint{},
 		expectedNewlyActiveUDPServices: map[ServicePortName]bool{},
 		expectedLocalEndpoints:         map[types.NamespacedName]int{},
-		expectedChangedEndpoints:       sets.NewString(),
+		expectedChangedEndpoints:       sets.New[types.NamespacedName](),
 	}, {
 		name: "no change, named port, local",
 		previousEndpoints: []*discovery.EndpointSlice{
@@ -560,7 +560,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		expectedLocalEndpoints: map[types.NamespacedName]int{
 			makeNSN("ns1", "ep1"): 1,
 		},
-		expectedChangedEndpoints: sets.NewString(),
+		expectedChangedEndpoints: sets.New[types.NamespacedName](),
 	}, {
 		name: "no change, multiple slices",
 		previousEndpoints: []*discovery.EndpointSlice{
@@ -590,7 +590,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		expectedDeletedUDPEndpoints:    []ServiceEndpoint{},
 		expectedNewlyActiveUDPServices: map[ServicePortName]bool{},
 		expectedLocalEndpoints:         map[types.NamespacedName]int{},
-		expectedChangedEndpoints:       sets.NewString(),
+		expectedChangedEndpoints:       sets.New[types.NamespacedName](),
 	}, {
 		name: "no change, multiple slices, multiple ports, local",
 		previousEndpoints: []*discovery.EndpointSlice{
@@ -628,7 +628,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		expectedLocalEndpoints: map[types.NamespacedName]int{
 			makeNSN("ns1", "ep1"): 1,
 		},
-		expectedChangedEndpoints: sets.NewString(),
+		expectedChangedEndpoints: sets.New[types.NamespacedName](),
 	}, {
 		name: "no change, multiple services, slices, IPs, and ports",
 		previousEndpoints: []*discovery.EndpointSlice{
@@ -699,7 +699,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 			makeNSN("ns1", "ep1"): 2,
 			makeNSN("ns2", "ep2"): 1,
 		},
-		expectedChangedEndpoints: sets.NewString(),
+		expectedChangedEndpoints: sets.New[types.NamespacedName](),
 	}, {
 		name: "add an EndpointSlice",
 		previousEndpoints: []*discovery.EndpointSlice{
@@ -721,7 +721,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		expectedLocalEndpoints: map[types.NamespacedName]int{
 			makeNSN("ns1", "ep1"): 1,
 		},
-		expectedChangedEndpoints: sets.NewString("ns1/ep1"),
+		expectedChangedEndpoints: sets.New(makeNSN("ns1", "ep1")),
 	}, {
 		name: "remove an EndpointSlice",
 		previousEndpoints: []*discovery.EndpointSlice{
@@ -742,7 +742,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		}},
 		expectedNewlyActiveUDPServices: map[ServicePortName]bool{},
 		expectedLocalEndpoints:         map[types.NamespacedName]int{},
-		expectedChangedEndpoints:       sets.NewString("ns1/ep1"),
+		expectedChangedEndpoints:       sets.New(makeNSN("ns1", "ep1")),
 	}, {
 		name: "add an IP and port",
 		previousEndpoints: []*discovery.EndpointSlice{
@@ -773,7 +773,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		expectedLocalEndpoints: map[types.NamespacedName]int{
 			makeNSN("ns1", "ep1"): 1,
 		},
-		expectedChangedEndpoints: sets.NewString("ns1/ep1"),
+		expectedChangedEndpoints: sets.New(makeNSN("ns1", "ep1")),
 	}, {
 		name: "remove an IP and port",
 		previousEndpoints: []*discovery.EndpointSlice{
@@ -809,7 +809,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		}},
 		expectedNewlyActiveUDPServices: map[ServicePortName]bool{},
 		expectedLocalEndpoints:         map[types.NamespacedName]int{},
-		expectedChangedEndpoints:       sets.NewString("ns1/ep1"),
+		expectedChangedEndpoints:       sets.New(makeNSN("ns1", "ep1")),
 	}, {
 		name: "add a slice to an endpoint",
 		previousEndpoints: []*discovery.EndpointSlice{
@@ -840,7 +840,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		expectedLocalEndpoints: map[types.NamespacedName]int{
 			makeNSN("ns1", "ep1"): 1,
 		},
-		expectedChangedEndpoints: sets.NewString("ns1/ep1"),
+		expectedChangedEndpoints: sets.New(makeNSN("ns1", "ep1")),
 	}, {
 		name: "remove a slice from an endpoint",
 		previousEndpoints: []*discovery.EndpointSlice{
@@ -870,7 +870,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		}},
 		expectedNewlyActiveUDPServices: map[ServicePortName]bool{},
 		expectedLocalEndpoints:         map[types.NamespacedName]int{},
-		expectedChangedEndpoints:       sets.NewString("ns1/ep1"),
+		expectedChangedEndpoints:       sets.New(makeNSN("ns1", "ep1")),
 	}, {
 		name: "rename a port",
 		previousEndpoints: []*discovery.EndpointSlice{
@@ -897,7 +897,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 			makeServicePortName("ns1", "ep1", "p11-2", v1.ProtocolUDP): true,
 		},
 		expectedLocalEndpoints:   map[types.NamespacedName]int{},
-		expectedChangedEndpoints: sets.NewString("ns1/ep1"),
+		expectedChangedEndpoints: sets.New(makeNSN("ns1", "ep1")),
 	}, {
 		name: "renumber a port",
 		previousEndpoints: []*discovery.EndpointSlice{
@@ -922,7 +922,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		}},
 		expectedNewlyActiveUDPServices: map[ServicePortName]bool{},
 		expectedLocalEndpoints:         map[types.NamespacedName]int{},
-		expectedChangedEndpoints:       sets.NewString("ns1/ep1"),
+		expectedChangedEndpoints:       sets.New(makeNSN("ns1", "ep1")),
 	}, {
 		name: "complex add and remove",
 		previousEndpoints: []*discovery.EndpointSlice{
@@ -1012,7 +1012,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		expectedLocalEndpoints: map[types.NamespacedName]int{
 			makeNSN("ns4", "ep4"): 1,
 		},
-		expectedChangedEndpoints: sets.NewString("ns1/ep1", "ns2/ep2", "ns3/ep3", "ns4/ep4"),
+		expectedChangedEndpoints: sets.New(makeNSN("ns1", "ep1"), makeNSN("ns2", "ep2"), makeNSN("ns3", "ep3"), makeNSN("ns4", "ep4")),
 	}, {
 		name: "change from 0 endpoint address to 1 unnamed port",
 		previousEndpoints: []*discovery.EndpointSlice{
@@ -1032,7 +1032,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 			makeServicePortName("ns1", "ep1", "", v1.ProtocolUDP): true,
 		},
 		expectedLocalEndpoints:   map[types.NamespacedName]int{},
-		expectedChangedEndpoints: sets.NewString("ns1/ep1"),
+		expectedChangedEndpoints: sets.New(makeNSN("ns1", "ep1")),
 	},
 	}
 
@@ -1071,14 +1071,12 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				}
 			}
 
-			pendingChanges := fp.endpointsChanges.PendingChanges()
-			if !pendingChanges.Equal(tc.expectedChangedEndpoints) {
-				t.Errorf("[%d] expected changed endpoints %q, got %q", tci, tc.expectedChangedEndpoints.List(), pendingChanges.List())
-			}
-
 			result := fp.endpointsMap.Update(fp.endpointsChanges)
 			newMap := fp.endpointsMap
 			compareEndpointsMapsStr(t, newMap, tc.expectedResult)
+			if !result.UpdatedServices.Equal(tc.expectedChangedEndpoints) {
+				t.Errorf("[%d] expected changed endpoints %q, got %q", tci, tc.expectedChangedEndpoints.UnsortedList(), result.UpdatedServices.UnsortedList())
+			}
 			if len(result.DeletedUDPEndpoints) != len(tc.expectedDeletedUDPEndpoints) {
 				t.Errorf("[%d] expected %d staleEndpoints, got %d: %v", tci, len(tc.expectedDeletedUDPEndpoints), len(result.DeletedUDPEndpoints), result.DeletedUDPEndpoints)
 			}
@@ -1266,14 +1264,13 @@ func TestEndpointSliceUpdate(t *testing.T) {
 	fqdnSlice.AddressType = discovery.AddressTypeFQDN
 
 	testCases := map[string]struct {
-		startingSlices           []*discovery.EndpointSlice
-		endpointChangeTracker    *EndpointChangeTracker
-		namespacedName           types.NamespacedName
-		paramEndpointSlice       *discovery.EndpointSlice
-		paramRemoveSlice         bool
-		expectedReturnVal        bool
-		expectedCurrentChange    map[ServicePortName][]*BaseEndpointInfo
-		expectedChangedEndpoints sets.String
+		startingSlices        []*discovery.EndpointSlice
+		endpointChangeTracker *EndpointChangeTracker
+		namespacedName        types.NamespacedName
+		paramEndpointSlice    *discovery.EndpointSlice
+		paramRemoveSlice      bool
+		expectedReturnVal     bool
+		expectedCurrentChange map[ServicePortName][]*BaseEndpointInfo
 	}{
 		// test starting from an empty state
 		"add a simple slice that doesn't already exist": {
@@ -1295,33 +1292,30 @@ func TestEndpointSliceUpdate(t *testing.T) {
 					&BaseEndpointInfo{Endpoint: "10.0.1.3:443", IsLocal: false, Ready: true, Serving: true, Terminating: false},
 				},
 			},
-			expectedChangedEndpoints: sets.NewString("ns1/svc1"),
 		},
 		// test no modification to state - current change should be nil as nothing changes
 		"add the same slice that already exists": {
 			startingSlices: []*discovery.EndpointSlice{
 				generateEndpointSlice("svc1", "ns1", 1, 3, 999, 999, []string{"host1", "host2"}, []*int32{pointer.Int32(80), pointer.Int32(443)}),
 			},
-			endpointChangeTracker:    NewEndpointChangeTracker("host1", nil, v1.IPv4Protocol, nil, nil),
-			namespacedName:           types.NamespacedName{Name: "svc1", Namespace: "ns1"},
-			paramEndpointSlice:       generateEndpointSlice("svc1", "ns1", 1, 3, 999, 999, []string{"host1", "host2"}, []*int32{pointer.Int32(80), pointer.Int32(443)}),
-			paramRemoveSlice:         false,
-			expectedReturnVal:        false,
-			expectedCurrentChange:    nil,
-			expectedChangedEndpoints: sets.NewString(),
+			endpointChangeTracker: NewEndpointChangeTracker("host1", nil, v1.IPv4Protocol, nil, nil),
+			namespacedName:        types.NamespacedName{Name: "svc1", Namespace: "ns1"},
+			paramEndpointSlice:    generateEndpointSlice("svc1", "ns1", 1, 3, 999, 999, []string{"host1", "host2"}, []*int32{pointer.Int32(80), pointer.Int32(443)}),
+			paramRemoveSlice:      false,
+			expectedReturnVal:     false,
+			expectedCurrentChange: nil,
 		},
 		// ensure that only valide address types are processed
 		"add an FQDN slice (invalid address type)": {
 			startingSlices: []*discovery.EndpointSlice{
 				generateEndpointSlice("svc1", "ns1", 1, 3, 999, 999, []string{"host1", "host2"}, []*int32{pointer.Int32(80), pointer.Int32(443)}),
 			},
-			endpointChangeTracker:    NewEndpointChangeTracker("host1", nil, v1.IPv4Protocol, nil, nil),
-			namespacedName:           types.NamespacedName{Name: "svc1", Namespace: "ns1"},
-			paramEndpointSlice:       fqdnSlice,
-			paramRemoveSlice:         false,
-			expectedReturnVal:        false,
-			expectedCurrentChange:    nil,
-			expectedChangedEndpoints: sets.NewString(),
+			endpointChangeTracker: NewEndpointChangeTracker("host1", nil, v1.IPv4Protocol, nil, nil),
+			namespacedName:        types.NamespacedName{Name: "svc1", Namespace: "ns1"},
+			paramEndpointSlice:    fqdnSlice,
+			paramRemoveSlice:      false,
+			expectedReturnVal:     false,
+			expectedCurrentChange: nil,
 		},
 		// test additions to existing state
 		"add a slice that overlaps with existing state": {
@@ -1354,7 +1348,6 @@ func TestEndpointSliceUpdate(t *testing.T) {
 					&BaseEndpointInfo{Endpoint: "10.0.2.2:443", IsLocal: true, Ready: true, Serving: true, Terminating: false},
 				},
 			},
-			expectedChangedEndpoints: sets.NewString("ns1/svc1"),
 		},
 		// test additions to existing state with partially overlapping slices and ports
 		"add a slice that overlaps with existing state and partial ports": {
@@ -1385,7 +1378,6 @@ func TestEndpointSliceUpdate(t *testing.T) {
 					&BaseEndpointInfo{Endpoint: "10.0.2.2:443", IsLocal: true, Ready: true, Serving: true, Terminating: false},
 				},
 			},
-			expectedChangedEndpoints: sets.NewString("ns1/svc1"),
 		},
 		// test deletions from existing state with partially overlapping slices and ports
 		"remove a slice that overlaps with existing state": {
@@ -1408,7 +1400,6 @@ func TestEndpointSliceUpdate(t *testing.T) {
 					&BaseEndpointInfo{Endpoint: "10.0.2.2:443", IsLocal: true, Ready: true, Serving: true, Terminating: false},
 				},
 			},
-			expectedChangedEndpoints: sets.NewString("ns1/svc1"),
 		},
 		// ensure a removal that has no effect turns into a no-op
 		"remove a slice that doesn't even exist in current state": {
@@ -1416,13 +1407,12 @@ func TestEndpointSliceUpdate(t *testing.T) {
 				generateEndpointSlice("svc1", "ns1", 1, 5, 999, 999, []string{"host1"}, []*int32{pointer.Int32(80), pointer.Int32(443)}),
 				generateEndpointSlice("svc1", "ns1", 2, 2, 999, 999, []string{"host1"}, []*int32{pointer.Int32(80), pointer.Int32(443)}),
 			},
-			endpointChangeTracker:    NewEndpointChangeTracker("host1", nil, v1.IPv4Protocol, nil, nil),
-			namespacedName:           types.NamespacedName{Name: "svc1", Namespace: "ns1"},
-			paramEndpointSlice:       generateEndpointSlice("svc1", "ns1", 3, 5, 999, 999, []string{"host1"}, []*int32{pointer.Int32(80), pointer.Int32(443)}),
-			paramRemoveSlice:         true,
-			expectedReturnVal:        false,
-			expectedCurrentChange:    nil,
-			expectedChangedEndpoints: sets.NewString(),
+			endpointChangeTracker: NewEndpointChangeTracker("host1", nil, v1.IPv4Protocol, nil, nil),
+			namespacedName:        types.NamespacedName{Name: "svc1", Namespace: "ns1"},
+			paramEndpointSlice:    generateEndpointSlice("svc1", "ns1", 3, 5, 999, 999, []string{"host1"}, []*int32{pointer.Int32(80), pointer.Int32(443)}),
+			paramRemoveSlice:      true,
+			expectedReturnVal:     false,
+			expectedCurrentChange: nil,
 		},
 		// start with all endpoints ready, transition to no endpoints ready
 		"transition all endpoints to unready state": {
@@ -1446,7 +1436,6 @@ func TestEndpointSliceUpdate(t *testing.T) {
 					&BaseEndpointInfo{Endpoint: "10.0.1.3:443", IsLocal: true, Ready: false, Serving: false, Terminating: false},
 				},
 			},
-			expectedChangedEndpoints: sets.NewString("ns1/svc1"),
 		},
 		// start with no endpoints ready, transition to all endpoints ready
 		"transition all endpoints to ready state": {
@@ -1468,7 +1457,6 @@ func TestEndpointSliceUpdate(t *testing.T) {
 					&BaseEndpointInfo{Endpoint: "10.0.1.2:443", IsLocal: true, Ready: true, Serving: true, Terminating: false},
 				},
 			},
-			expectedChangedEndpoints: sets.NewString("ns1/svc1"),
 		},
 		// start with some endpoints ready, transition to more endpoints ready
 		"transition some endpoints to ready state": {
@@ -1497,7 +1485,6 @@ func TestEndpointSliceUpdate(t *testing.T) {
 					&BaseEndpointInfo{Endpoint: "10.0.2.2:443", IsLocal: true, Ready: false, Serving: false, Terminating: false},
 				},
 			},
-			expectedChangedEndpoints: sets.NewString("ns1/svc1"),
 		},
 		// start with some endpoints ready, transition to some terminating
 		"transition some endpoints to terminating state": {
@@ -1526,7 +1513,6 @@ func TestEndpointSliceUpdate(t *testing.T) {
 					&BaseEndpointInfo{Endpoint: "10.0.2.2:443", IsLocal: true, Ready: false, Serving: false, Terminating: true},
 				},
 			},
-			expectedChangedEndpoints: sets.NewString("ns1/svc1"),
 		},
 	}
 
@@ -1539,21 +1525,16 @@ func TestEndpointSliceUpdate(t *testing.T) {
 				t.Errorf("EndpointSliceUpdate return value got: %v, want %v", got, tc.expectedReturnVal)
 			}
 
-			pendingChanges := tc.endpointChangeTracker.PendingChanges()
-			if !pendingChanges.Equal(tc.expectedChangedEndpoints) {
-				t.Errorf("expected changed endpoints %q, got %q", tc.expectedChangedEndpoints.List(), pendingChanges.List())
-			}
-
 			changes := tc.endpointChangeTracker.checkoutChanges()
 			if tc.expectedCurrentChange == nil {
 				if len(changes) != 0 {
 					t.Errorf("Expected %s to have no changes", tc.namespacedName)
 				}
 			} else {
-				if len(changes) == 0 || changes[0] == nil {
+				if _, exists := changes[tc.namespacedName]; !exists {
 					t.Fatalf("Expected %s to have changes", tc.namespacedName)
 				}
-				compareEndpointsMapsStr(t, changes[0].current, tc.expectedCurrentChange)
+				compareEndpointsMapsStr(t, changes[tc.namespacedName].current, tc.expectedCurrentChange)
 			}
 		})
 	}
@@ -1624,15 +1605,17 @@ func TestCheckoutChanges(t *testing.T) {
 				t.Fatalf("Expected %d changes, got %d", len(tc.expectedChanges), len(changes))
 			}
 
-			for i, change := range changes {
-				expectedChange := tc.expectedChanges[i]
+			for _, change := range changes {
+				// All of the test cases have 0 or 1 changes, so if we're
+				// here, then expectedChanges[0] is what we expect.
+				expectedChange := tc.expectedChanges[0]
 
 				if !reflect.DeepEqual(change.previous, expectedChange.previous) {
-					t.Errorf("[%d] Expected change.previous: %+v, got: %+v", i, expectedChange.previous, change.previous)
+					t.Errorf("Expected change.previous: %+v, got: %+v", expectedChange.previous, change.previous)
 				}
 
 				if !reflect.DeepEqual(change.current, expectedChange.current) {
-					t.Errorf("[%d] Expected change.current: %+v, got: %+v", i, expectedChange.current, change.current)
+					t.Errorf("Expected change.current: %+v, got: %+v", expectedChange.current, change.current)
 				}
 			}
 		})

--- a/pkg/proxy/endpointslicecache.go
+++ b/pkg/proxy/endpointslicecache.go
@@ -188,25 +188,10 @@ func (cache *EndpointSliceCache) updatePending(endpointSlice *discovery.Endpoint
 	return changed
 }
 
-// pendingChanges returns a set whose keys are the names of the services whose endpoints
-// have changed since the last time checkoutChanges was called
-func (cache *EndpointSliceCache) pendingChanges() sets.String {
-	cache.lock.Lock()
-	defer cache.lock.Unlock()
-
-	changes := sets.NewString()
-	for serviceNN, esTracker := range cache.trackerByServiceMap {
-		if len(esTracker.pending) > 0 {
-			changes.Insert(serviceNN.String())
-		}
-	}
-	return changes
-}
-
-// checkoutChanges returns a list of all endpointsChanges that are
+// checkoutChanges returns a map of all endpointsChanges that are
 // pending and then marks them as applied.
-func (cache *EndpointSliceCache) checkoutChanges() []*endpointsChange {
-	changes := []*endpointsChange{}
+func (cache *EndpointSliceCache) checkoutChanges() map[types.NamespacedName]*endpointsChange {
+	changes := make(map[types.NamespacedName]*endpointsChange)
 
 	cache.lock.Lock()
 	defer cache.lock.Unlock()
@@ -231,7 +216,7 @@ func (cache *EndpointSliceCache) checkoutChanges() []*endpointsChange {
 		}
 
 		change.current = cache.getEndpointsMap(serviceNN, esTracker.applied)
-		changes = append(changes, change)
+		changes[serviceNN] = change
 	}
 
 	return changes

--- a/pkg/proxy/iptables/proxier.go
+++ b/pkg/proxy/iptables/proxier.go
@@ -823,11 +823,6 @@ func (proxier *Proxier) syncProxyRules() {
 	}()
 
 	tryPartialSync := !proxier.needFullSync && utilfeature.DefaultFeatureGate.Enabled(features.MinimizeIPTablesRestore)
-	var serviceChanged, endpointsChanged sets.String
-	if tryPartialSync {
-		serviceChanged = proxier.serviceChanges.PendingChanges()
-		endpointsChanged = proxier.endpointsChanges.PendingChanges()
-	}
 	serviceUpdateResult := proxier.svcPortMap.Update(proxier.serviceChanges)
 	endpointUpdateResult := proxier.endpointsMap.Update(proxier.endpointsChanges)
 
@@ -1247,7 +1242,7 @@ func (proxier *Proxier) syncProxyRules() {
 		// If the SVC/SVL/EXT/FW/SEP chains have not changed since the last sync
 		// then we can omit them from the restore input. (We have already marked
 		// them in activeNATChains, so they won't get deleted.)
-		if tryPartialSync && !serviceChanged.Has(svcName.NamespacedName.String()) && !endpointsChanged.Has(svcName.NamespacedName.String()) {
+		if tryPartialSync && !serviceUpdateResult.UpdatedServices.Has(svcName.NamespacedName) && !endpointUpdateResult.UpdatedServices.Has(svcName.NamespacedName) {
 			continue
 		}
 

--- a/pkg/proxy/service.go
+++ b/pkg/proxy/service.go
@@ -327,22 +327,12 @@ func (sct *ServiceChangeTracker) Update(previous, current *v1.Service) bool {
 	return len(sct.items) > 0
 }
 
-// PendingChanges returns a set whose keys are the names of the services that have changed
-// since the last time sct was used to update a ServiceMap. (You must call this _before_
-// calling sm.Update(sct).)
-func (sct *ServiceChangeTracker) PendingChanges() sets.String {
-	sct.lock.Lock()
-	defer sct.lock.Unlock()
-
-	changes := sets.NewString()
-	for name := range sct.items {
-		changes.Insert(name.String())
-	}
-	return changes
-}
-
 // UpdateServiceMapResult is the updated results after applying service changes.
 type UpdateServiceMapResult struct {
+	// UpdatedServices lists the names of all services added/updated/deleted since the
+	// last Update.
+	UpdatedServices sets.Set[types.NamespacedName]
+
 	// DeletedUDPClusterIPs holds stale (no longer assigned to a Service) Service IPs
 	// that had UDP ports. Callers can use this to abort timeout-waits or clear
 	// connection-tracking information.
@@ -406,13 +396,16 @@ func (sm ServicePortMap) Update(sct *ServiceChangeTracker) UpdateServiceMapResul
 	defer sct.lock.Unlock()
 
 	result := UpdateServiceMapResult{
+		UpdatedServices:      sets.New[types.NamespacedName](),
 		DeletedUDPClusterIPs: sets.NewString(),
 	}
 
-	for _, change := range sct.items {
+	for nn, change := range sct.items {
 		if sct.processServiceMapChange != nil {
 			sct.processServiceMapChange(change.previous, change.current)
 		}
+		result.UpdatedServices.Insert(nn)
+
 		sm.merge(change.current)
 		// filter out the Update event of current changes from previous changes
 		// before calling unmerge() so that can skip deleting the Update events.

--- a/pkg/proxy/service.go
+++ b/pkg/proxy/service.go
@@ -349,13 +349,6 @@ type UpdateServiceMapResult struct {
 	DeletedUDPClusterIPs sets.String
 }
 
-// Update updates ServicePortMap base on the given changes.
-func (sm ServicePortMap) Update(changes *ServiceChangeTracker) (result UpdateServiceMapResult) {
-	result.DeletedUDPClusterIPs = sets.NewString()
-	sm.apply(changes, result.DeletedUDPClusterIPs)
-	return result
-}
-
 // HealthCheckNodePorts returns a map of Service names to HealthCheckNodePort values
 // for all Services in sm with non-zero HealthCheckNodePort.
 func (sm ServicePortMap) HealthCheckNodePorts() map[types.NamespacedName]uint16 {
@@ -405,24 +398,32 @@ func (sct *ServiceChangeTracker) serviceToServiceMap(service *v1.Service) Servic
 	return svcPortMap
 }
 
-// apply the changes to ServicePortMap and update the deleted UDP cluster IP set.
-// apply triggers processServiceMapChange on every change.
-func (sm *ServicePortMap) apply(changes *ServiceChangeTracker, deletedUDPClusterIPs sets.String) {
-	changes.lock.Lock()
-	defer changes.lock.Unlock()
-	for _, change := range changes.items {
-		if changes.processServiceMapChange != nil {
-			changes.processServiceMapChange(change.previous, change.current)
+// Update updates ServicePortMap base on the given changes, returns information about the
+// diff since the last Update, triggers processServiceMapChange on every change, and
+// clears the changes map.
+func (sm ServicePortMap) Update(sct *ServiceChangeTracker) UpdateServiceMapResult {
+	sct.lock.Lock()
+	defer sct.lock.Unlock()
+
+	result := UpdateServiceMapResult{
+		DeletedUDPClusterIPs: sets.NewString(),
+	}
+
+	for _, change := range sct.items {
+		if sct.processServiceMapChange != nil {
+			sct.processServiceMapChange(change.previous, change.current)
 		}
 		sm.merge(change.current)
-		// filter out the Update event of current changes from previous changes before calling unmerge() so that can
-		// skip deleting the Update events.
+		// filter out the Update event of current changes from previous changes
+		// before calling unmerge() so that can skip deleting the Update events.
 		change.previous.filter(change.current)
-		sm.unmerge(change.previous, deletedUDPClusterIPs)
+		sm.unmerge(change.previous, result.DeletedUDPClusterIPs)
 	}
 	// clear changes after applying them to ServicePortMap.
-	changes.items = make(map[types.NamespacedName]*serviceChange)
+	sct.items = make(map[types.NamespacedName]*serviceChange)
 	metrics.ServiceChangesPending.Set(0)
+
+	return result
 }
 
 // merge adds other ServicePortMap's elements to current ServicePortMap.

--- a/pkg/proxy/service_test.go
+++ b/pkg/proxy/service_test.go
@@ -560,15 +560,14 @@ func TestServiceMapUpdateHeadless(t *testing.T) {
 	)
 
 	// Headless service should be ignored
-	pending := fp.serviceChanges.PendingChanges()
-	if pending.Len() != 0 {
-		t.Errorf("expected 0 pending service changes, got %d", pending.Len())
-	}
 	result := fp.svcPortMap.Update(fp.serviceChanges)
 	if len(fp.svcPortMap) != 0 {
 		t.Errorf("expected service map length 0, got %d", len(fp.svcPortMap))
 	}
 
+	if len(result.UpdatedServices) != 0 {
+		t.Errorf("expected 0 updated services, got %d", len(result.UpdatedServices))
+	}
 	if len(result.DeletedUDPClusterIPs) != 0 {
 		t.Errorf("expected stale UDP services length 0, got %d", len(result.DeletedUDPClusterIPs))
 	}
@@ -592,13 +591,12 @@ func TestUpdateServiceTypeExternalName(t *testing.T) {
 		}),
 	)
 
-	pending := fp.serviceChanges.PendingChanges()
-	if pending.Len() != 0 {
-		t.Errorf("expected 0 pending service changes, got %d", pending.Len())
-	}
 	result := fp.svcPortMap.Update(fp.serviceChanges)
 	if len(fp.svcPortMap) != 0 {
 		t.Errorf("expected service map length 0, got %v", fp.svcPortMap)
+	}
+	if len(result.UpdatedServices) != 0 {
+		t.Errorf("expected 0 updated services, got %v", result.UpdatedServices)
 	}
 	if len(result.DeletedUDPClusterIPs) != 0 {
 		t.Errorf("expected stale UDP services length 0, got %v", result.DeletedUDPClusterIPs)
@@ -659,20 +657,18 @@ func TestBuildServiceMapAddRemove(t *testing.T) {
 		fp.addService(services[i])
 	}
 
-	pending := fp.serviceChanges.PendingChanges()
-	for i := range services {
-		name := services[i].Namespace + "/" + services[i].Name
-		if !pending.Has(name) {
-			t.Errorf("expected pending change for %q", name)
-		}
-	}
-	if pending.Len() != len(services) {
-		t.Errorf("expected %d pending service changes, got %d", len(services), pending.Len())
-	}
-
 	result := fp.svcPortMap.Update(fp.serviceChanges)
 	if len(fp.svcPortMap) != 8 {
 		t.Errorf("expected service map length 2, got %v", fp.svcPortMap)
+	}
+	for i := range services {
+		name := makeNSN(services[i].Namespace, services[i].Name)
+		if !result.UpdatedServices.Has(name) {
+			t.Errorf("expected updated service for %q", name)
+		}
+	}
+	if len(result.UpdatedServices) != len(services) {
+		t.Errorf("expected %d updated services, got %d", len(services), len(result.UpdatedServices))
 	}
 	if len(result.DeletedUDPClusterIPs) != 0 {
 		// Services only added, so nothing stale yet
@@ -703,13 +699,12 @@ func TestBuildServiceMapAddRemove(t *testing.T) {
 	fp.deleteService(services[2])
 	fp.deleteService(services[3])
 
-	pending = fp.serviceChanges.PendingChanges()
-	if pending.Len() != 4 {
-		t.Errorf("expected 4 pending service changes, got %d", pending.Len())
-	}
 	result = fp.svcPortMap.Update(fp.serviceChanges)
 	if len(fp.svcPortMap) != 1 {
 		t.Errorf("expected service map length 1, got %v", fp.svcPortMap)
+	}
+	if len(result.UpdatedServices) != 4 {
+		t.Errorf("expected 4 updated services, got %d", len(result.UpdatedServices))
 	}
 
 	healthCheckNodePorts = fp.svcPortMap.HealthCheckNodePorts()
@@ -757,13 +752,12 @@ func TestBuildServiceMapServiceUpdate(t *testing.T) {
 
 	fp.addService(servicev1)
 
-	pending := fp.serviceChanges.PendingChanges()
-	if pending.Len() != 1 {
-		t.Errorf("expected 1 pending service change, got %d", pending.Len())
-	}
 	result := fp.svcPortMap.Update(fp.serviceChanges)
 	if len(fp.svcPortMap) != 2 {
 		t.Errorf("expected service map length 2, got %v", fp.svcPortMap)
+	}
+	if len(result.UpdatedServices) != 1 {
+		t.Errorf("expected 1 updated service, got %d", len(result.UpdatedServices))
 	}
 	if len(result.DeletedUDPClusterIPs) != 0 {
 		// Services only added, so nothing stale yet
@@ -777,13 +771,12 @@ func TestBuildServiceMapServiceUpdate(t *testing.T) {
 
 	// Change service to load-balancer
 	fp.updateService(servicev1, servicev2)
-	pending = fp.serviceChanges.PendingChanges()
-	if pending.Len() != 1 {
-		t.Errorf("expected 1 pending service change, got %d", pending.Len())
-	}
 	result = fp.svcPortMap.Update(fp.serviceChanges)
 	if len(fp.svcPortMap) != 2 {
 		t.Errorf("expected service map length 2, got %v", fp.svcPortMap)
+	}
+	if len(result.UpdatedServices) != 1 {
+		t.Errorf("expected 1 updated service, got %d", len(result.UpdatedServices))
 	}
 	if len(result.DeletedUDPClusterIPs) != 0 {
 		t.Errorf("expected stale UDP services length 0, got %v", result.DeletedUDPClusterIPs.UnsortedList())
@@ -797,13 +790,12 @@ func TestBuildServiceMapServiceUpdate(t *testing.T) {
 	// No change; make sure the service map stays the same and there are
 	// no health-check changes
 	fp.updateService(servicev2, servicev2)
-	pending = fp.serviceChanges.PendingChanges()
-	if pending.Len() != 0 {
-		t.Errorf("expected 0 pending service changes, got %d", pending.Len())
-	}
 	result = fp.svcPortMap.Update(fp.serviceChanges)
 	if len(fp.svcPortMap) != 2 {
 		t.Errorf("expected service map length 2, got %v", fp.svcPortMap)
+	}
+	if len(result.UpdatedServices) != 0 {
+		t.Errorf("expected 0 updated services, got %d", len(result.UpdatedServices))
 	}
 	if len(result.DeletedUDPClusterIPs) != 0 {
 		t.Errorf("expected stale UDP services length 0, got %v", result.DeletedUDPClusterIPs.UnsortedList())
@@ -816,13 +808,12 @@ func TestBuildServiceMapServiceUpdate(t *testing.T) {
 
 	// And back to ClusterIP
 	fp.updateService(servicev2, servicev1)
-	pending = fp.serviceChanges.PendingChanges()
-	if pending.Len() != 1 {
-		t.Errorf("expected 1 pending service change, got %d", pending.Len())
-	}
 	result = fp.svcPortMap.Update(fp.serviceChanges)
 	if len(fp.svcPortMap) != 2 {
 		t.Errorf("expected service map length 2, got %v", fp.svcPortMap)
+	}
+	if len(result.UpdatedServices) != 1 {
+		t.Errorf("expected 1 updated service, got %d", len(result.UpdatedServices))
 	}
 	if len(result.DeletedUDPClusterIPs) != 0 {
 		// Services only added, so nothing stale yet


### PR DESCRIPTION
Cherry pick of #122204 on release-1.27.

#122204: Fix race condition in iptables partial sync handling

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fixes a race condition in the iptables mode of kube-proxy in 1.27 and later
that could result in some updates getting lost (e.g., when a service gets a
new endpoint, the rules for the new endpoint might not be added until
much later).
```