### PR TITLE
Cherry pick of #123003 and #123082: bugfix: dont skip reconcile for unchanged policy if last sync

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/validatingadmissionpolicy/controller_reconcile.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/validatingadmissionpolicy/controller_reconcile.go
@@ -180,8 +180,9 @@ func (c *policyController) reconcilePolicyDefinitionSpec(namespace, name string,
 		celmetrics.Metrics.ObserveDefinition(context.TODO(), "active", "deny")
 	}
 
-	// Skip reconcile if the spec of the definition is unchanged
-	if info.lastReconciledValue != nil && definition != nil &&
+	// Skip reconcile if the spec of the definition is unchanged and had a
+	// successful previous sync
+	if info.configurationError == nil && info.lastReconciledValue != nil && definition != nil &&
 		apiequality.Semantic.DeepEqual(info.lastReconciledValue.Spec, definition.Spec) {
 		return nil
 	}

--- a/test/integration/apiserver/cel/validatingadmissionpolicy_test.go
+++ b/test/integration/apiserver/cel/validatingadmissionpolicy_test.go
@@ -2533,9 +2533,7 @@ func TestCRDsOnStartup(t *testing.T) {
 	// Start the server.
 	server = apiservertesting.StartTestServerOrDie(
 		t,
-		&apiservertesting.TestServerInstanceOptions{
-			SkipHealthzCheck: true,
-		},
+		&apiservertesting.TestServerInstanceOptions{},
 		[]string{
 			"--enable-admission-plugins", "ValidatingAdmissionPolicy",
 			"--authorization-mode=RBAC",


### PR DESCRIPTION
Cherry pick of #123003 and #123082 on release-1.29.

#123003: bugfix: dont skip reconcile for unchanged policy if last sync
#123082: test: remove unnecessary skip healthz check from test

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fixed a bug in ValidatingAdmissionPolicy that caused policies which were using CRD parameters to fail to synchronize
```

I think this is a very low risk but impactful bugfix for VAP which is in beta but not enabled by default in 1.29.