### PR TITLE
Increase client-side websocket write deadline

### DIFF
--- a/staging/src/k8s.io/client-go/tools/remotecommand/websocket.go
+++ b/staging/src/k8s.io/client-go/tools/remotecommand/websocket.go
@@ -36,13 +36,9 @@ import (
 	"k8s.io/klog/v2"
 )
 
-// writeDeadline defines the time that a write to the websocket connection
-// must complete by, otherwise an i/o timeout occurs. The writeDeadline
-// has nothing to do with a response from the other websocket connection
-// endpoint; only that the message was successfully processed by the
-// local websocket connection. The typical write deadline within the websocket
-// library is one second.
-const writeDeadline = 2 * time.Second
+// writeDeadline defines the time that a client-side write to the websocket
+// connection must complete before an i/o timeout occurs.
+const writeDeadline = 30 * time.Second
 
 var (
 	_ Executor          = &wsStreamExecutor{}
@@ -65,8 +61,8 @@ const (
 	// "pong" message before a timeout error occurs for websocket reading.
 	// This duration must always be greater than the "pingPeriod". By defining
 	// this deadline in terms of the ping period, we are essentially saying
-	// we can drop "X-1" (e.g. 3-1=2) pings before firing the timeout.
-	pingReadDeadline = (pingPeriod * 3) + (1 * time.Second)
+	// we can drop "X-1" (e.g. 6-1=5) pings before firing the timeout.
+	pingReadDeadline = (pingPeriod * 6) + (1 * time.Second)
 )
 
 // wsStreamExecutor handles transporting standard shell streams over an httpstream connection.
@@ -497,7 +493,7 @@ func (h *heartbeat) start() {
 			// "WriteControl" does not need to be protected by a mutex. According to
 			// gorilla/websockets library docs: "The Close and WriteControl methods can
 			// be called concurrently with all other methods."
-			if err := h.conn.WriteControl(gwebsocket.PingMessage, h.message, time.Now().Add(writeDeadline)); err == nil {
+			if err := h.conn.WriteControl(gwebsocket.PingMessage, h.message, time.Now().Add(pingReadDeadline)); err == nil {
 				klog.V(8).Infof("Websocket Ping succeeeded")
 			} else {
 				klog.Errorf("Websocket Ping failed: %v", err)


### PR DESCRIPTION
* Increases the `RemoteCommand` client-side WebSockets write deadline to 30 seconds. The legacy SPDY client side writes do not have a timeout. We need to increase it to *not* timeout if the TCP connection is flaky, but can become re-established.
* Increases the ping deadline equal to losing 6 pings (= 30 seconds), before the connection is considered lost and torn down.

/kind cleanup

```release-note
NONE
```

- [Transition from SPDY to WebSockets #4006](https://github.com/kubernetes/enhancements/issues/4006)
