### PR TITLE
Improving kubectl get output

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/get/get.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/get/get.go
@@ -91,8 +91,8 @@ var (
 
 		Prints a table of the most important information about the specified resources.
 		You can filter the list using a label selector and the --selector flag. If the
-		desired resource type is namespaced you will only see results in your current
-		namespace unless you pass --all-namespaces or --namespace(for specific namespace)
+		desired resource type is namespaced you will only see results in other namespaces
+		by passing --namespace(for specific namespace) or --all-namespaces.
 
 		By specifying the output as 'template' and providing a Go template as the value
 		of the --template flag, you can filter the attributes of the fetched resources.`))
@@ -134,11 +134,11 @@ var (
 		# List the 'status' subresource for a single pod
 		kubectl get pod web-pod-13je7 --subresource status
 
-		# List all deployments in namespace - backend
+		# List all deployments in namespace 'backend'
 		kubectl get deployments.apps --namespace backend
 
 		# List all pods existing in all namespaces
-		kubectl get pods --all-namspaces`))
+		kubectl get pods --all-namespaces`))
 )
 
 const (

--- a/staging/src/k8s.io/kubectl/pkg/cmd/get/get.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/get/get.go
@@ -92,7 +92,7 @@ var (
 		Prints a table of the most important information about the specified resources.
 		You can filter the list using a label selector and the --selector flag. If the
 		desired resource type is namespaced you will only see results in your current
-		namespace unless you pass --all-namespaces.
+		namespace unless you pass --all-namespaces or --namespace(for specific namespace)
 
 		By specifying the output as 'template' and providing a Go template as the value
 		of the --template flag, you can filter the attributes of the fetched resources.`))
@@ -132,7 +132,13 @@ var (
 		kubectl get rc/web service/frontend pods/web-pod-13je7
 
 		# List the 'status' subresource for a single pod
-		kubectl get pod web-pod-13je7 --subresource status`))
+		kubectl get pod web-pod-13je7 --subresource status
+
+		# List all deployments in namespace - backend
+		kubectl get deployments.apps --namespace backend
+
+		# List all pods existing in all namespaces
+		kubectl get pods --all-namspaces`))
 )
 
 const (

--- a/staging/src/k8s.io/kubectl/pkg/cmd/get/get.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/get/get.go
@@ -91,8 +91,8 @@ var (
 
 		Prints a table of the most important information about the specified resources.
 		You can filter the list using a label selector and the --selector flag. If the
-		desired resource type is namespaced you will only see results in other namespaces
-		by passing --namespace(for specific namespace) or --all-namespaces.
+		desired resource type is namespaced you will only see results in the current
+		namespace if you don't specify any namespace.
 
 		By specifying the output as 'template' and providing a Go template as the value
 		of the --template flag, you can filter the attributes of the fetched resources.`))


### PR DESCRIPTION
Signed-off-by: Ritikaa96 <ritika@india.nec.com


#### What this PR does / why we need it:
 Adding namespace flag & examples
kubectl get --help states the following even though we can use --namespace to get details for other namespace resources.
```shell
Display one or many resources.

 Prints a table of the most important information about the specified resources.
You can filter the list using a label selector and the --selector flag. If the
desired resource type is namespaced you will only see results in your current
namespace unless you pass --all-namespaces.
...
```
The description should mention `--namespace ` as this can show objects/resources from different namespace as well

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #https://github.com/kubernetes/kubectl/issues/1555

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
NONE

#### Does this PR introduce a user-facing change?
NONE

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
NONE