### PR TITLE
KEP-3705 CloudDualStackNodeIPs to GA

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -1208,7 +1208,7 @@ func RunKubelet(kubeServer *options.KubeletServer, kubeDeps *kubelet.Dependencie
 	// Setup event recorder if required.
 	makeEventRecorder(context.TODO(), kubeDeps, nodeName)
 
-	nodeIPs, err := nodeutil.ParseNodeIPArgument(kubeServer.NodeIP, kubeServer.CloudProvider, utilfeature.DefaultFeatureGate.Enabled(features.CloudDualStackNodeIPs))
+	nodeIPs, err := nodeutil.ParseNodeIPArgument(kubeServer.NodeIP, kubeServer.CloudProvider)
 	if err != nil {
 		return fmt.Errorf("bad --node-ip %q: %v", kubeServer.NodeIP, err)
 	}

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -66,6 +66,7 @@ const (
 	// owner: @danwinship
 	// alpha: v1.27
 	// beta: v1.29
+	// GA: v1.30
 	//
 	// Enables dual-stack --node-ip in kubelet with external cloud providers
 	CloudDualStackNodeIPs featuregate.Feature = "CloudDualStackNodeIPs"
@@ -935,7 +936,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 
 	AppArmor: {Default: true, PreRelease: featuregate.Beta},
 
-	CloudDualStackNodeIPs: {Default: true, PreRelease: featuregate.Beta},
+	CloudDualStackNodeIPs: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.32
 
 	ClusterTrustBundle: {Default: false, PreRelease: featuregate.Alpha},
 

--- a/staging/src/k8s.io/cloud-provider/controllers/node/node_controller.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/node/node_controller.go
@@ -29,7 +29,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	coreinformers "k8s.io/client-go/informers/core/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -44,7 +43,6 @@ import (
 	cloudnodeutil "k8s.io/cloud-provider/node/helpers"
 	controllersmetrics "k8s.io/component-base/metrics/prometheus/controllers"
 	nodeutil "k8s.io/component-helpers/node/util"
-	"k8s.io/controller-manager/pkg/features"
 	"k8s.io/klog/v2"
 )
 
@@ -748,7 +746,7 @@ func updateNodeAddressesFromNodeIP(node *v1.Node, nodeAddresses []v1.NodeAddress
 
 	providedNodeIP, exists := node.ObjectMeta.Annotations[cloudproviderapi.AnnotationAlphaProvidedIPAddr]
 	if exists {
-		nodeAddresses, err = cloudnodeutil.GetNodeAddressesFromNodeIP(providedNodeIP, nodeAddresses, utilfeature.DefaultFeatureGate.Enabled(features.CloudDualStackNodeIPs))
+		nodeAddresses, err = cloudnodeutil.GetNodeAddressesFromNodeIP(providedNodeIP, nodeAddresses)
 	}
 
 	return nodeAddresses, err

--- a/staging/src/k8s.io/cloud-provider/node/helpers/address.go
+++ b/staging/src/k8s.io/cloud-provider/node/helpers/address.go
@@ -85,7 +85,7 @@ func GetNodeAddressesFromNodeIPLegacy(nodeIP net.IP, cloudNodeAddresses []v1.Nod
 	}
 
 	// Otherwise the result is the same as for GetNodeAddressesFromNodeIP
-	return GetNodeAddressesFromNodeIP(nodeIP.String(), cloudNodeAddresses, false)
+	return GetNodeAddressesFromNodeIP(nodeIP.String(), cloudNodeAddresses)
 }
 
 // GetNodeAddressesFromNodeIP filters the provided list of nodeAddresses to match the
@@ -102,8 +102,8 @@ func GetNodeAddressesFromNodeIPLegacy(nodeIP net.IP, cloudNodeAddresses []v1.Nod
 // GetNodeAddressesFromNodeIPLegacy, because that case never occurs for external cloud
 // providers, because kubelet does not set the `provided-node-ip` annotation in that
 // case.)
-func GetNodeAddressesFromNodeIP(providedNodeIP string, cloudNodeAddresses []v1.NodeAddress, allowDualStack bool) ([]v1.NodeAddress, error) {
-	nodeIPs, err := nodeutil.ParseNodeIPAnnotation(providedNodeIP, allowDualStack)
+func GetNodeAddressesFromNodeIP(providedNodeIP string, cloudNodeAddresses []v1.NodeAddress) ([]v1.NodeAddress, error) {
+	nodeIPs, err := nodeutil.ParseNodeIPAnnotation(providedNodeIP)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse node IP %q: %v", providedNodeIP, err)
 	}

--- a/staging/src/k8s.io/cloud-provider/node/helpers/address_test.go
+++ b/staging/src/k8s.io/cloud-provider/node/helpers/address_test.go
@@ -552,7 +552,7 @@ func TestGetNodeAddressesFromNodeIP(t *testing.T) {
 
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := GetNodeAddressesFromNodeIP(tt.nodeIP, tt.nodeAddresses, true)
+			got, err := GetNodeAddressesFromNodeIP(tt.nodeIP, tt.nodeAddresses)
 			if (err != nil) != tt.shouldError {
 				t.Errorf("GetNodeAddressesFromNodeIP() error = %v, wantErr %v", err, tt.shouldError)
 				return

--- a/staging/src/k8s.io/component-helpers/node/util/ips.go
+++ b/staging/src/k8s.io/component-helpers/node/util/ips.go
@@ -64,19 +64,18 @@ func parseNodeIP(nodeIP string, allowDual, sloppy bool) ([]net.IP, error) {
 
 // ParseNodeIPArgument parses kubelet's --node-ip argument. If nodeIP contains invalid
 // values, they will be logged and ignored. Dual-stack node IPs are allowed if
-// cloudProvider is unset, or if it is `"external"` and allowCloudDualStack is true.
-func ParseNodeIPArgument(nodeIP, cloudProvider string, allowCloudDualStack bool) ([]net.IP, error) {
+// cloudProvider is unset or `"external"`.
+func ParseNodeIPArgument(nodeIP, cloudProvider string) ([]net.IP, error) {
 	var allowDualStack bool
-	if (cloudProvider == cloudProviderNone) || (cloudProvider == cloudProviderExternal && allowCloudDualStack) {
+	if cloudProvider == cloudProviderNone || cloudProvider == cloudProviderExternal {
 		allowDualStack = true
 	}
 	return parseNodeIP(nodeIP, allowDualStack, true)
 }
 
 // ParseNodeIPAnnotation parses the `alpha.kubernetes.io/provided-node-ip` annotation,
-// which can be either a single IP address or (if allowDualStack is true) a
-// comma-separated pair of IP addresses. Unlike with ParseNodeIPArgument, invalid values
-// are considered an error.
-func ParseNodeIPAnnotation(nodeIP string, allowDualStack bool) ([]net.IP, error) {
-	return parseNodeIP(nodeIP, allowDualStack, false)
+// which can be either a single IP address or a comma-separated pair of IP addresses.
+// Unlike with ParseNodeIPArgument, invalid values are considered an error.
+func ParseNodeIPAnnotation(nodeIP string) ([]net.IP, error) {
+	return parseNodeIP(nodeIP, true, false)
 }

--- a/staging/src/k8s.io/controller-manager/pkg/features/kube_features.go
+++ b/staging/src/k8s.io/controller-manager/pkg/features/kube_features.go
@@ -41,6 +41,7 @@ const (
 	// owner: @danwinship
 	// alpha: v1.27
 	// beta: v1.29
+	// GA: v1.30
 	//
 	// Enables dual-stack values in the
 	// `alpha.kubernetes.io/provided-node-ip` annotation
@@ -64,6 +65,6 @@ func SetupCurrentKubernetesSpecificFeatureGates(featuregates featuregate.Mutable
 // To add a new feature, define a key for it at k8s.io/api/pkg/features and add it here.
 var cloudPublicFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	CloudControllerManagerWebhook: {Default: false, PreRelease: featuregate.Alpha},
-	CloudDualStackNodeIPs:         {Default: true, PreRelease: featuregate.Beta},
+	CloudDualStackNodeIPs:         {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.32
 	StableLoadBalancerNodeSet:     {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // GA in 1.30, remove in 1.31
 }


### PR DESCRIPTION
#### What this PR does / why we need it:
Moves KEP-3705 CloudDualStackNodeIPs to GA, as per https://github.com/kubernetes/enhancements/pull/4415

#### Special notes for your reviewer:
I removed the `allowCloudDualStack` argument from `ParseNodeIPArgument` (since it would always be `true` now) but left the `cloudProvider` argument since kubelet still has some code for the legacy providers?

#### Does this PR introduce a user-facing change?
```release-note
Graduated support for passing dual-stack `kubelet --node-ip` values when using
a cloud provider. The feature is now GA and the `CloudDualStackNodeIPs` feature
gate is always enabled.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/3705
```

/kind feature
/priority important-soon
/assign @thockin 
