### PR TITLE
Add PrivateEndpoint option to APIServerTracing configuration

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/types.go
@@ -154,6 +154,12 @@ type TLSConfig struct {
 type TracingConfiguration struct {
 	metav1.TypeMeta
 
+	// PrivateEndpoint, if true, uses the trace context from incoming requests for tracing.
+	// Enabling this is not recommended unless access to the APIServer is limited
+	// to trusted clients.
+	// Default: false
+	PrivateEndpoint bool
+
 	// Embed the component config tracing configuration struct
 	tracingapi.TracingConfiguration
 }

--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1alpha1/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1alpha1/types.go
@@ -155,6 +155,12 @@ type TLSConfig struct {
 type TracingConfiguration struct {
 	metav1.TypeMeta `json:",inline"`
 
+	// PrivateEndpoint, if true, uses the trace context from incoming requests for tracing.
+	// Enabling this is not recommended unless access to the APIServer is limited
+	// to trusted clients.
+	// Default: false
+	PrivateEndpoint bool `json:"privateEndpoint,omitempty"`
+
 	// Embed the component config tracing configuration struct
 	tracingapi.TracingConfiguration `json:",inline"`
 }

--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1alpha1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1alpha1/zz_generated.conversion.go
@@ -709,6 +709,7 @@ func Convert_apiserver_TLSConfig_To_v1alpha1_TLSConfig(in *apiserver.TLSConfig, 
 }
 
 func autoConvert_v1alpha1_TracingConfiguration_To_apiserver_TracingConfiguration(in *TracingConfiguration, out *apiserver.TracingConfiguration, s conversion.Scope) error {
+	out.PrivateEndpoint = in.PrivateEndpoint
 	out.TracingConfiguration = in.TracingConfiguration
 	return nil
 }
@@ -719,6 +720,7 @@ func Convert_v1alpha1_TracingConfiguration_To_apiserver_TracingConfiguration(in 
 }
 
 func autoConvert_apiserver_TracingConfiguration_To_v1alpha1_TracingConfiguration(in *apiserver.TracingConfiguration, out *TracingConfiguration, s conversion.Scope) error {
+	out.PrivateEndpoint = in.PrivateEndpoint
 	out.TracingConfiguration = in.TracingConfiguration
 	return nil
 }

--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1beta1/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1beta1/types.go
@@ -126,6 +126,12 @@ type TLSConfig struct {
 type TracingConfiguration struct {
 	metav1.TypeMeta `json:",inline"`
 
+	// PrivateEndpoint, if true, uses the trace context from incoming requests for tracing.
+	// Enabling this is not recommended unless access to the APIServer is limited
+	// to trusted clients.
+	// Default: false
+	PrivateEndpoint bool `json:"privateEndpoint,omitempty"`
+
 	// Embed the component config tracing configuration struct
 	tracingapi.TracingConfiguration `json:",inline"`
 }

--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1beta1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1beta1/zz_generated.conversion.go
@@ -249,6 +249,7 @@ func Convert_apiserver_TLSConfig_To_v1beta1_TLSConfig(in *apiserver.TLSConfig, o
 }
 
 func autoConvert_v1beta1_TracingConfiguration_To_apiserver_TracingConfiguration(in *TracingConfiguration, out *apiserver.TracingConfiguration, s conversion.Scope) error {
+	out.PrivateEndpoint = in.PrivateEndpoint
 	out.TracingConfiguration = in.TracingConfiguration
 	return nil
 }
@@ -259,6 +260,7 @@ func Convert_v1beta1_TracingConfiguration_To_apiserver_TracingConfiguration(in *
 }
 
 func autoConvert_apiserver_TracingConfiguration_To_v1beta1_TracingConfiguration(in *apiserver.TracingConfiguration, out *TracingConfiguration, s conversion.Scope) error {
+	out.PrivateEndpoint = in.PrivateEndpoint
 	out.TracingConfiguration = in.TracingConfiguration
 	return nil
 }

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/traces.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/traces.go
@@ -27,11 +27,13 @@ import (
 )
 
 // WithTracing adds tracing to requests if the incoming request is sampled
-func WithTracing(handler http.Handler, tp trace.TracerProvider) http.Handler {
+func WithTracing(handler http.Handler, tp trace.TracerProvider, privateEndpoint bool) http.Handler {
 	opts := []otelhttp.Option{
 		otelhttp.WithPropagators(tracing.Propagators()),
-		otelhttp.WithPublicEndpoint(),
 		otelhttp.WithTracerProvider(tp),
+	}
+	if !privateEndpoint {
+		opts = append(opts, otelhttp.WithPublicEndpoint())
 	}
 	wrappedHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Add the http.target attribute to the otelhttp span

--- a/staging/src/k8s.io/apiserver/pkg/server/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config.go
@@ -160,6 +160,9 @@ type Config struct {
 	// TracerProvider can provide a tracer, which records spans for distributed tracing.
 	TracerProvider tracing.TracerProvider
 
+	// PrivateEndpoint, if true, uses the trace context from incoming requests for tracing.
+	PrivateEndpoint bool
+
 	//===========================================================================
 	// Fields you probably don't care about changing
 	//===========================================================================
@@ -1040,7 +1043,7 @@ func DefaultBuildHandlerChain(apiHandler http.Handler, c *Config) http.Handler {
 	}
 	handler = genericfilters.WithHTTPLogging(handler)
 	if utilfeature.DefaultFeatureGate.Enabled(genericfeatures.APIServerTracing) {
-		handler = genericapifilters.WithTracing(handler, c.TracerProvider)
+		handler = genericapifilters.WithTracing(handler, c.TracerProvider, c.PrivateEndpoint)
 	}
 	handler = genericapifilters.WithLatencyTrackers(handler)
 	// WithRoutine will execute future handlers in a separate goroutine and serving

--- a/staging/src/k8s.io/apiserver/pkg/server/options/tracing_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/tracing_test.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"testing"
 
+	apiserverapi "k8s.io/apiserver/pkg/apis/apiserver"
 	tracingapi "k8s.io/component-base/tracing/api/v1"
 )
 
@@ -81,14 +82,14 @@ func TestReadTracingConfiguration(t *testing.T) {
 		name           string
 		contents       string
 		createFile     bool
-		expectedResult *tracingapi.TracingConfiguration
+		expectedResult *apiserverapi.TracingConfiguration
 		expectedError  *string
 	}{
 		{
 			name:           "empty",
 			createFile:     true,
 			contents:       ``,
-			expectedResult: &tracingapi.TracingConfiguration{},
+			expectedResult: &apiserverapi.TracingConfiguration{},
 			expectedError:  nil,
 		},
 		{
@@ -105,11 +106,34 @@ func TestReadTracingConfiguration(t *testing.T) {
 apiVersion: apiserver.config.k8s.io/v1alpha1
 kind: TracingConfiguration
 endpoint: localhost:4317
+privateEndpoint: true
 samplingRatePerMillion: 12345
 `,
-			expectedResult: &tracingapi.TracingConfiguration{
-				Endpoint:               &localhost,
-				SamplingRatePerMillion: &samplingRate,
+			expectedResult: &apiserverapi.TracingConfiguration{
+				PrivateEndpoint: true,
+				TracingConfiguration: tracingapi.TracingConfiguration{
+					Endpoint:               &localhost,
+					SamplingRatePerMillion: &samplingRate,
+				},
+			},
+			expectedError: nil,
+		},
+		{
+			name:       "v1beta1",
+			createFile: true,
+			contents: `
+apiVersion: apiserver.config.k8s.io/v1beta1
+kind: TracingConfiguration
+endpoint: localhost:4317
+privateEndpoint: true
+samplingRatePerMillion: 12345
+`,
+			expectedResult: &apiserverapi.TracingConfiguration{
+				PrivateEndpoint: true,
+				TracingConfiguration: tracingapi.TracingConfiguration{
+					Endpoint:               &localhost,
+					SamplingRatePerMillion: &samplingRate,
+				},
 			},
 			expectedError: nil,
 		},
@@ -121,8 +145,23 @@ apiVersion: apiserver.config.k8s.io/v1alpha1
 kind: TracingConfiguration
 endpoint: 127.0.0.1:4317
 `,
-			expectedResult: &tracingapi.TracingConfiguration{
-				Endpoint: &ipAddress,
+			expectedResult: &apiserverapi.TracingConfiguration{
+				TracingConfiguration: tracingapi.TracingConfiguration{
+					Endpoint: &ipAddress,
+				},
+			},
+			expectedError: nil,
+		},
+		{
+			name:       "privateEndpoint",
+			createFile: true,
+			contents: `
+apiVersion: apiserver.config.k8s.io/v1alpha1
+kind: TracingConfiguration
+privateEndpoint: true
+`,
+			expectedResult: &apiserverapi.TracingConfiguration{
+				PrivateEndpoint: true,
 			},
 			expectedError: nil,
 		},

--- a/test/integration/apiserver/tracing/tracing_test.go
+++ b/test/integration/apiserver/tracing/tracing_test.go
@@ -24,13 +24,17 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"math/rand"
 	"net"
+	"net/http"
 	"os"
 	"strings"
 	"sync"
 	"testing"
 	"time"
 
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+	"go.opentelemetry.io/otel/trace"
 	traceservice "go.opentelemetry.io/proto/otlp/collector/trace/v1"
 	commonv1 "go.opentelemetry.io/proto/otlp/common/v1"
 	tracev1 "go.opentelemetry.io/proto/otlp/trace/v1"
@@ -42,6 +46,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	kmsv2mock "k8s.io/apiserver/pkg/storage/value/encrypt/envelope/testing/v2"
 	client "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	utiltesting "k8s.io/client-go/util/testing"
 	kubeapiservertesting "k8s.io/kubernetes/cmd/kube-apiserver/app/testing"
 	"k8s.io/kubernetes/test/integration/framework"
@@ -85,14 +90,14 @@ resources:
 	if err := os.WriteFile(tracingConfigFile.Name(), []byte(fmt.Sprintf(`
 apiVersion: apiserver.config.k8s.io/v1beta1
 kind: TracingConfiguration
-samplingRatePerMillion: 1000000
+privateEndpoint: true
 endpoint: %s`, listener.Addr().String())), os.FileMode(0755)); err != nil {
 		t.Fatal(err)
 	}
 
 	srv := grpc.NewServer()
 	fakeServer := &traceServer{t: t}
-	fakeServer.resetExpectations([]*spanExpectation{})
+	fakeServer.resetExpectations([]*spanExpectation{}, trace.TraceID{})
 	traceservice.RegisterTraceServiceServer(srv, fakeServer)
 
 	go func() {
@@ -122,13 +127,13 @@ endpoint: %s`, listener.Addr().String())), os.FileMode(0755)); err != nil {
 
 	for _, tc := range []struct {
 		desc          string
-		apiCall       func(client.Interface) error
+		apiCall       func(context.Context, client.Interface) error
 		expectedTrace []*spanExpectation
 	}{
 		{
 			desc: "create secret",
-			apiCall: func(c client.Interface) error {
-				_, err = clientSet.CoreV1().Secrets(v1.NamespaceDefault).Create(context.Background(),
+			apiCall: func(ctx context.Context, c client.Interface) error {
+				_, err = clientSet.CoreV1().Secrets(v1.NamespaceDefault).Create(ctx,
 					&v1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "fake"}, Data: map[string][]byte{"foo": []byte("bar")}}, metav1.CreateOptions{})
 				return err
 			},
@@ -151,9 +156,9 @@ endpoint: %s`, listener.Addr().String())), os.FileMode(0755)); err != nil {
 		},
 		{
 			desc: "get secret",
-			apiCall: func(c client.Interface) error {
+			apiCall: func(ctx context.Context, c client.Interface) error {
 				// This depends on the "create secret" step having completed successfully
-				_, err = clientSet.CoreV1().Secrets(v1.NamespaceDefault).Get(context.Background(), "fake", metav1.GetOptions{})
+				_, err = clientSet.CoreV1().Secrets(v1.NamespaceDefault).Get(ctx, "fake", metav1.GetOptions{})
 				return err
 			},
 			expectedTrace: []*spanExpectation{
@@ -175,10 +180,11 @@ endpoint: %s`, listener.Addr().String())), os.FileMode(0755)); err != nil {
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
-			fakeServer.resetExpectations(tc.expectedTrace)
+			ctx, traceID := sampledContext()
+			fakeServer.resetExpectations(tc.expectedTrace, traceID)
 
 			// Make our call to the API server
-			if err := tc.apiCall(clientSet); err != nil {
+			if err := tc.apiCall(ctx, clientSet); err != nil {
 				t.Fatal(err)
 			}
 
@@ -228,6 +234,7 @@ egressSelections:
 	if err := os.WriteFile(tracingConfigFile.Name(), []byte(fmt.Sprintf(`
 apiVersion: apiserver.config.k8s.io/v1beta1
 kind: TracingConfiguration
+privateEndpoint: true
 endpoint: %s`, listener.Addr().String())), os.FileMode(0755)); err != nil {
 		t.Fatal(err)
 	}
@@ -253,6 +260,69 @@ endpoint: %s`, listener.Addr().String())), os.FileMode(0755)); err != nil {
 	}
 }
 
+func TestPublicEndpointAPIServerTracing(t *testing.T) {
+	// Listen for traces from the API Server before starting it, so the
+	// API Server will successfully connect right away during the test.
+	listener, err := net.Listen("tcp", "localhost:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Write the configuration for tracing to a file
+	tracingConfigFile, err := os.CreateTemp("", "tracing-config.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tracingConfigFile.Name())
+
+	if err := os.WriteFile(tracingConfigFile.Name(), []byte(fmt.Sprintf(`
+apiVersion: apiserver.config.k8s.io/v1beta1
+kind: TracingConfiguration
+privateEndpoint: false
+endpoint: %s`, listener.Addr().String())), os.FileMode(0755)); err != nil {
+		t.Fatal(err)
+	}
+
+	srv := grpc.NewServer()
+	fakeServer := &traceServer{t: t}
+	fakeServer.resetExpectations([]*spanExpectation{{}}, trace.TraceID{})
+	traceservice.RegisterTraceServiceServer(srv, fakeServer)
+
+	go srv.Serve(listener)
+	defer srv.Stop()
+
+	// Start the API Server with our tracing configuration
+	testServer := kubeapiservertesting.StartTestServerOrDie(t,
+		kubeapiservertesting.NewDefaultTestServerOptions(),
+		[]string{"--tracing-config-file=" + tracingConfigFile.Name()},
+		framework.SharedEtcd(),
+	)
+	defer testServer.TearDownFn()
+
+	ctx, testTraceID := sampledContext()
+	// Match any span that has the tests' Trace ID
+	fakeServer.resetExpectations([]*spanExpectation{{}}, testTraceID)
+
+	req, err := http.NewRequestWithContext(ctx, "GET", testServer.ClientConfig.Host+"/healthz", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	transport, err := rest.TransportFor(testServer.ClientConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := &http.Client{Transport: otelhttp.NewTransport(transport)}
+	if _, err = client.Do(req); err != nil {
+		t.Fatal(err)
+	}
+
+	// Ensure we do not find any matching traces, since the request was not authenticated
+	select {
+	case <-fakeServer.traceFound:
+		t.Fatal("Found a trace when none was expected")
+	case <-time.After(10 * time.Second):
+	}
+}
+
 func TestAPIServerTracing(t *testing.T) {
 	// Listen for traces from the API Server before starting it, so the
 	// API Server will successfully connect right away during the test.
@@ -270,14 +340,14 @@ func TestAPIServerTracing(t *testing.T) {
 	if err := os.WriteFile(tracingConfigFile.Name(), []byte(fmt.Sprintf(`
 apiVersion: apiserver.config.k8s.io/v1beta1
 kind: TracingConfiguration
-samplingRatePerMillion: 1000000
+privateEndpoint: true
 endpoint: %s`, listener.Addr().String())), os.FileMode(0755)); err != nil {
 		t.Fatal(err)
 	}
 
 	srv := grpc.NewServer()
 	fakeServer := &traceServer{t: t}
-	fakeServer.resetExpectations([]*spanExpectation{})
+	fakeServer.resetExpectations([]*spanExpectation{}, trace.TraceID{})
 	traceservice.RegisterTraceServiceServer(srv, fakeServer)
 
 	go srv.Serve(listener)
@@ -297,13 +367,13 @@ endpoint: %s`, listener.Addr().String())), os.FileMode(0755)); err != nil {
 
 	for _, tc := range []struct {
 		desc          string
-		apiCall       func(*client.Clientset) error
+		apiCall       func(context.Context) error
 		expectedTrace []*spanExpectation
 	}{
 		{
 			desc: "create node",
-			apiCall: func(c *client.Clientset) error {
-				_, err = clientSet.CoreV1().Nodes().Create(context.Background(),
+			apiCall: func(ctx context.Context) error {
+				_, err = clientSet.CoreV1().Nodes().Create(ctx,
 					&v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "fake"}}, metav1.CreateOptions{})
 				return err
 			},
@@ -421,9 +491,9 @@ endpoint: %s`, listener.Addr().String())), os.FileMode(0755)); err != nil {
 		},
 		{
 			desc: "get node",
-			apiCall: func(c *client.Clientset) error {
+			apiCall: func(ctx context.Context) error {
 				// This depends on the "create node" step having completed successfully
-				_, err = clientSet.CoreV1().Nodes().Get(context.Background(), "fake", metav1.GetOptions{})
+				_, err = clientSet.CoreV1().Nodes().Get(ctx, "fake", metav1.GetOptions{})
 				return err
 			},
 			expectedTrace: []*spanExpectation{
@@ -512,8 +582,8 @@ endpoint: %s`, listener.Addr().String())), os.FileMode(0755)); err != nil {
 		},
 		{
 			desc: "list nodes",
-			apiCall: func(c *client.Clientset) error {
-				_, err = clientSet.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+			apiCall: func(ctx context.Context) error {
+				_, err = clientSet.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
 				return err
 			},
 			expectedTrace: []*spanExpectation{
@@ -625,9 +695,9 @@ endpoint: %s`, listener.Addr().String())), os.FileMode(0755)); err != nil {
 		},
 		{
 			desc: "update node",
-			apiCall: func(c *client.Clientset) error {
+			apiCall: func(ctx context.Context) error {
 				// This depends on the "create node" step having completed successfully
-				_, err = clientSet.CoreV1().Nodes().Update(context.Background(),
+				_, err = clientSet.CoreV1().Nodes().Update(ctx,
 					&v1.Node{ObjectMeta: metav1.ObjectMeta{
 						Name:        "fake",
 						Annotations: map[string]string{"foo": "bar"},
@@ -751,7 +821,7 @@ endpoint: %s`, listener.Addr().String())), os.FileMode(0755)); err != nil {
 		},
 		{
 			desc: "patch node",
-			apiCall: func(c *client.Clientset) error {
+			apiCall: func(ctx context.Context) error {
 				// This depends on the "create node" step having completed successfully
 				oldNode := &v1.Node{ObjectMeta: metav1.ObjectMeta{
 					Name:        "fake",
@@ -775,7 +845,7 @@ endpoint: %s`, listener.Addr().String())), os.FileMode(0755)); err != nil {
 				if err != nil {
 					return err
 				}
-				_, err = clientSet.CoreV1().Nodes().Patch(context.Background(), "fake", types.StrategicMergePatchType, patchBytes, metav1.PatchOptions{})
+				_, err = clientSet.CoreV1().Nodes().Patch(ctx, "fake", types.StrategicMergePatchType, patchBytes, metav1.PatchOptions{})
 				return err
 			},
 			expectedTrace: []*spanExpectation{
@@ -895,9 +965,9 @@ endpoint: %s`, listener.Addr().String())), os.FileMode(0755)); err != nil {
 		},
 		{
 			desc: "delete node",
-			apiCall: func(c *client.Clientset) error {
+			apiCall: func(ctx context.Context) error {
 				// This depends on the "create node" step having completed successfully
-				return clientSet.CoreV1().Nodes().Delete(context.Background(), "fake", metav1.DeleteOptions{})
+				return clientSet.CoreV1().Nodes().Delete(ctx, "fake", metav1.DeleteOptions{})
 			},
 			expectedTrace: []*spanExpectation{
 				{
@@ -989,10 +1059,11 @@ endpoint: %s`, listener.Addr().String())), os.FileMode(0755)); err != nil {
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
-			fakeServer.resetExpectations(tc.expectedTrace)
+			ctx, testTraceID := sampledContext()
+			fakeServer.resetExpectations(tc.expectedTrace, testTraceID)
 
 			// Make our call to the API server
-			if err := tc.apiCall(clientSet); err != nil {
+			if err := tc.apiCall(ctx); err != nil {
 				t.Fatal(err)
 			}
 
@@ -1015,13 +1086,14 @@ type traceServer struct {
 	lock         sync.Mutex
 	traceFound   chan struct{}
 	expectations traceExpectation
+	testTraceID  trace.TraceID
 }
 
 func (t *traceServer) Export(ctx context.Context, req *traceservice.ExportTraceServiceRequest) (*traceservice.ExportTraceServiceResponse, error) {
 	t.lock.Lock()
 	defer t.lock.Unlock()
 
-	t.expectations.update(req)
+	t.expectations.update(req, t.testTraceID)
 	// if all expectations are met, notify the test scenario by closing traceFound
 	if t.expectations.met() {
 		select {
@@ -1036,11 +1108,12 @@ func (t *traceServer) Export(ctx context.Context, req *traceservice.ExportTraceS
 
 // resetExpectations is used by a new test scenario to set new expectations for
 // the test server.
-func (t *traceServer) resetExpectations(newExpectations traceExpectation) {
+func (t *traceServer) resetExpectations(newExpectations traceExpectation, traceID trace.TraceID) {
 	t.lock.Lock()
 	defer t.lock.Unlock()
 	t.traceFound = make(chan struct{})
 	t.expectations = newExpectations
+	t.testTraceID = traceID
 }
 
 // traceExpectation is an expectation for an entire trace
@@ -1049,25 +1122,8 @@ type traceExpectation []*spanExpectation
 // met returns true if all span expectations the server is looking for have
 // been satisfied.
 func (t traceExpectation) met() bool {
-	if len(t) == 0 {
-		return true
-	}
-	// we want to find any trace ID which all span IDs contain.
-	// try each trace ID met by the first span.
-	possibleTraceIDs := t[0].metTraceIDs
-	for _, tid := range possibleTraceIDs {
-		if t.contains(tid) {
-			return true
-		}
-	}
-	return false
-}
-
-// contains returns true if the all spans in the trace expectation contain the
-// trace ID
-func (t traceExpectation) contains(checkTID string) bool {
-	for _, expectation := range t {
-		if !expectation.contains(checkTID) {
+	for _, se := range t {
+		if !se.met {
 			return false
 		}
 	}
@@ -1076,20 +1132,23 @@ func (t traceExpectation) contains(checkTID string) bool {
 
 // update finds all expectations that are met by a span in the
 // incoming request.
-func (t traceExpectation) update(req *traceservice.ExportTraceServiceRequest) {
+func (t traceExpectation) update(req *traceservice.ExportTraceServiceRequest, traceID trace.TraceID) {
 	for _, resourceSpans := range req.GetResourceSpans() {
 		for _, instrumentationSpans := range resourceSpans.GetScopeSpans() {
 			for _, span := range instrumentationSpans.GetSpans() {
-				t.updateForSpan(span)
+				t.updateForSpan(span, traceID)
 			}
 		}
 	}
 }
 
 // updateForSpan updates expectations based on a single incoming span.
-func (t traceExpectation) updateForSpan(span *tracev1.Span) {
+func (t traceExpectation) updateForSpan(span *tracev1.Span, traceID trace.TraceID) {
+	if hex.EncodeToString(span.TraceId) != traceID.String() {
+		return
+	}
 	for i, spanExpectation := range t {
-		if span.Name != spanExpectation.name {
+		if spanExpectation.name != "" && span.Name != spanExpectation.name {
 			continue
 		}
 		if !spanExpectation.attributes.matches(span.GetAttributes()) {
@@ -1098,7 +1157,7 @@ func (t traceExpectation) updateForSpan(span *tracev1.Span) {
 		if !spanExpectation.events.matches(span.GetEvents()) {
 			continue
 		}
-		t[i].metTraceIDs = append(spanExpectation.metTraceIDs, hex.EncodeToString(span.TraceId[:]))
+		t[i].met = true
 	}
 
 }
@@ -1108,18 +1167,7 @@ type spanExpectation struct {
 	name       string
 	attributes attributeExpectation
 	events     eventExpectation
-	// For each trace ID that meets this expectation, record it here.
-	// This way, we can ensure that all spans that should be in the same trace have the same trace ID
-	metTraceIDs []string
-}
-
-func (s *spanExpectation) contains(tid string) bool {
-	for _, metTID := range s.metTraceIDs {
-		if tid == metTID {
-			return true
-		}
-	}
-	return false
+	met        bool
 }
 
 // eventExpectation is the expectation for an event attached to a span.
@@ -1156,4 +1204,19 @@ func (a attributeExpectation) matches(attrs []*commonv1.KeyValue) bool {
 		}
 	}
 	return true
+}
+
+var r = rand.New(rand.NewSource(time.Now().UnixNano()))
+
+func sampledContext() (context.Context, trace.TraceID) {
+	tid := trace.TraceID{}
+	_, _ = r.Read(tid[:])
+	sid := trace.SpanID{}
+	_, _ = r.Read(sid[:])
+	sc := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    tid,
+		SpanID:     sid,
+		TraceFlags: trace.FlagsSampled,
+	})
+	return trace.ContextWithSpanContext(context.Background(), sc), tid
 }


### PR DESCRIPTION
### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Add an option, PrivateEndpoint for the APIServer's tracing configuration.  When enabled, the APIServer will use the context from incoming requests to make sampling decisions, and for trace context propagation.

Alternative to https://github.com/kubernetes/kubernetes/pull/123807

#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/kubernetes/issues/103186

#### Special notes for your reviewer:

See discussions in:
* https://github.com/kubernetes/kubernetes/pull/94942#discussion_r657114027
* https://github.com/kubernetes/kubernetes/issues/103186#issuecomment-1970288470

#### Does this PR introduce a user-facing change?
```release-note
Add PrivateEndpoint option to APIServerTracing configuration to use the trace context from apiserver requests.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [KEP]: https://github.com/kubernetes/enhancements/blob/master/keps/sig-instrumentation/0034-distributed-tracing-kep.md
```

@kubernetes/sig-instrumentation-approvers
@liggitt 