### PR TITLE
ktesting: several fixes and better unit testing

### DIFF
--- a/test/utils/ktesting/assert.go
+++ b/test/utils/ktesting/assert.go
@@ -118,17 +118,18 @@ func buildDescription(explain ...interface{}) string {
 // is passed in. For example, errors can be checked with ExpectNoError:
 //
 //	cb := func(func(tCtx ktesting.TContext) int {
-//	   value, err := doSomething(...)
-//	   ktesting.ExpectNoError(tCtx, err, "something failed")
-//	   return value
+//	    value, err := doSomething(...)
+//	    tCtx.ExpectNoError(err, "something failed")
+//	    assert(tCtx, 42, value, "the answer")
+//	    return value
 //	}
 //	tCtx.Eventually(cb).Should(gomega.Equal(42), "should be the answer to everything")
 //
 // If there is no value, then an error can be returned:
 //
 //	cb := func(func(tCtx ktesting.TContext) error {
-//	   err := doSomething(...)
-//	   return err
+//	    err := doSomething(...)
+//	    return err
 //	}
 //	tCtx.Eventually(cb).Should(gomega.Succeed(), "foobar should succeed")
 //
@@ -143,12 +144,21 @@ func buildDescription(explain ...interface{}) string {
 // anymore, use [gomega.StopTrying]:
 //
 //	cb := func(func(tCtx ktesting.TContext) int {
-//	   value, err := doSomething(...)
-//	   if errors.Is(err, SomeFinalErr) {
-//	    gomega.StopTrying("permanent failure).Wrap(err).Now()
-//	   }
-//	   ktesting.ExpectNoError(tCtx, err, "something failed")
-//	   return value
+//	    value, err := doSomething(...)
+//	    if errors.Is(err, SomeFinalErr) {
+//	        // This message completely replaces the normal
+//	        // failure message and thus should include all
+//	        // relevant information.
+//	        //
+//	        // github.com/onsi/gomega/format is a good way
+//	        // to format arbitrary data. It uses indention
+//	        // and falls back to YAML for Kubernetes API
+//	        // structs for readability.
+//	        gomega.StopTrying("permanent failure, last value:\n%s", format.Object(value, 1 /* indent one level */)).
+//	            Wrap(err).Now()
+//	    }
+//	    ktesting.ExpectNoError(tCtx, err, "something failed")
+//	    return value
 //	}
 //	tCtx.Eventually(cb).Should(gomega.Equal(42), "should be the answer to everything")
 //
@@ -156,15 +166,15 @@ func buildDescription(explain ...interface{}) string {
 // particularly useful in [Consistently] to ignore some intermittent error.
 //
 //	cb := func(func(tCtx ktesting.TContext) int {
-//	   value, err := doSomething(...)
-//	   var intermittentErr SomeIntermittentError
-//	   if errors.As(err, &intermittentErr) {
-//	       gomega.TryAgainAfter(intermittentErr.RetryPeriod).Wrap(err).Now()
-//	   }
-//	   ktesting.ExpectNoError(tCtx, err, "something failed")
-//	   return value
-//	}
-//	tCtx.Eventually(cb).Should(gomega.Equal(42), "should be the answer to everything")
+//	    value, err := doSomething(...)
+//	    var intermittentErr SomeIntermittentError
+//	    if errors.As(err, &intermittentErr) {
+//	        gomega.TryAgainAfter(intermittentErr.RetryPeriod).Wrap(err).Now()
+//	    }
+//	    ktesting.ExpectNoError(tCtx, err, "something failed")
+//	    return value
+//	 }
+//	 tCtx.Eventually(cb).Should(gomega.Equal(42), "should be the answer to everything")
 func Eventually[T any](tCtx TContext, cb func(TContext) T) gomega.AsyncAssertion {
 	tCtx.Helper()
 	return gomega.NewWithT(tCtx).Eventually(tCtx, func(ctx context.Context) (val T, err error) {

--- a/test/utils/ktesting/errorcontext.go
+++ b/test/utils/ktesting/errorcontext.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/onsi/gomega"
 	"k8s.io/klog/v2"
 )
 
@@ -136,6 +137,16 @@ func (eCtx *errorContext) Fatalf(format string, args ...any) {
 func (eCtx *errorContext) CleanupCtx(cb func(TContext)) {
 	eCtx.Helper()
 	cleanupCtx(eCtx, cb)
+}
+
+func (eCtx *errorContext) Expect(actual interface{}, extra ...interface{}) gomega.Assertion {
+	eCtx.Helper()
+	return expect(eCtx, actual, extra...)
+}
+
+func (eCtx *errorContext) ExpectNoError(err error, explain ...interface{}) {
+	eCtx.Helper()
+	expectNoError(eCtx, err, explain...)
 }
 
 func (eCtx *errorContext) Logger() klog.Logger {

--- a/test/utils/ktesting/helper_test.go
+++ b/test/utils/ktesting/helper_test.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ktesting
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// testcase wraps a callback which is called with a TContext that intercepts
+// errors and log output. Those get compared.
+type testcase struct {
+	cb             func(TContext)
+	expectNoFail   bool
+	expectError    string
+	expectDuration time.Duration
+	expectLog      string
+}
+
+func (tc testcase) run(t *testing.T) {
+	bufferT := &logBufferT{T: t}
+	tCtx := Init(bufferT)
+	var err error
+	tCtx, finalize := WithError(tCtx, &err)
+	start := time.Now()
+	func() {
+		defer finalize()
+		tc.cb(tCtx)
+	}()
+
+	log := bufferT.log.String()
+	t.Logf("Log output:\n%s\n", log)
+	if tc.expectLog != "" {
+		assert.Equal(t, tc.expectLog, normalize(log))
+	} else if log != "" {
+		t.Error("Expected no log output.")
+	}
+
+	duration := time.Since(start)
+	assert.InDelta(t, tc.expectDuration.Seconds(), duration.Seconds(), 0.1, fmt.Sprintf("callback invocation duration %s", duration))
+	assert.Equal(t, !tc.expectNoFail, tCtx.Failed(), "Failed()")
+	if tc.expectError == "" {
+		assert.NoError(t, err)
+	} else if assert.NotNil(t, err) {
+		t.Logf("Result:\n%s", err.Error())
+		assert.Equal(t, tc.expectError, normalize(err.Error()))
+	}
+}
+
+// normalize replaces parts of message texts which may vary with constant strings.
+func normalize(msg string) string {
+	// duration
+	msg = regexp.MustCompile(`[[:digit:]]+\.[[:digit:]]+s`).ReplaceAllString(msg, "x.y s")
+	// hex pointer value
+	msg = regexp.MustCompile(`0x[[:xdigit:]]+`).ReplaceAllString(msg, "0xXXXX")
+	// per-test klog header
+	msg = regexp.MustCompile(`[EI][[:digit:]]{4} [[:digit:]]{2}:[[:digit:]]{2}:[[:digit:]]{2}\.[[:digit:]]{6}\]`).ReplaceAllString(msg, "<klog header>:")
+	return msg
+}
+
+type logBufferT struct {
+	*testing.T
+	log strings.Builder
+}
+
+func (l *logBufferT) Log(args ...any) {
+	l.log.WriteString(fmt.Sprintln(args...))
+}
+
+func (l *logBufferT) Logf(format string, args ...any) {
+	l.log.WriteString(fmt.Sprintf(format, args...))
+	l.log.WriteRune('\n')
+}

--- a/test/utils/ktesting/main_test.go
+++ b/test/utils/ktesting/main_test.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ktesting
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	// Bail out early when -help was given as parameter.
+	flag.Parse()
+
+	// Must be called *before* creating new goroutines.
+	goleakOpts := []goleak.Option{
+		goleak.IgnoreCurrent(),
+	}
+
+	result := m.Run()
+
+	if err := goleak.Find(goleakOpts...); err != nil {
+		fmt.Fprintf(os.Stderr, "leaked Goroutines: %v", err)
+		os.Exit(1)
+	}
+
+	os.Exit(result)
+}

--- a/test/utils/ktesting/stepcontext.go
+++ b/test/utils/ktesting/stepcontext.go
@@ -76,7 +76,7 @@ func (sCtx *stepContext) Fatalf(format string, args ...any) {
 	sCtx.TContext.Fatal(sCtx.what + ": " + strings.TrimSpace(fmt.Sprintf(format, args...)))
 }
 
-// Value intercepts a search for the special
+// Value intercepts a search for the special "GINKGO_SPEC_CONTEXT".
 func (sCtx *stepContext) Value(key any) any {
 	if s, ok := key.(string); ok && s == ginkgoSpecContextKey {
 		if reporter, ok := sCtx.TContext.Value(key).(ginkgoReporter); ok {

--- a/test/utils/ktesting/stepcontext_test.go
+++ b/test/utils/ktesting/stepcontext_test.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ktesting
+
+import (
+	"bytes"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStepContext(t *testing.T) {
+	for name, tc := range map[string]testcase{
+		"output": {
+			cb: func(tCtx TContext) {
+				tCtx = WithStep(tCtx, "step")
+				tCtx.Log("Log", "a", "b", 42)
+				tCtx.Logf("Logf %s %s %d", "a", "b", 42)
+				tCtx.Error("Error", "a", "b", 42)
+				tCtx.Errorf("Errorf %s %s %d", "a", "b", 42)
+			},
+			expectLog: `<klog header>: step: Log a b 42
+<klog header>: step: Logf a b 42
+`,
+			expectError: `step: Error a b 42
+step: Errorf a b 42`,
+		},
+		"fatal": {
+			cb: func(tCtx TContext) {
+				tCtx = WithStep(tCtx, "step")
+				tCtx.Fatal("Error", "a", "b", 42)
+				// not reached
+				tCtx.Log("Log")
+			},
+			expectError: `step: Error a b 42`,
+		},
+		"fatalf": {
+			cb: func(tCtx TContext) {
+				tCtx = WithStep(tCtx, "step")
+				tCtx.Fatalf("Error %s %s %d", "a", "b", 42)
+				// not reached
+				tCtx.Log("Log")
+			},
+			expectError: `step: Error a b 42`,
+		},
+		"progress": {
+			cb: func(tCtx TContext) {
+				tCtx = WithStep(tCtx, "step")
+				var buffer bytes.Buffer
+				oldOut := defaultProgressReporter.setOutput(&buffer)
+				defer defaultProgressReporter.setOutput(oldOut)
+				remove := tCtx.Value("GINKGO_SPEC_CONTEXT").(ginkgoReporter).AttachProgressReporter(func() string { return "hello world" })
+				defer remove()
+				defaultSignalChannel <- os.Interrupt
+				// No good way to sync here, so let's just wait.
+				time.Sleep(5 * time.Second)
+				defaultProgressReporter.setOutput(oldOut)
+				tCtx.Log(buffer.String())
+
+				noSuchValue := tCtx.Value("some other key")
+				assert.Equal(tCtx, nil, noSuchValue, "value for unknown context value key")
+			},
+			expectLog: `<klog header>: step: You requested a progress report.
+
+step: hello world
+`,
+			expectDuration: 5 * time.Second,
+			expectNoFail:   true,
+		},
+	} {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			tc.run(t)
+		})
+	}
+}

--- a/test/utils/ktesting/tcontext.go
+++ b/test/utils/ktesting/tcontext.go
@@ -83,7 +83,7 @@ type TContext interface {
 	Cancel(cause string)
 
 	// Cleanup registers a callback that will get invoked when the test
-	// has finished. Callbacks get invoked in first-in-first-out order.
+	// has finished. Callbacks get invoked in last-in-first-out order (LIFO).
 	//
 	// Beware of context cancellation. The following cleanup code
 	// will use a canceled context, which is not desirable:

--- a/test/utils/ktesting/tcontext.go
+++ b/test/utils/ktesting/tcontext.go
@@ -35,6 +35,10 @@ import (
 	"k8s.io/kubernetes/test/utils/ktesting/internal"
 )
 
+// Underlier is the additional interface implemented by the per-test LogSink
+// behind [TContext.Logger].
+type Underlier = ktesting.Underlier
+
 // CleanupGracePeriod is the time that a [TContext] gets canceled before the
 // deadline of its underlying test suite (usually determined via "go test
 // -timeout"). This gives the running test(s) time to fail with an informative


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The new ktesting still had some issues. Not relevant for anything yet, but it will be once more tests start using it.

#### Special notes for your reviewer:

Overall coverage is now at 80.4%. Running the examples would cover some more code, but cannot be done easily in a unit test.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
