### PR TITLE
WIP: Allow to build with go 1.21

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@
 
 module k8s.io/kubernetes
 
-go 1.22.0
+go 1.21
 
 require (
 	bitbucket.org/bertimus9/systemstat v0.5.0


### PR DESCRIPTION


#### What type of PR is this?

/kind regression


#### What this PR does / why we need it:
The glibc bug used by go 1.22 is breaking runc 1.2.0 in some cases. This does not directly influence Kubernetes, but downstream may rely on Kubernetes as well as runc in their build environments. This means that forcing users to build Kubernetes with go 1.22 may break their build toolchain, which is especially the case for container runtimes. We now relax that restriction to allow building with go 1.21 until the runc issue has been resolved.



#### Which issue(s) this PR fixes:

Refers to: https://github.com/opencontainers/runc/issues/4233, https://github.com/kubernetes/kubernetes/issues/124168

#### Special notes for your reviewer:
cc @kubernetes/sig-architecture @kubernetes/sig-release 
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Allow to build Kubernetes with go 1.21.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
