### PR TITLE
Fixed go versions for CI K8s unit tests in dependency files

### DIFF
--- a/build/build-image/cross/VERSION
+++ b/build/build-image/cross/VERSION
@@ -1,1 +1,1 @@
-v1.30.0-go1.22-bullseye.0
+v1.30.0-go1.22.0-bullseye.0

--- a/build/common.sh
+++ b/build/common.sh
@@ -97,7 +97,7 @@ readonly KUBE_CONTAINER_RSYNC_PORT=8730
 
 # These are the default versions (image tags) for their respective base images.
 readonly __default_distroless_iptables_version=v0.5.1
-readonly __default_go_runner_version=v2.3.1-go1.22-bookworm.0
+readonly __default_go_runner_version=v2.3.1-go1.22.0-bookworm.0
 readonly __default_setcap_version=bookworm-v1.0.1
 
 # These are the base images for the Docker-wrapped binaries.

--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -118,7 +118,7 @@ dependencies:
 
   # Golang
   - name: "golang: upstream version"
-    version: 1.22
+    version: 1.22.0
     refPaths:
     - path: .go-version
     - path: build/build-image/cross/VERSION
@@ -140,7 +140,7 @@ dependencies:
       match: minimum_go_version=go([0-9]+\.[0-9]+)
 
   - name: "registry.k8s.io/kube-cross: dependents"
-    version: v1.30.0-go1.22-bullseye.0
+    version: v1.30.0-go1.22.0-bullseye.0
     refPaths:
     - path: build/build-image/cross/VERSION
 
@@ -186,7 +186,7 @@ dependencies:
       match: configs\[DistrolessIptables\] = Config{list\.BuildImageRegistry, "distroless-iptables", "v([0-9]+)\.([0-9]+)\.([0-9]+)"}
 
   - name: "registry.k8s.io/go-runner: dependents"
-    version: v2.3.1-go1.22-bookworm.0
+    version: v2.3.1-go1.22.0-bookworm.0
     refPaths:
     - path: build/common.sh
       match: __default_go_runner_version=


### PR DESCRIPTION
Kubernetes unit tests are not able to execute due to mismatched versions in dependency files.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR corrected the versions in different files by replacing `go1.22` with `go.1.22.0`.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #123256

#### Special notes for your reviewer:
This CI runs on `ppc arch`
Failed job link : https://prow.ppc64le-cloud.cis.ibm.net/view/gs/ppc64le-kubernetes/logs/periodic-kubernetes-unit-test-ppc64le/1756891004578828288
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
