### PR TITLE
[KEP-2371] Fixing bug with windows criStatsProvider sometimes not reporting AvailableBytes correctly

### DIFF
--- a/pkg/kubelet/stats/cri_stats_provider_windows.go
+++ b/pkg/kubelet/stats/cri_stats_provider_windows.go
@@ -142,7 +142,7 @@ func (p *criStatsProvider) makeWinContainerStats(
 			result.Memory.AvailableBytes = &stats.Memory.AvailableBytes.Value
 		}
 		if stats.Memory.PageFaults != nil {
-			result.Memory.AvailableBytes = &stats.Memory.PageFaults.Value
+			result.Memory.PageFaults = &stats.Memory.PageFaults.Value
 		}
 	} else {
 		result.Memory.Time = metav1.NewTime(time.Unix(0, time.Now().UnixNano()))

--- a/pkg/kubelet/stats/cri_stats_provider_windows_test.go
+++ b/pkg/kubelet/stats/cri_stats_provider_windows_test.go
@@ -22,8 +22,16 @@ import (
 	"time"
 
 	"github.com/Microsoft/hcsshim"
+	cadvisorapiv2 "github.com/google/cadvisor/info/v2"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/api/resource"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	statsapi "k8s.io/kubelet/pkg/apis/stats/v1alpha1"
+	kubecontainertest "k8s.io/kubernetes/pkg/kubelet/container/testing"
+	"k8s.io/kubernetes/pkg/kubelet/kuberuntime"
+	"k8s.io/kubernetes/pkg/volume"
 	testingclock "k8s.io/utils/clock/testing"
 )
 
@@ -425,4 +433,124 @@ func Test_criStatsProvider_listContainerNetworkStats(t *testing.T) {
 
 func toP(i uint64) *uint64 {
 	return &i
+}
+
+func Test_criStatsProvider_makeWinContainerStats(t *testing.T) {
+	fakeClock := testingclock.NewFakeClock(time.Time{})
+	containerStartTime := fakeClock.Now()
+
+	cpuUsageTimestamp := int64(555555)
+	cpuUsageNanoSeconds := uint64(0x123456)
+	cpuUsageNanoCores := uint64(0x4000)
+	memoryUsageTimestamp := int64(666666)
+	memoryUsageWorkingSetBytes := uint64(0x11223344)
+	memoryUsageAvailableBytes := uint64(0x55667788)
+	memoryUsagePageFaults := uint64(200)
+	logStatsUsed := uint64(5000)
+	logStatsInodesUsed := uint64(5050)
+
+	// getPodContainerLogStats is called during makeWindowsContainerStats to populate ContainerStats.Logs
+	c0LogStats := &volume.Metrics{
+		Used:       resource.NewQuantity(int64(logStatsUsed), resource.BinarySI),
+		InodesUsed: resource.NewQuantity(int64(logStatsInodesUsed), resource.BinarySI),
+	}
+	fakeStats := map[string]*volume.Metrics{
+		kuberuntime.BuildContainerLogsDirectory("sb0-ns", "sb0-name", types.UID("sb0-uid"), "c0"): c0LogStats,
+	}
+	fakeOS := &kubecontainertest.FakeOS{}
+	fakeHostStatsProvider := NewFakeHostStatsProviderWithData(fakeStats, fakeOS)
+
+	p := &criStatsProvider{
+		clock:             fakeClock,
+		hostStatsProvider: fakeHostStatsProvider,
+	}
+
+	inputStats := &runtimeapi.WindowsContainerStats{
+		Attributes: &runtimeapi.ContainerAttributes{
+			Metadata: &runtimeapi.ContainerMetadata{
+				Name: "c0",
+			},
+		},
+		Cpu: &runtimeapi.WindowsCpuUsage{
+			Timestamp: cpuUsageTimestamp,
+			UsageCoreNanoSeconds: &runtimeapi.UInt64Value{
+				Value: cpuUsageNanoSeconds,
+			},
+			UsageNanoCores: &runtimeapi.UInt64Value{
+				Value: cpuUsageNanoCores,
+			},
+		},
+		Memory: &runtimeapi.WindowsMemoryUsage{
+			Timestamp: memoryUsageTimestamp,
+			AvailableBytes: &runtimeapi.UInt64Value{
+				Value: memoryUsageAvailableBytes,
+			},
+			WorkingSetBytes: &runtimeapi.UInt64Value{
+				Value: memoryUsageWorkingSetBytes,
+			},
+			PageFaults: &runtimeapi.UInt64Value{
+				Value: memoryUsagePageFaults,
+			},
+		},
+	}
+
+	inputContainer := &runtimeapi.Container{
+		CreatedAt: containerStartTime.Unix(),
+		Metadata: &runtimeapi.ContainerMetadata{
+			Name: "c0",
+		},
+	}
+
+	inputRootFsInfo := &cadvisorapiv2.FsInfo{}
+
+	// Used by the getPodContainerLogStats() call in makeWinContainerStats()
+	inputPodSandboxMetadata := &runtimeapi.PodSandboxMetadata{
+		Namespace: "sb0-ns",
+		Name:      "sb0-name",
+		Uid:       "sb0-uid",
+	}
+
+	got, err := p.makeWinContainerStats(inputStats, inputContainer, inputRootFsInfo, make(map[runtimeapi.FilesystemIdentifier]*cadvisorapiv2.FsInfo), inputPodSandboxMetadata)
+
+	expected := &statsapi.ContainerStats{
+		Name:      "c0",
+		StartTime: v1.NewTime(time.Unix(0, containerStartTime.Unix())),
+		CPU: &statsapi.CPUStats{
+			Time:                 v1.NewTime(time.Unix(0, cpuUsageTimestamp)),
+			UsageNanoCores:       toP(cpuUsageNanoCores),
+			UsageCoreNanoSeconds: toP(cpuUsageNanoSeconds),
+		},
+		Memory: &statsapi.MemoryStats{
+			Time:            v1.NewTime(time.Unix(0, memoryUsageTimestamp)),
+			AvailableBytes:  toP(memoryUsageAvailableBytes),
+			WorkingSetBytes: toP(memoryUsageWorkingSetBytes),
+			PageFaults:      toP(memoryUsagePageFaults),
+		},
+		Rootfs: &statsapi.FsStats{},
+		Logs: &statsapi.FsStats{
+			Time:       c0LogStats.Time,
+			UsedBytes:  toP(logStatsUsed),
+			InodesUsed: toP(logStatsInodesUsed),
+		},
+	}
+
+	if err != nil {
+		t.Fatalf("makeWinContainerStats() error = %v, expected no error", err)
+	}
+
+	if !reflect.DeepEqual(got.CPU, expected.CPU) {
+		t.Errorf("makeWinContainerStats() CPU = %v, expected %v", got.CPU, expected.CPU)
+	}
+
+	if !reflect.DeepEqual(got.Memory, expected.Memory) {
+		t.Errorf("makeWinContainerStats() Memory = %v, want %v", got.Memory, expected.Memory)
+	}
+
+	if !reflect.DeepEqual(got.Rootfs, expected.Rootfs) {
+		t.Errorf("makeWinContainerStats() Rootfs = %v, want %v", got.Rootfs, expected.Rootfs)
+	}
+
+	// Log stats contain pointers to calculated resource values so we cannot use DeepEqual here
+	assert.Equal(t, *got.Logs.UsedBytes, logStatsUsed, "Logs.UsedBytes does not match expected value")
+	assert.Equal(t, *got.Logs.InodesUsed, logStatsInodesUsed, "Logs.InodesUsed does not match expected value")
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:

/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixing issue where AvailableBytes sometimes does not report correctly on WindowsNodes when PodAndContainerStatsFromCRI feature is enabled.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/area kubelet
/sig node windows
/assign @jsturtevant @dashpole @haircommander 