### PR TITLE
jwt: strictly support compact serialization only

### DIFF
--- a/pkg/serviceaccount/jwt.go
+++ b/pkg/serviceaccount/jwt.go
@@ -291,6 +291,11 @@ func (j *jwtTokenAuthenticator) AuthenticateToken(ctx context.Context, tokenData
 		return nil, false, utilerrors.NewAggregate(errlist)
 	}
 
+	// sanity check issuer since we parsed it out before signature validation
+	if !j.issuers[public.Issuer] {
+		return nil, false, fmt.Errorf("token issuer %q is invalid", public.Issuer)
+	}
+
 	tokenAudiences := authenticator.Audiences(public.Audience)
 	if len(tokenAudiences) == 0 {
 		// only apiserver audiences are allowed for legacy tokens
@@ -330,6 +335,9 @@ func (j *jwtTokenAuthenticator) AuthenticateToken(ctx context.Context, tokenData
 // Note: go-jose currently does not allow access to unverified JWS payloads.
 // See https://github.com/square/go-jose/issues/169
 func (j *jwtTokenAuthenticator) hasCorrectIssuer(tokenData string) bool {
+	if strings.HasPrefix(strings.TrimSpace(tokenData), "{") {
+		return false
+	}
 	parts := strings.Split(tokenData, ".")
 	if len(parts) != 3 {
 		return false

--- a/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/oidc/oidc.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/oidc/oidc.go
@@ -342,6 +342,9 @@ func New(opts Options) (*Authenticator, error) {
 // or returns an error if the token can not be parsed.  Since the JWT is not
 // verified, the returned issuer should not be trusted.
 func untrustedIssuer(token string) (string, error) {
+	if strings.HasPrefix(strings.TrimSpace(token), "{") {
+		return "", fmt.Errorf("token is not compact JWT")
+	}
 	parts := strings.Split(token, ".")
 	if len(parts) != 3 {
 		return "", fmt.Errorf("malformed token")


### PR DESCRIPTION
/kind bug
/sig auth
/assign liggitt 
/priority important-soon

```release-note
JWTs used in service account and OIDC authentication are now strictly parsed to confirm that they use compact serialization.  Other encodings were not previously accepted, but would result in different unspecific errors.
```