### PR TITLE
Aggregated Discovery, mark APIServices stale before initial health check

### DIFF
--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_discovery.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_discovery.go
@@ -443,7 +443,9 @@ func (dm *discoveryManager) Run(stopCh <-chan struct{}, discoverySyncedCh chan<-
 	}
 	wg.Wait()
 
-	close(discoverySyncedCh)
+	if discoverySyncedCh != nil {
+		close(discoverySyncedCh)
+	}
 
 	// Spawn workers
 	// These workers wait for APIServices to be marked dirty.

--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_discovery_test.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_discovery_test.go
@@ -61,6 +61,10 @@ func waitForQueueComplete(stopCh <-chan struct{}, dm *discoveryManager) bool {
 	})
 }
 
+func fakeCh() chan struct{} {
+	return make(chan struct{})
+}
+
 // Test that the discovery manager starts and aggregates from two local API services
 func TestBasic(t *testing.T) {
 	service1 := discoveryendpoint.NewResourceManager("apis")
@@ -204,7 +208,7 @@ func TestBasic(t *testing.T) {
 	testCtx, testCancel := context.WithCancel(context.Background())
 	defer testCancel()
 
-	go aggregatedManager.Run(testCtx.Done())
+	go aggregatedManager.Run(testCtx.Done(), fakeCh())
 
 	require.True(t, waitForQueueComplete(testCtx.Done(), aggregatedManager))
 
@@ -240,6 +244,62 @@ func checkAPIGroups(t *testing.T, api apidiscoveryv2beta1.APIGroupDiscoveryList,
 	}
 }
 
+// TestInitialRunHasAllAPIServices tests that when discovery is ready, all APIService
+// are present and ones that have not synced are in the list as Stale.
+func TestInitialRunHasAllAPIServices(t *testing.T) {
+	neverReturnCh := make(chan struct{})
+	defer close(neverReturnCh)
+	service := discoveryendpoint.NewResourceManager("apis")
+	aggregatedResourceManager := discoveryendpoint.NewResourceManager("apis")
+
+	aggregatedManager := newDiscoveryManager(aggregatedResourceManager)
+
+	aggregatedManager.AddAPIService(&apiregistrationv1.APIService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "v1.stable.example.com",
+		},
+		Spec: apiregistrationv1.APIServiceSpec{
+			Group:   "stable.example.com",
+			Version: "v1",
+			Service: &apiregistrationv1.ServiceReference{
+				Name: "test-service",
+			},
+		},
+	}, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-neverReturnCh
+		service.ServeHTTP(w, r)
+	}))
+	testCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	initialSyncedCh := fakeCh()
+	go aggregatedManager.Run(testCtx.Done(), initialSyncedCh)
+	select {
+	case <-initialSyncedCh:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for initial sync")
+	}
+
+	response, _, parsed := fetchPath(aggregatedResourceManager, "")
+	if response.StatusCode != 200 {
+		t.Fatalf("unexpected status code %d", response.StatusCode)
+	}
+
+	apiGroup := apidiscoveryv2beta1.APIGroupDiscoveryList{Items: []apidiscoveryv2beta1.APIGroupDiscovery{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "stable.example.com"},
+			Versions: []apidiscoveryv2beta1.APIVersionDiscovery{
+				{
+					Version:   "v1",
+					Freshness: "Stale",
+				},
+			},
+		},
+	}}
+
+	checkAPIGroups(t, apiGroup, parsed)
+}
+
 // Test that a handler associated with an APIService gets pinged after the
 // APIService has been marked as dirty
 func TestDirty(t *testing.T) {
@@ -267,7 +327,7 @@ func TestDirty(t *testing.T) {
 	testCtx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	go aggregatedManager.Run(testCtx.Done())
+	go aggregatedManager.Run(testCtx.Done(), fakeCh())
 	require.True(t, waitForQueueComplete(testCtx.Done(), aggregatedManager))
 
 	// immediately check for ping, since Run() should block for local services
@@ -304,7 +364,7 @@ func TestWaitForSync(t *testing.T) {
 	testCtx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	go aggregatedManager.Run(testCtx.Done())
+	go aggregatedManager.Run(testCtx.Done(), fakeCh())
 	require.True(t, waitForQueueComplete(testCtx.Done(), aggregatedManager))
 
 	// immediately check for ping, since Run() should block for local services
@@ -351,7 +411,7 @@ func TestRemoveAPIService(t *testing.T) {
 	testCtx, testCancel := context.WithCancel(context.Background())
 	defer testCancel()
 
-	go aggregatedManager.Run(testCtx.Done())
+	go aggregatedManager.Run(testCtx.Done(), fakeCh())
 
 	for _, s := range apiServices {
 		aggregatedManager.RemoveAPIService(s.Name)
@@ -527,7 +587,7 @@ func TestLegacyFallbackNoCache(t *testing.T) {
 	testCtx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	go aggregatedManager.Run(testCtx.Done())
+	go aggregatedManager.Run(testCtx.Done(), fakeCh())
 	require.True(t, waitForQueueComplete(testCtx.Done(), aggregatedManager))
 
 	// At this point external services have synced. Check if discovery document
@@ -665,7 +725,7 @@ func testLegacyFallbackWithCustomRootHandler(t *testing.T, rootHandlerFn func(ht
 	testCtx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	go aggregatedManager.Run(testCtx.Done())
+	go aggregatedManager.Run(testCtx.Done(), fakeCh())
 	require.True(t, waitForQueueComplete(testCtx.Done(), aggregatedManager))
 
 	// At this point external services have synced. Check if discovery document
@@ -745,7 +805,7 @@ func TestAPIServiceStale(t *testing.T) {
 	testCtx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	go aggregatedManager.Run(testCtx.Done())
+	go aggregatedManager.Run(testCtx.Done(), fakeCh())
 	require.True(t, waitForQueueComplete(testCtx.Done(), aggregatedManager))
 
 	// At this point external services have synced. Check if discovery document
@@ -807,7 +867,7 @@ func TestNotModified(t *testing.T) {
 	testCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	go aggregatedManager.Run(testCtx.Done())
+	go aggregatedManager.Run(testCtx.Done(), fakeCh())
 
 	// Important to wait here to ensure we prime the cache with the initial list
 	// of documents in order to exercise 304 Not Modified

--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_discovery_test.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_discovery_test.go
@@ -61,10 +61,6 @@ func waitForQueueComplete(stopCh <-chan struct{}, dm *discoveryManager) bool {
 	})
 }
 
-func fakeCh() chan struct{} {
-	return make(chan struct{})
-}
-
 // Test that the discovery manager starts and aggregates from two local API services
 func TestBasic(t *testing.T) {
 	service1 := discoveryendpoint.NewResourceManager("apis")
@@ -208,7 +204,7 @@ func TestBasic(t *testing.T) {
 	testCtx, testCancel := context.WithCancel(context.Background())
 	defer testCancel()
 
-	go aggregatedManager.Run(testCtx.Done(), fakeCh())
+	go aggregatedManager.Run(testCtx.Done(), nil)
 
 	require.True(t, waitForQueueComplete(testCtx.Done(), aggregatedManager))
 
@@ -272,7 +268,7 @@ func TestInitialRunHasAllAPIServices(t *testing.T) {
 	testCtx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	initialSyncedCh := fakeCh()
+	initialSyncedCh := make(chan struct{})
 	go aggregatedManager.Run(testCtx.Done(), initialSyncedCh)
 	select {
 	case <-initialSyncedCh:
@@ -327,7 +323,7 @@ func TestDirty(t *testing.T) {
 	testCtx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	go aggregatedManager.Run(testCtx.Done(), fakeCh())
+	go aggregatedManager.Run(testCtx.Done(), nil)
 	require.True(t, waitForQueueComplete(testCtx.Done(), aggregatedManager))
 
 	// immediately check for ping, since Run() should block for local services
@@ -364,7 +360,7 @@ func TestWaitForSync(t *testing.T) {
 	testCtx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	go aggregatedManager.Run(testCtx.Done(), fakeCh())
+	go aggregatedManager.Run(testCtx.Done(), nil)
 	require.True(t, waitForQueueComplete(testCtx.Done(), aggregatedManager))
 
 	// immediately check for ping, since Run() should block for local services
@@ -411,7 +407,7 @@ func TestRemoveAPIService(t *testing.T) {
 	testCtx, testCancel := context.WithCancel(context.Background())
 	defer testCancel()
 
-	go aggregatedManager.Run(testCtx.Done(), fakeCh())
+	go aggregatedManager.Run(testCtx.Done(), nil)
 
 	for _, s := range apiServices {
 		aggregatedManager.RemoveAPIService(s.Name)
@@ -587,7 +583,7 @@ func TestLegacyFallbackNoCache(t *testing.T) {
 	testCtx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	go aggregatedManager.Run(testCtx.Done(), fakeCh())
+	go aggregatedManager.Run(testCtx.Done(), nil)
 	require.True(t, waitForQueueComplete(testCtx.Done(), aggregatedManager))
 
 	// At this point external services have synced. Check if discovery document
@@ -725,7 +721,7 @@ func testLegacyFallbackWithCustomRootHandler(t *testing.T, rootHandlerFn func(ht
 	testCtx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	go aggregatedManager.Run(testCtx.Done(), fakeCh())
+	go aggregatedManager.Run(testCtx.Done(), nil)
 	require.True(t, waitForQueueComplete(testCtx.Done(), aggregatedManager))
 
 	// At this point external services have synced. Check if discovery document
@@ -805,7 +801,7 @@ func TestAPIServiceStale(t *testing.T) {
 	testCtx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	go aggregatedManager.Run(testCtx.Done(), fakeCh())
+	go aggregatedManager.Run(testCtx.Done(), nil)
 	require.True(t, waitForQueueComplete(testCtx.Done(), aggregatedManager))
 
 	// At this point external services have synced. Check if discovery document
@@ -867,7 +863,7 @@ func TestNotModified(t *testing.T) {
 	testCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	go aggregatedManager.Run(testCtx.Done(), fakeCh())
+	go aggregatedManager.Run(testCtx.Done(), nil)
 
 	// Important to wait here to ensure we prime the cache with the initial list
 	// of documents in order to exercise 304 Not Modified

--- a/test/integration/apiserver/discovery/discovery_test.go
+++ b/test/integration/apiserver/discovery/discovery_test.go
@@ -121,6 +121,18 @@ var (
 		},
 	}
 
+	basicTestGroupStale = apidiscoveryv2beta1.APIGroupDiscovery{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "stable.example.com",
+		},
+		Versions: []apidiscoveryv2beta1.APIVersionDiscovery{
+			{
+				Version:   "v1",
+				Freshness: apidiscoveryv2beta1.DiscoveryFreshnessStale,
+			},
+		},
+	}
+
 	stableGroup    = "stable.example.com"
 	stableV1       = metav1.GroupVersion{Group: stableGroup, Version: "v1"}
 	stableV1alpha1 = metav1.GroupVersion{Group: stableGroup, Version: "v1alpha1"}
@@ -170,6 +182,64 @@ func setup(t *testing.T) (context.Context, testClientSet, context.CancelFunc) {
 		dynamicClientset:       dynamicClientset,
 	}
 	return ctx, client, cancelCtx
+}
+
+func TestReadinessAggregatedAPIServiceDiscovery(t *testing.T) {
+	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.AggregatedDiscoveryEndpoint, true)()
+
+	// Keep any goroutines spawned from running past the execution of this test
+	ctx, client, cleanup := setup(t)
+	defer cleanup()
+
+	// Create a resource manager whichs serves our GroupVersion
+	resourceManager := discoveryendpoint.NewResourceManager("apis")
+	resourceManager.SetGroups([]apidiscoveryv2beta1.APIGroupDiscovery{basicTestGroup})
+
+	apiServiceWaitCh := make(chan struct{})
+
+	// Install our ResourceManager as an Aggregated APIService to the
+	// test server
+	service := NewFakeService("test-server", client, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/apis/stable.example.com") {
+			// Return invalid response so APIService can be marked as "available"
+			w.WriteHeader(http.StatusOK)
+		} else if strings.HasPrefix(r.URL.Path, "/apis") {
+			select {
+			case <-apiServiceWaitCh:
+				// Hang responding to discovery until aggregated discovery document contains the aggregated group marked as Stale.
+				resourceManager.ServeHTTP(w, r)
+			case <-ctx.Done():
+				return
+			}
+		} else {
+			// reject openapi/v2, openapi/v3, apis/<group>/<version>
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	go func() {
+		require.NoError(t, service.Run(ctx))
+	}()
+	require.NoError(t, service.WaitForReady(ctx))
+
+	// For each groupversion served by our resourcemanager, create an APIService
+	// object connected to our fake APIServer
+	for _, versionInfo := range basicTestGroup.Versions {
+		groupVersion := metav1.GroupVersion{
+			Group:   basicTestGroup.Name,
+			Version: versionInfo.Version,
+		}
+
+		require.NoError(t, registerAPIService(ctx, client, groupVersion, service))
+	}
+
+	// Keep repeatedly fetching document from aggregator.
+	// Check to see if it initially contains the aggregated group as stale
+	require.NoError(t, WaitForGroups(ctx, client, basicTestGroupStale))
+	require.NoError(t, WaitForRootPaths(t, ctx, client, sets.New("/apis/"+basicTestGroup.Name), nil))
+
+	// Allow the APIService to start responding and ensure that Freshness is updated when the APIService is reacheable.
+	close(apiServiceWaitCh)
+	require.NoError(t, WaitForGroups(ctx, client, basicTestGroupWithFixup))
 }
 
 func registerAPIService(ctx context.Context, client aggregator.Interface, gv metav1.GroupVersion, service FakeService) error {

--- a/test/integration/apiserver/discovery/framework.go
+++ b/test/integration/apiserver/discovery/framework.go
@@ -601,13 +601,18 @@ func WaitForRootPaths(t *testing.T, ctx context.Context, client testClient, requ
 func WaitForGroups(ctx context.Context, client testClient, groups ...apidiscoveryv2beta1.APIGroupDiscovery) error {
 	return WaitForResultWithCondition(ctx, client, func(groupList apidiscoveryv2beta1.APIGroupDiscoveryList) bool {
 		for _, searchGroup := range groups {
+			found := false
 			for _, docGroup := range groupList.Items {
 				if reflect.DeepEqual(searchGroup, docGroup) {
-					return true
+					found = true
+					break
 				}
 			}
+			if !found {
+				return false
+			}
 		}
-		return false
+		return true
 	})
 }
 


### PR DESCRIPTION
/kind bug

#### What this PR does / why we need it:

Ensure all APIServices are present in Aggregated Discovery document before health check is completed.

I've moved the aggregator initialization earlier into `NewWithDelegate` instead of `PrepareRun`. I don't think there should be any impact/races by doing this.

- `AddPostStartHookOrDie` is always called after the initialization of the apiserver so creating a deferred function earlier should have no impact
- Moving `GenericAPIServer.AggregatedDiscoveryGroupManager.WithSource(aggregated.AggregatorSource)` earlier should be safe. The AggregatedDiscoveryGroupManager is initialized in `BuildGenericConfig` https://github.com/kubernetes/kubernetes/blob/9c1c603fbef4abb1bfd257a02a32d7d16832a8a4/pkg/controlplane/apiserver/config.go#L165-L167 which is called before `NewWithDelegate` in the aggregator is called. (initialization goes through this path: https://github.com/kubernetes/kubernetes/blob/9c1c603fbef4abb1bfd257a02a32d7d16832a8a4/cmd/kube-apiserver/app/server.go#L152 while aggregator usage goes through https://github.com/kubernetes/kubernetes/blob/9c1c603fbef4abb1bfd257a02a32d7d16832a8a4/cmd/kube-apiserver/app/server.go#L160

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/115303

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix bug where health check could pass while APIServices are missing from aggregated discovery
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/triage accepted