### PR TITLE
Prevent unneeded roundtrips

### DIFF
--- a/staging/src/k8s.io/client-go/discovery/cached/disk/cached_discovery.go
+++ b/staging/src/k8s.io/client-go/discovery/cached/disk/cached_discovery.go
@@ -84,11 +84,6 @@ func (d *CachedDiscoveryClient) ServerResourcesForGroupVersion(groupVersion stri
 		klog.V(3).Infof("skipped caching discovery info due to %v", err)
 		return liveResources, err
 	}
-	if liveResources == nil || len(liveResources.APIResources) == 0 {
-		klog.V(3).Infof("skipped caching discovery info, no resources found")
-		return liveResources, err
-	}
-
 	if err := d.writeCachedFile(filename, liveResources); err != nil {
 		klog.V(1).Infof("failed to write cache to %v due to %v", filename, err)
 	}


### PR DESCRIPTION
Allow negative caching of empty resources. Otherwise the api client will requery them every time.

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Kubernetes clients will cache server resources to save round-trips. However, if a group does not contain any resources it will be queried every time.

This happens for instance in kubectl if you do not have any external metrics defined in metric-server. On every (!) kubectl invocation it will request that group three times and then not cache it:

```
kubectl get pods -v=9
I0118 18:02:20.478396   46992 loader.go:372] Config loaded from file:  /xxx/.kube/config
I0118 18:02:20.484366   46992 round_trippers.go:435] curl -v -XGET  -H "Accept: application/json, */*" -H "User-Agent: kubectl/v1.22.15 (darwin/amd64) kubernetes/1d79bc3" 'https://my.api/apis/external.metrics.k8s.io/v1beta1?timeout=32s'
I0118 18:02:20.833978   46992 round_trippers.go:454] GET https://my.api/apis/external.metrics.k8s.io/v1beta1?timeout=32s 200 OK in 349 milliseconds
I0118 18:02:20.834074   46992 round_trippers.go:460] Response Headers:
I0118 18:02:20.834085   46992 round_trippers.go:463]     Content-Type: application/json
I0118 18:02:20.834091   46992 round_trippers.go:463]     X-Kubernetes-Pf-Flowschema-Uid: 8aa418a2-0975-4318-821c-42d03092a001
I0118 18:02:20.834097   46992 round_trippers.go:463]     Audit-Id: 2faceb6f-eb9c-4902-a9ee-c35ee07db76c
I0118 18:02:20.834102   46992 round_trippers.go:463]     Audit-Id: 2faceb6f-eb9c-4902-a9ee-c35ee07db76c
I0118 18:02:20.834108   46992 round_trippers.go:463]     Cache-Control: no-cache, private
I0118 18:02:20.834124   46992 round_trippers.go:463]     Cache-Control: no-cache, private
I0118 18:02:20.834129   46992 round_trippers.go:463]     Date: Thu, 18 Jan 2024 17:02:21 GMT
I0118 18:02:20.834135   46992 round_trippers.go:463]     X-Kubernetes-Pf-Prioritylevel-Uid: ea667343-52f7-4ee5-a985-ca94646620c3
I0118 18:02:20.834362   46992 round_trippers.go:463]     Content-Length: 109
I0118 18:02:20.841112   46992 request.go:1181] Response Body: {"kind":"APIResourceList","apiVersion":"v1","groupVersion":"external.metrics.k8s.io/v1beta1","resources":[]}
I0118 18:02:20.858308   46992 cached_discovery.go:82] skipped caching discovery info, no resources found
```
That request is then repeated two more times.

#### Which issue(s) this PR fixes:
I did not create an issue. Let me know if you want me to create one.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Kubernetes Client will now cache empty resource groups to safe roundtrips.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
NONE
