### PR TITLE
Fix discovery v2 conversion registration data race

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/apis/apidiscovery/v2/fuzzer_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apidiscovery/v2/fuzzer_test.go
@@ -37,8 +37,9 @@ func TestConversionRoundTrip(t *testing.T) {
 	scheme := runtime.NewScheme()
 	err := v2beta1scheme.AddToScheme(scheme)
 	require.NoError(t, err)
-	v2scheme.SchemeBuilder.Register(v2scheme.RegisterConversions)
 	err = v2scheme.AddToScheme(scheme)
+	require.NoError(t, err)
+	err = v2scheme.RegisterConversions(scheme)
 	require.NoError(t, err)
 
 	fuzzer := fuzz.NewWithSeed(2374375)

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/discovery/aggregated/handler.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/discovery/aggregated/handler.go
@@ -151,10 +151,10 @@ type priorityInfo struct {
 
 func NewResourceManager(path string) ResourceManager {
 	scheme := runtime.NewScheme()
-	// Register conversion for apidiscovery
-	apidiscoveryv2.SchemeBuilder.Register(apidiscoveryv2conversion.RegisterConversions)
 	utilruntime.Must(apidiscoveryv2.AddToScheme(scheme))
 	utilruntime.Must(apidiscoveryv2beta1.AddToScheme(scheme))
+	// Register conversion for apidiscovery
+	utilruntime.Must(apidiscoveryv2conversion.RegisterConversions(scheme))
 
 	codecs := serializer.NewCodecFactory(scheme)
 	rdm := &resourceDiscoveryManager{

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/discovery/aggregated/handler_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/discovery/aggregated/handler_test.go
@@ -32,6 +32,7 @@ import (
 	fuzz "github.com/google/gofuzz"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	apidiscoveryv2 "k8s.io/api/apidiscovery/v2"
 	apidiscoveryv2beta1 "k8s.io/api/apidiscovery/v2beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -50,10 +51,10 @@ var codecs = runtimeserializer.NewCodecFactory(scheme)
 const discoveryPath = "/apis"
 
 func init() {
-	// Register conversion for apidiscovery
-	apidiscoveryv2.SchemeBuilder.Register(apidiscoveryv2conversion.RegisterConversions)
 	utilruntime.Must(apidiscoveryv2.AddToScheme(scheme))
 	utilruntime.Must(apidiscoveryv2beta1.AddToScheme(scheme))
+	// Register conversion for apidiscovery
+	utilruntime.Must(apidiscoveryv2conversion.RegisterConversions(scheme))
 	codecs = runtimeserializer.NewCodecFactory(scheme)
 }
 

--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_discovery.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_discovery.go
@@ -187,10 +187,10 @@ func NewDiscoveryManager(
 	target discoveryendpoint.ResourceManager,
 ) DiscoveryAggregationController {
 	discoveryScheme := runtime.NewScheme()
-	// Register conversion for apidiscovery
-	apidiscoveryv2.SchemeBuilder.Register(apidiscoveryv2conversion.RegisterConversions)
 	utilruntime.Must(apidiscoveryv2.AddToScheme(discoveryScheme))
 	utilruntime.Must(apidiscoveryv2beta1.AddToScheme(discoveryScheme))
+	// Register conversion for apidiscovery
+	utilruntime.Must(apidiscoveryv2conversion.RegisterConversions(discoveryScheme))
 	codecs := serializer.NewCodecFactory(discoveryScheme)
 
 	return &discoveryManager{


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind flake

#### What this PR does / why we need it:

Registers v2 discovery conversions into the local scheme instead of mutating the global SchemeBuilder

Fixes https://github.com/kubernetes/kubernetes/issues/123632

/priority critical-urgent
/sig apimachinery
/assign @Jefftree 

```release-note
NONE
```