### PR TITLE
Fix func name typo

### DIFF
--- a/pkg/kubelet/nodeshutdown/nodeshutdown_manager_linux.go
+++ b/pkg/kubelet/nodeshutdown/nodeshutdown_manager_linux.go
@@ -234,7 +234,7 @@ func (m *managerImpl) start() (chan struct{}, error) {
 		}
 	}
 
-	err = m.aquireInhibitLock()
+	err = m.acquireInhibitLock()
 	if err != nil {
 		return nil, err
 	}
@@ -287,7 +287,7 @@ func (m *managerImpl) start() (chan struct{}, error) {
 
 					m.processShutdownEvent()
 				} else {
-					m.aquireInhibitLock()
+					_ = m.acquireInhibitLock()
 				}
 			}
 		}
@@ -295,7 +295,7 @@ func (m *managerImpl) start() (chan struct{}, error) {
 	return stop, nil
 }
 
-func (m *managerImpl) aquireInhibitLock() error {
+func (m *managerImpl) acquireInhibitLock() error {
 	lock, err := m.dbusCon.InhibitShutdown()
 	if err != nil {
 		return err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
This PR fixes a typo for the `aquireInhibitLock` func in kubelet's `nodeshutdown` package

#### Which issue(s) this PR fixes:
NONE

#### Special notes for your reviewer:
NONE

#### Does this PR introduce a user-facing change?
NONE

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

NONE