### PR TITLE
Make local-up-cluster non-verbose by default

### DIFF
--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -14,7 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -x
+KUBE_VERBOSE=${KUBE_VERBOSE:-1}
+if (( KUBE_VERBOSE > 4 )); then
+  set -x
+fi
 
 KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 


### PR DESCRIPTION
Silences excessive script output by default.

Follow-up from https://github.com/kubernetes/kubernetes/commit/48671a3a20ba7e6102ec60e0a3424680c6c91ccb#r137443396

/kind cleanup
/assign @dims

```release-note
NONE
```