### PR TITLE
metrics: add and use ContainerRestartCount

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -2245,6 +2245,7 @@ func (kl *Kubelet) deletePod(pod *v1.Pod) error {
 		return fmt.Errorf("skipping delete because sources aren't ready yet")
 	}
 	klog.V(3).InfoS("Pod has been deleted and must be killed", "pod", klog.KObj(pod), "podUID", pod.UID)
+	metrics.ContainerRestartCount.Reset()
 	kl.podWorkers.UpdatePod(UpdatePodOptions{
 		Pod:        pod,
 		UpdateType: kubetypes.SyncPodKill,

--- a/pkg/kubelet/metrics/metrics.go
+++ b/pkg/kubelet/metrics/metrics.go
@@ -602,6 +602,16 @@ var (
 		},
 		[]string{"static"},
 	)
+	// ContainerRestartCount is a Counter that tracks the cumulative number of container restart count.
+	ContainerRestartCount = metrics.NewCounterVec(
+		&metrics.CounterOpts{
+			Subsystem:      KubeletSubsystem,
+			Name:           "pod_container_restart_count",
+			Help:           "Cumulative number of container restart count by pod and container name.",
+			StabilityLevel: metrics.ALPHA,
+		},
+		[]string{"pod_name", "container_name"},
+	)
 	// StartedPodsTotal is a counter that tracks pod sandbox creation operations
 	StartedPodsTotal = metrics.NewCounter(
 		&metrics.CounterOpts{


### PR DESCRIPTION
to help find container restart count by pod name and container name

What type of PR is this?
/kind feature

What this PR does / why we need it:
to count the restart count of container in the pod using Prometheus metrics

Special notes for your reviewer:
kubelet can't count when the container in pod restarts repeatedly, so add a new counter type of Prometheus metrics

Does this PR introduce a user-facing change?
```release-note
NONE
```

SIG labels
*kubelet

