### PR TITLE
golangci-lint: optionally skip it during "make verify"

### DIFF
--- a/hack/make-rules/verify.sh
+++ b/hack/make-rules/verify.sh
@@ -58,6 +58,13 @@ if [[ ${EXCLUDE_GODEP:-} =~ ^[yY]$ ]]; then
     )
 fi
 
+# Exclude golangci-lint if requested, for example in pull-kubernetes-verify.
+if [[ ${EXCLUDE_GOLANGCI_LINT:-} =~ ^[yY]$ ]]; then
+  EXCLUDED_PATTERNS+=(
+    "verify-golangci.sh"              # runs in separate pull-kubernetes-verify-lint
+    )
+fi
+
 # Exclude readonly package check in certain cases, aka, in periodic jobs we don't care and a readonly package won't be touched
 if [[ ${EXCLUDE_READONLY_PACKAGE:-} =~ ^[yY]$ ]]; then
   EXCLUDED_PATTERNS+=(


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The pull-kubernetes-verify job is going to use this to run the base verify-golangci.sh only in the pull-kubernetes-verify-lint job.

#### Which issue(s) this PR fixes:
Related-to: https://github.com/kubernetes/test-infra/pull/31972

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
