### PR TITLE
kube_codegen: expose applyconfig-openapi-schema flag for client generatio

### DIFF
--- a/staging/src/k8s.io/code-generator/kube_codegen.sh
+++ b/staging/src/k8s.io/code-generator/kube_codegen.sh
@@ -443,6 +443,7 @@ function kube::codegen::gen_client() {
     local applyconfig="false"
     local applyconfig_subdir="applyconfiguration"
     local applyconfig_external=""
+    local applyconfig_openapi_schema=""
     local watchable="false"
     local listers_subdir="listers"
     local informers_subdir="informers"
@@ -486,6 +487,10 @@ function kube::codegen::gen_client() {
                 ;;
             "--applyconfig-externals")
                 applyconfig_external="$2"
+                shift 2
+                ;;
+            "--applyconfig-openapi-schema")
+                applyconfig_openapi_schema="$2"
                 shift 2
                 ;;
             "--with-watch")
@@ -594,6 +599,7 @@ function kube::codegen::gen_client() {
             --output-dir "${out_dir}/${applyconfig_subdir}" \
             --output-pkg "${applyconfig_pkg}" \
             --external-applyconfigurations "${applyconfig_external}" \
+            --openapi-schema "${applyconfig_openapi_schema}" \
             "${input_pkgs[@]}"
     fi
 


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
This PR exposes `--applyconfig-openapi-schema` flag which allows overriding the openapi-schema in applyconfiguration-gen.

#### Special notes for your reviewer:
/assign @thockin 
/cc @JoelSpeed 

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
