### PR TITLE
Refactor Code to Remove Deprecated `PollImmediate` in `pkg/proxy`

### DIFF
--- a/pkg/proxy/config/api_test.go
+++ b/pkg/proxy/config/api_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package config
 
 import (
+	"context"
 	"reflect"
 	"testing"
 	"time"
@@ -203,26 +204,28 @@ func TestInitialSync(t *testing.T) {
 	defer close(stopCh)
 	sharedInformers.Start(stopCh)
 
-	err := wait.PollImmediate(time.Millisecond*10, wait.ForeverTestTimeout, func() (bool, error) {
-		svcHandler.lock.Lock()
-		defer svcHandler.lock.Unlock()
-		if reflect.DeepEqual(svcHandler.state, expectedSvcState) {
-			return true, nil
-		}
-		return false, nil
-	})
+	err := wait.PollUntilContextTimeout(context.Background(), time.Millisecond*10, wait.ForeverTestTimeout, true,
+		func(ctx context.Context) (bool, error) {
+			svcHandler.lock.Lock()
+			defer svcHandler.lock.Unlock()
+			if reflect.DeepEqual(svcHandler.state, expectedSvcState) {
+				return true, nil
+			}
+			return false, nil
+		})
 	if err != nil {
 		t.Fatal("Timed out waiting for the completion of handler `OnServiceAdd`")
 	}
 
-	err = wait.PollImmediate(time.Millisecond*10, wait.ForeverTestTimeout, func() (bool, error) {
-		epsHandler.lock.Lock()
-		defer epsHandler.lock.Unlock()
-		if reflect.DeepEqual(epsHandler.state, expectedEpsState) {
-			return true, nil
-		}
-		return false, nil
-	})
+	err = wait.PollUntilContextTimeout(context.Background(), time.Millisecond*10, wait.ForeverTestTimeout, true,
+		func(ctx context.Context) (bool, error) {
+			epsHandler.lock.Lock()
+			defer epsHandler.lock.Unlock()
+			if reflect.DeepEqual(epsHandler.state, expectedEpsState) {
+				return true, nil
+			}
+			return false, nil
+		})
 	if err != nil {
 		t.Fatal("Timed out waiting for the completion of handler `OnEndpointsAdd`")
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Refactor code to use `PollUntilContextTimeout` replacing deprecated `PolImmediate`.

#### Which issue(s) this PR fixes:

Related: #122800

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
