### PR TITLE
 kubeadm: Validate only the first cert entry when external ca mode is used

### DIFF
--- a/cmd/kubeadm/app/util/certs/util.go
+++ b/cmd/kubeadm/app/util/certs/util.go
@@ -38,7 +38,20 @@ func SetupCertificateAuthority(t *testing.T) (*x509.Certificate, crypto.Signer) 
 		Config: certutil.Config{CommonName: "kubernetes"},
 	})
 	if err != nil {
-		t.Fatalf("failure while generating CA certificate and key: %v", err)
+		t.Fatalf("Failure while generating CA certificate and key: %v", err)
+	}
+
+	return caCert, caKey
+}
+
+// SetupIntermediateCertificateAuthority is a utility function for kubeadm testing that creates a
+// Intermediate CertificateAuthority cert/key pair
+func SetupIntermediateCertificateAuthority(t *testing.T, parentCert *x509.Certificate, parentKey crypto.Signer, cn string) (*x509.Certificate, crypto.Signer) {
+	caCert, caKey, err := pkiutil.NewIntermediateCertificateAuthority(parentCert, parentKey, &pkiutil.CertConfig{
+		Config: certutil.Config{CommonName: cn},
+	})
+	if err != nil {
+		t.Fatalf("Failure while generating intermediate CA certificate and key: %v", err)
 	}
 
 	return caCert, caKey


### PR DESCRIPTION
/sig cluster-lifecycle

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
We are deploying kubernetes using kubeadm using an external ca cert file / external ca mode. This external ca cert file contains multiple certificates. When kubeadm runs in external CA mode, kubeadm runs validation logic that compares the entire existing ca certificate file (` /etc/kubernetes/pki/ca.crt`) to the newly rendered 'dummy' kubeconfig that only reads in the first certificate from `ca.crt`. The bytes are then compared & fails the check since they are different -- 1 contains 1+N certificates, the other only contains 1 certificate.

The `ca.crt` used within validation is read here:
https://github.com/kubernetes/kubernetes/blob/master/cmd/kubeadm/app/util/pkiutil/pki_helpers.go#L292

The original `ca.crt` is read here:
https://github.com/kubernetes/kubernetes/blob/master/cmd/kubeadm/app/phases/kubeconfig/kubeconfig.go#L257

The check is happening here:
https://github.com/kubernetes/kubernetes/blob/master/cmd/kubeadm/app/phases/kubeconfig/kubeconfig.go#L268

#### Which issue(s) this PR fixes:
Fixes kubernetes/kubeadm#3011

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```YES```

```release-note
kubeadm: during the validation of existing kubeconfig files on disk, handle cases where the "ca.crt" is a bundle and has intermediate certificates. Find a common trust anchor between the "ca.crt" bundle and the CA in the existing kubeconfig on disk instead of treating "ca.crt" as a file containing a single CA.
```

