### PR TITLE
Automated cherry pick of #122703: dra: increase timeout in setupFakeDRADriverGRPCServer to

### DIFF
--- a/pkg/kubelet/cm/dra/manager_test.go
+++ b/pkg/kubelet/cm/dra/manager_test.go
@@ -117,7 +117,7 @@ func setupFakeDRADriverGRPCServer(shouldTimeout bool) (fakeDRAServerInfo, error)
 		driverName: driverName,
 	}
 	if shouldTimeout {
-		timeout := plugin.PluginClientTimeout + 10*time.Millisecond
+		timeout := plugin.PluginClientTimeout + time.Second
 		fakeDRADriverGRPCServer.timeout = &timeout
 	}
 


### PR DESCRIPTION
Cherry pick of #122703 on release-1.29.

#122703: dra: increase timeout in setupFakeDRADriverGRPCServer to

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```