### PR TITLE
ValidatingAdmissionPolicy: detect schema changes and re-check affected policies.

### DIFF
--- a/cmd/kube-controller-manager/app/validatingadmissionpolicystatus.go
+++ b/cmd/kube-controller-manager/app/validatingadmissionpolicystatus.go
@@ -42,18 +42,19 @@ func newValidatingAdmissionPolicyStatusControllerDescriptor() *ControllerDescrip
 }
 
 func startValidatingAdmissionPolicyStatusController(ctx context.Context, controllerContext ControllerContext, controllerName string) (controller.Interface, bool, error) {
-	// KCM won't start the controller without the feature gate set.
-
+	discoveryClient := controllerContext.ClientBuilder.DiscoveryClientOrDie(names.ValidatingAdmissionPolicyStatusController)
 	schemaResolver := resolver.NewDefinitionsSchemaResolver(openapi.GetOpenAPIDefinitions, k8sscheme.Scheme, apiextensionsscheme.Scheme).
-		Combine(&resolver.ClientDiscoveryResolver{Discovery: controllerContext.ClientBuilder.DiscoveryClientOrDie(names.ValidatingAdmissionPolicyStatusController)})
+		Combine(&resolver.ClientDiscoveryResolver{Discovery: discoveryClient})
 
 	typeChecker := &pluginvalidatingadmissionpolicy.TypeChecker{
 		SchemaResolver: schemaResolver,
 		RestMapper:     controllerContext.RESTMapper,
 	}
+
 	c, err := validatingadmissionpolicystatus.NewController(
 		controllerContext.InformerFactory.Admissionregistration().V1().ValidatingAdmissionPolicies(),
 		controllerContext.ClientBuilder.ClientOrDie(names.ValidatingAdmissionPolicyStatusController).AdmissionregistrationV1().ValidatingAdmissionPolicies(),
+		discoveryClient.OpenAPIV3(),
 		typeChecker,
 	)
 

--- a/pkg/controller/validatingadmissionpolicystatus/controller_test.go
+++ b/pkg/controller/validatingadmissionpolicystatus/controller_test.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/openapi/openapitest"
 	"k8s.io/kubernetes/pkg/generated/openapi"
 )
 
@@ -108,6 +109,7 @@ func TestTypeChecking(t *testing.T) {
 			controller, err := NewController(
 				informerFactory.Admissionregistration().V1().ValidatingAdmissionPolicies(),
 				client.AdmissionregistrationV1().ValidatingAdmissionPolicies(),
+				openapitest.NewFakeClient(),
 				typeChecker,
 			)
 			if err != nil {

--- a/pkg/controller/validatingadmissionpolicystatus/schemawatcher/protocol.go
+++ b/pkg/controller/validatingadmissionpolicystatus/schemawatcher/protocol.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package schemawatcher
+
+import (
+	"crypto/sha512"
+	"encoding/json"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/openapi"
+	"k8s.io/client-go/openapi3"
+	"k8s.io/kube-openapi/pkg/validation/spec"
+)
+
+const gvkExtensionName = "x-kubernetes-group-version-kind"
+
+type schemaWithHash struct {
+	Schema *spec.Schema
+	Hash   [32]byte
+}
+
+// parseOpenAPIv3Doc parses the OpenAPI v3 doc, and returns all parsed schemas and their corresponding hashes.
+//
+// The hash is calculated based on the raw binary JSON form of the schema.
+// Even if the schema is schematically unchanged, for example, when only the order of fields changes or whitespace-only
+// changes, the hash will change. However, the API server always returns "minimized" JSON, so this is not a problem.
+func parseOpenAPIv3Doc(doc []byte) []schemaWithHash {
+	var rawDoc struct {
+		Components struct {
+			Schemas map[string]json.RawMessage `json:"schemas"`
+		} `json:"components"`
+	}
+	err := json.Unmarshal(doc, &rawDoc)
+	if err != nil {
+		utilruntime.HandleError(fmt.Errorf("fail to parse OpenAPI v3 document: %w", err))
+		return nil
+	}
+	var result []schemaWithHash
+	for _, rawSchema := range rawDoc.Components.Schemas {
+		s := new(spec.Schema)
+		err := json.Unmarshal(rawSchema, &s)
+		if err != nil {
+			utilruntime.HandleError(fmt.Errorf("fail to parse OpenAPI v3 schema: %w", err))
+		}
+		hash := sha512.Sum512_256(rawSchema)
+		result = append(result, schemaWithHash{Hash: hash, Schema: s})
+	}
+	return result
+}
+
+func parseOpenAPIPathItem(path string, gv openapi.GroupVersion) (groupVersion schema.GroupVersion, hash string, err error) {
+	groupVersion, err = openapi3.PathToGroupVersion(path)
+	if err != nil {
+		return
+	}
+	h, ok := gv.(openapi.Hasher)
+	if !ok {
+		return schema.GroupVersion{}, "", fmt.Errorf("%w: not a hasher", ErrNoHash)
+	}
+	hash, err = h.Hash()
+	if err != nil {
+		return schema.GroupVersion{}, "", fmt.Errorf("%w: %w", ErrNoHash, err)
+	}
+	if hash == "" {
+		return schema.GroupVersion{}, "", fmt.Errorf("%w: empty hash", ErrNoHash)
+	}
+	return
+}

--- a/pkg/controller/validatingadmissionpolicystatus/schemawatcher/protocol.go
+++ b/pkg/controller/validatingadmissionpolicystatus/schemawatcher/protocol.go
@@ -69,11 +69,7 @@ func parseOpenAPIPathItem(path string, gv openapi.GroupVersion) (groupVersion sc
 	if err != nil {
 		return
 	}
-	h, ok := gv.(openapi.Hasher)
-	if !ok {
-		return schema.GroupVersion{}, "", fmt.Errorf("%w: not a hasher", ErrNoHash)
-	}
-	hash, err = h.Hash()
+	hash, err = gv.Hash()
 	if err != nil {
 		return schema.GroupVersion{}, "", fmt.Errorf("%w: %w", ErrNoHash, err)
 	}

--- a/pkg/controller/validatingadmissionpolicystatus/schemawatcher/protocol_test.go
+++ b/pkg/controller/validatingadmissionpolicystatus/schemawatcher/protocol_test.go
@@ -1,0 +1,222 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package schemawatcher
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+var jsonGVDocs = []string{
+	// doc0 contains only apis.example.com/v1.Foo
+	`
+{
+  "info": {
+    "title": "Kubernetes",
+    "version": "unversioned"
+  },
+  "openapi": "3.0.0",
+  "components": {
+    "schemas": {
+      "com.example.apis.v1.Foo": {
+        "description": "Foo",
+        "properties": {
+          "name": {
+            "default": "",
+            "description": "The name.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object",
+        "x-kubernetes-group-version-kind": [
+          {
+            "group": "apis.example.com",
+            "kind": "Foo",
+            "version": "v1"
+          }
+        ]
+      }
+    }
+  }
+}
+`,
+	// doc1 contains apis.example.com/v1.Foo and apis.example.com/v1.Bar
+	// Foo is unchanged.
+	`
+{
+  "info": {
+    "title": "Kubernetes",
+    "version": "unversioned"
+  },
+  "openapi": "3.0.0",
+  "components": {
+    "schemas": {
+      "com.example.apis.v1.Foo": {
+        "description": "Foo",
+        "properties": {
+          "name": {
+            "default": "",
+            "description": "The name.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object",
+        "x-kubernetes-group-version-kind": [
+          {
+            "group": "apis.example.com",
+            "kind": "Foo",
+            "version": "v1"
+          }
+        ]
+      },
+      "com.example.apis.v1.Bar": {
+        "description": "Bar",
+        "properties": {
+          "type": {
+            "default": "",
+            "description": "The type.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "type": "object",
+        "x-kubernetes-group-version-kind": [
+          {
+            "group": "apis.example.com",
+            "kind": "Bar",
+            "version": "v1"
+          }
+        ]
+      }
+    }
+  }
+}
+`,
+
+	// doc2 contains apis.example.com/v1.Foo and apis.example.com/v1.Bar
+	// but v1.Foo changes.
+	`
+{
+  "info": {
+    "title": "Kubernetes",
+    "version": "unversioned"
+  },
+  "openapi": "3.0.0",
+  "components": {
+    "schemas": {
+      "com.example.apis.v1.Foo": {
+        "description": "Foo",
+        "properties": {
+          "name": {
+            "default": "",
+            "description": "The name, but fancier",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object",
+        "x-kubernetes-group-version-kind": [
+          {
+            "group": "apis.example.com",
+            "kind": "Foo",
+            "version": "v1"
+          }
+        ]
+      },
+      "com.example.apis.v1.Bar": {
+        "description": "Bar",
+        "properties": {
+          "type": {
+            "default": "",
+            "description": "The type.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "type": "object",
+        "x-kubernetes-group-version-kind": [
+          {
+            "group": "apis.example.com",
+            "kind": "Bar",
+            "version": "v1"
+          }
+        ]
+      }
+    }
+  }
+}
+`,
+}
+
+func TestSchemaHashing(t *testing.T) {
+	r1 := parseOpenAPIv3Doc([]byte(jsonGVDocs[0]))
+	if len(r1) != 1 {
+		t.Fatalf("unexpected r1 length: expected %d but got %d", 1, len(r1))
+	}
+	r2 := parseOpenAPIv3Doc([]byte(jsonGVDocs[1]))
+	if len(r2) != 2 {
+		t.Fatalf("unexpected r2 length: expected %d but got %d", 2, len(r2))
+	}
+	r3 := parseOpenAPIv3Doc([]byte(jsonGVDocs[2]))
+	if len(r3) != 2 {
+		t.Fatalf("unexpected r3 length: expected %d but got %d", 2, len(r3))
+	}
+
+	hashOf := func(results []schemaWithHash, gvk schema.GroupVersionKind) [32]byte {
+		for _, r := range results {
+			if s, gvks := r.Schema, []schema.GroupVersionKind{}; s.Extensions.GetObject(gvkExtensionName, &gvks) != nil ||
+				len(gvks) != 1 {
+				t.Fatalf("invalid gvk: %v", gvks)
+			} else if gvks[0] == gvk {
+				return r.Hash
+			}
+		}
+		t.Fatalf("gvk not found: %v", gvk)
+		return [32]byte{}
+	}
+
+	gv := schema.GroupVersion{
+		Group:   "apis.example.com",
+		Version: "v1",
+	}
+	gvkFoo := gv.WithKind("Foo")
+	gvkBar := gv.WithKind("Bar")
+	// Foo is unchanged from doc1 -> doc2, but changed doc2 -> doc3
+	// Bar appears doc1 -> doc2, unchanged doc2 -> doc3.
+	if h1, h2 := hashOf(r1, gvkFoo), hashOf(r2, gvkFoo); h1 != h2 {
+		t.Fatalf("unexpected unequalive hash, %x vs %x.", h1, h2)
+	}
+	if h1, h3 := hashOf(r1, gvkFoo), hashOf(r3, gvkFoo); h1 == h3 {
+		t.Fatalf("unexpected unchanged hash, %x vs %x.", h1, h3)
+	}
+	if h1, h3 := hashOf(r2, gvkBar), hashOf(r3, gvkBar); h1 != h3 {
+		t.Fatalf("unexpected unequalive hash, %x vs %x.", h1, h3)
+	}
+}

--- a/pkg/controller/validatingadmissionpolicystatus/schemawatcher/watcher.go
+++ b/pkg/controller/validatingadmissionpolicystatus/schemawatcher/watcher.go
@@ -1,0 +1,167 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package schemawatcher
+
+import (
+	"fmt"
+	"sync"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/openapi"
+)
+
+var ErrNoHash = fmt.Errorf("fail to obtain hash")
+
+type gvkToHashMap map[schema.GroupVersionKind][32]byte
+
+// Instance keeps track of all types and the hash of their schemas.
+type Instance struct {
+	client openapi.Client
+
+	groupVersionToHash     map[schema.GroupVersion]string
+	groupVersionKindToHash map[schema.GroupVersion]gvkToHashMap
+	mu                     sync.Mutex
+}
+
+// New creates a new schema watcher with given OpenAPI v3 client.
+func New(client openapi.Client) *Instance {
+	return &Instance{
+		client:                 client,
+		groupVersionToHash:     make(map[schema.GroupVersion]string),
+		groupVersionKindToHash: make(map[schema.GroupVersion]gvkToHashMap),
+	}
+}
+
+// ChangedGVKs refreshes and compares the stored schema hashes, and returns
+// all GroupVersionKind that have a schema that changes compared to last refresh.
+func (w *Instance) ChangedGVKs() ([]schema.GroupVersionKind, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	return w.detectChanges()
+}
+
+func (w *Instance) detectChanges() (changedGVKs []schema.GroupVersionKind, err error) {
+	paths, err := w.client.Paths()
+	if err != nil {
+		return nil, err
+	}
+
+	newGroupVersionToHash, openapiGroupVersions := parseDiscoveryRoot(paths)
+	changed, removed := diffGroupVersionToHash(w.groupVersionToHash, newGroupVersionToHash)
+
+	for gv := range changed {
+		if _, ok := w.groupVersionKindToHash[gv]; !ok {
+			w.groupVersionKindToHash[gv] = make(gvkToHashMap)
+		}
+		doc, err := openapiGroupVersions[gv].Schema(runtime.ContentTypeJSON)
+		if err != nil {
+			utilruntime.HandleError(fmt.Errorf("fail to fetch schema: %w", err))
+			continue
+		}
+		changed, err := w.detectChangeInGroupVersion(gv, doc)
+		if err != nil {
+			utilruntime.HandleError(fmt.Errorf("fail to detect changes in GV %q schema: %w", gv, err))
+			continue
+		}
+		changedGVKs = append(changedGVKs, changed...)
+	}
+
+	for gv := range removed {
+		changed := sets.KeySet(w.groupVersionKindToHash[gv]).UnsortedList()
+		delete(w.groupVersionKindToHash, gv)
+		changedGVKs = append(changedGVKs, changed...)
+	}
+
+	w.groupVersionToHash = newGroupVersionToHash
+
+	return changedGVKs, nil
+}
+
+func (w *Instance) detectChangeInGroupVersion(groupVersion schema.GroupVersion, doc []byte) (changedGVKs []schema.GroupVersionKind, err error) {
+	newGVKToHashMap, err := parseOpenAPIGroupVersion(groupVersion, doc)
+	if err != nil {
+		return nil, err
+	}
+	oldGVKToHashMap := w.groupVersionKindToHash[groupVersion]
+	// changed = removed + hash changed
+	changed := sets.KeySet(oldGVKToHashMap).Difference(sets.KeySet(newGVKToHashMap))
+	for gv, hash := range newGVKToHashMap {
+		oldHash := oldGVKToHashMap[gv]
+		if hash != oldHash {
+			changed.Insert(gv)
+		}
+	}
+	w.groupVersionKindToHash[groupVersion] = newGVKToHashMap
+
+	return changed.UnsortedList(), nil
+}
+
+func parseDiscoveryRoot(paths map[string]openapi.GroupVersion) (map[schema.GroupVersion]string, map[schema.GroupVersion]openapi.GroupVersion) {
+	hashes := make(map[schema.GroupVersion]string)
+	openapiGroupVersions := make(map[schema.GroupVersion]openapi.GroupVersion)
+	for path, groupVersion := range paths {
+		gv, hash, err := parseOpenAPIPathItem(path, groupVersion)
+		if err != nil {
+			// malformed OpenAPI v3 response, considered internal error.
+			// ignore the broken GV and continue
+			utilruntime.HandleError(err)
+			continue
+		}
+		hashes[gv] = hash
+		openapiGroupVersions[gv] = groupVersion
+	}
+	return hashes, openapiGroupVersions
+}
+
+func parseOpenAPIGroupVersion(gv schema.GroupVersion, doc []byte) (gvkToHashMap, error) {
+	schemasWithHash := parseOpenAPIv3Doc(doc)
+	result := make(gvkToHashMap)
+	for _, schemaWithHash := range schemasWithHash {
+		s := schemaWithHash.Schema
+		hash := schemaWithHash.Hash
+		var gvks []schema.GroupVersionKind
+		err := s.Extensions.GetObject(gvkExtensionName, &gvks)
+		if err != nil {
+			return nil, err
+		}
+		for _, gvk := range gvks {
+			if gvk.Group != gv.Group || gvk.Version != gv.Version {
+				// ignore dependencies, which does not match the current GV
+				continue
+			}
+			result[gvk] = hash
+		}
+	}
+	return result, nil
+}
+
+func diffGroupVersionToHash(oldMap, newMap map[schema.GroupVersion]string) (changed, removed sets.Set[schema.GroupVersion]) {
+	oldKeySet, newKeySet := sets.KeySet(oldMap), sets.KeySet(newMap)
+	removed = oldKeySet.Difference(newKeySet)
+	changed = sets.New[schema.GroupVersion]()
+	for gv, hash := range newMap {
+		oldHash := oldMap[gv]
+		if hash != oldHash {
+			changed.Insert(gv)
+		}
+	}
+	return
+}

--- a/pkg/controller/validatingadmissionpolicystatus/schemawatcher/watcher_test.go
+++ b/pkg/controller/validatingadmissionpolicystatus/schemawatcher/watcher_test.go
@@ -138,7 +138,6 @@ type mockGroupVersion struct {
 
 var _ openapi.Client = (*mockOpenAPIClient)(nil)
 var _ openapi.GroupVersion = (*mockGroupVersion)(nil)
-var _ openapi.Hasher = (*mockGroupVersion)(nil)
 
 func (c *mockOpenAPIClient) Paths() (map[string]openapi.GroupVersion, error) {
 	return c.paths, nil

--- a/pkg/controller/validatingadmissionpolicystatus/schemawatcher/watcher_test.go
+++ b/pkg/controller/validatingadmissionpolicystatus/schemawatcher/watcher_test.go
@@ -1,0 +1,156 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package schemawatcher
+
+import (
+	"strings"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/openapi"
+)
+
+func TestDetectChange(t *testing.T) {
+	client := new(mockOpenAPIClient)
+	watcher := New(client)
+	for _, step := range []struct {
+		paths    map[string]openapi.GroupVersion
+		expected []schema.GroupVersionKind
+	}{
+		{
+			// Initial step, empty
+			paths:    map[string]openapi.GroupVersion{},
+			expected: nil,
+		},
+		{
+			// 1st step, apis.example.com/v1 presents, contains Foo
+			paths: map[string]openapi.GroupVersion{
+				"apis/apis.example.com/v1": &mockGroupVersion{json: jsonGVDocs[0], hash: "1"},
+			},
+			expected: []schema.GroupVersionKind{
+				{
+					Group:   "apis.example.com",
+					Version: "v1",
+					Kind:    "Foo",
+				},
+			},
+		},
+		{
+			// 2nd step, apis.example.com/v1 mutates, contains Foo and Bar, Foo did not change
+			paths: map[string]openapi.GroupVersion{
+				"apis/apis.example.com/v1": &mockGroupVersion{json: jsonGVDocs[1], hash: "2"},
+			},
+			expected: []schema.GroupVersionKind{
+				{
+					Group:   "apis.example.com",
+					Version: "v1",
+					Kind:    "Bar",
+				},
+			},
+		},
+		{
+			// 3rd step, apis.example.com/v1 mutates, contains Foo and Bar, Foo mutates
+			paths: map[string]openapi.GroupVersion{
+				"apis/apis.example.com/v1": &mockGroupVersion{json: jsonGVDocs[2], hash: "3"},
+			},
+			expected: []schema.GroupVersionKind{
+				{
+					Group:   "apis.example.com",
+					Version: "v1",
+					Kind:    "Foo",
+				},
+			},
+		},
+		{
+			// 4th step, new version apis.example.com/v2, contains Foo
+			// also v1 reverted to original
+			paths: map[string]openapi.GroupVersion{
+				"apis/apis.example.com/v1": &mockGroupVersion{json: jsonGVDocs[0], hash: "1"},
+				"apis/apis.example.com/v2": &mockGroupVersion{json: strings.ReplaceAll(jsonGVDocs[0], "v1", "v2"), hash: "11"},
+			},
+			expected: []schema.GroupVersionKind{
+				{
+					Group:   "apis.example.com",
+					Version: "v1",
+					Kind:    "Foo", // reverted
+				},
+				{
+					Group:   "apis.example.com",
+					Version: "v1",
+					Kind:    "Bar", // removed
+				},
+				{
+					Group:   "apis.example.com",
+					Version: "v2",
+					Kind:    "Foo", // new
+				},
+			},
+		},
+		{
+			// 5th step, apis.example.com/v1 unmounted
+			paths: map[string]openapi.GroupVersion{
+				"apis/apis.example.com/v2": &mockGroupVersion{json: strings.ReplaceAll(jsonGVDocs[0], "v1", "v2"), hash: "11"},
+			},
+			expected: []schema.GroupVersionKind{
+				{
+					Group:   "apis.example.com",
+					Version: "v1",
+					Kind:    "Foo", // removed
+				},
+			},
+		},
+	} {
+		client.paths = step.paths
+		changed, err := watcher.detectChanges()
+		if err != nil {
+			t.Fatalf("fail to detect changes: %v", err)
+		}
+		if !sets.New[schema.GroupVersionKind](step.expected...).Equal(sets.New[schema.GroupVersionKind](changed...)) {
+			t.Fatalf("unexpected result, expected %v but got %v", step.expected, changed)
+		}
+	}
+}
+
+type mockOpenAPIClient struct {
+	paths map[string]openapi.GroupVersion
+}
+
+type mockGroupVersion struct {
+	json string
+	hash string
+}
+
+var _ openapi.Client = (*mockOpenAPIClient)(nil)
+var _ openapi.GroupVersion = (*mockGroupVersion)(nil)
+var _ openapi.Hasher = (*mockGroupVersion)(nil)
+
+func (c *mockOpenAPIClient) Paths() (map[string]openapi.GroupVersion, error) {
+	return c.paths, nil
+}
+
+func (gv *mockGroupVersion) Schema(contentType string) ([]byte, error) {
+	if contentType != runtime.ContentTypeJSON {
+		panic("unexpected content type: " + contentType)
+	}
+	return []byte(gv.json), nil
+}
+
+func (gv *mockGroupVersion) Hash() (string, error) {
+	return gv.hash, nil
+}

--- a/pkg/controller/validatingadmissionpolicystatus/typetracker/typetracker.go
+++ b/pkg/controller/validatingadmissionpolicystatus/typetracker/typetracker.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package typetracker
+
+import (
+	"sync"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+// Instance keeps a bidirectional mapping of policy <-> referred GVKs.
+type Instance struct {
+	// map of policyName -> referred GVKs
+	policyToGVKs map[string]sets.Set[schema.GroupVersionKind]
+	// map of referred GVK to policies
+	gvkToPolicies map[schema.GroupVersionKind]sets.Set[string]
+
+	mu sync.Mutex
+}
+
+// New creates an empty type tracker.
+func New() *Instance {
+	return &Instance{
+		policyToGVKs:  make(map[string]sets.Set[schema.GroupVersionKind]),
+		gvkToPolicies: make(map[schema.GroupVersionKind]sets.Set[string]),
+	}
+}
+
+// ObserveChange observes the creation/update of a policy. The tracker updates its internal bidirectional
+// policy from/to GVKs mapping.
+func (t *Instance) ObserveChange(policyName string, referredGVKs []schema.GroupVersionKind) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	oldGVKsSet, ok := t.policyToGVKs[policyName]
+	if !ok {
+		oldGVKsSet = sets.New[schema.GroupVersionKind]()
+	}
+	newGVKsSet := sets.New[schema.GroupVersionKind](referredGVKs...)
+	toRemove := oldGVKsSet.Difference(newGVKsSet)
+	toAdd := newGVKsSet.Difference(oldGVKsSet)
+	for gvk := range toRemove {
+		if s, ok := t.gvkToPolicies[gvk]; ok {
+			s.Delete(policyName)
+			if s.Len() == 0 {
+				delete(t.gvkToPolicies, gvk)
+			}
+		}
+	}
+	for gvk := range toAdd {
+		s, ok := t.gvkToPolicies[gvk]
+		if !ok {
+			s = sets.New[string](policyName)
+			t.gvkToPolicies[gvk] = s
+		}
+		s.Insert(policyName)
+	}
+	t.policyToGVKs[policyName] = newGVKsSet
+}
+
+// ObservedDeletion observes the deletion of a policy. The tracker updates its internal bidirectional
+// policy from/to GVKs mapping.
+func (t *Instance) ObservedDeletion(policyName string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if oldGVKsSet, ok := t.policyToGVKs[policyName]; ok {
+		for gvk := range oldGVKsSet {
+			if s, ok := t.gvkToPolicies[gvk]; ok {
+				s.Delete(policyName)
+				if s.Len() == 0 {
+					delete(t.gvkToPolicies, gvk)
+				}
+			}
+		}
+	}
+	delete(t.policyToGVKs, policyName)
+}
+
+// AffectedPolicies find all policies that are affected due to the change of the give list of GVKs.
+func (t *Instance) AffectedPolicies(changedGVKs []schema.GroupVersionKind) []string {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	result := sets.New[string]()
+	for _, gvk := range changedGVKs {
+		if policies, ok := t.gvkToPolicies[gvk]; ok {
+			// insert one-by-one instead of Set[T].Union to avoid the copy from the latter,
+			// which otherwise increase the whole operation to O(N^2) from O(N)
+			for policy := range policies {
+				result.Insert(policy)
+			}
+		}
+	}
+	return result.UnsortedList()
+}

--- a/pkg/controller/validatingadmissionpolicystatus/typetracker/typetracker_test.go
+++ b/pkg/controller/validatingadmissionpolicystatus/typetracker/typetracker_test.go
@@ -1,0 +1,126 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package typetracker
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+// TestMappingTracking is an open-box testing of the update & deletion tracking.
+func TestMappingTracking(t *testing.T) {
+	gv := schema.GroupVersion{Group: "apis.example.com", Version: "v1"}
+
+	gvks := []schema.GroupVersionKind{
+		gv.WithKind("Zero"),
+		gv.WithKind("One"),
+		gv.WithKind("Two"),
+		gv.WithKind("Three"),
+		gv.WithKind("Four"),
+	}
+
+	tracker := New()
+
+	for _, step := range []struct {
+		isDeletion                  bool
+		policyName                  string
+		gvks                        []schema.GroupVersionKind
+		expectedPolicyToGVKsMapping map[string]sets.Set[schema.GroupVersionKind]
+	}{
+		// insert test1 -> [gvk0]
+		{
+			policyName: "test1",
+			gvks:       []schema.GroupVersionKind{gvks[0]},
+			expectedPolicyToGVKsMapping: map[string]sets.Set[schema.GroupVersionKind]{
+				"test1": sets.New[schema.GroupVersionKind](gvks[0]),
+			},
+		},
+		// update test1 -> [gvk0] -> [gvk1, gvk2]
+		{
+			policyName: "test1",
+			gvks:       []schema.GroupVersionKind{gvks[1], gvks[2]},
+			expectedPolicyToGVKsMapping: map[string]sets.Set[schema.GroupVersionKind]{
+				"test1": sets.New[schema.GroupVersionKind](gvks[1], gvks[2]),
+			},
+		},
+		// insert test2 -> [gvk0, gvk1, gvk2, gvk3, gvk4]
+		{
+			policyName: "test2",
+			gvks:       []schema.GroupVersionKind{gvks[0], gvks[1], gvks[2], gvks[3], gvks[4]},
+			expectedPolicyToGVKsMapping: map[string]sets.Set[schema.GroupVersionKind]{
+				"test1": sets.New[schema.GroupVersionKind](gvks[1], gvks[2]),
+				"test2": sets.New[schema.GroupVersionKind](gvks[0], gvks[1], gvks[2], gvks[3], gvks[4]),
+			},
+		},
+		// delete test1
+		{
+			isDeletion: true,
+			policyName: "test1",
+			expectedPolicyToGVKsMapping: map[string]sets.Set[schema.GroupVersionKind]{
+				"test2": sets.New[schema.GroupVersionKind](gvks[0], gvks[1], gvks[2], gvks[3], gvks[4]),
+			},
+		},
+	} {
+		invertedMapping := make(map[schema.GroupVersionKind]sets.Set[string])
+		for policyName, gvkSet := range step.expectedPolicyToGVKsMapping {
+			for gvk := range gvkSet {
+				s, ok := invertedMapping[gvk]
+				if !ok {
+					s = sets.New[string]()
+					invertedMapping[gvk] = s
+				}
+				s.Insert(policyName)
+			}
+		}
+		if step.isDeletion {
+			tracker.ObservedDeletion(step.policyName)
+		} else {
+			tracker.ObserveChange(step.policyName, step.gvks)
+		}
+		if expected, got := sets.KeySet(step.expectedPolicyToGVKsMapping),
+			sets.KeySet(tracker.policyToGVKs); !expected.Equal(got) {
+			t.Fatalf("wrong tracked policies, expected %v but got %v", expected, got)
+		}
+		allGVKs := sets.New[schema.GroupVersionKind]()
+		for _, gvkSet := range step.expectedPolicyToGVKsMapping {
+			allGVKs = allGVKs.Union(gvkSet)
+		}
+		if got := sets.KeySet(tracker.gvkToPolicies); !allGVKs.Equal(got) {
+			t.Fatalf("wrong tracked GVKs, expected %v but got %v", allGVKs, got)
+		}
+		for policyName, gvkSet := range tracker.policyToGVKs {
+			expected := step.expectedPolicyToGVKsMapping[policyName]
+			if !expected.Equal(gvkSet) {
+				t.Fatalf("wrong tracked GVKs for %q, expeceted %v but got %v", policyName, expected, gvkSet)
+			}
+		}
+		for gvk, policySet := range tracker.gvkToPolicies {
+			expected := invertedMapping[gvk]
+			if !expected.Equal(policySet) {
+				t.Fatalf("wrong tracked policies for %v, expeceted %v but got %v", gvk, expected, policySet)
+			}
+		}
+		for gvk, expectedPolicies := range invertedMapping {
+			policies := sets.New[string](tracker.AffectedPolicies([]schema.GroupVersionKind{gvk})...)
+			if !expectedPolicies.Equal(policies) {
+				t.Fatalf("wrong AffectedPolicies result: expected %v but got %v", expectedPolicies, policies)
+			}
+		}
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/validating/plugin.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/validating/plugin.go
@@ -121,7 +121,7 @@ func compilePolicy(policy *Policy) Validator {
 	matchConditions := policy.Spec.MatchConditions
 
 	filterCompiler := cel.NewCompositedCompilerFromTemplate(compositionEnvTemplate)
-	filterCompiler.CompileAndStoreVariables(convertv1beta1Variables(policy.Spec.Variables), optionalVars, environment.StoredExpressions)
+	filterCompiler.CompileAndStoreVariables(convertv1Variables(policy.Spec.Variables), optionalVars, environment.StoredExpressions)
 
 	if len(matchConditions) > 0 {
 		matchExpressionAccessors := make([]cel.ExpressionAccessor, len(matchConditions))
@@ -179,7 +179,7 @@ func convertv1AuditAnnotations(inputValidations []v1.AuditAnnotation) []cel.Expr
 	return celExpressionAccessor
 }
 
-func convertv1beta1Variables(variables []v1.Variable) []cel.NamedExpressionAccessor {
+func convertv1Variables(variables []v1.Variable) []cel.NamedExpressionAccessor {
 	namedExpressions := make([]cel.NamedExpressionAccessor, len(variables))
 	for i, variable := range variables {
 		namedExpressions[i] = &Variable{Name: variable.Name, Expression: variable.Expression}

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/validating/typechecking.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/validating/typechecking.go
@@ -17,7 +17,6 @@ limitations under the License.
 package validating
 
 import (
-	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -29,17 +28,13 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apimachinery/pkg/util/version"
 	plugincel "k8s.io/apiserver/pkg/admission/plugin/cel"
 	apiservercel "k8s.io/apiserver/pkg/cel"
-	"k8s.io/apiserver/pkg/cel/common"
 	"k8s.io/apiserver/pkg/cel/environment"
 	"k8s.io/apiserver/pkg/cel/library"
-	"k8s.io/apiserver/pkg/cel/openapi"
 	"k8s.io/apiserver/pkg/cel/openapi/resolver"
-	"k8s.io/klog/v2"
 )
 
 const maxTypesToCheck = 10
@@ -47,17 +42,6 @@ const maxTypesToCheck = 10
 type TypeChecker struct {
 	SchemaResolver resolver.SchemaResolver
 	RestMapper     meta.RESTMapper
-}
-
-// TypeCheckingContext holds information about the policy being type-checked.
-// The struct is opaque to the caller.
-type TypeCheckingContext struct {
-	gvks          []schema.GroupVersionKind
-	declTypes     []*apiservercel.DeclType
-	paramGVK      schema.GroupVersionKind
-	paramDeclType *apiservercel.DeclType
-
-	variables []v1.Variable
 }
 
 type typeOverwrite struct {
@@ -107,7 +91,14 @@ func (r *TypeCheckingResult) String() string {
 // The policy object is NOT mutated. The caller should update Status accordingly
 func (c *TypeChecker) Check(policy *v1.ValidatingAdmissionPolicy) []v1.ExpressionWarning {
 	ctx := c.CreateContext(policy)
+	return c.CheckContext(ctx, policy)
+}
 
+// CheckContext preforms the type check against the given policy, with the provided context,
+// and format the result as []ExpressionWarning that is ready to be set in policy.Status
+// The result is nil if type checking returns no warning.
+// The policy object is NOT mutated. The caller should update Status accordingly
+func (c *TypeChecker) CheckContext(ctx *TypeCheckingContext, policy *v1.ValidatingAdmissionPolicy) []v1.ExpressionWarning {
 	// warnings to return, note that the capacity is optimistically set to zero
 	var warnings []v1.ExpressionWarning // intentionally not setting capacity
 
@@ -135,44 +126,6 @@ func (c *TypeChecker) Check(policy *v1.ValidatingAdmissionPolicy) []v1.Expressio
 	}
 
 	return warnings
-}
-
-// CreateContext resolves all types and their schemas from a policy definition and creates the context.
-func (c *TypeChecker) CreateContext(policy *v1.ValidatingAdmissionPolicy) *TypeCheckingContext {
-	ctx := new(TypeCheckingContext)
-	allGvks := c.typesToCheck(policy)
-	gvks := make([]schema.GroupVersionKind, 0, len(allGvks))
-	declTypes := make([]*apiservercel.DeclType, 0, len(allGvks))
-	for _, gvk := range allGvks {
-		declType, err := c.declType(gvk)
-		if err != nil {
-			// type checking errors MUST NOT alter the behavior of the policy
-			// even if an error occurs.
-			if !errors.Is(err, resolver.ErrSchemaNotFound) {
-				// Anything except ErrSchemaNotFound is an internal error
-				klog.V(2).ErrorS(err, "internal error: schema resolution failure", "gvk", gvk)
-			}
-			// skip for not found or internal error
-			continue
-		}
-		gvks = append(gvks, gvk)
-		declTypes = append(declTypes, declType)
-	}
-	ctx.gvks = gvks
-	ctx.declTypes = declTypes
-
-	paramsGVK := c.paramsGVK(policy) // maybe empty, correctly handled
-	paramsDeclType, err := c.declType(paramsGVK)
-	if err != nil {
-		if !errors.Is(err, resolver.ErrSchemaNotFound) {
-			klog.V(2).ErrorS(err, "internal error: cannot resolve schema for params", "gvk", paramsGVK)
-		}
-		paramsDeclType = nil
-	}
-	ctx.paramGVK = paramsGVK
-	ctx.paramDeclType = paramsDeclType
-	ctx.variables = policy.Spec.Variables
-	return ctx
 }
 
 func (c *TypeChecker) compiler(ctx *TypeCheckingContext, typeOverwrite typeOverwrite) (*plugincel.CompositedCompiler, error) {
@@ -211,7 +164,7 @@ func (c *TypeChecker) CheckExpression(ctx *TypeCheckingContext, expression strin
 			HasParams:     ctx.paramDeclType != nil,
 			HasAuthorizer: true,
 		}
-		compiler.CompileAndStoreVariables(convertv1beta1Variables(ctx.variables), options, environment.StoredExpressions)
+		compiler.CompileAndStoreVariables(convertv1Variables(ctx.variables), options, environment.StoredExpressions)
 		result := compiler.CompileCELExpression(celExpression(expression), options, environment.StoredExpressions)
 		if err := result.Error; err != nil {
 			typeCheckingResult := &TypeCheckingResult{GVK: gvk}
@@ -237,135 +190,6 @@ func (c celExpression) ReturnTypes() []*cel.Type {
 }
 func generateUniqueTypeName(kind string) string {
 	return fmt.Sprintf("%s%d", kind, time.Now().Nanosecond())
-}
-
-func (c *TypeChecker) declType(gvk schema.GroupVersionKind) (*apiservercel.DeclType, error) {
-	if gvk.Empty() {
-		return nil, nil
-	}
-	s, err := c.SchemaResolver.ResolveSchema(gvk)
-	if err != nil {
-		return nil, err
-	}
-	return common.SchemaDeclType(&openapi.Schema{Schema: s}, true).MaybeAssignTypeName(generateUniqueTypeName(gvk.Kind)), nil
-}
-
-func (c *TypeChecker) paramsGVK(policy *v1.ValidatingAdmissionPolicy) schema.GroupVersionKind {
-	if policy.Spec.ParamKind == nil {
-		return schema.GroupVersionKind{}
-	}
-	gv, err := schema.ParseGroupVersion(policy.Spec.ParamKind.APIVersion)
-	if err != nil {
-		return schema.GroupVersionKind{}
-	}
-	return gv.WithKind(policy.Spec.ParamKind.Kind)
-}
-
-// typesToCheck extracts a list of GVKs that needs type checking from the policy
-// the result is sorted in the order of Group, Version, and Kind
-func (c *TypeChecker) typesToCheck(p *v1.ValidatingAdmissionPolicy) []schema.GroupVersionKind {
-	gvks := sets.New[schema.GroupVersionKind]()
-	if p.Spec.MatchConstraints == nil || len(p.Spec.MatchConstraints.ResourceRules) == 0 {
-		return nil
-	}
-	restMapperRefreshAttempted := false // at most once per policy, refresh RESTMapper and retry resolution.
-	for _, rule := range p.Spec.MatchConstraints.ResourceRules {
-		groups := extractGroups(&rule.Rule)
-		if len(groups) == 0 {
-			continue
-		}
-		versions := extractVersions(&rule.Rule)
-		if len(versions) == 0 {
-			continue
-		}
-		resources := extractResources(&rule.Rule)
-		if len(resources) == 0 {
-			continue
-		}
-		// sort GVRs so that the loop below provides
-		// consistent results.
-		sort.Strings(groups)
-		sort.Strings(versions)
-		sort.Strings(resources)
-		count := 0
-		for _, group := range groups {
-			for _, version := range versions {
-				for _, resource := range resources {
-					gvr := schema.GroupVersionResource{
-						Group:    group,
-						Version:  version,
-						Resource: resource,
-					}
-					resolved, err := c.RestMapper.KindsFor(gvr)
-					if err != nil {
-						if restMapperRefreshAttempted {
-							// RESTMapper refresh happens at most once per policy
-							continue
-						}
-						c.tryRefreshRESTMapper()
-						restMapperRefreshAttempted = true
-						resolved, err = c.RestMapper.KindsFor(gvr)
-						if err != nil {
-							continue
-						}
-					}
-					for _, r := range resolved {
-						if !r.Empty() {
-							gvks.Insert(r)
-							count++
-							// early return if maximum number of types are already
-							// collected
-							if count == maxTypesToCheck {
-								if gvks.Len() == 0 {
-									return nil
-								}
-								return sortGVKList(gvks.UnsortedList())
-							}
-						}
-					}
-				}
-			}
-		}
-	}
-	if gvks.Len() == 0 {
-		return nil
-	}
-	return sortGVKList(gvks.UnsortedList())
-}
-
-func extractGroups(rule *v1.Rule) []string {
-	groups := make([]string, 0, len(rule.APIGroups))
-	for _, group := range rule.APIGroups {
-		// give up if wildcard
-		if strings.ContainsAny(group, "*") {
-			return nil
-		}
-		groups = append(groups, group)
-	}
-	return groups
-}
-
-func extractVersions(rule *v1.Rule) []string {
-	versions := make([]string, 0, len(rule.APIVersions))
-	for _, version := range rule.APIVersions {
-		if strings.ContainsAny(version, "*") {
-			return nil
-		}
-		versions = append(versions, version)
-	}
-	return versions
-}
-
-func extractResources(rule *v1.Rule) []string {
-	resources := make([]string, 0, len(rule.Resources))
-	for _, resource := range rule.Resources {
-		// skip wildcard and subresources
-		if strings.ContainsAny(resource, "*/") {
-			continue
-		}
-		resources = append(resources, resource)
-	}
-	return resources
 }
 
 // sortGVKList sorts the list by Group, Version, and Kind

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/validating/typecheckingcontext.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/validating/typecheckingcontext.go
@@ -1,0 +1,223 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validating
+
+import (
+	"errors"
+	"sort"
+	"strings"
+
+	"k8s.io/api/admissionregistration/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/sets"
+	apiservercel "k8s.io/apiserver/pkg/cel"
+	"k8s.io/apiserver/pkg/cel/common"
+	"k8s.io/apiserver/pkg/cel/openapi"
+	"k8s.io/apiserver/pkg/cel/openapi/resolver"
+	"k8s.io/klog/v2"
+)
+
+// TypeCheckingContext holds information about the policy being type-checked.
+// The context can also provide information about referred types to the caller.
+type TypeCheckingContext struct {
+	gvks          []schema.GroupVersionKind
+	declTypes     []*apiservercel.DeclType
+	paramGVK      schema.GroupVersionKind
+	paramDeclType *apiservercel.DeclType
+
+	variables []v1.Variable
+}
+
+// CreateContext resolves all types and their schemas from a policy definition and creates the context.
+func (c *TypeChecker) CreateContext(policy *v1.ValidatingAdmissionPolicy) *TypeCheckingContext {
+	ctx := new(TypeCheckingContext)
+	allGvks := c.typesToCheck(policy)
+	gvks := make([]schema.GroupVersionKind, 0, len(allGvks))
+	declTypes := make([]*apiservercel.DeclType, 0, len(allGvks))
+	for _, gvk := range allGvks {
+		declType, err := c.declType(gvk)
+		if err != nil {
+			// type checking errors MUST NOT alter the behavior of the policy
+			// even if an error occurs.
+			if !errors.Is(err, resolver.ErrSchemaNotFound) {
+				// Anything except ErrSchemaNotFound is an internal error
+				klog.V(2).ErrorS(err, "internal error: schema resolution failure", "gvk", gvk)
+			}
+			// skip for not found or internal error
+			continue
+		}
+		gvks = append(gvks, gvk)
+		declTypes = append(declTypes, declType)
+	}
+	ctx.gvks = gvks
+	ctx.declTypes = declTypes
+
+	paramsGVK := c.paramsGVK(policy) // maybe empty, correctly handled
+	paramsDeclType, err := c.declType(paramsGVK)
+	if err != nil {
+		if !errors.Is(err, resolver.ErrSchemaNotFound) {
+			klog.V(2).ErrorS(err, "internal error: cannot resolve schema for params", "gvk", paramsGVK)
+		}
+		paramsDeclType = nil
+	}
+	ctx.paramGVK = paramsGVK
+	ctx.paramDeclType = paramsDeclType
+	ctx.variables = policy.Spec.Variables
+	return ctx
+}
+
+// GVKs returns GVKs that the policy refers to in its MatchConstraints.
+func (c *TypeCheckingContext) GVKs() []schema.GroupVersionKind {
+	result := make([]schema.GroupVersionKind, len(c.gvks))
+	copy(result, c.gvks)
+	return result
+}
+
+// ParamGVK returns the GVK of the param.
+// It may be empty of the policy does not refer to a param.
+func (c *TypeCheckingContext) ParamGVK() schema.GroupVersionKind {
+	return c.paramGVK
+}
+
+func (c *TypeChecker) declType(gvk schema.GroupVersionKind) (*apiservercel.DeclType, error) {
+	if gvk.Empty() {
+		return nil, nil
+	}
+	s, err := c.SchemaResolver.ResolveSchema(gvk)
+	if err != nil {
+		return nil, err
+	}
+	return common.SchemaDeclType(&openapi.Schema{Schema: s}, true).MaybeAssignTypeName(generateUniqueTypeName(gvk.Kind)), nil
+}
+
+func (c *TypeChecker) paramsGVK(policy *v1.ValidatingAdmissionPolicy) schema.GroupVersionKind {
+	if policy.Spec.ParamKind == nil {
+		return schema.GroupVersionKind{}
+	}
+	gv, err := schema.ParseGroupVersion(policy.Spec.ParamKind.APIVersion)
+	if err != nil {
+		return schema.GroupVersionKind{}
+	}
+	return gv.WithKind(policy.Spec.ParamKind.Kind)
+}
+
+// typesToCheck extracts a list of GVKs that needs type checking from the policy
+// the result is sorted in the order of Group, Version, and Kind
+func (c *TypeChecker) typesToCheck(p *v1.ValidatingAdmissionPolicy) []schema.GroupVersionKind {
+	gvks := sets.New[schema.GroupVersionKind]()
+	if p.Spec.MatchConstraints == nil || len(p.Spec.MatchConstraints.ResourceRules) == 0 {
+		return nil
+	}
+	restMapperRefreshAttempted := false // at most once per policy, refresh RESTMapper and retry resolution.
+	for _, rule := range p.Spec.MatchConstraints.ResourceRules {
+		groups := extractGroups(&rule.Rule)
+		if len(groups) == 0 {
+			continue
+		}
+		versions := extractVersions(&rule.Rule)
+		if len(versions) == 0 {
+			continue
+		}
+		resources := extractResources(&rule.Rule)
+		if len(resources) == 0 {
+			continue
+		}
+		// sort GVRs so that the loop below provides
+		// consistent results.
+		sort.Strings(groups)
+		sort.Strings(versions)
+		sort.Strings(resources)
+		count := 0
+		for _, group := range groups {
+			for _, version := range versions {
+				for _, resource := range resources {
+					gvr := schema.GroupVersionResource{
+						Group:    group,
+						Version:  version,
+						Resource: resource,
+					}
+					resolved, err := c.RestMapper.KindsFor(gvr)
+					if err != nil {
+						if restMapperRefreshAttempted {
+							// RESTMapper refresh happens at most once per policy
+							continue
+						}
+						c.tryRefreshRESTMapper()
+						restMapperRefreshAttempted = true
+						resolved, err = c.RestMapper.KindsFor(gvr)
+						if err != nil {
+							continue
+						}
+					}
+					for _, r := range resolved {
+						if !r.Empty() {
+							gvks.Insert(r)
+							count++
+							// early return if maximum number of types are already
+							// collected
+							if count == maxTypesToCheck {
+								if gvks.Len() == 0 {
+									return nil
+								}
+								return sortGVKList(gvks.UnsortedList())
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	if gvks.Len() == 0 {
+		return nil
+	}
+	return sortGVKList(gvks.UnsortedList())
+}
+
+func extractGroups(rule *v1.Rule) []string {
+	groups := make([]string, 0, len(rule.APIGroups))
+	for _, group := range rule.APIGroups {
+		// give up if wildcard
+		if strings.ContainsAny(group, "*") {
+			return nil
+		}
+		groups = append(groups, group)
+	}
+	return groups
+}
+
+func extractVersions(rule *v1.Rule) []string {
+	versions := make([]string, 0, len(rule.APIVersions))
+	for _, version := range rule.APIVersions {
+		if strings.ContainsAny(version, "*") {
+			return nil
+		}
+		versions = append(versions, version)
+	}
+	return versions
+}
+
+func extractResources(rule *v1.Rule) []string {
+	resources := make([]string, 0, len(rule.Resources))
+	for _, resource := range rule.Resources {
+		// skip wildcard and subresources
+		if strings.ContainsAny(resource, "*/") {
+			continue
+		}
+		resources = append(resources, resource)
+	}
+	return resources
+}

--- a/staging/src/k8s.io/client-go/openapi/cached/groupversion.go
+++ b/staging/src/k8s.io/client-go/openapi/cached/groupversion.go
@@ -56,3 +56,9 @@ func (g *groupversion) Schema(contentType string) ([]byte, error) {
 
 	return cachedInfo.data, cachedInfo.err
 }
+
+func (g *groupversion) Hash() (string, error) {
+	// obtaining hash does not involve a network round-trip
+	// delegate directly.
+	return g.delegate.Hash()
+}

--- a/staging/src/k8s.io/client-go/openapi/groupversion.go
+++ b/staging/src/k8s.io/client-go/openapi/groupversion.go
@@ -25,8 +25,19 @@ import (
 
 const ContentTypeOpenAPIV3PB = "application/com.github.proto-openapi.spec.v3@v1.0+protobuf"
 
+// HashParamName is the name of the query parameter in the schema URL.
+// the schema URL is expected to be like /openapi/v3/apis/apps/v1?hash=014fbff9a07c
+const HashParamName = "hash"
+
 type GroupVersion interface {
 	Schema(contentType string) ([]byte, error)
+}
+
+type Hasher interface {
+	// Hash returns the hash that uniquely identifies the version of the requested schema.
+	// It returns an empty string if the hash does not present in the URL to the schema,
+	// or an error if the URL fails to parse.
+	Hash() (string, error)
 }
 
 type groupversion struct {
@@ -67,4 +78,15 @@ func (g *groupversion) Schema(contentType string) ([]byte, error) {
 	}
 
 	return path.Do(context.TODO()).Raw()
+}
+
+func (g *groupversion) Hash() (string, error) {
+	locator, err := url.Parse(g.item.ServerRelativeURL)
+	if err != nil {
+		return "", err
+	}
+	if query := locator.Query(); query.Has(HashParamName) {
+		return query.Get(HashParamName), nil
+	}
+	return "", nil
 }

--- a/staging/src/k8s.io/client-go/openapi/groupversion.go
+++ b/staging/src/k8s.io/client-go/openapi/groupversion.go
@@ -31,9 +31,7 @@ const HashParamName = "hash"
 
 type GroupVersion interface {
 	Schema(contentType string) ([]byte, error)
-}
 
-type Hasher interface {
 	// Hash returns the hash that uniquely identifies the version of the requested schema.
 	// It returns an empty string if the hash does not present in the URL to the schema,
 	// or an error if the URL fails to parse.

--- a/staging/src/k8s.io/client-go/openapi/groupversion_test.go
+++ b/staging/src/k8s.io/client-go/openapi/groupversion_test.go
@@ -93,13 +93,25 @@ func TestGroupVersion(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error occurred: %v", err)
 			}
-			schema, err := paths["apis/apps/v1"].Schema(runtime.ContentTypeJSON)
+			gv := paths["apis/apps/v1"]
+			schema, err := gv.Schema(runtime.ContentTypeJSON)
 			if err != nil {
 				t.Fatalf("unexpected error occurred: %v", err)
 			}
 			expectedResult := `{"openapi":"3.0.0","info":{"title":"Kubernetes","version":"unversioned"}}`
 			if string(schema) != expectedResult {
 				t.Fatalf("unexpected result actual: %s expected: %s", string(schema), expectedResult)
+			}
+			if hasher, ok := gv.(Hasher); ok {
+				if h, err := hasher.Hash(); err == nil {
+					if h != "014fbff9a07c" {
+						t.Fatalf("unexpected hash, expected %q but got %q", "014fbff9a07c", h)
+					}
+				} else {
+					t.Fatalf("unexpected error when parsing the hash: %v", err)
+				}
+			} else {
+				t.Fatalf("unexpected not a Hasher")
 			}
 		})
 	}

--- a/staging/src/k8s.io/client-go/openapi/groupversion_test.go
+++ b/staging/src/k8s.io/client-go/openapi/groupversion_test.go
@@ -102,16 +102,12 @@ func TestGroupVersion(t *testing.T) {
 			if string(schema) != expectedResult {
 				t.Fatalf("unexpected result actual: %s expected: %s", string(schema), expectedResult)
 			}
-			if hasher, ok := gv.(Hasher); ok {
-				if h, err := hasher.Hash(); err == nil {
-					if h != "014fbff9a07c" {
-						t.Fatalf("unexpected hash, expected %q but got %q", "014fbff9a07c", h)
-					}
-				} else {
-					t.Fatalf("unexpected error when parsing the hash: %v", err)
+			if h, err := gv.Hash(); err == nil {
+				if h != "014fbff9a07c" {
+					t.Fatalf("unexpected hash, expected %q but got %q", "014fbff9a07c", h)
 				}
 			} else {
-				t.Fatalf("unexpected not a Hasher")
+				t.Fatalf("unexpected error when parsing the hash: %v", err)
 			}
 		})
 	}

--- a/staging/src/k8s.io/client-go/openapi/openapitest/fakeclient.go
+++ b/staging/src/k8s.io/client-go/openapi/openapitest/fakeclient.go
@@ -17,6 +17,7 @@ limitations under the License.
 package openapitest
 
 import (
+	"crypto/sha512"
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -76,4 +77,8 @@ func (f FakeGroupVersion) Schema(contentType string) ([]byte, error) {
 		return nil, f.ForcedErr
 	}
 	return f.GVSpec, nil
+}
+
+func (f FakeGroupVersion) Hash() (string, error) {
+	return fmt.Sprintf("%x", sha512.Sum512(f.GVSpec)), nil
 }

--- a/staging/src/k8s.io/client-go/openapi/openapitest/fileclient.go
+++ b/staging/src/k8s.io/client-go/openapi/openapitest/fileclient.go
@@ -17,8 +17,10 @@ limitations under the License.
 package openapitest
 
 import (
+	"crypto/sha512"
 	"embed"
 	"errors"
+	"fmt"
 	"io/fs"
 	"os"
 	"strings"
@@ -93,4 +95,8 @@ func (f *fileGroupVersion) Schema(contentType string) ([]byte, error) {
 		return nil, errors.New("openapitest only supports 'application/json' contentType")
 	}
 	return fs.ReadFile(f.f, f.filename)
+}
+
+func (f *fileGroupVersion) Hash() (string, error) {
+	return fmt.Sprintf("%x", sha512.Sum512([]byte(f.filename))), nil
 }

--- a/staging/src/k8s.io/client-go/openapi3/root.go
+++ b/staging/src/k8s.io/client-go/openapi3/root.go
@@ -78,7 +78,7 @@ func (r *root) GroupVersions() ([]schema.GroupVersion, error) {
 	// Example GroupVersion API path: "apis/apps/v1"
 	gvs := make([]schema.GroupVersion, 0, len(paths))
 	for gvAPIPath := range paths {
-		gv, err := pathToGroupVersion(gvAPIPath)
+		gv, err := PathToGroupVersion(gvAPIPath)
 		if err != nil {
 			// Ignore paths which do not parse to GroupVersion
 			continue
@@ -122,7 +122,7 @@ func (r *root) retrieveGVBytes(gv schema.GroupVersion) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	apiPath := gvToAPIPath(gv)
+	apiPath := GroupVersionToAPIPath(gv)
 	gvOpenAPI, found := paths[apiPath]
 	if !found {
 		return nil, &GroupVersionNotFoundError{gv: gv}
@@ -130,11 +130,11 @@ func (r *root) retrieveGVBytes(gv schema.GroupVersion) ([]byte, error) {
 	return gvOpenAPI.Schema(runtime.ContentTypeJSON)
 }
 
-// gvToAPIPath maps the passed GroupVersion to a relative api
+// GroupVersionToAPIPath maps the passed GroupVersion to a relative api
 // server url. Example:
 //
 //	GroupVersion{Group: "apps", Version: "v1"} -> "apis/apps/v1".
-func gvToAPIPath(gv schema.GroupVersion) string {
+func GroupVersionToAPIPath(gv schema.GroupVersion) string {
 	var resourcePath string
 	if len(gv.Group) == 0 {
 		resourcePath = fmt.Sprintf("api/%s", gv.Version)
@@ -144,12 +144,12 @@ func gvToAPIPath(gv schema.GroupVersion) string {
 	return resourcePath
 }
 
-// pathToGroupVersion is a helper function parsing the passed relative
+// PathToGroupVersion is a helper function parsing the passed relative
 // url into a GroupVersion.
 //
 //	Example: apis/apps/v1 -> GroupVersion{Group: "apps", Version: "v1"}
 //	Example: api/v1 -> GroupVersion{Group: "", Version: "v1"}
-func pathToGroupVersion(path string) (schema.GroupVersion, error) {
+func PathToGroupVersion(path string) (schema.GroupVersion, error) {
 	var gv schema.GroupVersion
 	parts := strings.Split(path, "/")
 	if len(parts) < 2 {

--- a/staging/src/k8s.io/client-go/openapi3/root_test.go
+++ b/staging/src/k8s.io/client-go/openapi3/root_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/openapi"
 	"k8s.io/client-go/openapi/openapitest"
@@ -259,7 +260,7 @@ func TestOpenAPIV3Root_GroupVersionToPath(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			actualPath := gvToAPIPath(test.groupVersion)
+			actualPath := GroupVersionToAPIPath(test.groupVersion)
 			assert.Equal(t, test.expectedPath, actualPath, "expected API path (%s), got (%s)",
 				test.expectedPath, actualPath)
 		})
@@ -305,7 +306,7 @@ func TestOpenAPIV3Root_PathToGroupVersion(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			actualGV, err := pathToGroupVersion(test.path)
+			actualGV, err := PathToGroupVersion(test.path)
 			if test.expectedErr {
 				require.Error(t, err, "should have received error for path: %s", test.path)
 			} else {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This is the "Schema Watcher" that detects changes to the types in the cluster, and re-check affected policies if it detects a change.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Not exactly fixes anything, but it is a GA-blocker for ValidatingAdmissinPolicy
#### Special notes for your reviewer:
- Complexities
  - Let N be the number of policies, M be the number of types, in the cluster; because a policy can refer to at most 10 types to be checked, assuming the number of types a policy refers to is a constant.
  - Space: always O(N) for policies <-> GVKs mapping, always O(M) for GVKs -> hash mapping;
    - No more "subscribe/unsubscribe to GV/GVKs", because it otherwise does not affect the complexities
  - single schema changes: worst case O(N) where all policies refers to the exact same type; average case O(1) where a constant number of policies refer to a single type;
  - Cluster restart: O(M + N), for refreshing all types and re-checking all policies;
    - because there may be changes when KCM was restarting. To ensure the controller catches all changes, do an "overkill" here;
  - Policy changes: always O(1), existing behavior before this PR.
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed a missing mechanism around updates to the `.status` for ValidatingAdmissionPolicies.
These statuses now update every time any referred type has a change to its schema.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
