### PR TITLE
Automated cherry pick of #123038: Fix deprecated version for pod_scheduling_duration_seconds

### DIFF
--- a/pkg/scheduler/metrics/metrics.go
+++ b/pkg/scheduler/metrics/metrics.go
@@ -124,7 +124,7 @@ var (
 			// Start with 10ms with the last bucket being [~88m, Inf).
 			Buckets:           metrics.ExponentialBuckets(0.01, 2, 20),
 			StabilityLevel:    metrics.STABLE,
-			DeprecatedVersion: "1.28.0",
+			DeprecatedVersion: "1.29.0",
 		},
 		[]string{"attempts"})
 

--- a/test/instrumentation/testdata/stable-metrics-list.yaml
+++ b/test/instrumentation/testdata/stable-metrics-list.yaml
@@ -529,7 +529,7 @@
   help: E2e latency for a pod being scheduled which may include multiple scheduling
     attempts.
   type: Histogram
-  deprecatedVersion: 1.28.0
+  deprecatedVersion: 1.29.0
   stabilityLevel: STABLE
   labels:
   - attempts


### PR DESCRIPTION
Cherry pick of #123038 on release-1.29.

#123038: Fix deprecated version for pod_scheduling_duration_seconds

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fix 1.29.0 regression to correctly set deprecated version for pod_scheduling_duration_seconds that caused the metric to be hidden by default in 1.29.
```