### PR TITLE
Promote some InTreePluginXXXUnregister to GA

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -1016,19 +1016,19 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 
 	ImageMaximumGCAge: {Default: true, PreRelease: featuregate.Beta},
 
-	InTreePluginAWSUnregister: {Default: false, PreRelease: featuregate.Alpha},
+	InTreePluginAWSUnregister: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.32
 
-	InTreePluginAzureDiskUnregister: {Default: false, PreRelease: featuregate.Alpha},
+	InTreePluginAzureDiskUnregister: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.32
 
-	InTreePluginAzureFileUnregister: {Default: false, PreRelease: featuregate.Alpha},
+	InTreePluginAzureFileUnregister: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.32
 
-	InTreePluginGCEUnregister: {Default: false, PreRelease: featuregate.Alpha},
+	InTreePluginGCEUnregister: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.32
 
-	InTreePluginOpenStackUnregister: {Default: false, PreRelease: featuregate.Alpha},
+	InTreePluginOpenStackUnregister: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.32
 
 	InTreePluginPortworxUnregister: {Default: false, PreRelease: featuregate.Alpha},
 
-	InTreePluginvSphereUnregister: {Default: false, PreRelease: featuregate.Alpha},
+	InTreePluginvSphereUnregister: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.32
 
 	JobBackoffLimitPerIndex: {Default: true, PreRelease: featuregate.Beta},
 

--- a/pkg/volume/csimigration/plugin_manager.go
+++ b/pkg/volume/csimigration/plugin_manager.go
@@ -61,17 +61,17 @@ func (pm PluginManager) IsMigrationCompleteForPlugin(pluginName string) bool {
 
 	switch pluginName {
 	case csilibplugins.AWSEBSInTreePluginName:
-		return pm.featureGate.Enabled(features.InTreePluginAWSUnregister)
+		return true
 	case csilibplugins.GCEPDInTreePluginName:
-		return pm.featureGate.Enabled(features.InTreePluginGCEUnregister)
+		return true
 	case csilibplugins.AzureFileInTreePluginName:
-		return pm.featureGate.Enabled(features.InTreePluginAzureFileUnregister)
+		return true
 	case csilibplugins.AzureDiskInTreePluginName:
-		return pm.featureGate.Enabled(features.InTreePluginAzureDiskUnregister)
+		return true
 	case csilibplugins.CinderInTreePluginName:
-		return pm.featureGate.Enabled(features.InTreePluginOpenStackUnregister)
+		return true
 	case csilibplugins.VSphereInTreePluginName:
-		return pm.featureGate.Enabled(features.InTreePluginvSphereUnregister)
+		return true
 	case csilibplugins.PortworxVolumePluginName:
 		return pm.featureGate.Enabled(features.InTreePluginPortworxUnregister)
 	default:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup
/sig storage

#### What this PR does / why we need it:

The following plugins in the `Special notes for your reviewer` section already completed the migration task and its in-tree code was removed as part of the migration process. So, the corresponding feature gate should be removed, but it has not been removed yet.

Whatever the value of the feature gate is, it won't affect the code's behavior. Even if the feature gate is false, we will still get the right value from csinode's annotations. The PR updates the value to true and promotes them to GA. And those feature gates will be removed in v1.32.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

KEPs:
- https://github.com/kubernetes/enhancements/issues/1487
- https://github.com/kubernetes/enhancements/issues/1490
- https://github.com/kubernetes/enhancements/issues/1885
- https://github.com/kubernetes/enhancements/issues/1488
- https://github.com/kubernetes/enhancements/issues/1489
- https://github.com/kubernetes/enhancements/issues/1491

/cc @leakingtapan @andyzhangx  @davidz627 @adisky @dims @divyenpatel @xing-yang

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Promoted the following feature gates to general availability:
- `InTreePluginAWSUnregister`
- `InTreePluginAzureDiskUnregister`
- `InTreePluginAzureFileUnregister`
- `InTreePluginGCEUnregister`
- `InTreePluginOpenStackUnregister`
- `InTreePluginvSphereUnregister`
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
