### PR TITLE
kubeadm: introduce the WaitForAllControlPlaneComponents feature gate

### DIFF
--- a/cmd/kubeadm/app/cmd/join.go
+++ b/cmd/kubeadm/app/cmd/join.go
@@ -220,6 +220,7 @@ func newCmdJoin(out io.Writer, joinOptions *joinOptions) *cobra.Command {
 	joinRunner.AppendPhase(phases.NewCheckEtcdPhase())
 	joinRunner.AppendPhase(phases.NewKubeletStartPhase())
 	joinRunner.AppendPhase(phases.NewControlPlaneJoinPhase())
+	joinRunner.AppendPhase(phases.NewWaitControlPlanePhase())
 
 	// sets the data builder function, that will be used by the runner
 	// both when running the entire workflow or single phases

--- a/cmd/kubeadm/app/cmd/phases/join/data.go
+++ b/cmd/kubeadm/app/cmd/phases/join/data.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package phases includes command line phases for kubeadm join
 package phases
 
 import (

--- a/cmd/kubeadm/app/cmd/phases/join/waitcontrolplane.go
+++ b/cmd/kubeadm/app/cmd/phases/join/waitcontrolplane.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package phases
+
+import (
+	"io"
+	"time"
+
+	"github.com/pkg/errors"
+
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+
+	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/workflow"
+	"k8s.io/kubernetes/cmd/kubeadm/app/features"
+	"k8s.io/kubernetes/cmd/kubeadm/app/util/apiclient"
+	dryrunutil "k8s.io/kubernetes/cmd/kubeadm/app/util/dryrun"
+)
+
+// NewWaitControlPlanePhase is a hidden phase that runs after the control-plane and etcd phases
+func NewWaitControlPlanePhase() workflow.Phase {
+	phase := workflow.Phase{
+		Name: "wait-control-plane",
+		// TODO: remove this EXPERIMENTAL prefix once WaitForAllControlPlaneComponents goes GA:
+		// https://github.com/kubernetes/kubeadm/issues/2907
+		Short: "EXPERIMENTAL: Wait for the control plane to start",
+		Run:   runWaitControlPlanePhase,
+	}
+	return phase
+}
+
+func runWaitControlPlanePhase(c workflow.RunData) error {
+	data, ok := c.(JoinData)
+	if !ok {
+		return errors.New("wait-control-plane phase invoked with an invalid data struct")
+	}
+
+	if data.Cfg().ControlPlane == nil {
+		return nil
+	}
+
+	initCfg, err := data.InitCfg()
+	if err != nil {
+		return errors.Wrap(err, "could not obtain InitConfiguration during the wait-control-plane phase")
+	}
+
+	// TODO: remove this check once WaitForAllControlPlaneComponents goes GA
+	// https://github.com/kubernetes/kubeadm/issues/2907
+	if !features.Enabled(initCfg.ClusterConfiguration.FeatureGates, features.WaitForAllControlPlaneComponents) {
+		klog.V(5).Infof("[wait-control-plane] Skipping phase as the feature gate WaitForAllControlPlaneComponents is disabled")
+		return nil
+	}
+
+	waiter, err := newControlPlaneWaiter(data.DryRun(), 0, nil, data.OutputWriter())
+	if err != nil {
+		return errors.Wrap(err, "error creating waiter")
+	}
+
+	waiter.SetTimeout(data.Cfg().Timeouts.ControlPlaneComponentHealthCheck.Duration)
+	if err := waiter.WaitForControlPlaneComponents(&initCfg.ClusterConfiguration); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// newControlPlaneWaiter returns a new waiter that is used to wait on the control plane to boot up.
+func newControlPlaneWaiter(dryRun bool, timeout time.Duration, client clientset.Interface, out io.Writer) (apiclient.Waiter, error) {
+	if dryRun {
+		return dryrunutil.NewWaiter(), nil
+	}
+	return apiclient.NewKubeWaiter(client, timeout, out), nil
+}

--- a/cmd/kubeadm/app/features/features.go
+++ b/cmd/kubeadm/app/features/features.go
@@ -38,6 +38,8 @@ const (
 	EtcdLearnerMode = "EtcdLearnerMode"
 	// UpgradeAddonsBeforeControlPlane is expected to be in deprecated in v1.28 and will be removed in future release
 	UpgradeAddonsBeforeControlPlane = "UpgradeAddonsBeforeControlPlane"
+	// WaitForAllControlPlaneComponents is expected to be alpha in v1.30
+	WaitForAllControlPlaneComponents = "WaitForAllControlPlaneComponents"
 )
 
 // InitFeatureGates are the default feature gates for the init command
@@ -53,6 +55,7 @@ var InitFeatureGates = FeatureList{
 		FeatureSpec:        featuregate.FeatureSpec{Default: false, PreRelease: featuregate.Deprecated},
 		DeprecationMessage: "The UpgradeAddonsBeforeControlPlane feature gate is deprecated and will be removed in a future release.",
 	},
+	WaitForAllControlPlaneComponents: {FeatureSpec: featuregate.FeatureSpec{Default: false, PreRelease: featuregate.Alpha}},
 }
 
 // Feature represents a feature being gated

--- a/cmd/kubeadm/app/phases/upgrade/staticpods_test.go
+++ b/cmd/kubeadm/app/phases/upgrade/staticpods_test.go
@@ -98,6 +98,11 @@ func NewFakeStaticPodWaiter(errsToReturn map[string]error) apiclient.Waiter {
 	}
 }
 
+// WaitForControlPlaneComponents just returns a dummy nil, to indicate that the program should just proceed
+func (w *fakeWaiter) WaitForControlPlaneComponents(cfg *kubeadmapi.ClusterConfiguration) error {
+	return nil
+}
+
 // WaitForAPI just returns a dummy nil, to indicate that the program should just proceed
 func (w *fakeWaiter) WaitForAPI() error {
 	return nil

--- a/cmd/kubeadm/app/util/apiclient/wait_test.go
+++ b/cmd/kubeadm/app/util/apiclient/wait_test.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apiclient
+
+import (
+	"reflect"
+	"testing"
+
+	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+)
+
+func TestGetControlPlaneComponents(t *testing.T) {
+	testcases := []struct {
+		name     string
+		cfg      *kubeadmapi.ClusterConfiguration
+		expected []controlPlaneComponent
+	}{
+		{
+			name: "port values from config",
+			cfg: &kubeadmapi.ClusterConfiguration{
+				APIServer: kubeadmapi.APIServer{
+					ControlPlaneComponent: kubeadmapi.ControlPlaneComponent{
+						ExtraArgs: []kubeadmapi.Arg{
+							{Name: "secure-port", Value: "1111"},
+						},
+					},
+				},
+				ControllerManager: kubeadmapi.ControlPlaneComponent{
+					ExtraArgs: []kubeadmapi.Arg{
+						{Name: "secure-port", Value: "2222"},
+					},
+				},
+				Scheduler: kubeadmapi.ControlPlaneComponent{
+					ExtraArgs: []kubeadmapi.Arg{
+						{Name: "secure-port", Value: "3333"},
+					},
+				},
+			},
+			expected: []controlPlaneComponent{
+				{name: "kube-apiserver", url: "https://127.0.0.1:1111/healthz"},
+				{name: "kube-controller-manager", url: "https://127.0.0.1:2222/healthz"},
+				{name: "kube-scheduler", url: "https://127.0.0.1:3333/healthz"},
+			},
+		},
+		{
+			name: "default ports",
+			cfg:  &kubeadmapi.ClusterConfiguration{},
+			expected: []controlPlaneComponent{
+				{name: "kube-apiserver", url: "https://127.0.0.1:6443/healthz"},
+				{name: "kube-controller-manager", url: "https://127.0.0.1:10257/healthz"},
+				{name: "kube-scheduler", url: "https://127.0.0.1:10259/healthz"},
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := getControlPlaneComponents(tc.cfg)
+			if !reflect.DeepEqual(tc.expected, actual) {
+				t.Fatalf("expected result: %+v, got: %+v", tc.expected, actual)
+			}
+		})
+	}
+}

--- a/cmd/kubeadm/app/util/dryrun/dryrun.go
+++ b/cmd/kubeadm/app/util/dryrun/dryrun.go
@@ -26,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	errorsutil "k8s.io/apimachinery/pkg/util/errors"
 
+	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/apiclient"
 )
@@ -86,6 +87,11 @@ type Waiter struct{}
 // NewWaiter returns a new Waiter object that talks to the given Kubernetes cluster
 func NewWaiter() apiclient.Waiter {
 	return &Waiter{}
+}
+
+// WaitForControlPlaneComponents just returns a dummy nil, to indicate that the program should just proceed
+func (w *Waiter) WaitForControlPlaneComponents(cfg *kubeadmapi.ClusterConfiguration) error {
+	return nil
 }
 
 // WaitForAPI just returns a dummy nil, to indicate that the program should just proceed


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature
(there is no KEP for this)

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

WaitForAllControlPlaneComponents is a new feature gate that can be used to tell kubeadm to wait for all control plane components and not only kube-apiserver.

- Add the Waiter function WaitForControlPlaneComponents that waits for all CP components in parallel. Uses the regular healthz endpoint for checks of status 200.
- Add a new experimental phase to kubeadm join called "wait-control-plane". A similar phase exists for kubeadm init.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
xref https://github.com/kubernetes/kubernetes/pull/119598
xref https://github.com/kubernetes/kubeadm/issues/2907

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubeadm: add the WaitForAllControlPlaneComponents feature gate. It can be used to tell kubeadm to wait for all control plane components to be ready when running "kubeadm init" or "kubeadm join --control-plane". Currently kubeadm only waits for the kube-apiserver. The "kubeadm join" workflow now includes a new experimental phase called "wait-control-plane". This phase will be marked as non-experimental when WaitForAllControlPlaneComponents becomes GA. Accordingly a "kubeadm init" phase "wait-control-plane" will also be available once WaitForAllControlPlaneComponents becomes GA. These phases can be skipped if the user prefers to not wait for the control plane components.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
