### PR TITLE
Fix data race in apiserver mux handler

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/mux/pathrecorder.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/mux/pathrecorder.go
@@ -96,9 +96,11 @@ func NewPathRecorderMux(name string) *PathRecorderMux {
 
 // ListedPaths returns the registered handler exposedPaths.
 func (m *PathRecorderMux) ListedPaths() []string {
+	m.lock.Lock()
 	handledPaths := append([]string{}, m.exposedPaths...)
-	sort.Strings(handledPaths)
+	m.lock.Unlock()
 
+	sort.Strings(handledPaths)
 	return handledPaths
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

```
Read at 0x00c003ac4e48 by goroutine 4206:
  k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/server/mux.(*PathRecorderMux).ListedPaths()
      /home/prow/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/server/mux/pathrecorder.go:99 +0x1fa
  k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/server.(*APIServerHandler).ListedPaths()
      /home/prow/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/server/handler.go:110 +0x86
  k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/server/routes.ListedPathProviders.ListedPaths()
      /home/prow/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/server/routes/index.go:41 +0xb9
  k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/server/routes.(*ListedPathProviders).ListedPaths()
      <autogenerated>:1 +0x49
  k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/server/routes.IndexLister.ServeHTTP()
      /home/prow/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/server/routes/index.go:68 +0x54
  k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/server/routes.(*IndexLister).ServeHTTP()
      <autogenerated>:1 +0x74
  k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/server/mux.(*pathHandler).ServeHTTP()
      /home/prow/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/server/mux/pathrecorder.go:242 +0x333
  k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/server/mux.(*PathRecorderMux).ServeHTTP()
      /home/prow/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/server/mux/pathrecorder.go:235 +0x5e
  k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/server.director.ServeHTTP()
      /home/prow/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/server/handler.go:154 +0xa9e
  k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/server.(*director).ServeHTTP()
      <autogenerated>:1 +0x7b
  k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.TrackCompleted.trackCompleted.func21.deferwrap1()
      /home/prow/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/endpoints/filterlatency/filterlatency.go:103 +0x6f
  runtime.deferreturn()
      /home/prow/go/src/k8s.io/kubernetes/_output/local/.gimme/versions/go1.22rc2.linux.amd64/src/runtime/panic.go:602 +0x5d
  net/http.HandlerFunc.ServeHTTP()
      /home/prow/go/src/k8s.io/kubernetes/_output/local/.gimme/versions/go1.22rc2.linux.amd64/src/net/http/server.go:2166 +0x47
  k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/endpoints/filters.withAuthorization.func1()
      /home/prow/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/endpoints/filters/authorization.go:78 +0x872
  net/http.HandlerFunc.ServeHTTP()
      /home/prow/go/src/k8s.io/kubernetes/_output/local/.gimme/versions/go1.22rc2.linux.amd64/src/net/http/server.go:2166 +0x47
  k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/endpoints/filterlatency.trackStarted.func1()
      /home/prow/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/endpoints/filterlatency/filterlatency.go:84 +0x23c
  net/http.HandlerFunc.ServeHTTP()
      /home/prow/go/src/k8s.io/kubernetes/_output/local/.gimme/versions/go1.22rc2.linux.amd64/src/net/http/server.go:2166 +0x47
  k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.TrackCompleted.trackCompleted.func22.deferwrap1()
      /home/prow/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/endpoints/filterlatency/filterlatency.go:103 +0x6f
  runtime.deferreturn()
      /home/prow/go/src/k8s.io/kubernetes/_output/local/.gimme/versions/go1.22rc2.linux.amd64/src/runtime/panic.go:602 +0x5d
  net/http.HandlerFunc.ServeHTTP()
      /home/prow/go/src/k8s.io/kubernetes/_output/local/.gimme/versions/go1.22rc2.linux.amd64/src/net/http/server.go:2166 +0x47
  k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/server/filters.(*priorityAndFairnessHandler).Handle.func9()
      /home/prow/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/server/filters/priority-and-fairness.go:292 +0x13c
  k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/util/flowcontrol.(*configController).Handle.func2()
      /home/prow/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/util/flowcontrol/apf_filter.go:192 +0x3e9
  k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset.(*request).Finish.func1()
      /home/prow/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/queueset.go:391 +0x9a
  k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset.(*request).Finish()
      /home/prow/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/queueset.go:392 +0x4a
  k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/util/flowcontrol.(*configController).Handle()
      /home/prow/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/util/flowcontrol/apf_filter.go:179 +0xd43
  k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/server/filters.(*priorityAndFairnessHandler).Handle.func10()
      /home/prow/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/server/filters/priority-and-fairness.go:298 +0x15a
  k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/server/filters.(*priorityAndFairnessHandler).Handle()
      /home/prow/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/server/filters/priority-and-fairness.go:299 +0x14a4
  k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/server/filters.(*priorityAndFairnessHandler).Handle-fm()
      <autogenerated>:1 +0x51
  net/http.HandlerFunc.ServeHTTP()
      /home/prow/go/src/k8s.io/kubernetes/_output/local/.gimme/versions/go1.22rc2.linux.amd64/src/net/http/server.go:2166 +0x47
  k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/endpoints/filterlatency.trackStarted.func1()
      /home/prow/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/endpoints/filterlatency/filterlatency.go:84 +0x23c
  net/http.HandlerFunc.ServeHTTP()
      /home/prow/go/src/k8s.io/kubernetes/_output/local/.gimme/versions/go1.22rc2.linux.amd64/src/net/http/server.go:2166 +0x47
  k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.TrackCompleted.trackCompleted.func23.deferwrap1()
      /home/prow/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/endpoints/filterlatency/filterlatency.go:103 +0x6f
  runtime.deferreturn()
      /home/prow/go/src/k8s.io/kubernetes/_output/local/.gimme/versions/go1.22rc2.linux.amd64/src/runtime/panic.go:602 +0x5d
  net/http.HandlerFunc.ServeHTTP()
      /home/prow/go/src/k8s.io/kubernetes/_output/local/.gimme/versions/go1.22rc2.linux.amd64/src/net/http/server.go:2166 +0x47
  k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithImpersonation.func4()
      /home/prow/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/endpoints/filters/impersonation.go:50 +0x214
  net/http.HandlerFunc.ServeHTTP()
      /home/prow/go/src/k8s.io/kubernetes/_output/local/.gimme/versions/go1.22rc2.linux.amd64/src/net/http/server.go:2166 +0x47
  k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/endpoints/filterlatency.trackStarted.func1()
      /home/prow/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/endpoints/filterlatency/filterlatency.go:84 +0x23c
  net/http.HandlerFunc.ServeHTTP()
      /home/prow/go/src/k8s.io/kubernetes/_output/local/.gimme/versions/go1.22rc2.linux.amd64/src/net/http/server.go:2166 +0x47
  k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.TrackCompleted.trackCompleted.func24.deferwrap1()
      /home/prow/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/endpoints/filterlatency/filterlatency.go:103 +0x6f
  runtime.deferreturn()
      /home/prow/go/src/k8s.io/kubernetes/_output/local/.gimme/versions/go1.22rc2.linux.amd64/src/runtime/panic.go:602 +0x5d
  net/http.HandlerFunc.ServeHTTP()
      /home/prow/go/src/k8s.io/kubernetes/_output/local/.gimme/versions/go1.22rc2.linux.amd64/src/net/http/server.go:2166 +0x47
  k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/endpoints/filterlatency.trackStarted.func1()
      /home/prow/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/endpoints/filterlatency/filterlatency.go:84 +0x23c
  net/http.HandlerFunc.ServeHTTP()
      /home/prow/go/src/k8s.io/kubernetes/_output/local/.gimme/versions/go1.22rc2.linux.amd64/src/net/http/server.go:2166 +0x47
  k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.TrackCompleted.trackCompleted.func26.deferwrap1()
      /home/prow/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/endpoints/filterlatency/filterlatency.go:103 +0x6f
  runtime.deferreturn()
      /home/prow/go/src/k8s.io/kubernetes/_output/local/.gimme/versions/go1.22rc2.linux.amd64/src/runtime/panic.go:602 +0x5d
  net/http.HandlerFunc.ServeHTTP()
      /home/prow/go/src/k8s.io/kubernetes/_output/local/.gimme/versions/go1.22rc2.linux.amd64/src/net/http/server.go:2166 +0x47
  k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/endpoints/filters.withAuthentication.func1()
      /home/prow/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/endpoints/filters/authentication.go:120 +0xc81
  net/http.HandlerFunc.ServeHTTP()
      /home/prow/go/src/k8s.io/kubernetes/_output/local/.gimme/versions/go1.22rc2.linux.amd64/src/net/http/server.go:2166 +0x47
  k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/endpoints/filterlatency.trackStarted.func1()
      /home/prow/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/endpoints/filterlatency/filterlatency.go:94 +0x4b5
  net/http.HandlerFunc.ServeHTTP()
      /home/prow/go/src/k8s.io/kubernetes/_output/local/.gimme/versions/go1.22rc2.linux.amd64/src/net/http/server.go:2166 +0x47
  k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithWarningRecorder.func11()
      /home/prow/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/endpoints/filters/warning.go:35 +0x11d
  net/http.HandlerFunc.ServeHTTP()
      /home/prow/go/src/k8s.io/kubernetes/_output/local/.gimme/versions/go1.22rc2.linux.amd64/src/net/http/server.go:2166 +0x47
  k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/server/filters.(*timeoutHandler).ServeHTTP.func1()
      /home/prow/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/server/filters/timeout.go:115 +0xd3

Previous write at 0x00c003ac4e48 by goroutine 2842:
  k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/server/mux.(*PathRecorderMux).Unregister()
      /home/prow/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/server/mux/pathrecorder.go:161 +0x3c9
  k8s.io/kubernetes/vendor/k8s.io/kube-aggregator/pkg/apiserver.(*APIAggregator).RemoveAPIService()
      /home/prow/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/kube-aggregator/pkg/apiserver/apiserver.go:584 +0x5e8
  k8s.io/kubernetes/vendor/k8s.io/kube-aggregator/pkg/apiserver.(*APIServiceRegistrationController).sync()
      /home/prow/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/kube-aggregator/pkg/apiserver/apiservice_controller.go:82 +0x103
  k8s.io/kubernetes/vendor/k8s.io/kube-aggregator/pkg/apiserver.(*APIServiceRegistrationController).sync-fm()
      <autogenerated>:1 +0x47
  k8s.io/kubernetes/vendor/k8s.io/kube-aggregator/pkg/apiserver.(*APIServiceRegistrationController).processNextWorkItem()
      /home/prow/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/kube-aggregator/pkg/apiserver/apiservice_controller.go:146 +0x1c8
  k8s.io/kubernetes/vendor/k8s.io/kube-aggregator/pkg/apiserver.(*APIServiceRegistrationController).runWorker()
      /home/prow/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/kube-aggregator/pkg/apiserver/apiservice_controller.go:134 +0x33
  k8s.io/kubernetes/vendor/k8s.io/kube-aggregator/pkg/apiserver.(*APIServiceRegistrationController).runWorker-fm()
      <autogenerated>:1 +0x17
  k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1()
      /home/prow/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:226 +0x41
  k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/wait.BackoffUntil()
      /home/prow/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:227 +0xc4
  k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/wait.JitterUntil()
      /home/prow/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:204 +0x10a
  k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/wait.Until()
      /home/prow/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:161 +0x4e
  k8s.io/kubernetes/vendor/k8s.io/kube-aggregator/pkg/apiserver.(*APIServiceRegistrationController).Run.gowrap4()
      /home/prow/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/kube-aggregator/pkg/apiserver/apiservice_controller.go:128 +0x17
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/123172

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
