### PR TITLE
Correct variable names in EndpointSliceMirroring controller

### DIFF
--- a/pkg/controller/endpointslicemirroring/endpointslicemirroring_controller.go
+++ b/pkg/controller/endpointslicemirroring/endpointslicemirroring_controller.go
@@ -464,8 +464,8 @@ func (c *Controller) onEndpointSliceAdd(obj interface{}) {
 // version in the endpointSliceTracker or the managed-by value of the
 // EndpointSlice has changed from or to this controller.
 func (c *Controller) onEndpointSliceUpdate(logger klog.Logger, prevObj, obj interface{}) {
-	prevEndpointSlice := obj.(*discovery.EndpointSlice)
-	endpointSlice := prevObj.(*discovery.EndpointSlice)
+	endpointSlice := obj.(*discovery.EndpointSlice)
+	prevEndpointSlice := prevObj.(*discovery.EndpointSlice)
 	if endpointSlice == nil || prevEndpointSlice == nil {
 		utilruntime.HandleError(fmt.Errorf("onEndpointSliceUpdated() expected type discovery.EndpointSlice, got %T, %T", prevObj, obj))
 		return


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This Pull Request addresses a variable naming issue identified in the codebase. Specifically, the variables endpointSlice and prevEndpointSlice were found to have names that are contrary to their intended meanings, which could lead to confusion among readers and maintainers of the code, ultimately impacting the clarity and potential execution logic of the program.

#### Does this PR introduce a user-facing change?
```release-note
Endpointslices mirrored from Endpoints by the EndpointSliceMirroring controller were not reconciled if modified
```