### PR TITLE
update client/kernel version requirements for nftables kube-proxy

### DIFF
--- a/pkg/util/kernel/constants.go
+++ b/pkg/util/kernel/constants.go
@@ -49,3 +49,8 @@ const IPVSConnReuseModeFixedKernelVersion = "5.9"
 const UserNamespacesSupportKernelVersion = "6.3"
 
 const TmpfsNoswapSupportKernelVersion = "6.4"
+
+// NFTablesKubeProxyKernelVersion is the lowest kernel version kube-proxy supports using
+// nftables mode with by default. This is not directly related to any specific kernel
+// commit; see https://issues.k8s.io/122743#issuecomment-1893922424
+const NFTablesKubeProxyKernelVersion = "5.13"


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/sig network
/area kube-proxy
/priority important-soon

#### What this PR does / why we need it:
Addresses the problem that (a) sometimes older versions of `nft` will crash if they see rules created by newer versions of nft, and that (b) with `nft` < 1.0.1, when you do `nft -f ...` it will try to parse the entire ruleset at startup, rather than only trying to parse the tables that you actually reference in the commands passed to `nft`. Thus:

1. Require that kube-proxy be using `nft` 1.0.1 or later, to ensure that other people's use of nftables won't break kube-proxy.
2. Require that the kernel is 5.13 or newer, to hopefully ensure that the system has `nft` 1.0.1 or later, to ensure that kube-proxy's use of nftables won't break other people. (We can't directly check the system nft version, but all known distros with kernel 5.13 or later also have nft 1.0.1 or later.)
3. The `nftables.skipKernelVersionCheck` config option allows bypassing the above check for dev/testing purposes. (As of April 2024 there are still supported versions of LTS distros using slightly older kernels, though by the time we go GA this should no longer be true.)

More discussion in #122743.

#### Which issue(s) this PR fixes:
Fixes #122743

#### Special notes for your reviewer:
knftables rebase stolen from #123389...

#### Does this PR introduce a user-facing change?
```release-note
The (alpha) nftables mode of kube-proxy now requires version 1.0.1 or later
of the nft command-line, and kernel 5.13 or later. (For testing/development
purposes, you can use older kernels, as far back as 5.4, if you set the
`nftables.skipKernelVersionCheck` option in the kube-proxy config, but this is not
recommended in production since it may cause problems with other nftables
users on the system.)
```
