### PR TITLE
Always test PDB's during service upgrade test

### DIFF
--- a/test/e2e/upgrades/network/services.go
+++ b/test/e2e/upgrades/network/services.go
@@ -41,8 +41,6 @@ type ServiceUpgradeTest struct {
 // Name returns the tracking name of the test.
 func (ServiceUpgradeTest) Name() string { return "service-upgrade" }
 
-func shouldTestPDBs() bool { return framework.ProviderIs("gce", "gke") }
-
 // Setup creates a service with a load balancer and makes sure it's reachable.
 func (t *ServiceUpgradeTest) Setup(ctx context.Context, f *framework.Framework) {
 	serviceName := "service-test"
@@ -67,11 +65,9 @@ func (t *ServiceUpgradeTest) Setup(ctx context.Context, f *framework.Framework) 
 	rc, err := jig.Run(ctx, jig.AddRCAntiAffinity)
 	framework.ExpectNoError(err)
 
-	if shouldTestPDBs() {
-		ginkgo.By("creating a PodDisruptionBudget to cover the ReplicationController")
-		_, err = jig.CreatePDB(ctx, rc)
-		framework.ExpectNoError(err)
-	}
+	ginkgo.By("creating a PodDisruptionBudget to cover the ReplicationController")
+	_, err = jig.CreatePDB(ctx, rc)
+	framework.ExpectNoError(err)
 
 	// Hit it once before considering ourselves ready
 	ginkgo.By("hitting the pod through the service's LoadBalancer")
@@ -93,8 +89,7 @@ func (t *ServiceUpgradeTest) Test(ctx context.Context, f *framework.Framework, d
 	case upgrades.MasterUpgrade, upgrades.ClusterUpgrade:
 		t.test(ctx, f, done, true, true)
 	case upgrades.NodeUpgrade:
-		// Node upgrades should test during disruption only on GCE/GKE for now.
-		t.test(ctx, f, done, shouldTestPDBs(), false)
+		t.test(ctx, f, done, true, false)
 	default:
 		t.test(ctx, f, done, false, false)
 	}


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
/kind cleanup
/sig apps
/sig testing

#### What this PR does / why we need it:
We have OpenShift has been running this tests on various platform for several years now without any problems.
I don't see any reason we should not turn this on  permanently. 

#### Special notes for your reviewer:
/assign @liggitt @aojea 

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
