### PR TITLE
Automated cherry pick of #123038: Fix deprecated version for pod_scheduling_duration_seconds

### DIFF
--- a/pkg/scheduler/metrics/metrics.go
+++ b/pkg/scheduler/metrics/metrics.go
@@ -124,7 +124,7 @@ var (
 			// Start with 10ms with the last bucket being [~88m, Inf).
 			Buckets:           metrics.ExponentialBuckets(0.01, 2, 20),
 			StabilityLevel:    metrics.STABLE,
-			DeprecatedVersion: "1.28.0",
+			DeprecatedVersion: "1.29.0",
 		},
 		[]string{"attempts"})
 


### PR DESCRIPTION
Cherry pick of #123038 on release-1.29.

#123038: Fix deprecated version for pod_scheduling_duration_seconds

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```