### PR TITLE
Fix kube-aggregator support of v1.Service ExternalName

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/util/proxy/proxy.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/proxy/proxy.go
@@ -131,6 +131,19 @@ func ResolveCluster(services listersv1.ServiceLister, namespace, id string, port
 	}
 }
 
+// ResolveExternalName returns the external service value and a boolean indicating if the service is ServiceTypeExternalName.
+// This is used to set the Server Name Indication (SNI) in the proxy handler's TLS config.
+func ResolveExternalName(services listersv1.ServiceLister, namespace, id string) (string, bool, error) {
+	svc, err := services.Services(namespace).Get(id)
+	if err != nil {
+		return "", false, err
+	}
+	if svc.Spec.Type == v1.ServiceTypeExternalName {
+		return svc.Spec.ExternalName, true, nil
+	}
+	return "", false, nil
+}
+
 // NewRequestForProxy returns a shallow copy of the original request with a context that may include a timeout for discovery requests
 func NewRequestForProxy(location *url.URL, req *http.Request) (*http.Request, context.CancelFunc) {
 	newCtx := req.Context()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Currently when [kube-aggregator's handler_proxy](https://github.com/kubernetes/kube-aggregator/blob/0484f16783b2442a3739ebdd1bbfa0d194719823/pkg/apiserver/handler_proxy.go#L135) attempts to resolve a `v1.Service` with a type of `ExternalName`, the request will fail due to a TLS error unless the external name matches the [value set here](https://github.com/kubernetes/kube-aggregator/blob/0484f16783b2442a3739ebdd1bbfa0d194719823/pkg/apiserver/handler_proxy.go#L209). This forces the use of workarounds like setting `insecureSkipTLSVerify: true` in the `APIService`, which is obviously not ideal.

The use of extension API servers that are external to the cluster seems to be a supported use case (although not the common approach) based on [this section of the docs](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/apiserver-aggregation/#aggregation-layer):

> The most common way to implement the APIService is to run an extension API server in Pod(s) that run in your cluster.

This PR adds `ServerNameResolver`, which is an additional interface a `ServiceResolver` can optionally implement. This allows the TLS config's `ServerName` property to be properly set when `ServerNameResolver` is implemented and returns a valid hostname.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/123571

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
