### PR TITLE
kubelet: add resource allocation events

### DIFF
--- a/pkg/kubelet/cm/admission/events.go
+++ b/pkg/kubelet/cm/admission/events.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package admission
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/record"
+)
+
+const (
+	ErrorReasonAllocation = "ResourceAllocationError"
+)
+
+type ResourceAllocationError struct {
+	Reason       string
+	Resource     string
+	NUMAAffinity string
+	Err          error
+}
+
+func (e ResourceAllocationError) Error() string {
+	return fmt.Sprintf("cannot allocate resource %s NUMA affinity %v: %v", e.Resource, e.NUMAAffinity, e.Err)
+}
+
+func (e ResourceAllocationError) Type() string {
+	return ErrorReasonAllocation
+}
+
+func (e ResourceAllocationError) Unwrap() error {
+	return e.Err
+}
+
+func MakeResourceAllocationError(reason, resource string, needed int, affinity fmt.Stringer, err error) ResourceAllocationError {
+	return ResourceAllocationError{
+		Reason:       reason,
+		Resource:     fmt.Sprintf("%s=%d", resource, needed),
+		NUMAAffinity: affinityToString(affinity),
+		Err:          err,
+	}
+}
+
+func MakeMultiResourceAllocationError(reason string, resources v1.ResourceList, affinity fmt.Stringer, err error) ResourceAllocationError {
+	return ResourceAllocationError{
+		Reason:       reason,
+		Resource:     formatRequestedResources(resources),
+		NUMAAffinity: affinityToString(affinity),
+		Err:          err,
+	}
+}
+
+func ResourceAllocationFailureEvent(recorder record.EventRecorder, pod *v1.Pod, cntName string, err error) error {
+	var ra ResourceAllocationError
+	if !errors.As(err, &ra) {
+		return err
+	}
+	recorder.Eventf(pod, v1.EventTypeWarning, ra.Reason, "container %q: %v", cntName, ra)
+	return ra.Err
+}
+
+func affinityToString(affinity fmt.Stringer) string {
+	if affinity == nil {
+		return "N/A"
+	}
+	return affinity.String()
+}
+
+func formatRequestedResources(res v1.ResourceList) string {
+	items := make([]string, 0, len(res))
+	for resName, resQty := range res {
+		items = append(items, string(resName)+"="+resQty.String())
+	}
+	return strings.Join(items, ", ")
+}

--- a/pkg/kubelet/cm/container_manager_linux.go
+++ b/pkg/kubelet/cm/container_manager_linux.go
@@ -288,6 +288,7 @@ func NewContainerManager(mountUtil mount.Interface, cadvisorInterface cadvisor.I
 	}
 
 	cm.topologyManager, err = topologymanager.NewManager(
+		recorder,
 		machineInfo.Topology,
 		nodeConfig.TopologyManagerPolicy,
 		nodeConfig.TopologyManagerScope,

--- a/pkg/kubelet/cm/container_manager_linux.go
+++ b/pkg/kubelet/cm/container_manager_linux.go
@@ -303,7 +303,7 @@ func NewContainerManager(mountUtil mount.Interface, cadvisorInterface cadvisor.I
 	if err != nil {
 		return nil, err
 	}
-	cm.topologyManager.AddHintProvider(cm.deviceManager)
+	cm.topologyManager.RegisterProvider(cm.deviceManager)
 
 	// initialize DRA manager
 	if utilfeature.DefaultFeatureGate.Enabled(kubefeatures.DynamicResourceAllocation) {
@@ -329,7 +329,7 @@ func NewContainerManager(mountUtil mount.Interface, cadvisorInterface cadvisor.I
 		klog.ErrorS(err, "Failed to initialize cpu manager")
 		return nil, err
 	}
-	cm.topologyManager.AddHintProvider(cm.cpuManager)
+	cm.topologyManager.RegisterProvider(cm.cpuManager)
 
 	if utilfeature.DefaultFeatureGate.Enabled(kubefeatures.MemoryManager) {
 		cm.memoryManager, err = memorymanager.NewManager(
@@ -344,7 +344,7 @@ func NewContainerManager(mountUtil mount.Interface, cadvisorInterface cadvisor.I
 			klog.ErrorS(err, "Failed to initialize memory manager")
 			return nil, err
 		}
-		cm.topologyManager.AddHintProvider(cm.memoryManager)
+		cm.topologyManager.RegisterProvider(cm.memoryManager)
 	}
 
 	return cm, nil

--- a/pkg/kubelet/cm/container_manager_windows.go
+++ b/pkg/kubelet/cm/container_manager_windows.go
@@ -122,7 +122,7 @@ func NewContainerManager(mountUtil mount.Interface, cadvisorInterface cadvisor.I
 	if err != nil {
 		return nil, err
 	}
-	cm.topologyManager.AddHintProvider(cm.deviceManager)
+	cm.topologyManager.RegisterProvider(cm.deviceManager)
 
 	return cm, nil
 }

--- a/pkg/kubelet/cm/cpumanager/cpu_manager.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_manager.go
@@ -93,6 +93,11 @@ type Manager interface {
 	// GetCPUAffinity returns cpuset which includes cpus from shared pools
 	// as well as exclusively allocated cpus
 	GetCPUAffinity(podUID, containerName string) cpuset.CPUSet
+
+	// GetExclusiveResources returns a list of resource names whose instances were
+	// exclusively allocated to this container. This is used by the orchestrator to
+	// check if a container got exclusive (vs shared) resources or not.
+	GetExclusiveResources(pod *v1.Pod, container *v1.Container) []string
 }
 
 type manager struct {
@@ -531,6 +536,13 @@ func (m *manager) GetExclusiveCPUs(podUID, containerName string) cpuset.CPUSet {
 	}
 
 	return cpuset.CPUSet{}
+}
+
+func (m *manager) GetExclusiveResources(pod *v1.Pod, container *v1.Container) []string {
+	if _, ok := m.state.GetCPUSet(string(pod.UID), container.Name); ok {
+		return []string{string(v1.ResourceCPU)}
+	}
+	return nil
 }
 
 func (m *manager) GetCPUAffinity(podUID, containerName string) cpuset.CPUSet {

--- a/pkg/kubelet/cm/cpumanager/fake_cpu_manager.go
+++ b/pkg/kubelet/cm/cpumanager/fake_cpu_manager.go
@@ -75,6 +75,11 @@ func (m *fakeManager) GetExclusiveCPUs(podUID, containerName string) cpuset.CPUS
 	return cpuset.CPUSet{}
 }
 
+func (m *fakeManager) GetExclusiveResources(pod *v1.Pod, container *v1.Container) []string {
+	klog.InfoS("GetExclusiveResources", "podUID", pod.UID, "containerName", container.Name)
+	return nil
+}
+
 func (m *fakeManager) GetAllocatableCPUs() cpuset.CPUSet {
 	klog.InfoS("Get Allocatable CPUs")
 	return cpuset.CPUSet{}

--- a/pkg/kubelet/cm/cpumanager/policy_static_test.go
+++ b/pkg/kubelet/cm/cpumanager/policy_static_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cpumanager
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 	"testing"
@@ -621,8 +622,17 @@ func runStaticPolicyTestCase(t *testing.T, testCase staticPolicyTest) {
 		defaultCPUSet: testCase.stDefaultCPUSet,
 	}
 
+	// special case, because this is the only specific and concrete error type we had
+	smtErr := SMTAlignmentError{}
 	container := &testCase.pod.Spec.Containers[0]
 	err := policy.Allocate(st, testCase.pod, container)
+	if err != nil {
+		if errors.As(err, &smtErr) {
+			err = smtErr
+		} else {
+			err = errors.Unwrap(err)
+		}
+	}
 	if !reflect.DeepEqual(err, testCase.expErr) {
 		t.Errorf("StaticPolicy Allocate() error (%v). expected add error: %q but got: %q",
 			testCase.description, testCase.expErr, err)
@@ -1068,8 +1078,18 @@ func TestStaticPolicyAddWithResvList(t *testing.T) {
 			defaultCPUSet: testCase.stDefaultCPUSet,
 		}
 
+		// special case, because this is the only specific and concrete error type we had
+		smtErr := SMTAlignmentError{}
 		container := &testCase.pod.Spec.Containers[0]
 		err := policy.Allocate(st, testCase.pod, container)
+		if err != nil {
+			if errors.As(err, &smtErr) {
+				err = smtErr
+			} else {
+				err = errors.Unwrap(err)
+			}
+		}
+
 		if !reflect.DeepEqual(err, testCase.expErr) {
 			t.Errorf("StaticPolicy Allocate() error (%v). expected add error: %v but got: %v",
 				testCase.description, testCase.expErr, err)

--- a/pkg/kubelet/cm/devicemanager/manager.go
+++ b/pkg/kubelet/cm/devicemanager/manager.go
@@ -1051,6 +1051,17 @@ func (m *ManagerImpl) GetDevices(podUID, containerName string) ResourceDeviceIns
 	return m.podDevices.getContainerDevices(podUID, containerName)
 }
 
+// GetExclusiveResources returns a list of resource names whose instances were esclusively
+// allocated to this container.
+func (m *ManagerImpl) GetExclusiveResources(pod *v1.Pod, container *v1.Container) []string {
+	var res []string
+	devs := m.podDevices.getContainerDevices(string(pod.UID), container.Name)
+	for resName := range devs {
+		res = append(res, resName)
+	}
+	return res
+}
+
 // ShouldResetExtendedResourceCapacity returns whether the extended resources should be zeroed or not,
 // depending on whether the node has been recreated. Absence of the checkpoint file strongly indicates the node
 // has been recreated.

--- a/pkg/kubelet/cm/devicemanager/manager_test.go
+++ b/pkg/kubelet/cm/devicemanager/manager_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package devicemanager
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -1056,6 +1057,9 @@ func TestPodContainerDeviceAllocation(t *testing.T) {
 		activePods = append(activePods, pod)
 		podsStub.updateActivePods(activePods)
 		err := testManager.Allocate(pod, &pod.Spec.Containers[0])
+		if err != nil {
+			err = errors.Unwrap(err)
+		}
 		if !reflect.DeepEqual(err, testCase.expErr) {
 			t.Errorf("DevicePluginManager error (%v). expected error: %v but got: %v",
 				testCase.description, testCase.expErr, err)

--- a/pkg/kubelet/cm/devicemanager/types.go
+++ b/pkg/kubelet/cm/devicemanager/types.go
@@ -81,6 +81,10 @@ type Manager interface {
 
 	// UpdateAllocatedDevices frees any Devices that are bound to terminated pods.
 	UpdateAllocatedDevices()
+
+	// GetExclusiveResources returns a list of resource names whose instances were esclusively
+	// allocated to this container.
+	GetExclusiveResources(pod *v1.Pod, container *v1.Container) []string
 }
 
 // DeviceRunContainerOptions contains the combined container runtime settings to consume its allocated devices.

--- a/pkg/kubelet/cm/memorymanager/fake_memory_manager.go
+++ b/pkg/kubelet/cm/memorymanager/fake_memory_manager.go
@@ -86,6 +86,13 @@ func (m *fakeManager) GetMemory(podUID, containerName string) []state.Block {
 	return []state.Block{}
 }
 
+// GetExclusiveResources returns a list of resource names whose instances were esclusively
+// allocated to this container.
+func (m *fakeManager) GetExclusiveResources(pod *v1.Pod, container *v1.Container) []string {
+	klog.InfoS("Get Exclusive Resources", "podUID", pod.UID, "containerName", container.Name)
+	return nil
+}
+
 // NewFakeManager creates empty/fake memory manager
 func NewFakeManager() Manager {
 	return &fakeManager{

--- a/pkg/kubelet/cm/memorymanager/memory_manager.go
+++ b/pkg/kubelet/cm/memorymanager/memory_manager.go
@@ -91,6 +91,10 @@ type Manager interface {
 
 	// GetMemory returns the memory allocated by a container from NUMA nodes
 	GetMemory(podUID, containerName string) []state.Block
+
+	// GetExclusiveResources returns a list of resource names whose instances were esclusively
+	// allocated to this container.
+	GetExclusiveResources(pod *v1.Pod, container *v1.Container) []string
 }
 
 type manager struct {
@@ -238,6 +242,14 @@ func (m *manager) GetMemoryNUMANodes(pod *v1.Pod, container *v1.Container) sets.
 
 	klog.InfoS("Memory affinity", "pod", klog.KObj(pod), "containerName", container.Name, "numaNodes", numaNodes)
 	return numaNodes
+}
+
+func (m *manager) GetExclusiveResources(pod *v1.Pod, container *v1.Container) []string {
+	res := sets.New[string]()
+	for _, block := range m.state.GetMemoryBlocks(string(pod.UID), container.Name) {
+		res.Insert(string(block.Type))
+	}
+	return res.UnsortedList()
 }
 
 // Allocate is called to pre-allocate memory resources during Pod admission.

--- a/pkg/kubelet/cm/memorymanager/policy_static.go
+++ b/pkg/kubelet/cm/memorymanager/policy_static.go
@@ -31,9 +31,11 @@ import (
 	corehelper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
 	v1qos "k8s.io/kubernetes/pkg/apis/core/v1/helper/qos"
 	"k8s.io/kubernetes/pkg/features"
+	"k8s.io/kubernetes/pkg/kubelet/cm/admission"
 	"k8s.io/kubernetes/pkg/kubelet/cm/memorymanager/state"
 	"k8s.io/kubernetes/pkg/kubelet/cm/topologymanager"
 	"k8s.io/kubernetes/pkg/kubelet/cm/topologymanager/bitmask"
+	"k8s.io/kubernetes/pkg/kubelet/events"
 	"k8s.io/kubernetes/pkg/kubelet/metrics"
 	"k8s.io/kubernetes/pkg/kubelet/types"
 )
@@ -122,7 +124,8 @@ func (p *staticPolicy) Allocate(s state.State, pod *v1.Pod, container *v1.Contai
 	hint := p.affinity.GetAffinity(podUID, container.Name)
 	klog.InfoS("Got topology affinity", "pod", klog.KObj(pod), "podUID", pod.UID, "containerName", container.Name, "hint", hint)
 
-	requestedResources, err := getRequestedResources(pod, container)
+	specResources := filterMemoryResources(pod, container)           // used only for reporting
+	requestedResources, err := getRequestedResources(pod, container) // used for internal accounting
 	if err != nil {
 		return err
 	}
@@ -137,11 +140,11 @@ func (p *staticPolicy) Allocate(s state.State, pod *v1.Pod, container *v1.Contai
 
 		defaultHint, err := p.getDefaultHint(machineState, pod, requestedResources)
 		if err != nil {
-			return err
+			return admission.MakeMultiResourceAllocationError(events.FailedAllocationMemory, specResources, nil, err)
 		}
 
 		if !defaultHint.Preferred && bestHint.Preferred {
-			return fmt.Errorf("[memorymanager] failed to find the default preferred hint")
+			return admission.MakeMultiResourceAllocationError(events.FailedAllocationMemory, specResources, nil, fmt.Errorf("[memorymanager] failed to find the default preferred hint"))
 		}
 
 		klog.V(3).InfoS("Topology Hint recomputed", "pod", klog.KObj(pod), "podUID", pod.UID, "containerName", container.Name, "previous", bestHint, "recomputed", defaultHint)
@@ -157,11 +160,12 @@ func (p *staticPolicy) Allocate(s state.State, pod *v1.Pod, container *v1.Contai
 
 		extendedHint, err := p.extendTopologyManagerHint(machineState, pod, requestedResources, bestHint.NUMANodeAffinity)
 		if err != nil {
-			return err
+			return admission.MakeMultiResourceAllocationError(events.FailedAllocationMemory, specResources, bestHint.NUMANodeAffinity, err)
 		}
 
 		if !extendedHint.Preferred && bestHint.Preferred {
-			return fmt.Errorf("[memorymanager] failed to find the extended preferred hint")
+			return admission.MakeMultiResourceAllocationError(events.FailedAllocationMemory, specResources, bestHint.NUMANodeAffinity, fmt.Errorf("[memorymanager] failed to find the extended preferred hint"))
+
 		}
 
 		klog.V(3).InfoS("Topology Hint extended", "pod", klog.KObj(pod), "podUID", pod.UID, "containerName", container.Name, "previous", bestHint, "extended", extendedHint)
@@ -443,6 +447,27 @@ func (p *staticPolicy) GetTopologyHints(s state.State, pod *v1.Pod, container *v
 	}
 
 	return p.calculateHints(s.GetMachineState(), pod, requestedResources)
+}
+
+func filterMemoryResources(pod *v1.Pod, container *v1.Container) v1.ResourceList {
+	res := v1.ResourceList{}
+	resources := container.Resources.Requests
+	// In-place pod resize feature makes Container.Resources field mutable for CPU & memory.
+	// AllocatedResources holds the value of Container.Resources.Requests when the pod was admitted.
+	// We should return this value because this is what kubelet agreed to allocate for the container
+	// and the value configured with runtime.
+	if utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScaling) {
+		if cs, ok := podutil.GetContainerStatus(pod.Status.ContainerStatuses, container.Name); ok {
+			resources = cs.AllocatedResources
+		}
+	}
+	for resourceName, quantity := range resources {
+		if resourceName != v1.ResourceMemory && !corehelper.IsHugePageResourceName(resourceName) {
+			continue
+		}
+		res[resourceName] = quantity
+	}
+	return res
 }
 
 func getRequestedResources(pod *v1.Pod, container *v1.Container) (map[v1.ResourceName]uint64, error) {

--- a/pkg/kubelet/cm/memorymanager/policy_static_test.go
+++ b/pkg/kubelet/cm/memorymanager/policy_static_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package memorymanager
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 	"testing"
@@ -1776,6 +1777,9 @@ func TestStaticPolicyAllocate(t *testing.T) {
 			}
 
 			err = p.Allocate(s, testCase.pod, &testCase.pod.Spec.Containers[0])
+			if err != nil {
+				err = errors.Unwrap(err)
+			}
 			if !reflect.DeepEqual(err, testCase.expectedError) {
 				t.Fatalf("The actual error %v is different from the expected one %v", err, testCase.expectedError)
 			}

--- a/pkg/kubelet/cm/topologymanager/fake_topology_manager.go
+++ b/pkg/kubelet/cm/topologymanager/fake_topology_manager.go
@@ -17,7 +17,7 @@ limitations under the License.
 package topologymanager
 
 import (
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/kubelet/cm/admission"
 	"k8s.io/kubernetes/pkg/kubelet/lifecycle"
@@ -64,8 +64,8 @@ func (m *fakeManager) GetPolicy() Policy {
 	return m.policy
 }
 
-func (m *fakeManager) AddHintProvider(h HintProvider) {
-	klog.InfoS("AddHintProvider", "hintProvider", h)
+func (m *fakeManager) RegisterProvider(ra ResourceAllocator) {
+	klog.InfoS("RegisterProvider", "resourceAllocator", ra)
 }
 
 func (m *fakeManager) AddContainer(pod *v1.Pod, container *v1.Container, containerID string) {

--- a/pkg/kubelet/cm/topologymanager/policy_test.go
+++ b/pkg/kubelet/cm/topologymanager/policy_test.go
@@ -20,7 +20,7 @@ import (
 	"reflect"
 	"testing"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/kubernetes/pkg/kubelet/cm/topologymanager/bitmask"
 )
 
@@ -35,7 +35,7 @@ func commonPolicyMergeTestCases(numaNodes []int) []policyMergeTestCase {
 		{
 			name: "Two providers, 1 hint each, same mask, both preferred 1/2",
 			hp: []HintProvider{
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource1": {
 							{
@@ -45,7 +45,7 @@ func commonPolicyMergeTestCases(numaNodes []int) []policyMergeTestCase {
 						},
 					},
 				},
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource2": {
 							{
@@ -64,7 +64,7 @@ func commonPolicyMergeTestCases(numaNodes []int) []policyMergeTestCase {
 		{
 			name: "Two providers, 1 hint each, same mask, both preferred 2/2",
 			hp: []HintProvider{
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource1": {
 							{
@@ -74,7 +74,7 @@ func commonPolicyMergeTestCases(numaNodes []int) []policyMergeTestCase {
 						},
 					},
 				},
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource2": {
 							{
@@ -93,8 +93,8 @@ func commonPolicyMergeTestCases(numaNodes []int) []policyMergeTestCase {
 		{
 			name: "Two providers, 1 no hints, 1 single hint preferred 1/2",
 			hp: []HintProvider{
-				&mockHintProvider{},
-				&mockHintProvider{
+				&fakeResourceAllocator{},
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource": {
 							{
@@ -113,8 +113,8 @@ func commonPolicyMergeTestCases(numaNodes []int) []policyMergeTestCase {
 		{
 			name: "Two providers, 1 no hints, 1 single hint preferred 2/2",
 			hp: []HintProvider{
-				&mockHintProvider{},
-				&mockHintProvider{
+				&fakeResourceAllocator{},
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource": {
 							{
@@ -133,7 +133,7 @@ func commonPolicyMergeTestCases(numaNodes []int) []policyMergeTestCase {
 		{
 			name: "Two providers, 1 with 2 hints, 1 with single hint matching 1/2",
 			hp: []HintProvider{
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource1": {
 							{
@@ -147,7 +147,7 @@ func commonPolicyMergeTestCases(numaNodes []int) []policyMergeTestCase {
 						},
 					},
 				},
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource2": {
 							{
@@ -166,7 +166,7 @@ func commonPolicyMergeTestCases(numaNodes []int) []policyMergeTestCase {
 		{
 			name: "Two providers, 1 with 2 hints, 1 with single hint matching 2/2",
 			hp: []HintProvider{
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource1": {
 							{
@@ -180,7 +180,7 @@ func commonPolicyMergeTestCases(numaNodes []int) []policyMergeTestCase {
 						},
 					},
 				},
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource2": {
 							{
@@ -199,7 +199,7 @@ func commonPolicyMergeTestCases(numaNodes []int) []policyMergeTestCase {
 		{
 			name: "Two providers, both with 2 hints, matching narrower preferred hint from both",
 			hp: []HintProvider{
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource1": {
 							{
@@ -213,7 +213,7 @@ func commonPolicyMergeTestCases(numaNodes []int) []policyMergeTestCase {
 						},
 					},
 				},
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource2": {
 							{
@@ -236,7 +236,7 @@ func commonPolicyMergeTestCases(numaNodes []int) []policyMergeTestCase {
 		{
 			name: "Ensure less narrow preferred hints are chosen over narrower non-preferred hints",
 			hp: []HintProvider{
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource1": {
 							{
@@ -250,7 +250,7 @@ func commonPolicyMergeTestCases(numaNodes []int) []policyMergeTestCase {
 						},
 					},
 				},
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource2": {
 							{
@@ -277,7 +277,7 @@ func commonPolicyMergeTestCases(numaNodes []int) []policyMergeTestCase {
 		{
 			name: "Multiple resources, same provider",
 			hp: []HintProvider{
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource1": {
 							{
@@ -319,7 +319,7 @@ func (p *bestEffortPolicy) mergeTestCases(numaNodes []int) []policyMergeTestCase
 		{
 			name: "Two providers, 2 hints each, same mask (some with different bits), same preferred",
 			hp: []HintProvider{
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource1": {
 							{
@@ -333,7 +333,7 @@ func (p *bestEffortPolicy) mergeTestCases(numaNodes []int) []policyMergeTestCase
 						},
 					},
 				},
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource2": {
 							{
@@ -364,7 +364,7 @@ func (p *bestEffortPolicy) mergeTestCases(numaNodes []int) []policyMergeTestCase
 		{
 			name: "HintProvider returns empty non-nil map[string][]TopologyHint",
 			hp: []HintProvider{
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{},
 				},
 			},
@@ -376,7 +376,7 @@ func (p *bestEffortPolicy) mergeTestCases(numaNodes []int) []policyMergeTestCase
 		{
 			name: "HintProvider returns -nil map[string][]TopologyHint from provider",
 			hp: []HintProvider{
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource": nil,
 					},
@@ -389,7 +389,7 @@ func (p *bestEffortPolicy) mergeTestCases(numaNodes []int) []policyMergeTestCase
 		},
 		{
 			name: "HintProvider returns empty non-nil map[string][]TopologyHint from provider", hp: []HintProvider{
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource": {},
 					},
@@ -403,7 +403,7 @@ func (p *bestEffortPolicy) mergeTestCases(numaNodes []int) []policyMergeTestCase
 		{
 			name: "Single TopologyHint with Preferred as true and NUMANodeAffinity as nil",
 			hp: []HintProvider{
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource": {
 							{
@@ -422,7 +422,7 @@ func (p *bestEffortPolicy) mergeTestCases(numaNodes []int) []policyMergeTestCase
 		{
 			name: "Single TopologyHint with Preferred as false and NUMANodeAffinity as nil",
 			hp: []HintProvider{
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource": {
 							{
@@ -441,7 +441,7 @@ func (p *bestEffortPolicy) mergeTestCases(numaNodes []int) []policyMergeTestCase
 		{
 			name: "Two providers, 1 hint each, no common mask",
 			hp: []HintProvider{
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource1": {
 							{
@@ -451,7 +451,7 @@ func (p *bestEffortPolicy) mergeTestCases(numaNodes []int) []policyMergeTestCase
 						},
 					},
 				},
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource2": {
 							{
@@ -470,7 +470,7 @@ func (p *bestEffortPolicy) mergeTestCases(numaNodes []int) []policyMergeTestCase
 		{
 			name: "Two providers, 1 hint each, same mask, 1 preferred, 1 not 1/2",
 			hp: []HintProvider{
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource1": {
 							{
@@ -480,7 +480,7 @@ func (p *bestEffortPolicy) mergeTestCases(numaNodes []int) []policyMergeTestCase
 						},
 					},
 				},
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource2": {
 							{
@@ -499,7 +499,7 @@ func (p *bestEffortPolicy) mergeTestCases(numaNodes []int) []policyMergeTestCase
 		{
 			name: "Two providers, 1 hint each, same mask, 1 preferred, 1 not 2/2",
 			hp: []HintProvider{
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource1": {
 							{
@@ -509,7 +509,7 @@ func (p *bestEffortPolicy) mergeTestCases(numaNodes []int) []policyMergeTestCase
 						},
 					},
 				},
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource2": {
 							{
@@ -528,7 +528,7 @@ func (p *bestEffortPolicy) mergeTestCases(numaNodes []int) []policyMergeTestCase
 		{
 			name: "Two providers, 1 hint each, 1 wider mask, both preferred 1/2",
 			hp: []HintProvider{
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource1": {
 							{
@@ -538,7 +538,7 @@ func (p *bestEffortPolicy) mergeTestCases(numaNodes []int) []policyMergeTestCase
 						},
 					},
 				},
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource2": {
 							{
@@ -557,7 +557,7 @@ func (p *bestEffortPolicy) mergeTestCases(numaNodes []int) []policyMergeTestCase
 		{
 			name: "Two providers, 1 with 2 hints, 1 with single non-preferred hint matching",
 			hp: []HintProvider{
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource1": {
 							{
@@ -571,7 +571,7 @@ func (p *bestEffortPolicy) mergeTestCases(numaNodes []int) []policyMergeTestCase
 						},
 					},
 				},
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource2": {
 							{
@@ -590,7 +590,7 @@ func (p *bestEffortPolicy) mergeTestCases(numaNodes []int) []policyMergeTestCase
 		{
 			name: "Two providers, 1 hint each, 1 wider mask, both preferred 2/2",
 			hp: []HintProvider{
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource1": {
 							{
@@ -600,7 +600,7 @@ func (p *bestEffortPolicy) mergeTestCases(numaNodes []int) []policyMergeTestCase
 						},
 					},
 				},
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource2": {
 							{
@@ -619,7 +619,7 @@ func (p *bestEffortPolicy) mergeTestCases(numaNodes []int) []policyMergeTestCase
 		{
 			name: "bestNonPreferredAffinityCount (1)",
 			hp: []HintProvider{
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource1": {
 							{
@@ -633,7 +633,7 @@ func (p *bestEffortPolicy) mergeTestCases(numaNodes []int) []policyMergeTestCase
 						},
 					},
 				},
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource2": {
 							{
@@ -652,7 +652,7 @@ func (p *bestEffortPolicy) mergeTestCases(numaNodes []int) []policyMergeTestCase
 		{
 			name: "bestNonPreferredAffinityCount (2)",
 			hp: []HintProvider{
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource1": {
 							{
@@ -666,7 +666,7 @@ func (p *bestEffortPolicy) mergeTestCases(numaNodes []int) []policyMergeTestCase
 						},
 					},
 				},
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource2": {
 							{
@@ -685,7 +685,7 @@ func (p *bestEffortPolicy) mergeTestCases(numaNodes []int) []policyMergeTestCase
 		{
 			name: "bestNonPreferredAffinityCount (3)",
 			hp: []HintProvider{
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource1": {
 							{
@@ -699,7 +699,7 @@ func (p *bestEffortPolicy) mergeTestCases(numaNodes []int) []policyMergeTestCase
 						},
 					},
 				},
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource2": {
 							{
@@ -718,7 +718,7 @@ func (p *bestEffortPolicy) mergeTestCases(numaNodes []int) []policyMergeTestCase
 		{
 			name: "bestNonPreferredAffinityCount (4)",
 			hp: []HintProvider{
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource1": {
 							{
@@ -732,7 +732,7 @@ func (p *bestEffortPolicy) mergeTestCases(numaNodes []int) []policyMergeTestCase
 						},
 					},
 				},
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource2": {
 							{
@@ -756,7 +756,7 @@ func (p *bestEffortPolicy) mergeTestCasesNoPolicies(numaNodes []int) []policyMer
 		{
 			name: "bestNonPreferredAffinityCount (5)",
 			hp: []HintProvider{
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource1": {
 							{
@@ -770,7 +770,7 @@ func (p *bestEffortPolicy) mergeTestCasesNoPolicies(numaNodes []int) []policyMer
 						},
 					},
 				},
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource2": {
 							{
@@ -793,7 +793,7 @@ func (p *bestEffortPolicy) mergeTestCasesNoPolicies(numaNodes []int) []policyMer
 		{
 			name: "bestNonPreferredAffinityCount (6)",
 			hp: []HintProvider{
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource1": {
 							{
@@ -807,7 +807,7 @@ func (p *bestEffortPolicy) mergeTestCasesNoPolicies(numaNodes []int) []policyMer
 						},
 					},
 				},
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource2": {
 							{
@@ -843,7 +843,7 @@ func (p *bestEffortPolicy) mergeTestCasesClosestNUMA(numaNodes []int) []policyMe
 		{
 			name: "Two providers, 2 hints each, same mask (some with different bits), same preferred",
 			hp: []HintProvider{
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource1": {
 							{
@@ -857,7 +857,7 @@ func (p *bestEffortPolicy) mergeTestCasesClosestNUMA(numaNodes []int) []policyMe
 						},
 					},
 				},
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource2": {
 							{
@@ -880,7 +880,7 @@ func (p *bestEffortPolicy) mergeTestCasesClosestNUMA(numaNodes []int) []policyMe
 		{
 			name: "Two providers, 2 hints each, different mask",
 			hp: []HintProvider{
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource1": {
 							{
@@ -894,7 +894,7 @@ func (p *bestEffortPolicy) mergeTestCasesClosestNUMA(numaNodes []int) []policyMe
 						},
 					},
 				},
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource2": {
 							{
@@ -917,7 +917,7 @@ func (p *bestEffortPolicy) mergeTestCasesClosestNUMA(numaNodes []int) []policyMe
 		{
 			name: "bestNonPreferredAffinityCount (5)",
 			hp: []HintProvider{
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource1": {
 							{
@@ -931,7 +931,7 @@ func (p *bestEffortPolicy) mergeTestCasesClosestNUMA(numaNodes []int) []policyMe
 						},
 					},
 				},
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource2": {
 							{
@@ -954,7 +954,7 @@ func (p *bestEffortPolicy) mergeTestCasesClosestNUMA(numaNodes []int) []policyMe
 		{
 			name: "bestNonPreferredAffinityCount (6)",
 			hp: []HintProvider{
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource1": {
 							{
@@ -968,7 +968,7 @@ func (p *bestEffortPolicy) mergeTestCasesClosestNUMA(numaNodes []int) []policyMe
 						},
 					},
 				},
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource2": {
 							{
@@ -1012,7 +1012,7 @@ func (p *singleNumaNodePolicy) mergeTestCases(numaNodes []int) []policyMergeTest
 		{
 			name: "HintProvider returns empty non-nil map[string][]TopologyHint",
 			hp: []HintProvider{
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{},
 				},
 			},
@@ -1024,7 +1024,7 @@ func (p *singleNumaNodePolicy) mergeTestCases(numaNodes []int) []policyMergeTest
 		{
 			name: "HintProvider returns -nil map[string][]TopologyHint from provider",
 			hp: []HintProvider{
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource": nil,
 					},
@@ -1037,7 +1037,7 @@ func (p *singleNumaNodePolicy) mergeTestCases(numaNodes []int) []policyMergeTest
 		},
 		{
 			name: "HintProvider returns empty non-nil map[string][]TopologyHint from provider", hp: []HintProvider{
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource": {},
 					},
@@ -1051,7 +1051,7 @@ func (p *singleNumaNodePolicy) mergeTestCases(numaNodes []int) []policyMergeTest
 		{
 			name: "Single TopologyHint with Preferred as true and NUMANodeAffinity as nil",
 			hp: []HintProvider{
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource": {
 							{
@@ -1070,7 +1070,7 @@ func (p *singleNumaNodePolicy) mergeTestCases(numaNodes []int) []policyMergeTest
 		{
 			name: "Single TopologyHint with Preferred as false and NUMANodeAffinity as nil",
 			hp: []HintProvider{
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource": {
 							{
@@ -1089,7 +1089,7 @@ func (p *singleNumaNodePolicy) mergeTestCases(numaNodes []int) []policyMergeTest
 		{
 			name: "Two providers, 1 hint each, no common mask",
 			hp: []HintProvider{
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource1": {
 							{
@@ -1099,7 +1099,7 @@ func (p *singleNumaNodePolicy) mergeTestCases(numaNodes []int) []policyMergeTest
 						},
 					},
 				},
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource2": {
 							{
@@ -1118,7 +1118,7 @@ func (p *singleNumaNodePolicy) mergeTestCases(numaNodes []int) []policyMergeTest
 		{
 			name: "Two providers, 1 hint each, same mask, 1 preferred, 1 not 1/2",
 			hp: []HintProvider{
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource1": {
 							{
@@ -1128,7 +1128,7 @@ func (p *singleNumaNodePolicy) mergeTestCases(numaNodes []int) []policyMergeTest
 						},
 					},
 				},
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource2": {
 							{
@@ -1147,7 +1147,7 @@ func (p *singleNumaNodePolicy) mergeTestCases(numaNodes []int) []policyMergeTest
 		{
 			name: "Two providers, 1 hint each, same mask, 1 preferred, 1 not 2/2",
 			hp: []HintProvider{
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource1": {
 							{
@@ -1157,7 +1157,7 @@ func (p *singleNumaNodePolicy) mergeTestCases(numaNodes []int) []policyMergeTest
 						},
 					},
 				},
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource2": {
 							{
@@ -1176,7 +1176,7 @@ func (p *singleNumaNodePolicy) mergeTestCases(numaNodes []int) []policyMergeTest
 		{
 			name: "Two providers, 1 with 2 hints, 1 with single non-preferred hint matching",
 			hp: []HintProvider{
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource1": {
 							{
@@ -1190,7 +1190,7 @@ func (p *singleNumaNodePolicy) mergeTestCases(numaNodes []int) []policyMergeTest
 						},
 					},
 				},
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource2": {
 							{
@@ -1209,7 +1209,7 @@ func (p *singleNumaNodePolicy) mergeTestCases(numaNodes []int) []policyMergeTest
 		{
 			name: "Single NUMA hint generation",
 			hp: []HintProvider{
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource1": {
 							{
@@ -1242,7 +1242,7 @@ func (p *singleNumaNodePolicy) mergeTestCases(numaNodes []int) []policyMergeTest
 		{
 			name: "One no-preference provider",
 			hp: []HintProvider{
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource1": {
 							{
@@ -1260,7 +1260,7 @@ func (p *singleNumaNodePolicy) mergeTestCases(numaNodes []int) []policyMergeTest
 						},
 					},
 				},
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					nil,
 				},
 			},

--- a/pkg/kubelet/cm/topologymanager/scope.go
+++ b/pkg/kubelet/cm/topologymanager/scope.go
@@ -17,12 +17,17 @@ limitations under the License.
 package topologymanager
 
 import (
+	"fmt"
+	"sort"
+	"strings"
 	"sync"
 
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/kubelet/cm/admission"
 	"k8s.io/kubernetes/pkg/kubelet/cm/containermap"
+	"k8s.io/kubernetes/pkg/kubelet/events"
 	"k8s.io/kubernetes/pkg/kubelet/lifecycle"
 )
 
@@ -55,8 +60,9 @@ type Scope interface {
 }
 
 type scope struct {
-	mutex sync.Mutex
-	name  string
+	recorder record.EventRecorder
+	mutex    sync.Mutex
+	name     string
 	// Mapping of a Pods mapping of Containers and their TopologyHints
 	// Indexed by PodUID to ContainerName
 	podTopologyHints podTopologyHints
@@ -136,24 +142,62 @@ func (s *scope) RemoveContainer(containerID string) error {
 	return nil
 }
 
+type allocationMap map[string][]string
+
+func (am allocationMap) Add(containerName string, resources []string) {
+	for _, resource := range resources {
+		am[resource] = append(am[resource], containerName)
+	}
+}
+
+func (am allocationMap) String() string {
+	if len(am) == 0 {
+		return "none"
+	}
+
+	resources := make([]string, 0, len(am))
+	for resource := range am {
+		resources = append(resources, resource)
+	}
+	sort.Strings(resources)
+
+	items := []string{}
+	for _, resource := range resources {
+		contNames := am[resource]
+		items = append(items, resource+fmt.Sprintf(": containers=%d", len(contNames)))
+	}
+	return strings.Join(items, "; ")
+}
+
+func (s *scope) resourceAllocationSuccessEvent(pod *v1.Pod, allocs allocationMap) {
+	s.recorder.Event(pod, v1.EventTypeNormal, events.AllocatedResources, allocs.String())
+}
+
 func (s *scope) admitPolicyNone(pod *v1.Pod) lifecycle.PodAdmitResult {
+	allocs := make(allocationMap)
 	for _, container := range append(pod.Spec.InitContainers, pod.Spec.Containers...) {
-		err := s.allocateAlignedResources(pod, &container)
+		resources, err := s.allocateAlignedResources(pod, &container)
 		if err != nil {
+			err = admission.ResourceAllocationFailureEvent(s.recorder, pod, container.Name, err)
 			return admission.GetPodAdmitResult(err)
 		}
+		allocs.Add(container.Name, resources)
 	}
+	s.resourceAllocationSuccessEvent(pod, allocs)
 	return admission.GetPodAdmitResult(nil)
 }
 
 // It would be better to implement this function in topologymanager instead of scope
 // but topologymanager do not track providers anymore
-func (s *scope) allocateAlignedResources(pod *v1.Pod, container *v1.Container) error {
+func (s *scope) allocateAlignedResources(pod *v1.Pod, container *v1.Container) ([]string, error) {
+	allocated := []string{}
 	for _, provider := range s.providers {
 		err := provider.Allocate(pod, container)
 		if err != nil {
-			return err
+			return allocated, err
 		}
+		res := provider.GetExclusiveResources(pod, container)
+		allocated = append(allocated, res...)
 	}
-	return nil
+	return allocated, nil
 }

--- a/pkg/kubelet/cm/topologymanager/scope.go
+++ b/pkg/kubelet/cm/topologymanager/scope.go
@@ -43,7 +43,8 @@ type Scope interface {
 	GetPolicy() Policy
 	Admit(pod *v1.Pod) lifecycle.PodAdmitResult
 	// RegisterProvider adds a hint provider to manager to indicate the hint provider
-	// wants to be consulted with when making topology hints
+	// wants to be consulted with when making topology hints, and is authoritative about
+	// the current resource allocation.
 	RegisterProvider(ra ResourceAllocator)
 	// AddContainer adds pod to Manager for tracking
 	AddContainer(pod *v1.Pod, container *v1.Container, containerID string)

--- a/pkg/kubelet/cm/topologymanager/scope_container.go
+++ b/pkg/kubelet/cm/topologymanager/scope_container.go
@@ -17,7 +17,7 @@ limitations under the License.
 package topologymanager
 
 import (
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/kubelet/cm/admission"
 	"k8s.io/kubernetes/pkg/kubelet/cm/containermap"
@@ -68,7 +68,7 @@ func (s *containerScope) Admit(pod *v1.Pod) lifecycle.PodAdmitResult {
 func (s *containerScope) accumulateProvidersHints(pod *v1.Pod, container *v1.Container) []map[string][]TopologyHint {
 	var providersHints []map[string][]TopologyHint
 
-	for _, provider := range s.hintProviders {
+	for _, provider := range s.providers {
 		// Get the TopologyHints for a Container from a provider.
 		hints := provider.GetTopologyHints(pod, container)
 		providersHints = append(providersHints, hints)

--- a/pkg/kubelet/cm/topologymanager/scope_container_test.go
+++ b/pkg/kubelet/cm/topologymanager/scope_container_test.go
@@ -26,17 +26,17 @@ import (
 func TestContainerCalculateAffinity(t *testing.T) {
 	tcases := []struct {
 		name     string
-		hp       []HintProvider
+		prov     []ResourceAllocator
 		expected []map[string][]TopologyHint
 	}{
 		{
 			name:     "No hint providers",
-			hp:       []HintProvider{},
+			prov:     []ResourceAllocator{},
 			expected: ([]map[string][]TopologyHint)(nil),
 		},
 		{
 			name: "HintProvider returns empty non-nil map[string][]TopologyHint",
-			hp: []HintProvider{
+			prov: []ResourceAllocator{
 				&mockHintProvider{
 					map[string][]TopologyHint{},
 				},
@@ -47,7 +47,7 @@ func TestContainerCalculateAffinity(t *testing.T) {
 		},
 		{
 			name: "HintProvider returns -nil map[string][]TopologyHint from provider",
-			hp: []HintProvider{
+			prov: []ResourceAllocator{
 				&mockHintProvider{
 					map[string][]TopologyHint{
 						"resource": nil,
@@ -62,7 +62,7 @@ func TestContainerCalculateAffinity(t *testing.T) {
 		},
 		{
 			name: "Assorted HintProviders",
-			hp: []HintProvider{
+			prov: []ResourceAllocator{
 				&mockHintProvider{
 					map[string][]TopologyHint{
 						"resource-1/A": {
@@ -124,9 +124,9 @@ func TestContainerCalculateAffinity(t *testing.T) {
 	for _, tc := range tcases {
 		ctnScope := &containerScope{
 			scope{
-				hintProviders: tc.hp,
-				policy:        &mockPolicy{},
-				name:          podTopologyScope,
+				providers: tc.prov,
+				policy:    &mockPolicy{},
+				name:      podTopologyScope,
 			},
 		}
 
@@ -142,17 +142,17 @@ func TestContainerCalculateAffinity(t *testing.T) {
 func TestContainerAccumulateProvidersHints(t *testing.T) {
 	tcases := []struct {
 		name     string
-		hp       []HintProvider
+		prov     []ResourceAllocator
 		expected []map[string][]TopologyHint
 	}{
 		{
 			name:     "TopologyHint not set",
-			hp:       []HintProvider{},
+			prov:     []ResourceAllocator{},
 			expected: nil,
 		},
 		{
 			name: "HintProvider returns empty non-nil map[string][]TopologyHint",
-			hp: []HintProvider{
+			prov: []ResourceAllocator{
 				&mockHintProvider{
 					map[string][]TopologyHint{},
 				},
@@ -163,7 +163,7 @@ func TestContainerAccumulateProvidersHints(t *testing.T) {
 		},
 		{
 			name: "HintProvider returns - nil map[string][]TopologyHint from provider",
-			hp: []HintProvider{
+			prov: []ResourceAllocator{
 				&mockHintProvider{
 					map[string][]TopologyHint{
 						"resource": nil,
@@ -178,7 +178,7 @@ func TestContainerAccumulateProvidersHints(t *testing.T) {
 		},
 		{
 			name: "2 HintProviders with 1 resource returns hints",
-			hp: []HintProvider{
+			prov: []ResourceAllocator{
 				&mockHintProvider{
 					map[string][]TopologyHint{
 						"resource1": {TopologyHint{}},
@@ -201,7 +201,7 @@ func TestContainerAccumulateProvidersHints(t *testing.T) {
 		},
 		{
 			name: "2 HintProviders 1 with 1 resource 1 with nil hints",
-			hp: []HintProvider{
+			prov: []ResourceAllocator{
 				&mockHintProvider{
 					map[string][]TopologyHint{
 						"resource1": {TopologyHint{}},
@@ -218,7 +218,7 @@ func TestContainerAccumulateProvidersHints(t *testing.T) {
 		},
 		{
 			name: "2 HintProviders 1 with 1 resource 1 empty hints",
-			hp: []HintProvider{
+			prov: []ResourceAllocator{
 				&mockHintProvider{
 					map[string][]TopologyHint{
 						"resource1": {TopologyHint{}},
@@ -237,7 +237,7 @@ func TestContainerAccumulateProvidersHints(t *testing.T) {
 		},
 		{
 			name: "HintProvider with 2 resources returns hints",
-			hp: []HintProvider{
+			prov: []ResourceAllocator{
 				&mockHintProvider{
 					map[string][]TopologyHint{
 						"resource1": {TopologyHint{}},
@@ -257,7 +257,7 @@ func TestContainerAccumulateProvidersHints(t *testing.T) {
 	for _, tc := range tcases {
 		ctnScope := containerScope{
 			scope{
-				hintProviders: tc.hp,
+				providers: tc.prov,
 			},
 		}
 		actual := ctnScope.accumulateProvidersHints(&v1.Pod{}, &v1.Container{})

--- a/pkg/kubelet/cm/topologymanager/scope_container_test.go
+++ b/pkg/kubelet/cm/topologymanager/scope_container_test.go
@@ -37,7 +37,7 @@ func TestContainerCalculateAffinity(t *testing.T) {
 		{
 			name: "HintProvider returns empty non-nil map[string][]TopologyHint",
 			prov: []ResourceAllocator{
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{},
 				},
 			},
@@ -48,7 +48,7 @@ func TestContainerCalculateAffinity(t *testing.T) {
 		{
 			name: "HintProvider returns -nil map[string][]TopologyHint from provider",
 			prov: []ResourceAllocator{
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource": nil,
 					},
@@ -63,7 +63,7 @@ func TestContainerCalculateAffinity(t *testing.T) {
 		{
 			name: "Assorted HintProviders",
 			prov: []ResourceAllocator{
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource-1/A": {
 							{NUMANodeAffinity: NewTestBitMask(0), Preferred: true},
@@ -75,7 +75,7 @@ func TestContainerCalculateAffinity(t *testing.T) {
 						},
 					},
 				},
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource-2/A": {
 							{NUMANodeAffinity: NewTestBitMask(2), Preferred: true},
@@ -87,7 +87,7 @@ func TestContainerCalculateAffinity(t *testing.T) {
 						},
 					},
 				},
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource-3": nil,
 					},
@@ -153,7 +153,7 @@ func TestContainerAccumulateProvidersHints(t *testing.T) {
 		{
 			name: "HintProvider returns empty non-nil map[string][]TopologyHint",
 			prov: []ResourceAllocator{
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{},
 				},
 			},
@@ -164,7 +164,7 @@ func TestContainerAccumulateProvidersHints(t *testing.T) {
 		{
 			name: "HintProvider returns - nil map[string][]TopologyHint from provider",
 			prov: []ResourceAllocator{
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource": nil,
 					},
@@ -179,12 +179,12 @@ func TestContainerAccumulateProvidersHints(t *testing.T) {
 		{
 			name: "2 HintProviders with 1 resource returns hints",
 			prov: []ResourceAllocator{
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource1": {TopologyHint{}},
 					},
 				},
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource2": {TopologyHint{}},
 					},
@@ -202,12 +202,12 @@ func TestContainerAccumulateProvidersHints(t *testing.T) {
 		{
 			name: "2 HintProviders 1 with 1 resource 1 with nil hints",
 			prov: []ResourceAllocator{
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource1": {TopologyHint{}},
 					},
 				},
-				&mockHintProvider{nil},
+				&fakeResourceAllocator{nil},
 			},
 			expected: []map[string][]TopologyHint{
 				{
@@ -219,12 +219,12 @@ func TestContainerAccumulateProvidersHints(t *testing.T) {
 		{
 			name: "2 HintProviders 1 with 1 resource 1 empty hints",
 			prov: []ResourceAllocator{
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource1": {TopologyHint{}},
 					},
 				},
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{},
 				},
 			},
@@ -238,7 +238,7 @@ func TestContainerAccumulateProvidersHints(t *testing.T) {
 		{
 			name: "HintProvider with 2 resources returns hints",
 			prov: []ResourceAllocator{
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource1": {TopologyHint{}},
 						"resource2": {TopologyHint{}},

--- a/pkg/kubelet/cm/topologymanager/scope_none.go
+++ b/pkg/kubelet/cm/topologymanager/scope_none.go
@@ -17,7 +17,8 @@ limitations under the License.
 package topologymanager
 
 import (
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/kubernetes/pkg/kubelet/cm/containermap"
 	"k8s.io/kubernetes/pkg/kubelet/lifecycle"
 )
@@ -30,10 +31,11 @@ type noneScope struct {
 var _ Scope = &noneScope{}
 
 // NewNoneScope returns a none scope.
-func NewNoneScope() Scope {
+func NewNoneScope(recorder record.EventRecorder) Scope {
 	return &noneScope{
 		scope{
 			name:             noneTopologyScope,
+			recorder:         recorder,
 			podTopologyHints: podTopologyHints{},
 			policy:           NewNonePolicy(),
 			podMap:           containermap.NewContainerMap(),

--- a/pkg/kubelet/cm/topologymanager/scope_pod.go
+++ b/pkg/kubelet/cm/topologymanager/scope_pod.go
@@ -17,7 +17,7 @@ limitations under the License.
 package topologymanager
 
 import (
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/kubelet/cm/admission"
 	"k8s.io/kubernetes/pkg/kubelet/cm/containermap"
@@ -68,7 +68,7 @@ func (s *podScope) Admit(pod *v1.Pod) lifecycle.PodAdmitResult {
 func (s *podScope) accumulateProvidersHints(pod *v1.Pod) []map[string][]TopologyHint {
 	var providersHints []map[string][]TopologyHint
 
-	for _, provider := range s.hintProviders {
+	for _, provider := range s.providers {
 		// Get the TopologyHints for a Pod from a provider.
 		hints := provider.GetPodTopologyHints(pod)
 		providersHints = append(providersHints, hints)

--- a/pkg/kubelet/cm/topologymanager/scope_pod.go
+++ b/pkg/kubelet/cm/topologymanager/scope_pod.go
@@ -18,6 +18,7 @@ package topologymanager
 
 import (
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/kubelet/cm/admission"
 	"k8s.io/kubernetes/pkg/kubelet/cm/containermap"
@@ -33,10 +34,11 @@ type podScope struct {
 var _ Scope = &podScope{}
 
 // NewPodScope returns a pod scope.
-func NewPodScope(policy Policy) Scope {
+func NewPodScope(policy Policy, recorder record.EventRecorder) Scope {
 	return &podScope{
 		scope{
 			name:             podTopologyScope,
+			recorder:         recorder,
 			podTopologyHints: podTopologyHints{},
 			policy:           policy,
 			podMap:           containermap.NewContainerMap(),
@@ -49,19 +51,24 @@ func (s *podScope) Admit(pod *v1.Pod) lifecycle.PodAdmitResult {
 	klog.InfoS("Best TopologyHint", "bestHint", bestHint, "pod", klog.KObj(pod))
 	if !admit {
 		metrics.TopologyManagerAdmissionErrorsTotal.Inc()
-		return admission.GetPodAdmitResult(&TopologyAffinityError{})
+		return admission.GetPodAdmitResult(&TopologyAffinityError{
+			Hint: bestHint.String(),
+		})
 	}
 
+	allocs := make(allocationMap)
 	for _, container := range append(pod.Spec.InitContainers, pod.Spec.Containers...) {
 		klog.InfoS("Topology Affinity", "bestHint", bestHint, "pod", klog.KObj(pod), "containerName", container.Name)
 		s.setTopologyHints(string(pod.UID), container.Name, bestHint)
 
-		err := s.allocateAlignedResources(pod, &container)
+		resources, err := s.allocateAlignedResources(pod, &container)
 		if err != nil {
 			metrics.TopologyManagerAdmissionErrorsTotal.Inc()
 			return admission.GetPodAdmitResult(err)
 		}
+		allocs.Add(container.Name, resources)
 	}
+	s.resourceAllocationSuccessEvent(pod, allocs)
 	return admission.GetPodAdmitResult(nil)
 }
 

--- a/pkg/kubelet/cm/topologymanager/scope_pod_test.go
+++ b/pkg/kubelet/cm/topologymanager/scope_pod_test.go
@@ -26,17 +26,17 @@ import (
 func TestPodCalculateAffinity(t *testing.T) {
 	tcases := []struct {
 		name     string
-		hp       []HintProvider
+		prov     []ResourceAllocator
 		expected []map[string][]TopologyHint
 	}{
 		{
 			name:     "No hint providers",
-			hp:       []HintProvider{},
+			prov:     []ResourceAllocator{},
 			expected: ([]map[string][]TopologyHint)(nil),
 		},
 		{
 			name: "HintProvider returns empty non-nil map[string][]TopologyHint",
-			hp: []HintProvider{
+			prov: []ResourceAllocator{
 				&mockHintProvider{
 					map[string][]TopologyHint{},
 				},
@@ -47,7 +47,7 @@ func TestPodCalculateAffinity(t *testing.T) {
 		},
 		{
 			name: "HintProvider returns -nil map[string][]TopologyHint from provider",
-			hp: []HintProvider{
+			prov: []ResourceAllocator{
 				&mockHintProvider{
 					map[string][]TopologyHint{
 						"resource": nil,
@@ -62,7 +62,7 @@ func TestPodCalculateAffinity(t *testing.T) {
 		},
 		{
 			name: "Assorted HintProviders",
-			hp: []HintProvider{
+			prov: []ResourceAllocator{
 				&mockHintProvider{
 					map[string][]TopologyHint{
 						"resource-1/A": {
@@ -124,9 +124,9 @@ func TestPodCalculateAffinity(t *testing.T) {
 	for _, tc := range tcases {
 		podScope := &podScope{
 			scope{
-				hintProviders: tc.hp,
-				policy:        &mockPolicy{},
-				name:          podTopologyScope,
+				providers: tc.prov,
+				policy:    &mockPolicy{},
+				name:      podTopologyScope,
 			},
 		}
 
@@ -142,17 +142,17 @@ func TestPodCalculateAffinity(t *testing.T) {
 func TestPodAccumulateProvidersHints(t *testing.T) {
 	tcases := []struct {
 		name     string
-		hp       []HintProvider
+		prov     []ResourceAllocator
 		expected []map[string][]TopologyHint
 	}{
 		{
 			name:     "TopologyHint not set",
-			hp:       []HintProvider{},
+			prov:     []ResourceAllocator{},
 			expected: nil,
 		},
 		{
 			name: "HintProvider returns empty non-nil map[string][]TopologyHint",
-			hp: []HintProvider{
+			prov: []ResourceAllocator{
 				&mockHintProvider{
 					map[string][]TopologyHint{},
 				},
@@ -163,7 +163,7 @@ func TestPodAccumulateProvidersHints(t *testing.T) {
 		},
 		{
 			name: "HintProvider returns - nil map[string][]TopologyHint from provider",
-			hp: []HintProvider{
+			prov: []ResourceAllocator{
 				&mockHintProvider{
 					map[string][]TopologyHint{
 						"resource": nil,
@@ -178,7 +178,7 @@ func TestPodAccumulateProvidersHints(t *testing.T) {
 		},
 		{
 			name: "2 HintProviders with 1 resource returns hints",
-			hp: []HintProvider{
+			prov: []ResourceAllocator{
 				&mockHintProvider{
 					map[string][]TopologyHint{
 						"resource1": {TopologyHint{}},
@@ -201,7 +201,7 @@ func TestPodAccumulateProvidersHints(t *testing.T) {
 		},
 		{
 			name: "2 HintProviders 1 with 1 resource 1 with nil hints",
-			hp: []HintProvider{
+			prov: []ResourceAllocator{
 				&mockHintProvider{
 					map[string][]TopologyHint{
 						"resource1": {TopologyHint{}},
@@ -218,7 +218,7 @@ func TestPodAccumulateProvidersHints(t *testing.T) {
 		},
 		{
 			name: "2 HintProviders 1 with 1 resource 1 empty hints",
-			hp: []HintProvider{
+			prov: []ResourceAllocator{
 				&mockHintProvider{
 					map[string][]TopologyHint{
 						"resource1": {TopologyHint{}},
@@ -237,7 +237,7 @@ func TestPodAccumulateProvidersHints(t *testing.T) {
 		},
 		{
 			name: "HintProvider with 2 resources returns hints",
-			hp: []HintProvider{
+			prov: []ResourceAllocator{
 				&mockHintProvider{
 					map[string][]TopologyHint{
 						"resource1": {TopologyHint{}},
@@ -257,7 +257,7 @@ func TestPodAccumulateProvidersHints(t *testing.T) {
 	for _, tc := range tcases {
 		pScope := podScope{
 			scope{
-				hintProviders: tc.hp,
+				providers: tc.prov,
 			},
 		}
 		actual := pScope.accumulateProvidersHints(&v1.Pod{})

--- a/pkg/kubelet/cm/topologymanager/scope_pod_test.go
+++ b/pkg/kubelet/cm/topologymanager/scope_pod_test.go
@@ -37,7 +37,7 @@ func TestPodCalculateAffinity(t *testing.T) {
 		{
 			name: "HintProvider returns empty non-nil map[string][]TopologyHint",
 			prov: []ResourceAllocator{
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{},
 				},
 			},
@@ -48,7 +48,7 @@ func TestPodCalculateAffinity(t *testing.T) {
 		{
 			name: "HintProvider returns -nil map[string][]TopologyHint from provider",
 			prov: []ResourceAllocator{
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource": nil,
 					},
@@ -63,7 +63,7 @@ func TestPodCalculateAffinity(t *testing.T) {
 		{
 			name: "Assorted HintProviders",
 			prov: []ResourceAllocator{
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource-1/A": {
 							{NUMANodeAffinity: NewTestBitMask(0), Preferred: true},
@@ -75,7 +75,7 @@ func TestPodCalculateAffinity(t *testing.T) {
 						},
 					},
 				},
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource-2/A": {
 							{NUMANodeAffinity: NewTestBitMask(2), Preferred: true},
@@ -87,7 +87,7 @@ func TestPodCalculateAffinity(t *testing.T) {
 						},
 					},
 				},
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource-3": nil,
 					},
@@ -153,7 +153,7 @@ func TestPodAccumulateProvidersHints(t *testing.T) {
 		{
 			name: "HintProvider returns empty non-nil map[string][]TopologyHint",
 			prov: []ResourceAllocator{
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{},
 				},
 			},
@@ -164,7 +164,7 @@ func TestPodAccumulateProvidersHints(t *testing.T) {
 		{
 			name: "HintProvider returns - nil map[string][]TopologyHint from provider",
 			prov: []ResourceAllocator{
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource": nil,
 					},
@@ -179,12 +179,12 @@ func TestPodAccumulateProvidersHints(t *testing.T) {
 		{
 			name: "2 HintProviders with 1 resource returns hints",
 			prov: []ResourceAllocator{
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource1": {TopologyHint{}},
 					},
 				},
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource2": {TopologyHint{}},
 					},
@@ -202,12 +202,12 @@ func TestPodAccumulateProvidersHints(t *testing.T) {
 		{
 			name: "2 HintProviders 1 with 1 resource 1 with nil hints",
 			prov: []ResourceAllocator{
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource1": {TopologyHint{}},
 					},
 				},
-				&mockHintProvider{nil},
+				&fakeResourceAllocator{nil},
 			},
 			expected: []map[string][]TopologyHint{
 				{
@@ -219,12 +219,12 @@ func TestPodAccumulateProvidersHints(t *testing.T) {
 		{
 			name: "2 HintProviders 1 with 1 resource 1 empty hints",
 			prov: []ResourceAllocator{
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource1": {TopologyHint{}},
 					},
 				},
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{},
 				},
 			},
@@ -238,7 +238,7 @@ func TestPodAccumulateProvidersHints(t *testing.T) {
 		{
 			name: "HintProvider with 2 resources returns hints",
 			prov: []ResourceAllocator{
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource1": {TopologyHint{}},
 						"resource2": {TopologyHint{}},

--- a/pkg/kubelet/cm/topologymanager/topology_manager.go
+++ b/pkg/kubelet/cm/topologymanager/topology_manager.go
@@ -22,6 +22,7 @@ import (
 
 	cadvisorapi "github.com/google/cadvisor/info/v1"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/kubelet/cm/topologymanager/bitmask"
 	"k8s.io/kubernetes/pkg/kubelet/lifecycle"
@@ -165,11 +166,11 @@ func (th *TopologyHint) LessThan(other TopologyHint) bool {
 var _ Manager = &manager{}
 
 // NewManager creates a new TopologyManager based on provided policy and scope
-func NewManager(topology []cadvisorapi.Node, topologyPolicyName string, topologyScopeName string, topologyPolicyOptions map[string]string) (Manager, error) {
+func NewManager(recorder record.EventRecorder, topology []cadvisorapi.Node, topologyPolicyName string, topologyScopeName string, topologyPolicyOptions map[string]string) (Manager, error) {
 	// When policy is none, the scope is not relevant, so we can short circuit here.
 	if topologyPolicyName == PolicyNone {
 		klog.InfoS("Creating topology manager with none policy")
-		return &manager{scope: NewNoneScope()}, nil
+		return &manager{scope: NewNoneScope(recorder)}, nil
 	}
 
 	opts, err := NewPolicyOptions(topologyPolicyOptions)
@@ -208,10 +209,10 @@ func NewManager(topology []cadvisorapi.Node, topologyPolicyName string, topology
 	switch topologyScopeName {
 
 	case containerTopologyScope:
-		scope = NewContainerScope(policy)
+		scope = NewContainerScope(policy, recorder)
 
 	case podTopologyScope:
-		scope = NewPodScope(policy)
+		scope = NewPodScope(policy, recorder)
 
 	default:
 		return nil, fmt.Errorf("unknown scope: \"%s\"", topologyScopeName)

--- a/pkg/kubelet/cm/topologymanager/topology_manager.go
+++ b/pkg/kubelet/cm/topologymanager/topology_manager.go
@@ -68,7 +68,8 @@ type Manager interface {
 	// PodAdmitHandler is implemented by Manager
 	lifecycle.PodAdmitHandler
 	// RegisterProvider adds a hint provider to manager to indicate the hint provider
-	// wants to be consulted with when making topology hints
+	// wants to be consulted with when making topology hints, and is authoritative
+	// about the current resource allocation.
 	RegisterProvider(ra ResourceAllocator)
 	// AddContainer adds pod to Manager for tracking
 	AddContainer(pod *v1.Pod, container *v1.Container, containerID string)
@@ -108,12 +109,20 @@ type HintProvider interface {
 // which can allocate resources, provide allocation hints.
 type ResourceAllocator interface {
 	HintProvider
+	AllocationInfoProvider
 }
 
 // Store interface is to allow Hint Providers to retrieve pod affinity
 type Store interface {
 	GetAffinity(podUID string, containerName string) TopologyHint
 	GetPolicy() Policy
+}
+
+type AllocationInfoProvider interface {
+	// GetExclusiveResources returns a list of resource names whose instances were
+	// esclusively allocated to this container. This is used by the orchestrator to
+	// check if a container got exclusive (vs shared) resources or not.
+	GetExclusiveResources(pod *v1.Pod, container *v1.Container) []string
 }
 
 // TopologyHint is a struct containing the NUMANodeAffinity for a Container

--- a/pkg/kubelet/cm/topologymanager/topology_manager.go
+++ b/pkg/kubelet/cm/topologymanager/topology_manager.go
@@ -67,9 +67,9 @@ func (e TopologyAffinityError) Type() string {
 type Manager interface {
 	// PodAdmitHandler is implemented by Manager
 	lifecycle.PodAdmitHandler
-	// AddHintProvider adds a hint provider to manager to indicate the hint provider
+	// RegisterProvider adds a hint provider to manager to indicate the hint provider
 	// wants to be consulted with when making topology hints
-	AddHintProvider(HintProvider)
+	RegisterProvider(ra ResourceAllocator)
 	// AddContainer adds pod to Manager for tracking
 	AddContainer(pod *v1.Pod, container *v1.Container, containerID string)
 	// RemoveContainer removes pod from Manager tracking
@@ -102,6 +102,12 @@ type HintProvider interface {
 	// all hints have been gathered and the aggregated Hint is available via a
 	// call to Store.GetAffinity().
 	Allocate(pod *v1.Pod, container *v1.Container) error
+}
+
+// ResourceAllocator is an interface for components which manage concrete resources,
+// which can allocate resources, provide allocation hints.
+type ResourceAllocator interface {
+	HintProvider
 }
 
 // Store interface is to allow Hint Providers to retrieve pod affinity
@@ -217,8 +223,8 @@ func (m *manager) GetPolicy() Policy {
 	return m.scope.GetPolicy()
 }
 
-func (m *manager) AddHintProvider(h HintProvider) {
-	m.scope.AddHintProvider(h)
+func (m *manager) RegisterProvider(ra ResourceAllocator) {
+	m.scope.RegisterProvider(ra)
 }
 
 func (m *manager) AddContainer(pod *v1.Pod, container *v1.Container, containerID string) {

--- a/pkg/kubelet/cm/topologymanager/topology_manager.go
+++ b/pkg/kubelet/cm/topologymanager/topology_manager.go
@@ -43,10 +43,20 @@ const (
 )
 
 // TopologyAffinityError represents an resource alignment error
-type TopologyAffinityError struct{}
+type TopologyAffinityError struct {
+	ContainerName string
+	Hint          string
+}
 
 func (e TopologyAffinityError) Error() string {
-	return "Resources cannot be allocated with Topology locality"
+	msg := "Resources cannot be allocated with Topology locality"
+	if e.ContainerName != "" {
+		msg += " container=" + e.ContainerName
+	}
+	if e.Hint != "" {
+		msg += " hint=" + e.Hint
+	}
+	return msg
 }
 
 func (e TopologyAffinityError) Type() string {
@@ -117,6 +127,14 @@ func (th *TopologyHint) IsEqual(topologyHint TopologyHint) bool {
 		return th.NUMANodeAffinity.IsEqual(topologyHint.NUMANodeAffinity)
 	}
 	return false
+}
+
+func (th TopologyHint) String() string {
+	aff := "N/A"
+	if th.NUMANodeAffinity != nil {
+		aff = th.NUMANodeAffinity.String()
+	}
+	return fmt.Sprintf("[affinity=%s preferred=%v]", aff, th.Preferred)
 }
 
 // LessThan checks if TopologyHint `a` is less than TopologyHint `b`

--- a/pkg/kubelet/cm/topologymanager/topology_manager_test.go
+++ b/pkg/kubelet/cm/topologymanager/topology_manager_test.go
@@ -201,22 +201,22 @@ func TestManagerScope(t *testing.T) {
 	}
 }
 
-type mockHintProvider struct {
+type fakeResourceAllocator struct {
 	th map[string][]TopologyHint
 	//TODO: Add this field and add some tests to make sure things error out
 	//appropriately on allocation errors.
 	//allocateError error
 }
 
-func (m *mockHintProvider) GetTopologyHints(pod *v1.Pod, container *v1.Container) map[string][]TopologyHint {
-	return m.th
+func (ra *fakeResourceAllocator) GetTopologyHints(pod *v1.Pod, container *v1.Container) map[string][]TopologyHint {
+	return ra.th
 }
 
-func (m *mockHintProvider) GetPodTopologyHints(pod *v1.Pod) map[string][]TopologyHint {
-	return m.th
+func (ra *fakeResourceAllocator) GetPodTopologyHints(pod *v1.Pod) map[string][]TopologyHint {
+	return ra.th
 }
 
-func (m *mockHintProvider) Allocate(pod *v1.Pod, container *v1.Container) error {
+func (ra *fakeResourceAllocator) Allocate(pod *v1.Pod, container *v1.Container) error {
 	//return allocateError
 	return nil
 }
@@ -239,9 +239,9 @@ func TestAddHintProvider(t *testing.T) {
 		{
 			name: "RegisterProvider",
 			prov: []ResourceAllocator{
-				&mockHintProvider{},
-				&mockHintProvider{},
-				&mockHintProvider{},
+				&fakeResourceAllocator{},
+				&fakeResourceAllocator{},
+				&fakeResourceAllocator{},
 			},
 		},
 	}
@@ -298,7 +298,7 @@ func TestAdmit(t *testing.T) {
 			qosClass: v1.PodQOSBestEffort,
 			policy:   singleNumaPolicy,
 			prov: []ResourceAllocator{
-				&mockHintProvider{},
+				&fakeResourceAllocator{},
 			},
 			expected: true,
 		},
@@ -307,7 +307,7 @@ func TestAdmit(t *testing.T) {
 			qosClass: v1.PodQOSBestEffort,
 			policy:   restrictedPolicy,
 			prov: []ResourceAllocator{
-				&mockHintProvider{},
+				&fakeResourceAllocator{},
 			},
 			expected: true,
 		},
@@ -316,7 +316,7 @@ func TestAdmit(t *testing.T) {
 			qosClass: v1.PodQOSGuaranteed,
 			policy:   bePolicy,
 			prov: []ResourceAllocator{
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource": {
 							{
@@ -338,7 +338,7 @@ func TestAdmit(t *testing.T) {
 			qosClass: v1.PodQOSGuaranteed,
 			policy:   bePolicy,
 			prov: []ResourceAllocator{
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource": {
 							{
@@ -364,7 +364,7 @@ func TestAdmit(t *testing.T) {
 			qosClass: v1.PodQOSBurstable,
 			policy:   bePolicy,
 			prov: []ResourceAllocator{
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource": {
 							{
@@ -390,7 +390,7 @@ func TestAdmit(t *testing.T) {
 			qosClass: v1.PodQOSGuaranteed,
 			policy:   bePolicy,
 			prov: []ResourceAllocator{
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource": {
 							{
@@ -408,7 +408,7 @@ func TestAdmit(t *testing.T) {
 			qosClass: v1.PodQOSGuaranteed,
 			policy:   restrictedPolicy,
 			prov: []ResourceAllocator{
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource": {
 							{
@@ -430,7 +430,7 @@ func TestAdmit(t *testing.T) {
 			qosClass: v1.PodQOSBurstable,
 			policy:   restrictedPolicy,
 			prov: []ResourceAllocator{
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource": {
 							{
@@ -451,7 +451,7 @@ func TestAdmit(t *testing.T) {
 			qosClass: v1.PodQOSGuaranteed,
 			policy:   restrictedPolicy,
 			prov: []ResourceAllocator{
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource": {
 							{
@@ -477,7 +477,7 @@ func TestAdmit(t *testing.T) {
 			qosClass: v1.PodQOSBurstable,
 			policy:   restrictedPolicy,
 			prov: []ResourceAllocator{
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource": {
 							{
@@ -503,7 +503,7 @@ func TestAdmit(t *testing.T) {
 			qosClass: v1.PodQOSGuaranteed,
 			policy:   restrictedPolicy,
 			prov: []ResourceAllocator{
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource": {
 							{
@@ -521,7 +521,7 @@ func TestAdmit(t *testing.T) {
 			qosClass: v1.PodQOSBurstable,
 			policy:   restrictedPolicy,
 			prov: []ResourceAllocator{
-				&mockHintProvider{
+				&fakeResourceAllocator{
 					map[string][]TopologyHint{
 						"resource": {
 							{

--- a/pkg/kubelet/cm/topologymanager/topology_manager_test.go
+++ b/pkg/kubelet/cm/topologymanager/topology_manager_test.go
@@ -221,6 +221,11 @@ func (ra *fakeResourceAllocator) Allocate(pod *v1.Pod, container *v1.Container) 
 	return nil
 }
 
+func (ra *fakeResourceAllocator) GetExclusiveResources(pod *v1.Pod, container *v1.Container) []string {
+	//TODO: add a field and use it
+	return nil
+}
+
 type mockPolicy struct {
 	nonePolicy
 	ph []map[string][]TopologyHint
@@ -231,7 +236,7 @@ func (p *mockPolicy) Merge(providersHints []map[string][]TopologyHint) (Topology
 	return TopologyHint{}, true
 }
 
-func TestAddHintProvider(t *testing.T) {
+func TestRegisterProvider(t *testing.T) {
 	tcases := []struct {
 		name string
 		prov []ResourceAllocator

--- a/pkg/kubelet/events/event.go
+++ b/pkg/kubelet/events/event.go
@@ -75,6 +75,10 @@ const (
 	FailedStatusPodSandBox               = "FailedPodSandBoxStatus"
 	FailedMountOnFilesystemMismatch      = "FailedMountOnFilesystemMismatch"
 	FailedPrepareDynamicResources        = "FailedPrepareDynamicResources"
+	FailedAllocationCPU                  = "FailedAllocationCPU"
+	FailedAllocationMemory               = "FailedAllocationMemory"
+	FailedAllocationDevice               = "FailedAllocationDevice"
+	AllocatedResources                   = "Allocated"
 )
 
 // Image manager event reason list

--- a/test/e2e_node/resource_allocation_events_test.go
+++ b/test/e2e_node/resource_allocation_events_test.go
@@ -1,0 +1,137 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2enode
+
+import (
+	"context"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	kubeletconfig "k8s.io/kubernetes/pkg/kubelet/apis/config"
+	"k8s.io/kubernetes/pkg/kubelet/cm/topologymanager"
+	kubeletevents "k8s.io/kubernetes/pkg/kubelet/events"
+	"k8s.io/kubernetes/test/e2e/feature"
+	"k8s.io/kubernetes/test/e2e/framework"
+	e2eevents "k8s.io/kubernetes/test/e2e/framework/events"
+	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
+	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
+	admissionapi "k8s.io/pod-security-admission/api"
+)
+
+var _ = SIGDescribe("Resource Allocation Events", framework.WithSerial(), feature.TopologyManager, feature.CPUManager, feature.MemoryManager, feature.DeviceManager, func() {
+	f := framework.NewDefaultFramework("resource-allocation-events")
+	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
+
+	ginkgo.Context("with topology and cpumanager configured", func() {
+		var oldCfg *kubeletconfig.KubeletConfiguration
+		var testPod *v1.Pod
+		var cpusNumPerNUMA, coresNumPerNUMA, numaNodes, threadsPerCore int
+
+		ginkgo.BeforeEach(func(ctx context.Context) {
+			var err error
+			if oldCfg == nil {
+				oldCfg, err = getCurrentKubeletConfig(ctx)
+				framework.ExpectNoError(err)
+			}
+
+			numaNodes = detectNUMANodes()
+			if numaNodes < minNumaNodes {
+				e2eskipper.Skipf("this test is intended to be run on a system with at least %d NUMA cells", minNumaNodes)
+			}
+			coresNumPerNUMA = detectCoresPerSocket() // this is not completely correct but holds true on amd64 nowadays
+			if coresNumPerNUMA < minCoreCount {
+				e2eskipper.Skipf("this test is intended to be run on a system with at least %d cores per socket", minCoreCount)
+			}
+			threadsPerCore = detectThreadPerCore()
+			cpusNumPerNUMA = coresNumPerNUMA * threadsPerCore
+
+			// It is safe to assume that the CPUs are distributed equally across
+			// NUMA nodes and therefore number of CPUs on all NUMA nodes are same
+			// so we just check the CPUs on the first NUMA node
+
+			framework.Logf("numaNodes on the system %d", numaNodes)
+			framework.Logf("Cores per NUMA on the system %d", coresNumPerNUMA)
+			framework.Logf("Threads per Core on the system %d", threadsPerCore)
+			framework.Logf("CPUs per NUMA on the system %d", cpusNumPerNUMA)
+
+			policy := topologymanager.PolicyRestricted // events will be emitted anyway
+			scope := podScopeTopology                  // not relevant
+
+			newCfg, _ := configureTopologyManagerInKubelet(oldCfg, policy, scope, nil, 0)
+			updateKubeletConfig(ctx, f, newCfg, true)
+
+			gomega.Eventually(ctx, func(ctx context.Context) bool {
+				_, ready := getLocalTestNode(ctx, f)
+				return ready
+			}).WithPolling(framework.Poll).WithTimeout(5 * time.Minute).Should(gomega.BeTrueBecause("local node not ready"))
+		})
+
+		ginkgo.AfterEach(func(ctx context.Context) {
+			if testPod != nil {
+				deletePodSyncByName(ctx, f, testPod.Name)
+			}
+			updateKubeletConfig(ctx, f, oldCfg, true)
+		})
+
+		ginkgo.It("should emit event when resource allocation is successful", func(ctx context.Context) {
+			ginkgo.By("Creating the test pod which will be admitted")
+			testPod = e2epod.NewPodClient(f).CreateSync(ctx, makeGuaranteedCPUExclusiveSleeperPod("pin-alloc-good", threadsPerCore))
+
+			eventSelector := fields.Set{
+				"involvedObject.kind":      "Pod",
+				"involvedObject.name":      testPod.Name,
+				"involvedObject.namespace": testPod.Namespace,
+				"reason":                   kubeletevents.AllocatedResources,
+			}.AsSelector().String()
+			framework.ExpectNoError(e2eevents.WaitTimeoutForEvent(ctx, f.ClientSet, testPod.Namespace, eventSelector, "", framework.PodEventTimeout))
+		})
+
+		ginkgo.It("should emit event when resource allocation fails", func(ctx context.Context) {
+			ginkgo.By("Creating the test pod which will be fail admission")
+			// +1 to make sure the requested cpus can't be aligned on a single node
+			testPod = e2epod.NewPodClient(f).Create(ctx, makeGuaranteedCPUExclusiveSleeperPod("pin-alloc-fail", cpusNumPerNUMA+1))
+
+			err := e2epod.WaitForPodCondition(ctx, f.ClientSet, f.Namespace.Name, testPod.Name, "Failed", 30*time.Second, func(pod *v1.Pod) (bool, error) {
+				if pod.Status.Phase != v1.PodPending {
+					return true, nil
+				}
+				return false, nil
+			})
+			framework.ExpectNoError(err)
+			testPod, err = e2epod.NewPodClient(f).Get(ctx, testPod.Name, metav1.GetOptions{})
+			framework.ExpectNoError(err)
+
+			if testPod.Status.Phase != v1.PodFailed {
+				framework.Failf("pod %s not failed: %v", testPod.Name, testPod.Status)
+			}
+
+			eventSelector := fields.Set{
+				"involvedObject.kind":      "Pod",
+				"involvedObject.name":      testPod.Name,
+				"involvedObject.namespace": testPod.Namespace,
+				"reason":                   kubeletevents.FailedAllocationCPU,
+			}.AsSelector().String()
+			framework.ExpectNoError(e2eevents.WaitTimeoutForEvent(ctx, f.ClientSet, testPod.Namespace, eventSelector, "container", framework.PodEventTimeout))
+		})
+
+	})
+})


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
Add events for resource allocation, both for the happy path to give some explicit feedback about succesfull allocation, and improve the error path to add information to events to help the troubleshooting.

Notably, we can improve also the workload awareness, projecting somehow the information in the container (maybe environment variables), but this is deferred to a future change

[EDIT 20240214]
addressing possible drawbacks of events:

1. [short lived](https://www.cncf.io/blog/2023/03/13/how-to-use-kubernetes-events-for-effective-alerting-and-monitoring/) - but should not be a problem for this context: users can fetch the events after pod admission failure to gain more insights, or after the pod goes running.
2. event can be [throttled](https://kubernetes.slack.com/archives/C0EG7JC6T/p1708002244634309?thread_ts=1707930394.080309&cid=C0EG7JC6T):
  a.  the core/v1 API has a client-side throttle of 1000 concurrent events: https://github.com/openshift/kubernetes/blob/master/staging/src/k8s.io/client-go/tools/record/event.go#L43
  b. the events/v1 API is merging event together and delaying their submission to reduce the pressure on the apiserver. Events will never be lost with this one, but their update on the apiserver side can be delayed by either 7 or 30 minutes

The conversation about [events](https://kubernetes.slack.com/archives/C0EG7JC6T/p1708001716829729?thread_ts=1707930394.080309&cid=C0EG7JC6T) further reinforces what emerged in the previous conversations: events are an improvement for fast-feedback, but to improve visibility/observability we will need to review and potentially enhance also metrics and logs. I'll update/file the issues 

#### Which issue(s) this PR fixes:
Part of the fix for #123037 

#### Special notes for your reviewer:
Please check the commit message(s) for full context and implementation rationale
We will need to review events and logs before to call 123037 done

#### Does this PR introduce a user-facing change?
```release-note
Add events to improve the observability of the resource allocation done by the kubelet
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
N/A
```
