### PR TITLE
KEP-4193: promote ServiceAccountTokenJTI, ServiceAccountTokenPodNodeInfo and ServiceAccountTokenNodeBindingValidation to beta

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -694,6 +694,7 @@ const (
 	// owner: @munnerz
 	// kep: http://kep.k8s.io/4193
 	// alpha: v1.29
+	// beta: v1.30
 	//
 	// Controls whether JTIs (UUIDs) are embedded into generated service account tokens, and whether these JTIs are
 	// recorded into the audit log for future requests made by these tokens.
@@ -709,6 +710,7 @@ const (
 	// owner: @munnerz
 	// kep: http://kep.k8s.io/4193
 	// alpha: v1.29
+	// beta: v1.30
 	//
 	// Controls whether the apiserver will validate Node claims in service account tokens.
 	ServiceAccountTokenNodeBindingValidation featuregate.Feature = "ServiceAccountTokenNodeBindingValidation"
@@ -716,6 +718,7 @@ const (
 	// owner: @munnerz
 	// kep: http://kep.k8s.io/4193
 	// alpha: v1.29
+	// beta: v1.30
 	//
 	// Controls whether the apiserver embeds the node name and uid for the associated node when issuing
 	// service account tokens bound to Pod objects.
@@ -1101,13 +1104,13 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 
 	SeparateTaintEvictionController: {Default: true, PreRelease: featuregate.Beta},
 
-	ServiceAccountTokenJTI: {Default: false, PreRelease: featuregate.Alpha},
+	ServiceAccountTokenJTI: {Default: true, PreRelease: featuregate.Beta},
 
-	ServiceAccountTokenPodNodeInfo: {Default: false, PreRelease: featuregate.Alpha},
+	ServiceAccountTokenPodNodeInfo: {Default: true, PreRelease: featuregate.Beta},
 
 	ServiceAccountTokenNodeBinding: {Default: false, PreRelease: featuregate.Alpha},
 
-	ServiceAccountTokenNodeBindingValidation: {Default: false, PreRelease: featuregate.Alpha},
+	ServiceAccountTokenNodeBindingValidation: {Default: true, PreRelease: featuregate.Beta},
 
 	ServiceNodePortStaticSubrange: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // GA in 1.29; remove in 1.31
 

--- a/pkg/kubeapiserver/options/authentication.go
+++ b/pkg/kubeapiserver/options/authentication.go
@@ -260,6 +260,11 @@ func (o *BuiltInAuthenticationOptions) Validate() []error {
 		}
 	}
 
+	// verify that if ServiceAccountTokenNodeBinding is enabled, ServiceAccountTokenNodeBindingValidation is also enabled.
+	if utilfeature.DefaultFeatureGate.Enabled(features.ServiceAccountTokenNodeBinding) && !utilfeature.DefaultFeatureGate.Enabled(features.ServiceAccountTokenNodeBindingValidation) {
+		allErrors = append(allErrors, fmt.Errorf("the %q feature gate can only be enabled if the %q feature gate is also enabled", features.ServiceAccountTokenNodeBinding, features.ServiceAccountTokenNodeBindingValidation))
+	}
+
 	if o.WebHook != nil {
 		retryBackoff := o.WebHook.RetryBackoff
 		if retryBackoff != nil && retryBackoff.Steps <= 0 {

--- a/pkg/kubeapiserver/options/authentication_test.go
+++ b/pkg/kubeapiserver/options/authentication_test.go
@@ -35,19 +35,22 @@ import (
 	"k8s.io/apiserver/pkg/features"
 	apiserveroptions "k8s.io/apiserver/pkg/server/options"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/component-base/featuregate"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	kubefeatures "k8s.io/kubernetes/pkg/features"
 	kubeauthenticator "k8s.io/kubernetes/pkg/kubeapiserver/authenticator"
 	"k8s.io/utils/pointer"
 )
 
 func TestAuthenticationValidate(t *testing.T) {
 	testCases := []struct {
-		name                         string
-		testOIDC                     *OIDCAuthenticationOptions
-		testSA                       *ServiceAccountAuthenticationOptions
-		testWebHook                  *WebHookAuthenticationOptions
-		testAuthenticationConfigFile string
-		expectErr                    string
+		name                              string
+		testOIDC                          *OIDCAuthenticationOptions
+		testSA                            *ServiceAccountAuthenticationOptions
+		testWebHook                       *WebHookAuthenticationOptions
+		testAuthenticationConfigFile      string
+		expectErr                         string
+		enabledFeatures, disabledFeatures []featuregate.Feature
 	}{
 		{
 			name: "test when OIDC and ServiceAccounts are nil",
@@ -226,6 +229,12 @@ func TestAuthenticationValidate(t *testing.T) {
 			},
 			expectErr: "authentication-config file and oidc-* flags are mutually exclusive",
 		},
+		{
+			name:             "fails to validate if ServiceAccountTokenNodeBindingValidation is disabled and ServiceAccountTokenNodeBinding is enabled",
+			enabledFeatures:  []featuregate.Feature{kubefeatures.ServiceAccountTokenNodeBinding},
+			disabledFeatures: []featuregate.Feature{kubefeatures.ServiceAccountTokenNodeBindingValidation},
+			expectErr:        "the \"ServiceAccountTokenNodeBinding\" feature gate can only be enabled if the \"ServiceAccountTokenNodeBindingValidation\" feature gate is also enabled",
+		},
 	}
 
 	for _, testcase := range testCases {
@@ -235,7 +244,12 @@ func TestAuthenticationValidate(t *testing.T) {
 			options.ServiceAccounts = testcase.testSA
 			options.WebHook = testcase.testWebHook
 			options.AuthenticationConfigFile = testcase.testAuthenticationConfigFile
-
+			for _, f := range testcase.enabledFeatures {
+				defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, f, true)()
+			}
+			for _, f := range testcase.disabledFeatures {
+				defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, f, false)()
+			}
 			errs := options.Validate()
 			if len(errs) > 0 && (!strings.Contains(utilerrors.NewAggregate(errs).Error(), testcase.expectErr) || testcase.expectErr == "") {
 				t.Errorf("Got err: %v, Expected err: %s", errs, testcase.expectErr)

--- a/test/integration/auth/svcaccttoken_test.go
+++ b/test/integration/auth/svcaccttoken_test.go
@@ -306,6 +306,8 @@ func TestServiceAccountTokenCreate(t *testing.T) {
 		checkPayload(t, treq.Status.Token, "null", "kubernetes.io", "node")
 
 		info := doTokenReview(t, cs, treq, false)
+		// we are not testing the credential-id feature, so delete this value from the returned extra info map
+		delete(info.Extra, apiserverserviceaccount.CredentialIDKey)
 		if len(info.Extra) != 2 {
 			t.Fatalf("expected Extra have length of 2 but was length %d: %#v", len(info.Extra), info.Extra)
 		}
@@ -400,6 +402,8 @@ func TestServiceAccountTokenCreate(t *testing.T) {
 			}
 
 			info := doTokenReview(t, cs, treq, false)
+			// we are not testing the credential-id feature, so delete this value from the returned extra info map
+			delete(info.Extra, apiserverserviceaccount.CredentialIDKey)
 			if len(info.Extra) != len(expectedExtraValues) {
 				t.Fatalf("expected Extra have length of %d but was length %d: %#v", len(expectedExtraValues), len(info.Extra), info.Extra)
 			}

--- a/test/integration/auth/svcaccttoken_test.go
+++ b/test/integration/auth/svcaccttoken_test.go
@@ -237,8 +237,14 @@ func TestServiceAccountTokenCreate(t *testing.T) {
 		checkPayload(t, treq.Status.Token, `"test-svcacct"`, "kubernetes.io", "serviceaccount", "name")
 
 		info := doTokenReview(t, cs, treq, false)
+		// we are not testing the credential-id feature, so delete this value from the returned extra info map
 		if info.Extra != nil {
-			t.Fatalf("expected Extra to be nil but got: %#v", info.Extra)
+			if _, ok := info.Extra[apiserverserviceaccount.CredentialIDKey]; ok {
+				delete(info.Extra, apiserverserviceaccount.CredentialIDKey)
+			}
+		}
+		if len(info.Extra) > 0 {
+			t.Fatalf("expected Extra to be empty but got: %#v", info.Extra)
 		}
 		delSvcAcct()
 		doTokenReview(t, cs, treq, true)

--- a/test/integration/auth/svcaccttoken_test.go
+++ b/test/integration/auth/svcaccttoken_test.go
@@ -313,7 +313,9 @@ func TestServiceAccountTokenCreate(t *testing.T) {
 
 		info := doTokenReview(t, cs, treq, false)
 		// we are not testing the credential-id feature, so delete this value from the returned extra info map
-		delete(info.Extra, apiserverserviceaccount.CredentialIDKey)
+		if _, ok := info.Extra[apiserverserviceaccount.CredentialIDKey]; ok {
+			delete(info.Extra, apiserverserviceaccount.CredentialIDKey)
+		}
 		if len(info.Extra) != 2 {
 			t.Fatalf("expected Extra have length of 2 but was length %d: %#v", len(info.Extra), info.Extra)
 		}
@@ -409,7 +411,9 @@ func TestServiceAccountTokenCreate(t *testing.T) {
 
 			info := doTokenReview(t, cs, treq, false)
 			// we are not testing the credential-id feature, so delete this value from the returned extra info map
-			delete(info.Extra, apiserverserviceaccount.CredentialIDKey)
+			if _, ok := info.Extra[apiserverserviceaccount.CredentialIDKey]; ok {
+				delete(info.Extra, apiserverserviceaccount.CredentialIDKey)
+			}
 			if len(info.Extra) != len(expectedExtraValues) {
 				t.Fatalf("expected Extra have length of %d but was length %d: %#v", len(expectedExtraValues), len(info.Extra), info.Extra)
 			}

--- a/test/integration/auth/svcaccttoken_test.go
+++ b/test/integration/auth/svcaccttoken_test.go
@@ -239,9 +239,7 @@ func TestServiceAccountTokenCreate(t *testing.T) {
 		info := doTokenReview(t, cs, treq, false)
 		// we are not testing the credential-id feature, so delete this value from the returned extra info map
 		if info.Extra != nil {
-			if _, ok := info.Extra[apiserverserviceaccount.CredentialIDKey]; ok {
-				delete(info.Extra, apiserverserviceaccount.CredentialIDKey)
-			}
+			delete(info.Extra, apiserverserviceaccount.CredentialIDKey)
 		}
 		if len(info.Extra) > 0 {
 			t.Fatalf("expected Extra to be empty but got: %#v", info.Extra)
@@ -313,9 +311,7 @@ func TestServiceAccountTokenCreate(t *testing.T) {
 
 		info := doTokenReview(t, cs, treq, false)
 		// we are not testing the credential-id feature, so delete this value from the returned extra info map
-		if _, ok := info.Extra[apiserverserviceaccount.CredentialIDKey]; ok {
-			delete(info.Extra, apiserverserviceaccount.CredentialIDKey)
-		}
+		delete(info.Extra, apiserverserviceaccount.CredentialIDKey)
 		if len(info.Extra) != 2 {
 			t.Fatalf("expected Extra have length of 2 but was length %d: %#v", len(info.Extra), info.Extra)
 		}
@@ -411,9 +407,7 @@ func TestServiceAccountTokenCreate(t *testing.T) {
 
 			info := doTokenReview(t, cs, treq, false)
 			// we are not testing the credential-id feature, so delete this value from the returned extra info map
-			if _, ok := info.Extra[apiserverserviceaccount.CredentialIDKey]; ok {
-				delete(info.Extra, apiserverserviceaccount.CredentialIDKey)
-			}
+			delete(info.Extra, apiserverserviceaccount.CredentialIDKey)
 			if len(info.Extra) != len(expectedExtraValues) {
 				t.Fatalf("expected Extra have length of %d but was length %d: %#v", len(expectedExtraValues), len(info.Extra), info.Extra)
 			}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Promotes 3 out of 4 features from KEP-4193 to beta for the v1.30 release.

#### Which issue(s) this PR fixes:

N/A (part of https://github.com/kubernetes/enhancements/issues/4193)

#### Special notes for your reviewer:

As per the KEP, `ServiceAccountTokenNodeBinding` feature must be enabled *after* `ServiceAccountTokenNodeBindingValidation` to allow for safe rollbacks, so has been held back as alpha for the time being.

#### Does this PR introduce a user-facing change?
```release-note
* Embed Node information into Pod-bound service account tokens as additional metadata
* Set the 'JTI' field in issued service account tokens, and embed this information as `authentication.kubernetes.io/credential-id` in user's ExtraInfo
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/4193
```

/cc @enj @liggitt