### PR TITLE
kubeadm: increase ut coverage for apiclient/idempotency

### DIFF
--- a/cmd/kubeadm/app/util/apiclient/idempotency_test.go
+++ b/cmd/kubeadm/app/util/apiclient/idempotency_test.go
@@ -18,15 +18,18 @@ package apiclient
 
 import (
 	"context"
+	"reflect"
 	"testing"
 
 	"github.com/pkg/errors"
 
 	v1 "k8s.io/api/core/v1"
+	rbac "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 	core "k8s.io/client-go/testing"
 )
@@ -236,4 +239,216 @@ func TestMutateConfigMapWithConflict(t *testing.T) {
 	if cm.Data["key"] != "some-other-value" {
 		t.Fatalf("ConfigMap mutation with conflict was invalid, has: %q", cm.Data["key"])
 	}
+}
+
+func TestGetConfigMapWithShortRetry(t *testing.T) {
+	type args struct {
+		client    clientset.Interface
+		namespace string
+		name      string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *v1.ConfigMap
+		wantErr bool
+	}{
+		{
+			name: "ConfigMap exists",
+			args: args{
+				client:    newMockClientForTest(t, "default", "foo", "ConfigMap"),
+				namespace: "default",
+				name:      "foo",
+			},
+			want: &v1.ConfigMap{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       configMapName,
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "default",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "ConfigMap does not exist",
+			args: args{
+				client:    fake.NewSimpleClientset(),
+				namespace: "default",
+				name:      "foo",
+			},
+			want:    nil,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetConfigMapWithShortRetry(tt.args.client, tt.args.namespace, tt.args.name)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetConfigMapWithShortRetry() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetConfigMapWithShortRetry() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCreateOrUpdateClusterRole(t *testing.T) {
+	testClusterRole := &rbac.ClusterRole{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ClusterRole",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "foo",
+		},
+	}
+
+	type args struct {
+		client      clientset.Interface
+		clusterRole *rbac.ClusterRole
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "ClusterRole does not exist",
+			args: args{
+				client:      fake.NewSimpleClientset(),
+				clusterRole: testClusterRole,
+			},
+			wantErr: false,
+		},
+		{
+			name: "ClusterRole exists",
+			args: args{
+				client:      newMockClientForTest(t, "", "foo", "ClusterRole"),
+				clusterRole: testClusterRole,
+			},
+			wantErr: false,
+		},
+		{
+			name: "ClusterRole is invalid",
+			args: args{
+				client:      fake.NewSimpleClientset(),
+				clusterRole: nil,
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := CreateOrUpdateClusterRole(tt.args.client, tt.args.clusterRole); (err != nil) != tt.wantErr {
+				t.Errorf("CreateOrUpdateClusterRole() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestCreateOrUpdateClusterRoleBinding(t *testing.T) {
+	testClusterRoleBinding := &rbac.ClusterRoleBinding{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ClusterRoleBinding",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "foo",
+		},
+	}
+
+	type args struct {
+		client             clientset.Interface
+		clusterRoleBinding *rbac.ClusterRoleBinding
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "ClusterRoleBinding does not exist",
+			args: args{
+				client:             fake.NewSimpleClientset(),
+				clusterRoleBinding: testClusterRoleBinding,
+			},
+			wantErr: false,
+		},
+		{
+			name: "ClusterRoleBinding exists",
+			args: args{
+				client:             newMockClientForTest(t, "", "foo", "ClusterRoleBinding"),
+				clusterRoleBinding: testClusterRoleBinding,
+			},
+			wantErr: false,
+		},
+		{
+			name: "ClusterRoleBinding is invalid",
+			args: args{
+				client:             fake.NewSimpleClientset(),
+				clusterRoleBinding: nil,
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := CreateOrUpdateClusterRoleBinding(tt.args.client, tt.args.clusterRoleBinding); (err != nil) != tt.wantErr {
+				t.Errorf("CreateOrUpdateClusterRoleBinding() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func newMockClientForTest(t *testing.T, namepsace string, name string, kind string) *fake.Clientset {
+	client := fake.NewSimpleClientset()
+
+	switch kind {
+	case "ConfigMap":
+		_, err := client.CoreV1().ConfigMaps(namepsace).Create(context.Background(), &v1.ConfigMap{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       configMapName,
+				APIVersion: "v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namepsace,
+			},
+		}, metav1.CreateOptions{})
+		if err != nil {
+			t.Fatalf("error creating ConfigMap: %v", err)
+		}
+	case "ClusterRole":
+		_, err := client.RbacV1().ClusterRoles().Create(context.Background(), &rbac.ClusterRole{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "ClusterRole",
+				APIVersion: "v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name,
+			},
+		}, metav1.CreateOptions{})
+		if err != nil {
+			t.Fatalf("error creating ClusterRole: %v", err)
+		}
+	case "ClusterRoleBinding":
+		_, err := client.RbacV1().ClusterRoleBindings().Create(context.Background(), &rbac.ClusterRoleBinding{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "ClusterRoleBinding",
+				APIVersion: "v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name,
+			},
+		}, metav1.CreateOptions{})
+		if err != nil {
+			t.Fatalf("error creating ClusterRoleBinding: %v", err)
+		}
+	}
+	return client
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

kubeadm: increase ut coverage for apiclient/idempotency

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
