### PR TITLE
Promote KEP-2681 to GA in 1.30

### DIFF
--- a/pkg/api/pod/util_test.go
+++ b/pkg/api/pod/util_test.go
@@ -1179,81 +1179,42 @@ func TestDropDisabledPodStatusFields(t *testing.T) {
 	}
 
 	tests := []struct {
-		name           string
-		podStatus      *api.PodStatus
-		oldPodStatus   *api.PodStatus
-		wantPodStatus  *api.PodStatus
-		featureEnabled bool
+		name          string
+		podStatus     *api.PodStatus
+		oldPodStatus  *api.PodStatus
+		wantPodStatus *api.PodStatus
 	}{
 		{
-			name:           "gate off, old=without, new=without",
-			oldPodStatus:   podWithoutHostIPs(),
-			podStatus:      podWithoutHostIPs(),
-			featureEnabled: false,
+			name:         "old=without, new=without",
+			oldPodStatus: podWithoutHostIPs(),
+			podStatus:    podWithoutHostIPs(),
 
 			wantPodStatus: podWithoutHostIPs(),
 		},
 		{
-			name:           "gate off, old=without, new=with",
-			oldPodStatus:   podWithoutHostIPs(),
-			podStatus:      podWithHostIPs(),
-			featureEnabled: false,
-
-			wantPodStatus: podWithoutHostIPs(),
-		},
-		{
-			name:           "gate off, old=with, new=without",
-			oldPodStatus:   podWithHostIPs(),
-			podStatus:      podWithoutHostIPs(),
-			featureEnabled: false,
-
-			wantPodStatus: podWithoutHostIPs(),
-		},
-		{
-			name:           "gate off, old=with, new=with",
-			oldPodStatus:   podWithHostIPs(),
-			podStatus:      podWithHostIPs(),
-			featureEnabled: false,
+			name:         "old=without, new=with",
+			oldPodStatus: podWithoutHostIPs(),
+			podStatus:    podWithHostIPs(),
 
 			wantPodStatus: podWithHostIPs(),
 		},
 		{
-			name:           "gate on, old=without, new=without",
-			oldPodStatus:   podWithoutHostIPs(),
-			podStatus:      podWithoutHostIPs(),
-			featureEnabled: true,
+			name:         "old=with, new=without",
+			oldPodStatus: podWithHostIPs(),
+			podStatus:    podWithoutHostIPs(),
 
 			wantPodStatus: podWithoutHostIPs(),
 		},
 		{
-			name:           "gate on, old=without, new=with",
-			oldPodStatus:   podWithoutHostIPs(),
-			podStatus:      podWithHostIPs(),
-			featureEnabled: true,
-
-			wantPodStatus: podWithHostIPs(),
-		},
-		{
-			name:           "gate on, old=with, new=without",
-			oldPodStatus:   podWithHostIPs(),
-			podStatus:      podWithoutHostIPs(),
-			featureEnabled: true,
-
-			wantPodStatus: podWithoutHostIPs(),
-		},
-		{
-			name:           "gate on, old=with, new=with",
-			oldPodStatus:   podWithHostIPs(),
-			podStatus:      podWithHostIPs(),
-			featureEnabled: true,
+			name:         "old=with, new=with",
+			oldPodStatus: podWithHostIPs(),
+			podStatus:    podWithHostIPs(),
 
 			wantPodStatus: podWithHostIPs(),
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.PodHostIPs, tt.featureEnabled)()
-
 			dropDisabledPodStatusFields(tt.podStatus, tt.oldPodStatus, &api.PodSpec{}, &api.PodSpec{})
 
 			if !reflect.DeepEqual(tt.podStatus, tt.wantPodStatus) {

--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -24590,18 +24590,6 @@ func TestValidateDownwardAPIHostIPs(t *testing.T) {
 			featureEnabled: true,
 			fieldSel:       &core.ObjectFieldSelector{FieldPath: "status.hostIPs"},
 		},
-		{
-			name:           "has no hostIPs field, featuregate disabled",
-			expectError:    false,
-			featureEnabled: false,
-			fieldSel:       &core.ObjectFieldSelector{FieldPath: "status.hostIP"},
-		},
-		{
-			name:           "has hostIPs field, featuregate disabled",
-			expectError:    true,
-			featureEnabled: false,
-			fieldSel:       &core.ObjectFieldSelector{FieldPath: "status.hostIPs"},
-		},
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -604,6 +604,7 @@ const (
 	// kep: http://kep.k8s.io/2681
 	// alpha: v1.28
 	// beta: v1.29
+	// GA: v1.30
 	//
 	// Adds pod.status.hostIPs and downward API
 	PodHostIPs featuregate.Feature = "PodHostIPs"
@@ -1087,7 +1088,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 
 	PodReadyToStartContainersCondition: {Default: true, PreRelease: featuregate.Beta},
 
-	PodHostIPs: {Default: true, PreRelease: featuregate.Beta},
+	PodHostIPs: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.32
 
 	PodLifecycleSleepAction: {Default: true, PreRelease: featuregate.Beta},
 

--- a/test/e2e/network/dual_stack.go
+++ b/test/e2e/network/dual_stack.go
@@ -112,7 +112,7 @@ var _ = common.SIGDescribe(feature.IPv6DualStack, func() {
 		framework.ExpectNoError(err, "failed to delete pod")
 	})
 
-	f.It("should create pod, add ipv6 and ipv4 ip to host ips", feature.PodHostIPs, func(ctx context.Context) {
+	f.It("should create pod, add ipv6 and ipv4 ip to host ips", func(ctx context.Context) {
 		podName := "pod-dualstack-ips"
 
 		pod := &v1.Pod{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Promoted the `status.hostIPs` field for Pods to general availability.
The `PodHostIPs` feature gate no longer has any effect, and the
`status.hostIPs` field is always available within the Pod API.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/2681
- [Usage]: <link>
- [Other doc]:
```
