### PR TITLE
[WIP] Remove --pod-infra-container-image from kubelet

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -200,11 +200,6 @@ is checked every 20 seconds (also configurable with a flag).`,
 				return fmt.Errorf("failed to validate kubelet flags: %w", err)
 			}
 
-			if cleanFlagSet.Changed("pod-infra-container-image") {
-				klog.InfoS("--pod-infra-container-image will not be pruned by the image garbage collector in kubelet and should also be set in the remote runtime")
-				_ = cmd.Flags().MarkDeprecated("pod-infra-container-image", "--pod-infra-container-image will be removed in 1.30. Image garbage collector will get sandbox image information from CRI.")
-			}
-
 			// load kubelet config file, if provided
 			if len(kubeletFlags.KubeletConfigFile) > 0 {
 				kubeletConfig, err = loadConfigFile(kubeletFlags.KubeletConfigFile)

--- a/pkg/kubelet/config/flags.go
+++ b/pkg/kubelet/config/flags.go
@@ -17,8 +17,6 @@ limitations under the License.
 package config
 
 import (
-	"fmt"
-
 	"github.com/spf13/pflag"
 )
 
@@ -28,9 +26,7 @@ type ContainerRuntimeOptions struct {
 
 	// RuntimeCgroups that container runtime is expected to be isolated in.
 	RuntimeCgroups string
-	// PodSandboxImage is the image whose network/ipc namespaces
-	// containers in each pod will use.
-	PodSandboxImage string
+
 	// Image credential provider plugin options
 
 	// ImageCredentialProviderConfigFile is the path to the credential provider plugin config file.
@@ -50,8 +46,6 @@ type ContainerRuntimeOptions struct {
 func (s *ContainerRuntimeOptions) AddFlags(fs *pflag.FlagSet) {
 	// General settings.
 	fs.StringVar(&s.RuntimeCgroups, "runtime-cgroups", s.RuntimeCgroups, "Optional absolute name of cgroups to create and run the runtime in.")
-	fs.StringVar(&s.PodSandboxImage, "pod-infra-container-image", s.PodSandboxImage, fmt.Sprintf("Specified image will not be pruned by the image garbage collector. CRI implementations have their own configuration to set this image."))
-	fs.MarkDeprecated("pod-infra-container-image", "will be removed in a future release. Image garbage collector will get sandbox image information from CRI.")
 
 	// Image credential provider settings.
 	fs.StringVar(&s.ImageCredentialProviderConfigFile, "image-credential-provider-config", s.ImageCredentialProviderConfigFile, "The path to the credential provider plugin config file.")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

We were left in an odd position by #118544. That PR marked this flag as deprecated (though it had already been marked as deprecated in an earlier release), while also removing the functionality that the flag controlled. The documentation for the flag was not updated to reflect this. In practice, this meant that with the 1.29.0 release, `kubelet` *required* that the CRI implementation had proper pinning for the sandbox image, or `kubelet` will delete it.

For 1.30, I don't think it's unreasonable for `kubelet` to assume this aspect of the CRI is implemented by the runtime, but I do think it's misleading to leave this flag in the CLI when it does nothing.

Some alternatives:
1. Document that this flag no longer has any effect and that `kubelet ` requires e.g. `container` 1.7.2/1.6.22 or above (etc.).
2. Consider this a bug in 1.29 and add the functionality for this flag back.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Removes the `--pod-infra-container-image` from kubelet. The CRI is now responsible for marking the sandbox image as pinned; otherwise it will be eligible for kubelet's image garbage collection.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
