### PR TITLE
Retry generate name

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/dryrun.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/dryrun.go
@@ -67,6 +67,10 @@ func (s *DryRunnableStorage) Get(ctx context.Context, key string, opts storage.G
 	return s.Storage.Get(ctx, key, opts, objPtr)
 }
 
+func (s *DryRunnableStorage) Exists(ctx context.Context, key string) (bool, error) {
+	return s.Storage.Exists(ctx, key)
+}
+
 func (s *DryRunnableStorage) GetList(ctx context.Context, key string, opts storage.ListOptions, listObj runtime.Object) error {
 	return s.Storage.GetList(ctx, key, opts, listObj)
 }

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
@@ -421,9 +421,9 @@ func (e *Store) Create(ctx context.Context, obj runtime.Object, createValidation
 			// - only checking the watch cache (this is tricky to do though...)
 			// - maintaining known names in a set or bloom filter
 			foundNonConflict := false
+			var name string
 			for i := 0; i < 10 && !foundNonConflict; i++ {
-				name := e.CreateStrategy.GenerateName(objectMeta.GetGenerateName())
-				objectMeta.SetName(name)
+				name = e.CreateStrategy.GenerateName(objectMeta.GetGenerateName())
 				key, err := e.KeyFunc(ctx, name)
 				if err != nil {
 					return nil, err
@@ -434,6 +434,7 @@ func (e *Store) Create(ctx context.Context, obj runtime.Object, createValidation
 				}
 				foundNonConflict = !exists
 			}
+			objectMeta.SetName(name)
 		}
 	}
 

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
@@ -714,6 +714,11 @@ func (c *Cacher) Get(ctx context.Context, key string, opts storage.GetOptions, o
 	return nil
 }
 
+// Exists implements storage.Interface.
+func (c *Cacher) Exists(ctx context.Context, key string) (bool, error) {
+	return c.storage.Exists(ctx, key)
+}
+
 // NOTICE: Keep in sync with shouldListFromStorage function in
 //
 //	staging/src/k8s.io/apiserver/pkg/util/flowcontrol/request/list_work_estimator.go

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_test.go
@@ -106,6 +106,12 @@ func TestGet(t *testing.T) {
 	storagetesting.RunTestGet(ctx, t, cacher)
 }
 
+func TestExists(t *testing.T) {
+	ctx, cacher, terminate := testSetup(t)
+	t.Cleanup(terminate)
+	storagetesting.RunTestExists(ctx, t, cacher)
+}
+
 func TestUnconditionalDelete(t *testing.T) {
 	ctx, cacher, terminate := testSetup(t)
 	t.Cleanup(terminate)

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
@@ -131,6 +131,12 @@ func (d *dummyStorage) Get(_ context.Context, _ string, _ storage.GetOptions, _ 
 
 	return d.err
 }
+func (d *dummyStorage) Exists(_ context.Context, _ string) (bool, error) {
+	d.RLock()
+	defer d.RUnlock()
+
+	return false, d.err
+}
 func (d *dummyStorage) GetList(ctx context.Context, resPrefix string, opts storage.ListOptions, listObj runtime.Object) error {
 	if d.getListFn != nil {
 		return d.getListFn(ctx, resPrefix, opts, listObj)

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
@@ -183,6 +183,21 @@ func (s *store) Get(ctx context.Context, key string, opts storage.GetOptions, ou
 	return nil
 }
 
+// Exists implements storage.Interface.Exists.
+func (s *store) Exists(ctx context.Context, key string) (bool, error) {
+	preparedKey, err := s.prepareKey(key)
+	if err != nil {
+		return false, err
+	}
+	startTime := time.Now()
+	getResp, err := s.client.KV.Get(ctx, preparedKey, clientv3.WithCountOnly())
+	metrics.RecordEtcdRequest("exists", s.groupResourceString, err, startTime)
+	if err != nil {
+		return false, err
+	}
+	return getResp.Count > 0, nil
+}
+
 // Create implements storage.Interface.Create.
 func (s *store) Create(ctx context.Context, key string, obj, out runtime.Object, ttl uint64) error {
 	preparedKey, err := s.prepareKey(key)

--- a/staging/src/k8s.io/apiserver/pkg/storage/interfaces.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/interfaces.go
@@ -190,6 +190,8 @@ type Interface interface {
 	// match 'opts.ResourceVersion' according 'opts.ResourceVersionMatch'.
 	Get(ctx context.Context, key string, opts GetOptions, objPtr runtime.Object) error
 
+	Exists(ctx context.Context, key string) (bool, error)
+
 	// GetList unmarshalls objects found at key into a *List api object (an object
 	// that satisfies runtime.IsList definition).
 	// If 'opts.Recursive' is false, 'key' is used as an exact match. If `opts.Recursive'

--- a/staging/src/k8s.io/apiserver/pkg/storage/names/generate.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/names/generate.go
@@ -42,7 +42,7 @@ var SimpleNameGenerator NameGenerator = simpleNameGenerator{}
 const (
 	// TODO: make this flexible for non-core resources with alternate naming rules.
 	maxNameLength          = 63
-	randomLength           = 5
+	randomLength           = 1
 	MaxGeneratedNameLength = maxNameLength - randomLength
 )
 


### PR DESCRIPTION
#### What type of PR is this?

/kind feature


#### What this PR does / why we need it:

Implements https://github.com/kubernetes/enhancements/issues/4420

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
When the RetryGenerateName feature gate is enabled on the kube-apiserver,
create requests using generateName are retried automatically by the apiserver when the generated name conflicts with an existing resource name, up to a max limit of 7 retries.
This feature is in alpha.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

- KEP-4421: https://github.com/kubernetes/enhancements/pull/4421

/sig api-machinery