### PR TITLE
Remove redundant CEL function binding type assertions

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/cel/lazy/lazy.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/lazy/lazy.go
@@ -99,7 +99,7 @@ func (m *MapValue) ConvertToType(typeVal ref.Type) ref.Val {
 func (m *MapValue) Equal(other ref.Val) ref.Val {
 	otherMap, ok := other.(*MapValue)
 	if !ok {
-		return types.MaybeNoSuchOverloadErr(other)
+		return types.False
 	}
 	return types.Bool(m == otherMap)
 }
@@ -165,7 +165,7 @@ func (i *iterator) ConvertToType(typeValue ref.Type) ref.Val {
 func (i *iterator) Equal(other ref.Val) ref.Val {
 	otherIterator, ok := other.(*iterator)
 	if !ok {
-		return types.MaybeNoSuchOverloadErr(other)
+		return types.False
 	}
 	return types.Bool(otherIterator == i)
 }

--- a/staging/src/k8s.io/apiserver/pkg/cel/library/authz.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/library/authz.go
@@ -260,35 +260,19 @@ func (*authz) ProgramOptions() []cel.ProgramOption {
 }
 
 func authorizerPath(arg1, arg2 ref.Val) ref.Val {
-	authz, ok := arg1.(authorizerVal)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg1)
-	}
+	authz := arg1.(authorizerVal)
+	path := arg2.(types.String)
 
-	path, ok := arg2.Value().(string)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg1)
-	}
-
-	if len(strings.TrimSpace(path)) == 0 {
+	if len(strings.TrimSpace(string(path))) == 0 {
 		return types.NewErr("path must not be empty")
 	}
-
-	return authz.pathCheck(path)
+	return authz.pathCheck(string(path))
 }
 
 func authorizerGroup(arg1, arg2 ref.Val) ref.Val {
-	authz, ok := arg1.(authorizerVal)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg1)
-	}
-
-	group, ok := arg2.Value().(string)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg1)
-	}
-
-	return authz.groupCheck(group)
+	authz := arg1.(authorizerVal)
+	group := arg2.(types.String)
+	return authz.groupCheck(string(group))
 }
 
 func authorizerServiceAccount(args ...ref.Val) ref.Val {
@@ -322,113 +306,61 @@ func authorizerServiceAccount(args ...ref.Val) ref.Val {
 }
 
 func groupCheckResource(arg1, arg2 ref.Val) ref.Val {
-	groupCheck, ok := arg1.(groupCheckVal)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg1)
-	}
+	groupCheck := arg1.(groupCheckVal)
+	resource := arg2.(types.String)
 
-	resource, ok := arg2.Value().(string)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg1)
-	}
-
-	if len(strings.TrimSpace(resource)) == 0 {
+	if len(strings.TrimSpace(string(resource))) == 0 {
 		return types.NewErr("resource must not be empty")
 	}
-	return groupCheck.resourceCheck(resource)
+	return groupCheck.resourceCheck(string(resource))
 }
 
 func resourceCheckSubresource(arg1, arg2 ref.Val) ref.Val {
-	resourceCheck, ok := arg1.(resourceCheckVal)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg1)
-	}
-
-	subresource, ok := arg2.Value().(string)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg1)
-	}
+	resourceCheck := arg1.(resourceCheckVal)
+	subresource := arg2.(types.String)
 
 	result := resourceCheck
-	result.subresource = subresource
+	result.subresource = string(subresource)
 	return result
 }
 
 func resourceCheckNamespace(arg1, arg2 ref.Val) ref.Val {
-	resourceCheck, ok := arg1.(resourceCheckVal)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg1)
-	}
-
-	namespace, ok := arg2.Value().(string)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg1)
-	}
+	resourceCheck := arg1.(resourceCheckVal)
+	namespace := arg2.(types.String)
 
 	result := resourceCheck
-	result.namespace = namespace
+	result.namespace = string(namespace)
 	return result
 }
 
 func resourceCheckName(arg1, arg2 ref.Val) ref.Val {
-	resourceCheck, ok := arg1.(resourceCheckVal)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg1)
-	}
-
-	name, ok := arg2.Value().(string)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg1)
-	}
+	resourceCheck := arg1.(resourceCheckVal)
+	name := arg2.(types.String)
 
 	result := resourceCheck
-	result.name = name
+	result.name = string(name)
 	return result
 }
 
 func pathCheckCheck(arg1, arg2 ref.Val) ref.Val {
-	pathCheck, ok := arg1.(pathCheckVal)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg1)
-	}
-
-	httpRequestVerb, ok := arg2.Value().(string)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg1)
-	}
-
-	return pathCheck.Authorize(context.TODO(), httpRequestVerb)
+	pathCheck := arg1.(pathCheckVal)
+	httpRequestVerb := arg2.(types.String)
+	return pathCheck.Authorize(context.TODO(), string(httpRequestVerb))
 }
 
 func resourceCheckCheck(arg1, arg2 ref.Val) ref.Val {
-	resourceCheck, ok := arg1.(resourceCheckVal)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg1)
-	}
-
-	apiVerb, ok := arg2.Value().(string)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg1)
-	}
-
-	return resourceCheck.Authorize(context.TODO(), apiVerb)
+	resourceCheck := arg1.(resourceCheckVal)
+	apiVerb := arg2.(types.String)
+	return resourceCheck.Authorize(context.TODO(), string(apiVerb))
 }
 
 func decisionErrored(arg ref.Val) ref.Val {
-	decision, ok := arg.(decisionVal)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg)
-	}
-
+	decision := arg.(decisionVal)
 	return types.Bool(decision.err != nil)
 }
 
 func decisionError(arg ref.Val) ref.Val {
-	decision, ok := arg.(decisionVal)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg)
-	}
-
+	decision := arg.(decisionVal)
 	if decision.err == nil {
 		return types.String("")
 	}
@@ -436,20 +368,12 @@ func decisionError(arg ref.Val) ref.Val {
 }
 
 func decisionAllowed(arg ref.Val) ref.Val {
-	decision, ok := arg.(decisionVal)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg)
-	}
-
+	decision := arg.(decisionVal)
 	return types.Bool(decision.authDecision == authorizer.DecisionAllow)
 }
 
 func decisionReason(arg ref.Val) ref.Val {
-	decision, ok := arg.(decisionVal)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg)
-	}
-
+	decision := arg.(decisionVal)
 	return types.String(decision.reason)
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/cel/library/cidr.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/library/cidr.go
@@ -166,12 +166,8 @@ func (*cidrs) ProgramOptions() []cel.ProgramOption {
 }
 
 func stringToCIDR(arg ref.Val) ref.Val {
-	s, ok := arg.Value().(string)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg)
-	}
-
-	net, err := parseCIDR(s)
+	s := arg.(types.String)
+	net, err := parseCIDR(string(s))
 	if err != nil {
 		return types.NewErr("network address parse error during conversion from string: %v", err)
 	}
@@ -182,11 +178,7 @@ func stringToCIDR(arg ref.Val) ref.Val {
 }
 
 func cidrToString(arg ref.Val) ref.Val {
-	cidr, ok := arg.(apiservercel.CIDR)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg)
-	}
-
+	cidr := arg.(apiservercel.CIDR)
 	return types.String(cidr.Prefix.String())
 }
 
@@ -199,73 +191,42 @@ func cidrContainsCIDRString(arg ref.Val, other ref.Val) ref.Val {
 }
 
 func cidrContainsIP(arg ref.Val, other ref.Val) ref.Val {
-	cidr, ok := arg.(apiservercel.CIDR)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(other)
-	}
-
-	ip, ok := other.(apiservercel.IP)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg)
-	}
-
+	cidr := arg.(apiservercel.CIDR)
+	ip := other.(apiservercel.IP)
 	return types.Bool(cidr.Contains(ip.Addr))
 }
 
 func cidrContainsCIDR(arg ref.Val, other ref.Val) ref.Val {
-	cidr, ok := arg.(apiservercel.CIDR)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg)
-	}
-
-	containsCIDR, ok := other.(apiservercel.CIDR)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(other)
-	}
+	cidr := arg.(apiservercel.CIDR)
+	containsCIDR := other.(apiservercel.CIDR)
 
 	equalMasked := cidr.Prefix.Masked() == netip.PrefixFrom(containsCIDR.Prefix.Addr(), cidr.Prefix.Bits())
 	return types.Bool(equalMasked && cidr.Prefix.Bits() <= containsCIDR.Prefix.Bits())
 }
 
 func prefixLength(arg ref.Val) ref.Val {
-	cidr, ok := arg.(apiservercel.CIDR)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg)
-	}
-
+	cidr := arg.(apiservercel.CIDR)
 	return types.Int(cidr.Prefix.Bits())
 }
 
 func isCIDR(arg ref.Val) ref.Val {
-	s, ok := arg.Value().(string)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg)
-	}
+	s := arg.(types.String)
 
-	_, err := parseCIDR(s)
+	_, err := parseCIDR(string(s))
 	return types.Bool(err == nil)
 }
 
 func cidrToIP(arg ref.Val) ref.Val {
-	cidr, ok := arg.(apiservercel.CIDR)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg)
-	}
-
+	cidr := arg.(apiservercel.CIDR)
 	return apiservercel.IP{
 		Addr: cidr.Prefix.Addr(),
 	}
 }
 
 func masked(arg ref.Val) ref.Val {
-	cidr, ok := arg.(apiservercel.CIDR)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg)
-	}
-
-	maskedCIDR := cidr.Prefix.Masked()
+	cidr := arg.(apiservercel.CIDR)
 	return apiservercel.CIDR{
-		Prefix: maskedCIDR,
+		Prefix: cidr.Prefix.Masked(),
 	}
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/cel/library/cidr_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/library/cidr_test.go
@@ -117,8 +117,13 @@ func TestCIDR(t *testing.T) {
 		expectCompileErrs []string
 	}{
 		{
+			name:              "compilation error for cidr(int)",
+			expr:              `cidr(192168)`,
+			expectCompileErrs: []string{"found no matching overload for 'cidr' applied to '\\(int\\)'"},
+		},
+		{
 			name:         "parse ipv4",
-			expr:         `cidr("192.168.0.0/24")`,
+			expr:         `cidr(dyn("192.168.0.0/24"))`,
 			expectResult: apiservercel.CIDR{Prefix: ipv4CIDR},
 		},
 		{

--- a/staging/src/k8s.io/apiserver/pkg/cel/library/ip.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/library/ip.go
@@ -193,12 +193,8 @@ func (*ip) ProgramOptions() []cel.ProgramOption {
 }
 
 func stringToIP(arg ref.Val) ref.Val {
-	s, ok := arg.Value().(string)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg)
-	}
-
-	addr, err := parseIPAddr(s)
+	s := arg.(types.String)
+	addr, err := parseIPAddr(string(s))
 	if err != nil {
 		// Don't add context, we control the error message already.
 		return types.NewErr("%v", err)
@@ -210,19 +206,12 @@ func stringToIP(arg ref.Val) ref.Val {
 }
 
 func ipToString(arg ref.Val) ref.Val {
-	ip, ok := arg.(apiservercel.IP)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg)
-	}
-
+	ip := arg.(apiservercel.IP)
 	return types.String(ip.Addr.String())
 }
 
 func family(arg ref.Val) ref.Val {
-	ip, ok := arg.(apiservercel.IP)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg)
-	}
+	ip := arg.(apiservercel.IP)
 
 	switch {
 	case ip.Addr.Is4():
@@ -235,12 +224,9 @@ func family(arg ref.Val) ref.Val {
 }
 
 func ipIsCanonical(arg ref.Val) ref.Val {
-	s, ok := arg.Value().(string)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg)
-	}
+	s := arg.(types.String)
 
-	addr, err := parseIPAddr(s)
+	addr, err := parseIPAddr(string(s))
 	if err != nil {
 		// Don't add context, we control the error message already.
 		return types.NewErr("%v", err)
@@ -249,61 +235,38 @@ func ipIsCanonical(arg ref.Val) ref.Val {
 	// Addr.String() always returns the canonical form of the IP address.
 	// Therefore comparing this with the original string representation
 	// will tell us if the IP address is in its canonical form.
-	return types.Bool(addr.String() == s)
+	return types.Bool(addr.String() == string(s))
 }
 
 func isIP(arg ref.Val) ref.Val {
-	s, ok := arg.Value().(string)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg)
-	}
+	s := arg.(types.String)
 
-	_, err := parseIPAddr(s)
+	_, err := parseIPAddr(string(s))
 	return types.Bool(err == nil)
 }
 
 func isUnspecified(arg ref.Val) ref.Val {
-	ip, ok := arg.(apiservercel.IP)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg)
-	}
-
+	ip := arg.(apiservercel.IP)
 	return types.Bool(ip.Addr.IsUnspecified())
 }
 
 func isLoopback(arg ref.Val) ref.Val {
-	ip, ok := arg.(apiservercel.IP)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg)
-	}
-
+	ip := arg.(apiservercel.IP)
 	return types.Bool(ip.Addr.IsLoopback())
 }
 
 func isLinkLocalMulticast(arg ref.Val) ref.Val {
-	ip, ok := arg.(apiservercel.IP)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg)
-	}
-
+	ip := arg.(apiservercel.IP)
 	return types.Bool(ip.Addr.IsLinkLocalMulticast())
 }
 
 func isLinkLocalUnicast(arg ref.Val) ref.Val {
-	ip, ok := arg.(apiservercel.IP)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg)
-	}
-
+	ip := arg.(apiservercel.IP)
 	return types.Bool(ip.Addr.IsLinkLocalUnicast())
 }
 
 func isGlobalUnicast(arg ref.Val) ref.Val {
-	ip, ok := arg.(apiservercel.IP)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg)
-	}
-
+	ip := arg.(apiservercel.IP)
 	return types.Bool(ip.Addr.IsGlobalUnicast())
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/cel/library/quantity_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/library/quantity_test.go
@@ -231,6 +231,11 @@ func TestQuantity(t *testing.T) {
 			expectValue: types.Int(1),
 		},
 		{
+			name:        "quantity_sign_zero",
+			expr:        `sign(quantity("0"))`,
+			expectValue: types.Int(0),
+		},
+		{
 			name:        "add_quantity",
 			expr:        `quantity("50k").add(quantity("20")) == quantity("50.02k")`,
 			expectValue: trueVal,
@@ -256,9 +261,19 @@ func TestQuantity(t *testing.T) {
 			expectValue: types.Int(-49980),
 		},
 		{
+			name:        "arith_chain_1_sign",
+			expr:        `sign(quantity("50k").add(20).sub(quantity("100k")))`,
+			expectValue: types.Int(-1),
+		},
+		{
 			name:        "arith_chain",
 			expr:        `quantity("50k").add(20).sub(quantity("100k")).sub(-50000).asInteger()`,
 			expectValue: types.Int(20),
+		},
+		{
+			name:        "arith_chain_sign",
+			expr:        `sign(quantity("50k").add(20).sub(quantity("100k")).sub(-50000))`,
+			expectValue: types.Int(1),
 		},
 		{
 			name:        "as_integer",

--- a/staging/src/k8s.io/apiserver/pkg/cel/library/regex.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/library/regex.go
@@ -87,19 +87,13 @@ func (*regex) ProgramOptions() []cel.ProgramOption {
 }
 
 func find(strVal ref.Val, regexVal ref.Val) ref.Val {
-	str, ok := strVal.Value().(string)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(strVal)
-	}
-	regex, ok := regexVal.Value().(string)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(regexVal)
-	}
-	re, err := regexp.Compile(regex)
+	str := strVal.(types.String)
+	regex := regexVal.(types.String)
+	re, err := regexp.Compile(string(regex))
 	if err != nil {
 		return types.NewErr("Illegal regex: %v", err.Error())
 	}
-	result := re.FindString(str)
+	result := re.FindString(string(str))
 	return types.String(result)
 }
 
@@ -108,28 +102,19 @@ func findAll(args ...ref.Val) ref.Val {
 	if argn < 2 || argn > 3 {
 		return types.NoSuchOverloadErr()
 	}
-	str, ok := args[0].Value().(string)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(args[0])
-	}
-	regex, ok := args[1].Value().(string)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(args[1])
-	}
+	str := args[0].(types.String)
+	regex := args[1].(types.String)
 	n := int64(-1)
 	if argn == 3 {
-		n, ok = args[2].Value().(int64)
-		if !ok {
-			return types.MaybeNoSuchOverloadErr(args[2])
-		}
+		n = int64(args[2].(types.Int))
 	}
 
-	re, err := regexp.Compile(regex)
+	re, err := regexp.Compile(string(regex))
 	if err != nil {
 		return types.NewErr("Illegal regex: %v", err.Error())
 	}
 
-	result := re.FindAllString(str, int(n))
+	result := re.FindAllString(string(str), int(n))
 
 	return types.NewStringList(types.DefaultTypeAdapter, result)
 }

--- a/staging/src/k8s.io/apiserver/pkg/cel/library/urls.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/library/urls.go
@@ -157,19 +157,16 @@ func (*urls) ProgramOptions() []cel.ProgramOption {
 }
 
 func stringToUrl(arg ref.Val) ref.Val {
-	s, ok := arg.Value().(string)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg)
-	}
+	s := arg.(types.String)
 	// Use ParseRequestURI to check the URL before conversion.
 	// ParseRequestURI requires absolute URLs and is used by the OpenAPIv3 'uri' format.
-	_, err := url.ParseRequestURI(s)
+	_, err := url.ParseRequestURI(string(s))
 	if err != nil {
 		return types.NewErr("URL parse error during conversion from string: %v", err)
 	}
 	// We must parse again with Parse since ParseRequestURI incorrectly parses URLs that contain a fragment
 	// part and will incorrectly append the fragment to either the path or the query, depending on which it was adjacent to.
-	u, err := url.Parse(s)
+	u, err := url.Parse(string(s))
 	if err != nil {
 		// Errors are not expected here since Parse is a more lenient parser than ParseRequestURI.
 		return types.NewErr("URL parse error during conversion from string: %v", err)
@@ -178,50 +175,32 @@ func stringToUrl(arg ref.Val) ref.Val {
 }
 
 func getScheme(arg ref.Val) ref.Val {
-	u, ok := arg.Value().(*url.URL)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg)
-	}
+	u := arg.(apiservercel.URL)
 	return types.String(u.Scheme)
 }
 
 func getHost(arg ref.Val) ref.Val {
-	u, ok := arg.Value().(*url.URL)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg)
-	}
+	u := arg.(apiservercel.URL)
 	return types.String(u.Host)
 }
 
 func getHostname(arg ref.Val) ref.Val {
-	u, ok := arg.Value().(*url.URL)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg)
-	}
+	u := arg.(apiservercel.URL)
 	return types.String(u.Hostname())
 }
 
 func getPort(arg ref.Val) ref.Val {
-	u, ok := arg.Value().(*url.URL)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg)
-	}
+	u := arg.(apiservercel.URL)
 	return types.String(u.Port())
 }
 
 func getEscapedPath(arg ref.Val) ref.Val {
-	u, ok := arg.Value().(*url.URL)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg)
-	}
+	u := arg.(apiservercel.URL)
 	return types.String(u.EscapedPath())
 }
 
 func getQuery(arg ref.Val) ref.Val {
-	u, ok := arg.Value().(*url.URL)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg)
-	}
+	u := arg.(apiservercel.URL)
 
 	result := map[ref.Val]ref.Val{}
 	for k, v := range u.Query() {
@@ -231,10 +210,7 @@ func getQuery(arg ref.Val) ref.Val {
 }
 
 func isURL(arg ref.Val) ref.Val {
-	s, ok := arg.Value().(string)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg)
-	}
-	_, err := url.ParseRequestURI(s)
+	s := arg.(types.String)
+	_, err := url.ParseRequestURI(string(s))
 	return types.Bool(err == nil)
 }

--- a/staging/src/k8s.io/apiserver/pkg/cel/quantity.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/quantity.go
@@ -33,7 +33,7 @@ var (
 	QuantityType      = cel.ObjectType("kubernetes.Quantity")
 )
 
-// Quantity provdes a CEL representation of a resource.Quantity
+// Quantity provides a CEL representation of a resource.Quantity
 type Quantity struct {
 	*resource.Quantity
 }
@@ -60,11 +60,11 @@ func (d Quantity) ConvertToType(typeVal ref.Type) ref.Val {
 }
 
 func (d Quantity) Equal(other ref.Val) ref.Val {
-	otherDur, ok := other.(Quantity)
+	otherQuantity, ok := other.(Quantity)
 	if !ok {
-		return types.MaybeNoSuchOverloadErr(other)
+		return types.False
 	}
-	return types.Bool(d.Quantity.Equal(*otherDur.Quantity))
+	return types.Bool(d.Quantity.Equal(*otherQuantity.Quantity))
 }
 
 func (d Quantity) Type() ref.Type {

--- a/staging/src/k8s.io/apiserver/pkg/cel/url.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/url.go
@@ -62,11 +62,11 @@ func (d URL) ConvertToType(typeVal ref.Type) ref.Val {
 
 // Equal implements ref.Val.Equal.
 func (d URL) Equal(other ref.Val) ref.Val {
-	otherDur, ok := other.(URL)
+	otherURL, ok := other.(URL)
 	if !ok {
-		return types.MaybeNoSuchOverloadErr(other)
+		return types.False
 	}
-	return types.Bool(d.URL.String() == otherDur.URL.String())
+	return types.Bool(d.URL.String() == otherURL.URL.String())
 }
 
 // Type implements ref.Val.Type.

--- a/staging/src/k8s.io/apiserver/pkg/cel/value.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/value.go
@@ -648,7 +648,7 @@ func (lv *ListValue) ConvertToType(t ref.Type) ref.Val {
 func (lv *ListValue) Equal(other ref.Val) ref.Val {
 	oArr, isArr := other.(traits.Lister)
 	if !isArr {
-		return types.MaybeNoSuchOverloadErr(other)
+		return types.False
 	}
 	sz := types.Int(len(lv.Entries))
 	if sz != oArr.Size() {


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Argument types are validated by CEL during compilation and no longer need to be validated at runtime.

#### Which issue(s) this PR fixes:
Fixes #122239 

#### Special notes for your reviewer:
I'm especially interested in what we think is best with regards to test coverage. Is this something that we expect to be fundamental to how CEL will work? Are unit tests here the right place for validating this?

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->