### PR TITLE
api: add plural exception for "parameters"

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/meta/restmapper.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/meta/restmapper.go
@@ -118,6 +118,7 @@ func (m *DefaultRESTMapper) AddSpecific(kind schema.GroupVersionKind, plural, si
 // callers to use the RESTMapper they mean.
 var unpluralizedSuffixes = []string{
 	"endpoints",
+	"parameters",
 }
 
 // UnsafeGuessKindToResource converts Kind to a resource name.


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This is for ResourceClassParameters and ResourceClaimParameters (added in 1.30). Without this, the fake clientset does not handle those objects correctly because it computes the resource name
incorrectly ("resourceclassparameterses").

#### Which issue(s) this PR fixes:

Nothing affected in the wild (yet).

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
