### PR TITLE
Automated cherry pick of #122750: Add processStartTime in metrics/slis

### DIFF
--- a/staging/src/k8s.io/component-base/metrics/prometheus/slis/metrics.go
+++ b/staging/src/k8s.io/component-base/metrics/prometheus/slis/metrics.go
@@ -57,6 +57,7 @@ var (
 func Register(registry k8smetrics.KubeRegistry) {
 	registry.Register(healthcheck)
 	registry.Register(healthchecksTotal)
+	_ = k8smetrics.RegisterProcessStartTime(registry.Register)
 }
 
 func ResetHealthMetrics() {


### PR DESCRIPTION
Cherry pick of #122750 on release-1.28.

#122750: Add processStartTime in metrics/slis

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```