### PR TITLE
Reduce verbose logs in MetaAllocator

### DIFF
--- a/pkg/registry/core/service/ipallocator/cidrallocator.go
+++ b/pkg/registry/core/service/ipallocator/cidrallocator.go
@@ -178,7 +178,7 @@ func (c *MetaAllocator) processNextItem() bool {
 func (c *MetaAllocator) syncTree() error {
 	now := time.Now()
 	defer func() {
-		klog.Infof("Finished sync for CIDRs took %v", time.Since(now))
+		klog.V(2).Infof("Finished sync for CIDRs took %v", time.Since(now))
 	}()
 
 	serviceCIDRs, err := c.serviceCIDRLister.List(labels.Everything())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

It reduces a MultiCIDRServiceAllocator related verbose log, which was logged every 10 mins even there is no change.
```
I0119 00:03:14.320165       1 cidrallocator.go:181] Finished sync for CIDRs took 18.301µs
I0119 00:13:14.320379       1 cidrallocator.go:181] Finished sync for CIDRs took 23.186µs
I0119 00:23:14.321253       1 cidrallocator.go:181] Finished sync for CIDRs took 19.43µs
I0119 00:33:14.321873       1 cidrallocator.go:181] Finished sync for CIDRs took 27.833µs
I0119 00:43:14.322507       1 cidrallocator.go:181] Finished sync for CIDRs took 16.797µs
I0119 00:53:14.322852       1 cidrallocator.go:181] Finished sync for CIDRs took 17.962µs
I0119 01:03:14.322922       1 cidrallocator.go:181] Finished sync for CIDRs took 14.087µs
I0119 01:13:14.323954       1 cidrallocator.go:181] Finished sync for CIDRs took 24.427µs
I0119 01:23:14.324231       1 cidrallocator.go:181] Finished sync for CIDRs took 20.047µs
I0119 01:33:14.325273       1 cidrallocator.go:181] Finished sync for CIDRs took 16.129µs
I0119 01:43:14.325434       1 cidrallocator.go:181] Finished sync for CIDRs took 23.062µs
I0119 01:53:14.325854       1 cidrallocator.go:181] Finished sync for CIDRs took 16.491µs
I0119 02:03:14.326914       1 cidrallocator.go:181] Finished sync for CIDRs took 28.204µs
I0119 02:13:14.327186       1 cidrallocator.go:181] Finished sync for CIDRs took 17.488µs
I0119 02:23:14.327629       1 cidrallocator.go:181] Finished sync for CIDRs took 14.427µs
I0119 02:33:14.328471       1 cidrallocator.go:181] Finished sync for CIDRs took 26.836µs
I0119 02:43:14.329282       1 cidrallocator.go:181] Finished sync for CIDRs took 16.329µs
I0119 02:53:14.330603       1 cidrallocator.go:181] Finished sync for CIDRs took 27.811µs
I0119 03:03:14.330697       1 cidrallocator.go:181] Finished sync for CIDRs took 22.377µs
I0119 03:13:14.331064       1 cidrallocator.go:181] Finished sync for CIDRs took 21.047µs
I0119 03:23:14.331345       1 cidrallocator.go:181] Finished sync for CIDRs took 19.408µs
I0119 03:33:14.331351       1 cidrallocator.go:181] Finished sync for CIDRs took 18.913µs
I0119 03:43:14.332756       1 cidrallocator.go:181] Finished sync for CIDRs took 27.076µs
I0119 03:53:14.332980       1 cidrallocator.go:181] Finished sync for CIDRs took 21.082µs
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

cc @aojea I found these errors/events/logs a bit confusing after enabling MultiCIDRServiceAllocator feature, and suppose they are not intentional.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
