### PR TITLE
Automated cherry pick of #122704: If a pvc has an empty storageclass name, don't try to assign

### DIFF
--- a/pkg/controller/volume/persistentvolume/pv_controller.go
+++ b/pkg/controller/volume/persistentvolume/pv_controller.go
@@ -943,7 +943,8 @@ func (ctrl *PersistentVolumeController) updateVolumePhaseWithEvent(ctx context.C
 func (ctrl *PersistentVolumeController) assignDefaultStorageClass(ctx context.Context, claim *v1.PersistentVolumeClaim) (bool, error) {
 	logger := klog.FromContext(ctx)
 
-	if storagehelpers.GetPersistentVolumeClaimClass(claim) != "" {
+	if storagehelpers.PersistentVolumeClaimHasClass(claim) {
+		// The user asked for a class.
 		return false, nil
 	}
 

--- a/staging/src/k8s.io/component-helpers/storage/volume/helpers.go
+++ b/staging/src/k8s.io/component-helpers/storage/volume/helpers.go
@@ -24,6 +24,20 @@ import (
 	"k8s.io/component-helpers/scheduling/corev1"
 )
 
+// PersistentVolumeClaimHasClass returns true if given claim has set StorageClassName field.
+func PersistentVolumeClaimHasClass(claim *v1.PersistentVolumeClaim) bool {
+	// Use beta annotation first
+	if _, found := claim.Annotations[v1.BetaStorageClassAnnotation]; found {
+		return true
+	}
+
+	if claim.Spec.StorageClassName != nil {
+		return true
+	}
+
+	return false
+}
+
 // GetPersistentVolumeClaimClass returns StorageClassName. If no storage class was
 // requested, it returns "".
 func GetPersistentVolumeClaimClass(claim *v1.PersistentVolumeClaim) string {


### PR DESCRIPTION
Cherry pick of #122704 on release-1.28.

#122704: If a pvc has an empty storageclass name, don't try to assign

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fixes a regression in 1.26+ default configurations: If a pvc has an empty storageClassName, persistentvolume controller won't try to assign a default StorageClass
```