### PR TITLE
Refactor Code to Remove Deprecated `PollImmediate` in `test/e2e/network`

### DIFF
--- a/test/e2e/network/dns.go
+++ b/test/e2e/network/dns.go
@@ -532,7 +532,7 @@ var _ = common.SIGDescribe("DNS", func() {
 		// - Custom search path is appended.
 		// - DNS query is sent to the specified server.
 		cmd = []string{"dig", "+short", "+search", testDNSNameShort}
-		digFunc := func() (bool, error) {
+		digFunc := func(ctx context.Context) (bool, error) {
 			stdout, stderr, err := e2epod.ExecWithOptions(f, e2epod.ExecOptions{
 				Command:       cmd,
 				Namespace:     f.Namespace.Name,
@@ -552,7 +552,7 @@ var _ = common.SIGDescribe("DNS", func() {
 			}
 			return true, nil
 		}
-		err = wait.PollImmediate(5*time.Second, 3*time.Minute, digFunc)
+		err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 3*time.Minute, true, digFunc)
 		framework.ExpectNoError(err, "failed to verify customized name server and search path")
 
 		// TODO: Add more test cases for other DNSPolicies.

--- a/test/e2e/network/dns_common.go
+++ b/test/e2e/network/dns_common.go
@@ -92,10 +92,12 @@ func (t *dnsTestCommon) init(ctx context.Context) {
 func (t *dnsTestCommon) checkDNSRecordFrom(name string, predicate func([]string) bool, target string, timeout time.Duration) {
 	var actual []string
 
-	err := wait.PollImmediate(
+	err := wait.PollUntilContextTimeout(
+		context.Background(),
 		time.Duration(1)*time.Second,
 		timeout,
-		func() (bool, error) {
+		true,
+		func(ctx context.Context) (bool, error) {
 			actual = t.runDig(name, target)
 			if predicate(actual) {
 				return true, nil

--- a/test/e2e/network/dual_stack.go
+++ b/test/e2e/network/dual_stack.go
@@ -272,15 +272,16 @@ var _ = common.SIGDescribe(feature.IPv6DualStack, func() {
 		validateServiceAndClusterIPFamily(svc, expectedFamilies, &expectedPolicy)
 
 		// ensure endpoint belong to same ipfamily as service
-		if err := wait.PollImmediate(500*time.Millisecond, 10*time.Second, func() (bool, error) {
-			endpoint, err := cs.CoreV1().Endpoints(svc.Namespace).Get(ctx, svc.Name, metav1.GetOptions{})
-			if err != nil {
-				return false, nil
-			}
-			validateEndpointsBelongToIPFamily(svc, endpoint, expectedFamilies[0] /*endpoint controller works on primary ip*/)
+		if err := wait.PollUntilContextTimeout(ctx, 500*time.Millisecond, 10*time.Second, true,
+			func(ctx context.Context) (bool, error) {
+				endpoint, err := cs.CoreV1().Endpoints(svc.Namespace).Get(ctx, svc.Name, metav1.GetOptions{})
+				if err != nil {
+					return false, nil
+				}
+				validateEndpointsBelongToIPFamily(svc, endpoint, expectedFamilies[0] /*endpoint controller works on primary ip*/)
 
-			return true, nil
-		}); err != nil {
+				return true, nil
+			}); err != nil {
 			framework.Failf("Get endpoints for service %s/%s failed (%s)", svc.Namespace, svc.Name, err)
 		}
 	})
@@ -318,14 +319,15 @@ var _ = common.SIGDescribe(feature.IPv6DualStack, func() {
 		validateServiceAndClusterIPFamily(svc, expectedFamilies, &expectedPolicy)
 
 		// ensure endpoints belong to same ipfamily as service
-		if err := wait.PollImmediate(500*time.Millisecond, 10*time.Second, func() (bool, error) {
-			endpoint, err := cs.CoreV1().Endpoints(svc.Namespace).Get(ctx, svc.Name, metav1.GetOptions{})
-			if err != nil {
-				return false, nil
-			}
-			validateEndpointsBelongToIPFamily(svc, endpoint, expectedFamilies[0] /* endpoint controller operates on primary ip */)
-			return true, nil
-		}); err != nil {
+		if err := wait.PollUntilContextTimeout(context.Background(), 500*time.Millisecond, 10*time.Second, true,
+			func(ctx context.Context) (bool, error) {
+				endpoint, err := cs.CoreV1().Endpoints(svc.Namespace).Get(ctx, svc.Name, metav1.GetOptions{})
+				if err != nil {
+					return false, nil
+				}
+				validateEndpointsBelongToIPFamily(svc, endpoint, expectedFamilies[0] /* endpoint controller operates on primary ip */)
+				return true, nil
+			}); err != nil {
 			framework.Failf("Get endpoints for service %s/%s failed (%s)", svc.Namespace, svc.Name, err)
 		}
 	})
@@ -363,14 +365,15 @@ var _ = common.SIGDescribe(feature.IPv6DualStack, func() {
 		validateServiceAndClusterIPFamily(svc, expectedFamilies, &expectedPolicy)
 
 		// ensure endpoints belong to same ipfamily as service
-		if err := wait.PollImmediate(500*time.Millisecond, 10*time.Second, func() (bool, error) {
-			endpoint, err := cs.CoreV1().Endpoints(svc.Namespace).Get(ctx, svc.Name, metav1.GetOptions{})
-			if err != nil {
-				return false, nil
-			}
-			validateEndpointsBelongToIPFamily(svc, endpoint, ipv6)
-			return true, nil
-		}); err != nil {
+		if err := wait.PollUntilContextTimeout(context.Background(), 500*time.Millisecond, 10*time.Second, true,
+			func(ctx context.Context) (bool, error) {
+				endpoint, err := cs.CoreV1().Endpoints(svc.Namespace).Get(ctx, svc.Name, metav1.GetOptions{})
+				if err != nil {
+					return false, nil
+				}
+				validateEndpointsBelongToIPFamily(svc, endpoint, ipv6)
+				return true, nil
+			}); err != nil {
 			framework.Failf("Get endpoints for service %s/%s failed (%s)", svc.Namespace, svc.Name, err)
 		}
 	})
@@ -408,14 +411,15 @@ var _ = common.SIGDescribe(feature.IPv6DualStack, func() {
 		validateServiceAndClusterIPFamily(svc, expectedFamilies, &expectedPolicy)
 
 		// ensure endpoints belong to same ipfamily as service
-		if err := wait.PollImmediate(500*time.Millisecond, 10*time.Second, func() (bool, error) {
-			endpoint, err := cs.CoreV1().Endpoints(svc.Namespace).Get(ctx, svc.Name, metav1.GetOptions{})
-			if err != nil {
-				return false, nil
-			}
-			validateEndpointsBelongToIPFamily(svc, endpoint, expectedFamilies[0] /* endpoint controller operates on primary ip */)
-			return true, nil
-		}); err != nil {
+		if err := wait.PollUntilContextTimeout(context.Background(), 500*time.Millisecond, 10*time.Second, true,
+			func(ctx context.Context) (bool, error) {
+				endpoint, err := cs.CoreV1().Endpoints(svc.Namespace).Get(ctx, svc.Name, metav1.GetOptions{})
+				if err != nil {
+					return false, nil
+				}
+				validateEndpointsBelongToIPFamily(svc, endpoint, expectedFamilies[0] /* endpoint controller operates on primary ip */)
+				return true, nil
+			}); err != nil {
 			framework.Failf("Get endpoints for service %s/%s failed (%s)", svc.Namespace, svc.Name, err)
 		}
 	})
@@ -453,14 +457,15 @@ var _ = common.SIGDescribe(feature.IPv6DualStack, func() {
 		validateServiceAndClusterIPFamily(svc, expectedFamilies, &expectedPolicy)
 
 		// ensure endpoints belong to same ipfamily as service
-		if err := wait.PollImmediate(500*time.Millisecond, 10*time.Second, func() (bool, error) {
-			endpoint, err := cs.CoreV1().Endpoints(svc.Namespace).Get(ctx, svc.Name, metav1.GetOptions{})
-			if err != nil {
-				return false, nil
-			}
-			validateEndpointsBelongToIPFamily(svc, endpoint, expectedFamilies[0] /* endpoint controller operates on primary ip */)
-			return true, nil
-		}); err != nil {
+		if err := wait.PollUntilContextTimeout(context.Background(), 500*time.Millisecond, 10*time.Second, true,
+			func(ctx context.Context) (bool, error) {
+				endpoint, err := cs.CoreV1().Endpoints(svc.Namespace).Get(ctx, svc.Name, metav1.GetOptions{})
+				if err != nil {
+					return false, nil
+				}
+				validateEndpointsBelongToIPFamily(svc, endpoint, expectedFamilies[0] /* endpoint controller operates on primary ip */)
+				return true, nil
+			}); err != nil {
 			framework.Failf("Get endpoints for service %s/%s failed (%s)", svc.Namespace, svc.Name, err)
 		}
 	})

--- a/test/e2e/network/netpol/kubemanager.go
+++ b/test/e2e/network/netpol/kubemanager.go
@@ -186,15 +186,15 @@ func (k *kubeManager) probeConnectivity(args *probeConnectivityArgs) (bool, stri
 	var probeError error
 	var stderr string
 
-	// Instead of re-running the job on connectivity failure, the following conditionFunc when passed to PollImmediate, reruns
-	// the job when the observed value don't match the expected value, so we don't rely on return value of PollImmediate, we
+	// Instead of re-running the job on connectivity failure, the following conditionFunc when passed to PollUntilContextTimeout, reruns
+	// the job when the observed value don't match the expected value, so we don't rely on return value of PollUntilContextTimeout, we
 	// simply discard it and use probeError, defined outside scope of conditionFunc, for returning the result of probeConnectivity.
-	conditionFunc := func() (bool, error) {
+	conditionFunc := func(ctx context.Context) (bool, error) {
 		_, stderr, probeError = k.executeRemoteCommand(args.nsFrom, args.podFrom, args.containerFrom, cmd)
 		// retry should only occur if expected and observed value don't match.
 		if args.expectConnectivity {
 			if probeError != nil {
-				// since we expect connectivity here, we fail the condition for PollImmediate to reattempt the probe.
+				// since we expect connectivity here, we fail the condition for PollUntilContextTimeout to reattempt the probe.
 				// this happens in the cases where network is congested, we don't have any policy rejecting traffic
 				// from "podFrom" to "podTo" and probes from "podFrom" to "podTo" are failing.
 				framework.Logf("probe #%d :: connectivity expected :: %s/%s -> %s :: stderr - %s",
@@ -211,7 +211,7 @@ func (k *kubeManager) probeConnectivity(args *probeConnectivityArgs) (bool, stri
 				// we got the expected results, exit immediately.
 				return true, nil
 			} else {
-				// since we don't expect connectivity here, we fail the condition for PollImmediate to reattempt the probe.
+				// since we don't expect connectivity here, we fail the condition for PollUntilContextTimeout to reattempt the probe.
 				// this happens in the cases where we have policy rejecting traffic from "podFrom" to "podTo", but CNI takes
 				// time to implement the policy and probe from "podFrom" to "podTo" was successful in that window.
 				framework.Logf(" probe #%d :: connectivity not expected :: %s/%s -> %s",
@@ -223,10 +223,12 @@ func (k *kubeManager) probeConnectivity(args *probeConnectivityArgs) (bool, stri
 		}
 	}
 
-	// ignore the result of PollImmediate, we are only concerned with probeError.
-	_ = wait.PollImmediate(
+	// ignore the result of PollUntilContextTimeout, we are only concerned with probeError.
+	_ = wait.PollUntilContextTimeout(
+		context.Background(),
 		time.Duration(args.pollIntervalSeconds)*time.Second,
 		time.Duration(args.pollTimeoutSeconds)*time.Second,
+		true,
 		conditionFunc,
 	)
 

--- a/test/e2e/network/network_tiers.go
+++ b/test/e2e/network/network_tiers.go
@@ -180,14 +180,15 @@ func waitAndVerifyLBWithTier(ctx context.Context, jig *e2eservice.TestJig, exist
 func getLBNetworkTierByIP(ip string) (cloud.NetworkTier, error) {
 	var rule *compute.ForwardingRule
 	// Retry a few times to tolerate flakes.
-	err := wait.PollImmediate(5*time.Second, 15*time.Second, func() (bool, error) {
-		obj, err := getGCEForwardingRuleByIP(ip)
-		if err != nil {
-			return false, err
-		}
-		rule = obj
-		return true, nil
-	})
+	err := wait.PollUntilContextTimeout(context.Background(), 5*time.Second, 15*time.Second, true,
+		func(ctx context.Context) (bool, error) {
+			obj, err := getGCEForwardingRuleByIP(ip)
+			if err != nil {
+				return false, err
+			}
+			rule = obj
+			return true, nil
+		})
 	if err != nil {
 		return "", err
 	}

--- a/test/e2e/network/proxy.go
+++ b/test/e2e/network/proxy.go
@@ -353,7 +353,9 @@ var _ = common.SIGDescribe("Proxy", func() {
 				urlString := strings.TrimRight(f.ClientConfig().Host, "/") + "/api/v1/namespaces/" + ns + "/pods/agnhost/proxy/some/path/with/" + httpVerb
 				framework.Logf("Starting http.Client for %s", urlString)
 
-				pollErr := wait.PollImmediate(requestRetryPeriod, requestRetryTimeout, validateProxyVerbRequest(client, urlString, httpVerb, msg))
+				pollErr := wait.PollUntilContextTimeout(ctx, requestRetryPeriod, requestRetryTimeout, true,
+					validateProxyVerbRequest(client, urlString, httpVerb, msg))
+
 				framework.ExpectNoError(err, "Service didn't start within time out period. %v", pollErr)
 			}
 
@@ -364,7 +366,8 @@ var _ = common.SIGDescribe("Proxy", func() {
 				urlString := strings.TrimRight(f.ClientConfig().Host, "/") + "/api/v1/namespaces/" + ns + "/services/test-service/proxy/some/path/with/" + httpVerb
 				framework.Logf("Starting http.Client for %s", urlString)
 
-				pollErr := wait.PollImmediate(requestRetryPeriod, requestRetryTimeout, validateProxyVerbRequest(client, urlString, httpVerb, msg))
+				pollErr := wait.PollUntilContextTimeout(ctx, requestRetryPeriod, requestRetryTimeout, true,
+					validateProxyVerbRequest(client, urlString, httpVerb, msg))
 				framework.ExpectNoError(err, "Service didn't start within time out period. %v", pollErr)
 			}
 		})
@@ -447,7 +450,8 @@ var _ = common.SIGDescribe("Proxy", func() {
 				urlString := strings.TrimRight(f.ClientConfig().Host, "/") + "/api/v1/namespaces/" + ns + "/pods/agnhost/proxy?method=" + httpVerb
 				framework.Logf("Starting http.Client for %s", urlString)
 
-				pollErr := wait.PollImmediate(requestRetryPeriod, requestRetryTimeout, validateProxyVerbRequest(client, urlString, httpVerb, msg))
+				pollErr := wait.PollUntilContextTimeout(ctx, requestRetryPeriod, requestRetryTimeout, true,
+					validateProxyVerbRequest(client, urlString, httpVerb, msg))
 				framework.ExpectNoError(pollErr, "Pod didn't start within time out period. %v", pollErr)
 			}
 
@@ -458,7 +462,8 @@ var _ = common.SIGDescribe("Proxy", func() {
 				urlString := strings.TrimRight(f.ClientConfig().Host, "/") + "/api/v1/namespaces/" + ns + "/services/" + testSvcName + "/proxy?method=" + httpVerb
 				framework.Logf("Starting http.Client for %s", urlString)
 
-				pollErr := wait.PollImmediate(requestRetryPeriod, requestRetryTimeout, validateProxyVerbRequest(client, urlString, httpVerb, msg))
+				pollErr := wait.PollUntilContextTimeout(ctx, requestRetryPeriod, requestRetryTimeout, true,
+					validateProxyVerbRequest(client, urlString, httpVerb, msg))
 				framework.ExpectNoError(pollErr, "Service didn't start within time out period. %v", pollErr)
 			}
 
@@ -491,8 +496,8 @@ func validateRedirectRequest(client *http.Client, redirectVerb string, urlString
 // validateProxyVerbRequest checks that a http request to a pod
 // or service was valid for any http verb. Requires agnhost image
 // with porter --json-response
-func validateProxyVerbRequest(client *http.Client, urlString string, httpVerb string, msg string) func() (bool, error) {
-	return func() (bool, error) {
+func validateProxyVerbRequest(client *http.Client, urlString string, httpVerb string, msg string) func(ctx context.Context) (bool, error) {
+	return func(ctx context.Context) (bool, error) {
 		var err error
 
 		request, err := http.NewRequest(httpVerb, urlString, nil)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Refactor code to use `PollUntilContextTimeout` replacing deprecated `PolImmediate`.

#### Which issue(s) this PR fixes:

Related: #122800

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
