### PR TITLE
e2e_node: fix podresources test

### DIFF
--- a/test/e2e_node/podresources_test.go
+++ b/test/e2e_node/podresources_test.go
@@ -1027,7 +1027,7 @@ var _ = SIGDescribe("POD Resources", framework.WithSerial(), feature.PodResource
 					}
 					pod := makePodResourcesTestPod(pd)
 					pod.Spec.Containers[0].Command = []string{"sh", "-c", "/bin/true"}
-					pod = e2epod.NewPodClient(f).CreateSync(ctx, pod)
+					pod = e2epod.NewPodClient(f).Create(ctx, pod)
 					defer e2epod.NewPodClient(f).DeleteSync(ctx, pod.Name, metav1.DeleteOptions{}, time.Minute)
 					err := e2epod.WaitForPodCondition(ctx, f.ClientSet, pod.Namespace, pod.Name, "Pod Succeeded", time.Minute*2, testutils.PodSucceeded)
 					framework.ExpectNoError(err)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind failing-test
/kind flake

#### What this PR does / why we need it:

Fixed `The phase of Pod e2e-test-pod is Succeeded which is unexpected` error.

`e2epod.NewPodClient(f).CreateSync` is unable to catch 'Running' status of the pod as pod finishes too fast.
Using `Create` API should solve the issue as it doesn't query pod status.

#### Which issue(s) this PR fixes:

Ref: https://github.com/kubernetes/kubernetes/issues/123589

#### Special notes for your reviewer:

Here is an example of failed job: https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/120459/pull-kubernetes-node-kubelet-serial-crio-cgroupv1/1769614075580387328/build-log.txt

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
