### PR TITLE
nodeipam: poll nodes immediately

### DIFF
--- a/pkg/controller/nodeipam/ipam/cidr_allocator.go
+++ b/pkg/controller/nodeipam/ipam/cidr_allocator.go
@@ -75,10 +75,10 @@ const (
 
 	// updateMaxRetries is the max retries for a failed node
 	updateMaxRetries = 10
-
-	// nodePollInterval is used in listing node
-	nodePollInterval = 10 * time.Second
 )
+
+// nodePollInterval is used in listing node
+var nodePollInterval = 10 * time.Second
 
 // CIDRAllocator is an interface implemented by things that know how
 // to allocate/occupy/recycle CIDR for nodes.

--- a/pkg/controller/nodeipam/ipam/controller_legacyprovider.go
+++ b/pkg/controller/nodeipam/ipam/controller_legacyprovider.go
@@ -118,7 +118,8 @@ func NewController(
 func (c *Controller) Start(logger klog.Logger, nodeInformer informers.NodeInformer) error {
 	logger.Info("Starting IPAM controller", "config", c.config)
 
-	nodes, err := listNodes(logger, c.adapter.k8s)
+	ctx := klog.NewContext(context.TODO(), logger)
+	nodes, err := listNodes(ctx, c.adapter.k8s)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/nodeipam/ipam/range_allocator_test.go
+++ b/pkg/controller/nodeipam/ipam/range_allocator_test.go
@@ -292,6 +292,13 @@ func TestOccupyPreExistingCIDR(t *testing.T) {
 }
 
 func TestAllocateOrOccupyCIDRSuccess(t *testing.T) {
+	// Non-parallel test (overrides global var)
+	oldNodePollInterval := nodePollInterval
+	nodePollInterval = test.NodePollInterval
+	defer func() {
+		nodePollInterval = oldNodePollInterval
+	}()
+
 	// all tests operate on a single node
 	testCases := []testCase{
 		{
@@ -673,6 +680,13 @@ type releaseTestCase struct {
 }
 
 func TestReleaseCIDRSuccess(t *testing.T) {
+	// Non-parallel test (overrides global var)
+	oldNodePollInterval := nodePollInterval
+	nodePollInterval = test.NodePollInterval
+	defer func() {
+		nodePollInterval = oldNodePollInterval
+	}()
+
 	testCases := []releaseTestCase{
 		{
 			description: "Correctly release preallocated CIDR",

--- a/pkg/controller/nodeipam/ipam/range_allocator_test.go
+++ b/pkg/controller/nodeipam/ipam/range_allocator_test.go
@@ -292,13 +292,6 @@ func TestOccupyPreExistingCIDR(t *testing.T) {
 }
 
 func TestAllocateOrOccupyCIDRSuccess(t *testing.T) {
-	// Non-parallel test (overrides global var)
-	oldNodePollInterval := nodePollInterval
-	nodePollInterval = test.NodePollInterval
-	defer func() {
-		nodePollInterval = oldNodePollInterval
-	}()
-
 	// all tests operate on a single node
 	testCases := []testCase{
 		{
@@ -680,13 +673,6 @@ type releaseTestCase struct {
 }
 
 func TestReleaseCIDRSuccess(t *testing.T) {
-	// Non-parallel test (overrides global var)
-	oldNodePollInterval := nodePollInterval
-	nodePollInterval = test.NodePollInterval
-	defer func() {
-		nodePollInterval = oldNodePollInterval
-	}()
-
 	testCases := []releaseTestCase{
 		{
 			description: "Correctly release preallocated CIDR",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
The `ipam.CIDRAllocator` is currently waiting 10 seconds before listing the nodes, slowing down the `nodeimap.NewNodeIpamController` and tests associated with it.

#### Which issue(s) this PR fixes:
Fixes part of #123685

#### Special notes for your reviewer:
The PR changes deprecated `wait.Pool` to `wait.PollUntilContextTimeout` and modifies the relevant code to use the context.

These changes improved time of the tests for `nodeipam` package.

<details>
<summary>Before change</summary>

```
--- PASS: TestNewNodeIpamControllerWithCIDRMasks (0.00s)
    --- PASS: TestNewNodeIpamControllerWithCIDRMasks/invalid_CIDR_smaller_than_mask_other_allocators (0.00s)
    --- PASS: TestNewNodeIpamControllerWithCIDRMasks/invalid_CIDR_mask_size (0.00s)
    --- PASS: TestNewNodeIpamControllerWithCIDRMasks/invalid_cluster_CIDR (0.00s)
    --- PASS: TestNewNodeIpamControllerWithCIDRMasks/invalid_serviceCIDR_contains_clusterCIDR (0.00s)
    --- PASS: TestNewNodeIpamControllerWithCIDRMasks/valid_ipam_from_cluster (10.00s)
    --- PASS: TestNewNodeIpamControllerWithCIDRMasks/valid_range_allocator_dualstack_dualstackservice (10.00s)
    --- PASS: TestNewNodeIpamControllerWithCIDRMasks/valid_ipam_from_cloud (10.00s)
    --- PASS: TestNewNodeIpamControllerWithCIDRMasks/valid_cloud_allocator (10.00s)
    --- PASS: TestNewNodeIpamControllerWithCIDRMasks/valid_skip_cluster_CIDR_validation_for_cloud_allocator (10.00s)
    --- PASS: TestNewNodeIpamControllerWithCIDRMasks/valid_range_allocator (10.00s)
    --- PASS: TestNewNodeIpamControllerWithCIDRMasks/valid_range_allocator_dualstack (10.00s)
    --- PASS: TestNewNodeIpamControllerWithCIDRMasks/valid_CIDR_larger_than_mask_cloud_allocator (10.00s)
ok      k8s.io/kubernetes/pkg/controller/nodeipam       10.810s

--- PASS: TestBoundedRetries (0.00s)
--- PASS: TestNodeUpdateRetryTimeout (0.00s)
    --- PASS: TestNodeUpdateRetryTimeout/count_0 (0.00s)
    --- PASS: TestNodeUpdateRetryTimeout/count_1 (0.00s)
    --- PASS: TestNodeUpdateRetryTimeout/count_2 (0.00s)
    --- PASS: TestNodeUpdateRetryTimeout/count_3 (0.00s)
    --- PASS: TestNodeUpdateRetryTimeout/count_50 (0.00s)
--- PASS: TestNeedPodCIDRsUpdate (0.00s)
    --- PASS: TestNeedPodCIDRsUpdate/want_error_-_invalid_cidr (0.00s)
    --- PASS: TestNeedPodCIDRsUpdate/want_error_-_cidr_len_2_but_not_dual_stack (0.00s)
    --- PASS: TestNeedPodCIDRsUpdate/want_false_-_matching_v4_only_cidr (0.00s)
    --- PASS: TestNeedPodCIDRsUpdate/want_false_-_nil_node.Spec.PodCIDR (0.00s)
    --- PASS: TestNeedPodCIDRsUpdate/want_true_-_non_matching_v4_only_cidr (0.00s)
    --- PASS: TestNeedPodCIDRsUpdate/want_false_-_matching_v4_and_v6_cidrs (0.00s)
    --- PASS: TestNeedPodCIDRsUpdate/want_false_-_matching_v4_and_v6_cidrs,_different_strings_but_same_CIDRs (0.00s)
    --- PASS: TestNeedPodCIDRsUpdate/want_true_-_matching_v4_and_non_matching_v6_cidrs (0.00s)
    --- PASS: TestNeedPodCIDRsUpdate/want_true_-_nil_node.Spec.PodCIDRs (0.00s)
    --- PASS: TestNeedPodCIDRsUpdate/want_true_-_matching_v6_and_non_matching_v4_cidrs (0.00s)
    --- PASS: TestNeedPodCIDRsUpdate/want_true_-_missing_v6 (0.00s)
--- PASS: TestOccupyServiceCIDR (0.00s)
--- PASS: TestOccupyPreExistingCIDR (0.00s)
    --- PASS: TestOccupyPreExistingCIDR/success,_single_stack_no_node_allocation (0.00s)
    --- PASS: TestOccupyPreExistingCIDR/success,_dual_stack_no_node_allocation (0.00s)
    --- PASS: TestOccupyPreExistingCIDR/success,_single_stack_correct_node_allocation (0.00s)
    --- PASS: TestOccupyPreExistingCIDR/success,_dual_stack_both_allocated_correctly (0.00s)
    --- PASS: TestOccupyPreExistingCIDR/fail,_single_stack_incorrect_node_allocation (0.00s)
    --- PASS: TestOccupyPreExistingCIDR/fail,_dualstack_node_allocating_from_non_existing_cidr (0.00s)
    --- PASS: TestOccupyPreExistingCIDR/fail,_dualstack_node_allocating_bad_v4 (0.00s)
    --- PASS: TestOccupyPreExistingCIDR/fail,_dualstack_node_allocating_bad_v6 (0.00s)
--- PASS: TestAllocateOrOccupyCIDRSuccess (0.08s)
--- PASS: TestAllocateOrOccupyCIDRFailure (1.00s)
--- PASS: TestReleaseCIDRSuccess (1.03s)
--- PASS: TestTimeout (0.00s)
ok      k8s.io/kubernetes/pkg/controller/nodeipam/ipam  2.872s
```
</details>

<details>
<summary>After change</summary>

```
--- PASS: TestNewNodeIpamControllerWithCIDRMasks (0.00s)
    --- PASS: TestNewNodeIpamControllerWithCIDRMasks/invalid_cluster_CIDR (0.00s)
    --- PASS: TestNewNodeIpamControllerWithCIDRMasks/invalid_CIDR_smaller_than_mask_other_allocators (0.00s)
    --- PASS: TestNewNodeIpamControllerWithCIDRMasks/invalid_CIDR_mask_size (0.00s)
    --- PASS: TestNewNodeIpamControllerWithCIDRMasks/valid_range_allocator_dualstack_dualstackservice (0.00s)
    --- PASS: TestNewNodeIpamControllerWithCIDRMasks/invalid_serviceCIDR_contains_clusterCIDR (0.00s)
    --- PASS: TestNewNodeIpamControllerWithCIDRMasks/valid_range_allocator_dualstack (0.00s)
    --- PASS: TestNewNodeIpamControllerWithCIDRMasks/valid_range_allocator (0.00s)
    --- PASS: TestNewNodeIpamControllerWithCIDRMasks/valid_skip_cluster_CIDR_validation_for_cloud_allocator (0.00s)
    --- PASS: TestNewNodeIpamControllerWithCIDRMasks/valid_ipam_from_cloud (0.00s)
    --- PASS: TestNewNodeIpamControllerWithCIDRMasks/valid_cloud_allocator (0.00s)
    --- PASS: TestNewNodeIpamControllerWithCIDRMasks/valid_CIDR_larger_than_mask_cloud_allocator (0.00s)
    --- PASS: TestNewNodeIpamControllerWithCIDRMasks/valid_ipam_from_cluster (0.00s)
ok      k8s.io/kubernetes/pkg/controller/nodeipam       0.749s

--- PASS: TestBoundedRetries (0.00s)
--- PASS: TestNodeUpdateRetryTimeout (0.00s)
    --- PASS: TestNodeUpdateRetryTimeout/count_0 (0.00s)
    --- PASS: TestNodeUpdateRetryTimeout/count_1 (0.00s)
    --- PASS: TestNodeUpdateRetryTimeout/count_2 (0.00s)
    --- PASS: TestNodeUpdateRetryTimeout/count_3 (0.00s)
    --- PASS: TestNodeUpdateRetryTimeout/count_50 (0.00s)
--- PASS: TestNeedPodCIDRsUpdate (0.00s)
    --- PASS: TestNeedPodCIDRsUpdate/want_error_-_invalid_cidr (0.00s)
    --- PASS: TestNeedPodCIDRsUpdate/want_error_-_cidr_len_2_but_not_dual_stack (0.00s)
    --- PASS: TestNeedPodCIDRsUpdate/want_false_-_matching_v4_only_cidr (0.00s)
    --- PASS: TestNeedPodCIDRsUpdate/want_false_-_nil_node.Spec.PodCIDR (0.00s)
    --- PASS: TestNeedPodCIDRsUpdate/want_true_-_non_matching_v4_only_cidr (0.00s)
    --- PASS: TestNeedPodCIDRsUpdate/want_false_-_matching_v4_and_v6_cidrs (0.00s)
    --- PASS: TestNeedPodCIDRsUpdate/want_false_-_matching_v4_and_v6_cidrs,_different_strings_but_same_CIDRs (0.00s)
    --- PASS: TestNeedPodCIDRsUpdate/want_true_-_matching_v4_and_non_matching_v6_cidrs (0.00s)
    --- PASS: TestNeedPodCIDRsUpdate/want_true_-_nil_node.Spec.PodCIDRs (0.00s)
    --- PASS: TestNeedPodCIDRsUpdate/want_true_-_matching_v6_and_non_matching_v4_cidrs (0.00s)
    --- PASS: TestNeedPodCIDRsUpdate/want_true_-_missing_v6 (0.00s)
--- PASS: TestOccupyServiceCIDR (0.00s)
--- PASS: TestOccupyPreExistingCIDR (0.00s)
    --- PASS: TestOccupyPreExistingCIDR/success,_single_stack_no_node_allocation (0.00s)
    --- PASS: TestOccupyPreExistingCIDR/success,_dual_stack_no_node_allocation (0.00s)
    --- PASS: TestOccupyPreExistingCIDR/success,_single_stack_correct_node_allocation (0.00s)
    --- PASS: TestOccupyPreExistingCIDR/success,_dual_stack_both_allocated_correctly (0.00s)
    --- PASS: TestOccupyPreExistingCIDR/fail,_single_stack_incorrect_node_allocation (0.00s)
    --- PASS: TestOccupyPreExistingCIDR/fail,_dualstack_node_allocating_from_non_existing_cidr (0.00s)
    --- PASS: TestOccupyPreExistingCIDR/fail,_dualstack_node_allocating_bad_v4 (0.00s)
    --- PASS: TestOccupyPreExistingCIDR/fail,_dualstack_node_allocating_bad_v6 (0.00s)
--- PASS: TestAllocateOrOccupyCIDRSuccess (0.07s)
--- PASS: TestAllocateOrOccupyCIDRFailure (1.00s)
--- PASS: TestReleaseCIDRSuccess (1.04s)
--- PASS: TestTimeout (0.00s)
ok      k8s.io/kubernetes/pkg/controller/nodeipam/ipam  2.891s
```
</details>

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
