### PR TITLE
Fix internal error when serializing groupLookupFailures in log

### DIFF
--- a/pkg/controller/garbagecollector/garbagecollector.go
+++ b/pkg/controller/garbagecollector/garbagecollector.go
@@ -832,7 +832,9 @@ func GetDeletableResources(logger klog.Logger, discoveryClient discovery.ServerR
 	preferredResources, lookupErr := discoveryClient.ServerPreferredResources()
 	if lookupErr != nil {
 		if groupLookupFailures, isLookupFailure := discovery.GroupDiscoveryFailedErrorGroups(lookupErr); isLookupFailure {
-			logger.Info("failed to discover some groups", "groups", groupLookupFailures)
+			// Serialize groupLookupFailures here as map[schema.GroupVersion]error is not json encodable, otherwise the
+			// logger would throw internal error.
+			logger.Info("failed to discover some groups", "groups", fmt.Sprintf("%q", groupLookupFailures))
 		} else {
 			logger.Info("failed to discover preferred resources", "error", lookupErr)
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

When garbagecollector failed to look up ServerPreferredResources, it logged the failed groups as "<internal error: json: unsupported type: map[schema.GroupVersion]error>", making the failure more obscure.

It's because the logger tried to serialize the value using json encoder but the type map[schema.GroupVersion]error is not supported. Either schema.GroupVersion needs to implement TextMarshaler interface, or we can serialize the type before passing it to the logger.

Before the patch:
```
1 garbagecollector.go:835] "failed to discover some groups" groups="<internal error: json: unsupported type: map[schema.GroupVersion]error>"
```

After the patch:
```
1 garbagecollector.go:837] "failed to discover some groups" groups="map[\"controlplane.antrea.io/v1beta2\":\"stale GroupVersion discovery: controlplane.antrea.io/v1beta2\" \"stats.antrea.io/v1alpha1\":\"stale GroupVersion discovery: stats.antrea.io/v1alpha1\"]"
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
