### PR TITLE
kubeadm: don't set crbResult to nil if the error is already exists

### DIFF
--- a/cmd/kubeadm/app/phases/kubeconfig/kubeconfig.go
+++ b/cmd/kubeadm/app/phases/kubeconfig/kubeconfig.go
@@ -592,10 +592,14 @@ func EnsureAdminClusterRoleBinding(outDir string, ensureRBACFunc EnsureRBACFunc)
 	}
 
 	ctx := context.Background()
-	return ensureRBACFunc(
+	crb, err := ensureRBACFunc(
 		ctx, adminClient, superAdminClient,
 		kubeadmconstants.KubernetesAPICallRetryInterval, kubeadmapi.GetActiveTimeouts().KubernetesAPICall.Duration,
 	)
+	if apierrors.IsAlreadyExists(err) {
+		return crb, nil
+	}
+	return crb, err
 }
 
 // EnsureAdminClusterRoleBindingImpl first attempts to see if the ClusterRoleBinding


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/kind failing-test


#### What this PR does / why we need it:
error handling crb existing

#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes/kubeadm/issues/3000  #122901

#### Special notes for your reviewer:

https://github.com/kubernetes/kubernetes/pull/122893 was merged yesterday to fix the test with #122892.

If EnsureAdminClusterRoleBindingImpl now works as expected, we should handle the existing error in post upgrade progress to make it pass.

#### Does this PR introduce a user-facing change?

```release-note
None
```