### PR TITLE
kubectl proxy should warn about dangerous configurations

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/proxy/proxy.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/proxy/proxy.go
@@ -185,6 +185,13 @@ func (o *ProxyOptions) Complete(f cmdutil.Factory) error {
 			RejectMethods: proxy.MakeRegexpArrayOrDie(o.rejectMethods),
 		}
 	}
+	if o.address == "0.0.0.0" {
+		klog.Warning("kubectl proxy will serve on all network interfaces (0.0.0.0), which may expose cluster access via the proxy to anyone who can access your network.")
+	}
+	// string contains will use exact match, not regex.
+	if strings.Contains(o.acceptHosts, ".*") {
+		klog.Warning("--accept-hosts will accept any host, which may expose cluster access via the proxy to anyone who can access your network.")
+	}
 	return nil
 }
 


### PR DESCRIPTION
#### What this PR does / why we need it:
In AquaSec recent research, they have identified a common misconfiguration related to the use of the kubectl proxy command in Kubernetes clusters. This misconfiguration can expose the Kubernetes API server to unauthorized access and poses significant security risks. 
Scope:
The misconfiguration occurs when practitioners run the kubectl proxy command with specific flags, such as --address=0.0.0.0 --accept-hosts .*. This configuration causes the proxy on the workstation to listen and forward authorized and authenticated requests to the API server from any host that has HTTP access to the workstation. Importantly, the privileges granted to the kubectl proxy command are the same as those of the user who ran it. Risks:
This misconfiguration can lead to unauthorized access to the Kubernetes cluster, potentially compromising the security of the cluster and the applications running on it. Threat actors can exploit this exposure to gain access to sensitive information, secrets, and other critical resources.

#### Which issue(s) this PR fixes:
To address this issue and mitigate the risks associated with misconfigured kubectl proxy commands, we propose the following steps: 
##### Kuberenetes warning: 
- Running kubectl proxy with wide-open configurations can expose your Kubernetes cluster to potential security threats. Attackers could exploit this vulnerability to gain unauthorized access to your cluster and its resources. Add one section check o.address and acceptHosts in https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/kubectl/pkg/cmd/proxy/proxy.go#L151 
##### Securing kubectl proxy: 
- Ensure that the kubectl proxy is not exposed to the internet, and set it up within a secure network environment accessible only by authenticated and authorized users. 

#### Special notes for your reviewer:
This issue highlights the security risks associated with misconfigured kubectl proxy commands and provides recommendations for addressing these risks. It's crucial for Kubernetes users to be aware of the potential dangers and take appropriate precautions to secure their clusters. References:
https://blog.aquasec.com/kubernetes-exposed-one-yaml-away-from-disaster
#### Does this PR introduce a user-facing change?
```release-note
Users will get warnings when proxy set to 0.0.0.0 or accept hosts contains .*
```

```docs
[blog]: <https://blog.aquasec.com/kubernetes-exposed-one-yaml-away-from-disaster>
```
