### PR TITLE
KEP-127: require userns support from the CRI runtime before using it

### DIFF
--- a/pkg/kubelet/container/helpers.go
+++ b/pkg/kubelet/container/helpers.go
@@ -59,7 +59,7 @@ type RuntimeHelper interface {
 	GetExtraSupplementalGroupsForPod(pod *v1.Pod) []int64
 
 	// GetOrCreateUserNamespaceMappings returns the configuration for the sandbox user namespace
-	GetOrCreateUserNamespaceMappings(pod *v1.Pod) (*runtimeapi.UserNamespace, error)
+	GetOrCreateUserNamespaceMappings(pod *v1.Pod, runtimeHandler string) (*runtimeapi.UserNamespace, error)
 
 	// PrepareDynamicResources prepares resources for a pod.
 	PrepareDynamicResources(pod *v1.Pod) error

--- a/pkg/kubelet/container/runtime.go
+++ b/pkg/kubelet/container/runtime.go
@@ -526,6 +526,8 @@ const (
 type RuntimeStatus struct {
 	// Conditions is an array of current observed runtime conditions.
 	Conditions []RuntimeCondition
+	// Handlers is a map of current available handlers
+	Handlers map[string]RuntimeHandler
 }
 
 // GetRuntimeCondition gets a specified runtime condition from the runtime status.
@@ -542,10 +544,28 @@ func (r *RuntimeStatus) GetRuntimeCondition(t RuntimeConditionType) *RuntimeCond
 // String formats the runtime status into human readable string.
 func (r *RuntimeStatus) String() string {
 	var ss []string
+	var sh []string
 	for _, c := range r.Conditions {
 		ss = append(ss, c.String())
 	}
-	return fmt.Sprintf("Runtime Conditions: %s", strings.Join(ss, ", "))
+	for _, h := range r.Handlers {
+		sh = append(sh, h.String())
+	}
+	return fmt.Sprintf("Runtime Conditions: %s; Handlers: %s", strings.Join(ss, ", "), strings.Join(sh, ", "))
+}
+
+// RuntimeHandler contains condition information for the runtime handler.
+type RuntimeHandler struct {
+	// Name is the handler name.
+	Name string
+	// SupportsUserNamespaces is true if the handler has support for
+	// user namespaces.
+	SupportsUserNamespaces bool
+}
+
+// String formats the runtime handler into human readable string.
+func (h *RuntimeHandler) String() string {
+	return fmt.Sprintf("Name=%s SupportsUserNamespaces: %v", h.Name, h.SupportsUserNamespaces)
 }
 
 // RuntimeCondition contains condition information for the runtime.

--- a/pkg/kubelet/container/testing/fake_runtime_helper.go
+++ b/pkg/kubelet/container/testing/fake_runtime_helper.go
@@ -68,7 +68,7 @@ func (f *FakeRuntimeHelper) GetExtraSupplementalGroupsForPod(pod *v1.Pod) []int6
 	return nil
 }
 
-func (f *FakeRuntimeHelper) GetOrCreateUserNamespaceMappings(pod *v1.Pod) (*runtimeapi.UserNamespace, error) {
+func (f *FakeRuntimeHelper) GetOrCreateUserNamespaceMappings(pod *v1.Pod, runtimeHandler string) (*runtimeapi.UserNamespace, error) {
 	return nil, nil
 }
 

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1178,7 +1178,8 @@ type Kubelet struct {
 	updatePodCIDRMux sync.Mutex
 
 	// updateRuntimeMux is a lock on updating runtime, because this path is not thread-safe.
-	// This lock is used by Kubelet.updateRuntimeUp and Kubelet.fastNodeStatusUpdate functions and shouldn't be used anywhere else.
+	// This lock is used by Kubelet.updateRuntimeUp, Kubelet.fastNodeStatusUpdate and
+	// Kubelet.HandlerSupportsUserNamespaces functions and shouldn't be used anywhere else.
 	updateRuntimeMux sync.Mutex
 
 	// nodeLeaseController claims and renews the node lease for this Kubelet

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -2898,7 +2898,9 @@ func (kl *Kubelet) updateRuntimeUp() {
 		kl.runtimeState.setRuntimeState(fmt.Errorf("container runtime not ready: %v", runtimeReady))
 		return
 	}
+
 	kl.runtimeState.setRuntimeState(nil)
+	kl.runtimeState.setRuntimeHandlers(s.Handlers)
 	kl.oneTimeInitializer.Do(kl.initializeRuntimeDependentModules)
 	kl.runtimeState.setRuntimeSync(kl.clock.Now())
 }

--- a/pkg/kubelet/kubelet_getters.go
+++ b/pkg/kubelet/kubelet_getters.go
@@ -109,6 +109,20 @@ func (kl *Kubelet) ListPodsFromDisk() ([]types.UID, error) {
 	return kl.listPodsFromDisk()
 }
 
+// HandlerSupportsUserNamespaces checks whether the specified handler supports
+// user namespaces.
+func (kl *Kubelet) HandlerSupportsUserNamespaces(rtHandler string) (bool, error) {
+	rtHandlers := kl.runtimeState.runtimeHandlers()
+	if rtHandlers == nil {
+		return false, fmt.Errorf("runtime handlers are not set")
+	}
+	h, found := rtHandlers[rtHandler]
+	if !found {
+		return false, fmt.Errorf("the handler %q is not known", rtHandler)
+	}
+	return h.SupportsUserNamespaces, nil
+}
+
 // getPodDir returns the full path to the per-pod directory for the pod with
 // the given UID.
 func (kl *Kubelet) getPodDir(podUID types.UID) string {

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -425,8 +425,8 @@ func truncatePodHostnameIfNeeded(podName, hostname string) (string, error) {
 }
 
 // GetOrCreateUserNamespaceMappings returns the configuration for the sandbox user namespace
-func (kl *Kubelet) GetOrCreateUserNamespaceMappings(pod *v1.Pod) (*runtimeapi.UserNamespace, error) {
-	return kl.usernsManager.GetOrCreateUserNamespaceMappings(pod)
+func (kl *Kubelet) GetOrCreateUserNamespaceMappings(pod *v1.Pod, runtimeHandler string) (*runtimeapi.UserNamespace, error) {
+	return kl.usernsManager.GetOrCreateUserNamespaceMappings(pod, runtimeHandler)
 }
 
 // GeneratePodHostNameAndDomain creates a hostname and domain name for a pod,

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -353,7 +353,7 @@ func (m *kubeGenericRuntimeManager) Status(ctx context.Context) (*kubecontainer.
 	if resp.GetStatus() == nil {
 		return nil, errors.New("runtime status is nil")
 	}
-	return toKubeRuntimeStatus(resp.GetStatus()), nil
+	return toKubeRuntimeStatus(resp.GetStatus(), resp.GetRuntimeHandlers()), nil
 }
 
 // GetPods returns a list of containers grouped by pods. The boolean parameter

--- a/pkg/kubelet/kuberuntime/util/util.go
+++ b/pkg/kubelet/kuberuntime/util/util.go
@@ -100,7 +100,11 @@ func PidNamespaceForPod(pod *v1.Pod) runtimeapi.NamespaceMode {
 // namespacesForPod returns the runtimeapi.NamespaceOption for a given pod.
 // An empty or nil pod can be used to get the namespace defaults for v1.Pod.
 func NamespacesForPod(pod *v1.Pod, runtimeHelper kubecontainer.RuntimeHelper) (*runtimeapi.NamespaceOption, error) {
-	userNs, err := runtimeHelper.GetOrCreateUserNamespaceMappings(pod)
+	runtimeHandler := ""
+	if pod != nil && pod.Spec.RuntimeClassName != nil {
+		runtimeHandler = *pod.Spec.RuntimeClassName
+	}
+	userNs, err := runtimeHelper.GetOrCreateUserNamespaceMappings(pod, runtimeHandler)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kubelet/runtime.go
+++ b/pkg/kubelet/runtime.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 )
 
 type runtimeState struct {
@@ -34,6 +35,7 @@ type runtimeState struct {
 	storageError             error
 	cidr                     string
 	healthChecks             []*healthCheck
+	rtHandlers               map[string]kubecontainer.RuntimeHandler
 }
 
 // A health check function should be efficient and not rely on external
@@ -67,6 +69,18 @@ func (s *runtimeState) setRuntimeState(err error) {
 	s.Lock()
 	defer s.Unlock()
 	s.runtimeError = err
+}
+
+func (s *runtimeState) setRuntimeHandlers(rtHandlers map[string]kubecontainer.RuntimeHandler) {
+	s.Lock()
+	defer s.Unlock()
+	s.rtHandlers = rtHandlers
+}
+
+func (s *runtimeState) runtimeHandlers() map[string]kubecontainer.RuntimeHandler {
+	s.RLock()
+	defer s.RUnlock()
+	return s.rtHandlers
 }
 
 func (s *runtimeState) setStorageState(err error) {

--- a/pkg/kubelet/userns/userns_manager_disabled_test.go
+++ b/pkg/kubelet/userns/userns_manager_disabled_test.go
@@ -49,6 +49,10 @@ func TestReleaseDisabled(t *testing.T) {
 
 func TestGetOrCreateUserNamespaceMappingsDisabled(t *testing.T) {
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, pkgfeatures.UserNamespacesSupport, false)()
+
+	trueVal := true
+	falseVal := false
+
 	tests := []struct {
 		name    string
 		pod     *v1.Pod
@@ -58,6 +62,31 @@ func TestGetOrCreateUserNamespaceMappingsDisabled(t *testing.T) {
 			name:    "pod is nil",
 			pod:     nil,
 			success: true,
+		},
+		{
+			name: "hostUsers is nil",
+			pod: &v1.Pod{
+				Spec: v1.PodSpec{
+					HostUsers: nil,
+				},
+			},
+			success: true,
+		},
+		{
+			name: "hostUsers is true",
+			pod: &v1.Pod{
+				Spec: v1.PodSpec{
+					HostUsers: &trueVal,
+				},
+			},
+		},
+		{
+			name: "hostUsers is false",
+			pod: &v1.Pod{
+				Spec: v1.PodSpec{
+					HostUsers: &falseVal,
+				},
+			},
 		},
 	}
 

--- a/pkg/kubelet/userns/userns_manager_disabled_test.go
+++ b/pkg/kubelet/userns/userns_manager_disabled_test.go
@@ -53,7 +53,7 @@ func TestGetOrCreateUserNamespaceMappingsDisabled(t *testing.T) {
 	m, err := MakeUserNsManager(testUserNsPodsManager)
 	require.NoError(t, err)
 
-	userns, err := m.GetOrCreateUserNamespaceMappings(nil)
+	userns, err := m.GetOrCreateUserNamespaceMappings(nil, "")
 	assert.NoError(t, err)
 	assert.Nil(t, userns)
 }

--- a/pkg/kubelet/userns/userns_manager_disabled_test.go
+++ b/pkg/kubelet/userns/userns_manager_disabled_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	pkgfeatures "k8s.io/kubernetes/pkg/features"
@@ -48,14 +49,33 @@ func TestReleaseDisabled(t *testing.T) {
 
 func TestGetOrCreateUserNamespaceMappingsDisabled(t *testing.T) {
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, pkgfeatures.UserNamespacesSupport, false)()
+	tests := []struct {
+		name    string
+		pod     *v1.Pod
+		success bool
+	}{
+		{
+			name:    "pod is nil",
+			pod:     nil,
+			success: true,
+		},
+	}
 
-	testUserNsPodsManager := &testUserNsPodsManager{}
-	m, err := MakeUserNsManager(testUserNsPodsManager)
-	require.NoError(t, err)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			testUserNsPodsManager := &testUserNsPodsManager{}
+			m, err := MakeUserNsManager(testUserNsPodsManager)
+			require.NoError(t, err)
 
-	userns, err := m.GetOrCreateUserNamespaceMappings(nil, "")
-	assert.NoError(t, err)
-	assert.Nil(t, userns)
+			userns, err := m.GetOrCreateUserNamespaceMappings(test.pod, "")
+			assert.Nil(t, userns)
+			if test.success {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+			}
+		})
+	}
 }
 
 func TestCleanupOrphanedPodUsernsAllocationsDisabled(t *testing.T) {

--- a/pkg/kubelet/userns/userns_manager_test.go
+++ b/pkg/kubelet/userns/userns_manager_test.go
@@ -52,6 +52,10 @@ func (m *testUserNsPodsManager) ListPodsFromDisk() ([]types.UID, error) {
 	return m.podList, nil
 }
 
+func (m *testUserNsPodsManager) HandlerSupportsUserNamespaces(runtimeHandler string) (bool, error) {
+	return true, nil
+}
+
 func TestUserNsManagerAllocate(t *testing.T) {
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, pkgfeatures.UserNamespacesSupport, true)()
 
@@ -232,7 +236,7 @@ func TestGetOrCreateUserNamespaceMappings(t *testing.T) {
 			m, err := MakeUserNsManager(testUserNsPodsManager)
 			assert.NoError(t, err)
 
-			userns, err := m.GetOrCreateUserNamespaceMappings(tc.pod)
+			userns, err := m.GetOrCreateUserNamespaceMappings(tc.pod, "")
 			if (tc.success && err != nil) || (!tc.success && err == nil) {
 				t.Errorf("expected success: %v but got error: %v", tc.success, err)
 			}

--- a/pkg/kubelet/userns/userns_manager_test.go
+++ b/pkg/kubelet/userns/userns_manager_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package userns
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"testing"
@@ -36,6 +37,7 @@ import (
 type testUserNsPodsManager struct {
 	podDir  string
 	podList []types.UID
+	userns  bool
 }
 
 func (m *testUserNsPodsManager) GetPodDir(podUID types.UID) string {
@@ -53,7 +55,10 @@ func (m *testUserNsPodsManager) ListPodsFromDisk() ([]types.UID, error) {
 }
 
 func (m *testUserNsPodsManager) HandlerSupportsUserNamespaces(runtimeHandler string) (bool, error) {
-	return true, nil
+	if runtimeHandler == "error" {
+		return false, errors.New("unknown runtime")
+	}
+	return m.userns, nil
 }
 
 func TestUserNsManagerAllocate(t *testing.T) {
@@ -196,14 +201,22 @@ func TestGetOrCreateUserNamespaceMappings(t *testing.T) {
 	falseVal := false
 
 	cases := []struct {
-		name    string
-		pod     *v1.Pod
-		expMode runtimeapi.NamespaceMode
-		success bool
+		name           string
+		pod            *v1.Pod
+		expMode        runtimeapi.NamespaceMode
+		runtimeUserns  bool
+		runtimeHandler string
+		success        bool
 	}{
 		{
 			name:    "no user namespace",
 			pod:     &v1.Pod{},
+			expMode: runtimeapi.NamespaceMode_NODE,
+			success: true,
+		},
+		{
+			name:    "nil pod",
+			pod:     nil,
 			expMode: runtimeapi.NamespaceMode_NODE,
 			success: true,
 		},
@@ -224,19 +237,42 @@ func TestGetOrCreateUserNamespaceMappings(t *testing.T) {
 					HostUsers: &falseVal,
 				},
 			},
-			expMode: runtimeapi.NamespaceMode_POD,
-			success: true,
+			expMode:       runtimeapi.NamespaceMode_POD,
+			runtimeUserns: true,
+			success:       true,
+		},
+		{
+			name: "user namespace, but no runtime support",
+			pod: &v1.Pod{
+				Spec: v1.PodSpec{
+					HostUsers: &falseVal,
+				},
+			},
+			runtimeUserns: false,
+		},
+		{
+			name: "user namespace, but runtime returns error",
+			pod: &v1.Pod{
+				Spec: v1.PodSpec{
+					HostUsers: &falseVal,
+				},
+			},
+			// This handler name makes the fake runtime return an error.
+			runtimeHandler: "error",
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			// These tests will create the userns file, so use an existing podDir.
-			testUserNsPodsManager := &testUserNsPodsManager{podDir: t.TempDir()}
+			testUserNsPodsManager := &testUserNsPodsManager{
+				podDir: t.TempDir(),
+				userns: tc.runtimeUserns,
+			}
 			m, err := MakeUserNsManager(testUserNsPodsManager)
 			assert.NoError(t, err)
 
-			userns, err := m.GetOrCreateUserNamespaceMappings(tc.pod, "")
+			userns, err := m.GetOrCreateUserNamespaceMappings(tc.pod, tc.runtimeHandler)
 			if (tc.success && err != nil) || (!tc.success && err == nil) {
 				t.Errorf("expected success: %v but got error: %v", tc.success, err)
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


/kind feature


#### What this PR does / why we need it:

as agreed in https://github.com/kubernetes/enhancements/pull/4439 we need to notify the Kubelet when the CRI runtime supports user namespaces and fail if it does not.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
The Kubelet rejects creating the pod if hostUserns=false and the CRI runtime does not support user namespaces.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

- [KEP]: https://kep.k8s.io/127

