### PR TITLE
unittests: Fixes unit tests for Windows (part 10)

### DIFF
--- a/cmd/gotemplate/gotemplate_test.go
+++ b/cmd/gotemplate/gotemplate_test.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path"
 	"strings"
+	"syscall"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -28,6 +29,7 @@ import (
 )
 
 func TestGenerate(t *testing.T) {
+	noFileErr := os.PathError{Op: "open", Path: "no-such-file.txt", Err: syscall.Errno(syscall.ENOENT)}
 	for name, tt := range map[string]struct {
 		in          string
 		data        map[string]string
@@ -37,7 +39,7 @@ func TestGenerate(t *testing.T) {
 	}{
 		"missing-file": {
 			in:          `{{include "no-such-file.txt"}}`,
-			expectedErr: "open no-such-file.txt: no such file or directory",
+			expectedErr: noFileErr.Error(),
 		},
 		"data": {
 			in:       `{{.Hello}} {{.World}}`,

--- a/cmd/kube-proxy/app/server_windows.go
+++ b/cmd/kube-proxy/app/server_windows.go
@@ -42,6 +42,9 @@ func (o *Options) platformApplyDefaults(config *proxyconfigapi.KubeProxyConfigur
 	if config.Mode == "" {
 		config.Mode = proxyconfigapi.ProxyModeKernelspace
 	}
+	if config.Winkernel.RootHnsEndpointName == "" {
+		config.Winkernel.RootHnsEndpointName = "cbr0"
+	}
 }
 
 // platformSetup is called after setting up the ProxyServer, but before creating the

--- a/cmd/kube-scheduler/app/options/configfile_test.go
+++ b/cmd/kube-scheduler/app/options/configfile_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"syscall"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -32,7 +33,6 @@ const (
 	apiVersionMissing = "'apiVersion' is missing"
 	apiVersionTooOld  = "no kind \"KubeSchedulerConfiguration\" is registered for" +
 		" version \"kubescheduler.config.k8s.io/v1alpha1\""
-	fileNotFound = "no such file or directory"
 
 	// schedulerConfigMinimalCorrect is the minimal
 	// correct scheduler config
@@ -91,7 +91,7 @@ func TestLoadConfigFromFile(t *testing.T) {
 		{
 			name:           "Empty scheduler config file path",
 			path:           "",
-			expectedErr:    fmt.Errorf(fileNotFound),
+			expectedErr:    syscall.Errno(syscall.ENOENT),
 			expectedConfig: nil,
 		},
 		{

--- a/pkg/kubeapiserver/options/authentication_test.go
+++ b/pkg/kubeapiserver/options/authentication_test.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"reflect"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -866,7 +867,7 @@ func TestLoadAuthenticationConfig(t *testing.T) {
 		{
 			name:           "missing file",
 			file:           func() string { return "bogus-missing-file" },
-			expectErr:      "no such file or directory",
+			expectErr:      syscall.Errno(syscall.ENOENT).Error(),
 			expectedConfig: nil,
 		},
 		{
@@ -998,6 +999,10 @@ func writeTempFile(t *testing.T, content string) string {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() {
+		// An open file cannot be removed on Windows. Close it first.
+		if err := file.Close(); err != nil {
+			t.Fatal(err)
+		}
 		if err := os.Remove(file.Name()); err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/kubelet/server/stats/summary_windows_test.go
+++ b/pkg/kubelet/server/stats/summary_windows_test.go
@@ -64,7 +64,7 @@ func TestSummaryProvider(t *testing.T) {
 	mockStatsProvider.EXPECT().GetPodCgroupRoot().Return(cgroupRoot).AnyTimes()
 	mockStatsProvider.EXPECT().ListPodStats(ctx).Return(podStats, nil).AnyTimes()
 	mockStatsProvider.EXPECT().ListPodStatsAndUpdateCPUNanoCoreUsage(ctx).Return(podStats, nil).AnyTimes()
-	mockStatsProvider.EXPECT().ImageFsStats(ctx).Return(imageFsStats, nil).AnyTimes()
+	mockStatsProvider.EXPECT().ImageFsStats(ctx).Return(imageFsStats, ImageFsStats, nil).AnyTimes()
 	mockStatsProvider.EXPECT().RootFsStats().Return(rootFsStats, nil).AnyTimes()
 	mockStatsProvider.EXPECT().RlimitStats().Return(nil, nil).AnyTimes()
 	mockStatsProvider.EXPECT().GetCgroupStats("/", true).Return(cgroupStatsMap["/"].cs, cgroupStatsMap["/"].ns, nil).AnyTimes()
@@ -81,7 +81,7 @@ func TestSummaryProvider(t *testing.T) {
 	assert.Equal(summary.Node.Memory, cgroupStatsMap["/"].cs.Memory)
 	assert.Equal(summary.Node.Network, cgroupStatsMap["/"].ns)
 	assert.Equal(summary.Node.Fs, rootFsStats)
-	assert.Equal(summary.Node.Runtime, &statsapi.RuntimeStats{ImageFs: imageFsStats})
+	assert.Equal(summary.Node.Runtime, &statsapi.RuntimeStats{ContainerFs: imageFsStats, ImageFs: imageFsStats})
 
 	assert.Equal(len(summary.Node.SystemContainers), 1)
 	assert.Equal(summary.Node.SystemContainers[0].Name, "pods")

--- a/pkg/volume/util/hostutil/hostutil.go
+++ b/pkg/volume/util/hostutil/hostutil.go
@@ -41,6 +41,10 @@ const (
 	FileTypeUnknown FileType = ""
 )
 
+var (
+	errUnknownFileType = fmt.Errorf("only recognise file, directory, socket, block device and character device")
+)
+
 // HostUtils defines the set of methods for interacting with paths on a host.
 type HostUtils interface {
 	// DeviceOpened determines if the device (e.g. /dev/sdc) is in use elsewhere
@@ -108,5 +112,5 @@ func getFileType(pathname string) (FileType, error) {
 		return FileTypeBlockDev, nil
 	}
 
-	return pathType, fmt.Errorf("only recognise file, directory, socket, block device and character device")
+	return pathType, errUnknownFileType
 }

--- a/pkg/volume/util/hostutil/hostutil_windows.go
+++ b/pkg/volume/util/hostutil/hostutil_windows.go
@@ -106,7 +106,7 @@ func (hu *(HostUtil)) GetFileType(pathname string) (FileType, error) {
 
 	// os.Stat will return a 1920 error (windows.ERROR_CANT_ACCESS_FILE) if we use it on a Unix Socket
 	// on Windows. In this case, we need to use a different method to check if it's a Unix Socket.
-	if isSystemCannotAccessErr(err) {
+	if err == errUnknownFileType || isSystemCannotAccessErr(err) {
 		if isSocket, errSocket := filesystem.IsUnixDomainSocket(pathname); errSocket == nil && isSocket {
 			return FileTypeSocket, nil
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/sig windows
/sig testing

/kind failing-test
/priority important-soon

#### What this PR does / why we need it:

Currently, there are some unit tests that are failing on Windows due to various reasons:

- Different ``File not found`` error messages on Windows.
- Files need to be closed on Windows before removing them.
- The default ``RootHnsEndpointName`` (``root-hnsendpoint-name``) flag value is ``cbr0``.
- On Windows, Unix Domain sockets are not checked in the same way in golang, which is why ``hostutils_windows.go`` checks for it differently. ``GetFileType`` will return an error in this case. We need to check for it, and see if it's actually a Unix Domain Socket.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Related: https://github.com/kubernetes/kubernetes/issues/51540

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
