### PR TITLE
Automated cherry pick of #124124: fix panic with SIGSEGV in kubeadm certs check-expiration

### DIFF
--- a/cmd/kubeadm/app/phases/certs/renewal/manager.go
+++ b/cmd/kubeadm/app/phases/certs/renewal/manager.go
@@ -297,7 +297,7 @@ func (rm *Manager) CertificateExists(name string) (bool, error) {
 		return false, errors.Errorf("%s is not a known certificate", name)
 	}
 
-	return handler.readwriter.Exists(), nil
+	return handler.readwriter.Exists()
 }
 
 // GetCertificateExpirationInfo returns certificate expiration info.
@@ -333,7 +333,7 @@ func (rm *Manager) CAExists(name string) (bool, error) {
 		return false, errors.Errorf("%s is not a known certificate", name)
 	}
 
-	return handler.readwriter.Exists(), nil
+	return handler.readwriter.Exists()
 }
 
 // GetCAExpirationInfo returns CA expiration info.

--- a/cmd/kubeadm/app/phases/certs/renewal/readwriter_test.go
+++ b/cmd/kubeadm/app/phases/certs/renewal/readwriter_test.go
@@ -19,6 +19,7 @@ package renewal
 import (
 	"crypto"
 	"crypto/x509"
+	"fmt"
 	"net"
 	"os"
 	"path/filepath"
@@ -198,4 +199,148 @@ func writeTestKubeconfig(t *testing.T, dir, name string, caCert *x509.Certificat
 	}
 
 	return cert
+}
+
+func TestFileExists(t *testing.T) {
+	tmpdir, err := os.MkdirTemp("", "")
+	if err != nil {
+		t.Fatalf("Couldn't create tmpdir: %v", err)
+	}
+	defer func() {
+		err = os.RemoveAll(tmpdir)
+		if err != nil {
+			t.Fatalf("Fail to remove tmpdir: %v", err)
+		}
+	}()
+	tmpfile, err := os.CreateTemp(tmpdir, "")
+	if err != nil {
+		t.Fatalf("Couldn't create tmpfile: %v", err)
+	}
+	tests := []struct {
+		name     string
+		filename string
+		want     bool
+	}{
+		{
+			name:     "file exist",
+			filename: tmpfile.Name(),
+			want:     true,
+		},
+		{
+			name:     "file does not exist",
+			filename: "foo",
+			want:     false,
+		},
+		{
+			name:     "file path is a dir",
+			filename: tmpdir,
+			want:     false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got, _ := fileExists(tt.filename); got != tt.want {
+				t.Errorf("fileExists() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPKICertificateReadWriterExists(t *testing.T) {
+	tmpdir, err := os.MkdirTemp("", "")
+	if err != nil {
+		t.Fatalf("Couldn't create tmpdir: %v", err)
+	}
+	defer func() {
+		err = os.RemoveAll(tmpdir)
+		if err != nil {
+			t.Fatalf("Fail to remove tmpdir: %v", err)
+		}
+	}()
+	filename := "testfile"
+	tmpfilepath := filepath.Join(tmpdir, fmt.Sprintf(filename+".crt"))
+	err = os.WriteFile(tmpfilepath, nil, 0644)
+	if err != nil {
+		t.Fatalf("Couldn't write file: %v", err)
+	}
+	type fields struct {
+		baseName       string
+		certificateDir string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   bool
+	}{
+		{
+			name: "cert file exists",
+			fields: fields{
+				baseName:       filename,
+				certificateDir: tmpdir,
+			},
+			want: true,
+		},
+		{
+			name: "cert file does not exist",
+			fields: fields{
+				baseName:       "foo",
+				certificateDir: tmpdir,
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rw := &pkiCertificateReadWriter{
+				baseName:       tt.fields.baseName,
+				certificateDir: tt.fields.certificateDir,
+			}
+			if got, _ := rw.Exists(); got != tt.want {
+				t.Errorf("pkiCertificateReadWriter.Exists() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestKubeConfigReadWriterExists(t *testing.T) {
+	tmpdir, err := os.MkdirTemp("", "")
+	if err != nil {
+		t.Fatalf("Couldn't create tmpdir: %v", err)
+	}
+	defer func() {
+		err = os.RemoveAll(tmpdir)
+		if err != nil {
+			t.Fatalf("Fail to remove tmpdir: %v", err)
+		}
+	}()
+	tmpfile, err := os.CreateTemp(tmpdir, "")
+	if err != nil {
+		t.Fatalf("Couldn't create tmpfile: %v", err)
+	}
+	tests := []struct {
+		name               string
+		kubeConfigFilePath string
+		want               bool
+	}{
+		{
+			name:               "file exists",
+			kubeConfigFilePath: tmpfile.Name(),
+			want:               true,
+		},
+		{
+			name:               "file does not exist",
+			kubeConfigFilePath: "foo",
+			want:               false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rw := &kubeConfigReadWriter{
+				kubeConfigFilePath: tt.kubeConfigFilePath,
+			}
+			if got, _ := rw.Exists(); got != tt.want {
+				t.Errorf("kubeConfigReadWriter.Exists() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }


### PR DESCRIPTION
Cherry pick of #124124 on release-1.27.

#124124: fix panic with SIGSEGV in kubeadm certs check-expiration

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```