### PR TITLE
apimachinery: add IntOrString.IsZero() helper

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/intstr/intstr.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/intstr/intstr.go
@@ -114,6 +114,21 @@ func (intstr *IntOrString) IntValue() int {
 	return int(intstr.IntVal)
 }
 
+// IsZero returns if the value is nil, or is parsed as 0 (for int), or
+// "0" or "0%" as string.
+func (intstr *IntOrString) IsZero() bool {
+	if intstr == nil {
+		return true
+	}
+	switch intstr.Type {
+	case Int:
+		return intstr.IntVal == 0
+	case String:
+		return intstr.StrVal == "0" || intstr.StrVal == "0%"
+	}
+	return false
+}
+
 // MarshalJSON implements the json.Marshaller interface.
 func (intstr IntOrString) MarshalJSON() ([]byte, error) {
 	switch intstr.Type {

--- a/staging/src/k8s.io/apimachinery/pkg/util/intstr/intstr_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/intstr/intstr_test.go
@@ -21,6 +21,7 @@ import (
 	"reflect"
 	"testing"
 
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/yaml"
 )
 
@@ -323,4 +324,42 @@ func TestParse(t *testing.T) {
 			t.Errorf("expected string value %q (%v), but got %q (%v)", test.output.StrVal, test.output, value.StrVal, value)
 		}
 	}
+}
+
+func TestIsZero(t *testing.T) {
+	tests := []struct {
+		input    *IntOrString
+		expected bool
+	}{
+		{
+			input:    nil,
+			expected: true,
+		},
+		{
+			input:    ptr.To(FromInt(0)),
+			expected: true,
+		},
+		{
+			input:    ptr.To(FromString("0")),
+			expected: true,
+		},
+		{
+			input:    ptr.To(FromString("0%")),
+			expected: true,
+		},
+		{
+			input:    ptr.To(FromInt(1)),
+			expected: false,
+		},
+		{
+			input:    ptr.To(FromString("1%")),
+			expected: false,
+		},
+	}
+	for i, tc := range tests {
+		if tc.input.IsZero() != tc.expected {
+			t.Errorf("case#%d: expected %v, but got %v for input %s", i, tc.expected, tc.input.IsZero(), tc.input.String())
+		}
+	}
+
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/kind api-change

#### What this PR does / why we need it:

> Very frequently in our codebases, we're finding ourself doing defaulting in admission webhooks for [intstr.IntOrString](https://pkg.go.dev/k8s.io/apimachinery/pkg/util/intstr#IntOrString) fields. However, comparing a value to the zero value of this struct looks like:
> 
> ```go
> if v := intstr.IntOrString{} { ...
> ```
> 
>  which is syntactically poor, and on top of that we've seen more junior engineers make incorrect assumptions of how the type works, and buggy code like that only looks at the `int` portion of the union.
> 
> ```go
> if v.IntVal == 0 { ...
> ```

Similar to [meta/v1#Time.IsZero](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Time.IsZero), I'm proposing we add an `IsZero()` method, which returns `true` in the following cases

- `nil`
- zero-value of the struct
- `{Type:Int, IntVal:0}`
- `{Type:String, StrVal:"0"}`
- `{Type:String, StrVal:"0%"}`

If a caller is interested in distinguishing between value unset (`nil`) vs actual zero, they can still do by doing a `v == nil` check. A few cases I am not sure about:

- `{Type:String, StrVal:"0"}` → should this be considered zero - are clients expected to use this type to store non-percent strings?
- `{Type:String, StrVal:""}` (i.e. `FromString("")`) → should this be zero?


#### Which issue(s) this PR fixes:
N/A

#### Special notes for your reviewer:
N/A

#### Does this PR introduce a user-facing change?
N/A

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
N/A
