### PR TITLE
Fix adding new line after interrupting kubectl watch

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/get/get.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/get/get.go
@@ -686,7 +686,7 @@ func (o *GetOptions) watch(f cmdutil.Factory, args []string) error {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	intr := interrupt.New(nil, cancel)
+	intr := interrupt.New(nil, cancel).NewLineAfterTermination(true)
 	intr.Run(func() error {
 		_, err := watchtools.UntilWithoutRetry(ctx, w, func(e watch.Event) (bool, error) {
 			objToPrint := e.Object

--- a/staging/src/k8s.io/kubectl/pkg/util/interrupt/interrupt.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/interrupt/interrupt.go
@@ -17,6 +17,7 @@ limitations under the License.
 package interrupt
 
 import (
+	"fmt"
 	"os"
 	"os/signal"
 	"sync"
@@ -76,6 +77,8 @@ func (h *Handler) Signal(s os.Signal) {
 			fn()
 		}
 		if h.final == nil {
+			// Add new line before exiting to fix kubectl #1544
+			fmt.Print("\n")
 			os.Exit(1)
 		}
 		h.final(s)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Add new line after interrupt signal came for `kubectl watch`
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubectl/issues/1544

#### Special notes for your reviewer:
In interrupt module we add `\n` to add new line before killing program, this change simply fixes the issue and has the effect as below inside terminal:
Before:
```
^C$
```

After:
```
^C
$
```
Also we can remove the `^C` by changing the `\n` to `\r`.

Additionally because we use interrupt module inside `debug`, `events`, `rollout_status`, `run` they all should have this problem and adding new line can fix them all.
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE

```


<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->

