### PR TITLE
Addd negative case for the fix in #123570

### DIFF
--- a/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapi/aggregator/aggregator_test.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapi/aggregator/aggregator_test.go
@@ -210,6 +210,7 @@ func TestAPIServiceOpenAPIServiceMismatch(t *testing.T) {
 	expectPath(t, swagger, "/apis/apiservicegroup/v1")
 	expectPath(t, swagger, "/apis/apiservicegroup/v2")
 	expectPath(t, swagger, "/apis/apiregistration.k8s.io/v1")
+	expectNoPath(t, swagger, "/apis/a")
 
 	t.Logf("Remove APIService %s", apiService.Name)
 	s.RemoveAPIService(apiService.Name)
@@ -221,6 +222,7 @@ func TestAPIServiceOpenAPIServiceMismatch(t *testing.T) {
 	// Ensure that the if the APIService is added then removed, the OpenAPI disappears from the aggregated OpenAPI as well.
 	expectNoPath(t, swagger, "/apis/apiservicegroup/v1")
 	expectPath(t, swagger, "/apis/apiregistration.k8s.io/v1")
+	expectNoPath(t, swagger, "/apis/a")
 }
 
 func TestAddRemoveAPIService(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR is addon to existing PR made [here](https://github.com/kubernetes/kubernetes/pull/123570), which checks to see if the [filter](https://github.com/kubernetes/kubernetes/blob/9a404b590b1e451e8349eb9730d93167c9650fed/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapi/aggregator/aggregator.go#L196-L203) is working as intended through negative test, i.e; to catch `paths`  from malicious `apiservice` containing the `path` other than advertised gv prefix `"/apis/" + group + "/" + version}` in its path.

This negative case would have helped us catching the`metrics.k8s.io/api/nodes <something>` path being served under GV `custom.metrics.k8s.io` mentioned in the issue even before this [fix](https://github.com/kubernetes/kubernetes/pull/123570) was made IIUC like for example  how its being done [here](https://github.com/kubernetes/kubernetes/blob/9a404b590b1e451e8349eb9730d93167c9650fed/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapi/aggregator/aggregator_test.go#L184) .

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
addon test case to this PR [here](https://github.com/kubernetes/kubernetes/pull/123570) 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
