### PR TITLE
Refactor Code to Remove Deprecated `PollImmediate` in `pkg/util`

### DIFF
--- a/pkg/util/filesystem/util_windows.go
+++ b/pkg/util/filesystem/util_windows.go
@@ -20,6 +20,7 @@ limitations under the License.
 package filesystem
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"os"
@@ -60,8 +61,8 @@ func IsUnixDomainSocket(filePath string) (bool, error) {
 	// on the Unix Domain socket working on the very first try, hence the potential need to
 	// dial multiple times
 	var lastSocketErr error
-	err := wait.PollImmediate(socketDialRetryPeriod, socketDialTimeout,
-		func() (bool, error) {
+	err := wait.PollUntilContextTimeout(context.Background(), socketDialRetryPeriod, socketDialTimeout, true,
+		func(ctx context.Context) (bool, error) {
 			klog.V(6).InfoS("Dialing the socket", "filePath", filePath)
 			var c net.Conn
 			c, lastSocketErr = net.Dial("unix", filePath)
@@ -76,10 +77,10 @@ func IsUnixDomainSocket(filePath string) (bool, error) {
 			return false, nil
 		})
 
-	// PollImmediate will return "timed out waiting for the condition" if the function it
+	// PollUntilContextTimeout will return "context deadline exceeded" if the function it
 	// invokes never returns true
 	if err != nil {
-		klog.V(2).InfoS("Failed all attempts to dial the socket so marking it as a non-Unix Domain socket. Last socket error along with the error from PollImmediate follow",
+		klog.V(2).InfoS("Failed all attempts to dial the socket so marking it as a non-Unix Domain socket. Last socket error along with the error from PollUntilContextTimeout follow",
 			"filePath", filePath, "lastSocketErr", lastSocketErr, "err", err)
 		return false, nil
 	}

--- a/pkg/util/iptables/iptables_linux.go
+++ b/pkg/util/iptables/iptables_linux.go
@@ -20,6 +20,7 @@ limitations under the License.
 package iptables
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"os"
@@ -72,23 +73,25 @@ func grabIptablesLocks(lockfilePath14x, lockfilePath16x string) (iptablesLocker,
 		return nil, fmt.Errorf("failed to open iptables lock %s: %v", lockfilePath16x, err)
 	}
 
-	if err := wait.PollImmediate(200*time.Millisecond, 2*time.Second, func() (bool, error) {
-		if err := grabIptablesFileLock(l.lock16); err != nil {
-			return false, nil
-		}
-		return true, nil
-	}); err != nil {
+	if err = wait.PollUntilContextTimeout(context.Background(), 200*time.Millisecond, 2*time.Second, true,
+		func(ctx context.Context) (bool, error) {
+			if err := grabIptablesFileLock(l.lock16); err != nil {
+				return false, nil
+			}
+			return true, nil
+		}); err != nil {
 		return nil, fmt.Errorf("failed to acquire new iptables lock: %v", err)
 	}
 
 	// Roughly duplicate iptables 1.4.x xtables_lock() function.
-	if err := wait.PollImmediate(200*time.Millisecond, 2*time.Second, func() (bool, error) {
-		l.lock14, err = net.ListenUnix("unix", &net.UnixAddr{Name: lockfilePath14x, Net: "unix"})
-		if err != nil {
-			return false, nil
-		}
-		return true, nil
-	}); err != nil {
+	if err = wait.PollUntilContextTimeout(context.Background(), 200*time.Millisecond, 2*time.Second, true,
+		func(ctx context.Context) (bool, error) {
+			l.lock14, err = net.ListenUnix("unix", &net.UnixAddr{Name: lockfilePath14x, Net: "unix"})
+			if err != nil {
+				return false, nil
+			}
+			return true, nil
+		}); err != nil {
 		return nil, fmt.Errorf("failed to acquire old iptables lock: %v", err)
 	}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Refactor code to use `PollUntilContextTimeout` replacing deprecated `PolImmediate`.

#### Which issue(s) this PR fixes:

Related: #122800

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
