### PR TITLE
Improve accuracy of the PodsCreationTotal metric and use fast pod failure backoff for ReplacementPolicy integration tests

### DIFF
--- a/pkg/controller/job/job_controller.go
+++ b/pkg/controller/job/job_controller.go
@@ -1921,7 +1921,7 @@ func (jm *Controller) cleanupPodFinalizers(job *batch.Job) {
 func recordJobPodsCreationTotal(job *batch.Job, jobCtx *syncJobCtx, succeeded, failed int32) {
 	reason := metrics.PodCreateNew
 	if feature.DefaultFeatureGate.Enabled(features.JobPodReplacementPolicy) {
-		if *job.Spec.PodReplacementPolicy == batch.Failed && jobCtx.failed > 0 {
+		if ptr.Deref(job.Spec.PodReplacementPolicy, batch.TerminatingOrFailed) == batch.Failed && jobCtx.failed > 0 {
 			reason = metrics.PodRecreateFailed
 		} else if jobCtx.failed > 0 || ptr.Deref(jobCtx.terminating, 0) > 0 {
 			reason = metrics.PodRecreateTerminatingOrFailed

--- a/pkg/controller/job/job_controller.go
+++ b/pkg/controller/job/job_controller.go
@@ -130,6 +130,7 @@ type syncJobCtx struct {
 	finishedCondition               *batch.JobCondition
 	activePods                      []*v1.Pod
 	succeeded                       int32
+	failed                          int32
 	prevSucceededIndexes            orderedIntervals
 	succeededIndexes                orderedIntervals
 	failedIndexes                   *orderedIntervals
@@ -790,7 +791,7 @@ func (jm *Controller) syncJob(ctx context.Context, key string) (rErr error) {
 	active := int32(len(jobCtx.activePods))
 	newSucceededPods, newFailedPods := getNewFinishedPods(jobCtx)
 	jobCtx.succeeded = job.Status.Succeeded + int32(len(newSucceededPods)) + int32(len(jobCtx.uncounted.succeeded))
-	failed := job.Status.Failed + int32(nonIgnoredFailedPodsCount(jobCtx, newFailedPods)) + int32(len(jobCtx.uncounted.failed))
+	jobCtx.failed = job.Status.Failed + int32(nonIgnoredFailedPodsCount(jobCtx, newFailedPods)) + int32(len(jobCtx.uncounted.failed))
 	var ready *int32
 	if feature.DefaultFeatureGate.Enabled(features.JobReadyPods) {
 		ready = ptr.To(countReadyPods(jobCtx.activePods))
@@ -806,7 +807,7 @@ func (jm *Controller) syncJob(ctx context.Context, key string) (rErr error) {
 
 	var manageJobErr error
 
-	exceedsBackoffLimit := failed > *job.Spec.BackoffLimit
+	exceedsBackoffLimit := jobCtx.failed > *job.Spec.BackoffLimit
 
 	if feature.DefaultFeatureGate.Enabled(features.JobPodFailurePolicy) {
 		if failureTargetCondition := findConditionByType(job.Status.Conditions, batch.JobFailureTarget); failureTargetCondition != nil {
@@ -1618,7 +1619,7 @@ func (jm *Controller) manageJob(ctx context.Context, job *batch.Job, jobCtx *syn
 			}
 			diff -= batchSize
 		}
-		recordJobPodsCreationTotal(job, creationsSucceeded, creationsFailed)
+		recordJobPodsCreationTotal(job, jobCtx, creationsSucceeded, creationsFailed)
 		return active, metrics.JobSyncActionPodsCreated, errorFromChannel(errCh)
 	}
 
@@ -1917,16 +1918,13 @@ func (jm *Controller) cleanupPodFinalizers(job *batch.Job) {
 	}
 }
 
-func recordJobPodsCreationTotal(job *batch.Job, succeeded, failed int32) {
+func recordJobPodsCreationTotal(job *batch.Job, jobCtx *syncJobCtx, succeeded, failed int32) {
 	reason := metrics.PodCreateNew
 	if feature.DefaultFeatureGate.Enabled(features.JobPodReplacementPolicy) {
-		podsTerminating := job.Status.Terminating != nil && *job.Status.Terminating > 0
-		isRecreateAction := podsTerminating || job.Status.Failed > 0
-		if isRecreateAction {
+		if *job.Spec.PodReplacementPolicy == batch.Failed && jobCtx.failed > 0 {
+			reason = metrics.PodRecreateFailed
+		} else if jobCtx.failed > 0 || ptr.Deref(jobCtx.terminating, 0) > 0 {
 			reason = metrics.PodRecreateTerminatingOrFailed
-			if *job.Spec.PodReplacementPolicy == batch.Failed {
-				reason = metrics.PodRecreateFailed
-			}
 		}
 	}
 	if succeeded > 0 {

--- a/pkg/controller/job/job_controller_test.go
+++ b/pkg/controller/job/job_controller_test.go
@@ -115,7 +115,7 @@ func newJobWithName(name string, parallelism, completions, backoffLimit int32, c
 		j.Spec.Parallelism = nil
 	}
 	j.Spec.BackoffLimit = &backoffLimit
-	defaultPodReplacementPolicy(j)
+
 	return j
 }
 
@@ -3880,7 +3880,6 @@ func TestSyncJobWithJobBackoffLimitPerIndex(t *testing.T) {
 			manager.podStoreSynced = alwaysReady
 			manager.jobStoreSynced = alwaysReady
 			job := &tc.job
-			defaultPodReplacementPolicy(job)
 
 			actual := job
 			manager.updateStatusHandler = func(ctx context.Context, job *batch.Job) (*batch.Job, error) {
@@ -5530,13 +5529,5 @@ func setDurationDuringTest(val *time.Duration, newVal time.Duration) func() {
 	*val = newVal
 	return func() {
 		*val = origVal
-	}
-}
-
-// Helper to simulate defaulting of the PodReplacementPolicy field in unit tests
-// as the job controller code assumes it is set by the kube-apiserver.
-func defaultPodReplacementPolicy(job *batch.Job) {
-	if feature.DefaultFeatureGate.Enabled(features.JobPodReplacementPolicy) && job.Spec.PodReplacementPolicy == nil {
-		job.Spec.PodReplacementPolicy = ptr.To(batch.TerminatingOrFailed)
 	}
 }

--- a/pkg/controller/job/job_controller_test.go
+++ b/pkg/controller/job/job_controller_test.go
@@ -115,7 +115,7 @@ func newJobWithName(name string, parallelism, completions, backoffLimit int32, c
 		j.Spec.Parallelism = nil
 	}
 	j.Spec.BackoffLimit = &backoffLimit
-
+	defaultPodReplacementPolicy(j)
 	return j
 }
 
@@ -3880,6 +3880,7 @@ func TestSyncJobWithJobBackoffLimitPerIndex(t *testing.T) {
 			manager.podStoreSynced = alwaysReady
 			manager.jobStoreSynced = alwaysReady
 			job := &tc.job
+			defaultPodReplacementPolicy(job)
 
 			actual := job
 			manager.updateStatusHandler = func(ctx context.Context, job *batch.Job) (*batch.Job, error) {
@@ -5529,5 +5530,13 @@ func setDurationDuringTest(val *time.Duration, newVal time.Duration) func() {
 	*val = newVal
 	return func() {
 		*val = origVal
+	}
+}
+
+// Helper to simulate defaulting of the PodReplacementPolicy field in unit tests
+// as the job controller code assumes it is set by the kube-apiserver.
+func defaultPodReplacementPolicy(job *batch.Job) {
+	if feature.DefaultFeatureGate.Enabled(features.JobPodReplacementPolicy) && job.Spec.PodReplacementPolicy == nil {
+		job.Spec.PodReplacementPolicy = ptr.To(batch.TerminatingOrFailed)
 	}
 }

--- a/test/integration/job/job_test.go
+++ b/test/integration/job/job_test.go
@@ -1587,6 +1587,7 @@ func TestIndexedJob(t *testing.T) {
 }
 
 func TestJobPodReplacementPolicy(t *testing.T) {
+	t.Cleanup(setDurationDuringTest(&jobcontroller.DefaultJobPodFailureBackOff, fastPodFailureBackoff))
 	indexedCompletion := batchv1.IndexedCompletion
 	nonIndexedCompletion := batchv1.NonIndexedCompletion
 	var podReplacementPolicy = func(obj batchv1.PodReplacementPolicy) *batchv1.PodReplacementPolicy {
@@ -1632,7 +1633,7 @@ func TestJobPodReplacementPolicy(t *testing.T) {
 				new: 4,
 			},
 		},
-		"feature flag true, TerminatingOrFailed policy, delete & fail pods, recreate terminating pods, and verify job status counters": {
+		"feature flag true with IndexedJob, TerminatingOrFailed policy, delete & fail pods, recreate terminating pods, and verify job status counters": {
 			podReplacementPolicyEnabled: true,
 			jobSpec: &batchv1.JobSpec{
 				Parallelism:          ptr.To[int32](2),
@@ -1665,7 +1666,7 @@ func TestJobPodReplacementPolicy(t *testing.T) {
 			jobSpec: &batchv1.JobSpec{
 				Parallelism:          ptr.To[int32](2),
 				Completions:          ptr.To[int32](2),
-				CompletionMode:       &indexedCompletion,
+				CompletionMode:       &nonIndexedCompletion,
 				PodReplacementPolicy: podReplacementPolicy(batchv1.TerminatingOrFailed),
 				Template: v1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
@@ -1846,6 +1847,7 @@ func TestJobPodReplacementPolicy(t *testing.T) {
 // Disable reverts to previous behavior.
 // Enabling will then match the original failed case.
 func TestJobPodReplacementPolicyFeatureToggling(t *testing.T) {
+	t.Cleanup(setDurationDuringTest(&jobcontroller.DefaultJobPodFailureBackOff, fastPodFailureBackoff))
 	const podCount int32 = 2
 	jobSpec := batchv1.JobSpec{
 		Parallelism:          ptr.To(podCount),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

To reduce the execution time by **>1min**

The integration tests simulate failing and recreating pods. However, the default waiting time for recreation is 10s, which makes the tests very slow.  For the similar reason we use backoff delay of 100ms in pod failure policy tests, and other tests which fail pods, such as backoff limit per index.

Here are results before:
```
> go test ./test/integration/job -v -run "JobPodReplacementPolicy" 2>&1 | grep -e "^---" -e "^==="
=== RUN   TestJobPodReplacementPolicy
=== RUN   TestJobPodReplacementPolicy/feature_flag_false,_podFailurePolicy_enabled,_delete_&_fail_pods,_recreate_failed_pods,_and_verify_job_status_counters
=== RUN   TestJobPodReplacementPolicy/feature_flag_true,_Failed_policy,_delete_&_fail_pods,_recreate_failed_pods,_and_verify_job_status_counters
=== RUN   TestJobPodReplacementPolicy/feature_flag_true_with_NonIndexedJob,_Failed_policy,_delete_&_fail_pods,_recreate_failed_pods,_and_verify_job_status_counters
=== RUN   TestJobPodReplacementPolicy/feature_flag_off,_delete_&_fail_pods,_recreate_terminating_pods,_and_verify_job_status_counters
=== RUN   TestJobPodReplacementPolicy/feature_flag_true,_TerminatingOrFailed_policy,_delete_&_fail_pods,_recreate_terminating_pods,_and_verify_job_status_counters
=== RUN   TestJobPodReplacementPolicy/feature_flag_true_with_NonIndexedJob,_TerminatingOrFailed_policy,_delete_&_fail_pods,_recreate_terminating_pods,_and_verify_job_status_counters
--- PASS: TestJobPodReplacementPolicy (116.69s)
=== RUN   TestJobPodReplacementPolicyFeatureToggling
--- PASS: TestJobPodReplacementPolicyFeatureToggling (23.39s)
```
After:
```
> go test ./test/integration/job -v -run "JobPodReplacementPolicy" 2>&1 | grep -e "^---" -e "^==="
=== RUN   TestJobPodReplacementPolicy
=== RUN   TestJobPodReplacementPolicy/feature_flag_off,_delete_&_fail_pods,_recreate_terminating_pods,_and_verify_job_status_counters
=== RUN   TestJobPodReplacementPolicy/feature_flag_true_with_IndexedJob,_TerminatingOrFailed_policy,_delete_&_fail_pods,_recreate_terminating_pods,_and_verify_job_status_counters
=== RUN   TestJobPodReplacementPolicy/feature_flag_true_with_NonIndexedJob,_TerminatingOrFailed_policy,_delete_&_fail_pods,_recreate_terminating_pods,_and_verify_job_status_counters
=== RUN   TestJobPodReplacementPolicy/feature_flag_false,_podFailurePolicy_enabled,_delete_&_fail_pods,_recreate_failed_pods,_and_verify_job_status_counters
=== RUN   TestJobPodReplacementPolicy/feature_flag_true,_Failed_policy,_delete_&_fail_pods,_recreate_failed_pods,_and_verify_job_status_counters
=== RUN   TestJobPodReplacementPolicy/feature_flag_true_with_NonIndexedJob,_Failed_policy,_delete_&_fail_pods,_recreate_failed_pods,_and_verify_job_status_counters
--- PASS: TestJobPodReplacementPolicy (26.10s)
=== RUN   TestJobPodReplacementPolicyFeatureToggling
--- PASS: TestJobPodReplacementPolicyFeatureToggling (5.27s)
```


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

For context, while working on the managed-by label PR, where I add new integration tests, taking >10s, so I want to make sure we don't run into risks of integration tests taking too long. The PodReplacementPolicy tests are currently quite outstanding, taking even more time than `BenchmarkLargeIndexedJob` (16s) or `BenchmarkLargeFailureHandling` (22s).

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
