### PR TITLE
Refactor Code to Remove Deprecated `PollImmediate` in `pkg/controller`

### DIFF
--- a/pkg/controller/daemon/daemon_controller_test.go
+++ b/pkg/controller/daemon/daemon_controller_test.go
@@ -513,21 +513,22 @@ func TestExpectationsOnRecreate(t *testing.T) {
 	waitForQueueLength := func(expected int, msg string) {
 		t.Helper()
 		i := 0
-		err = wait.PollImmediate(100*time.Millisecond, informerSyncTimeout, func() (bool, error) {
-			current := dsc.queue.Len()
-			switch {
-			case current == expected:
-				return true, nil
-			case current > expected:
-				return false, fmt.Errorf("queue length %d exceeded expected length %d", current, expected)
-			default:
-				i++
-				if i > 1 {
-					t.Logf("Waiting for queue to have %d item, currently has: %d", expected, current)
+		err = wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, informerSyncTimeout, true,
+			func(ctx context.Context) (bool, error) {
+				current := dsc.queue.Len()
+				switch {
+				case current == expected:
+					return true, nil
+				case current > expected:
+					return false, fmt.Errorf("queue length %d exceeded expected length %d", current, expected)
+				default:
+					i++
+					if i > 1 {
+						t.Logf("Waiting for queue to have %d item, currently has: %d", expected, current)
+					}
+					return false, nil
 				}
-				return false, nil
-			}
-		})
+			})
 		if err != nil {
 			t.Fatalf("%s: %v", msg, err)
 		}

--- a/pkg/controller/endpoint/endpoints_controller_test.go
+++ b/pkg/controller/endpoint/endpoints_controller_test.go
@@ -1015,9 +1015,10 @@ func TestWaitsForAllInformersToBeSynced2(t *testing.T) {
 			time.Sleep(150 * time.Millisecond)
 			if test.shouldUpdateEndpoints {
 				// Ensure the work queue has been processed by looping for up to a second to prevent flakes.
-				wait.PollImmediate(50*time.Millisecond, 1*time.Second, func() (bool, error) {
-					return endpoints.queue.Len() == 0, nil
-				})
+				_ = wait.PollUntilContextTimeout(context.Background(), 50*time.Millisecond, 1*time.Second, true,
+					func(ctx context.Context) (bool, error) {
+						return endpoints.queue.Len() == 0, nil
+					})
 				endpointsHandler.ValidateRequestCount(t, 1)
 			} else {
 				endpointsHandler.ValidateRequestCount(t, 0)
@@ -2279,9 +2280,10 @@ func TestMultipleServiceChanges(t *testing.T) {
 	controller.onServiceUpdate(svc)
 
 	// Ensure the work queue has been processed by looping for up to a second to prevent flakes.
-	wait.PollImmediate(50*time.Millisecond, 1*time.Second, func() (bool, error) {
-		return controller.queue.Len() == 0, nil
-	})
+	_ = wait.PollUntilContextTimeout(context.Background(), 50*time.Millisecond, 1*time.Second, true,
+		func(ctx context.Context) (bool, error) {
+			return controller.queue.Len() == 0, nil
+		})
 
 	// Cause test server to delete endpoints
 	close(blockDelete)

--- a/pkg/controller/endpointslice/endpointslice_controller_test.go
+++ b/pkg/controller/endpointslice/endpointslice_controller_test.go
@@ -541,12 +541,13 @@ func TestOnEndpointSliceUpdate(t *testing.T) {
 
 	assert.Equal(t, 0, esController.queue.Len())
 	esController.onEndpointSliceUpdate(logger, epSlice1, epSlice2)
-	err := wait.PollImmediate(100*time.Millisecond, 3*time.Second, func() (bool, error) {
-		if esController.queue.Len() > 0 {
-			return true, nil
-		}
-		return false, nil
-	})
+	err := wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 3*time.Second, true,
+		func(ctx context.Context) (bool, error) {
+			if esController.queue.Len() > 0 {
+				return true, nil
+			}
+			return false, nil
+		})
 	if err != nil {
 		t.Fatalf("unexpected error waiting for add to queue")
 	}

--- a/pkg/controller/endpointslicemirroring/endpointslicemirroring_controller_test.go
+++ b/pkg/controller/endpointslicemirroring/endpointslicemirroring_controller_test.go
@@ -253,15 +253,16 @@ func TestSyncEndpoints(t *testing.T) {
 
 			numInitialActions := len(tc.endpointSlices)
 			// Wait for the expected event show up in test "Endpoints with 1001 addresses - 1 should not be mirrored"
-			err = wait.PollImmediate(time.Millisecond*100, wait.ForeverTestTimeout, func() (done bool, err error) {
-				actions := client.Actions()
-				numExtraActions := len(actions) - numInitialActions
-				if numExtraActions != tc.expectedNumActions {
-					t.Logf("Expected %d additional client actions, got %d: %#v. Will retry", tc.expectedNumActions, numExtraActions, actions[numInitialActions:])
-					return false, nil
-				}
-				return true, nil
-			})
+			err = wait.PollUntilContextTimeout(ctx, time.Millisecond*100, wait.ForeverTestTimeout, true,
+				func(ctx context.Context) (done bool, err error) {
+					actions := client.Actions()
+					numExtraActions := len(actions) - numInitialActions
+					if numExtraActions != tc.expectedNumActions {
+						t.Logf("Expected %d additional client actions, got %d: %#v. Will retry", tc.expectedNumActions, numExtraActions, actions[numInitialActions:])
+						return false, nil
+					}
+					return true, nil
+				})
 			if err != nil {
 				t.Fatal("Timed out waiting for expected actions")
 			}

--- a/pkg/controller/nodelifecycle/node_lifecycle_controller.go
+++ b/pkg/controller/nodelifecycle/node_lifecycle_controller.go
@@ -689,7 +689,7 @@ func (nc *Controller) monitorNodeHealth(ctx context.Context) error {
 	var zoneToNodeConditionsLock sync.Mutex
 	zoneToNodeConditions := map[string][]*v1.NodeCondition{}
 	updateNodeFunc := func(piece int) {
-		start := nc.now()
+		start = nc.now()
 		defer func() {
 			updateNodeHealthDuration.Observe(time.Since(start.Time).Seconds())
 		}()
@@ -698,20 +698,21 @@ func (nc *Controller) monitorNodeHealth(ctx context.Context) error {
 		var currentReadyCondition *v1.NodeCondition
 		node := nodes[piece].DeepCopy()
 
-		if err := wait.PollImmediate(retrySleepTime, retrySleepTime*scheduler.NodeHealthUpdateRetry, func() (bool, error) {
-			var err error
-			_, observedReadyCondition, currentReadyCondition, err = nc.tryUpdateNodeHealth(ctx, node)
-			if err == nil {
-				return true, nil
-			}
-			name := node.Name
-			node, err = nc.kubeClient.CoreV1().Nodes().Get(ctx, name, metav1.GetOptions{})
-			if err != nil {
-				logger.Error(nil, "Failed while getting a Node to retry updating node health. Probably Node was deleted", "node", klog.KRef("", name))
-				return false, err
-			}
-			return false, nil
-		}); err != nil {
+		if pollErr := wait.PollUntilContextTimeout(ctx, retrySleepTime, retrySleepTime*scheduler.NodeHealthUpdateRetry, true,
+			func(ctx context.Context) (bool, error) {
+				var err error
+				_, observedReadyCondition, currentReadyCondition, err = nc.tryUpdateNodeHealth(ctx, node)
+				if err == nil {
+					return true, nil
+				}
+				name := node.Name
+				node, err = nc.kubeClient.CoreV1().Nodes().Get(ctx, name, metav1.GetOptions{})
+				if err != nil {
+					logger.Error(nil, "Failed while getting a Node to retry updating node health. Probably Node was deleted", "node", klog.KRef("", name))
+					return false, err
+				}
+				return false, nil
+			}); pollErr != nil {
 			logger.Error(err, "Update health of Node from Controller error, Skipping - no pods will be evicted", "node", klog.KObj(node))
 			return
 		}

--- a/pkg/controller/replicaset/replica_set_test.go
+++ b/pkg/controller/replicaset/replica_set_test.go
@@ -1218,10 +1218,11 @@ func TestExpectationsOnRecreate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = wait.PollImmediate(100*time.Millisecond, informerSyncTimeout, func() (bool, error) {
-		logger.V(8).Info("Waiting for queue to have 1 item", "length", manager.queue.Len())
-		return manager.queue.Len() == 1, nil
-	})
+	err = wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, informerSyncTimeout, true,
+		func(ctx context.Context) (bool, error) {
+			logger.V(8).Info("Waiting for queue to have 1 item", "length", manager.queue.Len())
+			return manager.queue.Len() == 1, nil
+		})
 	if err != nil {
 		t.Fatalf("initial RS didn't result in new item in the queue: %v", err)
 	}
@@ -1262,10 +1263,11 @@ func TestExpectationsOnRecreate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = wait.PollImmediate(100*time.Millisecond, informerSyncTimeout, func() (bool, error) {
-		logger.V(8).Info("Waiting for queue to have 1 item", "length", manager.queue.Len())
-		return manager.queue.Len() == 1, nil
-	})
+	err = wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, informerSyncTimeout, true,
+		func(ctx context.Context) (bool, error) {
+			logger.V(8).Info("Waiting for queue to have 1 item", "length", manager.queue.Len())
+			return manager.queue.Len() == 1, nil
+		})
 	if err != nil {
 		t.Fatalf("Deleting RS didn't result in new item in the queue: %v", err)
 	}
@@ -1304,10 +1306,11 @@ func TestExpectationsOnRecreate(t *testing.T) {
 		t.Fatal("New RS has the same UID as the old one!")
 	}
 
-	err = wait.PollImmediate(100*time.Millisecond, informerSyncTimeout, func() (bool, error) {
-		logger.V(8).Info("Waiting for queue to have 1 item", "length", manager.queue.Len())
-		return manager.queue.Len() == 1, nil
-	})
+	err = wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, informerSyncTimeout, true,
+		func(ctx context.Context) (bool, error) {
+			logger.V(8).Info("Waiting for queue to have 1 item", "length", manager.queue.Len())
+			return manager.queue.Len() == 1, nil
+		})
 	if err != nil {
 		t.Fatalf("Re-creating RS didn't result in new item in the queue: %v", err)
 	}

--- a/pkg/controller/tainteviction/taint_eviction_test.go
+++ b/pkg/controller/tainteviction/taint_eviction_test.go
@@ -314,10 +314,11 @@ func TestUpdatePod(t *testing.T) {
 
 			if item.awaitForScheduledEviction {
 				nsName := types.NamespacedName{Namespace: item.prevPod.Namespace, Name: item.prevPod.Name}
-				err := wait.PollImmediate(time.Millisecond*10, time.Second, func() (bool, error) {
-					scheduledEviction := controller.taintEvictionQueue.GetWorkerUnsafe(nsName.String())
-					return scheduledEviction != nil, nil
-				})
+				err := wait.PollUntilContextTimeout(ctx, time.Millisecond*10, time.Second, true,
+					func(ctx context.Context) (bool, error) {
+						scheduledEviction := controller.taintEvictionQueue.GetWorkerUnsafe(nsName.String())
+						return scheduledEviction != nil, nil
+					})
 				if err != nil {
 					t.Fatalf("Failed to await for scheduled eviction: %q", err)
 				}
@@ -396,12 +397,13 @@ func TestDeleteNode(t *testing.T) {
 	controller.NodeUpdated(testutil.NewNode("node1"), nil)
 
 	// await until controller.taintedNodes is empty
-	err := wait.PollImmediate(10*time.Millisecond, time.Second, func() (bool, error) {
-		controller.taintedNodesLock.Lock()
-		defer controller.taintedNodesLock.Unlock()
-		_, ok := controller.taintedNodes["node1"]
-		return !ok, nil
-	})
+	err := wait.PollUntilContextTimeout(ctx, 10*time.Millisecond, time.Second, true,
+		func(ctx context.Context) (bool, error) {
+			controller.taintedNodesLock.Lock()
+			defer controller.taintedNodesLock.Unlock()
+			_, ok := controller.taintedNodes["node1"]
+			return !ok, nil
+		})
 	if err != nil {
 		t.Errorf("Failed to await for processing node deleted: %q", err)
 	}

--- a/pkg/controller/volume/persistentvolume/pv_controller_test.go
+++ b/pkg/controller/volume/persistentvolume/pv_controller_test.go
@@ -191,14 +191,15 @@ func TestControllerSync(t *testing.T) {
 					return err
 				}
 				// wait for volume delete operation to appear once volumeWorker() runs
-				return wait.PollImmediate(10*time.Millisecond, wait.ForeverTestTimeout, func() (bool, error) {
-					// make sure the operation timestamp cache is NOT empty
-					if ctrl.operationTimestamps.Has("volume5-6") {
-						return true, nil
-					}
-					t.Logf("missing volume5-6 from timestamp cache, will retry")
-					return false, nil
-				})
+				return wait.PollUntilContextTimeout(context.Background(), 10*time.Millisecond, wait.ForeverTestTimeout, true,
+					func(ctx context.Context) (bool, error) {
+						// make sure the operation timestamp cache is NOT empty
+						if ctrl.operationTimestamps.Has("volume5-6") {
+							return true, nil
+						}
+						t.Logf("missing volume5-6 from timestamp cache, will retry")
+						return false, nil
+					})
 			},
 		},
 		{


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Refactor code to use `PollUntilContextTimeout` replacing deprecated `PolImmediate`.

#### Which issue(s) this PR fixes:

Related: #122800

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
