### PR TITLE
image_gc_test: Increase ImageMaximumGCAge to 3 minutes

### DIFF
--- a/test/e2e_node/image_gc_test.go
+++ b/test/e2e_node/image_gc_test.go
@@ -55,7 +55,7 @@ var _ = SIGDescribe("ImageGarbageCollect", framework.WithSerial(), framework.Wit
 	})
 	ginkgo.Context("when ImageMaximumGCAge is set", func() {
 		tempSetCurrentKubeletConfig(f, func(ctx context.Context, initialConfig *kubeletconfig.KubeletConfiguration) {
-			initialConfig.ImageMaximumGCAge = metav1.Duration{Duration: time.Duration(time.Minute * 1)}
+			initialConfig.ImageMaximumGCAge = metav1.Duration{Duration: time.Duration(time.Minute * 3)}
 			initialConfig.ImageMinimumGCAge = metav1.Duration{Duration: time.Duration(time.Second * 1)}
 			if initialConfig.FeatureGates == nil {
 				initialConfig.FeatureGates = make(map[string]bool)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind failing-test
/kind flake

#### What this PR does / why we need it:

ImageGarbageCollect Serial with existing ImageMaximumGCAge set to 1 minute fail because KubeletRestart takes to much time resulting to GC unused images prematurely.

This commit tries to fix this by increasing ImageMaximumGCAge to 3 minutes, thus giving it sufficient time for the test to pass.

3 minutes was selected to cover the worst case scenario for waitForKubeletToStart timeouts

https://github.com/kubernetes/kubernetes/blob/fa07055b1f35a5c316e95c7e620c28ed44d890d5/test/e2e_node/util.go#L240-L252

#### Which issue(s) this PR fixes:

[Failed run](https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/123386/pull-kubernetes-node-kubelet-serial-crio-cgroupv1/1765800552832176128/build-log.txt)


```
STEP: Destroying namespace "image-garbage-collect-test-9548" for this suite. @ 03/07/24 20:22:56.18
• [FAILED] [1408.810 seconds]
[sig-node] ImageGarbageCollect [Serial] [NodeFeature:GarbageCollect] when ImageMaximumGCAge is set [It] should not GC unused images prematurely [sig-node, Serial, NodeFeature:GarbageCollect]
k8s.io/kubernetes/test/e2e_node/image_gc_test.go:85

  [FAILED] Failed after 0.001s.
  Expected
      <int>: 1
  to equal
      <int>: 19
  In [It] at: k8s.io/kubernetes/test/e2e_node/image_gc_test.go:106 @ 03/07/24 20:13:44.367
```

#### Special notes for your reviewer:


#### Does this PR introduce a user-facing change?

```release-note
NONE
```
#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
