### PR TITLE
bump metrics server to v0.7.0

### DIFF
--- a/cluster/addons/metrics-server/metrics-server-deployment.yaml
+++ b/cluster/addons/metrics-server/metrics-server-deployment.yaml
@@ -23,23 +23,23 @@ data:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: metrics-server-v0.6.3
+  name: metrics-server-v0.7.0
   namespace: kube-system
   labels:
     k8s-app: metrics-server
     addonmanager.kubernetes.io/mode: Reconcile
-    version: v0.6.3
+    version: v0.7.0
 spec:
   selector:
     matchLabels:
       k8s-app: metrics-server
-      version: v0.6.3
+      version: v0.7.0
   template:
     metadata:
       name: metrics-server
       labels:
         k8s-app: metrics-server
-        version: v0.6.3
+        version: v0.7.0
     spec:
       securityContext:
         seccompProfile:
@@ -50,7 +50,7 @@ spec:
         kubernetes.io/os: linux
       containers:
       - name: metrics-server
-        image: registry.k8s.io/metrics-server/metrics-server:v0.6.3
+        image: registry.k8s.io/metrics-server/metrics-server:v0.7.0
         command:
         - /metrics-server
         - --metric-resolution=15s
@@ -109,7 +109,7 @@ spec:
           - --memory={{ base_metrics_server_memory }}
           - --extra-memory={{ metrics_server_memory_per_node }}Mi
           - --threshold=5
-          - --deployment=metrics-server-v0.6.3
+          - --deployment=metrics-server-v0.7.0
           - --container=metrics-server
           - --poll-period=30000
           - --estimator=exponential

--- a/cluster/addons/metrics-server/resource-reader.yaml
+++ b/cluster/addons/metrics-server/resource-reader.yaml
@@ -23,7 +23,7 @@ rules:
     resources:
       - deployments
     resourceNames:
-      - metrics-server-v0.6.3
+      - metrics-server-v0.7.0
     verbs:
       - get
       - patch


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup


#### What this PR does / why we need it:

- https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.7.0
- https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.6.4

#### Which issue(s) this PR fixes:

Fixes None

#### Special notes for your reviewer:

```release-note
upgrade metrics server to v0.7.0
```
