### PR TITLE
golangci-lint: add hints for error wrapping

### DIFF
--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -84,6 +84,7 @@ linters:
     - ginkgolinter
     - gocritic
     - govet
+    - errorlint
     - ineffassign
     - logcheck
     - revive

--- a/hack/golangci.yaml.in
+++ b/hack/golangci.yaml.in
@@ -140,6 +140,9 @@ linters:
     - ginkgolinter
     - gocritic
     - govet
+    {{- if .Hints}}
+    - errorlint
+    {{- end}}
     - ineffassign
     - logcheck
     - revive


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Wrapping errors may or may not be the right thing to do (see https://go.dev/blog/go1.13-errors#whether-to-wrap and the discussion in https://github.com/kubernetes/kubernetes/issues/123234). But developers should at least think about it, so let's emit linter hints for it: the golangci-lint config by default enables it for go-errorlint, just not the linter itself, so we just need to add it for the "hints" config.

Direct error comparisons and assertions also get checked. Those are typically something that should be replaced by errors.Is and errors.As, but as the existing code often doesn't do that, let's also treat those as just hints.

#### Which issue(s) this PR fixes:
Related-to: https://github.com/kubernetes/kubernetes/issues/123234

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
