### PR TITLE
kube_codegen: expose external-applyconfigurations flag for client generation

### DIFF
--- a/staging/src/k8s.io/code-generator/kube_codegen.sh
+++ b/staging/src/k8s.io/code-generator/kube_codegen.sh
@@ -451,6 +451,10 @@ function kube::codegen::gen_openapi() {
 #   --applyconfig-name <string = "applyconfiguration">
 #     An optional override for the leaf name of the generated "applyconfiguration" directory.
 #
+#   --applyconfig-externals <string = "">
+#     An optional list of comma separated external apply configurations locations
+#     in <type-package>.<type-name>:<applyconfiguration-package> form.
+#
 #   --with-watch
 #     Enables generation of listers and informers for APIs which support WATCH.
 #
@@ -461,7 +465,7 @@ function kube::codegen::gen_openapi() {
 #     An optional override for the leaf name of the generated "informers" directory.
 #
 #   --plural-exceptions <string = "">
-#     An  optional list of comma separated plural exception definitions in Type:PluralizedType form.
+#     An optional list of comma separated plural exception definitions in Type:PluralizedType form.
 #
 function kube::codegen::gen_client() {
     local in_pkg_root=""
@@ -472,6 +476,7 @@ function kube::codegen::gen_client() {
     local clientset_versioned_name="versioned"
     local applyconfig="false"
     local applyconfig_subdir="applyconfiguration"
+    local applyconfig_external=""
     local watchable="false"
     local listers_subdir="listers"
     local informers_subdir="informers"
@@ -515,6 +520,10 @@ function kube::codegen::gen_client() {
                 ;;
             "--applyconfig-name")
                 applyconfig_subdir="$2"
+                shift 2
+                ;;
+            "--applyconfig-externals")
+                applyconfig_external="$2"
                 shift 2
                 ;;
             "--with-watch")
@@ -624,6 +633,7 @@ function kube::codegen::gen_client() {
             --go-header-file "${boilerplate}" \
             --output-base "${out_base}" \
             --output-package "${out_pkg_root}/${applyconfig_subdir}" \
+            --external-applyconfigurations "${applyconfig_external}" \
             "${inputs[@]}"
     fi
 


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:

This PR exposes `--applyconfig-externals` flag which allows overriding the external types in applyconfiguration-gen. 

#### Special notes for your reviewer:
/assign @thockin 

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
