### PR TITLE
Add option to upgrade subresource from CSA to SSA

### DIFF
--- a/staging/src/k8s.io/client-go/util/csaupgrade/options.go
+++ b/staging/src/k8s.io/client-go/util/csaupgrade/options.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package csaupgrade
+
+type Option func(*options)
+
+// Subresource set the subresource to upgrade from CSA to SSA.
+func Subresource(s string) Option {
+	return func(opts *options) {
+		opts.subresource = s
+	}
+}
+
+type options struct {
+	subresource string
+}

--- a/staging/src/k8s.io/client-go/util/csaupgrade/upgrade.go
+++ b/staging/src/k8s.io/client-go/util/csaupgrade/upgrade.go
@@ -82,7 +82,13 @@ func UpgradeManagedFields(
 	obj runtime.Object,
 	csaManagerNames sets.Set[string],
 	ssaManagerName string,
+	opts ...Option,
 ) error {
+	o := options{}
+	for _, opt := range opts {
+		opt(&o)
+	}
+
 	accessor, err := meta.Accessor(obj)
 	if err != nil {
 		return err
@@ -92,7 +98,7 @@ func UpgradeManagedFields(
 
 	for csaManagerName := range csaManagerNames {
 		filteredManagers, err = upgradedManagedFields(
-			filteredManagers, csaManagerName, ssaManagerName)
+			filteredManagers, csaManagerName, ssaManagerName, o)
 
 		if err != nil {
 			return err
@@ -116,7 +122,14 @@ func UpgradeManagedFields(
 func UpgradeManagedFieldsPatch(
 	obj runtime.Object,
 	csaManagerNames sets.Set[string],
-	ssaManagerName string) ([]byte, error) {
+	ssaManagerName string,
+	opts ...Option,
+) ([]byte, error) {
+	o := options{}
+	for _, opt := range opts {
+		opt(&o)
+	}
+
 	accessor, err := meta.Accessor(obj)
 	if err != nil {
 		return nil, err
@@ -126,7 +139,7 @@ func UpgradeManagedFieldsPatch(
 	filteredManagers := accessor.GetManagedFields()
 	for csaManagerName := range csaManagerNames {
 		filteredManagers, err = upgradedManagedFields(
-			filteredManagers, csaManagerName, ssaManagerName)
+			filteredManagers, csaManagerName, ssaManagerName, o)
 		if err != nil {
 			return nil, err
 		}
@@ -166,6 +179,7 @@ func upgradedManagedFields(
 	managedFields []metav1.ManagedFieldsEntry,
 	csaManagerName string,
 	ssaManagerName string,
+	opts options,
 ) ([]metav1.ManagedFieldsEntry, error) {
 	if managedFields == nil {
 		return nil, nil
@@ -183,7 +197,7 @@ func upgradedManagedFields(
 		func(entry metav1.ManagedFieldsEntry) bool {
 			return entry.Manager == ssaManagerName &&
 				entry.Operation == metav1.ManagedFieldsOperationApply &&
-				entry.Subresource == ""
+				entry.Subresource == opts.subresource
 		})
 
 	if !managerExists {
@@ -196,7 +210,7 @@ func upgradedManagedFields(
 			func(entry metav1.ManagedFieldsEntry) bool {
 				return entry.Manager == csaManagerName &&
 					entry.Operation == metav1.ManagedFieldsOperationUpdate &&
-					entry.Subresource == ""
+					entry.Subresource == opts.subresource
 			})
 
 		if !managerExists {
@@ -209,7 +223,7 @@ func upgradedManagedFields(
 		managedFields[replaceIndex].Operation = metav1.ManagedFieldsOperationApply
 		managedFields[replaceIndex].Manager = ssaManagerName
 	}
-	err := unionManagerIntoIndex(managedFields, replaceIndex, csaManagerName)
+	err := unionManagerIntoIndex(managedFields, replaceIndex, csaManagerName, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -218,7 +232,7 @@ func upgradedManagedFields(
 	filteredManagers := filter(managedFields, func(entry metav1.ManagedFieldsEntry) bool {
 		return !(entry.Manager == csaManagerName &&
 			entry.Operation == metav1.ManagedFieldsOperationUpdate &&
-			entry.Subresource == "")
+			entry.Subresource == opts.subresource)
 	})
 
 	return filteredManagers, nil
@@ -231,6 +245,7 @@ func unionManagerIntoIndex(
 	entries []metav1.ManagedFieldsEntry,
 	targetIndex int,
 	csaManagerName string,
+	opts options,
 ) error {
 	ssaManager := entries[targetIndex]
 
@@ -240,9 +255,7 @@ func unionManagerIntoIndex(
 		func(entry metav1.ManagedFieldsEntry) bool {
 			return entry.Manager == csaManagerName &&
 				entry.Operation == metav1.ManagedFieldsOperationUpdate &&
-				//!TODO: some users may want to migrate subresources.
-				// should thread through the args at some point.
-				entry.Subresource == "" &&
+				entry.Subresource == opts.subresource &&
 				entry.APIVersion == ssaManager.APIVersion
 		})
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

I am working on migrating multiple operators from CSA to SSA. As part of this, it is required to upgrade controller `managedFields` from `Update` to `Apply` - to ensure fields set by `Update` are uset if removed from the apply.

After asking on Slack, I was routed to [UpgradeManagedFields](https://github.com/kubernetes/kubernetes/blob/26a6e1234869b5c546195aaf416f3424cd3c3dc8/staging/src/k8s.io/client-go/util/csaupgrade/upgrade.go#L81-L85) that `kubectl` uses to perform this upgrade. While this works well for upgrading `managedFields` on resources owned by the controller, it is currently not possible to use the same approach for upgrading the `status` subresource on controller resource.

This PR introduces variadic options to the relevant functions in this package allowing a caller to supply a subresource to upgrade. The change is non-breaking and allows more options to be added - if required. And seems to follow an established pattern for options in this project.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
None AFAIK  (please let me know if an issue is required)

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added `client-go` support for upgrading subresource fields from client-side to server-side management
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/hold (I want to squash commits before this is eventually merged)