### PR TITLE
remotecommand: treat unexpected EOF as error to avoid returning success in case of network blip

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/util/proxy/streamtranslator_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/proxy/streamtranslator_test.go
@@ -75,7 +75,13 @@ func TestStreamTranslator_LoopbackStdinToStdout(t *testing.T) {
 		if err != nil {
 			t.Fatalf("error copying STDIN to STDOUT: %v", err)
 		}
-
+		err = ctx.writeStatus(&apierrors.StatusError{ErrStatus: metav1.Status{
+			Status: metav1.StatusSuccess,
+		}})
+		if err != nil {
+			t.Errorf("failed to write status to stream: %v", err)
+			return
+		}
 	}))
 	defer spdyServer.Close()
 	// Create StreamTranslatorHandler, which points upstream to fake SPDY server with
@@ -175,6 +181,13 @@ func TestStreamTranslator_LoopbackStdinToStderr(t *testing.T) {
 		_, err = io.Copy(ctx.stderrStream, ctx.stdinStream)
 		if err != nil {
 			t.Fatalf("error copying STDIN to STDERR: %v", err)
+		}
+		err = ctx.writeStatus(&apierrors.StatusError{ErrStatus: metav1.Status{
+			Status: metav1.StatusSuccess,
+		}})
+		if err != nil {
+			t.Errorf("failed to write status to stream: %v", err)
+			return
 		}
 	}))
 	defer spdyServer.Close()
@@ -390,6 +403,13 @@ func TestStreamTranslator_MultipleReadChannels(t *testing.T) {
 		if err != nil {
 			t.Errorf("error copying STDIN to STDOUT: %v", err)
 		}
+		err = ctx.writeStatus(&apierrors.StatusError{ErrStatus: metav1.Status{
+			Status: metav1.StatusSuccess,
+		}})
+		if err != nil {
+			t.Errorf("failed to write status to stream: %v", err)
+			return
+		}
 	}))
 	defer spdyServer.Close()
 	// Create StreamTranslatorHandler, which points upstream to fake SPDY server with
@@ -494,6 +514,13 @@ func TestStreamTranslator_ThrottleReadChannels(t *testing.T) {
 		_, err = io.Copy(ctx.stdoutStream, stdinReader)
 		if err != nil {
 			t.Errorf("error copying STDIN to STDOUT: %v", err)
+		}
+		err = ctx.writeStatus(&apierrors.StatusError{ErrStatus: metav1.Status{
+			Status: metav1.StatusSuccess,
+		}})
+		if err != nil {
+			t.Errorf("failed to write status to stream: %v", err)
+			return
 		}
 	}))
 	defer spdyServer.Close()
@@ -633,6 +660,13 @@ func TestStreamTranslator_TTYResizeChannel(t *testing.T) {
 		for i := 0; i < numSizeQueue; i++ {
 			actualTerminalSize := <-ctx.resizeChan
 			actualTerminalSizes = append(actualTerminalSizes, actualTerminalSize)
+		}
+		err = ctx.writeStatus(&apierrors.StatusError{ErrStatus: metav1.Status{
+			Status: metav1.StatusSuccess,
+		}})
+		if err != nil {
+			t.Errorf("failed to write status to stream: %v", err)
+			return
 		}
 	}))
 	defer spdyServer.Close()

--- a/staging/src/k8s.io/client-go/tools/remotecommand/v2.go
+++ b/staging/src/k8s.io/client-go/tools/remotecommand/v2.go
@@ -175,8 +175,7 @@ func (p *streamProtocolV2) stream(conn streamCreator) error {
 	}
 
 	// now that all the streams have been created, proceed with reading & copying
-
-	errorChan := watchErrorStream(p.errorStream, &errorDecoderV2{})
+	errorChan := watchErrorStream(p.errorStream, &errorDecoderV2{}, true)
 
 	p.copyStdin()
 

--- a/staging/src/k8s.io/client-go/tools/remotecommand/v2_test.go
+++ b/staging/src/k8s.io/client-go/tools/remotecommand/v2_test.go
@@ -199,7 +199,7 @@ func TestV2ErrorStreamReading(t *testing.T) {
 		h := newStreamProtocolV2(StreamOptions{}).(*streamProtocolV2)
 		h.errorStream = test.stream
 
-		ch := watchErrorStream(h.errorStream, &errorDecoderV2{})
+		ch := watchErrorStream(h.errorStream, &errorDecoderV2{}, true)
 		if ch == nil {
 			t.Fatalf("%s: unexpected nil channel", test.name)
 		}

--- a/staging/src/k8s.io/client-go/tools/remotecommand/v3.go
+++ b/staging/src/k8s.io/client-go/tools/remotecommand/v3.go
@@ -88,8 +88,7 @@ func (p *streamProtocolV3) stream(conn streamCreator) error {
 	}
 
 	// now that all the streams have been created, proceed with reading & copying
-
-	errorChan := watchErrorStream(p.errorStream, &errorDecoderV3{})
+	errorChan := watchErrorStream(p.errorStream, &errorDecoderV3{}, true)
 
 	p.handleResizes()
 

--- a/staging/src/k8s.io/client-go/tools/remotecommand/v4_test.go
+++ b/staging/src/k8s.io/client-go/tools/remotecommand/v4_test.go
@@ -32,6 +32,10 @@ func TestV4ErrorDecoder(t *testing.T) {
 
 	for _, test := range []Test{
 		{
+			message: "",
+			err:     "error stream protocol error: no status",
+		},
+		{
 			message: "{}",
 			err:     "error stream protocol error: unknown error",
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Version 4 (and newer) of the remote command protocol specify that it is expected to get a `metav1.Status` response after termination of the remote process. However, the implementation of the client side of this protocol considered an `EOF` of the error stream (on which this response is expected) to be a successful termination, even if no such `Status` message was received.

This patch changes that behaviour for v4 and up, by letting the (already protocol-specific) error decoder handle the zero length message case. In the v4 error decoder, then, we consider this case an error (as we do with any other unexpected response). The reason I think this change is necessary is that it is possible to observe this EOF in case of a network blip somewhere along the (reasonably long) path from client-go to the CRI.

Notably, this fixes the case where `StreamWithContext` could return successfully (i.e. nil error) even if the program exited with a non-zero exit code, or didn't exit at all. This has caused flakes in cilium's CI in the past, as it heavily relies on this mechanism. The related cilium issue is https://github.com/cilium/cilium/issues/31067.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:

Probably worth reviewing commit by commit - I intentionally put the test changes into the first two commits to demonstrate that they pass with the existing implementation. Then, the implementation change in the third can be done without changing tests, increasing confidence. 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixes an issue where remotecommand StreamWithContext could succeed even though the underlying transport failed.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

