### PR TITLE
kubelet/userns: Remove tests that fail as root

### DIFF
--- a/pkg/kubelet/userns/userns_manager_test.go
+++ b/pkg/kubelet/userns/userns_manager_test.go
@@ -378,21 +378,3 @@ func TestMakeUserNsManagerFailsListPod(t *testing.T) {
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "read pods from disk")
 }
-
-func TestMakeUserNsManagerFailsPodRecord(t *testing.T) {
-	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, pkgfeatures.UserNamespacesSupport, true)()
-
-	testUserNsPodsManager := &testUserNsPodsManager{
-		podList: []types.UID{"pod-1", "pod-2"},
-		podDir:  t.TempDir(),
-	}
-
-	// Remove read/execute permissions from this directory.
-	if err := os.Chmod(testUserNsPodsManager.podDir, 0222); err != nil {
-		t.Fatal(err)
-	}
-
-	_, err := MakeUserNsManager(testUserNsPodsManager)
-	assert.Error(t, err)
-	assert.ErrorContains(t, err, "record pod mappings")
-}


### PR DESCRIPTION
For some reason the CI didn't fail when we open the PR. But when you run
"go test" as root, with all the capabilities, tests that exercise
permission errors will never work. As the capabilities makes them bypass the permission checks.
    
For some reason it seems that one of these happened:
 * Not all our CI was run when the PR was open
 * The CI was changed to run as root now
 * _Some_ CI was added and it runs as root
    
If it wasn't one of that, or a combination, I don't see how this could
have happened. If any of that indeed happened, it can break more tests
outside the userns package too.



<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes: 

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #123378 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
