### PR TITLE
Add 'change-cause' annotation example to kubectl annotate docs

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/annotate/annotate.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/annotate/annotate.go
@@ -142,7 +142,11 @@ var (
 
     # Update pod 'foo' by removing an annotation named 'description' if it exists
     # Does not require the --overwrite flag
-    kubectl annotate pods foo description-`))
+    kubectl annotate pods foo description-
+
+    # Update deployment 'nginx' with a 'change-cause' annotation to track the reason for a change
+    # This is useful for maintaining historical records of changes made
+    kubectl annotate deployment nginx kubernetes.io/change-cause='image updated to 1.16.1'`))
 )
 
 // NewCmdAnnotate creates the `annotate` command


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

Enhance the kubectl annotate documentation by providing a practical example of using the kubernetes.io/change-cause annotation. This addition highlights a widely utilised feature of the annotate command, often cited in documentation, videos and discussions about deployments, statefulsets, and rolling updates.

As a command line option that may be required in the likes of the CKA/CKAD exam, having this available in the command line documentation will not only benefit everyday usage and best practices but also those who require this reference for exam purposes.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Updated annotations help text to include change-cause
```