### PR TITLE
Add `AudienceMatchPolicy` and support multiple audiences in AuthenticationConfiguration

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/types.go
@@ -180,7 +180,16 @@ type Issuer struct {
 	URL                  string
 	CertificateAuthority string
 	Audiences            []string
+	AudienceMatchPolicy  AudienceMatchPolicyType
 }
+
+// AudienceMatchPolicyType is a set of valid values for Issuer.AudienceMatchPolicy
+type AudienceMatchPolicyType string
+
+// Valid types for AudienceMatchPolicyType
+const (
+	AudienceMatchPolicyMatchAny AudienceMatchPolicyType = "MatchAny"
+)
 
 // ClaimValidationRule provides the configuration for a single claim validation rule.
 type ClaimValidationRule struct {

--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1alpha1/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1alpha1/types.go
@@ -225,7 +225,31 @@ type Issuer struct {
 	// Required to be non-empty.
 	// +required
 	Audiences []string `json:"audiences"`
+
+	// audienceMatchPolicy defines how the "audiences" field is used to match the "aud" claim in the presented JWT.
+	// Allowed values are:
+	// 1. "MatchAny" when multiple audiences are specified and
+	// 2. empty (or unset) or "MatchAny" when a single audience is specified.
+	//
+	// - MatchAny: the "aud" claim in the presented JWT must match at least one of the entries in the "audiences" field.
+	// For example, if "audiences" is ["foo", "bar"], the "aud" claim in the presented JWT must contain either "foo" or "bar" (and may contain both).
+	//
+	// - "": The match policy can be empty (or unset) when a single audience is specified in the "audiences" field. The "aud" claim in the presented JWT must contain the single audience (and may contain others).
+	//
+	// For more nuanced audience validation, use claimValidationRules.
+	//   example: claimValidationRule[].expression: 'sets.equivalent(claims.aud, ["bar", "foo", "baz"])' to require an exact match.
+	// +optional
+	AudienceMatchPolicy AudienceMatchPolicyType `json:"audienceMatchPolicy,omitempty"`
 }
+
+// AudienceMatchPolicyType is a set of valid values for Issuer.AudienceMatchPolicy
+type AudienceMatchPolicyType string
+
+// Valid types for AudienceMatchPolicyType
+const (
+	// MatchAny means the "aud" claim in the presented JWT must match at least one of the entries in the "audiences" field.
+	AudienceMatchPolicyMatchAny AudienceMatchPolicyType = "MatchAny"
+)
 
 // ClaimValidationRule provides the configuration for a single claim validation rule.
 type ClaimValidationRule struct {

--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1alpha1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1alpha1/zz_generated.conversion.go
@@ -582,6 +582,7 @@ func autoConvert_v1alpha1_Issuer_To_apiserver_Issuer(in *Issuer, out *apiserver.
 	out.URL = in.URL
 	out.CertificateAuthority = in.CertificateAuthority
 	out.Audiences = *(*[]string)(unsafe.Pointer(&in.Audiences))
+	out.AudienceMatchPolicy = apiserver.AudienceMatchPolicyType(in.AudienceMatchPolicy)
 	return nil
 }
 
@@ -594,6 +595,7 @@ func autoConvert_apiserver_Issuer_To_v1alpha1_Issuer(in *apiserver.Issuer, out *
 	out.URL = in.URL
 	out.CertificateAuthority = in.CertificateAuthority
 	out.Audiences = *(*[]string)(unsafe.Pointer(&in.Audiences))
+	out.AudienceMatchPolicy = AudienceMatchPolicyType(in.AudienceMatchPolicy)
 	return nil
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/validation/validation.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/validation/validation.go
@@ -101,7 +101,7 @@ func validateIssuer(issuer api.Issuer, fldPath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 
 	allErrs = append(allErrs, validateURL(issuer.URL, fldPath.Child("url"))...)
-	allErrs = append(allErrs, validateAudiences(issuer.Audiences, fldPath.Child("audiences"))...)
+	allErrs = append(allErrs, validateAudiences(issuer.Audiences, issuer.AudienceMatchPolicy, fldPath.Child("audiences"), fldPath.Child("audienceMatchPolicy"))...)
 	allErrs = append(allErrs, validateCertificateAuthority(issuer.CertificateAuthority, fldPath.Child("certificateAuthority"))...)
 
 	return allErrs
@@ -136,7 +136,7 @@ func validateURL(issuerURL string, fldPath *field.Path) field.ErrorList {
 	return allErrs
 }
 
-func validateAudiences(audiences []string, fldPath *field.Path) field.ErrorList {
+func validateAudiences(audiences []string, audienceMatchPolicy api.AudienceMatchPolicyType, fldPath, audienceMatchPolicyFldPath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 
 	if len(audiences) == 0 {
@@ -155,6 +155,10 @@ func validateAudiences(audiences []string, fldPath *field.Path) field.ErrorList 
 		if len(audience) == 0 {
 			allErrs = append(allErrs, field.Required(fldPath, "audience can't be empty"))
 		}
+	}
+
+	if len(audienceMatchPolicy) > 0 && audienceMatchPolicy != api.AudienceMatchPolicyMatchAny {
+		allErrs = append(allErrs, field.Invalid(audienceMatchPolicyFldPath, audienceMatchPolicy, "audienceMatchPolicy must be empty or MatchAny for single audience"))
 	}
 
 	return allErrs

--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/validation/validation_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/validation/validation_test.go
@@ -304,6 +304,23 @@ func TestValidateAudiences(t *testing.T) {
 			matchPolicy: "MatchAny",
 			want:        "",
 		},
+		{
+			name:        "duplicate audience",
+			in:          []string{"audience", "audience"},
+			matchPolicy: "MatchAny",
+			want:        `issuer.audiences[1]: Duplicate value: "audience"`,
+		},
+		{
+			name: "match policy not set with multiple audiences",
+			in:   []string{"audience1", "audience2"},
+			want: `issuer.audienceMatchPolicy: Invalid value: "": audienceMatchPolicy must be MatchAny for multiple audiences`,
+		},
+		{
+			name:        "valid multiple audiences",
+			in:          []string{"audience1", "audience2"},
+			matchPolicy: "MatchAny",
+			want:        "",
+		},
 	}
 
 	for _, tt := range testCases {

--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/validation/validation_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/validation/validation_test.go
@@ -269,11 +269,13 @@ func TestValidateURL(t *testing.T) {
 
 func TestValidateAudiences(t *testing.T) {
 	fldPath := field.NewPath("issuer", "audiences")
+	audienceMatchPolicyFldPath := field.NewPath("issuer", "audienceMatchPolicy")
 
 	testCases := []struct {
-		name string
-		in   []string
-		want string
+		name        string
+		in          []string
+		matchPolicy string
+		want        string
 	}{
 		{
 			name: "audiences is empty",
@@ -281,25 +283,32 @@ func TestValidateAudiences(t *testing.T) {
 			want: "issuer.audiences: Required value: at least one issuer.audiences is required",
 		},
 		{
-			name: "at most one audiences is allowed",
-			in:   []string{"audience1", "audience2"},
-			want: "issuer.audiences: Too many: 2: must have at most 1 items",
-		},
-		{
 			name: "audience is empty",
 			in:   []string{""},
 			want: "issuer.audiences[0]: Required value: audience can't be empty",
+		},
+		{
+			name:        "invalid match policy with single audience",
+			in:          []string{"audience"},
+			matchPolicy: "MatchExact",
+			want:        `issuer.audienceMatchPolicy: Invalid value: "MatchExact": audienceMatchPolicy must be empty or MatchAny for single audience`,
 		},
 		{
 			name: "valid audience",
 			in:   []string{"audience"},
 			want: "",
 		},
+		{
+			name:        "valid audience with MatchAny policy",
+			in:          []string{"audience"},
+			matchPolicy: "MatchAny",
+			want:        "",
+		},
 	}
 
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
-			got := validateAudiences(tt.in, fldPath).ToAggregate()
+			got := validateAudiences(tt.in, api.AudienceMatchPolicyType(tt.matchPolicy), fldPath, audienceMatchPolicyFldPath).ToAggregate()
 			if d := cmp.Diff(tt.want, errString(got)); d != "" {
 				t.Fatalf("Audiences validation mismatch (-want +got):\n%s", d)
 			}

--- a/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/oidc/oidc_test.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/oidc/oidc_test.go
@@ -1522,6 +1522,70 @@ func TestToken(t *testing.T) {
 			},
 		},
 		{
+			name: "multiple-audiences in authentication config",
+			options: Options{
+				JWTAuthenticator: apiserver.JWTAuthenticator{
+					Issuer: apiserver.Issuer{
+						URL:                 "https://auth.example.com",
+						Audiences:           []string{"random-client", "my-client"},
+						AudienceMatchPolicy: "MatchAny",
+					},
+					ClaimMappings: apiserver.ClaimMappings{
+						Username: apiserver.PrefixedClaimOrExpression{
+							Claim:  "username",
+							Prefix: pointer.String(""),
+						},
+					},
+				},
+				now: func() time.Time { return now },
+			},
+			signingKey: loadRSAPrivKey(t, "testdata/rsa_1.pem", jose.RS256),
+			pubKeys: []*jose.JSONWebKey{
+				loadRSAKey(t, "testdata/rsa_1.pem", jose.RS256),
+			},
+			claims: fmt.Sprintf(`{
+				"iss": "https://auth.example.com",
+				"aud": ["not-my-client", "my-client"],
+				"azp": "not-my-client",
+				"username": "jane",
+				"exp": %d
+			}`, valid.Unix()),
+			want: &user.DefaultInfo{
+				Name: "jane",
+			},
+		},
+		{
+			name: "multiple-audiences in authentication config, no match",
+			options: Options{
+				JWTAuthenticator: apiserver.JWTAuthenticator{
+					Issuer: apiserver.Issuer{
+						URL:                 "https://auth.example.com",
+						Audiences:           []string{"random-client", "my-client"},
+						AudienceMatchPolicy: "MatchAny",
+					},
+					ClaimMappings: apiserver.ClaimMappings{
+						Username: apiserver.PrefixedClaimOrExpression{
+							Claim:  "username",
+							Prefix: pointer.String(""),
+						},
+					},
+				},
+				now: func() time.Time { return now },
+			},
+			signingKey: loadRSAPrivKey(t, "testdata/rsa_1.pem", jose.RS256),
+			pubKeys: []*jose.JSONWebKey{
+				loadRSAKey(t, "testdata/rsa_1.pem", jose.RS256),
+			},
+			claims: fmt.Sprintf(`{
+				"iss": "https://auth.example.com",
+				"aud": ["not-my-client"],
+				"azp": "not-my-client",
+				"username": "jane",
+				"exp": %d
+			}`, valid.Unix()),
+			wantErr: `oidc: verify token: oidc: expected audience in ["my-client" "random-client"] got ["not-my-client"]`,
+		},
+		{
 			name: "invalid-issuer",
 			options: Options{
 				JWTAuthenticator: apiserver.JWTAuthenticator{

--- a/test/integration/apiserver/oidc/oidc_test.go
+++ b/test/integration/apiserver/oidc/oidc_test.go
@@ -432,6 +432,8 @@ jwt:
     url: %s
     audiences:
     - %s
+    - another-audience
+    audienceMatchPolicy: MatchAny
     certificateAuthority: |
         %s
   claimMappings:
@@ -475,6 +477,8 @@ jwt:
     url: %s
     audiences:
     - %s
+    - another-audience
+    audienceMatchPolicy: MatchAny
     certificateAuthority: |
         %s
   claimMappings:
@@ -522,6 +526,8 @@ jwt:
     url: %s
     audiences:
     - %s
+    - another-audience
+    audienceMatchPolicy: MatchAny
     certificateAuthority: |
         %s
   claimMappings:
@@ -565,6 +571,8 @@ jwt:
     url: %s
     audiences:
     - %s
+    - another-audience
+    audienceMatchPolicy: MatchAny
     certificateAuthority: |
         %s
   claimMappings:
@@ -621,6 +629,8 @@ jwt:
     url: %s
     audiences:
     - %s
+    - another-audience
+    audienceMatchPolicy: MatchAny
     certificateAuthority: |
         %s
   claimMappings:
@@ -668,6 +678,8 @@ jwt:
     url: %s
     audiences:
     - %s
+    - another-audience
+    audienceMatchPolicy: MatchAny
     certificateAuthority: |
         %s
   claimMappings:


### PR DESCRIPTION
/kind feature
/kind api-change

- Adds `AudienceMatchPolicy` API field in the `AuthenticationConfiguration`.
- Support for configuring multiple audiences in the authenticator.

part of https://github.com/kubernetes/kubernetes/issues/121553

```release-note
Added audienceMatchPolicy field to AuthenticationConfiguration and support for configuring multiple audiences.

- The "audienceMatchPolicy" can be empty (or unset) when a single audience is specified in the "audiences" field.
- The "audienceMatchPolicy" must be set to "MatchAny" when multiple audiences are specified in the "audiences" field.
```

```docs
[KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-auth/3331-structured-authentication-configuration
```
