### PR TITLE
build/rsyncd: replace newlines with spaces when generating ALLOW_HOST list

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -611,7 +611,7 @@ function kube::build::start_rsyncd_container() {
   V=3 kube::log::status "Starting rsyncd container"
   kube::build::run_build_command_ex \
     "${KUBE_RSYNC_CONTAINER_NAME}" -p 127.0.0.1:"${KUBE_RSYNC_PORT}":"${KUBE_CONTAINER_RSYNC_PORT}" -d \
-    -e ALLOW_HOST="$(${IPTOOL} | grep -Eo 'inet (addr:)?([0-9]*\.){3}[0-9]*' | grep -Eo '([0-9]*\.){3}[0-9]*' | grep -v '127.0.0.1')" \
+    -e ALLOW_HOST="$(${IPTOOL} | grep -Eo 'inet (addr:)?([0-9]*\.){3}[0-9]*' | grep -Eo '([0-9]*\.){3}[0-9]*' | grep -v '127.0.0.1' | tr '\n' ' ')" \
     -- /rsyncd.sh >/dev/null
 
   local mapped_port


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When the ALLOW_LIST variable is generated, depending on the network configuration of the container runtime being used, there may be multiple addresses/hosts returned.

This PR replaces newlines with spaces, leading to my build working 🎉 

#### Which issue(s) this PR fixes:

Fixes #99025 (I think..)

#### Special notes for your reviewer:

As noted in the linked issue, building with anything other than Docker isn't expected to be supported/work.

That said, this one line change *does* enable it to work in a wider range of circumstances/situations, and as far as I can tell will have no adverse effects on other existing users.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/cc @BenTheElder 