### PR TITLE
Add --no-headers option to config get-clusters cli

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/config.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/config.go
@@ -64,7 +64,7 @@ func NewCmdConfig(pathOptions *clientcmd.PathOptions, streams genericiooptions.I
 	cmd.AddCommand(NewCmdConfigCurrentContext(streams.Out, pathOptions))
 	cmd.AddCommand(NewCmdConfigUseContext(streams.Out, pathOptions))
 	cmd.AddCommand(NewCmdConfigGetContexts(streams, pathOptions))
-	cmd.AddCommand(NewCmdConfigGetClusters(streams.Out, pathOptions))
+	cmd.AddCommand(NewCmdConfigGetClusters(streams, pathOptions))
 	cmd.AddCommand(NewCmdConfigGetUsers(streams, pathOptions))
 	cmd.AddCommand(NewCmdConfigDeleteCluster(streams.Out, pathOptions))
 	cmd.AddCommand(NewCmdConfigDeleteContext(streams.Out, streams.ErrOut, pathOptions))


### PR DESCRIPTION
/kind bug

This PR adds --no-headers option cli flag for displaying the output of 'kubectl config get-clusters' without the headers 

Fixes #123466 --no-headers available for k config get-contexts but not get-clusters
