### PR TITLE
Automated cherry pick of #123251: ci: bump kind to latest for kms jobs

### DIFF
--- a/test/e2e/testing-manifests/auth/encrypt/run-e2e.sh
+++ b/test/e2e/testing-manifests/auth/encrypt/run-e2e.sh
@@ -137,7 +137,7 @@ main(){
     mkdir -p "${ARTIFACTS}"
 
     export GO111MODULE=on;
-    go install sigs.k8s.io/kind@v0.17.0;
+    go install sigs.k8s.io/kind@latest;
     go install sigs.k8s.io/kubetest2@latest;
     go install sigs.k8s.io/kubetest2/kubetest2-kind@latest;
     go install sigs.k8s.io/kubetest2/kubetest2-tester-ginkgo@latest;

--- a/test/e2e/testing-manifests/auth/encrypt/run-e2e.sh
+++ b/test/e2e/testing-manifests/auth/encrypt/run-e2e.sh
@@ -91,7 +91,7 @@ create_cluster_and_run_test() {
     TEST_ARGS=""
     if [ "${SKIP_RUN_TESTS:-}" != "true" ]; then
         # (--use-built-binaries) use the kubectl, e2e.test, and ginkgo binaries built during --build as opposed to from a GCS release tarball
-        TEST_ARGS="--test=ginkgo -- --v=5 --focus-regex=\[Conformance\] --skip-regex=\[Serial\] --parallel 20 --use-built-binaries"
+        TEST_ARGS="--test=ginkgo -- --focus-regex=\[Conformance\] --skip-regex=\[Serial\] --parallel 20 --use-built-binaries"
     else
         echo "Skipping running tests"
     fi


### PR DESCRIPTION
Cherry pick of #123251 on release-1.29.

#123251: ci: bump kind to latest for kms jobs

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```