### PR TITLE
Allow almost all printable ASCII characters in environment variables

### DIFF
--- a/pkg/api/pod/util.go
+++ b/pkg/api/pod/util.go
@@ -23,6 +23,8 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	metavalidation "k8s.io/apimachinery/pkg/apis/meta/v1/validation"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/validation"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/apis/core/helper"
@@ -387,6 +389,10 @@ func GetValidationOptionsFromPodSpecAndMeta(podSpec, oldPodSpec *api.PodSpec, po
 		AllowNonLocalProjectedTokenPath:                   false,
 	}
 
+	// If old spec uses relaxed validation or enabled the RelaxedEnvironmentVariableValidation feature gate,
+	// we must allow it
+	opts.AllowRelaxedEnvironmentVariableValidation = useRelaxedEnvironmentVariableValidation(podSpec, oldPodSpec)
+
 	if oldPodSpec != nil {
 		// if old spec has status.hostIPs downwardAPI set, we must allow it
 		opts.AllowHostIPsField = opts.AllowHostIPsField || hasUsedDownwardAPIFieldPathWithPodSpec(oldPodSpec, "status.hostIPs")
@@ -418,6 +424,84 @@ func GetValidationOptionsFromPodSpecAndMeta(podSpec, oldPodSpec *api.PodSpec, po
 	}
 
 	return opts
+}
+
+func useRelaxedEnvironmentVariableValidation(podSpec, oldPodSpec *api.PodSpec) bool {
+	var oldPodEnvVarNames, podEnvVarNames sets.Set[string]
+	if oldPodSpec != nil {
+		oldPodEnvVarNames = gatherPodEnvVarNames(oldPodSpec)
+	}
+
+	if podSpec != nil {
+		podEnvVarNames = gatherPodEnvVarNames(podSpec)
+	}
+
+	for env := range podEnvVarNames {
+		if utilfeature.DefaultFeatureGate.Enabled(features.RelaxedEnvironmentVariableValidation) || relaxedEnvVarUsed(env, oldPodEnvVarNames) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func gatherPodEnvVarNames(podSpec *api.PodSpec) sets.Set[string] {
+	podEnvVarNames := sets.Set[string]{}
+
+	for _, c := range podSpec.Containers {
+		for _, env := range c.Env {
+			podEnvVarNames.Insert(env.Name)
+		}
+
+		for _, env := range c.EnvFrom {
+			podEnvVarNames.Insert(env.Prefix)
+		}
+	}
+
+	for _, c := range podSpec.InitContainers {
+		for _, env := range c.Env {
+			podEnvVarNames.Insert(env.Name)
+		}
+
+		for _, env := range c.EnvFrom {
+			podEnvVarNames.Insert(env.Prefix)
+		}
+	}
+
+	for _, c := range podSpec.EphemeralContainers {
+		for _, env := range c.Env {
+			podEnvVarNames.Insert(env.Name)
+		}
+
+		for _, env := range c.EnvFrom {
+			podEnvVarNames.Insert(env.Prefix)
+		}
+	}
+
+	return podEnvVarNames
+}
+
+func relaxedEnvVarUsed(name string, oldPodEnvVarNames sets.Set[string]) bool {
+	// A length of 0 means this is not an update request,
+	// or the old pod does not exist in the env.
+	// We will let the feature gate decide whether to use relaxed rules.
+	if oldPodEnvVarNames.Len() == 0 {
+		return false
+	}
+
+	if len(validation.IsEnvVarName(name)) == 0 || len(validation.IsRelaxedEnvVarName(name)) != 0 {
+		// It's either a valid name by strict rules or an invalid name under relaxed rules.
+		// Either way, we'll use strict rules to validate.
+		return false
+	}
+
+	// The name in question failed strict rules but passed relaxed rules.
+	if oldPodEnvVarNames.Has(name) {
+		// This relaxed-rules name was already in use.
+		return true
+	}
+
+	return false
 }
 
 func hasUsedDownwardAPIFieldPathWithPodSpec(podSpec *api.PodSpec, fieldPath string) bool {

--- a/pkg/apis/core/types.go
+++ b/pkg/apis/core/types.go
@@ -2068,7 +2068,11 @@ type VolumeDevice struct {
 
 // EnvVar represents an environment variable present in a Container.
 type EnvVar struct {
-	// Required: This must be a C_IDENTIFIER.
+	// Required: Name of the environment variable.
+	// When the RelaxedEnvironmentVariableValidation feature gate is disabled, this must consist of alphabetic characters,
+	// digits, '_', '-', or '.', and must not start with a digit.
+	// When the RelaxedEnvironmentVariableValidation feature gate is enabled,
+	// this may contain any printable ASCII characters except '='.
 	Name string
 	// Optional: no more than one of the following may be specified.
 	// Optional: Defaults to ""; variable references $(VAR_NAME) are expanded

--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -2557,8 +2557,14 @@ func ValidateEnv(vars []core.EnvVar, fldPath *field.Path, opts PodValidationOpti
 		if len(ev.Name) == 0 {
 			allErrs = append(allErrs, field.Required(idxPath.Child("name"), ""))
 		} else {
-			for _, msg := range validation.IsEnvVarName(ev.Name) {
-				allErrs = append(allErrs, field.Invalid(idxPath.Child("name"), ev.Name, msg))
+			if opts.AllowRelaxedEnvironmentVariableValidation {
+				for _, msg := range validation.IsRelaxedEnvVarName(ev.Name) {
+					allErrs = append(allErrs, field.Invalid(idxPath.Child("name"), ev.Name, msg))
+				}
+			} else {
+				for _, msg := range validation.IsEnvVarName(ev.Name) {
+					allErrs = append(allErrs, field.Invalid(idxPath.Child("name"), ev.Name, msg))
+				}
 			}
 		}
 		allErrs = append(allErrs, validateEnvVarValueFrom(ev, idxPath.Child("valueFrom"), opts)...)
@@ -2703,13 +2709,19 @@ func validateContainerResourceFieldSelector(fs *core.ResourceFieldSelector, expr
 	return allErrs
 }
 
-func ValidateEnvFrom(vars []core.EnvFromSource, fldPath *field.Path) field.ErrorList {
+func ValidateEnvFrom(vars []core.EnvFromSource, fldPath *field.Path, opts PodValidationOptions) field.ErrorList {
 	allErrs := field.ErrorList{}
 	for i, ev := range vars {
 		idxPath := fldPath.Index(i)
 		if len(ev.Prefix) > 0 {
-			for _, msg := range validation.IsEnvVarName(ev.Prefix) {
-				allErrs = append(allErrs, field.Invalid(idxPath.Child("prefix"), ev.Prefix, msg))
+			if opts.AllowRelaxedEnvironmentVariableValidation {
+				for _, msg := range validation.IsRelaxedEnvVarName(ev.Prefix) {
+					allErrs = append(allErrs, field.Invalid(idxPath.Child("prefix"), ev.Prefix, msg))
+				}
+			} else {
+				for _, msg := range validation.IsEnvVarName(ev.Prefix) {
+					allErrs = append(allErrs, field.Invalid(idxPath.Child("prefix"), ev.Prefix, msg))
+				}
 			}
 		}
 
@@ -3532,7 +3544,7 @@ func validateContainerCommon(ctr *core.Container, volumes map[string]core.Volume
 	volDevices := GetVolumeDeviceMap(ctr.VolumeDevices)
 	allErrs = append(allErrs, validateContainerPorts(ctr.Ports, path.Child("ports"))...)
 	allErrs = append(allErrs, ValidateEnv(ctr.Env, path.Child("env"), opts)...)
-	allErrs = append(allErrs, ValidateEnvFrom(ctr.EnvFrom, path.Child("envFrom"))...)
+	allErrs = append(allErrs, ValidateEnvFrom(ctr.EnvFrom, path.Child("envFrom"), opts)...)
 	allErrs = append(allErrs, ValidateVolumeMounts(ctr.VolumeMounts, volDevices, volumes, ctr, path.Child("volumeMounts"))...)
 	allErrs = append(allErrs, ValidateVolumeDevices(ctr.VolumeDevices, volMounts, volumes, path.Child("volumeDevices"))...)
 	allErrs = append(allErrs, validatePullPolicy(ctr.ImagePullPolicy, path.Child("imagePullPolicy"))...)
@@ -3983,6 +3995,8 @@ type PodValidationOptions struct {
 	// The top-level resource being validated is a Pod, not just a PodSpec
 	// embedded in some other resource.
 	ResourceIsPod bool
+	// Allow relaxed validation of environment variable names
+	AllowRelaxedEnvironmentVariableValidation bool
 }
 
 // validatePodMetadataAndSpec tests if required fields in the pod.metadata and pod.spec are set,

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -646,6 +646,13 @@ const (
 	// Allow users to recover from volume expansion failure
 	RecoverVolumeExpansionFailure featuregate.Feature = "RecoverVolumeExpansionFailure"
 
+	// owner: @HirazawaUi
+	// kep: https://kep.k8s.io/4369
+	// alpha: v1.30
+	//
+	// Allow almost all printable ASCII characters in environment variables
+	RelaxedEnvironmentVariableValidation featuregate.Feature = "RelaxedEnvironmentVariableValidation"
+
 	// owner: @mikedanese
 	// alpha: v1.7
 	// beta: v1.12
@@ -1102,6 +1109,8 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	ReadWriteOncePod: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.31
 
 	RecoverVolumeExpansionFailure: {Default: false, PreRelease: featuregate.Alpha},
+
+	RelaxedEnvironmentVariableValidation: {Default: false, PreRelease: featuregate.Alpha},
 
 	RotateKubeletServerCertificate: {Default: true, PreRelease: featuregate.Beta},
 

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -638,20 +638,12 @@ func (kl *Kubelet) makeEnvironmentVariables(pod *v1.Pod, container *v1.Container
 				configMaps[name] = configMap
 			}
 
-			invalidKeys := []string{}
 			for k, v := range configMap.Data {
 				if len(envFrom.Prefix) > 0 {
 					k = envFrom.Prefix + k
 				}
-				if errMsgs := utilvalidation.IsEnvVarName(k); len(errMsgs) != 0 {
-					invalidKeys = append(invalidKeys, k)
-					continue
-				}
+
 				tmpEnv[k] = v
-			}
-			if len(invalidKeys) > 0 {
-				sort.Strings(invalidKeys)
-				kl.recorder.Eventf(pod, v1.EventTypeWarning, "InvalidEnvironmentVariableNames", "Keys [%s] from the EnvFrom configMap %s/%s were skipped since they are considered invalid environment variable names.", strings.Join(invalidKeys, ", "), pod.Namespace, name)
 			}
 		case envFrom.SecretRef != nil:
 			s := envFrom.SecretRef
@@ -673,20 +665,12 @@ func (kl *Kubelet) makeEnvironmentVariables(pod *v1.Pod, container *v1.Container
 				secrets[name] = secret
 			}
 
-			invalidKeys := []string{}
 			for k, v := range secret.Data {
 				if len(envFrom.Prefix) > 0 {
 					k = envFrom.Prefix + k
 				}
-				if errMsgs := utilvalidation.IsEnvVarName(k); len(errMsgs) != 0 {
-					invalidKeys = append(invalidKeys, k)
-					continue
-				}
+
 				tmpEnv[k] = string(v)
-			}
-			if len(invalidKeys) > 0 {
-				sort.Strings(invalidKeys)
-				kl.recorder.Eventf(pod, v1.EventTypeWarning, "InvalidEnvironmentVariableNames", "Keys [%s] from the EnvFrom secret %s/%s were skipped since they are considered invalid environment variable names.", strings.Join(invalidKeys, ", "), pod.Namespace, name)
 			}
 		}
 	}

--- a/staging/src/k8s.io/apimachinery/pkg/util/validation/validation.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/validation/validation.go
@@ -21,6 +21,7 @@ import (
 	"math"
 	"regexp"
 	"strings"
+	"unicode"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	netutils "k8s.io/utils/net"
@@ -418,6 +419,9 @@ func IsHTTPHeaderName(value string) []string {
 const envVarNameFmt = "[-._a-zA-Z][-._a-zA-Z0-9]*"
 const envVarNameFmtErrMsg string = "a valid environment variable name must consist of alphabetic characters, digits, '_', '-', or '.', and must not start with a digit"
 
+// TODO(hirazawaui): Rename this when the RelaxedEnvironmentVariableValidation gate is removed.
+const relaxedEnvVarNameFmtErrMsg string = "a valid environment variable names must be printable ASCII characters other than '=' character"
+
 var envVarNameRegexp = regexp.MustCompile("^" + envVarNameFmt + "$")
 
 // IsEnvVarName tests if a string is a valid environment variable name.
@@ -428,6 +432,24 @@ func IsEnvVarName(value string) []string {
 	}
 
 	errs = append(errs, hasChDirPrefix(value)...)
+	return errs
+}
+
+// IsRelaxedEnvVarName tests if a string is a valid environment variable name.
+func IsRelaxedEnvVarName(value string) []string {
+	var errs []string
+
+	if len(value) == 0 {
+		errs = append(errs, "environment variable name"+EmptyError())
+	}
+
+	for _, r := range value {
+		if r > unicode.MaxASCII || !unicode.IsPrint(r) || r == '=' {
+			errs = append(errs, relaxedEnvVarNameFmtErrMsg)
+			break
+		}
+	}
+
 	return errs
 }
 

--- a/staging/src/k8s.io/apimachinery/pkg/util/validation/validation_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/validation/validation_test.go
@@ -904,3 +904,30 @@ func TestIsDomainPrefixedPath(t *testing.T) {
 		}
 	}
 }
+
+func TestIsRelaxedEnvVarName(t *testing.T) {
+	goodValues := []string{
+		"-", ":", "_", "+a", ">a", "<a",
+		"a.", "a..", "*a", "%a", "?a",
+		"a:a", "a_a", "aAz", "~a", "|a",
+		"a0a", "a9", "/a", "a ", "#a",
+		"0a", "0 a", "'a", "(a", "@a",
+	}
+	for _, val := range goodValues {
+		if msgs := IsRelaxedEnvVarName(val); len(msgs) != 0 {
+			t.Errorf("expected true for '%s': %v", val, msgs)
+		}
+	}
+
+	badValues := []string{
+		"", "=", "a=", "1=a", "a=b", "#%=&&",
+		string(rune(1)) + "abc", string(rune(130)) + "abc",
+		"Ç ç", "Ä ä", "Ñ ñ", "Ø ø",
+	}
+
+	for _, val := range badValues {
+		if msgs := IsRelaxedEnvVarName(val); len(msgs) == 0 {
+			t.Errorf("expected false for '%s'", val)
+		}
+	}
+}

--- a/test/e2e/common/node/expansion.go
+++ b/test/e2e/common/node/expansion.go
@@ -22,6 +22,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/kubernetes/test/e2e/feature"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	e2epodoutput "k8s.io/kubernetes/test/e2e/framework/pod/output"
@@ -371,6 +372,42 @@ var _ = SIGDescribe("Variable Expansion", func() {
 		err = e2epod.DeletePodWithWait(ctx, f.ClientSet, pod)
 		framework.ExpectNoError(err, "failed to delete pod")
 	})
+
+	/*
+		Release: v1.30
+		Testname: Environment variables, expansion
+		Description: Create a Pod with environment variables. Environment variables defined using previously defined environment variables MUST expand to proper values.
+		Allow almost all printable ASCII characters in environment variables.
+	*/
+	framework.It("allow almost all printable ASCII characters as environment variable names", feature.RelaxedEnvironmentVariableValidation, func(ctx context.Context) {
+		envVars := []v1.EnvVar{
+			{
+				Name:  "!\"#$%&'()",
+				Value: "value-1",
+			},
+			{
+				Name:  "* +,-./0123456789",
+				Value: "value-2",
+			},
+			{
+				Name:  ":;<>?@",
+				Value: "value-3",
+			},
+			{
+				Name:  "[\\]^_`{}|~",
+				Value: "value-4",
+			},
+		}
+		pod := newPod([]string{"sh", "-c", "env"}, envVars, nil, nil)
+
+		e2epodoutput.TestContainerOutput(ctx, f, "env composition", pod, 0, []string{
+			"!\"#$%&'()=value-1",
+			"* +,-./0123456789=value-2",
+			":;<>?@=value-3",
+			"[\\]^_`{}|~=value-4",
+		})
+	})
+
 })
 
 func testPodFailSubpath(ctx context.Context, f *framework.Framework, pod *v1.Pod) {

--- a/test/e2e/common/node/secrets.go
+++ b/test/e2e/common/node/secrets.go
@@ -22,17 +22,18 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
-
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/kubernetes/test/e2e/feature"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2epodoutput "k8s.io/kubernetes/test/e2e/framework/pod/output"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 	admissionapi "k8s.io/pod-security-admission/api"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
 )
 
 var _ = SIGDescribe("Secrets", func() {
@@ -237,6 +238,54 @@ var _ = SIGDescribe("Secrets", func() {
 		if foundCreatedSecret {
 			framework.Failf("secret %s/%s was not deleted successfully", f.Namespace.Name, secretTestName)
 		}
+	})
+
+	/*
+		Release: v1.30
+		Testname: Secrets, pod environment from source
+		Description: Create a secret. Create a Pod with Container that declares a environment variable using 'EnvFrom' which references the secret created to extract a key value from the secret.
+		Allows users to use envFrom to set prefix starting with a digit as environment variable names.
+	*/
+	framework.It("should be consumable as environment variable names when secret keys start with a digit", feature.RelaxedEnvironmentVariableValidation, func(ctx context.Context) {
+		name := "secret-test-" + string(uuid.NewUUID())
+		secret := secretForTest(f.Namespace.Name, name)
+
+		ginkgo.By(fmt.Sprintf("creating secret %v/%v", f.Namespace.Name, secret.Name))
+		var err error
+		if secret, err = f.ClientSet.CoreV1().Secrets(f.Namespace.Name).Create(ctx, secret, metav1.CreateOptions{}); err != nil {
+			framework.Failf("unable to create test secret %s: %v", secret.Name, err)
+		}
+
+		pod := &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "pod-configmaps-" + string(uuid.NewUUID()),
+			},
+			Spec: v1.PodSpec{
+				Containers: []v1.Container{
+					{
+						Name:    "env-test",
+						Image:   imageutils.GetE2EImage(imageutils.BusyBox),
+						Command: []string{"sh", "-c", "env"},
+						EnvFrom: []v1.EnvFromSource{
+							{
+								SecretRef: &v1.SecretEnvSource{LocalObjectReference: v1.LocalObjectReference{Name: name}},
+							},
+							{
+								// prefix start with a digit can be consumed as environment variables.
+								Prefix:    "1-",
+								SecretRef: &v1.SecretEnvSource{LocalObjectReference: v1.LocalObjectReference{Name: name}},
+							},
+						},
+					},
+				},
+				RestartPolicy: v1.RestartPolicyNever,
+			},
+		}
+
+		e2epodoutput.TestContainerOutput(ctx, f, "consume secrets", pod, 0, []string{
+			"data-1=value-1", "data-2=value-2", "data-3=value-3",
+			"1-data-1=value-1", "1-data-2=value-2", "1-data-3=value-3",
+		})
 	})
 })
 

--- a/test/e2e/feature/feature.go
+++ b/test/e2e/feature/feature.go
@@ -253,6 +253,10 @@ var (
 	// TODO: document the feature (owning SIG, when to use this feature for a test)
 	RecoverVolumeExpansionFailure = framework.WithFeature(framework.ValidFeatures.Add("RecoverVolumeExpansionFailure"))
 
+	// RelaxedEnvironmentVariableValidation used when we verify whether the pod can consume all printable ASCII characters as environment variable names,
+	// and whether the pod can consume configmap/secret that key starts with a number.
+	RelaxedEnvironmentVariableValidation = framework.WithFeature(framework.ValidFeatures.Add("RelaxedEnvironmentVariableValidation"))
+
 	// TODO: document the feature (owning SIG, when to use this feature for a test)
 	Recreate = framework.WithFeature(framework.ValidFeatures.Add("Recreate"))
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Allows users to set all ASCII characters with serial numbers in the range of 32-126 except "=" as environment variables.

Kubernetes should not restrict which environment variable names can be used, because it has no way of knowing what the application may need, and people can't always choose their own variable names, which may limit the adoption of Kubernetes.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #53201

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added a alpha feature, behind the `RelaxedEnvironmentVariableValidation` feature gate.
When that gate is enabled, Kubernetes allows almost all printable ASCII characters to be used in the names
of environment variables for containers in Pods.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/4369-allow-special-characters-environment-variable
```
