### PR TITLE
APIServerTracing: Respect trace context only for system:master

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config.go
@@ -1009,6 +1009,11 @@ func DefaultBuildHandlerChain(apiHandler http.Handler, c *Config) http.Handler {
 	failedHandler := genericapifilters.Unauthorized(c.Serializer)
 	failedHandler = genericapifilters.WithFailedAuthenticationAudit(failedHandler, c.AuditBackend, c.AuditPolicyRuleEvaluator)
 
+	// WithTracing comes after authentication so we can allow authenticated
+	// clients to influence sampling.
+	if utilfeature.DefaultFeatureGate.Enabled(genericfeatures.APIServerTracing) {
+		handler = genericapifilters.WithTracing(handler, c.TracerProvider)
+	}
 	failedHandler = filterlatency.TrackCompleted(failedHandler)
 	handler = filterlatency.TrackCompleted(handler)
 	handler = genericapifilters.WithAuthentication(handler, c.Authentication.Authenticator, failedHandler, c.Authentication.APIAudiences, c.Authentication.RequestHeaderConfig)
@@ -1039,9 +1044,6 @@ func DefaultBuildHandlerChain(apiHandler http.Handler, c *Config) http.Handler {
 		handler = genericfilters.WithRetryAfter(handler, c.lifecycleSignals.NotAcceptingNewRequest.Signaled())
 	}
 	handler = genericfilters.WithHTTPLogging(handler)
-	if utilfeature.DefaultFeatureGate.Enabled(genericfeatures.APIServerTracing) {
-		handler = genericapifilters.WithTracing(handler, c.TracerProvider)
-	}
 	handler = genericapifilters.WithLatencyTrackers(handler)
 	// WithRoutine will execute future handlers in a separate goroutine and serving
 	// handler in current goroutine to minimize the stack memory usage. It must be


### PR DESCRIPTION
### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Move the tracing filter to after the authorization filter, and only respect the incoming context for requests from the privileged `system:master` group.

This has some downsides:

* Tracing from authorization isn't part of the APIServer trace
* The start time of the trace will be after authorization
* Exemplars won't work, since the trace filter comes after the metric filter.

#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/kubernetes/issues/103186

#### Special notes for your reviewer:

See discussions in:
* https://github.com/kubernetes/kubernetes/pull/94942#discussion_r657114027
* https://github.com/kubernetes/kubernetes/issues/103186#issuecomment-1970288470

#### Does this PR introduce a user-facing change?
```release-note
Respect the incoming trace context for authenticated requests to the kube-apiserver for APIServer tracing.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [KEP]: https://github.com/kubernetes/enhancements/blob/master/keps/sig-instrumentation/0034-distributed-tracing-kep.md
```

@kubernetes/sig-instrumentation-approvers
@liggitt 