### PR TITLE
#124157 Jsonpath impl does not support left match regex

### DIFF
--- a/staging/src/k8s.io/client-go/util/jsonpath/jsonpath_test.go
+++ b/staging/src/k8s.io/client-go/util/jsonpath/jsonpath_test.go
@@ -601,6 +601,41 @@ func TestFilterPartialMatchesSometimesMissingAnnotations(t *testing.T) {
 	testJSONPath(
 		[]jsonpathTest{
 			{
+				"filter, should match 'pod2 pod4' by regex",
+				`{.items[?(@.metadata.name =~ /POD[24]/i)].metadata.name}`,
+				data,
+				"pod2 pod4",
+				false, // expect no error
+			},
+			{
+				"filter, should match 'pod1 pod3' by regex",
+				`{.items[?(@.metadata.name =~ /POD[13]/i)].metadata.name}`,
+				data,
+				"pod1 pod3",
+				false, // expect no error
+			},
+			{
+				"filter, regex invalid flags",
+				`{.items[?(@.metadata.name =~ /POD[13]/b)].metadata.name}`,
+				data,
+				"pod1 pod3",
+				true, // expect error
+			},
+			{
+				"filter, regex no flags",
+				`{.items[?(@.metadata.name =~ /.{3}[13]/)].metadata.name}`,
+				data,
+				"pod1 pod3",
+				false, // expect no error
+			},
+		},
+		true, // allow missing keys
+		t,
+	)
+
+	testJSONPath(
+		[]jsonpathTest{
+			{
 				"filter, should only match a subset, some items don't have annotations, error on missing items",
 				`{.items[?(@.metadata.annotations.color=="blue")].metadata.name}`,
 				data,

--- a/staging/src/k8s.io/client-go/util/jsonpath/node.go
+++ b/staging/src/k8s.io/client-go/util/jsonpath/node.go
@@ -16,7 +16,10 @@ limitations under the License.
 
 package jsonpath
 
-import "fmt"
+import (
+	"fmt"
+	"regexp"
+)
 
 // NodeType identifies the type of a parse tree node.
 type NodeType int
@@ -43,6 +46,7 @@ const (
 	NodeRecursive
 	NodeUnion
 	NodeBool
+	NodeRegex
 )
 
 var NodeTypeName = map[NodeType]string{
@@ -58,6 +62,7 @@ var NodeTypeName = map[NodeType]string{
 	NodeRecursive:  "NodeRecursive",
 	NodeUnion:      "NodeUnion",
 	NodeBool:       "NodeBool",
+	NodeRegex:      "NodeRegex",
 }
 
 type Node interface {
@@ -225,6 +230,20 @@ func newRecursive() *RecursiveNode {
 
 func (r *RecursiveNode) String() string {
 	return r.Type().String()
+}
+
+// RegexNode holds Regexp
+type RegexNode struct {
+	NodeType
+	Regex regexp.Regexp
+}
+
+func newRegex(regex regexp.Regexp) *RegexNode {
+	return &RegexNode{NodeType: NodeRegex, Regex: regex}
+}
+
+func (r *RegexNode) String() string {
+	return fmt.Sprintf("%s: %s", r.Type(), &r.Regex)
 }
 
 // UnionNode is union of ListNode

--- a/staging/src/k8s.io/client-go/util/jsonpath/parser_test.go
+++ b/staging/src/k8s.io/client-go/util/jsonpath/parser_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package jsonpath
 
 import (
+	"regexp"
 	"testing"
 )
 
@@ -44,6 +45,9 @@ var parserTests = []parserTest{
 	{"filter", `{[?(@.price<3)]}`,
 		[]Node{newList(), newFilter(newList(), newList(), "<"),
 			newList(), newField("price"), newList(), newInt(3)}, false},
+	{"regex", `{[?(@.name=~/Tom/i)]}`,
+		[]Node{newList(), newFilter(newList(), newList(), "=~"),
+			newList(), newField("name"), newList(), newRegex(*regexp.MustCompile("(?i)Tom"))}, false},
 	{"recursive", `{..}`, []Node{newList(), newRecursive()}, false},
 	{"recurField", `{..price}`,
 		[]Node{newList(), newRecursive(), newField("price")}, false},


### PR DESCRIPTION
fixes #124157

Signed-off-by: Raymond Augé <raymond.auge@liferay.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

#### What this PR does / why we need it:
Allows jsonpath filters to use regex like so:
```shell
k get pods -o jsonpath='{.items[?(@.metadata.name =~ /^node.*/)].metadata.name}'
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #124157

#### Special notes for your reviewer:
Nothing special!

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
JSONPath filter operations now support `=~` in addition to `<|>|==|!=|<=|>=`.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
