### PR TITLE
Add tests for SELinuxMount feature

### DIFF
--- a/test/e2e/feature/feature.go
+++ b/test/e2e/feature/feature.go
@@ -268,11 +268,15 @@ var (
 	// TODO: document the feature (owning SIG, when to use this feature for a test)
 	SeccompDefault = framework.WithFeature(framework.ValidFeatures.Add("SeccompDefault"))
 
-	// TODO: document the feature (owning SIG, when to use this feature for a test)
+	// Owner: sig-storage
+	// This feature marks tests that need all schedulable Linux nodes in the cluster to have SELinux enabled.
 	SELinux = framework.WithFeature(framework.ValidFeatures.Add("SELinux"))
 
-	// TODO: document the feature (owning SIG, when to use this feature for a test)
-	SELinuxMountReadWriteOncePod = framework.WithFeature(framework.ValidFeatures.Add("SELinuxMountReadWriteOncePod"))
+	// Owner: sig-storage
+	// This feature marks tests that need SELinuxMountReadWriteOncePod feature gate enabled and SELinuxMount **disabled**.
+	// This is a temporary feature to allow testing of metrics when SELinuxMount is disabled.
+	// TODO: remove when SELinuxMount feature gate is enabled by default.
+	SELinuxMountReadWriteOncePodOnly = framework.WithFeature(framework.ValidFeatures.Add("SELinuxMountReadWriteOncePodOnly"))
 
 	// TODO: document the feature (owning SIG, when to use this feature for a test)
 	ServiceCIDRs = framework.WithFeature(framework.ValidFeatures.Add("ServiceCIDRs"))

--- a/test/e2e/storage/csi_mock/csi_selinux_mount.go
+++ b/test/e2e/storage/csi_mock/csi_selinux_mount.go
@@ -43,6 +43,19 @@ import (
 	admissionapi "k8s.io/pod-security-admission/api"
 )
 
+// Tests for SELinuxMount feature.
+// KEP: https://github.com/kubernetes/enhancements/tree/master/keps/sig-storage/1710-selinux-relabeling
+// There are two feature gates: SELinuxMountReadWriteOncePod and SELinuxMount.
+// These tags are used in the tests:
+//
+// [FeatureGate:SELinuxMountReadWriteOncePod]
+//   - The test requires SELinuxMountReadWriteOncePod enabled. SELinuxMount may be enabled or disabled, except for tests with Feature:SELinuxMountReadWriteOncePodOnly (see below).
+//
+// [FeatureGate:SELinuxMountReadWriteOncePod] [Feature:SELinuxMountReadWriteOncePodOnly]
+//   - The test requires SELinuxMountReadWriteOncePod enabled and SELinuxMount disabled. This checks metrics that are emitted only when SELinuxMount is disabled.
+//
+// [FeatureGate:SELinuxMount]
+//   - The test requires SELinuxMountReadWriteOncePod and SELinuxMount enabled.
 var _ = utils.SIGDescribe("CSI Mock selinux on mount", func() {
 	f := framework.NewDefaultFramework("csi-mock-volumes-selinux")
 	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:

Add tests for SELinuxMount feature.

Since there are two semi-independent feature gates `SELinuxMountReadWriteOncePod` and `SELinuxMount`, there are three classes of tests:

* Tests with `[FeatureGate:SELinuxMountReadWriteOncePod]`: requires `SELinuxMountReadWriteOncePod` feature gate to be enabled and `SELinuxMount` to be either disabled or enabled (unless `[Feature:SELinuxMountReadWriteOncePodOnly]` is specified, see below).
* Tests with `[FeatureGate:SELinuxMountReadWriteOncePod, Feature:SELinuxMountReadWriteOncePodOnly]` require `SELinuxMountReadWriteOncePod` enabled and `SELinuxMount` disabled. These tests ensure that appropriate warning metrics are increased when the feature is limited to RWOP volumes.
* Tests with `[FeatureGate:SELinuxMountReadWriteOncePod, FeatureGate:SELinuxMount]` require both `SELinuxMountReadWriteOncePodOnly` and `SELinuxMount` enabled.

#### Special notes for your reviewer:
* I moved away from using generic `[Feature:SELinuxMountReadWriteOncePod]` tag in favor of feature-gate specific `[FeatureGate:SELinuxMountReadWriteOncePod]`.
* I had to rework tests that run two Pods with the same volume in parallel. With the feature limited to RWOP volumes only, the second Pod always got stuck until the first pod was deleted (because RWOP). Now that we support RWO / RWX volumes, the second Pod may start and the test needs to reflect that and start counting CSI calls *before* deleting the second pod.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-storage/1710-selinux-relabeling
```
