### PR TITLE
[WIP] client-go/transport: support dynamic reloading of CA file

### DIFF
--- a/pkg/kubelet/client/kubelet_client.go
+++ b/pkg/kubelet/client/kubelet_client.go
@@ -120,6 +120,7 @@ func (c *KubeletClientConfig) transportConfig() *transport.Config {
 			// transport.loadTLSFiles would set this to true because we are only using files
 			// it is clearer to set it explicitly here so we remember that this is happening
 			ReloadTLSFiles: true,
+			ReloadCAFile:   true,
 		},
 	}
 	if !cfg.HasCA() {

--- a/staging/src/k8s.io/apimachinery/pkg/util/wait/wait.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/wait/wait.go
@@ -39,6 +39,9 @@ var ForeverTestTimeout = time.Second * 30
 // NeverStop may be passed to Until to make it never stop.
 var NeverStop <-chan struct{} = make(chan struct{})
 
+// NeverStopCtx may be passed to functions to make it never stop.
+var NeverStopCtx context.Context = context.Background()
+
 // Group allows to start a group of goroutines and wait for their completion.
 type Group struct {
 	wg sync.WaitGroup

--- a/staging/src/k8s.io/client-go/transport/cache.go
+++ b/staging/src/k8s.io/client-go/transport/cache.go
@@ -38,10 +38,10 @@ type tlsTransportCache struct {
 	transports map[tlsCacheKey]*http.Transport
 }
 
-// DialerStopCh is stop channel that is passed down to dynamic cert dialer.
-// It's exposed as variable for testing purposes to avoid testing for goroutine
-// leakages.
-var DialerStopCh = wait.NeverStop
+// ControllerStopCtx is a stop context object that is passed down to
+// the dynamic cert dialer. It's exposed as a variable for testing
+// purposes to avoid goroutine leakages.
+var ControllerStopCtx = wait.NeverStopCtx
 
 const idleConnsPerHost = 25
 
@@ -119,7 +119,7 @@ func (c *tlsTransportCache) get(config *Config) (http.RoundTripper, error) {
 		dynamicCertDialer := certRotatingDialer(tlsConfig.GetClientCertificate, dial)
 		tlsConfig.GetClientCertificate = dynamicCertDialer.GetClientCertificate
 		dial = dynamicCertDialer.connDialer.DialContext
-		go dynamicCertDialer.Run(DialerStopCh)
+		go dynamicCertDialer.Run(ControllerStopCtx)
 	}
 
 	proxy := http.ProxyFromEnvironment

--- a/staging/src/k8s.io/client-go/transport/cache.go
+++ b/staging/src/k8s.io/client-go/transport/cache.go
@@ -144,7 +144,7 @@ func (c *tlsTransportCache) get(config *Config) (http.RoundTripper, error) {
 	if config.TLS.ReloadCAFile && tlsConfig != nil {
 		reloadable := newDynamicRootCATransport(transport)
 		rt = reloadable
-		controller := newDynamicRootCATransportController(newRootCASyncer(reloadable, config.TLS.CAFile, config.TLS.CAData))
+		controller := newDynamicRootCATransportController(newRootCASyncer(ControllerStopCtx, reloadable, config.TLS.CAFile, config.TLS.CAData))
 		go controller.Run(ControllerStopCtx)
 	}
 

--- a/staging/src/k8s.io/client-go/transport/cache.go
+++ b/staging/src/k8s.io/client-go/transport/cache.go
@@ -41,6 +41,10 @@ type tlsTransportCache struct {
 // ControllerStopCtx is a stop context object that is passed down to
 // the dynamic cert dialer. It's exposed as a variable for testing
 // purposes to avoid goroutine leakages.
+// NOTE: the initial value of the 'ControllerStopCtx' is set to
+// 'wait.NeverStopCtx', and the integration testing framework relies
+// on this initial value to determine if a test has modified the variable,
+// so changing the initial value here will break the integration tests.
 var ControllerStopCtx = wait.NeverStopCtx
 
 const idleConnsPerHost = 25

--- a/staging/src/k8s.io/client-go/transport/cache_test.go
+++ b/staging/src/k8s.io/client-go/transport/cache_test.go
@@ -82,14 +82,21 @@ func TestTLSConfigKey(t *testing.T) {
 	keyFile2, removeKeyFile2Fn := writeBytesToFile(t, []byte{2})
 	defer removeKeyFile2Fn(t)
 
+	caFile1, removeCAFile1Fn := writeBytesToFile(t, []byte{1})
+	defer removeCAFile1Fn(t)
+	caFile2, removeCAFile2Fn := writeBytesToFile(t, []byte{2})
+	defer removeCAFile2Fn(t)
+
 	uniqueConfigurations := map[string]*Config{
-		"proxy":    {Proxy: func(request *http.Request) (*url.URL, error) { return nil, nil }},
-		"no tls":   {},
-		"dialer":   {DialHolder: &DialHolder{Dial: dialer.DialContext}},
-		"dialer2":  {DialHolder: &DialHolder{Dial: func(ctx context.Context, network, address string) (net.Conn, error) { return nil, nil }}},
-		"insecure": {TLS: TLSConfig{Insecure: true}},
-		"cadata 1": {TLS: TLSConfig{CAData: []byte{1}}},
-		"cadata 2": {TLS: TLSConfig{CAData: []byte{2}}},
+		"proxy":     {Proxy: func(request *http.Request) (*url.URL, error) { return nil, nil }},
+		"no tls":    {},
+		"dialer":    {DialHolder: &DialHolder{Dial: dialer.DialContext}},
+		"dialer2":   {DialHolder: &DialHolder{Dial: func(ctx context.Context, network, address string) (net.Conn, error) { return nil, nil }}},
+		"insecure":  {TLS: TLSConfig{Insecure: true}},
+		"cadata 1":  {TLS: TLSConfig{CAData: []byte{1}}},
+		"cadata 2":  {TLS: TLSConfig{CAData: []byte{2}}},
+		"ca file 1": {TLS: TLSConfig{CAFile: caFile1}},
+		"ca file 2": {TLS: TLSConfig{CAFile: caFile2}},
 		"cert 1, key 1": {
 			TLS: TLSConfig{
 				CertData: []byte{1},
@@ -142,6 +149,20 @@ func TestTLSConfigKey(t *testing.T) {
 				KeyData:  []byte{1},
 			},
 		},
+		"ca file 1, cert 1, key 1": {
+			TLS: TLSConfig{
+				CAFile:   caFile1,
+				CertData: []byte{1},
+				KeyData:  []byte{1},
+			},
+		},
+		"ca file 2, cert 1, key 1": {
+			TLS: TLSConfig{
+				CAFile:   caFile2,
+				CertData: []byte{1},
+				KeyData:  []byte{1},
+			},
+		},
 		"cert file 1, key file 1": {
 			TLS: TLSConfig{
 				CertFile: certFile1,
@@ -158,6 +179,14 @@ func TestTLSConfigKey(t *testing.T) {
 		"cadata 1, cert file 1, key file 1, servername 1": {
 			TLS: TLSConfig{
 				CAData:     []byte{1},
+				CertFile:   certFile1,
+				KeyFile:    keyFile1,
+				ServerName: "1",
+			},
+		},
+		"ca file 1, cert file 1, key file 1, servername 1": {
+			TLS: TLSConfig{
+				CAFile:     caFile1,
 				CertFile:   certFile1,
 				KeyFile:    keyFile1,
 				ServerName: "1",
@@ -191,6 +220,13 @@ func TestTLSConfigKey(t *testing.T) {
 		"cadata 1, cert file 1, key file 1": {
 			TLS: TLSConfig{
 				CAData:   []byte{1},
+				CertFile: certFile1,
+				KeyFile:  keyFile1,
+			},
+		},
+		"ca file 1, cert file 1, key file 1": {
+			TLS: TLSConfig{
+				CAFile:   caFile1,
 				CertFile: certFile1,
 				KeyFile:  keyFile1,
 			},

--- a/staging/src/k8s.io/client-go/transport/config.go
+++ b/staging/src/k8s.io/client-go/transport/config.go
@@ -132,6 +132,7 @@ func (c *Config) Wrap(fn WrapperFunc) {
 // TLSConfig holds the information needed to set up a TLS transport.
 type TLSConfig struct {
 	CAFile         string // Path of the PEM-encoded server trusted root certificates.
+	ReloadCAFile   bool   // Set to indicate that the root CA file should be reloaded.
 	CertFile       string // Path of the PEM-encoded client certificate.
 	KeyFile        string // Path of the PEM-encoded client key.
 	ReloadTLSFiles bool   // Set to indicate that the original config provided files, and that they should be reloaded

--- a/staging/src/k8s.io/client-go/transport/reloadable.go
+++ b/staging/src/k8s.io/client-go/transport/reloadable.go
@@ -1,0 +1,181 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package transport
+
+import (
+	"bytes"
+	"context"
+	"crypto/x509"
+	"fmt"
+	"net/http"
+	"os"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
+)
+
+const (
+	dynamicRootCATransportControllerName = "DynamicRootCA"
+	queueKey                             = "dynamic-root-ca-key"
+)
+
+func newDynamicRootCATransport(transport *http.Transport) *dynamicRootCATransport {
+	p := &atomic.Pointer[http.Transport]{}
+	p.Store(transport)
+	return &dynamicRootCATransport{p: p}
+}
+
+func newRootCASyncer(dt *dynamicRootCATransport, caFile string, caBytes []byte) *rootCASyncer {
+	return &rootCASyncer{
+		dynamicRootCATransport: dt,
+		caFile:                 caFile,
+		caBytes:                caBytes,
+	}
+}
+
+// the controller uses this abstraction to periodically
+// refresh the reloadable transport object.
+type syncer interface {
+	sync() error
+}
+
+func newDynamicRootCATransportController(syncer syncer) *dynamicRootCATransportController {
+	// TODO: the default has an exponential failure rate limiter with a base
+	// delay of 5ms which may be more aggressive than what we need here
+	queue := workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), dynamicRootCATransportControllerName)
+	controller := &dynamicRootCATransportController{queue: queue, syncer: syncer}
+	controller.queueAdderFn = func(stopCtx context.Context) {
+		// same interval as dynamic client cert rotation
+		err := wait.PollUntilContextCancel(stopCtx, CertCallbackRefreshDuration, true, func(_ context.Context) (bool, error) {
+			queue.Add(queueKey)
+			return false, nil
+		})
+		klog.V(3).InfoS("Controller queue add function has finished", "name", dynamicRootCATransportControllerName, "err", err)
+	}
+	return controller
+}
+
+type dynamicRootCATransport struct {
+	p *atomic.Pointer[http.Transport]
+}
+
+func (dt *dynamicRootCATransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	transport := dt.p.Load()
+	return transport.RoundTrip(req)
+}
+
+func (dt *dynamicRootCATransport) WrappedRoundTripper() http.RoundTripper {
+	// TODO: side effects for exposing the internal transport object?
+	return dt.p.Load()
+}
+
+func (dt *dynamicRootCATransport) refresh(rootCAs *x509.CertPool) *http.Transport {
+	old := dt.p.Load()
+	new := old.Clone()
+	new.TLSClientConfig.RootCAs = rootCAs
+	dt.p.Store(new)
+	return old
+}
+
+type rootCASyncer struct {
+	*dynamicRootCATransport
+
+	lock    sync.Mutex
+	caBytes []byte
+	caFile  string
+}
+
+// sync refreshes the transport object with a new root CA certificate,
+// if the file has been written to with a new CA.
+func (r *rootCASyncer) sync() error {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	newCABytes, err := os.ReadFile(r.caFile)
+	if err != nil {
+		return fmt.Errorf("failed to read CA file: %q - err: %w", r.caFile, err)
+	}
+	if len(newCABytes) == 0 {
+		klog.InfoS("CA file is empty", "file", r.caFile)
+		return nil
+	}
+	if bytes.Equal(newCABytes, r.caBytes) {
+		return nil
+	}
+
+	rootCAs, err := rootCertPool(newCABytes)
+	if err != nil {
+		return fmt.Errorf("failed to build cert pool from CA file: %q - err: %w", r.caFile, err)
+	}
+
+	old := r.refresh(rootCAs)
+	r.caBytes = newCABytes
+	klog.InfoS("Root CA has been reloaded", "controller", dynamicRootCATransportControllerName, "file", r.caFile)
+
+	old.CloseIdleConnections()
+	return nil
+}
+
+type dynamicRootCATransportController struct {
+	queue workqueue.RateLimitingInterface
+	// this function is responsible for adding keys to the queue,
+	// it will be executed asynchronusly in a new goroutine.
+	// it makes unit tests flake free and not dependent on time.Sleep
+	queueAdderFn func(stopCtx context.Context)
+	// this is the work function that refreshes the transport
+	syncer syncer
+}
+
+func (c *dynamicRootCATransportController) Run(stopCtx context.Context) {
+	defer utilruntime.HandleCrash()
+	defer c.queue.ShutDown()
+
+	klog.V(3).InfoS("Controller is starting", "name", dynamicRootCATransportControllerName)
+	defer klog.V(3).InfoS("Controller is shutting down", "name", dynamicRootCATransportControllerName)
+
+	go wait.Until(c.runWorker, time.Second, stopCtx.Done())
+	go wait.Until(func() { c.queueAdderFn(stopCtx) }, time.Second, stopCtx.Done())
+
+	<-stopCtx.Done()
+}
+
+func (c *dynamicRootCATransportController) runWorker() {
+	for c.processNextWorkItem() {
+	}
+}
+
+func (c *dynamicRootCATransportController) processNextWorkItem() bool {
+	dsKey, quit := c.queue.Get()
+	if quit {
+		return false
+	}
+	defer c.queue.Done(dsKey)
+
+	if err := c.syncer.sync(); err != nil {
+		utilruntime.HandleError(fmt.Errorf("[%s]: %v failed with: %w", dynamicRootCATransportControllerName, dsKey, err))
+		c.queue.AddRateLimited(dsKey)
+		return true
+	}
+
+	c.queue.Forget(dsKey)
+	return true
+}

--- a/staging/src/k8s.io/client-go/transport/reloadable_test.go
+++ b/staging/src/k8s.io/client-go/transport/reloadable_test.go
@@ -1,0 +1,709 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package transport
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"io"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"net/http/httptrace"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+func TestNewReloadableTransport(t *testing.T) {
+	want := &http.Transport{}
+	dt := newDynamicRootCATransport(want)
+	if got := dt.p.Load(); want != got {
+		t.Errorf("expected the original transport object: %p, but got: %p", want, got)
+	}
+	if got := dt.WrappedRoundTripper(); want != got {
+		t.Errorf("expected the original transport object: %p, but got: %p", want, got)
+	}
+
+	want = &http.Transport{}
+	dt.p.Store(want)
+	if got := dt.WrappedRoundTripper(); want != got {
+		t.Errorf("expected the original transport object: %p, but got: %p", want, got)
+	}
+}
+
+func TestReloadableTransportWithConfigAndCache(t *testing.T) {
+	ca := setupCA(t)
+	caFileName, removeFn := writeCACertToFile(t, ca.PEM)
+	defer removeFn(t)
+
+	getReloadableFn := func(rt http.RoundTripper) *dynamicRootCATransport {
+		for {
+			if rt == nil {
+				return nil
+			}
+			switch transport := rt.(type) {
+			case *dynamicRootCATransport:
+				return transport
+			case interface{ WrappedRoundTripper() http.RoundTripper }:
+				rt = transport.WrappedRoundTripper()
+			default:
+				return nil
+			}
+		}
+	}
+
+	config1 := &Config{
+		TLS: TLSConfig{
+			CAFile: caFileName,
+		},
+	}
+	key, _, err := tlsConfigKey(config1)
+	if err != nil {
+		t.Errorf("did not expect any error from tlsConfigKey: %v", err)
+	}
+
+	rt1, err := New(config1)
+	if err != nil {
+		t.Errorf("did not expect an error from New: %v", err)
+		return
+	}
+	reloadable1 := getReloadableFn(rt1)
+	if reloadable1 == nil {
+		t.Errorf("expected the given RoundTripper object to have an embedded %T", &dynamicRootCATransport{})
+		return
+	}
+	if cached, ok := tlsCache.transports[key]; !ok || cached != reloadable1 {
+		t.Errorf("expected the reloadable transport to be cached")
+	}
+
+	config2 := config1
+	rt2, err := New(config2)
+	if err != nil {
+		t.Errorf("did not expect an error from New: %v", err)
+		return
+	}
+	reloadable2 := getReloadableFn(rt2)
+	if reloadable2 == nil {
+		t.Errorf("expected the given RoundTripper object to have an embedded %T", &dynamicRootCATransport{})
+		return
+	}
+	if cached, ok := tlsCache.transports[key]; !ok || cached != reloadable2 {
+		t.Errorf("expected the reloadable transport to be cached")
+	}
+	if reloadable1 != reloadable2 {
+		t.Errorf("expected a single reloadable instance")
+	}
+
+	config3 := &Config{
+		TLS: TLSConfig{
+			CAFile: caFileName,
+		},
+	}
+	key, _, err = tlsConfigKey(config3)
+	if err != nil {
+		t.Errorf("did not expect any error from tlsConfigKey: %v", err)
+	}
+	rt3, err := New(config1)
+	if err != nil {
+		t.Errorf("did not expect an error from New: %v", err)
+		return
+	}
+	reloadable3 := getReloadableFn(rt3)
+	if reloadable3 == nil {
+		t.Errorf("expected the given RoundTripper object to have an embedded %T", &dynamicRootCATransport{})
+		return
+	}
+	if cached, ok := tlsCache.transports[key]; !ok || cached != reloadable3 {
+		t.Errorf("expected the reloadable transport to be cached")
+	}
+	if reloadable2 != reloadable3 {
+		t.Errorf("expected a single reloadable instance")
+	}
+}
+
+type fakeSyncer struct {
+	invokedCh chan time.Time
+}
+
+func (fs *fakeSyncer) sync() error {
+	fs.invokedCh <- time.Now()
+	return errors.New("always fail")
+}
+
+func TestReloadableTransportControllerRetry(t *testing.T) {
+	syncer := &fakeSyncer{invokedCh: make(chan time.Time, 1)}
+	var once sync.Once
+	keyAddedCh := make(chan struct{})
+	controller := newDynamicRootCATransportController(syncer)
+	// add a key once, and see how many attempt(s) are made
+	controller.queueAdderFn = func(stopCtx context.Context) {
+		once.Do(func() {
+			defer close(keyAddedCh)
+			controller.queue.Add(queueKey)
+		})
+		<-stopCtx.Done()
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	go controller.Run(ctx)
+
+	select {
+	case <-keyAddedCh:
+	case <-time.After(wait.ForeverTestTimeout):
+		t.Errorf("expected the sync to have completed")
+		return
+	}
+
+	var attempts int
+	var lastAt time.Time
+	intervals := make([]time.Duration, 0)
+	func() {
+		for {
+			select {
+			case at, ok := <-syncer.invokedCh:
+				if !ok {
+					t.Errorf("the channel closed unexpectedly")
+					return
+				}
+				attempts++
+				if !lastAt.IsZero() {
+					intervals = append(intervals, at.Sub(lastAt))
+				}
+				lastAt = at
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	if attempts < 2 {
+		t.Errorf("expected sync attempts to be 2+, but got: %d", attempts)
+	}
+	t.Logf("attempts: %d, intervals: %v", attempts, intervals)
+}
+
+func TestSync(t *testing.T) {
+	ca1 := setupCA(t)
+	caFileName, removeFn := writeCACertToFile(t, ca1.PEM)
+	defer removeFn(t)
+
+	original := &http.Transport{TLSClientConfig: &tls.Config{}}
+	rt := newDynamicRootCATransport(original)
+	syncer := newRootCASyncer(rt, caFileName, ca1.PEM)
+
+	// reloadable transport is a long lived object, so use a single
+	// instance to exercise various aspects of sync operations.
+	t.Run("no change in file content, no new transport", func(t *testing.T) {
+		if err := syncer.sync(); err != nil {
+			t.Errorf("expected no error from sync, but got: %v", err)
+		}
+		if want, got := original, rt.WrappedRoundTripper(); want != got {
+			t.Errorf("expected the original transport object: %p, but got: %p", want, got)
+		}
+		if !bytes.Equal(syncer.caBytes, ca1.PEM) {
+			t.Errorf("the CA data has changed unexpectedly")
+		}
+	})
+
+	t.Run("bad bytes, now new transport", func(t *testing.T) {
+		if err := os.WriteFile(caFileName, []byte("foo/bar"), 0664); err != nil {
+			t.Fatalf("did not expect any error while writing to the CA file %q: %v", caFileName, err)
+		}
+		if err := syncer.sync(); err == nil {
+			t.Errorf("expected an error from sync")
+		}
+		if want, got := original, rt.WrappedRoundTripper(); want != got {
+			t.Errorf("expected the original transport object: %p, but got: %p", want, got)
+		}
+		if !bytes.Equal(syncer.caBytes, ca1.PEM) {
+			t.Errorf("the CA data has changed unexpectedly")
+		}
+	})
+
+	t.Run("empty file, no new transport", func(t *testing.T) {
+		if err := os.WriteFile(caFileName, []byte{}, 0664); err != nil {
+			t.Fatalf("did not expect any error while writing to the CA file %q: %v", caFileName, err)
+		}
+		if err := syncer.sync(); err != nil {
+			t.Errorf("expected no error from sync, but got: %v", err)
+		}
+		if want, got := original, rt.WrappedRoundTripper(); want != got {
+			t.Errorf("expected the original transport object: %p, but got: %p", want, got)
+		}
+		if !bytes.Equal(syncer.caBytes, ca1.PEM) {
+			t.Errorf("the CA data has changed unexpectedly")
+		}
+	})
+
+	t.Run("new and valid root CA cert has been written to the file, new transport", func(t *testing.T) {
+		oldRootCAs := rt.p.Load().TLSClientConfig.RootCAs
+		ca2 := setupCA(t)
+		if err := os.WriteFile(caFileName, ca2.PEM, 0664); err != nil {
+			t.Fatalf("did not expect any error while writing to the CA file %q: %v", caFileName, err)
+		}
+		if err := syncer.sync(); err != nil {
+			t.Errorf("expected no error from sync, but got: %v", err)
+		}
+		if got := rt.WrappedRoundTripper(); original == got {
+			t.Errorf("expected a new transport object: old: %p, new: %p", original, got)
+		}
+		if !bytes.Equal(syncer.caBytes, ca2.PEM) {
+			t.Errorf("expected the new CA data to be stored")
+		}
+		if newTransort := rt.p.Load(); newTransort.TLSClientConfig.RootCAs == oldRootCAs {
+			t.Errorf("expected the new RootCAs to be in use")
+		}
+	})
+}
+
+func TestReloadableTransport(t *testing.T) {
+	serverName := "s1.k8s.io"
+	ca1, ca2, caUnknown := setupCA(t), setupCA(t), setupCA(t)
+	serverCert1 := setupServerCertWithCA(t, ca1, serverName)
+	serverCert2 := setupServerCertWithCA(t, ca2, serverName)
+
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if _, err := w.Write([]byte("pong")); err != nil {
+			t.Errorf("did not expect error from Write: %v", err)
+		}
+	}))
+	serverSwitchCertCh := make(chan struct{})
+	server.TLS = &tls.Config{
+		// the server maintains two certificates:
+		//  a) server cert 1: signed by ca1
+		//  b) server cert 2: signed by ca2
+		// the test dictates which one to send to the client
+		GetCertificate: func(ch *tls.ClientHelloInfo) (*tls.Certificate, error) {
+			select {
+			case <-serverSwitchCertCh:
+				return &serverCert2, nil
+			default:
+				return &serverCert1, nil
+			}
+		},
+	}
+	defer server.Close()
+	server.StartTLS()
+
+	caFileName, removeFn := writeCACertToFile(t, ca1.PEM)
+	defer removeFn(t)
+	config := &Config{
+		TLS: TLSConfig{
+			ServerName: serverName,
+			NextProtos: []string{"http/1.1"},
+			CAFile:     caFileName, // should point to ca1
+		},
+	}
+	tlsConfig, err := TLSConfigFor(config)
+	if err != nil {
+		t.Errorf("did not expect TLSConfigFor to return an error: %v", err)
+		return
+	}
+
+	// keep connection reuse enabled, so we can verify that the reloadable
+	// transport works as expected with cached connections.
+	transport := &http.Transport{TLSClientConfig: tlsConfig}
+	rt := newDynamicRootCATransport(transport)
+	syncer := newRootCASyncer(rt, caFileName, ca1.PEM)
+	client := &http.Client{Transport: rt}
+
+	// step 1: the server is configured to send cert 1 to the client, the
+	// reloadable transport points to ca1
+	resp, err := do(t, client, server.URL+"/ping", shouldUseNewConnection)
+	expectStatusOK(t, resp, err)
+	resp, err = do(t, client, server.URL+"/ping", shouldUseExistingConnection)
+	expectStatusOK(t, resp, err)
+
+	// step 2: overwrite the CA file with an unknown CA, reload the
+	// transport, the server should return a TLS error.
+	if err := os.WriteFile(caFileName, caUnknown.PEM, 0664); err != nil {
+		t.Errorf("did not expect any error while writing to the CA file %q: %v", caFileName, err)
+		return
+	}
+	if err := syncer.sync(); err != nil {
+		t.Errorf("did not expect any error from ReloadCA: %v", err)
+		return
+	}
+	resp, err = do(t, client, server.URL+"/ping", shouldNotGotConn)
+	expectTLSError(t, resp, err, "x509: certificate signed by unknown authority")
+
+	// step 3: overwrite ths CA file file with ca2 and sync, we expect the
+	// server to return an error
+	if err := os.WriteFile(caFileName, ca2.PEM, 0664); err != nil {
+		t.Errorf("did not expect any error while writing to the CA file %q: %v", caFileName, err)
+		return
+	}
+	if err := syncer.sync(); err != nil {
+		t.Errorf("did not expect any error from ReloadCA: %v", err)
+		return
+	}
+
+	resp, err = do(t, client, server.URL+"/ping", shouldNotGotConn)
+	expectTLSError(t, resp, err, "x509: certificate signed by unknown authority")
+
+	// switch the server to send server cert 2
+	close(serverSwitchCertCh)
+
+	resp, err = do(t, client, server.URL+"/ping", shouldUseNewConnection)
+	expectStatusOK(t, resp, err)
+	resp, err = do(t, client, server.URL+"/ping", shouldUseExistingConnection)
+	expectStatusOK(t, resp, err)
+
+	// let's revist the old transport, it should not be able to make new connectons
+	// but the old connection should be able to talk to the server
+	client = &http.Client{Transport: transport}
+	resp, err = do(t, client, server.URL+"/ping", shouldNotGotConn)
+	expectTLSError(t, resp, err, "x509: certificate signed by unknown authority")
+}
+
+func TestReloadableTransportWithController(t *testing.T) {
+	serverName := "s1.k8s.io"
+	ca1, ca2, caUnknown := setupCA(t), setupCA(t), setupCA(t)
+	serverCert1 := setupServerCertWithCA(t, ca1, serverName)
+	serverCert2 := setupServerCertWithCA(t, ca2, serverName)
+
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if _, err := w.Write([]byte("pong")); err != nil {
+			t.Errorf("did not expect error from Write: %v", err)
+		}
+	}))
+	serverSwitchCertCh := make(chan struct{})
+	server.TLS = &tls.Config{
+		// the server maintains two certificates:
+		//  a) server cert 1: signed by ca1
+		//  b) server cert 2: signed by ca2
+		// the test dictates which one to send to the client
+		GetCertificate: func(ch *tls.ClientHelloInfo) (*tls.Certificate, error) {
+			select {
+			case <-serverSwitchCertCh:
+				return &serverCert2, nil
+			default:
+				return &serverCert1, nil
+			}
+		},
+	}
+	defer server.Close()
+	server.EnableHTTP2 = true
+	server.StartTLS()
+
+	caFileName, removeFn := writeCACertToFile(t, ca1.PEM)
+	defer removeFn(t)
+	config := &Config{
+		TLS: TLSConfig{
+			ServerName: serverName,
+			CAFile:     caFileName, // should point to ca1
+			NextProtos: []string{"h2"},
+		},
+	}
+	tlsConfig, err := TLSConfigFor(config)
+	if err != nil {
+		t.Errorf("did not expect TLSConfigFor to return an error: %v", err)
+		return
+	}
+
+	// keep connection reuse enabled, so we can verify that the reloadable
+	// transport works as expected with cached connections.
+	transport := &http.Transport{TLSClientConfig: tlsConfig, ForceAttemptHTTP2: true}
+
+	reloadable := newDynamicRootCATransport(transport)
+	syncer := &withSyncCount{
+		rootCASyncer: newRootCASyncer(reloadable, caFileName, ca1.PEM),
+		syncedCh:     make(chan error, 1),
+	}
+	client := &http.Client{Transport: reloadable}
+
+	syncCh := make(chan struct{}, 1)
+	controller := newDynamicRootCATransportController(syncer)
+	controller.queueAdderFn = func(stopCtx context.Context) {
+		for {
+			select {
+			case _, ok := <-syncCh:
+				if !ok {
+					return
+				}
+				controller.queue.Add(queueKey)
+			case <-stopCtx.Done():
+				return
+			}
+		}
+	}
+	triggerSyncAndWaitFn := func() error {
+		syncCh <- struct{}{}
+		select {
+		case err, ok := <-syncer.syncedCh:
+			if !ok {
+				return errors.New("did not expect the channel to be closed")
+			}
+			return err
+		case <-time.After(wait.ForeverTestTimeout):
+			return errors.New("expected the sync to have completed")
+		}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go controller.Run(ctx)
+
+	// step 1: server is on serving cert 1, the reloadable transport points
+	// to ca1, so we expect success.
+	resp, err := do(t, client, server.URL+"/ping", shouldUseNewConnection)
+	expectStatusOK(t, resp, err)
+	resp, err = do(t, client, server.URL+"/ping", shouldUseExistingConnection)
+	expectStatusOK(t, resp, err)
+
+	// step 2: overwrite the CA file with an unknown CA, wait for the
+	// transport to be reloaded; the server should return a TLS error.
+	if err := os.WriteFile(caFileName, caUnknown.PEM, 0664); err != nil {
+		t.Fatalf("did not expect any error while writing to the CA file %q: %v", caFileName, err)
+	}
+	if err := triggerSyncAndWaitFn(); err != nil {
+		t.Fatalf("sync error: %v", err)
+	}
+
+	// reloadable has refreshed the underlying http.Transport object,
+	// we expect TLS error, so no successful connection setup
+	resp, err = do(t, client, server.URL+"/ping", shouldNotGotConn)
+	expectTLSError(t, resp, err, "x509: certificate signed by unknown authority")
+
+	// step 3: overwrite ths CA file file with ca2, and have the server be
+	// serving on server cert 2 now.
+	if err := os.WriteFile(caFileName, ca2.PEM, 0664); err != nil {
+		t.Fatalf("did not expect any error while writing to the CA file %q: %v", caFileName, err)
+	}
+	if err := triggerSyncAndWaitFn(); err != nil {
+		t.Fatalf("sync error: %v", err)
+	}
+	// switch the server to send server cert 2
+	close(serverSwitchCertCh)
+
+	// reloadable has refreshed the underlying http.Transport object, the
+	resp, err = do(t, client, server.URL+"/ping", shouldUseNewConnection)
+	expectStatusOK(t, resp, err)
+	resp, err = do(t, client, server.URL+"/ping", shouldUseExistingConnection)
+	expectStatusOK(t, resp, err)
+
+	// let's revist the old transport, it should not be able to make new connectons
+	// but the old connection should be able to talk to the server
+	client = &http.Client{Transport: transport}
+	resp, err = do(t, client, server.URL+"/ping", shouldNotGotConn)
+	expectTLSError(t, resp, err, "x509: certificate signed by unknown authority")
+}
+
+func do(t *testing.T, client *http.Client, url string, f func(*testing.T, httptrace.GotConnInfo)) (*http.Response, error) {
+	t.Helper()
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		t.Fatalf("failed to create new request: %v", err)
+	}
+
+	trace := &httptrace.ClientTrace{
+		GotConn: func(ci httptrace.GotConnInfo) {
+			t.Logf("GotConnInfo: %+v", ci)
+			f(t, ci)
+		},
+	}
+	req = req.WithContext(httptrace.WithClientTrace(req.Context(), trace))
+	resp, err := client.Do(req)
+	// the content of the response body is not asserted on, so discard it here.
+	if resp != nil {
+		if _, err = io.Copy(io.Discard, resp.Body); err != nil {
+			t.Errorf("unexpected error while reading the Response Body: %v", err)
+		}
+		if err := resp.Body.Close(); err != nil {
+			t.Errorf("unexpected error while closing the Body of the Response object: %v", err)
+		}
+	}
+	return resp, err
+}
+
+func shouldUseExistingConnection(t *testing.T, ci httptrace.GotConnInfo) {
+	t.Helper()
+	if !ci.Reused {
+		t.Errorf("expected an existing TCP connection to be reused, but got: %+v", ci)
+	}
+}
+
+func shouldUseNewConnection(t *testing.T, ci httptrace.GotConnInfo) {
+	t.Helper()
+	if ci.Reused {
+		t.Errorf("expected a new connection, but got: %+v", ci)
+	}
+}
+
+func shouldNotGotConn(t *testing.T, ci httptrace.GotConnInfo) {
+	t.Helper()
+	t.Errorf("unexpected GotConnInfo: %+v", ci)
+}
+
+type withSyncCount struct {
+	*rootCASyncer
+	syncedCh chan error
+}
+
+func (r *withSyncCount) sync() error {
+	var err error
+	defer func() {
+		if r.syncedCh != nil {
+			r.syncedCh <- err
+		}
+	}()
+	err = r.rootCASyncer.sync()
+	return err
+}
+
+type ca struct {
+	PEM           []byte
+	privateKeyPEM []byte
+	certificate   *x509.Certificate
+	privateKey    *rsa.PrivateKey
+}
+
+func writeCACertToFile(t *testing.T, bytes []byte) (string, func(*testing.T)) {
+	t.Helper()
+	f, err := os.CreateTemp("", "test-*-ca.crt")
+	if err != nil {
+		t.Fatalf("unexpected error while creating a temporary file: %v", err)
+	}
+	if _, err := f.Write(bytes); err != nil {
+		t.Fatalf("unexpected error while writing to the ca file %q: %v", f.Name(), err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("unexpected error while closing the ca file %q: %v", f.Name(), err)
+	}
+	return f.Name(), func(t *testing.T) {
+		if err := os.Remove(f.Name()); err != nil {
+			t.Errorf("unexpected error while removing file: %q - %v", f.Name(), err)
+		}
+	}
+}
+
+func setupCA(t *testing.T) ca {
+	t.Helper()
+	caPrivateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate private key: %v", err)
+	}
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			CommonName: fmt.Sprintf("ca@%d", time.Now().Unix()),
+		},
+		NotBefore:             time.Unix(0, 0),
+		NotAfter:              time.Now().Add(time.Hour * 24 * 365 * 100),
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+
+	caBytes, err := x509.CreateCertificate(rand.Reader, template, template, &caPrivateKey.PublicKey, caPrivateKey)
+	if err != nil {
+		t.Fatalf("failed to generate ca certificate: %v", err)
+	}
+	caPEM := bytes.Buffer{}
+	if err := pem.Encode(&caPEM, &pem.Block{Type: "CERTIFICATE", Bytes: caBytes}); err != nil {
+		t.Fatalf("failed to PEM encode the ca certificate: %v", err)
+	}
+	caPrivKeyPEM := bytes.Buffer{}
+	if err := pem.Encode(&caPrivKeyPEM, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(caPrivateKey)}); err != nil {
+		t.Fatalf("failed to PEM encode the ca key: %v", err)
+	}
+
+	return ca{PEM: caPEM.Bytes(), privateKeyPEM: caPrivKeyPEM.Bytes(), privateKey: caPrivateKey, certificate: template}
+}
+
+func setupServerCertWithCA(t *testing.T, ca ca, serverName string) tls.Certificate {
+	t.Helper()
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject: pkix.Name{
+			CommonName: fmt.Sprintf("server@%d", time.Now().Unix()),
+		},
+		DNSNames:     []string{serverName},
+		NotBefore:    time.Unix(0, 0),
+		NotAfter:     time.Now().Add(time.Hour * 24 * 365 * 100),
+		SubjectKeyId: []byte{1, 2, 3, 4, 6},
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+	}
+
+	serverPrivateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate private key: %v", err)
+	}
+	serverCertBytes, err := x509.CreateCertificate(rand.Reader, template, ca.certificate, &serverPrivateKey.PublicKey, ca.privateKey)
+	if err != nil {
+		t.Fatalf("failed to generate server certificate: %v", err)
+	}
+
+	serverCertPEM := bytes.Buffer{}
+	if err := pem.Encode(&serverCertPEM, &pem.Block{Type: "CERTIFICATE", Bytes: serverCertBytes}); err != nil {
+		t.Fatalf("failed to PEM encode the server certificate: %v", err)
+	}
+	serverPriKeyPEM := bytes.Buffer{}
+	if err := pem.Encode(&serverPriKeyPEM, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(serverPrivateKey)}); err != nil {
+		t.Fatalf("failed to PEM encode the server key: %v", err)
+	}
+
+	serverCertKP, err := tls.X509KeyPair(serverCertPEM.Bytes(), serverPriKeyPEM.Bytes())
+	if err != nil {
+		t.Fatalf("failed to generate server certificate: %v", err)
+	}
+	return serverCertKP
+}
+
+func expectStatusOK(t *testing.T, resp *http.Response, err error) {
+	t.Helper()
+	if err != nil {
+		t.Errorf("expected no error, but got: %#v", err)
+		return
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected status code: %d, but got: %v", http.StatusOK, resp)
+	}
+}
+
+func expectTLSError(t *testing.T, resp *http.Response, err error, shouldContain string) {
+	t.Helper()
+	if resp != nil {
+		t.Errorf("did not expect a response from the server, but got: %v", resp)
+		return
+	}
+	var wantErr *tls.CertificateVerificationError
+	if !errors.As(err, &wantErr) {
+		t.Errorf("expected an error: %v, but got: %#v", tls.CertificateVerificationError{}, err)
+		return
+	}
+	if !strings.Contains(wantErr.Error(), shouldContain) {
+		t.Errorf("expected internal error to contain: %q, but got: %v", shouldContain, wantErr)
+	}
+}

--- a/staging/src/k8s.io/client-go/transport/transport.go
+++ b/staging/src/k8s.io/client-go/transport/transport.go
@@ -211,6 +211,10 @@ func TLSConfigFor(c *Config) (*tls.Config, error) {
 // KeyData, and CAFile fields, or returns an error. If no error is returned, all three fields are
 // either populated or were empty to start.
 func loadTLSFiles(c *Config) error {
+	if len(c.TLS.CAFile) > 0 && len(c.TLS.CAData) == 0 {
+		c.TLS.ReloadCAFile = true
+	}
+
 	var err error
 	c.TLS.CAData, err = dataFromSliceOrFile(c.TLS.CAData, c.TLS.CAFile)
 	if err != nil {

--- a/test/integration/apiserver/peerproxy/peer_proxy_test.go
+++ b/test/integration/apiserver/peerproxy/peer_proxy_test.go
@@ -54,7 +54,7 @@ func TestPeerProxiedRequest(t *testing.T) {
 	t.Cleanup(cancel)
 
 	// ensure to stop cert reloading after shutdown
-	transport.DialerStopCh = ctx.Done()
+	transport.ControllerStopCtx = ctx
 
 	// enable feature flags
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.APIServerIdentity, true)()
@@ -115,7 +115,7 @@ func TestPeerProxiedRequestToThirdServerAfterFirstDies(t *testing.T) {
 	t.Cleanup(cancel)
 
 	// ensure to stop cert reloading after shutdown
-	transport.DialerStopCh = ctx.Done()
+	transport.ControllerStopCtx = ctx
 
 	// enable feature flags
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.APIServerIdentity, true)()

--- a/test/integration/apiserver/podlogs/podlogs_test.go
+++ b/test/integration/apiserver/podlogs/podlogs_test.go
@@ -202,12 +202,12 @@ func TestPodLogsKubeletClientCertReload(t *testing.T) {
 	t.Cleanup(cancel)
 
 	origCertCallbackRefreshDuration := transport.CertCallbackRefreshDuration
-	origDialerStopCh := transport.DialerStopCh
+	origControllerStopCtx := transport.ControllerStopCtx
 	transport.CertCallbackRefreshDuration = time.Second // make client cert reloading fast
-	transport.DialerStopCh = ctx.Done()
+	transport.ControllerStopCtx = ctx
 	t.Cleanup(func() {
 		transport.CertCallbackRefreshDuration = origCertCallbackRefreshDuration
-		transport.DialerStopCh = origDialerStopCh
+		transport.ControllerStopCtx = origControllerStopCtx
 	})
 
 	// create a CA to sign the API server's kubelet client cert

--- a/test/integration/client/cert_rotation_test.go
+++ b/test/integration/client/cert_rotation_test.go
@@ -42,11 +42,11 @@ import (
 )
 
 func TestCertRotation(t *testing.T) {
-	stopCh := make(chan struct{})
-	defer close(stopCh)
+	stopCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	transport.CertCallbackRefreshDuration = 1 * time.Second
-	transport.DialerStopCh = stopCh
+	transport.ControllerStopCtx = stopCtx
 
 	certDir := os.TempDir()
 	clientCAFilename, clientSigningCert, clientSigningKey := writeCACertFiles(t, certDir)
@@ -100,11 +100,11 @@ func TestCertRotation(t *testing.T) {
 }
 
 func TestCertRotationContinuousRequests(t *testing.T) {
-	stopCh := make(chan struct{})
-	defer close(stopCh)
+	stopCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	transport.CertCallbackRefreshDuration = 1 * time.Second
-	transport.DialerStopCh = stopCh
+	transport.ControllerStopCtx = stopCtx
 
 	certDir := os.TempDir()
 	clientCAFilename, clientSigningCert, clientSigningKey := writeCACertFiles(t, certDir)


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
Automatic reloading of root CA file, based on the idea from: https://github.com/kubernetes/kubernetes/pull/122749 

#### Which issue(s) this PR fixes:

Fixes #119483

#### Special notes for your reviewer:

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
