### PR TITLE
Clean unused code in kubelet server.

### DIFF
--- a/pkg/kubelet/server/server.go
+++ b/pkg/kubelet/server/server.go
@@ -210,13 +210,6 @@ func ListenAndServeKubeletReadOnlyServer(
 	}
 }
 
-type PodResourcesProviders struct {
-	Pods    podresources.PodsProvider
-	Devices podresources.DevicesProvider
-	Cpus    podresources.CPUsProvider
-	Memory  podresources.MemoryProvider
-}
-
 // ListenAndServePodResources initializes a gRPC server to serve the PodResources service
 func ListenAndServePodResources(endpoint string, providers podresources.PodResourcesProviders) {
 	server := grpc.NewServer(apisgrpc.WithRateLimiter("podresources", podresources.DefaultQPS, podresources.DefaultBurstTokens))


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
This struct ```PodResourcesProviders``` has moved into ```pkg/kubelet/apis/podresources/types.go```.
So clean that unused code.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
None
```

