### PR TITLE
Automated cherry pick of #123532: Prevent watch cache starvation, by moving its watch to

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -1188,6 +1188,8 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 
 	genericfeatures.OpenAPIV3: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.29
 
+	genericfeatures.SeparateCacheWatchRPC: {Default: false, PreRelease: featuregate.Beta},
+
 	genericfeatures.ServerSideApply: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.29
 
 	genericfeatures.ServerSideFieldValidation: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.29

--- a/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
+++ b/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
@@ -172,6 +172,13 @@ const (
 	// Deprecates and removes SelfLink from ObjectMeta and ListMeta.
 	RemoveSelfLink featuregate.Feature = "RemoveSelfLink"
 
+	// owner: @serathius
+	// beta: v1.30
+	//
+	// Allow watch cache to create a watch on a dedicated RPC.
+	// This prevents watch cache from being starved by other watches.
+	SeparateCacheWatchRPC featuregate.Feature = "SeparateCacheWatchRPC"
+
 	// owner: @apelisse, @lavalamp
 	// alpha: v1.14
 	// beta: v1.16
@@ -284,6 +291,8 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	RemainingItemCount: {Default: true, PreRelease: featuregate.Beta},
 
 	RemoveSelfLink: {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
+
+	SeparateCacheWatchRPC: {Default: false, PreRelease: featuregate.Beta},
 
 	ServerSideApply: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.29
 

--- a/staging/src/k8s.io/apiserver/pkg/storage/tests/cacher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/tests/cacher_test.go
@@ -548,7 +548,7 @@ func TestCacherListerWatcher(t *testing.T) {
 	_ = updatePod(t, store, podBar, nil)
 	_ = updatePod(t, store, podBaz, nil)
 
-	lw := cacherstorage.NewCacherListerWatcher(store, prefix, fn)
+	lw := cacherstorage.NewCacherListerWatcher(store, prefix, fn, nil)
 
 	obj, err := lw.List(metav1.ListOptions{})
 	if err != nil {
@@ -577,7 +577,7 @@ func TestCacherListerWatcherPagination(t *testing.T) {
 	_ = updatePod(t, store, podBar, nil)
 	_ = updatePod(t, store, podBaz, nil)
 
-	lw := cacherstorage.NewCacherListerWatcher(store, prefix, fn)
+	lw := cacherstorage.NewCacherListerWatcher(store, prefix, fn, nil)
 
 	obj1, err := lw.List(metav1.ListOptions{Limit: 2})
 	if err != nil {


### PR DESCRIPTION
**NOTE to reviewers**: There's no straightforward way to cherry pick it to 1.27 due to:
- `conditionalProgressRequester` is implemented in 1.28+
- The unit test (2nd commit in https://github.com/kubernetes/kubernetes/pull/123532/commits) is NOT cherry picked due to some of its testing dependencies are not available in 1.27 (e.g. https://github.com/kubernetes/kubernetes/pull/118495). I guess we should keep the cherry pick as minimum as possible.

Partial cherry pick of #123532 on release-1.27.

#123532: Prevent watch cache starvation, by moving its watch to

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Prevent watch cache starvation by moving its watch to separate RPC and add a SeparateCacheWatchRPC feature flag to disable this behavior
```