### PR TITLE
Support watch option on kubelet /pods endpoint

### DIFF
--- a/pkg/kubelet/server/server.go
+++ b/pkg/kubelet/server/server.go
@@ -747,6 +747,47 @@ func encodePods(pods []*v1.Pod) (data []byte, err error) {
 
 // getPods returns a list of pods bound to the Kubelet and their spec.
 func (s *Server) getPods(request *restful.Request, response *restful.Response) {
+	if watch := request.QueryParameter("watch"); len(watch) > 0 {
+		response.Header().Set("Transfer-Encoding", "chunked")
+		response.Header().Set(restful.HEADER_ContentType, restful.MIME_JSON)
+		response.WriteHeader(http.StatusOK)
+		fw := flushwriter.Wrap(response.ResponseWriter)
+		ticker := time.NewTicker(1 * time.Second)
+		var lastPods []*v1.Pod
+		for {
+			select {
+			case <-ticker.C:
+				pods := s.host.GetPods()
+				var podUpdates []*v1.Pod
+				for _, pod := range pods {
+					found := false
+					// If pod same as in lastPods (same pod and status), ignore it.
+					// We only want to push changes
+					for _, lpod := range lastPods {
+						if pod == lpod {
+							found = true
+							break
+						}
+					}
+					if !found {
+						podUpdates = append(podUpdates, pod)
+					}
+				}
+				lastPods = pods
+				if len(podUpdates) > 0 {
+					data, err := encodePods(podUpdates)
+					if err != nil {
+						response.WriteError(http.StatusInternalServerError, err)
+						return
+					}
+					if _, err := fw.Write(data); err != nil {
+						klog.ErrorS(err, "Error writing response")
+						return
+					}
+				}
+			}
+		}
+	}
 	pods := s.host.GetPods()
 	data, err := encodePods(pods)
 	if err != nil {


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/kind api-change

#### What this PR does / why we need it:

Supports a `watch` option on the Kubelet API's `GET /pods` endpoint, effectively allowing a user to make a request to the Kubelet to watch for changes to pods (new pod; change in status; etc). This feature is currently present on the Kube API and it would be nice to have parity in the Kubelet API. It would allow our application to detect changes to pods by watching the Kubelet instead of hitting the cluster API; or constantly polling the Kubelet on an interval.

#### Which issue(s) this PR fixes:

n/a

#### Special notes for your reviewer:

The endpoint only provides updates relating to new pods or changes to existing pods. It does not provide an update about deleted pods. Is this necessary?

#### Does this PR introduce a user-facing change?

```release-note
Supports a `watch` option on the Kubelet API's `GET /pods` endpoint
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

n/a