### PR TITLE
KEP-4265: Update Unmasked ProcMountType to fail validation without a pod level user namespace

### DIFF
--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -3362,7 +3362,7 @@ func validateResizePolicy(policyList []core.ContainerResizePolicy, fldPath *fiel
 
 // validateEphemeralContainers is called by pod spec and template validation to validate the list of ephemeral containers.
 // Note that this is called for pod template even though ephemeral containers aren't allowed in pod templates.
-func validateEphemeralContainers(ephemeralContainers []core.EphemeralContainer, containers, initContainers []core.Container, volumes map[string]core.VolumeSource, podClaimNames sets.Set[string], fldPath *field.Path, opts PodValidationOptions, podRestartPolicy *core.RestartPolicy) field.ErrorList {
+func validateEphemeralContainers(ephemeralContainers []core.EphemeralContainer, containers, initContainers []core.Container, volumes map[string]core.VolumeSource, podClaimNames sets.Set[string], fldPath *field.Path, opts PodValidationOptions, podRestartPolicy *core.RestartPolicy, hostUsers bool) field.ErrorList {
 	var allErrs field.ErrorList
 
 	if len(ephemeralContainers) == 0 {
@@ -3383,7 +3383,7 @@ func validateEphemeralContainers(ephemeralContainers []core.EphemeralContainer, 
 		idxPath := fldPath.Index(i)
 
 		c := (*core.Container)(&ec.EphemeralContainerCommon)
-		allErrs = append(allErrs, validateContainerCommon(c, volumes, podClaimNames, idxPath, opts, podRestartPolicy)...)
+		allErrs = append(allErrs, validateContainerCommon(c, volumes, podClaimNames, idxPath, opts, podRestartPolicy, hostUsers)...)
 		// Ephemeral containers don't need looser constraints for pod templates, so it's convenient to apply both validations
 		// here where we've already converted EphemeralContainerCommon to Container.
 		allErrs = append(allErrs, validateContainerOnlyForPod(c, idxPath)...)
@@ -3445,7 +3445,7 @@ func validateFieldAllowList(value interface{}, allowedFields map[string]bool, er
 }
 
 // validateInitContainers is called by pod spec and template validation to validate the list of init containers
-func validateInitContainers(containers []core.Container, regularContainers []core.Container, volumes map[string]core.VolumeSource, podClaimNames sets.Set[string], gracePeriod int64, fldPath *field.Path, opts PodValidationOptions, podRestartPolicy *core.RestartPolicy) field.ErrorList {
+func validateInitContainers(containers []core.Container, regularContainers []core.Container, volumes map[string]core.VolumeSource, podClaimNames sets.Set[string], gracePeriod int64, fldPath *field.Path, opts PodValidationOptions, podRestartPolicy *core.RestartPolicy, hostUsers bool) field.ErrorList {
 	var allErrs field.ErrorList
 
 	allNames := sets.Set[string]{}
@@ -3456,7 +3456,7 @@ func validateInitContainers(containers []core.Container, regularContainers []cor
 		idxPath := fldPath.Index(i)
 
 		// Apply the validation common to all container types
-		allErrs = append(allErrs, validateContainerCommon(&ctr, volumes, podClaimNames, idxPath, opts, podRestartPolicy)...)
+		allErrs = append(allErrs, validateContainerCommon(&ctr, volumes, podClaimNames, idxPath, opts, podRestartPolicy, hostUsers)...)
 
 		restartAlways := false
 		// Apply the validation specific to init containers
@@ -3511,7 +3511,7 @@ func validateInitContainers(containers []core.Container, regularContainers []cor
 
 // validateContainerCommon applies validation common to all container types. It's called by regular, init, and ephemeral
 // container list validation to require a properly formatted name, image, etc.
-func validateContainerCommon(ctr *core.Container, volumes map[string]core.VolumeSource, podClaimNames sets.Set[string], path *field.Path, opts PodValidationOptions, podRestartPolicy *core.RestartPolicy) field.ErrorList {
+func validateContainerCommon(ctr *core.Container, volumes map[string]core.VolumeSource, podClaimNames sets.Set[string], path *field.Path, opts PodValidationOptions, podRestartPolicy *core.RestartPolicy, hostUsers bool) field.ErrorList {
 	var allErrs field.ErrorList
 
 	namePath := path.Child("name")
@@ -3550,7 +3550,7 @@ func validateContainerCommon(ctr *core.Container, volumes map[string]core.Volume
 	allErrs = append(allErrs, validatePullPolicy(ctr.ImagePullPolicy, path.Child("imagePullPolicy"))...)
 	allErrs = append(allErrs, ValidateResourceRequirements(&ctr.Resources, podClaimNames, path.Child("resources"), opts)...)
 	allErrs = append(allErrs, validateResizePolicy(ctr.ResizePolicy, path.Child("resizePolicy"), podRestartPolicy)...)
-	allErrs = append(allErrs, ValidateSecurityContext(ctr.SecurityContext, path.Child("securityContext"))...)
+	allErrs = append(allErrs, ValidateSecurityContext(ctr.SecurityContext, path.Child("securityContext"), hostUsers)...)
 	return allErrs
 }
 
@@ -3583,7 +3583,7 @@ func validateHostUsers(spec *core.PodSpec, fldPath *field.Path) field.ErrorList 
 }
 
 // validateContainers is called by pod spec and template validation to validate the list of regular containers.
-func validateContainers(containers []core.Container, volumes map[string]core.VolumeSource, podClaimNames sets.Set[string], gracePeriod int64, fldPath *field.Path, opts PodValidationOptions, podRestartPolicy *core.RestartPolicy) field.ErrorList {
+func validateContainers(containers []core.Container, volumes map[string]core.VolumeSource, podClaimNames sets.Set[string], gracePeriod int64, fldPath *field.Path, opts PodValidationOptions, podRestartPolicy *core.RestartPolicy, hostUsers bool) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	if len(containers) == 0 {
@@ -3595,7 +3595,7 @@ func validateContainers(containers []core.Container, volumes map[string]core.Vol
 		path := fldPath.Index(i)
 
 		// Apply validation common to all containers
-		allErrs = append(allErrs, validateContainerCommon(&ctr, volumes, podClaimNames, path, opts, podRestartPolicy)...)
+		allErrs = append(allErrs, validateContainerCommon(&ctr, volumes, podClaimNames, path, opts, podRestartPolicy, hostUsers)...)
 
 		// Container names must be unique within the list of regular containers.
 		// Collisions with init or ephemeral container names will be detected by the init or ephemeral
@@ -4139,13 +4139,17 @@ func ValidatePodSpec(spec *core.PodSpec, podMeta *metav1.ObjectMeta, fldPath *fi
 		gracePeriod = *spec.TerminationGracePeriodSeconds
 	}
 
+	// The default for hostUsers is true, so a spec with no SecurityContext or no HostUsers field will be true.
+	// If the default ever changes, this condition will need to be changed.
+	hostUsers := spec.SecurityContext == nil || spec.SecurityContext.HostUsers == nil || *spec.SecurityContext.HostUsers
+
 	vols, vErrs := ValidateVolumes(spec.Volumes, podMeta, fldPath.Child("volumes"), opts)
 	allErrs = append(allErrs, vErrs...)
 	podClaimNames := gatherPodResourceClaimNames(spec.ResourceClaims)
 	allErrs = append(allErrs, validatePodResourceClaims(podMeta, spec.ResourceClaims, fldPath.Child("resourceClaims"))...)
-	allErrs = append(allErrs, validateContainers(spec.Containers, vols, podClaimNames, gracePeriod, fldPath.Child("containers"), opts, &spec.RestartPolicy)...)
-	allErrs = append(allErrs, validateInitContainers(spec.InitContainers, spec.Containers, vols, podClaimNames, gracePeriod, fldPath.Child("initContainers"), opts, &spec.RestartPolicy)...)
-	allErrs = append(allErrs, validateEphemeralContainers(spec.EphemeralContainers, spec.Containers, spec.InitContainers, vols, podClaimNames, fldPath.Child("ephemeralContainers"), opts, &spec.RestartPolicy)...)
+	allErrs = append(allErrs, validateContainers(spec.Containers, vols, podClaimNames, gracePeriod, fldPath.Child("containers"), opts, &spec.RestartPolicy, hostUsers)...)
+	allErrs = append(allErrs, validateInitContainers(spec.InitContainers, spec.Containers, vols, podClaimNames, gracePeriod, fldPath.Child("initContainers"), opts, &spec.RestartPolicy, hostUsers)...)
+	allErrs = append(allErrs, validateEphemeralContainers(spec.EphemeralContainers, spec.Containers, spec.InitContainers, vols, podClaimNames, fldPath.Child("ephemeralContainers"), opts, &spec.RestartPolicy, hostUsers)...)
 	allErrs = append(allErrs, validatePodHostNetworkDeps(spec, fldPath, opts)...)
 	allErrs = append(allErrs, validateRestartPolicy(&spec.RestartPolicy, fldPath.Child("restartPolicy"))...)
 	allErrs = append(allErrs, validateDNSPolicy(&spec.DNSPolicy, fldPath.Child("dnsPolicy"))...)
@@ -7051,7 +7055,7 @@ func validateEndpointPort(port *core.EndpointPort, requireName bool, fldPath *fi
 }
 
 // ValidateSecurityContext ensures the security context contains valid settings
-func ValidateSecurityContext(sc *core.SecurityContext, fldPath *field.Path) field.ErrorList {
+func ValidateSecurityContext(sc *core.SecurityContext, fldPath *field.Path, hostUsers bool) field.ErrorList {
 	allErrs := field.ErrorList{}
 	// this should only be true for testing since SecurityContext is defaulted by the core
 	if sc == nil {
@@ -7079,6 +7083,9 @@ func ValidateSecurityContext(sc *core.SecurityContext, fldPath *field.Path) fiel
 	if sc.ProcMount != nil {
 		if err := ValidateProcMountType(fldPath.Child("procMount"), *sc.ProcMount); err != nil {
 			allErrs = append(allErrs, err)
+		}
+		if hostUsers && *sc.ProcMount == core.UnmaskedProcMount {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("procMount"), sc.ProcMount, "`hostUsers` must be false to use `Unmasked`"))
 		}
 
 	}

--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -55,6 +55,7 @@ const (
 	envVarNameErrMsg                  = "a valid environment variable name must consist of"
 	relaxedEnvVarNameFmtErrMsg string = "a valid environment variable names must be printable ASCII characters other than '=' character"
 	defaultGracePeriod                = int64(30)
+	noUserNamespace                   = false
 )
 
 var (
@@ -7895,17 +7896,17 @@ func TestValidateEphemeralContainers(t *testing.T) {
 	} {
 		var PodRestartPolicy core.RestartPolicy
 		PodRestartPolicy = "Never"
-		if errs := validateEphemeralContainers(ephemeralContainers, containers, initContainers, vols, nil, field.NewPath("ephemeralContainers"), PodValidationOptions{}, &PodRestartPolicy); len(errs) != 0 {
+		if errs := validateEphemeralContainers(ephemeralContainers, containers, initContainers, vols, nil, field.NewPath("ephemeralContainers"), PodValidationOptions{}, &PodRestartPolicy, noUserNamespace); len(errs) != 0 {
 			t.Errorf("expected success for '%s' but got errors: %v", title, errs)
 		}
 
 		PodRestartPolicy = "Always"
-		if errs := validateEphemeralContainers(ephemeralContainers, containers, initContainers, vols, nil, field.NewPath("ephemeralContainers"), PodValidationOptions{}, &PodRestartPolicy); len(errs) != 0 {
+		if errs := validateEphemeralContainers(ephemeralContainers, containers, initContainers, vols, nil, field.NewPath("ephemeralContainers"), PodValidationOptions{}, &PodRestartPolicy, noUserNamespace); len(errs) != 0 {
 			t.Errorf("expected success for '%s' but got errors: %v", title, errs)
 		}
 
 		PodRestartPolicy = "OnFailure"
-		if errs := validateEphemeralContainers(ephemeralContainers, containers, initContainers, vols, nil, field.NewPath("ephemeralContainers"), PodValidationOptions{}, &PodRestartPolicy); len(errs) != 0 {
+		if errs := validateEphemeralContainers(ephemeralContainers, containers, initContainers, vols, nil, field.NewPath("ephemeralContainers"), PodValidationOptions{}, &PodRestartPolicy, noUserNamespace); len(errs) != 0 {
 			t.Errorf("expected success for '%s' but got errors: %v", title, errs)
 		}
 	}
@@ -8230,19 +8231,19 @@ func TestValidateEphemeralContainers(t *testing.T) {
 		t.Run(tc.title+"__@L"+tc.line, func(t *testing.T) {
 
 			PodRestartPolicy = "Never"
-			errs := validateEphemeralContainers(tc.ephemeralContainers, containers, initContainers, vols, nil, field.NewPath("ephemeralContainers"), PodValidationOptions{}, &PodRestartPolicy)
+			errs := validateEphemeralContainers(tc.ephemeralContainers, containers, initContainers, vols, nil, field.NewPath("ephemeralContainers"), PodValidationOptions{}, &PodRestartPolicy, noUserNamespace)
 			if len(errs) == 0 {
 				t.Fatal("expected error but received none")
 			}
 
 			PodRestartPolicy = "Always"
-			errs = validateEphemeralContainers(tc.ephemeralContainers, containers, initContainers, vols, nil, field.NewPath("ephemeralContainers"), PodValidationOptions{}, &PodRestartPolicy)
+			errs = validateEphemeralContainers(tc.ephemeralContainers, containers, initContainers, vols, nil, field.NewPath("ephemeralContainers"), PodValidationOptions{}, &PodRestartPolicy, noUserNamespace)
 			if len(errs) == 0 {
 				t.Fatal("expected error but received none")
 			}
 
 			PodRestartPolicy = "OnFailure"
-			errs = validateEphemeralContainers(tc.ephemeralContainers, containers, initContainers, vols, nil, field.NewPath("ephemeralContainers"), PodValidationOptions{}, &PodRestartPolicy)
+			errs = validateEphemeralContainers(tc.ephemeralContainers, containers, initContainers, vols, nil, field.NewPath("ephemeralContainers"), PodValidationOptions{}, &PodRestartPolicy, noUserNamespace)
 			if len(errs) == 0 {
 				t.Fatal("expected error but received none")
 			}
@@ -8542,7 +8543,7 @@ func TestValidateContainers(t *testing.T) {
 	}
 
 	var PodRestartPolicy core.RestartPolicy = "Always"
-	if errs := validateContainers(successCase, volumeDevices, nil, defaultGracePeriod, field.NewPath("field"), PodValidationOptions{}, &PodRestartPolicy); len(errs) != 0 {
+	if errs := validateContainers(successCase, volumeDevices, nil, defaultGracePeriod, field.NewPath("field"), PodValidationOptions{}, &PodRestartPolicy, noUserNamespace); len(errs) != 0 {
 		t.Errorf("expected success: %v", errs)
 	}
 
@@ -9156,7 +9157,7 @@ func TestValidateContainers(t *testing.T) {
 
 	for _, tc := range errorCases {
 		t.Run(tc.title+"__@L"+tc.line, func(t *testing.T) {
-			errs := validateContainers(tc.containers, volumeDevices, nil, defaultGracePeriod, field.NewPath("containers"), PodValidationOptions{}, &PodRestartPolicy)
+			errs := validateContainers(tc.containers, volumeDevices, nil, defaultGracePeriod, field.NewPath("containers"), PodValidationOptions{}, &PodRestartPolicy, noUserNamespace)
 			if len(errs) == 0 {
 				t.Fatal("expected error but received none")
 			}
@@ -9245,7 +9246,7 @@ func TestValidateInitContainers(t *testing.T) {
 	},
 	}
 	var PodRestartPolicy core.RestartPolicy = "Never"
-	if errs := validateInitContainers(successCase, containers, volumeDevices, nil, defaultGracePeriod, field.NewPath("field"), PodValidationOptions{}, &PodRestartPolicy); len(errs) != 0 {
+	if errs := validateInitContainers(successCase, containers, volumeDevices, nil, defaultGracePeriod, field.NewPath("field"), PodValidationOptions{}, &PodRestartPolicy, noUserNamespace); len(errs) != 0 {
 		t.Errorf("expected success: %v", errs)
 	}
 
@@ -9624,7 +9625,7 @@ func TestValidateInitContainers(t *testing.T) {
 
 	for _, tc := range errorCases {
 		t.Run(tc.title+"__@L"+tc.line, func(t *testing.T) {
-			errs := validateInitContainers(tc.initContainers, containers, volumeDevices, nil, defaultGracePeriod, field.NewPath("initContainers"), PodValidationOptions{}, &PodRestartPolicy)
+			errs := validateInitContainers(tc.initContainers, containers, volumeDevices, nil, defaultGracePeriod, field.NewPath("initContainers"), PodValidationOptions{}, &PodRestartPolicy, noUserNamespace)
 			if len(errs) == 0 {
 				t.Fatal("expected error but received none")
 			}
@@ -22624,17 +22625,28 @@ func TestValidateSecurityContext(t *testing.T) {
 	noRunAsUser := fullValidSC()
 	noRunAsUser.RunAsUser = nil
 
+	procMountSet := fullValidSC()
+	defPmt := core.DefaultProcMount
+	procMountSet.ProcMount = &defPmt
+
+	umPmt := core.UnmaskedProcMount
+	procMountUnmasked := fullValidSC()
+	procMountUnmasked.ProcMount = &umPmt
+
 	successCases := map[string]struct {
-		sc *core.SecurityContext
+		sc        *core.SecurityContext
+		hostUsers bool
 	}{
-		"all settings":    {allSettings},
-		"no capabilities": {noCaps},
-		"no selinux":      {noSELinux},
-		"no priv request": {noPrivRequest},
-		"no run as user":  {noRunAsUser},
+		"all settings":        {allSettings, false},
+		"no capabilities":     {noCaps, false},
+		"no selinux":          {noSELinux, false},
+		"no priv request":     {noPrivRequest, false},
+		"no run as user":      {noRunAsUser, false},
+		"proc mount set":      {procMountSet, true},
+		"proc mount unmasked": {procMountUnmasked, false},
 	}
 	for k, v := range successCases {
-		if errs := ValidateSecurityContext(v.sc, field.NewPath("field")); len(errs) != 0 {
+		if errs := ValidateSecurityContext(v.sc, field.NewPath("field"), v.hostUsers); len(errs) != 0 {
 			t.Errorf("[%s] Expected success, got %v", k, errs)
 		}
 	}
@@ -22681,12 +22693,19 @@ func TestValidateSecurityContext(t *testing.T) {
 			errorDetail:  "cannot set `allowPrivilegeEscalation` to false and `privileged` to true",
 			capAllowPriv: true,
 		},
+		"with unmasked proc mount type and no user namespace": {
+			sc:          procMountUnmasked,
+			errorType:   "FieldValueInvalid",
+			errorDetail: "`hostUsers` must be false to use `Unmasked`",
+		},
 	}
 	for k, v := range errorCases {
 		capabilities.SetForTests(capabilities.Capabilities{
 			AllowPrivileged: v.capAllowPriv,
 		})
-		if errs := ValidateSecurityContext(v.sc, field.NewPath("field")); len(errs) == 0 || errs[0].Type != v.errorType || !strings.Contains(errs[0].Detail, v.errorDetail) {
+		// note the unconditional `true` here for hostUsers. The failure case to test for ProcMount only includes it being true,
+		// and the field is ignored if ProcMount isn't set. Thus, we can unconditionally set to `true` and simplify the test matrix setup.
+		if errs := ValidateSecurityContext(v.sc, field.NewPath("field"), true); len(errs) == 0 || errs[0].Type != v.errorType || !strings.Contains(errs[0].Detail, v.errorDetail) {
 			t.Errorf("[%s] Expected error type %q with detail %q, got %v", k, v.errorType, v.errorDetail, errs)
 		}
 	}

--- a/staging/src/k8s.io/pod-security-admission/policy/check_procMount_test.go
+++ b/staging/src/k8s.io/pod-security-admission/policy/check_procMount_test.go
@@ -27,6 +27,7 @@ func TestProcMount(t *testing.T) {
 	unmaskedValue := corev1.UnmaskedProcMount
 	otherValue := corev1.ProcMountType("other")
 
+	hostUsers := false
 	tests := []struct {
 		name         string
 		pod          *corev1.Pod
@@ -43,6 +44,7 @@ func TestProcMount(t *testing.T) {
 					{Name: "d", SecurityContext: &corev1.SecurityContext{ProcMount: &unmaskedValue}},
 					{Name: "e", SecurityContext: &corev1.SecurityContext{ProcMount: &otherValue}},
 				},
+				HostUsers: &hostUsers,
 			}},
 			expectReason: `procMount`,
 			expectDetail: `containers "d", "e" must not set securityContext.procMount to "Unmasked", "other"`,

--- a/staging/src/k8s.io/pod-security-admission/test/fixtures_procMount.go
+++ b/staging/src/k8s.io/pod-security-admission/test/fixtures_procMount.go
@@ -23,6 +23,7 @@ import (
 )
 
 func init() {
+	hostUsers := false
 	fixtureData_1_0 := fixtureGenerator{
 		expectErrorSubstring: "procMount",
 		generatePass: func(p *corev1.Pod) []*corev1.Pod {
@@ -33,6 +34,7 @@ func init() {
 					validProcMountType := corev1.DefaultProcMount
 					copy.Spec.Containers[0].SecurityContext.ProcMount = &validProcMountType
 					copy.Spec.InitContainers[0].SecurityContext.ProcMount = &validProcMountType
+					copy.Spec.HostUsers = &hostUsers
 				}),
 			}
 		},
@@ -44,11 +46,13 @@ func init() {
 				tweak(p, func(copy *corev1.Pod) {
 					unmaskedProcMountType := corev1.UnmaskedProcMount
 					copy.Spec.Containers[0].SecurityContext.ProcMount = &unmaskedProcMountType
+					copy.Spec.HostUsers = &hostUsers
 				}),
 				// set proc mount of init container to a forbidden value
 				tweak(p, func(copy *corev1.Pod) {
 					unmaskedProcMountType := corev1.UnmaskedProcMount
 					copy.Spec.InitContainers[0].SecurityContext.ProcMount = &unmaskedProcMountType
+					copy.Spec.HostUsers = &hostUsers
 				}),
 			}
 		},

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.0/fail/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.0/fail/procmount0.yaml
@@ -8,6 +8,7 @@ spec:
     name: container1
     securityContext:
       procMount: Unmasked
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.0/fail/procmount1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.0/fail/procmount1.yaml
@@ -7,6 +7,7 @@ spec:
   - image: registry.k8s.io/pause
     name: container1
     securityContext: {}
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.0/pass/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.0/pass/procmount0.yaml
@@ -8,6 +8,7 @@ spec:
     name: container1
     securityContext:
       procMount: Default
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.1/fail/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.1/fail/procmount0.yaml
@@ -8,6 +8,7 @@ spec:
     name: container1
     securityContext:
       procMount: Unmasked
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.1/fail/procmount1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.1/fail/procmount1.yaml
@@ -7,6 +7,7 @@ spec:
   - image: registry.k8s.io/pause
     name: container1
     securityContext: {}
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.1/pass/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.1/pass/procmount0.yaml
@@ -8,6 +8,7 @@ spec:
     name: container1
     securityContext:
       procMount: Default
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.10/fail/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.10/fail/procmount0.yaml
@@ -8,6 +8,7 @@ spec:
     name: container1
     securityContext:
       procMount: Unmasked
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.10/fail/procmount1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.10/fail/procmount1.yaml
@@ -7,6 +7,7 @@ spec:
   - image: registry.k8s.io/pause
     name: container1
     securityContext: {}
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.10/pass/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.10/pass/procmount0.yaml
@@ -8,6 +8,7 @@ spec:
     name: container1
     securityContext:
       procMount: Default
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.11/fail/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.11/fail/procmount0.yaml
@@ -8,6 +8,7 @@ spec:
     name: container1
     securityContext:
       procMount: Unmasked
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.11/fail/procmount1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.11/fail/procmount1.yaml
@@ -7,6 +7,7 @@ spec:
   - image: registry.k8s.io/pause
     name: container1
     securityContext: {}
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.11/pass/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.11/pass/procmount0.yaml
@@ -8,6 +8,7 @@ spec:
     name: container1
     securityContext:
       procMount: Default
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.12/fail/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.12/fail/procmount0.yaml
@@ -8,6 +8,7 @@ spec:
     name: container1
     securityContext:
       procMount: Unmasked
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.12/fail/procmount1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.12/fail/procmount1.yaml
@@ -7,6 +7,7 @@ spec:
   - image: registry.k8s.io/pause
     name: container1
     securityContext: {}
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.12/pass/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.12/pass/procmount0.yaml
@@ -8,6 +8,7 @@ spec:
     name: container1
     securityContext:
       procMount: Default
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.13/fail/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.13/fail/procmount0.yaml
@@ -8,6 +8,7 @@ spec:
     name: container1
     securityContext:
       procMount: Unmasked
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.13/fail/procmount1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.13/fail/procmount1.yaml
@@ -7,6 +7,7 @@ spec:
   - image: registry.k8s.io/pause
     name: container1
     securityContext: {}
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.13/pass/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.13/pass/procmount0.yaml
@@ -8,6 +8,7 @@ spec:
     name: container1
     securityContext:
       procMount: Default
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.14/fail/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.14/fail/procmount0.yaml
@@ -8,6 +8,7 @@ spec:
     name: container1
     securityContext:
       procMount: Unmasked
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.14/fail/procmount1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.14/fail/procmount1.yaml
@@ -7,6 +7,7 @@ spec:
   - image: registry.k8s.io/pause
     name: container1
     securityContext: {}
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.14/pass/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.14/pass/procmount0.yaml
@@ -8,6 +8,7 @@ spec:
     name: container1
     securityContext:
       procMount: Default
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.15/fail/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.15/fail/procmount0.yaml
@@ -8,6 +8,7 @@ spec:
     name: container1
     securityContext:
       procMount: Unmasked
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.15/fail/procmount1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.15/fail/procmount1.yaml
@@ -7,6 +7,7 @@ spec:
   - image: registry.k8s.io/pause
     name: container1
     securityContext: {}
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.15/pass/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.15/pass/procmount0.yaml
@@ -8,6 +8,7 @@ spec:
     name: container1
     securityContext:
       procMount: Default
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.16/fail/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.16/fail/procmount0.yaml
@@ -8,6 +8,7 @@ spec:
     name: container1
     securityContext:
       procMount: Unmasked
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.16/fail/procmount1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.16/fail/procmount1.yaml
@@ -7,6 +7,7 @@ spec:
   - image: registry.k8s.io/pause
     name: container1
     securityContext: {}
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.16/pass/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.16/pass/procmount0.yaml
@@ -8,6 +8,7 @@ spec:
     name: container1
     securityContext:
       procMount: Default
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.17/fail/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.17/fail/procmount0.yaml
@@ -8,6 +8,7 @@ spec:
     name: container1
     securityContext:
       procMount: Unmasked
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.17/fail/procmount1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.17/fail/procmount1.yaml
@@ -7,6 +7,7 @@ spec:
   - image: registry.k8s.io/pause
     name: container1
     securityContext: {}
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.17/pass/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.17/pass/procmount0.yaml
@@ -8,6 +8,7 @@ spec:
     name: container1
     securityContext:
       procMount: Default
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.18/fail/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.18/fail/procmount0.yaml
@@ -8,6 +8,7 @@ spec:
     name: container1
     securityContext:
       procMount: Unmasked
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.18/fail/procmount1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.18/fail/procmount1.yaml
@@ -7,6 +7,7 @@ spec:
   - image: registry.k8s.io/pause
     name: container1
     securityContext: {}
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.18/pass/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.18/pass/procmount0.yaml
@@ -8,6 +8,7 @@ spec:
     name: container1
     securityContext:
       procMount: Default
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.19/fail/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.19/fail/procmount0.yaml
@@ -8,6 +8,7 @@ spec:
     name: container1
     securityContext:
       procMount: Unmasked
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.19/fail/procmount1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.19/fail/procmount1.yaml
@@ -7,6 +7,7 @@ spec:
   - image: registry.k8s.io/pause
     name: container1
     securityContext: {}
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.19/pass/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.19/pass/procmount0.yaml
@@ -8,6 +8,7 @@ spec:
     name: container1
     securityContext:
       procMount: Default
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.2/fail/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.2/fail/procmount0.yaml
@@ -8,6 +8,7 @@ spec:
     name: container1
     securityContext:
       procMount: Unmasked
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.2/fail/procmount1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.2/fail/procmount1.yaml
@@ -7,6 +7,7 @@ spec:
   - image: registry.k8s.io/pause
     name: container1
     securityContext: {}
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.2/pass/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.2/pass/procmount0.yaml
@@ -8,6 +8,7 @@ spec:
     name: container1
     securityContext:
       procMount: Default
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.20/fail/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.20/fail/procmount0.yaml
@@ -8,6 +8,7 @@ spec:
     name: container1
     securityContext:
       procMount: Unmasked
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.20/fail/procmount1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.20/fail/procmount1.yaml
@@ -7,6 +7,7 @@ spec:
   - image: registry.k8s.io/pause
     name: container1
     securityContext: {}
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.20/pass/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.20/pass/procmount0.yaml
@@ -8,6 +8,7 @@ spec:
     name: container1
     securityContext:
       procMount: Default
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.21/fail/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.21/fail/procmount0.yaml
@@ -8,6 +8,7 @@ spec:
     name: container1
     securityContext:
       procMount: Unmasked
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.21/fail/procmount1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.21/fail/procmount1.yaml
@@ -7,6 +7,7 @@ spec:
   - image: registry.k8s.io/pause
     name: container1
     securityContext: {}
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.21/pass/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.21/pass/procmount0.yaml
@@ -8,6 +8,7 @@ spec:
     name: container1
     securityContext:
       procMount: Default
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.22/fail/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.22/fail/procmount0.yaml
@@ -8,6 +8,7 @@ spec:
     name: container1
     securityContext:
       procMount: Unmasked
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.22/fail/procmount1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.22/fail/procmount1.yaml
@@ -7,6 +7,7 @@ spec:
   - image: registry.k8s.io/pause
     name: container1
     securityContext: {}
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.22/pass/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.22/pass/procmount0.yaml
@@ -8,6 +8,7 @@ spec:
     name: container1
     securityContext:
       procMount: Default
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.23/fail/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.23/fail/procmount0.yaml
@@ -8,6 +8,7 @@ spec:
     name: container1
     securityContext:
       procMount: Unmasked
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.23/fail/procmount1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.23/fail/procmount1.yaml
@@ -7,6 +7,7 @@ spec:
   - image: registry.k8s.io/pause
     name: container1
     securityContext: {}
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.23/pass/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.23/pass/procmount0.yaml
@@ -8,6 +8,7 @@ spec:
     name: container1
     securityContext:
       procMount: Default
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.24/fail/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.24/fail/procmount0.yaml
@@ -8,6 +8,7 @@ spec:
     name: container1
     securityContext:
       procMount: Unmasked
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.24/fail/procmount1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.24/fail/procmount1.yaml
@@ -7,6 +7,7 @@ spec:
   - image: registry.k8s.io/pause
     name: container1
     securityContext: {}
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.24/pass/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.24/pass/procmount0.yaml
@@ -8,6 +8,7 @@ spec:
     name: container1
     securityContext:
       procMount: Default
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.25/fail/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.25/fail/procmount0.yaml
@@ -8,6 +8,7 @@ spec:
     name: container1
     securityContext:
       procMount: Unmasked
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.25/fail/procmount1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.25/fail/procmount1.yaml
@@ -7,6 +7,7 @@ spec:
   - image: registry.k8s.io/pause
     name: container1
     securityContext: {}
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.25/pass/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.25/pass/procmount0.yaml
@@ -8,6 +8,7 @@ spec:
     name: container1
     securityContext:
       procMount: Default
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.26/fail/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.26/fail/procmount0.yaml
@@ -8,6 +8,7 @@ spec:
     name: container1
     securityContext:
       procMount: Unmasked
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.26/fail/procmount1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.26/fail/procmount1.yaml
@@ -7,6 +7,7 @@ spec:
   - image: registry.k8s.io/pause
     name: container1
     securityContext: {}
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.26/pass/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.26/pass/procmount0.yaml
@@ -8,6 +8,7 @@ spec:
     name: container1
     securityContext:
       procMount: Default
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.27/fail/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.27/fail/procmount0.yaml
@@ -8,6 +8,7 @@ spec:
     name: container1
     securityContext:
       procMount: Unmasked
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.27/fail/procmount1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.27/fail/procmount1.yaml
@@ -7,6 +7,7 @@ spec:
   - image: registry.k8s.io/pause
     name: container1
     securityContext: {}
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.27/pass/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.27/pass/procmount0.yaml
@@ -8,6 +8,7 @@ spec:
     name: container1
     securityContext:
       procMount: Default
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.28/fail/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.28/fail/procmount0.yaml
@@ -8,6 +8,7 @@ spec:
     name: container1
     securityContext:
       procMount: Unmasked
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.28/fail/procmount1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.28/fail/procmount1.yaml
@@ -7,6 +7,7 @@ spec:
   - image: registry.k8s.io/pause
     name: container1
     securityContext: {}
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.28/pass/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.28/pass/procmount0.yaml
@@ -8,6 +8,7 @@ spec:
     name: container1
     securityContext:
       procMount: Default
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.29/fail/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.29/fail/procmount0.yaml
@@ -8,6 +8,7 @@ spec:
     name: container1
     securityContext:
       procMount: Unmasked
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.29/fail/procmount1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.29/fail/procmount1.yaml
@@ -7,6 +7,7 @@ spec:
   - image: registry.k8s.io/pause
     name: container1
     securityContext: {}
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.29/pass/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.29/pass/procmount0.yaml
@@ -8,6 +8,7 @@ spec:
     name: container1
     securityContext:
       procMount: Default
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.3/fail/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.3/fail/procmount0.yaml
@@ -8,6 +8,7 @@ spec:
     name: container1
     securityContext:
       procMount: Unmasked
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.3/fail/procmount1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.3/fail/procmount1.yaml
@@ -7,6 +7,7 @@ spec:
   - image: registry.k8s.io/pause
     name: container1
     securityContext: {}
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.3/pass/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.3/pass/procmount0.yaml
@@ -8,6 +8,7 @@ spec:
     name: container1
     securityContext:
       procMount: Default
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.4/fail/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.4/fail/procmount0.yaml
@@ -8,6 +8,7 @@ spec:
     name: container1
     securityContext:
       procMount: Unmasked
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.4/fail/procmount1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.4/fail/procmount1.yaml
@@ -7,6 +7,7 @@ spec:
   - image: registry.k8s.io/pause
     name: container1
     securityContext: {}
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.4/pass/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.4/pass/procmount0.yaml
@@ -8,6 +8,7 @@ spec:
     name: container1
     securityContext:
       procMount: Default
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.5/fail/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.5/fail/procmount0.yaml
@@ -8,6 +8,7 @@ spec:
     name: container1
     securityContext:
       procMount: Unmasked
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.5/fail/procmount1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.5/fail/procmount1.yaml
@@ -7,6 +7,7 @@ spec:
   - image: registry.k8s.io/pause
     name: container1
     securityContext: {}
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.5/pass/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.5/pass/procmount0.yaml
@@ -8,6 +8,7 @@ spec:
     name: container1
     securityContext:
       procMount: Default
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.6/fail/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.6/fail/procmount0.yaml
@@ -8,6 +8,7 @@ spec:
     name: container1
     securityContext:
       procMount: Unmasked
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.6/fail/procmount1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.6/fail/procmount1.yaml
@@ -7,6 +7,7 @@ spec:
   - image: registry.k8s.io/pause
     name: container1
     securityContext: {}
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.6/pass/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.6/pass/procmount0.yaml
@@ -8,6 +8,7 @@ spec:
     name: container1
     securityContext:
       procMount: Default
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.7/fail/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.7/fail/procmount0.yaml
@@ -8,6 +8,7 @@ spec:
     name: container1
     securityContext:
       procMount: Unmasked
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.7/fail/procmount1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.7/fail/procmount1.yaml
@@ -7,6 +7,7 @@ spec:
   - image: registry.k8s.io/pause
     name: container1
     securityContext: {}
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.7/pass/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.7/pass/procmount0.yaml
@@ -8,6 +8,7 @@ spec:
     name: container1
     securityContext:
       procMount: Default
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.8/fail/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.8/fail/procmount0.yaml
@@ -8,6 +8,7 @@ spec:
     name: container1
     securityContext:
       procMount: Unmasked
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.8/fail/procmount1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.8/fail/procmount1.yaml
@@ -7,6 +7,7 @@ spec:
   - image: registry.k8s.io/pause
     name: container1
     securityContext: {}
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.8/pass/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.8/pass/procmount0.yaml
@@ -8,6 +8,7 @@ spec:
     name: container1
     securityContext:
       procMount: Default
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.9/fail/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.9/fail/procmount0.yaml
@@ -8,6 +8,7 @@ spec:
     name: container1
     securityContext:
       procMount: Unmasked
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.9/fail/procmount1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.9/fail/procmount1.yaml
@@ -7,6 +7,7 @@ spec:
   - image: registry.k8s.io/pause
     name: container1
     securityContext: {}
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.9/pass/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.9/pass/procmount0.yaml
@@ -8,6 +8,7 @@ spec:
     name: container1
     securityContext:
       procMount: Default
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.0/fail/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.0/fail/procmount0.yaml
@@ -8,6 +8,7 @@ spec:
     name: container1
     securityContext:
       procMount: Unmasked
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.0/fail/procmount1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.0/fail/procmount1.yaml
@@ -7,6 +7,7 @@ spec:
   - image: registry.k8s.io/pause
     name: container1
     securityContext: {}
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.0/pass/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.0/pass/procmount0.yaml
@@ -8,6 +8,7 @@ spec:
     name: container1
     securityContext:
       procMount: Default
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.1/fail/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.1/fail/procmount0.yaml
@@ -8,6 +8,7 @@ spec:
     name: container1
     securityContext:
       procMount: Unmasked
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.1/fail/procmount1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.1/fail/procmount1.yaml
@@ -7,6 +7,7 @@ spec:
   - image: registry.k8s.io/pause
     name: container1
     securityContext: {}
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.1/pass/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.1/pass/procmount0.yaml
@@ -8,6 +8,7 @@ spec:
     name: container1
     securityContext:
       procMount: Default
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.10/fail/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.10/fail/procmount0.yaml
@@ -9,6 +9,7 @@ spec:
     securityContext:
       allowPrivilegeEscalation: false
       procMount: Unmasked
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.10/fail/procmount1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.10/fail/procmount1.yaml
@@ -8,6 +8,7 @@ spec:
     name: container1
     securityContext:
       allowPrivilegeEscalation: false
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.10/pass/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.10/pass/procmount0.yaml
@@ -9,6 +9,7 @@ spec:
     securityContext:
       allowPrivilegeEscalation: false
       procMount: Default
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.11/fail/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.11/fail/procmount0.yaml
@@ -9,6 +9,7 @@ spec:
     securityContext:
       allowPrivilegeEscalation: false
       procMount: Unmasked
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.11/fail/procmount1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.11/fail/procmount1.yaml
@@ -8,6 +8,7 @@ spec:
     name: container1
     securityContext:
       allowPrivilegeEscalation: false
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.11/pass/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.11/pass/procmount0.yaml
@@ -9,6 +9,7 @@ spec:
     securityContext:
       allowPrivilegeEscalation: false
       procMount: Default
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.12/fail/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.12/fail/procmount0.yaml
@@ -9,6 +9,7 @@ spec:
     securityContext:
       allowPrivilegeEscalation: false
       procMount: Unmasked
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.12/fail/procmount1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.12/fail/procmount1.yaml
@@ -8,6 +8,7 @@ spec:
     name: container1
     securityContext:
       allowPrivilegeEscalation: false
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.12/pass/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.12/pass/procmount0.yaml
@@ -9,6 +9,7 @@ spec:
     securityContext:
       allowPrivilegeEscalation: false
       procMount: Default
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.13/fail/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.13/fail/procmount0.yaml
@@ -9,6 +9,7 @@ spec:
     securityContext:
       allowPrivilegeEscalation: false
       procMount: Unmasked
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.13/fail/procmount1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.13/fail/procmount1.yaml
@@ -8,6 +8,7 @@ spec:
     name: container1
     securityContext:
       allowPrivilegeEscalation: false
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.13/pass/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.13/pass/procmount0.yaml
@@ -9,6 +9,7 @@ spec:
     securityContext:
       allowPrivilegeEscalation: false
       procMount: Default
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.14/fail/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.14/fail/procmount0.yaml
@@ -9,6 +9,7 @@ spec:
     securityContext:
       allowPrivilegeEscalation: false
       procMount: Unmasked
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.14/fail/procmount1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.14/fail/procmount1.yaml
@@ -8,6 +8,7 @@ spec:
     name: container1
     securityContext:
       allowPrivilegeEscalation: false
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.14/pass/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.14/pass/procmount0.yaml
@@ -9,6 +9,7 @@ spec:
     securityContext:
       allowPrivilegeEscalation: false
       procMount: Default
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.15/fail/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.15/fail/procmount0.yaml
@@ -9,6 +9,7 @@ spec:
     securityContext:
       allowPrivilegeEscalation: false
       procMount: Unmasked
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.15/fail/procmount1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.15/fail/procmount1.yaml
@@ -8,6 +8,7 @@ spec:
     name: container1
     securityContext:
       allowPrivilegeEscalation: false
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.15/pass/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.15/pass/procmount0.yaml
@@ -9,6 +9,7 @@ spec:
     securityContext:
       allowPrivilegeEscalation: false
       procMount: Default
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.16/fail/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.16/fail/procmount0.yaml
@@ -9,6 +9,7 @@ spec:
     securityContext:
       allowPrivilegeEscalation: false
       procMount: Unmasked
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.16/fail/procmount1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.16/fail/procmount1.yaml
@@ -8,6 +8,7 @@ spec:
     name: container1
     securityContext:
       allowPrivilegeEscalation: false
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.16/pass/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.16/pass/procmount0.yaml
@@ -9,6 +9,7 @@ spec:
     securityContext:
       allowPrivilegeEscalation: false
       procMount: Default
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.17/fail/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.17/fail/procmount0.yaml
@@ -9,6 +9,7 @@ spec:
     securityContext:
       allowPrivilegeEscalation: false
       procMount: Unmasked
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.17/fail/procmount1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.17/fail/procmount1.yaml
@@ -8,6 +8,7 @@ spec:
     name: container1
     securityContext:
       allowPrivilegeEscalation: false
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.17/pass/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.17/pass/procmount0.yaml
@@ -9,6 +9,7 @@ spec:
     securityContext:
       allowPrivilegeEscalation: false
       procMount: Default
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.18/fail/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.18/fail/procmount0.yaml
@@ -9,6 +9,7 @@ spec:
     securityContext:
       allowPrivilegeEscalation: false
       procMount: Unmasked
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.18/fail/procmount1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.18/fail/procmount1.yaml
@@ -8,6 +8,7 @@ spec:
     name: container1
     securityContext:
       allowPrivilegeEscalation: false
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.18/pass/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.18/pass/procmount0.yaml
@@ -9,6 +9,7 @@ spec:
     securityContext:
       allowPrivilegeEscalation: false
       procMount: Default
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.19/fail/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.19/fail/procmount0.yaml
@@ -9,6 +9,7 @@ spec:
     securityContext:
       allowPrivilegeEscalation: false
       procMount: Unmasked
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.19/fail/procmount1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.19/fail/procmount1.yaml
@@ -8,6 +8,7 @@ spec:
     name: container1
     securityContext:
       allowPrivilegeEscalation: false
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.19/pass/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.19/pass/procmount0.yaml
@@ -9,6 +9,7 @@ spec:
     securityContext:
       allowPrivilegeEscalation: false
       procMount: Default
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.2/fail/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.2/fail/procmount0.yaml
@@ -8,6 +8,7 @@ spec:
     name: container1
     securityContext:
       procMount: Unmasked
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.2/fail/procmount1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.2/fail/procmount1.yaml
@@ -7,6 +7,7 @@ spec:
   - image: registry.k8s.io/pause
     name: container1
     securityContext: {}
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.2/pass/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.2/pass/procmount0.yaml
@@ -8,6 +8,7 @@ spec:
     name: container1
     securityContext:
       procMount: Default
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.20/fail/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.20/fail/procmount0.yaml
@@ -9,6 +9,7 @@ spec:
     securityContext:
       allowPrivilegeEscalation: false
       procMount: Unmasked
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.20/fail/procmount1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.20/fail/procmount1.yaml
@@ -8,6 +8,7 @@ spec:
     name: container1
     securityContext:
       allowPrivilegeEscalation: false
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.20/pass/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.20/pass/procmount0.yaml
@@ -9,6 +9,7 @@ spec:
     securityContext:
       allowPrivilegeEscalation: false
       procMount: Default
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.21/fail/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.21/fail/procmount0.yaml
@@ -9,6 +9,7 @@ spec:
     securityContext:
       allowPrivilegeEscalation: false
       procMount: Unmasked
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.21/fail/procmount1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.21/fail/procmount1.yaml
@@ -8,6 +8,7 @@ spec:
     name: container1
     securityContext:
       allowPrivilegeEscalation: false
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.21/pass/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.21/pass/procmount0.yaml
@@ -9,6 +9,7 @@ spec:
     securityContext:
       allowPrivilegeEscalation: false
       procMount: Default
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.22/fail/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.22/fail/procmount0.yaml
@@ -12,6 +12,7 @@ spec:
         drop:
         - ALL
       procMount: Unmasked
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.22/fail/procmount1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.22/fail/procmount1.yaml
@@ -11,6 +11,7 @@ spec:
       capabilities:
         drop:
         - ALL
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.22/pass/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.22/pass/procmount0.yaml
@@ -12,6 +12,7 @@ spec:
         drop:
         - ALL
       procMount: Default
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/procmount0.yaml
@@ -12,6 +12,7 @@ spec:
         drop:
         - ALL
       procMount: Unmasked
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/procmount1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/fail/procmount1.yaml
@@ -11,6 +11,7 @@ spec:
       capabilities:
         drop:
         - ALL
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/pass/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.23/pass/procmount0.yaml
@@ -12,6 +12,7 @@ spec:
         drop:
         - ALL
       procMount: Default
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/procmount0.yaml
@@ -12,6 +12,7 @@ spec:
         drop:
         - ALL
       procMount: Unmasked
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/procmount1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/fail/procmount1.yaml
@@ -11,6 +11,7 @@ spec:
       capabilities:
         drop:
         - ALL
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/pass/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.24/pass/procmount0.yaml
@@ -12,6 +12,7 @@ spec:
         drop:
         - ALL
       procMount: Default
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/procmount0.yaml
@@ -12,6 +12,7 @@ spec:
         drop:
         - ALL
       procMount: Unmasked
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/procmount1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/fail/procmount1.yaml
@@ -11,6 +11,7 @@ spec:
       capabilities:
         drop:
         - ALL
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/pass/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.25/pass/procmount0.yaml
@@ -12,6 +12,7 @@ spec:
         drop:
         - ALL
       procMount: Default
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.26/fail/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.26/fail/procmount0.yaml
@@ -12,6 +12,7 @@ spec:
         drop:
         - ALL
       procMount: Unmasked
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.26/fail/procmount1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.26/fail/procmount1.yaml
@@ -11,6 +11,7 @@ spec:
       capabilities:
         drop:
         - ALL
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.26/pass/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.26/pass/procmount0.yaml
@@ -12,6 +12,7 @@ spec:
         drop:
         - ALL
       procMount: Default
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.27/fail/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.27/fail/procmount0.yaml
@@ -12,6 +12,7 @@ spec:
         drop:
         - ALL
       procMount: Unmasked
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.27/fail/procmount1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.27/fail/procmount1.yaml
@@ -11,6 +11,7 @@ spec:
       capabilities:
         drop:
         - ALL
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.27/pass/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.27/pass/procmount0.yaml
@@ -12,6 +12,7 @@ spec:
         drop:
         - ALL
       procMount: Default
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.28/fail/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.28/fail/procmount0.yaml
@@ -12,6 +12,7 @@ spec:
         drop:
         - ALL
       procMount: Unmasked
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.28/fail/procmount1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.28/fail/procmount1.yaml
@@ -11,6 +11,7 @@ spec:
       capabilities:
         drop:
         - ALL
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.28/pass/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.28/pass/procmount0.yaml
@@ -12,6 +12,7 @@ spec:
         drop:
         - ALL
       procMount: Default
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.29/fail/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.29/fail/procmount0.yaml
@@ -12,6 +12,7 @@ spec:
         drop:
         - ALL
       procMount: Unmasked
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.29/fail/procmount1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.29/fail/procmount1.yaml
@@ -11,6 +11,7 @@ spec:
       capabilities:
         drop:
         - ALL
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.29/pass/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.29/pass/procmount0.yaml
@@ -12,6 +12,7 @@ spec:
         drop:
         - ALL
       procMount: Default
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.3/fail/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.3/fail/procmount0.yaml
@@ -8,6 +8,7 @@ spec:
     name: container1
     securityContext:
       procMount: Unmasked
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.3/fail/procmount1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.3/fail/procmount1.yaml
@@ -7,6 +7,7 @@ spec:
   - image: registry.k8s.io/pause
     name: container1
     securityContext: {}
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.3/pass/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.3/pass/procmount0.yaml
@@ -8,6 +8,7 @@ spec:
     name: container1
     securityContext:
       procMount: Default
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.4/fail/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.4/fail/procmount0.yaml
@@ -8,6 +8,7 @@ spec:
     name: container1
     securityContext:
       procMount: Unmasked
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.4/fail/procmount1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.4/fail/procmount1.yaml
@@ -7,6 +7,7 @@ spec:
   - image: registry.k8s.io/pause
     name: container1
     securityContext: {}
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.4/pass/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.4/pass/procmount0.yaml
@@ -8,6 +8,7 @@ spec:
     name: container1
     securityContext:
       procMount: Default
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.5/fail/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.5/fail/procmount0.yaml
@@ -8,6 +8,7 @@ spec:
     name: container1
     securityContext:
       procMount: Unmasked
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.5/fail/procmount1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.5/fail/procmount1.yaml
@@ -7,6 +7,7 @@ spec:
   - image: registry.k8s.io/pause
     name: container1
     securityContext: {}
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.5/pass/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.5/pass/procmount0.yaml
@@ -8,6 +8,7 @@ spec:
     name: container1
     securityContext:
       procMount: Default
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.6/fail/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.6/fail/procmount0.yaml
@@ -8,6 +8,7 @@ spec:
     name: container1
     securityContext:
       procMount: Unmasked
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.6/fail/procmount1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.6/fail/procmount1.yaml
@@ -7,6 +7,7 @@ spec:
   - image: registry.k8s.io/pause
     name: container1
     securityContext: {}
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.6/pass/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.6/pass/procmount0.yaml
@@ -8,6 +8,7 @@ spec:
     name: container1
     securityContext:
       procMount: Default
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.7/fail/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.7/fail/procmount0.yaml
@@ -8,6 +8,7 @@ spec:
     name: container1
     securityContext:
       procMount: Unmasked
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.7/fail/procmount1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.7/fail/procmount1.yaml
@@ -7,6 +7,7 @@ spec:
   - image: registry.k8s.io/pause
     name: container1
     securityContext: {}
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.7/pass/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.7/pass/procmount0.yaml
@@ -8,6 +8,7 @@ spec:
     name: container1
     securityContext:
       procMount: Default
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.8/fail/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.8/fail/procmount0.yaml
@@ -9,6 +9,7 @@ spec:
     securityContext:
       allowPrivilegeEscalation: false
       procMount: Unmasked
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.8/fail/procmount1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.8/fail/procmount1.yaml
@@ -8,6 +8,7 @@ spec:
     name: container1
     securityContext:
       allowPrivilegeEscalation: false
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.8/pass/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.8/pass/procmount0.yaml
@@ -9,6 +9,7 @@ spec:
     securityContext:
       allowPrivilegeEscalation: false
       procMount: Default
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.9/fail/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.9/fail/procmount0.yaml
@@ -9,6 +9,7 @@ spec:
     securityContext:
       allowPrivilegeEscalation: false
       procMount: Unmasked
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.9/fail/procmount1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.9/fail/procmount1.yaml
@@ -8,6 +8,7 @@ spec:
     name: container1
     securityContext:
       allowPrivilegeEscalation: false
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.9/pass/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.9/pass/procmount0.yaml
@@ -9,6 +9,7 @@ spec:
     securityContext:
       allowPrivilegeEscalation: false
       procMount: Default
+  hostUsers: false
   initContainers:
   - image: registry.k8s.io/pause
     name: initcontainer1

--- a/test/integration/auth/podsecurity_test.go
+++ b/test/integration/auth/podsecurity_test.go
@@ -53,6 +53,7 @@ import (
 func TestPodSecurity(t *testing.T) {
 	// Enable all feature gates needed to allow all fields to be exercised
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ProcMountType, true)()
+	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.UserNamespacesSupport, true)()
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.AppArmor, true)()
 	// Start server
 	server := startPodSecurityServer(t)
@@ -99,6 +100,7 @@ func TestPodSecurityGAOnly(t *testing.T) {
 func TestPodSecurityWebhook(t *testing.T) {
 	// Enable all feature gates needed to allow all fields to be exercised
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ProcMountType, true)()
+	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.UserNamespacesSupport, true)()
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.AppArmor, true)()
 
 	// Start test API server.


### PR DESCRIPTION
fail if container uses proc mount unmasked but pod does not use user namespace

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature
#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
In the Pod API, setting the alpha `procMount` field to `Unmasked` in a container now requires setting `spec.hostUsers=false` as well.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/pull/4265
```
