### PR TITLE
[DNM] WIP: Test PR

### DIFF
--- a/pkg/kubelet/pleg/evented.go
+++ b/pkg/kubelet/pleg/evented.go
@@ -264,8 +264,10 @@ func (e *EventedPLEG) processCRIEvents(containerEventsResponseCh chan *runtimeap
 			}
 			shouldSendPLEGEvent = true
 		} else {
-			if e.cache.Set(podID, status, err, time.Unix(event.GetCreatedAt(), 0)) {
-				shouldSendPLEGEvent = true
+			if event.ContainerEventType != runtimeapi.ContainerEventType_CONTAINER_CREATED_EVENT {
+				if e.cache.Set(podID, status, err, time.Unix(event.GetCreatedAt(), 0)) {
+					shouldSendPLEGEvent = true
+				}
 			}
 		}
 


### PR DESCRIPTION
Do not update the container cache when a container created event is received This helps in not refreshing the pod status until the container started event is received.
Thus, the GetNewerThan() function helps in blocking any Pod updates until a container is created and avoids the creation of duplicate containers for the same pod.
Ref: https://github.com/kubernetes/kubernetes/issues/123087

This PR is to check if it fixes the issue observed with Evented PLEG's behavior