### PR TITLE
Allowing direct CEL reserved keyword usage in CRD

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation_test.go
@@ -8251,35 +8251,19 @@ func TestValidateCustomResourceDefinitionValidation(t *testing.T) {
 			},
 		},
 		{
-			name: "invalid x-kubernetes-validations for escaping",
+			name: "invalid x-kubernetes-validations for unknown property",
 			input: apiextensions.CustomResourceValidation{
 				OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
 					Type: "object",
 					XValidations: apiextensions.ValidationRules{
 						{
-							Rule: "self.if > 0",
-						},
-						{
-							Rule: "self.namespace > 0",
-						},
-						{
 							Rule: "self.unknownProp > 0",
-						},
-					},
-					Properties: map[string]apiextensions.JSONSchemaProps{
-						"if": {
-							Type: "integer",
-						},
-						"namespace": {
-							Type: "integer",
 						},
 					},
 				},
 			},
 			expectedErrors: []validationMatch{
 				invalid("spec.validation.openAPIV3Schema.x-kubernetes-validations[0].rule"),
-				invalid("spec.validation.openAPIV3Schema.x-kubernetes-validations[1].rule"),
-				invalid("spec.validation.openAPIV3Schema.x-kubernetes-validations[2].rule"),
 			},
 			opts: validationOptions{
 				requireStructuralSchema: true,

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/compilation_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/compilation_test.go
@@ -693,8 +693,8 @@ func TestCelCompilation(t *testing.T) {
 				},
 			},
 			expectedResults: []validationMatcher{
-				invalidError("undefined field 'namespace'"),
-				invalidError("undefined field 'if'"),
+				noError(),
+				noError(),
 				invalidError("found no matching overload"),
 			},
 		},

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/validation_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/validation_test.go
@@ -896,6 +896,48 @@ func TestValidationExpressions(t *testing.T) {
 				"has(self.embedded.metadata.namespace)": "undefined field 'namespace'",
 			},
 		},
+		{name: "embedded object with usage of reserved keywords",
+			obj: map[string]interface{}{
+				"embedded": map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "Pod",
+					"metadata": map[string]interface{}{
+						"name":         "foo",
+						"generateName": "pickItForMe",
+						"namespace":    "reserved_keyword_namespace",
+					},
+					"spec": map[string]interface{}{
+						"if": "reserved_keyword_if",
+					},
+				},
+			},
+			schema: objectTypePtr(map[string]schema.Structural{
+				"embedded": {
+					Generic: schema.Generic{Type: "object"},
+					Extensions: schema.Extensions{
+						XEmbeddedResource: true,
+					},
+					Properties: map[string]schema.Structural{
+						"kind":       stringType,
+						"apiVersion": stringType,
+						"metadata": objectType(map[string]schema.Structural{
+							"name":         stringType,
+							"generateName": stringType,
+							"namespace":    stringType,
+						}),
+						"spec": objectType(map[string]schema.Structural{
+							"if": stringType,
+						}),
+					},
+				},
+			}),
+			valid: []string{
+				"has(self.embedded.metadata.namespace)",
+				"self.embedded.metadata.namespace == 'reserved_keyword_namespace'",
+				"has(self.embedded.spec.if)",
+				"self.embedded.spec.if == 'reserved_keyword_if'",
+			},
+		},
 		{name: "embedded object with preserve unknown",
 			obj: map[string]interface{}{
 				"embedded": map[string]interface{}{

--- a/staging/src/k8s.io/apiserver/pkg/cel/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/types.go
@@ -452,6 +452,10 @@ func (rt *DeclTypeProvider) FindFieldType(typeName, fieldName string) (*ref.Fiel
 	}
 
 	f, found := st.Fields[fieldName]
+	if !found {
+		f, found = st.Fields["__"+fieldName+"__"]
+	}
+
 	if found {
 		ft := f.Type
 		expT, err := ft.ExprType()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

#### What this PR does / why we need it:

This PR addresses a critical usability issue where CRD validation using CEL could not directly reference fields with names that are reserved keywords in CEL, such as namespace. By adding a check to handle reserved keywords without requiring them to be escaped, we enhance the developer experience by allowing direct reference to these fields in validation rules. This change aligns with the intuitive use of field names and removes the need for workarounds or confusing error messages related to field name usage.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes [#122777](https://github.com/kubernetes/kubernetes/issues/122777)

#### Special notes for your reviewer:

Following @thockin's advice, this solution does not introduce additional error messages for using reserved keywords as field names. Instead, it implements a check to support the direct use of reserved keywords, improving clarity and usability in CRD validation rules. The implementation has been tested to ensure backward compatibility and to avoid introducing breaking changes.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
CRD validation rules now support direct use of reserved keywords as field names in CEL expressions, enhancing usability and developer experience.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
[CRD validation rule doc](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#validation-rules)
-->
[CEL reserved keyword](https://github.com/google/cel-spec/blob/master/doc/langdef.md#syntax)
```
