### PR TITLE
Do not send 'failed with error' JWTs to the webhook authenticator

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -1297,6 +1297,8 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 
 	genericfeatures.StorageVersionHash: {Default: true, PreRelease: featuregate.Beta},
 
+	genericfeatures.StrictAuthenticationTokenHandling: {Default: true, PreRelease: featuregate.Beta},
+
 	genericfeatures.StructuredAuthenticationConfiguration: {Default: true, PreRelease: featuregate.Beta},
 
 	genericfeatures.StructuredAuthorizationConfiguration: {Default: true, PreRelease: featuregate.Beta},

--- a/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
+++ b/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
@@ -234,6 +234,14 @@ const (
 	// document.
 	StorageVersionHash featuregate.Feature = "StorageVersionHash"
 
+	// owner: @enj
+	// beta: v1.31
+	//
+	// When enabled, StrictAuthenticationTokenHandling prevents authentication tokens that are
+	// handled and fail authentication via the service account or JWT authenticator from being
+	// sent to any configured webhook authenticator.
+	StrictAuthenticationTokenHandling featuregate.Feature = "StrictAuthenticationTokenHandling"
+
 	// owner: @aramase, @enj, @nabokihms
 	// kep: https://kep.k8s.io/3331
 	// alpha: v1.29
@@ -340,6 +348,8 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	StorageVersionAPI: {Default: false, PreRelease: featuregate.Alpha},
 
 	StorageVersionHash: {Default: true, PreRelease: featuregate.Beta},
+
+	StrictAuthenticationTokenHandling: {Default: true, PreRelease: featuregate.Beta},
 
 	StructuredAuthenticationConfiguration: {Default: true, PreRelease: featuregate.Beta},
 


### PR DESCRIPTION
This change prevents authentication tokens that are handled and fail authentication via the service account or JWT authenticator from being sent to any configured webhook authenticator.  The old behavior of forwarding these tokens to the webhook authenticator can be temporarily restored by disabling the StrictAuthenticationTokenHandling feature gate.

Some important implementation details:

tokenAuthenticators are now split into opaqueTokenAuthenticators and jwtSchemaAuthenticators but the webhook authenticator is modeled as as jwtSchemaAuthenticator because it just needs to come at the end. opaqueTokenAuthenticators and jwtSchemaAuthenticators are unioned and will continue to the next authenticator on error.

Bootstrap tokens are handled before service account tokens (this should be a no-op since they have no schema overlap).

Swap the ordering of the service account authenticators so that new style tokens are attempted first.  The service account authenticators are unioned together because we do not validate that their issuers do not overlap.  This should also be a no-op with a slight performance improvement since legacy tokens are rare in comparison to the new style service account tokens.

jwtSchemaAuthenticators are unioned but will fail on the first error. Validation already guarantees that the JWT issuers of these authenticators never overlap, so the only behavioral change is that if a incoming JWT has an issuer that matches either the service account authenticators or the any JWT authenticators, they will never be sent to the webhook authenticator.  Previously, if all of the prior JWT schema authenticators failed to validate the token, it would be sent to the webhook authenticator so that it could attempt to validate the token.

Note that any non-JWT tokens will continue to be sent to the webhook authenticator, even if they fail with an error on any one of the previous opaqueTokenAuthenticators.

/kind bug
/kind api-change
/sig auth
/triage accepted
/milestone v1.31

```release-note
Authentication tokens that are handled and fail authentication via the service account or JWT authenticator are no longer sent to any configured webhook authenticator.  The old behavior of forwarding these tokens to the webhook authenticator can be temporarily restored by disabling the StrictAuthenticationTokenHandling feature gate.
```

Remaining tasks:

- [ ] Discuss at SIG Auth meeting
- [ ] Get an API review
- [ ] Add integration tests