### PR TITLE
add StreamDropEventTime variable

### DIFF
--- a/staging/src/k8s.io/kubelet/pkg/cri/streaming/server.go
+++ b/staging/src/k8s.io/kubelet/pkg/cri/streaming/server.go
@@ -80,6 +80,8 @@ type Config struct {
 	StreamIdleTimeout time.Duration
 	// How long to wait for clients to create streams. Only used for SPDY streaming.
 	StreamCreationTimeout time.Duration
+	// How long to wait before dropping an event
+	StreamDropEventTime time.Duration
 
 	// The streaming protocols the server supports (understands and permits).  See
 	// k8s.io/kubernetes/pkg/kubelet/server/remotecommand/constants.go for available protocols.
@@ -98,6 +100,7 @@ type Config struct {
 // DefaultConfig provides default values for server Config. The DefaultConfig is partial, so
 // some fields like Addr must still be provided.
 var DefaultConfig = Config{
+	StreamDropEventTime:             5 * time.Minute,
 	StreamIdleTimeout:               4 * time.Hour,
 	StreamCreationTimeout:           remotecommandconsts.DefaultStreamCreationTimeout,
 	SupportedRemoteCommandProtocols: remotecommandconsts.SupportedStreamingProtocols,

--- a/staging/src/k8s.io/kubelet/pkg/cri/streaming/server.go
+++ b/staging/src/k8s.io/kubelet/pkg/cri/streaming/server.go
@@ -81,7 +81,7 @@ type Config struct {
 	// How long to wait for clients to create streams. Only used for SPDY streaming.
 	StreamCreationTimeout time.Duration
 	// How long to wait before dropping an event
-	StreamDropEventTime time.Duration
+	StreamEventTimeout time.Duration
 
 	// The streaming protocols the server supports (understands and permits).  See
 	// k8s.io/kubernetes/pkg/kubelet/server/remotecommand/constants.go for available protocols.
@@ -100,7 +100,7 @@ type Config struct {
 // DefaultConfig provides default values for server Config. The DefaultConfig is partial, so
 // some fields like Addr must still be provided.
 var DefaultConfig = Config{
-	StreamDropEventTime:             5 * time.Minute,
+	StreamEventTimeout:              5 * time.Minute,
 	StreamIdleTimeout:               4 * time.Hour,
 	StreamCreationTimeout:           remotecommandconsts.DefaultStreamCreationTimeout,
 	SupportedRemoteCommandProtocols: remotecommandconsts.SupportedStreamingProtocols,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:
this pr add a variable to kubelet. 
in containerd cri there is a timeout value for queue of events that's hard coded.
I want to refactor and use a variable. In order to do that i need a new variable in config struct and a default value for that
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```docs
kubelet: set a variable for event subscriber timeout
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
