### PR TITLE
Fix IPPVS unit tests for windows

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_container_windows_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_windows_test.go
@@ -165,7 +165,7 @@ func TestCalculateWindowsResources(t *testing.T) {
 			cpuLim: resource.MustParse("2"),
 			memLim: resource.MustParse("128Mi"),
 			expected: &runtimeapi.WindowsContainerResources{
-				CpuMaximum:         2500,
+				CpuMaximum:         10000 / int64(winstats.ProcessorCount()),
 				MemoryLimitInBytes: 134217728,
 			},
 		},
@@ -183,7 +183,7 @@ func TestCalculateWindowsResources(t *testing.T) {
 			cpuLim: resource.MustParse("0"),
 			memLim: resource.MustParse("128Mi"),
 			expected: &runtimeapi.WindowsContainerResources{
-				CpuMaximum:         1,
+				CpuMaximum:         0,
 				MemoryLimitInBytes: 134217728,
 			},
 		},


### PR DESCRIPTION
#### What type of PR is this?

/sig windows
/sig testing

/kind failing-test

#### What this PR does / why we need it:

Currently, there are some unit tests for In-Place Pod Vertical Scaling that fail on Windows:
- [Request128MBLimit256MB](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/kuberuntime/kuberuntime_container_windows_test.go#L164)
- [RequestZeroCPU](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/kuberuntime/kuberuntime_container_windows_test.go#L164)

Those tests are expecting the wrong values for `CpuMaximum`.

#### Special notes for your reviewer:
- function to [calculateWindowsResources](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/kuberuntime/kuberuntime_container_windows.go)

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
/cc @claudiubelu