### PR TITLE
oomkiller_linux_test: fix warnings

### DIFF
--- a/test/e2e_node/oomkiller_linux_test.go
+++ b/test/e2e_node/oomkiller_linux_test.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/onsi/ginkgo/v2"
 	libcontainercgroups "github.com/opencontainers/runc/libcontainer/cgroups"
+	"k8s.io/utils/ptr"
 )
 
 type testCase struct {
@@ -211,6 +212,16 @@ func getOOMTargetContainer(name string) v1.Container {
 				v1.ResourceMemory: resource.MustParse("15Mi"),
 			},
 		},
+		SecurityContext: &v1.SecurityContext{
+			SeccompProfile: &v1.SeccompProfile{
+				Type: v1.SeccompProfileTypeRuntimeDefault,
+			},
+			AllowPrivilegeEscalation: ptr.To(false),
+			RunAsUser:                ptr.To[int64](999),
+			RunAsGroup:               ptr.To[int64](999),
+			RunAsNonRoot:             ptr.To(true),
+			Capabilities:             &v1.Capabilities{Drop: []v1.Capability{"ALL"}},
+		},
 	}
 }
 
@@ -234,6 +245,16 @@ func getOOMTargetContainerMultiProcess(name string) v1.Container {
 				v1.ResourceMemory: resource.MustParse("15Mi"),
 			},
 		},
+		SecurityContext: &v1.SecurityContext{
+			SeccompProfile: &v1.SeccompProfile{
+				Type: v1.SeccompProfileTypeRuntimeDefault,
+			},
+			AllowPrivilegeEscalation: ptr.To(false),
+			RunAsUser:                ptr.To[int64](999),
+			RunAsGroup:               ptr.To[int64](999),
+			RunAsNonRoot:             ptr.To(true),
+			Capabilities:             &v1.Capabilities{Drop: []v1.Capability{"ALL"}},
+		},
 	}
 }
 
@@ -248,6 +269,16 @@ func getOOMTargetContainerWithoutLimit(name string) v1.Container {
 			"-c",
 			// use the dd tool to attempt to allocate huge block of memory which exceeds the node allocatable
 			"sleep 5 && dd if=/dev/zero of=/dev/null iflag=fullblock count=10 bs=10G",
+		},
+		SecurityContext: &v1.SecurityContext{
+			SeccompProfile: &v1.SeccompProfile{
+				Type: v1.SeccompProfileTypeRuntimeDefault,
+			},
+			AllowPrivilegeEscalation: ptr.To(false),
+			RunAsUser:                ptr.To[int64](999),
+			RunAsGroup:               ptr.To[int64](999),
+			RunAsNonRoot:             ptr.To(true),
+			Capabilities:             &v1.Capabilities{Drop: []v1.Capability{"ALL"}},
 		},
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind failing-test
/kind flake

#### What this PR does / why we need it:

Checking https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-cgroupv1-containerd-node-arm64-e2e-serial-ec2-eks/1767568635812909056 , theory to be tested is that perhaps test fails due to warning message before the failed test

`W0312 16:26:24.831637    4727 warnings.go:70] would violate PodSecurity "restricted:latest": allowPrivilegeEscalation != false (container "oomkill-nodeallocatable-container" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container "oomkill-nodeallocatable-container" must set securityContext.capabilities.drop=["ALL"]), runAsNonRoot != true (pod or container "oomkill-nodeallocatable-container" must set securityContext.runAsNonRoot=true), seccompProfile (pod or container "oomkill-nodeallocatable-container" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
`
This commit set in PodSpec according to satisfy above recommendations

#### Which issue(s) this PR fixes:

Attempt to fix failing OOMKiller for pod using more memory than node allocatable [LinuxOnly] [Serial] failing ( Failed waiting for pod to terminate, nodeallocatable-oomkiller-test-831/oomkill-nodeallocatable-pod )

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
