### PR TITLE
bump cloud controller manager to 0.30.0-alpha to fix provider id issues

### DIFF
--- a/cluster/gce/manifests/cloud-controller-manager.manifest
+++ b/cluster/gce/manifests/cloud-controller-manager.manifest
@@ -23,7 +23,7 @@
 "containers":[
     {
     "name": "cloud-controller-manager",
-    "image": "gcr.io/k8s-staging-cloud-provider-gcp/cloud-controller-manager:v29.0.0",
+    "image": "gcr.io/k8s-staging-cloud-provider-gcp/cloud-controller-manager:v0.30.0-alpha",
     "resources": {
       "requests": {
         "cpu": "{{cpurequest}}"


### PR DESCRIPTION
/kind bug


```release-note
NONE
```

This is built with https://github.com/kubernetes/cloud-provider-gcp/pull/651 and should fix all the issues related to https://github.com/kubernetes/kubernetes/pull/123331