### PR TITLE
Fix for TestStorageVersionMigrationWithCRD integration test failure

### DIFF
--- a/test/integration/storageversionmigrator/util.go
+++ b/test/integration/storageversionmigrator/util.go
@@ -33,6 +33,7 @@ import (
 	"time"
 
 	clientv3 "go.etcd.io/etcd/client/v3"
+
 	corev1 "k8s.io/api/core/v1"
 	svmv1alpha1 "k8s.io/api/storagemigration/v1alpha1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -1002,7 +1003,7 @@ func (svm *svmTest) isCRDMigrated(ctx context.Context, t *testing.T, crdSVMName 
 	err := wait.PollUntilContextTimeout(
 		ctx,
 		500*time.Millisecond,
-		wait.ForeverTestTimeout,
+		1*time.Minute,
 		true,
 		func(ctx context.Context) (bool, error) {
 			triggerCR := svm.createCR(ctx, t, "triggercr", "v1")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind flake

#### What this PR does / why we need it:
Looking at the logs, the actual failure is here
```bash
 util.go:1008: Failed to create CR: client rate limiter Wait returned an error: context deadline exceeded
```

https://github.com/kubernetes/kubernetes/blob/a2a709077f74f310ce197da41e0208ac76553a86/test/integration/storageversionmigrator/util.go#L798-L801

that's from

https://github.com/kubernetes/kubernetes/blob/a2a709077f74f310ce197da41e0208ac76553a86/test/integration/storageversionmigrator/util.go#L1002-L1010

which is failing after the 30s context deadline. Increasing the timeout to wait for migration to complete.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/123921

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
