### PR TITLE
[KEP-2400] Mount tmpfs memory-backed volumes with a noswap option if supported

### DIFF
--- a/pkg/kubelet/cm/container_manager_linux.go
+++ b/pkg/kubelet/cm/container_manager_linux.go
@@ -57,6 +57,7 @@ import (
 	cmutil "k8s.io/kubernetes/pkg/kubelet/cm/util"
 	"k8s.io/kubernetes/pkg/kubelet/config"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
+	"k8s.io/kubernetes/pkg/kubelet/events"
 	"k8s.io/kubernetes/pkg/kubelet/lifecycle"
 	"k8s.io/kubernetes/pkg/kubelet/pluginmanager/cache"
 	"k8s.io/kubernetes/pkg/kubelet/stats/pidlimit"
@@ -214,7 +215,11 @@ func NewContainerManager(mountUtil mount.Interface, cadvisorInterface cadvisor.I
 		}
 
 		if !swap.IsTmpfsNoswapOptionSupported(mountUtil) {
-			klog.InfoS("tmpfs noswap option is not supported, hence memory-backed volumes (e.g. secrets, emptyDirs) might be swapped to disk")
+			nodeRef := nodeRefFromNode(string(nodeConfig.NodeName))
+			recorder.Event(nodeRef, v1.EventTypeWarning, events.PossibleMemoryBackedVolumesOnDisk,
+				"The tmpfs noswap option is not supported. Memory-backed volumes (e.g. secrets, emptyDirs, etc.) "+
+					"might be swapped to disk and should no longer be considered secure.",
+			)
 		}
 	}
 

--- a/pkg/kubelet/cm/container_manager_linux.go
+++ b/pkg/kubelet/cm/container_manager_linux.go
@@ -214,7 +214,7 @@ func NewContainerManager(mountUtil mount.Interface, cadvisorInterface cadvisor.I
 			return nil, fmt.Errorf("running with swap on is not supported, please disable swap or set --fail-swap-on flag to false")
 		}
 
-		if !swap.IsTmpfsNoswapOptionSupported(mountUtil) {
+		if !swap.IsTmpfsNoswapOptionSupported(mountUtil, nodeConfig.KubeletRootDir) {
 			nodeRef := nodeRefFromNode(string(nodeConfig.NodeName))
 			recorder.Event(nodeRef, v1.EventTypeWarning, events.PossibleMemoryBackedVolumesOnDisk,
 				"The tmpfs noswap option is not supported. Memory-backed volumes (e.g. secrets, emptyDirs, etc.) "+

--- a/pkg/kubelet/cm/node_container_manager_linux.go
+++ b/pkg/kubelet/cm/node_container_manager_linux.go
@@ -84,12 +84,7 @@ func (cm *containerManagerImpl) enforceNodeAllocatableCgroups() error {
 	}
 
 	// Using ObjectReference for events as the node maybe not cached; refer to #42701 for detail.
-	nodeRef := &v1.ObjectReference{
-		Kind:      "Node",
-		Name:      cm.nodeInfo.Name,
-		UID:       types.UID(cm.nodeInfo.Name),
-		Namespace: "",
-	}
+	nodeRef := nodeRefFromNode(cm.nodeInfo.Name)
 
 	// If Node Allocatable is enforced on a node that has not been drained or is updated on an existing node to a lower value,
 	// existing memory usage across pods might be higher than current Node Allocatable Memory Limits.
@@ -264,4 +259,14 @@ func (cm *containerManagerImpl) validateNodeAllocatable() error {
 		return fmt.Errorf("invalid Node Allocatable configuration. %s", strings.Join(errors, " "))
 	}
 	return nil
+}
+
+// Using ObjectReference for events as the node maybe not cached; refer to #42701 for detail.
+func nodeRefFromNode(nodeName string) *v1.ObjectReference {
+	return &v1.ObjectReference{
+		Kind:      "Node",
+		Name:      nodeName,
+		UID:       types.UID(nodeName),
+		Namespace: "",
+	}
 }

--- a/pkg/kubelet/events/event.go
+++ b/pkg/kubelet/events/event.go
@@ -75,6 +75,7 @@ const (
 	FailedStatusPodSandBox               = "FailedPodSandBoxStatus"
 	FailedMountOnFilesystemMismatch      = "FailedMountOnFilesystemMismatch"
 	FailedPrepareDynamicResources        = "FailedPrepareDynamicResources"
+	PossibleMemoryBackedVolumesOnDisk    = "PossibleMemoryBackedVolumesOnDisk"
 )
 
 // Image manager event reason list

--- a/pkg/kubelet/util/swap/swap_util.go
+++ b/pkg/kubelet/util/swap/swap_util.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package swap
+
+import (
+	"os"
+	sysruntime "runtime"
+	"sync"
+
+	"k8s.io/klog/v2"
+	"k8s.io/mount-utils"
+)
+
+var (
+	tmpfsNoswapOptionSupported        bool
+	tmpfsNoswapOptionAvailabilityOnce sync.Once
+)
+
+const TmpfsNoswapOption = "noswap"
+
+func IsTmpfsNoswapOptionSupported(mounter mount.Interface) bool {
+	isTmpfsNoswapOptionSupportedHelper := func() bool {
+		if sysruntime.GOOS == "windows" {
+			return false
+		}
+
+		mountDir, err := os.MkdirTemp("", "tmpfs-noswap-test-")
+		if err != nil {
+			klog.InfoS("error creating dir to test if tmpfs noswap is enabled. Assuming not supported", "mount path", mountDir, "error", err)
+			return false
+		}
+
+		defer func() {
+			err = os.RemoveAll(mountDir)
+			if err != nil {
+				klog.ErrorS(err, "error removing test tmpfs dir", "mount path", mountDir)
+			}
+		}()
+
+		err = mounter.MountSensitiveWithoutSystemd("tmpfs", mountDir, "tmpfs", []string{TmpfsNoswapOption}, nil)
+		if err != nil {
+			klog.InfoS("error mounting tmpfs with the noswap option. Assuming not supported", "error", err)
+			return false
+		}
+
+		err = mounter.Unmount(mountDir)
+		if err != nil {
+			klog.ErrorS(err, "error unmounting test tmpfs dir", "mount path", mountDir)
+		}
+
+		return true
+	}
+
+	tmpfsNoswapOptionAvailabilityOnce.Do(func() {
+		tmpfsNoswapOptionSupported = isTmpfsNoswapOptionSupportedHelper()
+	})
+
+	return tmpfsNoswapOptionSupported
+}

--- a/pkg/kubelet/util/swap/swap_util.go
+++ b/pkg/kubelet/util/swap/swap_util.go
@@ -17,8 +17,10 @@ limitations under the License.
 package swap
 
 import (
+	"bytes"
 	"os"
 	sysruntime "runtime"
+	"strings"
 	"sync"
 
 	"k8s.io/apimachinery/pkg/util/version"
@@ -82,4 +84,15 @@ func IsTmpfsNoswapOptionSupported(mounter mount.Interface) bool {
 	})
 
 	return tmpfsNoswapOptionSupported
+}
+
+// gets /proc/swaps's content as an input, returns true if swap is enabled.
+func isSwapOnAccordingToProcSwaps(procSwapsContent []byte) bool {
+	procSwapsContent = bytes.TrimSpace(procSwapsContent) // extra trailing \n
+	procSwapsStr := string(procSwapsContent)
+	procSwapsLines := strings.Split(procSwapsStr, "\n")
+
+	// If there is more than one line (table headers) in /proc/swaps then swap is enabled
+	klog.InfoS("Swap is on", "/proc/swaps contents", procSwapsStr)
+	return len(procSwapsLines) > 1
 }

--- a/pkg/kubelet/util/swap/swap_util_test.go
+++ b/pkg/kubelet/util/swap/swap_util_test.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package swap
+
+import "testing"
+
+func TestIsSwapEnabled(t *testing.T) {
+	testCases := []struct {
+		name             string
+		procSwapsContent string
+		expectedEnabled  bool
+	}{
+		{
+			name:             "empty",
+			procSwapsContent: "",
+			expectedEnabled:  false,
+		},
+		{
+			name: "with swap enabled, one partition",
+			procSwapsContent: `
+Filename				Type		Size		Used		Priority
+/dev/dm-1               partition	33554428	0		-2
+`,
+			expectedEnabled: true,
+		},
+		{
+			name: "with swap enabled, 2 partitions",
+			procSwapsContent: `
+Filename				Type		Size		Used		Priority
+/dev/dm-1               partition	33554428	0		-2
+/dev/zram0              partition	8388604		0		100
+`,
+			expectedEnabled: true,
+		},
+		{
+			name: "empty lines",
+			procSwapsContent: `
+
+`,
+			expectedEnabled: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			isEnabled := isSwapOnAccordingToProcSwaps([]byte(tc.procSwapsContent))
+			if isEnabled != tc.expectedEnabled {
+				t.Errorf("expected %v, got %v", tc.expectedEnabled, isEnabled)
+			}
+		})
+	}
+}

--- a/pkg/util/kernel/constants.go
+++ b/pkg/util/kernel/constants.go
@@ -47,3 +47,5 @@ const IPVSConnReuseModeFixedKernelVersion = "5.9"
 // UserNamespacesSupportKernelVersion is the kernel version where idmap for tmpfs support was added
 // (ref: https://github.com/torvalds/linux/commit/05e6295f7b5e05f09e369a3eb2882ec5b40fff20)
 const UserNamespacesSupportKernelVersion = "6.3"
+
+const TmpfsNoswapSupportKernelVersion = "6.4"

--- a/pkg/volume/emptydir/empty_dir.go
+++ b/pkg/volume/emptydir/empty_dir.go
@@ -328,7 +328,7 @@ func (ed *emptyDir) setupTmpfs(dir string) error {
 		return nil
 	}
 
-	options := ed.generateTmpfsMountOptions(swap.IsTmpfsNoswapOptionSupported(ed.mounter))
+	options := ed.generateTmpfsMountOptions(swap.IsTmpfsNoswapOptionSupported(ed.mounter, ed.plugin.host.GetPluginDir(emptyDirPluginName)))
 
 	klog.V(3).Infof("pod %v: mounting tmpfs for volume %v", ed.pod.UID, ed.volName)
 	return ed.mounter.MountSensitiveWithoutSystemd("tmpfs", dir, "tmpfs", options, nil)


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
This PR addresses https://github.com/kubernetes/kubernetes/issues/105978 which is about preventing memory-backed volumes from being swapped.

This PR brings the following behavior:
* When kubelet starts running with the `fail-swap-on=false` argument, it will check if the tmpfs noswap option is supported. If it's not - a warning log will be raised.
  * To understand if tmpfs noswap is supported or not, kubelet would try to mount a dummy tmpfs with the option and check for success. The directory is obviously cleaned up afterwards.
* If the tmpfs noswap option [1] is supported, use it by default for every tmpfs volume mount. With this options, memory-backed volumes will not be able to swap.

[1] https://www.kernel.org/doc/html/latest/filesystems/tmpfs.html

#### Example
After running kubelet with the `--fail-swap-on=false` argument, I've created the following pod and secret:
```yaml
apiVersion: v1
kind: Secret
metadata:
  name: mysecret
data:
  username: dXNlcm5hbWU=  # Base64 encoded value of 'username'
  password: cGFzc3dvcmQ=  # Base64 encoded value of 'password'
---
apiVersion: v1
kind: Pod
metadata:
  name: mypod
spec:
  volumes:
  - name: my-volume
    emptyDir:
      medium: "Memory"
  - name: secret-volume
    secret:
      secretName: mysecret
  containers:
  - image: k8s.gcr.io/e2e-test-images/agnhost:2.9
    volumeMounts:
    - name: my-volume
      mountPath: /tmpfsdir
    - name: secret-volume
      mountPath: "/etc/secrets"
    command:
      - sleep
      - "36000"
    name: mycontainer
```

Then on the node we can see tmpfs noswap being used:
```bash
> grep noswap /proc/mounts
tmpfs /var/lib/kubelet/pods/a79290c3-8565-4d05-b065-e6fe3d471beb/volumes/kubernetes.io~projected/kube-api-access-dfw72 tmpfs rw,seclabel,relatime,size=51200k,inode64,noswap 0 0
tmpfs /var/lib/kubelet/pods/1b756da6-531f-40d0-aa44-df79de14ad04/volumes/kubernetes.io~projected/kube-api-access-gh9tk tmpfs rw,seclabel,relatime,size=394492600k,inode64,noswap 0 0
tmpfs /var/lib/kubelet/pods/1fe60428-4258-481a-99b6-bdc4ae671c71/volumes/kubernetes.io~empty-dir/my-volume tmpfs rw,seclabel,relatime,size=524288k,inode64,noswap 0 0
tmpfs /var/lib/kubelet/pods/1fe60428-4258-481a-99b6-bdc4ae671c71/volumes/kubernetes.io~secret/secret-volume tmpfs rw,seclabel,relatime,size=524288k,inode64,noswap 0 0
tmpfs /var/lib/kubelet/pods/1fe60428-4258-481a-99b6-bdc4ae671c71/volumes/kubernetes.io~projected/kube-api-access-sfr4d tmpfs rw,seclabel,relatime,size=524288k,inode64,noswap 0 0
````

#### Which issue(s) this PR fixes:
Fixes #105978

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
- [KEP]: https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/2400-node-swap/README.md
```

Note: I keep the functest and its revert commit for future reference, as in the future it would be a great candidate for a functional test (when noswap is widely supported enough)

/sig node