### PR TITLE
consistently use IsValidIP for IP validation

### DIFF
--- a/pkg/apis/networking/validation/validation.go
+++ b/pkg/apis/networking/validation/validation.go
@@ -354,9 +354,7 @@ func ValidateIngressLoadBalancerStatus(status *networking.IngressLoadBalancerSta
 	for i, ingress := range status.Ingress {
 		idxPath := fldPath.Child("ingress").Index(i)
 		if len(ingress.IP) > 0 {
-			if isIP := (netutils.ParseIPSloppy(ingress.IP) != nil); !isIP {
-				allErrs = append(allErrs, field.Invalid(idxPath.Child("ip"), ingress.IP, "must be a valid IP address"))
-			}
+			allErrs = append(allErrs, validation.IsValidIP(idxPath.Child("ip"), ingress.IP)...)
 		}
 		if len(ingress.Hostname) > 0 {
 			for _, msg := range validation.IsDNS1123Subdomain(ingress.Hostname) {

--- a/staging/src/k8s.io/apimachinery/pkg/util/validation/validation.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/validation/validation.go
@@ -19,9 +19,7 @@ package validation
 import (
 	"fmt"
 	"math"
-	"net"
 	"regexp"
-	"strconv"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -491,20 +489,5 @@ func hasChDirPrefix(value string) []string {
 	case strings.HasPrefix(value, ".."):
 		errs = append(errs, `must not start with '..'`)
 	}
-	return errs
-}
-
-// IsValidSocketAddr checks that string represents a valid socket address
-// as defined in RFC 789. (e.g 0.0.0.0:10254 or [::]:10254))
-func IsValidSocketAddr(value string) []string {
-	var errs []string
-	ip, port, err := net.SplitHostPort(value)
-	if err != nil {
-		errs = append(errs, "must be a valid socket address format, (e.g. 0.0.0.0:10254 or [::]:10254)")
-		return errs
-	}
-	portInt, _ := strconv.Atoi(port)
-	errs = append(errs, IsValidPortNum(portInt)...)
-	errs = append(errs, IsValidIP(ip)...)
 	return errs
 }

--- a/staging/src/k8s.io/apimachinery/pkg/util/validation/validation.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/validation/validation.go
@@ -350,11 +350,12 @@ func IsValidPortName(port string) []string {
 }
 
 // IsValidIP tests that the argument is a valid IP address.
-func IsValidIP(value string) []string {
+func IsValidIP(fldPath *field.Path, value string) field.ErrorList {
+	var allErrors field.ErrorList
 	if netutils.ParseIPSloppy(value) == nil {
-		return []string{"must be a valid IP address, (e.g. 10.9.8.7 or 2001:db8::ffff)"}
+		allErrors = append(allErrors, field.Invalid(fldPath, value, "must be a valid IP address, (e.g. 10.9.8.7 or 2001:db8::ffff)"))
 	}
-	return nil
+	return allErrors
 }
 
 // IsValidIPv4Address tests that the argument is a valid IPv4 address.

--- a/staging/src/k8s.io/apimachinery/pkg/util/validation/validation_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/validation/validation_test.go
@@ -458,20 +458,20 @@ func TestIsValidIP(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			msgs := IsValidIP(tc.in)
+			errs := IsValidIP(field.NewPath(""), tc.in)
 			if tc.err == "" {
-				if len(msgs) != 0 {
-					t.Errorf("expected %q to be valid but got: %v", tc.in, msgs)
+				if len(errs) != 0 {
+					t.Errorf("expected %q to be valid but got: %v", tc.in, errs)
 				}
 			} else {
-				if len(msgs) != 1 {
-					t.Errorf("expected %q to have 1 error but got: %v", tc.in, msgs)
-				} else if !strings.Contains(msgs[0], tc.err) {
-					t.Errorf("expected error for %q to contain %q but got: %q", tc.in, tc.err, msgs[0])
+				if len(errs) != 1 {
+					t.Errorf("expected %q to have 1 error but got: %v", tc.in, errs)
+				} else if !strings.Contains(errs[0].Detail, tc.err) {
+					t.Errorf("expected error for %q to contain %q but got: %q", tc.in, tc.err, errs[0].Detail)
 				}
 			}
 
-			errs := IsValidIPv4Address(field.NewPath(""), tc.in)
+			errs = IsValidIPv4Address(field.NewPath(""), tc.in)
 			if tc.family == 4 {
 				if len(errs) != 0 {
 					t.Errorf("expected %q to pass IsValidIPv4Address but got: %v", tc.in, errs)

--- a/staging/src/k8s.io/apimachinery/pkg/util/validation/validation_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/validation/validation_test.go
@@ -710,31 +710,3 @@ func TestIsDomainPrefixedPath(t *testing.T) {
 		}
 	}
 }
-
-func TestIsValidSocketAddr(t *testing.T) {
-	goodValues := []string{
-		"0.0.0.0:10254",
-		"127.0.0.1:8888",
-		"[2001:db8:1f70::999:de8:7648:6e8]:10254",
-		"[::]:10254",
-	}
-	for _, val := range goodValues {
-		if errs := IsValidSocketAddr(val); len(errs) != 0 {
-			t.Errorf("expected no errors for %q: %v", val, errs)
-		}
-	}
-
-	badValues := []string{
-		"0.0.0.0.0:2020",
-		"0.0.0.0",
-		"6.6.6.6:909090",
-		"2001:db8:1f70::999:de8:7648:6e8:87567:102545",
-		"",
-		"*",
-	}
-	for _, val := range badValues {
-		if errs := IsValidSocketAddr(val); len(errs) == 0 {
-			t.Errorf("expected errors for %q", val)
-		}
-	}
-}

--- a/staging/src/k8s.io/apimachinery/pkg/util/validation/validation_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/validation/validation_test.go
@@ -323,104 +323,176 @@ func TestIsValidLabelValue(t *testing.T) {
 }
 
 func TestIsValidIP(t *testing.T) {
-	goodValues := []string{
-		"::1",
-		"2a00:79e0:2:0:f1c3:e797:93c1:df80",
-		"::",
-		"2001:4860:4860::8888",
-		"::fff:1.1.1.1",
-		"1.1.1.1",
-		"1.1.1.01",
-		"255.0.0.1",
-		"1.0.0.0",
-		"0.0.0.0",
-	}
-	for _, val := range goodValues {
-		if msgs := IsValidIP(val); len(msgs) != 0 {
-			t.Errorf("expected true for %q: %v", val, msgs)
-		}
-	}
+	for _, tc := range []struct {
+		name   string
+		in     string
+		family int
+		err    string
+	}{
+		// GOOD VALUES
+		{
+			name:   "ipv4",
+			in:     "1.2.3.4",
+			family: 4,
+		},
+		{
+			name:   "ipv4, all zeros",
+			in:     "0.0.0.0",
+			family: 4,
+		},
+		{
+			name:   "ipv4, max",
+			in:     "255.255.255.255",
+			family: 4,
+		},
+		{
+			name:   "ipv6",
+			in:     "1234::abcd",
+			family: 6,
+		},
+		{
+			name:   "ipv6, all zeros, collapsed",
+			in:     "::",
+			family: 6,
+		},
+		{
+			name:   "ipv6, max",
+			in:     "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+			family: 6,
+		},
 
-	badValues := []string{
-		"[2001:db8:0:1]:80",
-		"myhost.mydomain",
-		"-1.0.0.0",
-		"[2001:db8:0:1]",
-		"a",
-	}
-	for _, val := range badValues {
-		if msgs := IsValidIP(val); len(msgs) == 0 {
-			t.Errorf("expected false for %q", val)
-		}
-	}
-}
+		// GOOD, THOUGH NON-CANONICAL, VALUES
+		{
+			name:   "ipv6, all zeros, expanded (non-canonical)",
+			in:     "0:0:0:0:0:0:0:0",
+			family: 6,
+		},
+		{
+			name:   "ipv6, leading 0s (non-canonical)",
+			in:     "0001:002:03:4::",
+			family: 6,
+		},
+		{
+			name:   "ipv6, capital letters (non-canonical)",
+			in:     "1234::ABCD",
+			family: 6,
+		},
 
-func TestIsValidIPv4Address(t *testing.T) {
-	goodValues := []string{
-		"1.1.1.1",
-		"1.1.1.01",
-		"255.0.0.1",
-		"1.0.0.0",
-		"0.0.0.0",
-	}
-	for _, val := range goodValues {
-		if msgs := IsValidIPv4Address(field.NewPath(""), val); len(msgs) != 0 {
-			t.Errorf("expected %q to be valid IPv4 address: %v", val, msgs)
-		}
-	}
+		// BAD VALUES WE CURRENTLY CONSIDER GOOD
+		{
+			name:   "ipv4 with leading 0s",
+			in:     "1.1.1.01",
+			family: 4,
+		},
+		{
+			name:   "ipv4-in-ipv6 value",
+			in:     "::ffff:1.1.1.1",
+			family: 4,
+		},
 
-	badValues := []string{
-		"[2001:db8:0:1]:80",
-		"myhost.mydomain",
-		"-1.0.0.0",
-		"[2001:db8:0:1]",
-		"a",
-		"2001:4860:4860::8888",
-		"::fff:1.1.1.1",
-		"::1",
-		"2a00:79e0:2:0:f1c3:e797:93c1:df80",
-		"::",
-	}
-	for _, val := range badValues {
-		if msgs := IsValidIPv4Address(field.NewPath(""), val); len(msgs) == 0 {
-			t.Errorf("expected %q to be invalid IPv4 address", val)
-		}
-	}
-}
+		// BAD VALUES
+		{
+			name: "empty string",
+			in:   "",
+			err:  "must be a valid IP address",
+		},
+		{
+			name: "junk",
+			in:   "aaaaaaa",
+			err:  "must be a valid IP address",
+		},
+		{
+			name: "domain name",
+			in:   "myhost.mydomain",
+			err:  "must be a valid IP address",
+		},
+		{
+			name: "cidr",
+			in:   "1.2.3.0/24",
+			err:  "must be a valid IP address",
+		},
+		{
+			name: "ipv4 with out-of-range octets",
+			in:   "1.2.3.400",
+			err:  "must be a valid IP address",
+		},
+		{
+			name: "ipv4 with negative octets",
+			in:   "-1.0.0.0",
+			err:  "must be a valid IP address",
+		},
+		{
+			name: "ipv6 with out-of-range segment",
+			in:   "2001:db8::10005",
+			err:  "must be a valid IP address",
+		},
+		{
+			name: "ipv4:port",
+			in:   "1.2.3.4:80",
+			err:  "must be a valid IP address",
+		},
+		{
+			name: "ipv6 with brackets",
+			in:   "[2001:db8::1]",
+			err:  "must be a valid IP address",
+		},
+		{
+			name: "[ipv6]:port",
+			in:   "[2001:db8::1]:80",
+			err:  "must be a valid IP address",
+		},
+		{
+			name: "host:port",
+			in:   "example.com:80",
+			err:  "must be a valid IP address",
+		},
+		{
+			name: "ipv6 with zone",
+			in:   "1234::abcd%eth0",
+			err:  "must be a valid IP address",
+		},
+		{
+			name: "ipv4 with zone",
+			in:   "169.254.0.0%eth0",
+			err:  "must be a valid IP address",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			msgs := IsValidIP(tc.in)
+			if tc.err == "" {
+				if len(msgs) != 0 {
+					t.Errorf("expected %q to be valid but got: %v", tc.in, msgs)
+				}
+			} else {
+				if len(msgs) != 1 {
+					t.Errorf("expected %q to have 1 error but got: %v", tc.in, msgs)
+				} else if !strings.Contains(msgs[0], tc.err) {
+					t.Errorf("expected error for %q to contain %q but got: %q", tc.in, tc.err, msgs[0])
+				}
+			}
 
-func TestIsValidIPv6Address(t *testing.T) {
-	goodValues := []string{
-		"2001:4860:4860::8888",
-		"2a00:79e0:2:0:f1c3:e797:93c1:df80",
-		"2001:0db8:85a3:0000:0000:8a2e:0370:7334",
-		"::fff:1.1.1.1",
-		"::1",
-		"::",
-	}
+			errs := IsValidIPv4Address(field.NewPath(""), tc.in)
+			if tc.family == 4 {
+				if len(errs) != 0 {
+					t.Errorf("expected %q to pass IsValidIPv4Address but got: %v", tc.in, errs)
+				}
+			} else {
+				if len(errs) == 0 {
+					t.Errorf("expected %q to fail IsValidIPv4Address", tc.in)
+				}
+			}
 
-	for _, val := range goodValues {
-		if msgs := IsValidIPv6Address(field.NewPath(""), val); len(msgs) != 0 {
-			t.Errorf("expected %q to be valid IPv6 address: %v", val, msgs)
-		}
-	}
-
-	badValues := []string{
-		"1.1.1.1",
-		"1.1.1.01",
-		"255.0.0.1",
-		"1.0.0.0",
-		"0.0.0.0",
-		"[2001:db8:0:1]:80",
-		"myhost.mydomain",
-		"2001:0db8:85a3:0000:0000:8a2e:0370:7334:2001:0db8:85a3:0000:0000:8a2e:0370:7334",
-		"-1.0.0.0",
-		"[2001:db8:0:1]",
-		"a",
-	}
-	for _, val := range badValues {
-		if msgs := IsValidIPv6Address(field.NewPath(""), val); len(msgs) == 0 {
-			t.Errorf("expected %q to be invalid IPv6 address", val)
-		}
+			errs = IsValidIPv6Address(field.NewPath(""), tc.in)
+			if tc.family == 6 {
+				if len(errs) != 0 {
+					t.Errorf("expected %q to pass IsValidIPv6Address but got: %v", tc.in, errs)
+				}
+			} else {
+				if len(errs) == 0 {
+					t.Errorf("expected %q to fail IsValidIPv6Address", tc.in)
+				}
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Extracted from #122550 to make that less-XXL... This part mostly just makes us use IsValidIP in a few places we weren't before. It doesn't change the success or failure result of any validation anywhere, it just sets us up to be able to do that later.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

cc @aojea 