### PR TITLE
ValidatingAdmissionPolicy: retry policy creation for CRD type checking E2E test

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -786,19 +786,6 @@
   file: test/e2e/apimachinery/validatingadmissionpolicy.go
 - testname: ValidatingAdmissionPolicy
   codename: '[sig-api-machinery] ValidatingAdmissionPolicy [Privileged:ClusterAdmin]
-    should type check a CRD [Conformance]'
-  description: ' The ValidatingAdmissionPolicy should type check a CRD.'
-  release: v1.30
-  file: test/e2e/apimachinery/validatingadmissionpolicy.go
-- testname: ValidatingAdmissionPolicy
-  codename: '[sig-api-machinery] ValidatingAdmissionPolicy [Privileged:ClusterAdmin]
-    should type check validation expressions [Conformance]'
-  description: ' The ValidatingAdmissionPolicy should type check the expressions defined
-    inside policy.'
-  release: v1.30
-  file: test/e2e/apimachinery/validatingadmissionpolicy.go
-- testname: ValidatingAdmissionPolicy
-  codename: '[sig-api-machinery] ValidatingAdmissionPolicy [Privileged:ClusterAdmin]
     should validate against a Deployment [Conformance]'
   description: ' The ValidatingAdmissionPolicy should validate a deployment as the
     expression defined inside the policy.'

--- a/test/e2e/apimachinery/validatingadmissionpolicy.go
+++ b/test/e2e/apimachinery/validatingadmissionpolicy.go
@@ -18,6 +18,8 @@ package apimachinery
 
 import (
 	"context"
+	"fmt"
+	"math/rand/v2"
 	"time"
 
 	"github.com/onsi/ginkgo/v2"
@@ -32,6 +34,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/wait"
+	applyadmissionregistrationv1 "k8s.io/client-go/applyconfigurations/admissionregistration/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/openapi3"
 	"k8s.io/kubernetes/test/e2e/framework"
@@ -356,6 +359,16 @@ var _ = SIGDescribe("ValidatingAdmissionPolicy [Privileged:ClusterAdmin]", func(
 					return false, err
 				}
 				if policy.Status.TypeChecking != nil {
+					// TODO(#123829) Remove once the schema watcher is merged.
+					// If the warnings are empty, touch the policy to retry type checking
+					if len(policy.Status.TypeChecking.ExpressionWarnings) == 0 {
+						applyConfig := applyadmissionregistrationv1.ValidatingAdmissionPolicy(policy.Name).WithLabels(map[string]string{
+							"touched": time.Now().String(),
+							"random":  fmt.Sprintf("%d", rand.Int()),
+						})
+						_, err := client.AdmissionregistrationV1().ValidatingAdmissionPolicies().Apply(ctx, applyConfig, metav1.ApplyOptions{})
+						return false, err
+					}
 					return true, nil
 				}
 				return false, nil

--- a/test/e2e/apimachinery/validatingadmissionpolicy.go
+++ b/test/e2e/apimachinery/validatingadmissionpolicy.go
@@ -133,7 +133,7 @@ var _ = SIGDescribe("ValidatingAdmissionPolicy [Privileged:ClusterAdmin]", func(
 	   Description:
 	   The ValidatingAdmissionPolicy should type check the expressions defined inside policy.
 	*/
-	framework.ConformanceIt("should type check validation expressions", func(ctx context.Context) {
+	framework.It("should type check validation expressions", func(ctx context.Context) {
 		var policy *admissionregistrationv1.ValidatingAdmissionPolicy
 		ginkgo.By("creating the policy with correct types", func() {
 			policy = newValidatingAdmissionPolicyBuilder(f.UniqueName+".correct-policy.example.com").
@@ -283,7 +283,7 @@ var _ = SIGDescribe("ValidatingAdmissionPolicy [Privileged:ClusterAdmin]", func(
 	   Description:
 	   The ValidatingAdmissionPolicy should type check a CRD.
 	*/
-	framework.ConformanceIt("should type check a CRD", func(ctx context.Context) {
+	framework.It("should type check a CRD", func(ctx context.Context) {
 		crd := crontabExampleCRD()
 		crd.Spec.Group = "stable." + f.UniqueName
 		crd.Name = crd.Spec.Names.Plural + "." + crd.Spec.Group


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind flake
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR modifies the test case of type checking a policy that refers to a CRD. Right now, to retry a type checking, the policy must be either mutated or deleted and recreated. This PR touches the policy to trigger a re-check.

This PR will be obsolete once https://github.com/kubernetes/kubernetes/pull/123350 is merged.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #123829

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
