### PR TITLE
Updated Dockerfile 

### DIFF
--- a/cluster/addons/addon-manager/Dockerfile
+++ b/cluster/addons/addon-manager/Dockerfile
@@ -22,4 +22,6 @@ ADD kube-addons.sh /opt/
 ADD kube-addons-main.sh /opt/
 ADD kubectl /usr/local/bin/
 
+RUN chmod +x /opt/kube-addons-main.sh
+
 CMD ["/opt/kube-addons-main.sh"]


### PR DESCRIPTION
I added **'chmod'** command to add execute permission.
Without execute permission, kube-addons-main.sh file would show **permission denied** error,