### PR TITLE
apiserver/storage/cacher: deflake TestGetListNonRecursiveWithConsistentListFromCache

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_test.go
@@ -194,7 +194,7 @@ func TestGetListNonRecursiveWithConsistentListFromCache(t *testing.T) {
 	t.Cleanup(terminate)
 	// Wait before sending watch progress request to avoid https://github.com/etcd-io/etcd/issues/17507
 	// TODO(https://github.com/etcd-io/etcd/issues/17507): Remove sleep when etcd is upgraded to version with fix.
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(time.Second)
 	storagetesting.RunTestGetListNonRecursive(ctx, t, compactStorage(cacher, server.V3Client), cacher)
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
flake introduced in https://github.com/kubernetes/kubernetes/pull/123674

```
❯ go run -mod=readonly golang.org/x/tools/cmd/stress ./cacher.test -test.run TestGetListNonRecursiveWithConsistentListFromCache
5s: 0 runs so far, 0 failures
10s: 10 runs so far, 0 failures
15s: 20 runs so far, 0 failures
20s: 30 runs so far, 0 failures
25s: 40 runs so far, 0 failures
30s: 47 runs so far, 0 failures
35s: 54 runs so far, 0 failures
40s: 60 runs so far, 0 failures
45s: 70 runs so far, 0 failures
50s: 80 runs so far, 0 failures
55s: 90 runs so far, 0 failures
1m0s: 100 runs so far, 0 failures
1m5s: 107 runs so far, 0 failures
1m10s: 116 runs so far, 0 failures
1m15s: 122 runs so far, 0 failures
1m20s: 130 runs so far, 0 failures
1m25s: 140 runs so far, 0 failures
1m30s: 150 runs so far, 0 failures
1m35s: 160 runs so far, 0 failures
1m40s: 169 runs so far, 0 failures
1m45s: 177 runs so far, 0 failures
1m50s: 184 runs so far, 0 failures
1m55s: 193 runs so far, 0 failures
2m0s: 201 runs so far, 0 failures
2m5s: 210 runs so far, 0 failures
2m10s: 220 runs so far, 0 failures
2m15s: 230 runs so far, 0 failures
2m20s: 237 runs so far, 0 failures
2m25s: 246 runs so far, 0 failures
2m30s: 253 runs so far, 0 failures
2m35s: 262 runs so far, 0 failures
2m40s: 271 runs so far, 0 failures
2m45s: 280 runs so far, 0 failures
2m50s: 290 runs so far, 0 failures
2m55s: 298 runs so far, 0 failures
3m0s: 306 runs so far, 0 failures
3m5s: 314 runs so far, 0 failures
3m10s: 322 runs so far, 0 failures
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
