### PR TITLE
cel: fix conversion of quantity to quantity

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/cel/quantity.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/quantity.go
@@ -50,7 +50,7 @@ func (d Quantity) ConvertToNative(typeDesc reflect.Type) (interface{}, error) {
 
 func (d Quantity) ConvertToType(typeVal ref.Type) ref.Val {
 	switch typeVal {
-	case typeValue:
+	case quantityTypeValue:
 		return d
 	case types.TypeType:
 		return quantityTypeValue


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The code in ConvertToType checked for conversion into typeValue (= "kubernetes.URL") instead of conversion into quantityTypeValue (= "kubernetes.Quantity") and thus most likely failed with an incorrect "type conversion error".

#### Special notes for your reviewer:

Found while reading the code. Not sure whether it has any real-world impact.

#### Does this PR introduce a user-facing change?
```release-note
cel: converting a quantity value into a quantity value failed.
```

/assign @cici37 