### PR TITLE
fix: handle socket file detection on Windows 

### DIFF
--- a/pkg/kubelet/cm/devicemanager/manager.go
+++ b/pkg/kubelet/cm/devicemanager/manager.go
@@ -192,15 +192,12 @@ func (m *ManagerImpl) CleanupPluginDirectory(dir string) error {
 		if filePath == m.checkpointFile() {
 			continue
 		}
-		// TODO: Until the bug - https://github.com/golang/go/issues/33357 is fixed, os.stat wouldn't return the
-		// right mode(socket) on windows. Hence deleting the file, without checking whether
-		// its a socket, on windows.
-		stat, err := os.Lstat(filePath)
+		stat, err := os.Stat(filePath)
 		if err != nil {
 			klog.ErrorS(err, "Failed to stat file", "path", filePath)
 			continue
 		}
-		if stat.IsDir() {
+		if stat.IsDir() || stat.Mode()&os.ModeSocket == 0 {
 			continue
 		}
 		err = os.RemoveAll(filePath)


### PR DESCRIPTION
Update socket file detection logic to use os.Stat as per upstream Go fix for https://github.com/golang/go/issues/33357. This resolves the issue where socket files could not be properly identified on Windows systems.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Update to use os.Stat instead of os.Lstat when deleting the device-plugins socket file, rather than deleting all files in the /var/lib/kubelet/device-plugins/ directory.

#### Which issue(s) this PR fixes:

related issue: https://github.com/kubernetes/kubernetes/issues/97554
Fixes #


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```



#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
