### PR TITLE
KEP-4265: add e2e tests for ProcMountType

### DIFF
--- a/test/e2e/nodefeature/nodefeature.go
+++ b/test/e2e/nodefeature/nodefeature.go
@@ -89,6 +89,9 @@ var (
 	RecursiveReadOnlyMounts = framework.WithNodeFeature(framework.ValidNodeFeatures.Add("RecursiveReadOnlyMounts"))
 
 	// TODO: document the feature (owning SIG, when to use this feature for a test)
+	ProcMountType = framework.WithNodeFeature(framework.ValidNodeFeatures.Add("ProcMountType"))
+
+	// TODO: document the feature (owning SIG, when to use this feature for a test)
 	ResourceMetrics = framework.WithNodeFeature(framework.ValidNodeFeatures.Add("ResourceMetrics"))
 
 	// TODO: document the feature (owning SIG, when to use this feature for a test)
@@ -104,6 +107,8 @@ var (
 	// TODO: document the feature (owning SIG, when to use this feature for a test)
 	SystemNodeCriticalPod = framework.WithNodeFeature(framework.ValidNodeFeatures.Add("SystemNodeCriticalPod"))
 
+	// TODO: document the feature (owning SIG, when to use this feature for a test)
+	UserNamespacesSupport = framework.WithNodeFeature(framework.ValidNodeFeatures.Add("UserNamespacesSupport"))
 	// Please keep the list in alphabetical order.
 )
 

--- a/test/e2e/windows/security_context.go
+++ b/test/e2e/windows/security_context.go
@@ -136,7 +136,7 @@ var _ = sigDescribe(feature.Windows, "SecurityContext", skipUnlessWindows(func()
 		e2eoutput.TestContainerOutput(ctx, f, "check pod SecurityContext username", pod, 1, []string{"ContainerAdministrator"})
 	})
 
-	ginkgo.It("should ignore Linux Specific SecurityContext if set", func(ctx context.Context) {
+	ginkgo.It("should ignore SELinux Specific SecurityContext if set", func(ctx context.Context) {
 		ginkgo.By("Creating a pod with SELinux options")
 		// It is sufficient to show that the pod comes up here. Since we're stripping the SELinux and other linux
 		// security contexts in apiserver and not updating the pod object in the apiserver, we cannot validate the
@@ -150,6 +150,30 @@ var _ = sigDescribe(feature.Windows, "SecurityContext", skipUnlessWindows(func()
 		windowsPodWithSELinux.Spec.SecurityContext.SELinuxOptions = &v1.SELinuxOptions{Level: "s0:c24,c9"}
 		windowsPodWithSELinux.Spec.Containers[0].SecurityContext = &v1.SecurityContext{
 			SELinuxOptions: &v1.SELinuxOptions{Level: "s0:c24,c9"},
+			WindowsOptions: &v1.WindowsSecurityContextOptions{RunAsUserName: &containerUserName}}
+		windowsPodWithSELinux.Spec.Tolerations = []v1.Toleration{{Key: "os", Value: "Windows"}}
+		windowsPodWithSELinux, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx,
+			windowsPodWithSELinux, metav1.CreateOptions{})
+		framework.ExpectNoError(err)
+		framework.Logf("Created pod %v", windowsPodWithSELinux)
+		framework.ExpectNoError(e2epod.WaitForPodNameRunningInNamespace(ctx, f.ClientSet, windowsPodWithSELinux.Name,
+			f.Namespace.Name), "failed to wait for pod %s to be running", windowsPodWithSELinux.Name)
+	})
+
+	ginkgo.It("should ignore ProcMount Specific SecurityContext if set", func(ctx context.Context) {
+		ginkgo.By("Creating a pod with ProcMount options")
+		// It is sufficient to show that the pod comes up here. Since we're stripping the SELinux and other linux
+		// security contexts in apiserver and not updating the pod object in the apiserver, we cannot validate the
+		// pod object to not have those security contexts. However the pod coming to running state is a sufficient
+		// enough condition for us to validate since prior to https://github.com/kubernetes/kubernetes/pull/93475
+		// the pod would have failed to come up.
+		windowsPodWithSELinux := createTestPod(f, imageutils.GetE2EImage(imageutils.Agnhost), windowsOS)
+		windowsPodWithSELinux.Spec.Containers[0].Args = []string{"test-webserver-with-selinux"}
+		windowsPodWithSELinux.Spec.SecurityContext = &v1.PodSecurityContext{}
+		pmt := v1.UnmaskedProcMount
+		containerUserName := "ContainerAdministrator"
+		windowsPodWithSELinux.Spec.Containers[0].SecurityContext = &v1.SecurityContext{
+			ProcMount:      &pmt,
 			WindowsOptions: &v1.WindowsSecurityContextOptions{RunAsUserName: &containerUserName}}
 		windowsPodWithSELinux.Spec.Tolerations = []v1.Toleration{{Key: "os", Value: "Windows"}}
 		windowsPodWithSELinux, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx,

--- a/test/e2e_node/proc_mount_test.go
+++ b/test/e2e_node/proc_mount_test.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2enode
+
+import (
+	"context"
+	"strings"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	gomegatypes "github.com/onsi/gomega/types"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/test/e2e/feature"
+	"k8s.io/kubernetes/test/e2e/framework"
+	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
+	"k8s.io/kubernetes/test/e2e/nodefeature"
+	testutils "k8s.io/kubernetes/test/utils"
+	imageutils "k8s.io/kubernetes/test/utils/image"
+	admissionapi "k8s.io/pod-security-admission/api"
+)
+
+var falseVar = false
+
+var _ = SIGDescribe("DefaultProcMount [LinuxOnly]", framework.WithNodeConformance(), func() {
+	f := framework.NewDefaultFramework("proc-mount-default-test")
+	f.NamespacePodSecurityLevel = admissionapi.LevelBaseline
+
+	ginkgo.It("will mask proc mounts by default", func(ctx context.Context) {
+		testProcMount(ctx, f, v1.DefaultProcMount, gomega.BeNumerically(">=", 10), gomega.BeNumerically(">=", 7))
+	})
+})
+
+var _ = SIGDescribe("ProcMount [LinuxOnly]", nodefeature.ProcMountType, nodefeature.UserNamespacesSupport, feature.UserNamespacesSupport, func() {
+	f := framework.NewDefaultFramework("proc-mount-baseline-test")
+	f.NamespacePodSecurityLevel = admissionapi.LevelBaseline
+
+	f.It("will fail to unmask proc mounts if not privileged", func(ctx context.Context) {
+		pmt := v1.UnmaskedProcMount
+		podClient := e2epod.NewPodClient(f)
+		_, err := podClient.PodInterface.Create(ctx, &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "proc-mount-pod"},
+			Spec: v1.PodSpec{
+				Containers: []v1.Container{
+					{
+						Name:    "test-container-1",
+						Image:   imageutils.GetE2EImage(imageutils.BusyBox),
+						Command: []string{"/bin/sleep"},
+						Args:    []string{"10000"},
+						SecurityContext: &v1.SecurityContext{
+							ProcMount: &pmt,
+						},
+					},
+				},
+				HostUsers: &falseVar,
+			},
+		}, metav1.CreateOptions{})
+		gomega.Expect(err).To(gomega.HaveOccurred())
+	})
+})
+
+var _ = SIGDescribe("ProcMount [LinuxOnly]", nodefeature.ProcMountType, nodefeature.UserNamespacesSupport, feature.UserNamespacesSupport, func() {
+	f := framework.NewDefaultFramework("proc-mount-privileged-test")
+
+	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
+
+	f.It("will unmask proc mounts if requested", func(ctx context.Context) {
+		testProcMount(ctx, f, v1.UnmaskedProcMount, gomega.Equal(1), gomega.BeZero())
+	})
+})
+
+func testProcMount(ctx context.Context, f *framework.Framework, pmt v1.ProcMountType, expectedLines gomegatypes.GomegaMatcher, expectedReadOnly gomegatypes.GomegaMatcher) {
+	ginkgo.By("creating a target pod")
+	podClient := e2epod.NewPodClient(f)
+	pod := podClient.CreateSync(ctx, &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "proc-mount-pod"},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name:    "test-container-1",
+					Image:   imageutils.GetE2EImage(imageutils.BusyBox),
+					Command: []string{"/bin/sleep"},
+					Args:    []string{"10000"},
+					SecurityContext: &v1.SecurityContext{
+						ProcMount: &pmt,
+					},
+				},
+			},
+			HostUsers: &falseVar,
+		},
+	})
+
+	_, err := testutils.PodRunningReady(pod)
+	framework.ExpectNoError(err)
+
+	output := e2epod.ExecCommandInContainer(f, pod.Name, pod.Spec.Containers[0].Name, "/bin/sh", "-ec", "mount | grep /proc")
+	ginkgo.By(output)
+	lines := strings.Split(output, "\n")
+	gomega.Expect(len(lines)).To(expectedLines)
+	gomega.Expect(strings.Count(output, "(ro")).To(expectedReadOnly)
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature
#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
none
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

- [KEP]: https://github.com/kubernetes/enhancements/pull/4265
```
