### PR TITLE
Add `apiserver_encryption_config_controller_automatic_reloads_total` metric and deprecate success/failure counter

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/controller/controller_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/controller/controller_test.go
@@ -47,11 +47,17 @@ func TestController(t *testing.T) {
 # HELP apiserver_encryption_config_controller_automatic_reload_success_total [ALPHA] Total number of successful automatic reloads of encryption configuration split by apiserver identity.
 # TYPE apiserver_encryption_config_controller_automatic_reload_success_total counter
 apiserver_encryption_config_controller_automatic_reload_success_total{apiserver_id_hash="sha256:cd8a60cec6134082e9f37e7a4146b4bc14a0bf8a863237c36ec8fdb658c3e027"} 1
+# HELP apiserver_encryption_config_controller_automatic_reloads_total [ALPHA] Total number of reload successes and failures of encryption configuration split by apiserver identity.
+# TYPE apiserver_encryption_config_controller_automatic_reloads_total counter
+apiserver_encryption_config_controller_automatic_reloads_total{apiserver_id_hash="sha256:cd8a60cec6134082e9f37e7a4146b4bc14a0bf8a863237c36ec8fdb658c3e027",status="success"} 1
 `
 	const expectedFailureMetricValue = `
 # HELP apiserver_encryption_config_controller_automatic_reload_failures_total [ALPHA] Total number of failed automatic reloads of encryption configuration split by apiserver identity.
 # TYPE apiserver_encryption_config_controller_automatic_reload_failures_total counter
 apiserver_encryption_config_controller_automatic_reload_failures_total{apiserver_id_hash="sha256:cd8a60cec6134082e9f37e7a4146b4bc14a0bf8a863237c36ec8fdb658c3e027"} 1
+# HELP apiserver_encryption_config_controller_automatic_reloads_total [ALPHA] Total number of reload successes and failures of encryption configuration split by apiserver identity.
+# TYPE apiserver_encryption_config_controller_automatic_reloads_total counter
+apiserver_encryption_config_controller_automatic_reloads_total{apiserver_id_hash="sha256:cd8a60cec6134082e9f37e7a4146b4bc14a0bf8a863237c36ec8fdb658c3e027",status="failure"} 1
 `
 
 	tests := []struct {
@@ -334,6 +340,7 @@ apiserver_encryption_config_controller_automatic_reload_failures_total{apiserver
 			if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(test.wantMetrics),
 				"apiserver_encryption_config_controller_automatic_reload_success_total",
 				"apiserver_encryption_config_controller_automatic_reload_failures_total",
+				"apiserver_encryption_config_controller_automatic_reloads_total",
 			); err != nil {
 				t.Errorf("failed to validate metrics: %v", err)
 			}

--- a/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/metrics/metrics_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/metrics/metrics_test.go
@@ -20,7 +20,7 @@ import (
 	"strings"
 	"testing"
 
-	"k8s.io/component-base/metrics/legacyregistry"
+	"k8s.io/component-base/metrics"
 	"k8s.io/component-base/metrics/testutil"
 )
 
@@ -29,40 +29,68 @@ const (
 	testAPIServerIDHash = "sha256:14f9d63e669337ac6bfda2e2162915ee6a6067743eddd4e5c374b572f951ff37"
 )
 
+func testMetricsRegistry(t *testing.T) metrics.KubeRegistry {
+	// setting the version to 1.30.0 to test deprecation
+	// of deprecatedEncryptionConfigAutomaticReloadFailureTotal and deprecatedEncryptionConfigAutomaticReloadSuccessTotal
+	registry := testutil.NewFakeKubeRegistry("1.30.0")
+	registry.MustRegister(encryptionConfigAutomaticReloadsTotal)
+	registry.MustRegister(deprecatedEncryptionConfigAutomaticReloadFailureTotal)
+	registry.MustRegister(deprecatedEncryptionConfigAutomaticReloadSuccessTotal)
+	registry.MustRegister(encryptionConfigAutomaticReloadLastTimestampSeconds)
+
+	t.Cleanup(func() { registry.Reset() })
+
+	return registry
+}
+
 func TestRecordEncryptionConfigAutomaticReloadFailure(t *testing.T) {
+	registry := testMetricsRegistry(t)
+
 	expectedValue := `
-	# HELP apiserver_encryption_config_controller_automatic_reload_failures_total [ALPHA] Total number of failed automatic reloads of encryption configuration split by apiserver identity.
+	# HELP apiserver_encryption_config_controller_automatic_reload_failures_total [ALPHA] (Deprecated since 1.30.0) Total number of failed automatic reloads of encryption configuration split by apiserver identity.
     # TYPE apiserver_encryption_config_controller_automatic_reload_failures_total counter
     apiserver_encryption_config_controller_automatic_reload_failures_total {apiserver_id_hash="sha256:14f9d63e669337ac6bfda2e2162915ee6a6067743eddd4e5c374b572f951ff37"} 1
+	# HELP apiserver_encryption_config_controller_automatic_reloads_total [ALPHA] Total number of reload successes and failures of encryption configuration split by apiserver identity.
+    # TYPE apiserver_encryption_config_controller_automatic_reloads_total counter
+    apiserver_encryption_config_controller_automatic_reloads_total {apiserver_id_hash="sha256:14f9d63e669337ac6bfda2e2162915ee6a6067743eddd4e5c374b572f951ff37",status="failure"} 1
 	`
-	metrics := []string{
+	metricNames := []string{
 		namespace + "_" + subsystem + "_automatic_reload_failures_total",
+		namespace + "_" + subsystem + "_automatic_reloads_total",
 	}
 
-	encryptionConfigAutomaticReloadFailureTotal.Reset()
+	deprecatedEncryptionConfigAutomaticReloadFailureTotal.Reset()
+	encryptionConfigAutomaticReloadsTotal.Reset()
 	RegisterMetrics()
 
 	RecordEncryptionConfigAutomaticReloadFailure(testAPIServerID)
-	if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(expectedValue), metrics...); err != nil {
+	if err := testutil.GatherAndCompare(registry, strings.NewReader(expectedValue), metricNames...); err != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestRecordEncryptionConfigAutomaticReloadSuccess(t *testing.T) {
+	registry := testMetricsRegistry(t)
+
 	expectedValue := `
-	# HELP apiserver_encryption_config_controller_automatic_reload_success_total [ALPHA] Total number of successful automatic reloads of encryption configuration split by apiserver identity.
+	# HELP apiserver_encryption_config_controller_automatic_reload_success_total [ALPHA] (Deprecated since 1.30.0) Total number of successful automatic reloads of encryption configuration split by apiserver identity.
     # TYPE apiserver_encryption_config_controller_automatic_reload_success_total counter
     apiserver_encryption_config_controller_automatic_reload_success_total {apiserver_id_hash="sha256:14f9d63e669337ac6bfda2e2162915ee6a6067743eddd4e5c374b572f951ff37"} 1
+	# HELP apiserver_encryption_config_controller_automatic_reloads_total [ALPHA] Total number of reload successes and failures of encryption configuration split by apiserver identity.
+    # TYPE apiserver_encryption_config_controller_automatic_reloads_total counter
+    apiserver_encryption_config_controller_automatic_reloads_total {apiserver_id_hash="sha256:14f9d63e669337ac6bfda2e2162915ee6a6067743eddd4e5c374b572f951ff37",status="success"} 1
 	`
-	metrics := []string{
+	metricNames := []string{
 		namespace + "_" + subsystem + "_automatic_reload_success_total",
+		namespace + "_" + subsystem + "_automatic_reloads_total",
 	}
 
-	encryptionConfigAutomaticReloadSuccessTotal.Reset()
+	deprecatedEncryptionConfigAutomaticReloadSuccessTotal.Reset()
+	encryptionConfigAutomaticReloadsTotal.Reset()
 	RegisterMetrics()
 
 	RecordEncryptionConfigAutomaticReloadSuccess(testAPIServerID)
-	if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(expectedValue), metrics...); err != nil {
+	if err := testutil.GatherAndCompare(registry, strings.NewReader(expectedValue), metricNames...); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -93,16 +121,18 @@ func TestEncryptionConfigAutomaticReloadLastTimestampSeconds(t *testing.T) {
 		},
 	}
 
-	metrics := []string{
+	metricNames := []string{
 		namespace + "_" + subsystem + "_automatic_reload_last_timestamp_seconds",
 	}
 	RegisterMetrics()
 
 	for _, tc := range testCases {
+		registry := testMetricsRegistry(t)
+
 		encryptionConfigAutomaticReloadLastTimestampSeconds.Reset()
 		encryptionConfigAutomaticReloadLastTimestampSeconds.WithLabelValues(tc.resultLabel, testAPIServerIDHash).Set(float64(tc.timestamp))
 
-		if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(tc.expectedValue), metrics...); err != nil {
+		if err := testutil.GatherAndCompare(registry, strings.NewReader(tc.expectedValue), metricNames...); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/test/integration/controlplane/transformation/kms_transformation_test.go
+++ b/test/integration/controlplane/transformation/kms_transformation_test.go
@@ -357,6 +357,7 @@ resources:
 	wantMetricStrings := []string{
 		`apiserver_encryption_config_controller_automatic_reload_last_timestamp_seconds{apiserver_id_hash="sha256:3c607df3b2bf22c9d9f01d5314b4bbf411c48ef43ff44ff29b1d55b41367c795",status="success"} FP`,
 		`apiserver_encryption_config_controller_automatic_reload_success_total{apiserver_id_hash="sha256:3c607df3b2bf22c9d9f01d5314b4bbf411c48ef43ff44ff29b1d55b41367c795"} 2`,
+		`apiserver_encryption_config_controller_automatic_reloads_total{apiserver_id_hash="sha256:3c607df3b2bf22c9d9f01d5314b4bbf411c48ef43ff44ff29b1d55b41367c795",status="success"} 2`,
 	}
 
 	test.secret, err = test.createSecret(testSecret, testNamespace)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
- Adds `apiserver_encryption_config_controller_automatic_reloads_total` metric for total number of reload successes and failures of encryption configuration split by apiserver identity. This metric contains the `status` label with enum value of `success` and `failure`.
  - With this new metric, we're deprecating the old alpha metrics `apiserver_encryption_config_controller_automatic_reload_success_total` and `apiserver_encryption_config_controller_automatic_reload_failure_total`.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/123175

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added a new metric `apiserver_encryption_config_controller_automatic_reloads_total` to measure total number of
API server encryption configuration reload successes and failures.
This metric contains the `status` label with a value that is either `success` or `failure`.

Deprecated the metrics `apiserver_encryption_config_controller_automatic_reload_success_total`
and `apiserver_encryption_config_controller_automatic_reload_failure_total`.
Use `apiserver_encryption_config_controller_automatic_reloads_total` instead.
```
