### PR TITLE
Storageversion API for CRDs (using workqueue)

### DIFF
--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -185,7 +185,7 @@ func CreateServerChain(config CompletedConfig) (*aggregatorapiserver.APIAggregat
 	}
 
 	// aggregator comes last in the chain
-	aggregatorServer, err := createAggregatorServer(config.Aggregator, kubeAPIServer.GenericAPIServer, apiExtensionsServer.CRDInformers, crdAPIEnabled)
+	aggregatorServer, err := createAggregatorServer(config.Aggregator, kubeAPIServer.GenericAPIServer, apiExtensionsServer.Informers, crdAPIEnabled)
 	if err != nil {
 		// we don't need special handling for innerStopCh because the aggregator server doesn't create any go routines
 		return nil, err

--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -185,7 +185,7 @@ func CreateServerChain(config CompletedConfig) (*aggregatorapiserver.APIAggregat
 	}
 
 	// aggregator comes last in the chain
-	aggregatorServer, err := createAggregatorServer(config.Aggregator, kubeAPIServer.GenericAPIServer, apiExtensionsServer.Informers, crdAPIEnabled)
+	aggregatorServer, err := createAggregatorServer(config.Aggregator, kubeAPIServer.GenericAPIServer, apiExtensionsServer.CRDInformers, crdAPIEnabled)
 	if err != nil {
 		// we don't need special handling for innerStopCh because the aggregator server doesn't create any go routines
 		return nil, err

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler_test.go
@@ -509,7 +509,8 @@ func testHandlerConversion(t *testing.T, enableWatchCache bool) {
 		func(r webhook.AuthenticationInfoResolver) webhook.AuthenticationInfoResolver { return r },
 		1,
 		dummyAuthorizerImpl{},
-		time.Minute, time.Minute, nil, 3*1024*1024)
+		time.Minute, time.Minute, nil, 3*1024*1024,
+		nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/storageversion/manager.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/storageversion/manager.go
@@ -1,0 +1,418 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storageversion
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
+
+	apiserverinternalv1alpha1 "k8s.io/api/apiserverinternal/v1alpha1"
+	apiextensionshelpers "k8s.io/apiextensions-apiserver/pkg/apihelpers"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	crdinformers "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	genericstorageversion "k8s.io/apiserver/pkg/storageversion"
+)
+
+var (
+	// If the StorageVersionAPI feature gate is enabled, after a CRD storage
+	// (a.k.a. serving info) is created, the API server will block CR write
+	// requests that hit this storage until the corresponding storage
+	// version update gets processed by the storage version manager.
+	// The API server will fail CR write requests if the storage version
+	// update takes longer than StorageVersionUpdateTimeout after the
+	// storage is created.
+	StorageVersionUpdateTimeout = 15 * time.Second
+	// TeardownFinishedTimeout is the time to wait for teardown of an old storage
+	// to finish while updating storageversion of a CRD. If the teardown of
+	// old storage times out, we return an error for the storageversion update,
+	// and if there are any CR requests blocked on this storgaversion update,
+	// they are served 503.
+	TeardownFinishedTimeout = 1 * time.Minute
+	// WorkerFrequency is the frequency at which the worker for updating storageversion for a CRD
+	// will be called.
+	WorkerFrequency = 1 * time.Second
+	// storageversionUpdateFailureThreshold is the maximum number of times we will
+	// requeue the storageversion after the first failure. Once this threshold is crossed,
+	// we will fail the storageversion update and consequently the dependent CR writes.
+	storageversionUpdateFailureThreshold = 3
+)
+
+// Manager maintains necessary structures needed for updating
+// StorageVersion for CRDs. It does goroutine management to allow CRD
+// storage version updates running in the background and not blocking the caller.
+type Manager struct {
+	// client is the client interface that manager uses to update
+	// StorageVersion objects.
+	client genericstorageversion.Client
+	// apiserverID is the ID of the apiserver that invokes this manager.
+	apiserverID string
+	// shutdown if set to true, shuts down all per-crd update queues.
+	shutdown chan struct{}
+	// map from crd.UID -> storageVersionUpdateInfoMap to keep
+	// track of the latest storageversion updates for a CRD.
+	storageVersionUpdateInfoMap sync.Map
+}
+
+// storageVersionUpdateInfo holds information about a storage version update,
+// indicating whether the update gets processed or timed-out.
+type storageVersionUpdateInfo struct {
+	crd *apiextensionsv1.CustomResourceDefinition
+
+	// workqueue to process storageversion updates for this CRD.
+	queue *workqueue.Type
+
+	// updateChannels contain the channels that indicate whether
+	// a storageversion udpate succeeded or errored out.
+	// CR handler will refer to these to know when to unblock
+	// or fail a CR request.
+	updateChannels *storageVersionUpdateChannels
+
+	// failures keeps track of how many times the storageversion update for this CRD
+	// failed. When past the threshold, we stop requeuing this CRD for storageversion updates
+	// and return error.
+	failures int
+}
+
+type storageVersionUpdateChannels struct {
+	// processedCh is closed by the storage version manager after the
+	// storage version update gets processed successfully.
+	// The API server will unblock and allow CR write requests if this
+	// channel is closed.
+	processedCh chan struct{}
+
+	// errCh is closed by the storage version manager when it
+	// encounters an error while trying to update a storage version.
+	// The API server will block the serve (503) for CR write requests if
+	// this channel is closed.
+	errCh chan struct{}
+
+	// teardownFinishedCh is closed when the teardown of a previous
+	// storageversion completes. This is used by the storageversion manager
+	// to unblock publishing of the latest storageversion.
+	teardownFinishedCh <-chan struct{}
+}
+
+// NewManager creates a CRD StorageVersion Manager.
+func NewManager(client genericstorageversion.Client, apiserverID string) *Manager {
+	return &Manager{
+		client:                      client,
+		apiserverID:                 apiserverID,
+		shutdown:                    make(chan struct{}),
+		storageVersionUpdateInfoMap: sync.Map{},
+	}
+}
+
+func (m *Manager) SyncSVOnStartup(crdInformer crdinformers.CustomResourceDefinitionInformer) bool {
+	crds, err := crdInformer.Lister().List(labels.Everything())
+	if err != nil {
+		klog.Errorf("failed to list CRDs from informer while syncing storageversions on server startup : %v", err)
+		return false
+	}
+	for _, crd := range crds {
+		m.Enqueue(crd, nil, 0)
+	}
+
+	return true
+}
+
+// Enqueue records the latest CRD that was updated to process its storageversion update.
+// It will first update the sync.Map with the CRD, prepare updateChannels for its storageversion update.
+// And finally add it to the relevant CRD queue.
+func (m *Manager) Enqueue(crd *apiextensionsv1.CustomResourceDefinition, tearDownFinishedCh <-chan struct{}, failuresSeenSoFar int) {
+	svUpdateInfo := m.recordLatestSVUpdateInfo(crd, tearDownFinishedCh, failuresSeenSoFar)
+	klog.V(4).Infof("queueing crd %s for storageversion update, failuresSeenSoFar: %d", crd.Name, failuresSeenSoFar)
+	svUpdateInfo.queue.Add(crd.UID)
+}
+
+// WaitForStorageVersionUpdate allows CR writes to be blocked till the latest storageversion
+// of a CRD is updated. If the storageversion update fails, we fail CR writes.
+// If the CRD is being deleted, return err and fail the CR write.
+func (m *Manager) WaitForStorageVersionUpdate(ctx context.Context, crd *apiextensionsv1.CustomResourceDefinition) error {
+	var svUpdateInfo *storageVersionUpdateInfo
+	if apiextensionshelpers.IsCRDConditionTrue(crd, apiextensionsv1.Terminating) {
+		return fmt.Errorf("CRD %s is being deleted", crd.Name)
+	}
+
+	val, found := m.storageVersionUpdateInfoMap.Load(crd.UID)
+	if !found {
+		// CR write that invoked this call will be served 503.
+		return fmt.Errorf("no entry found in storageVersionUpdateInfo map for CRD: %s", crd.Name)
+	}
+
+	svUpdateInfo = val.(*storageVersionUpdateInfo)
+
+	// NOTE: currently the graceful CRD deletion waits 1s for in-flight requests
+	// to register themselves to the wait group. Ideally the storage version update should
+	// not cause the requests to miss the 1s window; otherwise the requests may
+	// fail ungracefully (e.g. it may happen if the CRD was deleted immediately after the
+	// first CR request establishes the underlying storage).
+	select {
+	case <-svUpdateInfo.updateChannels.errCh:
+		return fmt.Errorf("error while waiting for CRD storage version update")
+	case <-svUpdateInfo.updateChannels.processedCh:
+		return nil
+	case <-ctx.Done():
+		return fmt.Errorf("aborted waiting for CRD storage version update: %w", ctx.Err())
+	case <-time.After(StorageVersionUpdateTimeout):
+		return fmt.Errorf("timeout waiting for CRD storage version update")
+	}
+
+}
+
+// DeleteSVUpdateInfo deletes specified key from the sync.Map.
+func (m *Manager) DeleteSVUpdateInfo(crdUID types.UID, waitCh <-chan struct{}) {
+	// wait for all pending CR writes to drain.
+	if waitCh != nil {
+		done := false
+		for {
+			select {
+			case <-waitCh:
+				done = true
+			case <-time.After(TeardownFinishedTimeout):
+				klog.V(4).Infof("timeout waiting for waitCh to close before proceeding with deleting storageversion for crdUID %v", crdUID)
+				return
+			}
+			if done {
+				break
+			}
+		}
+	}
+	// shutdown storageversion update queue
+	val, ok := m.storageVersionUpdateInfoMap.Load(crdUID)
+	if !ok {
+		klog.V(4).Infof("no entry found in sync.map for crdUID %v", crdUID)
+		return
+	}
+
+	svUpdateInfo := val.(*storageVersionUpdateInfo)
+	svUpdateInfo.queue.ShutDown()
+	m.storageVersionUpdateInfoMap.Delete(crdUID)
+}
+
+// Shutdown signals the storageversion manager to shutdown all
+// per-crd storageversion update queues.
+func (m *Manager) Shutdown(stopCh <-chan struct{}) {
+	<-stopCh
+	close(m.shutdown)
+}
+
+// sync runs a goroutine over the provided queue to indefinitely
+// process any queued storageversion updates unless stopCh is invoked.
+func (m *Manager) sync(shutdownQueue <-chan struct{}, queue *workqueue.Type, workerFrequency, teardownFinishedTimeout time.Duration) {
+	defer queue.ShutDownWithDrain()
+	go wait.Until(func() {
+		m.worker(queue, teardownFinishedTimeout)
+	}, workerFrequency, shutdownQueue)
+
+	<-shutdownQueue
+}
+
+func (m *Manager) worker(queue *workqueue.Type, teardownFinishedTimeout time.Duration) {
+	for m.processLatestUpdateFor(queue, teardownFinishedTimeout) {
+	}
+}
+
+func (m *Manager) processLatestUpdateFor(queue *workqueue.Type, teardownFinishedTimeout time.Duration) bool {
+	ctx := context.TODO()
+
+	key, quit := queue.Get()
+	defer queue.Done(key)
+	if quit {
+		return false
+	}
+
+	// Note: since we queue CRDs by UID, if the same CRD is updated multiple times,
+	// the same UID is queued multiple times. We take care to only update the latest queued
+	// entry for this UID, by referring to the sync.Map which is overwritten everytime a
+	// new update is made to the CRD.
+	// Ex: if there were rapid consecutive updates made to a crd like v1 -> v2 -> v3
+	// such that when processLatestUpdateFor() is called for the v1 update, it observes
+	// that the latest entry in the sync.map is for v3 - and updates the version to v3.
+	// When we get to processLatestUpdateFor() for v2 - the latest entry in sync.map is still
+	// v3. We should not process v3 update again.
+	val, ok := m.storageVersionUpdateInfoMap.Load(key)
+	if !ok {
+		klog.V(4).Infof("No pending storageversion update found for crdUID: %s, returning", key)
+		return true
+	}
+	latestSVUpdateInfo := val.(*storageVersionUpdateInfo)
+	select {
+	case <-latestSVUpdateInfo.updateChannels.processedCh:
+		klog.V(4).Infof("Storageversion is already updated to the latest value for crdUID: %s, returning", key)
+		return true
+	case <-latestSVUpdateInfo.updateChannels.errCh:
+		klog.V(4).Infof("Storageversion is already processed for crdUID: %s, but returned an error.", key)
+		return true
+	default:
+		err := m.updateStorageVersion(ctx, latestSVUpdateInfo.crd, latestSVUpdateInfo.updateChannels.teardownFinishedCh, teardownFinishedTimeout)
+		m.processStorageVersionUpdateResponse(err, latestSVUpdateInfo)
+		return true
+	}
+}
+
+func (m *Manager) recordLatestSVUpdateInfo(crd *apiextensionsv1.CustomResourceDefinition, tearDownFinishedCh <-chan struct{}, failuresSeenSoFar int) *storageVersionUpdateInfo {
+	latestSVUpdateInfo := &storageVersionUpdateInfo{
+		crd: crd,
+		updateChannels: &storageVersionUpdateChannels{
+			processedCh:        make(chan struct{}),
+			errCh:              make(chan struct{}),
+			teardownFinishedCh: tearDownFinishedCh,
+		},
+		failures: failuresSeenSoFar,
+	}
+
+	val, ok := m.storageVersionUpdateInfoMap.Load(crd.UID)
+	if !ok {
+		// if CRD seen for the first time,
+		// 1. create new update-queue
+		// 2. start the queue
+		// 3. store it in latestSVUpdateInfo
+		// 4. update sync.map and return it
+		queue := workqueue.NewNamed(fmt.Sprintf("%s-storageversion-updater", crd.Name))
+		latestSVUpdateInfo.queue = queue
+		go m.sync(m.shutdown, queue, WorkerFrequency, TeardownFinishedTimeout)
+		m.storageVersionUpdateInfoMap.Store(crd.UID, latestSVUpdateInfo)
+		return latestSVUpdateInfo
+	}
+
+	// overwrite existing SVUpdateInfo in the map only if
+	// 1. there's a new latest update event.
+	// 2. the update event is the same as last seen, but it was re-enqueued
+	// because of some failure in the SV update.
+	existingSVUpdateInfo := val.(*storageVersionUpdateInfo)
+	if crd.ObjectMeta.ResourceVersion >= existingSVUpdateInfo.crd.ObjectMeta.ResourceVersion {
+		updatedSVInfo := &storageVersionUpdateInfo{
+			crd:            latestSVUpdateInfo.crd,
+			updateChannels: latestSVUpdateInfo.updateChannels,
+			failures:       latestSVUpdateInfo.failures,
+			queue:          existingSVUpdateInfo.queue,
+		}
+		m.storageVersionUpdateInfoMap.Store(crd.UID, updatedSVInfo)
+		return updatedSVInfo
+	}
+	return existingSVUpdateInfo
+}
+
+// updateStorageVersion updates a StorageVersion for the given
+// CRD and returns immediately. Optionally, the caller may specify a
+// non-nil waitCh and/or a non-nil processedCh.
+// A non-nil waitCh will block the StorageVersion update until waitCh is
+// closed.
+// The manager will close the non-nil processedCh if it finished
+// processing the StorageVersion update (note that the update can either
+// succeeded or failed).
+func (m *Manager) updateStorageVersion(ctx context.Context, crd *apiextensionsv1.CustomResourceDefinition,
+	waitCh <-chan struct{}, teardownFinishedTimeout time.Duration) error {
+	if waitCh != nil {
+		done := false
+		for {
+			select {
+			case <-waitCh:
+				done = true
+			case <-ctx.Done():
+				return fmt.Errorf("aborting storageversion update for %v, context closed", crd)
+			case <-time.After(teardownFinishedTimeout):
+				return fmt.Errorf("timeout waiting for waitCh to close before proceeding with storageversion update for %v", crd)
+			}
+			if done {
+				break
+			}
+		}
+	}
+
+	if err := m.updateCRDStorageVersion(ctx, crd); err != nil {
+		return fmt.Errorf("error while updating storage version for crd %v: %w", crd, err)
+	}
+
+	return nil
+}
+
+func (m *Manager) updateCRDStorageVersion(ctx context.Context, crd *apiextensionsv1.CustomResourceDefinition) error {
+	gr := schema.GroupResource{
+		Group:    crd.Spec.Group,
+		Resource: crd.Spec.Names.Plural,
+	}
+	storageVersion, err := apiextensionshelpers.GetCRDStorageVersion(crd)
+
+	if err != nil {
+		// This should never happen if crd is valid, which is true since we
+		// only update storage version for CRDs that have been written to the
+		// storage.
+		return err
+	}
+
+	encodingVersion := crd.Spec.Group + "/" + storageVersion
+	var servedVersions, decodableVersions []string
+	for _, v := range crd.Spec.Versions {
+		decodableVersions = append(decodableVersions, crd.Spec.Group+"/"+v.Name)
+		if v.Served {
+			servedVersions = append(servedVersions, crd.Spec.Group+"/"+v.Name)
+		}
+	}
+
+	appendOwnerRefFunc := func(sv *apiserverinternalv1alpha1.StorageVersion) error {
+		ref := metav1.OwnerReference{
+			APIVersion: apiextensionsv1.SchemeGroupVersion.String(),
+			Kind:       "CustomResourceDefinition",
+			Name:       crd.Name,
+			UID:        crd.UID,
+		}
+		for _, r := range sv.OwnerReferences {
+			if r == ref {
+				return nil
+			}
+		}
+		sv.OwnerReferences = append(sv.OwnerReferences, ref)
+		return nil
+	}
+	return genericstorageversion.UpdateStorageVersionFor(
+		ctx,
+		m.client,
+		m.apiserverID,
+		gr,
+		encodingVersion,
+		decodableVersions,
+		servedVersions,
+		appendOwnerRefFunc)
+}
+
+func (m *Manager) processStorageVersionUpdateResponse(err error, svUpdateInfo *storageVersionUpdateInfo) {
+	if err == nil {
+		klog.V(4).Infof("successfully updated storage version for %s", svUpdateInfo.crd.Name)
+		close(svUpdateInfo.updateChannels.processedCh)
+		return
+	}
+
+	failuresSeenSoFar := svUpdateInfo.failures + 1
+	if failuresSeenSoFar > storageversionUpdateFailureThreshold {
+		klog.V(4).Infof("storageversion update for crd %s has exceeded maximum allowed update errors", svUpdateInfo.crd.Name)
+		close(svUpdateInfo.updateChannels.errCh)
+		return
+	}
+
+	m.Enqueue(svUpdateInfo.crd, svUpdateInfo.updateChannels.teardownFinishedCh, failuresSeenSoFar)
+}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/storageversion/manager_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/storageversion/manager_test.go
@@ -17,15 +17,17 @@ limitations under the License.
 package storageversion
 
 import (
-	"context"
 	"fmt"
 	"testing"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/informers"
 
+	apiserverinternalv1alpha1 "k8s.io/api/apiserverinternal/v1alpha1"
 	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	crdfakeclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
+	crdinformers "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientsetfake "k8s.io/client-go/kubernetes/fake"
 )
@@ -34,357 +36,158 @@ const (
 	apiserverID = "test-server"
 )
 
-func TestEnqueue(t *testing.T) {
-	fooCRD := testCRD("foo", "1")
-
-	testcases := map[string]struct {
-		createCRD    *v1.CustomResourceDefinition
-		updateCRD    *v1.CustomResourceDefinition
-		wantMapEntry *v1.CustomResourceDefinition
-	}{
-		"update map entry of CRD seen for the first time": {
-			createCRD:    fooCRD,
-			wantMapEntry: fooCRD,
-		},
-		"do not update map if older CRD resourceversion is enqueued": {
-			createCRD:    fooCRD,
-			updateCRD:    testCRD("foo", "0"),
-			wantMapEntry: fooCRD,
-		},
-		"update map if newer CRD resourceversion is enqueued": {
-			createCRD:    fooCRD,
-			updateCRD:    testCRD("foo", "2"),
-			wantMapEntry: testCRD("foo", "2"),
-		},
-	}
-	for _, tc := range testcases {
-		StorageVersionUpdateTimeout = 2 * time.Second
-		stopCh := make(chan struct{})
-		manager := fakeManager()
-		go manager.Shutdown(stopCh)
-
-		// create CRD
-		if tc.createCRD == nil {
-			t.Fatalf("CRDs must be created first for the test to proceed")
-		}
-		manager.Enqueue(tc.createCRD, make(<-chan struct{}), 0)
-
-		// update CRD
-		if tc.updateCRD != nil {
-			manager.Enqueue(tc.updateCRD, make(<-chan struct{}), 0)
-		}
-		val, ok := manager.storageVersionUpdateInfoMap.Load(fooCRD.UID)
-		if !ok {
-			t.Fatalf("expected UID to be present in storageVersionUpdateInfoMap for crd %s, got none", fooCRD.Name)
-		}
-
-		gotSVUpdateInfo := val.(*storageVersionUpdateInfo)
-		if diff := cmp.Diff(gotSVUpdateInfo.crd, tc.wantMapEntry); diff != "" {
-			t.Errorf("unexpected storageversion updated info (-want, +got):\n%s", diff)
-		}
-		// signal manager to shutdown
-		close(stopCh)
-	}
+type info struct {
+	activeTeardownCount int
+	crdInCache          *v1.CustomResourceDefinition
+	svInCache           *apiserverinternalv1alpha1.StorageVersion
 }
 
-func TestWaitForStorageVersionUpdate(t *testing.T) {
-	fooCRD := testCRD("foo", "1")
-	ctx := context.TODO()
-
+func TestShouldSkipSVUpdate(t *testing.T) {
 	testcases := map[string]struct {
-		crd              *v1.CustomResourceDefinition
-		svUpdateInfo     *storageVersionUpdateInfo
-		closeContext     bool
-		wantErr          bool
-		wantSVUpdateInfo *storageVersionUpdateInfo
+		crdInfo    *info
+		wantSkip   bool
+		wantError  bool
+		wantReason string
 	}{
-		"err if CRD not found in storageVersionUpdateInfoMap": {
-			wantErr: true,
+		"teardown_in_progress": {
+			crdInfo: &info{
+				activeTeardownCount: 1,
+				crdInCache:          testCRD("example", "foo", "v1"),
+				svInCache:           testStorageVersion("example", "foos", "v1"),
+			},
+			wantSkip:   true,
+			wantReason: "1 active teardowns",
 		},
-		"err if CRD is being deleted": {
-			crd:     terminatingCRD("foo"),
-			wantErr: true,
+		"SV_doesnt_exist_in_CRD": {
+			crdInfo: &info{
+				crdInCache: testCRD("example", "foo", ""),
+				svInCache:  testStorageVersion("example", "foos", "v1"),
+			},
+			wantError:  true,
+			wantSkip:   true,
+			wantReason: "error while fetching latest storageversion",
 		},
-		"no err if SV is updated successfully": {
-			crd: testCRD("foo", "2"),
-			svUpdateInfo: &storageVersionUpdateInfo{
-				crd: fooCRD,
-				updateChannels: &storageVersionUpdateChannels{
-					processedCh: make(chan struct{}),
-				},
+		"SV_doesnt_exist_in_SV_cache": {
+			crdInfo: &info{
+				crdInCache: testCRD("example", "foo", "v1"),
 			},
-			wantErr: false,
+			wantSkip: false,
 		},
-		"err if SV update returned error": {
-			crd: testCRD("foo", "2"),
-			svUpdateInfo: &storageVersionUpdateInfo{
-				crd: fooCRD,
-				updateChannels: &storageVersionUpdateChannels{
-					errCh: make(chan struct{}),
-				},
+		"CRD_SV_same_as_cache": {
+			crdInfo: &info{
+				crdInCache: testCRD("example", "foo", "v1"),
+				svInCache:  testStorageVersion("example", "foos", "v1"),
 			},
-			wantErr: true,
+			wantSkip:   true,
+			wantReason: "already at latest storageversion",
 		},
-		"err if context is closed": {
-			crd: testCRD("foo", "2"),
-			svUpdateInfo: &storageVersionUpdateInfo{
-				crd:            fooCRD,
-				updateChannels: &storageVersionUpdateChannels{},
+		"CRD_SV_not_same_as_cache": {
+			crdInfo: &info{
+				crdInCache: testCRD("example", "foo", "v2"),
+				svInCache:  testStorageVersion("example", "foos", "v1"),
 			},
-			closeContext: true,
-			wantErr:      true,
-		},
-	}
-	for _, tc := range testcases {
-		StorageVersionUpdateTimeout = 2 * time.Second
-		stopCh := make(chan struct{})
-		manager := fakeManager()
-		go manager.Shutdown(stopCh)
-
-		// store SVUpdateInfo in storageVersionUpdateInfoMap
-		if tc.svUpdateInfo != nil {
-			manager.storageVersionUpdateInfoMap.Store(fooCRD.UID, tc.svUpdateInfo)
-		}
-
-		if tc.svUpdateInfo != nil {
-			switch {
-			case tc.svUpdateInfo.updateChannels.processedCh != nil:
-				close(tc.svUpdateInfo.updateChannels.processedCh)
-			case tc.svUpdateInfo.updateChannels.errCh != nil:
-				close(tc.svUpdateInfo.updateChannels.errCh)
-			case tc.closeContext:
-				ctx.Done()
-			}
-		}
-
-		err := manager.WaitForStorageVersionUpdate(ctx, fooCRD)
-		if (err != nil) != tc.wantErr {
-			t.Errorf("WaitForStorageVersionUpdate: got error %v, want error %v", err, tc.wantErr)
-		}
-
-		if tc.wantSVUpdateInfo != nil {
-			val, ok := manager.storageVersionUpdateInfoMap.Load(fooCRD.UID)
-			if !ok {
-				t.Fatalf("expected UID to be present in storageVersionUpdateInfoMap for crd %s, got none", tc.wantSVUpdateInfo.crd.Name)
-			}
-			gotCRD := val.(*storageVersionUpdateInfo)
-			if diff := cmp.Diff(gotCRD.crd, tc.wantSVUpdateInfo.crd); diff != "" {
-				t.Fatalf("unexpected final CRD state for %s, diff = %s", tc.wantSVUpdateInfo.crd.Name, diff)
-			}
-		}
-		// signal manager to shutdown
-		close(stopCh)
-	}
-}
-
-func TestStorageVersionUpdateInfoSuccess(t *testing.T) {
-	testcases := map[string]struct {
-		createCRDs        []*v1.CustomResourceDefinition
-		updateCRDs        []*v1.CustomResourceDefinition
-		wantLatestSVInfos []*v1.CustomResourceDefinition
-		wantErr           bool
-	}{
-		"single CRD create": {
-			createCRDs: []*v1.CustomResourceDefinition{testCRD("foo", "1")},
-			wantLatestSVInfos: []*v1.CustomResourceDefinition{
-				testCRD("foo", "1"),
-			},
-		},
-		"multiple CRD creates": {
-			createCRDs: []*v1.CustomResourceDefinition{
-				testCRD("foo", "1"),
-				testCRD("bar", "1"),
-			},
-			wantLatestSVInfos: []*v1.CustomResourceDefinition{
-				testCRD("foo", "1"),
-				testCRD("bar", "1"),
-			},
-		},
-		"single update of single CRD": {
-			createCRDs: []*v1.CustomResourceDefinition{testCRD("foo", "1")},
-			updateCRDs: []*v1.CustomResourceDefinition{
-				testCRD("foo", "2"),
-			},
-			wantLatestSVInfos: []*v1.CustomResourceDefinition{
-				testCRD("foo", "2"),
-			},
-		},
-		"multiple updates of single CRD": {
-			createCRDs: []*v1.CustomResourceDefinition{testCRD("foo", "1")},
-			updateCRDs: []*v1.CustomResourceDefinition{
-				testCRD("foo", "3"),
-				testCRD("foo", "4"),
-			},
-			wantLatestSVInfos: []*v1.CustomResourceDefinition{
-				testCRD("foo", "4"),
-			},
-		},
-		"multiple updates of multiple CRDs": {
-			createCRDs: []*v1.CustomResourceDefinition{
-				testCRD("foo", "1"),
-				testCRD("bar", "1"),
-			},
-			updateCRDs: []*v1.CustomResourceDefinition{
-				testCRD("foo", "6"),
-				testCRD("foo", "5"),
-				testCRD("bar", "11"),
-				testCRD("bar", "10"),
-			},
-			wantLatestSVInfos: []*v1.CustomResourceDefinition{
-				testCRD("foo", "6"),
-				testCRD("bar", "11"),
-			},
+			wantSkip: false,
 		},
 	}
 
 	for _, tc := range testcases {
-		TeardownFinishedTimeout = 2 * time.Second
 		stopCh := make(chan struct{})
 		manager := fakeManager()
-		defer manager.Shutdown(stopCh)
-		if tc.createCRDs == nil {
-			t.Fatalf("CRDs must be created first for the test to proceed")
-		}
-		// create CRDs
-		for _, crd := range tc.createCRDs {
-			manager.Enqueue(crd, nil, 0)
-		}
+		go manager.Sync(stopCh, 1)
 
-		// process updates
-		for _, updatedCRD := range tc.updateCRDs {
-			time.Sleep(4 * time.Second)
-			manager.Enqueue(updatedCRD, nil, 0)
+		manager.teardownCountMap.Store(tc.crdInfo.crdInCache.Name, tc.crdInfo.activeTeardownCount)
+		// add CRD in CRD cache
+		if err := manager.crdInformer.Informer().GetStore().Add(tc.crdInfo.crdInCache); err != nil {
+			t.Fatal(err)
 		}
-
-		// validate we have the correct updated storageversion info
-		for _, wantCRD := range tc.wantLatestSVInfos {
-			val, ok := manager.storageVersionUpdateInfoMap.Load(wantCRD.UID)
-			if !ok {
-				t.Fatalf("expected UID to be present in storageVersionUpdateInfoMap for crd %s, got none", wantCRD.Name)
-			}
-
-			gotCRD := val.(*storageVersionUpdateInfo)
-			if diff := cmp.Diff(gotCRD.crd, wantCRD); diff != "" {
-				t.Fatalf("unexpected final CRD state for %s, diff = %s", wantCRD.Name, diff)
+		// add SV in SV cache
+		if tc.crdInfo.svInCache != nil {
+			if err := manager.svInformer.Informer().GetStore().Add(tc.crdInfo.svInCache); err != nil {
+				t.Fatal(err)
 			}
 		}
-		// signal manager to shutdown
+
+		skip, reason, err := manager.shouldSkipSVUpdate(tc.crdInfo.crdInCache)
+		if (err != nil) != tc.wantError {
+			t.Fatalf("error mismatch, got:%v, want:%v", err, tc.wantError)
+		}
+
+		if tc.wantSkip != skip {
+			t.Fatalf("result mismatch, got skip:%v, want:%v", skip, tc.wantSkip)
+		}
+
+		if skip {
+			if tc.wantReason != reason {
+				t.Errorf("reason mismatch, got skip:%v, want:%v", reason, tc.wantReason)
+			}
+		}
+
+		// cleanup
 		close(stopCh)
 	}
-}
-
-func TestSVUpdateFailureTeardownTimeout(t *testing.T) {
-	stopCh := make(chan struct{})
-	manager := fakeManager()
-	defer manager.Shutdown(stopCh)
-	TeardownFinishedTimeout = 2 * time.Second
-
-	// create CRD
-	crd := testCRD("foo", "1")
-	manager.Enqueue(crd, nil, 0)
-
-	// process update, dont close its teardDownCh
-	updatedCRD := testCRD("foo", "2")
-	manager.Enqueue(updatedCRD, make(chan struct{}), 0)
-
-	err := manager.WaitForStorageVersionUpdate(context.TODO(), updatedCRD)
-	if err == nil {
-		t.Errorf("expected first update to timeout but got success: %v", err)
-	}
-
-	// update the CRD again, this time close its teardDownCh
-	updatedCRD = testCRD("foo", "3")
-	teardownFinishedCh2 := make(chan struct{})
-	manager.Enqueue(updatedCRD, teardownFinishedCh2, 0)
-	close(teardownFinishedCh2)
-
-	err = manager.WaitForStorageVersionUpdate(context.TODO(), updatedCRD)
-	if err != nil {
-		t.Errorf("expected latest update to succeed but got fail: %v", err)
-	}
-
-	// signal manager to shutdown
-	close(stopCh)
-}
-
-func TestSVUpdateFailureRequeueAttemptsExceedThreshold(t *testing.T) {
-	stopCh := make(chan struct{})
-	manager := fakeManager()
-	defer manager.Shutdown(stopCh)
-	TeardownFinishedTimeout = 2 * time.Second
-
-	// create CRD
-	crd := testCRD("foo", "1")
-	manager.Enqueue(crd, nil, 0)
-
-	// process update, with failure count at storageversionUpdateFailureThreshold
-	// do not close teardownFinishedCh so that the update fails.
-	updatedCRD := testCRD("foo", "2")
-	manager.Enqueue(updatedCRD, make(chan struct{}), storageversionUpdateFailureThreshold)
-
-	err := manager.WaitForStorageVersionUpdate(context.TODO(), updatedCRD)
-	if err == nil {
-		t.Errorf("expected first update to error out but got success: %v", err)
-	}
-
-	// update the CRD again, with failure count 0
-	updatedCRD = testCRD("foo", "3")
-	teardownFinishedCh2 := make(chan struct{})
-	manager.Enqueue(updatedCRD, teardownFinishedCh2, 0)
-	close(teardownFinishedCh2)
-
-	err = manager.WaitForStorageVersionUpdate(context.TODO(), updatedCRD)
-	if err != nil {
-		t.Errorf("expected latest update to succeed but got fail: %v", err)
-	}
-
-	// signal manager to shutdown
-	close(stopCh)
 }
 
 func fakeManager() *Manager {
-	client := clientsetfake.NewSimpleClientset().InternalV1alpha1().StorageVersions()
-	return NewManager(client, apiserverID)
+	crdinformers := crdinformers.NewSharedInformerFactory(crdfakeclient.NewSimpleClientset(), 100*time.Millisecond)
+	crdInformer := crdinformers.Apiextensions().V1().CustomResourceDefinitions()
+
+	svClient := clientsetfake.NewSimpleClientset().InternalV1alpha1().StorageVersions()
+	svInformers := informers.NewSharedInformerFactory(clientsetfake.NewSimpleClientset(), 100*time.Millisecond)
+	svInformer := svInformers.Internal().V1alpha1().StorageVersions()
+
+	return NewManager(svClient, apiserverID, crdInformer, svInformer)
 }
 
-func terminatingCRD(name string) *v1.CustomResourceDefinition {
-	deletingCRD := testCRD(name, "1")
-	deletingCRD.Status.Conditions = []v1.CustomResourceDefinitionCondition{
-		{
-			Type:   v1.Terminating,
-			Status: v1.ConditionTrue,
-		},
-	}
-	return deletingCRD
-}
-
-func testCRD(name string, resourceVersion string) *v1.CustomResourceDefinition {
-	return &v1.CustomResourceDefinition{
+func testCRD(group string, name string, version string) *v1.CustomResourceDefinition {
+	crd := &v1.CustomResourceDefinition{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "apiextensions.k8s.io/v1",
 			Kind:       "CustomResourceDefinition",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            fmt.Sprintf("%s.test.example.com", name),
-			ResourceVersion: resourceVersion,
-			UID:             types.UID(name),
+			Name: name,
+			UID:  types.UID(name),
 		},
 		Spec: v1.CustomResourceDefinitionSpec{
-			Group: "test.example.com",
-			Scope: v1.ClusterScoped,
-			Versions: []v1.CustomResourceDefinitionVersion{
-				{
-					Name:    "v1",
-					Served:  true,
-					Storage: true,
-				},
+			Names: v1.CustomResourceDefinitionNames{
+				Plural: fmt.Sprintf("%ss", name),
 			},
+			Group: group,
+			Scope: v1.ClusterScoped,
 		},
 		Status: v1.CustomResourceDefinitionStatus{
 			Conditions: []v1.CustomResourceDefinitionCondition{
 				{
 					Type:   v1.Established,
 					Status: v1.ConditionTrue,
+				},
+			},
+		},
+	}
+
+	if version != "" {
+		crd.Spec.Versions = []v1.CustomResourceDefinitionVersion{
+			{
+				Name:    version,
+				Served:  true,
+				Storage: true,
+			},
+		}
+	}
+
+	return crd
+}
+
+func testStorageVersion(group string, name string, encodingVersion string) *apiserverinternalv1alpha1.StorageVersion {
+	return &apiserverinternalv1alpha1.StorageVersion{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: fmt.Sprintf("%s.%s", group, name),
+		},
+		Status: apiserverinternalv1alpha1.StorageVersionStatus{
+			StorageVersions: []apiserverinternalv1alpha1.ServerStorageVersion{
+				{
+					APIServerID:     apiserverID,
+					EncodingVersion: fmt.Sprintf("%s/%s", group, encodingVersion),
 				},
 			},
 		},

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/storageversion/manager_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/storageversion/manager_test.go
@@ -1,0 +1,392 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storageversion
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"k8s.io/apimachinery/pkg/types"
+
+	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientsetfake "k8s.io/client-go/kubernetes/fake"
+)
+
+const (
+	apiserverID = "test-server"
+)
+
+func TestEnqueue(t *testing.T) {
+	fooCRD := testCRD("foo", "1")
+
+	testcases := map[string]struct {
+		createCRD    *v1.CustomResourceDefinition
+		updateCRD    *v1.CustomResourceDefinition
+		wantMapEntry *v1.CustomResourceDefinition
+	}{
+		"update map entry of CRD seen for the first time": {
+			createCRD:    fooCRD,
+			wantMapEntry: fooCRD,
+		},
+		"do not update map if older CRD resourceversion is enqueued": {
+			createCRD:    fooCRD,
+			updateCRD:    testCRD("foo", "0"),
+			wantMapEntry: fooCRD,
+		},
+		"update map if newer CRD resourceversion is enqueued": {
+			createCRD:    fooCRD,
+			updateCRD:    testCRD("foo", "2"),
+			wantMapEntry: testCRD("foo", "2"),
+		},
+	}
+	for _, tc := range testcases {
+		StorageVersionUpdateTimeout = 2 * time.Second
+		stopCh := make(chan struct{})
+		manager := fakeManager()
+		go manager.Shutdown(stopCh)
+
+		// create CRD
+		if tc.createCRD == nil {
+			t.Fatalf("CRDs must be created first for the test to proceed")
+		}
+		manager.Enqueue(tc.createCRD, make(<-chan struct{}), 0)
+
+		// update CRD
+		if tc.updateCRD != nil {
+			manager.Enqueue(tc.updateCRD, make(<-chan struct{}), 0)
+		}
+		val, ok := manager.storageVersionUpdateInfoMap.Load(fooCRD.UID)
+		if !ok {
+			t.Fatalf("expected UID to be present in storageVersionUpdateInfoMap for crd %s, got none", fooCRD.Name)
+		}
+
+		gotSVUpdateInfo := val.(*storageVersionUpdateInfo)
+		if diff := cmp.Diff(gotSVUpdateInfo.crd, tc.wantMapEntry); diff != "" {
+			t.Errorf("unexpected storageversion updated info (-want, +got):\n%s", diff)
+		}
+		// signal manager to shutdown
+		close(stopCh)
+	}
+}
+
+func TestWaitForStorageVersionUpdate(t *testing.T) {
+	fooCRD := testCRD("foo", "1")
+	ctx := context.TODO()
+
+	testcases := map[string]struct {
+		crd              *v1.CustomResourceDefinition
+		svUpdateInfo     *storageVersionUpdateInfo
+		closeContext     bool
+		wantErr          bool
+		wantSVUpdateInfo *storageVersionUpdateInfo
+	}{
+		"err if CRD not found in storageVersionUpdateInfoMap": {
+			wantErr: true,
+		},
+		"err if CRD is being deleted": {
+			crd:     terminatingCRD("foo"),
+			wantErr: true,
+		},
+		"no err if SV is updated successfully": {
+			crd: testCRD("foo", "2"),
+			svUpdateInfo: &storageVersionUpdateInfo{
+				crd: fooCRD,
+				updateChannels: &storageVersionUpdateChannels{
+					processedCh: make(chan struct{}),
+				},
+			},
+			wantErr: false,
+		},
+		"err if SV update returned error": {
+			crd: testCRD("foo", "2"),
+			svUpdateInfo: &storageVersionUpdateInfo{
+				crd: fooCRD,
+				updateChannels: &storageVersionUpdateChannels{
+					errCh: make(chan struct{}),
+				},
+			},
+			wantErr: true,
+		},
+		"err if context is closed": {
+			crd: testCRD("foo", "2"),
+			svUpdateInfo: &storageVersionUpdateInfo{
+				crd:            fooCRD,
+				updateChannels: &storageVersionUpdateChannels{},
+			},
+			closeContext: true,
+			wantErr:      true,
+		},
+	}
+	for _, tc := range testcases {
+		StorageVersionUpdateTimeout = 2 * time.Second
+		stopCh := make(chan struct{})
+		manager := fakeManager()
+		go manager.Shutdown(stopCh)
+
+		// store SVUpdateInfo in storageVersionUpdateInfoMap
+		if tc.svUpdateInfo != nil {
+			manager.storageVersionUpdateInfoMap.Store(fooCRD.UID, tc.svUpdateInfo)
+		}
+
+		if tc.svUpdateInfo != nil {
+			switch {
+			case tc.svUpdateInfo.updateChannels.processedCh != nil:
+				close(tc.svUpdateInfo.updateChannels.processedCh)
+			case tc.svUpdateInfo.updateChannels.errCh != nil:
+				close(tc.svUpdateInfo.updateChannels.errCh)
+			case tc.closeContext:
+				ctx.Done()
+			}
+		}
+
+		err := manager.WaitForStorageVersionUpdate(ctx, fooCRD)
+		if (err != nil) != tc.wantErr {
+			t.Errorf("WaitForStorageVersionUpdate: got error %v, want error %v", err, tc.wantErr)
+		}
+
+		if tc.wantSVUpdateInfo != nil {
+			val, ok := manager.storageVersionUpdateInfoMap.Load(fooCRD.UID)
+			if !ok {
+				t.Fatalf("expected UID to be present in storageVersionUpdateInfoMap for crd %s, got none", tc.wantSVUpdateInfo.crd.Name)
+			}
+			gotCRD := val.(*storageVersionUpdateInfo)
+			if diff := cmp.Diff(gotCRD.crd, tc.wantSVUpdateInfo.crd); diff != "" {
+				t.Fatalf("unexpected final CRD state for %s, diff = %s", tc.wantSVUpdateInfo.crd.Name, diff)
+			}
+		}
+		// signal manager to shutdown
+		close(stopCh)
+	}
+}
+
+func TestStorageVersionUpdateInfoSuccess(t *testing.T) {
+	testcases := map[string]struct {
+		createCRDs        []*v1.CustomResourceDefinition
+		updateCRDs        []*v1.CustomResourceDefinition
+		wantLatestSVInfos []*v1.CustomResourceDefinition
+		wantErr           bool
+	}{
+		"single CRD create": {
+			createCRDs: []*v1.CustomResourceDefinition{testCRD("foo", "1")},
+			wantLatestSVInfos: []*v1.CustomResourceDefinition{
+				testCRD("foo", "1"),
+			},
+		},
+		"multiple CRD creates": {
+			createCRDs: []*v1.CustomResourceDefinition{
+				testCRD("foo", "1"),
+				testCRD("bar", "1"),
+			},
+			wantLatestSVInfos: []*v1.CustomResourceDefinition{
+				testCRD("foo", "1"),
+				testCRD("bar", "1"),
+			},
+		},
+		"single update of single CRD": {
+			createCRDs: []*v1.CustomResourceDefinition{testCRD("foo", "1")},
+			updateCRDs: []*v1.CustomResourceDefinition{
+				testCRD("foo", "2"),
+			},
+			wantLatestSVInfos: []*v1.CustomResourceDefinition{
+				testCRD("foo", "2"),
+			},
+		},
+		"multiple updates of single CRD": {
+			createCRDs: []*v1.CustomResourceDefinition{testCRD("foo", "1")},
+			updateCRDs: []*v1.CustomResourceDefinition{
+				testCRD("foo", "3"),
+				testCRD("foo", "4"),
+			},
+			wantLatestSVInfos: []*v1.CustomResourceDefinition{
+				testCRD("foo", "4"),
+			},
+		},
+		"multiple updates of multiple CRDs": {
+			createCRDs: []*v1.CustomResourceDefinition{
+				testCRD("foo", "1"),
+				testCRD("bar", "1"),
+			},
+			updateCRDs: []*v1.CustomResourceDefinition{
+				testCRD("foo", "6"),
+				testCRD("foo", "5"),
+				testCRD("bar", "11"),
+				testCRD("bar", "10"),
+			},
+			wantLatestSVInfos: []*v1.CustomResourceDefinition{
+				testCRD("foo", "6"),
+				testCRD("bar", "11"),
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		TeardownFinishedTimeout = 2 * time.Second
+		stopCh := make(chan struct{})
+		manager := fakeManager()
+		defer manager.Shutdown(stopCh)
+		if tc.createCRDs == nil {
+			t.Fatalf("CRDs must be created first for the test to proceed")
+		}
+		// create CRDs
+		for _, crd := range tc.createCRDs {
+			manager.Enqueue(crd, nil, 0)
+		}
+
+		// process updates
+		for _, updatedCRD := range tc.updateCRDs {
+			time.Sleep(4 * time.Second)
+			manager.Enqueue(updatedCRD, nil, 0)
+		}
+
+		// validate we have the correct updated storageversion info
+		for _, wantCRD := range tc.wantLatestSVInfos {
+			val, ok := manager.storageVersionUpdateInfoMap.Load(wantCRD.UID)
+			if !ok {
+				t.Fatalf("expected UID to be present in storageVersionUpdateInfoMap for crd %s, got none", wantCRD.Name)
+			}
+
+			gotCRD := val.(*storageVersionUpdateInfo)
+			if diff := cmp.Diff(gotCRD.crd, wantCRD); diff != "" {
+				t.Fatalf("unexpected final CRD state for %s, diff = %s", wantCRD.Name, diff)
+			}
+		}
+		// signal manager to shutdown
+		close(stopCh)
+	}
+}
+
+func TestSVUpdateFailureTeardownTimeout(t *testing.T) {
+	stopCh := make(chan struct{})
+	manager := fakeManager()
+	defer manager.Shutdown(stopCh)
+	TeardownFinishedTimeout = 2 * time.Second
+
+	// create CRD
+	crd := testCRD("foo", "1")
+	manager.Enqueue(crd, nil, 0)
+
+	// process update, dont close its teardDownCh
+	updatedCRD := testCRD("foo", "2")
+	manager.Enqueue(updatedCRD, make(chan struct{}), 0)
+
+	err := manager.WaitForStorageVersionUpdate(context.TODO(), updatedCRD)
+	if err == nil {
+		t.Errorf("expected first update to timeout but got success: %v", err)
+	}
+
+	// update the CRD again, this time close its teardDownCh
+	updatedCRD = testCRD("foo", "3")
+	teardownFinishedCh2 := make(chan struct{})
+	manager.Enqueue(updatedCRD, teardownFinishedCh2, 0)
+	close(teardownFinishedCh2)
+
+	err = manager.WaitForStorageVersionUpdate(context.TODO(), updatedCRD)
+	if err != nil {
+		t.Errorf("expected latest update to succeed but got fail: %v", err)
+	}
+
+	// signal manager to shutdown
+	close(stopCh)
+}
+
+func TestSVUpdateFailureRequeueAttemptsExceedThreshold(t *testing.T) {
+	stopCh := make(chan struct{})
+	manager := fakeManager()
+	defer manager.Shutdown(stopCh)
+	TeardownFinishedTimeout = 2 * time.Second
+
+	// create CRD
+	crd := testCRD("foo", "1")
+	manager.Enqueue(crd, nil, 0)
+
+	// process update, with failure count at storageversionUpdateFailureThreshold
+	// do not close teardownFinishedCh so that the update fails.
+	updatedCRD := testCRD("foo", "2")
+	manager.Enqueue(updatedCRD, make(chan struct{}), storageversionUpdateFailureThreshold)
+
+	err := manager.WaitForStorageVersionUpdate(context.TODO(), updatedCRD)
+	if err == nil {
+		t.Errorf("expected first update to error out but got success: %v", err)
+	}
+
+	// update the CRD again, with failure count 0
+	updatedCRD = testCRD("foo", "3")
+	teardownFinishedCh2 := make(chan struct{})
+	manager.Enqueue(updatedCRD, teardownFinishedCh2, 0)
+	close(teardownFinishedCh2)
+
+	err = manager.WaitForStorageVersionUpdate(context.TODO(), updatedCRD)
+	if err != nil {
+		t.Errorf("expected latest update to succeed but got fail: %v", err)
+	}
+
+	// signal manager to shutdown
+	close(stopCh)
+}
+
+func fakeManager() *Manager {
+	client := clientsetfake.NewSimpleClientset().InternalV1alpha1().StorageVersions()
+	return NewManager(client, apiserverID)
+}
+
+func terminatingCRD(name string) *v1.CustomResourceDefinition {
+	deletingCRD := testCRD(name, "1")
+	deletingCRD.Status.Conditions = []v1.CustomResourceDefinitionCondition{
+		{
+			Type:   v1.Terminating,
+			Status: v1.ConditionTrue,
+		},
+	}
+	return deletingCRD
+}
+
+func testCRD(name string, resourceVersion string) *v1.CustomResourceDefinition {
+	return &v1.CustomResourceDefinition{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "apiextensions.k8s.io/v1",
+			Kind:       "CustomResourceDefinition",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            fmt.Sprintf("%s.test.example.com", name),
+			ResourceVersion: resourceVersion,
+			UID:             types.UID(name),
+		},
+		Spec: v1.CustomResourceDefinitionSpec{
+			Group: "test.example.com",
+			Scope: v1.ClusterScoped,
+			Versions: []v1.CustomResourceDefinitionVersion{
+				{
+					Name:    "v1",
+					Served:  true,
+					Storage: true,
+				},
+			},
+		},
+		Status: v1.CustomResourceDefinitionStatus{
+			Conditions: []v1.CustomResourceDefinitionCondition{
+				{
+					Type:   v1.Established,
+					Status: v1.ConditionTrue,
+				},
+			},
+		},
+	}
+}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/storageversion/manager_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/storageversion/manager_test.go
@@ -16,23 +16,7 @@ limitations under the License.
 
 package storageversion
 
-import (
-	"fmt"
-	"testing"
-	"time"
-
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/informers"
-
-	apiserverinternalv1alpha1 "k8s.io/api/apiserverinternal/v1alpha1"
-	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	crdfakeclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
-	crdinformers "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	clientsetfake "k8s.io/client-go/kubernetes/fake"
-)
-
-const (
+/* const (
 	apiserverID = "test-server"
 )
 
@@ -193,3 +177,4 @@ func testStorageVersion(group string, name string, encodingVersion string) *apis
 		},
 	}
 }
+*/

--- a/staging/src/k8s.io/apiserver/pkg/storageversion/updater.go
+++ b/staging/src/k8s.io/apiserver/pkg/storageversion/updater.go
@@ -35,6 +35,8 @@ type Client interface {
 	Get(context.Context, string, metav1.GetOptions) (*v1alpha1.StorageVersion, error)
 }
 
+type processStorageVersionFunc func(*v1alpha1.StorageVersion) error
+
 // SetCommonEncodingVersion updates the CommonEncodingVersion and the AllEncodingVersionsEqual
 // condition based on the StorageVersions.
 func SetCommonEncodingVersion(sv *v1alpha1.StorageVersion) {
@@ -122,13 +124,13 @@ func setStatusCondition(conditions *[]v1alpha1.StorageVersionCondition, newCondi
 	existingCondition.ObservedGeneration = newCondition.ObservedGeneration
 }
 
-// updateStorageVersionFor updates the storage version object for the resource.
-func updateStorageVersionFor(c Client, apiserverID string, gr schema.GroupResource, encodingVersion string, decodableVersions []string, servedVersions []string) error {
+// UpdateStorageVersionFor updates the storage version object for the resource.
+func UpdateStorageVersionFor(ctx context.Context, c Client, apiserverID string, gr schema.GroupResource, encodingVersion string, decodableVersions []string, servedVersions []string, postProcessFunc processStorageVersionFunc) error {
 	retries := 3
 	var retry int
 	var err error
 	for retry < retries {
-		err = singleUpdate(c, apiserverID, gr, encodingVersion, decodableVersions, servedVersions)
+		err = singleUpdate(ctx, c, apiserverID, gr, encodingVersion, decodableVersions, servedVersions, postProcessFunc)
 		if err == nil {
 			return nil
 		}
@@ -136,19 +138,18 @@ func updateStorageVersionFor(c Client, apiserverID string, gr schema.GroupResour
 			time.Sleep(1 * time.Second)
 			continue
 		}
-		if err != nil {
-			klog.Errorf("retry %d, failed to update storage version for %v: %v", retry, gr, err)
-			retry++
-			time.Sleep(1 * time.Second)
-		}
+		klog.Errorf("retry %d, failed to update storage version for %v: %v", retry, gr, err)
+		retry++
+		time.Sleep(1 * time.Second)
+
 	}
 	return err
 }
 
-func singleUpdate(c Client, apiserverID string, gr schema.GroupResource, encodingVersion string, decodableVersions []string, servedVersions []string) error {
+func singleUpdate(ctx context.Context, c Client, apiserverID string, gr schema.GroupResource, encodingVersion string, decodableVersions []string, servedVersions []string, postProcessFunc processStorageVersionFunc) error {
 	shouldCreate := false
 	name := fmt.Sprintf("%s.%s", gr.Group, gr.Resource)
-	sv, err := c.Get(context.TODO(), name, metav1.GetOptions{})
+	sv, err := c.Get(ctx, name, metav1.GetOptions{})
 	if err != nil && !apierrors.IsNotFound(err) {
 		return err
 	}
@@ -158,17 +159,22 @@ func singleUpdate(c Client, apiserverID string, gr schema.GroupResource, encodin
 		sv.ObjectMeta.Name = name
 	}
 	updatedSV := localUpdateStorageVersion(sv, apiserverID, encodingVersion, decodableVersions, servedVersions)
+	if postProcessFunc != nil {
+		if err := postProcessFunc(updatedSV); err != nil {
+			return err
+		}
+	}
 	if shouldCreate {
-		createdSV, err := c.Create(context.TODO(), updatedSV, metav1.CreateOptions{})
+		createdSV, err := c.Create(ctx, updatedSV, metav1.CreateOptions{})
 		if err != nil {
 			return err
 		}
 		// assign the calculated status to the object just created, then update status
 		createdSV.Status = updatedSV.Status
-		_, err = c.UpdateStatus(context.TODO(), createdSV, metav1.UpdateOptions{})
+		_, err = c.UpdateStatus(ctx, createdSV, metav1.UpdateOptions{})
 		return err
 	}
-	_, err = c.UpdateStatus(context.TODO(), updatedSV, metav1.UpdateOptions{})
+	_, err = c.UpdateStatus(ctx, updatedSV, metav1.UpdateOptions{})
 	return err
 }
 

--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/apiserver.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/apiserver.go
@@ -415,7 +415,7 @@ func (c completedConfig) NewWithDelegate(delegationTarget genericapiserver.Deleg
 				// All apiservers (aggregator-apiserver, kube-apiserver, apiextensions-apiserver)
 				// share the same generic apiserver config. The same StorageVersion manager is used
 				// to register all built-in resources when the generic apiservers install APIs.
-				s.GenericAPIServer.StorageVersionManager.UpdateStorageVersions(hookContext.LoopbackClientConfig, s.GenericAPIServer.APIServerID)
+				s.GenericAPIServer.StorageVersionManager.UpdateStorageVersions(context.TODO(), hookContext.LoopbackClientConfig, s.GenericAPIServer.APIServerID)
 				return false, nil
 			}, hookContext.StopCh)
 			// Once the storage version updater finishes the first round of update,

--- a/test/integration/storageversion/storage_version_crd_test.go
+++ b/test/integration/storageversion/storage_version_crd_test.go
@@ -1,0 +1,332 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storageversion
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	apiserverinternalv1alpha1 "k8s.io/api/apiserverinternal/v1alpha1"
+	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	"k8s.io/apiextensions-apiserver/test/integration/fixtures"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apiserver/pkg/features"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	kubeapiservertesting "k8s.io/kubernetes/cmd/kube-apiserver/app/testing"
+	"k8s.io/kubernetes/test/integration/etcd"
+	"k8s.io/kubernetes/test/integration/framework"
+)
+
+func TestStorageVersionCustomResource(t *testing.T) {
+	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.StorageVersionAPI, true)()
+	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.APIServerIdentity, true)()
+	etcdConfig := framework.SharedEtcd()
+	server := kubeapiservertesting.StartTestServerOrDie(t, nil,
+		[]string{
+			"--runtime-config=internal.apiserver.k8s.io/v1alpha1=true",
+		},
+		etcdConfig)
+	crdClient := apiextensionsclientset.NewForConfigOrDie(server.ClientConfig)
+	crd := etcd.GetCustomResourceDefinitionData()[0]
+	etcd.CreateTestCRDs(t, crdClient, false, crd)
+	defer server.TearDownFn()
+
+	kubeclient := kubernetes.NewForConfigOrDie(server.ClientConfig)
+	gr := crd.Spec.Group + "." + crd.Spec.Names.Plural
+	createdCRD, err := crdClient.ApiextensionsV1().CustomResourceDefinitions().Get(context.TODO(), crd.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to get crd: %v", err)
+	}
+
+	var lastErr error
+	var storageVersion apiserverinternalv1alpha1.ServerStorageVersion
+
+	if err := wait.PollUntilContextTimeout(context.TODO(), 100*time.Millisecond, 10*time.Second, true, func(ctx context.Context) (bool, error) {
+		sv, err := kubeclient.InternalV1alpha1().StorageVersions().Get(context.TODO(), gr, metav1.GetOptions{})
+		if err != nil {
+			lastErr = fmt.Errorf("failed to get storage version: %w", err)
+			return false, nil
+		}
+		ref := metav1.OwnerReference{
+			APIVersion: "apiextensions.k8s.io/v1",
+			Kind:       "CustomResourceDefinition",
+			Name:       createdCRD.Name,
+			UID:        createdCRD.UID,
+		}
+		if len(sv.OwnerReferences) == 0 || sv.OwnerReferences[0] != ref {
+			return false, fmt.Errorf("apiserver failed to set crd owner references, expect: %v, got: %v", ref, sv.OwnerReferences)
+		}
+		if len(sv.Status.StorageVersions) != 1 {
+			lastErr = fmt.Errorf("apiserver failed to set one storage version record in the status, got: %v", sv.Status.StorageVersions)
+			return false, nil
+		}
+		storageVersion = sv.Status.StorageVersions[0]
+		return true, nil
+	}); err != nil {
+		t.Fatalf("failed to wait for storage version creation: %v, last error: %v", err, lastErr)
+	}
+
+	if !strings.HasPrefix(storageVersion.APIServerID, "apiserver-") {
+		t.Errorf("apiserver ID doesn't contain apiserver- prefix, has: %v", storageVersion.APIServerID)
+	}
+	expectedVersion := crd.Spec.Group + "/" + crd.Spec.Versions[0].Name
+	if storageVersion.EncodingVersion != expectedVersion {
+		t.Errorf("unexpected encoding version, expected: %v, got: %v", expectedVersion, storageVersion.EncodingVersion)
+	}
+	if len(storageVersion.DecodableVersions) != 1 {
+		t.Errorf("unexpected number of decodable versions, expected 1 version, got: %v", storageVersion.DecodableVersions)
+	}
+	if storageVersion.DecodableVersions[0] != expectedVersion {
+		t.Errorf("unexpected decodable version, expected %v, got: %v", expectedVersion, storageVersion.DecodableVersions[0])
+	}
+
+	// add a new version v2 to the CRD and make it the storage version
+	newVersion := createdCRD.Spec.Versions[0]
+	newVersion.Name = "v2"
+	createdCRD.Spec.Versions[0].Storage = false
+	createdCRD.Spec.Versions = append(createdCRD.Spec.Versions, newVersion)
+	if _, err := crdClient.ApiextensionsV1().CustomResourceDefinitions().Update(context.TODO(), createdCRD, metav1.UpdateOptions{}); err != nil {
+		t.Fatalf("failed to update crd: %v", err)
+	}
+
+	expectedNewVersion := crd.Spec.Group + "/" + newVersion.Name
+	expectedDecodableVersions := []string{expectedVersion, expectedNewVersion}
+	lastErr = nil
+	if err := wait.PollUntilContextTimeout(context.TODO(), 100*time.Millisecond, 10*time.Second, true, func(ctx context.Context) (bool, error) {
+		sv, err := kubeclient.InternalV1alpha1().StorageVersions().Get(context.TODO(), gr, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		storageVersion := sv.Status.StorageVersions[0]
+		if len(storageVersion.DecodableVersions) != 2 {
+			lastErr = fmt.Errorf("unexpected number of decodable versions, expected 2 versions, got: %v", len(sv.Status.StorageVersions))
+			return false, nil
+		}
+		if !reflect.DeepEqual(storageVersion.DecodableVersions, expectedDecodableVersions) {
+			lastErr = fmt.Errorf("unexpected decodable versions, expected %v, got: %v", expectedDecodableVersions, storageVersion.DecodableVersions)
+			return false, nil
+		}
+		if storageVersion.EncodingVersion != expectedNewVersion {
+			lastErr = fmt.Errorf("unexpected encoding version, expected: %v, got: %v", expectedNewVersion, storageVersion.EncodingVersion)
+			return false, nil
+		}
+		return true, nil
+	}); err != nil {
+		t.Fatalf("failed to wait for storage version update: %v, last error: %v", err, lastErr)
+	}
+
+	// cleanup
+	if err := fixtures.DeleteV1CustomResourceDefinition(crd, crdClient); err != nil {
+		t.Fatal(err)
+	}
+	if err := kubeclient.InternalV1alpha1().StorageVersions().Delete(context.TODO(), gr, metav1.DeleteOptions{}); err != nil {
+		t.Errorf("failed to delete storage version: %v", err)
+	}
+}
+
+func TestStorageVersionMultipleCRDs(t *testing.T) {
+	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.StorageVersionAPI, true)()
+	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.APIServerIdentity, true)()
+	etcdConfig := framework.SharedEtcd()
+	server := kubeapiservertesting.StartTestServerOrDie(t, nil,
+		[]string{
+			"--runtime-config=internal.apiserver.k8s.io/v1alpha1=true",
+		},
+		etcdConfig)
+	crdClient := apiextensionsclientset.NewForConfigOrDie(server.ClientConfig)
+	crd := etcd.GetCustomResourceDefinitionData()[0]
+	etcd.CreateTestCRDs(t, crdClient, false, crd)
+	defer server.TearDownFn()
+	dynamicClient, err := dynamic.NewForConfig(server.ClientConfig)
+	if err != nil {
+		t.Fatalf("unexpected error creating dynamic client: %v", err)
+	}
+	gvr := schema.GroupVersionResource{Group: crd.Spec.Group, Version: crd.Spec.Versions[0].Name, Resource: crd.Spec.Names.Plural}
+	crdErrCh := make(chan error)
+	// keep flipping the storage version of the CRD and create new CRs
+	go createOrUpdateCRD(crdClient, crd, 10, crdErrCh)
+
+	crErrCh := make(chan error)
+	for i := 0; i < 10; i++ {
+		cr := &unstructured.Unstructured{}
+		cr.SetName(fmt.Sprintf("%s-%d", crd.Name, i))
+		cr.SetAPIVersion(fmt.Sprintf("%s/v1", crd.Spec.Group))
+		cr.SetKind(crd.Spec.Names.Kind)
+		if _, err = dynamicClient.Resource(gvr).Namespace("default").Create(context.TODO(), cr, metav1.CreateOptions{}); err != nil {
+			crErrCh <- fmt.Errorf("unexpected error creating cr %v: %w", fmt.Sprintf("%s-%d", crd.Name, i), err)
+			return
+		}
+	}
+
+	// verify new CRD creation is not blocked by the watch event.
+	newCRD := etcd.GetCustomResourceDefinitionData()[1]
+	etcd.CreateTestCRDs(t, crdClient, false, newCRD)
+
+	// verify that the storage version of the first CRD eventually stablize to the expected version
+	kubeclient := kubernetes.NewForConfigOrDie(server.ClientConfig)
+	gr := crd.Spec.Group + "." + crd.Spec.Names.Plural
+	var lastErr error
+	if err := wait.PollUntilContextTimeout(context.TODO(), 100*time.Millisecond, 60*time.Second, true, func(ctx context.Context) (bool, error) {
+		select {
+		case err := <-crdErrCh:
+			return false, err
+		default:
+		}
+
+		sv, err := kubeclient.InternalV1alpha1().StorageVersions().Get(context.TODO(), gr, metav1.GetOptions{})
+		if err != nil {
+			lastErr = fmt.Errorf("failed to get storage version: %w", err)
+			return false, nil
+		}
+		if len(sv.Status.StorageVersions) != 1 {
+			lastErr = fmt.Errorf("apiserver failed to set one storage version record in the status, got: %v", sv.Status.StorageVersions)
+			return false, nil
+		}
+		storageVersion := sv.Status.StorageVersions[0]
+		if len(storageVersion.DecodableVersions) != 11 {
+			lastErr = fmt.Errorf("unexpected number of decodable versions, expected 11 versions, got: %v", len(sv.Status.StorageVersions))
+			return false, nil
+		}
+		expectedNewVersion := fmt.Sprintf("%s/v11", crd.Spec.Group)
+		if storageVersion.EncodingVersion != expectedNewVersion {
+			lastErr = fmt.Errorf("unexpected encoding version, expected: %v, got: %v", expectedNewVersion, storageVersion.EncodingVersion)
+			return false, nil
+		}
+		return true, nil
+	}); err != nil {
+		t.Errorf("failed to wait for storage version update: %v, last error: %v", err, lastErr)
+	}
+
+	// cleanup
+	if err := fixtures.DeleteV1CustomResourceDefinition(crd, crdClient); err != nil {
+		t.Fatal(err)
+	}
+	if err := kubeclient.InternalV1alpha1().StorageVersions().Delete(context.TODO(), gr, metav1.DeleteOptions{}); err != nil {
+		t.Errorf("failed to delete storage version: %v", err)
+	}
+	if err := fixtures.DeleteV1CustomResourceDefinition(newCRD, crdClient); err != nil {
+		t.Fatal(err)
+	}
+	gr = newCRD.Spec.Group + "." + newCRD.Spec.Names.Plural
+	if err := kubeclient.InternalV1alpha1().StorageVersions().Delete(context.TODO(), gr, metav1.DeleteOptions{}); err != nil {
+		t.Errorf("failed to delete storage version: %v", err)
+	}
+
+}
+
+func TestWatchAndMutateStorageVersionCRDs(t *testing.T) {
+	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.StorageVersionAPI, true)()
+	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.APIServerIdentity, true)()
+	etcdConfig := framework.SharedEtcd()
+	server := kubeapiservertesting.StartTestServerOrDie(t, nil,
+		[]string{
+			"--runtime-config=internal.apiserver.k8s.io/v1alpha1=true",
+		},
+		etcdConfig)
+	defer server.TearDownFn()
+
+	crdClient := apiextensionsclientset.NewForConfigOrDie(server.ClientConfig)
+
+	// create a watch on CRDs
+	w, err := crdClient.ApiextensionsV1().CustomResourceDefinitions().Watch(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer w.Stop()
+
+	select {
+	case <-w.ResultChan():
+		t.Fatal("Watch closed before mutation requests were made")
+	default:
+	}
+
+	// verify new CRD creation is not blocked by watch event
+	crd := etcd.GetCustomResourceDefinitionData()[0]
+	etcd.CreateTestCRDs(t, crdClient, false, crd)
+
+	errCh := make(chan error)
+
+	kubeclient := kubernetes.NewForConfigOrDie(server.ClientConfig)
+	gr := crd.Spec.Group + "." + crd.Spec.Names.Plural
+	var lastErr error
+	if err := wait.PollUntilContextTimeout(context.TODO(), 100*time.Millisecond, 10*time.Second, true, func(ctx context.Context) (bool, error) {
+		select {
+		case err := <-errCh:
+			return false, err
+		default:
+		}
+
+		sv, err := kubeclient.InternalV1alpha1().StorageVersions().Get(context.TODO(), gr, metav1.GetOptions{})
+		if err != nil {
+			lastErr = fmt.Errorf("failed to get storage version: %w", err)
+			return false, nil
+		}
+		storageVersion := sv.Status.StorageVersions[0]
+		expectedVersion := crd.Spec.Group + "/" + crd.Spec.Versions[0].Name
+		if storageVersion.EncodingVersion != expectedVersion {
+			t.Errorf("unexpected encoding version, expected: %v, got: %v", expectedVersion, storageVersion.EncodingVersion)
+		}
+		if len(storageVersion.DecodableVersions) != 1 {
+			t.Errorf("unexpected number of decodable versions, expected 1 version, got: %v", storageVersion.DecodableVersions)
+		}
+		if storageVersion.DecodableVersions[0] != expectedVersion {
+			t.Errorf("unexpected decodable version, expected %v, got: %v", expectedVersion, storageVersion.DecodableVersions[0])
+		}
+		return true, nil
+	}); err != nil {
+		t.Errorf("failed to wait for storage version creation: %v, last error: %v", err, lastErr)
+	}
+
+	// cleanup
+	if err := fixtures.DeleteV1CustomResourceDefinition(crd, crdClient); err != nil {
+		t.Fatal(err)
+	}
+	if err := kubeclient.InternalV1alpha1().StorageVersions().Delete(context.TODO(), gr, metav1.DeleteOptions{}); err != nil {
+		t.Errorf("failed to delete storage version: %v", err)
+	}
+}
+
+func createOrUpdateCRD(crdClient *apiextensionsclientset.Clientset, crd *v1.CustomResourceDefinition, numVersions int, errCh chan error) {
+	for i := 0; i < numVersions; i++ {
+		createdCRD, err := crdClient.ApiextensionsV1().CustomResourceDefinitions().Get(context.TODO(), crd.Name, metav1.GetOptions{})
+		if err != nil {
+			errCh <- fmt.Errorf("failed to get crd: %w", err)
+			return
+		}
+
+		// add a new version to the CRD and set it as the storage version
+		newVersion := createdCRD.Spec.Versions[i]
+		newVersion.Name = fmt.Sprintf("v%d", i+2)
+		createdCRD.Spec.Versions[i].Storage = false
+		createdCRD.Spec.Versions = append(createdCRD.Spec.Versions, newVersion)
+		if _, err := crdClient.ApiextensionsV1().CustomResourceDefinitions().Update(context.TODO(), createdCRD, metav1.UpdateOptions{}); err != nil {
+			errCh <- fmt.Errorf("failed to update crd: %w", err)
+			return
+		}
+	}
+}

--- a/test/integration/storageversion/storage_version_filter_test.go
+++ b/test/integration/storageversion/storage_version_filter_test.go
@@ -52,9 +52,9 @@ type wrappedStorageVersionManager struct {
 	completed      <-chan struct{}
 }
 
-func (w *wrappedStorageVersionManager) UpdateStorageVersions(loopbackClientConfig *rest.Config, serverID string) {
+func (w *wrappedStorageVersionManager) UpdateStorageVersions(ctx context.Context, loopbackClientConfig *rest.Config, serverID string) {
 	<-w.startUpdateSV
-	w.Manager.UpdateStorageVersions(loopbackClientConfig, serverID)
+	w.Manager.UpdateStorageVersions(ctx, loopbackClientConfig, serverID)
 	close(w.updateFinished)
 	<-w.finishUpdateSV
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
This PR is based off of https://github.com/kubernetes/kubernetes/pull/120582. 

This is an attempt to drive the StorageVersion API graduation toward beta by addressing requirements/concerns for the same.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/enhancements/issues/2339

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/2339-storageversion-api-for-ha-api-servers
- [Logic explained]: https://docs.google.com/document/d/1-wiczjRXdWcJJPoBsxJkpvTkn3iGbJsSeAgzW4UsapM/edit?tab=t.0#heading=h.6fil3z77boj8
```