### PR TITLE
e2e pod: dump pod in unexpected phase

### DIFF
--- a/test/e2e/framework/pod/wait.go
+++ b/test/e2e/framework/pod/wait.go
@@ -75,7 +75,7 @@ func BeRunningNoRetries() types.GomegaMatcher {
 		gcustom.MakeMatcher(func(pod *v1.Pod) (bool, error) {
 			switch pod.Status.Phase {
 			case v1.PodFailed, v1.PodSucceeded:
-				return false, gomega.StopTrying(fmt.Sprintf("Expected pod to reach phase %q, got final phase %q instead.", v1.PodRunning, pod.Status.Phase))
+				return false, gomega.StopTrying(fmt.Sprintf("Expected pod to reach phase %q, got final phase %q instead:\n%s", v1.PodRunning, pod.Status.Phase, format.Object(pod, 1)))
 			default:
 				return true, nil
 			}

--- a/test/e2e/framework/pod/wait_test.go
+++ b/test/e2e/framework/pod/wait_test.go
@@ -366,7 +366,16 @@ In [It] at: wait_test.go:71 <time>
 					Status: "failed",
 					Failure: &reporters.JUnitFailure{
 						Description: `[FAILED] Told to stop trying after <after>.
-Expected pod to reach phase "Running", got final phase "Failed" instead.
+Expected pod to reach phase "Running", got final phase "Failed" instead:
+    <*v1.Pod>: 
+        metadata:
+          creationTimestamp: null
+          name: failed-pod
+          namespace: default
+        spec:
+          containers: null
+        status:
+          phase: Failed
 In [It] at: wait_test.go:75 <time>
 `,
 						Type: "failed",
@@ -378,7 +387,16 @@ In [It] at: wait_test.go:75 <time>
     k8s.io/kubernetes/test/e2e/framework/pod_test.glob..func1.6()
     	wait_test.go:75
 [FAILED] Told to stop trying after <after>.
-Expected pod to reach phase "Running", got final phase "Failed" instead.
+Expected pod to reach phase "Running", got final phase "Failed" instead:
+    <*v1.Pod>: 
+        metadata:
+          creationTimestamp: null
+          name: failed-pod
+          namespace: default
+        spec:
+          containers: null
+        status:
+          phase: Failed
 In [It] at: wait_test.go:75 <time>
 < Exit [It] failed - wait_test.go:74 <time>
 `,


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

When stopping polling, the provided messages becomes the complete failure message. This means that the code which calls gomega.StopTrying must include the pod in the message instead of just summarizing the phase. This makes the failure more useful.

#### Which issue(s) this PR fixes:
Related-to: https://github.com/kubernetes/kubernetes/issues/120570#issuecomment-1934613476

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/assign @aojea 