### PR TITLE
apiserver/pkg/server decrease mock handler sleep time from 60s to 10s

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/graceful_shutdown_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/graceful_shutdown_test.go
@@ -94,7 +94,7 @@ W+S7SneWTL09leh5ATNhog6s
 // TestGracefulShutdownForActiveHTTP2Streams checks if graceful shut down of HTTP2 server works.
 // It expects that all active connections will be finished (without any errors) before the server exits.
 //
-// The test sends 25 requests to the target server in parallel. Each request is held by the target server for 60s.
+// The test sends 25 requests to the target server in parallel. Each request is held by the target server for 10s.
 // As soon as the target server receives the last request the test calls backendServer.Config.Shutdown which gracefully shuts down the server without interrupting any active connections.
 //
 // See more at: https://github.com/golang/go/issues/39776
@@ -187,7 +187,7 @@ func (b *backendHTTPHandler) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
 	}
 	handlerLock.Unlock()
 
-	time.Sleep(60 * time.Second)
+	time.Sleep(10 * time.Second)
 
 	w.Write([]byte("hello from the backend"))
 	w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:

I think 10s wait time is already enough for backendServer.Config.Shutdown to gracefully shut down the server and validating no interrupting on any active connections.
Open to any suggestion!

before:
```
go test -race -run TestGracefulShutdownForActiveHTTP2Streams -count=1 ./apiserver/pkg/server/
ok  	k8s.io/apiserver/pkg/server	62.424s
```
after:
```
go test -race -run TestGracefulShutdownForActiveHTTP2Streams -count=1 ./apiserver/pkg/server/
ok  	k8s.io/apiserver/pkg/server	12.361s
```
xref: https://github.com/kubernetes/kubernetes/issues/123685

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
