### PR TITLE
warn when a probe is turncated but still successful

### DIFF
--- a/pkg/probe/http/http.go
+++ b/pkg/probe/http/http.go
@@ -117,10 +117,9 @@ func DoHTTPProbe(req *http.Request, client GetHTTPInterface) (probe.Result, stri
 		}
 		if limitReached {
 			return probe.Warning, fmt.Sprintf("Non fatal body truncation for %s, Response: %v", url.String(), body), nil
-		} else {
-			klog.V(4).Infof("Probe succeeded for %s, Response: %v", url.String(), *res)
-			return probe.Success, body, nil
-		}
+		} 
+		klog.V(4).Infof("Probe succeeded for %s, Response: %v", url.String(), *res)
+		return probe.Success, body, nil	
 	}
 	klog.V(4).Infof("Probe failed for %s with request headers %v, response body: %v", url.String(), headers, body)
 	// Note: Until https://issue.k8s.io/99425 is addressed, this user-facing failure message must not contain the response body.

--- a/pkg/probe/http/http.go
+++ b/pkg/probe/http/http.go
@@ -101,7 +101,7 @@ func DoHTTPProbe(req *http.Request, client GetHTTPInterface) (probe.Result, stri
 	defer res.Body.Close()
 	b, err := utilio.ReadAtMost(res.Body, maxRespBodyLength)
 	if err != nil {
-		if err == utilio.ErrLimitReached {
+		if errors.Is(err, utilio.ErrLimitReached) {
 			klog.V(4).Infof("Non fatal body truncation for %s, Response: %v", url.String(), *res)
 		} else {
 			return probe.Failure, "", err
@@ -113,7 +113,7 @@ func DoHTTPProbe(req *http.Request, client GetHTTPInterface) (probe.Result, stri
 			klog.V(4).Infof("Probe terminated redirects for %s, Response: %v", url.String(), *res)
 			return probe.Warning, fmt.Sprintf("Probe terminated redirects, Response body: %v", body), nil
 		}
-		if err == utilio.ErrLimitReached {
+		if errors.Is(err, utilio.ErrLimitReached) {
 			return probe.Warning, fmt.Sprintf("Non fatal body truncation for %s", url.String()), nil
 		}
 		klog.V(4).Infof("Probe succeeded for %s, Response: %v", url.String(), *res)

--- a/pkg/probe/http/http.go
+++ b/pkg/probe/http/http.go
@@ -100,9 +100,11 @@ func DoHTTPProbe(req *http.Request, client GetHTTPInterface) (probe.Result, stri
 	}
 	defer res.Body.Close()
 	b, err := utilio.ReadAtMost(res.Body, maxRespBodyLength)
+	var limitReached = false
 	if err != nil {
 		if err == utilio.ErrLimitReached {
 			klog.V(4).Infof("Non fatal body truncation for %s, Response: %v", url.String(), *res)
+			limitReached = true
 		} else {
 			return probe.Failure, "", err
 		}
@@ -113,8 +115,12 @@ func DoHTTPProbe(req *http.Request, client GetHTTPInterface) (probe.Result, stri
 			klog.V(4).Infof("Probe terminated redirects for %s, Response: %v", url.String(), *res)
 			return probe.Warning, fmt.Sprintf("Probe terminated redirects, Response body: %v", body), nil
 		}
-		klog.V(4).Infof("Probe succeeded for %s, Response: %v", url.String(), *res)
-		return probe.Success, body, nil
+		if limitReached {
+			return probe.Warning, fmt.Sprintf("Non fatal body truncation for %s, Response: %v", url.String(), body), nil
+		} else {
+			klog.V(4).Infof("Probe succeeded for %s, Response: %v", url.String(), *res)
+			return probe.Success, body, nil
+		}
 	}
 	klog.V(4).Infof("Probe failed for %s with request headers %v, response body: %v", url.String(), headers, body)
 	// Note: Until https://issue.k8s.io/99425 is addressed, this user-facing failure message must not contain the response body.

--- a/pkg/probe/http/http.go
+++ b/pkg/probe/http/http.go
@@ -100,7 +100,7 @@ func DoHTTPProbe(req *http.Request, client GetHTTPInterface) (probe.Result, stri
 	}
 	defer res.Body.Close()
 	b, err := utilio.ReadAtMost(res.Body, maxRespBodyLength)
-	var limitReached = false
+	var limitReached bool
 	if err != nil {
 		if err == utilio.ErrLimitReached {
 			klog.V(4).Infof("Non fatal body truncation for %s, Response: %v", url.String(), *res)

--- a/pkg/probe/http/http_test.go
+++ b/pkg/probe/http/http_test.go
@@ -573,7 +573,7 @@ func TestHTTPProbeChecker_PayloadTruncatedAndTimeout(t *testing.T) {
 		result, body, err := prober.Probe(req, 1*time.Second)
 		assert.NoError(t, err)
 		assert.Equal(t, probe.Warning, result)
-		assert.Contains(t, body, string(truncatedPayload))
+		assert.NotContains(t, body, string(truncatedPayload))
 	})
 }
 

--- a/pkg/probe/http/http_test.go
+++ b/pkg/probe/http/http_test.go
@@ -534,8 +534,46 @@ func TestHTTPProbeChecker_PayloadTruncated(t *testing.T) {
 		require.NoError(t, err)
 		result, body, err := prober.Probe(req, wait.ForeverTestTimeout)
 		assert.NoError(t, err)
-		assert.Equal(t, probe.Success, result)
-		assert.Equal(t, string(truncatedPayload), body)
+		assert.Equal(t, probe.Warning, result)
+		assert.Contains(t, body, string(truncatedPayload))
+	})
+}
+
+// oversized body + timeout reached shall lead to a warning, not a failure
+func TestHTTPProbeChecker_PayloadTruncatedAndTimeout(t *testing.T) {
+	successHostHeader := "www.success.com"
+	oversizePayload := bytes.Repeat([]byte("a"), maxRespBodyLength+1)
+	truncatedPayload := bytes.Repeat([]byte("a"), maxRespBodyLength)
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/success":
+			if r.Host == successHostHeader {
+				w.WriteHeader(http.StatusOK)
+				w.Write(oversizePayload)
+				time.Sleep(2 * time.Second)
+			} else {
+				http.Error(w, "", http.StatusBadRequest)
+			}
+		default:
+			http.Error(w, "", http.StatusInternalServerError)
+		}
+	})
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	headers := http.Header{}
+	headers.Add("Host", successHostHeader)
+	t.Run("truncated payload", func(t *testing.T) {
+		prober := New(false)
+		target, err := url.Parse(server.URL + "/success")
+		require.NoError(t, err)
+		req, err := NewProbeRequest(target, headers)
+		require.NoError(t, err)
+		result, body, err := prober.Probe(req, 1*time.Second)
+		assert.NoError(t, err)
+		assert.Equal(t, probe.Warning, result)
+		assert.Contains(t, body, string(truncatedPayload))
 	})
 }
 

--- a/pkg/probe/http/http_test.go
+++ b/pkg/probe/http/http_test.go
@@ -535,7 +535,7 @@ func TestHTTPProbeChecker_PayloadTruncated(t *testing.T) {
 		result, body, err := prober.Probe(req, wait.ForeverTestTimeout)
 		assert.NoError(t, err)
 		assert.Equal(t, probe.Warning, result)
-		assert.Contains(t, body, string(truncatedPayload))
+		assert.NotContains(t, body, string(truncatedPayload))
 	})
 }
 

--- a/pkg/probe/http/http_test.go
+++ b/pkg/probe/http/http_test.go
@@ -513,7 +513,8 @@ func TestHTTPProbeChecker_PayloadTruncated(t *testing.T) {
 		case "/success":
 			if r.Host == successHostHeader {
 				w.WriteHeader(http.StatusOK)
-				w.Write(oversizePayload)
+				_, err := w.Write(oversizePayload)
+				require.NoError(t, err)
 			} else {
 				http.Error(w, "", http.StatusBadRequest)
 			}
@@ -550,7 +551,8 @@ func TestHTTPProbeChecker_PayloadTruncatedAndTimeout(t *testing.T) {
 		case "/success":
 			if r.Host == successHostHeader {
 				w.WriteHeader(http.StatusOK)
-				w.Write(oversizePayload)
+				_, err := w.Write(oversizePayload)
+				require.NoError(t, err)
 				time.Sleep(2 * time.Second)
 			} else {
 				http.Error(w, "", http.StatusBadRequest)


### PR DESCRIPTION
it can happen that an http server already returned the status code along with the body but has still not finished processing the request usually leading to a timeout thus a failure
but if more than maxRespBodyLength(10 KB) have been read already it was reported as a success, this behavior has been changed to a warning in order not to introduce a breaking change


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #gh-122948

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
