### PR TITLE
Relax WatchSemanticsTest to make it faster

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/testing/utils.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/testing/utils.go
@@ -197,7 +197,8 @@ func testCheckNoMoreResults(t *testing.T, w watch.Interface) {
 	select {
 	case e := <-w.ResultChan():
 		t.Errorf("Unexpected: %#v event received, expected no events", e)
-	case <-time.After(time.Second):
+	// We consciously make the timeout short here to speed up tests.
+	case <-time.After(100 * time.Millisecond):
 		return
 	}
 }


### PR DESCRIPTION
Ref https://github.com/kubernetes/kubernetes/issues/123850

/kind flake
/sig api-machinery
/priority important-soon

```release-note
NONE
```

/assign @liggitt @serathius 