### PR TITLE
Make more clear cloud-provider routes definition possibility

### DIFF
--- a/staging/src/k8s.io/cloud-provider/cloud.go
+++ b/staging/src/k8s.io/cloud-provider/cloud.go
@@ -237,6 +237,8 @@ type Route struct {
 	// DestinationCIDR is the CIDR format IP range that this routing rule
 	// applies to.
 	DestinationCIDR string
+	// GatewayAddress is the address that this routing rule applies to.
+	GatewayAddress string
 	// Blackhole is set to true if this is a blackhole route
 	// The node controller will delete the route if it is in the managed range.
 	Blackhole bool

--- a/staging/src/k8s.io/cloud-provider/controllers/route/route_controller.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/route/route_controller.go
@@ -448,10 +448,14 @@ func (rc *RouteController) isResponsibleForRoute(route *cloudprovider.Route) boo
 func getRouteAction(routes []*cloudprovider.Route, cidr string, nodeName types.NodeName, realNodeAddrs []v1.NodeAddress) routeAction {
 	for _, route := range routes {
 		if route.DestinationCIDR == cidr {
-			if !route.EnableNodeAddresses || equalNodeAddrs(realNodeAddrs, route.TargetNodeAddresses) {
+			if route.GatewayAddress != "" {
+				if hasAddressValue(realNodeAddrs, route.GatewayAddress) {
+					return keep
+				}
+			} else if !route.EnableNodeAddresses || equalNodeAddrs(realNodeAddrs, route.TargetNodeAddresses) {
 				return keep
 			}
-			klog.Infof("Node addresses have changed from %v to %v", route.TargetNodeAddresses, realNodeAddrs)
+			klog.Infof("Node addresses have changed to %v", realNodeAddrs)
 			return update
 		}
 	}
@@ -475,4 +479,14 @@ func equalNodeAddrs(addrs0 []v1.NodeAddress, addrs1 []v1.NodeAddress) bool {
 		}
 	}
 	return true
+}
+
+func hasAddressValue(nodeAddresses []v1.NodeAddress, routeGatewayAddress string) bool {
+	for _, value := range nodeAddresses {
+		if value.Address == routeGatewayAddress {
+			return true
+		}
+	}
+
+	return false
 }


### PR DESCRIPTION
Hello. This PR allow to simplify and make more clear route determination flow.
Existing implementation with `EnableNodeAddresses` feature gate looks strange. It seems like we need only one address for right route define. `EnableNodeAddresses` force to know all node addresses when `ListRoutes` method executes, but it information should not be contained in route table. In the end, `TargetNodeAddresses` field name misleads, because it's sounds like desired state, but it actually should contain current status of route table.