### PR TITLE
Fix Deep Copy issue in getting controller reference

### DIFF
--- a/staging/publishing/import-restrictions.yaml
+++ b/staging/publishing/import-restrictions.yaml
@@ -41,6 +41,7 @@
   - k8s.io/utils/net
   - k8s.io/utils/strings
   - k8s.io/klog
+  - k8s.io/utils/ptr
 
 - baseImportPath: "./staging/src/k8s.io/api"
   allowedImports:

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/controller_ref.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/controller_ref.go
@@ -18,6 +18,7 @@ package v1
 
 import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/utils/ptr"
 )
 
 // IsControlledBy checks if the  object has a controllerRef set to the given owner
@@ -36,10 +37,14 @@ func GetControllerOf(controllee Object) *OwnerReference {
 		return nil
 	}
 	cp := *ref
+	cp.Controller = ptr.To(*ref.Controller)
+	if ref.BlockOwnerDeletion != nil {
+		cp.BlockOwnerDeletion = ptr.To(*ref.BlockOwnerDeletion)
+	}
 	return &cp
 }
 
-// GetControllerOf returns a pointer to the controllerRef if controllee has a controller
+// GetControllerOfNoCopy returns a pointer to the controllerRef if controllee has a controller
 func GetControllerOfNoCopy(controllee Object) *OwnerReference {
 	refs := controllee.GetOwnerReferences()
 	for i := range refs {
@@ -52,14 +57,12 @@ func GetControllerOfNoCopy(controllee Object) *OwnerReference {
 
 // NewControllerRef creates an OwnerReference pointing to the given owner.
 func NewControllerRef(owner Object, gvk schema.GroupVersionKind) *OwnerReference {
-	blockOwnerDeletion := true
-	isController := true
 	return &OwnerReference{
 		APIVersion:         gvk.GroupVersion().String(),
 		Kind:               gvk.Kind,
 		Name:               owner.GetName(),
 		UID:                owner.GetUID(),
-		BlockOwnerDeletion: &blockOwnerDeletion,
-		Controller:         &isController,
+		BlockOwnerDeletion: ptr.To(true),
+		Controller:         ptr.To(true),
 	}
 }

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/controller_ref_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/controller_ref_test.go
@@ -69,6 +69,7 @@ func TestGetControllerOf(t *testing.T) {
 		},
 	}
 	controllerRef := NewControllerRef(obj1, gvk)
+	controllerRef.BlockOwnerDeletion = nil
 	var falseRef = false
 	obj2 := &metaObj{
 		ObjectMeta: ObjectMeta{
@@ -94,6 +95,12 @@ func TestGetControllerOf(t *testing.T) {
 	c := GetControllerOf(obj2)
 	if c.Name != controllerRef.Name || c.UID != controllerRef.UID {
 		t.Errorf("Incorrect result of GetControllerOf: %v", c)
+	}
+
+	// test that all pointers are also deep copied
+	if (c.Controller == controllerRef.Controller) ||
+		(c.BlockOwnerDeletion != nil && c.BlockOwnerDeletion == controllerRef.BlockOwnerDeletion) {
+		t.Errorf("GetControllerOf did not return deep copy: %v", c)
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR is to fix the Deep Copy issue in this [func](https://github.com/kubernetes/kubernetes/blob/3dedb8eb8c122d0a3221a5842c1d6697d8958151/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/controller_ref.go#L33). As in the same directory a function named "GetControllerOfNoCopy" present which is supposed to return the original controller reference and the function named "GetControllerOf" is supposed to return the controller reference after making Deep Copy. But, It just returns the copy reference of the controller which doesn't make deep copy of "Controller" and "BlockOwnerDeletion" field inside of "Owner Reference" struct. After making changes in copied controller reference(such as, *copiedControllerRef.BlockOwnerDeletion = false), the original value also changes.
#### Does this PR introduce a user-facing change?
NONE
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix Deep Copy issue in getting controller reference
```

