### PR TITLE
Fx scalability tests

### DIFF
--- a/cluster/gce/config-default.sh
+++ b/cluster/gce/config-default.sh
@@ -483,7 +483,7 @@ ROTATE_CERTIFICATES="${ROTATE_CERTIFICATES:-}"
 
 # The number of services that are allowed to sync concurrently. Will be passed
 # into kube-controller-manager via `--concurrent-service-syncs`
-CONCURRENT_SERVICE_SYNCS="${CONCURRENT_SERVICE_SYNCS:-}"
+CONCURRENT_SERVICE_SYNCS="${CONCURRENT_SERVICE_SYNCS:-5}"
 
 export SERVICEACCOUNT_ISSUER="https://kubernetes.io/${CLUSTER_NAME}"
 

--- a/cluster/gce/config-test.sh
+++ b/cluster/gce/config-test.sh
@@ -539,7 +539,7 @@ ROTATE_CERTIFICATES=${ROTATE_CERTIFICATES:-}
 
 # The number of services that are allowed to sync concurrently. Will be passed
 # into kube-controller-manager via `--concurrent-service-syncs`
-CONCURRENT_SERVICE_SYNCS=${CONCURRENT_SERVICE_SYNCS:-}
+CONCURRENT_SERVICE_SYNCS=${CONCURRENT_SERVICE_SYNCS:-5}
 
 # The value kubernetes.default.svc.cluster.local is only usable for full
 # OIDC discovery flows in Pods in the same cluster. For some providers

--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -2301,6 +2301,7 @@ function start-cloud-controller-manager {
   params+=("--secure-port=10258")
   params+=("--use-service-account-credentials")
   params+=("--cloud-provider=gce")
+  params+=("--concurrent-node-syncs=10")
   params+=("--kubeconfig=/etc/srv/kubernetes/cloud-controller-manager/kubeconfig")
   params+=("--authorization-kubeconfig=/etc/srv/kubernetes/cloud-controller-manager/kubeconfig")
   params+=("--authentication-kubeconfig=/etc/srv/kubernetes/cloud-controller-manager/kubeconfig")


### PR DESCRIPTION

/kind failing-test
/kind flake

Fixes #

```release-note
NONE
```
Seen in https://github.com/kubernetes/kubernetes/issues/122286#issuecomment-1972818540 , most probably there are multiple things here, but the fact that the controllers are serializing each operation makes the test to fail with timeout

We must use multiple workers for scale tests

/sig scalability 
