### PR TITLE
Refactor Code to Remove Deprecated `PollImmediate` in `pkg/kubelet`

### DIFF
--- a/pkg/kubelet/certificate/transport_test.go
+++ b/pkg/kubelet/certificate/transport_test.go
@@ -200,7 +200,7 @@ func TestRotateShutsDownConnections(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := client.Get().Do(context.TODO()).Error(); err != nil {
+	if err = client.Get().Do(context.TODO()).Error(); err != nil {
 		t.Fatal(err)
 	}
 	firstCertSerial := lastSerialNumber()
@@ -209,15 +209,16 @@ func TestRotateShutsDownConnections(t *testing.T) {
 	// its connections to the server.
 	m.setCurrent(client2CertData.certificate)
 
-	err = wait.PollImmediate(time.Millisecond*50, wait.ForeverTestTimeout, func() (done bool, err error) {
-		client.Get().Do(context.TODO())
-		if firstCertSerial.Cmp(lastSerialNumber()) != 0 {
-			// The certificate changed!
-			return true, nil
-		}
-		t.Logf("Certificate not changed, will retry.")
-		return false, nil
-	})
+	err = wait.PollUntilContextTimeout(context.Background(), 50*time.Millisecond, wait.ForeverTestTimeout, true,
+		func(ctx context.Context) (done bool, err error) {
+			client.Get().Do(context.TODO())
+			if firstCertSerial.Cmp(lastSerialNumber()) != 0 {
+				// The certificate changed!
+				return true, nil
+			}
+			t.Logf("Certificate not changed, will retry.")
+			return false, nil
+		})
 	if err != nil {
 		t.Fatal("certificate rotated but client never reconnected with new cert")
 	}

--- a/pkg/kubelet/cm/devicemanager/plugin/v1beta1/stub.go
+++ b/pkg/kubelet/cm/devicemanager/plugin/v1beta1/stub.go
@@ -160,15 +160,16 @@ func (m *Stub) Start() error {
 	}()
 
 	var lastDialErr error
-	wait.PollImmediate(1*time.Second, 10*time.Second, func() (bool, error) {
-		var conn *grpc.ClientConn
-		_, conn, lastDialErr = dial(m.socket)
-		if lastDialErr != nil {
-			return false, nil
-		}
-		conn.Close()
-		return true, nil
-	})
+	_ = wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 10*time.Second, true,
+		func(ctx context.Context) (bool, error) {
+			var conn *grpc.ClientConn
+			_, conn, lastDialErr = dial(m.socket)
+			if lastDialErr != nil {
+				return false, nil
+			}
+			_ = conn.Close()
+			return true, nil
+		})
 	if lastDialErr != nil {
 		return lastDialErr
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Refactor code to use `PollUntilContextTimeout` replacing deprecated `PolImmediate`.

#### Which issue(s) this PR fixes:

Related: #122800

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
