### PR TITLE
Re-allow building kube-proxy on all platforms

### DIFF
--- a/cmd/kube-proxy/app/init_other.go
+++ b/cmd/kube-proxy/app/init_other.go
@@ -1,0 +1,34 @@
+//go:build !windows && !linux
+// +build !windows,!linux
+
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package app
+
+import (
+	"fmt"
+	"runtime"
+
+	"github.com/spf13/pflag"
+)
+
+func initForOS(windowsService bool) error {
+	return fmt.Errorf(runtime.GOOS + "/" + runtime.GOARCH + "is unsupported")
+}
+
+func (o *Options) addOSFlags(fs *pflag.FlagSet) {
+}

--- a/cmd/kube-proxy/app/server_other.go
+++ b/cmd/kube-proxy/app/server_other.go
@@ -1,0 +1,60 @@
+//go:build !windows && !linux
+// +build !windows,!linux
+
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package app does all of the work necessary to configure and run a
+// Kubernetes app process.
+package app
+
+import (
+	"fmt"
+	"runtime"
+
+	"k8s.io/kubernetes/pkg/proxy"
+	proxyconfigapi "k8s.io/kubernetes/pkg/proxy/apis/config"
+)
+
+// platformApplyDefaults is called after parsing command-line flags and/or reading the
+// config file, to apply platform-specific default values to config.
+func (o *Options) platformApplyDefaults(config *proxyconfigapi.KubeProxyConfiguration) {
+}
+
+var unsupportedError = fmt.Errorf(runtime.GOOS + "/" + runtime.GOARCH + "is unsupported")
+
+// platformSetup is called after setting up the ProxyServer, but before creating the
+// Proxier. It should fill in any platform-specific fields and perform other
+// platform-specific setup.
+func (s *ProxyServer) platformSetup() error {
+	return unsupportedError
+}
+
+// platformCheckSupported is called immediately before creating the Proxier, to check
+// what IP families are supported (and whether the configuration is usable at all).
+func (s *ProxyServer) platformCheckSupported() (ipv4Supported, ipv6Supported, dualStackSupported bool, err error) {
+	return false, false, false, unsupportedError
+}
+
+// createProxier creates the proxy.Provider
+func (s *ProxyServer) createProxier(config *proxyconfigapi.KubeProxyConfiguration, dualStackMode, initOnly bool) (proxy.Provider, error) {
+	return nil, unsupportedError
+}
+
+// platformCleanup removes stale kube-proxy rules that can be safely removed.
+func platformCleanup(mode proxyconfigapi.ProxyMode, cleanupAndExit bool) error {
+	return unsupportedError
+}

--- a/hack/verify-typecheck.sh
+++ b/hack/verify-typecheck.sh
@@ -28,32 +28,13 @@ kube::golang::verify_go_version
 
 cd "${KUBE_ROOT}"
 
-ret=0
-TYPECHECK_SERIAL="${TYPECHECK_SERIAL:-false}"
-
-SERVER_PLATFORMS=$(echo "${KUBE_SUPPORTED_SERVER_PLATFORMS[@]}" | tr ' ' ',')
-CLIENT_PLATFORMS=$(echo "${KUBE_SUPPORTED_CLIENT_PLATFORMS[@]}" | tr ' ' ',')
-NODE_PLATFORMS=$(echo "${KUBE_SUPPORTED_NODE_PLATFORMS[@]}" | tr ' ' ',')
-TEST_PLATFORMS=$(echo "${KUBE_SUPPORTED_TEST_PLATFORMS[@]}" | tr ' ' ',')
-
 # As of June, 2020 the typecheck tool is written in terms of go/packages, but
 # that library doesn't work well with multiple modules.  Until that is done,
 # force this tooling to run in a fake GOPATH.
+ret=0
+TYPECHECK_SERIAL="${TYPECHECK_SERIAL:-false}"
 hack/run-in-gopath.sh \
-    go run test/typecheck/main.go "$@" --serial="${TYPECHECK_SERIAL}" --platform "${SERVER_PLATFORMS}" "${KUBE_SERVER_TARGETS[@]}" \
-    || ret=$?
-hack/run-in-gopath.sh \
-    go run test/typecheck/main.go "$@" --serial="${TYPECHECK_SERIAL}" --platform "${CLIENT_PLATFORMS}" "${KUBE_CLIENT_TARGETS[@]}" \
-    || ret=$?
-hack/run-in-gopath.sh \
-    go run test/typecheck/main.go "$@" --serial="${TYPECHECK_SERIAL}" --platform "${NODE_PLATFORMS}" "${KUBE_NODE_TARGETS[@]}" \
-    || ret=$?
-
-# $KUBE_TEST_TARGETS doesn't seem to work like the other TARGETS variables...
-hack/run-in-gopath.sh \
-    go run test/typecheck/main.go "$@" --serial="${TYPECHECK_SERIAL}" --platform "${TEST_PLATFORMS}" test/e2e \
-    || ret=$?
-
+    go run test/typecheck/main.go "$@" "--serial=$TYPECHECK_SERIAL" || ret=$?
 if [[ $ret -ne 0 ]]; then
   echo "!!! Type Check has failed. This may cause cross platform build failures." >&2
   echo "!!! Please see https://git.k8s.io/kubernetes/test/typecheck for more information." >&2

--- a/pkg/proxy/conntrack/doc.go
+++ b/pkg/proxy/conntrack/doc.go
@@ -1,0 +1,17 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package conntrack

--- a/pkg/proxy/conntrack/fake.go
+++ b/pkg/proxy/conntrack/fake.go
@@ -1,3 +1,6 @@
+//go:build linux
+// +build linux
+
 /*
 Copyright 2016 The Kubernetes Authors.
 

--- a/test/typecheck/main.go
+++ b/test/typecheck/main.go
@@ -294,11 +294,7 @@ func main() {
 			}()
 
 			f := false
-			if len(args) != 0 {
-				serialFprintf(os.Stdout, "type-checking %s against %s\n", plat, args)
-			} else {
-				serialFprintf(os.Stdout, "type-checking %s\n", plat)
-			}
+			serialFprintf(os.Stdout, "type-checking %s\n", plat)
 			errors, err := c.verify(plat)
 			if err != nil {
 				serialFprintf(os.Stderr, "ERROR(%s): failed to verify: %v\n", plat, err)

--- a/test/typecheck/main.go
+++ b/test/typecheck/main.go
@@ -241,10 +241,10 @@ func dedup(errors []packages.Error) []string {
 
 var outMu sync.Mutex
 
-func serialFprintf(w io.Writer, format string, a ...interface{}) (n int, err error) {
+func serialFprintf(w io.Writer, format string, a ...interface{}) {
 	outMu.Lock()
 	defer outMu.Unlock()
-	return fmt.Fprintf(w, format, a...)
+	_, _ = fmt.Fprintf(w, format, a...)
 }
 
 func main() {


### PR DESCRIPTION
Reverts https://github.com/kubernetes/kubernetes/pull/121722, re-adds stub methods to kube-proxy after https://github.com/kubernetes/kubernetes/pull/122373 so it type-checks and builds on platforms other than linux / windows again.

This has the following benefits:
* makes a simple `make` invocation work again (currently, running `make` explodes on darwin)
* allows using `kube-proxy --help` and `kube-proxy --write-config-to` on other platforms where *running* a proxy isn't needed
* improves visibility to kube-proxy use of methods when refactoring / building locally
* improves visibility to invalid use of build-tags within kube-proxy packages (like [OS-independent files relying on types declared in OS-dependent files](https://github.com/kubernetes/kubernetes/pull/122878#discussion_r1459280615))

/assign @danwinship @BenTheElder @dims

```release-note
NONE
```