### PR TITLE
kubeadm: support digests in DeployedDNSAddon()

### DIFF
--- a/cmd/kubeadm/app/phases/addons/dns/dns.go
+++ b/cmd/kubeadm/app/phases/addons/dns/dns.go
@@ -41,6 +41,7 @@ import (
 	"k8s.io/kubernetes/cmd/kubeadm/app/images"
 	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/apiclient"
+	"k8s.io/kubernetes/cmd/kubeadm/app/util/image"
 )
 
 const (
@@ -48,7 +49,7 @@ const (
 	coreDNSReplicas       = 2
 )
 
-// DeployedDNSAddon returns the type of DNS addon currently deployed
+// DeployedDNSAddon returns the image tag of the DNS addon currently deployed
 func DeployedDNSAddon(client clientset.Interface) (string, error) {
 	deploymentsClient := client.AppsV1().Deployments(metav1.NamespaceSystem)
 	deployments, err := deploymentsClient.List(context.TODO(), metav1.ListOptions{LabelSelector: "k8s-app=kube-dns"})
@@ -60,10 +61,7 @@ func DeployedDNSAddon(client clientset.Interface) (string, error) {
 	case 0:
 		return "", nil
 	case 1:
-		addonImage := deployments.Items[0].Spec.Template.Spec.Containers[0].Image
-		addonImageParts := strings.Split(addonImage, ":")
-		addonVersion := addonImageParts[len(addonImageParts)-1]
-		return addonVersion, nil
+		return image.TagFromImage(deployments.Items[0].Spec.Template.Spec.Containers[0].Image), nil
 	default:
 		return "", errors.Errorf("multiple DNS addon deployments found: %v", deployments.Items)
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

kubeadm upgrade checks the migration path for the existing CoreDNS deployment pre-flight. Migration paths are defined for CoreDNS versions, which are derived from the image tag used in the existing deployment.

The kubeadm `ClusterConfiguration.DNS.ImageMeta` supports suffixing the tag with a digest, but at upgrade time does not derive the version correctly from an image with digest suffix, because `DeployedDNSAddon` does not deal with digests correctly. This commit makes `DeployedDNSAddon` digest-aware.

Example:

```go
image = "registry.k8s.io/coredns/coredns:v1.11.1@sha256:a0ead06651cf580044aeb0a0feba63591858fb2e43ade8c9dea45a6a89ae7e5e"
expected = "v1.11.1"
actual = "a0ead06651cf580044aeb0a0feba63591858fb2e43ade8c9dea45a6a89ae7e5e"
```

#### Which issue(s) this PR fixes:

No issue opened.

#### Special notes for your reviewer:

:wave: 

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
