### PR TITLE
Fix broken go wiki links

### DIFF
--- a/hack/tools/tools.go
+++ b/hack/tools/tools.go
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 // Package tools is used to track binary dependencies with go modules
-// https://github.com/golang/go/wiki/Modules#how-can-i-track-tool-dependencies-for-a-module
+// https://go.dev/wiki/Modules#how-can-i-track-tool-dependencies-for-a-module
 package tools
 
 import (

--- a/pkg/registry/core/service/portallocator/storage/storage_test.go
+++ b/pkg/registry/core/service/portallocator/storage/storage_test.go
@@ -132,7 +132,7 @@ func TestAllocate(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // NOTE: https://github.com/golang/go/wiki/CommonMistakes#using-goroutines-on-loop-iterator-variables
+		tt := tt // NOTE: https://go.dev/wiki/CommonMistakes#using-goroutines-on-loop-iterator-variables
 		t.Run(tt.name, func(t *testing.T) {
 			err := storage.Allocate(tt.port)
 			if (err == nil) != (tt.errMsg == "") {
@@ -143,7 +143,6 @@ func TestAllocate(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 // TestReallocate test that we can not allocate a port already allocated until it is released
@@ -184,7 +183,6 @@ func TestReallocate(t *testing.T) {
 	if err := storage.Allocate(30100); err != nil {
 		t.Fatal(err)
 	}
-
 }
 
 func TestAllocateReserved(t *testing.T) {

--- a/staging/src/k8s.io/client-go/INSTALL.md
+++ b/staging/src/k8s.io/client-go/INSTALL.md
@@ -82,7 +82,7 @@ If you get a message like `cannot use path@version syntax in GOPATH mode`,
 you likely do not have go modules enabled.
 
 Dependency management tools are built into go 1.11+ in the form of 
-[go modules](https://github.com/golang/go/wiki/Modules).
+[go modules](https://go.dev/wiki/Modules).
 These are used by the main Kubernetes repo (>= `v1.15.0`) and 
 `client-go` (>= `kubernetes-1.15.0`) to manage dependencies.
 If you are using go 1.11 or 1.12 and are working with a project located within `$GOPATH`,

--- a/staging/src/k8s.io/endpointslice/topologycache/sliceinfo.go
+++ b/staging/src/k8s.io/endpointslice/topologycache/sliceinfo.go
@@ -56,7 +56,7 @@ func (si *SliceInfo) getAllocatedHintsByZone(allocations map[string]allocation) 
 	allocatedHintsByZone := EndpointZoneInfo{}
 
 	// Using filtering in place to remove any endpoints that are no longer
-	// unchanged (https://github.com/golang/go/wiki/SliceTricks#filter-in-place)
+	// unchanged (https://go.dev/wiki/SliceTricks#filter-in-place)
 	j := 0
 	for _, slice := range si.Unchanged {
 		hintsByZone := getHintsByZone(slice, allocatedHintsByZone, allocations)

--- a/staging/src/k8s.io/kubectl/README.md
+++ b/staging/src/k8s.io/kubectl/README.md
@@ -23,7 +23,7 @@ cli client. That client will eventually move here too.
   Not only for developers on the project, but also for external users of these packages.
 
 - When reviewing PRs, you are encouraged to use Golang's [code review
-  comments](https://github.com/golang/go/wiki/CodeReviewComments) page.
+  comments](https://go.dev/wiki/CodeReviewComments) page.
 
 - Packages in this repository should aspire to implement sensible, small
   interfaces and import a limited set of dependencies.


### PR DESCRIPTION
#### What type of PR is this?
/kind documentation

#### What this PR does / why we need it:

The links to the Go wiki are no longer valid as they moved it to go.dev. This PR uses the new updated urls.

#### Which issue(s) this PR fixes:


#### Special notes for your reviewer:


#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
