### PR TITLE
Use the websocket protocol header, verify selected protocol

### DIFF
--- a/staging/src/k8s.io/client-go/transport/websocket/roundtripper_test.go
+++ b/staging/src/k8s.io/client-go/transport/websocket/roundtripper_test.go
@@ -54,7 +54,7 @@ func TestWebSocketRoundTripper_RoundTripperSucceeds(t *testing.T) {
 	rt, wsRt, err := RoundTripperFor(&restclient.Config{Host: websocketLocation.Host})
 	require.NoError(t, err)
 	requestedProtocol := remotecommand.StreamProtocolV5Name
-	req.Header[httpstream.HeaderProtocolVersion] = []string{requestedProtocol}
+	req.Header[wsstream.WebSocketProtocolHeader] = []string{requestedProtocol}
 	_, err = rt.RoundTrip(req)
 	require.NoError(t, err)
 	// WebSocket Connection is stored in websocket RoundTripper.
@@ -83,11 +83,12 @@ func TestWebSocketRoundTripper_RoundTripperFails(t *testing.T) {
 	require.NoError(t, err)
 	// Requested subprotocol version 1 is not supported by test websocket server.
 	requestedProtocol := remotecommand.StreamProtocolV1Name
-	req.Header[httpstream.HeaderProtocolVersion] = []string{requestedProtocol}
+	req.Header[wsstream.WebSocketProtocolHeader] = []string{requestedProtocol}
 	_, err = rt.RoundTrip(req)
 	// Ensure a "bad handshake" error is returned, since requested protocol is not supported.
 	require.Error(t, err)
 	assert.True(t, strings.Contains(err.Error(), "bad handshake"))
+	assert.True(t, httpstream.IsUpgradeFailure(err))
 }
 
 func TestWebSocketRoundTripper_NegotiateCreatesConnection(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind cleanup

#### What this PR does / why we need it:

Found while working on https://github.com/kubernetes/kubernetes/pull/123413

1. This switches to use the standard websocket header to plumb the subprotocols between the Negotiate method and the websocket RoundTripper (this was all internal plumbing, there's no change on the wire due to this)
2. This verifies the subprotocol returned from the server is one of the requested ones and returns an upgrade error if not
3. This only returns an upgrade error if the error was a bad handshake. Normal network / timeout / TLS errors return an error that will not match IsUpgradeError and avoid triggering a fallback to spdy.

```release-note
NONE
```

/assign @seans3 
/sig cli apimachinery