### PR TITLE
workqueue: make queue as configurable

### DIFF
--- a/staging/src/k8s.io/client-go/util/workqueue/metrics_test.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/metrics_test.go
@@ -41,7 +41,7 @@ func TestMetricShutdown(t *testing.T) {
 		updateCalled: ch,
 	}
 	c := testingclock.NewFakeClock(time.Now())
-	q := newQueue(c, m, time.Millisecond)
+	q := newQueue(c, DefaultQueue(), m, time.Millisecond)
 	for !c.HasWaiters() {
 		// Wait for the go routine to call NewTicker()
 		time.Sleep(time.Millisecond)

--- a/staging/src/k8s.io/client-go/util/workqueue/queue_test.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/queue_test.go
@@ -27,6 +27,23 @@ import (
 	"k8s.io/client-go/util/workqueue"
 )
 
+// traceQueue traces whether items are touched
+type traceQueue struct {
+	workqueue.Queue
+
+	touched map[interface{}]struct{}
+}
+
+func (t *traceQueue) Touch(item interface{}) {
+	t.Queue.Touch(item)
+	if t.touched == nil {
+		t.touched = make(map[interface{}]struct{})
+	}
+	t.touched[item] = struct{}{}
+}
+
+var _ workqueue.Queue = &traceQueue{}
+
 func TestBasic(t *testing.T) {
 	tests := []struct {
 		queue         *workqueue.Type
@@ -198,7 +215,11 @@ func TestReinsert(t *testing.T) {
 }
 
 func TestCollapse(t *testing.T) {
-	q := workqueue.New()
+	tq := &traceQueue{Queue: workqueue.DefaultQueue()}
+	q := workqueue.NewWithConfig(workqueue.QueueConfig{
+		Name:  "",
+		Queue: tq,
+	})
 	// Add a new one twice
 	q.Add("bar")
 	q.Add("bar")
@@ -216,10 +237,18 @@ func TestCollapse(t *testing.T) {
 	if a := q.Len(); a != 0 {
 		t.Errorf("Expected queue to be empty. Has %v items", a)
 	}
+
+	if _, ok := tq.touched["bar"]; !ok {
+		t.Errorf("Expected bar to be Touched")
+	}
 }
 
 func TestCollapseWhileProcessing(t *testing.T) {
-	q := workqueue.New()
+	tq := &traceQueue{Queue: workqueue.DefaultQueue()}
+	q := workqueue.NewWithConfig(workqueue.QueueConfig{
+		Name:  "",
+		Queue: tq,
+	})
 	q.Add("foo")
 
 	// Start processing
@@ -260,6 +289,10 @@ func TestCollapseWhileProcessing(t *testing.T) {
 	<-waitCh
 	if a := q.Len(); a != 0 {
 		t.Errorf("Expected queue to be empty. Has %v items", a)
+	}
+
+	if _, ok := tq.touched["foo"]; ok {
+		t.Errorf("Unexpected Touch")
 	}
 }
 


### PR DESCRIPTION
The default queue implementation is mostly FIFO and it is not exchangeable unless we implement the whole `workqueue.Interface` which is less desirable as we have to duplicate a lot of code. There was one attempt done in [kubernetes/kubernetes#109349][1] which tried to implement a priority queue. That is really useful and [knative/pkg][2] implemented something called two-lane-queue. While two lane queue is great, but isn't perfect since a full slow queue can still slow down items in fast queue.

This change proposes a swappable queue implementation while not adding extra maintenance effort in kubernetes community. We are happy to maintain our own queue implementation (similar to two-lane-queue) in downstream.

[1]: https://github.com/kubernetes/kubernetes/pull/109349
[2]: https://github.com/knative/pkg/blob/main/controller/two_lane_queue.go

#### What type of PR is this?

/kind feature

```release-note
NONE
```
