### PR TITLE
Add allowed/denied metrics for authorizers

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/authorization/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/authorization/metrics/metrics.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"context"
+	"sync"
+
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+	"k8s.io/component-base/metrics"
+	"k8s.io/component-base/metrics/legacyregistry"
+)
+
+const (
+	namespace = "apiserver"
+	subsystem = "authorization"
+)
+
+var (
+	authorizationDecisionsTotal = metrics.NewCounterVec(
+		&metrics.CounterOpts{
+			Namespace:      namespace,
+			Subsystem:      subsystem,
+			Name:           "decisions_total",
+			Help:           "Total number of terminal decisions made by an authorizer split by authorizer type, name, and decision.",
+			StabilityLevel: metrics.ALPHA,
+		},
+		[]string{"type", "name", "decision"},
+	)
+)
+
+var registerMetrics sync.Once
+
+func RegisterMetrics() {
+	registerMetrics.Do(func() {
+		legacyregistry.MustRegister(authorizationDecisionsTotal)
+	})
+}
+
+func ResetMetricsForTest() {
+	authorizationDecisionsTotal.Reset()
+}
+
+func RecordAuthorizationDecision(authorizerType, authorizerName, decision string) {
+	authorizationDecisionsTotal.WithLabelValues(authorizerType, authorizerName, decision).Inc()
+}
+
+func InstrumentedAuthorizer(authorizerType string, authorizerName string, delegate authorizer.Authorizer) authorizer.Authorizer {
+	RegisterMetrics()
+	return &instrumentedAuthorizer{
+		authorizerType: string(authorizerType),
+		authorizerName: authorizerName,
+		delegate:       delegate,
+	}
+}
+
+type instrumentedAuthorizer struct {
+	authorizerType string
+	authorizerName string
+	delegate       authorizer.Authorizer
+}
+
+func (a *instrumentedAuthorizer) Authorize(ctx context.Context, attributes authorizer.Attributes) (authorizer.Decision, string, error) {
+	decision, reason, err := a.delegate.Authorize(ctx, attributes)
+	switch decision {
+	case authorizer.DecisionNoOpinion:
+		// non-terminal, not reported
+	case authorizer.DecisionAllow:
+		// matches SubjectAccessReview status.allowed field name
+		RecordAuthorizationDecision(a.authorizerType, a.authorizerName, "allowed")
+	case authorizer.DecisionDeny:
+		// matches SubjectAccessReview status.denied field name
+		RecordAuthorizationDecision(a.authorizerType, a.authorizerName, "denied")
+	default:
+		RecordAuthorizationDecision(a.authorizerType, a.authorizerName, "unknown")
+	}
+	return decision, reason, err
+}

--- a/staging/src/k8s.io/apiserver/pkg/authorization/metrics/metrics_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/authorization/metrics/metrics_test.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+	"k8s.io/component-base/metrics/legacyregistry"
+	"k8s.io/component-base/metrics/testutil"
+)
+
+func TestRecordAuthorizationDecisionsTotal(t *testing.T) {
+	prefix := `
+    # HELP apiserver_authorization_decisions_total [ALPHA] Total number of terminal decisions made by an authorizer split by authorizer type, name, and decision.
+    # TYPE apiserver_authorization_decisions_total counter`
+	metrics := []string{
+		namespace + "_" + subsystem + "_decisions_total",
+	}
+
+	authorizationDecisionsTotal.Reset()
+	RegisterMetrics()
+
+	dummyAuthorizer := &dummyAuthorizer{}
+	a := InstrumentedAuthorizer("mytype", "myname", dummyAuthorizer)
+
+	// allow
+	{
+		dummyAuthorizer.decision = authorizer.DecisionAllow
+		_, _, _ = a.Authorize(context.Background(), nil)
+		expectedValue := prefix + `
+			apiserver_authorization_decisions_total{decision="allowed",name="myname",type="mytype"} 1
+		`
+		if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(expectedValue), metrics...); err != nil {
+			t.Fatal(err)
+		}
+		authorizationDecisionsTotal.Reset()
+	}
+
+	// deny
+	{
+		dummyAuthorizer.decision = authorizer.DecisionDeny
+		_, _, _ = a.Authorize(context.Background(), nil)
+		_, _, _ = a.Authorize(context.Background(), nil)
+		expectedValue := prefix + `
+			apiserver_authorization_decisions_total{decision="denied",name="myname",type="mytype"} 2
+		`
+		if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(expectedValue), metrics...); err != nil {
+			t.Fatal(err)
+		}
+		authorizationDecisionsTotal.Reset()
+	}
+
+	// no-opinion emits no metric
+	{
+		dummyAuthorizer.decision = authorizer.DecisionNoOpinion
+		_, _, _ = a.Authorize(context.Background(), nil)
+		_, _, _ = a.Authorize(context.Background(), nil)
+		expectedValue := prefix + `
+		`
+		if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(expectedValue), metrics...); err != nil {
+			t.Fatal(err)
+		}
+		authorizationDecisionsTotal.Reset()
+	}
+
+	// unknown decision emits a metric
+	{
+		dummyAuthorizer.decision = authorizer.DecisionDeny + 10
+		_, _, _ = a.Authorize(context.Background(), nil)
+		expectedValue := prefix + `
+			apiserver_authorization_decisions_total{decision="unknown",name="myname",type="mytype"} 1
+		`
+		if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(expectedValue), metrics...); err != nil {
+			t.Fatal(err)
+		}
+		authorizationDecisionsTotal.Reset()
+	}
+
+}
+
+type dummyAuthorizer struct {
+	decision authorizer.Decision
+	err      error
+}
+
+func (d *dummyAuthorizer) Authorize(ctx context.Context, attrs authorizer.Attributes) (authorizer.Decision, string, error) {
+	return d.decision, "", d.err
+}

--- a/staging/src/k8s.io/apiserver/pkg/server/options/authorizationconfig/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/authorizationconfig/metrics/metrics.go
@@ -73,7 +73,6 @@ func RegisterMetrics() {
 func ResetMetricsForTest() {
 	authorizationConfigAutomaticReloadsTotal.Reset()
 	authorizationConfigAutomaticReloadLastTimestampSeconds.Reset()
-	legacyregistry.Reset()
 }
 
 func RecordAuthorizationConfigAutomaticReloadFailure(apiServerID string) {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1428,6 +1428,7 @@ k8s.io/apiserver/pkg/authentication/user
 k8s.io/apiserver/pkg/authorization/authorizer
 k8s.io/apiserver/pkg/authorization/authorizerfactory
 k8s.io/apiserver/pkg/authorization/cel
+k8s.io/apiserver/pkg/authorization/metrics
 k8s.io/apiserver/pkg/authorization/path
 k8s.io/apiserver/pkg/authorization/union
 k8s.io/apiserver/pkg/cel


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Records metrics for terminal decisions by all configured authorizers.

#### Which issue(s) this PR fixes:
Fixes #123324

#### Does this PR introduce a user-facing change?
```release-note
kube-apiserver now reports metrics for authorization decisions in the `apiserver_authorization_decisions_total` metric, labeled by authorizer type, name, and decision.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-auth/3221-structured-authorization-configuration
```

/sig auth
/assign @ritazh @palnabarun @enj 