### PR TITLE
ignore replicaset-replicas-before-scale annotation in deployment rollbacks

### DIFF
--- a/pkg/controller/deployment/util/deployment_util.go
+++ b/pkg/controller/deployment/util/deployment_util.go
@@ -56,6 +56,10 @@ const (
 	// is deployment.spec.replicas + maxSurge. Used by the underlying replica sets to estimate their
 	// proportions in case the deployment has surge replicas.
 	MaxReplicasAnnotation = "deployment.kubernetes.io/max-replicas"
+	// ReplicaSetReplicasBeforeScaleAnnotation is the number of replicas a replica set had before scaling began.
+	// Used by the underlying replica sets to estimate their proportions in case the deployment has surge replicas
+	// if the replica set is partially scaled due to the deployment's .spec.podReplacementPolicy.
+	ReplicaSetReplicasBeforeScaleAnnotation = "deployment.kubernetes.io/replicaset-replicas-before-scale"
 
 	// RollbackRevisionNotFound is not found rollback event reason
 	RollbackRevisionNotFound = "DeploymentRollbackRevisionNotFound"
@@ -293,12 +297,13 @@ func SetNewReplicaSetAnnotations(ctx context.Context, deployment *apps.Deploymen
 }
 
 var annotationsToSkip = map[string]bool{
-	v1.LastAppliedConfigAnnotation: true,
-	RevisionAnnotation:             true,
-	RevisionHistoryAnnotation:      true,
-	DesiredReplicasAnnotation:      true,
-	MaxReplicasAnnotation:          true,
-	apps.DeprecatedRollbackTo:      true,
+	v1.LastAppliedConfigAnnotation:          true,
+	RevisionAnnotation:                      true,
+	RevisionHistoryAnnotation:               true,
+	DesiredReplicasAnnotation:               true,
+	MaxReplicasAnnotation:                   true,
+	ReplicaSetReplicasBeforeScaleAnnotation: true,
+	apps.DeprecatedRollbackTo:               true,
 }
 
 // skipCopyAnnotation returns true if we should skip copying the annotation with the given annotation key

--- a/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/rollback.go
+++ b/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/rollback.go
@@ -182,12 +182,13 @@ func equalIgnoreHash(template1, template2 *corev1.PodTemplateSpec) bool {
 // annotationsToSkip lists the annotations that should be preserved from the deployment and not
 // copied from the replicaset when rolling a deployment back
 var annotationsToSkip = map[string]bool{
-	corev1.LastAppliedConfigAnnotation:       true,
-	deploymentutil.RevisionAnnotation:        true,
-	deploymentutil.RevisionHistoryAnnotation: true,
-	deploymentutil.DesiredReplicasAnnotation: true,
-	deploymentutil.MaxReplicasAnnotation:     true,
-	appsv1.DeprecatedRollbackTo:              true,
+	corev1.LastAppliedConfigAnnotation:                     true,
+	deploymentutil.RevisionAnnotation:                      true,
+	deploymentutil.RevisionHistoryAnnotation:               true,
+	deploymentutil.DesiredReplicasAnnotation:               true,
+	deploymentutil.MaxReplicasAnnotation:                   true,
+	deploymentutil.ReplicaSetReplicasBeforeScaleAnnotation: true,
+	appsv1.DeprecatedRollbackTo:                            true,
 }
 
 // getPatch returns a patch that can be applied to restore a Deployment to a

--- a/staging/src/k8s.io/kubectl/pkg/util/deployment/deployment.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/deployment/deployment.go
@@ -45,6 +45,10 @@ const (
 	// is deployment.spec.replicas + maxSurge. Used by the underlying replica sets to estimate their
 	// proportions in case the deployment has surge replicas.
 	MaxReplicasAnnotation = "deployment.kubernetes.io/max-replicas"
+	// ReplicaSetReplicasBeforeScaleAnnotation is the number of replicas a replica set had before scaling began.
+	// Used by the underlying replica sets to estimate their proportions in case the deployment has surge replicas
+	// if the replica set is partially scaled due to the deployment's .spec.podReplacementPolicy.
+	ReplicaSetReplicasBeforeScaleAnnotation = "deployment.kubernetes.io/replicaset-replicas-before-scale"
 	// RollbackRevisionNotFound is not found rollback event reason
 	RollbackRevisionNotFound = "DeploymentRollbackRevisionNotFound"
 	// RollbackTemplateUnchanged is the template unchanged rollback event reason


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


/kind feature

#### What this PR does / why we need it:

This is a prerequisite for upcoming feature `DeploymentPodReplacementPolicy` (https://github.com/kubernetes/kubernetes/pull/123430)

Add a new annotation to make sure N-1 kubectl rollback works with a cluster that turns on the new  feature. Same applies for  N-1 kube-controller-manager rollback.

We are unable to fully scale due to the new `TerminationComplete` policy . This policy ensures that there is only a certain number of pods specified up to `deployment.spec.replicas + maxSurge`, which includes terminating pods. If we want to scale above this number, we have to postpone the scaling to the future when terminating pods disappear.

1. We scale old replicaset(s) partially (e.g. from 6->7, later 7->9) according to the current running and terminating pods.
2. When these pods terminate, we can go back to scaling the old replicaset(s) (e.g. from 7->9). To implement this we need to know the original number of replicas (6) so that we do not overscale some of the replicasets. We are scaling proportionally the old state of the cluster and cannot obtain this information from the current/new state of the cluster. 

https://github.com/kubernetes/kubernetes/blob/a4eaf6e1200fa6f2050c71ef7a7e8ab27a8e4947/pkg/controller/deployment/util/deployment_util.go#L510

3. We can store this number in the `deployment.kubernetes.io/replicaset-replicas-before-scale` annotation and retrieve this in the next scaling iteration to compute the total number of replicas the old replicaset should scale to. We should not fallback the scaling to the newest replicaset instead of the old ones; to persist the original proportional availability of the application.

Storing the annotation for partial scaling (done only when scaling old replicasets):

https://github.com/kubernetes/kubernetes/blob/d8347ac1fdc767bc89826920359a7bb0dd922674/pkg/controller/deployment/sync.go#L410-L419

https://github.com/kubernetes/kubernetes/blob/d8347ac1fdc767bc89826920359a7bb0dd922674/pkg/controller/deployment/util/deployment_util.go#L456-L474

Scaling during partial scaling to ensure that we compute the correct number of replicas

https://github.com/kubernetes/kubernetes/blob/d8347ac1fdc767bc89826920359a7bb0dd922674/pkg/controller/deployment/util/deployment_util.go#L585-L620

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
KEP: https://github.com/kubernetes/enhancements/issues/3973
```
