### PR TITLE
Job: Stop unnecessary string casts in validations

### DIFF
--- a/pkg/apis/batch/validation/validation.go
+++ b/pkg/apis/batch/validation/validation.go
@@ -64,23 +64,23 @@ const (
 
 var (
 	supportedPodFailurePolicyActions = sets.New(
-		string(batch.PodFailurePolicyActionCount),
-		string(batch.PodFailurePolicyActionFailIndex),
-		string(batch.PodFailurePolicyActionFailJob),
-		string(batch.PodFailurePolicyActionIgnore))
+		batch.PodFailurePolicyActionCount,
+		batch.PodFailurePolicyActionFailIndex,
+		batch.PodFailurePolicyActionFailJob,
+		batch.PodFailurePolicyActionIgnore)
 
 	supportedPodFailurePolicyOnExitCodesOperator = sets.New(
-		string(batch.PodFailurePolicyOnExitCodesOpIn),
-		string(batch.PodFailurePolicyOnExitCodesOpNotIn))
+		batch.PodFailurePolicyOnExitCodesOpIn,
+		batch.PodFailurePolicyOnExitCodesOpNotIn)
 
 	supportedPodFailurePolicyOnPodConditionsStatus = sets.New(
-		string(api.ConditionFalse),
-		string(api.ConditionTrue),
-		string(api.ConditionUnknown))
+		api.ConditionFalse,
+		api.ConditionTrue,
+		api.ConditionUnknown)
 
 	supportedPodReplacementPolicy = sets.New(
-		string(batch.Failed),
-		string(batch.TerminatingOrFailed))
+		batch.Failed,
+		batch.TerminatingOrFailed)
 )
 
 // validateGeneratedSelector validates that the generated selector on a controller object match the controller object
@@ -207,7 +207,7 @@ func validateJobSpec(spec *batch.JobSpec, fldPath *field.Path, opts apivalidatio
 	}
 	if spec.CompletionMode != nil {
 		if *spec.CompletionMode != batch.NonIndexedCompletion && *spec.CompletionMode != batch.IndexedCompletion {
-			allErrs = append(allErrs, field.NotSupported(fldPath.Child("completionMode"), spec.CompletionMode, []string{string(batch.NonIndexedCompletion), string(batch.IndexedCompletion)}))
+			allErrs = append(allErrs, field.NotSupported(fldPath.Child("completionMode"), spec.CompletionMode, []batch.CompletionMode{batch.NonIndexedCompletion, batch.IndexedCompletion}))
 		}
 		if *spec.CompletionMode == batch.IndexedCompletion {
 			if spec.Completions == nil {
@@ -260,7 +260,7 @@ func validateJobSpec(spec *batch.JobSpec, fldPath *field.Path, opts apivalidatio
 			fmt.Sprintf("valid values: %q, %q", api.RestartPolicyOnFailure, api.RestartPolicyNever)))
 	} else if spec.Template.Spec.RestartPolicy != api.RestartPolicyOnFailure && spec.Template.Spec.RestartPolicy != api.RestartPolicyNever {
 		allErrs = append(allErrs, field.NotSupported(fldPath.Child("template", "spec", "restartPolicy"),
-			spec.Template.Spec.RestartPolicy, []string{string(api.RestartPolicyOnFailure), string(api.RestartPolicyNever)}))
+			spec.Template.Spec.RestartPolicy, []api.RestartPolicy{api.RestartPolicyOnFailure, api.RestartPolicyNever}))
 	} else if spec.PodFailurePolicy != nil && spec.Template.Spec.RestartPolicy != api.RestartPolicyNever {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("template", "spec", "restartPolicy"),
 			spec.Template.Spec.RestartPolicy, fmt.Sprintf("only %q is supported when podFailurePolicy is specified", api.RestartPolicyNever)))
@@ -293,10 +293,10 @@ func validatePodReplacementPolicy(spec *batch.JobSpec, fldPath *field.Path) fiel
 		// If PodFailurePolicy is specified then we only allow Failed.
 		if spec.PodFailurePolicy != nil {
 			if *spec.PodReplacementPolicy != batch.Failed {
-				allErrs = append(allErrs, field.NotSupported(fldPath, *spec.PodReplacementPolicy, []string{string(batch.Failed)}))
+				allErrs = append(allErrs, field.NotSupported(fldPath, *spec.PodReplacementPolicy, []batch.PodReplacementPolicy{batch.Failed}))
 			}
 			// If PodFailurePolicy not specified we allow values in supportedPodReplacementPolicy.
-		} else if !supportedPodReplacementPolicy.Has(string(*spec.PodReplacementPolicy)) {
+		} else if !supportedPodReplacementPolicy.Has(*spec.PodReplacementPolicy) {
 			allErrs = append(allErrs, field.NotSupported(fldPath, *spec.PodReplacementPolicy, sets.List(supportedPodReplacementPolicy)))
 		}
 	}
@@ -312,7 +312,7 @@ func validatePodFailurePolicyRule(spec *batch.JobSpec, rule *batch.PodFailurePol
 		if spec.BackoffLimitPerIndex == nil {
 			allErrs = append(allErrs, field.Invalid(actionPath, rule.Action, "requires the backoffLimitPerIndex to be set"))
 		}
-	} else if !supportedPodFailurePolicyActions.Has(string(rule.Action)) {
+	} else if !supportedPodFailurePolicyActions.Has(rule.Action) {
 		allErrs = append(allErrs, field.NotSupported(actionPath, rule.Action, sets.List(supportedPodFailurePolicyActions)))
 	}
 	if rule.OnExitCodes != nil {
@@ -341,7 +341,7 @@ func validatePodFailurePolicyRuleOnPodConditions(onPodConditions []batch.PodFail
 		allErrs = append(allErrs, apivalidation.ValidateQualifiedName(string(pattern.Type), patternPath.Child("type"))...)
 		if pattern.Status == "" {
 			allErrs = append(allErrs, field.Required(statusPath, fmt.Sprintf("valid values: %q", sets.List(supportedPodFailurePolicyOnPodConditionsStatus))))
-		} else if !supportedPodFailurePolicyOnPodConditionsStatus.Has(string(pattern.Status)) {
+		} else if !supportedPodFailurePolicyOnPodConditionsStatus.Has(pattern.Status) {
 			allErrs = append(allErrs, field.NotSupported(statusPath, pattern.Status, sets.List(supportedPodFailurePolicyOnPodConditionsStatus)))
 		}
 	}
@@ -353,7 +353,7 @@ func validatePodFailurePolicyRuleOnExitCodes(onExitCode *batch.PodFailurePolicyO
 	operatorPath := onExitCodesPath.Child("operator")
 	if onExitCode.Operator == "" {
 		allErrs = append(allErrs, field.Required(operatorPath, fmt.Sprintf("valid values: %q", sets.List(supportedPodFailurePolicyOnExitCodesOperator))))
-	} else if !supportedPodFailurePolicyOnExitCodesOperator.Has(string(onExitCode.Operator)) {
+	} else if !supportedPodFailurePolicyOnExitCodesOperator.Has(onExitCode.Operator) {
 		allErrs = append(allErrs, field.NotSupported(operatorPath, onExitCode.Operator, sets.List(supportedPodFailurePolicyOnExitCodesOperator)))
 	}
 	if onExitCode.ContainerName != nil && !containerNames.Has(*onExitCode.ContainerName) {
@@ -561,7 +561,7 @@ func validateConcurrencyPolicy(concurrencyPolicy *batch.ConcurrencyPolicy, fldPa
 	case "":
 		allErrs = append(allErrs, field.Required(fldPath, ""))
 	default:
-		validValues := []string{string(batch.AllowConcurrent), string(batch.ForbidConcurrent), string(batch.ReplaceConcurrent)}
+		validValues := []batch.ConcurrencyPolicy{batch.AllowConcurrent, batch.ForbidConcurrent, batch.ReplaceConcurrent}
 		allErrs = append(allErrs, field.NotSupported(fldPath, *concurrencyPolicy, validValues))
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
Since https://github.com/kubernetes/kubernetes/pull/120592, the `field.NotSupported` supported generics.
So, we can directly use aliased string vars without casts.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
