### PR TITLE
Make pkg/volume/fc unit tests more hermetic

### DIFF
--- a/pkg/volume/fc/fc_util_test.go
+++ b/pkg/volume/fc/fc_util_test.go
@@ -116,6 +116,10 @@ func (handler *fakeIOHandler) WriteFile(filename string, data []byte, perm os.Fi
 	return nil
 }
 
+func (handler *fakeIOHandler) ReadFile(filename string) ([]byte, error) {
+	return nil, nil
+}
+
 func TestSearchDisk(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -164,7 +168,7 @@ func TestSearchDisk(t *testing.T) {
 					lun:  test.lun,
 					io:   &fakeIOHandler{},
 				},
-				deviceUtil: util.NewDeviceHandler(util.NewIOHandler()),
+				deviceUtil: util.NewDeviceHandler(&fakeIOHandler{}),
 			}
 			devicePath, err := searchDisk(fakeMounter)
 			if test.expectError && err == nil {


### PR DESCRIPTION
In pkg/volume/fc the unit test 'TestSearchDisk' uses a normal device handler, which causes the local system to be searched for multipath devices. This results in test failures when a match is unexpectedly found, with errors like:
`fc_util_test.go: matching wrong disk, expected: /dev/sdb, actual: /dev/dm-6`

To prevent this, pass a fake IO handler to util.NewDeviceHandler() in the unit test.

#### What type of PR is this?

/kind bug
/kind failing-test

#### What this PR does / why we need it:

Fixes a unit test that fails in some host-system-specific circumstances due to not being 100% hermetic.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.: