### PR TITLE
e2e: remove dead code

### DIFF
--- a/test/e2e/framework/ingress/ingress_utils.go
+++ b/test/e2e/framework/ingress/ingress_utils.go
@@ -38,7 +38,6 @@ import (
 	"time"
 
 	compute "google.golang.org/api/compute/v1"
-	"k8s.io/klog/v2"
 	netutils "k8s.io/utils/net"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -123,19 +122,6 @@ const (
 type TestLogger interface {
 	Infof(format string, args ...interface{})
 	Errorf(format string, args ...interface{})
-}
-
-// GLogger is test logger.
-type GLogger struct{}
-
-// Infof outputs log with info level.
-func (l *GLogger) Infof(format string, args ...interface{}) {
-	klog.Infof(format, args...)
-}
-
-// Errorf outputs log with error level.
-func (l *GLogger) Errorf(format string, args ...interface{}) {
-	klog.Errorf(format, args...)
 }
 
 // E2ELogger is test logger.

--- a/test/e2e/framework/pod/wait.go
+++ b/test/e2e/framework/pod/wait.go
@@ -518,11 +518,6 @@ func WaitForPodSuccessInNamespace(ctx context.Context, c clientset.Interface, po
 	return WaitForPodSuccessInNamespaceTimeout(ctx, c, podName, namespace, podStartTimeout)
 }
 
-// WaitForPodSuccessInNamespaceSlow returns nil if the pod reached state success, or an error if it reached failure or until slowPodStartupTimeout.
-func WaitForPodSuccessInNamespaceSlow(ctx context.Context, c clientset.Interface, podName string, namespace string) error {
-	return WaitForPodSuccessInNamespaceTimeout(ctx, c, podName, namespace, slowPodStartTimeout)
-}
-
 // WaitForPodNotFoundInNamespace returns an error if it takes too long for the pod to fully terminate.
 // Unlike `waitForPodTerminatedInNamespace`, the pod's Phase and Reason are ignored. If the pod Get
 // api returns IsNotFound then the wait stops and nil is returned. If the Get api returns an error other

--- a/test/e2e/framework/skipper/skipper.go
+++ b/test/e2e/framework/skipper/skipper.go
@@ -22,13 +22,10 @@ import (
 
 	"github.com/onsi/ginkgo/v2"
 
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilversion "k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/client-go/discovery"
-	"k8s.io/client-go/dynamic"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/component-base/featuregate"
 	"k8s.io/kubernetes/test/e2e/framework"
@@ -82,34 +79,6 @@ func SkipUnlessFeatureGateEnabled(gate featuregate.Feature) {
 	}
 	if !featureGate.Enabled(gate) {
 		skipInternalf(1, "Only supported when %v feature is enabled", gate)
-	}
-}
-
-// SkipIfFeatureGateEnabled skips if the feature is enabled.
-//
-// Beware that this only works in test suites that have a --feature-gate
-// parameter and call InitFeatureGates. In test/e2e, the `Feature: XYZ` tag
-// has to be used instead and invocations have to make sure that they
-// only run tests that work with the given test cluster.
-func SkipIfFeatureGateEnabled(gate featuregate.Feature) {
-	if featureGate == nil {
-		framework.Failf("Feature gate checking is not enabled, don't use SkipFeatureGateEnabled(%v). Instead use the Feature tag.", gate)
-	}
-	if featureGate.Enabled(gate) {
-		skipInternalf(1, "Only supported when %v feature is disabled", gate)
-	}
-}
-
-// SkipIfMissingResource skips if the gvr resource is missing.
-func SkipIfMissingResource(ctx context.Context, dynamicClient dynamic.Interface, gvr schema.GroupVersionResource, namespace string) {
-	resourceClient := dynamicClient.Resource(gvr).Namespace(namespace)
-	_, err := resourceClient.List(ctx, metav1.ListOptions{})
-	if err != nil {
-		// not all resources support list, so we ignore those
-		if apierrors.IsMethodNotSupported(err) || apierrors.IsNotFound(err) || apierrors.IsForbidden(err) {
-			skipInternalf(1, "Could not find %s resource, skipping test: %#v", gvr, err)
-		}
-		framework.Failf("Unexpected error getting %v: %v", gvr, err)
 	}
 }
 
@@ -228,16 +197,6 @@ var AppArmorDistros = []string{"gci", "ubuntu"}
 // SkipIfAppArmorNotSupported skips if the AppArmor is not supported by the node OS distro.
 func SkipIfAppArmorNotSupported() {
 	SkipUnlessNodeOSDistroIs(AppArmorDistros...)
-}
-
-// RunIfSystemSpecNameIs runs if the system spec name is included in the names.
-func RunIfSystemSpecNameIs(names ...string) {
-	for _, name := range names {
-		if name == framework.TestContext.SystemSpecName {
-			return
-		}
-	}
-	skipInternalf(1, "Skipped because system spec name %q is not in %v", framework.TestContext.SystemSpecName, names)
 }
 
 // SkipUnlessComponentRunsAsPodsAndClientCanDeleteThem run if the component run as pods and client can delete them

--- a/test/e2e/network/scale/localrun/ingress_scale.go
+++ b/test/e2e/network/scale/localrun/ingress_scale.go
@@ -162,7 +162,7 @@ func main() {
 
 	// Setting up a localized scale test framework.
 	f := scale.NewIngressScaleFramework(cs, ns.Name, cloudConfig)
-	f.Logger = &e2eingress.GLogger{}
+	f.Logger = &e2eingress.E2ELogger{}
 	// Customizing scale test.
 	f.EnableTLS = enableTLS
 	f.OutputFile = outputFile


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The dead code was found with:

    deadcode -test -filter=k8s.io/kubernetes/test/e2e/framework/... ./test/e2e ./test/e2e_node ./test/e2e_node ./test/e2e_kubeadm

See https://go.dev/blog/deadcode for an introduction.

Only dead code which is clearly not needed anymore (glog logging), questionable (skipping based on feature gates) or
redundant (WaitForPodSuccessInNamespaceSlow) gets removed for now. More removals might make sense in the future.

#### Special notes for your reviewer:

Full report for remaining code:
```
test/e2e/framework/ingress/ingress_utils.go:369:6: unreachable func: BuildInsecureClient
test/e2e/framework/ingress/ingress_utils.go:590:19: unreachable func: TestJig.AddHTTPS
test/e2e/framework/ingress/ingress_utils.go:615:19: unreachable func: TestJig.RemoveHTTPS
test/e2e/framework/ingress/ingress_utils.go:816:19: unreachable func: TestJig.WaitForIngressWithCert
test/e2e/framework/ingress/ingress_utils.go:829:19: unreachable func: TestJig.VerifyURL
test/e2e/framework/ingress/ingress_utils.go:908:19: unreachable func: TestJig.GetIngressNodePorts
test/e2e/framework/ingress/ingress_utils.go:946:19: unreachable func: TestJig.ConstructFirewallForIngress
test/e2e/framework/ingress/ingress_utils.go:995:37: unreachable func: NginxIngressController.Init
test/e2e/framework/ingress/ingress_utils.go:1041:37: unreachable func: NginxIngressController.TearDown
test/e2e/framework/ingress/ingress_utils.go:1049:6: unreachable func: generateBacksideHTTPSIngressSpec
test/e2e/framework/ingress/ingress_utils.go:1069:6: unreachable func: generateBacksideHTTPSServiceSpec
test/e2e/framework/ingress/ingress_utils.go:1092:6: unreachable func: generateBacksideHTTPSDeploymentSpec
test/e2e/framework/ingress/ingress_utils.go:1111:19: unreachable func: TestJig.SetUpBacksideHTTPSIngress
test/e2e/framework/ingress/ingress_utils.go:1135:19: unreachable func: TestJig.DeleteTestResource
test/e2e/framework/manifest/manifest.go:38:6: unreachable func: PodFromManifest
test/e2e/framework/metrics/api.go:41:29: unreachable func: APIResponsiveness.SummaryKind
test/e2e/framework/metrics/api.go:46:29: unreachable func: APIResponsiveness.PrintHumanReadable
test/e2e/framework/metrics/api.go:51:29: unreachable func: APIResponsiveness.PrintJSON
test/e2e/framework/metrics/api.go:55:29: unreachable func: APIResponsiveness.Len
test/e2e/framework/metrics/api.go:56:29: unreachable func: APIResponsiveness.Swap
test/e2e/framework/metrics/api.go:59:29: unreachable func: APIResponsiveness.Less
test/e2e/framework/metrics/api.go:68:6: unreachable func: APICallToPerfData
test/e2e/framework/network/utils.go:120:6: unreachable func: PreferExternalAddresses
test/e2e/framework/pod/dial.go:43:6: unreachable func: NewTransport
test/e2e/framework/pod/dial.go:161:6: unreachable func: ParseAddr
test/e2e/framework/providers/gcp.go:32:6: unreachable func: EtcdUpgrade
test/e2e/framework/providers/gcp.go:41:6: unreachable func: etcdUpgradeGCE
test/e2e/framework/providers/gce/ingress.go:144:32: unreachable func: IngressController.ListGlobalForwardingRules
test/e2e/framework/providers/gce/ingress.go:180:32: unreachable func: IngressController.GetGlobalAddress
test/e2e/framework/providers/gce/ingress.go:208:32: unreachable func: IngressController.ListTargetHTTPProxies
test/e2e/framework/providers/gce/ingress.go:222:32: unreachable func: IngressController.ListTargetHTTPSProxies
test/e2e/framework/providers/gce/ingress.go:271:32: unreachable func: IngressController.ListURLMaps
test/e2e/framework/providers/gce/ingress.go:314:32: unreachable func: IngressController.ListGlobalBackendServices
test/e2e/framework/providers/gce/ingress.go:387:32: unreachable func: IngressController.ListSslCertificates
test/e2e/framework/providers/gce/ingress.go:429:32: unreachable func: IngressController.ListInstanceGroups
test/e2e/framework/providers/gce/ingress.go:537:32: unreachable func: IngressController.isOwned
test/e2e/framework/providers/gce/ingress.go:573:32: unreachable func: IngressController.GetFirewallRuleName
test/e2e/framework/providers/gce/ingress.go:579:32: unreachable func: IngressController.GetFirewallRule
test/e2e/framework/providers/gce/ingress.go:622:32: unreachable func: IngressController.WaitForIgBackendService
test/e2e/framework/providers/gce/ingress.go:770:32: unreachable func: IngressController.CreateStaticIP
test/e2e/framework/providers/gce/ingress.go:855:6: unreachable func: GcloudComputeResourceCreate
test/e2e/framework/service/resource.go:123:6: unreachable func: CreateServiceForSimpleAppWithPods
test/e2e/framework/service/resource.go:134:6: unreachable func: CreateServiceForSimpleApp
```

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/assign @aojea 