### PR TITLE
Fix makefile variable expansion for test-integration target

### DIFF
--- a/build/root/Makefile
+++ b/build/root/Makefile
@@ -197,10 +197,12 @@ define TEST_IT_HELP_INFO
 # Args:
 #   WHAT: Directory names to test.  All *_test.go files under these
 #     directories will be run.  If not specified, "everything" will be tested.
+#   KUBE_TEST_ARGS: Arguments to pass to the resulting go test invocation.
 #
 # Example:
 #   make test-integration
 #   make test-integration WHAT=./test/integration/kubelet GOFLAGS="-v -coverpkg=./pkg/kubelet/..." KUBE_COVER="y"
+#   make test-integration WHAT=./test/integration/pods GOFLAGS="-v" KUBE_TEST_ARGS='-run ^TestPodUpdateActiveDeadlineSeconds$$'
 endef
 .PHONY: test-integration
 ifeq ($(PRINT_HELP),y)
@@ -208,7 +210,8 @@ test-integration:
 	echo "$$TEST_IT_HELP_INFO"
 else
 test-integration:
-	hack/make-rules/test-integration.sh $(WHAT)
+	# KUBE_TEST_ARGS is explicitly passed here in order to ensure that we are preserving any dollar signs in the value.
+	KUBE_TEST_ARGS='$(value KUBE_TEST_ARGS)' hack/make-rules/test-integration.sh $(WHAT)
 endif
 
 define TEST_E2E_NODE_HELP_INFO

--- a/hack/make-rules/test-integration.sh
+++ b/hack/make-rules/test-integration.sh
@@ -75,12 +75,16 @@ runTests() {
   kube::etcd::start_scraping
   kube::log::status "Running integration test cases"
 
-  make -C "${KUBE_ROOT}" test \
+  # shellcheck disable=SC2034
+  # KUBE_RACE and MAKEFLAGS are used in the downstream make, and we set them to
+  # empty here to ensure that we aren't unintentionally consuming them from the
+  # previous make invocation.
+  KUBE_TEST_ARGS="${SHORT:--short=true} --vmodule=${KUBE_TEST_VMODULE} ${KUBE_TEST_ARGS}" \
       WHAT="${WHAT:-$(kube::test::find_integration_test_dirs | paste -sd' ' -)}" \
       GOFLAGS="${GOFLAGS:-}" \
-      KUBE_TEST_ARGS="${SHORT:--short=true} --vmodule=${KUBE_TEST_VMODULE} ${KUBE_TEST_ARGS:-}" \
-      KUBE_TIMEOUT="${KUBE_TIMEOUT}" \
-      KUBE_RACE=""
+      KUBE_RACE="" \
+      MAKEFLAGS="" \
+      make -C "${KUBE_ROOT}" test
 
   cleanup
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
The variable `KUBE_TEST_ARGS` was being inconsistently expanded, as sometimes it's passed via environment and sometimes as a make variable. This means you needed to add extra dollar signs to escape the variable, and this depended on if you specify it before the command (via the environment) or after the command (as a make variable). You also needed to know that we were always passing it as a make variable on the inside script, so you'd need to add a double $ no matter what.

This uses the `value` make builtin to explicitly take the value of the variable, no matter how it was passed in on the command line, and passes to the next step it as an environment variable. It also rearranges how the test target is called in the test-integration.sh script so that it will also always be passed as an environment variable avoiding further expansion by make, and clear out any previous `MAKEFLAGS` from the previous run.

While this should not impact functionality of existing tests, there may be some developer documentation that needs to be updated.

#### Which issue(s) this PR fixes:
ref https://github.com/kubernetes/community/pull/7724

#### Special notes for your reviewer:
Theses can be tested locally with the following two commands to exercise the use case where someone provides `KUBE_TEST_ARGS` before the command (an environment variable), or after the command (a make variable):
```bash
KUBE_TEST_ARGS='-run ^TestPodUpdateActiveDeadlineSeconds$' make test-integration WHAT=./test/integration/pods GOFLAGS="-v"
make test-integration WHAT=./test/integration/pods GOFLAGS="-v" KUBE_TEST_ARGS='-run ^TestPodUpdateActiveDeadlineSeconds$'
```

Both of those commands should run a successful integration test taking <15 seconds locally (although may take longer the first time you run if your go cache isn't warm)


#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
- [Usage]: https://git.k8s.io/community/contributors/devel/sig-testing/integration-tests.md
```