### PR TITLE
Add StructuredResourceModel to UnprepareResources call

### DIFF
--- a/pkg/kubelet/cm/dra/manager.go
+++ b/pkg/kubelet/cm/dra/manager.go
@@ -351,6 +351,9 @@ func (m *ManagerImpl) UnprepareResources(pod *v1.Pod) error {
 				Name:           claimInfo.ClaimName,
 				ResourceHandle: resourceHandle.Data,
 			}
+			if resourceHandle.StructuredData != nil {
+				claim.StructuredResourceHandle = []*resourceapi.StructuredResourceHandle{resourceHandle.StructuredData}
+			}
 			batches[pluginName] = append(batches[pluginName], claim)
 		}
 		claimInfos[claimInfo.ClaimUID] = claimInfo


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

This PR adds the StructuredResourceModel field to the UnprepareResources call for a DRA kubelet plugin. It was always meant to be passed, and adding it in was overlooked and causing bugs in external plugin implementations.

```release-note
NONE
```