### PR TITLE
[Scheduler] Fix flaky test on multi profiles waitingPods

### DIFF
--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -31,6 +31,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
@@ -977,6 +978,7 @@ func TestFrameworkHandler_IterateOverWaitingPods(t *testing.T) {
 			fakeClient := fake.NewSimpleClientset(objs...)
 			informerFactory := informers.NewSharedInformerFactory(fakeClient, 0)
 			eventBroadcaster := events.NewBroadcaster(&events.EventSinkImpl{Interface: fakeClient.EventsV1()})
+			defer eventBroadcaster.Shutdown()
 			eventRecorder := eventBroadcaster.NewRecorder(scheme.Scheme, fakePermit)
 
 			outOfTreeRegistry := frameworkruntime.Registry{
@@ -984,7 +986,8 @@ func TestFrameworkHandler_IterateOverWaitingPods(t *testing.T) {
 			}
 
 			_, ctx := ktesting.NewTestContext(t)
-			ctx, cancel := context.WithCancel(ctx)
+			// timeout equals to the permit plugin waiting time.
+			ctx, cancel := context.WithTimeout(ctx, 100*time.Second)
 			defer cancel()
 
 			scheduler, err := New(
@@ -1032,17 +1035,23 @@ func TestFrameworkHandler_IterateOverWaitingPods(t *testing.T) {
 			// Wait all pods in waitSchedulingPods to be scheduled.
 			wg.Wait()
 
-			// Ensure that all waitingPods in scheduler can be obtained from any profiles.
-			for _, fwk := range scheduler.Profiles {
-				actualPodNamesInWaitingPods := sets.NewString()
-				fwk.IterateOverWaitingPods(func(pod framework.WaitingPod) {
-					actualPodNamesInWaitingPods.Insert(pod.GetPod().Name)
-				})
-				// Validate the name of pods in waitingPods matches expectations.
-				if actualPodNamesInWaitingPods.Len() != len(tc.expectPodNamesInWaitingPods) ||
-					!actualPodNamesInWaitingPods.HasAll(tc.expectPodNamesInWaitingPods...) {
-					t.Fatalf("Unexpected waitingPods in scheduler profile %s, expect: %#v, got: %#v", fwk.ProfileName(), tc.expectPodNamesInWaitingPods, actualPodNamesInWaitingPods.List())
+			// When permit plugin emits the event, pod may not been added to the waitingPods pool yet, so we use pollUntil here.
+			if err := wait.PollUntilContextCancel(ctx, 100*time.Microsecond, true, func(context.Context) (done bool, err error) {
+				// Ensure that all waitingPods in scheduler can be obtained from any profiles.
+				for _, fwk := range scheduler.Profiles {
+					actualPodNamesInWaitingPods := sets.NewString()
+					fwk.IterateOverWaitingPods(func(pod framework.WaitingPod) {
+						actualPodNamesInWaitingPods.Insert(pod.GetPod().Name)
+					})
+					// Validate the name of pods in waitingPods matches expectations.
+					if actualPodNamesInWaitingPods.Len() != len(tc.expectPodNamesInWaitingPods) ||
+						!actualPodNamesInWaitingPods.HasAll(tc.expectPodNamesInWaitingPods...) {
+						return false, fmt.Errorf("Unexpected waitingPods in scheduler profile %s, expect: %#v, got: %#v", fwk.ProfileName(), tc.expectPodNamesInWaitingPods, actualPodNamesInWaitingPods.List())
+					}
 				}
+				return true, nil
+			}); err != nil {
+				t.Fatal("got unexpected result")
 			}
 		})
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind flake
/kind cleanup
/sig scheduling

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/123621

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
