### PR TITLE
Rename APIServer trace span name to conform to http server guidelines

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/traces.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/traces.go
@@ -39,7 +39,7 @@ func WithTracing(handler http.Handler, tp trace.TracerProvider) http.Handler {
 			if !exist {
 				return "KubernetesAPI"
 			}
-			return getSpanNameFromRequestInfo(info)
+			return getSpanNameFromRequestInfo(info, r)
 		}),
 	}
 	wrappedHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -55,9 +55,9 @@ func WithTracing(handler http.Handler, tp trace.TracerProvider) http.Handler {
 	return otelhttp.NewHandler(wrappedHandler, "KubernetesAPI", opts...)
 }
 
-func getSpanNameFromRequestInfo(info *request.RequestInfo) string {
+func getSpanNameFromRequestInfo(info *request.RequestInfo, r *http.Request) string {
 	if !info.IsResourceRequest {
-		return info.Path
+		return r.Method + " " + info.Path
 	}
 
 	spanName := "/" + info.APIPrefix
@@ -75,5 +75,5 @@ func getSpanNameFromRequestInfo(info *request.RequestInfo) string {
 	if info.Subresource != "" {
 		spanName += "/" + info.Subresource
 	}
-	return spanName
+	return r.Method + " " + spanName
 }

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/traces.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/traces.go
@@ -56,6 +56,10 @@ func WithTracing(handler http.Handler, tp trace.TracerProvider) http.Handler {
 }
 
 func getSpanNameFromRequestInfo(info *request.RequestInfo) string {
+	if !info.IsResourceRequest {
+		return info.Path
+	}
+
 	spanName := "/" + info.APIPrefix
 	if info.APIGroup != "" {
 		spanName += "/" + info.APIGroup
@@ -66,7 +70,7 @@ func getSpanNameFromRequestInfo(info *request.RequestInfo) string {
 	}
 	spanName += "/" + info.Resource
 	if info.Name != "" {
-		spanName += "/" + "{:id}"
+		spanName += "/" + "{:name}"
 	}
 	if info.Subresource != "" {
 		spanName += "/" + info.Subresource

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/traces.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/traces.go
@@ -36,8 +36,8 @@ func WithTracing(handler http.Handler, tp trace.TracerProvider) http.Handler {
 		otelhttp.WithSpanNameFormatter(func(operation string, r *http.Request) string {
 			ctx := r.Context()
 			info, exist := request.RequestInfoFrom(ctx)
-			if !exist {
-				return "KubernetesAPI"
+			if !exist || !info.IsResourceRequest {
+				return r.Method
 			}
 			return getSpanNameFromRequestInfo(info, r)
 		}),
@@ -56,10 +56,6 @@ func WithTracing(handler http.Handler, tp trace.TracerProvider) http.Handler {
 }
 
 func getSpanNameFromRequestInfo(info *request.RequestInfo, r *http.Request) string {
-	if !info.IsResourceRequest {
-		return r.Method + " " + info.Path
-	}
-
 	spanName := "/" + info.APIPrefix
 	if info.APIGroup != "" {
 		spanName += "/" + info.APIGroup

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/traces.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/traces.go
@@ -22,6 +22,7 @@ import (
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 	"go.opentelemetry.io/otel/trace"
+	"k8s.io/apiserver/pkg/endpoints/request"
 
 	tracing "k8s.io/component-base/tracing"
 )
@@ -32,6 +33,14 @@ func WithTracing(handler http.Handler, tp trace.TracerProvider) http.Handler {
 		otelhttp.WithPropagators(tracing.Propagators()),
 		otelhttp.WithPublicEndpoint(),
 		otelhttp.WithTracerProvider(tp),
+		otelhttp.WithSpanNameFormatter(func(operation string, r *http.Request) string {
+			ctx := r.Context()
+			info, exist := request.RequestInfoFrom(ctx)
+			if !exist {
+				return "KubernetesAPI"
+			}
+			return getSpanNameFromRequestInfo(info)
+		}),
 	}
 	wrappedHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Add the http.target attribute to the otelhttp span
@@ -44,4 +53,23 @@ func WithTracing(handler http.Handler, tp trace.TracerProvider) http.Handler {
 	// With Noop TracerProvider, the otelhttp still handles context propagation.
 	// See https://github.com/open-telemetry/opentelemetry-go/tree/main/example/passthrough
 	return otelhttp.NewHandler(wrappedHandler, "KubernetesAPI", opts...)
+}
+
+func getSpanNameFromRequestInfo(info *request.RequestInfo) string {
+	spanName := "/" + info.APIPrefix
+	if info.APIGroup != "" {
+		spanName += "/" + info.APIGroup
+	}
+	spanName += "/" + info.APIVersion
+	if info.Namespace != "" {
+		spanName += "/namespaces/{:namespace}"
+	}
+	spanName += "/" + info.Resource
+	if info.Name != "" {
+		spanName += "/" + "{:id}"
+	}
+	if info.Subresource != "" {
+		spanName += "/" + info.Subresource
+	}
+	return spanName
 }

--- a/test/integration/apiserver/tracing/tracing_test.go
+++ b/test/integration/apiserver/tracing/tracing_test.go
@@ -309,7 +309,7 @@ endpoint: %s`, listener.Addr().String())), os.FileMode(0755)); err != nil {
 			},
 			expectedTrace: []*spanExpectation{
 				{
-					name: "KubernetesAPI",
+					name: "/api/v1/nodes",
 					attributes: map[string]func(*commonv1.AnyValue) bool{
 						"http.user_agent": func(v *commonv1.AnyValue) bool {
 							return strings.HasPrefix(v.GetStringValue(), "tracing.test")
@@ -428,7 +428,7 @@ endpoint: %s`, listener.Addr().String())), os.FileMode(0755)); err != nil {
 			},
 			expectedTrace: []*spanExpectation{
 				{
-					name: "KubernetesAPI",
+					name: "/api/v1/nodes/{:name}",
 					attributes: map[string]func(*commonv1.AnyValue) bool{
 						"http.user_agent": func(v *commonv1.AnyValue) bool {
 							return strings.HasPrefix(v.GetStringValue(), "tracing.test")
@@ -518,7 +518,7 @@ endpoint: %s`, listener.Addr().String())), os.FileMode(0755)); err != nil {
 			},
 			expectedTrace: []*spanExpectation{
 				{
-					name: "KubernetesAPI",
+					name: "/api/v1/nodes",
 					attributes: map[string]func(*commonv1.AnyValue) bool{
 						"http.user_agent": func(v *commonv1.AnyValue) bool {
 							return strings.HasPrefix(v.GetStringValue(), "tracing.test")
@@ -636,7 +636,7 @@ endpoint: %s`, listener.Addr().String())), os.FileMode(0755)); err != nil {
 			},
 			expectedTrace: []*spanExpectation{
 				{
-					name: "KubernetesAPI",
+					name: "/api/v1/nodes/{:name}",
 					attributes: map[string]func(*commonv1.AnyValue) bool{
 						"http.user_agent": func(v *commonv1.AnyValue) bool {
 							return strings.HasPrefix(v.GetStringValue(), "tracing.test")
@@ -780,7 +780,7 @@ endpoint: %s`, listener.Addr().String())), os.FileMode(0755)); err != nil {
 			},
 			expectedTrace: []*spanExpectation{
 				{
-					name: "KubernetesAPI",
+					name: "/api/v1/nodes/{:name}",
 					attributes: map[string]func(*commonv1.AnyValue) bool{
 						"http.user_agent": func(v *commonv1.AnyValue) bool {
 							return strings.HasPrefix(v.GetStringValue(), "tracing.test")
@@ -901,7 +901,7 @@ endpoint: %s`, listener.Addr().String())), os.FileMode(0755)); err != nil {
 			},
 			expectedTrace: []*spanExpectation{
 				{
-					name: "KubernetesAPI",
+					name: "/api/v1/nodes/{:name}",
 					attributes: map[string]func(*commonv1.AnyValue) bool{
 						"http.user_agent": func(v *commonv1.AnyValue) bool {
 							return strings.HasPrefix(v.GetStringValue(), "tracing.test")

--- a/test/integration/apiserver/tracing/tracing_test.go
+++ b/test/integration/apiserver/tracing/tracing_test.go
@@ -309,7 +309,7 @@ endpoint: %s`, listener.Addr().String())), os.FileMode(0755)); err != nil {
 			},
 			expectedTrace: []*spanExpectation{
 				{
-					name: "/api/v1/nodes",
+					name: "POST /api/v1/nodes",
 					attributes: map[string]func(*commonv1.AnyValue) bool{
 						"http.user_agent": func(v *commonv1.AnyValue) bool {
 							return strings.HasPrefix(v.GetStringValue(), "tracing.test")
@@ -428,7 +428,7 @@ endpoint: %s`, listener.Addr().String())), os.FileMode(0755)); err != nil {
 			},
 			expectedTrace: []*spanExpectation{
 				{
-					name: "/api/v1/nodes/{:name}",
+					name: "GET /api/v1/nodes/{:name}",
 					attributes: map[string]func(*commonv1.AnyValue) bool{
 						"http.user_agent": func(v *commonv1.AnyValue) bool {
 							return strings.HasPrefix(v.GetStringValue(), "tracing.test")
@@ -518,7 +518,7 @@ endpoint: %s`, listener.Addr().String())), os.FileMode(0755)); err != nil {
 			},
 			expectedTrace: []*spanExpectation{
 				{
-					name: "/api/v1/nodes",
+					name: "GET /api/v1/nodes",
 					attributes: map[string]func(*commonv1.AnyValue) bool{
 						"http.user_agent": func(v *commonv1.AnyValue) bool {
 							return strings.HasPrefix(v.GetStringValue(), "tracing.test")
@@ -636,7 +636,7 @@ endpoint: %s`, listener.Addr().String())), os.FileMode(0755)); err != nil {
 			},
 			expectedTrace: []*spanExpectation{
 				{
-					name: "/api/v1/nodes/{:name}",
+					name: "PUT /api/v1/nodes/{:name}",
 					attributes: map[string]func(*commonv1.AnyValue) bool{
 						"http.user_agent": func(v *commonv1.AnyValue) bool {
 							return strings.HasPrefix(v.GetStringValue(), "tracing.test")
@@ -780,7 +780,7 @@ endpoint: %s`, listener.Addr().String())), os.FileMode(0755)); err != nil {
 			},
 			expectedTrace: []*spanExpectation{
 				{
-					name: "/api/v1/nodes/{:name}",
+					name: "PATCH /api/v1/nodes/{:name}",
 					attributes: map[string]func(*commonv1.AnyValue) bool{
 						"http.user_agent": func(v *commonv1.AnyValue) bool {
 							return strings.HasPrefix(v.GetStringValue(), "tracing.test")
@@ -901,7 +901,7 @@ endpoint: %s`, listener.Addr().String())), os.FileMode(0755)); err != nil {
 			},
 			expectedTrace: []*spanExpectation{
 				{
-					name: "/api/v1/nodes/{:name}",
+					name: "DELETE /api/v1/nodes/{:name}",
 					attributes: map[string]func(*commonv1.AnyValue) bool{
 						"http.user_agent": func(v *commonv1.AnyValue) bool {
 							return strings.HasPrefix(v.GetStringValue(), "tracing.test")


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
The span name of APIServer is not conformed to [http server's best practice](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.1.0/specification/trace/api.md#span). 

For now the span names are all "KubernetesAPI" 

After this change, the span name will be like following

![image](https://github.com/kubernetes/kubernetes/assets/11855957/53edad94-004c-4ba7-a604-05279b31d1c0)


#### Which issue(s) this PR fixes:
Fix #112059

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
