### PR TITLE
Fix publish openapi conformance tests to ignore x-kubernetes-selectable-fields

### DIFF
--- a/test/e2e/apimachinery/crd_publish_openapi.go
+++ b/test/e2e/apimachinery/crd_publish_openapi.go
@@ -27,9 +27,10 @@ import (
 	"time"
 
 	"github.com/onsi/ginkgo/v2"
+	"sigs.k8s.io/yaml"
+
 	openapiutil "k8s.io/kube-openapi/pkg/util"
 	"k8s.io/utils/pointer"
-	"sigs.k8s.io/yaml"
 
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -713,6 +714,7 @@ func dropDefaults(s *spec.Schema) {
 	delete(s.Properties, "apiVersion")
 	delete(s.Properties, "kind")
 	delete(s.Extensions, "x-kubernetes-group-version-kind")
+	delete(s.Extensions, "x-kubernetes-selectable-fields")
 }
 
 func verifyKubectlExplain(ns, name, pattern string) error {


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/123637

These conformance tests rely on a deep equals where additional metadata like `x-kubernetes-*` fields are ignored.  `x-kubernetes-selectable-fields` shows up as a difference in the expected result (this extension was introduced by https://github.com/kubernetes/kubernetes/pull/122717 which @dims correctly isolated as the probable cause of the test failure).

Adding `x-kubernetes-selectable-fields` to the list of field pruned before comparison should appease the test.