### PR TITLE
DRA: API cleanup + fix

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -15792,6 +15792,9 @@
           "description": "If StructuredData is set, then it needs to be used instead of Data."
         }
       },
+      "required": [
+        "driverName"
+      ],
       "type": "object"
     },
     "io.k8s.api.resource.v1alpha2.ResourceRequest": {

--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -9349,7 +9349,7 @@
           "type": "string"
         },
         "resourceClaimName": {
-          "description": "ResourceClaimName is the name of the ResourceClaim that was generated for the Pod in the namespace of the Pod. It this is unset, then generating a ResourceClaim was not necessary. The pod.spec.resourceClaims entry can be ignored in this case.",
+          "description": "ResourceClaimName is the name of the ResourceClaim that was generated for the Pod in the namespace of the Pod. If this is unset, then generating a ResourceClaim was not necessary. The pod.spec.resourceClaims entry can be ignored in this case.",
           "type": "string"
         }
       },
@@ -15026,7 +15026,7 @@
       "description": "NamedResourcesFilter is used in ResourceFilterModel.",
       "properties": {
         "selector": {
-          "description": "Selector is a CEL expression which must evaluate to true if a resource instance is suitable. The language is as defined in https://kubernetes.io/docs/reference/using-api/cel/\n\nIn addition, for each type NamedResourcesin AttributeValue there is a map that resolves to the corresponding value of the instance under evaluation. For example:\n\n   attributes.quantity[\"a\"].isGreaterThan(quantity(\"0\")) &&\n   attributes.stringslice[\"b\"].isSorted()",
+          "description": "Selector is a CEL expression which must evaluate to true if a resource instance is suitable. The language is as defined in https://kubernetes.io/docs/reference/using-api/cel/\n\nIn addition, for each type in NamedResourcesAttributeValue there is a map that resolves to the corresponding value of the instance under evaluation. For example:\n\n   attributes.quantity[\"a\"].isGreaterThan(quantity(\"0\")) &&\n   attributes.stringslice[\"b\"].isSorted()",
           "type": "string"
         }
       },

--- a/api/openapi-spec/v3/api__v1_openapi.json
+++ b/api/openapi-spec/v3/api__v1_openapi.json
@@ -5221,7 +5221,7 @@
             "type": "string"
           },
           "resourceClaimName": {
-            "description": "ResourceClaimName is the name of the ResourceClaim that was generated for the Pod in the namespace of the Pod. It this is unset, then generating a ResourceClaim was not necessary. The pod.spec.resourceClaims entry can be ignored in this case.",
+            "description": "ResourceClaimName is the name of the ResourceClaim that was generated for the Pod in the namespace of the Pod. If this is unset, then generating a ResourceClaim was not necessary. The pod.spec.resourceClaims entry can be ignored in this case.",
             "type": "string"
           }
         },

--- a/api/openapi-spec/v3/apis__resource.k8s.io__v1alpha2_openapi.json
+++ b/api/openapi-spec/v3/apis__resource.k8s.io__v1alpha2_openapi.json
@@ -244,7 +244,7 @@
         "properties": {
           "selector": {
             "default": "",
-            "description": "Selector is a CEL expression which must evaluate to true if a resource instance is suitable. The language is as defined in https://kubernetes.io/docs/reference/using-api/cel/\n\nIn addition, for each type NamedResourcesin AttributeValue there is a map that resolves to the corresponding value of the instance under evaluation. For example:\n\n   attributes.quantity[\"a\"].isGreaterThan(quantity(\"0\")) &&\n   attributes.stringslice[\"b\"].isSorted()",
+            "description": "Selector is a CEL expression which must evaluate to true if a resource instance is suitable. The language is as defined in https://kubernetes.io/docs/reference/using-api/cel/\n\nIn addition, for each type in NamedResourcesAttributeValue there is a map that resolves to the corresponding value of the instance under evaluation. For example:\n\n   attributes.quantity[\"a\"].isGreaterThan(quantity(\"0\")) &&\n   attributes.stringslice[\"b\"].isSorted()",
             "type": "string"
           }
         },

--- a/api/openapi-spec/v3/apis__resource.k8s.io__v1alpha2_openapi.json
+++ b/api/openapi-spec/v3/apis__resource.k8s.io__v1alpha2_openapi.json
@@ -1205,6 +1205,7 @@
             "type": "string"
           },
           "driverName": {
+            "default": "",
             "description": "DriverName specifies the name of the resource driver whose kubelet plugin should be invoked to process this ResourceHandle's data once it lands on a node. This may differ from the DriverName set in ResourceClaimStatus this ResourceHandle is embedded in.",
             "type": "string"
           },
@@ -1217,6 +1218,9 @@
             "description": "If StructuredData is set, then it needs to be used instead of Data."
           }
         },
+        "required": [
+          "driverName"
+        ],
         "type": "object"
       },
       "io.k8s.api.resource.v1alpha2.ResourceRequest": {

--- a/pkg/apis/core/types.go
+++ b/pkg/apis/core/types.go
@@ -3477,7 +3477,7 @@ type PodResourceClaimStatus struct {
 	Name string
 
 	// ResourceClaimName is the name of the ResourceClaim that was
-	// generated for the Pod in the namespace of the Pod. It this is
+	// generated for the Pod in the namespace of the Pod. If this is
 	// unset, then generating a ResourceClaim was not necessary. The
 	// pod.spec.resourceClaims entry can be ignored in this case.
 	ResourceClaimName *string

--- a/pkg/apis/resource/namedresources.go
+++ b/pkg/apis/resource/namedresources.go
@@ -92,8 +92,16 @@ type NamedResourcesRequest struct {
 
 // NamedResourcesFilter is used in ResourceFilterModel.
 type NamedResourcesFilter struct {
-	// Selector is a selector like the one in Request. It must be true for
-	// a resource instance to be suitable for a claim using the class.
+	// Selector is a CEL expression which must evaluate to true if a
+	// resource instance is suitable. The language is as defined in
+	// https://kubernetes.io/docs/reference/using-api/cel/
+	//
+	// In addition, for each type in NamedResourcesAttributeValue there is a map that
+	// resolves to the corresponding value of the instance under evaluation.
+	// For example:
+	//
+	//    attributes.quantity["a"].isGreaterThan(quantity("0")) &&
+	//    attributes.stringslice["b"].isSorted()
 	Selector string
 }
 

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -26996,7 +26996,7 @@ func schema_k8sio_api_core_v1_PodResourceClaimStatus(ref common.ReferenceCallbac
 					},
 					"resourceClaimName": {
 						SchemaProps: spec.SchemaProps{
-							Description: "ResourceClaimName is the name of the ResourceClaim that was generated for the Pod in the namespace of the Pod. It this is unset, then generating a ResourceClaim was not necessary. The pod.spec.resourceClaims entry can be ignored in this case.",
+							Description: "ResourceClaimName is the name of the ResourceClaim that was generated for the Pod in the namespace of the Pod. If this is unset, then generating a ResourceClaim was not necessary. The pod.spec.resourceClaims entry can be ignored in this case.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -45215,7 +45215,7 @@ func schema_k8sio_api_resource_v1alpha2_NamedResourcesFilter(ref common.Referenc
 				Properties: map[string]spec.Schema{
 					"selector": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Selector is a CEL expression which must evaluate to true if a resource instance is suitable. The language is as defined in https://kubernetes.io/docs/reference/using-api/cel/\n\nIn addition, for each type NamedResourcesin AttributeValue there is a map that resolves to the corresponding value of the instance under evaluation. For example:\n\n   attributes.quantity[\"a\"].isGreaterThan(quantity(\"0\")) &&\n   attributes.stringslice[\"b\"].isSorted()",
+							Description: "Selector is a CEL expression which must evaluate to true if a resource instance is suitable. The language is as defined in https://kubernetes.io/docs/reference/using-api/cel/\n\nIn addition, for each type in NamedResourcesAttributeValue there is a map that resolves to the corresponding value of the instance under evaluation. For example:\n\n   attributes.quantity[\"a\"].isGreaterThan(quantity(\"0\")) &&\n   attributes.stringslice[\"b\"].isSorted()",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -46488,6 +46488,7 @@ func schema_k8sio_api_resource_v1alpha2_ResourceHandle(ref common.ReferenceCallb
 					"driverName": {
 						SchemaProps: spec.SchemaProps{
 							Description: "DriverName specifies the name of the resource driver whose kubelet plugin should be invoked to process this ResourceHandle's data once it lands on a node. This may differ from the DriverName set in ResourceClaimStatus this ResourceHandle is embedded in.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -46506,6 +46507,7 @@ func schema_k8sio_api_resource_v1alpha2_ResourceHandle(ref common.ReferenceCallb
 						},
 					},
 				},
+				Required: []string{"driverName"},
 			},
 		},
 		Dependencies: []string{

--- a/staging/src/k8s.io/api/core/v1/generated.proto
+++ b/staging/src/k8s.io/api/core/v1/generated.proto
@@ -3813,7 +3813,7 @@ message PodResourceClaimStatus {
   optional string name = 1;
 
   // ResourceClaimName is the name of the ResourceClaim that was
-  // generated for the Pod in the namespace of the Pod. It this is
+  // generated for the Pod in the namespace of the Pod. If this is
   // unset, then generating a ResourceClaim was not necessary. The
   // pod.spec.resourceClaims entry can be ignored in this case.
   //

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -3929,7 +3929,7 @@ type PodResourceClaimStatus struct {
 	Name string `json:"name" protobuf:"bytes,1,name=name"`
 
 	// ResourceClaimName is the name of the ResourceClaim that was
-	// generated for the Pod in the namespace of the Pod. It this is
+	// generated for the Pod in the namespace of the Pod. If this is
 	// unset, then generating a ResourceClaim was not necessary. The
 	// pod.spec.resourceClaims entry can be ignored in this case.
 	//

--- a/staging/src/k8s.io/api/core/v1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/core/v1/types_swagger_doc_generated.go
@@ -1708,7 +1708,7 @@ func (PodResourceClaim) SwaggerDoc() map[string]string {
 var map_PodResourceClaimStatus = map[string]string{
 	"":                  "PodResourceClaimStatus is stored in the PodStatus for each PodResourceClaim which references a ResourceClaimTemplate. It stores the generated name for the corresponding ResourceClaim.",
 	"name":              "Name uniquely identifies this resource claim inside the pod. This must match the name of an entry in pod.spec.resourceClaims, which implies that the string must be a DNS_LABEL.",
-	"resourceClaimName": "ResourceClaimName is the name of the ResourceClaim that was generated for the Pod in the namespace of the Pod. It this is unset, then generating a ResourceClaim was not necessary. The pod.spec.resourceClaims entry can be ignored in this case.",
+	"resourceClaimName": "ResourceClaimName is the name of the ResourceClaim that was generated for the Pod in the namespace of the Pod. If this is unset, then generating a ResourceClaim was not necessary. The pod.spec.resourceClaims entry can be ignored in this case.",
 }
 
 func (PodResourceClaimStatus) SwaggerDoc() map[string]string {

--- a/staging/src/k8s.io/api/resource/v1alpha2/generated.proto
+++ b/staging/src/k8s.io/api/resource/v1alpha2/generated.proto
@@ -145,7 +145,7 @@ message NamedResourcesFilter {
   // resource instance is suitable. The language is as defined in
   // https://kubernetes.io/docs/reference/using-api/cel/
   //
-  // In addition, for each type NamedResourcesin AttributeValue there is a map that
+  // In addition, for each type in NamedResourcesAttributeValue there is a map that
   // resolves to the corresponding value of the instance under evaluation.
   // For example:
   //

--- a/staging/src/k8s.io/api/resource/v1alpha2/namedresources.go
+++ b/staging/src/k8s.io/api/resource/v1alpha2/namedresources.go
@@ -111,7 +111,7 @@ type NamedResourcesFilter struct {
 	// resource instance is suitable. The language is as defined in
 	// https://kubernetes.io/docs/reference/using-api/cel/
 	//
-	// In addition, for each type NamedResourcesin AttributeValue there is a map that
+	// In addition, for each type in NamedResourcesAttributeValue there is a map that
 	// resolves to the corresponding value of the instance under evaluation.
 	// For example:
 	//

--- a/staging/src/k8s.io/api/resource/v1alpha2/types.go
+++ b/staging/src/k8s.io/api/resource/v1alpha2/types.go
@@ -188,7 +188,7 @@ type ResourceHandle struct {
 	// plugin should be invoked to process this ResourceHandle's data once it
 	// lands on a node. This may differ from the DriverName set in
 	// ResourceClaimStatus this ResourceHandle is embedded in.
-	DriverName string `json:"driverName,omitempty" protobuf:"bytes,1,opt,name=driverName"`
+	DriverName string `json:"driverName" protobuf:"bytes,1,name=driverName"`
 
 	// Data contains the opaque data associated with this ResourceHandle. It is
 	// set by the controller component of the resource driver whose name

--- a/staging/src/k8s.io/api/resource/v1alpha2/types.go
+++ b/staging/src/k8s.io/api/resource/v1alpha2/types.go
@@ -26,6 +26,8 @@ import (
 const (
 	// Finalizer is the finalizer that gets set for claims
 	// which were allocated through a builtin controller.
+	// Reserved for use by Kubernetes, DRA driver controllers must
+	// use their own finalizer.
 	Finalizer = "dra.k8s.io/delete-protection"
 )
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/internal/internal.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/internal/internal.go
@@ -12413,6 +12413,7 @@ var schemaYAML = typed.YAMLObject(`types:
     - name: driverName
       type:
         scalar: string
+      default: ""
     - name: structuredData
       type:
         namedType: io.k8s.api.resource.v1alpha2.StructuredResourceHandle


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This is a minor documentation and OpenAPI update. The ResourceHandle.DriverName was already required
via validation, but was not declared as such by the OpenAPI.

#### Does this PR introduce a user-facing change?
```release-note
DRA: client-side validation of a ResourceHandle would have accepted a missing DriverName, whereas server-side validation then would have raised an error.
```
