### PR TITLE
Keep providing the deprecated AppArmor CRI API for runtimes that haven't migrated

### DIFF
--- a/pkg/kubelet/kuberuntime/security_context.go
+++ b/pkg/kubelet/kuberuntime/security_context.go
@@ -41,7 +41,7 @@ func (m *kubeGenericRuntimeManager) determineEffectiveSecurityContext(pod *v1.Po
 	}
 
 	// set ApparmorProfile.
-	synthesized.Apparmor, err = getAppArmorProfile(pod, container)
+	synthesized.Apparmor, synthesized.ApparmorProfile, err = getAppArmorProfile(pod, container)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

https://github.com/kubernetes/kubernetes/pull/123435 caused the Kubelet to stop passing the AppArmor profile to the CRI via the deprecated `apparmor_profile` field in favor of the newer structured `apparmor` field. However, I realized this is a breaking change for runtimes that haven't yet migrated to the newer field (which was previously unused), including CRI-O (https://github.com/cri-o/cri-o/issues/7857).

This change provides the AppArmor profile via both fields to maintain backwards compatibility. Containerd uses both fields, correctly preferring the newer field but falling back to the deprecated field if the newer one isn't provided.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/milestone v1.30
/sig-node
/assign @dchen1107 