### PR TITLE
Make explicit check in CronJob if Job is successful before setting LastSuccessfulTime

### DIFF
--- a/pkg/controller/cronjob/cronjob_controllerv2.go
+++ b/pkg/controller/cronjob/cronjob_controllerv2.go
@@ -443,7 +443,7 @@ func (jm *ControllerV2) syncCronJob(
 			deleteFromActiveList(cronJob, j.ObjectMeta.UID)
 			jm.recorder.Eventf(cronJob, corev1.EventTypeNormal, "SawCompletedJob", "Saw completed job: %s, status: %v", j.Name, status)
 			updateStatus = true
-		} else if IsJobFinished(j) {
+		} else if IsJobSucceeded(j) {
 			// a job does not have to be in active list, as long as it is finished, we will process the timestamp
 			if cronJob.Status.LastSuccessfulTime == nil {
 				cronJob.Status.LastSuccessfulTime = j.Status.CompletionTime

--- a/pkg/controller/cronjob/cronjob_controllerv2.go
+++ b/pkg/controller/cronjob/cronjob_controllerv2.go
@@ -444,7 +444,7 @@ func (jm *ControllerV2) syncCronJob(
 			jm.recorder.Eventf(cronJob, corev1.EventTypeNormal, "SawCompletedJob", "Saw completed job: %s, status: %v", j.Name, status)
 			updateStatus = true
 		} else if IsJobSucceeded(j) {
-			// a job does not have to be in active list, as long as it is finished, we will process the timestamp
+			// a job does not have to be in active list, as long as it has completed successfully, we will process the timestamp
 			if cronJob.Status.LastSuccessfulTime == nil {
 				cronJob.Status.LastSuccessfulTime = j.Status.CompletionTime
 				updateStatus = true

--- a/pkg/controller/cronjob/utils.go
+++ b/pkg/controller/cronjob/utils.go
@@ -292,6 +292,16 @@ func IsJobFinished(j *batchv1.Job) bool {
 	return isFinished
 }
 
+// IsJobSucceeded returns whether a job has completed successfully.
+func IsJobSucceeded(j *batchv1.Job) bool {
+	for _, c := range j.Status.Conditions {
+		if c.Type == batchv1.JobComplete && c.Status == corev1.ConditionTrue {
+			return true
+		}
+	}
+	return false
+}
+
 // byJobStartTime sorts a list of jobs by start timestamp, using their names as a tie breaker.
 type byJobStartTime []*batchv1.Job
 

--- a/pkg/controller/cronjob/utils_test.go
+++ b/pkg/controller/cronjob/utils_test.go
@@ -736,6 +736,10 @@ func TestIsJobSucceeded(t *testing.T) {
 				Status: batchv1.JobStatus{
 					Conditions: []batchv1.JobCondition{
 						{
+							Type:   batchv1.JobFailed,
+							Status: v1.ConditionTrue,
+						},
+						{
 							Type:   batchv1.JobComplete,
 							Status: v1.ConditionFalse,
 						},

--- a/pkg/controller/cronjob/utils_test.go
+++ b/pkg/controller/cronjob/utils_test.go
@@ -25,7 +25,7 @@ import (
 
 	cron "github.com/robfig/cron/v3"
 	batchv1 "k8s.io/api/batch/v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
@@ -701,6 +701,55 @@ func TestNextScheduleTimeDuration(t *testing.T) {
 			}
 			if !reflect.DeepEqual(gotScheduleTimeDuration, &tt.expectedDuration) {
 				t.Errorf("scheduleTimeDuration - got %s, want %s", gotScheduleTimeDuration, tt.expectedDuration)
+			}
+		})
+	}
+}
+
+func TestIsJobSucceeded(t *testing.T) {
+	tests := map[string]struct {
+		job        batchv1.Job
+		wantResult bool
+	}{
+		"job doesn't have any conditions": {
+			wantResult: false,
+		},
+		"job has Complete=True condition": {
+			job: batchv1.Job{
+				Status: batchv1.JobStatus{
+					Conditions: []batchv1.JobCondition{
+						{
+							Type:   batchv1.JobSuspended,
+							Status: v1.ConditionFalse,
+						},
+						{
+							Type:   batchv1.JobComplete,
+							Status: v1.ConditionTrue,
+						},
+					},
+				},
+			},
+			wantResult: true,
+		},
+		"job has Complete=False condition": {
+			job: batchv1.Job{
+				Status: batchv1.JobStatus{
+					Conditions: []batchv1.JobCondition{
+						{
+							Type:   batchv1.JobComplete,
+							Status: v1.ConditionFalse,
+						},
+					},
+				},
+			},
+			wantResult: false,
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			gotResult := IsJobSucceeded(&tc.job)
+			if tc.wantResult != gotResult {
+				t.Errorf("unexpected result, want=%v, got=%v", tc.wantResult, gotResult)
 			}
 		})
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

To compute CronJob's `.status.LastSuccessfulTime` based on the job's `status.completionTime` only if the job itself is marked as successful. Currently, the presence of the `CompletionTime` implies that the job is successful based on the Job controller logic.

One could say that with the validation checks in https://github.com/kubernetes/kubernetes/pull/123273 we are guaranteed that `CompletionTime` is set only when Completed=True. OTOH, this might still be useful when the JobManagedByLabel feature is disabled. Also, it better expresses the intention.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

This is a follow up to the proposal [here](https://github.com/kubernetes/enhancements/pull/4370#discussion_r1459186027).



#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
https://github.com/kubernetes/enhancements/tree/master/keps/sig-apps/4368-support-managed-by-label-for-batch-jobs
```
