### PR TITLE
Print error message regardless verbosity value

### DIFF
--- a/hack/lib/logging.sh
+++ b/hack/lib/logging.sh
@@ -82,6 +82,10 @@ kube::log::error_exit() {
   local stack_skip="${3:-0}"
   stack_skip=$((stack_skip + 1))
 
+  # Always print the error message, regardless of KUBE_VERBOSE value
+  kube::log::error "${message}"
+
+  # Additional debug information printed if KUBE_VERBOSE is 4 or greater
   if [[ ${KUBE_VERBOSE} -ge 4 ]]; then
     local source_file=${BASH_SOURCE[${stack_skip}]}
     local source_line=${BASH_LINENO[$((stack_skip - 1))]}


### PR DESCRIPTION
/kind cleanup

#### What this PR does / why we need it:
BEFORE:
```
$ make test-e2e-node FOCUS='\[NodeAlphaFeature:DynamicResourceAllocation\]' SKIP='\[Flaky\]'
PARALLELISM=1 TEST_ARGS='--feature-gates="DynamicResourceAllocation=true" --service-feature-gates="DynamicResourceAlloca
tion=true" --runtime-config=api/all=true'
+++ [0119 14:03:26] Building go targets for linux/amd64
    github.com/onsi/ginkgo/v2/ginkgo (non-static)
+++ [0119 14:03:28] Set GOMAXPROCS automatically to 24
Creating artifacts directory at /tmp/_artifacts/240119T140328
mkdir: cannot create directory ‘/tmp/_artifacts/240119T140328’: Permission denied
make: *** [Makefile:283: test-e2e-node] Error 1
```
AFTER:
```
$ make test-e2e-node FOCUS='\[NodeAlphaFeature:DynamicResourceAllocation\]' SKIP='\[Flaky\]'
PARALLELISM=1 TEST_ARGS='--feature-gates="DynamicResourceAllocation=true" --service-feature-gates="DynamicResourceAlloca
tion=true" --runtime-config=api/all=true'
+++ [0119 14:03:11] Building go targets for linux/amd64
    github.com/onsi/ginkgo/v2/ginkgo (non-static)
+++ [0119 14:03:12] Set GOMAXPROCS automatically to 24
Creating artifacts directory at /tmp/_artifacts/240119T140312
mkdir: cannot create directory ‘/tmp/_artifacts/240119T140312’: Permission denied
!!! [0119 14:03:12] Error in hack/make-rules/test-e2e-node.sh:77. 'mkdir -p "${artifacts}"' exited with status 1
make: *** [Makefile:283: test-e2e-node] Error 1
```

The update now displays both the specific location of the error in the code and a timestamp.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
