### PR TITLE
Add AdditionalLabels to cloudprovider.InstanceMetadata

### DIFF
--- a/staging/src/k8s.io/cloud-provider/cloud.go
+++ b/staging/src/k8s.io/cloud-provider/cloud.go
@@ -327,4 +327,9 @@ type InstanceMetadata struct {
 	//   * topology.kubernetes.io/region=<region>
 	//   * failure-domain.beta.kubernetes.io/region=<region> (DEPRECATED)
 	Region string
+
+	// AdditionalLabels is a map of additional labels provided by the cloud provider.
+	// When provided, they will be applied to the node and enable cloud providers
+	// to labels nodes with information that may be valuable to that provider.
+	AdditionalLabels map[string]string
 }

--- a/staging/src/k8s.io/cloud-provider/fake/fake.go
+++ b/staging/src/k8s.io/cloud-provider/fake/fake.go
@@ -97,7 +97,8 @@ type Cloud struct {
 	ProviderID     map[types.NodeName]string
 	addCallLock    sync.Mutex
 	cloudprovider.Zone
-	VolumeLabelMap map[string]map[string]string
+	VolumeLabelMap   map[string]map[string]string
+	AdditionalLabels map[string]string
 
 	OverrideInstanceMetadata func(ctx context.Context, node *v1.Node) (*cloudprovider.InstanceMetadata, error)
 
@@ -373,11 +374,12 @@ func (f *Cloud) InstanceMetadata(ctx context.Context, node *v1.Node) (*cloudprov
 	}
 
 	return &cloudprovider.InstanceMetadata{
-		ProviderID:    providerID,
-		InstanceType:  f.InstanceTypes[types.NodeName(node.Spec.ProviderID)],
-		NodeAddresses: f.Addresses,
-		Zone:          f.Zone.FailureDomain,
-		Region:        f.Zone.Region,
+		ProviderID:       providerID,
+		InstanceType:     f.InstanceTypes[types.NodeName(node.Spec.ProviderID)],
+		NodeAddresses:    f.Addresses,
+		Zone:             f.Zone.FailureDomain,
+		Region:           f.Zone.Region,
+		AdditionalLabels: f.AdditionalLabels,
 	}, f.MetadataErr
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adds the `AdditionalLabels` field to the `InstanceMetadata`, which can be set by cloud provider implementations to provide custom labels that will be applied to nodes. [There's a need in the AWS cloud provider](https://github.com/kubernetes/cloud-provider-aws/issues/300) to set labels specific to AWS on the nodes, and I assume that other cloud providers can put this to use as well. The change is backwards compatible because if the cloud providers never set the field, nothing will change. There's not a hook directly in the cloud provider implementations that allows them to customize node objects directly, so they either need to run additional controllers or provide it via the `InstanceMetadata` struct and instruct the `node_controller` on how to apply it to the node.

As a side node, this change also requires that cloud providers utilize `InstancesV2`, which gives them direct access to the instance metadata. The AWS cloud provider does not implement `InstancesV2`, so I will be doing that migration there directly.

#### Which issue(s) this PR fixes:
N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added support for cloud provider integrations to supply optional, per-Node custom labels that will be
applied to Nodes by the node controller.
Extra labels will only be applied where the cloud provider integration implements this.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
To use this feature, cloud providers must use the [InstancesV2 interface](https://github.com/kubernetes/kubernetes/blob/ad19beaa83363de89a7772f4d5af393b85ce5e61/staging/src/k8s.io/cloud-provider/cloud.go#L210) and
update the InstanceMetadata method to set the `AdditionalLabels` field with desired labels.
If no action is taken by cloud providers, the node controller behavior will be no different.
```
