### PR TITLE
Automated cherry pick of #123093: Revert "kubeadm: fix a bug where the uploaded kubelet

### DIFF
--- a/cmd/kubeadm/app/cmd/phases/init/uploadconfig.go
+++ b/cmd/kubeadm/app/cmd/phases/init/uploadconfig.go
@@ -104,7 +104,7 @@ func getUploadConfigPhaseFlags() []string {
 
 // runUploadKubeadmConfig uploads the kubeadm configuration to a ConfigMap
 func runUploadKubeadmConfig(c workflow.RunData) error {
-	cfg, client, _, err := getUploadConfigData(c)
+	cfg, client, err := getUploadConfigData(c)
 	if err != nil {
 		return err
 	}
@@ -118,13 +118,13 @@ func runUploadKubeadmConfig(c workflow.RunData) error {
 
 // runUploadKubeletConfig uploads the kubelet configuration to a ConfigMap
 func runUploadKubeletConfig(c workflow.RunData) error {
-	cfg, client, patchesDir, err := getUploadConfigData(c)
+	cfg, client, err := getUploadConfigData(c)
 	if err != nil {
 		return err
 	}
 
 	klog.V(1).Infoln("[upload-config] Uploading the kubelet component config to a ConfigMap")
-	if err = kubeletphase.CreateConfigMap(&cfg.ClusterConfiguration, patchesDir, client); err != nil {
+	if err = kubeletphase.CreateConfigMap(&cfg.ClusterConfiguration, client); err != nil {
 		return errors.Wrap(err, "error creating kubelet configuration ConfigMap")
 	}
 
@@ -135,15 +135,15 @@ func runUploadKubeletConfig(c workflow.RunData) error {
 	return nil
 }
 
-func getUploadConfigData(c workflow.RunData) (*kubeadmapi.InitConfiguration, clientset.Interface, string, error) {
+func getUploadConfigData(c workflow.RunData) (*kubeadmapi.InitConfiguration, clientset.Interface, error) {
 	data, ok := c.(InitData)
 	if !ok {
-		return nil, nil, "", errors.New("upload-config phase invoked with an invalid data struct")
+		return nil, nil, errors.New("upload-config phase invoked with an invalid data struct")
 	}
 	cfg := data.Cfg()
 	client, err := data.Client()
 	if err != nil {
-		return nil, nil, "", err
+		return nil, nil, err
 	}
-	return cfg, client, data.PatchesDir(), err
+	return cfg, client, err
 }

--- a/cmd/kubeadm/app/phases/kubelet/config.go
+++ b/cmd/kubeadm/app/phases/kubelet/config.go
@@ -68,7 +68,10 @@ func WriteConfigToDisk(cfg *kubeadmapi.ClusterConfiguration, kubeletDir, patches
 
 // CreateConfigMap creates a ConfigMap with the generic kubelet configuration.
 // Used at "kubeadm init" and "kubeadm upgrade" time
-func CreateConfigMap(cfg *kubeadmapi.ClusterConfiguration, patchesDir string, client clientset.Interface) error {
+func CreateConfigMap(cfg *kubeadmapi.ClusterConfiguration, client clientset.Interface) error {
+	configMapName := kubeadmconstants.KubeletBaseConfigurationConfigMap
+	fmt.Printf("[kubelet] Creating a ConfigMap %q in namespace %s with the configuration for the kubelets in the cluster\n", configMapName, metav1.NamespaceSystem)
+
 	kubeletCfg, ok := cfg.ComponentConfigs[componentconfigs.KubeletGroup]
 	if !ok {
 		return errors.New("no kubelet component config found in the active component config set")
@@ -78,17 +81,6 @@ func CreateConfigMap(cfg *kubeadmapi.ClusterConfiguration, patchesDir string, cl
 	if err != nil {
 		return err
 	}
-
-	// Apply patches to the KubeletConfiguration
-	if len(patchesDir) != 0 {
-		kubeletBytes, err = applyKubeletConfigPatches(kubeletBytes, patchesDir, os.Stdout)
-		if err != nil {
-			return errors.Wrap(err, "could not apply patches to the KubeletConfiguration")
-		}
-	}
-
-	configMapName := kubeadmconstants.KubeletBaseConfigurationConfigMap
-	fmt.Printf("[kubelet] Creating a ConfigMap %q in namespace %s with the configuration for the kubelets in the cluster\n", configMapName, metav1.NamespaceSystem)
 
 	configMap := &v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{

--- a/cmd/kubeadm/app/phases/kubelet/config_test.go
+++ b/cmd/kubeadm/app/phases/kubelet/config_test.go
@@ -58,7 +58,7 @@ func TestCreateConfigMap(t *testing.T) {
 		t.Fatalf("unexpected failure when defaulting InitConfiguration: %v", err)
 	}
 
-	if err := CreateConfigMap(&internalcfg.ClusterConfiguration, "", client); err != nil {
+	if err := CreateConfigMap(&internalcfg.ClusterConfiguration, client); err != nil {
 		t.Errorf("CreateConfigMap: unexpected error %v", err)
 	}
 }

--- a/cmd/kubeadm/app/phases/upgrade/postupgrade.go
+++ b/cmd/kubeadm/app/phases/upgrade/postupgrade.go
@@ -57,7 +57,7 @@ func PerformPostUpgradeTasks(client clientset.Interface, cfg *kubeadmapi.InitCon
 	}
 
 	// Create the new, version-branched kubelet ComponentConfig ConfigMap
-	if err := kubeletphase.CreateConfigMap(&cfg.ClusterConfiguration, patchesDir, client); err != nil {
+	if err := kubeletphase.CreateConfigMap(&cfg.ClusterConfiguration, client); err != nil {
 		errs = append(errs, errors.Wrap(err, "error creating kubelet configuration ConfigMap"))
 	}
 


### PR DESCRIPTION
Cherry pick of #123093 on release-1.27.

#123093: Revert "kubeadm: fix a bug where the uploaded kubelet

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
fixes a 1.27.0+ regression in kubeadm: do not upload kubelet patch configuration into `kube-system/kubelet-config` ConfigMap
```