### PR TITLE
Fix admission error on podresources e2e test

### DIFF
--- a/test/e2e_node/podresources_test.go
+++ b/test/e2e_node/podresources_test.go
@@ -447,12 +447,12 @@ func podresourcesListTests(ctx context.Context, f *framework.Framework, cli kube
 				cntName:        "cnt-00",
 				resourceName:   sd.resourceName,
 				resourceAmount: 1,
-				cpuRequest:     2000,
+				cpuRequest:     1000,
 			},
 			{
 				podName:    "pod-02",
 				cntName:    "cnt-00",
-				cpuRequest: 2000,
+				cpuRequest: 1000,
 			},
 			{
 				podName:        "pod-03",
@@ -471,12 +471,12 @@ func podresourcesListTests(ctx context.Context, f *framework.Framework, cli kube
 			{
 				podName:    "pod-01",
 				cntName:    "cnt-00",
-				cpuRequest: 2000,
+				cpuRequest: 1000,
 			},
 			{
 				podName:    "pod-02",
 				cntName:    "cnt-00",
-				cpuRequest: 2000,
+				cpuRequest: 1000,
 			},
 			{
 				podName:    "pod-03",
@@ -503,12 +503,12 @@ func podresourcesListTests(ctx context.Context, f *framework.Framework, cli kube
 				cntName:        "cnt-00",
 				resourceName:   sd.resourceName,
 				resourceAmount: 1,
-				cpuRequest:     2000,
+				cpuRequest:     1000,
 			},
 			{
 				podName:    "pod-02",
 				cntName:    "cnt-00",
-				cpuRequest: 2000,
+				cpuRequest: 1000,
 			},
 		}
 	} else {
@@ -520,12 +520,12 @@ func podresourcesListTests(ctx context.Context, f *framework.Framework, cli kube
 			{
 				podName:    "pod-01",
 				cntName:    "cnt-00",
-				cpuRequest: 2000,
+				cpuRequest: 1000,
 			},
 			{
 				podName:    "pod-02",
 				cntName:    "cnt-00",
-				cpuRequest: 2000,
+				cpuRequest: 1000,
 			},
 		}
 	}
@@ -791,7 +791,7 @@ func podresourcesGetTests(ctx context.Context, f *framework.Framework, cli kubel
 		{
 			podName:    "pod-01",
 			cntName:    "cnt-00",
-			cpuRequest: 2000,
+			cpuRequest: 1000,
 		},
 	}
 	tpd.createPodsForTest(ctx, f, expected)
@@ -812,7 +812,7 @@ func podresourcesGetTests(ctx context.Context, f *framework.Framework, cli kubel
 			{
 				podName:    "pod-01",
 				cntName:    "cnt-00",
-				cpuRequest: 2000,
+				cpuRequest: 1000,
 				initContainers: []initContainerDesc{
 					{
 						cntName:    "init-00",
@@ -820,7 +820,7 @@ func podresourcesGetTests(ctx context.Context, f *framework.Framework, cli kubel
 					},
 					{
 						cntName:       "restartable-init-01",
-						cpuRequest:    2000,
+						cpuRequest:    1000,
 						restartPolicy: &containerRestartPolicyAlways,
 					},
 				},


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind failing-test
/kind flake

#### What this PR does / why we need it:

Fix `UnexpectedAdmissionError: Allocate failed due to not enough cpus available to satisfy request: requested=2, available=1, which is unexpected` error in e2e_node podresources tests. 
The error caused by the test requesting more CPUs that the test instance has.

Here is an example of failed job: https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/124000/pull-kubernetes-node-kubelet-serial-crio-cgroupv1/1770195910098161664/build-log.txt

#### Which issue(s) this PR fixes:
Ref: https://github.com/kubernetes/kubernetes/issues/123589 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
