### PR TITLE
Move DockerHung test in the end

### DIFF
--- a/test/e2e/node/node_problem_detector.go
+++ b/test/e2e/node/node_problem_detector.go
@@ -161,34 +161,6 @@ var _ = SIGDescribe("NodeProblemDetector", nodefeature.NodeProblemDetector, func
 			gomega.Expect(result.Code).To(gomega.Equal(0))
 		}
 
-		ginkgo.By("Check node-problem-detector can post conditions and events to API server")
-		for _, node := range nodes {
-			ginkgo.By(fmt.Sprintf("Check node-problem-detector posted KernelDeadlock condition on node %q", node.Name))
-			gomega.Eventually(ctx, func() error {
-				return verifyNodeCondition(ctx, f, "KernelDeadlock", v1.ConditionTrue, "DockerHung", node.Name)
-			}, pollTimeout, pollInterval).Should(gomega.Succeed())
-
-			ginkgo.By(fmt.Sprintf("Check node-problem-detector posted DockerHung event on node %q", node.Name))
-			eventListOptions := metav1.ListOptions{FieldSelector: fields.Set{"involvedObject.kind": "Node"}.AsSelector().String()}
-			gomega.Eventually(ctx, func(ctx context.Context) error {
-				return verifyEvents(ctx, f, eventListOptions, 1, "DockerHung", node.Name)
-			}, pollTimeout, pollInterval).Should(gomega.Succeed())
-
-			if checkForKubeletStart {
-				// Node problem detector reports kubelet start events automatically starting from NPD v0.7.0+.
-				// Since Kubelet may be restarted for a few times after node is booted. We just check the event
-				// is detected, but do not check how many times Kubelet is started.
-				//
-				// Some test suites run for hours and KubeletStart event will already be cleaned up
-				ginkgo.By(fmt.Sprintf("Check node-problem-detector posted KubeletStart event on node %q", node.Name))
-				gomega.Eventually(ctx, func(ctx context.Context) error {
-					return verifyEventExists(ctx, f, eventListOptions, "KubeletStart", node.Name)
-				}, pollTimeout, pollInterval).Should(gomega.Succeed())
-			} else {
-				ginkgo.By("KubeletStart event will NOT be checked")
-			}
-		}
-
 		ginkgo.By("Gather node-problem-detector cpu and memory stats")
 		numIterations := 60
 		for i := 1; i <= numIterations; i++ {
@@ -237,6 +209,35 @@ var _ = SIGDescribe("NodeProblemDetector", nodefeature.NodeProblemDetector, func
 				workingSetStats[host][0], workingSetStats[host][len(workingSetStats[host])/2], workingSetStats[host][len(workingSetStats[host])-1])
 		}
 		framework.Logf("Node-Problem-Detector CPU and Memory Stats:\n\t%s\n\t%s\n\t%s", cpuStatsMsg, rssStatsMsg, workingSetStatsMsg)
+
+		ginkgo.By("Check node-problem-detector can post conditions and events to API server")
+		for _, node := range nodes {
+			ginkgo.By(fmt.Sprintf("Check node-problem-detector posted KernelDeadlock condition on node %q", node.Name))
+			gomega.Eventually(ctx, func() error {
+				return verifyNodeCondition(ctx, f, "KernelDeadlock", v1.ConditionTrue, "DockerHung", node.Name)
+			}, pollTimeout, pollInterval).Should(gomega.Succeed())
+
+			ginkgo.By(fmt.Sprintf("Check node-problem-detector posted DockerHung event on node %q", node.Name))
+			eventListOptions := metav1.ListOptions{FieldSelector: fields.Set{"involvedObject.kind": "Node"}.AsSelector().String()}
+			gomega.Eventually(ctx, func(ctx context.Context) error {
+				return verifyEvents(ctx, f, eventListOptions, 1, "DockerHung", node.Name)
+			}, pollTimeout, pollInterval).Should(gomega.Succeed())
+
+			if checkForKubeletStart {
+				// Node problem detector reports kubelet start events automatically starting from NPD v0.7.0+.
+				// Since Kubelet may be restarted for a few times after node is booted. We just check the event
+				// is detected, but do not check how many times Kubelet is started.
+				//
+				// Some test suites run for hours and KubeletStart event will already be cleaned up
+				ginkgo.By(fmt.Sprintf("Check node-problem-detector posted KubeletStart event on node %q", node.Name))
+				gomega.Eventually(ctx, func(ctx context.Context) error {
+					return verifyEventExists(ctx, f, eventListOptions, "KubeletStart", node.Name)
+				}, pollTimeout, pollInterval).Should(gomega.Succeed())
+			} else {
+				ginkgo.By("KubeletStart event will NOT be checked")
+			}
+		}
+
 	})
 })
 


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test

#### What this PR does / why we need it:

Checking the logs from https://gcsweb.k8s.io/gcs/kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-alpha-enabled-default/1768108836683517952/artifacts/bootstrap-e2e-minion-group-sgqx/ i noticed that container is destroyed 

I see also from kernel logs that docker is blocked for 120second ( around the same time the container is destroyed )

Could it be that Docker Hung should be moved to be last in the test to avoid deleting a container? 

![image](https://github.com/kubernetes/kubernetes/assets/159060890/e7714e63-9d6d-4741-85e5-8d3f0af55647)


#### Which issue(s) this PR fixes:
Attempt to fix https://github.com/kubernetes/kubernetes/issues/123928

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
