### PR TITLE
Update Job conformance test for job status updates

### DIFF
--- a/test/e2e/apps/job.go
+++ b/test/e2e/apps/job.go
@@ -848,12 +848,19 @@ done`}
 		err = e2ejob.WaitForJobPodsRunning(ctx, f.ClientSet, f.Namespace.Name, job.Name, parallelism)
 		framework.ExpectNoError(err, "failed to ensure number of pods associated with job %s is equal to parallelism count in namespace: %s", job.Name, f.Namespace.Name)
 
+		customConditionType := batchv1.JobConditionType("CustomConditionType")
 		// /status subresource operations
 		ginkgo.By("patching /status")
 		// we need to use RFC3339 version since conversion over the wire cuts nanoseconds
 		now1 := metav1.Now().Rfc3339Copy()
 		jStatus := batchv1.JobStatus{
-			StartTime: &now1,
+			Conditions: []batchv1.JobCondition{
+				{
+					Type:               customConditionType,
+					Status:             v1.ConditionTrue,
+					LastTransitionTime: now1,
+				},
+			},
 		}
 
 		jStatusJSON, err := json.Marshal(jStatus)
@@ -862,8 +869,12 @@ done`}
 			[]byte(`{"metadata":{"annotations":{"patchedstatus":"true"}},"status":`+string(jStatusJSON)+`}`),
 			metav1.PatchOptions{}, "status")
 		framework.ExpectNoError(err)
-		if !patchedStatus.Status.StartTime.Equal(&now1) {
-			framework.Failf("patched object should have the applied StartTime %#v, got %#v instead", jStatus.StartTime, patchedStatus.Status.StartTime)
+		if condition := findConditionByType(patchedStatus.Status.Conditions, customConditionType); condition != nil {
+			if !condition.LastTransitionTime.Equal(&now1) {
+				framework.Failf("patched object should have the applied condition with LastTransitionTime %#v, got %#v instead", now1, condition.LastTransitionTime)
+			}
+		} else {
+			framework.Failf("patched object does not have the required condition %v", customConditionType)
 		}
 		gomega.Expect(patchedStatus.Annotations).To(gomega.HaveKeyWithValue("patchedstatus", "true"), "patched object should have the applied annotation")
 
@@ -876,13 +887,21 @@ done`}
 			if err != nil {
 				return err
 			}
-			statusToUpdate.Status.StartTime = &now2
+			if condition := findConditionByType(patchedStatus.Status.Conditions, customConditionType); condition != nil {
+				condition.LastTransitionTime = now2
+			} else {
+				framework.Failf("patched object does not have the required condition %v", customConditionType)
+			}
 			updatedStatus, err = jClient.UpdateStatus(ctx, statusToUpdate, metav1.UpdateOptions{})
 			return err
 		})
 		framework.ExpectNoError(err)
-		if !updatedStatus.Status.StartTime.Equal(&now2) {
-			framework.Failf("updated object status expected to have updated StartTime %#v, got %#v", statusToUpdate.Status.StartTime, updatedStatus.Status.StartTime)
+		if condition := findConditionByType(updatedStatus.Status.Conditions, customConditionType); condition != nil {
+			if !condition.LastTransitionTime.Equal(&now2) {
+				framework.Failf("patched object should have the applied condition with LastTransitionTime %#v, got %#v instead", now2, condition.LastTransitionTime)
+			}
+		} else {
+			framework.Failf("patched object does not have the required condition %v", customConditionType)
 		}
 
 		ginkgo.By("get /status")
@@ -1118,4 +1137,13 @@ func waitForJobFailure(ctx context.Context, c clientset.Interface, ns, jobName s
 		}
 		return false, nil
 	})
+}
+
+func findConditionByType(list []batchv1.JobCondition, cType batchv1.JobConditionType) *batchv1.JobCondition {
+	for i := range list {
+		if list[i].Type == cType {
+			return &list[i]
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

In order to adapt the existing test to the new validation rule introduced in  https://github.com/kubernetes/kubernetes/pull/123273 that `status.startTime` cannot be updated for an unsuspended job. The feature is still in alpha, but it is good to prepare to the agreed validation.

The intention of the test is to verify the Job status can be updated by Update of Patch operations, not particular field to be updated.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Tracking issue: https://github.com/kubernetes/enhancements/issues/4368

#### Special notes for your reviewer:

The intention of the test was discussed with the API reviewers during the meeting discussing the label vs field approach. The note is second from the bottom point in the [doc](https://docs.google.com/document/d/1rvn4iWt841n0gwtJbCwBBldkLsGFcUmjWMOYpRgNoJM/edit?resourcekey=0-I0uag4jMQOue_wx7mvyWzg&tab=t.0#heading=h.6e1q5qmt924e). Adjusting the test to modify a field that would pass the new validation rules was the proposed approach.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
https://github.com/kubernetes/enhancements/tree/master/keps/sig-apps/4368-support-managed-by-for-batch-jobs
```
