### PR TITLE
golangci-lint: optionally skip it during "make verify", II

### DIFF
--- a/hack/make-rules/verify.sh
+++ b/hack/make-rules/verify.sh
@@ -61,7 +61,7 @@ fi
 # Exclude golangci-lint if requested, for example in pull-kubernetes-verify.
 if [[ ${EXCLUDE_GOLANGCI_LINT:-} =~ ^[yY]$ ]]; then
   EXCLUDED_PATTERNS+=(
-    "verify-golangci.sh"              # runs in separate pull-kubernetes-verify-lint
+    "verify-golangci-lint.sh"              # runs in separate pull-kubernetes-verify-lint
     )
 fi
 


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:

The pull-kubernetes-verify job is using this to run the base verify-golangci.sh only in the pull-kubernetes-verify-lint job. Because the file name was not quite right, it still ran.


#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/kubernetes/pull/123269

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/assign @dims 