### PR TITLE
Refactor Code to Remove Deprecated `PollImmediate` in `test/e2e/upgrade`

### DIFF
--- a/test/e2e/upgrades/apps/deployments.go
+++ b/test/e2e/upgrades/apps/deployments.go
@@ -177,14 +177,15 @@ func (t *DeploymentUpgradeTest) Teardown(ctx context.Context, f *framework.Frame
 
 // waitForDeploymentRevision waits for becoming the target revision of a delopyment.
 func waitForDeploymentRevision(ctx context.Context, c clientset.Interface, d *appsv1.Deployment, targetRevision string) error {
-	err := wait.PollImmediate(poll, pollLongTimeout, func() (bool, error) {
-		deployment, err := c.AppsV1().Deployments(d.Namespace).Get(ctx, d.Name, metav1.GetOptions{})
-		if err != nil {
-			return false, err
-		}
-		revision := deployment.Annotations[deploymentutil.RevisionAnnotation]
-		return revision == targetRevision, nil
-	})
+	err := wait.PollUntilContextTimeout(ctx, poll, pollLongTimeout, true,
+		func(ctx context.Context) (bool, error) {
+			deployment, err := c.AppsV1().Deployments(d.Namespace).Get(ctx, d.Name, metav1.GetOptions{})
+			if err != nil {
+				return false, err
+			}
+			revision := deployment.Annotations[deploymentutil.RevisionAnnotation]
+			return revision == targetRevision, nil
+		})
 	if err != nil {
 		return fmt.Errorf("error waiting for revision to become %q for deployment %q: %w", targetRevision, d.Name, err)
 	}

--- a/test/e2e/upgrades/network/kube_proxy_migration.go
+++ b/test/e2e/upgrades/network/kube_proxy_migration.go
@@ -115,7 +115,7 @@ func (t *KubeProxyDowngradeTest) Teardown(ctx context.Context, f *framework.Fram
 func waitForKubeProxyStaticPodsRunning(ctx context.Context, c clientset.Interface) error {
 	framework.Logf("Waiting up to %v for kube-proxy static pods running", defaultTestTimeout)
 
-	condition := func() (bool, error) {
+	condition := func(ctx context.Context) (bool, error) {
 		pods, err := getKubeProxyStaticPods(ctx, c)
 		if err != nil {
 			framework.Logf("Failed to get kube-proxy static pods: %v", err)
@@ -142,7 +142,7 @@ func waitForKubeProxyStaticPodsRunning(ctx context.Context, c clientset.Interfac
 		return true, nil
 	}
 
-	if err := wait.PollImmediate(5*time.Second, defaultTestTimeout, condition); err != nil {
+	if err := wait.PollUntilContextTimeout(ctx, 5*time.Second, defaultTestTimeout, true, condition); err != nil {
 		return fmt.Errorf("error waiting for kube-proxy static pods running: %w", err)
 	}
 	return nil
@@ -151,7 +151,7 @@ func waitForKubeProxyStaticPodsRunning(ctx context.Context, c clientset.Interfac
 func waitForKubeProxyStaticPodsDisappear(ctx context.Context, c clientset.Interface) error {
 	framework.Logf("Waiting up to %v for kube-proxy static pods disappear", defaultTestTimeout)
 
-	condition := func() (bool, error) {
+	condition := func(ctx context.Context) (bool, error) {
 		pods, err := getKubeProxyStaticPods(ctx, c)
 		if err != nil {
 			framework.Logf("Failed to get kube-proxy static pods: %v", err)
@@ -165,7 +165,7 @@ func waitForKubeProxyStaticPodsDisappear(ctx context.Context, c clientset.Interf
 		return true, nil
 	}
 
-	if err := wait.PollImmediate(5*time.Second, defaultTestTimeout, condition); err != nil {
+	if err := wait.PollUntilContextTimeout(ctx, 5*time.Second, defaultTestTimeout, true, condition); err != nil {
 		return fmt.Errorf("error waiting for kube-proxy static pods disappear: %w", err)
 	}
 	return nil
@@ -174,7 +174,7 @@ func waitForKubeProxyStaticPodsDisappear(ctx context.Context, c clientset.Interf
 func waitForKubeProxyDaemonSetRunning(ctx context.Context, f *framework.Framework, c clientset.Interface) error {
 	framework.Logf("Waiting up to %v for kube-proxy DaemonSet running", defaultTestTimeout)
 
-	condition := func() (bool, error) {
+	condition := func(ctx context.Context) (bool, error) {
 		daemonSets, err := getKubeProxyDaemonSet(ctx, c)
 		if err != nil {
 			framework.Logf("Failed to get kube-proxy DaemonSet: %v", err)
@@ -189,7 +189,7 @@ func waitForKubeProxyDaemonSetRunning(ctx context.Context, f *framework.Framewor
 		return e2edaemonset.CheckRunningOnAllNodes(ctx, f, &daemonSets.Items[0])
 	}
 
-	if err := wait.PollImmediate(5*time.Second, defaultTestTimeout, condition); err != nil {
+	if err := wait.PollUntilContextTimeout(context.Background(), 5*time.Second, defaultTestTimeout, true, condition); err != nil {
 		return fmt.Errorf("error waiting for kube-proxy DaemonSet running: %w", err)
 	}
 	return nil
@@ -198,7 +198,7 @@ func waitForKubeProxyDaemonSetRunning(ctx context.Context, f *framework.Framewor
 func waitForKubeProxyDaemonSetDisappear(ctx context.Context, c clientset.Interface) error {
 	framework.Logf("Waiting up to %v for kube-proxy DaemonSet disappear", defaultTestTimeout)
 
-	condition := func() (bool, error) {
+	condition := func(ctx context.Context) (bool, error) {
 		daemonSets, err := getKubeProxyDaemonSet(ctx, c)
 		if err != nil {
 			framework.Logf("Failed to get kube-proxy DaemonSet: %v", err)
@@ -212,7 +212,7 @@ func waitForKubeProxyDaemonSetDisappear(ctx context.Context, c clientset.Interfa
 		return true, nil
 	}
 
-	if err := wait.PollImmediate(5*time.Second, defaultTestTimeout, condition); err != nil {
+	if err := wait.PollUntilContextTimeout(context.Background(), 5*time.Second, defaultTestTimeout, true, condition); err != nil {
 		return fmt.Errorf("error waiting for kube-proxy DaemonSet disappear: %w", err)
 	}
 	return nil


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Refactor code to use `PollUntilContextTimeout` replacing deprecated `PolImmediate`.

#### Which issue(s) this PR fixes:

Related: #122800

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
