### PR TITLE
WIP: testing: make apiserver-based tests context-aware

### DIFF
--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -20,6 +20,7 @@ limitations under the License.
 package app
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"net/http"
@@ -115,7 +116,7 @@ cluster's shared state through which all other components interact.`,
 			}
 			// add feature enablement metrics
 			utilfeature.DefaultMutableFeatureGate.AddMetrics()
-			return Run(completedOptions, genericapiserver.SetupSignalHandler())
+			return Run(cmd.Context(), completedOptions)
 		},
 		Args: func(cmd *cobra.Command, args []string) error {
 			for _, arg := range args {
@@ -126,6 +127,7 @@ cluster's shared state through which all other components interact.`,
 			return nil
 		},
 	}
+	cmd.SetContext(genericapiserver.SetupSignalContext())
 
 	fs := cmd.Flags()
 	namedFlagSets := s.Flags()
@@ -143,7 +145,7 @@ cluster's shared state through which all other components interact.`,
 }
 
 // Run runs the specified APIServer.  This should never exit.
-func Run(opts options.CompletedOptions, stopCh <-chan struct{}) error {
+func Run(ctx context.Context, opts options.CompletedOptions) error {
 	// To help debugging, immediately log version
 	klog.Infof("Version: %+v", version.Get())
 
@@ -167,7 +169,7 @@ func Run(opts options.CompletedOptions, stopCh <-chan struct{}) error {
 		return err
 	}
 
-	return prepared.Run(stopCh)
+	return prepared.Run(ctx)
 }
 
 // CreateServerChain creates the apiservers connected via delegation.

--- a/cmd/kube-apiserver/app/testing/testserver.go
+++ b/cmd/kube-apiserver/app/testing/testserver.go
@@ -110,15 +110,6 @@ type TestServer struct {
 	EtcdStoragePrefix string                    // storage prefix in etcd
 }
 
-// Logger allows t.Testing and b.Testing to be passed to StartTestServer and StartTestServerOrDie
-type Logger interface {
-	Helper()
-	Errorf(format string, args ...interface{})
-	Fatalf(format string, args ...interface{})
-	Logf(format string, args ...interface{})
-	Cleanup(func())
-}
-
 // ProxyCA contains the certificate authority certificate and key which is used to verify client connections
 // to kube-apiservers. The clients can be :
 // 1. aggregated apiservers
@@ -501,7 +492,7 @@ func createLocalhostListenerOnFreePort() (net.Listener, int, error) {
 //
 // The approach taken here works for both go test and bazel on the assumption
 // that if and only if trimpath is passed, we are running under bazel.
-func pkgPath(t Logger) (string, error) {
+func pkgPath(t ktesting.TB) (string, error) {
 	_, thisFile, _, ok := runtime.Caller(0)
 	if !ok {
 		return "", fmt.Errorf("failed to get current file")

--- a/pkg/controller/endpointslicemirroring/endpointslicemirroring_controller_test.go
+++ b/pkg/controller/endpointslicemirroring/endpointslicemirroring_controller_test.go
@@ -225,7 +225,7 @@ func TestSyncEndpoints(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.testName, func(t *testing.T) {
-			_, ctx := ktesting.NewTestContext(t)
+			logger, ctx := ktesting.NewTestContext(t)
 			client, esController := newController(ctx, time.Duration(0))
 			tc.endpoints.Name = endpointsName
 			tc.endpoints.Namespace = namespace
@@ -245,7 +245,6 @@ func TestSyncEndpoints(t *testing.T) {
 				}
 			}
 
-			logger, _ := ktesting.NewTestContext(t)
 			err := esController.syncEndpoints(logger, fmt.Sprintf("%s/%s", namespace, endpointsName))
 			if err != nil {
 				t.Fatalf("Unexpected error from syncEndpoints: %v", err)
@@ -266,7 +265,7 @@ func TestSyncEndpoints(t *testing.T) {
 				t.Fatal("Timed out waiting for expected actions")
 			}
 
-			endpointSlices := fetchEndpointSlices(t, client, namespace)
+			endpointSlices := fetchEndpointSlices(ctx, t, client, namespace)
 			expectEndpointSlices(t, tc.expectedNumSlices, int(defaultMaxEndpointsPerSubset), *tc.endpoints, endpointSlices)
 		})
 	}

--- a/pkg/controller/endpointslicemirroring/reconciler_test.go
+++ b/pkg/controller/endpointslicemirroring/reconciler_test.go
@@ -1027,7 +1027,7 @@ func TestReconcile(t *testing.T) {
 					discovery.LabelServiceName: endpoints.Name,
 					discovery.LabelManagedBy:   controllerName,
 				}
-				_, err := client.DiscoveryV1().EndpointSlices(namespace).Create(context.TODO(), epSlice, metav1.CreateOptions{})
+				_, err := client.DiscoveryV1().EndpointSlices(namespace).Create(tCtx, epSlice, metav1.CreateOptions{})
 				if err != nil {
 					t.Fatalf("Expected no error creating EndpointSlice, got %v", err)
 				}
@@ -1050,7 +1050,7 @@ func TestReconcile(t *testing.T) {
 				expectMetrics(t, *tc.expectedMetrics)
 			}
 
-			endpointSlices := fetchEndpointSlices(t, client, namespace)
+			endpointSlices := fetchEndpointSlices(tCtx, t, client, namespace)
 			expectEndpointSlices(t, tc.expectedNumSlices, int(maxEndpointsPerSubset), endpoints, endpointSlices)
 		})
 	}
@@ -1249,9 +1249,9 @@ func expectMatchingAddresses(t *testing.T, epSubset corev1.EndpointSubset, esEnd
 	}
 }
 
-func fetchEndpointSlices(t *testing.T, client *fake.Clientset, namespace string) []discovery.EndpointSlice {
+func fetchEndpointSlices(ctx context.Context, t *testing.T, client *fake.Clientset, namespace string) []discovery.EndpointSlice {
 	t.Helper()
-	fetchedSlices, err := client.DiscoveryV1().EndpointSlices(namespace).List(context.TODO(), metav1.ListOptions{
+	fetchedSlices, err := client.DiscoveryV1().EndpointSlices(namespace).List(ctx, metav1.ListOptions{
 		LabelSelector: discovery.LabelManagedBy + "=" + controllerName,
 	})
 	if err != nil {

--- a/pkg/controller/garbagecollector/garbagecollector.go
+++ b/pkg/controller/garbagecollector/garbagecollector.go
@@ -20,10 +20,11 @@ import (
 	"context"
 	goerrors "errors"
 	"fmt"
-	"k8s.io/controller-manager/pkg/informerfactory"
 	"reflect"
 	"sync"
 	"time"
+
+	"k8s.io/controller-manager/pkg/informerfactory"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"

--- a/pkg/controller/nodeipam/ipam/range_allocator_test.go
+++ b/pkg/controller/nodeipam/ipam/range_allocator_test.go
@@ -274,9 +274,10 @@ func TestOccupyPreExistingCIDR(t *testing.T) {
 	}
 
 	// test function
-	tCtx := ktesting.Init(t)
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
+			tCtx := ktesting.Init(t)
+
 			// Initialize the range allocator.
 			fakeNodeInformer := test.FakeNodeInformer(tc.fakeNodeHandler)
 			nodeList, _ := tc.fakeNodeHandler.List(tCtx, metav1.ListOptions{})

--- a/pkg/controller/podautoscaler/horizontal_test.go
+++ b/pkg/controller/podautoscaler/horizontal_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package podautoscaler
 
 import (
-	"context"
 	"fmt"
 	"math"
 	"strings"
@@ -803,10 +802,9 @@ func coolCPUCreationTime() metav1.Time {
 }
 
 func (tc *testCase) runTestWithController(t *testing.T, hpaController *HorizontalController, informerFactory informers.SharedInformerFactory) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	informerFactory.Start(ctx.Done())
-	go hpaController.Run(ctx, 5)
+	tCtx := ktesting.Init(t)
+	informerFactory.Start(tCtx.Done())
+	go hpaController.Run(tCtx, 5)
 
 	tc.Lock()
 	shouldWait := tc.verifyEvents

--- a/pkg/controller/replicaset/replica_set_test.go
+++ b/pkg/controller/replicaset/replica_set_test.go
@@ -625,10 +625,9 @@ func TestWatchControllers(t *testing.T) {
 	fakeWatch := watch.NewFake()
 	client := fake.NewSimpleClientset()
 	client.PrependWatchReactor("replicasets", core.DefaultWatchReactor(fakeWatch, nil))
-	stopCh := make(chan struct{})
-	defer close(stopCh)
 	informers := informers.NewSharedInformerFactory(client, controller.NoResyncPeriodFunc())
 	tCtx := ktesting.Init(t)
+	stopCh := tCtx.Done()
 	manager := NewReplicaSetController(
 		tCtx,
 		informers.Apps().V1().ReplicaSets(),
@@ -1190,12 +1189,10 @@ func TestDeleteControllerAndExpectations(t *testing.T) {
 
 func TestExpectationsOnRecreate(t *testing.T) {
 	client := fake.NewSimpleClientset()
-	stopCh := make(chan struct{})
-	defer close(stopCh)
-
 	f := informers.NewSharedInformerFactory(client, controller.NoResyncPeriodFunc())
 	tCtx := ktesting.Init(t)
 	logger := tCtx.Logger()
+	stopCh := tCtx.Done()
 	manager := NewReplicaSetController(
 		tCtx,
 		f.Apps().V1().ReplicaSets(),

--- a/pkg/controller/volume/expand/expand_controller_test.go
+++ b/pkg/controller/volume/expand/expand_controller_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package expand
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"reflect"
@@ -138,7 +137,7 @@ func TestSyncHandler(t *testing.T) {
 			return true, pvc, nil
 		})
 
-		err = expController.syncHandler(context.TODO(), test.pvcKey)
+		err = expController.syncHandler(tCtx, test.pvcKey)
 		if err != nil && !test.hasError {
 			t.Fatalf("for: %s; unexpected error while running handler : %v", test.name, err)
 		}

--- a/pkg/controlplane/instance.go
+++ b/pkg/controlplane/instance.go
@@ -524,7 +524,7 @@ func (c completedConfig) New(delegationTarget genericapiserver.DelegationTarget)
 			)
 			// The default serviceCIDR must exist before the apiserver is healthy
 			// otherwise the allocators for Services will not work.
-			controller.Start(hookContext.StopCh)
+			controller.Start(hookContext)
 			return nil
 		})
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/main.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/main.go
@@ -25,8 +25,8 @@ import (
 )
 
 func main() {
-	stopCh := genericapiserver.SetupSignalHandler()
-	cmd := server.NewServerCommand(os.Stdout, os.Stderr, stopCh)
+	ctx := genericapiserver.SetupSignalContext()
+	cmd := server.NewServerCommand(ctx, os.Stdout, os.Stderr)
 	code := cli.Run(cmd)
 	os.Exit(code)
 }

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/cmd/server/server.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/cmd/server/server.go
@@ -17,6 +17,7 @@ limitations under the License.
 package server
 
 import (
+	"context"
 	"io"
 
 	"github.com/spf13/cobra"
@@ -25,7 +26,7 @@ import (
 	genericapiserver "k8s.io/apiserver/pkg/server"
 )
 
-func NewServerCommand(out, errOut io.Writer, stopCh <-chan struct{}) *cobra.Command {
+func NewServerCommand(ctx context.Context, out, errOut io.Writer) *cobra.Command {
 	o := options.NewCustomResourceDefinitionsServerOptions(out, errOut)
 
 	cmd := &cobra.Command{
@@ -38,19 +39,20 @@ func NewServerCommand(out, errOut io.Writer, stopCh <-chan struct{}) *cobra.Comm
 			if err := o.Validate(); err != nil {
 				return err
 			}
-			if err := Run(o, stopCh); err != nil {
+			if err := Run(c.Context(), o); err != nil {
 				return err
 			}
 			return nil
 		},
 	}
+	cmd.SetContext(ctx)
 
 	fs := cmd.Flags()
 	o.AddFlags(fs)
 	return cmd
 }
 
-func Run(o *options.CustomResourceDefinitionsServerOptions, stopCh <-chan struct{}) error {
+func Run(ctx context.Context, o *options.CustomResourceDefinitionsServerOptions) error {
 	config, err := o.Config()
 	if err != nil {
 		return err
@@ -60,5 +62,5 @@ func Run(o *options.CustomResourceDefinitionsServerOptions, stopCh <-chan struct
 	if err != nil {
 		return err
 	}
-	return server.GenericAPIServer.PrepareRun().Run(stopCh)
+	return server.GenericAPIServer.PrepareRun().Run(ctx)
 }

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/cmd/server/testing/testserver.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/cmd/server/testing/testserver.go
@@ -18,6 +18,7 @@ package testing
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -83,13 +84,13 @@ func NewDefaultTestServerOptions() *TestServerInstanceOptions {
 // files that because Golang testing's call to os.Exit will not give a stop channel go routine
 // enough time to remove temporary files.
 func StartTestServer(t Logger, _ *TestServerInstanceOptions, customFlags []string, storageConfig *storagebackend.Config) (result TestServer, err error) {
-	stopCh := make(chan struct{})
+	ctx, cancel := context.WithCancelCause(context.Background())
 	var errCh chan error
 	tearDown := func() {
-		// Closing stopCh is stopping apiextensions apiserver and its
+		// Cancel is stopping apiextensions apiserver and its
 		// delegates, which itself is cleaning up after itself,
 		// including shutting down its storage layer.
-		close(stopCh)
+		cancel(errors.New("tearing down"))
 
 		// If the apiextensions apiserver was started, let's wait for
 		// it to shutdown clearly.
@@ -166,13 +167,13 @@ func StartTestServer(t Logger, _ *TestServerInstanceOptions, customFlags []strin
 	}
 
 	errCh = make(chan error)
-	go func(stopCh <-chan struct{}) {
+	go func() {
 		defer close(errCh)
 
-		if err := server.GenericAPIServer.PrepareRun().Run(stopCh); err != nil {
+		if err := server.GenericAPIServer.PrepareRun().Run(ctx); err != nil {
 			errCh <- err
 		}
-	}(stopCh)
+	}()
 
 	t.Logf("Waiting for /healthz to be ok...")
 

--- a/staging/src/k8s.io/apiserver/pkg/server/config_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package server
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -42,6 +44,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/rest"
 	"k8s.io/component-base/tracing"
+	"k8s.io/klog/v2/ktesting"
 	netutils "k8s.io/utils/net"
 )
 
@@ -79,6 +82,9 @@ func TestAuthorizeClientBearerTokenNoops(t *testing.T) {
 }
 
 func TestNewWithDelegate(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
+	ctx, cancel := context.WithCancelCause(ctx)
+	defer cancel(errors.New("test is done"))
 	delegateConfig := NewConfig(codecs)
 	delegateConfig.ExternalAddress = "192.168.10.4:443"
 	delegateConfig.PublicAddress = netutils.ParseIPSloppy("192.168.10.4")
@@ -136,10 +142,8 @@ func TestNewWithDelegate(t *testing.T) {
 		return nil
 	})
 
-	stopCh := make(chan struct{})
-	defer close(stopCh)
 	wrappingServer.PrepareRun()
-	wrappingServer.RunPostStartHooks(stopCh)
+	wrappingServer.RunPostStartHooksWithContext(ctx)
 
 	server := httptest.NewServer(wrappingServer.Handler)
 	defer server.Close()

--- a/staging/src/k8s.io/apiserver/pkg/server/genericapiserver_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/genericapiserver_test.go
@@ -52,6 +52,7 @@ import (
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
 	restclient "k8s.io/client-go/rest"
+	"k8s.io/klog/v2/ktesting"
 	kubeopenapi "k8s.io/kube-openapi/pkg/common"
 	"k8s.io/kube-openapi/pkg/validation/spec"
 	netutils "k8s.io/utils/net"
@@ -317,6 +318,7 @@ func TestInstallAPIGroups(t *testing.T) {
 }
 
 func TestPrepareRun(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
 	s, config, assert := newMaster(t)
 
 	assert.NotNil(config.OpenAPIConfig)
@@ -327,7 +329,7 @@ func TestPrepareRun(t *testing.T) {
 	defer close(done)
 
 	s.PrepareRun()
-	s.RunPostStartHooks(done)
+	s.RunPostStartHooksWithContext(ctx)
 
 	// openapi is installed in PrepareRun
 	resp, err := http.Get(server.URL + "/openapi/v2")
@@ -353,9 +355,10 @@ func TestPrepareRun(t *testing.T) {
 }
 
 func TestUpdateOpenAPISpec(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
 	s, _, assert := newMaster(t)
 	s.PrepareRun()
-	s.RunPostStartHooks(make(chan struct{}))
+	s.RunPostStartHooksWithContext(ctx)
 
 	server := httptest.NewServer(s.Handler.Director)
 	defer server.Close()

--- a/staging/src/k8s.io/apiserver/pkg/server/options/serving_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/serving_test.go
@@ -18,6 +18,7 @@ package options
 
 import (
 	"bytes"
+	"context"
 	cryptorand "crypto/rand"
 	"crypto/rsa"
 	"crypto/tls"
@@ -25,6 +26,7 @@ import (
 	"crypto/x509/pkix"
 	"encoding/base64"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"math/big"
@@ -44,6 +46,7 @@ import (
 	"k8s.io/client-go/discovery"
 	restclient "k8s.io/client-go/rest"
 	cliflag "k8s.io/component-base/cli/flag"
+	"k8s.io/klog/v2/ktesting"
 	netutils "k8s.io/utils/net"
 )
 
@@ -215,6 +218,10 @@ func TestServerRunWithSNI(t *testing.T) {
 		test := tests[title]
 		t.Run(title, func(t *testing.T) {
 			t.Parallel()
+			_, ctx := ktesting.NewTestContext(t)
+			ctx, cancel := context.WithCancelCause(ctx)
+			defer cancel(errors.New("test has completed"))
+
 			// create server cert
 			certDir := "testdata/" + specToName(test.Cert)
 			serverCertBundleFile := filepath.Join(certDir, "cert")
@@ -267,9 +274,6 @@ func TestServerRunWithSNI(t *testing.T) {
 				signatures[sig] = j
 			}
 
-			stopCh := make(chan struct{})
-			defer close(stopCh)
-
 			// launch server
 			config := setUp(t)
 
@@ -316,7 +320,7 @@ func TestServerRunWithSNI(t *testing.T) {
 			preparedServer := s.PrepareRun()
 			preparedServerErrors := make(chan error)
 			go func() {
-				if err := preparedServer.Run(stopCh); err != nil {
+				if err := preparedServer.Run(ctx); err != nil {
 					preparedServerErrors <- err
 				}
 			}()

--- a/staging/src/k8s.io/kube-aggregator/main.go
+++ b/staging/src/k8s.io/kube-aggregator/main.go
@@ -32,9 +32,9 @@ import (
 )
 
 func main() {
-	stopCh := genericapiserver.SetupSignalHandler()
+	ctx := genericapiserver.SetupSignalContext()
 	options := server.NewDefaultOptions(os.Stdout, os.Stderr)
-	cmd := server.NewCommandStartAggregator(options, stopCh)
+	cmd := server.NewCommandStartAggregator(ctx, options)
 	code := cli.Run(cmd)
 	os.Exit(code)
 }

--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/apiserver.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/apiserver.go
@@ -120,7 +120,7 @@ type CompletedConfig struct {
 }
 
 type runnable interface {
-	Run(stopCh <-chan struct{}) error
+	Run(ctx context.Context) error
 }
 
 // preparedGenericAPIServer is a private wrapper that enforces a call of PrepareRun() before Run can be invoked.
@@ -484,8 +484,8 @@ func (s *APIAggregator) PrepareRun() (preparedAPIAggregator, error) {
 	return preparedAPIAggregator{APIAggregator: s, runnable: prepared}, nil
 }
 
-func (s preparedAPIAggregator) Run(stopCh <-chan struct{}) error {
-	return s.runnable.Run(stopCh)
+func (s preparedAPIAggregator) Run(ctx context.Context) error {
+	return s.runnable.Run(ctx)
 }
 
 // AddAPIService adds an API service.  It is not thread-safe, so only call it on one thread at a time please.

--- a/staging/src/k8s.io/kube-aggregator/pkg/cmd/server/start.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/cmd/server/start.go
@@ -17,6 +17,7 @@ limitations under the License.
 package server
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -55,7 +56,7 @@ type AggregatorOptions struct {
 
 // NewCommandStartAggregator provides a CLI handler for 'start master' command
 // with a default AggregatorOptions.
-func NewCommandStartAggregator(defaults *AggregatorOptions, stopCh <-chan struct{}) *cobra.Command {
+func NewCommandStartAggregator(ctx context.Context, defaults *AggregatorOptions) *cobra.Command {
 	o := *defaults
 	cmd := &cobra.Command{
 		Short: "Launch a API aggregator and proxy server",
@@ -67,12 +68,13 @@ func NewCommandStartAggregator(defaults *AggregatorOptions, stopCh <-chan struct
 			if err := o.Validate(args); err != nil {
 				return err
 			}
-			if err := o.RunAggregator(stopCh); err != nil {
+			if err := o.RunAggregator(c.Context()); err != nil {
 				return err
 			}
 			return nil
 		},
 	}
+	cmd.SetContext(ctx)
 
 	o.AddFlags(cmd.Flags())
 	return cmd
@@ -119,7 +121,7 @@ func (o *AggregatorOptions) Complete() error {
 }
 
 // RunAggregator runs the API Aggregator.
-func (o AggregatorOptions) RunAggregator(stopCh <-chan struct{}) error {
+func (o AggregatorOptions) RunAggregator(ctx context.Context) error {
 	// TODO have a "real" external address
 	if err := o.RecommendedOptions.SecureServing.MaybeDefaultWithSelfSignedCerts("localhost", nil, nil); err != nil {
 		return fmt.Errorf("error creating self-signed certificates: %v", err)
@@ -171,5 +173,5 @@ func (o AggregatorOptions) RunAggregator(stopCh <-chan struct{}) error {
 	if err != nil {
 		return err
 	}
-	return prepared.Run(stopCh)
+	return prepared.Run(ctx)
 }

--- a/staging/src/k8s.io/sample-apiserver/main.go
+++ b/staging/src/k8s.io/sample-apiserver/main.go
@@ -25,9 +25,9 @@ import (
 )
 
 func main() {
-	stopCh := genericapiserver.SetupSignalHandler()
+	ctx := genericapiserver.SetupSignalContext()
 	options := server.NewWardleServerOptions(os.Stdout, os.Stderr)
-	cmd := server.NewCommandStartWardleServer(options, stopCh)
+	cmd := server.NewCommandStartWardleServer(ctx, options)
 	code := cli.Run(cmd)
 	os.Exit(code)
 }

--- a/staging/src/k8s.io/sample-apiserver/pkg/cmd/server/start.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/cmd/server/start.go
@@ -17,6 +17,7 @@ limitations under the License.
 package server
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net"
@@ -71,7 +72,7 @@ func NewWardleServerOptions(out, errOut io.Writer) *WardleServerOptions {
 
 // NewCommandStartWardleServer provides a CLI handler for 'start master' command
 // with a default WardleServerOptions.
-func NewCommandStartWardleServer(defaults *WardleServerOptions, stopCh <-chan struct{}) *cobra.Command {
+func NewCommandStartWardleServer(ctx context.Context, defaults *WardleServerOptions) *cobra.Command {
 	o := *defaults
 	cmd := &cobra.Command{
 		Short: "Launch a wardle API server",
@@ -83,12 +84,13 @@ func NewCommandStartWardleServer(defaults *WardleServerOptions, stopCh <-chan st
 			if err := o.Validate(args); err != nil {
 				return err
 			}
-			if err := o.RunWardleServer(stopCh); err != nil {
+			if err := o.RunWardleServer(c.Context()); err != nil {
 				return err
 			}
 			return nil
 		},
 	}
+	cmd.SetContext(ctx)
 
 	flags := cmd.Flags()
 	o.RecommendedOptions.AddFlags(flags)
@@ -154,7 +156,7 @@ func (o *WardleServerOptions) Config() (*apiserver.Config, error) {
 }
 
 // RunWardleServer starts a new WardleServer given WardleServerOptions
-func (o WardleServerOptions) RunWardleServer(stopCh <-chan struct{}) error {
+func (o WardleServerOptions) RunWardleServer(ctx context.Context) error {
 	config, err := o.Config()
 	if err != nil {
 		return err
@@ -171,5 +173,5 @@ func (o WardleServerOptions) RunWardleServer(stopCh <-chan struct{}) error {
 		return nil
 	})
 
-	return server.GenericAPIServer.PrepareRun().Run(stopCh)
+	return server.GenericAPIServer.PrepareRun().Run(ctx)
 }

--- a/staging/src/k8s.io/sample-controller/controller.go
+++ b/staging/src/k8s.io/sample-controller/controller.go
@@ -101,7 +101,7 @@ func NewController(
 	utilruntime.Must(samplescheme.AddToScheme(scheme.Scheme))
 	logger.V(4).Info("Creating event broadcaster")
 
-	eventBroadcaster := record.NewBroadcaster()
+	eventBroadcaster := record.NewBroadcaster(record.WithContext(ctx))
 	eventBroadcaster.StartStructuredLogging(0)
 	eventBroadcaster.StartRecordingToSink(&typedcorev1.EventSinkImpl{Interface: kubeclientset.CoreV1().Events("")})
 	recorder := eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: controllerAgentName})

--- a/test/e2e_node/runner/remote/run_remote.go
+++ b/test/e2e_node/runner/remote/run_remote.go
@@ -38,7 +38,6 @@ var _ = flag.String("runtime-config", "", "The runtime configuration for the API
 var _ = flag.String("kubelet-config-file", "", "The KubeletConfiguration file that should be applied to the kubelet")
 
 func main() {
-	klog.InitFlags(nil)
 	flag.Parse()
 
 	suite, err := remote.GetTestSuite(*testSuite)

--- a/test/e2e_node/services/apiserver.go
+++ b/test/e2e_node/services/apiserver.go
@@ -52,9 +52,10 @@ type APIServer struct {
 
 // NewAPIServer creates an apiserver.
 func NewAPIServer(storageConfig storagebackend.Config) *APIServer {
-	return &APIServer{
+	a := &APIServer{
 		storageConfig: storageConfig,
 	}
+	return a
 }
 
 // Start starts the apiserver, returns when apiserver is ready.

--- a/test/e2e_node/services/apiserver.go
+++ b/test/e2e_node/services/apiserver.go
@@ -17,6 +17,8 @@ limitations under the License.
 package services
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"os"
 	"testing"
@@ -45,19 +47,20 @@ AwEHoUQDQgAEH6cuzP8XuD5wal6wf9M6xDljTOPLX2i8uIp/C/ASqiIGUeeKQtX0
 // APIServer is a server which manages apiserver.
 type APIServer struct {
 	storageConfig storagebackend.Config
-	stopCh        chan struct{}
+	cancel        func(error)
 }
 
 // NewAPIServer creates an apiserver.
 func NewAPIServer(storageConfig storagebackend.Config) *APIServer {
 	return &APIServer{
 		storageConfig: storageConfig,
-		stopCh:        make(chan struct{}),
 	}
 }
 
 // Start starts the apiserver, returns when apiserver is ready.
-func (a *APIServer) Start() error {
+// The background goroutine runs until the context is canceled
+// or Stop is called, whether happens first.
+func (a *APIServer) Start(ctx context.Context) error {
 	const tokenFilePath = "known_tokens.csv"
 
 	o := options.NewServerRunOptions()
@@ -93,9 +96,12 @@ func (a *APIServer) Start() error {
 
 	o.KubeletConfig.PreferredAddressTypes = []string{"InternalIP"}
 
+	ctx, cancel := context.WithCancelCause(ctx)
+	a.cancel = cancel
 	errCh := make(chan error)
 	go func() {
 		defer close(errCh)
+		defer cancel(errors.New("shutting down")) // Calling Stop is optional, but cancel always should be invoked.
 		completedOptions, err := o.Complete()
 		if err != nil {
 			errCh <- fmt.Errorf("set apiserver default options error: %w", err)
@@ -106,7 +112,7 @@ func (a *APIServer) Start() error {
 			return
 		}
 
-		err = apiserver.Run(completedOptions, a.stopCh)
+		err = apiserver.Run(ctx, completedOptions)
 		if err != nil {
 			errCh <- fmt.Errorf("run apiserver error: %w", err)
 			return
@@ -120,12 +126,11 @@ func (a *APIServer) Start() error {
 	return nil
 }
 
-// Stop stops the apiserver. Currently, there is no way to stop the apiserver.
-// The function is here only for completion.
+// Stop stops the apiserver. Does not block.
 func (a *APIServer) Stop() error {
-	if a.stopCh != nil {
-		close(a.stopCh)
-		a.stopCh = nil
+	if a.cancel != nil {
+		a.cancel(errors.New("stopping API server"))
+		a.cancel = nil
 	}
 	return nil
 }

--- a/test/e2e_node/services/internal_services.go
+++ b/test/e2e_node/services/internal_services.go
@@ -24,8 +24,8 @@ import (
 	etcd3testing "k8s.io/apiserver/pkg/storage/etcd3/testing"
 	"k8s.io/apiserver/pkg/storage/storagebackend"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
-	"k8s.io/klog/v2/ktesting"
 	"k8s.io/kubernetes/test/e2e/framework"
+	"k8s.io/kubernetes/test/utils/ktesting"
 
 	"k8s.io/klog/v2"
 )
@@ -58,17 +58,17 @@ func (es *e2eServices) run(t *testing.T) error {
 
 // start starts the tests embedded services or returns an error.
 func (es *e2eServices) start(t *testing.T) error {
-	_, ctx := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
 	klog.Info("Starting e2e services...")
 	err := es.startEtcd(t)
 	if err != nil {
 		return err
 	}
-	err = es.startAPIServer(es.etcdStorage)
+	err = es.startAPIServer(tCtx, es.etcdStorage)
 	if err != nil {
 		return err
 	}
-	err = es.startNamespaceController(ctx)
+	err = es.startNamespaceController(tCtx)
 	if err != nil {
 		return nil
 	}
@@ -121,10 +121,10 @@ func (es *e2eServices) startEtcd(t *testing.T) error {
 }
 
 // startAPIServer starts the embedded API server or returns an error.
-func (es *e2eServices) startAPIServer(etcdStorage *storagebackend.Config) error {
+func (es *e2eServices) startAPIServer(ctx context.Context, etcdStorage *storagebackend.Config) error {
 	klog.Info("Starting API server")
 	es.apiServer = NewAPIServer(*etcdStorage)
-	return es.apiServer.Start()
+	return es.apiServer.Start(ctx)
 }
 
 // startNamespaceController starts the embedded namespace controller or returns an error.

--- a/test/integration/controlplane/transformation/all_transformation_test.go
+++ b/test/integration/controlplane/transformation/all_transformation_test.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/kubernetes/test/integration/etcd"
+	"k8s.io/kubernetes/test/utils/ktesting"
 )
 
 func createResources(t *testing.T, test *transformTest,
@@ -120,9 +121,10 @@ resources:
 		tt := tt
 		t.Run(tt.resource, func(t *testing.T) {
 			t.Parallel()
+			tCtx := ktesting.Init(t)
 
 			createResources(t, test, tt.group, tt.version, tt.kind, tt.resource, tt.name, tt.namespace)
-			test.runResource(t, unSealWithCBCTransformer, aesCBCPrefix, tt.group, tt.version, tt.resource, tt.name, tt.namespace)
+			test.runResource(tCtx, unSealWithCBCTransformer, aesCBCPrefix, tt.group, tt.version, tt.resource, tt.name, tt.namespace)
 		})
 	}
 }

--- a/test/integration/controlplane/transformation/main_test.go
+++ b/test/integration/controlplane/transformation/main_test.go
@@ -17,19 +17,19 @@ limitations under the License.
 package transformation
 
 import (
-	"context"
 	"testing"
 	"time"
 
 	"k8s.io/kubernetes/test/integration/framework"
+	"k8s.io/kubernetes/test/utils/ktesting"
 )
 
 func TestMain(m *testing.M) {
 	framework.EtcdMain(m.Run)
 }
 
-func testContext(t *testing.T) context.Context {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	t.Cleanup(cancel)
-	return ctx
+func testContext(t *testing.T) ktesting.TContext {
+	tCtx := ktesting.Init(t)
+	tCtx = ktesting.WithTimeout(tCtx, 30*time.Second, "test timed out")
+	return tCtx
 }

--- a/test/integration/controlplane/transformation/secrets_transformation_test.go
+++ b/test/integration/controlplane/transformation/secrets_transformation_test.go
@@ -94,7 +94,7 @@ func TestSecretsShouldBeTransformed(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to create test secret, error: %v", err)
 		}
-		test.runResource(test.logger, tt.unSealFunc, tt.transformerPrefix, "", "v1", "secrets", test.secret.Name, test.secret.Namespace)
+		test.runResource(test.TContext, tt.unSealFunc, tt.transformerPrefix, "", "v1", "secrets", test.secret.Name, test.secret.Namespace)
 		test.cleanUp()
 	}
 }

--- a/test/integration/controlplane/transformation/transformation_test.go
+++ b/test/integration/controlplane/transformation/transformation_test.go
@@ -50,6 +50,7 @@ import (
 	"k8s.io/kubernetes/test/integration"
 	"k8s.io/kubernetes/test/integration/etcd"
 	"k8s.io/kubernetes/test/integration/framework"
+	"k8s.io/kubernetes/test/utils/ktesting"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/yaml"
 )
@@ -75,7 +76,7 @@ const (
 type unSealSecret func(ctx context.Context, cipherText []byte, dataCtx value.Context, config apiserverv1.ProviderConfiguration) ([]byte, error)
 
 type transformTest struct {
-	logger            kubeapiservertesting.Logger
+	ktesting.TContext
 	storageConfig     *storagebackend.Config
 	configDir         string
 	transformerConfig string
@@ -85,12 +86,13 @@ type transformTest struct {
 	secret            *corev1.Secret
 }
 
-func newTransformTest(l kubeapiservertesting.Logger, transformerConfigYAML string, reload bool, configDir string, storageConfig *storagebackend.Config) (*transformTest, error) {
+func newTransformTest(tb testing.TB, transformerConfigYAML string, reload bool, configDir string, storageConfig *storagebackend.Config) (*transformTest, error) {
+	tCtx := ktesting.Init(tb)
 	if storageConfig == nil {
 		storageConfig = framework.SharedEtcd()
 	}
 	e := transformTest{
-		logger:            l,
+		TContext:          tCtx,
 		transformerConfig: transformerConfigYAML,
 		storageConfig:     storageConfig,
 	}
@@ -113,7 +115,7 @@ func newTransformTest(l kubeapiservertesting.Logger, transformerConfigYAML strin
 		return nil, fmt.Errorf("failed to read config file: %w", err)
 	}
 
-	if e.kubeAPIServer, err = kubeapiservertesting.StartTestServer(l, nil, e.getEncryptionOptions(reload), e.storageConfig); err != nil {
+	if e.kubeAPIServer, err = kubeapiservertesting.StartTestServer(tb, nil, e.getEncryptionOptions(reload), e.storageConfig); err != nil {
 		e.cleanUp()
 		return nil, fmt.Errorf("failed to start KubeAPI server: %w", err)
 	}
@@ -131,11 +133,11 @@ func newTransformTest(l kubeapiservertesting.Logger, transformerConfigYAML strin
 
 	if transformerConfigYAML != "" && reload {
 		// when reloading is enabled, this healthz endpoint is always present
-		mustBeHealthy(l, "/kms-providers", "ok", e.kubeAPIServer.ClientConfig)
-		mustNotHaveLivez(l, "/kms-providers", "404 page not found", e.kubeAPIServer.ClientConfig)
+		mustBeHealthy(tCtx, "/kms-providers", "ok", e.kubeAPIServer.ClientConfig)
+		mustNotHaveLivez(tCtx, "/kms-providers", "404 page not found", e.kubeAPIServer.ClientConfig)
 
 		// excluding healthz endpoints even if they do not exist should work
-		mustBeHealthy(l, "", `warn: some health checks cannot be excluded: no matches for "kms-provider-0","kms-provider-1","kms-provider-2","kms-provider-3"`,
+		mustBeHealthy(tCtx, "", `warn: some health checks cannot be excluded: no matches for "kms-provider-0","kms-provider-1","kms-provider-2","kms-provider-3"`,
 			e.kubeAPIServer.ClientConfig, "kms-provider-0", "kms-provider-1", "kms-provider-2", "kms-provider-3")
 	}
 
@@ -530,7 +532,7 @@ func (e *transformTest) writeRawRecordToETCD(path string, data []byte) (*clientv
 }
 
 func (e *transformTest) printMetrics() error {
-	e.logger.Logf("Transformation Metrics:")
+	e.Logf("Transformation Metrics:")
 	metrics, err := legacyregistry.DefaultGatherer.Gather()
 	if err != nil {
 		return fmt.Errorf("failed to gather metrics: %s", err)
@@ -538,9 +540,9 @@ func (e *transformTest) printMetrics() error {
 
 	for _, mf := range metrics {
 		if strings.HasPrefix(*mf.Name, metricsPrefix) {
-			e.logger.Logf("%s", *mf.Name)
+			e.Logf("%s", *mf.Name)
 			for _, metric := range mf.GetMetric() {
-				e.logger.Logf("%v", metric)
+				e.Logf("%v", metric)
 			}
 		}
 	}

--- a/test/integration/endpoints/endpoints_test.go
+++ b/test/integration/endpoints/endpoints_test.go
@@ -48,6 +48,7 @@ func TestEndpointUpdates(t *testing.T) {
 	informers := informers.NewSharedInformerFactory(client, 0)
 
 	tCtx := ktesting.Init(t)
+	defer tCtx.Cancel("test completed")
 	epController := endpoint.NewEndpointController(
 		tCtx,
 		informers.Core().V1().Pods(),

--- a/test/integration/endpointslice/endpointslicemirroring_test.go
+++ b/test/integration/endpointslice/endpointslicemirroring_test.go
@@ -578,12 +578,12 @@ func TestEndpointSliceMirroringSelectorTransition(t *testing.T) {
 				}},
 			}
 
-			_, err = client.CoreV1().Services(ns.Name).Create(context.TODO(), service, metav1.CreateOptions{})
+			_, err = client.CoreV1().Services(ns.Name).Create(tCtx, service, metav1.CreateOptions{})
 			if err != nil {
 				t.Fatalf("Error creating service: %v", err)
 			}
 
-			_, err = client.CoreV1().Endpoints(ns.Name).Create(context.TODO(), customEndpoints, metav1.CreateOptions{})
+			_, err = client.CoreV1().Endpoints(ns.Name).Create(tCtx, customEndpoints, metav1.CreateOptions{})
 			if err != nil {
 				t.Fatalf("Error creating endpoints: %v", err)
 			}
@@ -595,7 +595,7 @@ func TestEndpointSliceMirroringSelectorTransition(t *testing.T) {
 			}
 
 			service.Spec.Selector = tc.endingSelector
-			_, err = client.CoreV1().Services(ns.Name).Update(context.TODO(), service, metav1.UpdateOptions{})
+			_, err = client.CoreV1().Services(ns.Name).Update(tCtx, service, metav1.UpdateOptions{})
 			if err != nil {
 				t.Fatalf("Error updating service: %v", err)
 			}

--- a/test/integration/examples/apiserver_test.go
+++ b/test/integration/examples/apiserver_test.go
@@ -62,9 +62,6 @@ func TestAPIServiceWaitOnStart(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 	t.Cleanup(cancel)
 
-	stopCh := make(chan struct{})
-	defer close(stopCh)
-
 	etcdConfig := framework.SharedEtcd()
 
 	etcd3Client, _, err := integration.GetEtcdClients(etcdConfig.Transport)
@@ -235,9 +232,6 @@ func TestAggregatedAPIServer(t *testing.T) {
 	// makes the kube-apiserver very responsive.  it's normally a minute
 	dynamiccertificates.FileRefreshDuration = 1 * time.Second
 
-	stopCh := make(chan struct{})
-	defer close(stopCh)
-
 	// we need the wardle port information first to set up the service resolver
 	listener, wardlePort, err := genericapiserveroptions.CreateListener("tcp", "127.0.0.1:0", net.ListenConfig{})
 	if err != nil {
@@ -291,7 +285,7 @@ func TestAggregatedAPIServer(t *testing.T) {
 		}
 		o.RecommendedOptions.SecureServing.Listener = listener
 		o.RecommendedOptions.SecureServing.BindAddress = netutils.ParseIPSloppy("127.0.0.1")
-		wardleCmd := sampleserver.NewCommandStartWardleServer(o, stopCh)
+		wardleCmd := sampleserver.NewCommandStartWardleServer(ctx, o)
 		wardleCmd.SetArgs([]string{
 			"--authentication-kubeconfig", wardleToKASKubeConfigFile,
 			"--authorization-kubeconfig", wardleToKASKubeConfigFile,

--- a/test/integration/framework/test_server.go
+++ b/test/integration/framework/test_server.go
@@ -176,7 +176,7 @@ func StartTestServer(ctx context.Context, t testing.TB, setup TestServerSetup) (
 	errCh = make(chan error)
 	go func() {
 		defer close(errCh)
-		if err := kubeAPIServer.GenericAPIServer.PrepareRun().Run(ctx.Done()); err != nil {
+		if err := kubeAPIServer.GenericAPIServer.PrepareRun().Run(ctx); err != nil {
 			errCh <- err
 		}
 	}()

--- a/test/integration/garbagecollector/cluster_scoped_owner_test.go
+++ b/test/integration/garbagecollector/cluster_scoped_owner_test.go
@@ -17,14 +17,13 @@ limitations under the License.
 package garbagecollector
 
 import (
-	"context"
 	"io"
 	"net/http"
 	"strings"
 	"testing"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -71,11 +70,11 @@ func TestClusterScopedOwners(t *testing.T) {
 
 	_, clientSet := ctx.gc, ctx.clientSet
 
-	ns := createNamespaceOrDie("gc-cluster-scope-deletion", clientSet, t)
-	defer deleteNamespaceOrDie(ns.Name, clientSet, t)
+	ns := createNamespaceOrDie(ctx, "gc-cluster-scope-deletion", clientSet, t)
+	defer deleteNamespaceOrDie(ctx, ns.Name, clientSet, t)
 
 	t.Log("Create a pair of objects")
-	pv, err := clientSet.CoreV1().PersistentVolumes().Create(context.TODO(), &v1.PersistentVolume{
+	pv, err := clientSet.CoreV1().PersistentVolumes().Create(ctx, &v1.PersistentVolume{
 		ObjectMeta: metav1.ObjectMeta{Name: "pv-valid"},
 		Spec: v1.PersistentVolumeSpec{
 			PersistentVolumeSource: v1.PersistentVolumeSource{HostPath: &v1.HostPathVolumeSource{Path: "/foo"}},
@@ -86,7 +85,7 @@ func TestClusterScopedOwners(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := clientSet.CoreV1().ConfigMaps(ns.Name).Create(context.TODO(), &v1.ConfigMap{
+	if _, err := clientSet.CoreV1().ConfigMaps(ns.Name).Create(ctx, &v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "cm-valid",
 			OwnerReferences: []metav1.OwnerReference{{Kind: "PersistentVolume", APIVersion: "v1", Name: pv.Name, UID: pv.UID}},
@@ -96,7 +95,7 @@ func TestClusterScopedOwners(t *testing.T) {
 	}
 
 	t.Log("Create a namespaced object with a missing parent")
-	if _, err := clientSet.CoreV1().ConfigMaps(ns.Name).Create(context.TODO(), &v1.ConfigMap{
+	if _, err := clientSet.CoreV1().ConfigMaps(ns.Name).Create(ctx, &v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "cm-missing",
 			Labels:          map[string]string{"missing": "true"},
@@ -107,7 +106,7 @@ func TestClusterScopedOwners(t *testing.T) {
 	}
 
 	t.Log("Create a namespaced object with a missing type parent")
-	if _, err := clientSet.CoreV1().ConfigMaps(ns.Name).Create(context.TODO(), &v1.ConfigMap{
+	if _, err := clientSet.CoreV1().ConfigMaps(ns.Name).Create(ctx, &v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "cm-invalid",
 			OwnerReferences: []metav1.OwnerReference{{Kind: "UnknownType", APIVersion: "unknown.group/v1", Name: "invalid-name", UID: types.UID("invalid-uid")}},
@@ -118,7 +117,7 @@ func TestClusterScopedOwners(t *testing.T) {
 
 	// wait for deletable children to go away
 	if err := wait.Poll(5*time.Second, 300*time.Second, func() (bool, error) {
-		_, err := clientSet.CoreV1().ConfigMaps(ns.Name).Get(context.TODO(), "cm-missing", metav1.GetOptions{})
+		_, err := clientSet.CoreV1().ConfigMaps(ns.Name).Get(ctx, "cm-missing", metav1.GetOptions{})
 		switch {
 		case apierrors.IsNotFound(err):
 			return true, nil
@@ -137,12 +136,12 @@ func TestClusterScopedOwners(t *testing.T) {
 	time.Sleep(5 * time.Second)
 
 	// ensure children with unverifiable parents don't get reaped
-	if _, err := clientSet.CoreV1().ConfigMaps(ns.Name).Get(context.TODO(), "cm-invalid", metav1.GetOptions{}); err != nil {
+	if _, err := clientSet.CoreV1().ConfigMaps(ns.Name).Get(ctx, "cm-invalid", metav1.GetOptions{}); err != nil {
 		t.Fatalf("child with invalid ownerRef is unexpectedly missing: %v", err)
 	}
 
 	// ensure children with present parents don't get reaped
-	if _, err := clientSet.CoreV1().ConfigMaps(ns.Name).Get(context.TODO(), "cm-valid", metav1.GetOptions{}); err != nil {
+	if _, err := clientSet.CoreV1().ConfigMaps(ns.Name).Get(ctx, "cm-valid", metav1.GetOptions{}); err != nil {
 		t.Fatalf("child with valid ownerRef is unexpectedly missing: %v", err)
 	}
 }

--- a/test/integration/service/loadbalancer_test.go
+++ b/test/integration/service/loadbalancer_test.go
@@ -37,6 +37,7 @@ import (
 	kubeapiservertesting "k8s.io/kubernetes/cmd/kube-apiserver/app/testing"
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/test/integration/framework"
+	"k8s.io/kubernetes/test/utils/ktesting"
 	"k8s.io/utils/net"
 	utilpointer "k8s.io/utils/pointer"
 )
@@ -44,6 +45,7 @@ import (
 // Test_ServiceLoadBalancerAllocateNodePorts tests that a Service with spec.allocateLoadBalancerNodePorts=false
 // does not allocate node ports for the Service.
 func Test_ServiceLoadBalancerDisableAllocateNodePorts(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
 	server := kubeapiservertesting.StartTestServerOrDie(t, nil, nil, framework.SharedEtcd())
 	defer server.TearDownFn()
 
@@ -71,7 +73,7 @@ func Test_ServiceLoadBalancerDisableAllocateNodePorts(t *testing.T) {
 		},
 	}
 
-	service, err = client.CoreV1().Services(ns.Name).Create(context.TODO(), service, metav1.CreateOptions{})
+	service, err = client.CoreV1().Services(ns.Name).Create(ctx, service, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("Error creating test service: %v", err)
 	}
@@ -84,6 +86,7 @@ func Test_ServiceLoadBalancerDisableAllocateNodePorts(t *testing.T) {
 // Test_ServiceUpdateLoadBalancerAllocateNodePorts tests that a Service that is updated from ClusterIP to LoadBalancer
 // with spec.allocateLoadBalancerNodePorts=false does not allocate node ports for the Service
 func Test_ServiceUpdateLoadBalancerDisableAllocateNodePorts(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
 	server := kubeapiservertesting.StartTestServerOrDie(t, nil, nil, framework.SharedEtcd())
 	defer server.TearDownFn()
 
@@ -110,7 +113,7 @@ func Test_ServiceUpdateLoadBalancerDisableAllocateNodePorts(t *testing.T) {
 		},
 	}
 
-	service, err = client.CoreV1().Services(ns.Name).Create(context.TODO(), service, metav1.CreateOptions{})
+	service, err = client.CoreV1().Services(ns.Name).Create(ctx, service, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("Error creating test service: %v", err)
 	}
@@ -121,7 +124,7 @@ func Test_ServiceUpdateLoadBalancerDisableAllocateNodePorts(t *testing.T) {
 
 	service.Spec.Type = corev1.ServiceTypeLoadBalancer
 	service.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(false)
-	service, err = client.CoreV1().Services(ns.Name).Update(context.TODO(), service, metav1.UpdateOptions{})
+	service, err = client.CoreV1().Services(ns.Name).Update(ctx, service, metav1.UpdateOptions{})
 	if err != nil {
 		t.Fatalf("Error updating test service: %v", err)
 	}
@@ -134,6 +137,7 @@ func Test_ServiceUpdateLoadBalancerDisableAllocateNodePorts(t *testing.T) {
 // Test_ServiceLoadBalancerSwitchToDeallocatedNodePorts test that switching a Service
 // to spec.allocateLoadBalancerNodePorts=false, does not de-allocate existing node ports.
 func Test_ServiceLoadBalancerEnableThenDisableAllocatedNodePorts(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
 	server := kubeapiservertesting.StartTestServerOrDie(t, nil, nil, framework.SharedEtcd())
 	defer server.TearDownFn()
 
@@ -161,7 +165,7 @@ func Test_ServiceLoadBalancerEnableThenDisableAllocatedNodePorts(t *testing.T) {
 		},
 	}
 
-	service, err = client.CoreV1().Services(ns.Name).Create(context.TODO(), service, metav1.CreateOptions{})
+	service, err = client.CoreV1().Services(ns.Name).Create(ctx, service, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("Error creating test service: %v", err)
 	}
@@ -171,7 +175,7 @@ func Test_ServiceLoadBalancerEnableThenDisableAllocatedNodePorts(t *testing.T) {
 	}
 
 	service.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(false)
-	service, err = client.CoreV1().Services(ns.Name).Update(context.TODO(), service, metav1.UpdateOptions{})
+	service, err = client.CoreV1().Services(ns.Name).Update(ctx, service, metav1.UpdateOptions{})
 	if err != nil {
 		t.Fatalf("Error updating test service: %v", err)
 	}
@@ -366,6 +370,7 @@ func Test_ServiceLoadBalancerDisableAllocatedNodePortsByPatch(t *testing.T) {
 // Test_ServiceLoadBalancerDisableThenEnableAllocatedNodePorts test that switching a Service
 // to spec.allocateLoadBalancerNodePorts=true from false, allocate new node ports.
 func Test_ServiceLoadBalancerDisableThenEnableAllocatedNodePorts(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
 	server := kubeapiservertesting.StartTestServerOrDie(t, nil, nil, framework.SharedEtcd())
 	defer server.TearDownFn()
 
@@ -393,7 +398,7 @@ func Test_ServiceLoadBalancerDisableThenEnableAllocatedNodePorts(t *testing.T) {
 		},
 	}
 
-	service, err = client.CoreV1().Services(ns.Name).Create(context.TODO(), service, metav1.CreateOptions{})
+	service, err = client.CoreV1().Services(ns.Name).Create(ctx, service, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("Error creating test service: %v", err)
 	}
@@ -403,7 +408,7 @@ func Test_ServiceLoadBalancerDisableThenEnableAllocatedNodePorts(t *testing.T) {
 	}
 
 	service.Spec.AllocateLoadBalancerNodePorts = utilpointer.Bool(true)
-	service, err = client.CoreV1().Services(ns.Name).Update(context.TODO(), service, metav1.UpdateOptions{})
+	service, err = client.CoreV1().Services(ns.Name).Update(ctx, service, metav1.UpdateOptions{})
 	if err != nil {
 		t.Fatalf("Error updating test service: %v", err)
 	}
@@ -426,6 +431,7 @@ func serviceHasNodePorts(svc *corev1.Service) bool {
 // Test_ServiceLoadBalancerEnableLoadBalancerClass tests that when a LoadBalancer
 // type of service has spec.LoadBalancerClass set, cloud provider should not create default load balancer.
 func Test_ServiceLoadBalancerEnableLoadBalancerClass(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	server := kubeapiservertesting.StartTestServerOrDie(t, nil, nil, framework.SharedEtcd())
 	defer server.TearDownFn()
 
@@ -439,10 +445,8 @@ func Test_ServiceLoadBalancerEnableLoadBalancerClass(t *testing.T) {
 
 	controller, cloud, informer := newServiceController(t, client)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	informer.Start(ctx.Done())
-	go controller.Run(ctx, 1, controllersmetrics.NewControllerManagerMetrics("loadbalancer-test"))
+	informer.Start(tCtx.Done())
+	go controller.Run(tCtx, 1, controllersmetrics.NewControllerManagerMetrics("loadbalancer-test"))
 
 	service := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
@@ -457,7 +461,7 @@ func Test_ServiceLoadBalancerEnableLoadBalancerClass(t *testing.T) {
 		},
 	}
 
-	_, err = client.CoreV1().Services(ns.Name).Create(ctx, service, metav1.CreateOptions{})
+	_, err = client.CoreV1().Services(ns.Name).Create(tCtx, service, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("Error creating test service: %v", err)
 	}
@@ -472,6 +476,7 @@ func Test_ServiceLoadBalancerEnableLoadBalancerClass(t *testing.T) {
 // type of service has spec.LoadBalancerClass set, it should be immutable as long as the service type
 // is still LoadBalancer.
 func Test_SetLoadBalancerClassThenUpdateLoadBalancerClass(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	server := kubeapiservertesting.StartTestServerOrDie(t, nil, nil, framework.SharedEtcd())
 	defer server.TearDownFn()
 
@@ -485,10 +490,8 @@ func Test_SetLoadBalancerClassThenUpdateLoadBalancerClass(t *testing.T) {
 
 	controller, cloud, informer := newServiceController(t, client)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	informer.Start(ctx.Done())
-	go controller.Run(ctx, 1, controllersmetrics.NewControllerManagerMetrics("loadbalancer-test"))
+	informer.Start(tCtx.Done())
+	go controller.Run(tCtx, 1, controllersmetrics.NewControllerManagerMetrics("loadbalancer-test"))
 
 	service := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
@@ -503,13 +506,13 @@ func Test_SetLoadBalancerClassThenUpdateLoadBalancerClass(t *testing.T) {
 		},
 	}
 
-	service, err = client.CoreV1().Services(ns.Name).Create(ctx, service, metav1.CreateOptions{})
+	service, err = client.CoreV1().Services(ns.Name).Create(tCtx, service, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("Error creating test service: %v", err)
 	}
 
 	service.Spec.LoadBalancerClass = utilpointer.String("test.com/update")
-	_, err = client.CoreV1().Services(ns.Name).Update(ctx, service, metav1.UpdateOptions{})
+	_, err = client.CoreV1().Services(ns.Name).Update(tCtx, service, metav1.UpdateOptions{})
 	if err == nil {
 		t.Fatal("Error: updating test service load balancer class should throw error, field is immutable")
 	}
@@ -523,6 +526,7 @@ func Test_SetLoadBalancerClassThenUpdateLoadBalancerClass(t *testing.T) {
 // Test_UpdateLoadBalancerWithLoadBalancerClass tests that when a Load Balancer type of Service that
 // is updated from non loadBalancerClass set to loadBalancerClass set, it should be not allowed.
 func Test_UpdateLoadBalancerWithLoadBalancerClass(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	server := kubeapiservertesting.StartTestServerOrDie(t, nil, nil, framework.SharedEtcd())
 	defer server.TearDownFn()
 
@@ -536,10 +540,8 @@ func Test_UpdateLoadBalancerWithLoadBalancerClass(t *testing.T) {
 
 	controller, cloud, informer := newServiceController(t, client)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	informer.Start(ctx.Done())
-	go controller.Run(ctx, 1, controllersmetrics.NewControllerManagerMetrics("loadbalancer-test"))
+	informer.Start(tCtx.Done())
+	go controller.Run(tCtx, 1, controllersmetrics.NewControllerManagerMetrics("loadbalancer-test"))
 
 	service := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
@@ -553,13 +555,13 @@ func Test_UpdateLoadBalancerWithLoadBalancerClass(t *testing.T) {
 		},
 	}
 
-	service, err = client.CoreV1().Services(ns.Name).Create(ctx, service, metav1.CreateOptions{})
+	service, err = client.CoreV1().Services(ns.Name).Create(tCtx, service, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("Error creating test service: %v", err)
 	}
 
 	service.Spec.LoadBalancerClass = utilpointer.String("test.com/test")
-	_, err = client.CoreV1().Services(ns.Name).Update(ctx, service, metav1.UpdateOptions{})
+	_, err = client.CoreV1().Services(ns.Name).Update(tCtx, service, metav1.UpdateOptions{})
 	if err == nil {
 		t.Fatal("Error: updating test service load balancer class should throw error, field is immutable")
 	}
@@ -573,6 +575,7 @@ func Test_UpdateLoadBalancerWithLoadBalancerClass(t *testing.T) {
 // Test_ServiceLoadBalancerMixedProtocolSetup tests that a LoadBalancer Service with different protocol values
 // can be created.
 func Test_ServiceLoadBalancerMixedProtocolSetup(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	server := kubeapiservertesting.StartTestServerOrDie(t, nil, nil, framework.SharedEtcd())
 	defer server.TearDownFn()
 
@@ -586,10 +589,8 @@ func Test_ServiceLoadBalancerMixedProtocolSetup(t *testing.T) {
 
 	controller, cloud, informer := newServiceController(t, client)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	informer.Start(ctx.Done())
-	go controller.Run(ctx, 1, controllersmetrics.NewControllerManagerMetrics("loadbalancer-test"))
+	informer.Start(tCtx.Done())
+	go controller.Run(tCtx, 1, controllersmetrics.NewControllerManagerMetrics("loadbalancer-test"))
 
 	service := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
@@ -612,7 +613,7 @@ func Test_ServiceLoadBalancerMixedProtocolSetup(t *testing.T) {
 		},
 	}
 
-	_, err = client.CoreV1().Services(ns.Name).Create(context.TODO(), service, metav1.CreateOptions{})
+	_, err = client.CoreV1().Services(ns.Name).Create(tCtx, service, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("Error creating test service: %v", err)
 	}
@@ -629,7 +630,8 @@ func newServiceController(t *testing.T, client *clientset.Clientset) (*serviceco
 	serviceInformer := informerFactory.Core().V1().Services()
 	nodeInformer := informerFactory.Core().V1().Nodes()
 
-	controller, err := servicecontroller.New(cloud,
+	controller, err := servicecontroller.New(
+		cloud,
 		client,
 		serviceInformer,
 		nodeInformer,
@@ -679,10 +681,9 @@ func Test_ServiceLoadBalancerIPMode(t *testing.T) {
 			controller, cloud, informer := newServiceController(t, client)
 			cloud.ExternalIP = net.ParseIPSloppy(tc.externalIP)
 
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
-			informer.Start(ctx.Done())
-			go controller.Run(ctx, 1, controllersmetrics.NewControllerManagerMetrics("loadbalancer-test"))
+			tCtx := ktesting.Init(t)
+			informer.Start(tCtx.Done())
+			go controller.Run(tCtx, 1, controllersmetrics.NewControllerManagerMetrics("loadbalancer-test"))
 
 			service := &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
@@ -696,13 +697,13 @@ func Test_ServiceLoadBalancerIPMode(t *testing.T) {
 				},
 			}
 
-			service, err = client.CoreV1().Services(ns.Name).Create(ctx, service, metav1.CreateOptions{})
+			service, err = client.CoreV1().Services(ns.Name).Create(tCtx, service, metav1.CreateOptions{})
 			if err != nil {
 				t.Fatalf("Error creating test service: %v", err)
 			}
 
 			time.Sleep(5 * time.Second) // sleep 5 second to wait for the service controller reconcile
-			service, err = client.CoreV1().Services(ns.Name).Get(ctx, service.Name, metav1.GetOptions{})
+			service, err = client.CoreV1().Services(ns.Name).Get(tCtx, service.Name, metav1.GetOptions{})
 			if err != nil {
 				t.Fatalf("Error getting test service: %v", err)
 			}

--- a/test/utils/replicaset.go
+++ b/test/utils/replicaset.go
@@ -19,13 +19,13 @@ package utils
 import (
 	"context"
 	"fmt"
-	"testing"
 	"time"
 
 	apps "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/utils/ktesting"
 )
 
 type UpdateReplicaSetFunc func(d *apps.ReplicaSet)
@@ -54,10 +54,10 @@ func UpdateReplicaSetWithRetries(c clientset.Interface, namespace, name string, 
 }
 
 // Verify .Status.Replicas is equal to .Spec.Replicas
-func WaitRSStable(t *testing.T, clientSet clientset.Interface, rs *apps.ReplicaSet, pollInterval, pollTimeout time.Duration) error {
+func WaitRSStable(tCtx ktesting.TContext, rs *apps.ReplicaSet, pollInterval, pollTimeout time.Duration) error {
 	desiredGeneration := rs.Generation
 	if err := wait.PollImmediate(pollInterval, pollTimeout, func() (bool, error) {
-		newRS, err := clientSet.AppsV1().ReplicaSets(rs.Namespace).Get(context.TODO(), rs.Name, metav1.GetOptions{})
+		newRS, err := tCtx.Client().AppsV1().ReplicaSets(rs.Namespace).Get(tCtx, rs.Name, metav1.GetOptions{})
 		if err != nil {
 			return false, err
 		}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This enables per-test output.

#### Special notes for your reviewer:

test/e2e_node/runner/remote/run_remote.go no longer needs to
add klog flags itself, ktesting takes care of that.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
