### PR TITLE
Refactor Code to Remove Deprecated `PollImmediate` in `test/images`

### DIFF
--- a/test/images/agnhost/openidmetadata/openidmetadata.go
+++ b/test/images/agnhost/openidmetadata/openidmetadata.go
@@ -210,13 +210,14 @@ func ensureWindowsDNSAvailability(issuer string) error {
 		return err
 	}
 
-	return wait.PollImmediate(5*time.Second, 20*time.Second, func() (bool, error) {
-		ips, err := net.LookupHost(u.Host)
-		if err != nil {
-			log.Println(err)
-			return false, nil
-		}
-		log.Printf("OK: Resolved host %s: %v", u.Host, ips)
-		return true, nil
-	})
+	return wait.PollUntilContextTimeout(context.Background(), 5*time.Second, 20*time.Second, true,
+		func(ctx context.Context) (bool, error) {
+			ips, err := net.LookupHost(u.Host)
+			if err != nil {
+				log.Println(err)
+				return false, nil
+			}
+			log.Printf("OK: Resolved host %s: %v", u.Host, ips)
+			return true, nil
+		})
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Refactor code to use `PollUntilContextTimeout` replacing deprecated `PolImmediate`.

#### Which issue(s) this PR fixes:

Related: #122800

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
