### PR TITLE
Write warning headers using safe writer

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/header.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/header.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package filters
+
+import (
+	"net/http"
+
+	"k8s.io/apiserver/pkg/header"
+)
+
+// WithSafeHeaderWriter adds an interface for setting response headers that is threadsafe and can be frozen
+func WithSafeHeaderWriter(handler http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := header.WithSafeHeaderWriter(r.Context(), w.Header())
+		r = r.WithContext(ctx)
+		handler.ServeHTTP(w, r)
+	})
+}

--- a/staging/src/k8s.io/apiserver/pkg/header/context.go
+++ b/staging/src/k8s.io/apiserver/pkg/header/context.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package header
+
+import (
+	"context"
+	"net/http"
+	"sync"
+)
+
+// The key type is unexported to prevent collisions
+type key int
+
+const (
+	// headerAccessorKey is the context key for the header accessor.
+	headerAccessorKey key = iota
+)
+
+type Header interface {
+	// Add adds or appends the given key/value
+	Add(key, value string)
+	// Set replaces the given key/value
+	Set(key, value string)
+	// Del removes any headers for key
+	Del(key string)
+	// Detach prevents future Add/Set/Del calls from propagating
+	// to the shared header set (makes them local-only).
+	Detach()
+}
+
+type header struct {
+	mu       sync.Mutex
+	detached bool
+	header   http.Header
+}
+
+func (h *header) Add(key, value string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.header.Add(key, value)
+}
+func (h *header) Set(key, value string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.header.Set(key, value)
+}
+func (h *header) Del(key string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.header.Del(key)
+}
+func (h *header) Detach() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if !h.detached {
+		h.detached = true
+		h.header = h.header.Clone()
+	}
+}
+
+// WithSafeHeaderWriter adds an interface for setting response headers that is threadsafe.
+func WithSafeHeaderWriter(ctx context.Context, h http.Header) context.Context {
+	return context.WithValue(ctx, headerAccessorKey, &header{header: h})
+}
+
+// SafeResponseHeader returns an interface for setting response headers that is threadsafe.
+// If no instance is registered into the context, (nil, false) is returned.
+func SafeResponseHeader(ctx context.Context) (Header, bool) {
+	accessor, ok := ctx.Value(headerAccessorKey).(*header)
+	return accessor, ok
+}

--- a/staging/src/k8s.io/apiserver/pkg/server/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config.go
@@ -1040,6 +1040,7 @@ func DefaultBuildHandlerChain(apiHandler http.Handler, c *Config) http.Handler {
 	handler = genericapifilters.WithMuxAndDiscoveryComplete(handler, c.lifecycleSignals.MuxAndDiscoveryComplete.Signaled())
 	handler = genericfilters.WithPanicRecovery(handler, c.RequestInfoResolver)
 	handler = genericapifilters.WithAuditInit(handler)
+	handler = genericapifilters.WithSafeHeaderWriter(handler)
 	return handler
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1447,6 +1447,7 @@ k8s.io/apiserver/pkg/endpoints/request
 k8s.io/apiserver/pkg/endpoints/responsewriter
 k8s.io/apiserver/pkg/endpoints/warning
 k8s.io/apiserver/pkg/features
+k8s.io/apiserver/pkg/header
 k8s.io/apiserver/pkg/quota/v1
 k8s.io/apiserver/pkg/quota/v1/generic
 k8s.io/apiserver/pkg/reconcilers


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Change warning header writes to use a thread-safe writer that can be frozen in the timeout path.

#### Which issue(s) this PR fixes:
Fixes #122940

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kube-apiserver: fixes race condition that can cause panics if warning headers are written during a request timeout
```

/cc @dims 