### PR TITLE
ValidatingAdmissionPolicy: support variables in TypeChecking

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/validatingadmissionpolicy/typechecking_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/validatingadmissionpolicy/typechecking_test.go
@@ -413,6 +413,95 @@ func TestTypeCheck(t *testing.T) {
 				toContain("found no matching overload for 'allowed' applied to 'kubernetes.authorization.Authorizer"),
 			},
 		},
+		{
+			name: "variables valid",
+			policy: &v1beta1.ValidatingAdmissionPolicy{Spec: v1beta1.ValidatingAdmissionPolicySpec{
+				Variables: []v1beta1.Variable{
+					{
+						Name:       "works",
+						Expression: "true",
+					},
+				},
+				Validations: []v1beta1.Validation{
+					{
+						Expression: "variables.works",
+					},
+				},
+				MatchConstraints: deploymentPolicy.Spec.MatchConstraints,
+			},
+			},
+			schemaToReturn: &spec.Schema{
+				SchemaProps: spec.SchemaProps{
+					Type: []string{"object"},
+					Properties: map[string]spec.Schema{
+						"foo": *spec.Int64Property(),
+					},
+				},
+			},
+			assertions: []assertionFunc{toHaveLengthOf(0)},
+		},
+		{
+			name: "variables missing field",
+			policy: &v1beta1.ValidatingAdmissionPolicy{Spec: v1beta1.ValidatingAdmissionPolicySpec{
+				Variables: []v1beta1.Variable{
+					{
+						Name:       "works",
+						Expression: "true",
+					},
+				},
+				Validations: []v1beta1.Validation{
+					{
+						Expression: "variables.nonExisting",
+					},
+				},
+				MatchConstraints: deploymentPolicy.Spec.MatchConstraints,
+			},
+			},
+			schemaToReturn: &spec.Schema{
+				SchemaProps: spec.SchemaProps{
+					Type: []string{"object"},
+					Properties: map[string]spec.Schema{
+						"foo": *spec.Int64Property(),
+					},
+				},
+			},
+			assertions: []assertionFunc{
+				toHaveLengthOf(1),
+				toHaveFieldRef("spec.validations[0].expression"),
+				toContain("undefined field 'nonExisting'"),
+			},
+		},
+		{
+			name: "variables field wrong type",
+			policy: &v1beta1.ValidatingAdmissionPolicy{Spec: v1beta1.ValidatingAdmissionPolicySpec{
+				Variables: []v1beta1.Variable{
+					{
+						Name:       "name",
+						Expression: "'something'",
+					},
+				},
+				Validations: []v1beta1.Validation{
+					{
+						Expression: "variables.name == object.foo", // foo is int64
+					},
+				},
+				MatchConstraints: deploymentPolicy.Spec.MatchConstraints,
+			},
+			},
+			schemaToReturn: &spec.Schema{
+				SchemaProps: spec.SchemaProps{
+					Type: []string{"object"},
+					Properties: map[string]spec.Schema{
+						"foo": *spec.Int64Property(),
+					},
+				},
+			},
+			assertions: []assertionFunc{
+				toHaveLengthOf(1),
+				toHaveFieldRef("spec.validations[0].expression"),
+				toContain("found no matching overload for '_==_' applied to '(string, int)"),
+			},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			typeChecker := buildTypeChecker(tc.schemaToReturn)

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/validatingadmissionpolicy/typechecking_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/validatingadmissionpolicy/typechecking_test.go
@@ -502,6 +502,35 @@ func TestTypeCheck(t *testing.T) {
 				toContain("found no matching overload for '_==_' applied to '(string, int)"),
 			},
 		},
+		{
+			name: "error in variables, not reported during type checking.",
+			policy: &v1beta1.ValidatingAdmissionPolicy{Spec: v1beta1.ValidatingAdmissionPolicySpec{
+				Variables: []v1beta1.Variable{
+					{
+						Name:       "name",
+						Expression: "object.foo == 'str'",
+					},
+				},
+				Validations: []v1beta1.Validation{
+					{
+						Expression: "variables.name == object.foo", // foo is int64
+					},
+				},
+				MatchConstraints: deploymentPolicy.Spec.MatchConstraints,
+			},
+			},
+			schemaToReturn: &spec.Schema{
+				SchemaProps: spec.SchemaProps{
+					Type: []string{"object"},
+					Properties: map[string]spec.Schema{
+						"foo": *spec.Int64Property(),
+					},
+				},
+			},
+			assertions: []assertionFunc{
+				toHaveLengthOf(0),
+			},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			typeChecker := buildTypeChecker(tc.schemaToReturn)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR add support of Variable Composition to ValidatingAdmissionPolicy by:

- refactor the Type Checker to use the FilterCompiler mechanism instead of raw CEL compilation
- create an implementation of compiler that uses actual types instead of `Dyn`, for `object`, `oldObject`, and `params`
- wire in the `CompositionEnv`
- add test cases for using `variables`

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #122935

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
ValidatingAdmissionPolicy now supports type checking policies that make use of `variables`.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
