### PR TITLE
update metrics for rotate kubelet server certificate

### DIFF
--- a/pkg/kubelet/certificate/kubelet.go
+++ b/pkg/kubelet/certificate/kubelet.go
@@ -61,7 +61,7 @@ func NewKubeletServerCertificateManager(kubeClient clientset.Interface, kubeCfg 
 			Subsystem:      metrics.KubeletSubsystem,
 			Name:           "server_expiration_renew_errors",
 			Help:           "Counter of certificate renewal errors.",
-			StabilityLevel: compbasemetrics.ALPHA,
+			StabilityLevel: compbasemetrics.BETA,
 		},
 	)
 	legacyregistry.MustRegister(certificateRenewFailure)
@@ -83,7 +83,7 @@ func NewKubeletServerCertificateManager(kubeClient clientset.Interface, kubeCfg 
 				31104000,  // 1  year
 				124416000, // 4  years
 			},
-			StabilityLevel: compbasemetrics.ALPHA,
+			StabilityLevel: compbasemetrics.BETA,
 		},
 	)
 	legacyregistry.MustRegister(certificateRotationAge)
@@ -125,7 +125,7 @@ func NewKubeletServerCertificateManager(kubeClient clientset.Interface, kubeCfg 
 				"until certificate expiry (negative if already expired). If " +
 				"serving certificate is invalid or unused, the value will " +
 				"be +INF.",
-			StabilityLevel: compbasemetrics.ALPHA,
+			StabilityLevel: compbasemetrics.BETA,
 		},
 		func() float64 {
 			if c := m.Current(); c != nil && c.Leaf != nil {

--- a/test/instrumentation/testdata/stable-metrics-list.yaml
+++ b/test/instrumentation/testdata/stable-metrics-list.yaml
@@ -88,6 +88,35 @@
   help: The count of hidden metrics.
   type: Counter
   stabilityLevel: BETA
+- name: certificate_manager_server_rotation_seconds
+  subsystem: kubelet
+  help: Histogram of the number of seconds the previous certificate lived before being
+    rotated.
+  type: Histogram
+  stabilityLevel: BETA
+  buckets:
+  - 60
+  - 3600
+  - 14400
+  - 86400
+  - 604800
+  - 2.592e+06
+  - 7.776e+06
+  - 1.5552e+07
+  - 3.1104e+07
+  - 1.24416e+08
+- name: certificate_manager_server_ttl_seconds
+  subsystem: kubelet
+  help: Gauge of the shortest TTL (time-to-live) of the Kubelet's serving certificate.
+    The value is in seconds until certificate expiry (negative if already expired).
+    If serving certificate is invalid or unused, the value will be +INF.
+  type: Gauge
+  stabilityLevel: BETA
+- name: server_expiration_renew_errors
+  subsystem: kubelet
+  help: Counter of certificate renewal errors.
+  type: Counter
+  stabilityLevel: BETA
 - name: feature_enabled
   namespace: kubernetes
   help: This metric records the data about the stage and enablement of a k8s feature.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
While drafting the retrospective KEP for RotateKubeletServerCertificate, we realize that the metrics are still in alpha stage.

This PR bumps the metrics to Beta. They have been in for a long time as alpha. Our goal is push this feature to GA.

Retrospective KEP is https://github.com/kubernetes/enhancements/pull/4411.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Promote stability level for metrics associated with kubelet server certificate rotation (these are now **beta**).
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
[KEP]: https://github.com/kubernetes/enhancements/issues/267
```
