### PR TITLE
[KEP-2400]: Add swap to kubectl describe node's output

### DIFF
--- a/pkg/apis/core/types.go
+++ b/pkg/apis/core/types.go
@@ -5131,6 +5131,8 @@ const (
 	ResourceCPU ResourceName = "cpu"
 	// Memory, in bytes. (500Gi = 500GiB = 500 * 1024 * 1024 * 1024)
 	ResourceMemory ResourceName = "memory"
+	// Swap Memory, in bytes. (500Gi = 500GiB = 500 * 1024 * 1024 * 1024)
+	ResourceSwapMemory ResourceName = "swap"
 	// Volume size, in bytes (e,g. 5Gi = 5GiB = 5 * 1024 * 1024 * 1024)
 	ResourceStorage ResourceName = "storage"
 	// Local ephemeral storage, in bytes. (500Gi = 500GiB = 500 * 1024 * 1024 * 1024)

--- a/pkg/kubelet/cadvisor/util.go
+++ b/pkg/kubelet/cadvisor/util.go
@@ -44,6 +44,9 @@ func CapacityFromMachineInfo(info *cadvisorapi.MachineInfo) v1.ResourceList {
 		v1.ResourceMemory: *resource.NewQuantity(
 			int64(info.MemoryCapacity),
 			resource.BinarySI),
+		v1.ResourceSwapMemory: *resource.NewQuantity(
+			int64(info.SwapCapacity),
+			resource.BinarySI),
 	}
 
 	// if huge pages are enabled, we report them as a schedulable resource on the node

--- a/pkg/kubelet/cadvisor/util_test.go
+++ b/pkg/kubelet/cadvisor/util_test.go
@@ -35,6 +35,7 @@ func TestCapacityFromMachineInfoWithHugePagesEnable(t *testing.T) {
 	machineInfo := &info.MachineInfo{
 		NumCores:       2,
 		MemoryCapacity: 2048,
+		SwapCapacity:   1024,
 		HugePages: []info.HugePagesInfo{
 			{
 				PageSize: 5,
@@ -44,9 +45,10 @@ func TestCapacityFromMachineInfoWithHugePagesEnable(t *testing.T) {
 	}
 
 	expected := v1.ResourceList{
-		v1.ResourceCPU:    *resource.NewMilliQuantity(int64(2000), resource.DecimalSI),
-		v1.ResourceMemory: *resource.NewQuantity(int64(2048), resource.BinarySI),
-		"hugepages-5Ki":   *resource.NewQuantity(int64(51200), resource.BinarySI),
+		v1.ResourceCPU:        *resource.NewMilliQuantity(int64(2000), resource.DecimalSI),
+		v1.ResourceMemory:     *resource.NewQuantity(int64(2048), resource.BinarySI),
+		v1.ResourceSwapMemory: *resource.NewQuantity(int64(1024), resource.BinarySI),
+		"hugepages-5Ki":       *resource.NewQuantity(int64(51200), resource.BinarySI),
 	}
 	actual := CapacityFromMachineInfo(machineInfo)
 	if !reflect.DeepEqual(actual, expected) {

--- a/pkg/kubelet/kubelet_node_status_test.go
+++ b/pkg/kubelet/kubelet_node_status_test.go
@@ -217,6 +217,7 @@ func TestUpdateNewNodeStatus(t *testing.T) {
 				BootID:         "1b3",
 				NumCores:       2,
 				MemoryCapacity: 10e9, // 10G
+				SwapCapacity:   5e9,  // 5G
 			}
 			kubelet.setCachedMachineInfo(machineInfo)
 
@@ -273,12 +274,14 @@ func TestUpdateNewNodeStatus(t *testing.T) {
 					Capacity: v1.ResourceList{
 						v1.ResourceCPU:              *resource.NewMilliQuantity(2000, resource.DecimalSI),
 						v1.ResourceMemory:           *resource.NewQuantity(10e9, resource.BinarySI),
+						v1.ResourceSwapMemory:       *resource.NewQuantity(5e9, resource.BinarySI),
 						v1.ResourcePods:             *resource.NewQuantity(0, resource.DecimalSI),
 						v1.ResourceEphemeralStorage: *resource.NewQuantity(5000, resource.BinarySI),
 					},
 					Allocatable: v1.ResourceList{
 						v1.ResourceCPU:              *resource.NewMilliQuantity(1800, resource.DecimalSI),
 						v1.ResourceMemory:           *resource.NewQuantity(9900e6, resource.BinarySI),
+						v1.ResourceSwapMemory:       *resource.NewQuantity(5e9, resource.BinarySI),
 						v1.ResourcePods:             *resource.NewQuantity(0, resource.DecimalSI),
 						v1.ResourceEphemeralStorage: *resource.NewQuantity(3000, resource.BinarySI),
 					},
@@ -396,6 +399,7 @@ func TestUpdateExistingNodeStatus(t *testing.T) {
 		BootID:         "1b3",
 		NumCores:       2,
 		MemoryCapacity: 20e9,
+		SwapCapacity:   5e9,
 	}
 	kubelet.setCachedMachineInfo(machineInfo)
 
@@ -452,12 +456,14 @@ func TestUpdateExistingNodeStatus(t *testing.T) {
 			Capacity: v1.ResourceList{
 				v1.ResourceCPU:              *resource.NewMilliQuantity(2000, resource.DecimalSI),
 				v1.ResourceMemory:           *resource.NewQuantity(20e9, resource.BinarySI),
+				v1.ResourceSwapMemory:       *resource.NewQuantity(5e9, resource.BinarySI),
 				v1.ResourcePods:             *resource.NewQuantity(0, resource.DecimalSI),
 				v1.ResourceEphemeralStorage: *resource.NewQuantity(5000, resource.BinarySI),
 			},
 			Allocatable: v1.ResourceList{
 				v1.ResourceCPU:              *resource.NewMilliQuantity(1800, resource.DecimalSI),
 				v1.ResourceMemory:           *resource.NewQuantity(19900e6, resource.BinarySI),
+				v1.ResourceSwapMemory:       *resource.NewQuantity(5e9, resource.BinarySI),
 				v1.ResourcePods:             *resource.NewQuantity(0, resource.DecimalSI),
 				v1.ResourceEphemeralStorage: *resource.NewQuantity(5000, resource.BinarySI),
 			},
@@ -608,6 +614,7 @@ func TestUpdateNodeStatusWithRuntimeStateError(t *testing.T) {
 		BootID:         "1b3",
 		NumCores:       2,
 		MemoryCapacity: 10e9,
+		SwapCapacity:   5e9,
 	}
 	kubelet.setCachedMachineInfo(machineInfo)
 
@@ -657,12 +664,14 @@ func TestUpdateNodeStatusWithRuntimeStateError(t *testing.T) {
 			Capacity: v1.ResourceList{
 				v1.ResourceCPU:              *resource.NewMilliQuantity(2000, resource.DecimalSI),
 				v1.ResourceMemory:           *resource.NewQuantity(10e9, resource.BinarySI),
+				v1.ResourceSwapMemory:       *resource.NewQuantity(5e9, resource.BinarySI),
 				v1.ResourcePods:             *resource.NewQuantity(0, resource.DecimalSI),
 				v1.ResourceEphemeralStorage: *resource.NewQuantity(20e9, resource.BinarySI),
 			},
 			Allocatable: v1.ResourceList{
 				v1.ResourceCPU:              *resource.NewMilliQuantity(1800, resource.DecimalSI),
 				v1.ResourceMemory:           *resource.NewQuantity(9900e6, resource.BinarySI),
+				v1.ResourceSwapMemory:       *resource.NewQuantity(5e9, resource.BinarySI),
 				v1.ResourcePods:             *resource.NewQuantity(0, resource.DecimalSI),
 				v1.ResourceEphemeralStorage: *resource.NewQuantity(10e9, resource.BinarySI),
 			},
@@ -830,6 +839,7 @@ func TestUpdateNodeStatusWithLease(t *testing.T) {
 		BootID:         "1b3",
 		NumCores:       2,
 		MemoryCapacity: 20e9,
+		SwapCapacity:   5e9,
 	}
 	kubelet.setCachedMachineInfo(machineInfo)
 
@@ -887,12 +897,14 @@ func TestUpdateNodeStatusWithLease(t *testing.T) {
 			Capacity: v1.ResourceList{
 				v1.ResourceCPU:              *resource.NewMilliQuantity(2000, resource.DecimalSI),
 				v1.ResourceMemory:           *resource.NewQuantity(20e9, resource.BinarySI),
+				v1.ResourceSwapMemory:       *resource.NewQuantity(5e9, resource.BinarySI),
 				v1.ResourcePods:             *resource.NewQuantity(0, resource.DecimalSI),
 				v1.ResourceEphemeralStorage: *resource.NewQuantity(5000, resource.BinarySI),
 			},
 			Allocatable: v1.ResourceList{
 				v1.ResourceCPU:              *resource.NewMilliQuantity(1800, resource.DecimalSI),
 				v1.ResourceMemory:           *resource.NewQuantity(19900e6, resource.BinarySI),
+				v1.ResourceSwapMemory:       *resource.NewQuantity(5e9, resource.BinarySI),
 				v1.ResourcePods:             *resource.NewQuantity(0, resource.DecimalSI),
 				v1.ResourceEphemeralStorage: *resource.NewQuantity(5000, resource.BinarySI),
 			},
@@ -1541,6 +1553,7 @@ func TestUpdateNewNodeStatusTooLargeReservation(t *testing.T) {
 		BootID:         "1b3",
 		NumCores:       2,
 		MemoryCapacity: 10e9, // 10G
+		SwapCapacity:   5e9,  // 5G
 	}
 	kubelet.setCachedMachineInfo(machineInfo)
 
@@ -1551,12 +1564,14 @@ func TestUpdateNewNodeStatusTooLargeReservation(t *testing.T) {
 			Capacity: v1.ResourceList{
 				v1.ResourceCPU:              *resource.NewMilliQuantity(2000, resource.DecimalSI),
 				v1.ResourceMemory:           *resource.NewQuantity(10e9, resource.BinarySI),
+				v1.ResourceSwapMemory:       *resource.NewQuantity(5e9, resource.BinarySI),
 				v1.ResourcePods:             *resource.NewQuantity(0, resource.DecimalSI),
 				v1.ResourceEphemeralStorage: *resource.NewQuantity(3000, resource.BinarySI),
 			},
 			Allocatable: v1.ResourceList{
 				v1.ResourceCPU:              *resource.NewMilliQuantity(0, resource.DecimalSI),
 				v1.ResourceMemory:           *resource.NewQuantity(10e9, resource.BinarySI),
+				v1.ResourceSwapMemory:       *resource.NewQuantity(5e9, resource.BinarySI),
 				v1.ResourcePods:             *resource.NewQuantity(0, resource.DecimalSI),
 				v1.ResourceEphemeralStorage: *resource.NewQuantity(2000, resource.BinarySI),
 			},

--- a/pkg/kubelet/nodestatus/setters.go
+++ b/pkg/kubelet/nodestatus/setters.go
@@ -284,6 +284,7 @@ func MachineInfo(nodeName string,
 			// See if the test should be updated instead.
 			node.Status.Capacity[v1.ResourceCPU] = *resource.NewMilliQuantity(0, resource.DecimalSI)
 			node.Status.Capacity[v1.ResourceMemory] = resource.MustParse("0Gi")
+			node.Status.Capacity[v1.ResourceSwapMemory] = resource.MustParse("0Gi")
 			node.Status.Capacity[v1.ResourcePods] = *resource.NewQuantity(int64(maxPods), resource.DecimalSI)
 			klog.ErrorS(err, "Error getting machine info")
 		} else {

--- a/pkg/kubelet/nodestatus/setters_test.go
+++ b/pkg/kubelet/nodestatus/setters_test.go
@@ -794,6 +794,7 @@ func TestMachineInfo(t *testing.T) {
 				SystemUUID:     "SystemUUID",
 				NumCores:       2,
 				MemoryCapacity: 1024,
+				SwapCapacity:   512,
 			},
 			expectNode: &v1.Node{
 				Status: v1.NodeStatus{
@@ -802,14 +803,16 @@ func TestMachineInfo(t *testing.T) {
 						SystemUUID: "SystemUUID",
 					},
 					Capacity: v1.ResourceList{
-						v1.ResourceCPU:    *resource.NewMilliQuantity(2000, resource.DecimalSI),
-						v1.ResourceMemory: *resource.NewQuantity(1024, resource.BinarySI),
-						v1.ResourcePods:   *resource.NewQuantity(110, resource.DecimalSI),
+						v1.ResourceCPU:        *resource.NewMilliQuantity(2000, resource.DecimalSI),
+						v1.ResourceMemory:     *resource.NewQuantity(1024, resource.BinarySI),
+						v1.ResourceSwapMemory: *resource.NewQuantity(512, resource.BinarySI),
+						v1.ResourcePods:       *resource.NewQuantity(110, resource.DecimalSI),
 					},
 					Allocatable: v1.ResourceList{
-						v1.ResourceCPU:    *resource.NewMilliQuantity(2000, resource.DecimalSI),
-						v1.ResourceMemory: *resource.NewQuantity(1024, resource.BinarySI),
-						v1.ResourcePods:   *resource.NewQuantity(110, resource.DecimalSI),
+						v1.ResourceCPU:        *resource.NewMilliQuantity(2000, resource.DecimalSI),
+						v1.ResourceMemory:     *resource.NewQuantity(1024, resource.BinarySI),
+						v1.ResourceSwapMemory: *resource.NewQuantity(512, resource.BinarySI),
+						v1.ResourcePods:       *resource.NewQuantity(110, resource.DecimalSI),
 					},
 				},
 			},
@@ -822,18 +825,21 @@ func TestMachineInfo(t *testing.T) {
 			machineInfo: &cadvisorapiv1.MachineInfo{
 				NumCores:       2,
 				MemoryCapacity: 1024,
+				SwapCapacity:   512,
 			},
 			expectNode: &v1.Node{
 				Status: v1.NodeStatus{
 					Capacity: v1.ResourceList{
-						v1.ResourceCPU:    *resource.NewMilliQuantity(2000, resource.DecimalSI),
-						v1.ResourceMemory: *resource.NewQuantity(1024, resource.BinarySI),
-						v1.ResourcePods:   *resource.NewQuantity(8, resource.DecimalSI),
+						v1.ResourceCPU:        *resource.NewMilliQuantity(2000, resource.DecimalSI),
+						v1.ResourceMemory:     *resource.NewQuantity(1024, resource.BinarySI),
+						v1.ResourceSwapMemory: *resource.NewQuantity(512, resource.BinarySI),
+						v1.ResourcePods:       *resource.NewQuantity(8, resource.DecimalSI),
 					},
 					Allocatable: v1.ResourceList{
-						v1.ResourceCPU:    *resource.NewMilliQuantity(2000, resource.DecimalSI),
-						v1.ResourceMemory: *resource.NewQuantity(1024, resource.BinarySI),
-						v1.ResourcePods:   *resource.NewQuantity(8, resource.DecimalSI),
+						v1.ResourceCPU:        *resource.NewMilliQuantity(2000, resource.DecimalSI),
+						v1.ResourceMemory:     *resource.NewQuantity(1024, resource.BinarySI),
+						v1.ResourceSwapMemory: *resource.NewQuantity(512, resource.BinarySI),
+						v1.ResourcePods:       *resource.NewQuantity(8, resource.DecimalSI),
 					},
 				},
 			},
@@ -846,18 +852,21 @@ func TestMachineInfo(t *testing.T) {
 			machineInfo: &cadvisorapiv1.MachineInfo{
 				NumCores:       2,
 				MemoryCapacity: 1024,
+				SwapCapacity:   512,
 			},
 			expectNode: &v1.Node{
 				Status: v1.NodeStatus{
 					Capacity: v1.ResourceList{
-						v1.ResourceCPU:    *resource.NewMilliQuantity(2000, resource.DecimalSI),
-						v1.ResourceMemory: *resource.NewQuantity(1024, resource.BinarySI),
-						v1.ResourcePods:   *resource.NewQuantity(10, resource.DecimalSI),
+						v1.ResourceCPU:        *resource.NewMilliQuantity(2000, resource.DecimalSI),
+						v1.ResourceMemory:     *resource.NewQuantity(1024, resource.BinarySI),
+						v1.ResourceSwapMemory: *resource.NewQuantity(512, resource.BinarySI),
+						v1.ResourcePods:       *resource.NewQuantity(10, resource.DecimalSI),
 					},
 					Allocatable: v1.ResourceList{
-						v1.ResourceCPU:    *resource.NewMilliQuantity(2000, resource.DecimalSI),
-						v1.ResourceMemory: *resource.NewQuantity(1024, resource.BinarySI),
-						v1.ResourcePods:   *resource.NewQuantity(10, resource.DecimalSI),
+						v1.ResourceCPU:        *resource.NewMilliQuantity(2000, resource.DecimalSI),
+						v1.ResourceMemory:     *resource.NewQuantity(1024, resource.BinarySI),
+						v1.ResourceSwapMemory: *resource.NewQuantity(512, resource.BinarySI),
+						v1.ResourcePods:       *resource.NewQuantity(10, resource.DecimalSI),
 					},
 				},
 			},
@@ -869,6 +878,7 @@ func TestMachineInfo(t *testing.T) {
 			machineInfo: &cadvisorapiv1.MachineInfo{
 				NumCores:       2,
 				MemoryCapacity: 1024,
+				SwapCapacity:   512,
 			},
 			nodeAllocatableReservation: v1.ResourceList{
 				// reserve 1 unit for each resource
@@ -880,14 +890,16 @@ func TestMachineInfo(t *testing.T) {
 			expectNode: &v1.Node{
 				Status: v1.NodeStatus{
 					Capacity: v1.ResourceList{
-						v1.ResourceCPU:    *resource.NewMilliQuantity(2000, resource.DecimalSI),
-						v1.ResourceMemory: *resource.NewQuantity(1024, resource.BinarySI),
-						v1.ResourcePods:   *resource.NewQuantity(110, resource.DecimalSI),
+						v1.ResourceCPU:        *resource.NewMilliQuantity(2000, resource.DecimalSI),
+						v1.ResourceMemory:     *resource.NewQuantity(1024, resource.BinarySI),
+						v1.ResourceSwapMemory: *resource.NewQuantity(512, resource.BinarySI),
+						v1.ResourcePods:       *resource.NewQuantity(110, resource.DecimalSI),
 					},
 					Allocatable: v1.ResourceList{
-						v1.ResourceCPU:    *resource.NewMilliQuantity(1999, resource.DecimalSI),
-						v1.ResourceMemory: *resource.NewQuantity(1023, resource.BinarySI),
-						v1.ResourcePods:   *resource.NewQuantity(109, resource.DecimalSI),
+						v1.ResourceCPU:        *resource.NewMilliQuantity(1999, resource.DecimalSI),
+						v1.ResourceMemory:     *resource.NewQuantity(1023, resource.BinarySI),
+						v1.ResourceSwapMemory: *resource.NewQuantity(512, resource.BinarySI),
+						v1.ResourcePods:       *resource.NewQuantity(109, resource.DecimalSI),
 					},
 				},
 			},
@@ -907,12 +919,14 @@ func TestMachineInfo(t *testing.T) {
 			machineInfo: &cadvisorapiv1.MachineInfo{
 				NumCores:       2,
 				MemoryCapacity: 1024,
+				SwapCapacity:   512,
 			},
 			expectNode: &v1.Node{
 				Status: v1.NodeStatus{
 					Capacity: v1.ResourceList{
 						v1.ResourceCPU:                      *resource.NewMilliQuantity(2000, resource.DecimalSI),
 						v1.ResourceMemory:                   *resource.NewQuantity(1024, resource.BinarySI),
+						v1.ResourceSwapMemory:               *resource.NewQuantity(512, resource.BinarySI),
 						v1.ResourceHugePagesPrefix + "test": *resource.NewQuantity(1, resource.BinarySI),
 						v1.ResourcePods:                     *resource.NewQuantity(110, resource.DecimalSI),
 					},
@@ -920,6 +934,7 @@ func TestMachineInfo(t *testing.T) {
 						v1.ResourceCPU: *resource.NewMilliQuantity(2000, resource.DecimalSI),
 						// memory has 1-unit difference for hugepages reservation
 						v1.ResourceMemory:                   *resource.NewQuantity(1023, resource.BinarySI),
+						v1.ResourceSwapMemory:               *resource.NewQuantity(512, resource.BinarySI),
 						v1.ResourceHugePagesPrefix + "test": *resource.NewQuantity(1, resource.BinarySI),
 						v1.ResourcePods:                     *resource.NewQuantity(110, resource.DecimalSI),
 					},
@@ -939,20 +954,23 @@ func TestMachineInfo(t *testing.T) {
 			machineInfo: &cadvisorapiv1.MachineInfo{
 				NumCores:       2,
 				MemoryCapacity: 1024,
+				SwapCapacity:   512,
 			},
 			expectNode: &v1.Node{
 				Status: v1.NodeStatus{
 					Capacity: v1.ResourceList{
-						v1.ResourceCPU:      *resource.NewMilliQuantity(2000, resource.DecimalSI),
-						v1.ResourceMemory:   *resource.NewQuantity(1024, resource.BinarySI),
-						v1.ResourcePods:     *resource.NewQuantity(110, resource.DecimalSI),
-						"negative-resource": *resource.NewQuantity(-1, resource.BinarySI),
+						v1.ResourceCPU:        *resource.NewMilliQuantity(2000, resource.DecimalSI),
+						v1.ResourceMemory:     *resource.NewQuantity(1024, resource.BinarySI),
+						v1.ResourceSwapMemory: *resource.NewQuantity(512, resource.BinarySI),
+						v1.ResourcePods:       *resource.NewQuantity(110, resource.DecimalSI),
+						"negative-resource":   *resource.NewQuantity(-1, resource.BinarySI),
 					},
 					Allocatable: v1.ResourceList{
-						v1.ResourceCPU:      *resource.NewMilliQuantity(2000, resource.DecimalSI),
-						v1.ResourceMemory:   *resource.NewQuantity(1024, resource.BinarySI),
-						v1.ResourcePods:     *resource.NewQuantity(110, resource.DecimalSI),
-						"negative-resource": *resource.NewQuantity(0, resource.BinarySI),
+						v1.ResourceCPU:        *resource.NewMilliQuantity(2000, resource.DecimalSI),
+						v1.ResourceMemory:     *resource.NewQuantity(1024, resource.BinarySI),
+						v1.ResourceSwapMemory: *resource.NewQuantity(512, resource.BinarySI),
+						v1.ResourcePods:       *resource.NewQuantity(110, resource.DecimalSI),
+						"negative-resource":   *resource.NewQuantity(0, resource.BinarySI),
 					},
 				},
 			},
@@ -970,18 +988,21 @@ func TestMachineInfo(t *testing.T) {
 			machineInfo: &cadvisorapiv1.MachineInfo{
 				NumCores:       2,
 				MemoryCapacity: 1024,
+				SwapCapacity:   512,
 			},
 			expectNode: &v1.Node{
 				Status: v1.NodeStatus{
 					Capacity: v1.ResourceList{
 						v1.ResourceCPU:                      *resource.NewMilliQuantity(2000, resource.DecimalSI),
 						v1.ResourceMemory:                   *resource.NewQuantity(1024, resource.BinarySI),
+						v1.ResourceSwapMemory:               *resource.NewQuantity(512, resource.BinarySI),
 						v1.ResourcePods:                     *resource.NewQuantity(110, resource.DecimalSI),
 						v1.ResourceHugePagesPrefix + "test": *resource.NewQuantity(1025, resource.BinarySI),
 					},
 					Allocatable: v1.ResourceList{
 						v1.ResourceCPU:                      *resource.NewMilliQuantity(2000, resource.DecimalSI),
 						v1.ResourceMemory:                   *resource.NewQuantity(0, resource.BinarySI),
+						v1.ResourceSwapMemory:               *resource.NewQuantity(512, resource.BinarySI),
 						v1.ResourcePods:                     *resource.NewQuantity(110, resource.DecimalSI),
 						v1.ResourceHugePagesPrefix + "test": *resource.NewQuantity(1025, resource.BinarySI),
 					},
@@ -995,6 +1016,7 @@ func TestMachineInfo(t *testing.T) {
 			machineInfo: &cadvisorapiv1.MachineInfo{
 				NumCores:       2,
 				MemoryCapacity: 1024,
+				SwapCapacity:   512,
 			},
 			capacity: v1.ResourceList{
 				v1.ResourceEphemeralStorage: *resource.NewQuantity(5000, resource.BinarySI),
@@ -1004,12 +1026,14 @@ func TestMachineInfo(t *testing.T) {
 					Capacity: v1.ResourceList{
 						v1.ResourceCPU:              *resource.NewMilliQuantity(2000, resource.DecimalSI),
 						v1.ResourceMemory:           *resource.NewQuantity(1024, resource.BinarySI),
+						v1.ResourceSwapMemory:       *resource.NewQuantity(512, resource.BinarySI),
 						v1.ResourcePods:             *resource.NewQuantity(110, resource.DecimalSI),
 						v1.ResourceEphemeralStorage: *resource.NewQuantity(5000, resource.BinarySI),
 					},
 					Allocatable: v1.ResourceList{
 						v1.ResourceCPU:              *resource.NewMilliQuantity(2000, resource.DecimalSI),
 						v1.ResourceMemory:           *resource.NewQuantity(1024, resource.BinarySI),
+						v1.ResourceSwapMemory:       *resource.NewQuantity(512, resource.BinarySI),
 						v1.ResourcePods:             *resource.NewQuantity(110, resource.DecimalSI),
 						v1.ResourceEphemeralStorage: *resource.NewQuantity(5000, resource.BinarySI),
 					},
@@ -1023,6 +1047,7 @@ func TestMachineInfo(t *testing.T) {
 			machineInfo: &cadvisorapiv1.MachineInfo{
 				NumCores:       2,
 				MemoryCapacity: 1024,
+				SwapCapacity:   512,
 			},
 			capacity: v1.ResourceList{
 				v1.ResourceEphemeralStorage: *resource.NewQuantity(5000, resource.BinarySI),
@@ -1032,12 +1057,14 @@ func TestMachineInfo(t *testing.T) {
 					Capacity: v1.ResourceList{
 						v1.ResourceCPU:              *resource.NewMilliQuantity(2000, resource.DecimalSI),
 						v1.ResourceMemory:           *resource.NewQuantity(1024, resource.BinarySI),
+						v1.ResourceSwapMemory:       *resource.NewQuantity(512, resource.BinarySI),
 						v1.ResourcePods:             *resource.NewQuantity(110, resource.DecimalSI),
 						v1.ResourceEphemeralStorage: *resource.NewQuantity(5000, resource.BinarySI),
 					},
 					Allocatable: v1.ResourceList{
 						v1.ResourceCPU:              *resource.NewMilliQuantity(2000, resource.DecimalSI),
 						v1.ResourceMemory:           *resource.NewQuantity(1024, resource.BinarySI),
+						v1.ResourceSwapMemory:       *resource.NewQuantity(512, resource.BinarySI),
 						v1.ResourcePods:             *resource.NewQuantity(110, resource.DecimalSI),
 						v1.ResourceEphemeralStorage: *resource.NewQuantity(5000, resource.BinarySI),
 					},
@@ -1052,6 +1079,7 @@ func TestMachineInfo(t *testing.T) {
 			machineInfo: &cadvisorapiv1.MachineInfo{
 				NumCores:       2,
 				MemoryCapacity: 1024,
+				SwapCapacity:   512,
 			},
 			devicePluginResourceCapacity: dprc{
 				capacity: v1.ResourceList{
@@ -1064,16 +1092,18 @@ func TestMachineInfo(t *testing.T) {
 			expectNode: &v1.Node{
 				Status: v1.NodeStatus{
 					Capacity: v1.ResourceList{
-						v1.ResourceCPU:    *resource.NewMilliQuantity(2000, resource.DecimalSI),
-						v1.ResourceMemory: *resource.NewQuantity(1024, resource.BinarySI),
-						v1.ResourcePods:   *resource.NewQuantity(110, resource.DecimalSI),
-						"device-plugin":   *resource.NewQuantity(1, resource.BinarySI),
+						v1.ResourceCPU:        *resource.NewMilliQuantity(2000, resource.DecimalSI),
+						v1.ResourceMemory:     *resource.NewQuantity(1024, resource.BinarySI),
+						v1.ResourceSwapMemory: *resource.NewQuantity(512, resource.BinarySI),
+						v1.ResourcePods:       *resource.NewQuantity(110, resource.DecimalSI),
+						"device-plugin":       *resource.NewQuantity(1, resource.BinarySI),
 					},
 					Allocatable: v1.ResourceList{
-						v1.ResourceCPU:    *resource.NewMilliQuantity(2000, resource.DecimalSI),
-						v1.ResourceMemory: *resource.NewQuantity(1024, resource.BinarySI),
-						v1.ResourcePods:   *resource.NewQuantity(110, resource.DecimalSI),
-						"device-plugin":   *resource.NewQuantity(1, resource.BinarySI),
+						v1.ResourceCPU:        *resource.NewMilliQuantity(2000, resource.DecimalSI),
+						v1.ResourceMemory:     *resource.NewQuantity(1024, resource.BinarySI),
+						v1.ResourceSwapMemory: *resource.NewQuantity(512, resource.BinarySI),
+						v1.ResourcePods:       *resource.NewQuantity(110, resource.DecimalSI),
+						"device-plugin":       *resource.NewQuantity(1, resource.BinarySI),
 					},
 				},
 			},
@@ -1091,6 +1121,7 @@ func TestMachineInfo(t *testing.T) {
 			machineInfo: &cadvisorapiv1.MachineInfo{
 				NumCores:       2,
 				MemoryCapacity: 1024,
+				SwapCapacity:   512,
 			},
 			devicePluginResourceCapacity: dprc{
 				inactive: []string{"inactive"},
@@ -1098,16 +1129,18 @@ func TestMachineInfo(t *testing.T) {
 			expectNode: &v1.Node{
 				Status: v1.NodeStatus{
 					Capacity: v1.ResourceList{
-						v1.ResourceCPU:    *resource.NewMilliQuantity(2000, resource.DecimalSI),
-						v1.ResourceMemory: *resource.NewQuantity(1024, resource.BinarySI),
-						v1.ResourcePods:   *resource.NewQuantity(110, resource.DecimalSI),
-						"inactive":        *resource.NewQuantity(0, resource.BinarySI),
+						v1.ResourceCPU:        *resource.NewMilliQuantity(2000, resource.DecimalSI),
+						v1.ResourceMemory:     *resource.NewQuantity(1024, resource.BinarySI),
+						v1.ResourceSwapMemory: *resource.NewQuantity(512, resource.BinarySI),
+						v1.ResourcePods:       *resource.NewQuantity(110, resource.DecimalSI),
+						"inactive":            *resource.NewQuantity(0, resource.BinarySI),
 					},
 					Allocatable: v1.ResourceList{
-						v1.ResourceCPU:    *resource.NewMilliQuantity(2000, resource.DecimalSI),
-						v1.ResourceMemory: *resource.NewQuantity(1024, resource.BinarySI),
-						v1.ResourcePods:   *resource.NewQuantity(110, resource.DecimalSI),
-						"inactive":        *resource.NewQuantity(0, resource.BinarySI),
+						v1.ResourceCPU:        *resource.NewMilliQuantity(2000, resource.DecimalSI),
+						v1.ResourceMemory:     *resource.NewQuantity(1024, resource.BinarySI),
+						v1.ResourceSwapMemory: *resource.NewQuantity(512, resource.BinarySI),
+						v1.ResourcePods:       *resource.NewQuantity(110, resource.DecimalSI),
+						"inactive":            *resource.NewQuantity(0, resource.BinarySI),
 					},
 				},
 			},
@@ -1125,18 +1158,21 @@ func TestMachineInfo(t *testing.T) {
 			machineInfo: &cadvisorapiv1.MachineInfo{
 				NumCores:       2,
 				MemoryCapacity: 1024,
+				SwapCapacity:   512,
 			},
 			expectNode: &v1.Node{
 				Status: v1.NodeStatus{
 					Capacity: v1.ResourceList{
-						v1.ResourceCPU:    *resource.NewMilliQuantity(2000, resource.DecimalSI),
-						v1.ResourceMemory: *resource.NewQuantity(1024, resource.BinarySI),
-						v1.ResourcePods:   *resource.NewQuantity(110, resource.DecimalSI),
+						v1.ResourceCPU:        *resource.NewMilliQuantity(2000, resource.DecimalSI),
+						v1.ResourceMemory:     *resource.NewQuantity(1024, resource.BinarySI),
+						v1.ResourceSwapMemory: *resource.NewQuantity(512, resource.BinarySI),
+						v1.ResourcePods:       *resource.NewQuantity(110, resource.DecimalSI),
 					},
 					Allocatable: v1.ResourceList{
-						v1.ResourceCPU:    *resource.NewMilliQuantity(2000, resource.DecimalSI),
-						v1.ResourceMemory: *resource.NewQuantity(1024, resource.BinarySI),
-						v1.ResourcePods:   *resource.NewQuantity(110, resource.DecimalSI),
+						v1.ResourceCPU:        *resource.NewMilliQuantity(2000, resource.DecimalSI),
+						v1.ResourceMemory:     *resource.NewQuantity(1024, resource.BinarySI),
+						v1.ResourceSwapMemory: *resource.NewQuantity(512, resource.BinarySI),
+						v1.ResourcePods:       *resource.NewQuantity(110, resource.DecimalSI),
 					},
 				},
 			},
@@ -1151,14 +1187,16 @@ func TestMachineInfo(t *testing.T) {
 			expectNode: &v1.Node{
 				Status: v1.NodeStatus{
 					Capacity: v1.ResourceList{
-						v1.ResourceCPU:    *resource.NewMilliQuantity(0, resource.DecimalSI),
-						v1.ResourceMemory: resource.MustParse("0Gi"),
-						v1.ResourcePods:   *resource.NewQuantity(110, resource.DecimalSI),
+						v1.ResourceCPU:        *resource.NewMilliQuantity(0, resource.DecimalSI),
+						v1.ResourceMemory:     resource.MustParse("0Gi"),
+						v1.ResourceSwapMemory: resource.MustParse("0Gi"),
+						v1.ResourcePods:       *resource.NewQuantity(110, resource.DecimalSI),
 					},
 					Allocatable: v1.ResourceList{
-						v1.ResourceCPU:    *resource.NewMilliQuantity(0, resource.DecimalSI),
-						v1.ResourceMemory: resource.MustParse("0Gi"),
-						v1.ResourcePods:   *resource.NewQuantity(110, resource.DecimalSI),
+						v1.ResourceCPU:        *resource.NewMilliQuantity(0, resource.DecimalSI),
+						v1.ResourceMemory:     resource.MustParse("0Gi"),
+						v1.ResourceSwapMemory: resource.MustParse("0Gi"),
+						v1.ResourcePods:       *resource.NewQuantity(110, resource.DecimalSI),
 					},
 				},
 			},
@@ -1177,6 +1215,7 @@ func TestMachineInfo(t *testing.T) {
 				BootID:         "bar",
 				NumCores:       2,
 				MemoryCapacity: 1024,
+				SwapCapacity:   512,
 			},
 			expectNode: &v1.Node{
 				Status: v1.NodeStatus{
@@ -1184,14 +1223,16 @@ func TestMachineInfo(t *testing.T) {
 						BootID: "bar",
 					},
 					Capacity: v1.ResourceList{
-						v1.ResourceCPU:    *resource.NewMilliQuantity(2000, resource.DecimalSI),
-						v1.ResourceMemory: *resource.NewQuantity(1024, resource.BinarySI),
-						v1.ResourcePods:   *resource.NewQuantity(110, resource.DecimalSI),
+						v1.ResourceCPU:        *resource.NewMilliQuantity(2000, resource.DecimalSI),
+						v1.ResourceMemory:     *resource.NewQuantity(1024, resource.BinarySI),
+						v1.ResourceSwapMemory: *resource.NewQuantity(512, resource.BinarySI),
+						v1.ResourcePods:       *resource.NewQuantity(110, resource.DecimalSI),
 					},
 					Allocatable: v1.ResourceList{
-						v1.ResourceCPU:    *resource.NewMilliQuantity(2000, resource.DecimalSI),
-						v1.ResourceMemory: *resource.NewQuantity(1024, resource.BinarySI),
-						v1.ResourcePods:   *resource.NewQuantity(110, resource.DecimalSI),
+						v1.ResourceCPU:        *resource.NewMilliQuantity(2000, resource.DecimalSI),
+						v1.ResourceMemory:     *resource.NewQuantity(1024, resource.BinarySI),
+						v1.ResourceSwapMemory: *resource.NewQuantity(512, resource.BinarySI),
+						v1.ResourcePods:       *resource.NewQuantity(110, resource.DecimalSI),
 					},
 				},
 			},

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -6104,6 +6104,8 @@ const (
 	ResourceCPU ResourceName = "cpu"
 	// Memory, in bytes. (500Gi = 500GiB = 500 * 1024 * 1024 * 1024)
 	ResourceMemory ResourceName = "memory"
+	// Swap Memory, in bytes. (500Gi = 500GiB = 500 * 1024 * 1024 * 1024)
+	ResourceSwapMemory ResourceName = "swap"
 	// Volume size, in bytes (e,g. 5Gi = 5GiB = 5 * 1024 * 1024 * 1024)
 	ResourceStorage ResourceName = "storage"
 	// Local ephemeral storage, in bytes. (500Gi = 500GiB = 500 * 1024 * 1024 * 1024)

--- a/staging/src/k8s.io/kubectl/pkg/describe/describe.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/describe.go
@@ -4238,7 +4238,7 @@ func describeNodeResource(nodeNonTerminatedPodsList *corev1.PodList, node *corev
 	for resource := range allocatable {
 		if resourcehelper.IsHugePageResourceName(resource) {
 			hugePageResources = append(hugePageResources, string(resource))
-		} else if !resourcehelper.IsStandardContainerResourceName(string(resource)) && resource != corev1.ResourcePods {
+		} else if !resourcehelper.IsStandardContainerResourceName(string(resource)) && resource != corev1.ResourcePods && resource != corev1.ResourceSwapMemory {
 			extResources = append(extResources, string(resource))
 		}
 	}

--- a/staging/src/k8s.io/kubectl/pkg/describe/describe_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/describe_test.go
@@ -5552,6 +5552,10 @@ func TestDescribeNode(t *testing.T) {
 		getHugePageResourceList("1Gi", "0"),
 	)
 
+	swapResource := resource.MustParse("10Gi")
+	nodeCapacity[corev1.ResourceSwapMemory] = swapResource
+	nodeAllocatable[corev1.ResourceSwapMemory] = swapResource
+
 	fake := fake.NewSimpleClientset(
 		&corev1.Node{
 			ObjectMeta: metav1.ObjectMeta{
@@ -5664,7 +5668,19 @@ func TestDescribeNode(t *testing.T) {
   hugepages-1Gi      0 (0%)       0 (0%)
   hugepages-2Mi      512Mi (25%)  512Mi (25%)`,
 		`Node bar status is now: NodeHasNoDiskPressure`,
-		`Node bar status is now: NodeReady`}
+		`Node bar status is now: NodeReady`,
+		`Capacity:
+  cpu:            8
+  hugepages-1Gi:  0
+  hugepages-2Mi:  4Gi
+  memory:         24Gi
+  swap:           10Gi
+Allocatable:
+  cpu:            4
+  hugepages-1Gi:  0
+  hugepages-2Mi:  2Gi
+  memory:         12Gi
+  swap:           10Gi`}
 	for _, expected := range expectedOut {
 		if !strings.Contains(out, expected) {
 			t.Errorf("expected to find %q in output: %q", expected, out)

--- a/staging/src/k8s.io/kubectl/pkg/describe/describe_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/describe_test.go
@@ -5666,7 +5666,8 @@ func TestDescribeNode(t *testing.T) {
   memory             1Gi (8%)     2Gi (16%)
   ephemeral-storage  0 (0%)       0 (0%)
   hugepages-1Gi      0 (0%)       0 (0%)
-  hugepages-2Mi      512Mi (25%)  512Mi (25%)`,
+  hugepages-2Mi      512Mi (25%)  512Mi (25%)
+Events:`,
 		`Node bar status is now: NodeHasNoDiskPressure`,
 		`Node bar status is now: NodeReady`,
 		`Capacity:


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR provides a way of easily inspecting the amount of swap memory that's available on nodes.
This has been an ongoing request from the community for a long time now. Although this data already exists as part of `/stats/summary` and `/metrics/resource` (see https://github.com/kubernetes/kubernetes/pull/118865), using `kubectl describe node` is much simpler and straight forward.

##### Example output:
```bash
> kubectl describe node | grep Capacity -A15
Capacity:
  cpu:                40
  ephemeral-storage:  1293695812Ki
  hugepages-1Gi:      0
  hugepages-2Mi:      0
  memory:             394492620Ki
  pods:               110
  swap:               41943032Ki
Allocatable:
  cpu:                40
  ephemeral-storage:  1293695812Ki
  hugepages-1Gi:      0
  hugepages-2Mi:      0
  memory:             394492620Ki
  pods:               110
  swap:               41943032Ki
```

#### Which issue(s) this PR fixes:
Fixes #123962

#### Special notes for your reviewer:
I've added swap as a `ResourceName`. However, it's important to note that it **cannot** be added to the pod spec.

Another alternative is to use "swap" as a string and cast it to `ResourceName`, but then we'd need to keep it as a constant string somewhere and remember it is actually used as a ResourceName.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Updated `kubectl describe node` to report the available amount of swap for Linux nodes.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/2400-node-swap
```
