### PR TITLE
Move chrishenzie to sig-store-reviewer emeritus

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -136,7 +136,6 @@ aliases:
   # - rootfs
   sig-storage-reviewers:
     - carlory
-    - chrishenzie
     - gnufied
     - humblec
     - jsafrane
@@ -147,6 +146,7 @@ aliases:
     - saikat-royc
     - xing-yang
   # emeritus:
+  # - chrishenzie
   # - davidz627
   # - Jiawei0227
   # - rootfs


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Moves me to the sig-storage-reviewer emeritus group. I haven't participated here in a while.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/sig storage
/assign @msau42 