### PR TITLE
Promote LoadBalancerIPMode to Beta

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -875,9 +875,10 @@ const (
 	// Enables In-Place Pod Vertical Scaling
 	InPlacePodVerticalScaling featuregate.Feature = "InPlacePodVerticalScaling"
 
-	// owner: @Sh4d1,@RyanAoh
+	// owner: @Sh4d1,@RyanAoh,@rikatz
 	// kep: http://kep.k8s.io/1860
 	// alpha: v1.29
+	// beta: v1.30
 	// LoadBalancerIPMode enables the IPMode field in the LoadBalancerIngress status of a Service
 	LoadBalancerIPMode featuregate.Feature = "LoadBalancerIPMode"
 
@@ -1151,7 +1152,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 
 	PodIndexLabel: {Default: true, PreRelease: featuregate.Beta},
 
-	LoadBalancerIPMode: {Default: false, PreRelease: featuregate.Alpha},
+	LoadBalancerIPMode: {Default: true, PreRelease: featuregate.Beta},
 
 	ImageMaximumGCAge: {Default: false, PreRelease: featuregate.Alpha},
 

--- a/pkg/registry/core/service/storage/storage_test.go
+++ b/pkg/registry/core/service/storage/storage_test.go
@@ -11933,8 +11933,10 @@ func TestUpdateServiceLoadBalancerStatus(t *testing.T) {
 			defer storage.Delete(ctx, svc.Name, rest.ValidateAllObjectFunc, &metav1.DeleteOptions{})
 
 			// prepare status
-			if loadbalancerIPModeInUse(tc.statusBeforeUpdate) {
-				defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.LoadBalancerIPMode, true)()
+			// Test here is negative, because starting with v1.30 the feature gate is enabled by default, so we should
+			// now disable it to do the proper test
+			if !loadbalancerIPModeInUse(tc.statusBeforeUpdate) {
+				defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.LoadBalancerIPMode, false)()
 			}
 			oldSvc := obj.(*api.Service).DeepCopy()
 			oldSvc.Status = tc.statusBeforeUpdate

--- a/pkg/registry/core/service/strategy_test.go
+++ b/pkg/registry/core/service/strategy_test.go
@@ -32,6 +32,7 @@ import (
 	_ "k8s.io/kubernetes/pkg/apis/core/install"
 	"k8s.io/kubernetes/pkg/features"
 	utilpointer "k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func TestCheckGeneratedNameError(t *testing.T) {
@@ -115,7 +116,10 @@ func TestServiceStatusStrategy(t *testing.T) {
 	newService.Status = api.ServiceStatus{
 		LoadBalancer: api.LoadBalancerStatus{
 			Ingress: []api.LoadBalancerIngress{
-				{IP: "127.0.0.2"},
+				{
+					IP:     "127.0.0.2",
+					IPMode: ptr.To(api.LoadBalancerIPModeVIP),
+				},
 			},
 		},
 	}

--- a/test/integration/apiserver/apply/reset_fields_test.go
+++ b/test/integration/apiserver/apply/reset_fields_test.go
@@ -48,7 +48,7 @@ const resetFieldsNamespace = "reset-fields-namespace"
 var resetFieldsStatusData = map[schema.GroupVersionResource]string{
 	gvr("", "v1", "persistentvolumes"):                              `{"status": {"message": "hello2"}}`,
 	gvr("", "v1", "resourcequotas"):                                 `{"status": {"used": {"cpu": "25M"}}}`,
-	gvr("", "v1", "services"):                                       `{"status": {"loadBalancer": {"ingress": [{"ip": "127.0.0.2"}]}}}`,
+	gvr("", "v1", "services"):                                       `{"status": {"loadBalancer": {"ingress": [{"ip": "127.0.0.2", "ipMode": "VIP"}]}}}`,
 	gvr("extensions", "v1beta1", "ingresses"):                       `{"status": {"loadBalancer": {"ingress": [{"ip": "127.0.0.2"}]}}}`,
 	gvr("networking.k8s.io", "v1beta1", "ingresses"):                `{"status": {"loadBalancer": {"ingress": [{"ip": "127.0.0.2"}]}}}`,
 	gvr("networking.k8s.io", "v1", "ingresses"):                     `{"status": {"loadBalancer": {"ingress": [{"ip": "127.0.0.2"}]}}}`,


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
Promote LoadBalancerIPMode feature to beta
#### Which issue(s) this PR fixes:
Part of https://github.com/kubernetes/enhancements/issues/1860

#### Special notes for your reviewer:
As this is a simple "promotion" no other change was made to the code, other than changing the default behavior of the feature flag

#### Does this PR introduce a user-facing change?
```release-note
LoadBalancerIPMode feature is now marked as Beta
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
Please use the following format for linking documentation:
- [KEP](https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/1860-kube-proxy-IP-node-binding)
- [Usage](https://kubernetes.io/docs/concepts/services-networking/service/#load-balancer-ip-mode)
