### PR TITLE
svm test: wait after updating CRD to avoid flakes

### DIFF
--- a/test/integration/storageversionmigrator/util.go
+++ b/test/integration/storageversionmigrator/util.go
@@ -773,6 +773,10 @@ func (svm *svmTest) updateCRD(
 		t.Fatalf("Failed to get CRD: %v", err)
 	}
 
+	// TODO: wrap all actions after updateCRD with wait loops so we do not need this sleep
+	//  it is currently necessary because we update the CRD but do not otherwise guarantee that the updated config is active
+	time.Sleep(10 * time.Second)
+
 	return crd
 }
 


### PR DESCRIPTION
Fixes #123921

/kind cleanup
/kind failing-test
/kind flake
/milestone v1.30

```release-note
NONE
```