### PR TITLE
client-go/tools/record: use struct as LRU key

### DIFF
--- a/staging/src/k8s.io/client-go/tools/record/event_test.go
+++ b/staging/src/k8s.io/client-go/tools/record/event_test.go
@@ -70,7 +70,7 @@ func (t *testEventSink) Patch(e *v1.Event, p []byte) (*v1.Event, error) {
 
 type OnCreateFunc func(*v1.Event) (*v1.Event, error)
 
-func OnCreateFactory(testCache map[string]*v1.Event, createEvent chan<- *v1.Event) OnCreateFunc {
+func OnCreateFactory(testCache map[any]*v1.Event, createEvent chan<- *v1.Event) OnCreateFunc {
 	return func(event *v1.Event) (*v1.Event, error) {
 		testCache[getEventKey(event)] = event
 		createEvent <- event
@@ -80,7 +80,7 @@ func OnCreateFactory(testCache map[string]*v1.Event, createEvent chan<- *v1.Even
 
 type OnPatchFunc func(*v1.Event, []byte) (*v1.Event, error)
 
-func OnPatchFactory(testCache map[string]*v1.Event, patchEvent chan<- *v1.Event) OnPatchFunc {
+func OnPatchFactory(testCache map[any]*v1.Event, patchEvent chan<- *v1.Event) OnPatchFunc {
 	return func(event *v1.Event, patch []byte) (*v1.Event, error) {
 		cachedEvent, found := testCache[getEventKey(event)]
 		if !found {
@@ -364,7 +364,7 @@ func TestEventf(t *testing.T) {
 		},
 	}
 
-	testCache := map[string]*v1.Event{}
+	testCache := map[any]*v1.Event{}
 	logCalled := make(chan struct{})
 	createEvent := make(chan *v1.Event)
 	updateEvent := make(chan *v1.Event)
@@ -645,7 +645,7 @@ func TestEventfNoNamespace(t *testing.T) {
 		},
 	}
 
-	testCache := map[string]*v1.Event{}
+	testCache := map[any]*v1.Event{}
 	logCalled := make(chan struct{})
 	createEvent := make(chan *v1.Event)
 	updateEvent := make(chan *v1.Event)
@@ -927,7 +927,7 @@ func TestMultiSinkCache(t *testing.T) {
 		},
 	}
 
-	testCache := map[string]*v1.Event{}
+	testCache := map[any]*v1.Event{}
 	createEvent := make(chan *v1.Event)
 	updateEvent := make(chan *v1.Event)
 	patchEvent := make(chan *v1.Event)
@@ -940,7 +940,7 @@ func TestMultiSinkCache(t *testing.T) {
 		OnPatch: OnPatchFactory(testCache, patchEvent),
 	}
 
-	testCache2 := map[string]*v1.Event{}
+	testCache2 := map[any]*v1.Event{}
 	createEvent2 := make(chan *v1.Event)
 	updateEvent2 := make(chan *v1.Event)
 	patchEvent2 := make(chan *v1.Event)

--- a/staging/src/k8s.io/client-go/tools/record/events_cache_test.go
+++ b/staging/src/k8s.io/client-go/tools/record/events_cache_test.go
@@ -283,18 +283,16 @@ func TestEventCorrelator(t *testing.T) {
 }
 
 func TestEventSpamFilter(t *testing.T) {
-	spamKeyFuncBasedOnObjectsAndReason := func(e *v1.Event) string {
-		return strings.Join([]string{
-			e.Source.Component,
-			e.Source.Host,
-			e.InvolvedObject.Kind,
-			e.InvolvedObject.Namespace,
-			e.InvolvedObject.Name,
-			string(e.InvolvedObject.UID),
-			e.InvolvedObject.APIVersion,
+	spamKeyFuncBasedOnObjectsAndReason := func(e *v1.Event) any {
+		return struct {
+			Source         v1.EventSource
+			InvolvedObject v1.ObjectReference
+			Reason         string
+		}{
+			e.Source,
+			e.InvolvedObject,
 			e.Reason,
-		},
-			"")
+		}
 	}
 	burstSize := 1
 	eventInterval := time.Duration(1) * time.Second


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

increase performance and avoid ambiguity

e.g.: these two produce the same key in the original code:
* Component="ab", Host="c"
* Component="a", Host="bc"

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

Users should change their code to change the return type of the callbacks. So, this is a breaking that is easy to fix. 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
EventSpamKeyFunc and EventAggregatorKeyFunc can return any comparable object now. 
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
