### PR TITLE
Scheduler: Fix the feature stage of preemptionPolicy in the API comment

### DIFF
--- a/pkg/apis/scheduling/types.go
+++ b/pkg/apis/scheduling/types.go
@@ -69,7 +69,8 @@ type PriorityClass struct {
 	Description string
 
 	// preemptionPolicy it the Policy for preempting pods with lower priority.
-	// This field is beta-level.
+	// One of Never, PreemptLowerPriority.
+	// Defaults to PreemptLowerPriority if unset.
 	// +optional
 	PreemptionPolicy *core.PreemptionPolicy
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind documentation
/kind api-change

#### What this PR does / why we need it:
In spite of the `PreemptionPolicy` already graduated to GA, the API comment still indicates that the `PreemptionPolicy` is in the beta stage: https://github.com/kubernetes/enhancements/blob/b63e9ae17c9265696d4fe8fd96f7d02497660a7e/keps/sig-scheduling/902-non-preempting-priorityclass/kep.yaml#L20-L23

So, I fixed the API comment.
Also, since other comments are older than the staging one, I synced staging comments to the `pkg/apis` one.

staging: https://github.com/kubernetes/kubernetes/blob/fae7ec4a37642060bf97dcffb24a7a55b3190485/staging/src/k8s.io/api/scheduling/v1/types.go#L54-L58

`pkg/apis`: https://github.com/kubernetes/kubernetes/blob/fae7ec4a37642060bf97dcffb24a7a55b3190485/pkg/apis/scheduling/types.go#L71-L74

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part-of: https://github.com/kubernetes/enhancements/issues/902

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
