### PR TITLE
kubeadm: special case context errors in GetConfigMapWithShortRetry

### DIFF
--- a/cmd/kubeadm/app/util/apiclient/idempotency_test.go
+++ b/cmd/kubeadm/app/util/apiclient/idempotency_test.go
@@ -237,3 +237,54 @@ func TestMutateConfigMapWithConflict(t *testing.T) {
 		t.Fatalf("ConfigMap mutation with conflict was invalid, has: %q", cm.Data["key"])
 	}
 }
+
+func TestGetConfigMapWithShortRetry(t *testing.T) {
+	testcases := []struct {
+		name           string
+		reactorFunc    func(core.Action) (bool, runtime.Object, error)
+		errorCheckFunc func(*testing.T, error)
+	}{
+		{
+			name: "context deadline exceeded error is handled",
+			reactorFunc: func(core.Action) (bool, runtime.Object, error) {
+				return true, nil, context.DeadlineExceeded
+			},
+			errorCheckFunc: func(t *testing.T, err error) {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+			},
+		},
+		{
+			name: "would exceed context deadline error is handled",
+			reactorFunc: func(core.Action) (bool, runtime.Object, error) {
+				return true, nil, errors.New("Wait returned an error: rate: Wait(n=1) would exceed context deadline")
+			},
+			errorCheckFunc: func(t *testing.T, err error) {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+			},
+		},
+		{
+			name: "API error is not handled",
+			reactorFunc: func(core.Action) (bool, runtime.Object, error) {
+				return true, nil, apierrors.NewNotFound(schema.GroupResource{}, "")
+			},
+			errorCheckFunc: func(t *testing.T, err error) {
+				if !apierrors.IsNotFound(err) {
+					t.Errorf("expected error: IsNotFound, got: %v", err)
+				}
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			client := fake.NewSimpleClientset()
+			client.PrependReactor("get", "configmaps", tc.reactorFunc)
+			_, err := GetConfigMapWithShortRetry(client, "foo", "bar")
+			tc.errorCheckFunc(t, err)
+		})
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

If some code is about to go over the context deadline, "x/time/rate/rate.go" would return and untyped error with the string "would exceed context deadline". If some code already exceeded the deadline the error would be of type DeadlineExceeded. Ignore such context errors and only store API and connectivity errors.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubeadm/issues/2998

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
