### PR TITLE
Automated cherry pick of #123251: ci: bump kind to latest for kms jobs

### DIFF
--- a/test/e2e/testing-manifests/auth/encrypt/run-e2e.sh
+++ b/test/e2e/testing-manifests/auth/encrypt/run-e2e.sh
@@ -96,7 +96,6 @@ create_cluster_and_run_test() {
     --cluster-name "${cluster_name}" \
     --test=ginkgo \
     -- \
-    --v=5 \
     --focus-regex='\[Conformance\]' \
     --skip-regex='\[Serial\]' \
     --parallel 20 \

--- a/test/e2e/testing-manifests/auth/encrypt/run-e2e.sh
+++ b/test/e2e/testing-manifests/auth/encrypt/run-e2e.sh
@@ -127,7 +127,7 @@ main(){
     mkdir -p "${ARTIFACTS}"
 
     export GO111MODULE=on;
-    go install sigs.k8s.io/kind@v0.17.0;
+    go install sigs.k8s.io/kind@latest;
     go install sigs.k8s.io/kubetest2@latest;
     go install sigs.k8s.io/kubetest2/kubetest2-kind@latest;
     go install sigs.k8s.io/kubetest2/kubetest2-tester-ginkgo@latest;


### PR DESCRIPTION
Cherry pick of #123251 on release-1.27.

#123251: ci: bump kind to latest for kms jobs

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```