### PR TITLE
Support all key algs with structured authn config

### DIFF
--- a/pkg/kubeapiserver/options/authentication.go
+++ b/pkg/kubeapiserver/options/authentication.go
@@ -40,6 +40,7 @@ import (
 	"k8s.io/apiserver/pkg/server/egressselector"
 	genericoptions "k8s.io/apiserver/pkg/server/options"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/apiserver/plugin/pkg/authenticator/token/oidc"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	v1listers "k8s.io/client-go/listers/core/v1"
@@ -461,6 +462,9 @@ func (o *BuiltInAuthenticationOptions) ToAuthenticationConfig() (kubeauthenticat
 		if ret.AuthenticationConfig, err = loadAuthenticationConfig(o.AuthenticationConfigFile); err != nil {
 			return kubeauthenticator.Config{}, err
 		}
+		// all known signing algs are allowed when using authentication config
+		// TODO: what we really want to express is 'any alg is fine as long it matches a public key'
+		ret.OIDCSigningAlgs = oidc.AllValidSigningAlgorithms()
 	} else if o.OIDC != nil && len(o.OIDC.IssuerURL) > 0 && len(o.OIDC.ClientID) > 0 {
 		usernamePrefix := o.OIDC.UsernamePrefix
 

--- a/pkg/kubeapiserver/options/authentication_test.go
+++ b/pkg/kubeapiserver/options/authentication_test.go
@@ -446,6 +446,8 @@ func TestBuiltInAuthenticationOptionsAddFlags(t *testing.T) {
 }
 
 func TestToAuthenticationConfig_OIDC(t *testing.T) {
+	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.StructuredAuthenticationConfiguration, true)()
+
 	testCases := []struct {
 		name         string
 		args         []string
@@ -638,6 +640,43 @@ func TestToAuthenticationConfig_OIDC(t *testing.T) {
 					},
 				},
 				OIDCSigningAlgs: []string{"RS256"},
+			},
+		},
+		{
+			name: "basic authentication configuration",
+			args: []string{
+				"--authentication-config=" + writeTempFile(t, `
+apiVersion: apiserver.config.k8s.io/v1alpha1
+kind: AuthenticationConfiguration
+jwt:
+- issuer:
+    url: https://test-issuer
+    audiences: [ "🐼" ]
+  claimMappings:
+    username:
+      claim: sub
+      prefix: ""
+`),
+			},
+			expectConfig: kubeauthenticator.Config{
+				TokenSuccessCacheTTL: 10 * time.Second,
+				AuthenticationConfig: &apiserver.AuthenticationConfiguration{
+					JWT: []apiserver.JWTAuthenticator{
+						{
+							Issuer: apiserver.Issuer{
+								URL:       "https://test-issuer",
+								Audiences: []string{"🐼"},
+							},
+							ClaimMappings: apiserver.ClaimMappings{
+								Username: apiserver.PrefixedClaimOrExpression{
+									Claim:  "sub",
+									Prefix: pointer.String(""),
+								},
+							},
+						},
+					},
+				},
+				OIDCSigningAlgs: []string{"ES256", "ES384", "ES512", "PS256", "PS384", "PS512", "RS256", "RS384", "RS512"},
 			},
 		},
 	}

--- a/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/oidc/oidc.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/oidc/oidc.go
@@ -49,6 +49,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/net"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apiserver/pkg/apis/apiserver"
 	apiservervalidation "k8s.io/apiserver/pkg/apis/apiserver/validation"
@@ -196,8 +197,11 @@ func (a *Authenticator) Close() {
 	a.cancel()
 }
 
-// whitelist of signing algorithms to ensure users don't mistakenly pass something
-// goofy.
+func AllValidSigningAlgorithms() []string {
+	return sets.List(sets.KeySet(allowedSigningAlgs))
+}
+
+// allowlist of signing algorithms to ensure users don't mistakenly pass something goofy.
 var allowedSigningAlgs = map[string]bool{
 	oidc.RS256: true,
 	oidc.RS384: true,


### PR DESCRIPTION
/kind bug
/assign aramase
/triage accepted
/priority important-soon

```release-note
Fixed an issue where a JWT authenticator configured via --authentication-config would fail to verify tokens that were not signed using RS256.
```