### PR TITLE
Add conditional endPort printing for NetworkPolicies

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/describe/describe.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/describe.go
@@ -4576,7 +4576,11 @@ func printNetworkPolicySpecIngressFrom(npirs []networkingv1.NetworkPolicyIngress
 				} else {
 					proto = corev1.ProtocolTCP
 				}
-				w.Write(LEVEL_0, "%s%s: %s/%s\n", initialIndent, "To Port", port.Port, proto)
+				if port.EndPort != nil {
+					w.Write(LEVEL_0, "%s%s: %s-%d/%s\n", initialIndent, "To Ports", port.Port, *port.EndPort, proto)
+				} else {
+					w.Write(LEVEL_0, "%s%s: %s/%s\n", initialIndent, "To Port", port.Port, proto)
+				}
 			}
 		}
 		if len(npir.From) == 0 {
@@ -4620,7 +4624,11 @@ func printNetworkPolicySpecEgressTo(npers []networkingv1.NetworkPolicyEgressRule
 				} else {
 					proto = corev1.ProtocolTCP
 				}
-				w.Write(LEVEL_0, "%s%s: %s/%s\n", initialIndent, "To Port", port.Port, proto)
+				if port.EndPort != nil {
+					w.Write(LEVEL_0, "%s%s: %s-%d/%s\n", initialIndent, "To Ports", port.Port, *port.EndPort, proto)
+				} else {
+					w.Write(LEVEL_0, "%s%s: %s/%s\n", initialIndent, "To Port", port.Port, proto)
+				}
 			}
 		}
 		if len(nper.To) == 0 {

--- a/staging/src/k8s.io/kubectl/pkg/describe/describe_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/describe_test.go
@@ -5243,6 +5243,7 @@ Spec:
   Allowing ingress traffic:
     To Port: 80/TCP
     To Port: 82/TCP
+    To Ports: 10443-10445/UDP
     From:
       NamespaceSelector: id=ns1,id2=ns2
       PodSelector: id=pod1,id2=pod2
@@ -5265,7 +5266,10 @@ Spec:
 
 	port80 := intstr.FromInt32(80)
 	port82 := intstr.FromInt32(82)
+	port10443 := intstr.FromInt32(10443)
+	var endPort10445 int32 = 10445
 	protoTCP := corev1.ProtocolTCP
+	protoUDP := corev1.ProtocolUDP
 
 	versionedFake := fake.NewSimpleClientset(&networkingv1.NetworkPolicy{
 		ObjectMeta: metav1.ObjectMeta{
@@ -5289,6 +5293,7 @@ Spec:
 					Ports: []networkingv1.NetworkPolicyPort{
 						{Port: &port80},
 						{Port: &port82, Protocol: &protoTCP},
+						{Port: &port10443, EndPort: &endPort10445, Protocol: &protoUDP},
 					},
 					From: []networkingv1.NetworkPolicyPeer{
 						{
@@ -5370,6 +5375,7 @@ Spec:
   Allowing ingress traffic:
     To Port: 80/TCP
     To Port: 82/TCP
+    To Ports: 10443-10445/UDP
     From:
       NamespaceSelector: id=ns1,id2=ns2
       PodSelector: id=pod1,id2=pod2
@@ -5393,7 +5399,10 @@ Spec:
 
 	port80 := intstr.FromInt32(80)
 	port82 := intstr.FromInt32(82)
+	port10443 := intstr.FromInt32(10443)
+	var endPort10445 int32 = 10445
 	protoTCP := corev1.ProtocolTCP
+	protoUDP := corev1.ProtocolUDP
 
 	versionedFake := fake.NewSimpleClientset(&networkingv1.NetworkPolicy{
 		ObjectMeta: metav1.ObjectMeta{
@@ -5417,6 +5426,7 @@ Spec:
 					Ports: []networkingv1.NetworkPolicyPort{
 						{Port: &port80},
 						{Port: &port82, Protocol: &protoTCP},
+						{Port: &port10443, EndPort: &endPort10445, Protocol: &protoUDP},
 					},
 					From: []networkingv1.NetworkPolicyPeer{
 						{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Adds a conditional to the networkpolicy print logic to print information about endPort.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #123506

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed a bug where `kubectl describe` incorrectly displayed NetworkPolicy port ranges
(showing only the starting port).
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
