### PR TITLE
Fail admission check upon nil/empty overhead map

### DIFF
--- a/plugin/pkg/admission/runtimeclass/admission.go
+++ b/plugin/pkg/admission/runtimeclass/admission.go
@@ -175,7 +175,7 @@ func setOverhead(a admission.Attributes, pod *api.Pod, runtimeClass *nodev1.Runt
 	}
 
 	// reject pod if Overhead is already set that differs from what is defined in RuntimeClass
-	if pod.Spec.Overhead != nil && !apiequality.Semantic.DeepEqual(nodeOverhead.PodFixed, pod.Spec.Overhead) {
+	if len(pod.Spec.Overhead) > 0 && !apiequality.Semantic.DeepEqual(nodeOverhead.PodFixed, pod.Spec.Overhead) {
 		return admission.NewForbidden(a, fmt.Errorf("pod rejected: Pod's Overhead doesn't match RuntimeClass's defined Overhead"))
 	}
 


### PR DESCRIPTION


#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Currently the runtime class admission has a validation check against pod's `.spec.overhead` field. This validation is not correctly implemented because it's still failing requests if the request payload just has an empty map e.g.:

```yaml
apiVersion: v1
kind: Pod
metadata:
  name: nginx
spec:
  containers:
  - name: nginx
    image: nginx:1.14.2
    ports:
    - containerPort: 80
  overhead: {}
```

note that this failure won't be reproduced with kubectl because (if i remember correctly) it has an internal codec filtering out the empty map. but when a client requests with raw http client library, the admission controller will keep rejecting the request constantly.

Generally, I think in Kubernetes' API convention, empty and nil map should be completely equal so this PR is trying to fix that gap. This PR is backward-compatible because it's loosening the validation check.
