### PR TITLE
kubeadm: don't fail post upgrade for already existing error

### DIFF
--- a/cmd/kubeadm/app/phases/kubeconfig/kubeconfig.go
+++ b/cmd/kubeadm/app/phases/kubeconfig/kubeconfig.go
@@ -694,9 +694,8 @@ func EnsureAdminClusterRoleBindingImpl(ctx context.Context, adminClient, superAd
 			); err != nil {
 				lastError = err
 				if apierrors.IsAlreadyExists(err) {
-					// This should not happen, as the previous "create" call that uses
-					// the admin.conf should have passed. Return the error.
-					return true, err
+					klog.V(5).Infof("ClusterRoleBinding  %s already exists.", kubeadmconstants.ClusterAdminsGroupAndClusterRoleBinding)
+					return true, nil
 				}
 				// Retry on any other type of error.
 				return false, nil

--- a/cmd/kubeadm/app/phases/kubeconfig/kubeconfig_test.go
+++ b/cmd/kubeadm/app/phases/kubeconfig/kubeconfig_test.go
@@ -850,6 +850,12 @@ func TestEnsureAdminClusterRoleBindingImpl(t *testing.T) {
 						schema.GroupResource{}, "name")
 				})
 			},
+			setupSuperAdminClient: func(client *clientsetfake.Clientset) {
+				client.PrependReactor("create", "clusterrolebindings", func(action clientgotesting.Action) (bool, runtime.Object, error) {
+					return true, nil, apierrors.NewAlreadyExists(
+						schema.GroupResource{}, "name")
+				})
+			},
 			expectedError: false,
 		},
 		{
@@ -916,7 +922,7 @@ func TestEnsureAdminClusterRoleBindingImpl(t *testing.T) {
 						schema.GroupResource{}, "name")
 				})
 			},
-			expectedError: true,
+			expectedError: false,
 		},
 	}
 


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/kind failing-test

Another try like  #122900 (I perfer this fix as the ensure func should not fail for already existing error)

- https://github.com/kubernetes/kubernetes/pull/122893 is merged to fix the CI failure. 
- This PR only want to make the behavior as expected and reasonable.

#### What this PR does / why we need it:
error handling crb existing

#### Which issue(s) this PR fixes:

xref https://github.com/kubernetes/kubeadm/issues/3000  

#### Special notes for your reviewer:

https://github.com/kubernetes/kubernetes/pull/122893 was merged yesterday to fix the test with #122892.



#### Does this PR introduce a user-facing change?

```release-note
None
```