### PR TITLE
Handle containerd "CRIU not found" error message

### DIFF
--- a/test/e2e_node/checkpoint_container.go
+++ b/test/e2e_node/checkpoint_container.go
@@ -217,6 +217,9 @@ var _ = SIGDescribe("Checkpoint Container", nodefeature.CheckpointContainer, fun
 			// or
 			// '(rpc error: code = Unknown desc = checkpoint/restore support not available)'
 			// if the container engine explicitly disabled the checkpoint/restore support
+			// or
+			// '(rpc error: code = Unknown desc = CRIU binary not found or too old (<31600). Failed to checkpoint container'
+			// if the CRIU binary was not found if it is too old
 			if (int(statusError.ErrStatus.Code)) == http.StatusInternalServerError {
 				if strings.Contains(
 					statusError.ErrStatus.Message,
@@ -237,6 +240,13 @@ var _ = SIGDescribe("Checkpoint Container", nodefeature.CheckpointContainer, fun
 					"(rpc error: code = Unknown desc = checkpoint/restore support not available)",
 				) {
 					ginkgo.Skip("Container engine does not implement 'CheckpointContainer'")
+					return
+				}
+				if strings.Contains(
+					statusError.ErrStatus.Message,
+					"(rpc error: code = Unknown desc = CRIU binary not found or too old (<31600). Failed to checkpoint container",
+				) {
+					ginkgo.Skip("Container engine reports missing or too old CRIU binary")
 					return
 				}
 			}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/kind failing-test

#### What this PR does / why we need it:

During the PR to get "Forensic Container Checkpointing" enabled in containerd the decision was made to not correctly report if containerd cannot find the CRIU binary. The reason was that the e2e_node checkpoint test did not understand the error message.

The e2e_node checkpoint test is skipped if the container runtime (CRI-O or containerd) does not enable checkpoint support of if checkpoint support is not implemented.

This commit adds another reason to skip a check. If the underlying OS which is used to test "Forensic Container Checkpointing" in combination with containerd or CRI-O is missing the CRIU binary.

This was encountered on Google's Container-Optimized OS (COS) based tests where CRIU was not installed.

With this change merged it is possible for containerd to return the correct error message without breaking Kubernetes e2e tests.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
