### PR TITLE
kube-controller-manager removes deprecated command flags

### DIFF
--- a/api/api-rules/violation_exceptions.list
+++ b/api/api-rules/violation_exceptions.list
@@ -3,7 +3,6 @@ API rule violation: list_type_missing,k8s.io/cloud-provider/config/v1alpha1,Webh
 API rule violation: list_type_missing,k8s.io/controller-manager/config/v1alpha1,GenericControllerManagerConfiguration,Controllers
 API rule violation: list_type_missing,k8s.io/controller-manager/config/v1alpha1,LeaderMigrationConfiguration,ControllerLeaders
 API rule violation: list_type_missing,k8s.io/kube-controller-manager/config/v1alpha1,GarbageCollectorControllerConfiguration,GCIgnoredResources
-API rule violation: list_type_missing,k8s.io/kube-controller-manager/config/v1alpha1,PersistentVolumeBinderControllerConfiguration,VolumeHostCIDRDenylist
 API rule violation: list_type_missing,k8s.io/kube-proxy/config/v1alpha1,KubeProxyConfiguration,NodePortAddresses
 API rule violation: list_type_missing,k8s.io/kube-proxy/config/v1alpha1,KubeProxyIPVSConfiguration,ExcludeCIDRs
 API rule violation: list_type_missing,k8s.io/kubelet/config/v1,CredentialProvider,Args
@@ -230,8 +229,6 @@ API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,N
 API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,NodeLifecycleControllerConfiguration,UnhealthyZoneThreshold
 API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,PersistentVolumeBinderControllerConfiguration,PVClaimBinderSyncPeriod
 API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,PersistentVolumeBinderControllerConfiguration,VolumeConfiguration
-API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,PersistentVolumeBinderControllerConfiguration,VolumeHostAllowLocalLoopback
-API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,PersistentVolumeBinderControllerConfiguration,VolumeHostCIDRDenylist
 API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,PersistentVolumeRecyclerConfiguration,IncrementTimeoutHostPath
 API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,PersistentVolumeRecyclerConfiguration,IncrementTimeoutNFS
 API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,PersistentVolumeRecyclerConfiguration,MaximumRetry

--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -2196,7 +2196,6 @@ function start-kube-controller-manager {
   params+=("--kubeconfig=${config_path}" "--authentication-kubeconfig=${config_path}" "--authorization-kubeconfig=${config_path}")
   params+=("--root-ca-file=${CA_CERT_BUNDLE_PATH}")
   params+=("--service-account-private-key-file=${SERVICEACCOUNT_KEY_PATH}")
-  params+=("--volume-host-allow-local-loopback=false")
   if [[ -n "${ENABLE_GARBAGE_COLLECTOR:-}" ]]; then
     params+=("--enable-garbage-collector=${ENABLE_GARBAGE_COLLECTOR}")
   fi

--- a/cmd/kube-controller-manager/app/options/options_test.go
+++ b/cmd/kube-controller-manager/app/options/options_test.go
@@ -115,8 +115,6 @@ var args = []string{
 	"--enable-hostpath-provisioner=true",
 	"--cluster-signing-duration=10h",
 	"--flex-volume-plugin-dir=/flex-volume-plugin",
-	"--volume-host-cidr-denylist=127.0.0.1/28,feed::/16",
-	"--volume-host-allow-local-loopback=false",
 	"--horizontal-pod-autoscaler-sync-period=45s",
 	"--horizontal-pod-autoscaler-downscale-stabilization=3m",
 	"--horizontal-pod-autoscaler-cpu-initialization-period=90s",
@@ -368,8 +366,6 @@ func TestAddFlags(t *testing.T) {
 						IncrementTimeoutHostPath: 45,
 					},
 				},
-				VolumeHostCIDRDenylist:       []string{"127.0.0.1/28", "feed::/16"},
-				VolumeHostAllowLocalLoopback: false,
 			},
 		},
 		PodGCController: &PodGCControllerOptions{
@@ -617,8 +613,6 @@ func TestApplyTo(t *testing.T) {
 						IncrementTimeoutHostPath: 45,
 					},
 				},
-				VolumeHostCIDRDenylist:       []string{"127.0.0.1/28", "feed::/16"},
-				VolumeHostAllowLocalLoopback: false,
 			},
 			PodGCController: podgcconfig.PodGCControllerConfiguration{
 				TerminatedPodGCThreshold: 12000,

--- a/cmd/kube-controller-manager/app/options/persistentvolumebindercontroller.go
+++ b/cmd/kube-controller-manager/app/options/persistentvolumebindercontroller.go
@@ -43,10 +43,6 @@ func (o *PersistentVolumeBinderControllerOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&o.VolumeConfiguration.EnableHostPathProvisioning, "enable-hostpath-provisioner", o.VolumeConfiguration.EnableHostPathProvisioning, "Enable HostPath PV provisioning when running without a cloud provider. This allows testing and development of provisioning features.  HostPath provisioning is not supported in any way, won't work in a multi-node cluster, and should not be used for anything other than testing or development.")
 	fs.BoolVar(&o.VolumeConfiguration.EnableDynamicProvisioning, "enable-dynamic-provisioning", o.VolumeConfiguration.EnableDynamicProvisioning, "Enable dynamic provisioning for environments that support it.")
 	fs.StringVar(&o.VolumeConfiguration.FlexVolumePluginDir, "flex-volume-plugin-dir", o.VolumeConfiguration.FlexVolumePluginDir, "Full path of the directory in which the flex volume plugin should search for additional third party volume plugins.")
-	fs.StringSliceVar(&o.VolumeHostCIDRDenylist, "volume-host-cidr-denylist", o.VolumeHostCIDRDenylist, "A comma-separated list of CIDR ranges to avoid from volume plugins.")
-	fs.MarkDeprecated("volume-host-cidr-denylist", "This flag is currently no-op and will be deleted.")
-	fs.BoolVar(&o.VolumeHostAllowLocalLoopback, "volume-host-allow-local-loopback", o.VolumeHostAllowLocalLoopback, "If false, deny local loopback IPs in addition to any CIDR ranges in --volume-host-cidr-denylist")
-	fs.MarkDeprecated("volume-host-allow-local-loopback", "This flag is currently no-op and will be deleted.")
 }
 
 // ApplyTo fills up PersistentVolumeBinderController config with options.
@@ -57,8 +53,6 @@ func (o *PersistentVolumeBinderControllerOptions) ApplyTo(cfg *persistentvolumec
 
 	cfg.PVClaimBinderSyncPeriod = o.PVClaimBinderSyncPeriod
 	cfg.VolumeConfiguration = o.VolumeConfiguration
-	cfg.VolumeHostCIDRDenylist = o.VolumeHostCIDRDenylist
-	cfg.VolumeHostAllowLocalLoopback = o.VolumeHostAllowLocalLoopback
 
 	return nil
 }

--- a/pkg/controller/apis/config/zz_generated.deepcopy.go
+++ b/pkg/controller/apis/config/zz_generated.deepcopy.go
@@ -65,7 +65,7 @@ func (in *KubeControllerManagerConfiguration) DeepCopyInto(out *KubeControllerMa
 	out.NamespaceController = in.NamespaceController
 	out.NodeIPAMController = in.NodeIPAMController
 	out.NodeLifecycleController = in.NodeLifecycleController
-	in.PersistentVolumeBinderController.DeepCopyInto(&out.PersistentVolumeBinderController)
+	out.PersistentVolumeBinderController = in.PersistentVolumeBinderController
 	out.PodGCController = in.PodGCController
 	out.ReplicaSetController = in.ReplicaSetController
 	out.ReplicationController = in.ReplicationController

--- a/pkg/controller/volume/persistentvolume/config/types.go
+++ b/pkg/controller/volume/persistentvolume/config/types.go
@@ -28,12 +28,6 @@ type PersistentVolumeBinderControllerConfiguration struct {
 	PVClaimBinderSyncPeriod metav1.Duration
 	// volumeConfiguration holds configuration for volume related features.
 	VolumeConfiguration VolumeConfiguration
-	// DEPRECATED: VolumeHostCIDRDenylist is a list of CIDRs that should not be reachable by the
-	// controller from plugins.
-	VolumeHostCIDRDenylist []string
-	// DEPRECATED: VolumeHostAllowLocalLoopback indicates if local loopback hosts (127.0.0.1, etc)
-	// should be allowed from plugins.
-	VolumeHostAllowLocalLoopback bool
 }
 
 // VolumeConfiguration contains *all* enumerated flags meant to configure all volume

--- a/pkg/controller/volume/persistentvolume/config/v1alpha1/defaults.go
+++ b/pkg/controller/volume/persistentvolume/config/v1alpha1/defaults.go
@@ -39,11 +39,6 @@ func RecommendedDefaultPersistentVolumeBinderControllerConfiguration(obj *kubect
 		obj.PVClaimBinderSyncPeriod = metav1.Duration{Duration: 15 * time.Second}
 	}
 
-	if obj.VolumeHostAllowLocalLoopback == nil {
-		trueValue := true
-		obj.VolumeHostAllowLocalLoopback = &trueValue
-	}
-
 	// Use the default VolumeConfiguration options.
 	RecommendedDefaultVolumeConfiguration(&obj.VolumeConfiguration)
 }

--- a/pkg/controller/volume/persistentvolume/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/controller/volume/persistentvolume/config/v1alpha1/zz_generated.conversion.go
@@ -22,8 +22,6 @@ limitations under the License.
 package v1alpha1
 
 import (
-	unsafe "unsafe"
-
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
@@ -108,20 +106,12 @@ func autoConvert_v1alpha1_PersistentVolumeBinderControllerConfiguration_To_confi
 	if err := Convert_v1alpha1_VolumeConfiguration_To_config_VolumeConfiguration(&in.VolumeConfiguration, &out.VolumeConfiguration, s); err != nil {
 		return err
 	}
-	out.VolumeHostCIDRDenylist = *(*[]string)(unsafe.Pointer(&in.VolumeHostCIDRDenylist))
-	if err := v1.Convert_Pointer_bool_To_bool(&in.VolumeHostAllowLocalLoopback, &out.VolumeHostAllowLocalLoopback, s); err != nil {
-		return err
-	}
 	return nil
 }
 
 func autoConvert_config_PersistentVolumeBinderControllerConfiguration_To_v1alpha1_PersistentVolumeBinderControllerConfiguration(in *config.PersistentVolumeBinderControllerConfiguration, out *v1alpha1.PersistentVolumeBinderControllerConfiguration, s conversion.Scope) error {
 	out.PVClaimBinderSyncPeriod = in.PVClaimBinderSyncPeriod
 	if err := Convert_config_VolumeConfiguration_To_v1alpha1_VolumeConfiguration(&in.VolumeConfiguration, &out.VolumeConfiguration, s); err != nil {
-		return err
-	}
-	out.VolumeHostCIDRDenylist = *(*[]string)(unsafe.Pointer(&in.VolumeHostCIDRDenylist))
-	if err := v1.Convert_bool_To_Pointer_bool(&in.VolumeHostAllowLocalLoopback, &out.VolumeHostAllowLocalLoopback, s); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/controller/volume/persistentvolume/config/zz_generated.deepcopy.go
+++ b/pkg/controller/volume/persistentvolume/config/zz_generated.deepcopy.go
@@ -26,11 +26,6 @@ func (in *PersistentVolumeBinderControllerConfiguration) DeepCopyInto(out *Persi
 	*out = *in
 	out.PVClaimBinderSyncPeriod = in.PVClaimBinderSyncPeriod
 	out.VolumeConfiguration = in.VolumeConfiguration
-	if in.VolumeHostCIDRDenylist != nil {
-		in, out := &in.VolumeHostCIDRDenylist, &out.VolumeHostCIDRDenylist
-		*out = make([]string, len(*in))
-		copy(*out, *in)
-	}
 	return
 }
 

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -58504,30 +58504,8 @@ func schema_k8sio_kube_controller_manager_config_v1alpha1_PersistentVolumeBinder
 							Ref:         ref("k8s.io/kube-controller-manager/config/v1alpha1.VolumeConfiguration"),
 						},
 					},
-					"VolumeHostCIDRDenylist": {
-						SchemaProps: spec.SchemaProps{
-							Description: "DEPRECATED: VolumeHostCIDRDenylist is a list of CIDRs that should not be reachable by the controller from plugins.",
-							Type:        []string{"array"},
-							Items: &spec.SchemaOrArray{
-								Schema: &spec.Schema{
-									SchemaProps: spec.SchemaProps{
-										Default: "",
-										Type:    []string{"string"},
-										Format:  "",
-									},
-								},
-							},
-						},
-					},
-					"VolumeHostAllowLocalLoopback": {
-						SchemaProps: spec.SchemaProps{
-							Description: "DEPRECATED: VolumeHostAllowLocalLoopback indicates if local loopback hosts (127.0.0.1, etc) should be allowed from plugins.",
-							Type:        []string{"boolean"},
-							Format:      "",
-						},
-					},
 				},
-				Required: []string{"PVClaimBinderSyncPeriod", "VolumeConfiguration", "VolumeHostCIDRDenylist", "VolumeHostAllowLocalLoopback"},
+				Required: []string{"PVClaimBinderSyncPeriod", "VolumeConfiguration"},
 			},
 		},
 		Dependencies: []string{

--- a/staging/src/k8s.io/kube-controller-manager/config/v1alpha1/types.go
+++ b/staging/src/k8s.io/kube-controller-manager/config/v1alpha1/types.go
@@ -422,12 +422,6 @@ type PersistentVolumeBinderControllerConfiguration struct {
 	PVClaimBinderSyncPeriod metav1.Duration
 	// volumeConfiguration holds configuration for volume related features.
 	VolumeConfiguration VolumeConfiguration
-	// DEPRECATED: VolumeHostCIDRDenylist is a list of CIDRs that should not be reachable by the
-	// controller from plugins.
-	VolumeHostCIDRDenylist []string
-	// DEPRECATED: VolumeHostAllowLocalLoopback indicates if local loopback hosts (127.0.0.1, etc)
-	// should be allowed from plugins.
-	VolumeHostAllowLocalLoopback *bool
 }
 
 // PodGCControllerConfiguration contains elements describing PodGCController.

--- a/staging/src/k8s.io/kube-controller-manager/config/v1alpha1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/kube-controller-manager/config/v1alpha1/zz_generated.deepcopy.go
@@ -416,16 +416,6 @@ func (in *PersistentVolumeBinderControllerConfiguration) DeepCopyInto(out *Persi
 	*out = *in
 	out.PVClaimBinderSyncPeriod = in.PVClaimBinderSyncPeriod
 	in.VolumeConfiguration.DeepCopyInto(&out.VolumeConfiguration)
-	if in.VolumeHostCIDRDenylist != nil {
-		in, out := &in.VolumeHostCIDRDenylist, &out.VolumeHostCIDRDenylist
-		*out = make([]string, len(*in))
-		copy(*out, *in)
-	}
-	if in.VolumeHostAllowLocalLoopback != nil {
-		in, out := &in.VolumeHostAllowLocalLoopback, &out.VolumeHostAllowLocalLoopback
-		*out = new(bool)
-		**out = **in
-	}
 	return
 }
 


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

`--volume-host-cidr-denylist and --volume-host-allow-local-loopback` was deprecated in v1.28. https://github.com/kubernetes/kubernetes/pull/118128

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kube-controller-manager removes deprecated command flags: --volume-host-cidr-denylist and --volume-host-allow-local-loopback
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
