### PR TITLE
KEP-127: kubelet: honor kubelet user mappings

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -822,6 +822,7 @@ const (
 	// owner: @rata, @giuseppe
 	// kep: https://kep.k8s.io/127
 	// alpha: v1.25
+	// beta: v1.30
 	//
 	// Enables user namespace support for stateless pods.
 	UserNamespacesSupport featuregate.Feature = "UserNamespacesSupport"
@@ -1153,7 +1154,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 
 	VolumeCapacityPriority: {Default: false, PreRelease: featuregate.Alpha},
 
-	UserNamespacesSupport: {Default: false, PreRelease: featuregate.Alpha},
+	UserNamespacesSupport: {Default: false, PreRelease: featuregate.Beta},
 
 	WinDSR: {Default: false, PreRelease: featuregate.Alpha},
 

--- a/pkg/kubelet/kubelet_getters.go
+++ b/pkg/kubelet/kubelet_getters.go
@@ -123,6 +123,11 @@ func (kl *Kubelet) HandlerSupportsUserNamespaces(rtHandler string) (bool, error)
 	return h.SupportsUserNamespaces, nil
 }
 
+// GetKubeletMappings gets the additional IDs allocated for the Kubelet.
+func (kl *Kubelet) GetKubeletMappings() (uint32, uint32, error) {
+	return kl.getKubeletMappings()
+}
+
 // getPodDir returns the full path to the per-pod directory for the pod with
 // the given UID.
 func (kl *Kubelet) getPodDir(podUID types.UID) string {

--- a/pkg/kubelet/kubelet_getters.go
+++ b/pkg/kubelet/kubelet_getters.go
@@ -128,6 +128,10 @@ func (kl *Kubelet) GetKubeletMappings() (uint32, uint32, error) {
 	return kl.getKubeletMappings()
 }
 
+func (kl *Kubelet) GetMaxPods() int {
+	return kl.maxPods
+}
+
 // getPodDir returns the full path to the per-pod directory for the pod with
 // the given UID.
 func (kl *Kubelet) getPodDir(podUID types.UID) string {

--- a/pkg/kubelet/userns/userns_manager_switch_test.go
+++ b/pkg/kubelet/userns/userns_manager_switch_test.go
@@ -1,0 +1,137 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package userns
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	pkgfeatures "k8s.io/kubernetes/pkg/features"
+)
+
+func TestMakeUserNsManagerSwitch(t *testing.T) {
+	// Create the manager with the feature gate enabled, to record some pods on disk.
+	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, pkgfeatures.UserNamespacesSupport, true)()
+
+	pods := []types.UID{"pod-1", "pod-2"}
+
+	testUserNsPodsManager := &testUserNsPodsManager{
+		podDir: t.TempDir(),
+		// List the same pods we will record, so the second time we create the userns
+		// manager, it will find these pods on disk with userns data.
+		podList: pods,
+	}
+	m, err := MakeUserNsManager(testUserNsPodsManager)
+	require.NoError(t, err)
+
+	// Record the pods on disk.
+	for _, podUID := range pods {
+		pod := v1.Pod{ObjectMeta: metav1.ObjectMeta{UID: podUID}}
+		_, err := m.GetOrCreateUserNamespaceMappings(&pod, "")
+		require.NoError(t, err, "failed to record userns range for pod %v", podUID)
+	}
+
+	// Test re-init works when the feature gate is disabled and there were some
+	// pods written on disk.
+	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, pkgfeatures.UserNamespacesSupport, false)()
+	m2, err := MakeUserNsManager(testUserNsPodsManager)
+	require.NoError(t, err)
+
+	// The feature gate is off, no pods should be allocated.
+	for _, pod := range pods {
+		ok := m2.podAllocated(pod)
+		assert.False(t, ok, "pod %q should not be allocated", pod)
+	}
+}
+
+func TestGetOrCreateUserNamespaceMappingsSwitch(t *testing.T) {
+	// Enable the feature gate to create some pods on disk.
+	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, pkgfeatures.UserNamespacesSupport, true)()
+
+	pods := []types.UID{"pod-1", "pod-2"}
+
+	testUserNsPodsManager := &testUserNsPodsManager{
+		podDir: t.TempDir(),
+		// List the same pods we will record, so the second time we create the userns
+		// manager, it will find these pods on disk with userns data.
+		podList: pods,
+	}
+	m, err := MakeUserNsManager(testUserNsPodsManager)
+	require.NoError(t, err)
+
+	// Record the pods on disk.
+	for _, podUID := range pods {
+		pod := v1.Pod{ObjectMeta: metav1.ObjectMeta{UID: podUID}}
+		_, err := m.GetOrCreateUserNamespaceMappings(&pod, "")
+		require.NoError(t, err, "failed to record userns range for pod %v", podUID)
+	}
+
+	// Test no-op when the feature gate is disabled and there were some
+	// pods registered on disk.
+	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, pkgfeatures.UserNamespacesSupport, false)()
+	// Create a new manager with the feature gate off and verify the userns range is nil.
+	m2, err := MakeUserNsManager(testUserNsPodsManager)
+	require.NoError(t, err)
+
+	for _, podUID := range pods {
+		pod := v1.Pod{ObjectMeta: metav1.ObjectMeta{UID: podUID}}
+		userns, err := m2.GetOrCreateUserNamespaceMappings(&pod, "")
+
+		assert.NoError(t, err, "failed to record userns range for pod %v", podUID)
+		assert.Nil(t, userns, "userns range should be nil for pod %v", podUID)
+	}
+}
+
+func TestCleanupOrphanedPodUsernsAllocationsSwitch(t *testing.T) {
+	// Enable the feature gate to create some pods on disk.
+	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, pkgfeatures.UserNamespacesSupport, true)()
+
+	listPods := []types.UID{"pod-1", "pod-2"}
+	pods := []types.UID{"pod-3", "pod-4"}
+	testUserNsPodsManager := &testUserNsPodsManager{
+		podDir:  t.TempDir(),
+		podList: listPods,
+	}
+
+	m, err := MakeUserNsManager(testUserNsPodsManager)
+	require.NoError(t, err)
+
+	// Record the pods on disk.
+	for _, podUID := range pods {
+		pod := v1.Pod{ObjectMeta: metav1.ObjectMeta{UID: podUID}}
+		_, err := m.GetOrCreateUserNamespaceMappings(&pod, "")
+		require.NoError(t, err, "failed to record userns range for pod %v", podUID)
+	}
+
+	// Test cleanup works when the feature gate is disabled and there were some
+	// pods registered.
+	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, pkgfeatures.UserNamespacesSupport, false)()
+	err = m.CleanupOrphanedPodUsernsAllocations(nil, nil)
+	require.NoError(t, err)
+
+	// The feature gate is off, no pods should be allocated.
+	for _, pod := range append(listPods, pods...) {
+		ok := m.podAllocated(pod)
+		assert.False(t, ok, "pod %q should not be allocated", pod)
+	}
+}

--- a/pkg/kubelet/userns/userns_manager_test.go
+++ b/pkg/kubelet/userns/userns_manager_test.go
@@ -38,13 +38,15 @@ const (
 	// skip the first block
 	minimumMappingUID = userNsLength
 	// allocate enough space for 2000 user namespaces
-	mappingLen = userNsLength * 2000
+	mappingLen  = userNsLength * 2000
+	testMaxPods = 110
 )
 
 type testUserNsPodsManager struct {
 	podDir  string
 	podList []types.UID
 	userns  bool
+	maxPods int
 }
 
 func (m *testUserNsPodsManager) GetPodDir(podUID types.UID) string {
@@ -70,6 +72,14 @@ func (m *testUserNsPodsManager) HandlerSupportsUserNamespaces(runtimeHandler str
 
 func (m *testUserNsPodsManager) GetKubeletMappings() (uint32, uint32, error) {
 	return minimumMappingUID, mappingLen, nil
+}
+
+func (m *testUserNsPodsManager) GetMaxPods() int {
+	if m.maxPods != 0 {
+		return m.maxPods
+	}
+
+	return testMaxPods
 }
 
 func TestUserNsManagerAllocate(t *testing.T) {

--- a/pkg/kubelet/userns/userns_manager_test.go
+++ b/pkg/kubelet/userns/userns_manager_test.go
@@ -79,8 +79,6 @@ func TestUserNsManagerAllocate(t *testing.T) {
 	m, err := MakeUserNsManager(testUserNsPodsManager)
 	require.NoError(t, err)
 
-	assert.Equal(t, true, m.isSet(0*65536), "m.isSet(0) should be true")
-
 	allocated, length, err := m.allocateOne("one")
 	assert.NoError(t, err)
 	assert.Equal(t, userNsLength, int(length), "m.isSet(%d).length=%v", allocated, length)

--- a/pkg/kubelet/userns/userns_manager_test.go
+++ b/pkg/kubelet/userns/userns_manager_test.go
@@ -43,10 +43,12 @@ const (
 )
 
 type testUserNsPodsManager struct {
-	podDir  string
-	podList []types.UID
-	userns  bool
-	maxPods int
+	podDir         string
+	podList        []types.UID
+	userns         bool
+	maxPods        int
+	mappingFirstID uint32
+	mappingLen     uint32
 }
 
 func (m *testUserNsPodsManager) GetPodDir(podUID types.UID) string {
@@ -71,6 +73,9 @@ func (m *testUserNsPodsManager) HandlerSupportsUserNamespaces(runtimeHandler str
 }
 
 func (m *testUserNsPodsManager) GetKubeletMappings() (uint32, uint32, error) {
+	if m.mappingFirstID != 0 {
+		return m.mappingFirstID, m.mappingLen, nil
+	}
 	return minimumMappingUID, mappingLen, nil
 }
 
@@ -130,6 +135,60 @@ func TestUserNsManagerAllocate(t *testing.T) {
 		assert.NoError(t, err)
 		m.Release(types.UID(fmt.Sprintf("%d", i)))
 		assert.Equal(t, false, m.isSet(v), "m.isSet(%d) should be false", v)
+	}
+}
+
+func TestMakeUserNsManager(t *testing.T) {
+	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, pkgfeatures.UserNamespacesSupport, true)()
+
+	cases := []struct {
+		name           string
+		mappingFirstID uint32
+		mappingLen     uint32
+		maxPods        int
+		success        bool
+	}{
+		{
+			name:    "default",
+			success: true,
+		},
+		{
+			name:           "firstID not multiple",
+			mappingFirstID: 65536 + 1,
+		},
+		{
+			name:           "firstID is less than 65535",
+			mappingFirstID: 1,
+		},
+		{
+			name:           "mappingLen not multiple",
+			mappingFirstID: 65536,
+			mappingLen:     65536 + 1,
+		},
+		{
+			name:           "range can't fit maxPods",
+			mappingFirstID: 65536,
+			mappingLen:     65536,
+			maxPods:        2,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			testUserNsPodsManager := &testUserNsPodsManager{
+				podDir:         t.TempDir(),
+				mappingFirstID: tc.mappingFirstID,
+				mappingLen:     tc.mappingLen,
+				maxPods:        tc.maxPods,
+			}
+			_, err := MakeUserNsManager(testUserNsPodsManager)
+
+			if tc.success {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+			}
+		})
 	}
 }
 
@@ -403,4 +462,26 @@ func TestMakeUserNsManagerFailsListPod(t *testing.T) {
 	_, err := MakeUserNsManager(testUserNsPodsManager)
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "read pods from disk")
+}
+
+func TestRecordBounds(t *testing.T) {
+	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, pkgfeatures.UserNamespacesSupport, true)()
+
+	// Allow exactly for 1 pod
+	testUserNsPodsManager := &testUserNsPodsManager{
+		mappingFirstID: 65536,
+		mappingLen:     65536,
+		maxPods:        1,
+	}
+	m, err := MakeUserNsManager(testUserNsPodsManager)
+	require.NoError(t, err)
+
+	// The first pod allocation should succeed.
+	err = m.record(types.UID(fmt.Sprintf("%d", 0)), 65536, 65536)
+	require.NoError(t, err)
+
+	// The next allocation should fail, as there is no space left.
+	err = m.record(types.UID(fmt.Sprintf("%d", 2)), uint32(2*65536), 65536)
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "out of range")
 }

--- a/pkg/kubelet/userns/userns_manager_test.go
+++ b/pkg/kubelet/userns/userns_manager_test.go
@@ -378,42 +378,6 @@ func TestCleanupOrphanedPodUsernsAllocations(t *testing.T) {
 	}
 }
 
-func TestAllocateMaxPods(t *testing.T) {
-	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, pkgfeatures.UserNamespacesSupport, true)()
-
-	testUserNsPodsManager := &testUserNsPodsManager{}
-	m, err := MakeUserNsManager(testUserNsPodsManager)
-	require.NoError(t, err)
-
-	// The first maxPods allocations should succeed.
-	for i := 0; i < maxPods; i++ {
-		_, _, err = m.allocateOne(types.UID(fmt.Sprintf("%d", i)))
-		require.NoError(t, err)
-	}
-
-	// The next allocation should fail, hitting maxPods.
-	_, _, err = m.allocateOne(types.UID(fmt.Sprintf("%d", maxPods+1)))
-	assert.Error(t, err)
-}
-
-func TestRecordMaxPods(t *testing.T) {
-	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, pkgfeatures.UserNamespacesSupport, true)()
-
-	testUserNsPodsManager := &testUserNsPodsManager{}
-	m, err := MakeUserNsManager(testUserNsPodsManager)
-	require.NoError(t, err)
-
-	// The first maxPods allocations should succeed.
-	for i := 0; i < maxPods; i++ {
-		err = m.record(types.UID(fmt.Sprintf("%d", i)), uint32((i+1)*65536), 65536)
-		require.NoError(t, err)
-	}
-
-	// The next allocation should fail, hitting maxPods.
-	err = m.record(types.UID(fmt.Sprintf("%d", maxPods+1)), uint32((maxPods+1)*65536), 65536)
-	assert.Error(t, err)
-}
-
 type failingUserNsPodsManager struct {
 	testUserNsPodsManager
 }


### PR DESCRIPTION
allow to specify what IDs must be used by the kubelet to create user namespaces.

If no additional UIDs/GIDs are not allocated to the "kubelet" user, then the kubelet assumes it can use any ID on the system.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature


#### What this PR does / why we need it:

implement a feature defined in the KEP 127 to move to Beta

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
It is possible to configure the IDs that the Kubelet uses to create user namespaces.


User namespaces support is a Beta feature now.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs
KEP: 127
```
