### PR TITLE
test: fix shutdown of test/integration/servicecidr.TestMigrateServiceCIDR

### DIFF
--- a/test/integration/servicecidr/migration_test.go
+++ b/test/integration/servicecidr/migration_test.go
@@ -209,7 +209,7 @@ func TestMigrateServiceCIDR(t *testing.T) {
 
 	// ServiceCIDR controller
 	tCtx2 := ktesting.Init(t)
-	defer tCtx.Cancel("tearing down ServiceCIDR controller 2")
+	defer tCtx2.Cancel("tearing down ServiceCIDR controller 2")
 	informers2 := informers.NewSharedInformerFactory(client2, resyncPeriod)
 	go servicecidrs.NewController(
 		tCtx2,


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind failing-test

#### What this PR does / why we need it:

Due to a typo in b584b87a94d6ff5256624bbf83dd5f758dff6eb2, the wrong context got canceled. The test still passes, but it takes an additional minute before it eventually shuts down.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/cc @mengjiao-liu 