### PR TITLE
Add alpha endpoint getStoragemigrationAPIGroup to pending_eligible_endpoints.yaml

### DIFF
--- a/test/conformance/testdata/pending_eligible_endpoints.yaml
+++ b/test/conformance/testdata/pending_eligible_endpoints.yaml
@@ -7,6 +7,7 @@
 - deleteStorageV1CSINode
 - getInternalApiserverAPIGroup
 - getResourceAPIGroup
+- getStoragemigrationAPIGroup
 - listStorageV1CSINode
 - patchStorageV1CSINode
 - patchStorageV1VolumeAttachmentStatus


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:

With PR #123344 merging, there is a new set of alpha endpoints. One of the new endpoints `getStoragemigrationAPIGroup` can not be filtered automatically by apisnoop and needs to be added to [pending_eligible_endpoints.yaml](https://github.com/kubernetes/kubernetes/blob/master/test/conformance/testdata/pending_eligible_endpoints.yaml).

https://apisnoop.cncf.io/conformance-progress/endpoints/1.30.0/?filter=promoted-without-tests

As agreed in #115976 any alpha or beta endpoints that can not be filtered by apisnoop are added to [pending_eligible_endpoints.yaml](https://github.com/kubernetes/kubernetes/blob/master/test/conformance/testdata/pending_eligible_endpoints.yaml) to keep the current Conformance coverage of 100%.

#### Special notes for your reviewer:
Confirming that storage migration have only alpha endpoints
```
~/go/src/k8s.io/kubernetes$ grep apis/storagemigration api/openapi-spec/swagger.json
    "/apis/storagemigration.k8s.io/": {
    "/apis/storagemigration.k8s.io/v1alpha1/": {
    "/apis/storagemigration.k8s.io/v1alpha1/storageversionmigrations": {
    "/apis/storagemigration.k8s.io/v1alpha1/storageversionmigrations/{name}": {
    "/apis/storagemigration.k8s.io/v1alpha1/storageversionmigrations/{name}/status": {
    "/apis/storagemigration.k8s.io/v1alpha1/watch/storageversionmigrations": {
    "/apis/storagemigration.k8s.io/v1alpha1/watch/storageversionmigrations/{name}": {
```

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```

/sig architecture
/area conformance