### PR TITLE
kubelet: check that the pod is finished before removing the container.

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -2716,8 +2716,8 @@ func (kl *Kubelet) HandlePodReconcile(pods []*v1.Pod) {
 		// been evicted, so if this is about minimizing the time to react to an eviction we
 		// can do better. If it's about preserving pod status info we can also do better.
 		if eviction.PodIsEvicted(pod.Status) {
-			if podStatus, err := kl.podCache.Get(pod.UID); err == nil {
-				kl.containerDeletor.deleteContainersInPod("", podStatus, true)
+			if _, err := kl.podCache.Get(pod.UID); err == nil {
+				kl.cleanUpContainersInPod(pod.UID, "")
 			}
 		}
 	}

--- a/pkg/kubelet/pod_workers.go
+++ b/pkg/kubelet/pod_workers.go
@@ -690,7 +690,7 @@ func (p *podWorkers) ShouldPodContentBeRemoved(uid types.UID) bool {
 	p.podLock.Lock()
 	defer p.podLock.Unlock()
 	if status, ok := p.podSyncStatuses[uid]; ok {
-		return status.IsEvicted() || (status.IsDeleted() && status.IsTerminated())
+		return status.IsEvicted() && status.IsFinished() || (status.IsDeleted() && status.IsTerminated())
 	}
 	// a pod that hasn't been sent to the pod worker yet should have no content on disk once we have
 	// synced all content.

--- a/test/e2e/framework/pod/wait.go
+++ b/test/e2e/framework/pod/wait.go
@@ -789,3 +789,18 @@ func WaitForContainerTerminated(ctx context.Context, c clientset.Interface, name
 		return false, nil
 	})
 }
+
+// EnsureValidContainerTerminatedReason ensures that the terminated reason is not unknown.
+func EnsureValidContainerTerminatedReason(ctx context.Context, c clientset.Interface, namespace, podName, containerName string, timeout time.Duration) error {
+	conditionDesc := fmt.Sprintf("container %s terminated", containerName)
+	return WaitForPodCondition(ctx, c, namespace, podName, conditionDesc, timeout, func(pod *v1.Pod) (bool, error) {
+		for _, statuses := range [][]v1.ContainerStatus{pod.Status.ContainerStatuses, pod.Status.InitContainerStatuses, pod.Status.EphemeralContainerStatuses} {
+			for _, cs := range statuses {
+				if cs.Name == containerName && cs.State.Terminated != nil {
+					return cs.State.Terminated.Reason != "ContainerStatusUnknown", nil
+				}
+			}
+		}
+		return false, nil
+	})
+}

--- a/test/e2e/node/pods.go
+++ b/test/e2e/node/pods.go
@@ -339,7 +339,10 @@ var _ = SIGDescribe("Pods Extended", func() {
 			if err != nil {
 				framework.Failf("error waiting for pod to be evicted: %v", err)
 			}
-
+			err = e2epod.EnsureValidContainerTerminatedReason(ctx, f.ClientSet, f.Namespace.Name, pod.Name, "bar", 2*time.Minute)
+			if err != nil {
+				framework.Failf("error waiting for a valid terminated reason: %v", err)
+			}
 		})
 	})
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When pods with ephemeral storage limits exceed their capacity, the kubelet tries to evict and kill the pod gracefully. We noticed that the pod status changes to `ContainerStatusUnknown`. This is due to a race condition removing the container before pod status can be updated.

In this change, we try to ensure that the pod is finished before removing the container.


#### Which issue(s) this PR fixes:

Fixes #122160 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Fixes an issue where the pod status changes to ContainerStatusUnknown when it is evicted due to exceeding the ephemeral storage limit.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:


```docs

```
