### PR TITLE
Set pd-balanced as default disk type for GCE disks

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/gce/gce_disks.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/gce/gce_disks.go
@@ -53,7 +53,12 @@ const (
 	// DiskTypeStandard the type for standard persistent storage
 	DiskTypeStandard = "pd-standard"
 
-	diskTypeDefault               = DiskTypeStandard
+	// DiskTypeBalanced the type for balanced persistent storage
+	DiskTypeBalanced = "pd-balanced"
+
+	// ref: https://cloud.google.com/kubernetes-engine/docs/how-to/custom-boot-disks#specify
+	DiskTypeDefault = DiskTypeBalanced
+
 	diskTypeURITemplateSingleZone = "%s/zones/%s/diskTypes/%s"   // {gce.projectID}/zones/{disk.Zone}/diskTypes/{disk.Type}"
 	diskTypeURITemplateRegional   = "%s/regions/%s/diskTypes/%s" // {gce.projectID}/regions/{disk.Region}/diskTypes/{disk.Type}"
 	diskTypePersistent            = "PERSISTENT"
@@ -783,10 +788,10 @@ func (g *Cloud) CreateRegionalDisk(
 
 func getDiskType(diskType string) (string, error) {
 	switch diskType {
-	case DiskTypeSSD, DiskTypeStandard:
+	case DiskTypeSSD, DiskTypeStandard, DiskTypeBalanced:
 		return diskType, nil
 	case "":
-		return diskTypeDefault, nil
+		return DiskTypeDefault, nil
 	default:
 		return "", fmt.Errorf("invalid GCE disk type %q", diskType)
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`pd-balanced` is the default persistent storage type across entire Google Compute Engine (GCE).
For GKE it's the default since v1.24.

#### Does this PR introduce a user-facing change?

```release-note
Change the default disk type for the legacy GCE storage provider; the default type is now `pd-balanced`.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [Other doc]: Doc: https://cloud.google.com/kubernetes-engine/docs/how-to/custom-boot-disks#specify
```
