### PR TITLE
Introduce constants for port values

### DIFF
--- a/pkg/probe/util.go
+++ b/pkg/probe/util.go
@@ -24,8 +24,15 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
+const (
+	invalidPort  = -1
+	noPortFound  = 0
+	minValidPort = 1
+	maxValidPort = 65535
+)
+
 func ResolveContainerPort(param intstr.IntOrString, container *v1.Container) (int, error) {
-	port := -1
+	port := invalidPort
 	var err error
 	switch param.Type {
 	case intstr.Int:
@@ -40,7 +47,7 @@ func ResolveContainerPort(param intstr.IntOrString, container *v1.Container) (in
 	default:
 		return port, fmt.Errorf("intOrString had no kind: %+v", param)
 	}
-	if port > 0 && port < 65536 {
+	if port >= minValidPort && port <= maxValidPort {
 		return port, nil
 	}
 	return port, fmt.Errorf("invalid port number: %v", port)
@@ -53,5 +60,5 @@ func findPortByName(container *v1.Container, portName string) (int, error) {
 			return int(port.ContainerPort), nil
 		}
 	}
-	return 0, fmt.Errorf("port %s not found", portName)
+	return noPortFound, fmt.Errorf("port %s not found", portName)
 }


### PR DESCRIPTION
This commit introduces constants for the initial and not-found port values, and the valid port range. This improves code readability and maintainability.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR introduces constants for port values in the `ResolveContainerPort` and `findPortByName` functions, which improves code readability and maintainability.

#### Special notes for your reviewer:
I think this PR can improve code readability and maintainability. Please give me feedback
#### Does this PR introduce a user-facing change?

```release-note
NONE
