### PR TITLE
use cmp.Diff instead of reflect.DeepEqual

### DIFF
--- a/pkg/scheduler/extender_test.go
+++ b/pkg/scheduler/extender_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -345,7 +346,7 @@ func TestSchedulerWithExtenders(t *testing.T) {
 					t.Errorf("Unexpected error: %v", err)
 					return
 				}
-				if diff := cmp.Diff(test.expectedResult, result); diff != "" {
+				if diff := cmp.Diff(test.expectedResult, result, cmpopts.EquateComparable(ScheduleResult{})); diff != "" {
 					t.Errorf("Unexpected result (-want +got):\n%s", diff)
 				}
 			}

--- a/pkg/scheduler/extender_test.go
+++ b/pkg/scheduler/extender_test.go
@@ -345,7 +345,7 @@ func TestSchedulerWithExtenders(t *testing.T) {
 					t.Errorf("Unexpected error: %v", err)
 					return
 				}
-				if diff := cmp.Diff(result, test.expectedResult); diff != "" {
+				if diff := cmp.Diff(test.expectedResult, result); diff != "" {
 					t.Errorf("Unexpected result (-want +got):\n%s", diff)
 				}
 			}
@@ -417,7 +417,6 @@ func TestIsInterested(t *testing.T) {
 }
 
 func TestConvertToMetaVictims(t *testing.T) {
-	t.Parallel()
 	tests := []struct {
 		name              string
 		nodeNameToVictims map[string]*extenderv1.Victims
@@ -460,9 +459,7 @@ func TestConvertToMetaVictims(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
 			got := convertToMetaVictims(tt.nodeNameToVictims)
 			if diff := cmp.Diff(tt.want, got); diff != "" {
 				t.Errorf("convertToMetaVictims() mismatch (-want +got):\n%s", diff)

--- a/pkg/scheduler/framework/plugins/interpodaffinity/scoring_test.go
+++ b/pkg/scheduler/framework/plugins/interpodaffinity/scoring_test.go
@@ -18,7 +18,6 @@ package interpodaffinity
 
 import (
 	"context"
-	"reflect"
 	"strings"
 	"testing"
 
@@ -34,14 +33,16 @@ import (
 	tf "k8s.io/kubernetes/pkg/scheduler/testing/framework"
 )
 
-var nsLabelT1 = map[string]string{"team": "team1"}
-var nsLabelT2 = map[string]string{"team": "team2"}
-var namespaces = []runtime.Object{
-	&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "subteam1.team1", Labels: nsLabelT1}},
-	&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "subteam2.team1", Labels: nsLabelT1}},
-	&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "subteam1.team2", Labels: nsLabelT2}},
-	&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "subteam2.team2", Labels: nsLabelT2}},
-}
+var (
+	nsLabelT1  = map[string]string{"team": "team1"}
+	nsLabelT2  = map[string]string{"team": "team2"}
+	namespaces = []runtime.Object{
+		&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "subteam1.team1", Labels: nsLabelT1}},
+		&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "subteam2.team1", Labels: nsLabelT1}},
+		&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "subteam1.team2", Labels: nsLabelT2}},
+		&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "subteam2.team2", Labels: nsLabelT2}},
+	}
+)
 
 func TestPreferredAffinity(t *testing.T) {
 	labelRgChina := map[string]string{
@@ -975,8 +976,8 @@ func TestPreferredAffinityWithHardPodAffinitySymmetricWeight(t *testing.T) {
 				t.Errorf("unexpected error: %v", status)
 			}
 
-			if !reflect.DeepEqual(test.expectedList, gotList) {
-				t.Errorf("expected:\n\t%+v,\ngot:\n\t%+v", test.expectedList, gotList)
+			if diff := cmp.Diff(test.expectedList, gotList); diff != "" {
+				t.Errorf("node score list doesn't match (-want,+got): \n %s", diff)
 			}
 		})
 	}

--- a/pkg/scheduler/framework/plugins/nodename/node_name_test.go
+++ b/pkg/scheduler/framework/plugins/nodename/node_name_test.go
@@ -17,9 +17,9 @@ limitations under the License.
 package nodename
 
 import (
-	"reflect"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 	st "k8s.io/kubernetes/pkg/scheduler/testing"
@@ -61,8 +61,8 @@ func TestNodeName(t *testing.T) {
 				t.Fatalf("creating plugin: %v", err)
 			}
 			gotStatus := p.(framework.FilterPlugin).Filter(ctx, nil, test.pod, nodeInfo)
-			if !reflect.DeepEqual(gotStatus, test.wantStatus) {
-				t.Errorf("status does not match: %v, want: %v", gotStatus, test.wantStatus)
+			if diff := cmp.Diff(test.wantStatus, gotStatus); diff != "" {
+				t.Errorf("unexpected status (-want, +got): %s", diff)
 			}
 		})
 	}

--- a/pkg/scheduler/framework/plugins/nodeports/node_ports_test.go
+++ b/pkg/scheduler/framework/plugins/nodeports/node_ports_test.go
@@ -181,8 +181,11 @@ func TestPreFilterDisabled(t *testing.T) {
 	cycleState := framework.NewCycleState()
 	gotStatus := p.(framework.FilterPlugin).Filter(ctx, cycleState, pod, nodeInfo)
 	wantStatus := framework.AsStatus(fmt.Errorf(`reading "PreFilterNodePorts" from cycleState: %w`, framework.ErrNotFound))
-	if diff := cmp.Diff(wantStatus, gotStatus); diff != "" {
-		t.Errorf("status does not match (-want,+got): %s", diff)
+	if wantStatus.Code() != gotStatus.Code() {
+		t.Error("Filter: status does not match")
+	}
+	if wantStatus.AsError().Error() != gotStatus.AsError().Error() {
+		t.Error("Filter: status does not match")
 	}
 }
 

--- a/pkg/scheduler/framework/plugins/nodeports/node_ports_test.go
+++ b/pkg/scheduler/framework/plugins/nodeports/node_ports_test.go
@@ -18,7 +18,6 @@ package nodeports
 
 import (
 	"fmt"
-	"reflect"
 	"strconv"
 	"strings"
 	"testing"
@@ -182,8 +181,8 @@ func TestPreFilterDisabled(t *testing.T) {
 	cycleState := framework.NewCycleState()
 	gotStatus := p.(framework.FilterPlugin).Filter(ctx, cycleState, pod, nodeInfo)
 	wantStatus := framework.AsStatus(fmt.Errorf(`reading "PreFilterNodePorts" from cycleState: %w`, framework.ErrNotFound))
-	if !reflect.DeepEqual(gotStatus, wantStatus) {
-		t.Errorf("status does not match: %v, want: %v", gotStatus, wantStatus)
+	if diff := cmp.Diff(wantStatus, gotStatus); diff != "" {
+		t.Errorf("status does not match (-want,+got): %s", diff)
 	}
 }
 
@@ -204,7 +203,8 @@ func TestGetContainerPorts(t *testing.T) {
 					ContainerPort: 8002,
 					HostPort:      8002,
 					Protocol:      v1.ProtocolTCP,
-				}}).ContainerPort([]v1.ContainerPort{
+				},
+			}).ContainerPort([]v1.ContainerPort{
 				{
 					ContainerPort: 8003,
 					HostPort:      8003,
@@ -214,7 +214,8 @@ func TestGetContainerPorts(t *testing.T) {
 					ContainerPort: 8004,
 					HostPort:      8004,
 					Protocol:      v1.ProtocolTCP,
-				}}).ContainerPort([]v1.ContainerPort{
+				},
+			}).ContainerPort([]v1.ContainerPort{
 				{
 					ContainerPort: 8005,
 					Protocol:      v1.ProtocolTCP,
@@ -230,7 +231,8 @@ func TestGetContainerPorts(t *testing.T) {
 					ContainerPort: 8012,
 					HostPort:      8012,
 					Protocol:      v1.ProtocolTCP,
-				}}).ContainerPort([]v1.ContainerPort{
+				},
+			}).ContainerPort([]v1.ContainerPort{
 				{
 					ContainerPort: 8013,
 					HostPort:      8013,
@@ -240,7 +242,8 @@ func TestGetContainerPorts(t *testing.T) {
 					ContainerPort: 8014,
 					HostPort:      8014,
 					Protocol:      v1.ProtocolTCP,
-				}}).ContainerPort([]v1.ContainerPort{
+				},
+			}).ContainerPort([]v1.ContainerPort{
 				{
 					ContainerPort: 8015,
 					Protocol:      v1.ProtocolTCP,

--- a/pkg/scheduler/framework/plugins/noderesources/balanced_allocation_test.go
+++ b/pkg/scheduler/framework/plugins/noderesources/balanced_allocation_test.go
@@ -18,9 +18,9 @@ package noderesources
 
 import (
 	"context"
-	"reflect"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -403,8 +403,8 @@ func TestNodeResourcesBalancedAllocation(t *testing.T) {
 				if !status.IsSuccess() {
 					t.Errorf("Score is expected to return success, but didn't. Got status: %v", status)
 				}
-				if !reflect.DeepEqual(test.expectedList[i].Score, hostResult) {
-					t.Errorf("got score %v for host %v, expected %v", hostResult, test.nodes[i].Name, test.expectedList[i].Score)
+				if diff := cmp.Diff(test.expectedList[i].Score, hostResult); diff != "" {
+					t.Errorf("Score() mismatch (-want +got):\n%s", diff)
 				}
 			}
 		})

--- a/pkg/scheduler/framework/plugins/noderesources/fit_test.go
+++ b/pkg/scheduler/framework/plugins/noderesources/fit_test.go
@@ -544,8 +544,11 @@ func TestPreFilterDisabled(t *testing.T) {
 	cycleState := framework.NewCycleState()
 	gotStatus := p.(framework.FilterPlugin).Filter(ctx, cycleState, pod, nodeInfo)
 	wantStatus := framework.AsStatus(fmt.Errorf(`error reading "PreFilterNodeResourcesFit" from cycleState: %w`, framework.ErrNotFound))
-	if diff := cmp.Diff(wantStatus, gotStatus); diff != "" {
-		t.Errorf("unexpected status (-want, +got):\n%s", diff)
+	if wantStatus.Code() != gotStatus.Code() {
+		t.Error("Filter: status does not match")
+	}
+	if wantStatus.AsError().Error() != gotStatus.AsError().Error() {
+		t.Error("Filter: status does not match")
 	}
 }
 

--- a/pkg/scheduler/framework/plugins/nodeunschedulable/node_unschedulable_test.go
+++ b/pkg/scheduler/framework/plugins/nodeunschedulable/node_unschedulable_test.go
@@ -17,9 +17,9 @@ limitations under the License.
 package nodeunschedulable
 
 import (
-	"reflect"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 	"k8s.io/kubernetes/test/utils/ktesting"
@@ -80,8 +80,8 @@ func TestNodeUnschedulable(t *testing.T) {
 			t.Fatalf("creating plugin: %v", err)
 		}
 		gotStatus := p.(framework.FilterPlugin).Filter(ctx, nil, test.pod, nodeInfo)
-		if !reflect.DeepEqual(gotStatus, test.wantStatus) {
-			t.Errorf("status does not match: %v, want: %v", gotStatus, test.wantStatus)
+		if diff := cmp.Diff(test.wantStatus, gotStatus); diff != "" {
+			t.Errorf("status mismatch (-want +got):\n%s", diff)
 		}
 	}
 }

--- a/pkg/scheduler/framework/plugins/nodevolumelimits/csi_test.go
+++ b/pkg/scheduler/framework/plugins/nodevolumelimits/csi_test.go
@@ -19,7 +19,6 @@ package nodevolumelimits
 import (
 	"errors"
 	"fmt"
-	"reflect"
 	"strings"
 	"testing"
 
@@ -47,9 +46,7 @@ const (
 	hostpathInTreePluginName = "kubernetes.io/hostpath"
 )
 
-var (
-	scName = "csi-sc"
-)
+var scName = "csi-sc"
 
 // getVolumeLimitKey returns a ResourceName by filter type
 func getVolumeLimitKey(filterType string) v1.ResourceName {
@@ -633,8 +630,8 @@ func TestCSILimits(t *testing.T) {
 			}
 			if gotPreFilterStatus.Code() != framework.Skip {
 				gotStatus := p.Filter(ctx, nil, test.newPod, node)
-				if !reflect.DeepEqual(gotStatus, test.wantStatus) {
-					t.Errorf("Filter status does not match: %v, want: %v", gotStatus, test.wantStatus)
+				if diff := cmp.Diff(test.wantStatus, gotStatus); diff != "" {
+					t.Errorf("Filter status does not match (-want, +got): %s", diff)
 				}
 			}
 		})

--- a/pkg/scheduler/framework/plugins/nodevolumelimits/csi_test.go
+++ b/pkg/scheduler/framework/plugins/nodevolumelimits/csi_test.go
@@ -630,8 +630,8 @@ func TestCSILimits(t *testing.T) {
 			}
 			if gotPreFilterStatus.Code() != framework.Skip {
 				gotStatus := p.Filter(ctx, nil, test.newPod, node)
-				if diff := cmp.Diff(test.wantStatus, gotStatus); diff != "" {
-					t.Errorf("Filter status does not match (-want, +got): %s", diff)
+				if test.wantStatus.Code() != gotStatus.Code() {
+					t.Error("Filter: status does not match")
 				}
 			}
 		})

--- a/pkg/scheduler/framework/plugins/nodevolumelimits/non_csi_test.go
+++ b/pkg/scheduler/framework/plugins/nodevolumelimits/non_csi_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"reflect"
 	"strings"
 	"testing"
 
@@ -193,8 +192,8 @@ func TestEphemeralLimits(t *testing.T) {
 
 			if gotPreFilterStatus.Code() != framework.Skip {
 				gotStatus := p.Filter(ctx, nil, test.newPod, node)
-				if !reflect.DeepEqual(gotStatus, test.wantStatus) {
-					t.Errorf("Filter status does not match: %v, want: %v", gotStatus, test.wantStatus)
+				if diff := cmp.Diff(test.wantStatus, gotStatus); diff != "" {
+					t.Errorf("Filter status does not match (-want, +got): %s", diff)
 				}
 			}
 		})
@@ -424,8 +423,8 @@ func TestAzureDiskLimits(t *testing.T) {
 
 			if gotPreFilterStatus.Code() != framework.Skip {
 				gotStatus := p.Filter(context.Background(), nil, test.newPod, node)
-				if !reflect.DeepEqual(gotStatus, test.wantStatus) {
-					t.Errorf("Filter status does not match: %v, want: %v", gotStatus, test.wantStatus)
+				if diff := cmp.Diff(test.wantStatus, gotStatus); diff != "" {
+					t.Errorf("Filter status does not match (-want, +got): %s", diff)
 				}
 			}
 		})
@@ -706,8 +705,8 @@ func TestEBSLimits(t *testing.T) {
 
 			if gotPreFilterStatus.Code() != framework.Skip {
 				gotStatus := p.Filter(ctx, nil, test.newPod, node)
-				if !reflect.DeepEqual(gotStatus, test.wantStatus) {
-					t.Errorf("Filter status does not match: %v, want: %v", gotStatus, test.wantStatus)
+				if diff := cmp.Diff(test.wantStatus, gotStatus); diff != "" {
+					t.Errorf("Filter status does not match (-want, +got): %s", diff)
 				}
 			}
 		})
@@ -937,8 +936,8 @@ func TestGCEPDLimits(t *testing.T) {
 
 			if gotPreFilterStatus.Code() != framework.Skip {
 				gotStatus := p.Filter(context.Background(), nil, test.newPod, node)
-				if !reflect.DeepEqual(gotStatus, test.wantStatus) {
-					t.Errorf("Filter status does not match: %v, want: %v", gotStatus, test.wantStatus)
+				if diff := cmp.Diff(test.wantStatus, gotStatus); diff != "" {
+					t.Errorf("Filter status does not match (-want, +got): %s", diff)
 				}
 			}
 		})

--- a/pkg/scheduler/framework/plugins/nodevolumelimits/non_csi_test.go
+++ b/pkg/scheduler/framework/plugins/nodevolumelimits/non_csi_test.go
@@ -192,8 +192,8 @@ func TestEphemeralLimits(t *testing.T) {
 
 			if gotPreFilterStatus.Code() != framework.Skip {
 				gotStatus := p.Filter(ctx, nil, test.newPod, node)
-				if diff := cmp.Diff(test.wantStatus, gotStatus); diff != "" {
-					t.Errorf("Filter status does not match (-want, +got): %s", diff)
+				if test.wantStatus.Code() != gotStatus.Code() {
+					t.Error("Filter: status does not match")
 				}
 			}
 		})

--- a/pkg/scheduler/framework/plugins/podtopologyspread/filtering_test.go
+++ b/pkg/scheduler/framework/plugins/podtopologyspread/filtering_test.go
@@ -68,7 +68,6 @@ func (p *criticalPaths) sort() {
 }
 
 func TestPreFilterState(t *testing.T) {
-
 	tests := []struct {
 		name                      string
 		pod                       *v1.Pod
@@ -3381,8 +3380,8 @@ func TestPreFilterDisabled(t *testing.T) {
 	cycleState := framework.NewCycleState()
 	gotStatus := p.(*PodTopologySpread).Filter(context.Background(), cycleState, pod, nodeInfo)
 	wantStatus := framework.AsStatus(fmt.Errorf(`reading "PreFilterPodTopologySpread" from cycleState: %w`, framework.ErrNotFound))
-	if !reflect.DeepEqual(gotStatus, wantStatus) {
-		t.Errorf("status does not match: %v, want: %v", gotStatus, wantStatus)
+	if diff := cmp.Diff(wantStatus, gotStatus, cmpOpts...); diff != "" {
+		t.Errorf("unexpected status (-want, +got): %s", diff)
 	}
 }
 

--- a/pkg/scheduler/framework/plugins/podtopologyspread/filtering_test.go
+++ b/pkg/scheduler/framework/plugins/podtopologyspread/filtering_test.go
@@ -3380,8 +3380,11 @@ func TestPreFilterDisabled(t *testing.T) {
 	cycleState := framework.NewCycleState()
 	gotStatus := p.(*PodTopologySpread).Filter(context.Background(), cycleState, pod, nodeInfo)
 	wantStatus := framework.AsStatus(fmt.Errorf(`reading "PreFilterPodTopologySpread" from cycleState: %w`, framework.ErrNotFound))
-	if diff := cmp.Diff(wantStatus, gotStatus, cmpOpts...); diff != "" {
-		t.Errorf("unexpected status (-want, +got): %s", diff)
+	if wantStatus.Code() != gotStatus.Code() {
+		t.Error("Filter: status does not match")
+	}
+	if wantStatus.AsError().Error() != gotStatus.AsError().Error() {
+		t.Error("Filter: status does not match")
 	}
 }
 

--- a/pkg/scheduler/framework/plugins/tainttoleration/taint_toleration_test.go
+++ b/pkg/scheduler/framework/plugins/tainttoleration/taint_toleration_test.go
@@ -18,9 +18,9 @@ package tainttoleration
 
 import (
 	"context"
-	"reflect"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2/ktesting"
@@ -209,10 +209,10 @@ func TestTaintTolerationScore(t *testing.T) {
 		},
 		{
 			name: "Default behaviour No taints and tolerations, lands on node with no taints",
-			//pod without tolerations
+			// pod without tolerations
 			pod: podWithTolerations("pod1", []v1.Toleration{}),
 			nodes: []*v1.Node{
-				//Node without taints
+				// Node without taints
 				nodeWithTaints("nodeA", []v1.Taint{}),
 				nodeWithTaints("nodeB", []v1.Taint{
 					{
@@ -261,8 +261,8 @@ func TestTaintTolerationScore(t *testing.T) {
 				t.Errorf("unexpected error: %v", status)
 			}
 
-			if !reflect.DeepEqual(test.expectedList, gotList) {
-				t.Errorf("expected:\n\t%+v,\ngot:\n\t%+v", test.expectedList, gotList)
+			if diff := cmp.Diff(test.expectedList, gotList); diff != "" {
+				t.Errorf("unexpected status (-want, +got): %s", diff)
 			}
 		})
 	}
@@ -347,8 +347,8 @@ func TestTaintTolerationFilter(t *testing.T) {
 				t.Fatalf("creating plugin: %v", err)
 			}
 			gotStatus := p.(framework.FilterPlugin).Filter(ctx, nil, test.pod, nodeInfo)
-			if !reflect.DeepEqual(gotStatus, test.wantStatus) {
-				t.Errorf("status does not match: %v, want: %v", gotStatus, test.wantStatus)
+			if diff := cmp.Diff(test.wantStatus, gotStatus); diff != "" {
+				t.Errorf("status mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/pkg/scheduler/framework/plugins/volumebinding/binder_test.go
+++ b/pkg/scheduler/framework/plugins/volumebinding/binder_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"reflect"
 	"sort"
 	"testing"
 	"time"
@@ -336,7 +335,6 @@ func (env *testEnv) initVolumes(cachedPVs []*v1.PersistentVolume, apiPVs []*v1.P
 	for _, pv := range apiPVs {
 		env.reactor.AddVolume(pv)
 	}
-
 }
 
 func (env *testEnv) updateVolumes(ctx context.Context, pvs []*v1.PersistentVolume) error {
@@ -534,8 +532,8 @@ func (env *testEnv) validateBind(
 	t *testing.T,
 	pod *v1.Pod,
 	expectedPVs []*v1.PersistentVolume,
-	expectedAPIPVs []*v1.PersistentVolume) {
-
+	expectedAPIPVs []*v1.PersistentVolume,
+) {
 	// Check pv cache
 	pvCache := env.internalBinder.pvCache
 	for _, pv := range expectedPVs {
@@ -561,8 +559,8 @@ func (env *testEnv) validateProvision(
 	t *testing.T,
 	pod *v1.Pod,
 	expectedPVCs []*v1.PersistentVolumeClaim,
-	expectedAPIPVCs []*v1.PersistentVolumeClaim) {
-
+	expectedAPIPVCs []*v1.PersistentVolumeClaim,
+) {
 	// Check pvc cache
 	pvcCache := env.internalBinder.pvcCache
 	for _, pvc := range expectedPVCs {
@@ -2455,14 +2453,8 @@ func TestGetEligibleNodes(t *testing.T) {
 		eligibleNodes := testEnv.binder.GetEligibleNodes(logger, scenario.pvcs)
 
 		// Validate
-        if diff := cmp.Diff(scenario.eligibleNodes, eligibleNodes, cmp.Comparer(func(a, b sets.Set[string]) bool {
-            return reflect.DeepEqual(a, b)
-        })); diff != "" {
-
-		if compDiff := cmp.Diff(scenario.eligibleNodes, eligibleNodes, cmp.Comparer(func(a, b sets.Set[string]) bool {
-			return reflect.DeepEqual(a, b)
-		})); compDiff != "" {
-			t.Errorf("Unexpected eligible nodes (-want +got):\n%s", compDiff)
+		if diff := cmp.Diff(scenario.eligibleNodes, eligibleNodes); diff != "" {
+			t.Errorf("Unexpected eligible nodes: %s", diff)
 		}
 	}
 

--- a/pkg/scheduler/framework/plugins/volumebinding/binder_test.go
+++ b/pkg/scheduler/framework/plugins/volumebinding/binder_test.go
@@ -2455,9 +2455,9 @@ func TestGetEligibleNodes(t *testing.T) {
 		eligibleNodes := testEnv.binder.GetEligibleNodes(logger, scenario.pvcs)
 
 		// Validate
-		if reflect.DeepEqual(scenario.eligibleNodes, eligibleNodes) {
-			fmt.Println("foo")
-		}
+        if diff := cmp.Diff(scenario.eligibleNodes, eligibleNodes, cmp.Comparer(func(a, b sets.Set[string]) bool {
+            return reflect.DeepEqual(a, b)
+        })); diff != "" {
 
 		if compDiff := cmp.Diff(scenario.eligibleNodes, eligibleNodes, cmp.Comparer(func(a, b sets.Set[string]) bool {
 			return reflect.DeepEqual(a, b)

--- a/pkg/scheduler/framework/runtime/framework_test.go
+++ b/pkg/scheduler/framework/runtime/framework_test.go
@@ -2232,8 +2232,12 @@ func TestPostFilterPlugins(t *testing.T) {
 				t.Fatalf("fail to create framework: %s", err)
 			}
 			_, gotStatus := f.RunPostFilterPlugins(ctx, nil, pod, nil)
-			if diff := cmp.Diff(tt.wantStatus, gotStatus); diff != "" {
-				t.Errorf("unexpected status (-want, +got): %s", diff)
+			if tt.wantStatus.Code() != gotStatus.Code() {
+				t.Errorf("unexpected status code: got %v, want %v", gotStatus.Code(), tt.wantStatus.Code())
+			}
+			asErr := tt.wantStatus.AsError()
+			if asErr != nil && gotStatus.AsError() != nil && asErr.Error() != gotStatus.AsError().Error() {
+				t.Errorf("unexpected status message: got %v, want %v", gotStatus.AsError().Error(), tt.wantStatus.AsError().Error())
 			}
 		})
 	}

--- a/pkg/scheduler/framework/runtime/registry_test.go
+++ b/pkg/scheduler/framework/runtime/registry_test.go
@@ -18,9 +18,9 @@ package runtime
 
 import (
 	"context"
-	"reflect"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -66,9 +66,8 @@ func TestDecodeInto(t *testing.T) {
 			if err := DecodeInto(test.args, &pluginFooConf); err != nil {
 				t.Errorf("DecodeInto(): failed to decode args %+v: %v", test.args, err)
 			}
-			if !reflect.DeepEqual(test.expected, pluginFooConf) {
-				t.Errorf("DecodeInto(): failed to decode plugin config, expected: %+v, got: %+v",
-					test.expected, pluginFooConf)
+			if diff := cmp.Diff(test.expected, pluginFooConf); diff != "" {
+				t.Errorf("DecodeInto() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/pkg/scheduler/framework/types_test.go
+++ b/pkg/scheduler/framework/types_test.go
@@ -18,7 +18,6 @@ package framework
 
 import (
 	"fmt"
-	"reflect"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -68,8 +67,8 @@ func TestNewResource(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			r := NewResource(test.resourceList)
-			if !reflect.DeepEqual(test.expected, r) {
-				t.Errorf("expected: %#v, got: %#v", test.expected, r)
+			if diff := cmp.Diff(test.expected, r); diff != "" {
+				t.Errorf("NewResource() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -107,8 +106,8 @@ func TestResourceClone(t *testing.T) {
 			r := test.resource.Clone()
 			// Modify the field to check if the result is a clone of the origin one.
 			test.resource.MilliCPU += 1000
-			if !reflect.DeepEqual(test.expected, r) {
-				t.Errorf("expected: %#v, got: %#v", test.expected, r)
+			if diff := cmp.Diff(test.expected, r); diff != "" {
+				t.Errorf("Clone() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -152,8 +151,8 @@ func TestResourceAddScalar(t *testing.T) {
 	for _, test := range tests {
 		t.Run(string(test.scalarName), func(t *testing.T) {
 			test.resource.AddScalar(test.scalarName, test.scalarQuantity)
-			if !reflect.DeepEqual(test.expected, test.resource) {
-				t.Errorf("expected: %#v, got: %#v", test.expected, test.resource)
+			if diff := cmp.Diff(test.expected, test.resource); diff != "" {
+				t.Errorf("AddScalar() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -204,8 +203,8 @@ func TestSetMaxResource(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("case_%d", i), func(t *testing.T) {
 			test.resource.SetMaxResource(test.resourceList)
-			if !reflect.DeepEqual(test.expected, test.resource) {
-				t.Errorf("expected: %#v, got: %#v", test.expected, test.resource)
+			if diff := cmp.Diff(test.expected, test.resource); diff != "" {
+				t.Errorf("SetMaxResource() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -330,8 +329,8 @@ func TestNewNodeInfo(t *testing.T) {
 		t.Errorf("Generation is not incremented. previous: %v, current: %v", gen, ni.Generation)
 	}
 	expected.Generation = ni.Generation
-	if !reflect.DeepEqual(expected, ni) {
-		t.Errorf("expected: %#v, got: %#v", expected, ni)
+	if diff := cmp.Diff(expected, ni); diff != "" {
+		t.Errorf("NewNodeInfo() mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -499,8 +498,8 @@ func TestNodeInfoClone(t *testing.T) {
 			// Modify the field to check if the result is a clone of the origin one.
 			test.nodeInfo.Generation += 10
 			test.nodeInfo.UsedPorts.Remove("127.0.0.1", "TCP", 80)
-			if !reflect.DeepEqual(test.expected, ni) {
-				t.Errorf("expected: %#v, got: %#v", test.expected, ni)
+			if diff := cmp.Diff(test.expected, ni); diff != "" {
+				t.Errorf("Snapshot() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -645,14 +644,14 @@ func TestNodeInfoAddPod(t *testing.T) {
 		},
 		Requested: &Resource{
 			MilliCPU:         2300,
-			Memory:           209716700, //1500 + 200MB in initContainers
+			Memory:           209716700, // 1500 + 200MB in initContainers
 			EphemeralStorage: 0,
 			AllowedPodNumber: 0,
 			ScalarResources:  map[v1.ResourceName]int64(nil),
 		},
 		NonZeroRequested: &Resource{
 			MilliCPU:         2300,
-			Memory:           419431900, //200MB(initContainers) + 200MB(default memory value) + 1500 specified in requests/overhead
+			Memory:           419431900, // 200MB(initContainers) + 200MB(default memory value) + 1500 specified in requests/overhead
 			EphemeralStorage: 0,
 			AllowedPodNumber: 0,
 			ScalarResources:  map[v1.ResourceName]int64(nil),
@@ -815,8 +814,8 @@ func TestNodeInfoAddPod(t *testing.T) {
 	}
 
 	expected.Generation = ni.Generation
-	if !reflect.DeepEqual(expected, ni) {
-		t.Errorf("expected: %#v, got: %#v", expected, ni)
+	if diff := cmp.Diff(expected, ni); diff != "" {
+		t.Errorf("AddPod() mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -1105,8 +1104,8 @@ func TestNodeInfoRemovePod(t *testing.T) {
 			}
 
 			test.expectedNodeInfo.Generation = ni.Generation
-			if !reflect.DeepEqual(test.expectedNodeInfo, ni) {
-				t.Errorf("expected: %#v, got: %#v", test.expectedNodeInfo, ni)
+			if diff := cmp.Diff(test.expectedNodeInfo, ni); diff != "" {
+				t.Errorf("RemovePod() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -1596,8 +1595,8 @@ func TestCalculatePodResourcesWithResize(t *testing.T) {
 			pod.Status.Resize = tt.resizeStatus
 
 			res, non0CPU, non0Mem := calculateResource(pod)
-			if !reflect.DeepEqual(tt.expectedResource, res) {
-				t.Errorf("Test: %s expected resource: %+v, got: %+v", tt.name, tt.expectedResource, res)
+			if diff := cmp.Diff(tt.expectedResource, res); diff != "" {
+				t.Errorf("calculateResource() mismatch (-want +got):\n%s", diff)
 			}
 			if non0CPU != tt.expectedNon0CPU {
 				t.Errorf("Test: %s expected non0CPU: %d, got: %d", tt.name, tt.expectedNon0CPU, non0CPU)

--- a/pkg/scheduler/framework/types_test.go
+++ b/pkg/scheduler/framework/types_test.go
@@ -329,7 +329,7 @@ func TestNewNodeInfo(t *testing.T) {
 		t.Errorf("Generation is not incremented. previous: %v, current: %v", gen, ni.Generation)
 	}
 	expected.Generation = ni.Generation
-	if diff := cmp.Diff(expected, ni); diff != "" {
+	if diff := cmp.Diff(expected, ni, cmp.AllowUnexported(NodeInfo{})); diff != "" {
 		t.Errorf("NewNodeInfo() mismatch (-want +got):\n%s", diff)
 	}
 }
@@ -498,7 +498,7 @@ func TestNodeInfoClone(t *testing.T) {
 			// Modify the field to check if the result is a clone of the origin one.
 			test.nodeInfo.Generation += 10
 			test.nodeInfo.UsedPorts.Remove("127.0.0.1", "TCP", 80)
-			if diff := cmp.Diff(test.expected, ni); diff != "" {
+			if diff := cmp.Diff(test.expected, ni, cmp.AllowUnexported(NodeInfo{})); diff != "" {
 				t.Errorf("Snapshot() mismatch (-want +got):\n%s", diff)
 			}
 		})
@@ -814,7 +814,7 @@ func TestNodeInfoAddPod(t *testing.T) {
 	}
 
 	expected.Generation = ni.Generation
-	if diff := cmp.Diff(expected, ni); diff != "" {
+	if diff := cmp.Diff(expected, ni, cmp.AllowUnexported(NodeInfo{})); diff != "" {
 		t.Errorf("AddPod() mismatch (-want +got):\n%s", diff)
 	}
 }
@@ -1104,7 +1104,7 @@ func TestNodeInfoRemovePod(t *testing.T) {
 			}
 
 			test.expectedNodeInfo.Generation = ni.Generation
-			if diff := cmp.Diff(test.expectedNodeInfo, ni); diff != "" {
+			if diff := cmp.Diff(test.expectedNodeInfo, ni, cmp.AllowUnexported(NodeInfo{})); diff != "" {
 				t.Errorf("RemovePod() mismatch (-want +got):\n%s", diff)
 			}
 		})

--- a/pkg/scheduler/schedule_one_test.go
+++ b/pkg/scheduler/schedule_one_test.go
@@ -822,8 +822,10 @@ func TestSchedulerScheduleOne(t *testing.T) {
 			if diff := cmp.Diff(item.expectForgetPod, gotForgetPod); diff != "" {
 				t.Errorf("forget pod diff (-want, +got): %s", diff)
 			}
-			if diff := cmp.Diff(item.expectError, gotError); diff != "" {
-				t.Errorf("got error diff (-want, +got): %s", diff)
+			if item.expectError != nil {
+				if item.expectError.Error() != gotError.Error() {
+					t.Error("mismatch error")
+				}
 			}
 			if diff := cmp.Diff(item.expectBind, gotBinding); diff != "" {
 				t.Errorf("got binding diff (-want, +got): %s", diff)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:

[It](https://github.com/kubernetes/community/blob/master/sig-scheduling/CONTRIBUTING.md) is stated that `Use cmp.Diff instead of reflect.Equal, to provide useful comparisons.`
So I replaced reflect.DeepEqual to cmp.Diff.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
