### PR TITLE
Add tnqn to sig-network-reviewers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -276,6 +276,7 @@ aliases:
     - mrhohn
     - robscott
     - thockin
+    - tnqn
   sig-apps-approvers:
     - kow3ns
     - janetkuo


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/sig network

#### What this PR does / why we need it:

The PR is an application for reviewership for sig-network. Thank you for your consideration.

A self-assessment according to [the requirements](https://github.com/kubernetes/community/blob/master/community-membership.md#requirements-1):

- [x] Member for at least 3 months: [Membership since Jul 8, 2020](https://github.com/kubernetes/org/issues/2001)
- [x] Primary reviewer for at least 5 PRs to the codebase: [Reviewed PRs](https://github.com/kubernetes/kubernetes/pulls?q=is%3Apr+reviewed-by%3Atnqn)
- [x] Reviewed or merged at least 20 substantial PRs to the codebase: [Merged PRs](https://github.com/kubernetes/kubernetes/pulls?q=is%3Apr+author%3Atnqn+is%3Amerged)
- [x] Knowledgeable about the codebase: [Authored issues and PRs](https://github.com/kubernetes/kubernetes/issues?q=author%3Atnqn)
- [x] Sponsored by a subproject approver: @danwinship 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
