### PR TITLE
fix: use package filepath over path for file system operations

### DIFF
--- a/cmd/kube-proxy/app/server_test.go
+++ b/cmd/kube-proxy/app/server_test.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net"
-	"path"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -499,7 +499,7 @@ kind: KubeProxyConfiguration
 			flags := tc.flags
 			if len(tc.config) > 0 {
 				tmp := t.TempDir()
-				configFile := path.Join(tmp, "kube-proxy.conf")
+				configFile := filepath.Join(tmp, "kube-proxy.conf")
 				require.NoError(t, ioutil.WriteFile(configFile, []byte(tc.config), 0666))
 				flags = append(flags, "--config", configFile)
 			}

--- a/cmd/kubeadm/app/cmd/phases/reset/cleanupnode.go
+++ b/cmd/kubeadm/app/cmd/phases/reset/cleanupnode.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -116,7 +115,7 @@ func runCleanupNode(c workflow.RunData) error {
 
 	dirsToClean = append(dirsToClean, certsDir)
 	if r.CleanupTmpDir() {
-		tempDir := path.Join(kubeadmconstants.KubernetesDir, kubeadmconstants.TempDirForKubeadm)
+		tempDir := filepath.Join(kubeadmconstants.KubernetesDir, kubeadmconstants.TempDirForKubeadm)
 		dirsToClean = append(dirsToClean, tempDir)
 	}
 	resetConfigDir(kubeadmconstants.KubernetesDir, dirsToClean, r.DryRun())

--- a/cmd/kubeadm/app/cmd/reset.go
+++ b/cmd/kubeadm/app/cmd/reset.go
@@ -20,7 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"path"
+	"path/filepath"
 
 	"github.com/lithammer/dedent"
 	"github.com/spf13/cobra"
@@ -185,7 +185,7 @@ func AddResetFlags(flagSet *flag.FlagSet, resetOptions *resetOptions) {
 	)
 	flagSet.BoolVar(
 		&resetOptions.externalcfg.CleanupTmpDir, options.CleanupTmpDir, resetOptions.externalcfg.CleanupTmpDir,
-		fmt.Sprintf("Cleanup the %q directory", path.Join(kubeadmconstants.KubernetesDir, kubeadmconstants.TempDirForKubeadm)),
+		fmt.Sprintf("Cleanup the %q directory", filepath.Join(kubeadmconstants.KubernetesDir, kubeadmconstants.TempDirForKubeadm)),
 	)
 	options.AddKubeConfigFlag(flagSet, &resetOptions.kubeconfigPath)
 	options.AddConfigFlag(flagSet, &resetOptions.cfgPath)

--- a/pkg/kubelet/cm/cgroup_manager_linux.go
+++ b/pkg/kubelet/cm/cgroup_manager_linux.go
@@ -113,7 +113,7 @@ func ParseSystemdToCgroupName(name string) CgroupName {
 }
 
 func (cgroupName CgroupName) ToCgroupfs() string {
-	return "/" + path.Join(cgroupName...)
+	return "/" + filepath.Join(cgroupName...)
 }
 
 func ParseCgroupfsToCgroupName(name string) CgroupName {
@@ -185,7 +185,7 @@ func (m *cgroupManagerImpl) buildCgroupPaths(name CgroupName) map[string]string 
 	cgroupFsAdaptedName := m.Name(name)
 	cgroupPaths := make(map[string]string, len(m.subsystems.MountPoints))
 	for key, val := range m.subsystems.MountPoints {
-		cgroupPaths[key] = path.Join(val, cgroupFsAdaptedName)
+		cgroupPaths[key] = filepath.Join(val, cgroupFsAdaptedName)
 	}
 	return cgroupPaths
 }
@@ -193,7 +193,7 @@ func (m *cgroupManagerImpl) buildCgroupPaths(name CgroupName) map[string]string 
 // buildCgroupUnifiedPath builds a path to the specified name.
 func (m *cgroupManagerImpl) buildCgroupUnifiedPath(name CgroupName) string {
 	cgroupFsAdaptedName := m.Name(name)
-	return path.Join(cmutil.CgroupRoot, cgroupFsAdaptedName)
+	return filepath.Join(cmutil.CgroupRoot, cgroupFsAdaptedName)
 }
 
 // libctCgroupConfig converts CgroupConfig to libcontainer's Cgroup config.
@@ -488,7 +488,7 @@ func (m *cgroupManagerImpl) Pids(name CgroupName) []int {
 	pidsToKill := sets.New[int]()
 	var pids []int
 	for _, val := range m.subsystems.MountPoints {
-		dir := path.Join(val, cgroupFsName)
+		dir := filepath.Join(val, cgroupFsName)
 		_, err := os.Stat(dir)
 		if os.IsNotExist(err) {
 			// The subsystem pod cgroup is already deleted

--- a/pkg/kubelet/cm/container_manager_linux.go
+++ b/pkg/kubelet/cm/container_manager_linux.go
@@ -24,7 +24,7 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -181,11 +181,11 @@ func validateSystemRequirements(mountUtil mount.Interface) (features, error) {
 
 	// Check if cpu quota is available.
 	// CPU cgroup is required and so it expected to be mounted at this point.
-	periodExists, err := utilpath.Exists(utilpath.CheckFollowSymlink, path.Join(cpuMountPoint, "cpu.cfs_period_us"))
+	periodExists, err := utilpath.Exists(utilpath.CheckFollowSymlink, filepath.Join(cpuMountPoint, "cpu.cfs_period_us"))
 	if err != nil {
 		klog.ErrorS(err, "Failed to detect if CPU cgroup cpu.cfs_period_us is available")
 	}
-	quotaExists, err := utilpath.Exists(utilpath.CheckFollowSymlink, path.Join(cpuMountPoint, "cpu.cfs_quota_us"))
+	quotaExists, err := utilpath.Exists(utilpath.CheckFollowSymlink, filepath.Join(cpuMountPoint, "cpu.cfs_quota_us"))
 	if err != nil {
 		klog.ErrorS(err, "Failed to detect if CPU cgroup cpu.cfs_quota_us is available")
 	}

--- a/pkg/kubelet/cm/pod_container_manager_linux.go
+++ b/pkg/kubelet/cm/pod_container_manager_linux.go
@@ -20,7 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 	"strings"
 
 	libcontainercgroups "github.com/opencontainers/runc/libcontainer/cgroups"
@@ -257,7 +257,7 @@ func (m *podContainerManagerImpl) GetAllPodsFromCgroups() (map[types.UID]CgroupN
 		for _, qosContainerName := range qosContainersList {
 			// get the subsystems QoS cgroup absolute name
 			qcConversion := m.cgroupManager.Name(qosContainerName)
-			qc := path.Join(val, qcConversion)
+			qc := filepath.Join(val, qcConversion)
 			dirInfo, err := os.ReadDir(qc)
 			if err != nil {
 				if os.IsNotExist(err) {
@@ -274,7 +274,7 @@ func (m *podContainerManagerImpl) GetAllPodsFromCgroups() (map[types.UID]CgroupN
 				// this is needed to handle path conversion for systemd environments.
 				// we pass the fully qualified path so decoding can work as expected
 				// since systemd encodes the path in each segment.
-				cgroupfsPath := path.Join(qcConversion, dirInfo[i].Name())
+				cgroupfsPath := filepath.Join(qcConversion, dirInfo[i].Name())
 				internalPath := m.cgroupManager.CgroupName(cgroupfsPath)
 				// we only care about base segment of the converted path since that
 				// is what we are reading currently to know if it is a pod or not.

--- a/pkg/kubelet/status/state/state_checkpoint.go
+++ b/pkg/kubelet/status/state/state_checkpoint.go
@@ -19,6 +19,7 @@ package state
 import (
 	"fmt"
 	"path"
+	"path/filepath"
 	"sync"
 
 	"k8s.io/api/core/v1"
@@ -50,7 +51,7 @@ func NewStateCheckpoint(stateDir, checkpointName string) (State, error) {
 
 	if err := stateCheckpoint.restoreState(); err != nil {
 		//lint:ignore ST1005 user-facing error message
-		return nil, fmt.Errorf("could not restore state from checkpoint: %v, please drain this node and delete pod allocation checkpoint file %q before restarting Kubelet", err, path.Join(stateDir, checkpointName))
+		return nil, fmt.Errorf("could not restore state from checkpoint: %v, please drain this node and delete pod allocation checkpoint file %q before restarting Kubelet", err, filepath.Join(stateDir, checkpointName))
 	}
 	return stateCheckpoint, nil
 }

--- a/pkg/kubelet/status/state/state_checkpoint.go
+++ b/pkg/kubelet/status/state/state_checkpoint.go
@@ -18,7 +18,6 @@ package state
 
 import (
 	"fmt"
-	"path"
 	"path/filepath"
 	"sync"
 

--- a/pkg/routes/logs.go
+++ b/pkg/routes/logs.go
@@ -19,7 +19,7 @@ package routes
 import (
 	"net/http"
 	"os"
-	"path"
+	"path/filepath"
 
 	"github.com/emicklei/go-restful/v3"
 )
@@ -42,7 +42,7 @@ func (l Logs) Install(c *restful.Container) {
 
 func logFileHandler(req *restful.Request, resp *restful.Response) {
 	logdir := "/var/log"
-	actual := path.Join(logdir, req.PathParameter("logpath"))
+	actual := filepath.Join(logdir, req.PathParameter("logpath"))
 
 	// check filename length first, return 404 if it's oversize.
 	if logFileNameIsTooLong(actual) {

--- a/pkg/util/oom/oom_linux.go
+++ b/pkg/util/oom/oom_linux.go
@@ -22,7 +22,6 @@ package oom
 import (
 	"fmt"
 	"os"
-	"path"
 	"path/filepath"
 	"strconv"
 	"time"
@@ -60,7 +59,7 @@ func applyOOMScoreAdj(pid int, oomScoreAdj int) error {
 	}
 
 	maxTries := 2
-	oomScoreAdjPath := path.Join("/proc", pidStr, "oom_score_adj")
+	oomScoreAdjPath := filepath.Join("/proc", pidStr, "oom_score_adj")
 	value := strconv.Itoa(oomScoreAdj)
 	klog.V(4).Infof("attempting to set %q to %q", oomScoreAdjPath, value)
 	var err error

--- a/pkg/util/procfs/procfs_linux.go
+++ b/pkg/util/procfs/procfs_linux.go
@@ -24,7 +24,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -54,7 +53,7 @@ func containerNameFromProcCgroup(content string) (string, error) {
 // E.g. if the devices cgroup for the container is stored in /sys/fs/cgroup/devices/docker/nginx,
 // return docker/nginx. Assumes that the process is part of exactly one cgroup hierarchy.
 func (pfs *ProcFS) GetFullContainerName(pid int) (string, error) {
-	filePath := path.Join("/proc", strconv.Itoa(pid), "cgroup")
+	filePath := filepath.Join("/proc", strconv.Itoa(pid), "cgroup")
 	content, err := os.ReadFile(filePath)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/staging/src/k8s.io/apiserver/pkg/server/options/serving.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/serving.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"path"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"syscall"
@@ -345,8 +345,8 @@ func (s *SecureServingOptions) MaybeDefaultWithSelfSignedCerts(publicAddress str
 		if len(s.ServerCert.PairName) == 0 {
 			return fmt.Errorf("PairName is required if CertDirectory is set")
 		}
-		keyCert.CertFile = path.Join(s.ServerCert.CertDirectory, s.ServerCert.PairName+".crt")
-		keyCert.KeyFile = path.Join(s.ServerCert.CertDirectory, s.ServerCert.PairName+".key")
+		keyCert.CertFile = filepath.Join(s.ServerCert.CertDirectory, s.ServerCert.PairName+".crt")
+		keyCert.KeyFile = filepath.Join(s.ServerCert.CertDirectory, s.ServerCert.PairName+".key")
 		if canRead, err := certutil.CanReadCertAndKey(keyCert.CertFile, keyCert.KeyFile); err != nil {
 			return err
 		} else {

--- a/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/tls_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/tls_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"io/ioutil"
 	"os"
-	"path"
 	"path/filepath"
 	"testing"
 
@@ -98,15 +97,15 @@ func configureTLSCerts(t *testing.T) (certFile, keyFile, caFile string) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	certFile = path.Join(tempDir, "etcdcert.pem")
+	certFile = filepath.Join(tempDir, "etcdcert.pem")
 	if err := ioutil.WriteFile(certFile, []byte(testingcert.CertFileContent), 0644); err != nil {
 		t.Fatal(err)
 	}
-	keyFile = path.Join(tempDir, "etcdkey.pem")
+	keyFile = filepath.Join(tempDir, "etcdkey.pem")
 	if err := ioutil.WriteFile(keyFile, []byte(testingcert.KeyFileContent), 0644); err != nil {
 		t.Fatal(err)
 	}
-	caFile = path.Join(tempDir, "ca.pem")
+	caFile = filepath.Join(tempDir, "ca.pem")
 	if err := ioutil.WriteFile(caFile, []byte(testingcert.CAFileContent), 0644); err != nil {
 		t.Fatal(err)
 	}

--- a/staging/src/k8s.io/client-go/tools/clientcmd/config.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/config.go
@@ -19,7 +19,6 @@ package clientcmd
 import (
 	"errors"
 	"os"
-	"path"
 	"path/filepath"
 	"reflect"
 	"sort"
@@ -148,7 +147,7 @@ func NewDefaultPathOptions() *PathOptions {
 		EnvVar:           RecommendedConfigPathEnvVar,
 		ExplicitFileFlag: RecommendedConfigPathFlag,
 
-		GlobalFileSubpath: path.Join(RecommendedHomeDir, RecommendedFileName),
+		GlobalFileSubpath: filepath.Join(RecommendedHomeDir, RecommendedFileName),
 
 		LoadingRules: NewDefaultClientConfigLoadingRules(),
 	}

--- a/staging/src/k8s.io/client-go/tools/clientcmd/loader_test.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/loader_test.go
@@ -539,13 +539,13 @@ func TestResolveRelativePaths(t *testing.T) {
 
 	configDir1, _ := os.MkdirTemp("", "")
 	defer os.RemoveAll(configDir1)
-	configFile1 := path.Join(configDir1, ".kubeconfig")
+	configFile1 := filepath.Join(configDir1, ".kubeconfig")
 	configDir1, _ = filepath.Abs(configDir1)
 
 	configDir2, _ := os.MkdirTemp("", "")
 	defer os.RemoveAll(configDir2)
 	configDir2, _ = os.MkdirTemp(configDir2, "")
-	configFile2 := path.Join(configDir2, ".kubeconfig")
+	configFile2 := filepath.Join(configDir2, ".kubeconfig")
 	configDir2, _ = filepath.Abs(configDir2)
 
 	WriteToFile(pathResolutionConfig1, configFile1)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/clusterinfo/clusterinfo_dump.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/clusterinfo/clusterinfo_dump.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"os"
 	"path"
+	"path/filepath"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -118,8 +119,8 @@ func setupOutputWriter(dir string, defaultWriter io.Writer, filename string, fil
 	if len(dir) == 0 || dir == "-" {
 		return defaultWriter
 	}
-	fullFile := path.Join(dir, filename) + fileExtension
-	parent := path.Dir(fullFile)
+	fullFile := filepath.Join(dir, filename) + fileExtension
+	parent := filepath.Dir(fullFile)
 	cmdutil.CheckErr(os.MkdirAll(parent, 0755))
 
 	file, err := os.Create(fullFile)
@@ -212,7 +213,7 @@ func (o *ClusterInfoDumpOptions) Run() error {
 		if err != nil {
 			return err
 		}
-		if err := o.PrintObj(events, setupOutputWriter(o.OutputDir, o.Out, path.Join(namespace, "events"), fileExtension)); err != nil {
+		if err := o.PrintObj(events, setupOutputWriter(o.OutputDir, o.Out, filepath.Join(namespace, "events"), fileExtension)); err != nil {
 			return err
 		}
 
@@ -220,7 +221,7 @@ func (o *ClusterInfoDumpOptions) Run() error {
 		if err != nil {
 			return err
 		}
-		if err := o.PrintObj(rcs, setupOutputWriter(o.OutputDir, o.Out, path.Join(namespace, "replication-controllers"), fileExtension)); err != nil {
+		if err := o.PrintObj(rcs, setupOutputWriter(o.OutputDir, o.Out, filepath.Join(namespace, "replication-controllers"), fileExtension)); err != nil {
 			return err
 		}
 
@@ -228,7 +229,7 @@ func (o *ClusterInfoDumpOptions) Run() error {
 		if err != nil {
 			return err
 		}
-		if err := o.PrintObj(svcs, setupOutputWriter(o.OutputDir, o.Out, path.Join(namespace, "services"), fileExtension)); err != nil {
+		if err := o.PrintObj(svcs, setupOutputWriter(o.OutputDir, o.Out, filepath.Join(namespace, "services"), fileExtension)); err != nil {
 			return err
 		}
 
@@ -236,7 +237,7 @@ func (o *ClusterInfoDumpOptions) Run() error {
 		if err != nil {
 			return err
 		}
-		if err := o.PrintObj(sets, setupOutputWriter(o.OutputDir, o.Out, path.Join(namespace, "daemonsets"), fileExtension)); err != nil {
+		if err := o.PrintObj(sets, setupOutputWriter(o.OutputDir, o.Out, filepath.Join(namespace, "daemonsets"), fileExtension)); err != nil {
 			return err
 		}
 
@@ -244,7 +245,7 @@ func (o *ClusterInfoDumpOptions) Run() error {
 		if err != nil {
 			return err
 		}
-		if err := o.PrintObj(deps, setupOutputWriter(o.OutputDir, o.Out, path.Join(namespace, "deployments"), fileExtension)); err != nil {
+		if err := o.PrintObj(deps, setupOutputWriter(o.OutputDir, o.Out, filepath.Join(namespace, "deployments"), fileExtension)); err != nil {
 			return err
 		}
 
@@ -252,7 +253,7 @@ func (o *ClusterInfoDumpOptions) Run() error {
 		if err != nil {
 			return err
 		}
-		if err := o.PrintObj(rps, setupOutputWriter(o.OutputDir, o.Out, path.Join(namespace, "replicasets"), fileExtension)); err != nil {
+		if err := o.PrintObj(rps, setupOutputWriter(o.OutputDir, o.Out, filepath.Join(namespace, "replicasets"), fileExtension)); err != nil {
 			return err
 		}
 
@@ -261,7 +262,7 @@ func (o *ClusterInfoDumpOptions) Run() error {
 			return err
 		}
 
-		if err := o.PrintObj(pods, setupOutputWriter(o.OutputDir, o.Out, path.Join(namespace, "pods"), fileExtension)); err != nil {
+		if err := o.PrintObj(pods, setupOutputWriter(o.OutputDir, o.Out, filepath.Join(namespace, "pods"), fileExtension)); err != nil {
 			return err
 		}
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/clusterinfo/clusterinfo_dump_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/clusterinfo/clusterinfo_dump_test.go
@@ -18,7 +18,7 @@ package clusterinfo
 
 import (
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 
 	"k8s.io/cli-runtime/pkg/genericiooptions"
@@ -60,7 +60,7 @@ func TestSetupOutputWriterFile(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
-	fullPath := path.Join(dir, file) + extension
+	fullPath := filepath.Join(dir, file) + extension
 	defer os.RemoveAll(dir)
 
 	_, _, buf, _ := genericiooptions.NewTestIOStreams()

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/config.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/config.go
@@ -18,7 +18,7 @@ package config
 
 import (
 	"fmt"
-	"path"
+	"path/filepath"
 	"strconv"
 
 	"github.com/spf13/cobra"
@@ -47,7 +47,7 @@ func NewCmdConfig(pathOptions *clientcmd.PathOptions, streams genericiooptions.I
 
 			1. If the --`) + pathOptions.ExplicitFileFlag + i18n.T(` flag is set, then only that file is loaded. The flag may only be set once and no merging takes place.
 			2. If $`) + pathOptions.EnvVar + i18n.T(` environment variable is set, then it is used as a list of paths (normal path delimiting rules for your system). These paths are merged. When a value is modified, it is modified in the file that defines the stanza. When a value is created, it is created in the first file that exists. If no files in the chain exist, then it creates the last file in the list.
-			3. Otherwise, `) + path.Join("${HOME}", pathOptions.GlobalFileSubpath) + i18n.T(` is used and no merging takes place.`)),
+			3. Otherwise, `) + filepath.Join("${HOME}", pathOptions.GlobalFileSubpath) + i18n.T(` is used and no merging takes place.`)),
 		Run: cmdutil.DefaultSubCommandRun(streams.ErrOut),
 	}
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_configmap.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_configmap.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 	"strings"
 	"unicode/utf8"
 
@@ -320,7 +320,7 @@ func handleConfigMapFromFileSources(configMap *corev1.ConfigMap, fileSources []s
 				return fmt.Errorf("error listing files in %s: %v", filePath, err)
 			}
 			for _, item := range fileList {
-				itemPath := path.Join(filePath, item.Name())
+				itemPath := filepath.Join(filePath, item.Name())
 				if item.Type().IsRegular() {
 					keyName = item.Name()
 					err = addKeyFromFileToConfigMap(configMap, keyName, itemPath)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_secret.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_secret.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -349,7 +349,7 @@ func handleSecretFromFileSources(secret *corev1.Secret, fileSources []string) er
 				return fmt.Errorf("error listing files in %s: %v", filePath, err)
 			}
 			for _, item := range fileList {
-				itemPath := path.Join(filePath, item.Name())
+				itemPath := filepath.Join(filePath, item.Name())
 				if item.Type().IsRegular() {
 					keyName = item.Name()
 					if err := addKeyFromFileToSecret(secret, keyName, itemPath); err != nil {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_secret_tls_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_secret_tls_test.go
@@ -18,7 +18,7 @@ package create
 
 import (
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -197,8 +197,8 @@ func write(path, contents string, t *testing.T) {
 }
 
 func writeKeyPair(tmpDirPath, key, cert string, t *testing.T) (keyPath, certPath string) {
-	keyPath = path.Join(tmpDirPath, "tls.key")
-	certPath = path.Join(tmpDirPath, "tls.cert")
+	keyPath = filepath.Join(tmpDirPath, "tls.key")
+	certPath = filepath.Join(tmpDirPath, "tls.cert")
 	write(keyPath, key, t)
 	write(certPath, cert, t)
 	return

--- a/test/e2e/auth/service_accounts.go
+++ b/test/e2e/auth/service_accounts.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"path"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"time"
@@ -101,11 +101,11 @@ var _ = SIGDescribe("ServiceAccounts", func() {
 		framework.ExpectNoError(e2epod.WaitForPodRunningInNamespace(ctx, f.ClientSet, pod))
 
 		tk := e2ekubectl.NewTestKubeconfig(framework.TestContext.CertDir, framework.TestContext.Host, framework.TestContext.KubeConfig, framework.TestContext.KubeContext, framework.TestContext.KubectlPath, f.Namespace.Name)
-		mountedToken, err := tk.ReadFileViaContainer(pod.Name, pod.Spec.Containers[0].Name, path.Join(serviceaccount.DefaultAPITokenMountPath, v1.ServiceAccountTokenKey))
+		mountedToken, err := tk.ReadFileViaContainer(pod.Name, pod.Spec.Containers[0].Name, filepath.Join(serviceaccount.DefaultAPITokenMountPath, v1.ServiceAccountTokenKey))
 		framework.ExpectNoError(err)
-		mountedCA, err := tk.ReadFileViaContainer(pod.Name, pod.Spec.Containers[0].Name, path.Join(serviceaccount.DefaultAPITokenMountPath, v1.ServiceAccountRootCAKey))
+		mountedCA, err := tk.ReadFileViaContainer(pod.Name, pod.Spec.Containers[0].Name, filepath.Join(serviceaccount.DefaultAPITokenMountPath, v1.ServiceAccountRootCAKey))
 		framework.ExpectNoError(err)
-		mountedNamespace, err := tk.ReadFileViaContainer(pod.Name, pod.Spec.Containers[0].Name, path.Join(serviceaccount.DefaultAPITokenMountPath, v1.ServiceAccountNamespaceKey))
+		mountedNamespace, err := tk.ReadFileViaContainer(pod.Name, pod.Spec.Containers[0].Name, filepath.Join(serviceaccount.DefaultAPITokenMountPath, v1.ServiceAccountNamespaceKey))
 		framework.ExpectNoError(err)
 
 		// CA and namespace should be identical
@@ -583,7 +583,7 @@ var _ = SIGDescribe("ServiceAccounts", func() {
 					Image: imageutils.GetE2EImage(imageutils.Agnhost),
 					Args: []string{
 						"test-service-account-issuer-discovery",
-						"--token-path", path.Join(tokenPath, tokenName),
+						"--token-path", filepath.Join(tokenPath, tokenName),
 						"--audience", audience,
 					},
 					VolumeMounts: []v1.VolumeMount{{

--- a/test/e2e/common/node/runtime.go
+++ b/test/e2e/common/node/runtime.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -95,7 +95,7 @@ if [ $count -eq 2 ]; then
 fi
 while true; do sleep 1; done
 `
-					tmpCmd := fmt.Sprintf(cmdScripts, path.Join(restartCountVolumePath, "restartCount"))
+					tmpCmd := fmt.Sprintf(cmdScripts, filepath.Join(restartCountVolumePath, "restartCount"))
 					testContainer.Name = testCase.Name
 					testContainer.Command = []string{"sh", "-c", tmpCmd}
 					terminateContainer := ConformanceContainer{

--- a/test/e2e/common/storage/configmap_volume.go
+++ b/test/e2e/common/storage/configmap_volume.go
@@ -19,7 +19,7 @@ package storage
 import (
 	"context"
 	"fmt"
-	"path"
+	"path/filepath"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
@@ -342,7 +342,7 @@ var _ = SIGDescribe("ConfigMap", func() {
 						VolumeMounts: []v1.VolumeMount{
 							{
 								Name:      deleteVolumeName,
-								MountPath: path.Join(volumeMountPath, "delete"),
+								MountPath: filepath.Join(volumeMountPath, "delete"),
 								ReadOnly:  true,
 							},
 						},
@@ -354,7 +354,7 @@ var _ = SIGDescribe("ConfigMap", func() {
 						VolumeMounts: []v1.VolumeMount{
 							{
 								Name:      updateVolumeName,
-								MountPath: path.Join(volumeMountPath, "update"),
+								MountPath: filepath.Join(volumeMountPath, "update"),
 								ReadOnly:  true,
 							},
 						},
@@ -366,7 +366,7 @@ var _ = SIGDescribe("ConfigMap", func() {
 						VolumeMounts: []v1.VolumeMount{
 							{
 								Name:      createVolumeName,
-								MountPath: path.Join(volumeMountPath, "create"),
+								MountPath: filepath.Join(volumeMountPath, "create"),
 								ReadOnly:  true,
 							},
 						},
@@ -689,7 +689,7 @@ func createNonOptionalConfigMapPod(ctx context.Context, f *framework.Framework, 
 	createVolumeName := "createcm-volume"
 
 	// creating a pod without configMap object created, by mentioning the configMap volume source's local reference name
-	pod := createConfigMapVolumeMounttestPod(f.Namespace.Name, createVolumeName, createName, path.Join(volumeMountPath, "create"),
+	pod := createConfigMapVolumeMounttestPod(f.Namespace.Name, createVolumeName, createName, filepath.Join(volumeMountPath, "create"),
 		"--break_on_expected_content=false", containerTimeoutArg, "--file_content_in_loop=/etc/configmap-volumes/create/data-1")
 	pod.Spec.Volumes[0].VolumeSource.ConfigMap.Optional = &falseValue
 
@@ -713,7 +713,7 @@ func createNonOptionalConfigMapPodWithConfig(ctx context.Context, f *framework.F
 		framework.Failf("unable to create test configMap %s: %v", configMap.Name, err)
 	}
 	// creating a pod with configMap object, but with different key which is not present in configMap object.
-	pod := createConfigMapVolumeMounttestPod(f.Namespace.Name, createVolumeName, createName, path.Join(volumeMountPath, "create"),
+	pod := createConfigMapVolumeMounttestPod(f.Namespace.Name, createVolumeName, createName, filepath.Join(volumeMountPath, "create"),
 		"--break_on_expected_content=false", containerTimeoutArg, "--file_content_in_loop=/etc/configmap-volumes/create/data-1")
 	pod.Spec.Volumes[0].VolumeSource.ConfigMap.Optional = &falseValue
 	pod.Spec.Volumes[0].VolumeSource.ConfigMap.Items = []v1.KeyToPath{

--- a/test/e2e/common/storage/empty_dir.go
+++ b/test/e2e/common/storage/empty_dir.go
@@ -19,7 +19,7 @@ package storage
 import (
 	"context"
 	"fmt"
-	"path"
+	"path/filepath"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
@@ -369,7 +369,7 @@ const (
 
 func doTestSetgidFSGroup(ctx context.Context, f *framework.Framework, uid int64, medium v1.StorageMedium) {
 	var (
-		filePath = path.Join(volumePath, "test-file")
+		filePath = filepath.Join(volumePath, "test-file")
 		source   = &v1.EmptyDirVolumeSource{Medium: medium}
 		pod      = testPodWithVolume(uid, volumePath, source)
 	)
@@ -457,7 +457,7 @@ func doTestVolumeModeFSGroup(ctx context.Context, f *framework.Framework, uid in
 
 func doTest0644FSGroup(ctx context.Context, f *framework.Framework, uid int64, medium v1.StorageMedium) {
 	var (
-		filePath = path.Join(volumePath, "test-file")
+		filePath = filepath.Join(volumePath, "test-file")
 		source   = &v1.EmptyDirVolumeSource{Medium: medium}
 		pod      = testPodWithVolume(uid, volumePath, source)
 	)
@@ -507,7 +507,7 @@ func doTestVolumeMode(ctx context.Context, f *framework.Framework, uid int64, me
 
 func doTest0644(ctx context.Context, f *framework.Framework, uid int64, medium v1.StorageMedium) {
 	var (
-		filePath = path.Join(volumePath, "test-file")
+		filePath = filepath.Join(volumePath, "test-file")
 		source   = &v1.EmptyDirVolumeSource{Medium: medium}
 		pod      = testPodWithVolume(uid, volumePath, source)
 	)
@@ -532,7 +532,7 @@ func doTest0644(ctx context.Context, f *framework.Framework, uid int64, medium v
 
 func doTest0666(ctx context.Context, f *framework.Framework, uid int64, medium v1.StorageMedium) {
 	var (
-		filePath = path.Join(volumePath, "test-file")
+		filePath = filepath.Join(volumePath, "test-file")
 		source   = &v1.EmptyDirVolumeSource{Medium: medium}
 		pod      = testPodWithVolume(uid, volumePath, source)
 	)
@@ -557,7 +557,7 @@ func doTest0666(ctx context.Context, f *framework.Framework, uid int64, medium v
 
 func doTest0777(ctx context.Context, f *framework.Framework, uid int64, medium v1.StorageMedium) {
 	var (
-		filePath = path.Join(volumePath, "test-file")
+		filePath = filepath.Join(volumePath, "test-file")
 		source   = &v1.EmptyDirVolumeSource{Medium: medium}
 		pod      = testPodWithVolume(uid, volumePath, source)
 	)

--- a/test/e2e/common/storage/host_path.go
+++ b/test/e2e/common/storage/host_path.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -67,7 +67,7 @@ var _ = SIGDescribe("HostPath", func() {
 
 	// This test requires mounting a folder into a container with write privileges.
 	f.It("should support r/w", f.WithNodeConformance(), func(ctx context.Context) {
-		filePath := path.Join(volumePath, "test-file")
+		filePath := filepath.Join(volumePath, "test-file")
 		retryDuration := 180
 		source := &v1.HostPathVolumeSource{
 			Path: "/tmp",
@@ -99,8 +99,8 @@ var _ = SIGDescribe("HostPath", func() {
 		fileName := "test-file"
 		retryDuration := 180
 
-		filePathInWriter := path.Join(volumePath, fileName)
-		filePathInReader := path.Join(volumePath, subPath, fileName)
+		filePathInWriter := filepath.Join(volumePath, fileName)
+		filePathInReader := filepath.Join(volumePath, subPath, fileName)
 
 		source := &v1.HostPathVolumeSource{
 			Path: "/tmp",

--- a/test/e2e/common/storage/projected_configmap.go
+++ b/test/e2e/common/storage/projected_configmap.go
@@ -19,7 +19,7 @@ package storage
 import (
 	"context"
 	"fmt"
-	"path"
+	"path/filepath"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -294,7 +294,7 @@ var _ = SIGDescribe("Projected configMap", func() {
 						VolumeMounts: []v1.VolumeMount{
 							{
 								Name:      deleteVolumeName,
-								MountPath: path.Join(volumeMountPath, "delete"),
+								MountPath: filepath.Join(volumeMountPath, "delete"),
 								ReadOnly:  true,
 							},
 						},
@@ -306,7 +306,7 @@ var _ = SIGDescribe("Projected configMap", func() {
 						VolumeMounts: []v1.VolumeMount{
 							{
 								Name:      updateVolumeName,
-								MountPath: path.Join(volumeMountPath, "update"),
+								MountPath: filepath.Join(volumeMountPath, "update"),
 								ReadOnly:  true,
 							},
 						},
@@ -318,7 +318,7 @@ var _ = SIGDescribe("Projected configMap", func() {
 						VolumeMounts: []v1.VolumeMount{
 							{
 								Name:      createVolumeName,
-								MountPath: path.Join(volumeMountPath, "create"),
+								MountPath: filepath.Join(volumeMountPath, "create"),
 								ReadOnly:  true,
 							},
 						},

--- a/test/e2e/common/storage/projected_secret.go
+++ b/test/e2e/common/storage/projected_secret.go
@@ -19,7 +19,7 @@ package storage
 import (
 	"context"
 	"fmt"
-	"path"
+	"path/filepath"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -334,7 +334,7 @@ var _ = SIGDescribe("Projected secret", func() {
 						VolumeMounts: []v1.VolumeMount{
 							{
 								Name:      deleteVolumeName,
-								MountPath: path.Join(volumeMountPath, "delete"),
+								MountPath: filepath.Join(volumeMountPath, "delete"),
 								ReadOnly:  true,
 							},
 						},
@@ -346,7 +346,7 @@ var _ = SIGDescribe("Projected secret", func() {
 						VolumeMounts: []v1.VolumeMount{
 							{
 								Name:      updateVolumeName,
-								MountPath: path.Join(volumeMountPath, "update"),
+								MountPath: filepath.Join(volumeMountPath, "update"),
 								ReadOnly:  true,
 							},
 						},
@@ -358,7 +358,7 @@ var _ = SIGDescribe("Projected secret", func() {
 						VolumeMounts: []v1.VolumeMount{
 							{
 								Name:      createVolumeName,
-								MountPath: path.Join(volumeMountPath, "create"),
+								MountPath: filepath.Join(volumeMountPath, "create"),
 								ReadOnly:  true,
 							},
 						},

--- a/test/e2e/common/storage/secrets_volume.go
+++ b/test/e2e/common/storage/secrets_volume.go
@@ -19,7 +19,7 @@ package storage
 import (
 	"context"
 	"fmt"
-	"path"
+	"path/filepath"
 
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -300,7 +300,7 @@ var _ = SIGDescribe("Secrets", func() {
 						VolumeMounts: []v1.VolumeMount{
 							{
 								Name:      deleteVolumeName,
-								MountPath: path.Join(volumeMountPath, "delete"),
+								MountPath: filepath.Join(volumeMountPath, "delete"),
 								ReadOnly:  true,
 							},
 						},
@@ -312,7 +312,7 @@ var _ = SIGDescribe("Secrets", func() {
 						VolumeMounts: []v1.VolumeMount{
 							{
 								Name:      updateVolumeName,
-								MountPath: path.Join(volumeMountPath, "update"),
+								MountPath: filepath.Join(volumeMountPath, "update"),
 								ReadOnly:  true,
 							},
 						},
@@ -324,7 +324,7 @@ var _ = SIGDescribe("Secrets", func() {
 						VolumeMounts: []v1.VolumeMount{
 							{
 								Name:      createVolumeName,
-								MountPath: path.Join(volumeMountPath, "create"),
+								MountPath: filepath.Join(volumeMountPath, "create"),
 								ReadOnly:  true,
 							},
 						},
@@ -642,7 +642,7 @@ func createNonOptionalSecretPod(ctx context.Context, f *framework.Framework, vol
 					VolumeMounts: []v1.VolumeMount{
 						{
 							Name:      createVolumeName,
-							MountPath: path.Join(volumeMountPath, "create"),
+							MountPath: filepath.Join(volumeMountPath, "create"),
 							ReadOnly:  true,
 						},
 					},
@@ -703,7 +703,7 @@ func createNonOptionalSecretPodWithSecret(ctx context.Context, f *framework.Fram
 					VolumeMounts: []v1.VolumeMount{
 						{
 							Name:      createVolumeName,
-							MountPath: path.Join(volumeMountPath, "create"),
+							MountPath: filepath.Join(volumeMountPath, "create"),
 							ReadOnly:  true,
 						},
 					},

--- a/test/e2e/dra/deploy.go
+++ b/test/e2e/dra/deploy.go
@@ -22,7 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
-	"path"
+	"path/filepath"
 	"sort"
 	"strings"
 	"sync"
@@ -206,7 +206,7 @@ func (d *Driver) SetUp(nodes *Nodes, resources app.Resources) {
 
 	instanceKey := "app.kubernetes.io/instance"
 	rsName := ""
-	draAddr := path.Join(framework.TestContext.KubeletRootDir, "plugins", d.Name+".sock")
+	draAddr := filepath.Join(framework.TestContext.KubeletRootDir, "plugins", d.Name+".sock")
 	numNodes := int32(len(nodes.NodeNames))
 	err := utils.CreateFromManifests(ctx, d.f, d.f.Namespace, func(item interface{}) error {
 		switch item := item.(type) {
@@ -232,8 +232,8 @@ func (d *Driver) SetUp(nodes *Nodes, resources app.Resources) {
 					},
 				},
 			}
-			item.Spec.Template.Spec.Volumes[0].HostPath.Path = path.Join(framework.TestContext.KubeletRootDir, "plugins")
-			item.Spec.Template.Spec.Volumes[2].HostPath.Path = path.Join(framework.TestContext.KubeletRootDir, "plugins_registry")
+			item.Spec.Template.Spec.Volumes[0].HostPath.Path = filepath.Join(framework.TestContext.KubeletRootDir, "plugins")
+			item.Spec.Template.Spec.Volumes[2].HostPath.Path = filepath.Join(framework.TestContext.KubeletRootDir, "plugins_registry")
 			item.Spec.Template.Spec.Containers[0].Args = append(item.Spec.Template.Spec.Containers[0].Args, "--endpoint=/plugins_registry/"+d.Name+"-reg.sock")
 			item.Spec.Template.Spec.Containers[1].Args = append(item.Spec.Template.Spec.Containers[1].Args, "--endpoint=/dra/"+d.Name+".sock")
 		case *apiextensionsv1.CustomResourceDefinition:

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -26,7 +26,7 @@ import (
 	"fmt"
 	"math/rand"
 	"os"
-	"path"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"time"
@@ -314,7 +314,7 @@ func printSummaries(summaries []TestDataSummary, testBaseName string) {
 				Logf(summaries[i].PrintHumanReadable())
 			} else {
 				// TODO: learn to extract test name and append it to the kind instead of timestamp.
-				filePath := path.Join(TestContext.ReportDir, summaries[i].SummaryKind()+"_"+testBaseName+"_"+now.Format(time.RFC3339)+".txt")
+				filePath := filepath.Join(TestContext.ReportDir, summaries[i].SummaryKind()+"_"+testBaseName+"_"+now.Format(time.RFC3339)+".txt")
 				if err := os.WriteFile(filePath, []byte(summaries[i].PrintHumanReadable()), 0644); err != nil {
 					Logf("Failed to write file %v with test performance data: %v", filePath, err)
 				}
@@ -330,7 +330,7 @@ func printSummaries(summaries []TestDataSummary, testBaseName string) {
 				Logf("Finished")
 			} else {
 				// TODO: learn to extract test name and append it to the kind instead of timestamp.
-				filePath := path.Join(TestContext.ReportDir, summaries[i].SummaryKind()+"_"+testBaseName+"_"+now.Format(time.RFC3339)+".json")
+				filePath := filepath.Join(TestContext.ReportDir, summaries[i].SummaryKind()+"_"+testBaseName+"_"+now.Format(time.RFC3339)+".json")
 				Logf("Writing to %s", filePath)
 				if err := os.WriteFile(filePath, []byte(summaries[i].PrintJSON()), 0644); err != nil {
 					Logf("Failed to write file %v with test performance data: %v", filePath, err)

--- a/test/e2e/framework/internal/output/output.go
+++ b/test/e2e/framework/internal/output/output.go
@@ -19,7 +19,7 @@ package output
 import (
 	"encoding/xml"
 	"os"
-	"path"
+	"path/filepath"
 	"regexp"
 	"testing"
 
@@ -43,7 +43,7 @@ import (
 // run tests with "go test -v".
 func TestGinkgoOutput(t *testing.T, expected TestResult, runSpecsArgs ...interface{}) {
 	tmpdir := t.TempDir()
-	junitFile := path.Join(tmpdir, "junit.xml")
+	junitFile := filepath.Join(tmpdir, "junit.xml")
 	gomega.RegisterFailHandler(framework.Fail)
 	ginkgo.ReportAfterSuite("write JUnit file", func(report ginkgo.Report) {
 		junit.WriteJUnitReport(report, junitFile)

--- a/test/e2e/framework/log_test.go
+++ b/test/e2e/framework/log_test.go
@@ -19,7 +19,7 @@ package framework_test
 import (
 	"errors"
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
@@ -288,7 +288,7 @@ In [AfterEach] at: log_test.go:53 <time>
 
 	oldStderr := os.Stderr
 	tmp := t.TempDir()
-	filename := path.Join(tmp, "stderr.log")
+	filename := filepath.Join(tmp, "stderr.log")
 	f, err := os.Create(filename)
 	require.NoError(t, err, "create temporary file")
 	os.Stderr = f

--- a/test/e2e/framework/providers/gcp.go
+++ b/test/e2e/framework/providers/gcp.go
@@ -19,7 +19,7 @@ package providers
 import (
 	"context"
 	"fmt"
-	"path"
+	"path/filepath"
 
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
@@ -61,7 +61,7 @@ func MasterUpgradeGKE(ctx context.Context, namespace string, v string) error {
 // GCEUpgradeScript returns path of script for upgrading on GCE.
 func GCEUpgradeScript() string {
 	if len(framework.TestContext.GCEUpgradeScript) == 0 {
-		return path.Join(framework.TestContext.RepoRoot, "cluster/gce/upgrade.sh")
+		return filepath.Join(framework.TestContext.RepoRoot, "cluster/gce/upgrade.sh")
 	}
 	return framework.TestContext.GCEUpgradeScript
 }

--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -26,7 +26,6 @@ import (
 	"io"
 	"math"
 	"os"
-	"path"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -592,7 +591,7 @@ func AfterReadingAllFlags(t *TestContextType) {
 			klog.Errorf("Create report dir: %v", err)
 			Exit(1)
 		}
-		ginkgoDir := path.Join(TestContext.ReportDir, "ginkgo")
+		ginkgoDir := filepath.Join(TestContext.ReportDir, "ginkgo")
 		if TestContext.ReportCompleteGinkgo || TestContext.ReportCompleteJUnit {
 			if err := os.MkdirAll(ginkgoDir, 0777); err != nil && !os.IsExist(err) {
 				klog.Errorf("Create <report-dir>/ginkgo: %v", err)
@@ -602,10 +601,10 @@ func AfterReadingAllFlags(t *TestContextType) {
 
 		if TestContext.ReportCompleteGinkgo {
 			ginkgo.ReportAfterSuite("Ginkgo JSON report", func(report ginkgo.Report) {
-				ExpectNoError(reporters.GenerateJSONReport(report, path.Join(ginkgoDir, "report.json")))
+				ExpectNoError(reporters.GenerateJSONReport(report, filepath.Join(ginkgoDir, "report.json")))
 			})
 			ginkgo.ReportAfterSuite("JUnit XML report", func(report ginkgo.Report) {
-				ExpectNoError(reporters.GenerateJUnitReport(report, path.Join(ginkgoDir, "report.xml")))
+				ExpectNoError(reporters.GenerateJUnitReport(report, filepath.Join(ginkgoDir, "report.xml")))
 			})
 		}
 
@@ -615,7 +614,7 @@ func AfterReadingAllFlags(t *TestContextType) {
 			// all results into a report for us. The 01 suffix is
 			// kept in case that users expect files to be called
 			// "junit_<prefix><number>.xml".
-			junitReport := path.Join(TestContext.ReportDir, "junit_"+TestContext.ReportPrefix+"01.xml")
+			junitReport := path.filepath(TestContext.ReportDir, "junit_"+TestContext.ReportPrefix+"01.xml")
 
 			// writeJUnitReport generates a JUnit file in the e2e
 			// report directory that is shorter than the one

--- a/test/e2e/storage/detach_mounted.go
+++ b/test/e2e/storage/detach_mounted.go
@@ -19,7 +19,7 @@ package storage
 import (
 	"context"
 	"fmt"
-	"path"
+	"path/filepath"
 
 	"time"
 
@@ -76,10 +76,10 @@ var _ = utils.SIGDescribe(feature.Flexvolumes, "Detaching volumes", func() {
 		driver := "attachable-with-long-mount"
 		driverInstallAs := driver + "-" + suffix
 
-		ginkgo.By(fmt.Sprintf("installing flexvolume %s on node %s as %s", path.Join(driverDir, driver), node.Name, driverInstallAs))
-		installFlex(ctx, cs, node, "k8s", driverInstallAs, path.Join(driverDir, driver))
-		ginkgo.By(fmt.Sprintf("installing flexvolume %s on master as %s", path.Join(driverDir, driver), driverInstallAs))
-		installFlex(ctx, cs, nil, "k8s", driverInstallAs, path.Join(driverDir, driver))
+		ginkgo.By(fmt.Sprintf("installing flexvolume %s on node %s as %s", filepath.Join(driverDir, driver), node.Name, driverInstallAs))
+		installFlex(ctx, cs, node, "k8s", driverInstallAs, filepath.Join(driverDir, driver))
+		ginkgo.By(fmt.Sprintf("installing flexvolume %s on master as %s", filepath.Join(driverDir, driver), driverInstallAs))
+		installFlex(ctx, cs, nil, "k8s", driverInstallAs, filepath.Join(driverDir, driver))
 		volumeSource := v1.VolumeSource{
 			FlexVolume: &v1.FlexVolumeSource{
 				Driver: "k8s/" + driverInstallAs,

--- a/test/e2e/storage/flexvolume.go
+++ b/test/e2e/storage/flexvolume.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"path"
+	"path/filepath"
 
 	"time"
 
@@ -73,7 +73,7 @@ func testFlexVolume(ctx context.Context, driver string, config e2evolume.TestCon
 // controller-manager if 'restart' is true.
 func installFlex(ctx context.Context, c clientset.Interface, node *v1.Node, vendor, driver, filePath string) {
 	flexDir := getFlexDir(c, node, vendor, driver)
-	flexFile := path.Join(flexDir, driver)
+	flexFile := filepath.Join(flexDir, driver)
 
 	host := ""
 	var err error
@@ -133,7 +133,7 @@ func getFlexDir(c clientset.Interface, node *v1.Node, vendor, driver string) str
 	if framework.ProviderIs("gce") {
 		volumePluginDir = gciVolumePluginDir
 	}
-	flexDir := path.Join(volumePluginDir, fmt.Sprintf("/%s~%s/", vendor, driver))
+	flexDir := filepath.Join(volumePluginDir, fmt.Sprintf("/%s~%s/", vendor, driver))
 	return flexDir
 }
 
@@ -192,8 +192,8 @@ var _ = utils.SIGDescribe("Flexvolumes", func() {
 		driver := "dummy"
 		driverInstallAs := driver + "-" + suffix
 
-		ginkgo.By(fmt.Sprintf("installing flexvolume %s on node %s as %s", path.Join(driverDir, driver), node.Name, driverInstallAs))
-		installFlex(ctx, cs, node, "k8s", driverInstallAs, path.Join(driverDir, driver))
+		ginkgo.By(fmt.Sprintf("installing flexvolume %s on node %s as %s", filepath.Join(driverDir, driver), node.Name, driverInstallAs))
+		installFlex(ctx, cs, node, "k8s", driverInstallAs, filepath.Join(driverDir, driver))
 
 		testFlexVolume(ctx, driverInstallAs, config, f)
 
@@ -205,10 +205,10 @@ var _ = utils.SIGDescribe("Flexvolumes", func() {
 		driver := "dummy-attachable"
 		driverInstallAs := driver + "-" + suffix
 
-		ginkgo.By(fmt.Sprintf("installing flexvolume %s on node %s as %s", path.Join(driverDir, driver), node.Name, driverInstallAs))
-		installFlex(ctx, cs, node, "k8s", driverInstallAs, path.Join(driverDir, driver))
-		ginkgo.By(fmt.Sprintf("installing flexvolume %s on master as %s", path.Join(driverDir, driver), driverInstallAs))
-		installFlex(ctx, cs, nil, "k8s", driverInstallAs, path.Join(driverDir, driver))
+		ginkgo.By(fmt.Sprintf("installing flexvolume %s on node %s as %s", filepath.Join(driverDir, driver), node.Name, driverInstallAs))
+		installFlex(ctx, cs, node, "k8s", driverInstallAs, filepath.Join(driverDir, driver))
+		ginkgo.By(fmt.Sprintf("installing flexvolume %s on master as %s", filepath.Join(driverDir, driver), driverInstallAs))
+		installFlex(ctx, cs, nil, "k8s", driverInstallAs, filepath.Join(driverDir, driver))
 
 		testFlexVolume(ctx, driverInstallAs, config, f)
 

--- a/test/e2e/storage/flexvolume_mounted_volume_resize.go
+++ b/test/e2e/storage/flexvolume_mounted_volume_resize.go
@@ -19,6 +19,8 @@ package storage
 import (
 	"context"
 	"fmt"
+	"path/filepath"
+
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
@@ -37,7 +39,6 @@ import (
 	"k8s.io/kubernetes/test/e2e/storage/testsuites"
 	"k8s.io/kubernetes/test/e2e/storage/utils"
 	admissionapi "k8s.io/pod-security-admission/api"
-	"path"
 )
 
 var _ = utils.SIGDescribe(feature.Flexvolumes, "Mounted flexvolume expand", framework.WithSlow(), func() {
@@ -108,10 +109,10 @@ var _ = utils.SIGDescribe(feature.Flexvolumes, "Mounted flexvolume expand", fram
 
 	ginkgo.It("Should verify mounted flex volumes can be resized", func(ctx context.Context) {
 		driver := "dummy-attachable"
-		ginkgo.By(fmt.Sprintf("installing flexvolume %s on node %s as %s", path.Join(driverDir, driver), node.Name, driver))
-		installFlex(ctx, c, node, "k8s", driver, path.Join(driverDir, driver))
-		ginkgo.By(fmt.Sprintf("installing flexvolume %s on (master) node %s as %s", path.Join(driverDir, driver), node.Name, driver))
-		installFlex(ctx, c, nil, "k8s", driver, path.Join(driverDir, driver))
+		ginkgo.By(fmt.Sprintf("installing flexvolume %s on node %s as %s", filepath.Join(driverDir, driver), node.Name, driver))
+		installFlex(ctx, c, node, "k8s", driver, filepath.Join(driverDir, driver))
+		ginkgo.By(fmt.Sprintf("installing flexvolume %s on (master) node %s as %s", filepath.Join(driverDir, driver), node.Name, driver))
+		installFlex(ctx, c, nil, "k8s", driver, filepath.Join(driverDir, driver))
 
 		pv := e2epv.MakePersistentVolume(e2epv.PersistentVolumeConfig{
 			PVSource: v1.PersistentVolumeSource{

--- a/test/e2e/storage/flexvolume_online_resize.go
+++ b/test/e2e/storage/flexvolume_online_resize.go
@@ -19,7 +19,7 @@ package storage
 import (
 	"context"
 	"fmt"
-	"path"
+	"path/filepath"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
@@ -113,10 +113,10 @@ var _ = utils.SIGDescribe(feature.Flexvolumes, "Mounted flexvolume volume expand
 
 		driver := "dummy-attachable"
 
-		ginkgo.By(fmt.Sprintf("installing flexvolume %s on node %s as %s", path.Join(driverDir, driver), node.Name, driver))
-		installFlex(ctx, c, node, "k8s", driver, path.Join(driverDir, driver))
-		ginkgo.By(fmt.Sprintf("installing flexvolume %s on (master) node %s as %s", path.Join(driverDir, driver), node.Name, driver))
-		installFlex(ctx, c, nil, "k8s", driver, path.Join(driverDir, driver))
+		ginkgo.By(fmt.Sprintf("installing flexvolume %s on node %s as %s", filepath.Join(driverDir, driver), node.Name, driver))
+		installFlex(ctx, c, node, "k8s", driver, filepath.Join(driverDir, driver))
+		ginkgo.By(fmt.Sprintf("installing flexvolume %s on (master) node %s as %s", filepath.Join(driverDir, driver), node.Name, driver))
+		installFlex(ctx, c, nil, "k8s", driver, filepath.Join(driverDir, driver))
 
 		pv := e2epv.MakePersistentVolume(e2epv.PersistentVolumeConfig{
 			PVSource: v1.PersistentVolumeSource{

--- a/test/e2e/storage/host_path_type.go
+++ b/test/e2e/storage/host_path_type.go
@@ -19,7 +19,7 @@ package storage
 import (
 	"context"
 	"fmt"
-	"path"
+	"path/filepath"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -61,17 +61,17 @@ var _ = utils.SIGDescribe("HostPathType Directory", framework.WithSlow(), func()
 		ns = f.Namespace.Name
 
 		ginkgo.By("Create a pod for further testing")
-		hostBaseDir = path.Join("/tmp", ns)
+		hostBaseDir = filepath.Join("/tmp", ns)
 		mountBaseDir = "/mnt/test"
 		basePod = e2epod.NewPodClient(f).CreateSync(ctx, newHostPathTypeTestPod(map[string]string{}, hostBaseDir, mountBaseDir, &hostPathDirectoryOrCreate))
 		ginkgo.By(fmt.Sprintf("running on node %s", basePod.Spec.NodeName))
-		targetDir = path.Join(hostBaseDir, "adir")
+		targetDir = filepath.Join(hostBaseDir, "adir")
 		ginkgo.By("Should automatically create a new directory 'adir' when HostPathType is HostPathDirectoryOrCreate")
 		verifyPodHostPathType(ctx, f, map[string]string{"kubernetes.io/hostname": basePod.Spec.NodeName}, targetDir, &hostPathDirectoryOrCreate)
 	})
 
 	ginkgo.It("Should fail on mounting non-existent directory 'does-not-exist-dir' when HostPathType is HostPathDirectory", func(ctx context.Context) {
-		dirPath := path.Join(hostBaseDir, "does-not-exist-dir")
+		dirPath := filepath.Join(hostBaseDir, "does-not-exist-dir")
 		verifyPodHostPathTypeFailure(ctx, f, map[string]string{"kubernetes.io/hostname": basePod.Spec.NodeName},
 			dirPath, fmt.Sprintf("%s is not a directory", dirPath), &hostPathDirectory)
 	})
@@ -129,17 +129,17 @@ var _ = utils.SIGDescribe("HostPathType File", framework.WithSlow(), func() {
 		ns = f.Namespace.Name
 
 		ginkgo.By("Create a pod for further testing")
-		hostBaseDir = path.Join("/tmp", ns)
+		hostBaseDir = filepath.Join("/tmp", ns)
 		mountBaseDir = "/mnt/test"
 		basePod = e2epod.NewPodClient(f).CreateSync(ctx, newHostPathTypeTestPod(map[string]string{}, hostBaseDir, mountBaseDir, &hostPathDirectoryOrCreate))
 		ginkgo.By(fmt.Sprintf("running on node %s", basePod.Spec.NodeName))
-		targetFile = path.Join(hostBaseDir, "afile")
+		targetFile = filepath.Join(hostBaseDir, "afile")
 		ginkgo.By("Should automatically create a new file 'afile' when HostPathType is HostPathFileOrCreate")
 		verifyPodHostPathType(ctx, f, map[string]string{"kubernetes.io/hostname": basePod.Spec.NodeName}, targetFile, &hostPathFileOrCreate)
 	})
 
 	ginkgo.It("Should fail on mounting non-existent file 'does-not-exist-file' when HostPathType is HostPathFile", func(ctx context.Context) {
-		filePath := path.Join(hostBaseDir, "does-not-exist-file")
+		filePath := filepath.Join(hostBaseDir, "does-not-exist-file")
 		verifyPodHostPathTypeFailure(ctx, f, map[string]string{"kubernetes.io/hostname": basePod.Spec.NodeName},
 			filePath, fmt.Sprintf("%s is not a file", filePath), &hostPathFile)
 	})
@@ -197,15 +197,15 @@ var _ = utils.SIGDescribe("HostPathType Socket", framework.WithSlow(), func() {
 		ns = f.Namespace.Name
 
 		ginkgo.By("Create a pod for further testing")
-		hostBaseDir = path.Join("/tmp", ns)
+		hostBaseDir = filepath.Join("/tmp", ns)
 		mountBaseDir = "/mnt/test"
-		basePod = e2epod.NewPodClient(f).CreateSync(ctx, newHostPathTypeTestPodWithCommand(map[string]string{}, hostBaseDir, mountBaseDir, &hostPathDirectoryOrCreate, fmt.Sprintf("nc -lU %s", path.Join(mountBaseDir, "asocket"))))
+		basePod = e2epod.NewPodClient(f).CreateSync(ctx, newHostPathTypeTestPodWithCommand(map[string]string{}, hostBaseDir, mountBaseDir, &hostPathDirectoryOrCreate, fmt.Sprintf("nc -lU %s", filepath.Join(mountBaseDir, "asocket"))))
 		ginkgo.By(fmt.Sprintf("running on node %s", basePod.Spec.NodeName))
-		targetSocket = path.Join(hostBaseDir, "asocket")
+		targetSocket = filepath.Join(hostBaseDir, "asocket")
 	})
 
 	ginkgo.It("Should fail on mounting non-existent socket 'does-not-exist-socket' when HostPathType is HostPathSocket", func(ctx context.Context) {
-		socketPath := path.Join(hostBaseDir, "does-not-exist-socket")
+		socketPath := filepath.Join(hostBaseDir, "does-not-exist-socket")
 		verifyPodHostPathTypeFailure(ctx, f, map[string]string{"kubernetes.io/hostname": basePod.Spec.NodeName},
 			socketPath, fmt.Sprintf("%s is not a socket", socketPath), &hostPathSocket)
 	})
@@ -263,19 +263,19 @@ var _ = utils.SIGDescribe("HostPathType Character Device", framework.WithSlow(),
 		ns = f.Namespace.Name
 
 		ginkgo.By("Create a pod for further testing")
-		hostBaseDir = path.Join("/tmp", ns)
+		hostBaseDir = filepath.Join("/tmp", ns)
 		mountBaseDir = "/mnt/test"
 		basePod = e2epod.NewPodClient(f).CreateSync(ctx, newHostPathTypeTestPod(map[string]string{}, hostBaseDir, mountBaseDir, &hostPathDirectoryOrCreate))
 		ginkgo.By(fmt.Sprintf("running on node %s", basePod.Spec.NodeName))
-		targetCharDev = path.Join(hostBaseDir, "achardev")
+		targetCharDev = filepath.Join(hostBaseDir, "achardev")
 		ginkgo.By("Create a character device for further testing")
-		cmd := fmt.Sprintf("mknod %s c 89 1", path.Join(mountBaseDir, "achardev"))
+		cmd := fmt.Sprintf("mknod %s c 89 1", filepath.Join(mountBaseDir, "achardev"))
 		stdout, stderr, err := e2evolume.PodExec(f, basePod, cmd)
 		framework.ExpectNoError(err, "command: %q, stdout: %s\nstderr: %s", cmd, stdout, stderr)
 	})
 
 	ginkgo.It("Should fail on mounting non-existent character device 'does-not-exist-char-dev' when HostPathType is HostPathCharDev", func(ctx context.Context) {
-		charDevPath := path.Join(hostBaseDir, "does-not-exist-char-dev")
+		charDevPath := filepath.Join(hostBaseDir, "does-not-exist-char-dev")
 		verifyPodHostPathTypeFailure(ctx, f, map[string]string{"kubernetes.io/hostname": basePod.Spec.NodeName},
 			charDevPath, fmt.Sprintf("%s is not a character device", charDevPath), &hostPathCharDev)
 	})
@@ -333,19 +333,19 @@ var _ = utils.SIGDescribe("HostPathType Block Device", framework.WithSlow(), fun
 		ns = f.Namespace.Name
 
 		ginkgo.By("Create a pod for further testing")
-		hostBaseDir = path.Join("/tmp", ns)
+		hostBaseDir = filepath.Join("/tmp", ns)
 		mountBaseDir = "/mnt/test"
 		basePod = e2epod.NewPodClient(f).CreateSync(ctx, newHostPathTypeTestPod(map[string]string{}, hostBaseDir, mountBaseDir, &hostPathDirectoryOrCreate))
 		ginkgo.By(fmt.Sprintf("running on node %s", basePod.Spec.NodeName))
-		targetBlockDev = path.Join(hostBaseDir, "ablkdev")
+		targetBlockDev = filepath.Join(hostBaseDir, "ablkdev")
 		ginkgo.By("Create a block device for further testing")
-		cmd := fmt.Sprintf("mknod %s b 89 1", path.Join(mountBaseDir, "ablkdev"))
+		cmd := fmt.Sprintf("mknod %s b 89 1", filepath.Join(mountBaseDir, "ablkdev"))
 		stdout, stderr, err := e2evolume.PodExec(f, basePod, cmd)
 		framework.ExpectNoError(err, "command %q: stdout: %s\nstderr: %s", cmd, stdout, stderr)
 	})
 
 	ginkgo.It("Should fail on mounting non-existent block device 'does-not-exist-blk-dev' when HostPathType is HostPathBlockDev", func(ctx context.Context) {
-		blkDevPath := path.Join(hostBaseDir, "does-not-exist-blk-dev")
+		blkDevPath := filepath.Join(hostBaseDir, "does-not-exist-blk-dev")
 		verifyPodHostPathTypeFailure(ctx, f, map[string]string{"kubernetes.io/hostname": basePod.Spec.NodeName},
 			blkDevPath, fmt.Sprintf("%s is not a block device", blkDevPath), &hostPathBlockDev)
 	})

--- a/test/e2e/storage/utils/deployment.go
+++ b/test/e2e/storage/utils/deployment.go
@@ -19,6 +19,7 @@ package utils
 import (
 	"fmt"
 	"path"
+	"path/filepath"
 	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -68,7 +69,7 @@ func PatchCSIDeployment(f *e2eframework.Framework, o PatchCSIOptions, object int
 				p := &volume.HostPath.Path
 				dir, file := path.Split(*p)
 				if file == o.OldDriverName {
-					*p = path.Join(dir, o.NewDriverName)
+					*p = filepath.Join(dir, o.NewDriverName)
 				}
 				// Inject non-standard kubelet path.
 				*p = substKubeletRootDir(*p)

--- a/test/e2e/suites.go
+++ b/test/e2e/suites.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 	"time"
 
 	clientset "k8s.io/client-go/kubernetes"
@@ -70,7 +70,7 @@ func gatherTestSuiteMetrics(ctx context.Context) error {
 	metricsForE2E := (*e2emetrics.ComponentCollection)(&received)
 	metricsJSON := metricsForE2E.PrintJSON()
 	if framework.TestContext.ReportDir != "" {
-		filePath := path.Join(framework.TestContext.ReportDir, "MetricsForE2ESuite_"+time.Now().Format(time.RFC3339)+".json")
+		filePath := filepath.Join(framework.TestContext.ReportDir, "MetricsForE2ESuite_"+time.Now().Format(time.RFC3339)+".json")
 		if err := os.WriteFile(filePath, []byte(metricsJSON), 0644); err != nil {
 			return fmt.Errorf("error writing to %q: %w", filePath, err)
 		}

--- a/test/e2e_node/benchmark_util.go
+++ b/test/e2e_node/benchmark_util.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 	"sort"
 	"strconv"
 	"time"
@@ -48,7 +48,7 @@ const (
 // data for the test into the file with the specified prefix.
 func dumpDataToFile(data interface{}, labels map[string]string, prefix string) {
 	testName := labels["test"]
-	fileName := path.Join(framework.TestContext.ReportDir, fmt.Sprintf("%s-%s-%s.json", prefix, framework.TestContext.ReportPrefix, testName))
+	fileName := filepath.Join(framework.TestContext.ReportDir, fmt.Sprintf("%s-%s-%s.json", prefix, framework.TestContext.ReportPrefix, testName))
 	labels["timestamp"] = strconv.FormatInt(time.Now().UTC().Unix(), 10)
 	framework.Logf("Dumping perf data for test %q to %q.", testName, fileName)
 	if err := os.WriteFile(fileName, []byte(framework.PrettyPrintJSON(data)), 0644); err != nil {

--- a/test/e2e_node/container_manager_test.go
+++ b/test/e2e_node/container_manager_test.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"fmt"
 	"os/exec"
-	"path"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -45,7 +45,7 @@ import (
 )
 
 func getOOMScoreForPid(pid int) (int, error) {
-	procfsPath := path.Join("/proc", strconv.Itoa(pid), "oom_score_adj")
+	procfsPath := filepath.Join("/proc", strconv.Itoa(pid), "oom_score_adj")
 	out, err := exec.Command("sudo", "cat", procfsPath).CombinedOutput()
 	if err != nil {
 		return 0, err

--- a/test/e2e_node/services/server.go
+++ b/test/e2e_node/services/server.go
@@ -22,7 +22,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
-	"path"
+	"path/filepath"
 	"reflect"
 	"strconv"
 	"strings"
@@ -124,7 +124,7 @@ func (s *server) start() error {
 		defer close(errCh)
 
 		// Create the output filename
-		outPath := path.Join(framework.TestContext.ReportDir, s.outFilename)
+		outPath := filepath.Join(framework.TestContext.ReportDir, s.outFilename)
 		outfile, err := os.Create(outPath)
 		if err != nil {
 			errCh <- fmt.Errorf("failed to create file %q for `%s` %v", outPath, s, err)

--- a/test/e2e_node/services/services.go
+++ b/test/e2e_node/services/services.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"path"
+	"path/filepath"
 	"testing"
 
 	"k8s.io/klog/v2"
@@ -153,7 +153,7 @@ func (e *E2EServices) collectLogFiles() {
 	klog.Info("Fetching log files...")
 	journaldFound := isJournaldAvailable()
 	for targetFileName, log := range e.logs {
-		targetLink := path.Join(framework.TestContext.ReportDir, targetFileName)
+		targetLink := filepath.Join(framework.TestContext.ReportDir, targetFileName)
 		if journaldFound {
 			// Skip log files that do not have an equivalent in journald-based machines.
 			if len(log.JournalctlCommand) == 0 {

--- a/test/images/apparmor-loader/loader.go
+++ b/test/images/apparmor-loader/loader.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"path"
 	"path/filepath"
 	"strings"
 	"time"
@@ -232,7 +231,7 @@ func resolveSymlink(basePath string, entry os.DirEntry) (os.FileInfo, error) {
 //
 //	Refactor that method to expose it in a reusable way, and delete this version.
 func getLoadedProfiles() (map[string]bool, error) {
-	profilesPath := path.Join(apparmorfs, "profiles")
+	profilesPath := filepath.Join(apparmorfs, "profiles")
 	profilesFile, err := os.Open(profilesPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open %s: %v", profilesPath, err)

--- a/test/integration/apiserver/certreload/certreload_test.go
+++ b/test/integration/apiserver/certreload/certreload_test.go
@@ -28,6 +28,7 @@ import (
 	"math/big"
 	"os"
 	"path"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -530,8 +531,8 @@ func TestSNICert(t *testing.T) {
 
 			opts.SecureServing.SNICertKeys = []flag.NamedCertKey{{
 				Names:    []string{"foo"},
-				CertFile: path.Join(servingCertPath, "foo.crt"),
-				KeyFile:  path.Join(servingCertPath, "foo.key"),
+				CertFile: filepath.Join(servingCertPath, "foo.crt"),
+				KeyFile:  filepath.Join(servingCertPath, "foo.key"),
 			}}
 		},
 	})

--- a/test/integration/certificates/duration_test.go
+++ b/test/integration/certificates/duration_test.go
@@ -24,7 +24,7 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"os"
-	"path"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -100,7 +100,7 @@ func TestCSRDuration(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	caPublicKeyFile := path.Join(s.TmpDir, "test-ca-public-key")
+	caPublicKeyFile := filepath.Join(s.TmpDir, "test-ca-public-key")
 	if err := os.WriteFile(caPublicKeyFile, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caCert.Raw}), os.FileMode(0600)); err != nil {
 		t.Fatal(err)
 	}
@@ -108,7 +108,7 @@ func TestCSRDuration(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	caPrivateKeyFile := path.Join(s.TmpDir, "test-ca-private-key")
+	caPrivateKeyFile := filepath.Join(s.TmpDir, "test-ca-private-key")
 	if err := os.WriteFile(caPrivateKeyFile, caPrivateKeyBytes, os.FileMode(0600)); err != nil {
 		t.Fatal(err)
 	}

--- a/test/integration/client/cert_rotation_test.go
+++ b/test/integration/client/cert_rotation_test.go
@@ -28,6 +28,7 @@ import (
 	"math/big"
 	"os"
 	"path"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -159,7 +160,7 @@ func writeCACertFiles(t *testing.T, certDir string) (string, *x509.Certificate, 
 		t.Fatal(err)
 	}
 
-	clientCAFilename := path.Join(certDir, "ca.crt")
+	clientCAFilename := filepath.Join(certDir, "ca.crt")
 
 	if err := os.WriteFile(clientCAFilename, utils.EncodeCertPEM(clientSigningCert), 0644); err != nil {
 		t.Fatal(err)
@@ -207,9 +208,9 @@ func writeCerts(t *testing.T, clientSigningCert *x509.Certificate, clientSigning
 		t.Fatal(err)
 	}
 
-	if err := os.WriteFile(path.Join(certDir, "client.crt"), pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDERBytes}), 0666); err != nil {
+	if err := os.WriteFile(filepath.Join(certDir, "client.crt"), pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDERBytes}), 0666); err != nil {
 		t.Fatal(err)
 	}
 
-	return path.Join(certDir, "client.crt"), path.Join(certDir, "client.key")
+	return filepath.Join(certDir, "client.crt"), filepath.Join(certDir, "client.key")
 }

--- a/test/integration/examples/apiserver_test.go
+++ b/test/integration/examples/apiserver_test.go
@@ -26,6 +26,7 @@ import (
 	"net/url"
 	"os"
 	"path"
+	"path/filepath"
 	"reflect"
 	"sort"
 	"strings"
@@ -511,7 +512,7 @@ func TestAggregatedAPIServer(t *testing.T) {
 
 func waitForWardleRunning(ctx context.Context, t *testing.T, wardleToKASKubeConfig *rest.Config, wardleCertDir string, wardlePort int) (*rest.Config, error) {
 	directWardleClientConfig := rest.AnonymousClientConfig(rest.CopyConfig(wardleToKASKubeConfig))
-	directWardleClientConfig.CAFile = path.Join(wardleCertDir, "apiserver.crt")
+	directWardleClientConfig.CAFile = filepath.Join(wardleCertDir, "apiserver.crt")
 	directWardleClientConfig.CAData = nil
 	directWardleClientConfig.ServerName = ""
 	directWardleClientConfig.BearerToken = wardleToKASKubeConfig.BearerToken

--- a/test/integration/framework/test_server.go
+++ b/test/integration/framework/test_server.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"os"
 	"path"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -183,7 +184,7 @@ func StartTestServer(ctx context.Context, t testing.TB, setup TestServerSetup) (
 
 	// Adjust the loopback config for external use (external server name and CA)
 	kubeAPIServerClientConfig := rest.CopyConfig(kubeAPIServerConfig.GenericConfig.LoopbackClientConfig)
-	kubeAPIServerClientConfig.CAFile = path.Join(certDir, "apiserver.crt")
+	kubeAPIServerClientConfig.CAFile = filepath.Join(certDir, "apiserver.crt")
 	kubeAPIServerClientConfig.CAData = nil
 	kubeAPIServerClientConfig.ServerName = ""
 

--- a/test/integration/scheduler_perf/scheduler_perf.go
+++ b/test/integration/scheduler_perf/scheduler_perf.go
@@ -24,7 +24,7 @@ import (
 	"io"
 	"math"
 	"os"
-	"path"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -616,7 +616,7 @@ func initTestOutput(tb testing.TB) io.Writer {
 		output = framework.NewTBWriter(tb)
 	} else {
 		tmpDir := tb.TempDir()
-		logfileName := path.Join(tmpDir, "output.log")
+		logfileName := filepath.Join(tmpDir, "output.log")
 		fileOutput, err := os.Create(logfileName)
 		if err != nil {
 			tb.Fatalf("create log file: %v", err)

--- a/test/integration/scheduler_perf/util.go
+++ b/test/integration/scheduler_perf/util.go
@@ -23,7 +23,7 @@ import (
 	"fmt"
 	"math"
 	"os"
-	"path"
+	"path/filepath"
 	"sort"
 	"strings"
 	"time"
@@ -230,7 +230,7 @@ func dataItems2JSONFile(dataItems DataItems, namePrefix string) error {
 		if err := os.MkdirAll(*dataItemsDir, 0750); err != nil {
 			return fmt.Errorf("dataItemsDir path %v does not exist and cannot be created: %v", *dataItemsDir, err)
 		}
-		destFile = path.Join(*dataItemsDir, destFile)
+		destFile = filepath.Join(*dataItemsDir, destFile)
 	}
 	formatted := &bytes.Buffer{}
 	if err := json.Indent(formatted, b, "", "  "); err != nil {

--- a/test/integration/serving/serving_test.go
+++ b/test/integration/serving/serving_test.go
@@ -24,7 +24,7 @@ import (
 	"io"
 	"net/http"
 	"os"
-	"path"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -242,7 +242,7 @@ func testComponentWithSecureServing(t *testing.T, tester componentTester, kubeco
 
 				// read self-signed server cert disk
 				pool := x509.NewCertPool()
-				serverCertPath := path.Join(secureOptions.ServerCert.CertDirectory, secureOptions.ServerCert.PairName+".crt")
+				serverCertPath := filepath.Join(secureOptions.ServerCert.CertDirectory, secureOptions.ServerCert.PairName+".crt")
 				serverCert, err := os.ReadFile(serverCertPath)
 				if err != nil {
 					t.Fatalf("Failed to read component server cert %q: %v", serverCertPath, err)

--- a/test/utils/apiserver/testapiserver.go
+++ b/test/utils/apiserver/testapiserver.go
@@ -18,6 +18,7 @@ package apiserver
 
 import (
 	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/google/uuid"
@@ -93,7 +94,7 @@ func writeKubeConfigForWardleServerToKASConnection(t *testing.T, kubeClientConfi
 
 	adminKubeConfig := kubeconfig.CreateKubeConfig(wardleToKASKubeClientConfig)
 	tmpDir := t.TempDir()
-	kubeConfigFile := path.Join(tmpDir, "kube.config")
+	kubeConfigFile := filepath.Join(tmpDir, "kube.config")
 	if err := clientcmd.WriteToFile(*adminKubeConfig, kubeConfigFile); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
// Package filepath implements utility routines for manipulating filename paths
// in a way compatible with the target operating system-defined file paths.
//
// The filepath package uses either forward slashes or backslashes,
// depending on the operating system. To process paths such as URLs
// that always use forward slashes regardless of the operating
// system, see the path package.

// Package path implements utility routines for manipulating slash-separated
// paths.
//
// The path package should only be used for paths separated by forward
// slashes, such as the paths in URLs. This package does not deal with
// Windows paths with drive letters or backslashes; to manipulate
// operating system paths, use the path/filepath package.

Filepath is used to process file paths, path is used to process url paths

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
