### PR TITLE
WIP: Add admission plugin for SELinuxMount feature

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -906,6 +906,13 @@ const (
 	//
 	// Allows namespace indexer for namespace scope resources in apiserver cache to accelerate list operations.
 	StorageNamespaceIndex featuregate.Feature = "StorageNamespaceIndex"
+
+	// owner: @jsafrane
+	// kep: https://kep.k8s.io/1710
+	// alpha: v1.30
+	// Speed up container startup by mounting volumes with the correct SELinux label
+	// instead of changing each file on the volumes srecursively.
+	SELinuxMount featuregate.Feature = "SELinuxMount"
 )
 
 func init() {
@@ -1157,6 +1164,8 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	ImageMaximumGCAge: {Default: false, PreRelease: featuregate.Alpha},
 
 	UserNamespacesPodSecurityStandards: {Default: false, PreRelease: featuregate.Alpha},
+
+	SELinuxMount: {Default: false, PreRelease: featuregate.Alpha},
 
 	// inherited features from generic apiserver, relisted here to get a conflict if it is changed
 	// unintentionally on either side:

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -843,6 +843,8 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 		keepTerminatedPodVolumes,
 		volumepathhandler.NewBlockVolumePathHandler())
 
+	klet.admitHandlers.AddPodAdmitHandler(klet.volumeManager.GetVolumeAdmitHandler())
+
 	klet.backOff = flowcontrol.NewBackOff(backOffPeriod, MaxContainerBackOff)
 
 	// setup eviction manager

--- a/pkg/kubelet/volumemanager/pod_admission.go
+++ b/pkg/kubelet/volumemanager/pod_admission.go
@@ -1,0 +1,28 @@
+package volumemanager
+
+import (
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/pkg/kubelet/lifecycle"
+	"k8s.io/kubernetes/pkg/kubelet/volumemanager/cache"
+	"k8s.io/kubernetes/pkg/volume"
+	"k8s.io/kubernetes/pkg/volume/csimigration"
+	"k8s.io/kubernetes/pkg/volume/util"
+)
+
+// volumeAdmitHandler is a lifecycle.PodAdmitHandler that admits pods based on the volumes it uses
+// and their compatibility with the volume manager's state.
+type volumeAdmitHandler struct {
+	desiredStateOfWorld      cache.DesiredStateOfWorld
+	csiMigratedPluginManager csimigration.PluginManager
+	intreeToCSITranslator    csimigration.InTreeToCSITranslator
+	volumePluginMgr          *volume.VolumePluginMgr
+	kubeClient               clientset.Interface
+}
+
+var _ lifecycle.PodAdmitHandler = &volumeAdmitHandler{}
+
+func (v *volumeAdmitHandler) Admit(attrs *lifecycle.PodAdmitAttributes) lifecycle.PodAdmitResult {
+	pod := attrs.Pod
+	podVolumeInfos := util.NewPodVolumeInfos(pod, v.csiMigratedPluginManager, v.intreeToCSITranslator, v.volumePluginMgr, v.kubeClient)
+	return v.desiredStateOfWorld.AdmitPodVolumes(pod, podVolumeInfos)
+}

--- a/pkg/kubelet/volumemanager/populator/desired_state_of_world_populator_test.go
+++ b/pkg/kubelet/volumemanager/populator/desired_state_of_world_populator_test.go
@@ -1212,6 +1212,7 @@ func TestCheckVolumeSELinux(t *testing.T) {
 		accessModes                  []v1.PersistentVolumeAccessMode
 		existingContainerSELinuxOpts *v1.SELinuxOptions
 		newContainerSELinuxOpts      *v1.SELinuxOptions
+		seLinuxMountFeatureEnabled   bool
 		pluginSupportsSELinux        bool
 		expectError                  bool
 		expectedContext              string
@@ -1231,11 +1232,19 @@ func TestCheckVolumeSELinux(t *testing.T) {
 			expectedContext:         "system_u:object_r:container_file_t:s0:c3,c4",
 		},
 		{
-			name:                    "RWX with plugin with SELinux with fill context in pod",
+			name:                    "RWX with plugin with SELinux with fill context in pod and SELinuxMount feature disabled",
 			accessModes:             []v1.PersistentVolumeAccessMode{v1.ReadWriteMany},
 			newContainerSELinuxOpts: fullOpts,
 			pluginSupportsSELinux:   true,
 			expectedContext:         "", // RWX volumes don't support SELinux
+		},
+		{
+			name:                       "RWX with plugin with SELinux with fill context in pod and SELinuxMount feature enabled",
+			accessModes:                []v1.PersistentVolumeAccessMode{v1.ReadWriteMany},
+			newContainerSELinuxOpts:    fullOpts,
+			pluginSupportsSELinux:      true,
+			seLinuxMountFeatureEnabled: true,
+			expectedContext:            "system_u:object_r:container_file_t:s0:c1,c2",
 		},
 		{
 			name:                    "RWOP with plugin with no SELinux with fill context in pod",
@@ -1266,6 +1275,25 @@ func TestCheckVolumeSELinux(t *testing.T) {
 			newContainerSELinuxOpts:      differentFullOpts,
 			pluginSupportsSELinux:        true,
 			expectedContext:              "",
+		},
+		{
+			name:                         "mismatched SELinux with RWX and SELinuxMount feature disabled",
+			accessModes:                  []v1.PersistentVolumeAccessMode{v1.ReadWriteMany},
+			existingContainerSELinuxOpts: fullOpts,
+			newContainerSELinuxOpts:      differentFullOpts,
+			pluginSupportsSELinux:        true,
+			expectedContext:              "",
+		},
+		{
+			name:                         "mismatched SELinux with RWX and SELinuxMount feature enabled",
+			accessModes:                  []v1.PersistentVolumeAccessMode{v1.ReadWriteMany},
+			existingContainerSELinuxOpts: fullOpts,
+			newContainerSELinuxOpts:      differentFullOpts,
+			pluginSupportsSELinux:        true,
+			seLinuxMountFeatureEnabled:   true,
+			expectError:                  true,
+			// The original seLinuxOpts are kept in DSW
+			expectedContext: "system_u:object_r:container_file_t:s0:c1,c2",
 		},
 		{
 			name:                         "mismatched SELinux with RWOP - failure",
@@ -1319,6 +1347,7 @@ func TestCheckVolumeSELinux(t *testing.T) {
 					},
 				},
 			}
+			defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.SELinuxMount, tc.seLinuxMountFeatureEnabled)()
 
 			fakeVolumePluginMgr, plugin := volumetesting.GetTestKubeletVolumePluginMgr(t)
 			plugin.SupportsSELinux = tc.pluginSupportsSELinux

--- a/pkg/kubelet/volumemanager/volume_manager.go
+++ b/pkg/kubelet/volumemanager/volume_manager.go
@@ -560,7 +560,7 @@ func filterUnmountedVolumes(mountedVolumes sets.String, expectedVolumes []string
 // getExpectedVolumes returns a list of volumes that must be mounted in order to
 // consider the volume setup step for this pod satisfied.
 func getExpectedVolumes(pod *v1.Pod) []string {
-	mounts, devices, _ := util.GetPodVolumeNames(pod)
+	mounts, devices := util.GetPodVolumeNames(pod)
 	return mounts.Union(devices).UnsortedList()
 }
 

--- a/pkg/volume/util/operationexecutor/operation_executor.go
+++ b/pkg/volume/util/operationexecutor/operation_executor.go
@@ -449,6 +449,9 @@ type VolumeToMount struct {
 	DesiredPersistentVolumeSize resource.Quantity
 
 	// SELinux label that should be used to mount.
+	// The label is set when:
+	// * SELinuxMountReadWriteOncePod feature gate is enabled and the volume is RWOP and kubelet knows the SELinux label.
+	// * Or, SELinuxMount feature gate is enabled and kubelet knows the SELinux label.
 	SELinuxLabel string
 }
 

--- a/pkg/volume/util/pod_volume_info.go
+++ b/pkg/volume/util/pod_volume_info.go
@@ -1,0 +1,348 @@
+package util
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/component-helpers/storage/ephemeral"
+	"k8s.io/klog/v2"
+	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
+	"k8s.io/kubernetes/pkg/features"
+	"k8s.io/kubernetes/pkg/securitycontext"
+	"k8s.io/kubernetes/pkg/volume"
+	"k8s.io/kubernetes/pkg/volume/csimigration"
+	volumetypes "k8s.io/kubernetes/pkg/volume/util/types"
+)
+
+// PodVolumeInfos is a helper struct that contains information about all volumes in a pod.
+type PodVolumeInfos struct {
+	pod                      *v1.Pod
+	csiMigratedPluginManager csimigration.PluginManager
+	intreeToCSITranslator    csimigration.InTreeToCSITranslator
+	volumePluginMgr          *volume.VolumePluginMgr
+	kubeClient               clientset.Interface
+
+	// Info for each volume, indexed by volume.name.
+	volumeInfos map[string]*VolumeSpecInfo
+}
+
+// VolumeSpecInfo contains information about a volume in a pod, with a dereferenced PVC and PV (if necessary).
+type VolumeSpecInfo struct {
+	// Name of the volume in the Pod (i.e. pod.volumes[*].name)
+	OuterVolumeName string
+
+	// Unique name of the pod.
+	PodName volumetypes.UniquePodName
+
+	// Whether the volume is mounted in the pod.
+	Mounted bool
+
+	// Whether the volume is mapped in the pod.
+	Mapped bool
+
+	// List of all SELinuxOpts that are used by all containers that mount the volume.
+	// (When SELinuxMountReadWriteOncePod feature is enabled).
+	SELinuxContexts []*v1.SELinuxOptions
+
+	// Volume spec, with dereferenced PVC and PV.
+	Spec *volume.Spec
+
+	// Volume plugin responsible for the volume.
+	VolumePlugin volume.VolumePlugin
+
+	// Corresponding PVC.
+	PVC *v1.PersistentVolumeClaim
+
+	// Value of GID annotation of corresponding PV.
+	VolumeGIDValue string
+}
+
+// NewPodVolumeInfos creates a new PodVolumeInfos object for the given pod.
+// It does not dereference any PV/PVCs yet, as it is expensive and not always needed.
+func NewPodVolumeInfos(
+	pod *v1.Pod,
+	csiMigratedPluginManager csimigration.PluginManager,
+	intreeToCSITranslator csimigration.InTreeToCSITranslator,
+	volumePluginMgr *volume.VolumePluginMgr,
+	kubeClient clientset.Interface) *PodVolumeInfos {
+
+	volumeInfos := make(map[string]*VolumeSpecInfo)
+	volumeNames := make([]string, 0, len(pod.Spec.Volumes))
+	for i := range pod.Spec.Volumes {
+		name := pod.Spec.Volumes[i].Name
+		volumeNames = append(volumeNames, name)
+		volumeInfos[name] = &VolumeSpecInfo{
+			OuterVolumeName: name,
+			PodName:         GetUniquePodName(pod),
+		}
+	}
+	// Collect all that is possible to collect with a single sweep through the pod.
+	podutil.VisitContainers(&pod.Spec, podutil.AllFeatureEnabledContainers(), func(container *v1.Container, containerType podutil.ContainerType) bool {
+		var seLinuxOptions *v1.SELinuxOptions
+		if utilfeature.DefaultFeatureGate.Enabled(features.SELinuxMountReadWriteOncePod) {
+			effectiveContainerSecurity := securitycontext.DetermineEffectiveSecurityContext(pod, container)
+			if effectiveContainerSecurity != nil {
+				// No DeepCopy, SELinuxOptions is already a copy of Pod's or container's SELinuxOptions
+				seLinuxOptions = effectiveContainerSecurity.SELinuxOptions
+			}
+		}
+
+		if container.VolumeMounts != nil {
+			for _, mount := range container.VolumeMounts {
+				volInfo, found := volumeInfos[mount.Name]
+				if !found {
+					klog.Infof("Volume %s is mounted in container %s, but not found in pod volumes", mount.Name, container.Name)
+					continue
+				}
+				volInfo.Mounted = true
+				volInfo.SELinuxContexts = append(volInfo.SELinuxContexts, seLinuxOptions.DeepCopy())
+			}
+		}
+		if container.VolumeDevices != nil {
+			for _, device := range container.VolumeDevices {
+				volInfo, found := volumeInfos[device.Name]
+				if !found {
+					klog.Infof("Volume %s is mapped in container %s, but not found in pod volumes", device.Name, container.Name)
+					continue
+				}
+				volInfo.Mapped = true
+			}
+		}
+		return true
+	})
+
+	ret := &PodVolumeInfos{
+		pod:                      pod,
+		csiMigratedPluginManager: csiMigratedPluginManager,
+		intreeToCSITranslator:    intreeToCSITranslator,
+		volumePluginMgr:          volumePluginMgr,
+		kubeClient:               kubeClient,
+
+		volumeInfos: volumeInfos,
+	}
+	return ret
+}
+
+// IsVolumeMounted returns true if the volume is mounted in the pod (i.e. there is a container that has it in container.volumeMounts).
+func (p *PodVolumeInfos) IsVolumeMounted(volumeName string) bool {
+	volumeInfo, found := p.volumeInfos[volumeName]
+	if !found {
+		return false
+	}
+	return volumeInfo.Mounted
+}
+
+// IsVolumeMapped returns true if the volume is mapped in the pod (i.e. there is a container that has it in container.volumeDevices).
+func (p *PodVolumeInfos) IsVolumeMapped(volumeName string) bool {
+	volumeInfo, found := p.volumeInfos[volumeName]
+	if !found {
+		return false
+	}
+	return volumeInfo.Mapped
+}
+
+// GetVolumeInfo returns the VolumeSpecInfo for the given volume in the pod.
+// It dereferences the PVC and PV if necessary, and caches the result.
+// The first call to this method for a given volume may be expensive and include API calls.
+func (p *PodVolumeInfos) GetVolumeInfo(podVolume *v1.Volume) (*VolumeSpecInfo, error) {
+	volumeInfo, found := p.volumeInfos[podVolume.Name]
+	if !found {
+		return nil, fmt.Errorf("podVolume %s not found in pod", podVolume.Name)
+	}
+	if volumeInfo.Spec != nil {
+		// The volume was already populated & cached.
+		return volumeInfo, nil
+	}
+
+	// Populate the volume info from PVC, PV and whatnot
+	err := p.populateFullVolumeInfo(volumeInfo, podVolume)
+	return volumeInfo, err
+}
+
+// populateFullVolumeInfo populates the VolumeSpecInfo with the full volume information, including dereferencing PVC and PV.
+func (p *PodVolumeInfos) populateFullVolumeInfo(info *VolumeSpecInfo, podVolume *v1.Volume) error {
+	pvcSource := podVolume.VolumeSource.PersistentVolumeClaim
+	isEphemeral := pvcSource == nil && podVolume.VolumeSource.Ephemeral != nil
+	if isEphemeral {
+		// Generic ephemeral inline volumes are handled the
+		// same way as a PVC reference. The only additional
+		// constraint (checked below) is that the PVC must be
+		// owned by the pod.
+		pvcSource = &v1.PersistentVolumeClaimVolumeSource{
+			ClaimName: ephemeral.VolumeClaimName(p.pod, podVolume),
+		}
+	}
+	if pvcSource != nil {
+		klog.V(5).InfoS("Found PVC", "PVC", klog.KRef(p.pod.Namespace, pvcSource.ClaimName))
+		// If podVolume is a PVC, fetch the real PV behind the claim
+		pvc, err := p.getPVCExtractPV(pvcSource.ClaimName)
+		if err != nil {
+			return fmt.Errorf("error processing PVC %s/%s: %v",
+				p.pod.Namespace,
+				pvcSource.ClaimName,
+				err)
+		}
+		if isEphemeral {
+			if err := ephemeral.VolumeIsForPod(p.pod, pvc); err != nil {
+				return err
+			}
+		}
+		pvName, pvcUID := pvc.Spec.VolumeName, pvc.UID
+		klog.V(5).InfoS("Found bound PV for PVC", "PVC", klog.KRef(p.pod.Namespace, pvcSource.ClaimName), "PVCUID", pvcUID, "PVName", pvName)
+		// Fetch actual PV object
+		volumeSpec, volumeGidValue, err := p.getPVSpec(pvName, pvcSource.ReadOnly, pvcUID)
+		if err != nil {
+			return fmt.Errorf("error processing PVC %s/%s: %v",
+				p.pod.Namespace,
+				pvcSource.ClaimName,
+				err)
+		}
+		klog.V(5).InfoS("Extracted volumeSpec from bound PV and PVC", "PVC", klog.KRef(p.pod.Namespace, pvcSource.ClaimName), "PVCUID", pvcUID, "PVName", pvName, "volumeSpecName", volumeSpec.Name())
+		migratable, err := p.csiMigratedPluginManager.IsMigratable(volumeSpec)
+		if err != nil {
+			return err
+		}
+		if migratable {
+			volumeSpec, err = csimigration.TranslateInTreeSpecToCSI(volumeSpec, p.pod.Namespace, p.intreeToCSITranslator)
+			if err != nil {
+				return err
+			}
+		}
+
+		volumeMode, err := GetVolumeMode(volumeSpec)
+		if err != nil {
+			return err
+		}
+		// Error if a container has volumeMounts but the volumeMode of PVC isn't Filesystem.
+		if info.Mounted && volumeMode != v1.PersistentVolumeFilesystem {
+			return fmt.Errorf("volume %s has volumeMode %s, but is specified in volumeMounts",
+				podVolume.Name,
+				volumeMode)
+		}
+		// Error if a container has volumeDevices but the volumeMode of PVC isn't Block
+		if info.Mapped && volumeMode != v1.PersistentVolumeBlock {
+			return fmt.Errorf("volume %s has volumeMode %s, but is specified in volumeDevices",
+				podVolume.Name,
+				volumeMode)
+		}
+
+		volumePlugin, err := p.volumePluginMgr.FindPluginBySpec(volumeSpec)
+		if err != nil || volumePlugin == nil {
+			return fmt.Errorf(
+				"failed to get Plugin from volumeSpec for volume %q err=%v",
+				volumeSpec.Name(),
+				err)
+		}
+
+		info.VolumeGIDValue = volumeGidValue
+		info.Spec = volumeSpec
+		info.PVC = pvc
+		info.VolumePlugin = volumePlugin
+
+		return nil
+	}
+
+	// Do not return the original volume object, since the source could mutate it
+	clonedPodVolume := podVolume.DeepCopy()
+
+	spec := volume.NewSpecFromVolume(clonedPodVolume)
+	migratable, err := p.csiMigratedPluginManager.IsMigratable(spec)
+	if err != nil {
+		return err
+	}
+	if migratable {
+		spec, err = csimigration.TranslateInTreeSpecToCSI(spec, p.pod.Namespace, p.intreeToCSITranslator)
+		if err != nil {
+			return err
+		}
+	}
+
+	volumePlugin, err := p.volumePluginMgr.FindPluginBySpec(spec)
+	if err != nil || volumePlugin == nil {
+		return fmt.Errorf(
+			"failed to get Plugin from volumeSpec for volume %q err=%v",
+			spec.Name(),
+			err)
+	}
+
+	info.Spec = spec
+	info.VolumePlugin = volumePlugin
+	return nil
+}
+
+// getPVCExtractPV fetches the PVC object with the given namespace and name from
+// the API server, checks whether PVC is being deleted, extracts the name of the PV
+// it is pointing to and returns it.
+// An error is returned if the PVC object's phase is not "Bound".
+func (p *PodVolumeInfos) getPVCExtractPV(claimName string) (*v1.PersistentVolumeClaim, error) {
+	pvc, err := p.kubeClient.CoreV1().PersistentVolumeClaims(p.pod.Namespace).Get(context.TODO(), claimName, metav1.GetOptions{})
+	if err != nil || pvc == nil {
+		return nil, fmt.Errorf("failed to fetch PVC from API server: %v", err)
+	}
+
+	// Pods that uses a PVC that is being deleted must not be started.
+	//
+	// In case an old kubelet is running without this check or some kubelets
+	// have this feature disabled, the worst that can happen is that such
+	// pod is scheduled. This was the default behavior in 1.8 and earlier
+	// and users should not be that surprised.
+	// It should happen only in very rare case when scheduler schedules
+	// a pod and user deletes a PVC that's used by it at the same time.
+	if pvc.ObjectMeta.DeletionTimestamp != nil {
+		return nil, errors.New("PVC is being deleted")
+	}
+
+	if pvc.Status.Phase != v1.ClaimBound {
+		return nil, errors.New("PVC is not bound")
+	}
+	if pvc.Spec.VolumeName == "" {
+		return nil, errors.New("PVC has empty pvc.Spec.VolumeName")
+	}
+
+	return pvc, nil
+}
+
+// getPVSpec fetches the PV object with the given name from the API server
+// and returns a volume.Spec representing it.
+// An error is returned if the call to fetch the PV object fails.
+func (p *PodVolumeInfos) getPVSpec(
+	name string,
+	pvcReadOnly bool,
+	expectedClaimUID types.UID) (*volume.Spec, string, error) {
+	pv, err := p.kubeClient.CoreV1().PersistentVolumes().Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil || pv == nil {
+		return nil, "", fmt.Errorf(
+			"failed to fetch PV %s from API server: %v", name, err)
+	}
+
+	if pv.Spec.ClaimRef == nil {
+		return nil, "", fmt.Errorf(
+			"found PV object %s but it has a nil pv.Spec.ClaimRef indicating it is not yet bound to the claim",
+			name)
+	}
+
+	if pv.Spec.ClaimRef.UID != expectedClaimUID {
+		return nil, "", fmt.Errorf(
+			"found PV object %s but its pv.Spec.ClaimRef.UID %s does not point to claim.UID %s",
+			name,
+			pv.Spec.ClaimRef.UID,
+			expectedClaimUID)
+	}
+
+	volumeGidValue := getPVVolumeGidAnnotationValue(pv)
+	return volume.NewSpecFromPersistentVolume(pv, pvcReadOnly), volumeGidValue, nil
+}
+
+func getPVVolumeGidAnnotationValue(pv *v1.PersistentVolume) string {
+	if volumeGid, ok := pv.Annotations[VolumeGidAnnotationKey]; ok {
+		return volumeGid
+	}
+
+	return ""
+}

--- a/pkg/volume/util/selinux.go
+++ b/pkg/volume/util/selinux.go
@@ -177,6 +177,10 @@ func VolumeSupportsSELinuxMount(volumeSpec *volume.Spec) bool {
 	if len(volumeSpec.PersistentVolume.Spec.AccessModes) != 1 {
 		return false
 	}
+	if utilfeature.DefaultFeatureGate.Enabled(features.SELinuxMount) {
+		return true
+	}
+	// Only SELinuxMountReadWriteOncePod feature enabled
 	if !v1helper.ContainsAccessMode(volumeSpec.PersistentVolume.Spec.AccessModes, v1.ReadWriteOncePod) {
 		return false
 	}

--- a/pkg/volume/util/util.go
+++ b/pkg/volume/util/util.go
@@ -34,13 +34,11 @@ import (
 	utypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	clientset "k8s.io/client-go/kubernetes"
 	storagehelpers "k8s.io/component-helpers/storage/volume"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
-	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/securitycontext"
 	"k8s.io/kubernetes/pkg/volume"
 	"k8s.io/kubernetes/pkg/volume/util/types"
@@ -616,27 +614,14 @@ func GetLocalPersistentVolumeNodeNames(pv *v1.PersistentVolume) []string {
 // GetPodVolumeNames returns names of volumes that are used in a pod,
 // either as filesystem mount or raw block device, together with list
 // of all SELinux contexts of all containers that use the volumes.
-func GetPodVolumeNames(pod *v1.Pod) (mounts sets.String, devices sets.String, seLinuxContainerContexts map[string][]*v1.SELinuxOptions) {
+func GetPodVolumeNames(pod *v1.Pod) (mounts sets.String, devices sets.String) {
 	mounts = sets.NewString()
 	devices = sets.NewString()
-	seLinuxContainerContexts = make(map[string][]*v1.SELinuxOptions)
 
 	podutil.VisitContainers(&pod.Spec, podutil.AllFeatureEnabledContainers(), func(container *v1.Container, containerType podutil.ContainerType) bool {
-		var seLinuxOptions *v1.SELinuxOptions
-		if utilfeature.DefaultFeatureGate.Enabled(features.SELinuxMountReadWriteOncePod) {
-			effectiveContainerSecurity := securitycontext.DetermineEffectiveSecurityContext(pod, container)
-			if effectiveContainerSecurity != nil {
-				// No DeepCopy, SELinuxOptions is already a copy of Pod's or container's SELinuxOptions
-				seLinuxOptions = effectiveContainerSecurity.SELinuxOptions
-			}
-		}
-
 		if container.VolumeMounts != nil {
 			for _, mount := range container.VolumeMounts {
 				mounts.Insert(mount.Name)
-				if seLinuxOptions != nil {
-					seLinuxContainerContexts[mount.Name] = append(seLinuxContainerContexts[mount.Name], seLinuxOptions.DeepCopy())
-				}
 			}
 		}
 		if container.VolumeDevices != nil {


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Add kubelet admission that checks if a new Pod and its volumes are compatible with already existing pods on a node. The pod is denied when it uses a volume that is already mounted / used by another pod that has a different SELinux label than the new one.

The [SELinux mount KEP](https://github.com/kubernetes/enhancements/tree/master/keps/sig-storage/1710-selinux-relabeling) proposed this kubelet admission to give user a clear message that the pod can't run.

Now that I am testing the admission, I am not happy with the results. The new pod (`testpod-c1`) gets correctly rejected with some message (that can be improved):

```
$ kubectl get pod
NAME                   READY   STATUS               RESTARTS   AGE
testpod-c1             0/1     SELinuxCheckFailed   0          10m
testpod-c2             1/1     Running              0          10m

$ kubectl describe pod testpod-c1
Events:                                                                  
  Type     Reason              Age   From               Message                                                                                                                                                                                                                                                               
  ----     ------              ----  ----               -------                                                                                                                                                                                                                                                               
  Normal   Scheduled           10m   default-scheduler  Successfully assigned default/testpod-c1 to 127.0.0.1          
  Warning  SELinuxCheckFailed  10m   kubelet            volume "pvc-a2842a8e-be59-4b61-b21f-6fe3d6506098" is already used the node by a pod with a different SELinux label
```

Problem is when the new pod is managed by a Deployment. Deployment controller sees the failure and creates a replacement pod that fails in the same way. In a minute or so I got 600 failed Pods.

```
mydeployment-8474f84dbc-zq6tb   0/1     SELinuxCheckFailed   0          54s
mydeployment-8474f84dbc-ztdgx   0/1     SELinuxCheckFailed   0          5s
mydeployment-8474f84dbc-ztj2m   0/1     SELinuxCheckFailed   0          12s
mydeployment-8474f84dbc-zwgvf   0/1     SELinuxCheckFailed   0          16s
mydeployment-8474f84dbc-zwkdq   0/1     SELinuxCheckFailed   0          69s
mydeployment-8474f84dbc-zx2cf   0/1     SELinuxCheckFailed   0          7s
mydeployment-8474f84dbc-zxb4r   0/1     SELinuxCheckFailed   0          46s

[snip a lot of pods]

testpod-c2                      1/1     Running              0          83s
```

The pod admission does not seem to be a good idea.

When we introduced the new ReadWriteOncePod access mode, we did not implement kubelet admission for it either. When a pod is force-scheduled to a node that already uses a ReadWriteOncePod PV, the new Pod gets ContainerCreating forever (or until the other pod finishes), with some event.

SELinuxMount feature should do the same. The new pod should wait ContainerCreating until the old pod that uses the same volume, but with a different SELinux context, finished. VolumeManager changes in #123157 already do that.

Code-wise, I did some refactoring of the VolumeManager - a lot of info parsed by `createVolumeSpec` was passed as variables / function arguments around. I need to call `createVolumeSpec` from the admission plugin, so I encapsulated the function + the parsed info into `PodVolumeInfos` and `VolumeInfo` structures. See the first commits. 
 The code can be improved, however, interaction with Deployment is really bad and I propose to skip the kubelet admission.

**WIP**:

* lot of unit tests - I did not move them from `createVolumeSpec` to the new code.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-storage/1710-selinux-relabeling
```
