### PR TITLE
Fix StatefulSet MaxUnavailable with MinReadySeconds, and add necessary e2e tests

### DIFF
--- a/pkg/controller/statefulset/stateful_set_control.go
+++ b/pkg/controller/statefulset/stateful_set_control.go
@@ -759,7 +759,7 @@ func updateStatefulSetAfterInvariantEstablished(
 	// those pods and count the successful deletions. Update the status with the correct number of deletions.
 	unavailablePods := 0
 	for target := len(replicas) - 1; target >= 0; target-- {
-		if !isHealthy(replicas[target]) {
+		if !isRunningAndAvailable(replicas[target], set.Spec.MinReadySeconds) || isTerminating(replicas[target]) {
 			unavailablePods++
 		}
 	}

--- a/test/e2e/apps/statefulset.go
+++ b/test/e2e/apps/statefulset.go
@@ -59,6 +59,7 @@ import (
 	imageutils "k8s.io/kubernetes/test/utils/image"
 	admissionapi "k8s.io/pod-security-admission/api"
 	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 const (
@@ -1670,6 +1671,123 @@ var _ = SIGDescribe("StatefulSet", func() {
 	})
 })
 
+var _ = SIGDescribe("Rolling update strategy with MaxUnavailable", feature.MaxUnavailableStatefulSet, func() {
+	f := framework.NewDefaultFramework("statefulset")
+	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
+	var ns string
+	var c clientset.Interface
+
+	ginkgo.BeforeEach(func() {
+		c = f.ClientSet
+		ns = f.Namespace.Name
+	})
+
+	ginkgo.Describe("Rolling update with the MaxUnavailable feature", func() {
+		ginkgo.AfterEach(func(ctx context.Context) {
+			if ginkgo.CurrentSpecReport().Failed() {
+				e2eoutput.DumpDebugInfo(ctx, c, ns)
+			}
+			framework.Logf("Deleting all statefulset in ns %v", ns)
+			e2estatefulset.DeleteAllStatefulSets(ctx, c, ns)
+		})
+
+		ginkgo.It("should honor MinReadySeconds", func(ctx context.Context) {
+			ssName := "minreadyseconds-maxunavailable"
+			headlessSvcName := "test"
+			ssPodLabels := map[string]string{
+				"name": "sample-pod",
+			}
+			replicas := int32(2)
+
+			ss := e2estatefulset.NewStatefulSet(ssName, ns, headlessSvcName, replicas, nil, nil, ssPodLabels)
+			ss.Spec.PodManagementPolicy = appsv1.ParallelPodManagement
+			ss, err := c.AppsV1().StatefulSets(ns).Create(ctx, ss, metav1.CreateOptions{})
+			framework.ExpectNoError(err)
+			e2estatefulset.WaitForStatusReadyReplicas(ctx, c, ss, replicas)
+
+			selector := ss.Spec.Selector.DeepCopy() // make a copy of the selector, gets lost after updating
+			// set old and new images which will be useful for test assertion
+			oldImage := ss.Spec.Template.Spec.Containers[0].Image
+			newImage := NewWebserverImage
+
+			// update the stateful set with desired settings
+			minReadySeconds := int32(20)
+			maxUnavailable := ptr.To(intstr.FromInt32(1))
+			ss, _ = updateStatefulSetWithRetries(ctx, c, ns, ss.Name, func(update *appsv1.StatefulSet) {
+				update.Spec.MinReadySeconds = minReadySeconds
+				update.Spec.PodManagementPolicy = appsv1.ParallelPodManagement
+				update.Spec.UpdateStrategy.RollingUpdate = &appsv1.RollingUpdateStatefulSetStrategy{
+					MaxUnavailable: maxUnavailable,
+				}
+			})
+			framework.ExpectNoError(err)
+			e2estatefulset.WaitForStatusReadyReplicas(ctx, c, ss, replicas)
+
+			// update the image version so it triggers the update strategy
+			ss, _ = updateStatefulSetWithRetries(ctx, c, ns, ss.Name, func(update *appsv1.StatefulSet) {
+				update.Spec.Template.Spec.Containers[0].Image = newImage
+			})
+			e2estatefulset.WaitForStatusReadyReplicas(ctx, c, ss, replicas)
+
+			// check the image in all pods immediately after update
+			// it should still be the old one while minReadySeconds is being honored
+			ss.Spec.Selector = selector // restore the selector
+			pods := e2estatefulset.GetPodList(ctx, c, ss)
+			for i := range pods.Items {
+				gomega.Expect(pods.Items[i].Spec.Containers[0].Image).To(gomega.Equal(oldImage), "Pod %s/%s has image %s, not the old image %s. MinReadySeconds was not honored.",
+					pods.Items[i].Namespace,
+					pods.Items[i].Name,
+					pods.Items[i].Spec.Containers[0].Image,
+					oldImage)
+			}
+
+			// sleep to allow minReadySeconds to occur
+			sleep := time.Duration(replicas*minReadySeconds*2) * time.Second
+			time.Sleep(sleep)
+			// then assert the pods have successfully updated to a new version
+			e2estatefulset.WaitForStatusReadyReplicas(ctx, c, ss, replicas)
+			pods = e2estatefulset.GetPodList(ctx, c, ss)
+			for i := range pods.Items {
+				gomega.Expect(pods.Items[i].Spec.Containers[0].Image).To(gomega.Equal(newImage), "Pod %s/%s has image %s, not the new image %s",
+					pods.Items[i].Namespace,
+					pods.Items[i].Name,
+					pods.Items[i].Spec.Containers[0].Image,
+					newImage)
+			}
+		})
+
+		ginkgo.It("should update successfully with Parallel PodManagementPolicy", func(ctx context.Context) {
+			ssName := "rolling-update-parallel-max-unavailable"
+			headlessSvcName := "test"
+			ssPodLabels := map[string]string{
+				"name": "sample-pod",
+			}
+			replicas := int32(2)
+			ss := e2estatefulset.NewStatefulSet(ssName, ns, headlessSvcName, replicas, nil, nil, ssPodLabels)
+			ss.Spec.PodManagementPolicy = appsv1.ParallelPodManagement
+			ss.Spec.UpdateStrategy.RollingUpdate = &appsv1.RollingUpdateStatefulSetStrategy{
+				MaxUnavailable: ptr.To(intstr.FromInt32(1)),
+			}
+			rollbackTest(ctx, c, ns, ss)
+		})
+
+		ginkgo.It("should update successfully with OrderedReady PodManagementPolicy", func(ctx context.Context) {
+			ssName := "rolling-update-orderedready-max-unavailable"
+			headlessSvcName := "test"
+			ssPodLabels := map[string]string{
+				"name": "sample-pod",
+			}
+			replicas := int32(2)
+			ss := e2estatefulset.NewStatefulSet(ssName, ns, headlessSvcName, replicas, nil, nil, ssPodLabels)
+			ss.Spec.PodManagementPolicy = appsv1.OrderedReadyPodManagement
+			ss.Spec.UpdateStrategy.RollingUpdate = &appsv1.RollingUpdateStatefulSetStrategy{
+				MaxUnavailable: ptr.To(intstr.FromInt32(1)),
+			}
+			rollbackTest(ctx, c, ns, ss)
+		})
+	})
+})
+
 func uncordonNode(ctx context.Context, c clientset.Interface, oldData, newData []byte, nodeName string) {
 	ginkgo.By("Uncordoning Node")
 	// uncordon node, by reverting patch
@@ -1890,8 +2008,8 @@ func pollReadWithTimeout(ctx context.Context, statefulPod statefulPodTester, sta
 	return err
 }
 
-// This function is used by two tests to test StatefulSet rollbacks: one using
-// PVCs and one using no storage.
+// This function is used by tests asserting StatefulSet update and rollback:
+// one using PVCs, one using no storage and a couple using PodManagementPolicies along with MaxUnavailable.
 func rollbackTest(ctx context.Context, c clientset.Interface, ns string, ss *appsv1.StatefulSet) {
 	setHTTPProbe(ss)
 	ss, err := c.AppsV1().StatefulSets(ns).Create(ctx, ss, metav1.CreateOptions{})

--- a/test/e2e/feature/feature.go
+++ b/test/e2e/feature/feature.go
@@ -181,6 +181,11 @@ var (
 	// TODO: document the feature (owning SIG, when to use this feature for a test)
 	LocalStorageCapacityIsolationQuota = framework.WithFeature(framework.ValidFeatures.Add("LocalStorageCapacityIsolationQuota"))
 
+	// TODO: Once the feature and API version are stable, this label should be removed and
+	// these tests will be run by default on any cluster. The test-infra job also should
+	// be updated to not focus on this feature anymore.
+	MaxUnavailableStatefulSet = framework.WithFeature(framework.ValidFeatures.Add("MaxUnavailableStatefulSet"))
+
 	// TODO: document the feature (owning SIG, when to use this feature for a test)
 	MasterUpgrade = framework.WithFeature(framework.ValidFeatures.Add("MasterUpgrade"))
 

--- a/test/e2e/framework/statefulset/rest.go
+++ b/test/e2e/framework/statefulset/rest.go
@@ -70,6 +70,26 @@ func GetPodList(ctx context.Context, c clientset.Interface, ss *appsv1.StatefulS
 	return podList
 }
 
+// GetPodReadyList gets the current Pods in ss with all pods in status Ready.
+func GetPodReadyList(ctx context.Context, c clientset.Interface, ss *appsv1.StatefulSet) v1.PodList {
+	selector, err := metav1.LabelSelectorAsSelector(ss.Spec.Selector)
+	framework.ExpectNoError(err)
+	listOptions := metav1.ListOptions{
+		LabelSelector: selector.String(),
+		FieldSelector: "status.phase=Running",
+	}
+	podList, err := c.CoreV1().Pods(ss.Namespace).List(ctx, listOptions)
+	var readyPods []v1.Pod
+	for _, pod := range podList.Items {
+		if podutils.IsPodReady(&pod) {
+			readyPods = append(readyPods, pod)
+		}
+	}
+	framework.ExpectNoError(err)
+
+	return v1.PodList{Items: readyPods}
+}
+
 // DeleteAllStatefulSets deletes all StatefulSet API Objects in Namespace ns.
 func DeleteAllStatefulSets(ctx context.Context, c clientset.Interface, ns string) {
 	ssList, err := c.AppsV1().StatefulSets(ns).List(ctx, metav1.ListOptions{LabelSelector: labels.Everything().String()})


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
This is necessary to promote this feature from alpha to beta. StatefulSet MaxUnavailable needs to honor MinReadySeconds, not ignore it. 


#### Which issue(s) this PR fixes:
Fixes #112307

#### Special notes for your reviewer:
Relates to https://github.com/kubernetes/enhancements/pull/4474

Addresses https://github.com/kubernetes/enhancements/pull/4474#discussion_r1478474701

#### Does this PR introduce a user-facing change?

```release-note
StatefulSet MaxUnavailable now properly honors MinReadySeconds.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
https://github.com/kubernetes/enhancements/pull/4474
