### PR TITLE
cel: add semantic version type

### DIFF
--- a/staging/src/k8s.io/apiserver/go.mod
+++ b/staging/src/k8s.io/apiserver/go.mod
@@ -5,6 +5,7 @@ module k8s.io/apiserver
 go 1.22.0
 
 require (
+	github.com/blang/semver/v4 v4.0.0
 	github.com/coreos/go-oidc v2.2.1+incompatible
 	github.com/coreos/go-systemd/v22 v22.5.0
 	github.com/emicklei/go-restful/v3 v3.11.0
@@ -61,7 +62,6 @@ require (
 	github.com/antlr/antlr4/runtime/Go/antlr/v4 v4.0.0-20230305170008-8188dc5388df // indirect
 	github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
-	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/cenkalti/backoff/v4 v4.2.1 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/coreos/go-semver v0.3.1 // indirect

--- a/staging/src/k8s.io/apiserver/pkg/cel/environment/base.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/environment/base.go
@@ -128,6 +128,7 @@ var baseOpts = []VersionedOptions{
 		EnvOptions: []cel.EnvOption{
 			library.IP(),
 			library.CIDR(),
+			library.SemVer(),
 		},
 	},
 }

--- a/staging/src/k8s.io/apiserver/pkg/cel/library/cost.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/library/cost.go
@@ -152,7 +152,12 @@ func (l *CostEstimator) CallCost(function, overloadId string, args []ref.Val, re
 			cost := uint64(math.Ceil(float64(actualSize(args[0])) * common.StringTraversalCostFactor))
 			return &cost
 		}
-	case "sign", "asInteger", "isInteger", "asApproximateFloat", "isGreaterThan", "isLessThan", "compareTo", "add", "sub":
+	case "semver", "isSemVer":
+		if len(args) >= 1 {
+			cost := uint64(math.Ceil(float64(actualSize(args[0])) * common.StringTraversalCostFactor))
+			return &cost
+		}
+	case "sign", "asInteger", "isInteger", "asApproximateFloat", "isGreaterThan", "isLessThan", "compareTo", "add", "sub", "major", "minor", "patch":
 		cost := uint64(1)
 		return &cost
 	}

--- a/staging/src/k8s.io/apiserver/pkg/cel/library/library_compatibility_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/library/library_compatibility_test.go
@@ -26,7 +26,7 @@ import (
 
 func TestLibraryCompatibility(t *testing.T) {
 	var libs []map[string][]cel.FunctionOpt
-	libs = append(libs, authzLibraryDecls, listsLibraryDecls, regexLibraryDecls, urlLibraryDecls, quantityLibraryDecls, ipLibraryDecls, cidrLibraryDecls)
+	libs = append(libs, authzLibraryDecls, listsLibraryDecls, regexLibraryDecls, urlLibraryDecls, quantityLibraryDecls, ipLibraryDecls, cidrLibraryDecls, semverLibraryDecls)
 	functionNames := sets.New[string]()
 	for _, lib := range libs {
 		for name := range lib {
@@ -49,6 +49,7 @@ func TestLibraryCompatibility(t *testing.T) {
 		"add", "asApproximateFloat", "asInteger", "compareTo", "isGreaterThan", "isInteger", "isLessThan", "isQuantity", "quantity", "sign", "sub",
 		// Kubernetes <1.30>:
 		"ip", "family", "isUnspecified", "isLoopback", "isLinkLocalMulticast", "isLinkLocalUnicast", "isGlobalUnicast", "ip.isCanonical", "isIP", "cidr", "containsIP", "containsCIDR", "masked", "prefixLength", "isCIDR", "string",
+		"isSemVer", "semver", "major", "minor", "patch",
 		// Kubernetes <1.??>:
 	)
 

--- a/staging/src/k8s.io/apiserver/pkg/cel/library/semver.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/library/semver.go
@@ -1,0 +1,230 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package library
+
+import (
+	"github.com/blang/semver/v4"
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+
+	apiservercel "k8s.io/apiserver/pkg/cel"
+)
+
+// SemVer provides a CEL function library extension for [semver.Version].
+//
+// semver
+//
+// Converts a string to a SemVer or results in an error if the string is not a valid SemVer. Refer
+// to semver.SemVer documentation for information on accepted patterns.
+//
+//	semver(<string>) <SemVer>
+//
+// Examples:
+//
+//	semver('1.0.0') // returns a SemVer
+//	semver('0.1.0-alpha.1') // returns a SemVer
+//	semver('200K') // error
+//	semver('Three') // error
+//	semver('Mi') // error
+//
+// isSemVer
+//
+// Returns true if a string is a valid SemVer. isSemVer returns true if and
+// only if semver does not result in error.
+//
+//	isSemVer( <string>) <bool>
+//
+// Examples:
+//
+//	isSemVer('1.0.0') // returns true
+//	isSemVer('v1.0') // returns true (tolerant parsing)
+//	isSemVer('hello') // returns false
+//
+// Conversion to Scalars:
+//
+//   - major/minor/patch: return the major version number as int64.
+//
+//     <SemVer>.major() <int>
+//
+// Examples:
+//
+// semver("1.2.3").major() // returns 1
+//
+// Comparisons
+//
+//   - isGreaterThan: Returns true if and only if the receiver is greater than the operand
+//
+//   - isLessThan: Returns true if and only if the receiver is less than the operand
+//
+//   - compareTo: Compares receiver to operand and returns 0 if they are equal, 1 if the receiver is greater, or -1 if the receiver is less than the operand
+//
+//
+//     <SemVer>.isLessThan(<semver>) <bool>
+//     <SemVer>.isGreaterThan(<semver>) <bool>
+//     <SemVer>.compareTo(<semver>) <int>
+//
+// Examples:
+//
+// semver("1.2.3").compareTo(semver("1.2.3")) // returns 0
+// semver("1.2.3").compareTo(semver("2.0.0")) // returns -1
+// semver("1.2.3").compareTo(semver("0.1.2")) // returns 1
+
+func SemVer() cel.EnvOption {
+	return cel.Lib(semverLib)
+}
+
+var semverLib = &semverLibType{}
+
+type semverLibType struct{}
+
+func (*semverLibType) LibraryName() string {
+	return "k8s.semver"
+}
+
+var semverLibraryDecls = map[string][]cel.FunctionOpt{
+	"semver": {
+		cel.Overload("string_to_semver", []*cel.Type{cel.StringType}, apiservercel.SemVerType, cel.UnaryBinding((stringToSemVer))),
+	},
+	"isSemVer": {
+		cel.Overload("is_semver_string", []*cel.Type{cel.StringType}, cel.BoolType, cel.UnaryBinding(isSemVer)),
+	},
+	"isGreaterThan": {
+		cel.MemberOverload("semver_is_greater_than", []*cel.Type{apiservercel.SemVerType, apiservercel.SemVerType}, cel.BoolType, cel.BinaryBinding(semverIsGreaterThan)),
+	},
+	"isLessThan": {
+		cel.MemberOverload("semver_is_less_than", []*cel.Type{apiservercel.SemVerType, apiservercel.SemVerType}, cel.BoolType, cel.BinaryBinding(semverIsLessThan)),
+	},
+	"compareTo": {
+		cel.MemberOverload("semver_compare_to", []*cel.Type{apiservercel.SemVerType, apiservercel.SemVerType}, cel.IntType, cel.BinaryBinding(semverCompareTo)),
+	},
+	"major": {
+		cel.MemberOverload("semver_major", []*cel.Type{apiservercel.SemVerType}, cel.IntType, cel.UnaryBinding(semverMajor)),
+	},
+	"minor": {
+		cel.MemberOverload("semver_minor", []*cel.Type{apiservercel.SemVerType}, cel.IntType, cel.UnaryBinding(semverMinor)),
+	},
+	"patch": {
+		cel.MemberOverload("semver_patch", []*cel.Type{apiservercel.SemVerType}, cel.IntType, cel.UnaryBinding(semverPatch)),
+	},
+}
+
+func (*semverLibType) CompileOptions() []cel.EnvOption {
+	options := make([]cel.EnvOption, 0, len(semverLibraryDecls))
+	for name, overloads := range semverLibraryDecls {
+		options = append(options, cel.Function(name, overloads...))
+	}
+	return options
+}
+
+func (*semverLibType) ProgramOptions() []cel.ProgramOption {
+	return []cel.ProgramOption{}
+}
+
+func isSemVer(arg ref.Val) ref.Val {
+	str, ok := arg.Value().(string)
+	if !ok {
+		return types.MaybeNoSuchOverloadErr(arg)
+	}
+
+	_, err := semver.Parse(str)
+	if err != nil {
+		return types.Bool(false)
+	}
+
+	return types.Bool(true)
+}
+
+func stringToSemVer(arg ref.Val) ref.Val {
+	str, ok := arg.Value().(string)
+	if !ok {
+		return types.MaybeNoSuchOverloadErr(arg)
+	}
+
+	v, err := semver.Parse(str)
+	if err != nil {
+		return types.WrapErr(err)
+	}
+
+	return apiservercel.SemVer{Version: v}
+}
+
+func semverMajor(arg ref.Val) ref.Val {
+	v, ok := arg.Value().(semver.Version)
+	if !ok {
+		return types.MaybeNoSuchOverloadErr(arg)
+	}
+	return types.Int(v.Major)
+}
+
+func semverMinor(arg ref.Val) ref.Val {
+	v, ok := arg.Value().(semver.Version)
+	if !ok {
+		return types.MaybeNoSuchOverloadErr(arg)
+	}
+	return types.Int(v.Minor)
+}
+
+func semverPatch(arg ref.Val) ref.Val {
+	v, ok := arg.Value().(semver.Version)
+	if !ok {
+		return types.MaybeNoSuchOverloadErr(arg)
+	}
+	return types.Int(v.Patch)
+}
+
+func semverIsGreaterThan(arg ref.Val, other ref.Val) ref.Val {
+	v, ok := arg.Value().(semver.Version)
+	if !ok {
+		return types.MaybeNoSuchOverloadErr(arg)
+	}
+
+	v2, ok := other.Value().(semver.Version)
+	if !ok {
+		return types.MaybeNoSuchOverloadErr(arg)
+	}
+
+	return types.Bool(v.Compare(v2) == 1)
+}
+
+func semverIsLessThan(arg ref.Val, other ref.Val) ref.Val {
+	v, ok := arg.Value().(semver.Version)
+	if !ok {
+		return types.MaybeNoSuchOverloadErr(arg)
+	}
+
+	v2, ok := other.Value().(semver.Version)
+	if !ok {
+		return types.MaybeNoSuchOverloadErr(arg)
+	}
+
+	return types.Bool(v.Compare(v2) == -1)
+}
+
+func semverCompareTo(arg ref.Val, other ref.Val) ref.Val {
+	v, ok := arg.Value().(semver.Version)
+	if !ok {
+		return types.MaybeNoSuchOverloadErr(arg)
+	}
+
+	v2, ok := other.Value().(semver.Version)
+	if !ok {
+		return types.MaybeNoSuchOverloadErr(arg)
+	}
+
+	return types.Int(v.Compare(v2))
+}

--- a/staging/src/k8s.io/apiserver/pkg/cel/library/semver_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/library/semver_test.go
@@ -1,0 +1,210 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package library_test
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/blang/semver/v4"
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+	"github.com/stretchr/testify/require"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+	apiservercel "k8s.io/apiserver/pkg/cel"
+	"k8s.io/apiserver/pkg/cel/library"
+)
+
+func testSemVer(t *testing.T, expr string, expectResult ref.Val, expectRuntimeErrPattern string, expectCompileErrs []string) {
+	env, err := cel.NewEnv(
+		library.SemVer(),
+	)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	compiled, issues := env.Compile(expr)
+
+	if len(expectCompileErrs) > 0 {
+		missingCompileErrs := []string{}
+		matchedCompileErrs := sets.New[int]()
+		for _, expectedCompileErr := range expectCompileErrs {
+			compiledPattern, err := regexp.Compile(expectedCompileErr)
+			if err != nil {
+				t.Fatalf("failed to compile expected err regex: %v", err)
+			}
+
+			didMatch := false
+
+			for i, compileError := range issues.Errors() {
+				if compiledPattern.Match([]byte(compileError.Message)) {
+					didMatch = true
+					matchedCompileErrs.Insert(i)
+				}
+			}
+
+			if !didMatch {
+				missingCompileErrs = append(missingCompileErrs, expectedCompileErr)
+			} else if len(matchedCompileErrs) != len(issues.Errors()) {
+				unmatchedErrs := []cel.Error{}
+				for i, issue := range issues.Errors() {
+					if !matchedCompileErrs.Has(i) {
+						unmatchedErrs = append(unmatchedErrs, *issue)
+					}
+				}
+				require.Empty(t, unmatchedErrs, "unexpected compilation errors")
+			}
+		}
+
+		require.Empty(t, missingCompileErrs, "expected compilation errors")
+		return
+	} else if len(issues.Errors()) > 0 {
+		for _, err := range issues.Errors() {
+			t.Errorf("unexpected compile error: %v", err)
+		}
+		t.FailNow()
+	}
+
+	prog, err := env.Program(compiled)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	res, _, err := prog.Eval(map[string]interface{}{})
+	if len(expectRuntimeErrPattern) > 0 {
+		if err == nil {
+			t.Fatalf("no runtime error thrown. Expected: %v", expectRuntimeErrPattern)
+		} else if matched, regexErr := regexp.MatchString(expectRuntimeErrPattern, err.Error()); regexErr != nil {
+			t.Fatalf("failed to compile expected err regex: %v", regexErr)
+		} else if !matched {
+			t.Fatalf("unexpected err: %v", err)
+		}
+	} else if err != nil {
+		t.Fatalf("%v", err)
+	} else if expectResult != nil {
+		converted := res.Equal(expectResult).Value().(bool)
+		require.True(t, converted, "expectation not equal to output")
+	} else {
+		t.Fatal("expected result must not be nil")
+	}
+
+}
+
+func TestSemVer(t *testing.T) {
+	trueVal := types.Bool(true)
+	falseVal := types.Bool(false)
+
+	cases := []struct {
+		name               string
+		expr               string
+		expectValue        ref.Val
+		expectedCompileErr []string
+		expectedRuntimeErr string
+	}{
+		{
+			name:        "parse",
+			expr:        `semver("1.2.3")`,
+			expectValue: apiservercel.SemVer{Version: semver.MustParse("1.2.3")},
+		},
+		{
+			name:               "parseInvalidVersion",
+			expr:               `semver("v1.0")`,
+			expectedRuntimeErr: "No Major.Minor.Patch elements found",
+		},
+		{
+			name:        "isSemVer",
+			expr:        `isSemVer("1.2.3-beta.1+build.1")`,
+			expectValue: trueVal,
+		},
+		{
+			name:        "isSemVer_false",
+			expr:        `isSemVer("v1.0")`,
+			expectValue: falseVal,
+		},
+		{
+			name:               "isSemVer_noOverload",
+			expr:               `isSemVer([1, 2, 3])`,
+			expectedCompileErr: []string{"found no matching overload for 'isSemVer' applied to.*"},
+		},
+		{
+			name:        "equality_reflexivity",
+			expr:        `semver("1.2.3") == semver("1.2.3")`,
+			expectValue: trueVal,
+		},
+		{
+			name:        "inequality",
+			expr:        `semver("1.2.3") == semver("1.0.0")`,
+			expectValue: falseVal,
+		},
+		{
+			name:        "semver_less",
+			expr:        `semver("1.0.0").isLessThan(semver("1.2.3"))`,
+			expectValue: trueVal,
+		},
+		{
+			name:        "semver_less_false",
+			expr:        `semver("1.0.0").isLessThan(semver("1.0.0"))`,
+			expectValue: falseVal,
+		},
+		{
+			name:        "semver_greater",
+			expr:        `semver("1.2.3").isGreaterThan(semver("1.0.0"))`,
+			expectValue: trueVal,
+		},
+		{
+			name:        "semver_greater_false",
+			expr:        `semver("1.0.0").isGreaterThan(semver("1.0.0"))`,
+			expectValue: falseVal,
+		},
+		{
+			name:        "compare_equal",
+			expr:        `semver("1.2.3").compareTo(semver("1.2.3"))`,
+			expectValue: types.Int(0),
+		},
+		{
+			name:        "compare_less",
+			expr:        `semver("1.0.0").compareTo(semver("1.2.3"))`,
+			expectValue: types.Int(-1),
+		},
+		{
+			name:        "compare_greater",
+			expr:        `semver("1.2.3").compareTo(semver("1.0.0"))`,
+			expectValue: types.Int(1),
+		},
+		{
+			name:        "major",
+			expr:        `semver("1.2.3").major()`,
+			expectValue: types.Int(1),
+		},
+		{
+			name:        "minor",
+			expr:        `semver("1.2.3").minor()`,
+			expectValue: types.Int(2),
+		},
+		{
+			name:        "patch",
+			expr:        `semver("1.2.3").patch()`,
+			expectValue: types.Int(3),
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			testSemVer(t, c.expr, c.expectValue, c.expectedRuntimeErr, c.expectedCompileErr)
+		})
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/cel/semver.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/semver.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cel
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/blang/semver/v4"
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+)
+
+var (
+	SemVerType = cel.ObjectType("kubernetes.SemVer")
+)
+
+// SemVer provdes a CEL representation of a [semver.SemVer].
+type SemVer struct {
+	semver.Version
+}
+
+func (v SemVer) ConvertToNative(typeDesc reflect.Type) (interface{}, error) {
+	if reflect.TypeOf(v.Version).AssignableTo(typeDesc) {
+		return v.Version, nil
+	}
+	if reflect.TypeOf("").AssignableTo(typeDesc) {
+		return v.Version.String(), nil
+	}
+	return nil, fmt.Errorf("type conversion error from 'SemVer' to '%v'", typeDesc)
+}
+
+func (v SemVer) ConvertToType(typeVal ref.Type) ref.Val {
+	switch typeVal {
+	case SemVerType:
+		return v
+	case types.TypeType:
+		return SemVerType
+	default:
+		return types.NewErr("type conversion error from '%s' to '%s'", SemVerType, typeVal)
+	}
+}
+
+func (v SemVer) Equal(other ref.Val) ref.Val {
+	otherDur, ok := other.(SemVer)
+	if !ok {
+		return types.MaybeNoSuchOverloadErr(other)
+	}
+	return types.Bool(v.Version.EQ(otherDur.Version))
+}
+
+func (v SemVer) Type() ref.Type {
+	return SemVerType
+}
+
+func (v SemVer) Value() interface{} {
+	return v.Version
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

[Structured parameters for Dynamic Resource Allocation](https://github.com/kubernetes/enhancements/issues/4381) use CEL expressions to filter resource instances by their attributes. One of the possible attribute value types is a semantic version string. The corresponding filter could be "attribute value >= 2.0.0".

#### Which issue(s) this PR fixes:
Related-to: https://github.com/kubernetes/enhancements/issues/4381

#### Special notes for your reviewer:

The key question from an API perspective is: can Kubernetes rely on some particular semver implementation ~~to validate API fields (not in this PR, but calling `semver.Parse` is what validation of the DRA API would do) and~~ to implement the version comparsion (this PR)? See https://github.com/kubernetes/kubernetes/pull/123516#discussion_r1509193118 for @liggitt's comments in the context of a different solution for the same problem.

github.com/blang/semver/v4 was chosen for this in this PR because it looks like a stable, high-quality implementation and also seems to be the most widely used semver implementation in Kubernetes.

Regarding the implementation: it is derived from the quantity type and supports the same operations, with one exception: comparison across types (like `<semver> == <int>` ?) is not supported.

#### Does this PR introduce a user-facing change?

```release-note
CEL: semver is a new type for semantic version string parsing and comparison.
```

/cc @liggitt @klueska @cici37 