### PR TITLE
Re-add KUBE_TIMEOUT explicitly to make test

### DIFF
--- a/hack/make-rules/test-integration.sh
+++ b/hack/make-rules/test-integration.sh
@@ -82,6 +82,7 @@ runTests() {
   KUBE_TEST_ARGS="${SHORT:--short=true} --vmodule=${KUBE_TEST_VMODULE} ${KUBE_TEST_ARGS}" \
       WHAT="${WHAT:-$(kube::test::find_integration_test_dirs | paste -sd' ' -)}" \
       GOFLAGS="${GOFLAGS:-}" \
+      KUBE_TIMEOUT="${KUBE_TIMEOUT}" \
       KUBE_RACE="" \
       MAKEFLAGS="" \
       make -C "${KUBE_ROOT}" test


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
In #123393 I made some changes to how variables were passed from `make test-integration`. Early in my testing, I had everything exported so https://github.com/kubernetes/kubernetes/pull/123393#discussion_r1501932334 was accurate.. but I think I made another change as I was trying to get that PR to work and now it is no longer true. As this variable is not exported, I'm explicitly passing it in which was the previous functionality

#### Which issue(s) this PR fixes:
ref https://github.com/kubernetes/kubernetes/pull/123393#issuecomment-1965493833

#### Special notes for your reviewer:
This can be tested localling with the following patch/command:
```patch
diff --git hack/make-rules/test.sh hack/make-rules/test.sh
index 14d26328dfb..ac06c3009e8 100755
--- hack/make-rules/test.sh
+++ hack/make-rules/test.sh
@@ -24,6 +24,9 @@ source "${KUBE_ROOT}/hack/lib/init.sh"
 kube::golang::setup_env
 kube::golang::setup_gomaxprocs
 
+env | grep KUBE_TIMEOUT
+exit 1
+
 # start the cache mutation detector by default so that cache mutators will be found
 KUBE_CACHE_MUTATION_DETECTOR="${KUBE_CACHE_MUTATION_DETECTOR:-true}"
 export KUBE_CACHE_MUTATION_DETECTOR
```
```bash
make test-integration WHAT=./test/integration/apiserver/oidc KUBE_TEST_ARGS="-v" | grep KUBE_TIMEOUT
```

This should print the value of `KUBE_TIMEOUT=-timeout=600s` with this fix to show the variable is being successfully defined in test-integration.sh, and passed through make to test.sh. Without this PR, you will get no value.


#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
- [Usage]: https://git.k8s.io/community/contributors/devel/sig-testing/integration-tests.md
```