### PR TITLE
client-go: use type assertions with nil pointers

### DIFF
--- a/staging/src/k8s.io/client-go/tools/cache/delta_fifo.go
+++ b/staging/src/k8s.io/client-go/tools/cache/delta_fifo.go
@@ -262,7 +262,7 @@ func NewDeltaFIFOWithOptions(opts DeltaFIFOOptions) *DeltaFIFO {
 }
 
 var (
-	_ = Queue(&DeltaFIFO{}) // DeltaFIFO is a Queue
+	_ Queue = (*DeltaFIFO)(nil) // DeltaFIFO is a Queue
 )
 
 var (

--- a/staging/src/k8s.io/client-go/tools/cache/fifo.go
+++ b/staging/src/k8s.io/client-go/tools/cache/fifo.go
@@ -136,7 +136,7 @@ type FIFO struct {
 }
 
 var (
-	_ = Queue(&FIFO{}) // FIFO is a Queue
+	_ Queue = (*FIFO)(nil) // FIFO is a Queue
 )
 
 // Close the queue.

--- a/staging/src/k8s.io/client-go/tools/cache/heap.go
+++ b/staging/src/k8s.io/client-go/tools/cache/heap.go
@@ -60,7 +60,7 @@ type heapData struct {
 }
 
 var (
-	_ = heap.Interface(&heapData{}) // heapData is a standard heap
+	_ heap.Interface = (*heapData)(nil) // heapData is a standard heap
 )
 
 // Less compares two objects and returns true if the first one should go

--- a/staging/src/k8s.io/client-go/tools/cache/store.go
+++ b/staging/src/k8s.io/client-go/tools/cache/store.go
@@ -163,7 +163,7 @@ type cache struct {
 	keyFunc KeyFunc
 }
 
-var _ Store = &cache{}
+var _ Store = (*cache)(nil)
 
 // Add inserts an item into the cache.
 func (c *cache) Add(obj interface{}) error {

--- a/staging/src/k8s.io/client-go/tools/cache/undelta_store.go
+++ b/staging/src/k8s.io/client-go/tools/cache/undelta_store.go
@@ -29,7 +29,7 @@ type UndeltaStore struct {
 }
 
 // Assert that it implements the Store interface.
-var _ Store = &UndeltaStore{}
+var _ Store = (*UndeltaStore)(nil)
 
 // Add inserts an object into the store and sends complete state by calling PushFunc.
 // Note about thread safety.  The Store implementation (cache.cache) uses a lock for all methods.


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:

This change updates several files within the client-go package to
use type assertions with nil pointers instead of creating an instance.
This approach avoids allocating unnecessary memory and is a more
idiomatic way to assert that structures implement specific interfaces.

Each assertion has been changed from the form `var _ = Interface(&Struct{})`
to `var _ Interface = (*Struct)(nil)`, ensuring no allocation is needed
for these assertions.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
