### PR TITLE
Refactor Code to Remove Deprecated `PollImmediate` in `test/e2e/apps`

### DIFF
--- a/test/e2e/apps/rc.go
+++ b/test/e2e/apps/rc.go
@@ -546,7 +546,7 @@ func testReplicationControllerConditionCheck(ctx context.Context, f *framework.F
 	_, err := c.CoreV1().ResourceQuotas(namespace).Create(ctx, quota, metav1.CreateOptions{})
 	framework.ExpectNoError(err)
 
-	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 		quota, err = c.CoreV1().ResourceQuotas(namespace).Get(ctx, name, metav1.GetOptions{})
 		if err != nil {
 			return false, err
@@ -568,20 +568,21 @@ func testReplicationControllerConditionCheck(ctx context.Context, f *framework.F
 	ginkgo.By(fmt.Sprintf("Checking rc %q has the desired failure condition set", name))
 	generation := rc.Generation
 	conditions := rc.Status.Conditions
-	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
-		rc, err = c.CoreV1().ReplicationControllers(namespace).Get(ctx, name, metav1.GetOptions{})
-		if err != nil {
-			return false, err
-		}
+	err = wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 1*time.Minute, true,
+		func(ctx context.Context) (bool, error) {
+			rc, err = c.CoreV1().ReplicationControllers(namespace).Get(ctx, name, metav1.GetOptions{})
+			if err != nil {
+				return false, err
+			}
 
-		if generation > rc.Status.ObservedGeneration {
-			return false, nil
-		}
-		conditions = rc.Status.Conditions
+			if generation > rc.Status.ObservedGeneration {
+				return false, nil
+			}
+			conditions = rc.Status.Conditions
 
-		cond := replication.GetCondition(rc.Status, v1.ReplicationControllerReplicaFailure)
-		return cond != nil, nil
-	})
+			cond := replication.GetCondition(rc.Status, v1.ReplicationControllerReplicaFailure)
+			return cond != nil, nil
+		})
 	if wait.Interrupted(err) {
 		err = fmt.Errorf("rc manager never added the failure condition for rc %q: %#v", name, conditions)
 	}
@@ -597,20 +598,21 @@ func testReplicationControllerConditionCheck(ctx context.Context, f *framework.F
 	ginkgo.By(fmt.Sprintf("Checking rc %q has no failure condition set", name))
 	generation = rc.Generation
 	conditions = rc.Status.Conditions
-	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
-		rc, err = c.CoreV1().ReplicationControllers(namespace).Get(ctx, name, metav1.GetOptions{})
-		if err != nil {
-			return false, err
-		}
+	err = wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 1*time.Minute, true,
+		func(ctx context.Context) (bool, error) {
+			rc, err = c.CoreV1().ReplicationControllers(namespace).Get(ctx, name, metav1.GetOptions{})
+			if err != nil {
+				return false, err
+			}
 
-		if generation > rc.Status.ObservedGeneration {
-			return false, nil
-		}
-		conditions = rc.Status.Conditions
+			if generation > rc.Status.ObservedGeneration {
+				return false, nil
+			}
+			conditions = rc.Status.Conditions
 
-		cond := replication.GetCondition(rc.Status, v1.ReplicationControllerReplicaFailure)
-		return cond == nil, nil
-	})
+			cond := replication.GetCondition(rc.Status, v1.ReplicationControllerReplicaFailure)
+			return cond == nil, nil
+		})
 	if wait.Interrupted(err) {
 		err = fmt.Errorf("rc manager never removed the failure condition for rc %q: %#v", name, conditions)
 	}
@@ -645,22 +647,23 @@ func testRCAdoptMatchingOrphans(ctx context.Context, f *framework.Framework) {
 	framework.ExpectNoError(err)
 
 	ginkgo.By("Then the orphan pod is adopted")
-	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
-		p2, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(ctx, p.Name, metav1.GetOptions{})
-		// The Pod p should either be adopted or deleted by the RC
-		if apierrors.IsNotFound(err) {
-			return true, nil
-		}
-		framework.ExpectNoError(err)
-		for _, owner := range p2.OwnerReferences {
-			if *owner.Controller && owner.UID == rc.UID {
-				// pod adopted
+	err = wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 1*time.Minute, true,
+		func(ctx context.Context) (bool, error) {
+			p2, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(ctx, p.Name, metav1.GetOptions{})
+			// The Pod p should either be adopted or deleted by the RC
+			if apierrors.IsNotFound(err) {
 				return true, nil
 			}
-		}
-		// pod still not adopted
-		return false, nil
-	})
+			framework.ExpectNoError(err)
+			for _, owner := range p2.OwnerReferences {
+				if *owner.Controller && owner.UID == rc.UID {
+					// pod adopted
+					return true, nil
+				}
+			}
+			// pod still not adopted
+			return false, nil
+		})
 	framework.ExpectNoError(err)
 }
 
@@ -678,35 +681,37 @@ func testRCReleaseControlledNotMatching(ctx context.Context, f *framework.Framew
 	framework.ExpectNoError(err)
 
 	p := pods.Items[0]
-	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
-		pod, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(ctx, p.Name, metav1.GetOptions{})
-		framework.ExpectNoError(err)
+	err = wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 1*time.Minute, true,
+		func(ctx context.Context) (bool, error) {
+			pod, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(ctx, p.Name, metav1.GetOptions{})
+			framework.ExpectNoError(err)
 
-		pod.Labels = map[string]string{"name": "not-matching-name"}
-		_, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Update(ctx, pod, metav1.UpdateOptions{})
-		if err != nil && apierrors.IsConflict(err) {
-			return false, nil
-		}
-		if err != nil {
-			return false, err
-		}
-		return true, nil
-	})
+			pod.Labels = map[string]string{"name": "not-matching-name"}
+			_, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Update(ctx, pod, metav1.UpdateOptions{})
+			if err != nil && apierrors.IsConflict(err) {
+				return false, nil
+			}
+			if err != nil {
+				return false, err
+			}
+			return true, nil
+		})
 	framework.ExpectNoError(err)
 
 	ginkgo.By("Then the pod is released")
-	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
-		p2, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(ctx, p.Name, metav1.GetOptions{})
-		framework.ExpectNoError(err)
-		for _, owner := range p2.OwnerReferences {
-			if *owner.Controller && owner.UID == rc.UID {
-				// pod still belonging to the replication controller
-				return false, nil
+	err = wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 1*time.Minute, true,
+		func(ctx context.Context) (bool, error) {
+			p2, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(ctx, p.Name, metav1.GetOptions{})
+			framework.ExpectNoError(err)
+			for _, owner := range p2.OwnerReferences {
+				if *owner.Controller && owner.UID == rc.UID {
+					// pod still belonging to the replication controller
+					return false, nil
+				}
 			}
-		}
-		// pod already released
-		return true, nil
-	})
+			// pod already released
+			return true, nil
+		})
 	framework.ExpectNoError(err)
 }
 
@@ -719,20 +724,21 @@ type updateRcFunc func(d *v1.ReplicationController)
 func updateReplicationControllerWithRetries(ctx context.Context, c clientset.Interface, namespace, name string, applyUpdate updateRcFunc) (*v1.ReplicationController, error) {
 	var rc *v1.ReplicationController
 	var updateErr error
-	pollErr := wait.PollImmediate(10*time.Millisecond, 1*time.Minute, func() (bool, error) {
-		var err error
-		if rc, err = c.CoreV1().ReplicationControllers(namespace).Get(ctx, name, metav1.GetOptions{}); err != nil {
-			return false, err
-		}
-		// Apply the update, then attempt to push it to the apiserver.
-		applyUpdate(rc)
-		if rc, err = c.CoreV1().ReplicationControllers(namespace).Update(ctx, rc, metav1.UpdateOptions{}); err == nil {
-			framework.Logf("Updating replication controller %q", name)
-			return true, nil
-		}
-		updateErr = err
-		return false, nil
-	})
+	pollErr := wait.PollUntilContextTimeout(context.Background(), 10*time.Millisecond, 1*time.Minute, true,
+		func(ctx context.Context) (bool, error) {
+			var err error
+			if rc, err = c.CoreV1().ReplicationControllers(namespace).Get(ctx, name, metav1.GetOptions{}); err != nil {
+				return false, err
+			}
+			// Apply the update, then attempt to push it to the apiserver.
+			applyUpdate(rc)
+			if rc, err = c.CoreV1().ReplicationControllers(namespace).Update(ctx, rc, metav1.UpdateOptions{}); err == nil {
+				framework.Logf("Updating replication controller %q", name)
+				return true, nil
+			}
+			updateErr = err
+			return false, nil
+		})
 	if wait.Interrupted(pollErr) {
 		pollErr = fmt.Errorf("couldn't apply the provided updated to rc %q: %v", name, updateErr)
 	}

--- a/test/e2e/apps/replica_set.go
+++ b/test/e2e/apps/replica_set.go
@@ -243,15 +243,16 @@ func testReplicaSetConditionCheck(ctx context.Context, f *framework.Framework) {
 	_, err := c.CoreV1().ResourceQuotas(namespace).Create(ctx, quota, metav1.CreateOptions{})
 	framework.ExpectNoError(err)
 
-	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
-		quota, err = c.CoreV1().ResourceQuotas(namespace).Get(ctx, name, metav1.GetOptions{})
-		if err != nil {
-			return false, err
-		}
-		quantity := resource.MustParse("2")
-		podQuota := quota.Status.Hard[v1.ResourcePods]
-		return (&podQuota).Cmp(quantity) == 0, nil
-	})
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, true,
+		func(ctx context.Context) (bool, error) {
+			quota, err = c.CoreV1().ResourceQuotas(namespace).Get(ctx, name, metav1.GetOptions{})
+			if err != nil {
+				return false, err
+			}
+			quantity := resource.MustParse("2")
+			podQuota := quota.Status.Hard[v1.ResourcePods]
+			return (&podQuota).Cmp(quantity) == 0, nil
+		})
 	if wait.Interrupted(err) {
 		err = fmt.Errorf("resource quota %q never synced", name)
 	}
@@ -265,21 +266,21 @@ func testReplicaSetConditionCheck(ctx context.Context, f *framework.Framework) {
 	ginkgo.By(fmt.Sprintf("Checking replica set %q has the desired failure condition set", name))
 	generation := rs.Generation
 	conditions := rs.Status.Conditions
-	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
-		rs, err = c.AppsV1().ReplicaSets(namespace).Get(ctx, name, metav1.GetOptions{})
-		if err != nil {
-			return false, err
-		}
+	err = wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 1*time.Minute, true,
+		func(ctx context.Context) (bool, error) {
+			rs, err = c.AppsV1().ReplicaSets(namespace).Get(ctx, name, metav1.GetOptions{})
+			if err != nil {
+				return false, err
+			}
 
-		if generation > rs.Status.ObservedGeneration {
-			return false, nil
-		}
-		conditions = rs.Status.Conditions
+			if generation > rs.Status.ObservedGeneration {
+				return false, nil
+			}
+			conditions = rs.Status.Conditions
 
-		cond := replicaset.GetCondition(rs.Status, appsv1.ReplicaSetReplicaFailure)
-		return cond != nil, nil
-
-	})
+			cond := replicaset.GetCondition(rs.Status, appsv1.ReplicaSetReplicaFailure)
+			return cond != nil, nil
+		})
 	if wait.Interrupted(err) {
 		err = fmt.Errorf("rs controller never added the failure condition for replica set %q: %#v", name, conditions)
 	}
@@ -295,20 +296,21 @@ func testReplicaSetConditionCheck(ctx context.Context, f *framework.Framework) {
 	ginkgo.By(fmt.Sprintf("Checking replica set %q has no failure condition set", name))
 	generation = rs.Generation
 	conditions = rs.Status.Conditions
-	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
-		rs, err = c.AppsV1().ReplicaSets(namespace).Get(ctx, name, metav1.GetOptions{})
-		if err != nil {
-			return false, err
-		}
+	err = wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 1*time.Minute, true,
+		func(ctx context.Context) (bool, error) {
+			rs, err = c.AppsV1().ReplicaSets(namespace).Get(ctx, name, metav1.GetOptions{})
+			if err != nil {
+				return false, err
+			}
 
-		if generation > rs.Status.ObservedGeneration {
-			return false, nil
-		}
-		conditions = rs.Status.Conditions
+			if generation > rs.Status.ObservedGeneration {
+				return false, nil
+			}
+			conditions = rs.Status.Conditions
 
-		cond := replicaset.GetCondition(rs.Status, appsv1.ReplicaSetReplicaFailure)
-		return cond == nil, nil
-	})
+			cond := replicaset.GetCondition(rs.Status, appsv1.ReplicaSetReplicaFailure)
+			return cond == nil, nil
+		})
 	if wait.Interrupted(err) {
 		err = fmt.Errorf("rs controller never removed the failure condition for rs %q: %#v", name, conditions)
 	}
@@ -343,22 +345,23 @@ func testRSAdoptMatchingAndReleaseNotMatching(ctx context.Context, f *framework.
 	framework.ExpectNoError(err)
 
 	ginkgo.By("Then the orphan pod is adopted")
-	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
-		p2, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(ctx, p.Name, metav1.GetOptions{})
-		// The Pod p should either be adopted or deleted by the ReplicaSet
-		if apierrors.IsNotFound(err) {
-			return true, nil
-		}
-		framework.ExpectNoError(err)
-		for _, owner := range p2.OwnerReferences {
-			if *owner.Controller && owner.UID == rs.UID {
-				// pod adopted
+	err = wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 1*time.Minute, true,
+		func(ctx context.Context) (bool, error) {
+			p2, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(ctx, p.Name, metav1.GetOptions{})
+			// The Pod p should either be adopted or deleted by the ReplicaSet
+			if apierrors.IsNotFound(err) {
 				return true, nil
 			}
-		}
-		// pod still not adopted
-		return false, nil
-	})
+			framework.ExpectNoError(err)
+			for _, owner := range p2.OwnerReferences {
+				if *owner.Controller && owner.UID == rs.UID {
+					// pod adopted
+					return true, nil
+				}
+			}
+			// pod still not adopted
+			return false, nil
+		})
 	framework.ExpectNoError(err)
 
 	ginkgo.By("When the matched label of one of its pods change")
@@ -366,35 +369,37 @@ func testRSAdoptMatchingAndReleaseNotMatching(ctx context.Context, f *framework.
 	framework.ExpectNoError(err)
 
 	p = &pods.Items[0]
-	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
-		pod, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(ctx, p.Name, metav1.GetOptions{})
-		framework.ExpectNoError(err)
+	err = wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 1*time.Minute, true,
+		func(ctx context.Context) (bool, error) {
+			pod, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(ctx, p.Name, metav1.GetOptions{})
+			framework.ExpectNoError(err)
 
-		pod.Labels = map[string]string{"name": "not-matching-name"}
-		_, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Update(ctx, pod, metav1.UpdateOptions{})
-		if err != nil && apierrors.IsConflict(err) {
-			return false, nil
-		}
-		if err != nil {
-			return false, err
-		}
-		return true, nil
-	})
+			pod.Labels = map[string]string{"name": "not-matching-name"}
+			_, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Update(ctx, pod, metav1.UpdateOptions{})
+			if err != nil && apierrors.IsConflict(err) {
+				return false, nil
+			}
+			if err != nil {
+				return false, err
+			}
+			return true, nil
+		})
 	framework.ExpectNoError(err)
 
 	ginkgo.By("Then the pod is released")
-	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
-		p2, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(ctx, p.Name, metav1.GetOptions{})
-		framework.ExpectNoError(err)
-		for _, owner := range p2.OwnerReferences {
-			if *owner.Controller && owner.UID == rs.UID {
-				// pod still belonging to the replicaset
-				return false, nil
+	err = wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 1*time.Minute, true,
+		func(ctx context.Context) (bool, error) {
+			p2, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(ctx, p.Name, metav1.GetOptions{})
+			framework.ExpectNoError(err)
+			for _, owner := range p2.OwnerReferences {
+				if *owner.Controller && owner.UID == rs.UID {
+					// pod still belonging to the replicaset
+					return false, nil
+				}
 			}
-		}
-		// pod already released
-		return true, nil
-	})
+			// pod already released
+			return true, nil
+		})
 	framework.ExpectNoError(err)
 }
 

--- a/test/e2e/apps/statefulset.go
+++ b/test/e2e/apps/statefulset.go
@@ -2265,38 +2265,39 @@ func verifyStatefulSetPVCsExist(ctx context.Context, c clientset.Interface, ss *
 	for _, id := range claimIds {
 		idSet[id] = struct{}{}
 	}
-	return wait.PollImmediate(e2estatefulset.StatefulSetPoll, e2estatefulset.StatefulSetTimeout, func() (bool, error) {
-		pvcList, err := c.CoreV1().PersistentVolumeClaims(ss.Namespace).List(ctx, metav1.ListOptions{LabelSelector: klabels.Everything().String()})
-		if err != nil {
-			framework.Logf("WARNING: Failed to list pvcs for verification, retrying: %v", err)
-			return false, nil
-		}
-		for _, claim := range ss.Spec.VolumeClaimTemplates {
-			pvcNameRE := regexp.MustCompile(fmt.Sprintf("^%s-%s-([0-9]+)$", claim.Name, ss.Name))
-			seenPVCs := map[int]struct{}{}
-			for _, pvc := range pvcList.Items {
-				matches := pvcNameRE.FindStringSubmatch(pvc.Name)
-				if len(matches) != 2 {
-					continue
+	return wait.PollUntilContextTimeout(ctx, e2estatefulset.StatefulSetPoll, e2estatefulset.StatefulSetTimeout, true,
+		func(ctx context.Context) (bool, error) {
+			pvcList, err := c.CoreV1().PersistentVolumeClaims(ss.Namespace).List(ctx, metav1.ListOptions{LabelSelector: klabels.Everything().String()})
+			if err != nil {
+				framework.Logf("WARNING: Failed to list pvcs for verification, retrying: %v", err)
+				return false, nil
+			}
+			for _, claim := range ss.Spec.VolumeClaimTemplates {
+				pvcNameRE := regexp.MustCompile(fmt.Sprintf("^%s-%s-([0-9]+)$", claim.Name, ss.Name))
+				seenPVCs := map[int]struct{}{}
+				for _, pvc := range pvcList.Items {
+					matches := pvcNameRE.FindStringSubmatch(pvc.Name)
+					if len(matches) != 2 {
+						continue
+					}
+					ordinal, err := strconv.ParseInt(matches[1], 10, 32)
+					if err != nil {
+						framework.Logf("ERROR: bad pvc name %s (%v)", pvc.Name, err)
+						return false, err
+					}
+					if _, found := idSet[int(ordinal)]; !found {
+						return false, nil // Retry until the PVCs are consistent.
+					} else {
+						seenPVCs[int(ordinal)] = struct{}{}
+					}
 				}
-				ordinal, err := strconv.ParseInt(matches[1], 10, 32)
-				if err != nil {
-					framework.Logf("ERROR: bad pvc name %s (%v)", pvc.Name, err)
-					return false, err
-				}
-				if _, found := idSet[int(ordinal)]; !found {
+				if len(seenPVCs) != len(idSet) {
+					framework.Logf("Found %d of %d PVCs", len(seenPVCs), len(idSet))
 					return false, nil // Retry until the PVCs are consistent.
-				} else {
-					seenPVCs[int(ordinal)] = struct{}{}
 				}
 			}
-			if len(seenPVCs) != len(idSet) {
-				framework.Logf("Found %d of %d PVCs", len(seenPVCs), len(idSet))
-				return false, nil // Retry until the PVCs are consistent.
-			}
-		}
-		return true, nil
-	})
+			return true, nil
+		})
 }
 
 // verifyStatefulSetPVCsExistWithOwnerRefs works as verifyStatefulSetPVCsExist, but also waits for the ownerRefs to match.
@@ -2310,61 +2311,62 @@ func verifyStatefulSetPVCsExistWithOwnerRefs(ctx context.Context, c clientset.In
 	if setUID == "" {
 		framework.Failf("Statefulset %s missing UID", ss.Name)
 	}
-	return wait.PollImmediate(e2estatefulset.StatefulSetPoll, e2estatefulset.StatefulSetTimeout, func() (bool, error) {
-		pvcList, err := c.CoreV1().PersistentVolumeClaims(ss.Namespace).List(ctx, metav1.ListOptions{LabelSelector: klabels.Everything().String()})
-		if err != nil {
-			framework.Logf("WARNING: Failed to list pvcs for verification, retrying: %v", err)
-			return false, nil
-		}
-		for _, claim := range ss.Spec.VolumeClaimTemplates {
-			pvcNameRE := regexp.MustCompile(fmt.Sprintf("^%s-%s-([0-9]+)$", claim.Name, ss.Name))
-			seenPVCs := map[int]struct{}{}
-			for _, pvc := range pvcList.Items {
-				matches := pvcNameRE.FindStringSubmatch(pvc.Name)
-				if len(matches) != 2 {
-					continue
+	return wait.PollUntilContextTimeout(context.Background(), e2estatefulset.StatefulSetPoll, e2estatefulset.StatefulSetTimeout, true,
+		func(ctx context.Context) (bool, error) {
+			pvcList, err := c.CoreV1().PersistentVolumeClaims(ss.Namespace).List(ctx, metav1.ListOptions{LabelSelector: klabels.Everything().String()})
+			if err != nil {
+				framework.Logf("WARNING: Failed to list pvcs for verification, retrying: %v", err)
+				return false, nil
+			}
+			for _, claim := range ss.Spec.VolumeClaimTemplates {
+				pvcNameRE := regexp.MustCompile(fmt.Sprintf("^%s-%s-([0-9]+)$", claim.Name, ss.Name))
+				seenPVCs := map[int]struct{}{}
+				for _, pvc := range pvcList.Items {
+					matches := pvcNameRE.FindStringSubmatch(pvc.Name)
+					if len(matches) != 2 {
+						continue
+					}
+					ordinal, err := strconv.ParseInt(matches[1], 10, 32)
+					if err != nil {
+						framework.Logf("ERROR: bad pvc name %s (%v)", pvc.Name, err)
+						return false, err
+					}
+					if _, found := indexSet[int(ordinal)]; !found {
+						framework.Logf("Unexpected, retrying")
+						return false, nil // Retry until the PVCs are consistent.
+					}
+					var foundSetRef, foundPodRef bool
+					for _, ref := range pvc.GetOwnerReferences() {
+						if ref.Kind == "StatefulSet" && ref.UID == setUID {
+							foundSetRef = true
+						}
+						if ref.Kind == "Pod" {
+							podName := fmt.Sprintf("%s-%d", ss.Name, ordinal)
+							pod, err := c.CoreV1().Pods(ss.Namespace).Get(ctx, podName, metav1.GetOptions{})
+							if err != nil {
+								framework.Logf("Pod %s not found, retrying (%v)", podName, err)
+								return false, nil
+							}
+							podUID := pod.GetUID()
+							if podUID == "" {
+								framework.Failf("Pod %s is missing UID", pod.Name)
+							}
+							if ref.UID == podUID {
+								foundPodRef = true
+							}
+						}
+					}
+					if foundSetRef == wantSetRef && foundPodRef == wantPodRef {
+						seenPVCs[int(ordinal)] = struct{}{}
+					}
 				}
-				ordinal, err := strconv.ParseInt(matches[1], 10, 32)
-				if err != nil {
-					framework.Logf("ERROR: bad pvc name %s (%v)", pvc.Name, err)
-					return false, err
-				}
-				if _, found := indexSet[int(ordinal)]; !found {
-					framework.Logf("Unexpected, retrying")
+				if len(seenPVCs) != len(indexSet) {
+					framework.Logf("Only %d PVCs, retrying", len(seenPVCs))
 					return false, nil // Retry until the PVCs are consistent.
 				}
-				var foundSetRef, foundPodRef bool
-				for _, ref := range pvc.GetOwnerReferences() {
-					if ref.Kind == "StatefulSet" && ref.UID == setUID {
-						foundSetRef = true
-					}
-					if ref.Kind == "Pod" {
-						podName := fmt.Sprintf("%s-%d", ss.Name, ordinal)
-						pod, err := c.CoreV1().Pods(ss.Namespace).Get(ctx, podName, metav1.GetOptions{})
-						if err != nil {
-							framework.Logf("Pod %s not found, retrying (%v)", podName, err)
-							return false, nil
-						}
-						podUID := pod.GetUID()
-						if podUID == "" {
-							framework.Failf("Pod %s is missing UID", pod.Name)
-						}
-						if ref.UID == podUID {
-							foundPodRef = true
-						}
-					}
-				}
-				if foundSetRef == wantSetRef && foundPodRef == wantPodRef {
-					seenPVCs[int(ordinal)] = struct{}{}
-				}
 			}
-			if len(seenPVCs) != len(indexSet) {
-				framework.Logf("Only %d PVCs, retrying", len(seenPVCs))
-				return false, nil // Retry until the PVCs are consistent.
-			}
-		}
-		return true, nil
-	})
+			return true, nil
+		})
 }
 
 // expectPodNames compares the names of the pods from actualPods with expectedPodNames.


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Refactor code to use `PollUntilContextTimeout` replacing deprecated `PolImmediate`.

#### Which issue(s) this PR fixes:

Related: #122800

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
