### PR TITLE
Don't embed plural exceptions in tools

### DIFF
--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -37,6 +37,7 @@ API_KNOWN_VIOLATIONS_DIR="${API_KNOWN_VIOLATIONS_DIR:-"${KUBE_ROOT}/api/api-rule
 OUT_DIR="_output"
 BOILERPLATE_FILENAME="hack/boilerplate/boilerplate.generatego.txt"
 APPLYCONFIG_PKG="k8s.io/client-go/applyconfigurations"
+PLURAL_EXCEPTIONS="Endpoints:Endpoints"
 
 # Any time we call sort, we want it in the same locale.
 export LC_ALL="C"
@@ -642,6 +643,7 @@ function codegen::clients() {
         --output-pkg="k8s.io/client-go" \
         --clientset-name="kubernetes" \
         --input-base="k8s.io/api" \
+        --plural-exceptions "${PLURAL_EXCEPTIONS}" \
         --apply-configuration-package "${APPLYCONFIG_PKG}" \
         $(printf -- " --input %s" "${gv_dirs[@]}") \
         "$@"
@@ -682,6 +684,7 @@ function codegen::listers() {
         --go-header-file "${BOILERPLATE_FILENAME}" \
         --output-dir "${KUBE_ROOT}/staging/src/k8s.io/client-go/listers" \
         --output-pkg "k8s.io/client-go/listers" \
+        --plural-exceptions "${PLURAL_EXCEPTIONS}" \
         "${ext_apis[@]}" \
         "$@"
 
@@ -724,6 +727,7 @@ function codegen::informers() {
         --single-directory \
         --versioned-clientset-package "k8s.io/client-go/kubernetes" \
         --listers-package "k8s.io/client-go/listers" \
+        --plural-exceptions "${PLURAL_EXCEPTIONS}" \
         "${ext_apis[@]}" \
         "$@"
 

--- a/staging/src/k8s.io/code-generator/cmd/client-gen/args/args.go
+++ b/staging/src/k8s.io/code-generator/cmd/client-gen/args/args.go
@@ -69,7 +69,6 @@ func New() *Args {
 		ClientsetAPIPath:          "/apis",
 		ClientsetOnly:             false,
 		FakeClient:                true,
-		PluralExceptions:          []string{"Endpoints:Endpoints"},
 		ApplyConfigurationPackage: "",
 	}
 }

--- a/staging/src/k8s.io/code-generator/cmd/informer-gen/args/args.go
+++ b/staging/src/k8s.io/code-generator/cmd/informer-gen/args/args.go
@@ -40,8 +40,7 @@ type Args struct {
 // New returns default arguments for the generator.
 func New() *Args {
 	return &Args{
-		SingleDirectory:  false,
-		PluralExceptions: []string{"Endpoints:Endpoints"},
+		SingleDirectory: false,
 	}
 }
 

--- a/staging/src/k8s.io/code-generator/cmd/lister-gen/args/args.go
+++ b/staging/src/k8s.io/code-generator/cmd/lister-gen/args/args.go
@@ -35,9 +35,7 @@ type Args struct {
 
 // New returns default arguments for the generator.
 func New() *Args {
-	return &Args{
-		PluralExceptions: []string{"Endpoints:Endpoints"},
-	}
+	return &Args{}
 }
 
 // AddFlags add the generator flags to the flag set.


### PR DESCRIPTION
I saw this in @pohly PR and remembered that I meant to fix this.  Not urgent.

/kind cleanup

```release-note
NONE
```
