### PR TITLE
Refactor Code to Remove Deprecated `PollImmediate` in `test/e2e/framework`

### DIFF
--- a/test/e2e/framework/job/wait.go
+++ b/test/e2e/framework/job/wait.go
@@ -102,14 +102,15 @@ func WaitForJobSuspend(ctx context.Context, c clientset.Interface, ns, jobName s
 
 // WaitForJobFailed uses c to wait for the Job jobName in namespace ns to fail
 func WaitForJobFailed(c clientset.Interface, ns, jobName string) error {
-	return wait.PollImmediate(framework.Poll, JobTimeout, func() (bool, error) {
-		curr, err := c.BatchV1().Jobs(ns).Get(context.TODO(), jobName, metav1.GetOptions{})
-		if err != nil {
-			return false, err
-		}
+	return wait.PollUntilContextTimeout(context.Background(), framework.Poll, JobTimeout, true,
+		func(ctx context.Context) (bool, error) {
+			curr, err := c.BatchV1().Jobs(ns).Get(context.TODO(), jobName, metav1.GetOptions{})
+			if err != nil {
+				return false, err
+			}
 
-		return isJobFailed(curr), nil
-	})
+			return isJobFailed(curr), nil
+		})
 }
 
 func isJobFailed(j *batchv1.Job) bool {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Refactor code to use `PollUntilContextTimeout` replacing deprecated `PolImmediate`.

#### Which issue(s) this PR fixes:

Related: #122800

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
