### PR TITLE
Replace fmt.Print with printer in upgrade plan code and fix configVersions are not printed when output is json or yaml

### DIFF
--- a/cmd/kubeadm/app/cmd/upgrade/common.go
+++ b/cmd/kubeadm/app/cmd/upgrade/common.go
@@ -176,7 +176,7 @@ func enforceRequirements(flags *applyPlanFlags, args []string, dryRun bool, upgr
 	}
 
 	// Run healthchecks against the cluster
-	if err := upgrade.CheckClusterHealth(client, &cfg.ClusterConfiguration, ignorePreflightErrorsSet); err != nil {
+	if err := upgrade.CheckClusterHealth(client, &cfg.ClusterConfiguration, ignorePreflightErrorsSet, printer); err != nil {
 		return nil, nil, nil, errors.Wrap(err, "[upgrade/health] FATAL")
 	}
 

--- a/cmd/kubeadm/app/cmd/upgrade/plan.go
+++ b/cmd/kubeadm/app/cmd/upgrade/plan.go
@@ -158,7 +158,8 @@ func (pf *upgradePlanJSONYamlPrintFlags) AllowedFormats() []string {
 // upgradePlanJSONYAMLPrinter prints upgrade plan in a JSON or YAML format
 type upgradePlanJSONYAMLPrinter struct {
 	output.ResourcePrinterWrapper
-	Buffer []outputapiv1alpha2.ComponentUpgradePlan
+	Components     []outputapiv1alpha2.ComponentUpgradePlan
+	ConfigVersions []outputapiv1alpha2.ComponentConfigVersionState
 }
 
 // newUpgradePlanJSONYAMLPrinter creates a new upgradePlanJSONYAMLPrinter object
@@ -175,7 +176,7 @@ func (p *upgradePlanJSONYAMLPrinter) PrintObj(obj runtime.Object, writer io.Writ
 	if !ok {
 		return errors.Errorf("expected ComponentUpgradePlan, but got %+v", obj)
 	}
-	p.Buffer = append(p.Buffer, *item)
+	p.Components = append(p.Components, *item)
 	return nil
 }
 
@@ -184,19 +185,18 @@ func (p *upgradePlanJSONYAMLPrinter) Flush(writer io.Writer, last bool) {
 	if !last {
 		return
 	}
-	if len(p.Buffer) == 0 {
+	if len(p.Components) == 0 && len(p.ConfigVersions) == 0 {
 		return
 	}
-	plan := &outputapiv1alpha2.UpgradePlan{Components: p.Buffer}
+	plan := &outputapiv1alpha2.UpgradePlan{Components: p.Components, ConfigVersions: p.ConfigVersions}
 	if err := p.Printer.PrintObj(plan, writer); err != nil {
 		fmt.Fprintf(os.Stderr, "could not flush output buffer: %v\n", err)
 	}
+	p.Components = p.Components[:0]
 }
 
-// Close empties the list of buffered components
-func (p *upgradePlanJSONYAMLPrinter) Close(writer io.Writer) {
-	p.Buffer = p.Buffer[:0]
-}
+// Close does nothing.
+func (p *upgradePlanJSONYAMLPrinter) Close(writer io.Writer) {}
 
 // upgradePlanTextPrinter prints upgrade plan in a text form
 type upgradePlanTextPrinter struct {
@@ -282,6 +282,11 @@ func runPlan(flags *planFlags, args []string, printer output.Printer) error {
 	if len(availUpgrades) == 0 {
 		klog.V(1).Infoln("[upgrade/plan] Awesome, you're up-to-date! Enjoy!")
 		return nil
+	}
+
+	// A workaround to set the configVersionStates in the printer
+	if p, ok := printer.(*upgradePlanJSONYAMLPrinter); ok {
+		p.ConfigVersions = configVersionStates
 	}
 
 	// Generate and print upgrade plans
@@ -387,6 +392,7 @@ func printUpgradePlan(up *upgrade.Upgrade, plan *outputapiv1alpha2.UpgradePlan, 
 			printer.PrintObj(&plan, writer)
 		}
 	}
+
 	printer.Flush(writer, true)
 
 	printer.Fprintln(writer, "You can now apply the upgrade by executing the following command:")

--- a/cmd/kubeadm/app/phases/upgrade/compute.go
+++ b/cmd/kubeadm/app/phases/upgrade/compute.go
@@ -216,7 +216,7 @@ func GetAvailableUpgrades(versionGetterImpl VersionGetter, experimentalUpgradesA
 		if err != nil {
 			return upgrades, err
 		}
-		fmt.Printf("[upgrade/versions] Latest %s: %s\n", "experimental version", latestVersionStr)
+		_, _ = printer.Printf("[upgrade/versions] Latest %s: %s\n", "experimental version", latestVersionStr)
 
 		minorUnstable := latestVersion.Components()[1]
 		// Get and output the current latest unstable version
@@ -225,7 +225,7 @@ func GetAvailableUpgrades(versionGetterImpl VersionGetter, experimentalUpgradesA
 		if err != nil {
 			return upgrades, err
 		}
-		fmt.Printf("[upgrade/versions] Latest %s: %s\n", "previous version", previousBranchLatestVersionStr)
+		_, _ = printer.Printf("[upgrade/versions] Latest %s: %s\n", "previous version", previousBranchLatestVersionStr)
 
 		// If that previous latest version is an RC, RCs are allowed and the cluster version is lower than the RC version, show the upgrade
 		if rcUpgradesAllowed && rcUpgradePossible(clusterVersion, previousBranchLatestVersion) {

--- a/cmd/kubeadm/app/phases/upgrade/health.go
+++ b/cmd/kubeadm/app/phases/upgrade/health.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	"k8s.io/kubernetes/cmd/kubeadm/app/images"
 	"k8s.io/kubernetes/cmd/kubeadm/app/preflight"
+	"k8s.io/kubernetes/cmd/kubeadm/app/util/output"
 )
 
 // healthCheck is a helper struct for easily performing healthchecks against the cluster and printing the output
@@ -66,8 +67,8 @@ func (c *healthCheck) Name() string {
 // - the API /healthz endpoint is healthy
 // - all control-plane Nodes are Ready
 // - (if static pod-hosted) that all required Static Pod manifests exist on disk
-func CheckClusterHealth(client clientset.Interface, cfg *kubeadmapi.ClusterConfiguration, ignoreChecksErrors sets.Set[string]) error {
-	fmt.Println("[upgrade] Running cluster health checks")
+func CheckClusterHealth(client clientset.Interface, cfg *kubeadmapi.ClusterConfiguration, ignoreChecksErrors sets.Set[string], printer output.Printer) error {
+	_, _ = printer.Println("[upgrade] Running cluster health checks")
 
 	healthChecks := []preflight.Checker{
 		&healthCheck{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

```
root@kind-control-plane:/# kubeadm upgrade plan -ojson
[upgrade] Running cluster health checks
I0223 06:41:31.158831    1526 version.go:256] remote version is much newer: v1.29.2; falling back to: stable-1.28
{
    "kind": "UpgradePlan",
    "apiVersion": "output.kubeadm.k8s.io/v1alpha2",
    "components": [
        {
            "name": "kubelet",
            "currentVersion": "1 x v1.28.0",
            "newVersion": "v1.28.7"
        },
        {
            "name": "kube-apiserver",
            "currentVersion": "v1.28.0",
            "newVersion": "v1.28.7"
        },
        {
            "name": "kube-controller-manager",
            "currentVersion": "v1.28.0",
            "newVersion": "v1.28.7"
        },
        {
            "name": "kube-scheduler",
            "currentVersion": "v1.28.0",
            "newVersion": "v1.28.7"
        },
        {
            "name": "kube-proxy",
            "currentVersion": "v1.28.0",
            "newVersion": "v1.28.7"
        },
        {
            "name": "CoreDNS",
            "currentVersion": "v1.10.1",
            "newVersion": "v1.10.1"
        },
        {
            "name": "etcd",
            "currentVersion": "3.5.9-0",
            "newVersion": "3.5.9-0"
        }
    ],
    "configVersions": null
}
root@kind-control-plane:/# kubeadm upgrade plan -ojson | jq .
parse error: Invalid numeric literal at line 1, column 9
^C
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Ref https://github.com/kubernetes/kubeadm/issues/494

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubeadm: fix a bug where "kubeadm upgrade plan -o yaml|json" includes unneeded output and was missing component config information.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
