### PR TITLE
kubectl: Allow namespaces with prefix

### DIFF
--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/config_flags.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/config_flags.go
@@ -221,7 +221,12 @@ func (f *ConfigFlags) toRawKubeConfigLoader() clientcmd.ClientConfig {
 		overrides.Context.AuthInfo = *f.AuthInfoName
 	}
 	if f.Namespace != nil {
-		overrides.Context.Namespace = *f.Namespace
+		namespaceWithoutPrefix, err := clientcmd.RemoveNamespacesPrefix(*f.Namespace)
+		if err != nil {
+			overrides.Context.Namespace = *f.Namespace
+		} else {
+			overrides.Context.Namespace = namespaceWithoutPrefix
+		}
 	}
 
 	if f.Timeout != nil {

--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/config_flags_test.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/config_flags_test.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package genericclioptions
+
+import "testing"
+
+func TestNamespacePrefixRemoval(t *testing.T) {
+	testCases := []struct {
+		name              string
+		namespace         string
+		expectedNamespace string
+	}{
+		{
+			name:              "Namespace without prefix should not change",
+			namespace:         "some-namespace",
+			expectedNamespace: "some-namespace",
+		},
+		{
+			name:              "Prefix without namespace should not change",
+			namespace:         "namespace/",
+			expectedNamespace: "namespace/",
+		},
+		{
+			name:              "Prefix of 'namespace/' should be removed",
+			namespace:         "namespace/some-namespace",
+			expectedNamespace: "some-namespace",
+		},
+		{
+			name:              "Prefix of 'ns/' should be removed",
+			namespace:         "namespace/some-namespace",
+			expectedNamespace: "some-namespace",
+		},
+		{
+			name:              "Prefix of 'namespaces/' should be removed",
+			namespace:         "namespace/some-namespace",
+			expectedNamespace: "some-namespace",
+		},
+		{
+			name:              "Prefix removal should be case insensitive",
+			namespace:         "NAMESPACE/some-namespace",
+			expectedNamespace: "some-namespace",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			configFlags := NewConfigFlags(true)
+			configFlags.Namespace = &tc.namespace
+
+			namespace, _, _ := configFlags.toRawKubeConfigLoader().Namespace()
+			if namespace != tc.expectedNamespace {
+				t.Errorf("expected namespace value (%s), got (%s)", tc.expectedNamespace, namespace)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug
/kind regression

#### What this PR does / why we need it:

Strip the prefix from the namespace flag if it starts with "namespace/", "namespaces/", or "ns/" (case insensitive), allowing the output of `kubectl get ns -o name` to be used directly in subsequent commands.

This was previously addressed in #50579, but lost in a refactor to config flag parsing (#63373).

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #29271

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed a regression in flag parsing, to allow using prefixed namespaces (kubectl -n namespace/example)
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
