### PR TITLE
refactor apf tests for per handler read/write timeout 

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/filters/priority-and-fairness_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/priority-and-fairness_test.go
@@ -903,8 +903,11 @@ func (test handlerWritesBeforeRequestTimesOut) runT(t *testing.T) {
 		if r.URL.Path == rquestTimesOutPath {
 			defer close(reqHandlerErr.ch)
 
-			// inner handler writes header and then let the request time out.
+			// inner handler writes and then let the request time out.
 			w.WriteHeader(http.StatusBadRequest)
+			if _, err := w.Write([]byte("hello world")); err != nil {
+				t.Errorf("unexpected error from Write: %v", err)
+			}
 			<-callerRoundTripDoneCh
 
 			// we expect the timeout handler to have timed out this request by now and any attempt
@@ -990,7 +993,7 @@ func (test enqueuedRequestTimingOut) runT(t *testing.T) {
 
 		case r.URL.Path == secondRequestEnqueuedPath:
 			// we expect the concurrency to be set to 1 and so this request should never be executed.
-			t.Errorf("Expected second request to be enqueued: %q", secondRequestEnqueuedPath)
+			t.Errorf("Expected second request to be rejected from queue: %q", secondRequestEnqueuedPath)
 		}
 	})
 

--- a/staging/src/k8s.io/apiserver/pkg/server/filters/priority-and-fairness_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/priority-and-fairness_test.go
@@ -34,6 +34,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apiserver/pkg/apis/flowcontrol/bootstrap"
@@ -684,11 +685,10 @@ func (test panicShouldNotRejectFutureRequest) runT(t *testing.T) {
 	// c) next request that follows should not be rejected
 	const (
 		userName                                              = "alice"
-		fsName                                                = "test-fs"
-		plName                                                = "test-pl"
 		serverConcurrency, plConcurrencyShares, plConcurrency = 1, 1, 1
 	)
 
+	fsName, plName := newFSandPLNames()
 	apfConfiguration := newConfiguration(fsName, plName, userName, plConcurrencyShares, 0)
 	stopCh := make(chan struct{})
 	controller, controllerCompletedCh := startAPFController(t, stopCh, apfConfiguration, serverConcurrency, plName, plConcurrency)
@@ -753,11 +753,10 @@ func (test requestTimesOutBeforeHandlerWrites) runT(t *testing.T) {
 	// underlying ResponseWriter object.
 	const (
 		userName                                              = "alice"
-		fsName                                                = "test-fs"
-		plName                                                = "test-pl"
 		serverConcurrency, plConcurrencyShares, plConcurrency = 1, 1, 1
 	)
 
+	fsName, plName := newFSandPLNames()
 	apfConfiguration := newConfiguration(fsName, plName, userName, plConcurrencyShares, 0)
 	stopCh := make(chan struct{})
 	controller, controllerCompletedCh := startAPFController(t, stopCh, apfConfiguration, serverConcurrency, plName, plConcurrency)
@@ -816,11 +815,10 @@ func (test handlerPanicsAfterRequestTimesOut) runT(t *testing.T) {
 	// b) then the inner hander of the request panics
 	const (
 		userName                                              = "alice"
-		fsName                                                = "test-fs"
-		plName                                                = "test-pl"
 		serverConcurrency, plConcurrencyShares, plConcurrency = 1, 1, 1
 	)
 
+	fsName, plName := newFSandPLNames()
 	apfConfiguration := newConfiguration(fsName, plName, userName, plConcurrencyShares, 0)
 	stopCh := make(chan struct{})
 	controller, controllerCompletedCh := startAPFController(t, stopCh, apfConfiguration, serverConcurrency, plName, plConcurrency)
@@ -884,11 +882,10 @@ func (test handlerWritesBeforeRequestTimesOut) runT(t *testing.T) {
 	// c) the request times out
 	const (
 		userName                                              = "alice"
-		fsName                                                = "test-fs"
-		plName                                                = "test-pl"
 		serverConcurrency, plConcurrencyShares, plConcurrency = 1, 1, 1
 	)
 
+	fsName, plName := newFSandPLNames()
 	apfConfiguration := newConfiguration(fsName, plName, userName, plConcurrencyShares, 0)
 	stopCh := make(chan struct{})
 	controller, controllerCompletedCh := startAPFController(t, stopCh, apfConfiguration, serverConcurrency, plName, plConcurrency)
@@ -959,11 +956,10 @@ func (test enqueuedRequestTimingOut) runT(t *testing.T) {
 	// f) the first request eventually times out
 	const (
 		userName                                                           = "alice"
-		fsName                                                             = "test-fs"
-		plName                                                             = "test-pl"
 		serverConcurrency, plConcurrencyShares, plConcurrency, queueLength = 1, 1, 1, 1
 	)
 
+	fsName, plName := newFSandPLNames()
 	apfConfiguration := newConfiguration(fsName, plName, userName, plConcurrencyShares, queueLength)
 	stopCh := make(chan struct{})
 	controller, controllerCompletedCh := startAPFController(t, stopCh, apfConfiguration, serverConcurrency, plName, plConcurrency)
@@ -1193,6 +1189,12 @@ func unsyncedInformers(status map[reflect.Type]bool) []string {
 	}
 
 	return names
+}
+
+func newFSandPLNames() (string, string) {
+	fsName := fmt.Sprintf("%s-%d", "test-fs", rand.IntnRange(100, 199))
+	plName := fmt.Sprintf("%s-%d", "test-pl", rand.IntnRange(200, 299))
+	return fsName, plName
 }
 
 func newConfiguration(fsName, plName, user string, concurrency int32, queueLength int32) []runtime.Object {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
In support of https://github.com/kubernetes/kubernetes/pull/114189

This PR refactors the priority and fairness unit tests so these tests can be extended to assert on the behavior with per request (handler) read/write timeout 

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:
Please go through the commits in chronological order in order to make review easier, otherwise changes in indentation makes it hard to pinpoint the changes made in the tests

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
