### PR TITLE
Updated calico-node-vertical-autoscaler-deployment.yaml

### DIFF
--- a/cluster/addons/calico-policy-controller/calico-node-vertical-autoscaler-deployment.yaml
+++ b/cluster/addons/calico-policy-controller/calico-node-vertical-autoscaler-deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       priorityClassName: system-cluster-critical
       containers:
-        - image: registry.k8s.io/cpvpa-amd64:v0.8.3
+        - image: registry.k8s.io/cpvpa-amd64:v0.8.6
           name: autoscaler
           command:
             - /cpvpa
@@ -31,6 +31,7 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /etc/config
+              readOnly=true
       volumes:
         - name: config
           configMap:


### PR DESCRIPTION
/kind feature

#### What this PR does / why we need it:
In this PR 
1. I have updated cpvpa version.
2. I added readOnly=true in volumeMounts section so that volume should be mounted in read-only mode.


#### Reference for cpvpa version:
[https://github.com/kubernetes-sigs/cluster-proportional-vertical-autoscaler/tags](url)






