### PR TITLE
Automated cherry pick of #122999: fixing issue with GetCPUUsageNanoCores on Windows

### DIFF
--- a/pkg/kubelet/winstats/perfcounter_nodestats.go
+++ b/pkg/kubelet/winstats/perfcounter_nodestats.go
@@ -250,7 +250,8 @@ func (p *perfCounterNodeStatsClient) convertCPUValue(cpuCores int, cpuValue uint
 
 func (p *perfCounterNodeStatsClient) getCPUUsageNanoCores() uint64 {
 	cachePeriodSeconds := uint64(defaultCachePeriod / time.Second)
-	cpuUsageNanoCores := (p.cpuUsageCoreNanoSecondsCache.latestValue - p.cpuUsageCoreNanoSecondsCache.previousValue) / cachePeriodSeconds
+	perfCounterUpdatePeriodSeconds := uint64(perfCounterUpdatePeriod / time.Second)
+	cpuUsageNanoCores := ((p.cpuUsageCoreNanoSecondsCache.latestValue - p.cpuUsageCoreNanoSecondsCache.previousValue) * perfCounterUpdatePeriodSeconds) / cachePeriodSeconds
 	return cpuUsageNanoCores
 }
 

--- a/pkg/kubelet/winstats/perfcounter_nodestats_test.go
+++ b/pkg/kubelet/winstats/perfcounter_nodestats_test.go
@@ -160,14 +160,16 @@ func TestConvertCPUValue(t *testing.T) {
 }
 
 func TestGetCPUUsageNanoCores(t *testing.T) {
+	// Scaled expected unit test values by the frequency the CPU perf counters are polled.
+	perfCounterUpdatePeriodSeconds := uint64(perfCounterUpdatePeriod / time.Second)
 	testCases := []struct {
 		latestValue   uint64
 		previousValue uint64
 		expected      uint64
 	}{
 		{latestValue: uint64(0), previousValue: uint64(0), expected: uint64(0)},
-		{latestValue: uint64(2000000000), previousValue: uint64(0), expected: uint64(200000000)},
-		{latestValue: uint64(5000000000), previousValue: uint64(2000000000), expected: uint64(300000000)},
+		{latestValue: uint64(2000000000), previousValue: uint64(0), expected: uint64(200000000 * perfCounterUpdatePeriodSeconds)},
+		{latestValue: uint64(5000000000), previousValue: uint64(2000000000), expected: uint64(300000000 * perfCounterUpdatePeriodSeconds)},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Cherry pick of #122999 on release-1.27

#122999: fixing issue with GetCPUUsageNanoCores on Windows

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fixes a 1.27.0+ regression calculating total CPU usage reported for Windows nodes
```