### PR TITLE
kubeadm: add timeouts to v1beta4.UpgradeConfiguration

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/fuzzer/fuzzer.go
+++ b/cmd/kubeadm/app/apis/kubeadm/fuzzer/fuzzer.go
@@ -162,4 +162,5 @@ func fuzzUpgradeConfiguration(obj *kubeadm.UpgradeConfiguration, c fuzz.Continue
 	obj.Apply.EtcdUpgrade = ptr.To(true)
 	obj.Apply.CertificateRenewal = ptr.To(false)
 	obj.Node.CertificateRenewal = ptr.To(false)
+	kubeadm.SetDefaultTimeouts(&obj.Timeouts)
 }

--- a/cmd/kubeadm/app/apis/kubeadm/timeoututils.go
+++ b/cmd/kubeadm/app/apis/kubeadm/timeoututils.go
@@ -32,6 +32,7 @@ func SetDefaultTimeouts(t **Timeouts) {
 		EtcdAPICall:                      &metav1.Duration{Duration: constants.EtcdAPICallTimeout},
 		TLSBootstrap:                     &metav1.Duration{Duration: constants.TLSBootstrapTimeout},
 		Discovery:                        &metav1.Duration{Duration: constants.DiscoveryTimeout},
+		UpgradeManifests:                 &metav1.Duration{Duration: constants.UpgradeManifestsTimeout},
 	}
 }
 

--- a/cmd/kubeadm/app/apis/kubeadm/types.go
+++ b/cmd/kubeadm/app/apis/kubeadm/types.go
@@ -658,6 +658,9 @@ type UpgradeConfiguration struct {
 
 	// Plan holds a list of options that are specific to the "kubeadm upgrade plan" command.
 	Plan UpgradePlanConfiguration
+
+	// Timeouts holds various timeouts that apply to kubeadm commands.
+	Timeouts *Timeouts
 }
 
 const (
@@ -724,4 +727,7 @@ type Timeouts struct {
 	// Discovery is the amount of time to wait for kubeadm to validate the API server identity
 	// for a joining node.
 	Discovery *metav1.Duration
+
+	// UpgradeManifests is the timeout for upgradring static Pod manifests
+	UpgradeManifests *metav1.Duration
 }

--- a/cmd/kubeadm/app/apis/kubeadm/v1beta4/defaults.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1beta4/defaults.go
@@ -255,6 +255,11 @@ func SetDefaults_Timeouts(obj *Timeouts) {
 			Duration: constants.DiscoveryTimeout,
 		}
 	}
+	if obj.UpgradeManifests == nil {
+		obj.UpgradeManifests = &metav1.Duration{
+			Duration: constants.UpgradeManifestsTimeout,
+		}
+	}
 }
 
 // SetDefaults_UpgradeConfiguration assigns default values for the UpgradeConfiguration
@@ -274,4 +279,8 @@ func SetDefaults_UpgradeConfiguration(obj *UpgradeConfiguration) {
 	if obj.Apply.CertificateRenewal == nil {
 		obj.Apply.CertificateRenewal = ptr.To(true)
 	}
+	if obj.Timeouts == nil {
+		obj.Timeouts = &Timeouts{}
+	}
+	SetDefaults_Timeouts(obj.Timeouts)
 }

--- a/cmd/kubeadm/app/apis/kubeadm/v1beta4/doc.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1beta4/doc.go
@@ -37,13 +37,13 @@ limitations under the License.
 //   - Add `ClusterConfiguration.DNS.Disabled` and `ClusterConfiguration.Proxy.Disabled` that can be used to disable
 //     the CoreDNS and kube-proxy addons during cluster initialization. Skipping the related addons phases,
 //     during cluster creation will set the same fields to `false`.
-//   - Add a `Timeouts` structure to `InitConfiguration`, `JoinConfiguration` and `ResetConfiguration“
-//     that can be used to configure various timeouts.
 //   - Add the `NodeRegistration.ImagePullSerial` field in 'InitConfiguration` and `JoinConfiguration`, which
 //     can be used to control if kubeadm pulls images serially or in parallel.
 //   - The UpgradeConfiguration kubeadm API is now supported in v1beta4 when passing --config to "kubeadm upgrade" subcommands.
 //     Usage of component configuration for kubelet and kube-proxy, InitConfiguration and ClusterConfiguration is deprecated
 //     and will be ignored when passing --config to upgrade subcommands.
+//   - Add a `Timeouts` structure to `InitConfiguration`, `JoinConfiguration`, `ResetConfiguration` and `UpgradeConfiguration`
+//     that can be used to configure various timeouts.
 //
 // Migration from old kubeadm config versions
 //

--- a/cmd/kubeadm/app/apis/kubeadm/v1beta4/types.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1beta4/types.go
@@ -596,6 +596,10 @@ type Timeouts struct {
 	// Default: 5m
 	// +optional
 	Discovery *metav1.Duration `json:"discovery,omitempty"`
+
+	// UpgradeManifests is the timeout for upgradring static Pod manifests
+	// Default: 5m
+	UpgradeManifests *metav1.Duration `json:"upgradeManifests,omitempty"`
 }
 
 // UpgradeApplyConfiguration contains a list of configurable options which are specific to the  "kubeadm upgrade apply" command.
@@ -744,4 +748,8 @@ type UpgradeConfiguration struct {
 	// Plan holds a list of options that are specific to the "kubeadm upgrade plan" command.
 	// +optional
 	Plan UpgradePlanConfiguration `json:"plan,omitempty"`
+
+	// Timeouts holds various timeouts that apply to kubeadm commands.
+	// +optional
+	Timeouts *Timeouts `json:"timeouts,omitempty"`
 }

--- a/cmd/kubeadm/app/apis/kubeadm/v1beta4/zz_generated.conversion.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1beta4/zz_generated.conversion.go
@@ -968,6 +968,7 @@ func autoConvert_v1beta4_Timeouts_To_kubeadm_Timeouts(in *Timeouts, out *kubeadm
 	out.EtcdAPICall = (*metav1.Duration)(unsafe.Pointer(in.EtcdAPICall))
 	out.TLSBootstrap = (*metav1.Duration)(unsafe.Pointer(in.TLSBootstrap))
 	out.Discovery = (*metav1.Duration)(unsafe.Pointer(in.Discovery))
+	out.UpgradeManifests = (*metav1.Duration)(unsafe.Pointer(in.UpgradeManifests))
 	return nil
 }
 
@@ -983,6 +984,7 @@ func autoConvert_kubeadm_Timeouts_To_v1beta4_Timeouts(in *kubeadm.Timeouts, out 
 	out.EtcdAPICall = (*metav1.Duration)(unsafe.Pointer(in.EtcdAPICall))
 	out.TLSBootstrap = (*metav1.Duration)(unsafe.Pointer(in.TLSBootstrap))
 	out.Discovery = (*metav1.Duration)(unsafe.Pointer(in.Discovery))
+	out.UpgradeManifests = (*metav1.Duration)(unsafe.Pointer(in.UpgradeManifests))
 	return nil
 }
 
@@ -1044,6 +1046,7 @@ func autoConvert_v1beta4_UpgradeConfiguration_To_kubeadm_UpgradeConfiguration(in
 	if err := Convert_v1beta4_UpgradePlanConfiguration_To_kubeadm_UpgradePlanConfiguration(&in.Plan, &out.Plan, s); err != nil {
 		return err
 	}
+	out.Timeouts = (*kubeadm.Timeouts)(unsafe.Pointer(in.Timeouts))
 	return nil
 }
 
@@ -1065,6 +1068,7 @@ func autoConvert_kubeadm_UpgradeConfiguration_To_v1beta4_UpgradeConfiguration(in
 	if err := Convert_kubeadm_UpgradePlanConfiguration_To_v1beta4_UpgradePlanConfiguration(&in.Plan, &out.Plan, s); err != nil {
 		return err
 	}
+	out.Timeouts = (*Timeouts)(unsafe.Pointer(in.Timeouts))
 	return nil
 }
 

--- a/cmd/kubeadm/app/apis/kubeadm/v1beta4/zz_generated.deepcopy.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1beta4/zz_generated.deepcopy.go
@@ -646,6 +646,11 @@ func (in *Timeouts) DeepCopyInto(out *Timeouts) {
 		*out = new(metav1.Duration)
 		**out = **in
 	}
+	if in.UpgradeManifests != nil {
+		in, out := &in.UpgradeManifests, &out.UpgradeManifests
+		*out = new(metav1.Duration)
+		**out = **in
+	}
 	return
 }
 
@@ -733,6 +738,11 @@ func (in *UpgradeConfiguration) DeepCopyInto(out *UpgradeConfiguration) {
 	out.Diff = in.Diff
 	in.Node.DeepCopyInto(&out.Node)
 	in.Plan.DeepCopyInto(&out.Plan)
+	if in.Timeouts != nil {
+		in, out := &in.Timeouts, &out.Timeouts
+		*out = new(Timeouts)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 

--- a/cmd/kubeadm/app/apis/kubeadm/v1beta4/zz_generated.defaults.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1beta4/zz_generated.defaults.go
@@ -91,4 +91,7 @@ func SetObjectDefaults_ResetConfiguration(in *ResetConfiguration) {
 
 func SetObjectDefaults_UpgradeConfiguration(in *UpgradeConfiguration) {
 	SetDefaults_UpgradeConfiguration(in)
+	if in.Timeouts != nil {
+		SetDefaults_Timeouts(in.Timeouts)
+	}
 }

--- a/cmd/kubeadm/app/apis/kubeadm/validation/validation.go
+++ b/cmd/kubeadm/app/apis/kubeadm/validation/validation.go
@@ -765,5 +765,8 @@ func ValidateUpgradeConfiguration(c *kubeadm.UpgradeConfiguration) field.ErrorLi
 	if c.Apply.Patches != nil {
 		allErrs = append(allErrs, ValidateAbsolutePath(c.Apply.Patches.Directory, field.NewPath("patches").Child("directory"))...)
 	}
+	if c.Node.Patches != nil {
+		allErrs = append(allErrs, ValidateAbsolutePath(c.Node.Patches.Directory, field.NewPath("patches").Child("directory"))...)
+	}
 	return allErrs
 }

--- a/cmd/kubeadm/app/apis/kubeadm/zz_generated.deepcopy.go
+++ b/cmd/kubeadm/app/apis/kubeadm/zz_generated.deepcopy.go
@@ -686,6 +686,11 @@ func (in *Timeouts) DeepCopyInto(out *Timeouts) {
 		*out = new(v1.Duration)
 		**out = **in
 	}
+	if in.UpgradeManifests != nil {
+		in, out := &in.UpgradeManifests, &out.UpgradeManifests
+		*out = new(v1.Duration)
+		**out = **in
+	}
 	return
 }
 
@@ -773,6 +778,11 @@ func (in *UpgradeConfiguration) DeepCopyInto(out *UpgradeConfiguration) {
 	out.Diff = in.Diff
 	in.Node.DeepCopyInto(&out.Node)
 	in.Plan.DeepCopyInto(&out.Plan)
+	if in.Timeouts != nil {
+		in, out := &in.Timeouts, &out.Timeouts
+		*out = new(Timeouts)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 

--- a/cmd/kubeadm/app/cmd/phases/upgrade/node/controlplane.go
+++ b/cmd/kubeadm/app/cmd/phases/upgrade/node/controlplane.go
@@ -73,7 +73,7 @@ func runControlPlane() func(c workflow.RunData) error {
 			return upgrade.DryRunStaticPodUpgrade(patchesDir, cfg)
 		}
 
-		waiter := apiclient.NewKubeWaiter(data.Client(), upgrade.UpgradeManifestTimeout, os.Stdout)
+		waiter := apiclient.NewKubeWaiter(data.Client(), data.Cfg().Timeouts.UpgradeManifests.Duration, os.Stdout)
 
 		if err := upgrade.PerformStaticPodUpgrade(client, waiter, cfg, etcdUpgrade, renewCerts, patchesDir); err != nil {
 			return errors.Wrap(err, "couldn't complete the static pod upgrade")

--- a/cmd/kubeadm/app/cmd/upgrade/apply.go
+++ b/cmd/kubeadm/app/cmd/upgrade/apply.go
@@ -183,7 +183,7 @@ func runApply(flagSet *pflag.FlagSet, flags *applyFlags, args []string) error {
 		fmt.Println("[upgrade/prepull] Would pull the required images (like 'kubeadm config images pull')")
 	}
 
-	waiter := getWaiter(flags.dryRun, client, upgrade.UpgradeManifestTimeout)
+	waiter := getWaiter(flags.dryRun, client, upgradeCfg.Timeouts.UpgradeManifests.Duration)
 
 	// If the config is set by flag, just overwrite it!
 	etcdUpgrade, ok := cmdutil.ValueFromFlagsOrConfig(flagSet, options.EtcdUpgrade, upgradeCfg.Apply.EtcdUpgrade, &flags.etcdUpgrade).(*bool)
@@ -260,7 +260,7 @@ func EnforceVersionPolicies(newK8sVersionStr string, newK8sVersion *version.Vers
 func PerformControlPlaneUpgrade(flags *applyFlags, client clientset.Interface, waiter apiclient.Waiter, initCfg *kubeadmapi.InitConfiguration, upgradeCfg *kubeadmapi.UpgradeConfiguration) error {
 	// OK, the cluster is hosted using static pods. Upgrade a static-pod hosted cluster
 	fmt.Printf("[upgrade/apply] Upgrading your Static Pod-hosted control plane to version %q (timeout: %v)...\n",
-		initCfg.KubernetesVersion, upgrade.UpgradeManifestTimeout)
+		initCfg.KubernetesVersion, upgradeCfg.Timeouts.UpgradeManifests.Duration)
 
 	if flags.dryRun {
 		return upgrade.DryRunStaticPodUpgrade(upgradeCfg.Apply.Patches.Directory, initCfg)

--- a/cmd/kubeadm/app/cmd/upgrade/common.go
+++ b/cmd/kubeadm/app/cmd/upgrade/common.go
@@ -36,6 +36,7 @@ import (
 
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	kubeadmapiv1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta3"
+	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta4"
 	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/validation"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/options"
 	cmdutil "k8s.io/kubernetes/cmd/kubeadm/app/cmd/util"
@@ -55,7 +56,9 @@ func enforceRequirements(flagSet *pflag.FlagSet, flags *applyPlanFlags, args []s
 	// Fetch the configuration from a file or ConfigMap and validate it
 	_, _ = printer.Printf("[upgrade/config] Making sure the configuration is correct:\n")
 
-	upgradeCfg, err := configutil.LoadUpgradeConfig(flags.cfgPath)
+	externalCfg := &v1beta4.UpgradeConfiguration{}
+	opt := configutil.LoadOrDefaultConfigurationOptions{}
+	upgradeCfg, err := configutil.LoadOrDefaultUpgradeConfiguration(flags.cfgPath, externalCfg, opt)
 	if err != nil {
 		return nil, nil, nil, nil, errors.Wrap(err, "[upgrade/upgrade config] FATAL")
 	}

--- a/cmd/kubeadm/app/cmd/upgrade/diff.go
+++ b/cmd/kubeadm/app/cmd/upgrade/diff.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/klog/v2"
 
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta4"
 	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/validation"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/options"
 	cmdutil "k8s.io/kubernetes/cmd/kubeadm/app/cmd/util"
@@ -118,7 +119,9 @@ func validateManifestsPath(manifests ...string) (err error) {
 type FetchInitConfigurationFunc func(client clientset.Interface, printer output.Printer, logPrefix string, newControlPlane, skipComponentConfigs bool) (*kubeadmapi.InitConfiguration, error)
 
 func runDiff(fs *pflag.FlagSet, flags *diffFlags, args []string, fetchInitConfigurationFromCluster FetchInitConfigurationFunc) error {
-	upgradeCfg, err := configutil.LoadUpgradeConfig(flags.cfgPath)
+	externalCfg := &v1beta4.UpgradeConfiguration{}
+	opt := configutil.LoadOrDefaultConfigurationOptions{}
+	upgradeCfg, err := configutil.LoadOrDefaultUpgradeConfiguration(flags.cfgPath, externalCfg, opt)
 	if err != nil {
 		return err
 	}

--- a/cmd/kubeadm/app/cmd/upgrade/diff_test.go
+++ b/cmd/kubeadm/app/cmd/upgrade/diff_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pkg/errors"
 
 	clientset "k8s.io/client-go/kubernetes"
+
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	kubeadmapiv1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta4"
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/output"
@@ -57,7 +58,9 @@ func TestRunDiff(t *testing.T) {
 	testUpgradeDiffConfigContents := []byte(fmt.Sprintf(`
 apiVersion: %s
 kind: UpgradeConfiguration
-contextLines: 4`, kubeadmapiv1.SchemeGroupVersion.String()))
+diff:
+  contextLines: 4`, kubeadmapiv1.SchemeGroupVersion.String()))
+
 	testUpgradeDiffConfig, err := createTestRunDiffFile(testUpgradeDiffConfigContents)
 	if err != nil {
 		t.Fatal(err)

--- a/cmd/kubeadm/app/cmd/upgrade/node.go
+++ b/cmd/kubeadm/app/cmd/upgrade/node.go
@@ -28,6 +28,7 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta4"
 	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/validation"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/options"
 	phases "k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/upgrade/node"
@@ -155,7 +156,9 @@ func newNodeData(cmd *cobra.Command, args []string, nodeOptions *nodeOptions, ou
 		}
 	}
 
-	upgradeCfg, err := configutil.LoadUpgradeConfig(nodeOptions.cfgPath)
+	externalCfg := &v1beta4.UpgradeConfiguration{}
+	opt := configutil.LoadOrDefaultConfigurationOptions{}
+	upgradeCfg, err := configutil.LoadOrDefaultUpgradeConfiguration(nodeOptions.cfgPath, externalCfg, opt)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/kubeadm/app/constants/constants.go
+++ b/cmd/kubeadm/app/constants/constants.go
@@ -241,6 +241,9 @@ const (
 	// KubeletHealthCheckTimeout specifies the default kubelet timeout
 	KubeletHealthCheckTimeout = 4 * time.Minute
 
+	// UpgradeManifestsTimeout specifies the default timeout for upgradring static Pod manifests
+	UpgradeManifestsTimeout = 5 * time.Minute
+
 	// PullImageRetry specifies how many times ContainerRuntime retries when pulling image failed
 	PullImageRetry = 5
 	// RemoveContainerRetry specifies how many times ContainerRuntime retries when removing container failed

--- a/cmd/kubeadm/app/constants/constants.go
+++ b/cmd/kubeadm/app/constants/constants.go
@@ -223,13 +223,6 @@ const (
 	// TLSBootstrapRetryInterval specifies how long kubeadm should wait before retrying the TLS Bootstrap check
 	TLSBootstrapRetryInterval = 1 * time.Second
 
-	// StaticPodMirroringTimeout specifies how much time kubeadm should wait for the static pods
-	// to be mirrored on the API server.
-	StaticPodMirroringTimeout = 30 * time.Second
-	// StaticPodMirroringRetryInterval specifies how often to check if static pods are mirrored at the
-	// API server.
-	StaticPodMirroringRetryInterval = 500 * time.Millisecond
-
 	// EtcdAPICallTimeout specifies how much time to wait for completion of requests against the etcd API.
 	EtcdAPICallTimeout = 2 * time.Minute
 	// EtcdAPICallRetryInterval specifies how frequently to retry requests against the etcd API.

--- a/cmd/kubeadm/app/phases/upgrade/staticpods.go
+++ b/cmd/kubeadm/app/phases/upgrade/staticpods.go
@@ -44,11 +44,6 @@ import (
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/staticpod"
 )
 
-const (
-	// UpgradeManifestTimeout is timeout of upgrading the static pod manifest
-	UpgradeManifestTimeout = 5 * time.Minute
-)
-
 // StaticPodPathManager is responsible for tracking the directories used in the static pod upgrade transition
 type StaticPodPathManager interface {
 	// MoveFile should move a file from oldPath to newPath
@@ -246,7 +241,7 @@ func upgradeComponent(component string, certsRenewMgr *renewal.Manager, waiter a
 	fmt.Printf("[upgrade/staticpods] Moved new manifest to %q and backed up old manifest to %q\n", currentManifestPath, backupManifestPath)
 
 	fmt.Println("[upgrade/staticpods] Waiting for the kubelet to restart the component")
-	fmt.Printf("[upgrade/staticpods] This might take a minute or longer depending on the component/version gap (timeout %v)\n", UpgradeManifestTimeout)
+	fmt.Printf("[upgrade/staticpods] This can take up to %v\n", kubeadmapi.GetActiveTimeouts().UpgradeManifests.Duration)
 
 	// Wait for the mirror Pod hash to change; otherwise we'll run into race conditions here when the kubelet hasn't had time to
 	// notice the removal of the Static Pod, leading to a false positive below where we check that the API endpoint is healthy

--- a/cmd/kubeadm/app/util/config/cluster.go
+++ b/cmd/kubeadm/app/util/config/cluster.go
@@ -197,7 +197,7 @@ func getNodeNameFromKubeletConfig(fileName string) (string, error) {
 
 func getAPIEndpoint(client clientset.Interface, nodeName string, apiEndpoint *kubeadmapi.APIEndpoint) error {
 	return getAPIEndpointWithRetry(client, nodeName, apiEndpoint,
-		constants.StaticPodMirroringRetryInterval, constants.StaticPodMirroringTimeout)
+		constants.KubernetesAPICallRetryInterval, kubeadmapi.GetActiveTimeouts().KubernetesAPICall.Duration)
 }
 
 func getAPIEndpointWithRetry(client clientset.Interface, nodeName string, apiEndpoint *kubeadmapi.APIEndpoint,

--- a/cmd/kubeadm/app/util/config/common.go
+++ b/cmd/kubeadm/app/util/config/common.go
@@ -390,11 +390,13 @@ func isKubeadmPrereleaseVersion(versionInfo *apimachineryversion.Info, k8sVersio
 func prepareStaticVariables(config any) {
 	switch c := config.(type) {
 	case *kubeadmapi.InitConfiguration:
-		kubeadmapi.SetActiveTimeouts(c.Timeouts.DeepCopy())
+		kubeadmapi.SetActiveTimeouts(c.Timeouts)
 	case *kubeadmapi.JoinConfiguration:
-		kubeadmapi.SetActiveTimeouts(c.Timeouts.DeepCopy())
+		kubeadmapi.SetActiveTimeouts(c.Timeouts)
 	case *kubeadmapi.ResetConfiguration:
-		kubeadmapi.SetActiveTimeouts(c.Timeouts.DeepCopy())
+		kubeadmapi.SetActiveTimeouts(c.Timeouts)
+	case *kubeadmapi.UpgradeConfiguration:
+		kubeadmapi.SetActiveTimeouts(c.Timeouts)
 	}
 }
 

--- a/cmd/kubeadm/app/util/config/upgradeconfiguration_test.go
+++ b/cmd/kubeadm/app/util/config/upgradeconfiguration_test.go
@@ -19,11 +19,13 @@ package config
 import (
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/yaml"
 
-	"github.com/google/go-cmp/cmp"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	kubeadmapiv1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta4"
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
@@ -96,7 +98,7 @@ func TestDocMapToUpgradeConfiguration(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error of DocMapToUpgradeConfiguration: %v\nconfig: %s", err, string(b))
 			}
-			if diff := cmp.Diff(*cfg, tc.expectedCfg); diff != "" {
+			if diff := cmp.Diff(*cfg, tc.expectedCfg, cmpopts.IgnoreFields(kubeadmapi.UpgradeConfiguration{}, "Timeouts")); diff != "" {
 				t.Fatalf("DocMapToUpgradeConfiguration returned unexpected diff (-want,+got):\n%s", diff)
 			}
 		})

--- a/cmd/kubeadm/app/util/etcd/etcd.go
+++ b/cmd/kubeadm/app/util/etcd/etcd.go
@@ -172,7 +172,7 @@ func NewFromCluster(client clientset.Interface, certificatesDir string) (*Client
 // getEtcdEndpoints returns the list of etcd endpoints.
 func getEtcdEndpoints(client clientset.Interface) ([]string, error) {
 	return getEtcdEndpointsWithRetry(client,
-		constants.StaticPodMirroringRetryInterval, constants.StaticPodMirroringTimeout)
+		constants.KubernetesAPICallRetryInterval, kubeadmapi.GetActiveTimeouts().KubernetesAPICall.Duration)
 }
 
 func getEtcdEndpointsWithRetry(client clientset.Interface, interval, timeout time.Duration) ([]string, error) {


### PR DESCRIPTION
#### What type of PR is this?

/kind feature cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Follow the same process of adding the Timeouts struct
to UpgradeConfiguration similarly to how it was done for
other API Kinds.

In the Timeouts struct include one new timeout:
- UpgradeManifests 
StaticPodMirroringTimeout and StaticPodMirroringRetryInterval
are use for just an API call to get Pods(). The already existing
constants.KubernetesAPICallRetryInterval
and kubeadmapi.GetActiveTimeouts().KubernetesAPICall.Duration
can be used for that instead.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
xref:
- https://github.com/kubernetes/kubernetes/pull/123068
- ttps://github.com/kubernetes/kubeadm/issues/2489
- https://github.com/kubernetes/kubeadm/issues/2890

#### Special notes for your reviewer:
NONE

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
