### PR TITLE
make use of latest snapshot controller version v6.3.3 in the deployment

### DIFF
--- a/cluster/addons/volumesnapshots/volume-snapshot-controller/volume-snapshot-controller-deployment.yaml
+++ b/cluster/addons/volumesnapshots/volume-snapshot-controller/volume-snapshot-controller-deployment.yaml
@@ -22,7 +22,7 @@ spec:
       serviceAccount: volume-snapshot-controller
       containers:
         - name: volume-snapshot-controller
-          image: registry.k8s.io/sig-storage/snapshot-controller:v6.3.1
+          image: registry.k8s.io/sig-storage/snapshot-controller:v6.3.3
           args:
             - "--v=5"
             - "--metrics-path=/metrics"


### PR DESCRIPTION
/kind cleanup
```release-note
NONE
```

Additional note for reviewer:

We can make use of v7.0.0  https://github.com/kubernetes-csi/external-snapshotter/releases/tag/v7.0.0 which got volume group support  too if needed