### PR TITLE
update distroless-iptables to v0.5.0 debian-base to bookworm-v1.0.1 and setcap to bookworm-v1.0.1

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -96,9 +96,9 @@ readonly KUBE_RSYNC_PORT="${KUBE_RSYNC_PORT:-}"
 readonly KUBE_CONTAINER_RSYNC_PORT=8730
 
 # These are the default versions (image tags) for their respective base images.
-readonly __default_distroless_iptables_version=v0.4.4
+readonly __default_distroless_iptables_version=v0.5.0
 readonly __default_go_runner_version=v2.3.1-go1.22rc2-bookworm.0
-readonly __default_setcap_version=bookworm-v1.0.0
+readonly __default_setcap_version=bookworm-v1.0.1
 
 # These are the base images for the Docker-wrapped binaries.
 readonly KUBE_GORUNNER_IMAGE="${KUBE_GORUNNER_IMAGE:-$KUBE_BASE_IMAGE_REGISTRY/go-runner:$__default_go_runner_version}"

--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -148,7 +148,7 @@ dependencies:
 
   # Base images
   - name: "registry.k8s.io/debian-base: dependents"
-    version: bookworm-v1.0.0
+    version: bookworm-v1.0.1
     refPaths:
     - path: cluster/images/etcd/Makefile
       match: BASEIMAGE\?\=registry\.k8s\.io\/build-image\/debian-base:[a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
@@ -180,7 +180,7 @@ dependencies:
       match: registry\.k8s\.io\/build-image\/debian-base:[a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)
 
   - name: "registry.k8s.io/distroless-iptables: dependents"
-    version: v0.4.4
+    version: v0.5.0
     refPaths:
     - path: build/common.sh
       match: __default_distroless_iptables_version=
@@ -256,7 +256,7 @@ dependencies:
       match: configs\[Pause\] = Config{list\.GcRegistry, "pause", "\d+\.\d+(.\d+)?"}
 
   - name: "registry.k8s.io/build-image/setcap: dependents"
-    version: bookworm-v1.0.0
+    version: bookworm-v1.0.1
     refPaths:
     - path: build/common.sh
       match: __default_setcap_version=

--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -3161,7 +3161,7 @@ spec:
   - name: vol
   containers:
   - name: pv-recycler
-    image: registry.k8s.io/build-image/debian-base:bookworm-v1.0.0
+    image: registry.k8s.io/build-image/debian-base:bookworm-v1.0.1
     command:
     - /bin/sh
     args:

--- a/cluster/images/etcd/Makefile
+++ b/cluster/images/etcd/Makefile
@@ -92,19 +92,19 @@ DOCKERFILE.windows = Dockerfile.windows
 DOCKERFILE := ${DOCKERFILE.${OS}}
 
 ifeq ($(ARCH),amd64)
-    BASEIMAGE?=registry.k8s.io/build-image/debian-base:bookworm-v1.0.0
+    BASEIMAGE?=registry.k8s.io/build-image/debian-base:bookworm-v1.0.1
 endif
 ifeq ($(ARCH),arm)
-    BASEIMAGE?=registry.k8s.io/build-image/debian-base-arm:bookworm-v1.0.0
+    BASEIMAGE?=registry.k8s.io/build-image/debian-base-arm:bookworm-v1.0.1
 endif
 ifeq ($(ARCH),arm64)
-    BASEIMAGE?=registry.k8s.io/build-image/debian-base-arm64:bookworm-v1.0.0
+    BASEIMAGE?=registry.k8s.io/build-image/debian-base-arm64:bookworm-v1.0.1
 endif
 ifeq ($(ARCH),ppc64le)
-    BASEIMAGE?=registry.k8s.io/build-image/debian-base-ppc64le:bookworm-v1.0.0
+    BASEIMAGE?=registry.k8s.io/build-image/debian-base-ppc64le:bookworm-v1.0.1
 endif
 ifeq ($(ARCH),s390x)
-    BASEIMAGE?=registry.k8s.io/build-image/debian-base-s390x:bookworm-v1.0.0
+    BASEIMAGE?=registry.k8s.io/build-image/debian-base-s390x:bookworm-v1.0.1
 endif
 
 BASE.windows = mcr.microsoft.com/windows/nanoserver

--- a/pkg/volume/plugins.go
+++ b/pkg/volume/plugins.go
@@ -1064,7 +1064,7 @@ func NewPersistentVolumeRecyclerPodTemplate() *v1.Pod {
 			Containers: []v1.Container{
 				{
 					Name:    "pv-recycler",
-					Image:   "registry.k8s.io/build-image/debian-base:bookworm-v1.0.0",
+					Image:   "registry.k8s.io/build-image/debian-base:bookworm-v1.0.1",
 					Command: []string{"/bin/sh"},
 					Args:    []string{"-c", "test -e /scrub && find /scrub -mindepth 1 -delete && test -z \"$(ls -A /scrub)\" || exit 1"},
 					VolumeMounts: []v1.VolumeMount{

--- a/test/conformance/image/Makefile
+++ b/test/conformance/image/Makefile
@@ -33,7 +33,7 @@ CLUSTER_DIR?=$(shell pwd)/../../../cluster/
 
 # This is defined in root Makefile, but some build contexts do not refer to them
 KUBE_BASE_IMAGE_REGISTRY?=registry.k8s.io
-BASE_IMAGE_VERSION?=bookworm-v1.0.0
+BASE_IMAGE_VERSION?=bookworm-v1.0.1
 RUNNERIMAGE?=${KUBE_BASE_IMAGE_REGISTRY}/build-image/debian-base-${ARCH}:${BASE_IMAGE_VERSION}
 
 TEMP_DIR:=$(shell mktemp -d -t conformance-XXXXXX)

--- a/test/images/nonroot/BASEIMAGE
+++ b/test/images/nonroot/BASEIMAGE
@@ -1,7 +1,7 @@
-linux/amd64=registry.k8s.io/build-image/debian-base-amd64:bookworm-v1.0.0
-linux/arm=registry.k8s.io/build-image/debian-base-arm:bookworm-v1.0.0
-linux/arm64=registry.k8s.io/build-image/debian-base-arm64:bookworm-v1.0.0
-linux/ppc64le=registry.k8s.io/build-image/debian-base-ppc64le:bookworm-v1.0.0
-linux/s390x=registry.k8s.io/build-image/debian-base-s390x:bookworm-v1.0.0
+linux/amd64=registry.k8s.io/build-image/debian-base-amd64:bookworm-v1.0.1
+linux/arm=registry.k8s.io/build-image/debian-base-arm:bookworm-v1.0.1
+linux/arm64=registry.k8s.io/build-image/debian-base-arm64:bookworm-v1.0.1
+linux/ppc64le=registry.k8s.io/build-image/debian-base-ppc64le:bookworm-v1.0.1
+linux/s390x=registry.k8s.io/build-image/debian-base-s390x:bookworm-v1.0.1
 windows/amd64/1809=mcr.microsoft.com/windows/nanoserver:1809
 windows/amd64/ltsc2022=mcr.microsoft.com/windows/nanoserver:ltsc2022

--- a/test/images/pets/peer-finder/BASEIMAGE
+++ b/test/images/pets/peer-finder/BASEIMAGE
@@ -1,5 +1,5 @@
-linux/amd64=registry.k8s.io/build-image/debian-base-amd64:bookworm-v1.0.0
-linux/arm=registry.k8s.io/build-image/debian-base-arm:bookworm-v1.0.0
-linux/arm64=registry.k8s.io/build-image/debian-base-arm64:bookworm-v1.0.0
-linux/ppc64le=registry.k8s.io/build-image/debian-base-ppc64le:bookworm-v1.0.0
-linux/s390x=registry.k8s.io/build-image/debian-base-s390x:bookworm-v1.0.0
+linux/amd64=registry.k8s.io/build-image/debian-base-amd64:bookworm-v1.0.1
+linux/arm=registry.k8s.io/build-image/debian-base-arm:bookworm-v1.0.1
+linux/arm64=registry.k8s.io/build-image/debian-base-arm64:bookworm-v1.0.1
+linux/ppc64le=registry.k8s.io/build-image/debian-base-ppc64le:bookworm-v1.0.1
+linux/s390x=registry.k8s.io/build-image/debian-base-s390x:bookworm-v1.0.1

--- a/test/images/pets/redis-installer/BASEIMAGE
+++ b/test/images/pets/redis-installer/BASEIMAGE
@@ -1,4 +1,4 @@
-linux/amd64=registry.k8s.io/build-image/debian-base-amd64:bookworm-v1.0.0
-linux/arm=registry.k8s.io/build-image/debian-base-arm:bookworm-v1.0.0
-linux/arm64=registry.k8s.io/build-image/debian-base-arm64:bookworm-v1.0.0
-linux/ppc64le=registry.k8s.io/build-image/debian-base-ppc64le:bookworm-v1.0.0
+linux/amd64=registry.k8s.io/build-image/debian-base-amd64:bookworm-v1.0.1
+linux/arm=registry.k8s.io/build-image/debian-base-arm:bookworm-v1.0.1
+linux/arm64=registry.k8s.io/build-image/debian-base-arm64:bookworm-v1.0.1
+linux/ppc64le=registry.k8s.io/build-image/debian-base-ppc64le:bookworm-v1.0.1

--- a/test/images/pets/zookeeper-installer/BASEIMAGE
+++ b/test/images/pets/zookeeper-installer/BASEIMAGE
@@ -1,4 +1,4 @@
-linux/amd64=registry.k8s.io/build-image/debian-base-amd64:bookworm-v1.0.0
-linux/arm=registry.k8s.io/build-image/debian-base-arm:bookworm-v1.0.0
-linux/arm64=registry.k8s.io/build-image/debian-base-arm64:bookworm-v1.0.0
-linux/ppc64le=registry.k8s.io/build-image/debian-base-ppc64le:bookworm-v1.0.0
+linux/amd64=registry.k8s.io/build-image/debian-base-amd64:bookworm-v1.0.1
+linux/arm=registry.k8s.io/build-image/debian-base-arm:bookworm-v1.0.1
+linux/arm64=registry.k8s.io/build-image/debian-base-arm64:bookworm-v1.0.1
+linux/ppc64le=registry.k8s.io/build-image/debian-base-ppc64le:bookworm-v1.0.1

--- a/test/images/regression-issue-74839/BASEIMAGE
+++ b/test/images/regression-issue-74839/BASEIMAGE
@@ -1,5 +1,5 @@
-linux/amd64=registry.k8s.io/build-image/debian-base-amd64:bookworm-v1.0.0
-linux/arm=registry.k8s.io/build-image/debian-base-arm:bookworm-v1.0.0
-linux/arm64=registry.k8s.io/build-image/debian-base-arm64:bookworm-v1.0.0
-linux/ppc64le=registry.k8s.io/build-image/debian-base-ppc64le:bookworm-v1.0.0
-linux/s390x=registry.k8s.io/build-image/debian-base-s390x:bookworm-v1.0.0
+linux/amd64=registry.k8s.io/build-image/debian-base-amd64:bookworm-v1.0.1
+linux/arm=registry.k8s.io/build-image/debian-base-arm:bookworm-v1.0.1
+linux/arm64=registry.k8s.io/build-image/debian-base-arm64:bookworm-v1.0.1
+linux/ppc64le=registry.k8s.io/build-image/debian-base-ppc64le:bookworm-v1.0.1
+linux/s390x=registry.k8s.io/build-image/debian-base-s390x:bookworm-v1.0.1

--- a/test/images/resource-consumer/BASEIMAGE
+++ b/test/images/resource-consumer/BASEIMAGE
@@ -1,7 +1,7 @@
-linux/amd64=registry.k8s.io/build-image/debian-base-amd64:bookworm-v1.0.0
-linux/arm=registry.k8s.io/build-image/debian-base-arm:bookworm-v1.0.0
-linux/arm64=registry.k8s.io/build-image/debian-base-arm64:bookworm-v1.0.0
-linux/ppc64le=registry.k8s.io/build-image/debian-base-ppc64le:bookworm-v1.0.0
-linux/s390x=registry.k8s.io/build-image/debian-base-s390x:bookworm-v1.0.0
+linux/amd64=registry.k8s.io/build-image/debian-base-amd64:bookworm-v1.0.1
+linux/arm=registry.k8s.io/build-image/debian-base-arm:bookworm-v1.0.1
+linux/arm64=registry.k8s.io/build-image/debian-base-arm64:bookworm-v1.0.1
+linux/ppc64le=registry.k8s.io/build-image/debian-base-ppc64le:bookworm-v1.0.1
+linux/s390x=registry.k8s.io/build-image/debian-base-s390x:bookworm-v1.0.1
 windows/amd64/1809=mcr.microsoft.com/windows/nanoserver:1809
 windows/amd64/ltsc2022=mcr.microsoft.com/windows/nanoserver:ltsc2022

--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -237,7 +237,7 @@ func initImageConfigs(list RegistryList) (map[ImageID]Config, map[ImageID]Config
 	configs[BusyBox] = Config{list.PromoterE2eRegistry, "busybox", "1.36.1-1"}
 	configs[CudaVectorAdd] = Config{list.PromoterE2eRegistry, "cuda-vector-add", "1.0"}
 	configs[CudaVectorAdd2] = Config{list.PromoterE2eRegistry, "cuda-vector-add", "2.3"}
-	configs[DistrolessIptables] = Config{list.BuildImageRegistry, "distroless-iptables", "v0.4.4"}
+	configs[DistrolessIptables] = Config{list.BuildImageRegistry, "distroless-iptables", "v0.5.0"}
 	configs[Etcd] = Config{list.GcEtcdRegistry, "etcd", "3.5.11-0"}
 	configs[Httpd] = Config{list.PromoterE2eRegistry, "httpd", "2.4.38-4"}
 	configs[HttpdNew] = Config{list.PromoterE2eRegistry, "httpd", "2.4.39-4"}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind feature

#### What this PR does / why we need it:

- update distroless-iptables to v0.5.0 debian-base to bookworm-v1.0.1 and setcap to bookworm-v1.0.1

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
update distroless-iptables to v0.5.0 debian-base to bookworm-v1.0.1 and setcap to bookworm-v1.0.1
```

/assign @saschagrunert @liggitt 
cc @kubernetes/release-engineering 

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
