### PR TITLE
apiserver: refactor handleError in endpoints/filters

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/webhook_duration.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/webhook_duration.go
@@ -18,7 +18,6 @@ package filters
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"time"
 
@@ -39,7 +38,7 @@ func WithLatencyTrackers(handler http.Handler) http.Handler {
 		ctx := req.Context()
 		requestInfo, ok := request.RequestInfoFrom(ctx)
 		if !ok {
-			handleError(w, req, http.StatusInternalServerError, fmt.Errorf("no RequestInfo found in context, handler chain must be wrong"))
+			handleError(w, req, http.StatusInternalServerError, nil, "no RequestInfo found in context, handler chain must be wrong")
 			return
 		}
 


### PR DESCRIPTION

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

In support of https://github.com/kubernetes/kubernetes/pull/114189

It's a small refactor of the `handleError` function inside `endpoints/filters` package

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
