### PR TITLE
Promote e2e test for VolumeAttachment Endpoints + 7 Endpoints

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -3545,4 +3545,18 @@
     was configured with a subpath.
   release: v1.12
   file: test/e2e/storage/subpath.go
+- testname: VolumeAttachment, lifecycle
+  codename: '[sig-storage] VolumeAttachment Conformance should run through the lifecycle
+    of a VolumeAttachment [Conformance]'
+  description: Creating an initial VolumeAttachment MUST succeed. Reading the VolumeAttachment
+    MUST succeed with with required name retrieved. Patching a VolumeAttachment MUST
+    succeed with its new label found. Listing VolumeAttachment with a labelSelector
+    MUST succeed with a single item retrieved. Deleting a VolumeAttachment MUST succeed
+    and it MUST be confirmed. Creating a second VolumeAttachment MUST succeed. Updating
+    the second VolumentAttachment with a new label MUST succeed with its new label
+    found. Creating a third VolumeAttachment MUST succeed. Updating the third VolumentAttachment
+    with a new label MUST succeed with its new label found. Deleting both VolumeAttachments
+    via deleteCollection MUST succeed and it MUST be confirmed.
+  release: v1.30
+  file: test/e2e/storage/volume_attachment.go
 

--- a/test/e2e/storage/volume_attachment.go
+++ b/test/e2e/storage/volume_attachment.go
@@ -39,9 +39,22 @@ var _ = utils.SIGDescribe("VolumeAttachment", func() {
 
 	f := framework.NewDefaultFramework("volumeattachment")
 
+	/*
+		Release: v1.30
+		Testname: VolumeAttachment, lifecycle
+		Description: Creating an initial VolumeAttachment MUST succeed. Reading the VolumeAttachment
+		MUST succeed with with required name retrieved. Patching a VolumeAttachment MUST
+		succeed with its new label found. Listing VolumeAttachment with a labelSelector
+		MUST succeed with a single item retrieved. Deleting a VolumeAttachment MUST succeed
+		and it MUST be confirmed. Creating a second VolumeAttachment MUST succeed. Updating
+		the second VolumentAttachment with a new label MUST succeed with its new label
+		found. Creating a third VolumeAttachment MUST succeed. Updating the third VolumentAttachment
+		with a new label MUST succeed with its new label found. Deleting both VolumeAttachments
+		via deleteCollection MUST succeed and it MUST be confirmed.
+	*/
 	ginkgo.Describe("Conformance", func() {
 
-		ginkgo.It("should run through the lifecycle of a VolumeAttachment", func(ctx context.Context) {
+		framework.ConformanceIt("should run through the lifecycle of a VolumeAttachment", func(ctx context.Context) {
 
 			vaClient := f.ClientSet.StorageV1().VolumeAttachments()
 


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
This PR promotes to Conformance the following endpoints in a recently added [e2e test](https://pr.k8s.io/122117):

- createStorageV1VolumeAttachment 
- deleteStorageV1CollectionVolumeAttachment
- deleteStorageV1VolumeAttachment
- listStorageV1VolumeAttachment
- patchStorageV1VolumeAttachment
- readStorageV1VolumeAttachment
- replaceStorageV1VolumeAttachment  

#### Which issue(s) this PR fixes:

Fixes #122116

#### Testgrid Link:
[sig-release-master-blocking: should run through the lifecycle of a VolumeAttachment](https://testgrid.k8s.io/sig-release-master-blocking#gce-cos-master-default&width=5&graph-metrics=test-duration-minutes&include-filter-by-regex=should.run.through.the.lifecycle.of.a.VolumeAttachment)

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
/sig testing
/sig architecture
/area conformance
