### PR TITLE
apiserver: decrease timeout for EncryptionConfiguration tests

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/testdata/valid-configs/kms/multiple-providers-kmsv2.yaml
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/testdata/valid-configs/kms/multiple-providers-kmsv2.yaml
@@ -8,9 +8,9 @@ resources:
           apiVersion: v2
           name: foo
           endpoint: unix:///tmp/testprovider.sock
-          timeout:   15s
+          timeout: 100ms
       - kms:
           apiVersion: v2
           name: bar
           endpoint: unix:///tmp/testprovider.sock
-          timeout:   15s
+          timeout: 100ms

--- a/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/testdata/valid-configs/kms/multiple-providers-mixed.yaml
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/testdata/valid-configs/kms/multiple-providers-mixed.yaml
@@ -8,8 +8,8 @@ resources:
           apiVersion: v2
           name: foo
           endpoint: unix:///tmp/testprovider.sock
-          timeout:   15s
+          timeout: 100ms
       - kms:
           name: bar
           endpoint: unix:///tmp/testprovider.sock
-          timeout:   15s
+          timeout: 15s


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
This PR changes timeouts in test `EncryptionConfiguration` files. High timeout values caused test `TestKMSvsEnablement` to run for 45 seconds. 

#### Which issue(s) this PR fixes:
Fixes part of #123685

#### Special notes for your reviewer:
KMSv2 is probing the endpoint when loading the configuration. In `TestKMSvsEnablement` it is not necessary for the endpoint to be available (it is not even checked in the test). By keeping the timeout relatively low, probe failes faster and test moves on. This behavior in only present in KMSv2.

<details>
<summary>Before change</summary>

```
--- PASS: TestLegacyConfig (0.00s)
--- PASS: TestEncryptionProviderConfigCorrect (0.00s)
--- PASS: TestKMSv1Deprecation (0.00s)
    --- PASS: TestKMSv1Deprecation/config_with_kmsv1,_KMSv1=false (0.00s)
    --- PASS: TestKMSv1Deprecation/config_with_kmsv1,_KMSv1=true (0.00s)
--- PASS: TestKMSvsEnablement (45.01s)
    --- PASS: TestKMSvsEnablement/config_with_kmsv2_and_kmsv1,_KMSv2=true,_KMSv1=false,_should_fail_when_feature_is_disabled (15.00s)
    --- PASS: TestKMSvsEnablement/config_with_kmsv2,_KMSv2=true,_KMSv1=false (30.00s)
    --- PASS: TestKMSvsEnablement/with_kmsv1_and_kmsv2,_KMSv2=true (0.00s)
--- PASS: TestKMSMaxTimeout (0.00s)
    --- PASS: TestKMSMaxTimeout/config_with_bad_provider (0.00s)
    --- PASS: TestKMSMaxTimeout/default_timeout (0.00s)
    --- PASS: TestKMSMaxTimeout/with_v1_provider (0.00s)
    --- PASS: TestKMSMaxTimeout/with_v2_provider (0.00s)
    --- PASS: TestKMSMaxTimeout/with_v1_and_v2_provider (0.00s)
--- PASS: TestKMSPluginHealthz (0.01s)
    --- PASS: TestKMSPluginHealthz/Invalid_config_file_path (0.00s)
    --- PASS: TestKMSPluginHealthz/Empty_config_file_content (0.00s)
    --- PASS: TestKMSPluginHealthz/Unable_to_decode (0.00s)
    --- PASS: TestKMSPluginHealthz/Unexpected_config_type (0.00s)
    --- PASS: TestKMSPluginHealthz/Install_Healthz (0.00s)
    --- PASS: TestKMSPluginHealthz/Install_multiple_healthz (0.00s)
    --- PASS: TestKMSPluginHealthz/No_KMS_Providers (0.00s)
    --- PASS: TestKMSPluginHealthz/Install_multiple_healthz_with_v1_and_v2 (0.00s)
    --- PASS: TestKMSPluginHealthz/Invalid_API_version (0.00s)
--- PASS: TestWildcardMasking (0.01s)
    --- PASS: TestWildcardMasking/resources_masked_by_*._group (0.00s)
    --- PASS: TestWildcardMasking/*._masked_by_*._group (0.00s)
    --- PASS: TestWildcardMasking/*.foo_masked_by_*.foo (0.00s)
    --- PASS: TestWildcardMasking/*.*_masked_by_*.* (0.00s)
    --- PASS: TestWildcardMasking/resources_masked_by_*._group_in_multiple_configurations (0.00s)
    --- PASS: TestWildcardMasking/resources_masked_by_*.* (0.00s)
    --- PASS: TestWildcardMasking/resources_masked_by_*.*_in_multiple_configurations (0.00s)
    --- PASS: TestWildcardMasking/resources_*._masked_by_*.* (0.00s)
    --- PASS: TestWildcardMasking/resources_*._masked_by_*.*_in_multiple_configurations (0.00s)
    --- PASS: TestWildcardMasking/resources_not_masked_by_any_rule (0.00s)
    --- PASS: TestWildcardMasking/resources_not_masked_by_any_rule_in_multiple_configurations (0.00s)
--- PASS: TestWildcardStructure (0.00s)
    --- PASS: TestWildcardStructure/should_not_result_in_error (0.00s)
    --- PASS: TestWildcardStructure/should_result_in_error (0.00s)
--- PASS: TestKMSPluginHealthzTTL (0.00s)
    --- PASS: TestKMSPluginHealthzTTL/kms_provider_in_good_state (0.00s)
    --- PASS: TestKMSPluginHealthzTTL/kms_provider_in_bad_state (0.00s)
--- PASS: TestKMSv2PluginHealthzTTL (0.00s)
    --- PASS: TestKMSv2PluginHealthzTTL/kmsv2_provider_in_good_state (0.00s)
    --- PASS: TestKMSv2PluginHealthzTTL/kmsv2_provider_in_bad_state (0.00s)
--- PASS: TestKMSv2InvalidKeyID (0.00s)
    --- PASS: TestKMSv2InvalidKeyID/kmsv2_provider_returns_an_invalid_empty_keyID (0.00s)
    --- PASS: TestKMSv2InvalidKeyID/kmsv2_provider_returns_a_valid_keyID (0.00s)
    --- PASS: TestKMSv2InvalidKeyID/kmsv2_provider_returns_an_invalid_long_keyID (0.00s)
--- PASS: TestCBCKeyRotationWithOverlappingProviders (0.00s)
--- PASS: TestCBCKeyRotationWithoutOverlappingProviders (0.00s)
=== RUN   TestIsKMSv2ProviderHealthyError/healthz_status_is_not_ok
--- PASS: TestIsKMSv2ProviderHealthyError (0.01s)
    --- PASS: TestIsKMSv2ProviderHealthyError/healthz_status_is_not_ok (0.00s)
    --- PASS: TestIsKMSv2ProviderHealthyError/version_is_not_v2 (0.00s)
    --- PASS: TestIsKMSv2ProviderHealthyError/missing_keyID (0.00s)
    --- PASS: TestIsKMSv2ProviderHealthyError/invalid_long_keyID (0.00s)
--- PASS: TestKMSv2SameVersionFromStatus (0.00s)
    --- PASS: TestKMSv2SameVersionFromStatus/version_changed (0.00s)
    --- PASS: TestKMSv2SameVersionFromStatus/version_unchanged (0.00s)
--- PASS: TestComputeEncryptionConfigHash (0.00s)
--- PASS: Test_kmsv2PluginProbe_rotateDEKOnKeyIDChange (0.01s)
    --- PASS: Test_kmsv2PluginProbe_rotateDEKOnKeyIDChange/happy_path,_no_previous_state (0.00s)
    --- PASS: Test_kmsv2PluginProbe_rotateDEKOnKeyIDChange/happy_path,_with_previous_state (0.00s)
    --- PASS: Test_kmsv2PluginProbe_rotateDEKOnKeyIDChange/happy_path,_with_previous_state,_useSeed=true (0.00s)
    --- PASS: Test_kmsv2PluginProbe_rotateDEKOnKeyIDChange/happy_path,_with_previous_useSeed=true_state (0.00s)
    --- PASS: Test_kmsv2PluginProbe_rotateDEKOnKeyIDChange/happy_path,_with_previous_useSeed=true_state,_useSeed=true (0.00s)
    --- PASS: Test_kmsv2PluginProbe_rotateDEKOnKeyIDChange/happy_path,_with_previous_state,_useSeed=default (0.00s)
    --- PASS: Test_kmsv2PluginProbe_rotateDEKOnKeyIDChange/happy_path,_with_previous_useSeed=true_state,_useSeed=default (0.00s)
    --- PASS: Test_kmsv2PluginProbe_rotateDEKOnKeyIDChange/previous_state_expired_but_key_ID_matches (0.00s)
    --- PASS: Test_kmsv2PluginProbe_rotateDEKOnKeyIDChange/previous_state_expired_but_key_ID_does_not_match (0.00s)
    --- PASS: Test_kmsv2PluginProbe_rotateDEKOnKeyIDChange/service_down_but_key_ID_does_not_match (0.00s)
    --- PASS: Test_kmsv2PluginProbe_rotateDEKOnKeyIDChange/invalid_service_response,_no_previous_state (0.00s)
    --- PASS: Test_kmsv2PluginProbe_rotateDEKOnKeyIDChange/invalid_service_response,_with_previous_state (0.00s)
--- PASS: TestGetEncryptionConfigHash (0.00s)
    --- PASS: TestGetEncryptionConfigHash/empty_config_file_content (0.00s)
    --- PASS: TestGetEncryptionConfigHash/missing_file (0.00s)
    --- PASS: TestGetEncryptionConfigHash/valid_file (0.00s)
ok      k8s.io/apiserver/pkg/server/options/encryptionconfig    45.441s
```
</details>

<details>
<summary>After change</summary>

```
--- PASS: TestLegacyConfig (0.00s)
--- PASS: TestEncryptionProviderConfigCorrect (0.00s)
--- PASS: TestKMSv1Deprecation (0.00s)
    --- PASS: TestKMSv1Deprecation/config_with_kmsv1,_KMSv1=false (0.00s)
    --- PASS: TestKMSv1Deprecation/config_with_kmsv1,_KMSv1=true (0.00s)
--- PASS: TestKMSvsEnablement (0.31s)
    --- PASS: TestKMSvsEnablement/config_with_kmsv2_and_kmsv1,_KMSv2=true,_KMSv1=false,_should_fail_when_feature_is_disabled (0.10s)
    --- PASS: TestKMSvsEnablement/config_with_kmsv2,_KMSv2=true,_KMSv1=false (0.20s)
    --- PASS: TestKMSvsEnablement/with_kmsv1_and_kmsv2,_KMSv2=true (0.00s)
--- PASS: TestKMSMaxTimeout (0.00s)
    --- PASS: TestKMSMaxTimeout/config_with_bad_provider (0.00s)
    --- PASS: TestKMSMaxTimeout/default_timeout (0.00s)
    --- PASS: TestKMSMaxTimeout/with_v1_provider (0.00s)
    --- PASS: TestKMSMaxTimeout/with_v2_provider (0.00s)
    --- PASS: TestKMSMaxTimeout/with_v1_and_v2_provider (0.00s)
--- PASS: TestKMSPluginHealthz (0.00s)
    --- PASS: TestKMSPluginHealthz/Invalid_config_file_path (0.00s)
    --- PASS: TestKMSPluginHealthz/Empty_config_file_content (0.00s)
    --- PASS: TestKMSPluginHealthz/Unable_to_decode (0.00s)
    --- PASS: TestKMSPluginHealthz/Unexpected_config_type (0.00s)
    --- PASS: TestKMSPluginHealthz/Install_Healthz (0.00s)
    --- PASS: TestKMSPluginHealthz/Install_multiple_healthz (0.00s)
    --- PASS: TestKMSPluginHealthz/No_KMS_Providers (0.00s)
    --- PASS: TestKMSPluginHealthz/Install_multiple_healthz_with_v1_and_v2 (0.00s)
    --- PASS: TestKMSPluginHealthz/Invalid_API_version (0.00s)
--- PASS: TestWildcardMasking (0.00s)
    --- PASS: TestWildcardMasking/resources_masked_by_*._group (0.00s)
    --- PASS: TestWildcardMasking/*._masked_by_*._group (0.00s)
    --- PASS: TestWildcardMasking/*.foo_masked_by_*.foo (0.00s)
    --- PASS: TestWildcardMasking/*.*_masked_by_*.* (0.00s)
    --- PASS: TestWildcardMasking/resources_masked_by_*._group_in_multiple_configurations (0.00s)
    --- PASS: TestWildcardMasking/resources_masked_by_*.* (0.00s)
    --- PASS: TestWildcardMasking/resources_masked_by_*.*_in_multiple_configurations (0.00s)
    --- PASS: TestWildcardMasking/resources_*._masked_by_*.* (0.00s)
    --- PASS: TestWildcardMasking/resources_*._masked_by_*.*_in_multiple_configurations (0.00s)
    --- PASS: TestWildcardMasking/resources_not_masked_by_any_rule (0.00s)
    --- PASS: TestWildcardMasking/resources_not_masked_by_any_rule_in_multiple_configurations (0.00s)
--- PASS: TestWildcardStructure (0.00s)
    --- PASS: TestWildcardStructure/should_not_result_in_error (0.00s)
    --- PASS: TestWildcardStructure/should_result_in_error (0.00s)
--- PASS: TestKMSPluginHealthzTTL (0.00s)
    --- PASS: TestKMSPluginHealthzTTL/kms_provider_in_good_state (0.00s)
    --- PASS: TestKMSPluginHealthzTTL/kms_provider_in_bad_state (0.00s)
--- PASS: TestKMSv2PluginHealthzTTL (0.00s)
    --- PASS: TestKMSv2PluginHealthzTTL/kmsv2_provider_in_good_state (0.00s)
    --- PASS: TestKMSv2PluginHealthzTTL/kmsv2_provider_in_bad_state (0.00s)
--- PASS: TestKMSv2InvalidKeyID (0.00s)
    --- PASS: TestKMSv2InvalidKeyID/kmsv2_provider_returns_an_invalid_empty_keyID (0.00s)
    --- PASS: TestKMSv2InvalidKeyID/kmsv2_provider_returns_a_valid_keyID (0.00s)
    --- PASS: TestKMSv2InvalidKeyID/kmsv2_provider_returns_an_invalid_long_keyID (0.00s)
--- PASS: TestCBCKeyRotationWithOverlappingProviders (0.00s)
--- PASS: TestCBCKeyRotationWithoutOverlappingProviders (0.00s)
=== RUN   TestIsKMSv2ProviderHealthyError/healthz_status_is_not_ok
--- PASS: TestIsKMSv2ProviderHealthyError (0.00s)
    --- PASS: TestIsKMSv2ProviderHealthyError/healthz_status_is_not_ok (0.00s)
    --- PASS: TestIsKMSv2ProviderHealthyError/version_is_not_v2 (0.00s)
    --- PASS: TestIsKMSv2ProviderHealthyError/missing_keyID (0.00s)
    --- PASS: TestIsKMSv2ProviderHealthyError/invalid_long_keyID (0.00s)
--- PASS: TestKMSv2SameVersionFromStatus (0.00s)
    --- PASS: TestKMSv2SameVersionFromStatus/version_changed (0.00s)
    --- PASS: TestKMSv2SameVersionFromStatus/version_unchanged (0.00s)
--- PASS: TestComputeEncryptionConfigHash (0.00s)
--- PASS: Test_kmsv2PluginProbe_rotateDEKOnKeyIDChange (0.01s)
    --- PASS: Test_kmsv2PluginProbe_rotateDEKOnKeyIDChange/happy_path,_no_previous_state (0.00s)
    --- PASS: Test_kmsv2PluginProbe_rotateDEKOnKeyIDChange/happy_path,_with_previous_state (0.00s)
    --- PASS: Test_kmsv2PluginProbe_rotateDEKOnKeyIDChange/happy_path,_with_previous_state,_useSeed=true (0.00s)
    --- PASS: Test_kmsv2PluginProbe_rotateDEKOnKeyIDChange/happy_path,_with_previous_useSeed=true_state (0.00s)
    --- PASS: Test_kmsv2PluginProbe_rotateDEKOnKeyIDChange/happy_path,_with_previous_useSeed=true_state,_useSeed=true (0.00s)
    --- PASS: Test_kmsv2PluginProbe_rotateDEKOnKeyIDChange/happy_path,_with_previous_state,_useSeed=default (0.00s)
    --- PASS: Test_kmsv2PluginProbe_rotateDEKOnKeyIDChange/happy_path,_with_previous_useSeed=true_state,_useSeed=default (0.00s)
    --- PASS: Test_kmsv2PluginProbe_rotateDEKOnKeyIDChange/previous_state_expired_but_key_ID_matches (0.00s)
    --- PASS: Test_kmsv2PluginProbe_rotateDEKOnKeyIDChange/previous_state_expired_but_key_ID_does_not_match (0.00s)
    --- PASS: Test_kmsv2PluginProbe_rotateDEKOnKeyIDChange/service_down_but_key_ID_does_not_match (0.00s)
    --- PASS: Test_kmsv2PluginProbe_rotateDEKOnKeyIDChange/invalid_service_response,_no_previous_state (0.00s)
    --- PASS: Test_kmsv2PluginProbe_rotateDEKOnKeyIDChange/invalid_service_response,_with_previous_state (0.00s)
--- PASS: TestGetEncryptionConfigHash (0.00s)
    --- PASS: TestGetEncryptionConfigHash/empty_config_file_content (0.00s)
    --- PASS: TestGetEncryptionConfigHash/missing_file (0.00s)
    --- PASS: TestGetEncryptionConfigHash/valid_file (0.00s)
ok      k8s.io/apiserver/pkg/server/options/encryptionconfig    0.758s
```
</details>

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
