### PR TITLE
[Swap][Tests][KEP-2400] Add swap serial stress tests, improve NodeConformance tests and adapt NoSwap behavior

### DIFF
--- a/test/e2e/framework/skipper/skipper.go
+++ b/test/e2e/framework/skipper/skipper.go
@@ -56,8 +56,7 @@ func SkipUnlessAtLeast(value int, minValue int, message string) {
 var featureGate featuregate.FeatureGate
 
 // InitFeatureGates must be called in test suites that have a --feature-gates parameter.
-// If not called, SkipUnlessFeatureGateEnabled and SkipIfFeatureGateEnabled will
-// record a test failure.
+// If not called, SkipUnlessFeatureGateEnabled will record a test failure.
 func InitFeatureGates(defaults featuregate.FeatureGate, overrides map[string]bool) error {
 	clone := defaults.DeepCopy()
 	if err := clone.SetFromMap(overrides); err != nil {
@@ -65,6 +64,16 @@ func InitFeatureGates(defaults featuregate.FeatureGate, overrides map[string]boo
 	}
 	featureGate = clone
 	return nil
+}
+
+// IsFeatureGateEnabled can be used during e2e tests to figure out if a certain feature gate is enabled.
+// This function is dependent on InitFeatureGates under the hood. Therefore, the test must be called with a
+// --feature-gates parameter.
+func IsFeatureGateEnabled(feature featuregate.Feature) bool {
+	if featureGate == nil {
+		framework.Failf("feature gate interface is not initialized")
+	}
+	return featureGate.Enabled(feature)
 }
 
 // SkipUnlessFeatureGateEnabled skips if the feature is disabled.

--- a/test/e2e/nodefeature/nodefeature.go
+++ b/test/e2e/nodefeature/nodefeature.go
@@ -97,6 +97,10 @@ var (
 	// TODO: document the feature (owning SIG, when to use this feature for a test)
 	RuntimeHandler = framework.WithNodeFeature(framework.ValidNodeFeatures.Add("RuntimeHandler"))
 
+	// Added to test Swap Feature
+	// This label should be used when testing KEP-2400 (Node Swap Support)
+	Swap = framework.WithNodeFeature(framework.ValidNodeFeatures.Add("NodeSwap"))
+
 	// TODO: document the feature (owning SIG, when to use this feature for a test)
 	SidecarContainers = framework.WithNodeFeature(framework.ValidNodeFeatures.Add("SidecarContainers"))
 

--- a/test/e2e_node/swap_test.go
+++ b/test/e2e_node/swap_test.go
@@ -19,6 +19,7 @@ package e2enode
 import (
 	"context"
 	"fmt"
+	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 	"k8s.io/kubernetes/test/e2e/nodefeature"
 	"path/filepath"
 	"strconv"
@@ -29,7 +30,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/kubelet/types"
 	"k8s.io/kubernetes/test/e2e/framework"
@@ -147,7 +147,7 @@ func runPodAndWaitUntilScheduled(f *framework.Framework, pod *v1.Pod) *v1.Pod {
 
 func isSwapFeatureGateEnabled() bool {
 	ginkgo.By("figuring if NodeSwap feature gate is turned on")
-	return utilfeature.DefaultFeatureGate.Enabled(features.NodeSwap)
+	return e2eskipper.IsFeatureGateEnabled(features.NodeSwap)
 }
 
 func readCgroupFile(f *framework.Framework, pod *v1.Pod, filename string) string {

--- a/test/e2e_node/util.go
+++ b/test/e2e_node/util.go
@@ -188,7 +188,6 @@ func cleanupPods(f *framework.Framework) {
 
 // Must be called within a Context. Allows the function to modify the KubeletConfiguration during the BeforeEach of the context.
 // The change is reverted in the AfterEach of the context.
-// Returns true on success.
 func tempSetCurrentKubeletConfig(f *framework.Framework, updateFunction func(ctx context.Context, initialConfig *kubeletconfig.KubeletConfiguration)) {
 	var oldCfg *kubeletconfig.KubeletConfiguration
 


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

Fixes https://github.com/kubernetes/kubernetes/issues/120798

#### What this PR does / why we need it:
This PR does the following:
1. Havily refactors and cleans swap node-e2e tests.
2. Adapt swap NodeConformance test to https://github.com/kubernetes/kubernetes/pull/122745 which drops `UnlimitedSwap` and introduces `NoSwap` behavior.
3. Adds serial tests for swap.

To expand on (3), two serial tests are now added which validate the following scenarios:
1. `"should be able over-commit the node memory"` - a pod is deployed which stresses memory. The test expects that once the pod uses all of the node's memory some of its memory would be swapped away.
2. `"should be able to use more memory than memory limits"` - a pod with memory limits stresses memory. Eventually it goes beyond its memory limits and instead of being OOM killed some of its memory is swapped away keeping it alive.

#### Special notes for your reviewer:
The original version of this PR was here: https://github.com/kubernetes/kubernetes/pull/120430

Due to unfortunate situations I had to be out of work for a while, therefore my PR was closed and continued here: https://github.com/kubernetes/kubernetes/pull/122175

Fortunately I was able to come back to work and therefore the PR is now continued here.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/2400-node-swap/README.md
```
