### PR TITLE
Revert "Update kubedns and nodelocaldns to v1.23.0"

### DIFF
--- a/cluster/addons/dns/kube-dns/kube-dns.yaml.base
+++ b/cluster/addons/dns/kube-dns/kube-dns.yaml.base
@@ -114,7 +114,7 @@ spec:
         kubernetes.io/os: linux
       containers:
       - name: kubedns
-        image: registry.k8s.io/dns/k8s-dns-kube-dns:1.23.0
+        image: registry.k8s.io/dns/k8s-dns-kube-dns:1.22.28
         resources:
           # TODO: Set memory limits when we've profiled the container for large
           # clusters, then set request = limit to keep this container in
@@ -170,7 +170,7 @@ spec:
           runAsUser: 1001
           runAsGroup: 1001
       - name: dnsmasq
-        image: registry.k8s.io/dns/k8s-dns-dnsmasq-nanny:1.23.0
+        image: registry.k8s.io/dns/k8s-dns-dnsmasq-nanny:1.22.28
         livenessProbe:
           httpGet:
             path: /healthcheck/dnsmasq
@@ -217,7 +217,7 @@ spec:
               - NET_BIND_SERVICE
               - SETGID
       - name: sidecar
-        image: registry.k8s.io/dns/k8s-dns-sidecar:1.23.0
+        image: registry.k8s.io/dns/k8s-dns-sidecar:1.22.28
         livenessProbe:
           httpGet:
             path: /metrics

--- a/cluster/addons/dns/kube-dns/kube-dns.yaml.in
+++ b/cluster/addons/dns/kube-dns/kube-dns.yaml.in
@@ -114,7 +114,7 @@ spec:
         kubernetes.io/os: linux
       containers:
       - name: kubedns
-        image: registry.k8s.io/dns/k8s-dns-kube-dns:1.23.0
+        image: registry.k8s.io/dns/k8s-dns-kube-dns:1.22.28
         resources:
           # TODO: Set memory limits when we've profiled the container for large
           # clusters, then set request = limit to keep this container in
@@ -170,7 +170,7 @@ spec:
           runAsUser: 1001
           runAsGroup: 1001
       - name: dnsmasq
-        image: registry.k8s.io/dns/k8s-dns-dnsmasq-nanny:1.23.0
+        image: registry.k8s.io/dns/k8s-dns-dnsmasq-nanny:1.22.28
         livenessProbe:
           httpGet:
             path: /healthcheck/dnsmasq
@@ -217,7 +217,7 @@ spec:
               - NET_BIND_SERVICE
               - SETGID
       - name: sidecar
-        image: registry.k8s.io/dns/k8s-dns-sidecar:1.23.0
+        image: registry.k8s.io/dns/k8s-dns-sidecar:1.22.28
         livenessProbe:
           httpGet:
             path: /metrics

--- a/cluster/addons/dns/kube-dns/kube-dns.yaml.sed
+++ b/cluster/addons/dns/kube-dns/kube-dns.yaml.sed
@@ -114,7 +114,7 @@ spec:
         kubernetes.io/os: linux
       containers:
       - name: kubedns
-        image: registry.k8s.io/dns/k8s-dns-kube-dns:1.23.0
+        image: registry.k8s.io/dns/k8s-dns-kube-dns:1.22.28
         resources:
           # TODO: Set memory limits when we've profiled the container for large
           # clusters, then set request = limit to keep this container in
@@ -170,7 +170,7 @@ spec:
           runAsUser: 1001
           runAsGroup: 1001
       - name: dnsmasq
-        image: registry.k8s.io/dns/k8s-dns-dnsmasq-nanny:1.23.0
+        image: registry.k8s.io/dns/k8s-dns-dnsmasq-nanny:1.22.28
         livenessProbe:
           httpGet:
             path: /healthcheck/dnsmasq
@@ -217,7 +217,7 @@ spec:
               - NET_BIND_SERVICE
               - SETGID
       - name: sidecar
-        image: registry.k8s.io/dns/k8s-dns-sidecar:1.23.0
+        image: registry.k8s.io/dns/k8s-dns-sidecar:1.22.28
         livenessProbe:
           httpGet:
             path: /metrics

--- a/cluster/addons/dns/nodelocaldns/nodelocaldns.yaml
+++ b/cluster/addons/dns/nodelocaldns/nodelocaldns.yaml
@@ -138,7 +138,7 @@ spec:
         operator: "Exists"
       containers:
       - name: node-cache
-        image: registry.k8s.io/dns/k8s-dns-node-cache:1.23.0
+        image: registry.k8s.io/dns/k8s-dns-node-cache:1.22.28
         resources:
           requests:
             cpu: 25m


### PR DESCRIPTION
Reverts kubernetes/kubernetes#123310



>  I0228 19:32:34.820278 10025 dump.go:53] At 2024-02-28 19:19:36 +0000 UTC - event for node-local-dns-fdhmh: {kubelet e2e-cc361f69af-1186e-minion-group-60n8} Pulling: Pulling image "[registry.k8s.io/dns/k8s-dns-node-cache:1.23.0](http://registry.k8s.io/dns/k8s-dns-node-cache:1.23.0)"
[615](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-coredns-nodecache/1762918645161267200#1:build-log.txt%3A615)

all networking dns jobs are failing because of this https://testgrid.k8s.io/sig-network-gce#gci-gce-coredns-nodecache

We need to promote the image before doing the changes to the manifest

/assign @xmudrii  @dims @liggitt 
/cc @MrHohn @bzsuni @kl52752 

```release-note
NONE
```