### PR TITLE
remove VolumePluginWithAttachLimits interface

### DIFF
--- a/pkg/kubelet/kubelet_node_status.go
+++ b/pkg/kubelet/kubelet_node_status.go
@@ -743,8 +743,6 @@ func (kl *Kubelet) defaultNodeStatusFuncs() []func(context.Context, *v1.Node) er
 		nodestatus.GoRuntime(),
 		nodestatus.RuntimeHandlers(kl.runtimeState.runtimeHandlers),
 	)
-	// Volume limits
-	setters = append(setters, nodestatus.VolumeLimits(kl.volumePluginMgr.ListVolumePluginWithLimits))
 
 	setters = append(setters,
 		nodestatus.MemoryPressureCondition(kl.clock.Now, kl.evictionManager.IsUnderMemoryPressure, kl.recordNodeStatusEvent),

--- a/pkg/kubelet/nodestatus/setters_test.go
+++ b/pkg/kubelet/nodestatus/setters_test.go
@@ -48,8 +48,6 @@ import (
 	kubecontainertest "k8s.io/kubernetes/pkg/kubelet/container/testing"
 	"k8s.io/kubernetes/pkg/kubelet/events"
 	"k8s.io/kubernetes/pkg/kubelet/util/sliceutils"
-	"k8s.io/kubernetes/pkg/volume"
-	volumetest "k8s.io/kubernetes/pkg/volume/testing"
 	netutils "k8s.io/utils/net"
 )
 
@@ -2072,70 +2070,6 @@ func TestVolumesInUse(t *testing.T) {
 			// check expected volumes
 			assert.True(t, apiequality.Semantic.DeepEqual(tc.expectVolumesInUse, tc.node.Status.VolumesInUse),
 				"Diff: %s", cmp.Diff(tc.expectVolumesInUse, tc.node.Status.VolumesInUse))
-		})
-	}
-}
-
-func TestVolumeLimits(t *testing.T) {
-	const (
-		volumeLimitKey = "attachable-volumes-fake-provider"
-		volumeLimitVal = 16
-	)
-
-	var cases = []struct {
-		desc             string
-		volumePluginList []volume.VolumePluginWithAttachLimits
-		expectNode       *v1.Node
-	}{
-		{
-			desc: "translate limits to capacity and allocatable for plugins that return successfully from GetVolumeLimits",
-			volumePluginList: []volume.VolumePluginWithAttachLimits{
-				&volumetest.FakeVolumePlugin{
-					VolumeLimits: map[string]int64{volumeLimitKey: volumeLimitVal},
-				},
-			},
-			expectNode: &v1.Node{
-				Status: v1.NodeStatus{
-					Capacity: v1.ResourceList{
-						volumeLimitKey: *resource.NewQuantity(volumeLimitVal, resource.DecimalSI),
-					},
-					Allocatable: v1.ResourceList{
-						volumeLimitKey: *resource.NewQuantity(volumeLimitVal, resource.DecimalSI),
-					},
-				},
-			},
-		},
-		{
-			desc: "skip plugins that return errors from GetVolumeLimits",
-			volumePluginList: []volume.VolumePluginWithAttachLimits{
-				&volumetest.FakeVolumePlugin{
-					VolumeLimitsError: fmt.Errorf("foo"),
-				},
-			},
-			expectNode: &v1.Node{},
-		},
-		{
-			desc:       "no plugins",
-			expectNode: &v1.Node{},
-		},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.desc, func(t *testing.T) {
-			ctx := context.Background()
-			volumePluginListFunc := func() []volume.VolumePluginWithAttachLimits {
-				return tc.volumePluginList
-			}
-			// construct setter
-			setter := VolumeLimits(volumePluginListFunc)
-			// call setter on node
-			node := &v1.Node{}
-			if err := setter(ctx, node); err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			// check expected node
-			assert.True(t, apiequality.Semantic.DeepEqual(tc.expectNode, node),
-				"Diff: %s", cmp.Diff(tc.expectNode, node))
 		})
 	}
 }

--- a/pkg/volume/plugins.go
+++ b/pkg/volume/plugins.go
@@ -263,32 +263,6 @@ type NodeExpandableVolumePlugin interface {
 	NodeExpand(resizeOptions NodeResizeOptions) (bool, error)
 }
 
-// VolumePluginWithAttachLimits is an extended interface of VolumePlugin that restricts number of
-// volumes that can be attached to a node.
-type VolumePluginWithAttachLimits interface {
-	VolumePlugin
-	// Return maximum number of volumes that can be attached to a node for this plugin.
-	// The key must be same as string returned by VolumeLimitKey function. The returned
-	// map may look like:
-	//     - { "storage-limits-aws-ebs": 39 }
-	//     - { "storage-limits-gce-pd": 10 }
-	// A volume plugin may return error from this function - if it can not be used on a given node or not
-	// applicable in given environment (where environment could be cloudprovider or any other dependency)
-	// For example - calling this function for EBS volume plugin on a GCE node should
-	// result in error.
-	// The returned values are stored in node allocatable property and will be used
-	// by scheduler to determine how many pods with volumes can be scheduled on given node.
-	GetVolumeLimits() (map[string]int64, error)
-	// Return volume limit key string to be used in node capacity constraints
-	// The key must start with prefix storage-limits-. For example:
-	//    - storage-limits-aws-ebs
-	//    - storage-limits-csi-cinder
-	// The key should respect character limit of ResourceName type
-	// This function may be called by kubelet or scheduler to identify node allocatable property
-	// which stores volumes limits.
-	VolumeLimitKey(spec *Spec) string
-}
-
 // BlockVolumePlugin is an extend interface of VolumePlugin and is used for block volumes support.
 type BlockVolumePlugin interface {
 	VolumePlugin
@@ -751,20 +725,6 @@ func (pm *VolumePluginMgr) refreshProbedPlugins() {
 	}
 }
 
-// ListVolumePluginWithLimits returns plugins that have volume limits on nodes
-func (pm *VolumePluginMgr) ListVolumePluginWithLimits() []VolumePluginWithAttachLimits {
-	pm.mutex.RLock()
-	defer pm.mutex.RUnlock()
-
-	matchedPlugins := []VolumePluginWithAttachLimits{}
-	for _, v := range pm.plugins {
-		if plugin, ok := v.(VolumePluginWithAttachLimits); ok {
-			matchedPlugins = append(matchedPlugins, plugin)
-		}
-	}
-	return matchedPlugins
-}
-
 // FindPersistentPluginBySpec looks for a persistent volume plugin that can
 // support a given volume specification.  If no plugin is found, return an
 // error
@@ -777,20 +737,6 @@ func (pm *VolumePluginMgr) FindPersistentPluginBySpec(spec *Spec) (PersistentVol
 		return persistentVolumePlugin, nil
 	}
 	return nil, fmt.Errorf("no persistent volume plugin matched")
-}
-
-// FindVolumePluginWithLimitsBySpec returns volume plugin that has a limit on how many
-// of them can be attached to a node
-func (pm *VolumePluginMgr) FindVolumePluginWithLimitsBySpec(spec *Spec) (VolumePluginWithAttachLimits, error) {
-	volumePlugin, err := pm.FindPluginBySpec(spec)
-	if err != nil {
-		return nil, fmt.Errorf("could not find volume plugin for spec : %#v", spec)
-	}
-
-	if limitedPlugin, ok := volumePlugin.(VolumePluginWithAttachLimits); ok {
-		return limitedPlugin, nil
-	}
-	return nil, fmt.Errorf("no plugin with limits found")
 }
 
 // FindPersistentPluginByName fetches a persistent volume plugin by name.  If

--- a/pkg/volume/testing/testing.go
+++ b/pkg/volume/testing/testing.go
@@ -212,7 +212,6 @@ var _ volume.RecyclableVolumePlugin = &FakeVolumePlugin{}
 var _ volume.DeletableVolumePlugin = &FakeVolumePlugin{}
 var _ volume.ProvisionableVolumePlugin = &FakeVolumePlugin{}
 var _ volume.AttachableVolumePlugin = &FakeVolumePlugin{}
-var _ volume.VolumePluginWithAttachLimits = &FakeVolumePlugin{}
 var _ volume.DeviceMountableVolumePlugin = &FakeVolumePlugin{}
 var _ volume.NodeExpandableVolumePlugin = &FakeVolumePlugin{}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

no in-tree volume plugin implements VolumePluginWithAttachLimits.

the following plugins were removed from Kubelet:

- awsElasticBlockStore
- azureDisk
- cinder
- gcePersistentDisk

FYI https://kubernetes.io/docs/concepts/storage/persistent-volumes/#types-of-persistent-volumes

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
