### PR TITLE
Resolved compatibility issue between Kubelet PLEG and inplace VPA

### DIFF
--- a/pkg/kubelet/container/runtime.go
+++ b/pkg/kubelet/container/runtime.go
@@ -412,6 +412,17 @@ func (podStatus *PodStatus) FindContainerStatusByName(containerName string) *Sta
 	return nil
 }
 
+// FindContainerStatusByContainerID returns container status in the pod status with the given name.
+// When there are multiple containers' statuses with the same name, the first match will be returned.
+func (podStatus *PodStatus) FindContainerStatusByContainerID(containerID *ContainerID) *Status {
+	for _, containerStatus := range podStatus.ContainerStatuses {
+		if containerStatus.ID.String() == containerID.String() {
+			return containerStatus
+		}
+	}
+	return nil
+}
+
 // GetRunningContainerStatuses returns container status of all the running containers in a pod
 func (podStatus *PodStatus) GetRunningContainerStatuses() []*Status {
 	runningContainerStatuses := []*Status{}

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1975,15 +1975,6 @@ func (kl *Kubelet) SyncPod(ctx context.Context, updateType kubetypes.SyncPodType
 		return false, nil
 	}
 
-	if utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScaling) && isPodResizeInProgress(pod, &apiPodStatus) {
-		// While resize is in progress, periodically call PLEG to update pod cache
-		runningPod := kubecontainer.ConvertPodStatusToRunningPod(kl.getRuntime().Type(), podStatus)
-		if err, _ := kl.pleg.UpdateCache(&runningPod, pod.UID); err != nil {
-			klog.ErrorS(err, "Failed to update pod cache", "pod", klog.KObj(pod))
-			return false, err
-		}
-	}
-
 	return false, nil
 }
 
@@ -2752,20 +2743,6 @@ func (kl *Kubelet) HandlePodSyncs(pods []*v1.Pod) {
 			StartTime:  start,
 		})
 	}
-}
-
-func isPodResizeInProgress(pod *v1.Pod, podStatus *v1.PodStatus) bool {
-	for _, c := range pod.Spec.Containers {
-		if cs, ok := podutil.GetContainerStatus(podStatus.ContainerStatuses, c.Name); ok {
-			if cs.Resources == nil {
-				continue
-			}
-			if !cmp.Equal(c.Resources.Limits, cs.Resources.Limits) || !cmp.Equal(cs.AllocatedResources, cs.Resources.Requests) {
-				return true
-			}
-		}
-	}
-	return false
 }
 
 func (kl *Kubelet) canResizePod(pod *v1.Pod) (bool, *v1.Pod, v1.PodResizeStatus) {

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -1781,6 +1781,7 @@ func (kl *Kubelet) generateAPIPodStatus(pod *v1.Pod, podStatus *kubecontainer.Po
 	if utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScaling) {
 		s.Resize = kl.determinePodResizeStatus(pod, s)
 	}
+	klog.V(5).InfoS("Pod Resize Status", "pod.status.resize", pod.Status.Resize, "oldPodStatus.resize", oldPodStatus.Resize, "status", s.Resize)
 	// calculate the next phase and preserve reason
 	allStatus := append(append([]v1.ContainerStatus{}, s.ContainerStatuses...), s.InitContainerStatuses...)
 	s.Phase = getPhase(pod, allStatus, podIsTerminal)

--- a/pkg/kubelet/pleg/generic.go
+++ b/pkg/kubelet/pleg/generic.go
@@ -255,10 +255,30 @@ func (g *GenericPLEG) Relist() {
 	for pid := range g.podRecords {
 		oldPod := g.podRecords.getOld(pid)
 		pod := g.podRecords.getCurrent(pid)
+
+		var cachePodStatus *kubecontainer.PodStatus
+		var podStatus *kubecontainer.PodStatus
+
+		// get cachePodStatus and runtimePodStatus to help distinguish the resized pod.
+		if utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScaling) {
+			cachePodStatus, err = g.cache.Get(pid)
+			if err != nil {
+				klog.ErrorS(err, "GenericPLEG: Unable to retrieve pods", "pid", pid)
+				return
+			}
+			if pod != nil {
+				podStatus, err = g.runtime.GetPodStatus(ctx, pod.ID, pod.Name, pod.Namespace)
+				if err != nil {
+					klog.ErrorS(err, "GenericPLEG: Unable to retrieve runtime pod status", "pod", pod)
+					continue
+				}
+			}
+		}
+
 		// Get all containers in the old and the new pod.
 		allContainers := getContainersFromPods(oldPod, pod)
 		for _, container := range allContainers {
-			events := computeEvents(g.logger, oldPod, pod, &container.ID)
+			events := computeEvents(g.logger, oldPod, pod, cachePodStatus, podStatus, &container.ID)
 			for _, e := range events {
 				updateEvents(eventsByPodID, e)
 			}
@@ -313,7 +333,10 @@ func (g *GenericPLEG) Relist() {
 		for i := range events {
 			// Filter out events that are not reliable and no other components use yet.
 			if events[i].Type == ContainerChanged {
-				continue
+				// resized pods can not be skipped, pass through the eventChannel to make sure it get synced.
+				if !utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScaling) {
+					continue
+				}
 			}
 			select {
 			case g.eventChannel <- events[i]:
@@ -389,8 +412,7 @@ func getContainersFromPods(pods ...*kubecontainer.Pod) []*kubecontainer.Containe
 	}
 	return containers
 }
-
-func computeEvents(logger klog.Logger, oldPod, newPod *kubecontainer.Pod, cid *kubecontainer.ContainerID) []*PodLifecycleEvent {
+func computeEvents(logger klog.Logger, oldPod, newPod *kubecontainer.Pod, cachedPodStatus, podStatus *kubecontainer.PodStatus, cid *kubecontainer.ContainerID) []*PodLifecycleEvent {
 	var pid types.UID
 	if oldPod != nil {
 		pid = oldPod.ID
@@ -399,7 +421,32 @@ func computeEvents(logger klog.Logger, oldPod, newPod *kubecontainer.Pod, cid *k
 	}
 	oldState := getContainerState(oldPod, cid)
 	newState := getContainerState(newPod, cid)
+
+	if utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScaling) && oldPod != nil && newPod != nil && cachedPodStatus != nil && podStatus != nil {
+		oldContainerStatus := cachedPodStatus.FindContainerStatusByContainerID(cid)
+		newContainerStatus := podStatus.FindContainerStatusByContainerID(cid)
+		if oldContainerStatus != nil && newContainerStatus != nil && !containerResourceSame(oldContainerStatus.Resources, newContainerStatus.Resources) {
+			klog.V(4).InfoS("resize pods triggers the plegContainerUnknown event", "oldContainerStatus", oldContainerStatus, "newContainerStatus", newContainerStatus)
+			return generateEvents(logger, pid, cid.ID, oldState, plegContainerUnknown)
+		}
+	}
+
 	return generateEvents(logger, pid, cid.ID, oldState, newState)
+}
+
+// TODO: use more elegant way to compare the resources
+func containerResourceSame(r1 *kubecontainer.ContainerResources, r2 *kubecontainer.ContainerResources) bool {
+	if r1 == nil && r2 == nil {
+		return true
+	}
+
+	cpuRequestsSame := (r1.CPURequest == nil && r2.CPURequest == nil) || (r1.CPURequest != nil && r2.CPURequest != nil && r1.CPURequest.Equal(*r2.CPURequest))
+	cpuLimitsSame := (r1.CPULimit == nil && r2.CPULimit == nil) || (r1.CPULimit != nil && r2.CPULimit != nil && r1.CPULimit.Equal(*r2.CPULimit))
+	memoryRequestsSame := (r1.MemoryRequest == nil && r2.MemoryRequest == nil) || (r1.MemoryRequest != nil && r2.MemoryRequest != nil && r1.MemoryRequest.Equal(*r2.MemoryRequest))
+	memoryLimitsSame := (r1.MemoryLimit == nil && r2.MemoryLimit == nil) || (r1.MemoryLimit != nil && r2.MemoryLimit != nil && r1.MemoryLimit.Equal(*r2.MemoryLimit))
+
+	// The container resources are the same only if all attributes are the same
+	return cpuRequestsSame && cpuLimitsSame && memoryRequestsSame && memoryLimitsSame
 }
 
 func (g *GenericPLEG) cacheEnabled() bool {

--- a/pkg/kubelet/pleg/generic.go
+++ b/pkg/kubelet/pleg/generic.go
@@ -261,6 +261,10 @@ func (g *GenericPLEG) Relist() {
 
 		// get cachePodStatus and runtimePodStatus to help distinguish the resized pod.
 		if utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScaling) {
+			if !g.cacheEnabled() {
+				klog.ErrorS(err, "GenericPLEG: Cache is not enabled")
+				return
+			}
 			cachePodStatus, err = g.cache.Get(pid)
 			if err != nil {
 				klog.ErrorS(err, "GenericPLEG: Unable to retrieve pods", "pid", pid)

--- a/pkg/kubelet/pleg/generic_test.go
+++ b/pkg/kubelet/pleg/generic_test.go
@@ -37,6 +37,10 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/metrics"
 	"k8s.io/utils/clock"
 	testingclock "k8s.io/utils/clock/testing"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/kubernetes/pkg/features"
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 const (
@@ -422,6 +426,71 @@ func TestRemoveCacheEntry(t *testing.T) {
 	actualStatus, actualErr := pleg.cache.Get(pods[0].ID)
 	assert.Equal(t, &kubecontainer.PodStatus{ID: pods[0].ID}, actualStatus)
 	assert.NoError(t, actualErr)
+}
+
+func TestRelistingWithResourcesChange(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.InPlacePodVerticalScaling, true)
+
+	ctx := context.Background()
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	runtimeMock := containertest.NewMockRuntime(mockCtrl)
+	pleg := newTestGenericPLEGWithRuntimeMock(runtimeMock)
+	ch := pleg.Watch()
+
+	pods, statuses, events := createTestPodsStatusesAndEvents(1)
+	// add resources to statuses
+	for _, status := range statuses {
+		status.ContainerStatuses[0].Resources = &kubecontainer.ContainerResources{
+			CPURequest: resource.NewMilliQuantity(100, resource.DecimalSI),
+			CPULimit: resource.NewMilliQuantity(100, resource.DecimalSI),
+			MemoryRequest: resource.NewQuantity(100*1024*1024, resource.BinarySI),
+			MemoryLimit: resource.NewQuantity(100*1024*1024, resource.BinarySI),
+		}
+	}
+	runtimeMock.EXPECT().GetPods(ctx, true).Return(pods, nil).Times(1)
+	// call two times on pod status. 1. get exist pod status; 2. update cache 
+	runtimeMock.EXPECT().GetPodStatus(ctx, pods[0].ID, "", "").Return(statuses[0], nil).Times(2)
+	// Does a relist to populate the cache.
+	pleg.Relist()
+
+	// verify cache is set correctly
+	actualStatus, actualErr := pleg.cache.Get(pods[0].ID)
+	assert.Equal(t, statuses[0], actualStatus)
+	assert.Equal(t, nil, actualErr)
+
+	// verify event is generated correctly
+	actualEvents := getEventsFromChannel(ch)
+	assert.Exactly(t, []*PodLifecycleEvent{events[0]}, actualEvents)
+
+	// Update pod status. Verify event for InPlaceUpdateVerticalScaling is created
+	updatedPods, updatedStatuses, updatedEvents := createTestPodsStatusesAndEvents(1)
+	// set updated status 
+	for _, status := range updatedStatuses {
+		status.ContainerStatuses[0].Resources = &kubecontainer.ContainerResources{
+			CPURequest: resource.NewMilliQuantity(200, resource.DecimalSI),
+			CPULimit: resource.NewMilliQuantity(200, resource.DecimalSI),
+			MemoryRequest: resource.NewQuantity(200*1024*1024, resource.BinarySI),
+			MemoryLimit: resource.NewQuantity(200*1024*1024, resource.BinarySI),
+		}
+	}
+	// set updated events
+	for _, event := range updatedEvents {
+		event.Type = ContainerChanged
+	} 
+
+	runtimeMock.EXPECT().GetPods(ctx, true).Return(updatedPods, nil).Times(1)
+	runtimeMock.EXPECT().GetPodStatus(ctx, pods[0].ID, "", "").Return(updatedStatuses[0], nil).Times(2)
+	pleg.Relist()
+
+	// verify cache is updated correctly
+	actualUpdatedStatus, actualUpdatedErr := pleg.cache.Get(pods[0].ID)
+	assert.Equal(t, updatedStatuses[0], actualUpdatedStatus)
+	assert.Equal(t, nil, actualUpdatedErr)
+
+	// verify event is generated correctly
+	actualUpdatedEvents := getEventsFromChannel(ch)
+	assert.Exactly(t, []*PodLifecycleEvent{updatedEvents[0]}, actualUpdatedEvents)
 }
 
 func TestHealthy(t *testing.T) {


### PR DESCRIPTION
Make In-place VPA feature work with PLEG relist. Use auxiliary runtime pod status and PLEG cache pod status to distinguish the resize pod and make sure it generate correct PLEG event and come into the event channel.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
Pleg doesn't handle resized pod well. See https://github.com/kubernetes/kubernetes/issues/123940 for more details

This is part of https://github.com/kubernetes/enhancements/pull/4433

#### Which issue(s) this PR fixes:

Fixes 
- https://github.com/kubernetes/kubernetes/issues/123940
- https://docs.google.com/document/d/1V3DLh3pH3CD-xhhJvAnOq_oWgPyjO-vj6wY6qdew9H0/edit#heading=h.5gfeh6i9awgb

#### Special notes for your reviewer:

I have not added tests yet. I did some manual e2e tests. If the idea looks good to you, I will spend some time improving the test coverage.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

- [KEP]: https://github.com/kubernetes/enhancements/pull/4433
