### PR TITLE
add cross field errors

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/validation/field/errors.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/validation/field/errors.go
@@ -191,6 +191,62 @@ func Duplicate(field *Path, value interface{}) *Error {
 	return &Error{ErrorTypeDuplicate, field.String(), value, ""}
 }
 
+// specified indicates that a field was specified, regardless of the value.
+const specified = "specified"
+
+func render(val interface{}) string {
+	if r, ok := val.(string); ok {
+		return r
+	}
+	return fmt.Sprintf("%#v", val)
+}
+
+func Not(val interface{}) string {
+	return fmt.Sprintf("not %v", render(val))
+}
+
+// IncompatibleSpecification returns a *Error indicating that the field is generally
+// invalid.
+func IncompatibleSpecification(field *Path, other *Path, value interface{}) *Error {
+	detail := fmt.Sprintf("may not specify %v", other.String())
+	return &Error{ErrorTypeTypeInvalid, field.String(), value, detail}
+}
+
+// IncompatibleWith returns a *Error indicating that the field is incompatible
+// with another field that has been specified
+func IncompatibleWith(field *Path, other *Path, value interface{}) *Error {
+	return IncompatibleWithValue(field, other, value, specified)
+}
+
+// IncompatibleWithValue returns a *Error indicating that the field is incompatible
+// with another field with regard for the value
+func IncompatibleWithValue(field *Path, other *Path, value interface{}, otherValue interface{}) *Error {
+	rov := render(otherValue)
+	detail := fmt.Sprintf("may not be specified when %v is %s", other.String(), rov)
+	return &Error{ErrorTypeInvalid, field.String(), value, detail}
+}
+
+// DependsOn returns a *Error indicating that a field depends on another field being specified
+func DependsOn(field *Path, dependency *Path, value interface{}) *Error {
+	return DependsOnValue(field, dependency, value, specified)
+}
+
+// DependsOnValue returns a *Error indicating that a field depends on another field
+// being specified with regard for the value
+func DependsOnValue(field *Path, dependency *Path, value interface{}, otherValue interface{}) *Error {
+	rov := render(otherValue)
+	detail := fmt.Sprintf("may only be specified when %v is %s", dependency.String(), rov)
+	return &Error{ErrorTypeInvalid, field.String(), value, detail}
+}
+
+// RequiredWhenValue returns a *Error indicating that a field is required due to the
+// value of another field
+func RequiredWhenValue(field *Path, other *Path, otherValue interface{}) *Error {
+	rov := render(otherValue)
+	detail := fmt.Sprintf("must be specified when %v is %s", other.String(), rov)
+	return &Error{ErrorTypeRequired, field.String(), "", detail}
+}
+
 // Invalid returns a *Error indicating "invalid value".  This is used
 // to report malformed values (e.g. failed regex match, too long, out of bounds).
 func Invalid(field *Path, value interface{}, detail string) *Error {

--- a/staging/src/k8s.io/apimachinery/pkg/util/validation/field/errors_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/validation/field/errors_test.go
@@ -173,3 +173,51 @@ func TestNotSupported(t *testing.T) {
 		t.Errorf("Expected: %s\n, but got: %s\n", expected, notSupported.ErrorBody())
 	}
 }
+
+func TestIncompatibleSpecification(t *testing.T) {
+	incompatibleSpecification := IncompatibleSpecification(NewPath("f"), NewPath("o"), "v")
+	expected := `Invalid value: "v": may not specify o`
+	if incompatibleSpecification.ErrorBody() != expected {
+		t.Errorf("Expected: %s\n, but got: %s\n", expected, incompatibleSpecification.ErrorBody())
+	}
+}
+
+func TestIncompatibleWith(t *testing.T) {
+	incompatibleWith := IncompatibleWith(NewPath("f"), NewPath("o"), "v")
+	expected := `Invalid value: "v": may not be specified when o is specified`
+	if incompatibleWith.ErrorBody() != expected {
+		t.Errorf("Expected: %s\n, but got: %s\n", expected, incompatibleWith.ErrorBody())
+	}
+}
+
+func TestIncompatibleWithValue(t *testing.T) {
+	incompatibleWithValue := IncompatibleWithValue(NewPath("f"), NewPath("o"), "v", "specified")
+	expected := `Invalid value: "v": may not be specified when o is specified`
+	if incompatibleWithValue.ErrorBody() != expected {
+		t.Errorf("Expected: %s\n, but got: %s\n", expected, incompatibleWithValue.ErrorBody())
+	}
+}
+
+func TestDependsOn(t *testing.T) {
+	dependsOn := DependsOn(NewPath("f"), NewPath("o"), "v")
+	expected := `Invalid value: "v": may only be specified when o is specified`
+	if dependsOn.ErrorBody() != expected {
+		t.Errorf("Expected: %s\n, but got: %s\n", expected, dependsOn.ErrorBody())
+	}
+}
+
+func TestDependsOnValue(t *testing.T) {
+	dependsOnValue := DependsOnValue(NewPath("f"), NewPath("o"), "v", "l")
+	expected := `Invalid value: "v": may only be specified when o is l`
+	if dependsOnValue.ErrorBody() != expected {
+		t.Errorf("Expected: %s\n, but got: %s\n", expected, dependsOnValue.ErrorBody())
+	}
+}
+
+func TestRequiredWhenValue(t *testing.T) {
+	requiredWhenValue := RequiredWhenValue(NewPath("f"), NewPath("o"), "v")
+	expected := `Required value: must be specified when o is v`
+	if requiredWhenValue.ErrorBody() != expected {
+		t.Errorf("Expected: %s\n, but got: %s\n", expected, requiredWhenValue.ErrorBody())
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Adds errors of the form "X: must not be set when Y is set" or "X: may only be set when Y is Z", relieving reliance on field.Invalid().

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
This is an ongoing effort of #121432 

#### Special notes for your reviewer:
As alluded to in the original issue, the affected errors will need to be addressed piecemeal, and may lead to the discovery of further errors that may be added. To avoid bloat, I've started with validation and will include more in later PRs that do not involve reviewing the error functions as well. 
There are a few very bespoke errors still in there that may prove out to warrant a dedicated error type based on usage elsewhere. Someone with deeper knowledge may already be able to speak to this and make recommendations, otherwise they will have to be revised in the future.


If I've left any required information out of this PR or have anything wrong, please let me know!

