### PR TITLE
Update CHANGELOG OWNERS to reflect 1.30 Release Notes team

### DIFF
--- a/CHANGELOG/OWNERS
+++ b/CHANGELOG/OWNERS
@@ -13,13 +13,14 @@ approvers:
   - ramrodo # 1.26 Release Notes Lead
   - sanchita-07 # 1.28 Release Notes Lead
   - fsmunoz # 1.29 Release Notes Lead
+  - rashansmith # 1.30 Release Notes Lead
 reviewers:
   - release-managers
-  - fsmunoz # 1.29 Release Notes Lead
-  - fykaa # 1.29 Release Notes Shadow
-  - mengjiao-liu # 1.29 Release Notes Shadow
-  - muddapu # 1.29 Release Notes Shadow
-  - rashansmith # 1.29 Release Notes Shadow
+  - fykaa # 1.30 Release Notes Shadow
+  - npolshakova # 1.30 Release Notes Shadow
+  - OrlinVasilev # 1.30 Release Notes Shadow
+  - rashansmith # 1.30 Release Notes Lead
+  - satyampsoni # 1.30 Release Notes Shadow
 labels:
   - sig/release
   - area/release-eng


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR updates the OWNERS file and adds the 1.30 release-notes team as approver and reviewers.

/assign @katcosgrove @gracenng 
