### PR TITLE
Support authentication for trace configuration

### DIFF
--- a/pkg/kubelet/apis/config/helpers_test.go
+++ b/pkg/kubelet/apis/config/helpers_test.go
@@ -299,6 +299,7 @@ var (
 		"ImageServiceEndpoint",
 		"Tracing.Endpoint",
 		"Tracing.SamplingRatePerMillion",
+		"Tracing.Authentication",
 		"LocalStorageCapacityIsolation",
 	)
 )

--- a/staging/src/k8s.io/component-base/tracing/api/v1/config.go
+++ b/staging/src/k8s.io/component-base/tracing/api/v1/config.go
@@ -41,6 +41,9 @@ func ValidateTracingConfiguration(traceConfig *TracingConfiguration, featureGate
 	if traceConfig.Endpoint != nil {
 		allErrs = append(allErrs, validateEndpoint(*traceConfig.Endpoint, fldPath.Child("endpoint"))...)
 	}
+	if traceConfig.Authentication != nil {
+		allErrs = append(allErrs, validateAuthentication(*traceConfig.Authentication, fldPath.Child("authentication"))...)
+	}
 	return allErrs
 }
 
@@ -84,5 +87,11 @@ func validateEndpoint(endpoint string, fldPath *field.Path) field.ErrorList {
 			fmt.Sprintf("unsupported scheme: %v.  Options are none, dns, unix, or unix-abstract.  See https://github.com/grpc/grpc/blob/master/doc/naming.md", url.Scheme),
 		))
 	}
+	return errs
+}
+
+func validateAuthentication(authentication string, fldPath *field.Path) field.ErrorList {
+	errs := field.ErrorList{}
+
 	return errs
 }

--- a/staging/src/k8s.io/component-base/tracing/api/v1/config_test.go
+++ b/staging/src/k8s.io/component-base/tracing/api/v1/config_test.go
@@ -31,6 +31,7 @@ func TestValidateTracingConfiguration(t *testing.T) {
 	unixEndpoint := "unix://path/to/socket"
 	invalidURL := "dn%2s://localhost:4317"
 	httpEndpoint := "http://localhost:4317"
+	validAuth := "valid-auth"
 	testcases := []struct {
 		name        string
 		expectError bool
@@ -90,6 +91,20 @@ func TestValidateTracingConfiguration(t *testing.T) {
 			expectError: true,
 			contents: &TracingConfiguration{
 				Endpoint: &invalidURL,
+			},
+		},
+		{
+			name:        "default Authentication",
+			expectError: false,
+			contents: &TracingConfiguration{
+				Endpoint: &validEndpoint,
+			},
+		},
+		{
+			name:        "valid auth",
+			expectError: false,
+			contents: &TracingConfiguration{
+				Authentication: &validAuth,
 			},
 		},
 	}

--- a/staging/src/k8s.io/component-base/tracing/api/v1/types.go
+++ b/staging/src/k8s.io/component-base/tracing/api/v1/types.go
@@ -29,4 +29,9 @@ type TracingConfiguration struct {
 	// rate, but otherwise never samples.
 	// +optional
 	SamplingRatePerMillion *int32 `json:"samplingRatePerMillion,omitempty"`
+
+	// Authentication for endpoint of the collector this component will report traces to.
+	// Recommended is unset. If unset, authentication is not used.
+	// +optional
+	Authentication *string `json:"authentication,omitempty"`
 }

--- a/staging/src/k8s.io/component-base/tracing/api/v1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/component-base/tracing/api/v1/zz_generated.deepcopy.go
@@ -34,6 +34,11 @@ func (in *TracingConfiguration) DeepCopyInto(out *TracingConfiguration) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.Authentication != nil {
+		in, out := &in.Authentication, &out.Authentication
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 

--- a/staging/src/k8s.io/component-base/tracing/utils.go
+++ b/staging/src/k8s.io/component-base/tracing/utils.go
@@ -64,6 +64,11 @@ func NewProvider(ctx context.Context,
 		opts = append(opts, otlptracegrpc.WithEndpoint(*tracingConfig.Endpoint))
 	}
 	opts = append(opts, otlptracegrpc.WithInsecure())
+	if tracingConfig.Authentication != nil {
+		opts = append(opts, otlptracegrpc.WithHeaders(map[string]string{
+			"Authentication": *tracingConfig.Authentication,
+		}))
+	}
 	exporter, err := otlptracegrpc.New(ctx, opts...)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR introduces authentication for K8s trace configuration, enabling K8s trace spans to be emitted to trace storage backends that require essential authentication (such as an OpenTelemetry Collector with an auth plugin or a cloud provider's trace storage product).

Up until now, K8s trace configuration has supported options for endpoint and sampling rate per million.

In certain scenarios, K8s can emit spans directly to a provider’s trace storage product, eliminating the need for an OpenTelemetry Collector, which would incur additional resource costs and operational complexity. Therefore, authentication is necessary for K8s in this context.

Furthermore, in scenarios where an OpenTelemetry Collector with authentication is used to enhance security, K8s also requires authentication.

In summary, introducing authentication for trace configuration is essential.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #123531

#### Special notes for your reviewer:
CC @dashpole 
Could you please help review this? Thanks!

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Introduces authentication for K8s trace configuration, enabling K8s trace spans to be emitted to trace storage backends that require essential authentication (such as an OpenTelemetry Collector with an auth plugin or a cloud provider's trace storage product).
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
