### PR TITLE
kube-proxy: query node from apiserver cache

### DIFF
--- a/cmd/kube-proxy/app/server.go
+++ b/cmd/kube-proxy/app/server.go
@@ -1046,7 +1046,8 @@ func getNodeIPs(logger klog.Logger, client clientset.Interface, name string) []n
 	}
 
 	err := wait.ExponentialBackoff(backoff, func() (bool, error) {
-		node, err := client.CoreV1().Nodes().Get(context.TODO(), name, metav1.GetOptions{})
+		// Improve the efficiency by setting ResourceVersion "0", which means "serve the current version held by the API server cache".
+		node, err := client.CoreV1().Nodes().Get(context.TODO(), name, metav1.GetOptions{ResourceVersion: "0"})
 		if err != nil {
 			logger.Error(err, "Failed to retrieve node info")
 			return false, nil


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Make `kube-proxy` query node object from apiserver cache instead of etcd to low the performance impact when a large number of nodes/kube-proxy's are starting up.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
