### PR TITLE
Mark StructuredAuthenticationConfiguration feature gate as beta

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -1243,7 +1243,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 
 	genericfeatures.StorageVersionHash: {Default: true, PreRelease: featuregate.Beta},
 
-	genericfeatures.StructuredAuthenticationConfiguration: {Default: false, PreRelease: featuregate.Alpha},
+	genericfeatures.StructuredAuthenticationConfiguration: {Default: true, PreRelease: featuregate.Beta},
 
 	genericfeatures.StructuredAuthorizationConfiguration: {Default: true, PreRelease: featuregate.Beta},
 

--- a/pkg/kubeapiserver/options/authentication_test.go
+++ b/pkg/kubeapiserver/options/authentication_test.go
@@ -214,9 +214,9 @@ func TestAuthenticationValidate(t *testing.T) {
 			expectErr: "number of webhook retry attempts must be greater than 0, but is: 0",
 		},
 		{
-			name:                         "test when authentication config file is set without feature gate",
+			name:                         "test when authentication config file is set (feature gate enabled by default)",
 			testAuthenticationConfigFile: "configfile",
-			expectErr:                    "set --feature-gates=StructuredAuthenticationConfiguration=true to use authentication-config file",
+			expectErr:                    "",
 		},
 		{
 			name:                         "test when authentication config file and oidc-* flags are set",

--- a/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
+++ b/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
@@ -234,6 +234,7 @@ const (
 	// owner: @aramase, @enj, @nabokihms
 	// kep: https://kep.k8s.io/3331
 	// alpha: v1.29
+	// beta: v1.30
 	//
 	// Enables Structured Authentication Configuration
 	StructuredAuthenticationConfiguration featuregate.Feature = "StructuredAuthenticationConfiguration"
@@ -337,7 +338,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 
 	StorageVersionHash: {Default: true, PreRelease: featuregate.Beta},
 
-	StructuredAuthenticationConfiguration: {Default: false, PreRelease: featuregate.Alpha},
+	StructuredAuthenticationConfiguration: {Default: true, PreRelease: featuregate.Beta},
 
 	StructuredAuthorizationConfiguration: {Default: true, PreRelease: featuregate.Beta},
 


### PR DESCRIPTION
/kind feature
/kind api-change
/sig auth
/assign aramase liggitt
/triage accepted

```release-note
The StructuredAuthenticationConfiguration feature is now beta and enabled by default.
```

Hold for:
- [x] https://github.com/kubernetes/kubernetes/pull/123696
- [x] https://github.com/kubernetes/kubernetes/pull/123431
- [x] https://github.com/kubernetes/kubernetes/pull/123737
- [x] https://github.com/kubernetes/kubernetes/pull/123525
- [x] https://github.com/kubernetes/kubernetes/pull/123793