### PR TITLE
kubelet: fix propagating optional CRI runtime conditions

### DIFF
--- a/pkg/kubelet/kubelet_node_status.go
+++ b/pkg/kubelet/kubelet_node_status.go
@@ -753,6 +753,7 @@ func (kl *Kubelet) defaultNodeStatusFuncs() []func(context.Context, *v1.Node) er
 		nodestatus.ReadyCondition(kl.clock.Now, kl.runtimeState.runtimeErrors, kl.runtimeState.networkErrors, kl.runtimeState.storageErrors,
 			kl.containerManager.Status, kl.shutdownManager.ShutdownStatus, kl.recordNodeStatusEvent, kl.supportLocalStorageCapacityIsolation()),
 		nodestatus.VolumesInUse(kl.volumeManager.ReconcilerStatesHasBeenSynced, kl.volumeManager.GetVolumesInUse),
+		nodestatus.Optional(kl.clock.Now, kl.runtimeState.getOptionalConditions),
 		// TODO(mtaufen): I decided not to move this setter for now, since all it does is send an event
 		// and record state back to the Kubelet runtime object. In the future, I'd like to isolate
 		// these side-effects by decoupling the decisions to send events and partial status recording

--- a/pkg/kubelet/runtime.go
+++ b/pkg/kubelet/runtime.go
@@ -36,6 +36,7 @@ type runtimeState struct {
 	cidr                     string
 	healthChecks             []*healthCheck
 	rtHandlers               []kubecontainer.RuntimeHandler
+	optionalConditions       []kubecontainer.RuntimeCondition
 }
 
 // A health check function should be efficient and not rely on external
@@ -140,6 +141,18 @@ func (s *runtimeState) storageErrors() error {
 		errs = append(errs, s.storageError)
 	}
 	return utilerrors.NewAggregate(errs)
+}
+
+func (s *runtimeState) setOptionalConditions(conds []kubecontainer.RuntimeCondition) {
+	s.Lock()
+	defer s.Unlock()
+	s.optionalConditions = conds
+}
+
+func (s *runtimeState) getOptionalConditions() []kubecontainer.RuntimeCondition {
+	s.Lock()
+	defer s.Unlock()
+	return s.optionalConditions
 }
 
 func newRuntimeState(runtimeSyncThreshold time.Duration) *runtimeState {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:

Fix propagating optional CRI runtime conditions.

This is needed because the CRI API states that optional runtime conditions will be "exposed to users to help them understand the status of the system", but the conditions were not visible via the core API.

https://github.com/kubernetes/cri-api/blob/v0.29.1/pkg/apis/runtime/v1/api.proto#L1496-L1518

```protobuf
// RuntimeCondition contains condition information for the runtime.
// There are 2 kinds of runtime conditions:
// 1. Required conditions: Conditions are required for kubelet to work
// properly. If any required condition is unmet, the node will be not ready.
// The required conditions include:
//   * RuntimeReady: RuntimeReady means the runtime is up and ready to accept
//   basic containers e.g. container only needs host network.
//   * NetworkReady: NetworkReady means the runtime network is up and ready to
//   accept containers which require container network.
// 2. Optional conditions: Conditions are informative to the user, but kubelet
// will not rely on. Since condition type is an arbitrary string, all conditions
// not required are optional. These conditions will be exposed to users to help
// them understand the status of the system.
message RuntimeCondition {
    // Type of runtime condition.
    string type = 1;
    // Status of the condition, one of true/false. Default: false.
    bool status = 2;
    // Brief CamelCase string containing reason for the condition's last transition.
    string reason = 3;
    // Human-readable message indicating details about last transition.
    string message = 4;
}
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #123148


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubelet: fix propagating optional CRI runtime conditions
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```

- - -

Example output:
```console
$ kubectl get nodes -o json | jq .items[0].status.conditions
[
  {
    "lastHeartbeatTime": "2024-02-07T10:01:49Z",
    "lastTransitionTime": "2024-02-07T04:19:34Z",
    "message": "kubelet has sufficient memory available",
    "reason": "KubeletHasSufficientMemory",
    "status": "False",
    "type": "MemoryPressure"
  },
  {
    "lastHeartbeatTime": "2024-02-07T10:01:49Z",
    "lastTransitionTime": "2024-02-07T04:19:34Z",
    "message": "kubelet has no disk pressure",
    "reason": "KubeletHasNoDiskPressure",
    "status": "False",
    "type": "DiskPressure"
  },
  {
    "lastHeartbeatTime": "2024-02-07T10:01:49Z",
    "lastTransitionTime": "2024-02-07T04:19:34Z",
    "message": "kubelet has sufficient PID available",
    "reason": "KubeletHasSufficientPID",
    "status": "False",
    "type": "PIDPressure"
  },
  {
    "lastHeartbeatTime": "2024-02-07T10:01:49Z",
    "lastTransitionTime": "2024-02-07T04:19:56Z",
    "message": "kubelet is posting ready status",
    "reason": "KubeletReady",
    "status": "True",
    "type": "Ready"
  },
  {
    "lastHeartbeatTime": "2024-02-07T10:01:49Z",
    "lastTransitionTime": "2024-02-07T10:01:49Z",
    "message": "{\"io.containerd.deprecation/pull-schema-1-image\":\"Schema 1 images are deprecated since containerd v1.7 and removed in containerd v2.0. Since containerd v1.7.8, schema 1 images are identified by the \\\"io.containerd.image/converted-docker-schema1\\\" label.\"}",
    "reason": "ContainerdHasDeprecationWarnings",
    "status": "False",
    "type": "ContainerdHasNoDeprecationWarnings"
  }
]
```

`ContainerdHasNoDeprecationWarning` is proposed in:
- https://github.com/containerd/containerd/pull/9767

The condition is set to "True" if no deprecated feature is being used.

