### PR TITLE
Fix some wrong behavior in controller testutil codes.

### DIFF
--- a/pkg/controller/apis/config/v1alpha1/defaults.go
+++ b/pkg/controller/apis/config/v1alpha1/defaults.go
@@ -63,7 +63,7 @@ func SetDefaults_KubeControllerManagerConfiguration(obj *kubectrlmgrconfigv1alph
 
 	// Use the default RecommendedDefaultGenericControllerManagerConfiguration options
 	cmconfigv1alpha1.RecommendedDefaultGenericControllerManagerConfiguration(&obj.Generic)
-	// Use the default RecommendedDefaultHPAControllerConfiguration options
+	// Use the default RecommendedDefaultAttachDetachControllerConfiguration options
 	attachdetachconfigv1alpha1.RecommendedDefaultAttachDetachControllerConfiguration(&obj.AttachDetachController)
 	// Use the default RecommendedDefaultCSRSigningControllerConfiguration options
 	csrsigningconfigv1alpha1.RecommendedDefaultCSRSigningControllerConfiguration(&obj.CSRSigningController)
@@ -81,7 +81,7 @@ func SetDefaults_KubeControllerManagerConfiguration(obj *kubectrlmgrconfigv1alph
 	endpointslicemirroringconfigv1alpha1.RecommendedDefaultEndpointSliceMirroringControllerConfiguration(&obj.EndpointSliceMirroringController)
 	// Use the default RecommendedDefaultEphemeralVolumeControllerConfiguration options
 	ephemeralvolumeconfigv1alpha1.RecommendedDefaultEphemeralVolumeControllerConfiguration(&obj.EphemeralVolumeController)
-	// Use the default RecommendedDefaultGenericControllerManagerConfiguration options
+	// Use the default RecommendedDefaultGarbageCollectorControllerConfiguration options
 	garbagecollectorconfigv1alpha1.RecommendedDefaultGarbageCollectorControllerConfiguration(&obj.GarbageCollectorController)
 	// Use the default RecommendedDefaultJobControllerConfiguration options
 	jobconfigv1alpha1.RecommendedDefaultJobControllerConfiguration(&obj.JobController)
@@ -103,7 +103,7 @@ func SetDefaults_KubeControllerManagerConfiguration(obj *kubectrlmgrconfigv1alph
 	replicationconfigv1alpha1.RecommendedDefaultReplicationControllerConfiguration(&obj.ReplicationController)
 	// Use the default RecommendedDefaultResourceQuotaControllerConfiguration options
 	resourcequotaconfigv1alpha1.RecommendedDefaultResourceQuotaControllerConfiguration(&obj.ResourceQuotaController)
-	// Use the default RecommendedDefaultGenericControllerManagerConfiguration options
+	// Use the default RecommendedDefaultServiceControllerConfiguration options
 	serviceconfigv1alpha1.RecommendedDefaultServiceControllerConfiguration(&obj.ServiceController)
 	// Use the default RecommendedDefaultLegacySATokenCleanerConfiguration options
 	serviceaccountconfigv1alpha1.RecommendedDefaultLegacySATokenCleanerConfiguration(&obj.LegacySATokenCleaner)

--- a/pkg/controller/testutil/test_utils.go
+++ b/pkg/controller/testutil/test_utils.go
@@ -90,7 +90,7 @@ type FakeLegacyHandler struct {
 func (m *FakeNodeHandler) GetUpdatedNodesCopy() []*v1.Node {
 	m.lock.Lock()
 	defer m.lock.Unlock()
-	updatedNodesCopy := make([]*v1.Node, len(m.UpdatedNodes), len(m.UpdatedNodes))
+	updatedNodesCopy := make([]*v1.Node, len(m.UpdatedNodes))
 	copy(updatedNodesCopy, m.UpdatedNodes)
 	return updatedNodesCopy
 }
@@ -336,7 +336,7 @@ func (m *FakeNodeHandler) Patch(ctx context.Context, name string, pt types.Patch
 			klog.FromContext(ctx).Error(err, "")
 			return nil, nil
 		}
-	case types.StrategicMergePatchType:
+	case types.StrategicMergePatchType, types.ApplyPatchType:
 		if patchedObjJS, err = strategicpatch.StrategicMergePatch(originalObjJS, data, originalNode); err != nil {
 			klog.FromContext(ctx).Error(err, "")
 			return nil, nil
@@ -373,7 +373,7 @@ func (m *FakeNodeHandler) Apply(ctx context.Context, node *v1apply.NodeApplyConf
 	}
 	name := node.Name
 	if name == nil {
-		return nil, fmt.Errorf("deployment.Name must be provided to Apply")
+		return nil, fmt.Errorf("node.Name must be provided to Apply")
 	}
 
 	return m.Patch(ctx, *name, types.ApplyPatchType, data, patchOpts)
@@ -388,7 +388,7 @@ func (m *FakeNodeHandler) ApplyStatus(ctx context.Context, node *v1apply.NodeApp
 	}
 	name := node.Name
 	if name == nil {
-		return nil, fmt.Errorf("deployment.Name must be provided to Apply")
+		return nil, fmt.Errorf("node.Name must be provided to Apply")
 	}
 
 	return m.Patch(ctx, *name, types.ApplyPatchType, data, patchOpts, "status")


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
1 Fix some typos notes
2 Fix ```pkg/controller/testutil/test_utils.go```
 1)lint error , like  copy(updatedNodesCopy, m.UpdatedNodes) 
 2) error logs info
 3)although these code is not used now, but it is not function as expected.
func (m *FakeNodeHandler) Apply(
func (m *FakeNodeHandler) ApplyStatus(

will call ```m.Patch(xxx, types.ApplyPatchType,  xxx) ```
But Patch() function can not support types.ApplyPatchType.


```release-note
None
```

