### PR TITLE
Automated cherry pick of #123003: bugfix: dont skip reconcile for unchanged policy if last sync

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/validatingadmissionpolicy/controller_reconcile.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/validatingadmissionpolicy/controller_reconcile.go
@@ -180,8 +180,9 @@ func (c *policyController) reconcilePolicyDefinitionSpec(namespace, name string,
 		celmetrics.Metrics.ObserveDefinition(context.TODO(), "active", "deny")
 	}
 
-	// Skip reconcile if the spec of the definition is unchanged
-	if info.lastReconciledValue != nil && definition != nil &&
+	// Skip reconcile if the spec of the definition is unchanged and had a
+	// successful previous sync
+	if info.configurationError == nil && info.lastReconciledValue != nil && definition != nil &&
 		apiequality.Semantic.DeepEqual(info.lastReconciledValue.Spec, definition.Spec) {
 		return nil
 	}


### PR DESCRIPTION
Cherry pick of #123003 on release-1.28.

#123003: bugfix: dont skip reconcile for unchanged policy if last sync

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```