### PR TITLE
Fix StatefulSetMinReadySeconds healthy concept

### DIFF
--- a/pkg/controller/statefulset/stateful_set_control.go
+++ b/pkg/controller/statefulset/stateful_set_control.go
@@ -605,7 +605,7 @@ func (ssc *defaultStatefulSetControl) updateStatefulSet(
 
 	// find the first unhealthy Pod
 	for i := range replicas {
-		if !isHealthy(replicas[i]) {
+		if !isHealthy(replicas[i], set.Spec.MinReadySeconds) {
 			unhealthy++
 			if firstUnhealthyPod == nil {
 				firstUnhealthyPod = replicas[i]
@@ -615,7 +615,7 @@ func (ssc *defaultStatefulSetControl) updateStatefulSet(
 
 	// or the first unhealthy condemned Pod (condemned are sorted in descending order for ease of use)
 	for i := len(condemned) - 1; i >= 0; i-- {
-		if !isHealthy(condemned[i]) {
+		if !isHealthy(condemned[i], set.Spec.MinReadySeconds) {
 			unhealthy++
 			if firstUnhealthyPod == nil {
 				firstUnhealthyPod = condemned[i]
@@ -664,7 +664,7 @@ func (ssc *defaultStatefulSetControl) updateStatefulSet(
 
 	// At this point, in monotonic mode all of the current Replicas are Running, Ready and Available,
 	// and we can consider termination.
-	// We will wait for all predecessors to be Running and Ready prior to attempting a deletion.
+	// We will wait for all predecessors to be Running and Available prior to attempting a deletion.
 	// We will terminate Pods in a monotonically decreasing order.
 	// Note that we do not resurrect Pods in this interval. Also note that scaling will take precedence over
 	// updates.
@@ -715,7 +715,7 @@ func (ssc *defaultStatefulSetControl) updateStatefulSet(
 		}
 
 		// wait for unhealthy Pods on update
-		if !isHealthy(replicas[target]) {
+		if !isHealthy(replicas[target], set.Spec.MinReadySeconds) {
 			logger.V(4).Info("StatefulSet is waiting for Pod to update",
 				"statefulSet", klog.KObj(set), "pod", klog.KObj(replicas[target]))
 			return &status, nil
@@ -754,12 +754,12 @@ func updateStatefulSetAfterInvariantEstablished(
 	}
 
 	// Collect all targets in the range between getStartOrdinal(set) and getEndOrdinal(set). Count any targets in that range
-	// that are unhealthy i.e. terminated or not running and ready as unavailable). Select the
+	// that are unhealthy i.e. terminated or not running and available as unavailable). Select the
 	// (MaxUnavailable - Unavailable) Pods, in order with respect to their ordinal for termination. Delete
 	// those pods and count the successful deletions. Update the status with the correct number of deletions.
 	unavailablePods := 0
 	for target := len(replicas) - 1; target >= 0; target-- {
-		if !isHealthy(replicas[target]) {
+		if !isHealthy(replicas[target], set.Spec.MinReadySeconds) {
 			unavailablePods++
 		}
 	}

--- a/pkg/controller/statefulset/stateful_set_utils.go
+++ b/pkg/controller/statefulset/stateful_set_utils.go
@@ -436,9 +436,9 @@ func isTerminating(pod *v1.Pod) bool {
 	return pod.DeletionTimestamp != nil
 }
 
-// isHealthy returns true if pod is running and ready and has not been terminated
-func isHealthy(pod *v1.Pod) bool {
-	return isRunningAndReady(pod) && !isTerminating(pod)
+// isHealthy returns true if pod is running and available and has not been terminated
+func isHealthy(pod *v1.Pod, minReadySeconds int32) bool {
+	return isRunningAndAvailable(pod, minReadySeconds) && !isTerminating(pod)
 }
 
 // allowsBurst is true if the alpha burst annotation is set.


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does
By the Kubernetes docs, a healthy pod is a pod that is ready to accept requests. But, this definition could be a bit misleading when we introduce MinReadySeconds. With the "MinReadySeconds" introduction, we should only consider a pod healthy when it is available (after "MinReadySeconds" is over).

#### Why we need it
It fixes some reported bugs with the StatefulSetMinReadySeconds feature. It's also necessary for promoting StatefulSet MaxUnavailable feature gate from alpha to beta.

#### Which issue(s) this PR fixes:
Fixes #112307, fixes #123918 and fixes #119234

#### Special notes for your reviewer:
Relates to https://github.com/kubernetes/enhancements/pull/4474

Addresses https://github.com/kubernetes/enhancements/pull/4474#discussion_r1478474701

#### Does this PR introduce a user-facing change?

```release-note
StatefulSet now respects MinReadySeconds.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
https://github.com/kubernetes/enhancements/pull/4474

