### PR TITLE
Undo double run of the TestWatchSemantics test to avoid hitting timeout

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_test.go
@@ -381,18 +381,9 @@ func TestSendInitialEventsBackwardCompatibility(t *testing.T) {
 }
 
 func TestWatchSemantics(t *testing.T) {
-	t.Run("WatchFromStorageWithoutResourceVersion=true", func(t *testing.T) {
-		defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.WatchFromStorageWithoutResourceVersion, true)()
-		store, terminate := testSetupWithEtcdAndCreateWrapper(t)
-		t.Cleanup(terminate)
-		storagetesting.RunWatchSemantics(context.TODO(), t, store)
-	})
-	t.Run("WatchFromStorageWithoutResourceVersion=false", func(t *testing.T) {
-		defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.WatchFromStorageWithoutResourceVersion, false)()
-		store, terminate := testSetupWithEtcdAndCreateWrapper(t)
-		t.Cleanup(terminate)
-		storagetesting.RunWatchSemantics(context.TODO(), t, store)
-	})
+	store, terminate := testSetupWithEtcdAndCreateWrapper(t)
+	t.Cleanup(terminate)
+	storagetesting.RunWatchSemantics(context.TODO(), t, store)
 }
 
 func TestWatchSemanticInitialEventsExtended(t *testing.T) {


### PR DESCRIPTION
/kind flake

Ref https://github.com/kubernetes/kubernetes/issues/123850 https://github.com/kubernetes/kubernetes/pull/123973

```release-note
NONE
```

