### PR TITLE
Bump CEL default compatibility version to 1.29 for 1.30 release

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/cel/environment/base.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/environment/base.go
@@ -43,7 +43,7 @@ import (
 // desirable because it means that CEL expressions are portable across a wider range
 // of Kubernetes versions.
 func DefaultCompatibilityVersion() *version.Version {
-	return version.MajorMinor(1, 28)
+	return version.MajorMinor(1, 29)
 }
 
 var baseOpts = []VersionedOptions{


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

We bump this each Kubernetes release to enable CEL features.

We won't need to bump this manually forever. https://github.com/kubernetes/enhancements/issues/4330 will eventually set this for us.  But for now, we bump it by hand.

#### Does this PR introduce a user-facing change?

-->
```release-note
CEL expressions now validate duration and timestamp string literals when expressions are written to the apiserver, instead of during evaluation, making it safer to author CEL expressions by preventing invalid expressions from being written to the apiserver. Note that regex pattern literals have always been validated this way.
CEL expressions now support the CEL [sets library](https://github.com/google/cel-go/blob/master/ext/sets.go) which provides `sets.contains(list1, list2)`, `sets.equivalent(list1, list2)` and `sets.intersects(list1, list2)` functions.
```
