### PR TITLE
apiserver: decrease timeout for TestKMSHealthzEndpoint

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/options/testdata/encryption-configs/multiple-kms-providers-with-v2.yaml
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/testdata/encryption-configs/multiple-kms-providers-with-v2.yaml
@@ -8,11 +8,14 @@ resources:
           name: kms-provider-1
           cachesize: 1000
           endpoint: unix:///@provider1.sock
+          timeout: 100ms
       - kms:
           name: kms-provider-2
           cachesize: 1000
           endpoint: unix:///@provider2.sock
+          timeout: 100ms
       - kms:
           apiVersion: v2
           name: kms-provider-3
           endpoint: unix:///@provider2.sock
+          timeout: 100ms

--- a/staging/src/k8s.io/apiserver/pkg/server/options/testdata/encryption-configs/multiple-kms-v2-providers.yaml
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/testdata/encryption-configs/multiple-kms-v2-providers.yaml
@@ -8,11 +8,14 @@ resources:
           apiVersion: v2
           name: kms-provider-1
           endpoint: unix:///@provider1.sock
+          timeout: 100ms
       - kms:
           apiVersion: v2
           name: kms-provider-2
           endpoint: unix:///@provider2.sock
+          timeout: 100ms
       - kms:
           apiVersion: v2
           name: kms-provider-3
           endpoint: unix:///@provider2.sock
+          timeout: 100ms


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
The `TestKMSHealthzEndpoint` takes over 20 seconds to pass right now.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes part of #123685

#### Special notes for your reviewer:
The test only counts the number of healthz probes, and does not check whether they were successful. Changing timeout to lower values allows tests to pass faster.

<details>
<summary>Before change</summary>

```
--- PASS: TestEnabledPluginNames (0.00s)
    --- PASS: TestEnabledPluginNames/scenario_0 (0.00s)
    --- PASS: TestEnabledPluginNames/scenario_1 (0.00s)
    --- PASS: TestEnabledPluginNames/scenario_2 (0.00s)
    --- PASS: TestEnabledPluginNames/scenario_3 (0.00s)
    --- PASS: TestEnabledPluginNames/scenario_4 (0.00s)
    --- PASS: TestEnabledPluginNames/scenario_5 (0.00s)
    --- PASS: TestEnabledPluginNames/scenario_6 (0.00s)
    --- PASS: TestEnabledPluginNames/scenario_7 (0.00s)
--- PASS: TestValidate (0.00s)
    --- PASS: TestValidate/scenario_0 (0.00s)
    --- PASS: TestValidate/scenario_1 (0.00s)
    --- PASS: TestValidate/scenario_2 (0.00s)
    --- PASS: TestValidate/scenario_3 (0.00s)
    --- PASS: TestValidate/scenario_4 (0.00s)
    --- PASS: TestValidate/scenario_5 (0.00s)
    --- PASS: TestValidate/scenario_6 (0.00s)
    --- PASS: TestValidate/scenario_7 (0.00s)
    --- PASS: TestValidate/scenario_8 (0.00s)
    --- PASS: TestValidate/scenario_9 (0.00s)
    --- PASS: TestValidate/scenario_10 (0.00s)
--- PASS: TestAPIEnablementOptionsValidate (0.00s)
    --- PASS: TestAPIEnablementOptionsValidate/test_when_options_is_nil (0.00s)
    --- PASS: TestAPIEnablementOptionsValidate/test_when_invalid_key_with_only_api/all=false (0.00s)
    --- PASS: TestAPIEnablementOptionsValidate/test_when_ConfigurationMap_key_is_invalid (0.00s)
    --- PASS: TestAPIEnablementOptionsValidate/test_when_unknown_api_groups (0.00s)
    --- PASS: TestAPIEnablementOptionsValidate/test_when_valid_api_groups (0.00s)
=== RUN   TestAuditValidOptions/default_webhook
=== RUN   TestAuditValidOptions/default_webhook_no_policy
=== RUN   TestAuditValidOptions/strict_webhook
=== RUN   TestAuditValidOptions/default_webhook_with_truncating
--- PASS: TestAuditValidOptions (0.00s)
    --- PASS: TestAuditValidOptions/default (0.00s)
    --- PASS: TestAuditValidOptions/default_log (0.00s)
    --- PASS: TestAuditValidOptions/stdout_log (0.00s)
    --- PASS: TestAuditValidOptions/create_audit_log_path_dir (0.00s)
    --- PASS: TestAuditValidOptions/default_log_no_policy (0.00s)
    --- PASS: TestAuditValidOptions/default_webhook (0.00s)
    --- PASS: TestAuditValidOptions/default_webhook_no_policy (0.00s)
    --- PASS: TestAuditValidOptions/strict_webhook (0.00s)
    --- PASS: TestAuditValidOptions/default_union (0.00s)
    --- PASS: TestAuditValidOptions/custom (0.00s)
    --- PASS: TestAuditValidOptions/default_webhook_with_truncating (0.00s)
=== RUN   TestAuditInvalidOptions/invalid_webhook_mode
=== RUN   TestAuditInvalidOptions/invalid_webhook_buffer_throttle_qps
=== RUN   TestAuditInvalidOptions/invalid_webhook_truncate_max_event_size
=== RUN   TestAuditInvalidOptions/invalid_webhook_truncate_max_batch_size
--- PASS: TestAuditInvalidOptions (0.00s)
    --- PASS: TestAuditInvalidOptions/invalid_log_format (0.00s)
    --- PASS: TestAuditInvalidOptions/invalid_log_mode (0.00s)
    --- PASS: TestAuditInvalidOptions/invalid_log_buffer_size (0.00s)
    --- PASS: TestAuditInvalidOptions/invalid_webhook_mode (0.00s)
    --- PASS: TestAuditInvalidOptions/invalid_webhook_buffer_throttle_qps (0.00s)
    --- PASS: TestAuditInvalidOptions/invalid_webhook_truncate_max_event_size (0.00s)
    --- PASS: TestAuditInvalidOptions/invalid_webhook_truncate_max_batch_size (0.00s)
--- PASS: TestToAuthenticationRequestHeaderConfig (0.00s)
    --- PASS: TestToAuthenticationRequestHeaderConfig/test_when_ClientCAFile_is_nil (0.00s)
    --- PASS: TestToAuthenticationRequestHeaderConfig/test_when_ClientCAFile_is_not_nil (0.00s)
--- PASS: TestApplyToFallback (0.01s)
    --- PASS: TestApplyToFallback/empty (0.00s)
    --- PASS: TestApplyToFallback/default (0.00s)
    --- PASS: TestApplyToFallback/optional_kubeconfig (0.00s)
    --- PASS: TestApplyToFallback/valid_client,_failed_cluster_info_lookup (0.00s)
    --- PASS: TestApplyToFallback/valid_client,_skip_cluster_info_lookup (0.00s)
    --- PASS: TestApplyToFallback/valid_client,_tolerate_failed_cluster_info_lookup (0.00s)
--- PASS: TestEtcdOptionsValidate (0.00s)
    --- PASS: TestEtcdOptionsValidate/test_when_ServerList_is_not_specified (0.00s)
    --- PASS: TestEtcdOptionsValidate/test_when_storage-backend_is_invalid (0.00s)
    --- PASS: TestEtcdOptionsValidate/test_when_etcd-servers-overrides_is_invalid (0.00s)
    --- PASS: TestEtcdOptionsValidate/test_when_encryption-provider-config-automatic-reload_is_invalid (0.00s)
    --- PASS: TestEtcdOptionsValidate/test_when_EtcdOptions_is_valid (0.00s)
    --- PASS: TestEtcdOptionsValidate/empty_storage-media-type (0.00s)
    --- PASS: TestEtcdOptionsValidate/recognized_storage-media-type (0.00s)
    --- PASS: TestEtcdOptionsValidate/unrecognized_storage-media-type (0.00s)
--- PASS: TestParseWatchCacheSizes (0.00s)
    --- PASS: TestParseWatchCacheSizes/test_when_invalid_value_of_watch_cache_size (0.00s)
    --- PASS: TestParseWatchCacheSizes/test_when_invalid_size_of_watch_cache_size (0.00s)
    --- PASS: TestParseWatchCacheSizes/test_when_watch_cache_size_is_negative (0.00s)
    --- PASS: TestParseWatchCacheSizes/test_when_parse_watch_cache_size_success (0.00s)
--- PASS: TestKMSHealthzEndpoint (24.06s)
    --- PASS: TestKMSHealthzEndpoint/no_kms-provider,_expect_no_kms_healthz_check,_no_kms_livez_check (0.00s)
    --- PASS: TestKMSHealthzEndpoint/no_kms-provider+reload,_expect_single_kms_healthz_check,_no_kms_livez_check (0.00s)
    --- PASS: TestKMSHealthzEndpoint/single_kms-provider,_expect_single_kms_healthz_check,_no_kms_livez_check (0.00s)
    --- PASS: TestKMSHealthzEndpoint/two_kms-providers,_expect_two_kms_healthz_checks,_no_kms_livez_check (0.00s)
    --- PASS: TestKMSHealthzEndpoint/two_kms-providers+reload,_expect_single_kms_healthz_check,_no_kms_livez_check (0.00s)
    --- PASS: TestKMSHealthzEndpoint/kms_v1+v2,_expect_three_kms_healthz_checks,_no_kms_livez_check (3.00s)
    --- PASS: TestKMSHealthzEndpoint/kms_v1+v2+reload,_expect_single_kms_healthz_check,_no_kms_livez_check (3.00s)
    --- PASS: TestKMSHealthzEndpoint/multiple_kms_v2,_expect_single_kms_healthz_check,_no_kms_livez_check (9.00s)
    --- PASS: TestKMSHealthzEndpoint/multiple_kms_v2+reload,_expect_single_kms_healthz_check,_no_kms_livez_check (9.00s)
    --- PASS: TestKMSHealthzEndpoint/two_kms-providers_with_skip,_expect_zero_kms_healthz_checks,_no_kms_livez_check (0.00s)
--- PASS: TestReadinessCheck (0.00s)
    --- PASS: TestReadinessCheck/Readyz_should_have_etcd-readiness_check (0.00s)
    --- PASS: TestReadinessCheck/skip_health,_Readyz_should_not_have_etcd-readiness_check (0.00s)
--- PASS: TestServerRunOptionsValidate (0.00s)
    --- PASS: TestServerRunOptionsValidate/Test_when_MaxRequestsInFlight_is_negative_value (0.00s)
    --- PASS: TestServerRunOptionsValidate/Test_when_MaxMutatingRequestsInFlight_is_negative_value (0.00s)
    --- PASS: TestServerRunOptionsValidate/Test_when_RequestTimeout_is_negative_value (0.00s)
    --- PASS: TestServerRunOptionsValidate/Test_when_MinRequestTimeout_is_negative_value (0.00s)
    --- PASS: TestServerRunOptionsValidate/Test_when_JSONPatchMaxCopyBytes_is_negative_value (0.00s)
    --- PASS: TestServerRunOptionsValidate/Test_when_MaxRequestBodyBytes_is_negative_value (0.00s)
    --- PASS: TestServerRunOptionsValidate/Test_when_LivezGracePeriod_is_negative_value (0.00s)
    --- PASS: TestServerRunOptionsValidate/Test_when_MinimalShutdownDuration_is_negative_value (0.00s)
    --- PASS: TestServerRunOptionsValidate/Test_when_HSTSHeaders_is_valid (0.00s)
    --- PASS: TestServerRunOptionsValidate/Test_when_ServerRunOptions_is_valid (0.00s)
--- PASS: TestValidateCorsAllowedOriginList (0.00s)
    --- PASS: TestValidateCorsAllowedOriginList/regexp/[] (0.00s)
    --- PASS: TestValidateCorsAllowedOriginList/regexp/[^http://foo.com$] (0.00s)
    --- PASS: TestValidateCorsAllowedOriginList/regexp/[^http://foo.com] (0.00s)
    --- PASS: TestValidateCorsAllowedOriginList/regexp/[://foo.com$] (0.00s)
    --- PASS: TestValidateCorsAllowedOriginList/regexp/[//foo.com$] (0.00s)
    --- PASS: TestValidateCorsAllowedOriginList/regexp/[^http://foo.com(:|$)] (0.00s)
    --- PASS: TestValidateCorsAllowedOriginList/regexp/[://foo.com(:|$)] (0.00s)
    --- PASS: TestValidateCorsAllowedOriginList/regexp/[//foo.com(:|$)] (0.00s)
    --- PASS: TestValidateCorsAllowedOriginList/regexp/[(^foo.com$)] (0.00s)
    --- PASS: TestValidateCorsAllowedOriginList/regexp/[^http://foo.com$_//bar.com(:|$)] (0.00s)
    --- PASS: TestValidateCorsAllowedOriginList/regexp/[^http://foo.com$_] (0.00s)
    --- PASS: TestValidateCorsAllowedOriginList/regexp/[^foo.com] (0.00s)
    --- PASS: TestValidateCorsAllowedOriginList/regexp/[//foo.com] (0.00s)
    --- PASS: TestValidateCorsAllowedOriginList/regexp/[foo.com$] (0.00s)
    --- PASS: TestValidateCorsAllowedOriginList/regexp/[foo.com(:|$)] (0.00s)
    --- PASS: TestValidateCorsAllowedOriginList/regexp/[^http://foo.com$_^foo.com] (0.00s)
--- PASS: TestServerRunOptionsWithShutdownWatchTerminationGracePeriod (0.00s)
    --- PASS: TestServerRunOptionsWithShutdownWatchTerminationGracePeriod/default_should_be_valid (0.00s)
    --- PASS: TestServerRunOptionsWithShutdownWatchTerminationGracePeriod/negative_not_allowed (0.00s)
    --- PASS: TestServerRunOptionsWithShutdownWatchTerminationGracePeriod/default_should_be_zero (0.00s)
--- PASS: TestServerRunWithSNI (0.00s)
    --- PASS: TestServerRunWithSNI/matching_SNI_cert (0.26s)
    --- PASS: TestServerRunWithSNI/wildcards (0.30s)
    --- PASS: TestServerRunWithSNI/one_SNI_and_the_default_cert_with_the_same_name (0.34s)
    --- PASS: TestServerRunWithSNI/matching_IP_in_SNI_cert_and_the_server_cert (0.34s)
    --- PASS: TestServerRunWithSNI/loopback:_LoopbackClientServerNameOverride_on_SNI_cert (0.34s)
    --- PASS: TestServerRunWithSNI/loopback:_bind_to_0.0.0.0_=>_loopback_uses_localhost (0.39s)
    --- PASS: TestServerRunWithSNI/only_one_cert (0.10s)
    --- PASS: TestServerRunWithSNI/loopback:_LoopbackClientServerNameOverride_not_on_any_cert (0.44s)
    --- PASS: TestServerRunWithSNI/loopback:_LoopbackClientServerNameOverride_on_server_cert (0.47s)
    --- PASS: TestServerRunWithSNI/cert_with_multiple_alternate_names (0.25s)
--- PASS: TestCreateListenerSharePort (0.00s)
--- PASS: TestCreateListenerPreventUpgrades (0.00s)
--- PASS: TestEmptyMainCert (0.26s)
--- PASS: TestValidateTracingOptions (0.00s)
    --- PASS: TestValidateTracingOptions/nil-valid (0.00s)
    --- PASS: TestValidateTracingOptions/empty-valid (0.00s)
    --- PASS: TestValidateTracingOptions/path-valid (0.00s)
    --- PASS: TestValidateTracingOptions/path-invalid (0.00s)
--- PASS: TestReadTracingConfiguration (0.00s)
    --- PASS: TestReadTracingConfiguration/empty (0.00s)
    --- PASS: TestReadTracingConfiguration/absent (0.00s)
    --- PASS: TestReadTracingConfiguration/v1alpha1 (0.00s)
    --- PASS: TestReadTracingConfiguration/ip_address (0.00s)
    --- PASS: TestReadTracingConfiguration/wrong_type (0.00s)
ok      k8s.io/apiserver/pkg/server/options     25.390s
```
</details>

<details>
<summary>After change</summary>

```
--- PASS: TestEnabledPluginNames (0.00s)
    --- PASS: TestEnabledPluginNames/scenario_0 (0.00s)
    --- PASS: TestEnabledPluginNames/scenario_1 (0.00s)
    --- PASS: TestEnabledPluginNames/scenario_2 (0.00s)
    --- PASS: TestEnabledPluginNames/scenario_3 (0.00s)
    --- PASS: TestEnabledPluginNames/scenario_4 (0.00s)
    --- PASS: TestEnabledPluginNames/scenario_5 (0.00s)
    --- PASS: TestEnabledPluginNames/scenario_6 (0.00s)
    --- PASS: TestEnabledPluginNames/scenario_7 (0.00s)
--- PASS: TestValidate (0.00s)
    --- PASS: TestValidate/scenario_0 (0.00s)
    --- PASS: TestValidate/scenario_1 (0.00s)
    --- PASS: TestValidate/scenario_2 (0.00s)
    --- PASS: TestValidate/scenario_3 (0.00s)
    --- PASS: TestValidate/scenario_4 (0.00s)
    --- PASS: TestValidate/scenario_5 (0.00s)
    --- PASS: TestValidate/scenario_6 (0.00s)
    --- PASS: TestValidate/scenario_7 (0.00s)
    --- PASS: TestValidate/scenario_8 (0.00s)
    --- PASS: TestValidate/scenario_9 (0.00s)
    --- PASS: TestValidate/scenario_10 (0.00s)
--- PASS: TestAPIEnablementOptionsValidate (0.00s)
    --- PASS: TestAPIEnablementOptionsValidate/test_when_options_is_nil (0.00s)
    --- PASS: TestAPIEnablementOptionsValidate/test_when_invalid_key_with_only_api/all=false (0.00s)
    --- PASS: TestAPIEnablementOptionsValidate/test_when_ConfigurationMap_key_is_invalid (0.00s)
    --- PASS: TestAPIEnablementOptionsValidate/test_when_unknown_api_groups (0.00s)
    --- PASS: TestAPIEnablementOptionsValidate/test_when_valid_api_groups (0.00s)
=== RUN   TestAuditValidOptions/default_webhook
=== RUN   TestAuditValidOptions/default_webhook_no_policy
=== RUN   TestAuditValidOptions/strict_webhook
=== RUN   TestAuditValidOptions/default_webhook_with_truncating
--- PASS: TestAuditValidOptions (0.00s)
    --- PASS: TestAuditValidOptions/default (0.00s)
    --- PASS: TestAuditValidOptions/default_log (0.00s)
    --- PASS: TestAuditValidOptions/stdout_log (0.00s)
    --- PASS: TestAuditValidOptions/create_audit_log_path_dir (0.00s)
    --- PASS: TestAuditValidOptions/default_log_no_policy (0.00s)
    --- PASS: TestAuditValidOptions/default_webhook (0.00s)
    --- PASS: TestAuditValidOptions/default_webhook_no_policy (0.00s)
    --- PASS: TestAuditValidOptions/strict_webhook (0.00s)
    --- PASS: TestAuditValidOptions/default_union (0.00s)
    --- PASS: TestAuditValidOptions/custom (0.00s)
    --- PASS: TestAuditValidOptions/default_webhook_with_truncating (0.00s)
=== RUN   TestAuditInvalidOptions/invalid_webhook_mode
=== RUN   TestAuditInvalidOptions/invalid_webhook_buffer_throttle_qps
=== RUN   TestAuditInvalidOptions/invalid_webhook_truncate_max_event_size
=== RUN   TestAuditInvalidOptions/invalid_webhook_truncate_max_batch_size
--- PASS: TestAuditInvalidOptions (0.00s)
    --- PASS: TestAuditInvalidOptions/invalid_log_format (0.00s)
    --- PASS: TestAuditInvalidOptions/invalid_log_mode (0.00s)
    --- PASS: TestAuditInvalidOptions/invalid_log_buffer_size (0.00s)
    --- PASS: TestAuditInvalidOptions/invalid_webhook_mode (0.00s)
    --- PASS: TestAuditInvalidOptions/invalid_webhook_buffer_throttle_qps (0.00s)
    --- PASS: TestAuditInvalidOptions/invalid_webhook_truncate_max_event_size (0.00s)
    --- PASS: TestAuditInvalidOptions/invalid_webhook_truncate_max_batch_size (0.00s)
--- PASS: TestToAuthenticationRequestHeaderConfig (0.00s)
    --- PASS: TestToAuthenticationRequestHeaderConfig/test_when_ClientCAFile_is_nil (0.00s)
    --- PASS: TestToAuthenticationRequestHeaderConfig/test_when_ClientCAFile_is_not_nil (0.00s)
=== RUN   TestApplyToFallback/valid_client,_failed_cluster_info_lookup
=== RUN   TestApplyToFallback/valid_client,_skip_cluster_info_lookup
=== RUN   TestApplyToFallback/valid_client,_tolerate_failed_cluster_info_lookup
--- PASS: TestApplyToFallback (0.01s)
    --- PASS: TestApplyToFallback/empty (0.00s)
    --- PASS: TestApplyToFallback/default (0.00s)
    --- PASS: TestApplyToFallback/optional_kubeconfig (0.00s)
    --- PASS: TestApplyToFallback/valid_client,_failed_cluster_info_lookup (0.00s)
    --- PASS: TestApplyToFallback/valid_client,_skip_cluster_info_lookup (0.00s)
    --- PASS: TestApplyToFallback/valid_client,_tolerate_failed_cluster_info_lookup (0.00s)
--- PASS: TestEtcdOptionsValidate (0.00s)
    --- PASS: TestEtcdOptionsValidate/test_when_ServerList_is_not_specified (0.00s)
    --- PASS: TestEtcdOptionsValidate/test_when_storage-backend_is_invalid (0.00s)
    --- PASS: TestEtcdOptionsValidate/test_when_etcd-servers-overrides_is_invalid (0.00s)
    --- PASS: TestEtcdOptionsValidate/test_when_encryption-provider-config-automatic-reload_is_invalid (0.00s)
    --- PASS: TestEtcdOptionsValidate/test_when_EtcdOptions_is_valid (0.00s)
    --- PASS: TestEtcdOptionsValidate/empty_storage-media-type (0.00s)
    --- PASS: TestEtcdOptionsValidate/recognized_storage-media-type (0.00s)
    --- PASS: TestEtcdOptionsValidate/unrecognized_storage-media-type (0.00s)
--- PASS: TestParseWatchCacheSizes (0.00s)
    --- PASS: TestParseWatchCacheSizes/test_when_invalid_value_of_watch_cache_size (0.00s)
    --- PASS: TestParseWatchCacheSizes/test_when_invalid_size_of_watch_cache_size (0.00s)
    --- PASS: TestParseWatchCacheSizes/test_when_watch_cache_size_is_negative (0.00s)
    --- PASS: TestParseWatchCacheSizes/test_when_parse_watch_cache_size_success (0.00s)
--- PASS: TestKMSHealthzEndpoint (0.82s)
    --- PASS: TestKMSHealthzEndpoint/no_kms-provider,_expect_no_kms_healthz_check,_no_kms_livez_check (0.00s)
    --- PASS: TestKMSHealthzEndpoint/no_kms-provider+reload,_expect_single_kms_healthz_check,_no_kms_livez_check (0.00s)
    --- PASS: TestKMSHealthzEndpoint/single_kms-provider,_expect_single_kms_healthz_check,_no_kms_livez_check (0.00s)
    --- PASS: TestKMSHealthzEndpoint/two_kms-providers,_expect_two_kms_healthz_checks,_no_kms_livez_check (0.00s)
    --- PASS: TestKMSHealthzEndpoint/two_kms-providers+reload,_expect_single_kms_healthz_check,_no_kms_livez_check (0.00s)
    --- PASS: TestKMSHealthzEndpoint/kms_v1+v2,_expect_three_kms_healthz_checks,_no_kms_livez_check (0.10s)
    --- PASS: TestKMSHealthzEndpoint/kms_v1+v2+reload,_expect_single_kms_healthz_check,_no_kms_livez_check (0.10s)
    --- PASS: TestKMSHealthzEndpoint/multiple_kms_v2,_expect_single_kms_healthz_check,_no_kms_livez_check (0.31s)
    --- PASS: TestKMSHealthzEndpoint/multiple_kms_v2+reload,_expect_single_kms_healthz_check,_no_kms_livez_check (0.31s)
    --- PASS: TestKMSHealthzEndpoint/two_kms-providers_with_skip,_expect_zero_kms_healthz_checks,_no_kms_livez_check (0.00s)
--- PASS: TestReadinessCheck (0.00s)
    --- PASS: TestReadinessCheck/Readyz_should_have_etcd-readiness_check (0.00s)
    --- PASS: TestReadinessCheck/skip_health,_Readyz_should_not_have_etcd-readiness_check (0.00s)
--- PASS: TestServerRunOptionsValidate (0.00s)
    --- PASS: TestServerRunOptionsValidate/Test_when_MaxRequestsInFlight_is_negative_value (0.00s)
    --- PASS: TestServerRunOptionsValidate/Test_when_MaxMutatingRequestsInFlight_is_negative_value (0.00s)
    --- PASS: TestServerRunOptionsValidate/Test_when_RequestTimeout_is_negative_value (0.00s)
    --- PASS: TestServerRunOptionsValidate/Test_when_MinRequestTimeout_is_negative_value (0.00s)
    --- PASS: TestServerRunOptionsValidate/Test_when_JSONPatchMaxCopyBytes_is_negative_value (0.00s)
    --- PASS: TestServerRunOptionsValidate/Test_when_MaxRequestBodyBytes_is_negative_value (0.00s)
    --- PASS: TestServerRunOptionsValidate/Test_when_LivezGracePeriod_is_negative_value (0.00s)
    --- PASS: TestServerRunOptionsValidate/Test_when_MinimalShutdownDuration_is_negative_value (0.00s)
    --- PASS: TestServerRunOptionsValidate/Test_when_HSTSHeaders_is_valid (0.00s)
    --- PASS: TestServerRunOptionsValidate/Test_when_ServerRunOptions_is_valid (0.00s)
--- PASS: TestValidateCorsAllowedOriginList (0.00s)
    --- PASS: TestValidateCorsAllowedOriginList/regexp/[] (0.00s)
    --- PASS: TestValidateCorsAllowedOriginList/regexp/[^http://foo.com$] (0.00s)
    --- PASS: TestValidateCorsAllowedOriginList/regexp/[^http://foo.com] (0.00s)
    --- PASS: TestValidateCorsAllowedOriginList/regexp/[://foo.com$] (0.00s)
    --- PASS: TestValidateCorsAllowedOriginList/regexp/[//foo.com$] (0.00s)
    --- PASS: TestValidateCorsAllowedOriginList/regexp/[^http://foo.com(:|$)] (0.00s)
    --- PASS: TestValidateCorsAllowedOriginList/regexp/[://foo.com(:|$)] (0.00s)
    --- PASS: TestValidateCorsAllowedOriginList/regexp/[//foo.com(:|$)] (0.00s)
    --- PASS: TestValidateCorsAllowedOriginList/regexp/[(^foo.com$)] (0.00s)
    --- PASS: TestValidateCorsAllowedOriginList/regexp/[^http://foo.com$_//bar.com(:|$)] (0.00s)
    --- PASS: TestValidateCorsAllowedOriginList/regexp/[^http://foo.com$_] (0.00s)
    --- PASS: TestValidateCorsAllowedOriginList/regexp/[^foo.com] (0.00s)
    --- PASS: TestValidateCorsAllowedOriginList/regexp/[//foo.com] (0.00s)
    --- PASS: TestValidateCorsAllowedOriginList/regexp/[foo.com$] (0.00s)
    --- PASS: TestValidateCorsAllowedOriginList/regexp/[foo.com(:|$)] (0.00s)
    --- PASS: TestValidateCorsAllowedOriginList/regexp/[^http://foo.com$_^foo.com] (0.00s)
--- PASS: TestServerRunOptionsWithShutdownWatchTerminationGracePeriod (0.00s)
    --- PASS: TestServerRunOptionsWithShutdownWatchTerminationGracePeriod/default_should_be_valid (0.00s)
    --- PASS: TestServerRunOptionsWithShutdownWatchTerminationGracePeriod/negative_not_allowed (0.00s)
    --- PASS: TestServerRunOptionsWithShutdownWatchTerminationGracePeriod/default_should_be_zero (0.00s)
--- PASS: TestServerRunWithSNI (0.00s)
    --- PASS: TestServerRunWithSNI/loopback:_LoopbackClientServerNameOverride_on_SNI_cert (0.29s)
    --- PASS: TestServerRunWithSNI/only_one_cert (0.32s)
    --- PASS: TestServerRunWithSNI/cert_with_multiple_alternate_names (0.35s)
    --- PASS: TestServerRunWithSNI/matching_SNI_cert (0.36s)
    --- PASS: TestServerRunWithSNI/one_SNI_and_the_default_cert_with_the_same_name (0.38s)
    --- PASS: TestServerRunWithSNI/loopback:_bind_to_0.0.0.0_=>_loopback_uses_localhost (0.40s)
    --- PASS: TestServerRunWithSNI/matching_IP_in_SNI_cert_and_the_server_cert (0.51s)
    --- PASS: TestServerRunWithSNI/loopback:_LoopbackClientServerNameOverride_on_server_cert (0.55s)
    --- PASS: TestServerRunWithSNI/loopback:_LoopbackClientServerNameOverride_not_on_any_cert (0.27s)
    --- PASS: TestServerRunWithSNI/wildcards (0.27s)
--- PASS: TestCreateListenerSharePort (0.00s)
--- PASS: TestCreateListenerPreventUpgrades (0.00s)
--- PASS: TestEmptyMainCert (0.16s)
--- PASS: TestValidateTracingOptions (0.00s)
    --- PASS: TestValidateTracingOptions/nil-valid (0.00s)
    --- PASS: TestValidateTracingOptions/empty-valid (0.00s)
    --- PASS: TestValidateTracingOptions/path-valid (0.00s)
    --- PASS: TestValidateTracingOptions/path-invalid (0.00s)
--- PASS: TestReadTracingConfiguration (0.00s)
    --- PASS: TestReadTracingConfiguration/empty (0.00s)
    --- PASS: TestReadTracingConfiguration/absent (0.00s)
    --- PASS: TestReadTracingConfiguration/v1alpha1 (0.00s)
    --- PASS: TestReadTracingConfiguration/ip_address (0.00s)
    --- PASS: TestReadTracingConfiguration/wrong_type (0.00s)
ok      k8s.io/apiserver/pkg/server/options     2.140s
```
</details>


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
