### PR TITLE
flake: avoid flake by ensuring params appear in the initial list

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/validating/admission_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/validating/admission_test.go
@@ -1646,13 +1646,13 @@ func testParamRefCase(t *testing.T, paramIsClusterScoped, nameIsSet, namespaceIs
 		newClusterScopedParam(matchingParamName+"5", otherNonmatchingLabels),
 	}
 
-	require.NoError(t, testContext.UpdateAndWait(&policy, &binding))
-
 	for _, p := range params {
 		// Don't wait for these sync the informers would not have been
 		// created unless bound to a policy
 		require.NoError(t, testContext.Update(p))
 	}
+
+	require.NoError(t, testContext.UpdateAndWait(&policy, &binding))
 
 	namespacedRequestObject := newParam("some param", nonMatchingNamespace, nil)
 	clusterScopedRequestObject := newClusterScopedParam("other param", nil)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
/kind failing-test
/kind flake

#### What this PR does / why we need it:

A test-only race caused by using an informer+ObjectTracker is affecting some of our tests. If objects are added to the object tracker right after the informer begins to run it is possible that some do not appear in the initial list nor in a subsequent watch event.

This PR is a simple attempt to work around the race by ensuring params are added to the object tracker before the policy can possibly sync and start the param informer. (The resulting obejcts end up in the initial list)

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

Another PR seeks to fix the race in the long-term:
- https://github.com/kubernetes/kubernetes/pull/123326

- Flake: https://storage.googleapis.com/k8s-triage/index.html?pr=1&text=TestParamRef&job=unit

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
