### PR TITLE
Fix: correct dryRunStratergy typo in kubectl expose cmd

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/expose/expose.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/expose/expose.go
@@ -225,12 +225,12 @@ func (flags *ExposeServiceFlags) AddFlags(cmd *cobra.Command) {
 }
 
 func (flags *ExposeServiceFlags) ToOptions(cmd *cobra.Command, args []string) (*ExposeServiceOptions, error) {
-	dryRunStratergy, err := cmdutil.GetDryRunStrategy(cmd)
+	dryRunStrategy, err := cmdutil.GetDryRunStrategy(cmd)
 	if err != nil {
 		return nil, err
 	}
 
-	cmdutil.PrintFlagsWithDryRunStrategy(flags.PrintFlags, dryRunStratergy)
+	cmdutil.PrintFlagsWithDryRunStrategy(flags.PrintFlags, dryRunStrategy)
 	printer, err := flags.PrintFlags.ToPrinter()
 	if err != nil {
 		return nil, err
@@ -243,7 +243,7 @@ func (flags *ExposeServiceFlags) ToOptions(cmd *cobra.Command, args []string) (*
 	}
 
 	e := &ExposeServiceOptions{
-		DryRunStrategy:  dryRunStratergy,
+		DryRunStrategy:  dryRunStrategy,
 		PrintObj:        printer.PrintObj,
 		Recorder:        recorder,
 		IOStreams:       flags.IOStreams,


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
there is a typo in ToOptions func in expose cmd for staging/kubectl.
the typo is dryRunStratergy.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
