### PR TITLE
e2e: replace klog.Fatal with assertion

### DIFF
--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -183,9 +183,7 @@ func setupSuite(ctx context.Context) {
 	}
 
 	c, err := framework.LoadClientset()
-	if err != nil {
-		klog.Fatal("Error loading client: ", err)
-	}
+	framework.ExpectNoError(err, "Error loading client")
 
 	// Delete any namespaces except those created by the system. This ensures no
 	// lingering resources are left over from a previous test run.
@@ -380,9 +378,7 @@ func setupSuitePerGinkgoNode(ctx context.Context) {
 	// the dual stack clusters can be ipv4-ipv6 or ipv6-ipv4, order matters,
 	// and services use the primary IP family by default
 	c, err := framework.LoadClientset()
-	if err != nil {
-		klog.Fatal("Error loading client: ", err)
-	}
+	framework.ExpectNoError(err, "Error loading client")
 	framework.TestContext.IPFamily = getDefaultClusterIPFamily(ctx, c)
 	framework.Logf("Cluster IP family: %s", framework.TestContext.IPFamily)
 }

--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -549,9 +549,7 @@ func AfterReadingAllFlags(t *TestContextType) {
 	if len(t.BearerToken) == 0 {
 		var err error
 		t.BearerToken, err = GenerateSecureToken(16)
-		if err != nil {
-			klog.Fatalf("Failed to generate bearer token: %v", err)
-		}
+		ExpectNoError(err, "Failed to generate bearer token")
 	}
 
 	// Allow 1% of nodes to be unready (statistically) - relevant for large clusters.


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Using klog.Fatal to abort a test leads to a poor user experience because the output is buffered in ginkgo.GinkgoWriter and not flushed before killing the process. The output is also different from other failures. Using the normal error checking is better.

Before:

    $ KUBECONFIG=/no/such/config go test -v ./test/e2e/
      Jan 19 10:06:58.475: INFO: The --provider flag is not set. Continuing as if --provider=skeleton had been used.
    === RUN   TestE2E
      I0119 10:06:58.475844   99472 e2e.go:109] Starting e2e run "5303f626-ae0e-44d7-abf1-b4956d910ef4" on Ginkgo node 1
    Running Suite: Kubernetes e2e suite - /nvme/gopath/src/k8s.io/kubernetes/test/e2e
    =================================================================================
    Random Seed: 1705655217 - will randomize all specs

    Will run 4678 of 7421 specs
    goroutine 817 [running]:
    k8s.io/klog/v2/internal/dbg.Stacks(0x0)
    	/nvme/gopath/src/k8s.io/kubernetes/vendor/k8s.io/klog/v2/internal/dbg/dbg.go:35 +0x85
    k8s.io/klog/v2.(*loggingT).output(0x9d92b20, 0x3, 0x0, 0xc00069d7a0, 0x2, {0x834c6e8?, 0x9d91c80?}, 0x300000060?, 0x0)
    ...
    k8s.io/klog/v2.Fatal(...)
    	/nvme/gopath/src/k8s.io/kubernetes/vendor/k8s.io/klog/v2/klog.go:1652
    k8s.io/kubernetes/test/e2e.setupSuite({0x7fb49064c078, 0xc003072360})
    	/nvme/gopath/src/k8s.io/kubernetes/test/e2e/e2e.go:187 +0x125
    ...
    FAIL	k8s.io/kubernetes/test/e2e	0.759s
    FAIL

After:

    $ KUBECONFIG=/no/such/config go test -v ./test/e2e/
      Jan 19 10:12:58.889: INFO: The --provider flag is not set. Continuing as if --provider=skeleton had been used.
    === RUN   TestE2E
      I0119 10:12:58.889224  106019 e2e.go:109] Starting e2e run "bed5a77a-f595-42d0-b512-5f601067444b" on Ginkgo node 1
    Running Suite: Kubernetes e2e suite - /nvme/gopath/src/k8s.io/kubernetes/test/e2e
    =================================================================================
    Random Seed: 1705655578 - will randomize all specs

    Will run 4678 of 7421 specs
    ------------------------------
    [SynchronizedBeforeSuite] [FAILED] [0.001 seconds]
    [SynchronizedBeforeSuite]
    /nvme/gopath/src/k8s.io/kubernetes/test/e2e/e2e.go:69

      Timeline >>
      Jan 19 10:12:59.063: INFO: >>> kubeConfig: /no/such/config
      Jan 19 10:12:59.063: INFO: Unexpected error: Error loading client:
          <*errors.errorString | 0xc00182c130>:
          error creating client: error loading KubeConfig: open /no/such/config: no such file or directory
          {
              s: "error creating client: error loading KubeConfig: open /no/such/config: no such file or directory",
          }
      [FAILED] in [SynchronizedBeforeSuite] - /nvme/gopath/src/k8s.io/kubernetes/test/e2e/e2e.go:186 @ 01/19/24 10:12:59.064
      << Timeline

      [FAILED] Error loading client: error creating client: error loading KubeConfig: open /no/such/config: no such file or directory
      In [SynchronizedBeforeSuite] at: /nvme/gopath/src/k8s.io/kubernetes/test/e2e/e2e.go:186 @ 01/19/24 10:12:59.064
    ------------------------------

    Summarizing 1 Failure:
      [FAIL] [SynchronizedBeforeSuite]
      /nvme/gopath/src/k8s.io/kubernetes/test/e2e/e2e.go:186

    Ran 0 of 7421 Specs in 0.001 seconds
    FAIL! -- A BeforeSuite node failed so all tests were skipped.
    --- FAIL: TestE2E (0.18s)
    FAIL
    FAIL	k8s.io/kubernetes/test/e2e	0.769s
    FAIL

#### Which issue(s) this PR fixes:

Found when accidentally setting KUBECONFIG incorrectly, no issue filed.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
