### PR TITLE
Update GroupPolicy to disable Windows Automatic Updates

### DIFF
--- a/cluster/gce/windows/k8s-node-setup.psm1
+++ b/cluster/gce/windows/k8s-node-setup.psm1
@@ -329,6 +329,10 @@ function Set-EnvironmentVars {
 function Set-PrerequisiteOptions {
   # Windows updates cause the node to reboot at arbitrary times.
   Log-Output "Disabling Windows Update service"
+  # 1 = Disables Automatic Updates. (see https://learn.microsoft.com/de-de/security-updates/windowsupdateservices/18127499)
+  Set-ItemProperty HKLM:\Software\Policies\Microsoft\Windows\WindowsUpdate\AU -Name NoAutoUpdate -Value 1
+  # 2 = notify of download. (see https://learn.microsoft.com/de-de/security-updates/windowsupdateservices/18127499)
+  Set-ItemProperty HKLM:\Software\Policies\Microsoft\Windows\WindowsUpdate\AU -Name AUOptions -Value 2
   & sc.exe config wuauserv start=disabled
   & sc.exe stop wuauserv
   Write-VerboseServiceInfoToConsole -Service 'wuauserv' -Delay 1


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig windows

#### What this PR does / why we need it:

I found that the Windows Update service started even though we disable it. I found out that Windows has a default Group Policy that schedules automatic updates via Windows Update. This re-enables the service again even though it is disabled. In this PR, we disable this policy.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
