### PR TITLE
apiserver/storage/cacher: decrease the running time of tests in the cacher package.

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/testing/watcher_tests.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/testing/watcher_tests.go
@@ -1481,7 +1481,6 @@ func RunWatchSemantics(ctx context.Context, t *testing.T, store storage.Interfac
 			// make sure we only get initial events
 			testCheckResultsInStrictOrder(t, w, scenario.expectedInitialEvents(createdPods))
 			testCheckResultsInStrictOrder(t, w, scenario.expectedInitialEventsBookmark(createdPods))
-			testCheckNoMoreResults(t, w)
 
 			createdPods = []*example.Pod{}
 			// add a pod that is greater than the storage's RV when the watch was started


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
It turns out that kube has a custom timeout for tests of 3 minutes. The tests in the cacher package are utilizing nearly the entire time and are being terminated, resulting in failing jobs (like https://github.com/kubernetes/kubernetes/issues/123850).

Before the change, the TestWatchSemantics took ~43s to run. With this simple change, it now takes ~18s.

When we created the tests, we didn't measure the running time and assumed that waiting 1 second on a watch channel
to make sure no more events are received was sufficient.
This PR decreases the waiting time to 300 milliseconds.
Modern computers can perform many tasks within that time.
In addition to that, the tests are serial in nature, meaning that there is no other
actor that could add items to the database, which could result in receiving new items.

After the change the total running time decreased by 17%.
Before the tests needed ~176s after they need ~146s.
The changes also improved TestWatchSemanticInitialEventsExtended.

To sum up:

Before:
```
go test -race -cover -run TestWatchSemantics
ok  	k8s.io/apiserver/pkg/storage/cacher	43.588s

go test -race -cover -run TestWatchSemanticInitialEventsExtended
ok  	k8s.io/apiserver/pkg/storage/cacher	5.331s

go test -race -cover
ok  	k8s.io/apiserver/pkg/storage/cacher	176.404s
```

After:
```
go test -race -cover -run TestWatchSemantics
ok  	k8s.io/apiserver/pkg/storage/cacher	17.958s

go test -race -cover -run TestWatchSemanticInitialEventsExtended
ok  	k8s.io/apiserver/pkg/storage/cacher	4.767

go test -race -cover
ok  	k8s.io/apiserver/pkg/storage/cacher	146.712s
```

xref: https://github.com/kubernetes/kubernetes/issues/123685
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
