### PR TITLE
PoC: object annotation trace context carrier

### DIFF
--- a/pkg/controller/controller_utils.go
+++ b/pkg/controller/controller_utils.go
@@ -51,6 +51,7 @@ import (
 	"k8s.io/kubernetes/pkg/features"
 	hashutil "k8s.io/kubernetes/pkg/util/hash"
 	taintutils "k8s.io/kubernetes/pkg/util/taints"
+	"k8s.io/kubernetes/staging/src/k8s.io/component-base/tracing"
 	"k8s.io/utils/clock"
 
 	"k8s.io/klog/v2"
@@ -579,6 +580,7 @@ func (r RealPodControl) createPods(ctx context.Context, namespace string, pod *v
 	if len(labels.Set(pod.Labels)) == 0 {
 		return fmt.Errorf("unable to create pods, no labels")
 	}
+	tracing.InjectContext(ctx, pod)
 	newPod, err := r.KubeClient.CoreV1().Pods(namespace).Create(ctx, pod, metav1.CreateOptions{})
 	if err != nil {
 		// only send an event if the namespace isn't terminating

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -124,6 +124,7 @@ import (
 	"k8s.io/kubernetes/pkg/volume/util/hostutil"
 	"k8s.io/kubernetes/pkg/volume/util/subpath"
 	"k8s.io/kubernetes/pkg/volume/util/volumepathhandler"
+	"k8s.io/kubernetes/staging/src/k8s.io/component-base/tracing"
 	"k8s.io/utils/clock"
 )
 
@@ -1721,6 +1722,7 @@ func (kl *Kubelet) Run(updates <-chan kubetypes.PodUpdate) {
 // the most accurate information possible about an error situation to aid debugging.
 // Callers should not write an event if this operation returns an error.
 func (kl *Kubelet) SyncPod(ctx context.Context, updateType kubetypes.SyncPodType, pod, mirrorPod *v1.Pod, podStatus *kubecontainer.PodStatus) (isTerminal bool, err error) {
+	ctx = tracing.ExtractContext(ctx, pod)
 	ctx, otelSpan := kl.tracer.Start(ctx, "syncPod", trace.WithAttributes(
 		semconv.K8SPodUIDKey.String(string(pod.UID)),
 		attribute.String("k8s.pod", klog.KObj(pod).String()),

--- a/staging/src/k8s.io/component-base/tracing/context.go
+++ b/staging/src/k8s.io/component-base/tracing/context.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tracing
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// assert that objectCarrier implements the TextMapCarrier interface.
+var _ propagation.TextMapCarrier = &objectCarrier{}
+
+// objectCarrier is a TextMapCarrier that stores and retrieves keys to/from
+// Object annotations.
+// TODO: Should this use a prefix?  e.g. tracing.kubernetes.io/traceparent vs traceparent
+type objectCarrier struct {
+	object metav1.Object
+}
+
+func (s *objectCarrier) Get(key string) string {
+	return s.object.GetAnnotations()[key]
+}
+
+func (s *objectCarrier) Set(key string, value string) {
+	annotations := s.object.GetAnnotations()
+	annotations[key] = value
+	s.object.SetAnnotations(annotations)
+}
+
+func (s *objectCarrier) Keys() []string {
+	annotations := s.object.GetAnnotations()
+	keys := make([]string, len(annotations))
+	i := 0
+	for k := range annotations {
+		keys[i] = k
+	}
+	return keys
+}
+
+// Extract reads context from the object into the returned Context using the
+// global propagators.
+// This should be called when reconciling an object before starting any spans.
+func ExtractContext(ctx context.Context, object metav1.Object) context.Context {
+	return otel.GetTextMapPropagator().Extract(ctx, &objectCarrier{object: object})
+}
+
+// Extract injects the Context into the object using the global propagators.
+// This should be called before updating the desired state of an object, including:
+// * Creating the object
+// * Setting the deletion timestamp of an object
+// * Updating the object's Spec
+// The caller needs to ensure the modified object is written after calling this
+// function.
+func InjectContext(ctx context.Context, object metav1.Object) {
+	otel.GetTextMapPropagator().Inject(ctx, &objectCarrier{object: object})
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Example implementation of context propagation using object annotations as the carrier.  This would enable linking kubelet spans to spans from other controllers.

`ExtractContext` gets the context from an object (this will be in the w3c traceparent format).

`InjectContext` adds the context to an object.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

This is similar to ideas documented in https://github.com/kubernetes/enhancements/pull/2312.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```

@richabanker @logicalhan @tallclair @dgrisonnet 