### PR TITLE
Graduate DevicePluginCDIDevices to GA

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -210,6 +210,7 @@ const (
 	// kep: http://kep.k8s.io/4009
 	// alpha: v1.28
 	// beta: v1.29
+	// GA: v1.30
 	//
 	// Add support for CDI Device IDs in the Device Plugin API.
 	DevicePluginCDIDevices featuregate.Feature = "DevicePluginCDIDevices"
@@ -980,7 +981,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 
 	DisableNodeKubeProxyVersion: {Default: false, PreRelease: featuregate.Alpha},
 
-	DevicePluginCDIDevices: {Default: true, PreRelease: featuregate.Beta},
+	DevicePluginCDIDevices: {Default: true, PreRelease: featuregate.GA},
 
 	DynamicResourceAllocation: {Default: false, PreRelease: featuregate.Alpha},
 


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR graduates DevicePluginCDIDevices to GA in 1.31

#### Which issue(s) this PR fixes:

Fixes [Add CDI devices to device plugin API](https://github.com/kubernetes/enhancements/issues/4009)

#### Special notes for your reviewer:

- KEP update PR has been merged: https://github.com/kubernetes/enhancements/pull/4446
- E2E job is green: https://testgrid.k8s.io/sig-node-cri-o#ci-crio-cdi-device-plugins
- Documentation PR is under review: https://github.com/kubernetes/website/pull/45144

#### Does this PR introduce a user-facing change?

```release-note
Graduated support for CDI device IDs to general availability. The `DevicePluginCDIDevices` feature gate is now enabled unconditionally.
```

