### PR TITLE
kubeadm: increase ut converage for config/upgradeconfiguration

### DIFF
--- a/cmd/kubeadm/app/util/config/upgradeconfiguration_test.go
+++ b/cmd/kubeadm/app/util/config/upgradeconfiguration_test.go
@@ -17,10 +17,13 @@ limitations under the License.
 package config
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/lithammer/dedent"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
@@ -100,6 +103,247 @@ func TestDocMapToUpgradeConfiguration(t *testing.T) {
 			}
 			if diff := cmp.Diff(*cfg, tc.expectedCfg, cmpopts.IgnoreFields(kubeadmapi.UpgradeConfiguration{}, "Timeouts")); diff != "" {
 				t.Fatalf("DocMapToUpgradeConfiguration returned unexpected diff (-want,+got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestLoadUpgradeConfigurationFromFile(t *testing.T) {
+	tmpdir, err := os.MkdirTemp("", "")
+	if err != nil {
+		t.Fatalf("Couldn't create tmpdir: %v", err)
+	}
+	defer func() {
+		if err := os.RemoveAll(tmpdir); err != nil {
+			t.Fatalf("Couldn't remove tmpdir: %v", err)
+		}
+	}()
+	filename := "kubeadmConfig"
+	filePath := filepath.Join(tmpdir, filename)
+	options := LoadOrDefaultConfigurationOptions{}
+
+	tests := []struct {
+		name         string
+		cfgPath      string
+		fileContents string
+		want         *kubeadmapi.UpgradeConfiguration
+		wantErr      bool
+	}{
+		{
+			name:    "Config file does not exists",
+			cfgPath: "tmp",
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name:         "Config file format is basic text",
+			cfgPath:      filePath,
+			want:         nil,
+			fileContents: "some-text",
+			wantErr:      true,
+		},
+		{
+			name:    "Unknown kind UpgradeConfiguration for kubeadm.k8s.io/unknown",
+			cfgPath: filePath,
+			fileContents: dedent.Dedent(`
+				apiVersion: kubeadm.k8s.io/unknown
+				kind: UpgradeConfiguration
+    		`),
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name:    "Valid kubeadm config",
+			cfgPath: filePath,
+			fileContents: dedent.Dedent(`
+				apiVersion: kubeadm.k8s.io/v1beta4
+				kind: UpgradeConfiguration`),
+			want: &kubeadmapi.UpgradeConfiguration{
+				Apply: kubeadmapi.UpgradeApplyConfiguration{
+					CertificateRenewal: ptr.To(true),
+					EtcdUpgrade:        ptr.To(true),
+				},
+				Node: kubeadmapi.UpgradeNodeConfiguration{
+					CertificateRenewal: ptr.To(true),
+					EtcdUpgrade:        ptr.To(true),
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.cfgPath == filePath {
+				err = os.WriteFile(tt.cfgPath, []byte(tt.fileContents), 0644)
+				if err != nil {
+					t.Fatalf("Couldn't write content to file: %v", err)
+				}
+				defer func() {
+					if err := os.RemoveAll(filePath); err != nil {
+						t.Fatalf("Couldn't remove filePath: %v", err)
+					}
+				}()
+			}
+
+			got, err := LoadUpgradeConfigurationFromFile(tt.cfgPath, options)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("LoadUpgradeConfigurationFromFile() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.want == nil && got != tt.want {
+				t.Errorf("LoadUpgradeConfigurationFromFile() got = %v, want %v", got, tt.want)
+			} else if tt.want != nil {
+				if diff := cmp.Diff(got, tt.want, cmpopts.IgnoreFields(kubeadmapi.UpgradeConfiguration{}, "Timeouts")); diff != "" {
+					t.Errorf("LoadUpgradeConfigurationFromFile returned unexpected diff (-want,+got):\n%s", diff)
+				}
+			}
+		})
+	}
+}
+
+func TestDefaultedUpgradeConfiguration(t *testing.T) {
+	options := LoadOrDefaultConfigurationOptions{}
+	tests := []struct {
+		name string
+		cfg  *kubeadmapiv1.UpgradeConfiguration
+		want *kubeadmapi.UpgradeConfiguration
+	}{
+		{
+			name: "config is empty",
+			cfg:  &kubeadmapiv1.UpgradeConfiguration{},
+			want: &kubeadmapi.UpgradeConfiguration{
+				Apply: kubeadmapi.UpgradeApplyConfiguration{
+					CertificateRenewal: ptr.To(true),
+					EtcdUpgrade:        ptr.To(true),
+				},
+				Node: kubeadmapi.UpgradeNodeConfiguration{
+					CertificateRenewal: ptr.To(true),
+					EtcdUpgrade:        ptr.To(true),
+				},
+			},
+		},
+		{
+			name: "config has some fields configured",
+			cfg: &kubeadmapiv1.UpgradeConfiguration{
+				Apply: kubeadmapiv1.UpgradeApplyConfiguration{
+					CertificateRenewal: ptr.To(false),
+				},
+				Node: kubeadmapiv1.UpgradeNodeConfiguration{
+					EtcdUpgrade: ptr.To(false),
+				},
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: kubeadmapiv1.SchemeGroupVersion.String(),
+					Kind:       constants.UpgradeConfigurationKind,
+				},
+			},
+			want: &kubeadmapi.UpgradeConfiguration{
+				Apply: kubeadmapi.UpgradeApplyConfiguration{
+					CertificateRenewal: ptr.To(false),
+					EtcdUpgrade:        ptr.To(true),
+				},
+				Node: kubeadmapi.UpgradeNodeConfiguration{
+					CertificateRenewal: ptr.To(true),
+					EtcdUpgrade:        ptr.To(false),
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, _ := DefaultedUpgradeConfiguration(tt.cfg, options)
+			if diff := cmp.Diff(got, tt.want, cmpopts.IgnoreFields(kubeadmapi.UpgradeConfiguration{}, "Timeouts")); diff != "" {
+				t.Errorf("DefaultedUpgradeConfiguration returned unexpected diff (-want,+got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestLoadOrDefaultUpgradeConfiguration(t *testing.T) {
+	tmpdir, err := os.MkdirTemp("", "")
+	if err != nil {
+		t.Fatalf("Couldn't create tmpdir: %v", err)
+	}
+	defer func() {
+		if err := os.RemoveAll(tmpdir); err != nil {
+			t.Fatalf("Couldn't remove tmpdir: %v", err)
+		}
+	}()
+	filename := "kubeadmConfig"
+	filePath := filepath.Join(tmpdir, filename)
+	fileContents := dedent.Dedent(`
+				apiVersion: kubeadm.k8s.io/v1beta4
+				kind: UpgradeConfiguration
+			`)
+	err = os.WriteFile(filePath, []byte(fileContents), 0644)
+	if err != nil {
+		t.Fatalf("Couldn't write content to file: %v", err)
+	}
+
+	options := LoadOrDefaultConfigurationOptions{}
+
+	tests := []struct {
+		name    string
+		cfgPath string
+		cfg     *kubeadmapiv1.UpgradeConfiguration
+		want    *kubeadmapi.UpgradeConfiguration
+	}{
+		{
+			name:    "cfgpPath is empty, the result should be obtained from cfg",
+			cfgPath: "",
+			cfg: &kubeadmapiv1.UpgradeConfiguration{
+				Apply: kubeadmapiv1.UpgradeApplyConfiguration{
+					CertificateRenewal: ptr.To(false),
+				},
+				Node: kubeadmapiv1.UpgradeNodeConfiguration{
+					EtcdUpgrade: ptr.To(false),
+				},
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: kubeadmapiv1.SchemeGroupVersion.String(),
+					Kind:       constants.UpgradeConfigurationKind,
+				},
+			},
+			want: &kubeadmapi.UpgradeConfiguration{
+				Apply: kubeadmapi.UpgradeApplyConfiguration{
+					CertificateRenewal: ptr.To(false),
+					EtcdUpgrade:        ptr.To(true),
+				},
+				Node: kubeadmapi.UpgradeNodeConfiguration{
+					CertificateRenewal: ptr.To(true),
+					EtcdUpgrade:        ptr.To(false),
+				},
+			},
+		},
+		{
+			name:    "cfgpPath is not empty, the result should be obtained from the configuration file",
+			cfgPath: filePath,
+			cfg: &kubeadmapiv1.UpgradeConfiguration{
+				Apply: kubeadmapiv1.UpgradeApplyConfiguration{
+					CertificateRenewal: ptr.To(false),
+				},
+				Node: kubeadmapiv1.UpgradeNodeConfiguration{
+					EtcdUpgrade: ptr.To(false),
+				},
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: kubeadmapiv1.SchemeGroupVersion.String(),
+					Kind:       constants.UpgradeConfigurationKind,
+				},
+			},
+			want: &kubeadmapi.UpgradeConfiguration{
+				Apply: kubeadmapi.UpgradeApplyConfiguration{
+					CertificateRenewal: ptr.To(true),
+					EtcdUpgrade:        ptr.To(true),
+				},
+				Node: kubeadmapi.UpgradeNodeConfiguration{
+					CertificateRenewal: ptr.To(true),
+					EtcdUpgrade:        ptr.To(true),
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, _ := LoadOrDefaultUpgradeConfiguration(tt.cfgPath, tt.cfg, options)
+			if diff := cmp.Diff(got, tt.want, cmpopts.IgnoreFields(kubeadmapi.UpgradeConfiguration{}, "Timeouts")); diff != "" {
+				t.Errorf("LoadOrDefaultUpgradeConfiguration returned unexpected diff (-want,+got):\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

kubeadm: increase ut converage for config/upgradeconfiguration

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
