### PR TITLE
RemoteCommand over WebSockets to Beta

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -165,14 +165,6 @@ const (
 	// Enables kubelet to detect CSI volume condition and send the event of the abnormal volume to the corresponding pod that is using it.
 	CSIVolumeHealth featuregate.Feature = "CSIVolumeHealth"
 
-	// owner: @seans3
-	// kep: http://kep.k8s.io/4006
-	// alpha: v1.29
-	//
-	// Enables StreamTranslator proxy to handle WebSockets upgrade requests for the
-	// version of the RemoteCommand subprotocol that supports the "close" signal.
-	TranslateStreamCloseWebsocketRequests featuregate.Feature = "TranslateStreamCloseWebsocketRequests"
-
 	// owner: @nckturner
 	// kep:  http://kep.k8s.io/2699
 	// alpha: v1.27
@@ -808,6 +800,14 @@ const (
 	// Allow the usage of options to fine-tune the topology manager policies.
 	TopologyManagerPolicyOptions featuregate.Feature = "TopologyManagerPolicyOptions"
 
+	// owner: @seans3
+	// kep: http://kep.k8s.io/4006
+	// beta: v1.30
+	//
+	// Enables StreamTranslator proxy to handle WebSockets upgrade requests for the
+	// version of the RemoteCommand subprotocol that supports the "close" signal.
+	TranslateStreamCloseWebsocketRequests featuregate.Feature = "TranslateStreamCloseWebsocketRequests"
+
 	// owner: @richabanker
 	// alpha: v1.28
 	//
@@ -970,8 +970,6 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	CSIVolumeHealth: {Default: false, PreRelease: featuregate.Alpha},
 
 	SkipReadOnlyValidationGCE: {Default: true, PreRelease: featuregate.Deprecated}, // remove in 1.31
-
-	TranslateStreamCloseWebsocketRequests: {Default: true, PreRelease: featuregate.Beta},
 
 	CloudControllerManagerWebhook: {Default: false, PreRelease: featuregate.Alpha},
 
@@ -1138,6 +1136,8 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	TopologyManagerPolicyBetaOptions: {Default: true, PreRelease: featuregate.Beta},
 
 	TopologyManagerPolicyOptions: {Default: true, PreRelease: featuregate.Beta},
+
+	TranslateStreamCloseWebsocketRequests: {Default: true, PreRelease: featuregate.Beta},
 
 	UnknownVersionInteroperabilityProxy: {Default: false, PreRelease: featuregate.Alpha},
 

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -971,7 +971,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 
 	SkipReadOnlyValidationGCE: {Default: true, PreRelease: featuregate.Deprecated}, // remove in 1.31
 
-	TranslateStreamCloseWebsocketRequests: {Default: false, PreRelease: featuregate.Alpha},
+	TranslateStreamCloseWebsocketRequests: {Default: true, PreRelease: featuregate.Beta},
 
 	CloudControllerManagerWebhook: {Default: false, PreRelease: featuregate.Alpha},
 

--- a/staging/src/k8s.io/apiserver/pkg/util/proxy/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/proxy/metrics/metrics.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"context"
+	"sync"
+
+	"k8s.io/component-base/metrics"
+	"k8s.io/component-base/metrics/legacyregistry"
+)
+
+const (
+	subsystem  = "apiserver"
+	statuscode = "code"
+)
+
+var registerMetricsOnce sync.Once
+
+var (
+	// streamTranslatorRequestsTotal counts the number of requests that were handled by
+	// the StreamTranslatorProxy.
+	streamTranslatorRequestsTotal = metrics.NewCounterVec(
+		&metrics.CounterOpts{
+			Subsystem:      subsystem,
+			Name:           "stream_translator_requests_total",
+			Help:           "Total number of requests that were handled by the StreamTranslatorProxy, which processes streaming RemoteCommand/V5",
+			StabilityLevel: metrics.ALPHA,
+		},
+		[]string{statuscode},
+	)
+)
+
+func Register() {
+	registerMetricsOnce.Do(func() {
+		legacyregistry.MustRegister(streamTranslatorRequestsTotal)
+	})
+}
+
+func ResetForTest() {
+	streamTranslatorRequestsTotal.Reset()
+}
+
+// IncStreamTranslatorRequest increments the # of requests handled by the StreamTranslatorProxy.
+func IncStreamTranslatorRequest(ctx context.Context, status string) {
+	streamTranslatorRequestsTotal.WithContext(ctx).WithLabelValues(status).Add(1)
+}

--- a/staging/src/k8s.io/client-go/tools/remotecommand/fallback.go
+++ b/staging/src/k8s.io/client-go/tools/remotecommand/fallback.go
@@ -20,9 +20,9 @@ import (
 	"context"
 )
 
-var _ Executor = &fallbackExecutor{}
+var _ Executor = &FallbackExecutor{}
 
-type fallbackExecutor struct {
+type FallbackExecutor struct {
 	primary        Executor
 	secondary      Executor
 	shouldFallback func(error) bool
@@ -33,7 +33,7 @@ type fallbackExecutor struct {
 // websocket "StreamWithContext" call fails.
 // func NewFallbackExecutor(config *restclient.Config, method string, url *url.URL) (Executor, error) {
 func NewFallbackExecutor(primary, secondary Executor, shouldFallback func(error) bool) (Executor, error) {
-	return &fallbackExecutor{
+	return &FallbackExecutor{
 		primary:        primary,
 		secondary:      secondary,
 		shouldFallback: shouldFallback,
@@ -41,14 +41,14 @@ func NewFallbackExecutor(primary, secondary Executor, shouldFallback func(error)
 }
 
 // Stream is deprecated. Please use "StreamWithContext".
-func (f *fallbackExecutor) Stream(options StreamOptions) error {
+func (f *FallbackExecutor) Stream(options StreamOptions) error {
 	return f.StreamWithContext(context.Background(), options)
 }
 
 // StreamWithContext initially attempts to call "StreamWithContext" using the
 // primary executor, falling back to calling the secondary executor if the
 // initial primary call to upgrade to a websocket connection fails.
-func (f *fallbackExecutor) StreamWithContext(ctx context.Context, options StreamOptions) error {
+func (f *FallbackExecutor) StreamWithContext(ctx context.Context, options StreamOptions) error {
 	err := f.primary.StreamWithContext(ctx, options)
 	if f.shouldFallback(err) {
 		return f.secondary.StreamWithContext(ctx, options)

--- a/staging/src/k8s.io/client-go/tools/remotecommand/fallback_test.go
+++ b/staging/src/k8s.io/client-go/tools/remotecommand/fallback_test.go
@@ -193,8 +193,8 @@ func TestFallbackClient_PrimaryAndSecondaryFail(t *testing.T) {
 	exec, err := NewFallbackExecutor(websocketExecutor, spdyExecutor, func(error) bool { return true })
 	require.NoError(t, err)
 	// Update the websocket executor to request remote command v4, which is unsupported.
-	fallbackExec, ok := exec.(*fallbackExecutor)
-	assert.True(t, ok, "error casting executor as fallbackExecutor")
+	fallbackExec, ok := exec.(*FallbackExecutor)
+	assert.True(t, ok, "error casting executor as FallbackExecutor")
 	websocketExec, ok := fallbackExec.primary.(*wsStreamExecutor)
 	assert.True(t, ok, "error casting executor as websocket executor")
 	// Set the attempted subprotocol version to V4; websocket server only accepts V5.

--- a/staging/src/k8s.io/kubectl/pkg/cmd/exec/exec.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/exec/exec.go
@@ -121,22 +121,9 @@ type RemoteExecutor interface {
 type DefaultRemoteExecutor struct{}
 
 func (*DefaultRemoteExecutor) Execute(url *url.URL, config *restclient.Config, stdin io.Reader, stdout, stderr io.Writer, tty bool, terminalSizeQueue remotecommand.TerminalSizeQueue) error {
-	// Legacy SPDY executor is default. If feature gate enabled, fallback
-	// executor attempts websockets first--then SPDY.
-	exec, err := remotecommand.NewSPDYExecutor(config, "POST", url)
+	exec, err := createExecutor(url, config)
 	if err != nil {
 		return err
-	}
-	if cmdutil.RemoteCommandWebsockets.IsEnabled() {
-		// WebSocketExecutor must be "GET" method as described in RFC 6455 Sec. 4.1 (page 17).
-		websocketExec, err := remotecommand.NewWebSocketExecutor(config, "GET", url.String())
-		if err != nil {
-			return err
-		}
-		exec, err = remotecommand.NewFallbackExecutor(websocketExec, exec, httpstream.IsUpgradeFailure)
-		if err != nil {
-			return err
-		}
 	}
 	return exec.StreamWithContext(context.Background(), remotecommand.StreamOptions{
 		Stdin:             stdin,
@@ -145,6 +132,27 @@ func (*DefaultRemoteExecutor) Execute(url *url.URL, config *restclient.Config, s
 		Tty:               tty,
 		TerminalSizeQueue: terminalSizeQueue,
 	})
+}
+
+// createExecutor returns the Executor or an error if one occurred.
+func createExecutor(url *url.URL, config *restclient.Config) (remotecommand.Executor, error) {
+	exec, err := remotecommand.NewSPDYExecutor(config, "POST", url)
+	if err != nil {
+		return nil, err
+	}
+	// Fallback executor is default, unless feature flag is explicitly disabled.
+	if !cmdutil.RemoteCommandWebsockets.IsDisabled() {
+		// WebSocketExecutor must be "GET" method as described in RFC 6455 Sec. 4.1 (page 17).
+		websocketExec, err := remotecommand.NewWebSocketExecutor(config, "GET", url.String())
+		if err != nil {
+			return nil, err
+		}
+		exec, err = remotecommand.NewFallbackExecutor(websocketExec, exec, httpstream.IsUpgradeFailure)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return exec, nil
 }
 
 type StreamOptions struct {

--- a/test/e2e/kubectl/kubectl.go
+++ b/test/e2e/kubectl/kubectl.go
@@ -42,8 +42,6 @@ import (
 
 	"sigs.k8s.io/yaml"
 
-	utilkubectl "k8s.io/kubectl/pkg/cmd/util"
-
 	v1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -818,7 +816,6 @@ metadata:
 			// We wait for a non-empty line so we know kubectl has attached
 			e2ekubectl.NewKubectlCommand(ns, "run", "run-test", "--image="+busyboxImage, "--restart=OnFailure", podRunningTimeoutArg, "--attach=true", "--stdin", "--", "sh", "-c", "echo -n read: && cat && echo 'stdin closed'").
 				WithStdinData("value\nabcd1234").
-				AppendEnv([]string{string(utilkubectl.RemoteCommandWebsockets), "true"}).
 				ExecOrDie(ns)
 
 			runOutput := waitForStdinContent("run-test", "stdin closed")
@@ -836,7 +833,6 @@ metadata:
 			// to the container, this does not solve the race though.
 			e2ekubectl.NewKubectlCommand(ns, "run", "run-test-2", "--image="+busyboxImage, "--restart=OnFailure", podRunningTimeoutArg, "--attach=true", "--leave-stdin-open=true", "--", "sh", "-c", "cat && echo 'stdin closed'").
 				WithStdinData("abcd1234").
-				AppendEnv([]string{string(utilkubectl.RemoteCommandWebsockets), "true"}).
 				ExecOrDie(ns)
 
 			runOutput = waitForStdinContent("run-test-2", "stdin closed")
@@ -848,7 +844,6 @@ metadata:
 			ginkgo.By("executing a command with run and attach with stdin with open stdin should remain running")
 			e2ekubectl.NewKubectlCommand(ns, "run", "run-test-3", "--image="+busyboxImage, "--restart=OnFailure", podRunningTimeoutArg, "--attach=true", "--leave-stdin-open=true", "--stdin", "--", "sh", "-c", "cat && echo 'stdin closed'").
 				WithStdinData("abcd1234\n").
-				AppendEnv([]string{string(utilkubectl.RemoteCommandWebsockets), "true"}).
 				ExecOrDie(ns)
 
 			runOutput = waitForStdinContent("run-test-3", "abcd1234")

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1525,6 +1525,7 @@ k8s.io/apiserver/pkg/util/openapi
 k8s.io/apiserver/pkg/util/peerproxy
 k8s.io/apiserver/pkg/util/peerproxy/metrics
 k8s.io/apiserver/pkg/util/proxy
+k8s.io/apiserver/pkg/util/proxy/metrics
 k8s.io/apiserver/pkg/util/shufflesharding
 k8s.io/apiserver/pkg/util/webhook
 k8s.io/apiserver/pkg/util/x509metrics


### PR DESCRIPTION
* Makes `TranslateStreamCloseWebsocketRequests` feature gate on be default.
* `kubectl exec` and `kubectl attach` default to use websockets in initial upgrade attempt. This functionality can be turned off by setting `KUBECTL_REMOTE_COMMAND_WEBSOCKETS` to `false`.
  * Added unit test for this feature flag used in `exec` and `attach`. 
* Add `StreamTranslatorProxy` counter metric by label (status codes).
  * Added unit test to validate stream translator metrics.

/kind feature

```release-note
- Feature gates for RemoteCommand (kubectl exec, cp, and attach) over WebSockets are now enabled by default (Beta).
  - Server-side feature gate: TranslateStreamCloseWebsocketRequests
  - Client-side (kubectl) feature gate: KUBECTL_REMOTE_COMMAND_WEBSOCKETS
  - To turn off RemoteCommand over WebSockets for kubectl, the environment variable feature gate must be explicitly set - KUBECTL_REMOTE_COMMAND_WEBSOCKETS=false
```

- [Transition from SPDY to WebSockets #4006](https://github.com/kubernetes/enhancements/issues/4006)
