### PR TITLE
Update publishing-bot rules to Go 1.21.8

### DIFF
--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -7,25 +7,25 @@ rules:
       dirs:
       - staging/src/k8s.io/apimachinery
   - name: release-1.26
-    go: 1.21.7
+    go: 1.21.8
     source:
       branch: release-1.26
       dirs:
       - staging/src/k8s.io/apimachinery
   - name: release-1.27
-    go: 1.21.7
+    go: 1.21.8
     source:
       branch: release-1.27
       dirs:
       - staging/src/k8s.io/apimachinery
   - name: release-1.28
-    go: 1.21.7
+    go: 1.21.8
     source:
       branch: release-1.28
       dirs:
       - staging/src/k8s.io/apimachinery
   - name: release-1.29
-    go: 1.21.7
+    go: 1.21.8
     source:
       branch: release-1.29
       dirs:
@@ -42,7 +42,7 @@ rules:
       dirs:
       - staging/src/k8s.io/api
   - name: release-1.26
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -51,7 +51,7 @@ rules:
       dirs:
       - staging/src/k8s.io/api
   - name: release-1.27
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -60,7 +60,7 @@ rules:
       dirs:
       - staging/src/k8s.io/api
   - name: release-1.28
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -69,7 +69,7 @@ rules:
       dirs:
       - staging/src/k8s.io/api
   - name: release-1.29
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -95,7 +95,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.26
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -110,7 +110,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.27
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -125,7 +125,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.28
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -140,7 +140,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.29
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -166,25 +166,25 @@ rules:
     - repository: apimachinery # for tests
       branch: master
   - name: release-1.26
-    go: 1.21.7
+    go: 1.21.8
     source:
       branch: release-1.26
       dirs:
       - staging/src/k8s.io/code-generator
   - name: release-1.27
-    go: 1.21.7
+    go: 1.21.8
     source:
       branch: release-1.27
       dirs:
       - staging/src/k8s.io/code-generator
   - name: release-1.28
-    go: 1.21.7
+    go: 1.21.8
     source:
       branch: release-1.28
       dirs:
       - staging/src/k8s.io/code-generator
   - name: release-1.29
-    go: 1.21.7
+    go: 1.21.8
     source:
       branch: release-1.29
       dirs:
@@ -204,7 +204,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-base
   - name: release-1.26
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -217,7 +217,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-base
   - name: release-1.27
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -230,7 +230,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-base
   - name: release-1.28
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -243,7 +243,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-base
   - name: release-1.29
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -271,7 +271,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-helpers
   - name: release-1.26
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -284,7 +284,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-helpers
   - name: release-1.27
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -297,7 +297,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-helpers
   - name: release-1.28
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -310,7 +310,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-helpers
   - name: release-1.29
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -334,13 +334,13 @@ rules:
       dirs:
       - staging/src/k8s.io/kms
   - name: release-1.26
-    go: 1.21.7
+    go: 1.21.8
     source:
       branch: release-1.26
       dirs:
       - staging/src/k8s.io/kms
   - name: release-1.27
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -353,7 +353,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kms
   - name: release-1.28
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -366,7 +366,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kms
   - name: release-1.29
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -394,7 +394,7 @@ rules:
       dirs:
       - staging/src/k8s.io/apiserver
   - name: release-1.26
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -411,7 +411,7 @@ rules:
       dirs:
       - staging/src/k8s.io/apiserver
   - name: release-1.27
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -428,7 +428,7 @@ rules:
       dirs:
       - staging/src/k8s.io/apiserver
   - name: release-1.28
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -445,7 +445,7 @@ rules:
       dirs:
       - staging/src/k8s.io/apiserver
   - name: release-1.29
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -485,7 +485,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-aggregator
   - name: release-1.26
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -506,7 +506,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-aggregator
   - name: release-1.27
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -527,7 +527,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-aggregator
   - name: release-1.28
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -548,7 +548,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-aggregator
   - name: release-1.29
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -596,7 +596,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.26
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -622,7 +622,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.27
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -648,7 +648,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.28
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -674,7 +674,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.29
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -721,7 +721,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.26
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -741,7 +741,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.27
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -761,7 +761,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.28
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -781,7 +781,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.29
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -825,7 +825,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.26
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -848,7 +848,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.27
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -871,7 +871,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.28
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -894,7 +894,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.29
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -933,7 +933,7 @@ rules:
       dirs:
       - staging/src/k8s.io/metrics
   - name: release-1.26
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -948,7 +948,7 @@ rules:
       dirs:
       - staging/src/k8s.io/metrics
   - name: release-1.27
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -963,7 +963,7 @@ rules:
       dirs:
       - staging/src/k8s.io/metrics
   - name: release-1.28
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -978,7 +978,7 @@ rules:
       dirs:
       - staging/src/k8s.io/metrics
   - name: release-1.29
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -1008,7 +1008,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cli-runtime
   - name: release-1.26
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: api
       branch: release-1.26
@@ -1021,7 +1021,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cli-runtime
   - name: release-1.27
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: api
       branch: release-1.27
@@ -1034,7 +1034,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cli-runtime
   - name: release-1.28
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: api
       branch: release-1.28
@@ -1047,7 +1047,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cli-runtime
   - name: release-1.29
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: api
       branch: release-1.29
@@ -1077,7 +1077,7 @@ rules:
       dirs:
       - staging/src/k8s.io/sample-cli-plugin
   - name: release-1.26
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: api
       branch: release-1.26
@@ -1092,7 +1092,7 @@ rules:
       dirs:
       - staging/src/k8s.io/sample-cli-plugin
   - name: release-1.27
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: api
       branch: release-1.27
@@ -1107,7 +1107,7 @@ rules:
       dirs:
       - staging/src/k8s.io/sample-cli-plugin
   - name: release-1.28
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: api
       branch: release-1.28
@@ -1122,7 +1122,7 @@ rules:
       dirs:
       - staging/src/k8s.io/sample-cli-plugin
   - name: release-1.29
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: api
       branch: release-1.29
@@ -1153,7 +1153,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-proxy
   - name: release-1.26
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -1168,7 +1168,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-proxy
   - name: release-1.27
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -1183,7 +1183,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-proxy
   - name: release-1.28
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -1198,7 +1198,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-proxy
   - name: release-1.29
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -1221,25 +1221,25 @@ rules:
       dirs:
       - staging/src/k8s.io/cri-api
   - name: release-1.26
-    go: 1.21.7
+    go: 1.21.8
     source:
       branch: release-1.26
       dirs:
       - staging/src/k8s.io/cri-api
   - name: release-1.27
-    go: 1.21.7
+    go: 1.21.8
     source:
       branch: release-1.27
       dirs:
       - staging/src/k8s.io/cri-api
   - name: release-1.28
-    go: 1.21.7
+    go: 1.21.8
     source:
       branch: release-1.28
       dirs:
       - staging/src/k8s.io/cri-api
   - name: release-1.29
-    go: 1.21.7
+    go: 1.21.8
     source:
       branch: release-1.29
       dirs:
@@ -1268,7 +1268,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubelet
   - name: release-1.26
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -1283,7 +1283,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubelet
   - name: release-1.27
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -1298,7 +1298,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubelet
   - name: release-1.28
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -1319,7 +1319,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubelet
   - name: release-1.29
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -1357,7 +1357,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-scheduler
   - name: release-1.26
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -1372,7 +1372,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-scheduler
   - name: release-1.27
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -1387,7 +1387,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-scheduler
   - name: release-1.28
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -1402,7 +1402,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-scheduler
   - name: release-1.29
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -1438,7 +1438,7 @@ rules:
       dirs:
       - staging/src/k8s.io/controller-manager
   - name: release-1.26
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: api
       branch: release-1.26
@@ -1457,7 +1457,7 @@ rules:
       dirs:
       - staging/src/k8s.io/controller-manager
   - name: release-1.27
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: api
       branch: release-1.27
@@ -1476,7 +1476,7 @@ rules:
       dirs:
       - staging/src/k8s.io/controller-manager
   - name: release-1.28
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: api
       branch: release-1.28
@@ -1495,7 +1495,7 @@ rules:
       dirs:
       - staging/src/k8s.io/controller-manager
   - name: release-1.29
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: api
       branch: release-1.29
@@ -1539,7 +1539,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cloud-provider
   - name: release-1.26
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: api
       branch: release-1.26
@@ -1562,7 +1562,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cloud-provider
   - name: release-1.27
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: api
       branch: release-1.27
@@ -1585,7 +1585,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cloud-provider
   - name: release-1.28
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: api
       branch: release-1.28
@@ -1608,7 +1608,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cloud-provider
   - name: release-1.29
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: api
       branch: release-1.29
@@ -1658,7 +1658,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-controller-manager
   - name: release-1.26
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -1683,7 +1683,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-controller-manager
   - name: release-1.27
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -1708,7 +1708,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-controller-manager
   - name: release-1.28
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -1733,7 +1733,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-controller-manager
   - name: release-1.29
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -1771,7 +1771,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cluster-bootstrap
   - name: release-1.26
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -1782,7 +1782,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cluster-bootstrap
   - name: release-1.27
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -1793,7 +1793,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cluster-bootstrap
   - name: release-1.28
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -1804,7 +1804,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cluster-bootstrap
   - name: release-1.29
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -1828,7 +1828,7 @@ rules:
       dirs:
       - staging/src/k8s.io/csi-translation-lib
   - name: release-1.26
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: api
       branch: release-1.26
@@ -1839,7 +1839,7 @@ rules:
       dirs:
       - staging/src/k8s.io/csi-translation-lib
   - name: release-1.27
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: api
       branch: release-1.27
@@ -1850,7 +1850,7 @@ rules:
       dirs:
       - staging/src/k8s.io/csi-translation-lib
   - name: release-1.28
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: api
       branch: release-1.28
@@ -1861,7 +1861,7 @@ rules:
       dirs:
       - staging/src/k8s.io/csi-translation-lib
   - name: release-1.29
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: api
       branch: release-1.29
@@ -1880,25 +1880,25 @@ rules:
       dirs:
       - staging/src/k8s.io/mount-utils
   - name: release-1.26
-    go: 1.21.7
+    go: 1.21.8
     source:
       branch: release-1.26
       dirs:
       - staging/src/k8s.io/mount-utils
   - name: release-1.27
-    go: 1.21.7
+    go: 1.21.8
     source:
       branch: release-1.27
       dirs:
       - staging/src/k8s.io/mount-utils
   - name: release-1.28
-    go: 1.21.7
+    go: 1.21.8
     source:
       branch: release-1.28
       dirs:
       - staging/src/k8s.io/mount-utils
   - name: release-1.29
-    go: 1.21.7
+    go: 1.21.8
     source:
       branch: release-1.29
       dirs:
@@ -1931,7 +1931,7 @@ rules:
       dirs:
       - staging/src/k8s.io/legacy-cloud-providers
   - name: release-1.26
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: api
       branch: release-1.26
@@ -1960,7 +1960,7 @@ rules:
       dirs:
       - staging/src/k8s.io/legacy-cloud-providers
   - name: release-1.27
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: api
       branch: release-1.27
@@ -1985,7 +1985,7 @@ rules:
       dirs:
       - staging/src/k8s.io/legacy-cloud-providers
   - name: release-1.28
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: api
       branch: release-1.28
@@ -2010,7 +2010,7 @@ rules:
       dirs:
       - staging/src/k8s.io/legacy-cloud-providers
   - name: release-1.29
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: api
       branch: release-1.29
@@ -2060,7 +2060,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubectl
   - name: release-1.26
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: api
       branch: release-1.26
@@ -2083,7 +2083,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubectl
   - name: release-1.27
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: api
       branch: release-1.27
@@ -2106,7 +2106,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubectl
   - name: release-1.28
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: api
       branch: release-1.28
@@ -2129,7 +2129,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubectl
   - name: release-1.29
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: api
       branch: release-1.29
@@ -2173,7 +2173,7 @@ rules:
       dirs:
       - staging/src/k8s.io/pod-security-admission
   - name: release-1.26
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: api
       branch: release-1.26
@@ -2192,7 +2192,7 @@ rules:
       dirs:
       - staging/src/k8s.io/pod-security-admission
   - name: release-1.27
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: api
       branch: release-1.27
@@ -2211,7 +2211,7 @@ rules:
       dirs:
       - staging/src/k8s.io/pod-security-admission
   - name: release-1.28
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: api
       branch: release-1.28
@@ -2230,7 +2230,7 @@ rules:
       dirs:
       - staging/src/k8s.io/pod-security-admission
   - name: release-1.29
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: api
       branch: release-1.29
@@ -2272,7 +2272,7 @@ rules:
       dirs:
       - staging/src/k8s.io/dynamic-resource-allocation
   - name: release-1.26
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -2289,7 +2289,7 @@ rules:
       dirs:
       - staging/src/k8s.io/dynamic-resource-allocation
   - name: release-1.27
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -2306,7 +2306,7 @@ rules:
       dirs:
       - staging/src/k8s.io/dynamic-resource-allocation
   - name: release-1.28
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -2327,7 +2327,7 @@ rules:
       dirs:
       - staging/src/k8s.io/dynamic-resource-allocation
   - name: release-1.29
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -2364,7 +2364,7 @@ rules:
       dirs:
       - staging/src/k8s.io/endpointslice
   - name: release-1.28
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: api
       branch: release-1.28
@@ -2379,7 +2379,7 @@ rules:
       dirs:
       - staging/src/k8s.io/endpointslice
   - name: release-1.29
-    go: 1.21.7
+    go: 1.21.8
     dependencies:
     - repository: api
       branch: release-1.29


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

- Update publishing-bot rules to Go 1.21.8

/assign @dims @saschagrunert  @xmudrii @Verolop 
cc @kubernetes/release-engineering 

#### Which issue(s) this PR fixes:

xref https://github.com/kubernetes/release/issues/3479

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
