### PR TITLE
Add authz webhook matchcondition metrics

### DIFF
--- a/pkg/kubeapiserver/authorizer/reload.go
+++ b/pkg/kubeapiserver/authorizer/reload.go
@@ -32,11 +32,13 @@ import (
 	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 	"k8s.io/apiserver/pkg/authorization/authorizerfactory"
+	"k8s.io/apiserver/pkg/authorization/cel"
 	authorizationmetrics "k8s.io/apiserver/pkg/authorization/metrics"
 	"k8s.io/apiserver/pkg/authorization/union"
 	"k8s.io/apiserver/pkg/server/options/authorizationconfig/metrics"
 	webhookutil "k8s.io/apiserver/pkg/util/webhook"
 	"k8s.io/apiserver/plugin/pkg/authorizer/webhook"
+	webhookmetrics "k8s.io/apiserver/plugin/pkg/authorizer/webhook/metrics"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/auth/authorizer/abac"
 	"k8s.io/kubernetes/pkg/kubeapiserver/authorizer/modes"
@@ -142,6 +144,8 @@ func (r *reloadableAuthorizerResolver) newForConfig(authzConfig *authzconfig.Aut
 				*r.initialConfig.WebhookRetryBackoff,
 				decisionOnError,
 				configuredAuthorizer.Webhook.MatchConditions,
+				configuredAuthorizer.Name,
+				kubeapiserverWebhookMetrics{MatcherMetrics: cel.NewMatcherMetrics()},
 			)
 			if err != nil {
 				return nil, nil, err
@@ -160,6 +164,13 @@ func (r *reloadableAuthorizerResolver) newForConfig(authzConfig *authzconfig.Aut
 	}
 
 	return union.New(authorizers...), union.NewRuleResolvers(ruleResolvers...), nil
+}
+
+type kubeapiserverWebhookMetrics struct {
+	// kube-apiserver doesn't report request metrics
+	webhookmetrics.NoopRequestMetrics
+	// kube-apiserver does report matchCondition metrics
+	cel.MatcherMetrics
 }
 
 // runReload starts checking the config file for changes and reloads the authorizer when it changes.

--- a/staging/src/k8s.io/apiserver/pkg/authorization/authorizerfactory/delegating.go
+++ b/staging/src/k8s.io/apiserver/pkg/authorization/authorizerfactory/delegating.go
@@ -26,7 +26,7 @@ import (
 	authorizationclient "k8s.io/client-go/kubernetes/typed/authorization/v1"
 )
 
-// DelegatingAuthorizerConfig is the minimal configuration needed to create an authenticator
+// DelegatingAuthorizerConfig is the minimal configuration needed to create an authorizer
 // built to delegate authorization to a kube API server
 type DelegatingAuthorizerConfig struct {
 	SubjectAccessReviewClient authorizationclient.AuthorizationV1Interface
@@ -55,9 +55,6 @@ func (c DelegatingAuthorizerConfig) New() (authorizer.Authorizer, error) {
 		c.DenyCacheTTL,
 		*c.WebhookRetryBackoff,
 		authorizer.DecisionNoOpinion,
-		webhook.AuthorizerMetrics{
-			RecordRequestTotal:   RecordRequestTotal,
-			RecordRequestLatency: RecordRequestLatency,
-		},
+		NewDelegatingAuthorizerMetrics(),
 	)
 }

--- a/staging/src/k8s.io/apiserver/pkg/authorization/authorizerfactory/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/authorization/authorizerfactory/metrics.go
@@ -18,18 +18,22 @@ package authorizerfactory
 
 import (
 	"context"
+	"sync"
 
+	celmetrics "k8s.io/apiserver/pkg/authorization/cel"
+	webhookmetrics "k8s.io/apiserver/plugin/pkg/authorizer/webhook/metrics"
 	compbasemetrics "k8s.io/component-base/metrics"
 	"k8s.io/component-base/metrics/legacyregistry"
 )
 
-type registerables []compbasemetrics.Registerable
+var registerMetrics sync.Once
 
-// init registers all metrics
-func init() {
-	for _, metric := range metrics {
-		legacyregistry.MustRegister(metric)
-	}
+// RegisterMetrics registers authorizer metrics.
+func RegisterMetrics() {
+	registerMetrics.Do(func() {
+		legacyregistry.MustRegister(requestTotal)
+		legacyregistry.MustRegister(requestLatency)
+	})
 }
 
 var (
@@ -51,19 +55,26 @@ var (
 		},
 		[]string{"code"},
 	)
-
-	metrics = registerables{
-		requestTotal,
-		requestLatency,
-	}
 )
 
+var _ = webhookmetrics.AuthorizerMetrics(delegatingAuthorizerMetrics{})
+
+type delegatingAuthorizerMetrics struct {
+	// no-op for matchCondition metrics for now, delegating authorization doesn't configure match conditions
+	celmetrics.NoopMatcherMetrics
+}
+
+func NewDelegatingAuthorizerMetrics() delegatingAuthorizerMetrics {
+	RegisterMetrics()
+	return delegatingAuthorizerMetrics{}
+}
+
 // RecordRequestTotal increments the total number of requests for the delegated authorization.
-func RecordRequestTotal(ctx context.Context, code string) {
+func (delegatingAuthorizerMetrics) RecordRequestTotal(ctx context.Context, code string) {
 	requestTotal.WithContext(ctx).WithLabelValues(code).Add(1)
 }
 
 // RecordRequestLatency measures request latency in seconds for the delegated authorization. Broken down by status code.
-func RecordRequestLatency(ctx context.Context, code string, latency float64) {
+func (delegatingAuthorizerMetrics) RecordRequestLatency(ctx context.Context, code string, latency float64) {
 	requestLatency.WithContext(ctx).WithLabelValues(code).Observe(latency)
 }

--- a/staging/src/k8s.io/apiserver/pkg/authorization/cel/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/authorization/cel/metrics.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cel
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"k8s.io/component-base/metrics"
+	"k8s.io/component-base/metrics/legacyregistry"
+)
+
+// MatcherMetrics defines methods for reporting matchCondition metrics
+type MatcherMetrics interface {
+	// RecordAuthorizationMatchConditionEvaluation records the total time taken to evaluate matchConditions for an Authorize() call to the given authorizer
+	RecordAuthorizationMatchConditionEvaluation(ctx context.Context, authorizerType, authorizerName string, elapsed time.Duration)
+	// RecordAuthorizationMatchConditionEvaluationFailure increments if any evaluation error was encountered evaluating matchConditions for an Authorize() call to the given authorizer
+	RecordAuthorizationMatchConditionEvaluationFailure(ctx context.Context, authorizerType, authorizerName string)
+	// RecordAuthorizationMatchConditionExclusion records increments when at least one matchCondition evaluates to false and excludes an Authorize() call to the given authorizer
+	RecordAuthorizationMatchConditionExclusion(ctx context.Context, authorizerType, authorizerName string)
+}
+
+type NoopMatcherMetrics struct{}
+
+func (NoopMatcherMetrics) RecordAuthorizationMatchConditionEvaluation(ctx context.Context, authorizerType, authorizerName string, elapsed time.Duration) {
+}
+func (NoopMatcherMetrics) RecordAuthorizationMatchConditionEvaluationFailure(ctx context.Context, authorizerType, authorizerName string) {
+}
+func (NoopMatcherMetrics) RecordAuthorizationMatchConditionExclusion(ctx context.Context, authorizerType, authorizerName string) {
+}
+
+type matcherMetrics struct{}
+
+func NewMatcherMetrics() MatcherMetrics {
+	RegisterMetrics()
+	return matcherMetrics{}
+}
+
+const (
+	namespace = "apiserver"
+	subsystem = "authorization"
+)
+
+var (
+	authorizationMatchConditionEvaluationErrorsTotal = metrics.NewCounterVec(
+		&metrics.CounterOpts{
+			Namespace:      namespace,
+			Subsystem:      subsystem,
+			Name:           "match_condition_evaluation_errors_total",
+			Help:           "Total number of errors when an authorization webhook encounters a match condition error split by authorizer type and name.",
+			StabilityLevel: metrics.ALPHA,
+		},
+		[]string{"type", "name"},
+	)
+	authorizationMatchConditionExclusionsTotal = metrics.NewCounterVec(
+		&metrics.CounterOpts{
+			Namespace:      namespace,
+			Subsystem:      subsystem,
+			Name:           "match_condition_exclusions_total",
+			Help:           "Total number of exclusions when an authorization webhook is skipped because match conditions exclude it.",
+			StabilityLevel: metrics.ALPHA,
+		},
+		[]string{"type", "name"},
+	)
+	authorizationMatchConditionEvaluationSeconds = metrics.NewHistogramVec(
+		&metrics.HistogramOpts{
+			Namespace:      namespace,
+			Subsystem:      subsystem,
+			Name:           "match_condition_evaluation_seconds",
+			Help:           "Authorization match condition evaluation time in seconds, split by authorizer type and name.",
+			Buckets:        []float64{0.001, 0.005, 0.01, 0.025, 0.1, 0.2, 0.25},
+			StabilityLevel: metrics.ALPHA,
+		},
+		[]string{"type", "name"},
+	)
+)
+
+var registerMetrics sync.Once
+
+func RegisterMetrics() {
+	registerMetrics.Do(func() {
+		legacyregistry.MustRegister(authorizationMatchConditionEvaluationErrorsTotal)
+		legacyregistry.MustRegister(authorizationMatchConditionExclusionsTotal)
+		legacyregistry.MustRegister(authorizationMatchConditionEvaluationSeconds)
+	})
+}
+
+func ResetMetricsForTest() {
+	authorizationMatchConditionEvaluationErrorsTotal.Reset()
+	authorizationMatchConditionExclusionsTotal.Reset()
+	authorizationMatchConditionEvaluationSeconds.Reset()
+}
+
+func (matcherMetrics) RecordAuthorizationMatchConditionEvaluationFailure(ctx context.Context, authorizerType, authorizerName string) {
+	authorizationMatchConditionEvaluationErrorsTotal.WithContext(ctx).WithLabelValues(authorizerType, authorizerName).Inc()
+}
+
+func (matcherMetrics) RecordAuthorizationMatchConditionExclusion(ctx context.Context, authorizerType, authorizerName string) {
+	authorizationMatchConditionExclusionsTotal.WithContext(ctx).WithLabelValues(authorizerType, authorizerName).Inc()
+}
+
+func (matcherMetrics) RecordAuthorizationMatchConditionEvaluation(ctx context.Context, authorizerType, authorizerName string, elapsed time.Duration) {
+	elapsedSeconds := elapsed.Seconds()
+	authorizationMatchConditionEvaluationSeconds.WithContext(ctx).WithLabelValues(authorizerType, authorizerName).Observe(elapsedSeconds)
+}

--- a/staging/src/k8s.io/apiserver/pkg/authorization/cel/metrics_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/authorization/cel/metrics_test.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cel
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"k8s.io/component-base/metrics/legacyregistry"
+	"k8s.io/component-base/metrics/testutil"
+)
+
+func TestRecordAuthorizationMatchConditionEvaluationFailure(t *testing.T) {
+	testCases := []struct {
+		desc      string
+		metrics   []string
+		name      string
+		authztype string
+		want      string
+	}{
+		{
+			desc: "evaluation failure total",
+			metrics: []string{
+				"apiserver_authorization_match_condition_evaluation_errors_total",
+				"apiserver_authorization_match_condition_exclusions_total",
+				"apiserver_authorization_match_condition_evaluation_seconds",
+			},
+			name:      "wh1.example.com",
+			authztype: "Webhook",
+			want: `
+			# HELP apiserver_authorization_match_condition_evaluation_errors_total [ALPHA] Total number of errors when an authorization webhook encounters a match condition error split by authorizer type and name.
+			# TYPE apiserver_authorization_match_condition_evaluation_errors_total counter
+			apiserver_authorization_match_condition_evaluation_errors_total{name="wh1.example.com",type="Webhook"} 1
+			# HELP apiserver_authorization_match_condition_evaluation_seconds [ALPHA] Authorization match condition evaluation time in seconds, split by authorizer type and name.
+        	# TYPE apiserver_authorization_match_condition_evaluation_seconds histogram
+        	apiserver_authorization_match_condition_evaluation_seconds_bucket{name="wh1.example.com",type="Webhook",le="0.001"} 0
+        	apiserver_authorization_match_condition_evaluation_seconds_bucket{name="wh1.example.com",type="Webhook",le="0.005"} 0
+        	apiserver_authorization_match_condition_evaluation_seconds_bucket{name="wh1.example.com",type="Webhook",le="0.01"} 0
+        	apiserver_authorization_match_condition_evaluation_seconds_bucket{name="wh1.example.com",type="Webhook",le="0.025"} 0
+        	apiserver_authorization_match_condition_evaluation_seconds_bucket{name="wh1.example.com",type="Webhook",le="0.1"} 0
+        	apiserver_authorization_match_condition_evaluation_seconds_bucket{name="wh1.example.com",type="Webhook",le="0.2"} 0
+        	apiserver_authorization_match_condition_evaluation_seconds_bucket{name="wh1.example.com",type="Webhook",le="0.25"} 0
+        	apiserver_authorization_match_condition_evaluation_seconds_bucket{name="wh1.example.com",type="Webhook",le="+Inf"} 1
+        	apiserver_authorization_match_condition_evaluation_seconds_sum{name="wh1.example.com",type="Webhook"} 1
+        	apiserver_authorization_match_condition_evaluation_seconds_count{name="wh1.example.com",type="Webhook"} 1
+			# HELP apiserver_authorization_match_condition_exclusions_total [ALPHA] Total number of exclusions when an authorization webhook is skipped because match conditions exclude it.
+			# TYPE apiserver_authorization_match_condition_exclusions_total counter
+			apiserver_authorization_match_condition_exclusions_total{name="wh1.example.com",type="Webhook"} 1
+			`,
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.desc, func(t *testing.T) {
+			ResetMetricsForTest()
+			m := NewMatcherMetrics()
+			m.RecordAuthorizationMatchConditionEvaluationFailure(context.Background(), tt.authztype, tt.name)
+			m.RecordAuthorizationMatchConditionExclusion(context.Background(), tt.authztype, tt.name)
+			m.RecordAuthorizationMatchConditionEvaluation(context.Background(), tt.authztype, tt.name, time.Duration(1*time.Second))
+			if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(tt.want), tt.metrics...); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}

--- a/staging/src/k8s.io/apiserver/plugin/pkg/authorizer/webhook/webhook_v1_test.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/authorizer/webhook/webhook_v1_test.go
@@ -44,11 +44,15 @@ import (
 	"k8s.io/apiserver/pkg/apis/apiserver"
 	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
+	celmetrics "k8s.io/apiserver/pkg/authorization/cel"
 	"k8s.io/apiserver/pkg/features"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	webhookutil "k8s.io/apiserver/pkg/util/webhook"
+	"k8s.io/apiserver/plugin/pkg/authorizer/webhook/metrics"
 	v1 "k8s.io/client-go/tools/clientcmd/api/v1"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	"k8s.io/component-base/metrics/legacyregistry"
+	"k8s.io/component-base/metrics/testutil"
 )
 
 var testRetryBackoff = wait.Backoff{
@@ -210,7 +214,7 @@ current-context: default
 			if err != nil {
 				return fmt.Errorf("error building sar client: %v", err)
 			}
-			_, err = newWithBackoff(sarClient, 0, 0, testRetryBackoff, authorizer.DecisionNoOpinion, []apiserver.WebhookMatchCondition{}, noopAuthorizerMetrics())
+			_, err = newWithBackoff(sarClient, 0, 0, testRetryBackoff, authorizer.DecisionNoOpinion, []apiserver.WebhookMatchCondition{}, noopAuthorizerMetrics(), "")
 			return err
 		}()
 		if err != nil && !tt.wantErr {
@@ -323,7 +327,7 @@ func (m *mockV1Service) HTTPStatusCode() int { return m.statusCode }
 
 // newV1Authorizer creates a temporary kubeconfig file from the provided arguments and attempts to load
 // a new WebhookAuthorizer from it.
-func newV1Authorizer(callbackURL string, clientCert, clientKey, ca []byte, cacheTime time.Duration, metrics AuthorizerMetrics, expressions []apiserver.WebhookMatchCondition) (*WebhookAuthorizer, error) {
+func newV1Authorizer(callbackURL string, clientCert, clientKey, ca []byte, cacheTime time.Duration, metrics metrics.AuthorizerMetrics, expressions []apiserver.WebhookMatchCondition, authzName string) (*WebhookAuthorizer, error) {
 	tempfile, err := ioutil.TempFile("", "")
 	if err != nil {
 		return nil, err
@@ -353,7 +357,7 @@ func newV1Authorizer(callbackURL string, clientCert, clientKey, ca []byte, cache
 	if err != nil {
 		return nil, fmt.Errorf("error building sar client: %v", err)
 	}
-	return newWithBackoff(sarClient, cacheTime, cacheTime, testRetryBackoff, authorizer.DecisionNoOpinion, expressions, metrics)
+	return newWithBackoff(sarClient, cacheTime, cacheTime, testRetryBackoff, authorizer.DecisionNoOpinion, expressions, metrics, authzName)
 }
 
 func TestV1TLSConfig(t *testing.T) {
@@ -412,7 +416,7 @@ func TestV1TLSConfig(t *testing.T) {
 			}
 			defer server.Close()
 
-			wh, err := newV1Authorizer(server.URL, tt.clientCert, tt.clientKey, tt.clientCA, 0, noopAuthorizerMetrics(), []apiserver.WebhookMatchCondition{})
+			wh, err := newV1Authorizer(server.URL, tt.clientCert, tt.clientKey, tt.clientCA, 0, noopAuthorizerMetrics(), []apiserver.WebhookMatchCondition{}, "")
 			if err != nil {
 				t.Errorf("%s: failed to create client: %v", tt.test, err)
 				return
@@ -477,7 +481,7 @@ func TestV1Webhook(t *testing.T) {
 	}
 	defer s.Close()
 
-	wh, err := newV1Authorizer(s.URL, clientCert, clientKey, caCert, 0, noopAuthorizerMetrics(), []apiserver.WebhookMatchCondition{})
+	wh, err := newV1Authorizer(s.URL, clientCert, clientKey, caCert, 0, noopAuthorizerMetrics(), []apiserver.WebhookMatchCondition{}, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -584,7 +588,7 @@ func TestV1WebhookCache(t *testing.T) {
 		},
 	}
 	// Create an authorizer that caches successful responses "forever" (100 days).
-	wh, err := newV1Authorizer(s.URL, clientCert, clientKey, caCert, 2400*time.Hour, noopAuthorizerMetrics(), expressions)
+	wh, err := newV1Authorizer(s.URL, clientCert, clientKey, caCert, 2400*time.Hour, noopAuthorizerMetrics(), expressions, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -760,7 +764,7 @@ func TestStructuredAuthzConfigFeatureEnablement(t *testing.T) {
 	for i, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.StructuredAuthorizationConfiguration, test.featureEnabled)()
-			wh, err := newV1Authorizer(s.URL, clientCert, clientKey, caCert, 0, noopAuthorizerMetrics(), test.expressions)
+			wh, err := newV1Authorizer(s.URL, clientCert, clientKey, caCert, 0, noopAuthorizerMetrics(), test.expressions, "")
 			if test.expectedCompileErr && err == nil {
 				t.Fatalf("%d: Expected compile error", i)
 			} else if !test.expectedCompileErr && err != nil {
@@ -777,6 +781,112 @@ func TestStructuredAuthzConfigFeatureEnablement(t *testing.T) {
 				if test.expectedDecision != authorized {
 					t.Errorf("%d: expected authorized=%v, got %v", i, test.expectedDecision, authorized)
 				}
+			}
+		})
+	}
+}
+
+func TestWebhookMetrics(t *testing.T) {
+	service := new(mockV1Service)
+	service.statusCode = 200
+	service.Allow()
+	s, err := NewV1TestServer(service, serverCert, serverKey, caCert)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.StructuredAuthorizationConfiguration, true)()
+
+	aliceAttr := authorizer.AttributesRecord{
+		User: &user.DefaultInfo{
+			Name: "alice",
+			UID:  "1",
+		},
+	}
+
+	testCases := []struct {
+		name         string
+		attr         authorizer.AttributesRecord
+		expressions1 []apiserver.WebhookMatchCondition
+		expressions2 []apiserver.WebhookMatchCondition
+		metrics      []string
+		want         string
+	}{
+		{
+			name: "should have one evaluation error from multiple failed match conditions",
+			attr: aliceAttr,
+			expressions1: []apiserver.WebhookMatchCondition{
+				{
+					Expression: "request.user == 'alice'",
+				},
+				{
+					Expression: "request.resourceAttributes.verb == 'get'",
+				},
+				{
+					Expression: "request.resourceAttributes.namespace == 'kittensandponies'",
+				},
+			},
+			expressions2: []apiserver.WebhookMatchCondition{
+				{
+					Expression: "request.user == 'alice'",
+				},
+			},
+			metrics: []string{
+				"apiserver_authorization_match_condition_evaluation_errors_total",
+			},
+			want: fmt.Sprintf(`
+					# HELP apiserver_authorization_match_condition_evaluation_errors_total [ALPHA] Total number of errors when an authorization webhook encounters a match condition error split by authorizer type and name.
+					# TYPE apiserver_authorization_match_condition_evaluation_errors_total counter
+					apiserver_authorization_match_condition_evaluation_errors_total{name="%s",type="%s"} 1
+					`, "wh1.example.com", "Webhook"),
+		},
+		{
+			name: "should have two webhook exclusions due to match condition",
+			attr: aliceAttr,
+			expressions1: []apiserver.WebhookMatchCondition{
+				{
+					Expression: "request.user == 'alice2'",
+				},
+				{
+					Expression: "request.uid == '1'",
+				},
+			},
+			expressions2: []apiserver.WebhookMatchCondition{
+				{
+					Expression: "request.user == 'alice1'",
+				},
+			},
+			metrics: []string{
+				"apiserver_authorization_match_condition_exclusions_total",
+			},
+			want: fmt.Sprintf(`
+					# HELP apiserver_authorization_match_condition_exclusions_total [ALPHA] Total number of exclusions when an authorization webhook is skipped because match conditions exclude it.
+					# TYPE apiserver_authorization_match_condition_exclusions_total counter
+					apiserver_authorization_match_condition_exclusions_total{name="%s",type="%s"} 1
+					apiserver_authorization_match_condition_exclusions_total{name="%s",type="%s"} 1
+					`, "wh1.example.com", "Webhook", "wh2.example.com", "Webhook"),
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			celmetrics.ResetMetricsForTest()
+			defer celmetrics.ResetMetricsForTest()
+			wh1, err := newV1Authorizer(s.URL, clientCert, clientKey, caCert, 0, celAuthorizerMetrics(), tt.expressions1, "wh1.example.com")
+			if err != nil {
+				t.Fatal(err)
+			}
+			wh2, err := newV1Authorizer(s.URL, clientCert, clientKey, caCert, 0, celAuthorizerMetrics(), tt.expressions2, "wh2.example.com")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err == nil {
+				_, _, _ = wh1.Authorize(context.Background(), tt.attr)
+				_, _, _ = wh2.Authorize(context.Background(), tt.attr)
+			}
+
+			if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(tt.want), tt.metrics...); err != nil {
+				t.Fatal(err)
 			}
 		})
 	}
@@ -942,7 +1052,7 @@ func benchmarkNewWebhookAuthorizer(b *testing.B, expressions []apiserver.Webhook
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		// Create an authorizer with or without expressions to compile
-		_, err := newV1Authorizer(s.URL, clientCert, clientKey, caCert, 0, noopAuthorizerMetrics(), expressions)
+		_, err := newV1Authorizer(s.URL, clientCert, clientKey, caCert, 0, noopAuthorizerMetrics(), expressions, "")
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -972,7 +1082,7 @@ func benchmarkWebhookAuthorize(b *testing.B, expressions []apiserver.WebhookMatc
 	defer s.Close()
 	defer featuregatetesting.SetFeatureGateDuringTest(b, utilfeature.DefaultFeatureGate, features.StructuredAuthorizationConfiguration, featureEnabled)()
 	// Create an authorizer with or without expressions to compile
-	wh, err := newV1Authorizer(s.URL, clientCert, clientKey, caCert, 0, noopAuthorizerMetrics(), expressions)
+	wh, err := newV1Authorizer(s.URL, clientCert, clientKey, caCert, 0, noopAuthorizerMetrics(), expressions, "")
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -1259,7 +1369,7 @@ func TestV1WebhookMatchConditions(t *testing.T) {
 
 	for i, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			wh, err := newV1Authorizer(s.URL, clientCert, clientKey, caCert, 0, noopAuthorizerMetrics(), test.expressions)
+			wh, err := newV1Authorizer(s.URL, clientCert, clientKey, caCert, 0, noopAuthorizerMetrics(), test.expressions, "")
 			if len(test.expectedCompileErr) > 0 && err == nil {
 				t.Fatalf("%d: Expected compile error", i)
 			} else if len(test.expectedCompileErr) == 0 && err != nil {
@@ -1292,9 +1402,17 @@ func TestV1WebhookMatchConditions(t *testing.T) {
 	}
 }
 
-func noopAuthorizerMetrics() AuthorizerMetrics {
-	return AuthorizerMetrics{
-		RecordRequestTotal:   noopMetrics{}.RecordRequestTotal,
-		RecordRequestLatency: noopMetrics{}.RecordRequestLatency,
+func noopAuthorizerMetrics() metrics.AuthorizerMetrics {
+	return metrics.NoopAuthorizerMetrics{}
+}
+
+func celAuthorizerMetrics() metrics.AuthorizerMetrics {
+	return celAuthorizerMetricsType{
+		MatcherMetrics: celmetrics.NewMatcherMetrics(),
 	}
+}
+
+type celAuthorizerMetricsType struct {
+	metrics.NoopRequestMetrics
+	celmetrics.MatcherMetrics
 }

--- a/staging/src/k8s.io/apiserver/plugin/pkg/authorizer/webhook/webhook_v1beta1_test.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/authorizer/webhook/webhook_v1beta1_test.go
@@ -197,7 +197,7 @@ current-context: default
 			if err != nil {
 				return fmt.Errorf("error building sar client: %v", err)
 			}
-			_, err = newWithBackoff(sarClient, 0, 0, testRetryBackoff, authorizer.DecisionNoOpinion, []authzconfig.WebhookMatchCondition{}, noopAuthorizerMetrics())
+			_, err = newWithBackoff(sarClient, 0, 0, testRetryBackoff, authorizer.DecisionNoOpinion, []authzconfig.WebhookMatchCondition{}, noopAuthorizerMetrics(), "")
 			return err
 		}()
 		if err != nil && !tt.wantErr {
@@ -340,7 +340,7 @@ func newV1beta1Authorizer(callbackURL string, clientCert, clientKey, ca []byte, 
 	if err != nil {
 		return nil, fmt.Errorf("error building sar client: %v", err)
 	}
-	return newWithBackoff(sarClient, cacheTime, cacheTime, testRetryBackoff, authorizer.DecisionNoOpinion, []authzconfig.WebhookMatchCondition{}, noopAuthorizerMetrics())
+	return newWithBackoff(sarClient, cacheTime, cacheTime, testRetryBackoff, authorizer.DecisionNoOpinion, []authzconfig.WebhookMatchCondition{}, noopAuthorizerMetrics(), "")
 }
 
 func TestV1beta1TLSConfig(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #123276 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kube-apiserver now reports the following metrics for authorization webhook match conditions:
- `apiserver_authorization_match_condition_evaluation_errors_total` counter metric labeled by authorizer type and name
- `apiserver_authorization_match_condition_exclusions_total` counter metric labeled by authorizer type and name
- `apiserver_authorization_match_condition_evaluation_seconds` histogram metric labeled by authorizer type and name
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-auth/3221-structured-authorization-configuration
```
/sig auth
/assign @liggitt @palnabarun @enj