### PR TITLE
Fix kubectl explain to shows enum for field types if they were defined

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/explain/v2/templates/plaintext.tmpl
+++ b/staging/src/k8s.io/kubectl/pkg/explain/v2/templates/plaintext.tmpl
@@ -110,7 +110,7 @@ Takes dictionary as argument with keys:
         {{- if eq 1 (len $.FieldPath) -}}
             {{- /* TODO: The original explain would say RESOURCE instead of FIELD here under some circumstances */ -}}
             FIELD: {{first $.FieldPath}} <{{ template "typeGuess" (dict "schema" $subschema "Document" $.Document) }}>{{"\n"}}
-            {{- template "extractEnum" (dict "schema" $subschema "Document" $.Document "singleView" true) -}}{{"\n"}}
+            {{- template "extractEnum" (dict "schema" $subschema "Document" $.Document "longFormView" false "limit" 3) -}}{{"\n"}}
             {{- "\n" -}}
         {{- end -}}
 
@@ -205,7 +205,7 @@ Takes dictionary as argument with keys:
     {{- $fieldSchema := index $.schema.properties $.name -}}
     {{- $.name | indent $indentAmount -}}{{"\t"}}<{{ template "typeGuess" (dict "schema" $fieldSchema "Document" $.Document) }}>
     {{- if contains $.schema.required $.name}} -required-{{- end -}}
-    {{- template "extractEnum" (dict "schema" $fieldSchema "Document" $.Document "singleView" false) -}}
+    {{- template "extractEnum" (dict "schema" $fieldSchema "Document" $.Document "longFormView" true "limit" -1 "indentAmount" $indentAmount) -}}
     {{- "\n" -}}
     {{- if not $.short -}}
         {{- or $fieldSchema.description "<no description>" | wrap (sub 78 $indentAmount) | indent (add $indentAmount 2) -}}{{- "\n" -}}
@@ -287,28 +287,45 @@ Takes dictionary as argument with keys:
 
 {{- /* Check if there is any enum returns it in this format e.g.:
 
-        ENUM: !=, =, =~, !~
-         enum: !=, =, =~, !~
+    ENUM: "", BlockDevice, CharDevice, Directory
+    enum: "", BlockDevice, CharDevice, Directory
 
     Can change the style of enum in future by modifying this function
 
 Takes dictionary as argument with keys:
     schema: openapiv3 JSON schema
     Document: openapi document
-    singleView: determine if ENUM should be printed uppercase or not, used in single Field view
+    longFormView: (boolean) prints the enums in extended long form view or not
+    limit: (int) truncate the amount of enums that can be printed in simple view, -1 means all items
+    indentAmount: intent of the beginning enum line in longform view
 */ -}}
 {{- define "extractEnum" -}}
     {{- with $.schema -}}
         {{- if .enum -}}
-            {{- if $.singleView -}}
-                {{- "ENUM: " -}}
+            {{- $enumLen := len .enum -}}
+            {{- $limit := or $.limit -1 -}}
+            {{- if $.longFormView -}}
+                {{- "\n" -}}
+                {{- "" | indent $.indentAmount -}}
+                {{- "enum: " -}}
             {{- else -}}
-                {{- " enum: " -}}
+                {{- "ENUM: " -}}
             {{- end -}}
             {{- range $index, $element := .enum -}}
+                {{- if and (gt $limit -1) (ge $index $limit) -}}
+                    {{- /* Prints ,..  and return the range when it goes over the limit */ -}}
+                    {{- ",.." -}}
+                    {{- break -}}
+                {{- end -}}
+                {{- /* Use to reflect "" when we see empty string */ -}}
+                {{- $elementType := printf "%T" $element -}}
                 {{- if gt $index 0 -}} {{- ", " -}} {{- end -}}
-                {{- $element -}}
-            {{- end -}}
+                {{- if and (eq "string" $elementType) (eq $element "") -}}
+                    {{- `""` -}}
+                {{- else -}}
+                    {{- $element -}}
+                {{- end -}}
+        {{- end -}}
         {{- end -}}
     {{- end -}}
 {{- end -}}

--- a/staging/src/k8s.io/kubectl/pkg/explain/v2/templates/plaintext.tmpl
+++ b/staging/src/k8s.io/kubectl/pkg/explain/v2/templates/plaintext.tmpl
@@ -110,7 +110,7 @@ Takes dictionary as argument with keys:
         {{- if eq 1 (len $.FieldPath) -}}
             {{- /* TODO: The original explain would say RESOURCE instead of FIELD here under some circumstances */ -}}
             FIELD: {{first $.FieldPath}} <{{ template "typeGuess" (dict "schema" $subschema "Document" $.Document) }}>{{"\n"}}
-            {{- template "extractEnum" (dict "schema" $subschema "Document" $.Document "longFormView" false "limit" 3) -}}{{"\n"}}
+            {{- template "extractEnum" (dict "schema" $subschema "Document" $.Document "isLongView" true "limit" -1) -}}{{"\n"}}
             {{- "\n" -}}
         {{- end -}}
 
@@ -205,7 +205,7 @@ Takes dictionary as argument with keys:
     {{- $fieldSchema := index $.schema.properties $.name -}}
     {{- $.name | indent $indentAmount -}}{{"\t"}}<{{ template "typeGuess" (dict "schema" $fieldSchema "Document" $.Document) }}>
     {{- if contains $.schema.required $.name}} -required-{{- end -}}
-    {{- template "extractEnum" (dict "schema" $fieldSchema "Document" $.Document "longFormView" true "limit" -1 "indentAmount" $indentAmount) -}}
+    {{- template "extractEnum" (dict "schema" $fieldSchema "Document" $.Document "isLongView" false "limit" 4 "indentAmount" $indentAmount) -}}
     {{- "\n" -}}
     {{- if not $.short -}}
         {{- or $fieldSchema.description "<no description>" | wrap (sub 78 $indentAmount) | indent (add $indentAmount 2) -}}{{- "\n" -}}
@@ -295,7 +295,7 @@ Takes dictionary as argument with keys:
 Takes dictionary as argument with keys:
     schema: openapiv3 JSON schema
     Document: openapi document
-    longFormView: (boolean) prints the enums in extended long form view or not
+    isLongView: (boolean) Simple view: long list of all fields. Long view: all details of one field
     limit: (int) truncate the amount of enums that can be printed in simple view, -1 means all items
     indentAmount: intent of the beginning enum line in longform view
 */ -}}
@@ -304,22 +304,30 @@ Takes dictionary as argument with keys:
         {{- if .enum -}}
             {{- $enumLen := len .enum -}}
             {{- $limit := or $.limit -1 -}}
-            {{- if $.longFormView -}}
+            {{- if eq $.isLongView false -}}
                 {{- "\n" -}}
                 {{- "" | indent $.indentAmount -}}
                 {{- "enum: " -}}
             {{- else -}}
-                {{- "ENUM: " -}}
+                {{- "ENUM:" -}}
             {{- end -}}
             {{- range $index, $element := .enum -}}
+                {{- /* Prints , ....  and return the range when it goes over the limit */ -}}
                 {{- if and (gt $limit -1) (ge $index $limit) -}}
-                    {{- /* Prints ,..  and return the range when it goes over the limit */ -}}
-                    {{- ",.." -}}
+                    {{- ", ...." -}}
                     {{- break -}}
                 {{- end -}}
                 {{- /* Use to reflect "" when we see empty string */ -}}
                 {{- $elementType := printf "%T" $element -}}
-                {{- if gt $index 0 -}} {{- ", " -}} {{- end -}}
+                {{- /* Print out either `, ` or `\n    ` based of the view */ -}}
+                {{- /* Simple view */ -}}
+                {{- if and (gt $index 0) (eq $.isLongView false) -}}
+                    {{- ", " -}}
+                {{- /* Long view */ -}}
+                {{- else if eq $.isLongView true -}}
+                    {{- "\n" -}}{{- "" | indent 4 -}}
+                {{- end -}}
+                {{- /* Convert empty string to `""` for more clarification */ -}}
                 {{- if and (eq "string" $elementType) (eq $element "") -}}
                     {{- `""` -}}
                 {{- else -}}

--- a/staging/src/k8s.io/kubectl/pkg/explain/v2/templates/plaintext.tmpl
+++ b/staging/src/k8s.io/kubectl/pkg/explain/v2/templates/plaintext.tmpl
@@ -109,9 +109,11 @@ Takes dictionary as argument with keys:
         {{- $subschema := index $resolved.properties (first $.FieldPath) -}}
         {{- if eq 1 (len $.FieldPath) -}}
             {{- /* TODO: The original explain would say RESOURCE instead of FIELD here under some circumstances */ -}}
-            FIELD: {{first $.FieldPath}} <{{ template "typeGuess" (dict "schema" $subschema "Document" $.Document) }}>{{ template "extractEnum" (dict "schema" $subschema "Document" $.Document) }}{{"\n"}}
+            FIELD: {{first $.FieldPath}} <{{ template "typeGuess" (dict "schema" $subschema "Document" $.Document) }}>{{"\n"}}
+            {{- template "extractEnum" (dict "schema" $subschema "Document" $.Document "singleView" true) -}}{{"\n"}}
             {{- "\n" -}}
         {{- end -}}
+
         {{- template "output" (set $nextContext "history" (dict) "FieldPath" (slice $.FieldPath 1) "schema" $subschema ) -}}
     {{- else if $resolved.items -}}
         {{- /* If the schema is an array then traverse the array item fields */ -}}
@@ -201,8 +203,9 @@ Takes dictionary as argument with keys:
     {{- $level := or $.level 0 -}}
     {{- $indentAmount := mul $level 2 -}}
     {{- $fieldSchema := index $.schema.properties $.name -}}
-    {{- $.name | indent $indentAmount -}}{{"\t"}}<{{ template "typeGuess" (dict "schema" $fieldSchema "Document" $.Document) }}>{{ template "extractEnum" (dict "schema" $fieldSchema "Document" $.Document) }}
+    {{- $.name | indent $indentAmount -}}{{"\t"}}<{{ template "typeGuess" (dict "schema" $fieldSchema "Document" $.Document) }}>
     {{- if contains $.schema.required $.name}} -required-{{- end -}}
+    {{- template "extractEnum" (dict "schema" $fieldSchema "Document" $.Document "singleView" false) -}}
     {{- "\n" -}}
     {{- if not $.short -}}
         {{- or $fieldSchema.description "<no description>" | wrap (sub 78 $indentAmount) | indent (add $indentAmount 2) -}}{{- "\n" -}}
@@ -284,23 +287,28 @@ Takes dictionary as argument with keys:
 
 {{- /* Check if there is any enum returns it in this format e.g.:
 
-        (enum: !=, =, =~, !~)
+        ENUM: !=, =, =~, !~
+         enum: !=, =, =~, !~
 
     Can change the style of enum in future by modifying this function
 
 Takes dictionary as argument with keys:
     schema: openapiv3 JSON schema
     Document: openapi document
+    singleView: determine if ENUM should be printed uppercase or not, used in single Field view
 */ -}}
 {{- define "extractEnum" -}}
     {{- with $.schema -}}
         {{- if .enum -}}
-            {{- " (enum: " -}}
+            {{- if $.singleView -}}
+                {{- "ENUM: " -}}
+            {{- else -}}
+                {{- " enum: " -}}
+            {{- end -}}
             {{- range $index, $element := .enum -}}
                 {{- if gt $index 0 -}} {{- ", " -}} {{- end -}}
                 {{- $element -}}
             {{- end -}}
-            {{- ")" -}}
         {{- end -}}
     {{- end -}}
 {{- end -}}

--- a/staging/src/k8s.io/kubectl/pkg/explain/v2/templates/plaintext.tmpl
+++ b/staging/src/k8s.io/kubectl/pkg/explain/v2/templates/plaintext.tmpl
@@ -109,7 +109,7 @@ Takes dictionary as argument with keys:
         {{- $subschema := index $resolved.properties (first $.FieldPath) -}}
         {{- if eq 1 (len $.FieldPath) -}}
             {{- /* TODO: The original explain would say RESOURCE instead of FIELD here under some circumstances */ -}}
-            FIELD: {{first $.FieldPath}} <{{ template "typeGuess" (dict "schema" $subschema "Document" $.Document) }}>{{"\n"}}
+            FIELD: {{first $.FieldPath}} <{{ template "typeGuess" (dict "schema" $subschema "Document" $.Document) }}>{{ template "extractEnum" (dict "schema" $subschema "Document" $.Document) }}{{"\n"}}
             {{- "\n" -}}
         {{- end -}}
         {{- template "output" (set $nextContext "history" (dict) "FieldPath" (slice $.FieldPath 1) "schema" $subschema ) -}}
@@ -201,7 +201,7 @@ Takes dictionary as argument with keys:
     {{- $level := or $.level 0 -}}
     {{- $indentAmount := mul $level 2 -}}
     {{- $fieldSchema := index $.schema.properties $.name -}}
-    {{- $.name | indent $indentAmount -}}{{"\t"}}<{{ template "typeGuess" (dict "schema" $fieldSchema "Document" $.Document) }}>
+    {{- $.name | indent $indentAmount -}}{{"\t"}}<{{ template "typeGuess" (dict "schema" $fieldSchema "Document" $.Document) }}>{{ template "extractEnum" (dict "schema" $fieldSchema "Document" $.Document) }}
     {{- if contains $.schema.required $.name}} -required-{{- end -}}
     {{- "\n" -}}
     {{- if not $.short -}}
@@ -279,5 +279,28 @@ Takes dictionary as argument with keys:
         {{- end -}}
     {{- else -}}
         {{- fail "expected schema argument to subtemplate 'typeguess'" -}}
+    {{- end -}}
+{{- end -}}
+
+{{- /* Check if there is any enum returns it in this format e.g.:
+
+        (enum: !=, =, =~, !~)
+
+    Can change the style of enum in future by modifying this function
+
+Takes dictionary as argument with keys:
+    schema: openapiv3 JSON schema
+    Document: openapi document
+*/ -}}
+{{- define "extractEnum" -}}
+    {{- with $.schema -}}
+        {{- if .enum -}}
+            {{- " (enum: " -}}
+            {{- range $index, $element := .enum -}}
+                {{- if gt $index 0 -}} {{- ", " -}} {{- end -}}
+                {{- $element -}}
+            {{- end -}}
+            {{- ")" -}}
+        {{- end -}}
     {{- end -}}
 {{- end -}}

--- a/staging/src/k8s.io/kubectl/pkg/explain/v2/templates/plaintext_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/explain/v2/templates/plaintext_test.go
@@ -673,10 +673,10 @@ func TestPlaintext(t *testing.T) {
 					"description": "a description that should not be printed",
 					"enum":        []any{0, 1, 2, 3},
 				},
-				"longFormView": false,
+				"isLongView": true,
 			},
 			Checks: []check{
-				checkEquals("ENUM: 0, 1, 2, 3"),
+				checkEquals("ENUM:\n    0\n    1\n    2\n    3"),
 			},
 		},
 		{
@@ -689,7 +689,7 @@ func TestPlaintext(t *testing.T) {
 					"description": "a description that should not be printed",
 					"enum":        []any{0, 1, 2, 3},
 				},
-				"longFormView": true,
+				"isLongView":   false,
 				"indentAmount": 2,
 			},
 			Checks: []check{
@@ -706,12 +706,12 @@ func TestPlaintext(t *testing.T) {
 					"description": "a description that should not be printed",
 					"enum":        []any{0, 1, 2, 3},
 				},
-				"longFormView": true,
+				"isLongView":   false,
 				"limit":        2,
 				"indentAmount": 2,
 			},
 			Checks: []check{
-				checkEquals("\n  enum: 0, 1,.."),
+				checkEquals("\n  enum: 0, 1, ...."),
 			},
 		},
 		{
@@ -724,12 +724,12 @@ func TestPlaintext(t *testing.T) {
 					"description": "a description that should not be printed",
 					"enum":        []any{0, 1, 2, 3},
 				},
-				"longFormView": false,
+				"isLongView":   true,
 				"limit":        2,
 				"indentAmount": 2,
 			},
 			Checks: []check{
-				checkEquals("ENUM: 0, 1,.."),
+				checkEquals("ENUM:\n    0\n    1, ...."),
 			},
 		},
 		{
@@ -742,10 +742,10 @@ func TestPlaintext(t *testing.T) {
 					"description": "a description that should not be printed",
 					"enum":        []any{"Block", "File", ""},
 				},
-				"longFormView": false,
+				"isLongView": true,
 			},
 			Checks: []check{
-				checkEquals("ENUM: Block, File, \"\""),
+				checkEquals("ENUM:\n    Block\n    File\n    \"\""),
 			},
 		},
 	}

--- a/staging/src/k8s.io/kubectl/pkg/explain/v2/templates/plaintext_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/explain/v2/templates/plaintext_test.go
@@ -650,13 +650,13 @@ func TestPlaintext(t *testing.T) {
 		},
 		{
 			// show that extractEnum can skip empty enum slice
-			Name:        "Enum",
+			Name:        "extractEmptyEnum",
 			Subtemplate: "extractEnum",
 			Context: map[string]any{
 				"schema": map[string]any{
 					"type":        "string",
 					"description": "a description that should not be printed",
-					"enum":        []int{},
+					"enum":        []any{},
 				},
 			},
 			Checks: []check{
@@ -665,34 +665,87 @@ func TestPlaintext(t *testing.T) {
 		},
 		{
 			// show that extractEnum can extract any enum slice and style it uppercase
-			Name:        "Enum",
+			Name:        "extractEnumSimpleForm",
 			Subtemplate: "extractEnum",
 			Context: map[string]any{
 				"schema": map[string]any{
 					"type":        "string",
 					"description": "a description that should not be printed",
-					"enum":        []int{1, 2, 3},
+					"enum":        []any{0, 1, 2, 3},
 				},
-				"singleView": true,
+				"longFormView": false,
 			},
 			Checks: []check{
-				checkEquals("ENUM: 1, 2, 3"),
+				checkEquals("ENUM: 0, 1, 2, 3"),
 			},
 		},
 		{
 			// show that extractEnum can extract any enum slice and style it lowercase
-			Name:        "Enum",
+			Name:        "extractEnumLongFormWithIndent",
 			Subtemplate: "extractEnum",
 			Context: map[string]any{
 				"schema": map[string]any{
 					"type":        "string",
 					"description": "a description that should not be printed",
-					"enum":        []int{1, 2, 3},
+					"enum":        []any{0, 1, 2, 3},
 				},
-				"singleView": false,
+				"longFormView": true,
+				"indentAmount": 2,
 			},
 			Checks: []check{
-				checkEquals(" enum: 1, 2, 3"),
+				checkEquals("\n  enum: 0, 1, 2, 3"),
+			},
+		},
+		{
+			// show that extractEnum can extract any enum slice and style it with truncated enums
+			Name:        "extractEnumLongFormWithLimitAndIndent",
+			Subtemplate: "extractEnum",
+			Context: map[string]any{
+				"schema": map[string]any{
+					"type":        "string",
+					"description": "a description that should not be printed",
+					"enum":        []any{0, 1, 2, 3},
+				},
+				"longFormView": true,
+				"limit":        2,
+				"indentAmount": 2,
+			},
+			Checks: []check{
+				checkEquals("\n  enum: 0, 1,.."),
+			},
+		},
+		{
+			// show that extractEnum can extract any enum slice and style it with truncated enums
+			Name:        "extractEnumSimpleFormWithLimitAndIndent",
+			Subtemplate: "extractEnum",
+			Context: map[string]any{
+				"schema": map[string]any{
+					"type":        "string",
+					"description": "a description that should not be printed",
+					"enum":        []any{0, 1, 2, 3},
+				},
+				"longFormView": false,
+				"limit":        2,
+				"indentAmount": 2,
+			},
+			Checks: []check{
+				checkEquals("ENUM: 0, 1,.."),
+			},
+		},
+		{
+			// show that extractEnum can extract any enum slice and style it with empty string
+			Name:        "extractEnumSimpleFormEmptyString",
+			Subtemplate: "extractEnum",
+			Context: map[string]any{
+				"schema": map[string]any{
+					"type":        "string",
+					"description": "a description that should not be printed",
+					"enum":        []any{"Block", "File", ""},
+				},
+				"longFormView": false,
+			},
+			Checks: []check{
+				checkEquals("ENUM: Block, File, \"\""),
 			},
 		},
 	}

--- a/staging/src/k8s.io/kubectl/pkg/explain/v2/templates/plaintext_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/explain/v2/templates/plaintext_test.go
@@ -656,7 +656,7 @@ func TestPlaintext(t *testing.T) {
 				"schema": map[string]any{
 					"type":        "string",
 					"description": "a description that should not be printed",
-					"enum": []any{},
+					"enum":        []int{},
 				},
 			},
 			Checks: []check{
@@ -671,9 +671,9 @@ func TestPlaintext(t *testing.T) {
 				"schema": map[string]any{
 					"type":        "string",
 					"description": "a description that should not be printed",
-					"enum": []any{1, 2, 3},
+					"enum":        []int{1, 2, 3},
 				},
-				"singleView":  true,
+				"singleView": true,
 			},
 			Checks: []check{
 				checkEquals("ENUM: 1, 2, 3"),
@@ -687,9 +687,9 @@ func TestPlaintext(t *testing.T) {
 				"schema": map[string]any{
 					"type":        "string",
 					"description": "a description that should not be printed",
-					"enum": []any{1, 2, 3},
+					"enum":        []int{1, 2, 3},
 				},
-				"singleView":  false,
+				"singleView": false,
 			},
 			Checks: []check{
 				checkEquals(" enum: 1, 2, 3"),

--- a/staging/src/k8s.io/kubectl/pkg/explain/v2/templates/plaintext_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/explain/v2/templates/plaintext_test.go
@@ -656,7 +656,7 @@ func TestPlaintext(t *testing.T) {
 				"schema": map[string]any{
 					"type":        "string",
 					"description": "a description that should not be printed",
-					"enum": []string{},
+					"enum": []any{},
 				},
 			},
 			Checks: []check{
@@ -664,33 +664,35 @@ func TestPlaintext(t *testing.T) {
 			},
 		},
 		{
-			// show that extractEnum can extract string enum and style it
+			// show that extractEnum can extract any enum slice and style it uppercase
 			Name:        "Enum",
 			Subtemplate: "extractEnum",
 			Context: map[string]any{
 				"schema": map[string]any{
 					"type":        "string",
 					"description": "a description that should not be printed",
-					"enum": []string{"!=", "!", "=="},
+					"enum": []any{1, 2, 3},
 				},
+				"singleView":  true,
 			},
 			Checks: []check{
-				checkEquals(" (enum: !=, !, ==)"),
+				checkEquals("ENUM: 1, 2, 3"),
 			},
 		},
 		{
-			// show that extractEnum can extract integer enum and style it
+			// show that extractEnum can extract any enum slice and style it lowercase
 			Name:        "Enum",
 			Subtemplate: "extractEnum",
 			Context: map[string]any{
 				"schema": map[string]any{
 					"type":        "string",
 					"description": "a description that should not be printed",
-					"enum": []int{1, 2, 3},
+					"enum": []any{1, 2, 3},
 				},
+				"singleView":  false,
 			},
 			Checks: []check{
-				checkEquals(" (enum: 1, 2, 3)"),
+				checkEquals(" enum: 1, 2, 3"),
 			},
 		},
 	}

--- a/staging/src/k8s.io/kubectl/pkg/explain/v2/templates/plaintext_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/explain/v2/templates/plaintext_test.go
@@ -648,6 +648,51 @@ func TestPlaintext(t *testing.T) {
 				checkEquals("          thefield\t<string> -required-\n"),
 			},
 		},
+		{
+			// show that extractEnum can skip empty enum slice
+			Name:        "Enum",
+			Subtemplate: "extractEnum",
+			Context: map[string]any{
+				"schema": map[string]any{
+					"type":        "string",
+					"description": "a description that should not be printed",
+					"enum": []string{},
+				},
+			},
+			Checks: []check{
+				checkEquals(""),
+			},
+		},
+		{
+			// show that extractEnum can extract string enum and style it
+			Name:        "Enum",
+			Subtemplate: "extractEnum",
+			Context: map[string]any{
+				"schema": map[string]any{
+					"type":        "string",
+					"description": "a description that should not be printed",
+					"enum": []string{"!=", "!", "=="},
+				},
+			},
+			Checks: []check{
+				checkEquals(" (enum: !=, !, ==)"),
+			},
+		},
+		{
+			// show that extractEnum can extract integer enum and style it
+			Name:        "Enum",
+			Subtemplate: "extractEnum",
+			Context: map[string]any{
+				"schema": map[string]any{
+					"type":        "string",
+					"description": "a description that should not be printed",
+					"enum": []int{1, 2, 3},
+				},
+			},
+			Checks: []check{
+				checkEquals(" (enum: 1, 2, 3)"),
+			},
+		},
 	}
 
 	tmpl, err := v2.WithBuiltinTemplateFuncs(template.New("")).Parse(plaintextSource)
@@ -668,6 +713,7 @@ func TestPlaintext(t *testing.T) {
 			} else {
 				outputErr = tmpl.ExecuteTemplate(buf, tcase.Subtemplate, tcase.Context)
 			}
+			fmt.Println(outputErr)
 
 			output := buf.String()
 			for _, check := range tcase.Checks {

--- a/staging/src/k8s.io/kubectl/pkg/explain/v2/templates/plaintext_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/explain/v2/templates/plaintext_test.go
@@ -713,7 +713,6 @@ func TestPlaintext(t *testing.T) {
 			} else {
 				outputErr = tmpl.ExecuteTemplate(buf, tcase.Subtemplate, tcase.Context)
 			}
-			fmt.Println(outputErr)
 
 			output := buf.String()
 			for _, check := range tcase.Checks {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Show enum values in kubectl explain if they were defined. Changes are:
1. Add `extractEnum` function to kubectl explain template(plaintext.tmpl) to extract enum from schema and style it like `(enum: !=, =, =~, !~)`
2. Add tests in plaintext_test.go to verify that this new function works fine
3. Use the function in two parts of plaintext.tmpl after field definitions to show messages like this: 
`FIELD:    matchType <string> (enum: !=, =, =~, !~)`
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubectl/issues/1538

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Show enum values in kubectl explain if they were defined
```

