### PR TITLE
kubeadm: stop storing the ResolverConfig in the global KubeletConfiguration and instead set it dynamically for each node

### DIFF
--- a/cmd/kubeadm/app/componentconfigs/kubelet.go
+++ b/cmd/kubeadm/app/componentconfigs/kubelet.go
@@ -28,7 +28,6 @@ import (
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	kubeadmapiv1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta3"
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
-	"k8s.io/kubernetes/cmd/kubeadm/app/util/initsystem"
 )
 
 const (
@@ -196,27 +195,4 @@ func (kc *kubeletConfig) Default(cfg *kubeadmapi.ClusterConfiguration, _ *kubead
 		klog.V(1).Infof("the value of KubeletConfiguration.cgroupDriver is empty; setting it to %q", constants.CgroupDriverSystemd)
 		kc.config.CgroupDriver = constants.CgroupDriverSystemd
 	}
-
-	ok, err := isServiceActive("systemd-resolved")
-	if err != nil {
-		klog.Warningf("cannot determine if systemd-resolved is active: %v", err)
-	}
-	if ok {
-		if kc.config.ResolverConfig == nil {
-			kc.config.ResolverConfig = ptr.To(kubeletSystemdResolverConfig)
-		} else {
-			if *kc.config.ResolverConfig != kubeletSystemdResolverConfig {
-				warnDefaultComponentConfigValue(kind, "resolvConf", kubeletSystemdResolverConfig, *kc.config.ResolverConfig)
-			}
-		}
-	}
-}
-
-// isServiceActive checks whether the given service exists and is running
-func isServiceActive(name string) (bool, error) {
-	initSystem, err := initsystem.GetInitSystem()
-	if err != nil {
-		return false, err
-	}
-	return initSystem.ServiceIsActive(name), nil
 }

--- a/cmd/kubeadm/app/componentconfigs/kubelet_test.go
+++ b/cmd/kubeadm/app/componentconfigs/kubelet_test.go
@@ -49,12 +49,6 @@ func testKubeletConfigMap(contents string) *v1.ConfigMap {
 }
 
 func TestKubeletDefault(t *testing.T) {
-	var resolverConfig *string
-	if isSystemdResolvedActive, _ := isServiceActive("systemd-resolved"); isSystemdResolvedActive {
-		// If systemd-resolved is active, we need to set the default resolver config
-		resolverConfig = ptr.To(kubeletSystemdResolverConfig)
-	}
-
 	tests := []struct {
 		name       string
 		clusterCfg kubeadmapi.ClusterConfiguration
@@ -85,7 +79,6 @@ func TestKubeletDefault(t *testing.T) {
 					HealthzBindAddress: kubeletHealthzBindAddress,
 					HealthzPort:        ptr.To[int32](constants.KubeletHealthzPort),
 					RotateCertificates: kubeletRotateCertificates,
-					ResolverConfig:     resolverConfig,
 					CgroupDriver:       constants.CgroupDriverSystemd,
 				},
 			},
@@ -119,7 +112,6 @@ func TestKubeletDefault(t *testing.T) {
 					HealthzBindAddress: kubeletHealthzBindAddress,
 					HealthzPort:        ptr.To[int32](constants.KubeletHealthzPort),
 					RotateCertificates: kubeletRotateCertificates,
-					ResolverConfig:     resolverConfig,
 					CgroupDriver:       constants.CgroupDriverSystemd,
 				},
 			},
@@ -153,7 +145,6 @@ func TestKubeletDefault(t *testing.T) {
 					HealthzBindAddress: kubeletHealthzBindAddress,
 					HealthzPort:        ptr.To[int32](constants.KubeletHealthzPort),
 					RotateCertificates: kubeletRotateCertificates,
-					ResolverConfig:     resolverConfig,
 					CgroupDriver:       constants.CgroupDriverSystemd,
 				},
 			},
@@ -188,7 +179,6 @@ func TestKubeletDefault(t *testing.T) {
 					HealthzBindAddress: kubeletHealthzBindAddress,
 					HealthzPort:        ptr.To[int32](constants.KubeletHealthzPort),
 					RotateCertificates: kubeletRotateCertificates,
-					ResolverConfig:     resolverConfig,
 					CgroupDriver:       constants.CgroupDriverSystemd,
 				},
 			},
@@ -220,7 +210,6 @@ func TestKubeletDefault(t *testing.T) {
 					HealthzBindAddress: kubeletHealthzBindAddress,
 					HealthzPort:        ptr.To[int32](constants.KubeletHealthzPort),
 					RotateCertificates: kubeletRotateCertificates,
-					ResolverConfig:     resolverConfig,
 					CgroupDriver:       constants.CgroupDriverSystemd,
 				},
 			},

--- a/cmd/kubeadm/app/componentconfigs/kubelet_unix.go
+++ b/cmd/kubeadm/app/componentconfigs/kubelet_unix.go
@@ -19,7 +19,45 @@ limitations under the License.
 
 package componentconfigs
 
+import (
+	"k8s.io/klog/v2"
+	kubeletconfig "k8s.io/kubelet/config/v1beta1"
+	"k8s.io/utils/ptr"
+
+	"k8s.io/kubernetes/cmd/kubeadm/app/util/initsystem"
+)
+
 // Mutate allows applying pre-defined modifications to the config before it's marshaled.
 func (kc *kubeletConfig) Mutate() error {
+	if err := mutateResolverConfig(&kc.config, isServiceActive); err != nil {
+		return err
+	}
 	return nil
+}
+
+// mutateResolverConfig mutates the ResolverConfig in the kubeletConfig dynamically.
+func mutateResolverConfig(cfg *kubeletconfig.KubeletConfiguration, isServiceActiveFunc func(string) (bool, error)) error {
+	ok, err := isServiceActiveFunc("systemd-resolved")
+	if err != nil {
+		klog.Warningf("cannot determine if systemd-resolved is active: %v", err)
+	}
+	if ok {
+		if cfg.ResolverConfig == nil {
+			cfg.ResolverConfig = ptr.To(kubeletSystemdResolverConfig)
+		} else if *cfg.ResolverConfig != kubeletSystemdResolverConfig {
+			warnDefaultComponentConfigValue("KubeletConfiguration", "resolvConf",
+				kubeletSystemdResolverConfig, *cfg.ResolverConfig)
+		}
+
+	}
+	return nil
+}
+
+// isServiceActive checks whether the given service exists and is running
+func isServiceActive(name string) (bool, error) {
+	initSystem, err := initsystem.GetInitSystem()
+	if err != nil {
+		return false, err
+	}
+	return initSystem.ServiceIsActive(name), nil
 }

--- a/cmd/kubeadm/app/componentconfigs/kubelet_unix_test.go
+++ b/cmd/kubeadm/app/componentconfigs/kubelet_unix_test.go
@@ -1,0 +1,83 @@
+//go:build !windows
+// +build !windows
+
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package componentconfigs
+
+import (
+	"reflect"
+	"testing"
+
+	kubeletconfig "k8s.io/kubelet/config/v1beta1"
+	"k8s.io/utils/ptr"
+)
+
+func TestMutateResolverConfig(t *testing.T) {
+	var fooResolverConfig = "/foo/resolver"
+
+	tests := []struct {
+		name                string
+		cfg                 *kubeletconfig.KubeletConfiguration
+		isServiceActiveFunc func(string) (bool, error)
+		expected            *kubeletconfig.KubeletConfiguration
+	}{
+		{
+			name: "the resolver config should not be mutated when it was set already even if systemd-resolved is active",
+			cfg: &kubeletconfig.KubeletConfiguration{
+				ResolverConfig: ptr.To(fooResolverConfig),
+			},
+			isServiceActiveFunc: func(string) (bool, error) { return true, nil },
+			expected: &kubeletconfig.KubeletConfiguration{
+				ResolverConfig: ptr.To(fooResolverConfig),
+			},
+		},
+		{
+			name: "the resolver config should be set when systemd-resolved is active",
+			cfg: &kubeletconfig.KubeletConfiguration{
+				ResolverConfig: nil,
+			},
+			isServiceActiveFunc: func(string) (bool, error) { return true, nil },
+			expected: &kubeletconfig.KubeletConfiguration{
+				ResolverConfig: ptr.To(kubeletSystemdResolverConfig),
+			},
+		},
+		{
+			name: "the resolver config should not be set when systemd-resolved is not active",
+			cfg: &kubeletconfig.KubeletConfiguration{
+				ResolverConfig: nil,
+			},
+			isServiceActiveFunc: func(string) (bool, error) { return false, nil },
+			expected: &kubeletconfig.KubeletConfiguration{
+				ResolverConfig: nil,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := mutateResolverConfig(test.cfg, test.isServiceActiveFunc)
+			if err != nil {
+				t.Fatalf("failed to mutate ResolverConfig for KubeletConfiguration, %v", err)
+			}
+			if !reflect.DeepEqual(test.cfg, test.expected) {
+				t.Errorf("Missmatch between expected and got:\nExpected:\n%+v\n---\nGot:\n%+v",
+					test.expected, test.cfg)
+			}
+		})
+	}
+}

--- a/cmd/kubeadm/app/componentconfigs/kubelet_windows.go
+++ b/cmd/kubeadm/app/componentconfigs/kubelet_windows.go
@@ -1,3 +1,6 @@
+//go:build windows
+// +build windows
+
 /*
 Copyright 2021 The Kubernetes Authors.
 

--- a/cmd/kubeadm/app/componentconfigs/kubelet_windows_test.go
+++ b/cmd/kubeadm/app/componentconfigs/kubelet_windows_test.go
@@ -1,3 +1,6 @@
+//go:build windows
+// +build windows
+
 /*
 Copyright 2021 The Kubernetes Authors.
 


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
kubeadm: stop storing the ResolverConfig in the global KubeletConfiguration and instead set it dynamically for each node

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes kubernetes/kubeadm#3034

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubeadm: stop storing the ResolverConfig in the global KubeletConfiguration and instead set it dynamically for each node
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
