### PR TITLE
resourcequota: use singleflight.Group to reduce apiserver load

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/resourcequota/resource_access_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/resourcequota/resource_access_test.go
@@ -17,7 +17,10 @@ limitations under the License.
 package resourcequota
 
 import (
+	"fmt"
 	"reflect"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -27,6 +30,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
+	core "k8s.io/client-go/testing"
 	"k8s.io/utils/lru"
 )
 
@@ -121,5 +125,122 @@ func TestLRUCacheLookup(t *testing.T) {
 			}
 		})
 	}
+}
 
+// TestGetQuotas ensures we do not have multiple LIST calls to the apiserver
+// in-flight at any one time. This is to ensure the issue described in #22422 do
+// not happen again.
+func TestGetQuotas(t *testing.T) {
+	var (
+		testNamespace1              = "test-a"
+		testNamespace2              = "test-b"
+		listCallCountTestNamespace1 int64
+		listCallCountTestNamespace2 int64
+	)
+	resourceQuota := &corev1.ResourceQuota{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "foo",
+		},
+	}
+
+	resourceQuotas := []*corev1.ResourceQuota{resourceQuota}
+
+	kubeClient := &fake.Clientset{}
+	informerFactory := informers.NewSharedInformerFactory(kubeClient, 0)
+
+	accessor, _ := newQuotaAccessor()
+	accessor.client = kubeClient
+	accessor.lister = informerFactory.Core().V1().ResourceQuotas().Lister()
+
+	kubeClient.AddReactor("list", "resourcequotas", func(action core.Action) (bool, runtime.Object, error) {
+		switch action.GetNamespace() {
+		case testNamespace1:
+			atomic.AddInt64(&listCallCountTestNamespace1, 1)
+		case testNamespace2:
+			atomic.AddInt64(&listCallCountTestNamespace2, 1)
+		default:
+			t.Error("unexpected namespace")
+		}
+
+		resourceQuotaList := &corev1.ResourceQuotaList{
+			ListMeta: metav1.ListMeta{
+				ResourceVersion: fmt.Sprintf("%d", len(resourceQuotas)),
+			},
+		}
+		for i, quota := range resourceQuotas {
+			quota.ResourceVersion = fmt.Sprintf("%d", i)
+			quota.Namespace = action.GetNamespace()
+			resourceQuotaList.Items = append(resourceQuotaList.Items, *quota)
+		}
+		// make the handler slow so concurrent calls exercise the singleflight
+		time.Sleep(time.Second)
+		return true, resourceQuotaList, nil
+	})
+
+	wg := sync.WaitGroup{}
+	for i := 0; i < 10; i++ {
+		wg.Add(2)
+		// simulating concurrent calls after a cache failure
+		go func() {
+			defer wg.Done()
+			quotas, err := accessor.GetQuotas(testNamespace1)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if len(quotas) != len(resourceQuotas) {
+				t.Errorf("Expected %d resource quotas, got %d", len(resourceQuotas), len(quotas))
+			}
+			for _, q := range quotas {
+				if q.Namespace != testNamespace1 {
+					t.Errorf("Expected %s namespace, got %s", testNamespace1, q.Namespace)
+				}
+			}
+		}()
+
+		// simulation of different namespaces is a call for a different group key, but not shared with the first namespace
+		go func() {
+			defer wg.Done()
+			quotas, err := accessor.GetQuotas(testNamespace2)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if len(quotas) != len(resourceQuotas) {
+				t.Errorf("Expected %d resource quotas, got %d", len(resourceQuotas), len(quotas))
+			}
+			for _, q := range quotas {
+				if q.Namespace != testNamespace2 {
+					t.Errorf("Expected %s namespace, got %s", testNamespace2, q.Namespace)
+				}
+			}
+		}()
+	}
+
+	// and here we wait for all the goroutines
+	wg.Wait()
+	// since all the calls with the same namespace will be held, they must
+	// be caught on the singleflight group. there are two different sets of
+	// namespace calls hence only 2.
+	if listCallCountTestNamespace1 != 1 {
+		t.Errorf("Expected 1 resource quota call, got %d", listCallCountTestNamespace1)
+	}
+	if listCallCountTestNamespace2 != 1 {
+		t.Errorf("Expected 1 resource quota call, got %d", listCallCountTestNamespace2)
+	}
+
+	// invalidate the cache
+	accessor.liveLookupCache.Remove(testNamespace1)
+	quotas, err := accessor.GetQuotas(testNamespace1)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if len(quotas) != len(resourceQuotas) {
+		t.Errorf("Expected %d resource quotas, got %d", len(resourceQuotas), len(quotas))
+	}
+
+	if listCallCountTestNamespace1 != 2 {
+		t.Errorf("Expected 2 resource quota call, got %d", listCallCountTestNamespace1)
+	}
+	if listCallCountTestNamespace2 != 1 {
+		t.Errorf("Expected 1 resource quota call, got %d", listCallCountTestNamespace2)
+	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup
/kind flake
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Wraps up the code that requests the apiserver directly (without a lister) with a `singleflight.Group`.
This conforms to how the limit range admission plugin makes requests to the apiserver. 
I'm also hoping this will fix a flaky replica set test, but since I can't reproduce the flake I cannot be sure.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Relates to #22422 and #123806.

And inspired by https://github.com/kubernetes/kubernetes/pull/112696 and https://github.com/kubernetes/kubernetes/pull/114919.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
