### PR TITLE
Avoid clearing go version in go.work update script

### DIFF
--- a/hack/update-go-workspace.sh
+++ b/hack/update-go-workspace.sh
@@ -32,17 +32,7 @@ kube::golang::setup_env
 
 cd "${KUBE_ROOT}"
 
-# Avoid issues and remove the workspace files.
-rm -f go.work go.work.sum
-
-# Generate the workspace.
-go work init
-(
-  echo "// This is a generated file. Do not edit directly."
-  echo
-  cat go.work
-) > .go.work.tmp
-mv .go.work.tmp go.work
+# Ensure all modules are included in go.work
 go work edit -use .
 git ls-files -z ':(glob)./staging/src/k8s.io/*/go.mod' \
     | xargs -0 -n1 dirname -z \


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind cleanup

#### What this PR does / why we need it:

Short-term fix to avoid stomping the go version in the go.work file during update-go-workspace.sh.

Needed to unblock https://github.com/kubernetes/kubernetes/pull/123750

As a follow-up, I plan to fold this file into update-vendor.sh

```release-note
NONE
```

/assign @thockin @dims @cpanato 