### PR TITLE
Update in-tree vSphere tests

### DIFF
--- a/test/e2e/storage/drivers/in_tree.go
+++ b/test/e2e/storage/drivers/in_tree.go
@@ -1182,14 +1182,7 @@ type vSphereDriver struct {
 	driverInfo storageframework.DriverInfo
 }
 
-type vSphereVolume struct {
-	volumePath string
-}
-
 var _ storageframework.TestDriver = &vSphereDriver{}
-var _ storageframework.PreprovisionedVolumeTestDriver = &vSphereDriver{}
-var _ storageframework.InlineVolumeTestDriver = &vSphereDriver{}
-var _ storageframework.PreprovisionedPVTestDriver = &vSphereDriver{}
 var _ storageframework.DynamicPVTestDriver = &vSphereDriver{}
 
 // InitVSphereDriver returns vSphereDriver that implements TestDriver interface
@@ -1220,56 +1213,13 @@ func InitVSphereDriver() storageframework.TestDriver {
 		},
 	}
 }
+
 func (v *vSphereDriver) GetDriverInfo() *storageframework.DriverInfo {
 	return &v.driverInfo
 }
 
 func (v *vSphereDriver) SkipUnsupportedTest(pattern storageframework.TestPattern) {
 	e2eskipper.SkipUnlessProviderIs("vsphere")
-}
-
-func (v *vSphereDriver) GetVolumeSource(readOnly bool, fsType string, e2evolume storageframework.TestVolume) *v1.VolumeSource {
-	vsv, ok := e2evolume.(*vSphereVolume)
-	if !ok {
-		framework.Failf("Failed to cast test volume of type %T to the cSphere test volume", e2evolume)
-	}
-
-	// vSphere driver doesn't seem to support readOnly volume
-	// TODO: check if it is correct
-	if readOnly {
-		return nil
-	}
-	volSource := v1.VolumeSource{
-		VsphereVolume: &v1.VsphereVirtualDiskVolumeSource{
-			VolumePath: vsv.volumePath,
-		},
-	}
-	if fsType != "" {
-		volSource.VsphereVolume.FSType = fsType
-	}
-	return &volSource
-}
-
-func (v *vSphereDriver) GetPersistentVolumeSource(readOnly bool, fsType string, e2evolume storageframework.TestVolume) (*v1.PersistentVolumeSource, *v1.VolumeNodeAffinity) {
-	vsv, ok := e2evolume.(*vSphereVolume)
-	if !ok {
-		framework.Failf("Failed to cast test volume of type %T to the vSphere test volume", e2evolume)
-	}
-
-	// vSphere driver doesn't seem to support readOnly volume
-	// TODO: check if it is correct
-	if readOnly {
-		return nil, nil
-	}
-	pvSource := v1.PersistentVolumeSource{
-		VsphereVolume: &v1.VsphereVirtualDiskVolumeSource{
-			VolumePath: vsv.volumePath,
-		},
-	}
-	if fsType != "" {
-		pvSource.VsphereVolume.FSType = fsType
-	}
-	return &pvSource, nil
 }
 
 func (v *vSphereDriver) GetDynamicProvisionStorageClass(ctx context.Context, config *storageframework.PerTestConfig, fsType string) *storagev1.StorageClass {
@@ -1289,13 +1239,6 @@ func (v *vSphereDriver) PrepareTest(ctx context.Context, f *framework.Framework)
 		Prefix:    "vsphere",
 		Framework: f,
 	}
-}
-
-func (v *vSphereDriver) CreateVolume(ctx context.Context, config *storageframework.PerTestConfig, volType storageframework.TestVolType) storageframework.TestVolume {
-	return &vSphereVolume{}
-}
-
-func (v *vSphereVolume) DeleteVolume(ctx context.Context) {
 }
 
 // Azure Disk


### PR DESCRIPTION
### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Don't implement interfaces that trigger tests with in-line and pre-provisioned vSphere volumes.

With cloud provider removal in https://github.com/kubernetes/kubernetes/pull/122937, the e2e tests won't be able to create a volume in vSphere and thus test in-line volumes in Pods and pre-provisioned PVs. Only dynamically provisioned volumes can be used for testing, because they're provisioned by the vSphere CSI driver.

#### Which issue(s) this PR fixes:
Related to https://github.com/kubernetes/kubernetes/pull/122937

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
