### PR TITLE
[WIP] repro watcher issue with services

### DIFF
--- a/test/integration/service/service_test.go
+++ b/test/integration/service/service_test.go
@@ -18,6 +18,7 @@ package service
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -25,12 +26,19 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	utilrand "k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/informers"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
+	watchtools "k8s.io/client-go/tools/watch"
+	"k8s.io/client-go/util/retry"
 	kubeapiservertesting "k8s.io/kubernetes/cmd/kube-apiserver/app/testing"
 	"k8s.io/kubernetes/test/integration/framework"
+	"k8s.io/utils/ptr"
 )
 
 // Test_ExternalNameServiceStopsDefaultingInternalTrafficPolicy tests that Services no longer default
@@ -405,4 +413,247 @@ func Test_ServiceClusterIPSelector(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error waiting for test service with ClusterIP: %v", err)
 	}
+}
+
+// Repro https://github.com/kubernetes/kubernetes/issues/123853
+func Test_ServiceWatchUntil(t *testing.T) {
+	svcReadyTimeout := 1 * time.Minute
+
+	server := kubeapiservertesting.StartTestServerOrDie(t, nil, nil, framework.SharedEtcd())
+	defer server.TearDownFn()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	client, err := clientset.NewForConfig(server.ClientConfig)
+	if err != nil {
+		t.Fatalf("Error creating clientset: %v", err)
+	}
+
+	ns := framework.CreateNamespaceOrDie(client, "test-service-watchuntil", t)
+	defer framework.DeleteNamespaceOrDie(client, ns, t)
+
+	testSvcName := "test-service-" + utilrand.String(5)
+	testSvcLabels := map[string]string{"test-service-static": "true"}
+	testSvcLabelsFlat := "test-service-static=true"
+
+	w := &cache.ListWatch{
+		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			options.LabelSelector = testSvcLabelsFlat
+			return client.CoreV1().Services(ns.Name).Watch(ctx, options)
+		},
+	}
+
+	svcList, err := client.CoreV1().Services("").List(ctx, metav1.ListOptions{LabelSelector: testSvcLabelsFlat})
+	if err != nil {
+		t.Fatalf("failed to list Services: %v", err)
+	}
+	// create  service
+	service := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   testSvcName,
+			Labels: testSvcLabels,
+		},
+		Spec: corev1.ServiceSpec{
+			Type: "LoadBalancer",
+			Ports: []corev1.ServicePort{{
+				Name:       "http",
+				Protocol:   corev1.ProtocolTCP,
+				Port:       int32(80),
+				TargetPort: intstr.FromInt32(80),
+			}},
+			LoadBalancerClass: ptr.To[string]("example.com/internal-vip"),
+		},
+	}
+	_, err = client.CoreV1().Services(ns.Name).Create(ctx, service, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Error creating test service: %v", err)
+	}
+
+	ctxUntil, cancel := context.WithTimeout(ctx, svcReadyTimeout)
+	defer cancel()
+	_, err = watchtools.Until(ctxUntil, svcList.ResourceVersion, w, func(event watch.Event) (bool, error) {
+		if svc, ok := event.Object.(*corev1.Service); ok {
+			found := svc.ObjectMeta.Name == service.ObjectMeta.Name &&
+				svc.ObjectMeta.Namespace == ns.Name &&
+				svc.Labels["test-service-static"] == "true"
+			if !found {
+				t.Logf("observed Service %v in namespace %v with labels: %v & ports %v", svc.ObjectMeta.Name, svc.ObjectMeta.Namespace, svc.Labels, svc.Spec.Ports)
+				return false, nil
+			}
+			t.Logf("Found Service %v in namespace %v with labels: %v & ports %v", svc.ObjectMeta.Name, svc.ObjectMeta.Namespace, svc.Labels, svc.Spec.Ports)
+			return found, nil
+		}
+		t.Logf("Observed event: %+v", event.Object)
+		return false, nil
+	})
+	if err != nil {
+		t.Fatalf("Error service not found: %v", err)
+	}
+
+	t.Log("patching the ServiceStatus")
+	lbStatus := corev1.LoadBalancerStatus{
+		Ingress: []corev1.LoadBalancerIngress{{IP: "203.0.113.1"}},
+	}
+	lbStatusJSON, err := json.Marshal(lbStatus)
+	if err != nil {
+		t.Fatalf("Error marshalling status: %v", err)
+	}
+	_, err = client.CoreV1().Services(ns.Name).Patch(ctx, testSvcName, types.MergePatchType,
+		[]byte(`{"metadata":{"annotations":{"patchedstatus":"true"}},"status":{"loadBalancer":`+string(lbStatusJSON)+`}}`),
+		metav1.PatchOptions{}, "status")
+	if err != nil {
+		t.Fatalf("Could not patch service status: %v", err)
+	}
+
+	t.Log("watching for the Service to be patched")
+	ctxUntil, cancel = context.WithTimeout(ctx, svcReadyTimeout)
+	defer cancel()
+
+	_, err = watchtools.Until(ctxUntil, svcList.ResourceVersion, w, func(event watch.Event) (bool, error) {
+		if svc, ok := event.Object.(*corev1.Service); ok {
+			found := svc.ObjectMeta.Name == service.ObjectMeta.Name &&
+				svc.ObjectMeta.Namespace == ns.Name &&
+				svc.Annotations["patchedstatus"] == "true"
+			if !found {
+				t.Logf("observed Service %v in namespace %v with annotations: %v & LoadBalancer: %v", svc.ObjectMeta.Name, svc.ObjectMeta.Namespace, svc.Annotations, svc.Status.LoadBalancer)
+				return false, nil
+			}
+			t.Logf("Found Service %v in namespace %v with annotations: %v & LoadBalancer: %v", svc.ObjectMeta.Name, svc.ObjectMeta.Namespace, svc.Annotations, svc.Status.LoadBalancer)
+			return found, nil
+		}
+		t.Logf("Observed event: %+v", event.Object)
+		return false, nil
+	})
+	if err != nil {
+		t.Fatalf("failed to locate Service %v in namespace %v", service.ObjectMeta.Name, ns)
+	}
+	t.Logf("Service %s has service status patched", testSvcName)
+
+	t.Log("updating the ServiceStatus")
+
+	var statusToUpdate, updatedStatus *corev1.Service
+	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		statusToUpdate, err = client.CoreV1().Services(ns.Name).Get(ctx, testSvcName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		statusToUpdate.Status.Conditions = append(statusToUpdate.Status.Conditions, metav1.Condition{
+			Type:    "StatusUpdate",
+			Status:  metav1.ConditionTrue,
+			Reason:  "E2E",
+			Message: "Set from e2e test",
+		})
+
+		updatedStatus, err = client.CoreV1().Services(ns.Name).UpdateStatus(ctx, statusToUpdate, metav1.UpdateOptions{})
+		return err
+	})
+	if err != nil {
+		t.Fatalf("\n\n Failed to UpdateStatus. %v\n\n", err)
+	}
+	t.Logf("updatedStatus.Conditions: %#v", updatedStatus.Status.Conditions)
+
+	t.Log("watching for the Service to be updated")
+	ctxUntil, cancel = context.WithTimeout(ctx, svcReadyTimeout)
+	defer cancel()
+	_, err = watchtools.Until(ctxUntil, svcList.ResourceVersion, w, func(event watch.Event) (bool, error) {
+		if svc, ok := event.Object.(*corev1.Service); ok {
+			found := svc.ObjectMeta.Name == service.ObjectMeta.Name &&
+				svc.ObjectMeta.Namespace == ns.Name &&
+				svc.Annotations["patchedstatus"] == "true"
+			if !found {
+				t.Logf("Observed Service %v in namespace %v with annotations: %v & Conditions: %v", svc.ObjectMeta.Name, svc.ObjectMeta.Namespace, svc.Annotations, svc.Status.LoadBalancer)
+				return false, nil
+			}
+			for _, cond := range svc.Status.Conditions {
+				if cond.Type == "StatusUpdate" &&
+					cond.Reason == "E2E" &&
+					cond.Message == "Set from e2e test" {
+					t.Logf("Found Service %v in namespace %v with annotations: %v & Conditions: %v", svc.ObjectMeta.Name, svc.ObjectMeta.Namespace, svc.Annotations, svc.Status.Conditions)
+					return found, nil
+				} else {
+					t.Logf("Observed Service %v in namespace %v with annotations: %v & Conditions: %v", svc.ObjectMeta.Name, svc.ObjectMeta.Namespace, svc.Annotations, svc.Status.LoadBalancer)
+					return false, nil
+				}
+			}
+		}
+		t.Logf("Observed event: %+v", event.Object)
+		return false, nil
+	})
+	if err != nil {
+		t.Fatalf("failed to locate Service %v in namespace %v", service.ObjectMeta.Name, ns)
+	}
+	t.Logf("Service %s has service status updated", testSvcName)
+
+	t.Log("patching the service")
+	servicePatchPayload, err := json.Marshal(corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				"test-service": "patched",
+			},
+		},
+	})
+
+	_, err = client.CoreV1().Services(ns.Name).Patch(ctx, testSvcName, types.StrategicMergePatchType, []byte(servicePatchPayload), metav1.PatchOptions{})
+	if err != nil {
+		t.Fatalf("failed to patch service. %v", err)
+	}
+
+	t.Log("watching for the Service to be patched")
+	ctxUntil, cancel = context.WithTimeout(ctx, svcReadyTimeout)
+	defer cancel()
+	_, err = watchtools.Until(ctxUntil, svcList.ResourceVersion, w, func(event watch.Event) (bool, error) {
+		if svc, ok := event.Object.(*corev1.Service); ok {
+			found := svc.ObjectMeta.Name == service.ObjectMeta.Name &&
+				svc.ObjectMeta.Namespace == ns.Name &&
+				svc.Labels["test-service"] == "patched"
+			if !found {
+				t.Logf("observed Service %v in namespace %v with labels: %v", svc.ObjectMeta.Name, svc.ObjectMeta.Namespace, svc.Labels)
+				return false, nil
+			}
+			t.Logf("Found Service %v in namespace %v with labels: %v", svc.ObjectMeta.Name, svc.ObjectMeta.Namespace, svc.Labels)
+			return found, nil
+		}
+		t.Logf("Observed event: %+v", event.Object)
+		return false, nil
+	})
+	if err != nil {
+		t.Fatalf("failed to locate Service %v in namespace %v", service.ObjectMeta.Name, ns)
+	}
+
+	t.Logf("Service %s patched", testSvcName)
+
+	t.Log("deleting the service")
+	err = client.CoreV1().Services(ns.Name).Delete(ctx, testSvcName, metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("failed to delete the Service. %v", err)
+	}
+
+	t.Log("watching for the Service to be deleted")
+	ctxUntil, cancel = context.WithTimeout(ctx, svcReadyTimeout)
+	defer cancel()
+	_, err = watchtools.Until(ctxUntil, svcList.ResourceVersion, w, func(event watch.Event) (bool, error) {
+		switch event.Type {
+		case watch.Deleted:
+			if svc, ok := event.Object.(*corev1.Service); ok {
+				found := svc.ObjectMeta.Name == service.ObjectMeta.Name &&
+					svc.ObjectMeta.Namespace == ns.Name &&
+					svc.Labels["test-service-static"] == "true"
+				if !found {
+					t.Logf("observed Service %v in namespace %v with labels: %v & annotations: %v", svc.ObjectMeta.Name, svc.ObjectMeta.Namespace, svc.Labels, svc.Annotations)
+					return false, nil
+				}
+				t.Logf("Found Service %v in namespace %v with labels: %v & annotations: %v", svc.ObjectMeta.Name, svc.ObjectMeta.Namespace, svc.Labels, svc.Annotations)
+				return found, nil
+			}
+		default:
+			t.Logf("Observed event: %+v", event.Type)
+		}
+		return false, nil
+	})
+	if err != nil {
+		t.Fatalf("failed to delete Service %v in namespace %v", service.ObjectMeta.Name, ns)
+	}
+	t.Logf("Service %s deleted", testSvcName)
 }


### PR DESCRIPTION
/kind flake
```release-note
NONE
```

Fixes: #123557 

```
go test -timeout 30s -run ^Test_ServiceWatchUntil$ k8s.io/kubernetes/test/integration/service -v -count 1 -c
stress ./service.test -test.run ^Test_ServiceWatchUntil$
```

It fails quickly skipping events, see the test has a timeout for the watchers, defaults to one minute, if you set to 10 seconds the tests start failing soon

Without my PR in https://github.com/kubernetes/kubernetes/pull/122541 does not flake

```
stress ./service.test -test.run ^Test_ServiceWatchUntil$ -test.failfast
5s: 42 runs so far, 0 failures
10s: 90 runs so far, 0 failures
15s: 141 runs so far, 0 failures
20s: 196 runs so far, 0 failures
25s: 255 runs so far, 0 failures
30s: 316 runs so far, 0 failures
35s: 373 runs so far, 0 failures
40s: 431 runs so far, 0 failures
45s: 488 runs so far, 0 failures
50s: 549 runs so far, 0 failures
55s: 607 runs so far, 0 failures
1m0s: 662 runs so far, 0 failures
1m5s: 722 runs so far, 0 failures
1m10s: 779 runs so far, 0 failures
```