### PR TITLE
hack: re-enable protobindings which use k8s.io/api

### DIFF
--- a/hack/lib/protoc.sh
+++ b/hack/lib/protoc.sh
@@ -69,6 +69,7 @@ function kube::protoc::protoc() {
     PATH="${gogopath}:${PATH}" protoc \
       --proto_path="$(pwd -P)" \
       --proto_path="${KUBE_ROOT}/vendor" \
+      --proto_path="${KUBE_ROOT}/staging/src" \
       --proto_path="${KUBE_ROOT}/third_party/protobuf" \
       --gogo_out=paths=source_relative,plugins=grpc:. \
       api.proto


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Before the workspace changes, it was possible to include proto files via the vendor path and the symlinks there. Now those symlinks are gone, so the search path for them must be given separately.

#### Special notes for your reviewer:

Needed for https://github.com/kubernetes/kubernetes/pull/123516, nothing else seems to run into this at the moment.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
