### PR TITLE
Allow CRDs with invalid conversion webhook CABundles to serve requests not requiring conversion

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/runtime/codec_check.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/codec_check.go
@@ -27,11 +27,15 @@ import (
 // CheckCodec makes sure that the codec can encode objects like internalType,
 // decode all of the external types listed, and also decode them into the given
 // object. (Will modify internalObject.) (Assumes JSON serialization.)
+// internalType may be nil for CRDs, which have no internal type.
 // TODO: verify that the correct external version is chosen on encode...
 func CheckCodec(c Codec, internalType Object, externalTypes ...schema.GroupVersionKind) error {
-	if _, err := Encode(c, internalType); err != nil {
-		return fmt.Errorf("internal type not encodable: %v", err)
+	if internalType != nil {
+		if _, err := Encode(c, internalType); err != nil {
+			return fmt.Errorf("internal type not encodable: %v", err)
+		}
 	}
+
 	for _, et := range externalTypes {
 		typeMeta := TypeMeta{
 			Kind:       et.Kind,

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
@@ -336,9 +336,15 @@ func (c *Cacher) RequestWatchProgress(ctx context.Context) error {
 func NewCacherFromConfig(config Config) (*Cacher, error) {
 	stopCh := make(chan struct{})
 	obj := config.NewFunc()
+
+	var internalType runtime.Object
+	v := obj.GetObjectKind().GroupVersionKind().Version
+	if len(v) == 0 { // Don't treat the preferred version of CRDs as an internal type.
+		internalType = obj
+	}
 	// Give this error when it is constructed rather than when you get the
 	// first watch item, because it's much easier to track down that way.
-	if err := runtime.CheckCodec(config.Codec, obj); err != nil {
+	if err := runtime.CheckCodec(config.Codec, internalType); err != nil {
 		return nil, fmt.Errorf("storage codec doesn't seem to match given type: %v", err)
 	}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

We already allow CRDs with conversion webhooks that refer to non-existant URLs/serviceReferences to serve requests not requiring conversion. This extends that to invalid CABundles.

Clusters that only actually use a CRD at the stroage version become more resilient to misconfigurations of a conversion webhook that is not actually needed for that particular workload.

The fix is arranged such that if we identify other non-transient mis-configurations we could allow serve requests not requiring conversion for those too.  I did a scan and was not able to identify other cases like this, so scoped this down just to invalid CABundles.

#### Which issue(s) this PR fixes:

Fixes #123835

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
CRDs with conversion webhooks containing invalid CABundles serve requests not requiring conversion instead of failing for all requests.
```

