### PR TITLE
Fix daemonset to ensure old unhealthy pods are counted towards max unavailable budget.

### DIFF
--- a/pkg/controller/daemon/update.go
+++ b/pkg/controller/daemon/update.go
@@ -99,6 +99,7 @@ func (dsc *DaemonSetsController) rollingUpdate(ctx context.Context, ds *apps.Dae
 						allowedReplacementPods = make([]string, 0, len(nodeToDaemonPods))
 					}
 					allowedReplacementPods = append(allowedReplacementPods, oldPod.Name)
+					numUnavailable++
 				case numUnavailable >= maxUnavailable:
 					// no point considering any other candidates
 					continue


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug


#### What this PR does / why we need it:
Fixes a bug in the daemonset update logic where old pods that are not available are not correctly counted against the maxUnavailable budget.

#### Which issue(s) this PR fixes:
Fixes #123232


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Ensure daemonset controller to count old unhealthy pods towards max unavailable budget
```

