### PR TITLE
Promote StructuredAuthorizationConfiguration feature gate to beta

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -1222,7 +1222,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 
 	genericfeatures.StructuredAuthenticationConfiguration: {Default: false, PreRelease: featuregate.Alpha},
 
-	genericfeatures.StructuredAuthorizationConfiguration: {Default: false, PreRelease: featuregate.Alpha},
+	genericfeatures.StructuredAuthorizationConfiguration: {Default: true, PreRelease: featuregate.Beta},
 
 	genericfeatures.UnauthenticatedHTTP2DOSMitigation: {Default: true, PreRelease: featuregate.Beta},
 

--- a/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
+++ b/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
@@ -234,6 +234,7 @@ const (
 	// owner: @palnabarun
 	// kep: https://kep.k8s.io/3221
 	// alpha: v1.29
+	// beta: v1.30
 	//
 	// Enables Structured Authorization Configuration
 	StructuredAuthorizationConfiguration featuregate.Feature = "StructuredAuthorizationConfiguration"
@@ -329,7 +330,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 
 	StructuredAuthenticationConfiguration: {Default: false, PreRelease: featuregate.Alpha},
 
-	StructuredAuthorizationConfiguration: {Default: false, PreRelease: featuregate.Alpha},
+	StructuredAuthorizationConfiguration: {Default: true, PreRelease: featuregate.Beta},
 
 	UnauthenticatedHTTP2DOSMitigation: {Default: true, PreRelease: featuregate.Beta},
 


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Promotes the StructuredAuthorizationConfiguration feature gate to beta

Part of https://github.com/kubernetes/enhancements/issues/3221

Beta graduation criteria:
- [x] Observability and metrics complete
  - https://github.com/kubernetes/kubernetes/pull/123333
  - https://github.com/kubernetes/kubernetes/pull/123611
  - https://github.com/kubernetes/kubernetes/pull/123639
- [x] File reloading functionality complete
  - https://github.com/kubernetes/kubernetes/pull/121946
- [x] Address user reviews and iterate (if needed, keep in Alpha until changes stabilize)
- [x] Feature flag will be turned on by default
  - https://github.com/kubernetes/kubernetes/pull/123641

#### Does this PR introduce a user-facing change?
```release-note
kube-apiserver: the StructuredAuthorizationConfiguration feature gate is promoted to beta and allows using the `--authorization-configuration` flag
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://kep.k8s.io/3221
```

/sig auth
/milestone v1.30
/assign @palnabarun @ritazh 