### PR TITLE
Change the MaxSkew of systemDefaultConstraints for PodTopologySpread Plugin

### DIFF
--- a/pkg/scheduler/framework/plugins/podtopologyspread/plugin.go
+++ b/pkg/scheduler/framework/plugins/podtopologyspread/plugin.go
@@ -48,12 +48,12 @@ var systemDefaultConstraints = []v1.TopologySpreadConstraint{
 	{
 		TopologyKey:       v1.LabelHostname,
 		WhenUnsatisfiable: v1.ScheduleAnyway,
-		MaxSkew:           3,
+		MaxSkew:           1,
 	},
 	{
 		TopologyKey:       v1.LabelTopologyZone,
 		WhenUnsatisfiable: v1.ScheduleAnyway,
-		MaxSkew:           5,
+		MaxSkew:           1,
 	},
 }
 

--- a/pkg/scheduler/framework/plugins/podtopologyspread/scoring_test.go
+++ b/pkg/scheduler/framework/plugins/podtopologyspread/scoring_test.go
@@ -253,7 +253,7 @@ func TestPreScoreStateEmptyNodes(t *testing.T) {
 			want: &preScoreState{
 				Constraints: []topologySpreadConstraint{
 					{
-						MaxSkew:            3,
+						MaxSkew:            1,
 						TopologyKey:        v1.LabelHostname,
 						Selector:           mustConvertLabelSelectorAsSelector(t, fooSelector),
 						MinDomains:         1,
@@ -261,7 +261,7 @@ func TestPreScoreStateEmptyNodes(t *testing.T) {
 						NodeTaintsPolicy:   v1.NodeInclusionPolicyIgnore,
 					},
 					{
-						MaxSkew:            5,
+						MaxSkew:            1,
 						TopologyKey:        v1.LabelTopologyZone,
 						Selector:           mustConvertLabelSelectorAsSelector(t, fooSelector),
 						MinDomains:         1,
@@ -819,9 +819,9 @@ func TestPodTopologySpreadScore(t *testing.T) {
 			},
 			want: []framework.NodeScore{
 				// Same scores as if we were using one spreading constraint.
-				{Name: "node-a", Score: 44},
-				{Name: "node-b", Score: 66},
-				{Name: "node-c", Score: 77},
+				{Name: "node-a", Score: 28},
+				{Name: "node-b", Score: 57},
+				{Name: "node-c", Score: 71},
 				{Name: "node-d", Score: 100},
 			},
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
/sig scheduling

#### What this PR does / why we need it:

This PR changes the MaxSkew of the systemDefaultConstraints to 1 for two well-known topology keys in PodTopologySpread Plugin. 

systemDefaultConstraints is used when topologySpreadConstraint is not specified in the PodSpec.
The default value was set to 5 and 3 for zone and host spread respectively. These settings have two problems:
1) They are different from the default values used in the TopologySpreadConstraint field in the Pod Spec (default is 1).
2) Large default MaxSkew often cause pods not being spread across multiple zones in the clusters. Users often need to set the TopologySpreadConstraint explicitly to work around the issue.

Note that when systemDefaultConstraints is used, the PodTopologySpread plugin will check the Pod's ownerreference.  If the Pod is owned by a workload, the plugin will check all pods that belong to the same workload as the group to meet the spread constraint. From this perspective, it is more consistent by changing the default MaxSkew in systemDefaultConstraints to match the default used in the Pod spec.
 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

Our internal test shows that after changing the default MaxSkew value to 1, when deploying multiple workloads with 3 replicas in a cluster span across three zones, 99% workloads have 3 copies evenly distributed across zones. With the previous default value of 5, only ~50% workloads have 3 copies evenly distributed across zones.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```


