### PR TITLE
Filter aggregated apiservice gv filter for OpenAPI

### DIFF
--- a/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapi/aggregator/aggregator.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapi/aggregator/aggregator.go
@@ -197,7 +197,9 @@ func (s *specAggregator) updateServiceLocked(name string) error {
 		if err != nil {
 			return nil, "", err
 		}
-		return aggregator.FilterSpecByPathsWithoutSideEffects(result, []string{"/apis/"}), etag, nil
+		group := specInfo.apiService.Spec.Group
+		version := specInfo.apiService.Spec.Version
+		return aggregator.FilterSpecByPathsWithoutSideEffects(result, []string{"/apis/" + group + "/" + version}), etag, nil
 	}, cached.Result[*spec.Swagger]{Value: result, Etag: etag, Err: err})
 	specInfo.spec.Store(filteredResult)
 	return err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This is an interesting issue that came up from a bug report. Currently, OpenAPI v2 is downloaded and merged from aggregated apiservices in its entirety, filtering for only `/apis/*` endpoints. As a result, any aggregated apiservice can claim they serve another endpoint and will be included in the resulting openapi. This is not usually a problem with overriding built-ins because we have different priorities. However, between apiservices gv priorities are usually the same, and merge order is not as deterministic. Thus, a malicious apiservice may claim they serve something like `/apis/someothergroup/version` despite their gv registered as `/apis/stable.example.com/v1`. This PR fixes that such that only the OpenAPI for an apiservice's registered GV is merged and published.

There is an orthogonal bug in [kube-openapi's merging](https://github.com/kubernetes/kube-openapi/blame/master/pkg/aggregator/aggregator.go#L73-L75)  but that will be addressed separately. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/122668

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
OpenAPI V2 will no longer publish aggregated apiserver OpenAPI for group-versions not matching the APIService specified group version
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
