### PR TITLE
Automated cherry pick of #122704: If a pvc has an empty storageclass name, don't try to assign

### DIFF
--- a/pkg/controller/volume/persistentvolume/pv_controller.go
+++ b/pkg/controller/volume/persistentvolume/pv_controller.go
@@ -943,7 +943,8 @@ func (ctrl *PersistentVolumeController) updateVolumePhaseWithEvent(ctx context.C
 func (ctrl *PersistentVolumeController) assignDefaultStorageClass(ctx context.Context, claim *v1.PersistentVolumeClaim) (bool, error) {
 	logger := klog.FromContext(ctx)
 
-	if storagehelpers.GetPersistentVolumeClaimClass(claim) != "" {
+	if storagehelpers.PersistentVolumeClaimHasClass(claim) {
+		// The user asked for a class.
 		return false, nil
 	}
 

--- a/staging/src/k8s.io/component-helpers/storage/volume/helpers.go
+++ b/staging/src/k8s.io/component-helpers/storage/volume/helpers.go
@@ -24,6 +24,20 @@ import (
 	"k8s.io/component-helpers/scheduling/corev1"
 )
 
+// PersistentVolumeClaimHasClass returns true if given claim has set StorageClassName field.
+func PersistentVolumeClaimHasClass(claim *v1.PersistentVolumeClaim) bool {
+	// Use beta annotation first
+	if _, found := claim.Annotations[v1.BetaStorageClassAnnotation]; found {
+		return true
+	}
+
+	if claim.Spec.StorageClassName != nil {
+		return true
+	}
+
+	return false
+}
+
 // GetPersistentVolumeClaimClass returns StorageClassName. If no storage class was
 // requested, it returns "".
 func GetPersistentVolumeClaimClass(claim *v1.PersistentVolumeClaim) string {

--- a/staging/src/k8s.io/component-helpers/storage/volume/helpers_test.go
+++ b/staging/src/k8s.io/component-helpers/storage/volume/helpers_test.go
@@ -21,6 +21,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 )
 
 var nodeLabels = map[string]string{
@@ -212,5 +213,49 @@ func testVolumeWithNodeAffinity(t *testing.T, affinity *v1.VolumeNodeAffinity) *
 		Spec: v1.PersistentVolumeSpec{
 			NodeAffinity: affinity,
 		},
+	}
+}
+
+func TestPersistentVolumeClaimHasClass(t *testing.T) {
+	testCases := []struct {
+		name string
+		pvc  *v1.PersistentVolumeClaim
+		want bool
+	}{
+		{
+			name: "no storage class",
+			pvc:  &v1.PersistentVolumeClaim{},
+			want: false,
+		},
+		{
+			name: "storage class set on annotation",
+			pvc: &v1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						v1.BetaStorageClassAnnotation: "",
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "storage class set on spec",
+			pvc: &v1.PersistentVolumeClaim{
+				Spec: v1.PersistentVolumeClaimSpec{
+					StorageClassName: ptr.To(""),
+				},
+			},
+			want: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got := PersistentVolumeClaimHasClass(tc.pvc)
+			if got != tc.want {
+				t.Errorf("PersistentVolumeClaimHasClass() = %v, want %v", got, tc.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Cherry pick of #122704 on release-1.29.

#122704: If a pvc has an empty storageclass name, don't try to assign

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fixes a regression in 1.26+ default configurations: If a pvc has an empty storageClassName, persistentvolume controller won't try to assign a default StorageClass
```