### PR TITLE
Refresh the token if the issued time is later than the system time.

### DIFF
--- a/pkg/kubelet/token/token_manager.go
+++ b/pkg/kubelet/token/token_manager.go
@@ -167,7 +167,7 @@ func (m *Manager) expired(t *authenticationv1.TokenRequest) bool {
 }
 
 // requiresRefresh returns true if the token is older than 80% of its total
-// ttl, or if the token is older than 24 hours.
+// ttl, or if the token is older than 24 hours, or if it is later than the system time.
 func (m *Manager) requiresRefresh(tr *authenticationv1.TokenRequest) bool {
 	if tr.Spec.ExpirationSeconds == nil {
 		cpy := tr.DeepCopy()
@@ -185,6 +185,10 @@ func (m *Manager) requiresRefresh(tr *authenticationv1.TokenRequest) bool {
 	}
 	// Require a refresh if within 20% of the TTL plus a jitter from the expiration time.
 	if now.After(exp.Add(-1*time.Duration((*tr.Spec.ExpirationSeconds*20)/100)*time.Second - jitter)) {
+		return true
+	}
+	// Require a refresh if the issued time is later than the system time.
+	if now.Before(iat) {
 		return true
 	}
 	return false

--- a/pkg/kubelet/token/token_manager.go
+++ b/pkg/kubelet/token/token_manager.go
@@ -166,8 +166,10 @@ func (m *Manager) expired(t *authenticationv1.TokenRequest) bool {
 	return m.clock.Now().After(t.Status.ExpirationTimestamp.Time)
 }
 
-// requiresRefresh returns true if the token is older than 80% of its total
-// ttl, or if the token is older than 24 hours, or if it is later than the system time.
+// requiresRefresh returns true if:
+// 1. token is older than 80% of its total.
+// 2. token is older than 24 hours.
+// 3. If system time leaps, the token time may be later than the system time.
 func (m *Manager) requiresRefresh(tr *authenticationv1.TokenRequest) bool {
 	if tr.Spec.ExpirationSeconds == nil {
 		cpy := tr.DeepCopy()


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

If the system time is adjusted to a time before the token's validity period, kubelet will refresh the token for the pod.

#### Which issue(s) this PR fixes:

Fixes #123415 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

None


#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
