### PR TITLE
Remove some dead options in KubeSchedulerConfiguration

### DIFF
--- a/pkg/scheduler/apis/config/types.go
+++ b/pkg/scheduler/apis/config/types.go
@@ -54,10 +54,6 @@ type KubeSchedulerConfiguration struct {
 	// ClientConnection specifies the kubeconfig file and client connection
 	// settings for the proxy server to use when communicating with the apiserver.
 	ClientConnection componentbaseconfig.ClientConnectionConfiguration
-	// HealthzBindAddress is the IP address and port for the health check server to serve on.
-	HealthzBindAddress string
-	// MetricsBindAddress is the IP address and port for the metrics server to serve on.
-	MetricsBindAddress string
 
 	// DebuggingConfiguration holds configuration for Debugging related features
 	// TODO: We might wanna make this a substruct like Debugging componentbaseconfig.DebuggingConfiguration

--- a/pkg/scheduler/apis/config/v1/zz_generated.conversion.go
+++ b/pkg/scheduler/apis/config/v1/zz_generated.conversion.go
@@ -443,8 +443,6 @@ func autoConvert_config_KubeSchedulerConfiguration_To_v1_KubeSchedulerConfigurat
 	if err := v1alpha1.Convert_config_ClientConnectionConfiguration_To_v1alpha1_ClientConnectionConfiguration(&in.ClientConnection, &out.ClientConnection, s); err != nil {
 		return err
 	}
-	// WARNING: in.HealthzBindAddress requires manual conversion: does not exist in peer-type
-	// WARNING: in.MetricsBindAddress requires manual conversion: does not exist in peer-type
 	if err := v1alpha1.Convert_config_DebuggingConfiguration_To_v1alpha1_DebuggingConfiguration(&in.DebuggingConfiguration, &out.DebuggingConfiguration, s); err != nil {
 		return err
 	}

--- a/pkg/scheduler/apis/config/validation/validation.go
+++ b/pkg/scheduler/apis/config/validation/validation.go
@@ -18,10 +18,7 @@ package validation
 
 import (
 	"fmt"
-	"net"
 	"reflect"
-	"strconv"
-	"strings"
 
 	v1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
@@ -68,32 +65,6 @@ func ValidateKubeSchedulerConfiguration(cc *config.KubeSchedulerConfiguration) u
 		}
 		errs = append(errs, validateCommonQueueSort(profilesPath, cc.Profiles)...)
 	}
-	if len(cc.HealthzBindAddress) > 0 {
-		host, port, err := splitHostIntPort(cc.HealthzBindAddress)
-		if err != nil {
-			errs = append(errs, field.Invalid(field.NewPath("healthzBindAddress"), cc.HealthzBindAddress, err.Error()))
-		} else {
-			if errMsgs := validation.IsValidIP(host); errMsgs != nil {
-				errs = append(errs, field.Invalid(field.NewPath("healthzBindAddress"), cc.HealthzBindAddress, strings.Join(errMsgs, ",")))
-			}
-			if port != 0 {
-				errs = append(errs, field.Invalid(field.NewPath("healthzBindAddress"), cc.HealthzBindAddress, "must be empty or with an explicit 0 port"))
-			}
-		}
-	}
-	if len(cc.MetricsBindAddress) > 0 {
-		host, port, err := splitHostIntPort(cc.MetricsBindAddress)
-		if err != nil {
-			errs = append(errs, field.Invalid(field.NewPath("metricsBindAddress"), cc.MetricsBindAddress, err.Error()))
-		} else {
-			if errMsgs := validation.IsValidIP(host); errMsgs != nil {
-				errs = append(errs, field.Invalid(field.NewPath("metricsBindAddress"), cc.MetricsBindAddress, strings.Join(errMsgs, ",")))
-			}
-			if port != 0 {
-				errs = append(errs, field.Invalid(field.NewPath("metricsBindAddress"), cc.MetricsBindAddress, "must be empty or with an explicit 0 port"))
-			}
-		}
-	}
 
 	errs = append(errs, validatePercentageOfNodesToScore(field.NewPath("percentageOfNodesToScore"), cc.PercentageOfNodesToScore))
 
@@ -108,18 +79,6 @@ func ValidateKubeSchedulerConfiguration(cc *config.KubeSchedulerConfiguration) u
 
 	errs = append(errs, validateExtenders(field.NewPath("extenders"), cc.Extenders)...)
 	return utilerrors.Flatten(utilerrors.NewAggregate(errs))
-}
-
-func splitHostIntPort(s string) (string, int, error) {
-	host, port, err := net.SplitHostPort(s)
-	if err != nil {
-		return "", 0, err
-	}
-	portInt, err := strconv.Atoi(port)
-	if err != nil {
-		return "", 0, err
-	}
-	return host, portInt, err
 }
 
 func validatePercentageOfNodesToScore(path *field.Path, percentageOfNodesToScore *int32) error {

--- a/pkg/scheduler/apis/config/validation/validation_test.go
+++ b/pkg/scheduler/apis/config/validation/validation_test.go
@@ -103,12 +103,6 @@ func TestValidateKubeSchedulerConfigurationV1(t *testing.T) {
 	enableContentProfilingSetWithoutEnableProfiling.EnableProfiling = false
 	enableContentProfilingSetWithoutEnableProfiling.EnableContentionProfiling = true
 
-	metricsBindAddrInvalid := validConfig.DeepCopy()
-	metricsBindAddrInvalid.MetricsBindAddress = "0.0.0.0:9090"
-
-	healthzBindAddrInvalid := validConfig.DeepCopy()
-	healthzBindAddrInvalid.HealthzBindAddress = "0.0.0.0:9090"
-
 	percentageOfNodesToScore101 := validConfig.DeepCopy()
 	percentageOfNodesToScore101.PercentageOfNodesToScore = ptr.To[int32](101)
 
@@ -235,24 +229,6 @@ func TestValidateKubeSchedulerConfigurationV1(t *testing.T) {
 				&field.Error{
 					Type:  field.ErrorTypeInvalid,
 					Field: "leaderElection.resourceLock",
-				},
-			},
-		},
-		"non-empty-metrics-bind-addr": {
-			config: metricsBindAddrInvalid,
-			wantErrs: field.ErrorList{
-				&field.Error{
-					Type:  field.ErrorTypeInvalid,
-					Field: "metricsBindAddress",
-				},
-			},
-		},
-		"non-empty-healthz-bind-addr": {
-			config: healthzBindAddrInvalid,
-			wantErrs: field.ErrorList{
-				&field.Error{
-					Type:  field.ErrorTypeInvalid,
-					Field: "healthzBindAddress",
 				},
 			},
 		},


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/priority backlog

#### What this PR does / why we need it:
The v1beta1 KubeSchedulerConfiguration API had `MetricsBindAddress` and `HealthzBindAddress` fields but they were removed in v1, and then never got removed from the unversioned type when the v1beta1 API went away.

(noticed while investigating users of `validation.IsValidIP`)

#### Which issue(s) this PR fixes:
none

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
