### PR TITLE
fix test flake caused by not waiting for CRD schema update

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/ratcheting_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/ratcheting_test.go
@@ -220,23 +220,12 @@ func (u updateMyCRDV1Beta1Schema) Do(ctx *ratchetingTestContext) error {
 		}
 
 		uuidString := string(uuid.NewUUID())
-		// UUID string is just hex separated by dashes, which is safe to
-		// throw into regex like this
-		pattern := "^" + uuidString + "$"
 		sentinelName := "__ratcheting_sentinel_field__"
 		sch.Properties[sentinelName] = apiextensionsv1.JSONSchemaProps{
-			Type:    "string",
-			Pattern: pattern,
-
-			// Put MaxLength condition inside AllOf since the string_validator
-			// in kube-openapi short circuits upon seeing MaxLength, and we
-			// want both pattern and MaxLength errors
-			AllOf: []apiextensionsv1.JSONSchemaProps{
-				{
-					MinLength: ptr((int64(1))), // 1 MinLength to prevent empty value from ever being admitted
-					MaxLength: ptr((int64(0))), // 0 MaxLength to prevent non-empty value from ever being admitted
-				},
-			},
+			Type: "string",
+			Enum: []apiextensionsv1.JSON{{
+				Raw: []byte(`"` + uuidString + `"`),
+			}},
 		}
 
 		for _, v := range myCRD.Spec.Versions {
@@ -254,7 +243,7 @@ func (u updateMyCRDV1Beta1Schema) Do(ctx *ratchetingTestContext) error {
 		}
 
 		// Keep trying to create an invalid instance of the CRD until we
-		// get an error containing the ResourceVersion we are looking for
+		// get an error containing the message we are looking for
 		//
 		counter := 0
 		return wait.PollUntilContextCancel(context.TODO(), 100*time.Millisecond, true, func(_ context.Context) (done bool, err error) {
@@ -263,8 +252,7 @@ func (u updateMyCRDV1Beta1Schema) Do(ctx *ratchetingTestContext) error {
 				gvr:  myCRDV1Beta1,
 				name: "sentinel-resource",
 				patch: map[string]interface{}{
-					// Just keep using different values
-					sentinelName: fmt.Sprintf("invalid %v %v", uuidString, counter),
+					sentinelName: fmt.Sprintf("invalid-%d", counter),
 				}}.Do(ctx)
 
 			if err == nil {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind failing-test
/kind flake

#### What this PR does / why we need it:

Fixes a flake in some test code. Flake was caused by our check to make sure CRD schema was updated. We would check to see a returned error had special string, but the error message would unconditionally contain the string since we had used within the send value, so we never would actually wait....I'm surprised it did not flake more than it had.

FIxed by no longer sending the special string in with the object, and instead encoding the special string as a custom CEL error message. This is a better way of checking that the new schema is being updated.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #123854

#### Special notes for your reviewer:

/assign @Jefftree 
/cc @pacoxu 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
