### PR TITLE
Fix SetFeatureGateDuringTest handling of Parallel tests

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/fieldselector_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/fieldselector_test.go
@@ -699,13 +699,13 @@ func TestFieldSelectorDisablement(t *testing.T) {
 
 	crd := selectableFieldFixture.DeepCopy()
 	// Write a field that uses the feature while the feature gate is enabled
-	func() {
+	t.Run("CustomResourceFieldSelectors", func(t *testing.T) {
 		defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, apiextensionsfeatures.CustomResourceFieldSelectors, true)()
 		crd, err = fixtures.CreateNewV1CustomResourceDefinition(crd, apiExtensionClient, dynamicClient)
 		if err != nil {
 			t.Fatal(err)
 		}
-	}()
+	})
 
 	// Now that the feature gate is disabled again, update the CRD to trigger an openAPI update
 	crd, err = apiExtensionClient.ApiextensionsV1().CustomResourceDefinitions().Get(ctx, crd.Name, metav1.GetOptions{})

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers_test.go
@@ -53,8 +53,6 @@ func TestSerializeObjectParallel(t *testing.T) {
 	type test struct {
 		name string
 
-		compressionEnabled bool
-
 		mediaType  string
 		out        []byte
 		outErrs    []error
@@ -67,10 +65,9 @@ func TestSerializeObjectParallel(t *testing.T) {
 	}
 	newTest := func() test {
 		return test{
-			name:               "compress on gzip",
-			compressionEnabled: true,
-			out:                largePayload,
-			mediaType:          "application/json",
+			name:      "compress on gzip",
+			out:       largePayload,
+			mediaType: "application/json",
 			req: &http.Request{
 				Header: http.Header{
 					"Accept-Encoding": []string{"gzip"},
@@ -85,6 +82,7 @@ func TestSerializeObjectParallel(t *testing.T) {
 			},
 		}
 	}
+	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.APIResponseCompression, true)()
 	for i := 0; i < 100; i++ {
 		ctt := newTest()
 		t.Run(ctt.name, func(t *testing.T) {
@@ -94,7 +92,6 @@ func TestSerializeObjectParallel(t *testing.T) {
 				}
 			}()
 			t.Parallel()
-			defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.APIResponseCompression, ctt.compressionEnabled)()
 
 			encoder := &fakeEncoder{
 				buf:  ctt.out,

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_test.go
@@ -173,6 +173,8 @@ func TestList(t *testing.T) {
 }
 
 func TestListWithListFromCache(t *testing.T) {
+	// TODO(https://github.com/etcd-io/etcd/issues/17507): Remove skip.
+	t.Skip("This test flakes flakes due to https://github.com/etcd-io/etcd/issues/17507")
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ConsistentListFromCache, true)()
 	ctx, cacher, server, terminate := testSetupWithEtcdServer(t)
 	t.Cleanup(terminate)

--- a/staging/src/k8s.io/component-base/featuregate/testing/feature_gate.go
+++ b/staging/src/k8s.io/component-base/featuregate/testing/feature_gate.go
@@ -18,18 +18,35 @@ package testing
 
 import (
 	"fmt"
+	"strings"
+	"sync"
 	"testing"
 
 	"k8s.io/component-base/featuregate"
 )
 
-// SetFeatureGateDuringTest sets the specified gate to the specified value, and returns a function that restores the original value.
-// Failures to set or restore cause the test to fail.
+var (
+	overrideLock        sync.Mutex
+	featureFlagOverride map[featuregate.Feature]string
+)
+
+func init() {
+	featureFlagOverride = map[featuregate.Feature]string{}
+}
+
+// SetFeatureGateDuringTest sets the specified gate to the specified value for duration of the test.
+// Fails when it detects second call to the same flag or is unable to set or restore feature flag.
+// Returns empty cleanup function to maintain the old function signature that uses defer.
+// TODO: Remove defer from calls to SetFeatureGateDuringTest and update hack/verify-test-featuregates.sh when we can do large scale code change.
+//
+// WARNING: Can leak set variable when called in test calling t.Parallel(), however second attempt to set the same feature flag will cause fatal.
 //
 // Example use:
 //
 // defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.<FeatureName>, true)()
 func SetFeatureGateDuringTest(tb testing.TB, gate featuregate.FeatureGate, f featuregate.Feature, value bool) func() {
+	tb.Helper()
+	detectParallelOverrideCleanup := detectParallelOverride(tb, f)
 	originalValue := gate.Enabled(f)
 
 	// Specially handle AllAlpha and AllBeta
@@ -50,12 +67,41 @@ func SetFeatureGateDuringTest(tb testing.TB, gate featuregate.FeatureGate, f fea
 		tb.Errorf("error setting %s=%v: %v", f, value, err)
 	}
 
-	return func() {
+	tb.Cleanup(func() {
+		tb.Helper()
+		detectParallelOverrideCleanup()
 		if err := gate.(featuregate.MutableFeatureGate).Set(fmt.Sprintf("%s=%v", f, originalValue)); err != nil {
 			tb.Errorf("error restoring %s=%v: %v", f, originalValue, err)
 		}
 		for _, cleanup := range cleanups {
 			cleanup()
 		}
+	})
+	return func() {}
+}
+
+func detectParallelOverride(tb testing.TB, f featuregate.Feature) func() {
+	tb.Helper()
+	overrideLock.Lock()
+	defer overrideLock.Unlock()
+	beforeOverrideTestName := featureFlagOverride[f]
+	if beforeOverrideTestName != "" && !sameTestOrSubtest(tb, beforeOverrideTestName) {
+		tb.Fatalf("Detected parallel setting of a feature gate by both %q and %q", beforeOverrideTestName, tb.Name())
 	}
+	featureFlagOverride[f] = tb.Name()
+
+	return func() {
+		tb.Helper()
+		overrideLock.Lock()
+		defer overrideLock.Unlock()
+		if afterOverrideTestName := featureFlagOverride[f]; afterOverrideTestName != tb.Name() {
+			tb.Fatalf("Detected parallel setting of a feature gate between both %q and %q", afterOverrideTestName, tb.Name())
+		}
+		featureFlagOverride[f] = beforeOverrideTestName
+	}
+}
+
+func sameTestOrSubtest(tb testing.TB, testName string) bool {
+	// Assumes that "/" is not used in test names.
+	return tb.Name() == testName || strings.HasPrefix(tb.Name(), testName+"/")
 }


### PR DESCRIPTION
/kind bug

Fixes https://github.com/kubernetes/kubernetes/issues/123677

```release-note
NONE
```

Test for ConsistentListFromCache feature flag were broken because they used t.Parallel(), which lead to **unpredictable incorrect setting of the feature flag**. As @wojtek-t is very set on not removing t.Parallel from cacher tests, I have implemented a proper fix to feature gates.
