### PR TITLE
dra scheduler: ensure that we never have nil claim/class parameters

### DIFF
--- a/pkg/kubelet/cm/dra/manager.go
+++ b/pkg/kubelet/cm/dra/manager.go
@@ -380,7 +380,7 @@ func (m *ManagerImpl) UnprepareResources(pod *v1.Pod) error {
 				return fmt.Errorf("NodeUnprepareResources returned result for unknown claim UID %s", claimUID)
 			}
 			if result.Error != "" {
-				return fmt.Errorf("NodeUnprepareResources failed for claim %s/%s: %s", reqClaim.Namespace, reqClaim.Name, err)
+				return fmt.Errorf("NodeUnprepareResources failed for claim %s/%s: %s", reqClaim.Namespace, reqClaim.Name, result.Error)
 			}
 
 			// Delete last pod UID only if unprepare succeeds.

--- a/pkg/scheduler/framework/plugins/dynamicresources/structuredparameters.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/structuredparameters.go
@@ -128,12 +128,10 @@ func newClaimController(logger klog.Logger, class *resourcev1alpha2.ResourceClas
 	}
 	for driverName, perDriver := range namedresourcesRequests {
 		var filter *resourcev1alpha2.NamedResourcesFilter
-		if classParameters != nil {
-			for _, f := range classParameters.Filters {
-				if f.DriverName == driverName && f.ResourceFilterModel.NamedResources != nil {
-					filter = f.ResourceFilterModel.NamedResources
-					break
-				}
+		for _, f := range classParameters.Filters {
+			if f.DriverName == driverName && f.ResourceFilterModel.NamedResources != nil {
+				filter = f.ResourceFilterModel.NamedResources
+				break
 			}
 		}
 		controller, err := namedresourcesmodel.NewClaimController(filter, perDriver.requests)


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
This PR adds logic to define **default** claim/class parameters that will allow
claim allocation to proceed even if an end user doesn't provide claim
parameters themselves.

Without this change, the scheduler was crashing in newClaimController() in `pkg/scheduler/framework/plugins/dynamicresources/structuredparameters.go`

The code in newClaimController() assumes that claim parameters are not nil.
Furthermore it assumes that there is at least one DriverRequest populated in
order to allocate any resources to a claim.

However, we shouldn't *force* a user to supply a ResourceClaimParameters
object if they don't want to. We also shouldn't force a driver implementor to
write a controller just to associate a static ResourceClaimParameters object
with every claim.

In this PR, the "default" claim parameters objects are hard-coded in the
scheduler code. This won't work going forward as we add new structured
models though. What we probably want is a field in the ResourceClass which
points to a default ResourceClaimPrameters object that should be used if one
is not supplied as part of the claim.

```release-note
None
```