### PR TITLE
Improve the efficiency of synchronizing Pod status

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -617,7 +617,7 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 	klet.mirrorPodClient = kubepod.NewBasicMirrorClient(klet.kubeClient, string(nodeName), nodeLister)
 	klet.podManager = kubepod.NewBasicPodManager()
 
-	klet.statusManager = status.NewManager(klet.kubeClient, klet.podManager, klet, kubeDeps.PodStartupLatencyTracker, klet.getRootDir())
+	klet.statusManager = status.NewManager(klet.kubeClient, klet.podManager, klet, kubeDeps.PodStartupLatencyTracker, klet.getRootDir(), string(nodeName))
 
 	klet.resourceAnalyzer = serverstats.NewResourceAnalyzer(klet, kubeCfg.VolumeStatsAggPeriod.Duration, kubeDeps.Recorder)
 

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -266,7 +266,7 @@ func newTestKubeletWithImageList(
 	kubelet.mirrorPodClient = fakeMirrorClient
 	kubelet.podManager = kubepod.NewBasicPodManager()
 	podStartupLatencyTracker := kubeletutil.NewPodStartupLatencyTracker()
-	kubelet.statusManager = status.NewManager(fakeKubeClient, kubelet.podManager, &statustest.FakePodDeletionSafetyProvider{}, podStartupLatencyTracker, kubelet.getRootDir())
+	kubelet.statusManager = status.NewManager(fakeKubeClient, kubelet.podManager, &statustest.FakePodDeletionSafetyProvider{}, podStartupLatencyTracker, kubelet.getRootDir(), string(kubelet.nodeName))
 	kubelet.nodeStartupLatencyTracker = kubeletutil.NewNodeStartupLatencyTracker()
 
 	kubelet.containerRuntime = fakeRuntime

--- a/pkg/kubelet/prober/common_test.go
+++ b/pkg/kubelet/prober/common_test.go
@@ -117,7 +117,7 @@ func newTestManager() *manager {
 		testRootDir = tempDir
 	}
 	m := NewManager(
-		status.NewManager(&fake.Clientset{}, podManager, &statustest.FakePodDeletionSafetyProvider{}, podStartupLatencyTracker, testRootDir),
+		status.NewManager(&fake.Clientset{}, podManager, &statustest.FakePodDeletionSafetyProvider{}, podStartupLatencyTracker, testRootDir, ""),
 		results.NewManager(),
 		results.NewManager(),
 		results.NewManager(),

--- a/pkg/kubelet/prober/scale_test.go
+++ b/pkg/kubelet/prober/scale_test.go
@@ -90,7 +90,7 @@ func TestTCPPortExhaustion(t *testing.T) {
 			podManager := kubepod.NewBasicPodManager()
 			podStartupLatencyTracker := kubeletutil.NewPodStartupLatencyTracker()
 			m := NewManager(
-				status.NewManager(&fake.Clientset{}, podManager, &statustest.FakePodDeletionSafetyProvider{}, podStartupLatencyTracker, testRootDir),
+				status.NewManager(&fake.Clientset{}, podManager, &statustest.FakePodDeletionSafetyProvider{}, podStartupLatencyTracker, testRootDir, ""),
 				results.NewManager(),
 				results.NewManager(),
 				results.NewManager(),

--- a/pkg/kubelet/prober/worker_test.go
+++ b/pkg/kubelet/prober/worker_test.go
@@ -159,7 +159,7 @@ func TestDoProbe(t *testing.T) {
 			} else {
 				testRootDir = tempDir
 			}
-			m.statusManager = status.NewManager(&fake.Clientset{}, kubepod.NewBasicPodManager(), &statustest.FakePodDeletionSafetyProvider{}, kubeletutil.NewPodStartupLatencyTracker(), testRootDir)
+			m.statusManager = status.NewManager(&fake.Clientset{}, kubepod.NewBasicPodManager(), &statustest.FakePodDeletionSafetyProvider{}, kubeletutil.NewPodStartupLatencyTracker(), testRootDir, "")
 			resultsManager(m, probeType).Remove(testContainerID)
 		}
 	}

--- a/pkg/kubelet/runonce_test.go
+++ b/pkg/kubelet/runonce_test.go
@@ -88,7 +88,7 @@ func TestRunOnce(t *testing.T) {
 		recorder:         &record.FakeRecorder{},
 		cadvisor:         cadvisor,
 		nodeLister:       testNodeLister{},
-		statusManager:    status.NewManager(nil, podManager, &statustest.FakePodDeletionSafetyProvider{}, podStartupLatencyTracker, basePath),
+		statusManager:    status.NewManager(nil, podManager, &statustest.FakePodDeletionSafetyProvider{}, podStartupLatencyTracker, basePath, ""),
 		mirrorPodClient:  podtest.NewFakeMirrorClient(),
 		podManager:       podManager,
 		podWorkers:       &fakePodWorkers{},

--- a/pkg/kubelet/status/status_manager.go
+++ b/pkg/kubelet/status/status_manager.go
@@ -32,6 +32,7 @@ import (
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
@@ -48,6 +49,9 @@ import (
 
 // podStatusManagerStateFile is the file name where status manager stores its state
 const podStatusManagerStateFile = "pod_status_manager_state"
+
+// defaultMinListPodCount is the minimum number of Pods, and all of these Pods need to update status, default to 50.
+const defaultMinListPodCount = 50
 
 // A wrapper around v1.PodStatus that includes a version to enforce that stale pod statuses are
 // not sent to the API server.
@@ -85,6 +89,8 @@ type manager struct {
 	state state.State
 	// stateFileDirectory holds the directory where the state file for checkpoints is held.
 	stateFileDirectory string
+
+	nodeName string
 }
 
 // PodManager is the subset of methods the manager needs to observe the actual state of the kubelet.
@@ -159,7 +165,8 @@ type Manager interface {
 const syncPeriod = 10 * time.Second
 
 // NewManager returns a functional Manager.
-func NewManager(kubeClient clientset.Interface, podManager PodManager, podDeletionSafety PodDeletionSafetyProvider, podStartupLatencyHelper PodStartupLatencyStateHelper, stateFileDirectory string) Manager {
+func NewManager(kubeClient clientset.Interface, podManager PodManager, podDeletionSafety PodDeletionSafetyProvider,
+	podStartupLatencyHelper PodStartupLatencyStateHelper, stateFileDirectory string, nodeName string) Manager {
 	return &manager{
 		kubeClient:              kubeClient,
 		podManager:              podManager,
@@ -169,6 +176,7 @@ func NewManager(kubeClient clientset.Interface, podManager PodManager, podDeleti
 		podDeletionSafety:       podDeletionSafety,
 		podStartupLatencyHelper: podStartupLatencyHelper,
 		stateFileDirectory:      stateFileDirectory,
+		nodeName:                nodeName,
 	}
 }
 
@@ -829,32 +837,58 @@ func (m *manager) syncBatch(all bool) int {
 		}
 	}()
 
+	podInfos := make(map[string]v1.Pod)
+	updatedStatusesCount := len(updatedStatuses)
+	if m.nodeName != "" && updatedStatusesCount >= defaultMinListPodCount {
+		podOpts := metav1.ListOptions{FieldSelector: fields.OneTermEqualSelector("spec.nodeName", m.nodeName).String()}
+		pods, err := m.kubeClient.CoreV1().Pods(metav1.NamespaceAll).List(context.TODO(), podOpts)
+		if err != nil {
+			klog.InfoS("Failed to list pods for node", "node", m.nodeName, "err", err)
+		} else if pods != nil && len(pods.Items) > 0 {
+			for index := range pods.Items {
+				podInfo := pods.Items[index]
+				key := fmt.Sprintf("%s_%s", podInfo.Name, podInfo.Namespace)
+				podInfos[key] = podInfo
+			}
+		}
+	}
+
+	// TODO: use ParallelizeUntil to do same syncPod
 	for _, update := range updatedStatuses {
 		klog.V(5).InfoS("Sync pod status", "podUID", update.podUID, "statusUID", update.statusUID, "version", update.status.version)
-		m.syncPod(update.podUID, update.status)
+		key := fmt.Sprintf("%s_%s", update.status.podName, update.status.podNamespace)
+		podInfo, ok := podInfos[key]
+		if ok {
+			m.syncPod(update.podUID, update.status, &podInfo)
+		} else {
+			m.syncPod(update.podUID, update.status, nil)
+		}
 	}
 
 	return len(updatedStatuses)
 }
 
 // syncPod syncs the given status with the API server. The caller must not hold the status lock.
-func (m *manager) syncPod(uid types.UID, status versionedPodStatus) {
-	// TODO: make me easier to express from client code
-	pod, err := m.kubeClient.CoreV1().Pods(status.podNamespace).Get(context.TODO(), status.podName, metav1.GetOptions{})
-	if errors.IsNotFound(err) {
-		klog.V(3).InfoS("Pod does not exist on the server",
-			"podUID", uid,
-			"pod", klog.KRef(status.podNamespace, status.podName))
-		// If the Pod is deleted the status will be cleared in
-		// RemoveOrphanedStatuses, so we just ignore the update here.
-		return
-	}
-	if err != nil {
-		klog.InfoS("Failed to get status for pod",
-			"podUID", uid,
-			"pod", klog.KRef(status.podNamespace, status.podName),
-			"err", err)
-		return
+func (m *manager) syncPod(uid types.UID, status versionedPodStatus, pod *v1.Pod) {
+	if pod == nil {
+		// TODO: make me easier to express from client code
+		var err error
+		pod, err = m.kubeClient.CoreV1().Pods(status.podNamespace).Get(context.TODO(), status.podName, metav1.GetOptions{})
+		if errors.IsNotFound(err) {
+			klog.V(3).InfoS("Pod does not exist on the server",
+				"podUID", uid,
+				"pod", klog.KRef(status.podNamespace, status.podName))
+			// If the Pod is deleted the status will be cleared in
+			// RemoveOrphanedStatuses, so we just ignore the update here.
+			return
+		}
+		if err != nil {
+			klog.InfoS("Failed to get status for pod",
+				"podUID", uid,
+				"pod", klog.KRef(status.podNamespace, status.podName),
+				"err", err)
+			return
+		}
 	}
 
 	translatedUID := m.podManager.TranslatePodUID(pod.UID)

--- a/pkg/kubelet/status/status_manager_test.go
+++ b/pkg/kubelet/status/status_manager_test.go
@@ -99,7 +99,7 @@ func newTestManager(kubeClient clientset.Interface) *manager {
 	} else {
 		testRootDir = tempDir
 	}
-	return NewManager(kubeClient, podManager, &statustest.FakePodDeletionSafetyProvider{}, podStartupLatencyTracker, testRootDir).(*manager)
+	return NewManager(kubeClient, podManager, &statustest.FakePodDeletionSafetyProvider{}, podStartupLatencyTracker, testRootDir, "").(*manager)
 }
 
 func generateRandomMessage() string {
@@ -1035,7 +1035,7 @@ func TestTerminatePod_DefaultUnknownStatus(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			podManager := kubepod.NewBasicPodManager()
 			podStartupLatencyTracker := util.NewPodStartupLatencyTracker()
-			syncer := NewManager(&fake.Clientset{}, podManager, &statustest.FakePodDeletionSafetyProvider{}, podStartupLatencyTracker, "").(*manager)
+			syncer := NewManager(&fake.Clientset{}, podManager, &statustest.FakePodDeletionSafetyProvider{}, podStartupLatencyTracker, "", "").(*manager)
 
 			original := tc.pod.DeepCopy()
 			syncer.SetPodStatus(original, original.Status)
@@ -1122,7 +1122,7 @@ func TestTerminatePod_EnsurePodPhaseIsTerminal(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			podManager := kubepod.NewBasicPodManager()
 			podStartupLatencyTracker := util.NewPodStartupLatencyTracker()
-			syncer := NewManager(&fake.Clientset{}, podManager, &statustest.FakePodDeletionSafetyProvider{}, podStartupLatencyTracker, "").(*manager)
+			syncer := NewManager(&fake.Clientset{}, podManager, &statustest.FakePodDeletionSafetyProvider{}, podStartupLatencyTracker, "", "").(*manager)
 
 			pod := getTestPod()
 			pod.Status = tc.status


### PR DESCRIPTION
Use a single List api instead of multiple Get api. 
About: #123875

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug

-->

#### What this PR does / why we need it:
My k8s node is a big machine(500C CPU & 2000GB Memory), the maxPods of kubelet could be set to 200+.
When I delete 200+ pods or create 200+ pods, the synchronization of Pod status by the kubelet becomes too slow(about 230s).
Making a large number of GET API calls can indeed increase the load on the API server.
