### PR TITLE
Expose ParseTaints

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/taint/taint.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/taint/taint.go
@@ -182,7 +182,7 @@ func (o *TaintOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []st
 		return fmt.Errorf("at least one taint update is required")
 	}
 
-	if o.taintsToAdd, o.taintsToRemove, err = parseTaints(taintArgs); err != nil {
+	if o.taintsToAdd, o.taintsToRemove, err = ParseTaints(taintArgs); err != nil {
 		return cmdutil.UsageErrorf(cmd, err.Error())
 	}
 	o.builder = f.NewBuilder().

--- a/staging/src/k8s.io/kubectl/pkg/cmd/taint/utils.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/taint/utils.go
@@ -34,7 +34,7 @@ const (
 	UNTAINTED = "untainted"
 )
 
-// parseTaints takes a spec which is an array and creates slices for new taints to be added, taints to be deleted.
+// ParseTaints takes a spec which is an array and creates slices for new taints to be added, taints to be deleted.
 // It also validates the spec. For example, the form `<key>` may be used to remove a taint, but not to add one.
 func ParseTaints(spec []string) ([]corev1.Taint, []corev1.Taint, error) {
 	var taints, taintsToRemove []corev1.Taint

--- a/staging/src/k8s.io/kubectl/pkg/cmd/taint/utils.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/taint/utils.go
@@ -36,7 +36,7 @@ const (
 
 // parseTaints takes a spec which is an array and creates slices for new taints to be added, taints to be deleted.
 // It also validates the spec. For example, the form `<key>` may be used to remove a taint, but not to add one.
-func parseTaints(spec []string) ([]corev1.Taint, []corev1.Taint, error) {
+func ParseTaints(spec []string) ([]corev1.Taint, []corev1.Taint, error) {
 	var taints, taintsToRemove []corev1.Taint
 	uniqueTaints := map[corev1.TaintEffect]sets.String{}
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/taint/utils_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/taint/utils_test.go
@@ -516,7 +516,7 @@ func TestParseTaints(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		taints, taintsToRemove, err := parseTaints(c.spec)
+		taints, taintsToRemove, err := ParseTaints(c.spec)
 		if c.expectedErr && err == nil {
 			t.Errorf("[%s] expected error for spec %s, but got nothing", c.name, c.spec)
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup


#### What this PR does / why we need it:
Needed to remove dependency on k8s.io/kubernetes which is unsupported
https://github.com/kubernetes/kubernetes/blob/master/pkg/util/taints/taints.go
https://github.com/kubernetes/kubernetes/issues/79384#issuecomment-505627280

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
