### PR TITLE
Refactor Code to Remove Deprecated `PollImmediate` in `pkg/volume`

### DIFF
--- a/pkg/volume/testing/volume_host.go
+++ b/pkg/volume/testing/volume_host.go
@@ -244,11 +244,12 @@ func (f *fakeVolumeHost) ScriptCommands(scripts []CommandScript) {
 }
 
 func (f *fakeVolumeHost) WaitForKubeletErrNil() error {
-	return wait.PollImmediate(10*time.Millisecond, 10*time.Second, func() (bool, error) {
-		f.mux.Lock()
-		defer f.mux.Unlock()
-		return f.kubeletErr == nil, nil
-	})
+	return wait.PollUntilContextTimeout(context.Background(), 10*time.Millisecond, 10*time.Second, true,
+		func(ctx context.Context) (bool, error) {
+			f.mux.Lock()
+			defer f.mux.Unlock()
+			return f.kubeletErr == nil, nil
+		})
 }
 
 type fakeAttachDetachVolumeHost struct {

--- a/pkg/volume/util/util.go
+++ b/pkg/volume/util/util.go
@@ -797,19 +797,20 @@ func IsDeviceMountableVolume(volumeSpec *volume.Spec, volumePluginMgr *volume.Vo
 func GetReliableMountRefs(mounter mount.Interface, mountPath string) ([]string, error) {
 	var paths []string
 	var lastErr error
-	err := wait.PollImmediate(10*time.Millisecond, time.Minute, func() (bool, error) {
-		var err error
-		paths, err = mounter.GetMountRefs(mountPath)
-		if io.IsInconsistentReadError(err) {
-			lastErr = err
-			return false, nil
-		}
-		if err != nil {
-			return false, err
-		}
-		return true, nil
-	})
-	if err == wait.ErrWaitTimeout {
+	err := wait.PollUntilContextTimeout(context.Background(), 10*time.Millisecond, time.Minute, true,
+		func(ctx context.Context) (bool, error) {
+			var err error
+			paths, err = mounter.GetMountRefs(mountPath)
+			if io.IsInconsistentReadError(err) {
+				lastErr = err
+				return false, nil
+			}
+			if err != nil {
+				return false, err
+			}
+			return true, nil
+		})
+	if wait.Interrupted(err) {
 		return nil, lastErr
 	}
 	return paths, err


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Refactor code to use `PollUntilContextTimeout` replacing deprecated `PolImmediate`.

#### Which issue(s) this PR fixes:

Related: #122800

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
