### PR TITLE
cleanup: delete rand.Seed(time.Now().UnixNano()) and using global number generator.

### DIFF
--- a/pkg/util/filesystem/util_windows_test.go
+++ b/pkg/util/filesystem/util_windows_test.go
@@ -34,7 +34,6 @@ import (
 
 func TestIsUnixDomainSocketPipe(t *testing.T) {
 	generatePipeName := func(suffixLen int) string {
-		rand.Seed(time.Now().UnixNano())
 		letter := []rune("abcdef0123456789")
 		b := make([]rune, suffixLen)
 		for i := range b {

--- a/staging/src/k8s.io/client-go/tools/cache/main_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/main_test.go
@@ -17,13 +17,10 @@ limitations under the License.
 package cache
 
 import (
-	"math/rand"
 	"os"
 	"testing"
-	"time"
 )
 
 func TestMain(m *testing.M) {
-	rand.Seed(time.Now().UnixNano())
 	os.Exit(m.Run())
 }

--- a/staging/src/k8s.io/client-go/tools/record/main_test.go
+++ b/staging/src/k8s.io/client-go/tools/record/main_test.go
@@ -17,13 +17,10 @@ limitations under the License.
 package record
 
 import (
-	"math/rand"
 	"os"
 	"testing"
-	"time"
 )
 
 func TestMain(m *testing.M) {
-	rand.Seed(time.Now().UnixNano())
 	os.Exit(m.Run())
 }

--- a/staging/src/k8s.io/client-go/util/workqueue/main_test.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/main_test.go
@@ -17,13 +17,10 @@ limitations under the License.
 package workqueue
 
 import (
-	"math/rand"
 	"os"
 	"testing"
-	"time"
 )
 
 func TestMain(m *testing.M) {
-	rand.Seed(time.Now().UnixNano())
 	os.Exit(m.Run())
 }

--- a/staging/src/k8s.io/component-base/cli/run.go
+++ b/staging/src/k8s.io/component-base/cli/run.go
@@ -18,9 +18,7 @@ package cli
 
 import (
 	"fmt"
-	"math/rand"
 	"os"
-	"time"
 
 	"github.com/spf13/cobra"
 
@@ -86,7 +84,6 @@ func RunNoErrOutput(cmd *cobra.Command) error {
 }
 
 func run(cmd *cobra.Command) (logsInitialized bool, err error) {
-	rand.Seed(time.Now().UnixNano())
 	defer logs.FlushLogs()
 
 	cmd.SetGlobalNormalizationFunc(cliflag.WordSepNormalizeFunc)

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -19,11 +19,9 @@ package e2e
 import (
 	"flag"
 	"fmt"
-	"math/rand"
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/onsi/ginkgo/v2"
 	"gopkg.in/yaml.v2"
@@ -142,7 +140,6 @@ func TestMain(m *testing.M) {
 		testfiles.AddFileSource(testfiles.RootFileSource{Root: framework.TestContext.RepoRoot})
 	}
 
-	rand.Seed(time.Now().UnixNano())
 	os.Exit(m.Run())
 }
 

--- a/test/e2e_node/e2e_node_suite_test.go
+++ b/test/e2e_node/e2e_node_suite_test.go
@@ -28,7 +28,6 @@ import (
 	"flag"
 	"fmt"
 
-	"math/rand"
 	"os"
 	"os/exec"
 	"syscall"
@@ -133,7 +132,6 @@ func TestMain(m *testing.M) {
 	// into TestContext.
 	// TODO(pohly): remove RegisterNodeFlags from test_context.go enable Viper config support here?
 
-	rand.Seed(time.Now().UnixNano())
 	pflag.Parse()
 	if pflag.CommandLine.NArg() > 0 {
 		fmt.Fprintf(os.Stderr, "unknown additional command line arguments: %s", pflag.CommandLine.Args())

--- a/test/e2e_node/remote/run_remote_suite.go
+++ b/test/e2e_node/remote/run_remote_suite.go
@@ -20,13 +20,11 @@ import (
 	"flag"
 	"fmt"
 	"log"
-	"math/rand"
 	"os"
 	"os/exec"
 	"os/signal"
 	"strings"
 	"sync"
-	"time"
 
 	"k8s.io/klog/v2"
 )
@@ -77,7 +75,6 @@ func RunRemoteTestSuite(testSuite TestSuite) {
 		os.Exit(1)
 	}()
 
-	rand.Seed(time.Now().UnixNano())
 	if *buildOnly {
 		// Build the archive and exit
 		CreateTestArchive(testSuite,

--- a/test/integration/volume/main_test.go
+++ b/test/integration/volume/main_test.go
@@ -17,14 +17,11 @@ limitations under the License.
 package volume
 
 import (
-	"math/rand"
 	"testing"
-	"time"
 
 	"k8s.io/kubernetes/test/integration/framework"
 )
 
 func TestMain(m *testing.M) {
-	rand.Seed(time.Now().UnixNano())
 	framework.EtcdMain(m.Run)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup
#### What this PR does / why we need it:

After go 1.20, the math/rand package now automatically seeds the global random number generator.

so this PR is working for delete `rand.Seed(time.Now().UnixNano())` and using global number generator.

 see https://tip.golang.org/doc/go1.20
 
 There are still codes like `rand.Seed(12345)` using fixed values in the code to create predictable results, and also need to update. But it's probably worth treating them with caution, so this PR doesn't update them and I can continue working on them in other PRs.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
