### PR TITLE
fix panic with SIGSEGV in kubeadm certs check-expiration

### DIFF
--- a/cmd/kubeadm/app/phases/certs/renewal/manager.go
+++ b/cmd/kubeadm/app/phases/certs/renewal/manager.go
@@ -322,7 +322,7 @@ func (rm *Manager) CertificateExists(name string) (bool, error) {
 		return false, errors.Errorf("%s is not a known certificate", name)
 	}
 
-	return handler.readwriter.Exists(), nil
+	return handler.readwriter.Exists()
 }
 
 // GetCertificateExpirationInfo returns certificate expiration info.
@@ -358,7 +358,7 @@ func (rm *Manager) CAExists(name string) (bool, error) {
 		return false, errors.Errorf("%s is not a known certificate", name)
 	}
 
-	return handler.readwriter.Exists(), nil
+	return handler.readwriter.Exists()
 }
 
 // GetCAExpirationInfo returns CA expiration info.

--- a/cmd/kubeadm/app/phases/certs/renewal/manager_test.go
+++ b/cmd/kubeadm/app/phases/certs/renewal/manager_test.go
@@ -54,8 +54,8 @@ type fakecertificateReadWriter struct {
 	cert  *x509.Certificate
 }
 
-func (cr fakecertificateReadWriter) Exists() bool {
-	return cr.exist
+func (cr fakecertificateReadWriter) Exists() (bool, error) {
+	return cr.exist, nil
 }
 
 func (cr fakecertificateReadWriter) Read() (*x509.Certificate, error) {

--- a/cmd/kubeadm/app/phases/certs/renewal/readwriter_test.go
+++ b/cmd/kubeadm/app/phases/certs/renewal/readwriter_test.go
@@ -239,7 +239,7 @@ func TestFileExists(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := fileExists(tt.filename); got != tt.want {
+			if got, _ := fileExists(tt.filename); got != tt.want {
 				t.Errorf("fileExists() = %v, want %v", got, tt.want)
 			}
 		})
@@ -295,7 +295,7 @@ func TestPKICertificateReadWriterExists(t *testing.T) {
 				baseName:       tt.fields.baseName,
 				certificateDir: tt.fields.certificateDir,
 			}
-			if got := rw.Exists(); got != tt.want {
+			if got, _ := rw.Exists(); got != tt.want {
 				t.Errorf("pkiCertificateReadWriter.Exists() = %v, want %v", got, tt.want)
 			}
 		})
@@ -338,7 +338,7 @@ func TestKubeConfigReadWriterExists(t *testing.T) {
 			rw := &kubeConfigReadWriter{
 				kubeConfigFilePath: tt.kubeConfigFilePath,
 			}
-			if got := rw.Exists(); got != tt.want {
+			if got, _ := rw.Exists(); got != tt.want {
 				t.Errorf("kubeConfigReadWriter.Exists() = %v, want %v", got, tt.want)
 			}
 		})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #124120

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubeadm: fix panic in the command "kubeadm certs check-expiration" when "/etc/kubernetes/pki" exists but cannot be read.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
