### PR TITLE
Drop API server localhost defaulting if kubeconfig is empty

### DIFF
--- a/cmd/kubectl-convert/kubectl-convert.go
+++ b/cmd/kubectl-convert/kubectl-convert.go
@@ -36,7 +36,7 @@ func main() {
 	kubeConfigFlags.AddFlags(flags)
 	matchVersionKubeConfigFlags := cmdutil.NewMatchVersionFlags(kubeConfigFlags)
 
-	f := cmdutil.NewFactory(matchVersionKubeConfigFlags)
+	f := cmdutil.NewFactory(matchVersionKubeConfigFlags, true)
 	cmd := convert.NewCmdConvert(f, genericiooptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr})
 	matchVersionKubeConfigFlags.AddFlags(cmd.PersistentFlags())
 	code := cli.Run(cmd)

--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/local_config_flags.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/local_config_flags.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package genericclioptions
+
+import (
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+)
+
+// LocalClientConfig is a wrapper to catch empty config errors
+// and return valid config to support local runs without accessing to API Server.
+type LocalClientConfig struct {
+	delegate clientcmd.ClientConfig
+}
+
+func NewLocalClientConfig(deletegate clientcmd.ClientConfig) clientcmd.ClientConfig {
+	return &LocalClientConfig{
+		delegate: deletegate,
+	}
+}
+
+func (c *LocalClientConfig) Namespace() (string, bool, error) {
+	ns, explicit, err := c.delegate.Namespace()
+	if err != nil && clientcmd.IsEmptyConfig(err) {
+		return "default", false, nil
+	}
+	return ns, explicit, err
+}
+
+func (c *LocalClientConfig) RawConfig() (clientcmdapi.Config, error) {
+	return c.delegate.RawConfig()
+}
+func (c *LocalClientConfig) ClientConfig() (*rest.Config, error) {
+	config, err := c.delegate.ClientConfig()
+	if err != nil && clientcmd.IsEmptyConfig(err) {
+		return &rest.Config{}, nil
+	}
+	return config, err
+}
+func (c *LocalClientConfig) ConfigAccess() clientcmd.ConfigAccess {
+	return c.delegate.ConfigAccess()
+}

--- a/staging/src/k8s.io/client-go/tools/clientcmd/client_config.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/client_config.go
@@ -41,22 +41,13 @@ const (
 var (
 	// ClusterDefaults has the same behavior as the old EnvVar and DefaultCluster fields
 	// DEPRECATED will be replaced
-	ClusterDefaults = clientcmdapi.Cluster{Server: getDefaultServer()}
+	ClusterDefaults = clientcmdapi.Cluster{Server: os.Getenv("KUBERNETES_MASTER")}
 	// DefaultClientConfig represents the legacy behavior of this package for defaulting
 	// DEPRECATED will be replace
 	DefaultClientConfig = DirectClientConfig{*clientcmdapi.NewConfig(), "", &ConfigOverrides{
 		ClusterDefaults: ClusterDefaults,
 	}, nil, NewDefaultClientConfigLoadingRules(), promptedCredentials{}}
 )
-
-// getDefaultServer returns a default setting for DefaultClientConfig
-// DEPRECATED
-func getDefaultServer() string {
-	if server := os.Getenv("KUBERNETES_MASTER"); len(server) > 0 {
-		return server
-	}
-	return "http://localhost:8080"
-}
 
 // ClientConfig is used to make it easy to get an api server client
 type ClientConfig interface {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/annotate/annotate.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/annotate/annotate.go
@@ -32,8 +32,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/json"
 
-	"k8s.io/client-go/tools/clientcmd"
-
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/printers"
@@ -229,7 +227,7 @@ func (flags *AnnotateFlags) ToOptions(f cmdutil.Factory, cmd *cobra.Command, arg
 	}
 
 	options.namespace, options.enforceNamespace, err = f.ToRawKubeConfigLoader().Namespace()
-	if err != nil && !(options.local && clientcmd.IsEmptyConfig(err)) {
+	if err != nil {
 		return nil, err
 	}
 	options.builder = f.NewBuilder()

--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply_test.go
@@ -2351,8 +2351,8 @@ func TestApplySetParentValidation(t *testing.T) {
 				kubeConfig := clientcmdapi.NewConfig()
 				kubeConfig.CurrentContext = "default"
 				kubeConfig.Contexts["default"] = &clientcmdapi.Context{Namespace: "bar"}
-				clientConfig := clientcmd.NewDefaultClientConfig(*kubeConfig, &clientcmd.ConfigOverrides{
-					ClusterDefaults: clientcmdapi.Cluster{Server: "http://localhost:8080"}})
+				clientConfig := genericclioptions.NewLocalClientConfig(clientcmd.NewDefaultClientConfig(*kubeConfig, &clientcmd.ConfigOverrides{
+					ClusterDefaults: clientcmdapi.Cluster{}}))
 				f.WithClientConfig(clientConfig)
 			},
 			expectBlankParentNs: true,

--- a/staging/src/k8s.io/kubectl/pkg/cmd/cmd.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/cmd.go
@@ -370,7 +370,15 @@ func NewKubectlCommand(o KubectlOptions) *cobra.Command {
 	// Updates hooks to add kubectl command headers: SIG CLI KEP 859.
 	addCmdHeaderHooks(cmds, kubeConfigFlags)
 
-	f := cmdutil.NewFactory(matchVersionKubeConfigFlags)
+	var local bool
+	for _, arg := range o.Arguments {
+		// We are setting client factory to local mode.
+		if arg == "--dry-run=client" || arg == "--dry-run" || arg == "--local" {
+			local = true
+		}
+	}
+
+	f := cmdutil.NewFactory(matchVersionKubeConfigFlags, local)
 
 	// Proxy command is incompatible with CommandHeaderRoundTripper, so
 	// clear the WrapConfigFn before running proxy command.

--- a/staging/src/k8s.io/kubectl/pkg/cmd/cmd_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/cmd_test.go
@@ -58,37 +58,6 @@ func TestNormalizationFuncGlobalExistence(t *testing.T) {
 }
 
 func TestKubectlSubcommandShadowPlugin(t *testing.T) {
-	tmpKubeconfig, _ := os.CreateTemp("", "")
-	defer func() {
-		err := os.Remove(tmpKubeconfig.Name())
-		if err != nil {
-			t.Fatalf("temp kubeconfig removal error %v", err)
-		}
-	}()
-
-	configContent := []byte(`
-apiVersion: v1
-kind: Config
-clusters:
-- cluster:
-    server: https://localhost:8080
-  name: test-cluster
-contexts:
-- context:
-    cluster: test-cluster
-    user: test-user
-  name: test-context
-current-context: test-context
-users:
-- name: test-user
-  user:
-    token: test-token
-`)
-	_, err := tmpKubeconfig.Write(configContent)
-	if err != nil {
-		t.Fatalf("temp kubeconfig write error %v", err)
-	}
-
 	tests := []struct {
 		name              string
 		args              []string
@@ -109,7 +78,7 @@ users:
 		},
 		{
 			name:             "test that normal commands are able to be executed, when builtin subcommand exists",
-			args:             []string{"kubectl", "create", "job", "foo", "--image=busybox", "--dry-run=client", "--namespace", "test-namespace", fmt.Sprintf("--kubeconfig=%s", tmpKubeconfig.Name())},
+			args:             []string{"kubectl", "create", "job", "foo", "--image=busybox", "--dry-run=client", "--namespace", "test-namespace"},
 			expectPlugin:     "",
 			expectPluginArgs: []string{},
 		},
@@ -202,37 +171,6 @@ users:
 }
 
 func TestKubectlCommandHandlesPlugins(t *testing.T) {
-	tmpKubeconfig, _ := os.CreateTemp("", "")
-	defer func() {
-		err := os.Remove(tmpKubeconfig.Name())
-		if err != nil {
-			t.Fatalf("temp kubeconfig removal error %v", err)
-		}
-	}()
-
-	configContent := []byte(`
-apiVersion: v1
-kind: Config
-clusters:
-- cluster:
-    server: https://localhost:8080
-  name: test-cluster
-contexts:
-- context:
-    cluster: test-cluster
-    user: test-user
-  name: test-context
-current-context: test-context
-users:
-- name: test-user
-  user:
-    token: test-token
-`)
-	_, err := tmpKubeconfig.Write(configContent)
-	if err != nil {
-		t.Fatalf("temp kubeconfig write error %v", err)
-	}
-
 	tests := []struct {
 		name              string
 		args              []string
@@ -248,7 +186,7 @@ users:
 		},
 		{
 			name:             "test that normal commands are able to be executed, when no plugin overshadows them and shadowing feature is not enabled",
-			args:             []string{"kubectl", "create", "job", "foo", "--image=busybox", "--dry-run=client", fmt.Sprintf("--kubeconfig=%s", tmpKubeconfig.Name())},
+			args:             []string{"kubectl", "create", "job", "foo", "--image=busybox", "--dry-run=client"},
 			expectPlugin:     "",
 			expectPluginArgs: []string{},
 		},

--- a/staging/src/k8s.io/kubectl/pkg/cmd/label/label.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/label/label.go
@@ -38,7 +38,6 @@ import (
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/cli-runtime/pkg/resource"
-	"k8s.io/client-go/tools/clientcmd"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/scheme"
 	"k8s.io/kubectl/pkg/util/completion"
@@ -205,7 +204,7 @@ func (o *LabelOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []st
 	}
 
 	o.namespace, o.enforceNamespace, err = f.ToRawKubeConfigLoader().Namespace()
-	if err != nil && !(o.local && clientcmd.IsEmptyConfig(err)) {
+	if err != nil {
 		return err
 	}
 	o.builder = f.NewBuilder()

--- a/staging/src/k8s.io/kubectl/pkg/cmd/patch/patch.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/patch/patch.go
@@ -40,7 +40,6 @@ import (
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/cli-runtime/pkg/resource"
-	"k8s.io/client-go/tools/clientcmd"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/scheme"
 	"k8s.io/kubectl/pkg/util/completion"
@@ -172,7 +171,7 @@ func (o *PatchOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []st
 	}
 
 	o.namespace, o.enforceNamespace, err = f.ToRawKubeConfigLoader().Namespace()
-	if err != nil && !(o.Local && clientcmd.IsEmptyConfig(err)) {
+	if err != nil {
 		return err
 	}
 	o.args = args

--- a/staging/src/k8s.io/kubectl/pkg/cmd/set/set_image.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/set/set_image.go
@@ -30,7 +30,6 @@ import (
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/cli-runtime/pkg/resource"
-	"k8s.io/client-go/tools/clientcmd"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/polymorphichelpers"
 	"k8s.io/kubectl/pkg/scheme"
@@ -168,7 +167,7 @@ func (o *SetImageOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args [
 	o.PrintObj = printer.PrintObj
 
 	cmdNamespace, enforceNamespace, err := f.ToRawKubeConfigLoader().Namespace()
-	if err != nil && !(o.Local && clientcmd.IsEmptyConfig(err)) {
+	if err != nil {
 		return err
 	}
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/set/set_resources.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/set/set_resources.go
@@ -30,7 +30,6 @@ import (
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/cli-runtime/pkg/resource"
-	"k8s.io/client-go/tools/clientcmd"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	generateversioned "k8s.io/kubectl/pkg/generate/versioned"
 	"k8s.io/kubectl/pkg/polymorphichelpers"
@@ -167,7 +166,7 @@ func (o *SetResourcesOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, ar
 	o.PrintObj = printer.PrintObj
 
 	cmdNamespace, enforceNamespace, err := f.ToRawKubeConfigLoader().Namespace()
-	if err != nil && !(o.Local && clientcmd.IsEmptyConfig(err)) {
+	if err != nil {
 		return err
 	}
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/set/set_serviceaccount.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/set/set_serviceaccount.go
@@ -31,7 +31,6 @@ import (
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/cli-runtime/pkg/resource"
-	"k8s.io/client-go/tools/clientcmd"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/polymorphichelpers"
 	"k8s.io/kubectl/pkg/scheme"
@@ -150,7 +149,7 @@ func (o *SetServiceAccountOptions) Complete(f cmdutil.Factory, cmd *cobra.Comman
 	o.PrintObj = printer.PrintObj
 
 	cmdNamespace, enforceNamespace, err := f.ToRawKubeConfigLoader().Namespace()
-	if err != nil && !(o.local && clientcmd.IsEmptyConfig(err)) {
+	if err != nil {
 		return err
 	}
 	if len(args) == 0 {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/set/set_subject.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/set/set_subject.go
@@ -31,7 +31,6 @@ import (
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/cli-runtime/pkg/resource"
-	"k8s.io/client-go/tools/clientcmd"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/scheme"
 	"k8s.io/kubectl/pkg/util/i18n"
@@ -139,7 +138,7 @@ func (o *SubjectOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []
 
 	var enforceNamespace bool
 	o.namespace, enforceNamespace, err = f.ToRawKubeConfigLoader().Namespace()
-	if err != nil && !(o.Local && clientcmd.IsEmptyConfig(err)) {
+	if err != nil {
 		return err
 	}
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/set/set_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/set/set_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 func TestLocalAndDryRunFlags(t *testing.T) {
-	f := clientcmdutil.NewFactory(genericclioptions.NewTestConfigFlags())
+	f := clientcmdutil.NewFactory(genericclioptions.NewTestConfigFlags(), true)
 	setCmd := NewCmdSet(f, genericiooptions.NewTestIOStreamsDiscard())
 	ensureLocalAndDryRunFlagsOnChildren(t, setCmd, "")
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/testing/fake.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/testing/fake.go
@@ -437,9 +437,9 @@ func NewTestFactory() *TestFactory {
 		MigrationRules: map[string]string{},
 	}
 
-	overrides := &clientcmd.ConfigOverrides{ClusterDefaults: clientcmdapi.Cluster{Server: "http://localhost:8080"}}
+	overrides := &clientcmd.ConfigOverrides{ClusterDefaults: clientcmdapi.Cluster{}}
 	fallbackReader := bytes.NewBuffer([]byte{})
-	clientConfig := clientcmd.NewInteractiveDeferredLoadingClientConfig(loadingRules, overrides, fallbackReader)
+	clientConfig := genericclioptions.NewLocalClientConfig(clientcmd.NewInteractiveDeferredLoadingClientConfig(loadingRules, overrides, fallbackReader))
 
 	configFlags := genericclioptions.NewTestConfigFlags().
 		WithClientConfig(clientConfig).
@@ -451,7 +451,7 @@ func NewTestFactory() *TestFactory {
 	}
 
 	return &TestFactory{
-		Factory:           cmdutil.NewFactory(configFlags),
+		Factory:           cmdutil.NewFactory(configFlags, true),
 		kubeConfigFlags:   configFlags,
 		FakeDynamicClient: fakedynamic.NewSimpleDynamicClient(scheme.Scheme),
 		tempConfigFile:    tmpFile,

--- a/test/integration/apiserver/print_test.go
+++ b/test/integration/apiserver/print_test.go
@@ -173,7 +173,7 @@ func TestServerSidePrint(t *testing.T) {
 
 	configFlags.WithDiscoveryClient(cachedClient)
 
-	factory := util.NewFactory(configFlags)
+	factory := util.NewFactory(configFlags, false)
 	mapper, err := factory.ToRESTMapper()
 	if err != nil {
 		t.Errorf("unexpected error getting mapper: %v", err)


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
As attempted in the past (https://github.com/kubernetes/kubernetes/pull/62469, https://github.com/kubernetes/kubernetes/pull/86173 but reverted https://github.com/kubernetes/kubernetes/pull/90243/ due to https://github.com/kubernetes/kubernetes/issues/90074), this PR drops defaulting to localhost API server when kubeconfig is empty. We can do this now, because the reason blocking this was resolved by https://github.com/kubernetes/kubernetes/pull/118677.

#### Does this PR introduce a user-facing change?
```release-note
if the kubeconfig is empty, instead of defaulting to http://localhost:8080, kubectl prints an descriptive error message.
```