### PR TITLE
Implement checking etcd version to warn about deprecated etcd versions

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
@@ -106,6 +106,10 @@ func (d *dummyStorage) getRequestWatchProgressCounter() int {
 	return d.requestWatchProgressCounter
 }
 
+func (d *dummyStorage) Supports(feature storage.Feature) (bool, error) {
+	return true, nil
+}
+
 type dummyWatch struct {
 	ch chan watch.Event
 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache_test.go
@@ -108,6 +108,11 @@ func (w *testWatchCache) getCacheIntervalForEvents(resourceVersion uint64, opts 
 	return w.getAllEventsSinceLocked(resourceVersion, opts)
 }
 
+// supports mocks the feature support.
+func supports(feature storage.Feature) (bool, error) {
+	return true, nil
+}
+
 // newTestWatchCache just adds a fake clock.
 func newTestWatchCache(capacity int, indexers *cache.Indexers) *testWatchCache {
 	keyFunc := func(obj runtime.Object) (string, error) {
@@ -127,7 +132,7 @@ func newTestWatchCache(capacity int, indexers *cache.Indexers) *testWatchCache {
 	wc.stopCh = make(chan struct{})
 	pr := newConditionalProgressRequester(wc.RequestWatchProgress, &immediateTickerFactory{}, nil)
 	go pr.Run(wc.stopCh)
-	wc.watchCache = newWatchCache(keyFunc, mockHandler, getAttrsFunc, versioner, indexers, testingclock.NewFakeClock(time.Now()), schema.GroupResource{Resource: "pods"}, pr)
+	wc.watchCache = newWatchCache(keyFunc, mockHandler, getAttrsFunc, versioner, indexers, testingclock.NewFakeClock(time.Now()), schema.GroupResource{Resource: "pods"}, pr, supports)
 	// To preserve behavior of tests that assume a given capacity,
 	// resize it to th expected size.
 	wc.capacity = capacity

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/etcdfeature/feature_support_checker.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/etcdfeature/feature_support_checker.go
@@ -1,0 +1,144 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package etcdfeature
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	clientv3 "go.etcd.io/etcd/client/v3"
+	"k8s.io/apimachinery/pkg/util/version"
+	"k8s.io/apiserver/pkg/storage"
+	"k8s.io/klog/v2"
+)
+
+var (
+	// Define these static versions to use for checking version of etcd, issue on kubernetes #123192
+	v3_4_25 = version.MustParseSemantic("3.4.25")
+	v3_5_0  = version.MustParseSemantic("3.5.0")
+	v3_5_8  = version.MustParseSemantic("3.5.8")
+
+	// DefaultFeatureSupportChecker is a shared global FeatureSupportChecker.
+	DefaultFeatureSupportChecker FeatureSupportChecker = newDefaultFeatureSupportChecker()
+)
+
+// FeatureSupportChecker to define Supports functions.
+type FeatureSupportChecker interface {
+	Supports(feature storage.Feature) (bool, error)
+	// This method works with etcd client to recalcuate feature support and caches it.
+	ClientSupports(ctx context.Context, c client, feature storage.Feature) (bool, error)
+}
+
+type defaultFeatureSupportChecker struct {
+	// mutex protects progressNotifySupported and progresNotifyEndpointCache.
+	mux                        sync.Mutex
+	progressNotifySupported    bool
+	progresNotifyEndpointCache map[string]bool
+}
+
+func newDefaultFeatureSupportChecker() *defaultFeatureSupportChecker {
+	return &defaultFeatureSupportChecker{
+		progresNotifyEndpointCache: make(map[string]bool),
+		// When the progresNotifyEndpointCache is empty the should be true.
+		progressNotifySupported: true,
+	}
+}
+
+// Supports can check the featue from anywhere without storage if it was checked before.
+func (f *defaultFeatureSupportChecker) Supports(feature storage.Feature) (bool, error) {
+	switch feature {
+	case storage.RequestWatchProgress:
+		f.mux.Lock()
+		defer f.mux.Unlock()
+
+		return f.progressNotifySupported, nil
+	default:
+		return false, fmt.Errorf("feature %q is not implemented in DefaultFeatureSupportChecker", feature)
+	}
+}
+
+// ClientSupports accepts client and calcuate the support per endpoint and caches it.
+// It will return at any point if error happens or one endpoint is not supported.
+func (f *defaultFeatureSupportChecker) ClientSupports(ctx context.Context, c client, feature storage.Feature) (bool, error) {
+	f.mux.Lock()
+	defer f.mux.Unlock()
+
+	for _, ep := range c.Endpoints() {
+		supported, err := f.checkAndCacheEndpoint(ctx, c, ep)
+		if err != nil {
+			return false, err
+		}
+		if !supported {
+			f.progressNotifySupported = false
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+func (f *defaultFeatureSupportChecker) checkAndCacheEndpoint(ctx context.Context, c client, ep string) (bool, error) {
+	if supported, ok := f.progresNotifyEndpointCache[ep]; ok {
+		return supported, nil
+	}
+
+	supported, err := endpointSupportsRequestWatchProgress(ctx, c, ep)
+	if err != nil {
+		return false, err
+	}
+
+	f.progresNotifyEndpointCache[ep] = supported
+	return supported, nil
+}
+
+// client defines the interface required for testing purposes.
+type client interface {
+	// Endpoints returns list of endpoints in etcd client.
+	Endpoints() []string
+	// Status retrieves the status information from the etcd client connected to the specified endpoint.
+	// It takes a context.Context parameter for cancellation or timeout control.
+	// It returns a clientv3.StatusResponse containing the status information or an error if the operation fails.
+	Status(ctx context.Context, endpoint string) (*clientv3.StatusResponse, error)
+}
+
+// endpointSupportsRequestWatchProgress evaluates whether RequestWatchProgress supported by current version of etcd endpoint.
+// Based on this issues:
+//   - Issue #15220: https://github.com/etcd-io/etcd/issues/15220
+//   - KEP 2340: Consistent reads from cache: https://github.com/kubernetes/enhancements/blob/master/keps/sig-api-machinery/2340-Consistent-reads-from-cache/README.md#bug-in-etcd-progress-notification
+//
+// It returns an boolean and error indicating whether the version is supported.
+func endpointSupportsRequestWatchProgress(ctx context.Context, c client, endpoint string) (bool, error) {
+	resp, err := c.Status(ctx, endpoint)
+	if err != nil {
+		return false, fmt.Errorf("failed checking etcd version, endpoint: %q: %w", endpoint, err)
+	}
+	return versionSupportsRequestWatchProgress(resp.Version)
+}
+
+// versionSupportsRequestWatchProgress cehcks for versions below 3.4.25 or between v3.5.[0-7] are considered deprecated.
+func versionSupportsRequestWatchProgress(ver string) (bool, error) {
+	respVer, err := version.ParseSemantic(ver)
+	if err != nil {
+		// Assume feature is not supported if etcd version cannot be parsed.
+		klog.ErrorS(err, "Failed to parse etcd version", "version", ver)
+		return false, nil
+	}
+	if respVer.LessThan(v3_4_25) || respVer.AtLeast(v3_5_0) && respVer.LessThan(v3_5_8) {
+		return false, nil
+	}
+	return true, nil
+}

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/etcdfeature/feature_support_checker_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/etcdfeature/feature_support_checker_test.go
@@ -1,0 +1,163 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package etcdfeature
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	clientv3 "go.etcd.io/etcd/client/v3"
+	"k8s.io/apiserver/pkg/features"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	fgt "k8s.io/component-base/featuregate/testing"
+)
+
+// MockEtcdClient is a mock implementation of the EtcdClientInterface interface.
+type MockEtcdClient struct {
+	Version string
+	// Indicates whether to return an error on Status
+	ReturnError  bool
+	ErrorMessage error
+}
+
+func (m *MockEtcdClient) Endpoints() []string {
+	return []string{"localhost:2390"}
+}
+
+// Status returns a mock status response.
+func (m *MockEtcdClient) Status(ctx context.Context, endpoint string) (*clientv3.StatusResponse, error) {
+	if m.ReturnError {
+		return nil, m.ErrorMessage
+	}
+	// Return a mock status response
+	return &clientv3.StatusResponse{
+		Version: m.Version,
+	}, nil
+}
+
+func TestCheckIsSupportedRequestWatchProgress(t *testing.T) {
+	tests := []struct {
+		name                  string
+		mockClientVersion     string
+		mockClientEndpoint    string
+		expectedSupportResult bool
+		featureDefaultValue   bool
+		expectedError         error
+		statusReturnError     bool
+		statusErrorMessage    error
+	}{
+		{
+			name:                  "Feature enabled and version not deprecated",
+			mockClientVersion:     "3.4.26",
+			mockClientEndpoint:    "localhost:2380",
+			expectedSupportResult: true,
+			featureDefaultValue:   true,
+			expectedError:         nil,
+			statusReturnError:     false,
+			statusErrorMessage:    nil,
+		},
+		{
+			name:                  "Feature disabled and version not deprecated",
+			mockClientVersion:     "3.4.26",
+			mockClientEndpoint:    "localhost:2380",
+			expectedSupportResult: true,
+			featureDefaultValue:   false,
+			expectedError:         nil,
+			statusReturnError:     false,
+			statusErrorMessage:    nil,
+		},
+		{
+			name:                  "Feature enabled and version deprecated, bounds",
+			mockClientVersion:     "3.4.24",
+			mockClientEndpoint:    "localhost:2380",
+			expectedSupportResult: false,
+			featureDefaultValue:   true,
+			expectedError:         nil,
+			statusReturnError:     false,
+			statusErrorMessage:    nil,
+		},
+		{
+			name:                  "Feature enabled and version deprecated, bounds",
+			mockClientVersion:     "3.5.0",
+			mockClientEndpoint:    "localhost:2380",
+			expectedSupportResult: false,
+			featureDefaultValue:   true,
+			expectedError:         nil,
+			statusReturnError:     false,
+			statusErrorMessage:    nil,
+		},
+		{
+			name:                  "Feature enabled and version deprecated, bounds",
+			mockClientVersion:     "3.5.7",
+			mockClientEndpoint:    "localhost:2380",
+			expectedSupportResult: false,
+			featureDefaultValue:   true,
+			expectedError:         nil,
+			statusReturnError:     false,
+			statusErrorMessage:    nil,
+		},
+		{
+			name:                  "Status return error",
+			mockClientVersion:     "3.5.10",
+			mockClientEndpoint:    "localhost:2380",
+			expectedSupportResult: false,
+			featureDefaultValue:   true,
+			expectedError:         fmt.Errorf("failed checking etcd version, endpoint: %q: %w", "localhost:2380", errors.New("")),
+			statusReturnError:     true,
+			statusErrorMessage:    errors.New(""),
+		},
+		{
+			name:                  "Malformed version",
+			mockClientVersion:     "3.5.--a",
+			mockClientEndpoint:    "localhost:2380",
+			expectedSupportResult: false,
+			featureDefaultValue:   true,
+			expectedError:         nil,
+			statusReturnError:     false,
+			statusErrorMessage:    nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Mock Etcd client
+			mockClient := &MockEtcdClient{Version: tt.mockClientVersion, ReturnError: tt.statusReturnError, ErrorMessage: tt.statusErrorMessage}
+
+			// Mock feature gate
+			defer fgt.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ConsistentListFromCache, tt.featureDefaultValue)()
+			ctx := context.Background()
+
+			// Call the function being tested
+			supported, err := endpointSupportsRequestWatchProgress(ctx, mockClient, tt.mockClientEndpoint)
+
+			// Assertions
+			assert.Equal(t, tt.expectedSupportResult, supported)
+			assert.Equal(t, tt.expectedError, err)
+		})
+	}
+}
+
+// func TestSetFeatureSupportCheckerDuringTest(t *testing.T) {
+// 	supports, _ := DefaultFeatureSupportChecker.Supports(storage.RequestWatchProgress)
+// 	assert.Equal(t, true, supports)
+// 	defer DefaultFeatureSupportChecker.SetFeatureSupportCheckerDuringTest("localhost:2390", false)()
+// 	supports, _ = DefaultFeatureSupportChecker.Supports(storage.RequestWatchProgress)
+// 	assert.Equal(t, false, supports)
+// }

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
@@ -40,6 +40,7 @@ import (
 	"k8s.io/apiserver/pkg/audit"
 	endpointsrequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/storage"
+	"k8s.io/apiserver/pkg/storage/etcd3/etcdfeature"
 	"k8s.io/apiserver/pkg/storage/etcd3/metrics"
 	"k8s.io/apiserver/pkg/storage/value"
 	"k8s.io/component-base/tracing"
@@ -85,6 +86,11 @@ func (s *store) RequestWatchProgress(ctx context.Context) error {
 	// Use watchContext to match ctx metadata provided when creating the watch.
 	// In best case scenario we would use the same context that watch was created, but there is no way access it from watchCache.
 	return s.client.RequestProgress(s.watchContext(ctx))
+}
+
+func (s *store) Supports(feature storage.Feature) (bool, error) {
+	ctx := context.Background()
+	return etcdfeature.DefaultFeatureSupportChecker.ClientSupports(ctx, s.client, feature)
 }
 
 type objState struct {

--- a/staging/src/k8s.io/apiserver/pkg/storage/interfaces.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/interfaces.go
@@ -29,6 +29,12 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 )
 
+// Feature is the name of each feature in storage that we check in feature_support_checker.
+type Feature = string
+
+// RequestWatchProgress is an etcd feature that may use to check if it supported or not.
+var RequestWatchProgress Feature = "RequestWatchProgress"
+
 // Versioner abstracts setting and retrieving metadata fields from database response
 // onto the object ot list. It is required to maintain storage invariants - updating an
 // object twice with the same data except for the ResourceVersion and SelfLink must be
@@ -251,6 +257,10 @@ type Interface interface {
 	// TODO: Remove when storage.Interface will be separate from etc3.store.
 	// Deprecated: Added temporarily to simplify exposing RequestProgress for watch cache.
 	RequestWatchProgress(ctx context.Context) error
+
+	// Supports checks whether the etcd instance supports the specified feature.
+	// The function accepts one Feature parameter representing the features to check.
+	Supports(feature Feature) (bool, error)
 }
 
 // GetOptions provides the options that may be provided for storage get operations.

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/request/list_work_estimator.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/request/list_work_estimator.go
@@ -25,6 +25,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/features"
+	"k8s.io/apiserver/pkg/storage"
+	"k8s.io/apiserver/pkg/storage/etcd3/etcdfeature"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/klog/v2"
 )
@@ -165,9 +167,10 @@ func shouldListFromStorage(query url.Values, opts *metav1.ListOptions) bool {
 	resourceVersion := opts.ResourceVersion
 	match := opts.ResourceVersionMatch
 	consistentListFromCacheEnabled := utilfeature.DefaultFeatureGate.Enabled(features.ConsistentListFromCache)
+	requestWatchProgressSupported, _ := etcdfeature.DefaultFeatureSupportChecker.Supports(storage.RequestWatchProgress)
 
 	// Serve consistent reads from storage if ConsistentListFromCache is disabled
-	consistentReadFromStorage := resourceVersion == "" && !consistentListFromCacheEnabled
+	consistentReadFromStorage := resourceVersion == "" && !(consistentListFromCacheEnabled && requestWatchProgressSupported)
 	// Watch cache doesn't support continuations, so serve them from etcd.
 	hasContinuation := len(opts.Continue) > 0
 	// Serve paginated requests about revision "0" from watch cache to avoid overwhelming etcd.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Implement warning for certain version of Etcd on active feature flag. 
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/123192

#### Special notes for your reviewer:
Warning should trigger on these versions:
<3.4.25
Between 3.5.0 and 3.5.7
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Checking etcd version to warn about deprecated etcd versions if `ConsistentListFromCache` is enabled.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
Part of https://github.com/kubernetes/enhancements/issues/2340
<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->

