### PR TITLE
kubectl - allow delay between nodes when draining

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/drain/drain.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/drain/drain.go
@@ -233,7 +233,7 @@ func NewCmdDrain(f cmdutil.Factory, ioStreams genericiooptions.IOStreams) *cobra
 	cmd.Flags().StringVarP(&o.drainer.PodSelector, "pod-selector", "", o.drainer.PodSelector, "Label selector to filter pods on the node")
 	cmd.Flags().BoolVar(&o.drainer.DisableEviction, "disable-eviction", o.drainer.DisableEviction, "Force drain to use delete, even if eviction is supported. This will bypass checking PodDisruptionBudgets, use with caution.")
 	cmd.Flags().IntVar(&o.drainer.SkipWaitForDeleteTimeoutSeconds, "skip-wait-for-delete-timeout", o.drainer.SkipWaitForDeleteTimeoutSeconds, "If pod DeletionTimestamp older than N seconds, skip waiting for the pod.  Seconds must be greater than 0 to skip.")
-	cmd.Flags().IntVar(&o.drainer.DelayBetweenNodeSeconds, "delay-between-nodes", o.drainer.DelayBetweenNodeSeconds, "When more than one node is targeted (e.g. via labels) this is the period of seconds to wait after each node completes draining.")
+	cmd.Flags().IntVar(&o.drainer.DelayBetweenNodeSeconds, "delay-between-nodes", o.drainer.DelayBetweenNodeSeconds, "When more than one node is targeted (e.g. via labels) this is the period of seconds to wait after each node completes draining. For workloads without PDBs this can be used as a grace period allowing replacements to become ready before all nodes they reside on are drained.")
 
 	cmdutil.AddChunkSizeFlag(cmd, &o.drainer.ChunkSize)
 	cmdutil.AddDryRunFlag(cmd)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/drain/drain.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/drain/drain.go
@@ -334,7 +334,8 @@ func (o *DrainCmdOptions) RunDrain() error {
 	var fatal []error
 
 	remainingNodes := []string{}
-	for _, info := range o.nodeInfos {
+	nodeCount := len(o.nodeInfos)
+	for idx, info := range o.nodeInfos {
 		if err := o.deleteOrEvictPodsSimple(info); err == nil {
 			drainedNodes.Insert(info.Name)
 
@@ -355,7 +356,7 @@ func (o *DrainCmdOptions) RunDrain() error {
 			continue
 		}
 
-		if o.drainer.DelayBetweenNodeSeconds > 0 {
+		if o.drainer.DelayBetweenNodeSeconds > 0 && idx+1 < nodeCount {
 			fmt.Fprintf(o.Out, "Waiting %d seconds before starting next node...\n", o.drainer.DelayBetweenNodeSeconds)
 			time.Sleep(time.Duration(o.drainer.DelayBetweenNodeSeconds) * time.Second)
 		}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/drain/drain.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/drain/drain.go
@@ -357,7 +357,7 @@ func (o *DrainCmdOptions) RunDrain() error {
 		}
 
 		if o.drainer.DelayBetweenNodeSeconds > 0 && idx+1 < nodeCount {
-			fmt.Fprintf(o.Out, "Waiting %d seconds before starting next node...\n", o.drainer.DelayBetweenNodeSeconds)
+			fmt.Fprintf(o.Out, "Waiting %d seconds before draining next node...\n", o.drainer.DelayBetweenNodeSeconds)
 			time.Sleep(time.Duration(o.drainer.DelayBetweenNodeSeconds) * time.Second)
 		}
 	}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/drain/drain.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/drain/drain.go
@@ -19,6 +19,7 @@ package drain
 import (
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -232,6 +233,7 @@ func NewCmdDrain(f cmdutil.Factory, ioStreams genericiooptions.IOStreams) *cobra
 	cmd.Flags().StringVarP(&o.drainer.PodSelector, "pod-selector", "", o.drainer.PodSelector, "Label selector to filter pods on the node")
 	cmd.Flags().BoolVar(&o.drainer.DisableEviction, "disable-eviction", o.drainer.DisableEviction, "Force drain to use delete, even if eviction is supported. This will bypass checking PodDisruptionBudgets, use with caution.")
 	cmd.Flags().IntVar(&o.drainer.SkipWaitForDeleteTimeoutSeconds, "skip-wait-for-delete-timeout", o.drainer.SkipWaitForDeleteTimeoutSeconds, "If pod DeletionTimestamp older than N seconds, skip waiting for the pod.  Seconds must be greater than 0 to skip.")
+	cmd.Flags().IntVar(&o.drainer.DelayBetweenNodeSeconds, "delay-between-nodes", o.drainer.DelayBetweenNodeSeconds, "When more than one node is targeted (e.g. via labels) this is the period of seconds to wait after each node completes draining.")
 
 	cmdutil.AddChunkSizeFlag(cmd, &o.drainer.ChunkSize)
 	cmdutil.AddDryRunFlag(cmd)
@@ -351,6 +353,11 @@ func (o *DrainCmdOptions) RunDrain() error {
 			}
 
 			continue
+		}
+
+		if o.drainer.DelayBetweenNodeSeconds > 0 {
+			fmt.Fprintf(o.Out, "Waiting %d seconds before starting next node...\n", o.drainer.DelayBetweenNodeSeconds)
+			time.Sleep(time.Duration(o.drainer.DelayBetweenNodeSeconds) * time.Second)
 		}
 	}
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/drain/drain_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/drain/drain_test.go
@@ -949,6 +949,64 @@ func TestDrain(t *testing.T) {
 		}
 	}
 }
+func TestDrainWithDelay(t *testing.T) {
+	tests := []struct {
+		description              string
+		args                     []string
+		expectOutputNotToContain string
+		expectOutputToContain    string
+	}{
+		{
+			description:              "no delay",
+			args:                     []string{"-l", "name in (node1,node2)"},
+			expectOutputNotToContain: "Waiting",
+		},
+		{
+			description:           "with delay",
+			args:                  []string{"-l", "name in (node1,node2)", "--delay-between-nodes", "1"},
+			expectOutputToContain: "1 seconds",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			tf := cmdtesting.NewTestFactory()
+			defer tf.Cleanup()
+			tf.ClientConfigVal = cmdtesting.DefaultClientConfig()
+			codec := scheme.Codecs.LegacyCodec(scheme.Scheme.PrioritizedVersionsAllGroups()...)
+			tf.Client = &fake.RESTClient{
+				GroupVersion:         schema.GroupVersion{Group: "", Version: "v1"},
+				NegotiatedSerializer: scheme.Codecs.WithoutConversion(),
+				Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+					m := &MyReq{req}
+					switch {
+					case m.isFor("GET", "/pods"):
+						return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &corev1.PodList{Items: []corev1.Pod{}})}, nil
+					case m.isFor("GET", "/nodes"):
+						return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &corev1.NodeList{Items: []corev1.Node{{}, {}}})}, nil
+					default:
+						t.Fatalf("%s: unexpected request: %v %#v\n%#v", test.description, req.Method, req.URL, req)
+						return nil, nil
+					}
+				}),
+			}
+			ioStreams, _, outBuf, _ := genericiooptions.NewTestIOStreams()
+			cmd := NewCmdDrain(tf, ioStreams)
+			cmd.SetArgs(test.args)
+			cmd.Execute()
+			out := outBuf.String()
+			if len(test.expectOutputToContain) > 0 {
+				if !strings.Contains(out, test.expectOutputToContain) {
+					t.Fatalf("%s: expected output to contain: %s\nGot:\n%s", test.description, test.expectOutputToContain, out)
+				}
+			}
+			if len(test.expectOutputNotToContain) > 0 {
+				if strings.Contains(out, test.expectOutputNotToContain) {
+					t.Fatalf("%s: expected output not to contain: %s\nGot:\n%s", test.description, test.expectOutputToContain, out)
+				}
+			}
+		})
+	}
+}
 
 type MyReq struct {
 	Request *http.Request

--- a/staging/src/k8s.io/kubectl/pkg/drain/drain.go
+++ b/staging/src/k8s.io/kubectl/pkg/drain/drain.go
@@ -74,6 +74,12 @@ type Helper struct {
 	// won't drain otherwise
 	SkipWaitForDeleteTimeoutSeconds int
 
+	// DelayBetweenNodeSeconds introduces a pause between node drains when
+	// a drain command is issued that targets multiple nodes. This provides
+	// an affordance for new workloads to start up during upgrades on clusters
+	// that do not have appropriately configured PDBs.
+	DelayBetweenNodeSeconds int
+
 	// AdditionalFilters are applied sequentially after base drain filters to
 	// exclude pods using custom logic.  Any filter that returns PodDeleteStatus
 	// with Delete == false will immediately stop execution of further filters.


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
This PR makes an affordance in kubectl for pausing between draining nodes. This can allow new workloads to start during upgrades on clusters without appropriately configured PDBs.

#### Which issue(s) this PR fixes:
n/a

#### Does this PR introduce a user-facing change?
Yes, here is a release note:

```release-note
Added `delay-between-nodes` flag to `kubectl drain`. This makes it possible for operators to control the rate at which nodes are drained during upgrades when more than one node is targeted (e.g. draining all nodes with a specific label). On clusters without appropriately configured pod disruption budgets this can introduce a desirable delay as the drain command iterates through all nodes selected. During the delay, workloads migrating to new nodes are given time to become ready.
```