### PR TITLE
Put validation utility packages used by API validation under API review

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/validation/OWNERS
+++ b/staging/src/k8s.io/apimachinery/pkg/api/validation/OWNERS
@@ -1,0 +1,11 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+# Disable inheritance as this is an api owners file
+options:
+  no_parent_owners: true
+approvers:
+  - api-approvers
+reviewers:
+  - api-reviewers
+labels:
+  - kind/api-change

--- a/staging/src/k8s.io/apimachinery/pkg/util/validation/OWNERS
+++ b/staging/src/k8s.io/apimachinery/pkg/util/validation/OWNERS
@@ -1,0 +1,11 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+# Disable inheritance as this is an api owners file
+options:
+  no_parent_owners: true
+approvers:
+  - api-approvers
+reviewers:
+  - api-reviewers
+labels:
+  - kind/api-change


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Came up in review of https://github.com/kubernetes/kubernetes/pull/122931#discussion_r1480448451 that there are utility methods outside API packages whose implementation directly impacts API surface. This puts those packages under API review.

cc @kubernetes/api-reviewers 
/assign @deads2k 
/sig architecture

```release-note
NONE
```