### PR TITLE
Make CIDR validation consistent

### DIFF
--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -5870,9 +5870,7 @@ func ValidateNode(node *core.Node) field.ErrorList {
 
 		// all PodCIDRs should be valid ones
 		for idx, value := range node.Spec.PodCIDRs {
-			if _, err := ValidateCIDR(value); err != nil {
-				allErrs = append(allErrs, field.Invalid(podCIDRsField.Index(idx), node.Spec.PodCIDRs, "must be valid CIDR"))
-			}
+			allErrs = append(allErrs, validation.IsValidCIDR(podCIDRsField.Index(idx), value)...)
 		}
 
 		// if more than PodCIDR then
@@ -7298,15 +7296,6 @@ func validateVolumeNodeAffinity(nodeAffinity *core.VolumeNodeAffinity, fldPath *
 	}
 
 	return true, allErrs
-}
-
-// ValidateCIDR validates whether a CIDR matches the conventions expected by net.ParseCIDR
-func ValidateCIDR(cidr string) (*net.IPNet, error) {
-	_, net, err := netutils.ParseCIDRSloppy(cidr)
-	if err != nil {
-		return nil, err
-	}
-	return net, nil
 }
 
 func IsDecremented(update, old *int32) bool {

--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -5450,24 +5450,32 @@ func ValidateService(service *core.Service) field.ErrorList {
 		ports[key] = true
 	}
 
-	// Validate SourceRange field and annotation
-	_, ok := service.Annotations[core.AnnotationLoadBalancerSourceRangesKey]
-	if len(service.Spec.LoadBalancerSourceRanges) > 0 || ok {
-		var fieldPath *field.Path
-		var val string
-		if len(service.Spec.LoadBalancerSourceRanges) > 0 {
-			fieldPath = specPath.Child("LoadBalancerSourceRanges")
-			val = fmt.Sprintf("%v", service.Spec.LoadBalancerSourceRanges)
-		} else {
-			fieldPath = field.NewPath("metadata", "annotations").Key(core.AnnotationLoadBalancerSourceRangesKey)
-			val = service.Annotations[core.AnnotationLoadBalancerSourceRangesKey]
-		}
+	// Validate SourceRanges field or annotation.
+	if len(service.Spec.LoadBalancerSourceRanges) > 0 {
+		fieldPath := specPath.Child("LoadBalancerSourceRanges")
+
 		if service.Spec.Type != core.ServiceTypeLoadBalancer {
 			allErrs = append(allErrs, field.Forbidden(fieldPath, "may only be used when `type` is 'LoadBalancer'"))
 		}
-		_, err := apiservice.GetLoadBalancerSourceRanges(service)
-		if err != nil {
-			allErrs = append(allErrs, field.Invalid(fieldPath, val, "must be a list of IP ranges. For example, 10.240.0.0/24,10.250.0.0/24 "))
+		for idx, value := range service.Spec.LoadBalancerSourceRanges {
+			// Note: due to a historical accident around transition from the
+			// annotation value, these values are allowed to be space-padded.
+			value = strings.TrimSpace(value)
+			allErrs = append(allErrs, validation.IsValidCIDR(fieldPath.Index(idx), value)...)
+		}
+	} else if val, annotationSet := service.Annotations[core.AnnotationLoadBalancerSourceRangesKey]; annotationSet {
+		fieldPath := field.NewPath("metadata", "annotations").Key(core.AnnotationLoadBalancerSourceRangesKey)
+		if service.Spec.Type != core.ServiceTypeLoadBalancer {
+			allErrs = append(allErrs, field.Forbidden(fieldPath, "may only be used when `type` is 'LoadBalancer'"))
+		}
+
+		val = strings.TrimSpace(val)
+		if val != "" {
+			cidrs := strings.Split(val, ",")
+			for _, value := range cidrs {
+				value = strings.TrimSpace(value)
+				allErrs = append(allErrs, validation.IsValidCIDR(fieldPath, value)...)
+			}
 		}
 	}
 

--- a/staging/src/k8s.io/apimachinery/pkg/util/validation/validation.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/validation/validation.go
@@ -378,6 +378,16 @@ func IsValidIPv6Address(fldPath *field.Path, value string) field.ErrorList {
 	return allErrors
 }
 
+// IsValidCIDR tests that the argument is a valid CIDR value.
+func IsValidCIDR(fldPath *field.Path, value string) field.ErrorList {
+	var allErrors field.ErrorList
+	_, _, err := netutils.ParseCIDRSloppy(value)
+	if err != nil {
+		allErrors = append(allErrors, field.Invalid(fldPath, value, "must be a valid CIDR value, (e.g. 10.9.8.0/24 or 2001:db8::/64)"))
+	}
+	return allErrors
+}
+
 const percentFmt string = "[0-9]+%"
 const percentErrMsg string = "a valid percent string must be a numeric string followed by an ending '%'"
 

--- a/staging/src/k8s.io/apimachinery/pkg/util/validation/validation_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/validation/validation_test.go
@@ -496,6 +496,128 @@ func TestIsValidIP(t *testing.T) {
 	}
 }
 
+func TestIsValidCIDR(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		in   string
+		err  string
+	}{
+		// GOOD VALUES
+		{
+			name: "ipv4",
+			in:   "1.0.0.0/8",
+		},
+		{
+			name: "ipv4, all IPs",
+			in:   "0.0.0.0/0",
+		},
+		{
+			name: "ipv4, single IP",
+			in:   "1.1.1.1/32",
+		},
+		{
+			name: "ipv6",
+			in:   "2001:4860:4860::/48",
+		},
+		{
+			name: "ipv6, all IPs",
+			in:   "::/0",
+		},
+		{
+			name: "ipv6, single IP",
+			in:   "::1/128",
+		},
+
+		// GOOD, THOUGH NON-CANONICAL, VALUES
+		{
+			name: "ipv6, extra 0s (non-canonical)",
+			in:   "2a00:79e0:2:0::/64",
+		},
+		{
+			name: "ipv6, capital letters (non-canonical)",
+			in:   "2001:DB8::/64",
+		},
+
+		// BAD VALUES WE CURRENTLY CONSIDER GOOD
+		{
+			name: "ipv4 with leading 0s",
+			in:   "1.1.01.0/24",
+		},
+		{
+			name: "ipv4-in-ipv6 with ipv4-sized prefix",
+			in:   "::ffff:1.1.1.0/24",
+		},
+		{
+			name: "ipv4-in-ipv6 with ipv6-sized prefix",
+			in:   "::ffff:1.1.1.0/120",
+		},
+		{
+			name: "ipv4 with bits past prefix",
+			in:   "1.2.3.4/24",
+		},
+		{
+			name: "ipv6 with bits past prefix",
+			in:   "2001:db8::1/64",
+		},
+		{
+			name: "prefix length with leading 0s",
+			in:   "192.168.0.0/016",
+		},
+
+		// BAD VALUES
+		{
+			name: "empty string",
+			in:   "",
+			err:  "must be a valid CIDR value",
+		},
+		{
+			name: "junk",
+			in:   "aaaaaaa",
+			err:  "must be a valid CIDR value",
+		},
+		{
+			name: "IP address",
+			in:   "1.2.3.4",
+			err:  "must be a valid CIDR value",
+		},
+		{
+			name: "partial URL",
+			in:   "192.168.0.1/healthz",
+			err:  "must be a valid CIDR value",
+		},
+		{
+			name: "partial URL 2",
+			in:   "192.168.0.1/0/99",
+			err:  "must be a valid CIDR value",
+		},
+		{
+			name: "negative prefix length",
+			in:   "192.168.0.0/-16",
+			err:  "must be a valid CIDR value",
+		},
+		{
+			name: "prefix length with sign",
+			in:   "192.168.0.0/+16",
+			err:  "must be a valid CIDR value",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			errs := IsValidCIDR(field.NewPath(""), tc.in)
+			if tc.err == "" {
+				if len(errs) != 0 {
+					t.Errorf("expected %q to be valid but got: %v", tc.in, errs)
+				}
+			} else {
+				if len(errs) != 1 {
+					t.Errorf("expected %q to have 1 error but got: %v", tc.in, errs)
+				} else if !strings.Contains(errs[0].Detail, tc.err) {
+					t.Errorf("expected error for %q to contain %q but got: %q", tc.in, tc.err, errs[0].Detail)
+				}
+			}
+		})
+	}
+}
+
 func TestIsHTTPHeaderName(t *testing.T) {
 	goodValues := []string{
 		// Common ones


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/sig network
/sig api-machinery

#### What this PR does / why we need it:
Followup to #122931, another subset of #122550.

This cleans up validation of CIDRs, moving the validation function from `pkg/apis/core/validation` to `k8s.io/apimachinery/pkg/util/validation`, and then rewriting the LoadBalancerSourceRanges validation to use it, rather than using a random function with crazy semantics. (Of course, we have to preserve the crazy semantics for backward-compatibility, but now they're explicit in `pkg/apis/core/validation` rather than being hidden in the helper function.)

As with #122931, this does not change any validation results, it just paves the way for making CIDR validation more strict later.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
