### PR TITLE
Update publishing-bot rules to Go 1.21.7

### DIFF
--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -7,25 +7,25 @@ rules:
       dirs:
       - staging/src/k8s.io/code-generator
   - name: release-1.26
-    go: 1.20.13
+    go: 1.21.7
     source:
       branch: release-1.26
       dirs:
       - staging/src/k8s.io/code-generator
   - name: release-1.27
-    go: 1.20.13
+    go: 1.21.7
     source:
       branch: release-1.27
       dirs:
       - staging/src/k8s.io/code-generator
   - name: release-1.28
-    go: 1.20.13
+    go: 1.21.7
     source:
       branch: release-1.28
       dirs:
       - staging/src/k8s.io/code-generator
   - name: release-1.29
-    go: 1.21.6
+    go: 1.21.7
     source:
       branch: release-1.29
       dirs:
@@ -38,25 +38,25 @@ rules:
       dirs:
       - staging/src/k8s.io/apimachinery
   - name: release-1.26
-    go: 1.20.13
+    go: 1.21.7
     source:
       branch: release-1.26
       dirs:
       - staging/src/k8s.io/apimachinery
   - name: release-1.27
-    go: 1.20.13
+    go: 1.21.7
     source:
       branch: release-1.27
       dirs:
       - staging/src/k8s.io/apimachinery
   - name: release-1.28
-    go: 1.20.13
+    go: 1.21.7
     source:
       branch: release-1.28
       dirs:
       - staging/src/k8s.io/apimachinery
   - name: release-1.29
-    go: 1.21.6
+    go: 1.21.7
     source:
       branch: release-1.29
       dirs:
@@ -73,7 +73,7 @@ rules:
       dirs:
       - staging/src/k8s.io/api
   - name: release-1.26
-    go: 1.20.13
+    go: 1.21.7
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -82,7 +82,7 @@ rules:
       dirs:
       - staging/src/k8s.io/api
   - name: release-1.27
-    go: 1.20.13
+    go: 1.21.7
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -91,7 +91,7 @@ rules:
       dirs:
       - staging/src/k8s.io/api
   - name: release-1.28
-    go: 1.20.13
+    go: 1.21.7
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -100,7 +100,7 @@ rules:
       dirs:
       - staging/src/k8s.io/api
   - name: release-1.29
-    go: 1.21.6
+    go: 1.21.7
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -126,7 +126,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.26
-    go: 1.20.13
+    go: 1.21.7
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -141,7 +141,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.27
-    go: 1.20.13
+    go: 1.21.7
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -156,7 +156,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.28
-    go: 1.20.13
+    go: 1.21.7
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -171,7 +171,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.29
-    go: 1.21.6
+    go: 1.21.7
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -201,7 +201,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-base
   - name: release-1.26
-    go: 1.20.13
+    go: 1.21.7
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -214,7 +214,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-base
   - name: release-1.27
-    go: 1.20.13
+    go: 1.21.7
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -227,7 +227,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-base
   - name: release-1.28
-    go: 1.20.13
+    go: 1.21.7
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -240,7 +240,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-base
   - name: release-1.29
-    go: 1.21.6
+    go: 1.21.7
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -268,7 +268,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-helpers
   - name: release-1.26
-    go: 1.20.13
+    go: 1.21.7
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -281,7 +281,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-helpers
   - name: release-1.27
-    go: 1.20.13
+    go: 1.21.7
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -294,7 +294,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-helpers
   - name: release-1.28
-    go: 1.20.13
+    go: 1.21.7
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -307,7 +307,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-helpers
   - name: release-1.29
-    go: 1.21.6
+    go: 1.21.7
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -331,13 +331,13 @@ rules:
       dirs:
       - staging/src/k8s.io/kms
   - name: release-1.26
-    go: 1.20.13
+    go: 1.21.7
     source:
       branch: release-1.26
       dirs:
       - staging/src/k8s.io/kms
   - name: release-1.27
-    go: 1.20.13
+    go: 1.21.7
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -350,7 +350,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kms
   - name: release-1.28
-    go: 1.20.13
+    go: 1.21.7
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -363,7 +363,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kms
   - name: release-1.29
-    go: 1.21.6
+    go: 1.21.7
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -391,7 +391,7 @@ rules:
       dirs:
       - staging/src/k8s.io/apiserver
   - name: release-1.26
-    go: 1.20.13
+    go: 1.21.7
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -408,7 +408,7 @@ rules:
       dirs:
       - staging/src/k8s.io/apiserver
   - name: release-1.27
-    go: 1.20.13
+    go: 1.21.7
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -425,7 +425,7 @@ rules:
       dirs:
       - staging/src/k8s.io/apiserver
   - name: release-1.28
-    go: 1.20.13
+    go: 1.21.7
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -442,7 +442,7 @@ rules:
       dirs:
       - staging/src/k8s.io/apiserver
   - name: release-1.29
-    go: 1.21.6
+    go: 1.21.7
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -482,7 +482,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-aggregator
   - name: release-1.26
-    go: 1.20.13
+    go: 1.21.7
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -503,7 +503,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-aggregator
   - name: release-1.27
-    go: 1.20.13
+    go: 1.21.7
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -524,7 +524,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-aggregator
   - name: release-1.28
-    go: 1.20.13
+    go: 1.21.7
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -545,7 +545,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-aggregator
   - name: release-1.29
-    go: 1.21.6
+    go: 1.21.7
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -593,7 +593,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.26
-    go: 1.20.13
+    go: 1.21.7
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -619,7 +619,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.27
-    go: 1.20.13
+    go: 1.21.7
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -645,7 +645,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.28
-    go: 1.20.13
+    go: 1.21.7
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -671,7 +671,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.29
-    go: 1.21.6
+    go: 1.21.7
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -718,7 +718,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.26
-    go: 1.20.13
+    go: 1.21.7
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -738,7 +738,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.27
-    go: 1.20.13
+    go: 1.21.7
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -758,7 +758,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.28
-    go: 1.20.13
+    go: 1.21.7
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -778,7 +778,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.29
-    go: 1.21.6
+    go: 1.21.7
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -822,7 +822,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.26
-    go: 1.20.13
+    go: 1.21.7
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -845,7 +845,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.27
-    go: 1.20.13
+    go: 1.21.7
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -868,7 +868,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.28
-    go: 1.20.13
+    go: 1.21.7
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -891,7 +891,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.29
-    go: 1.21.6
+    go: 1.21.7
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -930,7 +930,7 @@ rules:
       dirs:
       - staging/src/k8s.io/metrics
   - name: release-1.26
-    go: 1.20.13
+    go: 1.21.7
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -945,7 +945,7 @@ rules:
       dirs:
       - staging/src/k8s.io/metrics
   - name: release-1.27
-    go: 1.20.13
+    go: 1.21.7
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -960,7 +960,7 @@ rules:
       dirs:
       - staging/src/k8s.io/metrics
   - name: release-1.28
-    go: 1.20.13
+    go: 1.21.7
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -975,7 +975,7 @@ rules:
       dirs:
       - staging/src/k8s.io/metrics
   - name: release-1.29
-    go: 1.21.6
+    go: 1.21.7
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -1005,7 +1005,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cli-runtime
   - name: release-1.26
-    go: 1.20.13
+    go: 1.21.7
     dependencies:
     - repository: api
       branch: release-1.26
@@ -1018,7 +1018,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cli-runtime
   - name: release-1.27
-    go: 1.20.13
+    go: 1.21.7
     dependencies:
     - repository: api
       branch: release-1.27
@@ -1031,7 +1031,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cli-runtime
   - name: release-1.28
-    go: 1.20.13
+    go: 1.21.7
     dependencies:
     - repository: api
       branch: release-1.28
@@ -1044,7 +1044,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cli-runtime
   - name: release-1.29
-    go: 1.21.6
+    go: 1.21.7
     dependencies:
     - repository: api
       branch: release-1.29
@@ -1074,7 +1074,7 @@ rules:
       dirs:
       - staging/src/k8s.io/sample-cli-plugin
   - name: release-1.26
-    go: 1.20.13
+    go: 1.21.7
     dependencies:
     - repository: api
       branch: release-1.26
@@ -1089,7 +1089,7 @@ rules:
       dirs:
       - staging/src/k8s.io/sample-cli-plugin
   - name: release-1.27
-    go: 1.20.13
+    go: 1.21.7
     dependencies:
     - repository: api
       branch: release-1.27
@@ -1104,7 +1104,7 @@ rules:
       dirs:
       - staging/src/k8s.io/sample-cli-plugin
   - name: release-1.28
-    go: 1.20.13
+    go: 1.21.7
     dependencies:
     - repository: api
       branch: release-1.28
@@ -1119,7 +1119,7 @@ rules:
       dirs:
       - staging/src/k8s.io/sample-cli-plugin
   - name: release-1.29
-    go: 1.21.6
+    go: 1.21.7
     dependencies:
     - repository: api
       branch: release-1.29
@@ -1150,7 +1150,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-proxy
   - name: release-1.26
-    go: 1.20.13
+    go: 1.21.7
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -1165,7 +1165,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-proxy
   - name: release-1.27
-    go: 1.20.13
+    go: 1.21.7
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -1180,7 +1180,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-proxy
   - name: release-1.28
-    go: 1.20.13
+    go: 1.21.7
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -1195,7 +1195,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-proxy
   - name: release-1.29
-    go: 1.21.6
+    go: 1.21.7
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -1218,25 +1218,25 @@ rules:
       dirs:
       - staging/src/k8s.io/cri-api
   - name: release-1.26
-    go: 1.20.13
+    go: 1.21.7
     source:
       branch: release-1.26
       dirs:
       - staging/src/k8s.io/cri-api
   - name: release-1.27
-    go: 1.20.13
+    go: 1.21.7
     source:
       branch: release-1.27
       dirs:
       - staging/src/k8s.io/cri-api
   - name: release-1.28
-    go: 1.20.13
+    go: 1.21.7
     source:
       branch: release-1.28
       dirs:
       - staging/src/k8s.io/cri-api
   - name: release-1.29
-    go: 1.21.6
+    go: 1.21.7
     source:
       branch: release-1.29
       dirs:
@@ -1265,7 +1265,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubelet
   - name: release-1.26
-    go: 1.20.13
+    go: 1.21.7
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -1280,7 +1280,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubelet
   - name: release-1.27
-    go: 1.20.13
+    go: 1.21.7
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -1295,7 +1295,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubelet
   - name: release-1.28
-    go: 1.20.13
+    go: 1.21.7
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -1316,7 +1316,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubelet
   - name: release-1.29
-    go: 1.21.6
+    go: 1.21.7
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -1354,7 +1354,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-scheduler
   - name: release-1.26
-    go: 1.20.13
+    go: 1.21.7
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -1369,7 +1369,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-scheduler
   - name: release-1.27
-    go: 1.20.13
+    go: 1.21.7
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -1384,7 +1384,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-scheduler
   - name: release-1.28
-    go: 1.20.13
+    go: 1.21.7
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -1399,7 +1399,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-scheduler
   - name: release-1.29
-    go: 1.21.6
+    go: 1.21.7
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -1435,7 +1435,7 @@ rules:
       dirs:
       - staging/src/k8s.io/controller-manager
   - name: release-1.26
-    go: 1.20.13
+    go: 1.21.7
     dependencies:
     - repository: api
       branch: release-1.26
@@ -1454,7 +1454,7 @@ rules:
       dirs:
       - staging/src/k8s.io/controller-manager
   - name: release-1.27
-    go: 1.20.13
+    go: 1.21.7
     dependencies:
     - repository: api
       branch: release-1.27
@@ -1473,7 +1473,7 @@ rules:
       dirs:
       - staging/src/k8s.io/controller-manager
   - name: release-1.28
-    go: 1.20.13
+    go: 1.21.7
     dependencies:
     - repository: api
       branch: release-1.28
@@ -1492,7 +1492,7 @@ rules:
       dirs:
       - staging/src/k8s.io/controller-manager
   - name: release-1.29
-    go: 1.21.6
+    go: 1.21.7
     dependencies:
     - repository: api
       branch: release-1.29
@@ -1536,7 +1536,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cloud-provider
   - name: release-1.26
-    go: 1.20.13
+    go: 1.21.7
     dependencies:
     - repository: api
       branch: release-1.26
@@ -1559,7 +1559,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cloud-provider
   - name: release-1.27
-    go: 1.20.13
+    go: 1.21.7
     dependencies:
     - repository: api
       branch: release-1.27
@@ -1582,7 +1582,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cloud-provider
   - name: release-1.28
-    go: 1.20.13
+    go: 1.21.7
     dependencies:
     - repository: api
       branch: release-1.28
@@ -1605,7 +1605,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cloud-provider
   - name: release-1.29
-    go: 1.21.6
+    go: 1.21.7
     dependencies:
     - repository: api
       branch: release-1.29
@@ -1655,7 +1655,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-controller-manager
   - name: release-1.26
-    go: 1.20.13
+    go: 1.21.7
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -1680,7 +1680,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-controller-manager
   - name: release-1.27
-    go: 1.20.13
+    go: 1.21.7
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -1705,7 +1705,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-controller-manager
   - name: release-1.28
-    go: 1.20.13
+    go: 1.21.7
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -1730,7 +1730,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-controller-manager
   - name: release-1.29
-    go: 1.21.6
+    go: 1.21.7
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -1768,7 +1768,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cluster-bootstrap
   - name: release-1.26
-    go: 1.20.13
+    go: 1.21.7
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -1779,7 +1779,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cluster-bootstrap
   - name: release-1.27
-    go: 1.20.13
+    go: 1.21.7
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -1790,7 +1790,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cluster-bootstrap
   - name: release-1.28
-    go: 1.20.13
+    go: 1.21.7
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -1801,7 +1801,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cluster-bootstrap
   - name: release-1.29
-    go: 1.21.6
+    go: 1.21.7
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -1825,7 +1825,7 @@ rules:
       dirs:
       - staging/src/k8s.io/csi-translation-lib
   - name: release-1.26
-    go: 1.20.13
+    go: 1.21.7
     dependencies:
     - repository: api
       branch: release-1.26
@@ -1836,7 +1836,7 @@ rules:
       dirs:
       - staging/src/k8s.io/csi-translation-lib
   - name: release-1.27
-    go: 1.20.13
+    go: 1.21.7
     dependencies:
     - repository: api
       branch: release-1.27
@@ -1847,7 +1847,7 @@ rules:
       dirs:
       - staging/src/k8s.io/csi-translation-lib
   - name: release-1.28
-    go: 1.20.13
+    go: 1.21.7
     dependencies:
     - repository: api
       branch: release-1.28
@@ -1858,7 +1858,7 @@ rules:
       dirs:
       - staging/src/k8s.io/csi-translation-lib
   - name: release-1.29
-    go: 1.21.6
+    go: 1.21.7
     dependencies:
     - repository: api
       branch: release-1.29
@@ -1877,25 +1877,25 @@ rules:
       dirs:
       - staging/src/k8s.io/mount-utils
   - name: release-1.26
-    go: 1.20.13
+    go: 1.21.7
     source:
       branch: release-1.26
       dirs:
       - staging/src/k8s.io/mount-utils
   - name: release-1.27
-    go: 1.20.13
+    go: 1.21.7
     source:
       branch: release-1.27
       dirs:
       - staging/src/k8s.io/mount-utils
   - name: release-1.28
-    go: 1.20.13
+    go: 1.21.7
     source:
       branch: release-1.28
       dirs:
       - staging/src/k8s.io/mount-utils
   - name: release-1.29
-    go: 1.21.6
+    go: 1.21.7
     source:
       branch: release-1.29
       dirs:
@@ -1928,7 +1928,7 @@ rules:
       dirs:
       - staging/src/k8s.io/legacy-cloud-providers
   - name: release-1.26
-    go: 1.20.13
+    go: 1.21.7
     dependencies:
     - repository: api
       branch: release-1.26
@@ -1957,7 +1957,7 @@ rules:
       dirs:
       - staging/src/k8s.io/legacy-cloud-providers
   - name: release-1.27
-    go: 1.20.13
+    go: 1.21.7
     dependencies:
     - repository: api
       branch: release-1.27
@@ -1982,7 +1982,7 @@ rules:
       dirs:
       - staging/src/k8s.io/legacy-cloud-providers
   - name: release-1.28
-    go: 1.20.13
+    go: 1.21.7
     dependencies:
     - repository: api
       branch: release-1.28
@@ -2007,7 +2007,7 @@ rules:
       dirs:
       - staging/src/k8s.io/legacy-cloud-providers
   - name: release-1.29
-    go: 1.21.6
+    go: 1.21.7
     dependencies:
     - repository: api
       branch: release-1.29
@@ -2057,7 +2057,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubectl
   - name: release-1.26
-    go: 1.20.13
+    go: 1.21.7
     dependencies:
     - repository: api
       branch: release-1.26
@@ -2080,7 +2080,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubectl
   - name: release-1.27
-    go: 1.20.13
+    go: 1.21.7
     dependencies:
     - repository: api
       branch: release-1.27
@@ -2103,7 +2103,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubectl
   - name: release-1.28
-    go: 1.20.13
+    go: 1.21.7
     dependencies:
     - repository: api
       branch: release-1.28
@@ -2126,7 +2126,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubectl
   - name: release-1.29
-    go: 1.21.6
+    go: 1.21.7
     dependencies:
     - repository: api
       branch: release-1.29
@@ -2170,7 +2170,7 @@ rules:
       dirs:
       - staging/src/k8s.io/pod-security-admission
   - name: release-1.26
-    go: 1.20.13
+    go: 1.21.7
     dependencies:
     - repository: api
       branch: release-1.26
@@ -2189,7 +2189,7 @@ rules:
       dirs:
       - staging/src/k8s.io/pod-security-admission
   - name: release-1.27
-    go: 1.20.13
+    go: 1.21.7
     dependencies:
     - repository: api
       branch: release-1.27
@@ -2208,7 +2208,7 @@ rules:
       dirs:
       - staging/src/k8s.io/pod-security-admission
   - name: release-1.28
-    go: 1.20.13
+    go: 1.21.7
     dependencies:
     - repository: api
       branch: release-1.28
@@ -2227,7 +2227,7 @@ rules:
       dirs:
       - staging/src/k8s.io/pod-security-admission
   - name: release-1.29
-    go: 1.21.6
+    go: 1.21.7
     dependencies:
     - repository: api
       branch: release-1.29
@@ -2269,7 +2269,7 @@ rules:
       dirs:
       - staging/src/k8s.io/dynamic-resource-allocation
   - name: release-1.26
-    go: 1.20.13
+    go: 1.21.7
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -2286,7 +2286,7 @@ rules:
       dirs:
       - staging/src/k8s.io/dynamic-resource-allocation
   - name: release-1.27
-    go: 1.20.13
+    go: 1.21.7
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -2303,7 +2303,7 @@ rules:
       dirs:
       - staging/src/k8s.io/dynamic-resource-allocation
   - name: release-1.28
-    go: 1.20.13
+    go: 1.21.7
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -2324,7 +2324,7 @@ rules:
       dirs:
       - staging/src/k8s.io/dynamic-resource-allocation
   - name: release-1.29
-    go: 1.21.6
+    go: 1.21.7
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -2361,7 +2361,7 @@ rules:
       dirs:
       - staging/src/k8s.io/endpointslice
   - name: release-1.28
-    go: 1.20.13
+    go: 1.21.7
     dependencies:
     - repository: api
       branch: release-1.28
@@ -2376,7 +2376,7 @@ rules:
       dirs:
       - staging/src/k8s.io/endpointslice
   - name: release-1.29
-    go: 1.21.6
+    go: 1.21.7
     dependencies:
     - repository: api
       branch: release-1.29


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

- Update publishing-bot rules to Go 1.21.7

/assign @dims @liggitt @xmudrii @Verolop 
cc @kubernetes/release-engineering 

#### Which issue(s) this PR fixes:

xref https://github.com/kubernetes/release/issues/3451

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
