### PR TITLE
dra api: fix status updates

### DIFF
--- a/pkg/registry/resource/podschedulingcontext/strategy.go
+++ b/pkg/registry/resource/podschedulingcontext/strategy.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -125,6 +126,7 @@ func (podSchedulingStatusStrategy) PrepareForUpdate(ctx context.Context, obj, ol
 	newScheduling := obj.(*resource.PodSchedulingContext)
 	oldScheduling := old.(*resource.PodSchedulingContext)
 	newScheduling.Spec = oldScheduling.Spec
+	metav1.ResetObjectMetaForStatus(&newScheduling.ObjectMeta, &oldScheduling.ObjectMeta)
 }
 
 func (podSchedulingStatusStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.Object) field.ErrorList {

--- a/pkg/registry/resource/resourceclaim/strategy.go
+++ b/pkg/registry/resource/resourceclaim/strategy.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -125,6 +126,7 @@ func (resourceclaimStatusStrategy) PrepareForUpdate(ctx context.Context, obj, ol
 	newClaim := obj.(*resource.ResourceClaim)
 	oldClaim := old.(*resource.ResourceClaim)
 	newClaim.Spec = oldClaim.Spec
+	metav1.ResetObjectMetaForStatus(&newClaim.ObjectMeta, &oldClaim.ObjectMeta)
 }
 
 func (resourceclaimStatusStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.Object) field.ErrorList {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Changing object meta is not supposed to be possible via status updates. For example, it circumvents RBAC permission checks.


#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes/kubernetes/issues/123727

#### Special notes for your reviewer:

Found during review of https://github.com/kubernetes/kubernetes/pull/123516 because it relied on the buggy behavior.

#### Does this PR introduce a user-facing change?
```release-note
DRA: ResourceClaim and PodSchedulingContext status updates no longer allow changing object meta data.
```
