### PR TITLE
Remove unused Resolver interface in pkg/proxy/util

### DIFF
--- a/pkg/proxy/util/utils.go
+++ b/pkg/proxy/util/utils.go
@@ -17,7 +17,6 @@ limitations under the License.
 package util
 
 import (
-	"context"
 	"fmt"
 	"net"
 	"strconv"
@@ -84,11 +83,6 @@ func IsLoopBack(ip string) bool {
 		return netIP.IsLoopback()
 	}
 	return false
-}
-
-// Resolver is an interface for net.Resolver
-type Resolver interface {
-	LookupIPAddr(ctx context.Context, host string) ([]net.IPAddr, error)
 }
 
 // GetLocalAddrs returns a list of all network addresses on the local system


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Remove unused `Resolver` interface in `pkg/proxy/util`

The interface was introduced alongside with other changes in https://github.com/kubernetes/kubernetes/pull/71980
The code that was introduced by that PR was relocated to a more appropriate package in https://github.com/kubernetes/kubernetes/pull/118680. But the `Resolver` interface was "left behind".

#### Which issue(s) this PR fixes:
N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
