### PR TITLE
fix: dns forward exclude localhost

### DIFF
--- a/cluster/addons/dns/coredns/coredns.yaml.base
+++ b/cluster/addons/dns/coredns/coredns.yaml.base
@@ -76,7 +76,9 @@ data:
         prometheus :9153
         forward . /etc/resolv.conf {
             max_concurrent 1000
+            except localhost
         }
+        local
         cache 30
         loop
         reload

--- a/cluster/addons/dns/coredns/coredns.yaml.in
+++ b/cluster/addons/dns/coredns/coredns.yaml.in
@@ -76,7 +76,9 @@ data:
         prometheus :9153
         forward . /etc/resolv.conf {
             max_concurrent 1000
+            except localhost
         }
+        local
         cache 30
         loop
         reload

--- a/cluster/addons/dns/coredns/coredns.yaml.sed
+++ b/cluster/addons/dns/coredns/coredns.yaml.sed
@@ -76,7 +76,9 @@ data:
         prometheus :9153
         forward . /etc/resolv.conf {
             max_concurrent 1000
+            except localhost
         }
+        local
         cache 30
         loop
         reload


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/sig k8s-infra

#### What this PR does / why we need it:
Include the default forward configuration for CoreDNS, making sure to exclude localhost. I encountered a situation where a nameserver on the network was returning valid responses for records ending in `.localhost`, causing external queries to be resolved by the pod itself in error.

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:
CoreDNS log examples:

- Wrong behavior:
`[INFO] 192.168.182.173:47253 - 14438 "A IN www.google.com.svc.cluster.local. udp 50 false 512" NXDOMAIN qr,aa,rd 143 0.000208108s`
`[INFO] 192.168.182.173:47253 - 46146 "AAAA IN www.google.com.svc.cluster.local. udp 50 false 512" NXDOMAIN qr,aa,rd 143 0.000478103s`
`[INFO] 192.168.182.173:35588 - 40100 "A IN www.google.com.localhost. udp 42 false 512" NOERROR qr,rd,ra 82 0.000856649s`
`[INFO] 192.168.182.173:35588 - 44125 "AAAA IN www.google.com.localhost. udp 42 false 512" NXDOMAIN qr,rd,ra 117 0.014459894s`

- Expected behavior:
`[INFO] 192.168.182.173:34307 - 9752 "AAAA IN www.google.com.default.svc.cluster.local. udp 54 false 512" NXDOMAIN qr,aa,rd 147 0.000281345s`
`[INFO] 192.168.182.173:34307 - 64006 "A IN www.google.com.default.svc.cluster.local. udp 54 false 512" NXDOMAIN qr,aa,rd 147 0.000439861s`
`[INFO] 192.168.182.173:58391 - 34308 "AAAA IN www.google.com.svc.cluster.local. udp 50 false 512" NXDOMAIN qr,aa,rd 143 0.000236612s`
`[INFO] 192.168.182.173:58391 - 55945 "A IN www.google.com.svc.cluster.local. udp 50 false 512" NXDOMAIN qr,aa,rd 143 0.000180005s`
`[INFO] 192.168.182.173:39820 - 24192 "AAAA IN www.google.com.cluster.local. udp 46 false 512" NXDOMAIN qr,aa,rd 139 0.000162353s`
`[INFO] 192.168.182.173:39820 - 33470 "A IN www.google.com.cluster.local. udp 46 false 512" NXDOMAIN qr,aa,rd 139 0.00011766s`
`[INFO] 192.168.182.173:46804 - 26175 "AAAA IN www.google.com.localhost. udp 42 false 512" NXDOMAIN qr,rd,ra 117 0.015972327s`
`[INFO] 192.168.182.173:46804 - 25180 "A IN www.google.com.localhost. udp 42 false 512" NXDOMAIN qr,rd,ra 117 0.143355317s`
`[INFO] 192.168.182.173:49427 - 59993 "A IN www.google.com. udp 32 false 512" NOERROR qr,rd,ra 212 0.050041148s`

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
[Usage]: https://github.com/kubernetes/website/blob/89cbe46516437275ddaaa32d4639be16f7ec606c/content/en/docs/tasks/administer-cluster/dns-debugging-resolution.md
[Usage]: https://github.com/coredns/coredns/tree/8868454177bdd3e70e71bd52d3c0e38bcf0d77fd/plugin/forward
[Usage]: https://github.com/coredns/coredns/tree/8868454177bdd3e70e71bd52d3c0e38bcf0d77fd/plugin/local
```
