### PR TITLE
KEP-4222: Make CBOR roundtrip tests pass through interface{}.

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/cbor/internal/modes/decode_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/cbor/internal/modes/decode_test.go
@@ -105,13 +105,13 @@ func TestDecode(t *testing.T) {
 			assertOnError: assertNilError,
 		},
 	} {
-		ms := tc.modes
-		if len(ms) == 0 {
-			ms = allDecModes
+		decModes := tc.modes
+		if len(decModes) == 0 {
+			decModes = allDecModes
 		}
 
-		for _, dm := range ms {
-			modeName, ok := decModeNames[dm]
+		for _, decMode := range decModes {
+			modeName, ok := decModeNames[decMode]
 			if !ok {
 				t.Fatal("test case configured to run against unrecognized mode")
 			}
@@ -124,7 +124,7 @@ func TestDecode(t *testing.T) {
 				} else {
 					dst = reflect.New(reflect.TypeOf(tc.into))
 				}
-				err := dm.Unmarshal(tc.in, dst.Interface())
+				err := decMode.Unmarshal(tc.in, dst.Interface())
 				tc.assertOnError(t, err)
 				if tc.want != nil {
 					if diff := cmp.Diff(tc.want, dst.Elem().Interface()); diff != "" {

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/cbor/internal/modes/roundtrip_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/cbor/internal/modes/roundtrip_test.go
@@ -260,24 +260,24 @@ func TestRoundtrip(t *testing.T) {
 			}{},
 		},
 	} {
-		mps := tc.modePairs
-		if len(mps) == 0 {
+		modePairs := tc.modePairs
+		if len(modePairs) == 0 {
 			// Default is all modes to all modes.
-			mps = []modePair{}
-			for _, em := range allEncModes {
-				for _, dm := range allDecModes {
-					mps = append(mps, modePair{enc: em, dec: dm})
+			modePairs = []modePair{}
+			for _, encMode := range allEncModes {
+				for _, decMode := range allDecModes {
+					modePairs = append(modePairs, modePair{enc: encMode, dec: decMode})
 				}
 			}
 		}
 
-		for _, mp := range mps {
-			encModeName, ok := encModeNames[mp.enc]
+		for _, modePair := range modePairs {
+			encModeName, ok := encModeNames[modePair.enc]
 			if !ok {
 				t.Fatal("test case configured to run against unrecognized encode mode")
 			}
 
-			decModeName, ok := decModeNames[mp.dec]
+			decModeName, ok := decModeNames[modePair.dec]
 			if !ok {
 				t.Fatal("test case configured to run against unrecognized decode mode")
 			}
@@ -285,13 +285,13 @@ func TestRoundtrip(t *testing.T) {
 			t.Run(fmt.Sprintf("enc=%s/dec=%s/%s", encModeName, decModeName, tc.name), func(t *testing.T) {
 				original := tc.obj
 
-				b, err := mp.enc.Marshal(original)
+				b, err := modePair.enc.Marshal(original)
 				if err != nil {
 					t.Fatalf("unexpected error from Marshal: %v", err)
 				}
 
 				final := reflect.New(reflect.TypeOf(original))
-				err = mp.dec.Unmarshal(b, final.Interface())
+				err = modePair.dec.Unmarshal(b, final.Interface())
 				if err != nil {
 					t.Fatalf("unexpected error from Unmarshal: %v", err)
 				}

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/cbor/internal/modes/roundtrip_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/cbor/internal/modes/roundtrip_test.go
@@ -24,12 +24,14 @@ import (
 	"time"
 
 	"github.com/fxamacker/cbor/v2"
+	"github.com/google/go-cmp/cmp"
 )
 
 func nilPointerFor[T interface{}]() *T {
 	return nil
 }
 
+// TestRoundtrip roundtrips object serialization to interface{} and back via CBOR.
 func TestRoundtrip(t *testing.T) {
 	type modePair struct {
 		enc cbor.EncMode
@@ -100,10 +102,6 @@ func TestRoundtrip(t *testing.T) {
 		{
 			name: "int64 zero",
 			obj:  int64(math.MinInt64),
-		},
-		{
-			name: "uint64 max",
-			obj:  uint64(math.MaxUint64),
 		},
 		{
 			name: "uint64 zero",
@@ -285,18 +283,54 @@ func TestRoundtrip(t *testing.T) {
 			t.Run(fmt.Sprintf("enc=%s/dec=%s/%s", encModeName, decModeName, tc.name), func(t *testing.T) {
 				original := tc.obj
 
-				b, err := modePair.enc.Marshal(original)
+				cborFromOriginal, err := modePair.enc.Marshal(original)
 				if err != nil {
-					t.Fatalf("unexpected error from Marshal: %v", err)
+					t.Fatalf("unexpected error from Marshal of original: %v", err)
 				}
 
-				final := reflect.New(reflect.TypeOf(original))
-				err = modePair.dec.Unmarshal(b, final.Interface())
-				if err != nil {
-					t.Fatalf("unexpected error from Unmarshal: %v", err)
+				var iface interface{}
+				if err := modePair.dec.Unmarshal(cborFromOriginal, &iface); err != nil {
+					t.Fatalf("unexpected error from Unmarshal into %T: %v", &iface, err)
 				}
-				if !reflect.DeepEqual(original, final.Elem().Interface()) {
-					t.Errorf("roundtrip difference:\nwant: %#v\ngot: %#v", original, final)
+
+				cborFromIface, err := modePair.enc.Marshal(iface)
+				if err != nil {
+					t.Fatalf("unexpected error from Marshal of iface: %v", err)
+				}
+
+				{
+					// interface{} to interface{}
+					var iface2 interface{}
+					if err := modePair.dec.Unmarshal(cborFromIface, &iface2); err != nil {
+						t.Fatalf("unexpected error from Unmarshal into %T: %v", &iface2, err)
+					}
+					if diff := cmp.Diff(iface, iface2); diff != "" {
+						t.Errorf("unexpected difference on roundtrip from interface{} to interface{}:\n%s", diff)
+					}
+				}
+
+				{
+					// original to original
+					final := reflect.New(reflect.TypeOf(original))
+					err = modePair.dec.Unmarshal(cborFromOriginal, final.Interface())
+					if err != nil {
+						t.Fatalf("unexpected error from Unmarshal into %T: %v", final.Interface(), err)
+					}
+					if diff := cmp.Diff(original, final.Elem().Interface()); diff != "" {
+						t.Errorf("unexpected difference on roundtrip from original to original:\n%s", diff)
+					}
+				}
+
+				{
+					// original to interface{} to original
+					finalViaIface := reflect.New(reflect.TypeOf(original))
+					err = modePair.dec.Unmarshal(cborFromIface, finalViaIface.Interface())
+					if err != nil {
+						t.Fatalf("unexpected error from Unmarshal into %T: %v", finalViaIface.Interface(), err)
+					}
+					if diff := cmp.Diff(original, finalViaIface.Elem().Interface()); diff != "" {
+						t.Errorf("unexpected difference on roundtrip from original to interface{} to original:\n%s", diff)
+					}
 				}
 			})
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup
/sig api-machinery

#### What this PR does / why we need it:

Adds coverage for decode-to-interface{} and encode-from-interface{} paths to the CBOR roundtrip tests, as requested on https://github.com/kubernetes/kubernetes/pull/123267.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://kep.k8s.io/4222
```
