### PR TITLE
Refactor Code to Remove Deprecated `PollImmediate` in `test/e2e/apimachinery`

### DIFF
--- a/test/e2e/apimachinery/aggregator.go
+++ b/test/e2e/apimachinery/aggregator.go
@@ -732,7 +732,10 @@ func TestSampleAPIServer(ctx context.Context, f *framework.Framework, aggrclient
 	framework.ExpectNoError(err, "Unable to delete apiservice %s", apiServiceName)
 
 	ginkgo.By("Confirm that the generated APIService has been deleted")
-	err = wait.PollImmediate(apiServiceRetryPeriod, apiServiceRetryTimeout, checkApiServiceListQuantity(ctx, aggrclient, apiServiceLabelSelector, 0))
+	err = wait.PollUntilContextTimeout(ctx, apiServiceRetryPeriod, apiServiceRetryTimeout, true,
+		func(ctx context.Context) (done bool, err error) {
+			return checkApiServiceListQuantity(ctx, aggrclient, apiServiceLabelSelector, 0)()
+		})
 	framework.ExpectNoError(err, "failed to count the required APIServices")
 	framework.Logf("APIService %s has been deleted.", apiServiceName)
 

--- a/test/e2e/apimachinery/custom_resource_definition.go
+++ b/test/e2e/apimachinery/custom_resource_definition.go
@@ -312,23 +312,24 @@ var _ = SIGDescribe("CustomResourceDefinition resources [Privileged:ClusterAdmin
 		]`), metav1.PatchOptions{})
 		framework.ExpectNoError(err, "setting default for a to \"A\" in schema")
 
-		err = wait.PollImmediate(time.Millisecond*100, wait.ForeverTestTimeout, func() (bool, error) {
-			u1, err := crClient.Get(ctx, name1, metav1.GetOptions{})
-			if err != nil {
-				return false, err
-			}
-			a, found, err := unstructured.NestedFieldNoCopy(u1.Object, "a")
-			if err != nil {
-				return false, err
-			}
-			if !found {
-				return false, nil
-			}
-			if a != "A" {
-				return false, fmt.Errorf("expected a:\"A\", but got a:%q", a)
-			}
-			return true, nil
-		})
+		err = wait.PollUntilContextTimeout(ctx, time.Millisecond*100, wait.ForeverTestTimeout, true,
+			func(ctx context.Context) (bool, error) {
+				u1, err := crClient.Get(ctx, name1, metav1.GetOptions{})
+				if err != nil {
+					return false, err
+				}
+				a, found, err := unstructured.NestedFieldNoCopy(u1.Object, "a")
+				if err != nil {
+					return false, err
+				}
+				if !found {
+					return false, nil
+				}
+				if a != "A" {
+					return false, fmt.Errorf("expected a:\"A\", but got a:%q", a)
+				}
+				return true, nil
+			})
 		framework.ExpectNoError(err, "waiting for CR to be defaulted on read")
 
 		// create CR with default in storage
@@ -354,33 +355,34 @@ var _ = SIGDescribe("CustomResourceDefinition resources [Privileged:ClusterAdmin
 		]`), metav1.PatchOptions{})
 		framework.ExpectNoError(err, "setting default for b to \"B\" and remove default for a")
 
-		err = wait.PollImmediate(time.Millisecond*100, wait.ForeverTestTimeout, func() (bool, error) {
-			u2, err := crClient.Get(ctx, name2, metav1.GetOptions{})
-			if err != nil {
-				return false, err
-			}
-			b, found, err := unstructured.NestedFieldNoCopy(u2.Object, "b")
-			if err != nil {
-				return false, err
-			}
-			if !found {
-				return false, nil
-			}
-			if b != "B" {
-				return false, fmt.Errorf("expected b:\"B\", but got b:%q", b)
-			}
-			a, found, err := unstructured.NestedFieldNoCopy(u2.Object, "a")
-			if err != nil {
-				return false, err
-			}
-			if !found {
-				return false, fmt.Errorf("expected a:\"A\" to be unchanged, but it was removed")
-			}
-			if a != "A" {
-				return false, fmt.Errorf("expected a:\"A\" to be unchanged, but it changed to %q", a)
-			}
-			return true, nil
-		})
+		err = wait.PollUntilContextTimeout(ctx, time.Millisecond*100, wait.ForeverTestTimeout, true,
+			func(ctx context.Context) (bool, error) {
+				u2, err := crClient.Get(ctx, name2, metav1.GetOptions{})
+				if err != nil {
+					return false, err
+				}
+				b, found, err := unstructured.NestedFieldNoCopy(u2.Object, "b")
+				if err != nil {
+					return false, err
+				}
+				if !found {
+					return false, nil
+				}
+				if b != "B" {
+					return false, fmt.Errorf("expected b:\"B\", but got b:%q", b)
+				}
+				a, found, err := unstructured.NestedFieldNoCopy(u2.Object, "a")
+				if err != nil {
+					return false, err
+				}
+				if !found {
+					return false, fmt.Errorf("expected a:\"A\" to be unchanged, but it was removed")
+				}
+				if a != "A" {
+					return false, fmt.Errorf("expected a:\"A\" to be unchanged, but it changed to %q", a)
+				}
+				return true, nil
+			})
 		framework.ExpectNoError(err, "waiting for CR to be defaulted on read for b and a staying the same")
 	})
 

--- a/test/e2e/apimachinery/storage_version.go
+++ b/test/e2e/apimachinery/storage_version.go
@@ -69,18 +69,19 @@ var _ = SIGDescribe("StorageVersion resources", feature.StorageVersionAPI, func(
 
 		// wait for sv to be GC'ed
 		framework.Logf("Waiting for storage version %v to be garbage collected", createdSV.Name)
-		err = wait.PollImmediate(100*time.Millisecond, wait.ForeverTestTimeout, func() (bool, error) {
-			_, err := client.InternalV1alpha1().StorageVersions().Get(
-				ctx, createdSV.Name, metav1.GetOptions{})
-			if apierrors.IsNotFound(err) {
-				return true, nil
-			}
-			if err != nil {
-				return false, err
-			}
-			framework.Logf("The storage version %v hasn't been garbage collected yet. Retrying", createdSV.Name)
-			return false, nil
-		})
+		err = wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, wait.ForeverTestTimeout, true,
+			func(ctx context.Context) (bool, error) {
+				_, err := client.InternalV1alpha1().StorageVersions().Get(
+					ctx, createdSV.Name, metav1.GetOptions{})
+				if apierrors.IsNotFound(err) {
+					return true, nil
+				}
+				if err != nil {
+					return false, err
+				}
+				framework.Logf("The storage version %v hasn't been garbage collected yet. Retrying", createdSV.Name)
+				return false, nil
+			})
 		framework.ExpectNoError(err, "garbage-collecting storage version")
 	})
 })

--- a/test/e2e/apimachinery/webhook.go
+++ b/test/e2e/apimachinery/webhook.go
@@ -425,19 +425,20 @@ var _ = SIGDescribe("AdmissionWebhook [Privileged:ClusterAdmin]", func() {
 		framework.ExpectNoError(err, "waiting for webhook configuration to be ready")
 
 		ginkgo.By("Creating a configMap that does not comply to the validation webhook rules")
-		err = wait.PollImmediate(100*time.Millisecond, 30*time.Second, func() (bool, error) {
-			cm := namedNonCompliantConfigMap(string(uuid.NewUUID()), f)
-			_, err = client.CoreV1().ConfigMaps(f.Namespace.Name).Create(ctx, cm, metav1.CreateOptions{})
-			if err == nil {
-				err = client.CoreV1().ConfigMaps(f.Namespace.Name).Delete(ctx, cm.Name, metav1.DeleteOptions{})
-				framework.ExpectNoError(err, "Deleting successfully created configMap")
-				return false, nil
-			}
-			if !strings.Contains(err.Error(), "denied") {
-				return false, err
-			}
-			return true, nil
-		})
+		err = wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, 30*time.Second, true,
+			func(ctx context.Context) (bool, error) {
+				cm := namedNonCompliantConfigMap(string(uuid.NewUUID()), f)
+				_, err = client.CoreV1().ConfigMaps(f.Namespace.Name).Create(ctx, cm, metav1.CreateOptions{})
+				if err == nil {
+					err = client.CoreV1().ConfigMaps(f.Namespace.Name).Delete(ctx, cm.Name, metav1.DeleteOptions{})
+					framework.ExpectNoError(err, "Deleting successfully created configMap")
+					return false, nil
+				}
+				if !strings.Contains(err.Error(), "denied") {
+					return false, err
+				}
+				return true, nil
+			})
 
 		ginkgo.By("Updating a validating webhook configuration's rules to not include the create operation")
 		err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
@@ -450,19 +451,20 @@ var _ = SIGDescribe("AdmissionWebhook [Privileged:ClusterAdmin]", func() {
 		framework.ExpectNoError(err, "Updating validating webhook configuration")
 
 		ginkgo.By("Creating a configMap that does not comply to the validation webhook rules")
-		err = wait.PollImmediate(100*time.Millisecond, 30*time.Second, func() (bool, error) {
-			cm := namedNonCompliantConfigMap(string(uuid.NewUUID()), f)
-			_, err = client.CoreV1().ConfigMaps(f.Namespace.Name).Create(ctx, cm, metav1.CreateOptions{})
-			if err != nil {
-				if !strings.Contains(err.Error(), "denied") {
-					return false, err
+		err = wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 30*time.Second, true,
+			func(ctx context.Context) (bool, error) {
+				cm := namedNonCompliantConfigMap(string(uuid.NewUUID()), f)
+				_, err = client.CoreV1().ConfigMaps(f.Namespace.Name).Create(ctx, cm, metav1.CreateOptions{})
+				if err != nil {
+					if !strings.Contains(err.Error(), "denied") {
+						return false, err
+					}
+					return false, nil
 				}
-				return false, nil
-			}
-			err = client.CoreV1().ConfigMaps(f.Namespace.Name).Delete(ctx, cm.Name, metav1.DeleteOptions{})
-			framework.ExpectNoError(err, "Deleting successfully created configMap")
-			return true, nil
-		})
+				err = client.CoreV1().ConfigMaps(f.Namespace.Name).Delete(ctx, cm.Name, metav1.DeleteOptions{})
+				framework.ExpectNoError(err, "Deleting successfully created configMap")
+				return true, nil
+			})
 		framework.ExpectNoError(err, "Waiting for configMap in namespace %s to be allowed creation since webhook was updated to not validate create", f.Namespace.Name)
 
 		ginkgo.By("Patching a validating webhook configuration's rules to include the create operation")
@@ -472,19 +474,20 @@ var _ = SIGDescribe("AdmissionWebhook [Privileged:ClusterAdmin]", func() {
 		framework.ExpectNoError(err, "Patching validating webhook configuration")
 
 		ginkgo.By("Creating a configMap that does not comply to the validation webhook rules")
-		err = wait.PollImmediate(100*time.Millisecond, 30*time.Second, func() (bool, error) {
-			cm := namedNonCompliantConfigMap(string(uuid.NewUUID()), f)
-			_, err = client.CoreV1().ConfigMaps(f.Namespace.Name).Create(ctx, cm, metav1.CreateOptions{})
-			if err == nil {
-				err = client.CoreV1().ConfigMaps(f.Namespace.Name).Delete(ctx, cm.Name, metav1.DeleteOptions{})
-				framework.ExpectNoError(err, "Deleting successfully created configMap")
-				return false, nil
-			}
-			if !strings.Contains(err.Error(), "denied") {
-				return false, err
-			}
-			return true, nil
-		})
+		err = wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 30*time.Second, true,
+			func(ctx context.Context) (bool, error) {
+				cm := namedNonCompliantConfigMap(string(uuid.NewUUID()), f)
+				_, err = client.CoreV1().ConfigMaps(f.Namespace.Name).Create(ctx, cm, metav1.CreateOptions{})
+				if err == nil {
+					err = client.CoreV1().ConfigMaps(f.Namespace.Name).Delete(ctx, cm.Name, metav1.DeleteOptions{})
+					framework.ExpectNoError(err, "Deleting successfully created configMap")
+					return false, nil
+				}
+				if !strings.Contains(err.Error(), "denied") {
+					return false, err
+				}
+				return true, nil
+			})
 		framework.ExpectNoError(err, "Waiting for configMap in namespace %s to be denied creation by validating webhook", f.Namespace.Name)
 	})
 
@@ -527,17 +530,18 @@ var _ = SIGDescribe("AdmissionWebhook [Privileged:ClusterAdmin]", func() {
 		framework.ExpectNoError(err, "Updating mutating webhook configuration")
 
 		ginkgo.By("Creating a configMap that should not be mutated")
-		err = wait.PollImmediate(100*time.Millisecond, 30*time.Second, func() (bool, error) {
-			cm := namedToBeMutatedConfigMap(string(uuid.NewUUID()), f)
-			created, err := client.CoreV1().ConfigMaps(f.Namespace.Name).Create(ctx, cm, metav1.CreateOptions{})
-			if err != nil {
-				return false, err
-			}
-			err = client.CoreV1().ConfigMaps(f.Namespace.Name).Delete(ctx, cm.Name, metav1.DeleteOptions{})
-			framework.ExpectNoError(err, "Deleting successfully created configMap")
-			_, ok := created.Data["mutation-stage-1"]
-			return !ok, nil
-		})
+		err = wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 30*time.Second, true,
+			func(ctx context.Context) (bool, error) {
+				cm := namedToBeMutatedConfigMap(string(uuid.NewUUID()), f)
+				created, err := client.CoreV1().ConfigMaps(f.Namespace.Name).Create(ctx, cm, metav1.CreateOptions{})
+				if err != nil {
+					return false, err
+				}
+				err = client.CoreV1().ConfigMaps(f.Namespace.Name).Delete(ctx, cm.Name, metav1.DeleteOptions{})
+				framework.ExpectNoError(err, "Deleting successfully created configMap")
+				_, ok := created.Data["mutation-stage-1"]
+				return !ok, nil
+			})
 		framework.ExpectNoError(err, "Waiting for configMap in namespace %s this is not mutated", f.Namespace.Name)
 
 		ginkgo.By("Patching a mutating webhook configuration's rules to include the create operation")
@@ -547,17 +551,18 @@ var _ = SIGDescribe("AdmissionWebhook [Privileged:ClusterAdmin]", func() {
 		framework.ExpectNoError(err, "Patching mutating webhook configuration")
 
 		ginkgo.By("Creating a configMap that should be mutated")
-		err = wait.PollImmediate(100*time.Millisecond, 30*time.Second, func() (bool, error) {
-			cm := namedToBeMutatedConfigMap(string(uuid.NewUUID()), f)
-			created, err := client.CoreV1().ConfigMaps(f.Namespace.Name).Create(ctx, cm, metav1.CreateOptions{})
-			if err != nil {
-				return false, err
-			}
-			err = client.CoreV1().ConfigMaps(f.Namespace.Name).Delete(ctx, cm.Name, metav1.DeleteOptions{})
-			framework.ExpectNoError(err, "Deleting successfully created configMap")
-			_, ok := created.Data["mutation-stage-1"]
-			return ok, nil
-		})
+		err = wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 30*time.Second, true,
+			func(ctx context.Context) (bool, error) {
+				cm := namedToBeMutatedConfigMap(string(uuid.NewUUID()), f)
+				created, err := client.CoreV1().ConfigMaps(f.Namespace.Name).Create(ctx, cm, metav1.CreateOptions{})
+				if err != nil {
+					return false, err
+				}
+				err = client.CoreV1().ConfigMaps(f.Namespace.Name).Delete(ctx, cm.Name, metav1.DeleteOptions{})
+				framework.ExpectNoError(err, "Deleting successfully created configMap")
+				_, ok := created.Data["mutation-stage-1"]
+				return ok, nil
+			})
 		framework.ExpectNoError(err, "Waiting for configMap in namespace %s to be mutated", f.Namespace.Name)
 	})
 
@@ -599,19 +604,20 @@ var _ = SIGDescribe("AdmissionWebhook [Privileged:ClusterAdmin]", func() {
 		framework.ExpectNoError(err, "waiting for webhook configuration to be ready")
 
 		ginkgo.By("Creating a configMap that does not comply to the validation webhook rules")
-		err = wait.PollImmediate(100*time.Millisecond, 30*time.Second, func() (bool, error) {
-			cm := namedNonCompliantConfigMap(string(uuid.NewUUID()), f)
-			_, err = client.CoreV1().ConfigMaps(f.Namespace.Name).Create(ctx, cm, metav1.CreateOptions{})
-			if err == nil {
-				err = client.CoreV1().ConfigMaps(f.Namespace.Name).Delete(ctx, cm.Name, metav1.DeleteOptions{})
-				framework.ExpectNoError(err, "Deleting successfully created configMap")
-				return false, nil
-			}
-			if !strings.Contains(err.Error(), "denied") {
-				return false, err
-			}
-			return true, nil
-		})
+		err = wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 30*time.Second, true,
+			func(ctx context.Context) (bool, error) {
+				cm := namedNonCompliantConfigMap(string(uuid.NewUUID()), f)
+				_, err = client.CoreV1().ConfigMaps(f.Namespace.Name).Create(ctx, cm, metav1.CreateOptions{})
+				if err == nil {
+					err = client.CoreV1().ConfigMaps(f.Namespace.Name).Delete(ctx, cm.Name, metav1.DeleteOptions{})
+					framework.ExpectNoError(err, "Deleting successfully created configMap")
+					return false, nil
+				}
+				if !strings.Contains(err.Error(), "denied") {
+					return false, err
+				}
+				return true, nil
+			})
 		framework.ExpectNoError(err, "Waiting for configMap in namespace %s to be denied creation by validating webhook", f.Namespace.Name)
 
 		ginkgo.By("Deleting the collection of validation webhooks")
@@ -619,19 +625,20 @@ var _ = SIGDescribe("AdmissionWebhook [Privileged:ClusterAdmin]", func() {
 		framework.ExpectNoError(err, "Deleting collection of validating webhook configurations")
 
 		ginkgo.By("Creating a configMap that does not comply to the validation webhook rules")
-		err = wait.PollImmediate(100*time.Millisecond, 30*time.Second, func() (bool, error) {
-			cm := namedNonCompliantConfigMap(string(uuid.NewUUID()), f)
-			_, err = client.CoreV1().ConfigMaps(f.Namespace.Name).Create(ctx, cm, metav1.CreateOptions{})
-			if err != nil {
-				if !strings.Contains(err.Error(), "denied") {
-					return false, err
+		err = wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 30*time.Second, true,
+			func(ctx context.Context) (bool, error) {
+				cm := namedNonCompliantConfigMap(string(uuid.NewUUID()), f)
+				_, err = client.CoreV1().ConfigMaps(f.Namespace.Name).Create(ctx, cm, metav1.CreateOptions{})
+				if err != nil {
+					if !strings.Contains(err.Error(), "denied") {
+						return false, err
+					}
+					return false, nil
 				}
-				return false, nil
-			}
-			err = client.CoreV1().ConfigMaps(f.Namespace.Name).Delete(ctx, cm.Name, metav1.DeleteOptions{})
-			framework.ExpectNoError(err, "Deleting successfully created configMap")
-			return true, nil
-		})
+				err = client.CoreV1().ConfigMaps(f.Namespace.Name).Delete(ctx, cm.Name, metav1.DeleteOptions{})
+				framework.ExpectNoError(err, "Deleting successfully created configMap")
+				return true, nil
+			})
 		framework.ExpectNoError(err, "Waiting for configMap in namespace %s to be allowed creation since there are no webhooks", f.Namespace.Name)
 	})
 
@@ -673,17 +680,18 @@ var _ = SIGDescribe("AdmissionWebhook [Privileged:ClusterAdmin]", func() {
 		framework.ExpectNoError(err, "waiting for webhook configuration to be ready")
 
 		ginkgo.By("Creating a configMap that should be mutated")
-		err = wait.PollImmediate(100*time.Millisecond, 30*time.Second, func() (bool, error) {
-			cm := namedToBeMutatedConfigMap(string(uuid.NewUUID()), f)
-			created, err := client.CoreV1().ConfigMaps(f.Namespace.Name).Create(ctx, cm, metav1.CreateOptions{})
-			if err != nil {
-				return false, err
-			}
-			err = client.CoreV1().ConfigMaps(f.Namespace.Name).Delete(ctx, cm.Name, metav1.DeleteOptions{})
-			framework.ExpectNoError(err, "Deleting successfully created configMap")
-			_, ok := created.Data["mutation-stage-1"]
-			return ok, nil
-		})
+		err = wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 30*time.Second, true,
+			func(ctx context.Context) (bool, error) {
+				cm := namedToBeMutatedConfigMap(string(uuid.NewUUID()), f)
+				created, err := client.CoreV1().ConfigMaps(f.Namespace.Name).Create(ctx, cm, metav1.CreateOptions{})
+				if err != nil {
+					return false, err
+				}
+				err = client.CoreV1().ConfigMaps(f.Namespace.Name).Delete(ctx, cm.Name, metav1.DeleteOptions{})
+				framework.ExpectNoError(err, "Deleting successfully created configMap")
+				_, ok := created.Data["mutation-stage-1"]
+				return ok, nil
+			})
 		framework.ExpectNoError(err, "Waiting for configMap in namespace %s to be mutated", f.Namespace.Name)
 
 		ginkgo.By("Deleting the collection of validation webhooks")
@@ -691,17 +699,18 @@ var _ = SIGDescribe("AdmissionWebhook [Privileged:ClusterAdmin]", func() {
 		framework.ExpectNoError(err, "Deleting collection of mutating webhook configurations")
 
 		ginkgo.By("Creating a configMap that should not be mutated")
-		err = wait.PollImmediate(100*time.Millisecond, 30*time.Second, func() (bool, error) {
-			cm := namedToBeMutatedConfigMap(string(uuid.NewUUID()), f)
-			created, err := client.CoreV1().ConfigMaps(f.Namespace.Name).Create(ctx, cm, metav1.CreateOptions{})
-			if err != nil {
-				return false, err
-			}
-			err = client.CoreV1().ConfigMaps(f.Namespace.Name).Delete(ctx, cm.Name, metav1.DeleteOptions{})
-			framework.ExpectNoError(err, "Deleting successfully created configMap")
-			_, ok := created.Data["mutation-stage-1"]
-			return !ok, nil
-		})
+		err = wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 30*time.Second, true,
+			func(ctx context.Context) (bool, error) {
+				cm := namedToBeMutatedConfigMap(string(uuid.NewUUID()), f)
+				created, err := client.CoreV1().ConfigMaps(f.Namespace.Name).Create(ctx, cm, metav1.CreateOptions{})
+				if err != nil {
+					return false, err
+				}
+				err = client.CoreV1().ConfigMaps(f.Namespace.Name).Delete(ctx, cm.Name, metav1.DeleteOptions{})
+				framework.ExpectNoError(err, "Deleting successfully created configMap")
+				_, ok := created.Data["mutation-stage-1"]
+				return !ok, nil
+			})
 		framework.ExpectNoError(err, "Waiting for configMap in namespace %s this is not mutated", f.Namespace.Name)
 	})
 
@@ -1899,21 +1908,22 @@ type updateConfigMapFn func(cm *v1.ConfigMap)
 
 func updateConfigMap(ctx context.Context, c clientset.Interface, ns, name string, update updateConfigMapFn) (*v1.ConfigMap, error) {
 	var cm *v1.ConfigMap
-	pollErr := wait.PollImmediate(2*time.Second, 1*time.Minute, func() (bool, error) {
-		var err error
-		if cm, err = c.CoreV1().ConfigMaps(ns).Get(ctx, name, metav1.GetOptions{}); err != nil {
-			return false, err
-		}
-		update(cm)
-		if cm, err = c.CoreV1().ConfigMaps(ns).Update(ctx, cm, metav1.UpdateOptions{}); err == nil {
-			return true, nil
-		}
-		// Only retry update on conflict
-		if !apierrors.IsConflict(err) {
-			return false, err
-		}
-		return false, nil
-	})
+	pollErr := wait.PollUntilContextTimeout(context.Background(), 2*time.Second, 1*time.Minute, true,
+		func(ctx context.Context) (bool, error) {
+			var err error
+			if cm, err = c.CoreV1().ConfigMaps(ns).Get(ctx, name, metav1.GetOptions{}); err != nil {
+				return false, err
+			}
+			update(cm)
+			if cm, err = c.CoreV1().ConfigMaps(ns).Update(ctx, cm, metav1.UpdateOptions{}); err == nil {
+				return true, nil
+			}
+			// Only retry update on conflict
+			if !apierrors.IsConflict(err) {
+				return false, err
+			}
+			return false, nil
+		})
 	return cm, pollErr
 }
 
@@ -1921,21 +1931,22 @@ type updateCustomResourceFn func(cm *unstructured.Unstructured)
 
 func updateCustomResource(ctx context.Context, c dynamic.ResourceInterface, ns, name string, update updateCustomResourceFn) (*unstructured.Unstructured, error) {
 	var cr *unstructured.Unstructured
-	pollErr := wait.PollImmediate(2*time.Second, 1*time.Minute, func() (bool, error) {
-		var err error
-		if cr, err = c.Get(ctx, name, metav1.GetOptions{}); err != nil {
-			return false, err
-		}
-		update(cr)
-		if cr, err = c.Update(ctx, cr, metav1.UpdateOptions{}); err == nil {
-			return true, nil
-		}
-		// Only retry update on conflict
-		if !apierrors.IsConflict(err) {
-			return false, err
-		}
-		return false, nil
-	})
+	pollErr := wait.PollUntilContextTimeout(context.Background(), 2*time.Second, 1*time.Minute, true,
+		func(ctx context.Context) (bool, error) {
+			var err error
+			if cr, err = c.Get(ctx, name, metav1.GetOptions{}); err != nil {
+				return false, err
+			}
+			update(cr)
+			if cr, err = c.Update(ctx, cr, metav1.UpdateOptions{}); err == nil {
+				return true, nil
+			}
+			// Only retry update on conflict
+			if !apierrors.IsConflict(err) {
+				return false, err
+			}
+			return false, nil
+		})
 	return cr, pollErr
 }
 
@@ -2650,28 +2661,29 @@ func createWebhookConfigurationReadyNamespace(ctx context.Context, f *framework.
 // the webhook configuration.
 func waitWebhookConfigurationReady(ctx context.Context, f *framework.Framework, markersNamespaceName string) error {
 	cmClient := f.ClientSet.CoreV1().ConfigMaps(markersNamespaceName)
-	return wait.PollImmediate(100*time.Millisecond, 30*time.Second, func() (bool, error) {
-		marker := &v1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: string(uuid.NewUUID()),
-				Labels: map[string]string{
-					f.UniqueName: "true",
+	return wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 30*time.Second, true,
+		func(ctx context.Context) (bool, error) {
+			marker := &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: string(uuid.NewUUID()),
+					Labels: map[string]string{
+						f.UniqueName: "true",
+					},
 				},
-			},
-		}
-		_, err := cmClient.Create(ctx, marker, metav1.CreateOptions{})
-		if err != nil {
-			// The always-deny webhook does not provide a reason, so check for the error string we expect
-			if strings.Contains(err.Error(), "denied") {
-				return true, nil
 			}
-			return false, err
-		}
-		// best effort cleanup of markers that are no longer needed
-		_ = cmClient.Delete(ctx, marker.GetName(), metav1.DeleteOptions{})
-		framework.Logf("Waiting for webhook configuration to be ready...")
-		return false, nil
-	})
+			_, err := cmClient.Create(ctx, marker, metav1.CreateOptions{})
+			if err != nil {
+				// The always-deny webhook does not provide a reason, so check for the error string we expect
+				if strings.Contains(err.Error(), "denied") {
+					return true, nil
+				}
+				return false, err
+			}
+			// best effort cleanup of markers that are no longer needed
+			_ = cmClient.Delete(ctx, marker.GetName(), metav1.DeleteOptions{})
+			framework.Logf("Waiting for webhook configuration to be ready...")
+			return false, nil
+		})
 }
 
 // newValidatingIsReadyWebhookFixture creates a validating webhook that can be added to a webhook configuration and then probed


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Refactor code to use `PollUntilContextTimeout` replacing deprecated `PolImmediate`.

#### Which issue(s) this PR fixes:

Related: #122800

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
