### PR TITLE
add coverage tests for probes behavior

### DIFF
--- a/test/e2e_node/container_lifecycle_pod_construction.go
+++ b/test/e2e_node/container_lifecycle_pod_construction.go
@@ -125,10 +125,10 @@ func (o containerOutputList) String() string {
 // RunTogether returns an error the lhs and rhs run together
 func (o containerOutputList) RunTogether(lhs, rhs string) error {
 	lhsStart := o.findIndex(lhs, "Started", 0)
-	rhsStart := o.findIndex(rhs, "Started", 0)
+	rhsStart := o.findIndex(rhs, "Started", lhsStart+1)
 
-	lhsFinish := o.findIndex(lhs, "Finishing", 0)
-	rhsFinish := o.findIndex(rhs, "Finishing", 0)
+	lhsFinish := o.findIndex(lhs, "Exiting", lhsStart+1)
+	rhsFinish := o.findIndex(rhs, "Exiting", rhsStart+1)
 
 	if lhsStart == -1 {
 		return fmt.Errorf("couldn't find that %s ever started, got\n%v", lhs, o)

--- a/test/e2e_node/container_lifecycle_test.go
+++ b/test/e2e_node/container_lifecycle_test.go
@@ -32,11 +32,15 @@ import (
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	"k8s.io/kubernetes/test/e2e/nodefeature"
 	imageutils "k8s.io/kubernetes/test/utils/image"
+	"k8s.io/utils/ptr"
 )
 
 const (
+	LivenessPrefix  = "Liveness"
 	PostStartPrefix = "PostStart"
 	PreStopPrefix   = "PreStop"
+	ReadinessPrefix = "Readiness"
+	StartupPrefix   = "Startup"
 )
 
 var containerRestartPolicyAlways = v1.ContainerRestartPolicyAlways
@@ -745,6 +749,161 @@ var _ = SIGDescribe(framework.WithNodeConformance(), "Containers Lifecycle", fun
 		framework.ExpectNoError(results.RunTogether(regular1, prefixedName(PreStopPrefix, regular1)))
 		framework.ExpectNoError(results.Starts(prefixedName(PreStopPrefix, regular1)))
 		framework.ExpectNoError(results.Exits(regular1))
+	})
+
+	ginkgo.When("a pod is terminating because its liveness probe fails", func() {
+		regular1 := "regular-1"
+
+		testPod := func() *v1.Pod {
+			return &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-pod",
+				},
+				Spec: v1.PodSpec{
+					RestartPolicy:                 v1.RestartPolicyNever,
+					TerminationGracePeriodSeconds: ptr.To(int64(100)),
+					Containers: []v1.Container{
+						{
+							Name:  regular1,
+							Image: imageutils.GetE2EImage(imageutils.BusyBox),
+							Command: ExecCommand(regular1, execCommand{
+								Delay:              100,
+								TerminationSeconds: 15,
+								ExitCode:           0,
+							}),
+							LivenessProbe: &v1.Probe{
+								ProbeHandler: v1.ProbeHandler{
+									Exec: &v1.ExecAction{
+										Command: ExecCommand(prefixedName(LivenessPrefix, regular1), execCommand{
+											ExitCode:      1,
+											ContainerName: regular1,
+										}),
+									},
+								},
+								InitialDelaySeconds: 10,
+								PeriodSeconds:       1,
+								FailureThreshold:    1,
+							},
+						},
+					},
+				},
+			}
+		}
+
+		f.It("should execute readiness probe while in preStop, but not liveness", f.WithNodeConformance(), func() {
+			client := e2epod.NewPodClient(f)
+			podSpec := testPod()
+
+			ginkgo.By("creating a pod with a readiness probe and a preStop hook")
+			podSpec.Spec.Containers[0].Lifecycle = &v1.Lifecycle{
+				PreStop: &v1.LifecycleHandler{
+					Exec: &v1.ExecAction{
+						Command: ExecCommand(prefixedName(PreStopPrefix, regular1), execCommand{
+							Delay:         1,
+							ExitCode:      0,
+							ContainerName: regular1,
+						}),
+					},
+				},
+			}
+			podSpec.Spec.Containers[0].ReadinessProbe = &v1.Probe{
+				ProbeHandler: v1.ProbeHandler{
+					Exec: &v1.ExecAction{
+						Command: ExecCommand(prefixedName(ReadinessPrefix, regular1), execCommand{
+							ExitCode:      0,
+							ContainerName: regular1,
+						}),
+					},
+				},
+				InitialDelaySeconds: 1,
+				PeriodSeconds:       1,
+			}
+
+			preparePod(podSpec)
+
+			podSpec = client.Create(context.TODO(), podSpec)
+
+			ginkgo.By("Waiting for the pod to complete")
+			err := e2epod.WaitForPodNoLongerRunningInNamespace(context.TODO(), f.ClientSet, podSpec.Name, podSpec.Namespace)
+			framework.ExpectNoError(err)
+
+			ginkgo.By("Parsing results")
+			podSpec, err = client.Get(context.TODO(), podSpec.Name, metav1.GetOptions{})
+			framework.ExpectNoError(err)
+			results := parseOutput(context.TODO(), f, podSpec)
+
+			ginkgo.By("Analyzing results")
+			// readiness probes are called during pod termination
+			framework.ExpectNoError(results.RunTogether(prefixedName(PreStopPrefix, regular1), prefixedName(ReadinessPrefix, regular1)))
+			// liveness probes are not called during pod termination
+			err = results.RunTogether(prefixedName(PreStopPrefix, regular1), prefixedName(LivenessPrefix, regular1))
+			gomega.Expect(err).To(gomega.HaveOccurred())
+		})
+
+		f.It("should continue running liveness probes for restartable init containers and restart them while in preStop", f.WithNodeConformance(), func() {
+			client := e2epod.NewPodClient(f)
+			podSpec := testPod()
+			restartableInit1 := "restartable-init-1"
+
+			ginkgo.By("creating a pod with a restartable init container and a preStop hook")
+			podSpec.Spec.InitContainers = []v1.Container{{
+				RestartPolicy: &containerRestartPolicyAlways,
+				Name:          restartableInit1,
+				Image:         imageutils.GetE2EImage(imageutils.BusyBox),
+				Command: ExecCommand(restartableInit1, execCommand{
+					Delay:              100,
+					TerminationSeconds: 1,
+					ExitCode:           0,
+				}),
+				LivenessProbe: &v1.Probe{
+					ProbeHandler: v1.ProbeHandler{
+						Exec: &v1.ExecAction{
+							Command: ExecCommand(prefixedName(LivenessPrefix, restartableInit1), execCommand{
+								ExitCode:      1,
+								ContainerName: restartableInit1,
+							}),
+						},
+					},
+					InitialDelaySeconds: 1,
+					PeriodSeconds:       1,
+					FailureThreshold:    1,
+				},
+			}}
+			podSpec.Spec.Containers[0].Lifecycle = &v1.Lifecycle{
+				PreStop: &v1.LifecycleHandler{
+					Exec: &v1.ExecAction{
+						Command: ExecCommand(prefixedName(PreStopPrefix, regular1), execCommand{
+							Delay:         40,
+							ExitCode:      0,
+							ContainerName: regular1,
+						}),
+					},
+				},
+			}
+
+			preparePod(podSpec)
+
+			podSpec = client.Create(context.TODO(), podSpec)
+
+			ginkgo.By("Waiting for the pod to complete")
+			err := e2epod.WaitForPodNoLongerRunningInNamespace(context.TODO(), f.ClientSet, podSpec.Name, podSpec.Namespace)
+			framework.ExpectNoError(err)
+
+			ginkgo.By("Parsing results")
+			podSpec, err = client.Get(context.TODO(), podSpec.Name, metav1.GetOptions{})
+			framework.ExpectNoError(err)
+			results := parseOutput(context.TODO(), f, podSpec)
+
+			ginkgo.By("Analyzing results")
+			// FIXME ExpectNoError: this will be implemented in KEP 4438
+			// liveness probes are called for restartable init containers during pod termination
+			err = results.RunTogether(prefixedName(PreStopPrefix, regular1), prefixedName(LivenessPrefix, restartableInit1))
+			gomega.Expect(err).To(gomega.HaveOccurred())
+			// FIXME ExpectNoError: this will be implemented in KEP 4438
+			// restartable init containers are restarted during pod termination
+			err = results.RunTogether(prefixedName(PreStopPrefix, regular1), restartableInit1)
+			gomega.Expect(err).To(gomega.HaveOccurred())
+		})
 	})
 })
 


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Add test coverage on probes before refactoring.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
