### PR TITLE
Warn on deprecated AppArmor annotation use

### DIFF
--- a/pkg/api/pod/warnings.go
+++ b/pkg/api/pod/warnings.go
@@ -24,10 +24,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	nodeapi "k8s.io/kubernetes/pkg/api/node"
 	pvcutil "k8s.io/kubernetes/pkg/api/persistentvolumeclaim"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/apis/core/pods"
+	"k8s.io/kubernetes/pkg/features"
 )
 
 func GetWarningsForPod(ctx context.Context, pod, oldPod *api.Pod) []string {
@@ -212,12 +214,25 @@ func warningsForPodSpecAndMeta(fieldPath *field.Path, podSpec *api.PodSpec, meta
 			warnings = append(warnings, fmt.Sprintf(`%s: non-functional in v1.27+; use the "seccompProfile" field instead`, fieldPath.Child("metadata", "annotations").Key(api.SeccompPodAnnotationKey)))
 		}
 	}
+	hasPodAppArmorProfile := podSpec.SecurityContext != nil && podSpec.SecurityContext.AppArmorProfile != nil
 
 	pods.VisitContainersWithPath(podSpec, fieldPath.Child("spec"), func(c *api.Container, p *field.Path) bool {
 		// use of container seccomp annotation without accompanying field
 		if c.SecurityContext == nil || c.SecurityContext.SeccompProfile == nil {
 			if _, exists := meta.Annotations[api.SeccompContainerAnnotationKeyPrefix+c.Name]; exists {
 				warnings = append(warnings, fmt.Sprintf(`%s: non-functional in v1.27+; use the "seccompProfile" field instead`, fieldPath.Child("metadata", "annotations").Key(api.SeccompContainerAnnotationKeyPrefix+c.Name)))
+			}
+		}
+
+		// use of container AppArmor annotation without accompanying field
+		if utilfeature.DefaultFeatureGate.Enabled(features.AppArmorFields) {
+			isPodTemplate := fieldPath != nil // Pod warnings are emitted through applyAppArmorVersionSkew instead.
+			hasAppArmorField := hasPodAppArmorProfile || (c.SecurityContext != nil && c.SecurityContext.AppArmorProfile != nil)
+			if isPodTemplate && !hasAppArmorField {
+				key := api.DeprecatedAppArmorAnnotationKeyPrefix + c.Name
+				if _, exists := meta.Annotations[key]; exists {
+					warnings = append(warnings, fmt.Sprintf(`%s: deprecated since v1.30; use the "appArmorProfile" field instead`, fieldPath.Child("metadata", "annotations").Key(key)))
+				}
 			}
 		}
 

--- a/pkg/api/pod/warnings_test.go
+++ b/pkg/api/pod/warnings_test.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	utilpointer "k8s.io/utils/pointer"
 )
@@ -1091,6 +1092,93 @@ func TestWarnings(t *testing.T) {
 			}
 			for _, extra := range sets.List[string](actual.Difference(expected)) {
 				t.Errorf("extra: %s", extra)
+			}
+		})
+	}
+}
+
+func TestTemplateOnlyWarnings(t *testing.T) {
+	testcases := []struct {
+		name        string
+		template    *api.PodTemplateSpec
+		oldTemplate *api.PodTemplateSpec
+		expected    []string
+	}{
+		{
+			name: "annotations",
+			template: &api.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+					`container.apparmor.security.beta.kubernetes.io/foo`: `unconfined`,
+				}},
+				Spec: api.PodSpec{Containers: []api.Container{{Name: "foo"}}},
+			},
+			expected: []string{
+				`template.metadata.annotations[container.apparmor.security.beta.kubernetes.io/foo]: deprecated since v1.30; use the "appArmorProfile" field instead`,
+			},
+		},
+		{
+			name: "AppArmor pod field",
+			template: &api.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+					`container.apparmor.security.beta.kubernetes.io/foo`: `unconfined`,
+				}},
+				Spec: api.PodSpec{
+					SecurityContext: &api.PodSecurityContext{
+						AppArmorProfile: &api.AppArmorProfile{Type: api.AppArmorProfileTypeUnconfined},
+					},
+					Containers: []api.Container{{
+						Name: "foo",
+					}},
+				},
+			},
+			expected: []string{},
+		},
+		{
+			name: "AppArmor container field",
+			template: &api.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+					`container.apparmor.security.beta.kubernetes.io/foo`: `unconfined`,
+				}},
+				Spec: api.PodSpec{
+					Containers: []api.Container{{
+						Name: "foo",
+						SecurityContext: &api.SecurityContext{
+							AppArmorProfile: &api.AppArmorProfile{Type: api.AppArmorProfileTypeUnconfined},
+						},
+					}},
+				},
+			},
+			expected: []string{},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run("podspec_"+tc.name, func(t *testing.T) {
+			var oldTemplate *api.PodTemplateSpec
+			if tc.oldTemplate != nil {
+				oldTemplate = tc.oldTemplate
+			}
+			actual := sets.New[string](GetWarningsForPodTemplate(context.TODO(), field.NewPath("template"), tc.template, oldTemplate)...)
+			expected := sets.New[string](tc.expected...)
+			for _, missing := range sets.List[string](expected.Difference(actual)) {
+				t.Errorf("missing: %s", missing)
+			}
+			for _, extra := range sets.List[string](actual.Difference(expected)) {
+				t.Errorf("extra: %s", extra)
+			}
+		})
+
+		t.Run("pod_"+tc.name, func(t *testing.T) {
+			var pod *api.Pod
+			if tc.template != nil {
+				pod = &api.Pod{
+					ObjectMeta: tc.template.ObjectMeta,
+					Spec:       tc.template.Spec,
+				}
+			}
+			actual := GetWarningsForPod(context.TODO(), pod, &api.Pod{})
+			if len(actual) > 0 {
+				t.Errorf("unexpected template-only warnings on pod: %v", actual)
 			}
 		})
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

When the deprecated AppArmor annotations are used without matching fields, warn about their deprecation:

```
metadata.annotations[container.apparmor.security.beta.kubernetes.io/foo]: deprecated since v1.30; use the "appArmorProfile" field instead
```

Follow up to https://github.com/kubernetes/kubernetes/pull/123435.

#### Which issue(s) this PR fixes:
For https://github.com/kubernetes/enhancements/issues/24

#### Special notes for your reviewer:
The warning logic for templates is heuristic: don't warn if there is a pod-level apparmor field, even if it doesn't match the annotation (in which case the annotation value would be used for the matching container). This decision was made for simplicity, and I think is close enough for the sake of emitting warnings.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

Relevant note is already captured by https://github.com/kubernetes/kubernetes/pull/123435

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [KEP]: https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/24-apparmor/
```

/sig node
/milestone v1.30
/assign @liggitt 