### PR TITLE
Revert "[cloud-provider] require providerID to initialize node"

### DIFF
--- a/staging/src/k8s.io/controller-manager/pkg/features/kube_features.go
+++ b/staging/src/k8s.io/controller-manager/pkg/features/kube_features.go
@@ -47,13 +47,6 @@ const (
 	// `alpha.kubernetes.io/provided-node-ip` annotation
 	CloudDualStackNodeIPs featuregate.Feature = "CloudDualStackNodeIPs"
 
-	// owner: @aojea
-	// Deprecated: v1.30
-	// issue: https://issues.k8s.io/123024
-	//
-	// If enabled, the ProviderID field is not required for the node initialization.
-	OptionalProviderID featuregate.Feature = "OptionalProviderID"
-
 	// owner: @alexanderConstantinescu
 	// kep: http://kep.k8s.io/3458
 	// beta: v1.27
@@ -73,6 +66,5 @@ func SetupCurrentKubernetesSpecificFeatureGates(featuregates featuregate.Mutable
 var cloudPublicFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	CloudControllerManagerWebhook: {Default: false, PreRelease: featuregate.Alpha},
 	CloudDualStackNodeIPs:         {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.32
-	OptionalProviderID:            {Default: false, PreRelease: featuregate.Deprecated},             // remove after 1.31
 	StableLoadBalancerNodeSet:     {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // GA in 1.30, remove in 1.31
 }


### PR DESCRIPTION
This reverts commit 03bd3e25b16666a6c89d8875782d1132819eeb6e.


/kind bug
/kind cleanup
```release-note
NONE
```


We have to revert as there is some cases the cloud provider may not implement the ProviderID and this will make them fail to initialize the node

https://github.com/kubernetes/kubernetes/blob/6cc77a577e56c68e4fde81865e022e05e8e02538/staging/src/k8s.io/cloud-provider/controllers/node/node_controller.go#L622-L629

There is also a comment in the Instances2 metdata that is it possible for a cloud provider to not implement provider ID.

This is a regression on https://github.com/kubernetes/kubernetes/pull/87043 that already fixed the same issue

@andrewsykim it seems you are the most knowledgable  about this code, I will try to set up a meeting next week to get this working, I don't have clear which combinations are valid and when is it possible or not to know if providerId is required for initialize the node