### PR TITLE
Follow up fix to the job status update test

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -1049,10 +1049,9 @@
 - testname: Jobs, apply changes to status
   codename: '[sig-apps] Job should apply changes to a job status [Conformance]'
   description: Attempt to create a running Job which MUST succeed. Attempt to patch
-    the Job status to include a new start time which MUST succeed. An annotation for
-    the job that was patched MUST be found. Attempt to replace the job status with
-    a new start time which MUST succeed. Attempt to read its status sub-resource which
-    MUST succeed
+    the Job status which MUST succeed. An annotation for the job that was patched
+    MUST be found. Attempt to replace the job status with update which MUST succeed.
+    Attempt to read its status sub-resource which MUST succeed
   release: v1.24
   file: test/e2e/apps/job.go
 - testname: Ensure Pods of an Indexed Job get a unique index.

--- a/test/e2e/apps/job.go
+++ b/test/e2e/apps/job.go
@@ -825,10 +825,10 @@ done`}
 		Release: v1.24
 		Testname: Jobs, apply changes to status
 		Description: Attempt to create a running Job which MUST succeed.
-		Attempt to patch the Job status to include a new start time which
-		MUST succeed. An annotation for the job that was patched MUST be found.
-		Attempt to replace the job status with a new start time which MUST
-		succeed. Attempt to read its status sub-resource which MUST succeed
+		Attempt to patch the Job status which MUST succeed.
+		An annotation for the job that was patched MUST be found.
+		Attempt to replace the job status with update which MUST succeed.
+		Attempt to read its status sub-resource which MUST succeed
 	*/
 	framework.ConformanceIt("should apply changes to a job status", func(ctx context.Context) {
 
@@ -887,7 +887,7 @@ done`}
 			if err != nil {
 				return err
 			}
-			if condition := findConditionByType(patchedStatus.Status.Conditions, customConditionType); condition != nil {
+			if condition := findConditionByType(statusToUpdate.Status.Conditions, customConditionType); condition != nil {
 				condition.LastTransitionTime = now2
 			} else {
 				framework.Failf("patched object does not have the required condition %v", customConditionType)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
/kind failing-test
/kind flake
/kind documentation
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #123799

#### Special notes for your reviewer:

This is a follow up after https://github.com/kubernetes/kubernetes/pull/123751, which adjusted the test not to use startTime, but there is a bug causing it to flake.

Also, updated the test scenario description as more generic to capture the essence.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
