### PR TITLE
feat: add AnnotatedEventf to events.EventRecorder

### DIFF
--- a/staging/src/k8s.io/client-go/tools/events/event_recorder.go
+++ b/staging/src/k8s.io/client-go/tools/events/event_recorder.go
@@ -43,7 +43,11 @@ type recorderImpl struct {
 var _ EventRecorder = &recorderImpl{}
 
 func (recorder *recorderImpl) Eventf(regarding runtime.Object, related runtime.Object, eventtype, reason, action, note string, args ...interface{}) {
-	recorder.eventf(klog.Background(), regarding, related, eventtype, reason, action, note, args...)
+	recorder.eventf(klog.Background(), regarding, related, nil, eventtype, reason, action, note, args...)
+}
+
+func (recorder *recorderImpl) AnnotatedEventf(regarding runtime.Object, related runtime.Object, annotations map[string]string, eventtype, reason, action, note string, args ...interface{}) {
+	recorder.eventf(klog.Background(), regarding, related, annotations, eventtype, reason, action, note, args...)
 }
 
 type recorderImplLogger struct {
@@ -54,14 +58,18 @@ type recorderImplLogger struct {
 var _ EventRecorderLogger = &recorderImplLogger{}
 
 func (recorder *recorderImplLogger) Eventf(regarding runtime.Object, related runtime.Object, eventtype, reason, action, note string, args ...interface{}) {
-	recorder.eventf(recorder.logger, regarding, related, eventtype, reason, action, note, args...)
+	recorder.eventf(recorder.logger, regarding, related, nil, eventtype, reason, action, note, args...)
+}
+
+func (recorder *recorderImplLogger) AnnotatedEventf(regarding runtime.Object, related runtime.Object, annotations map[string]string, eventtype, reason, action, note string, args ...interface{}) {
+	recorder.eventf(recorder.logger, regarding, related, annotations, eventtype, reason, action, note, args...)
 }
 
 func (recorder *recorderImplLogger) WithLogger(logger klog.Logger) EventRecorderLogger {
 	return &recorderImplLogger{recorderImpl: recorder.recorderImpl, logger: logger}
 }
 
-func (recorder *recorderImpl) eventf(logger klog.Logger, regarding runtime.Object, related runtime.Object, eventtype, reason, action, note string, args ...interface{}) {
+func (recorder *recorderImpl) eventf(logger klog.Logger, regarding runtime.Object, related runtime.Object, annotations map[string]string, eventtype, reason, action, note string, args ...interface{}) {
 	timestamp := metav1.MicroTime{Time: time.Now()}
 	message := fmt.Sprintf(note, args...)
 	refRegarding, err := reference.GetReference(recorder.scheme, regarding)
@@ -81,14 +89,14 @@ func (recorder *recorderImpl) eventf(logger klog.Logger, regarding runtime.Objec
 		logger.Error(nil, "Unsupported event type", "eventType", eventtype)
 		return
 	}
-	event := recorder.makeEvent(refRegarding, refRelated, timestamp, eventtype, reason, message, recorder.reportingController, recorder.reportingInstance, action)
+	event := recorder.makeEvent(refRegarding, refRelated, timestamp, annotations, eventtype, reason, message, recorder.reportingController, recorder.reportingInstance, action)
 	go func() {
 		defer utilruntime.HandleCrash()
 		recorder.Action(watch.Added, event)
 	}()
 }
 
-func (recorder *recorderImpl) makeEvent(refRegarding *v1.ObjectReference, refRelated *v1.ObjectReference, timestamp metav1.MicroTime, eventtype, reason, message string, reportingController string, reportingInstance string, action string) *eventsv1.Event {
+func (recorder *recorderImpl) makeEvent(refRegarding *v1.ObjectReference, refRelated *v1.ObjectReference, timestamp metav1.MicroTime, annotations map[string]string, eventtype, reason, message string, reportingController string, reportingInstance string, action string) *eventsv1.Event {
 	t := metav1.Time{Time: recorder.clock.Now()}
 	namespace := refRegarding.Namespace
 	if namespace == "" {
@@ -96,8 +104,9 @@ func (recorder *recorderImpl) makeEvent(refRegarding *v1.ObjectReference, refRel
 	}
 	return &eventsv1.Event{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%v.%x", refRegarding.Name, t.UnixNano()),
-			Namespace: namespace,
+			Name:        fmt.Sprintf("%v.%x", refRegarding.Name, t.UnixNano()),
+			Namespace:   namespace,
+			Annotations: annotations,
 		},
 		EventTime:           timestamp,
 		Series:              nil,

--- a/staging/src/k8s.io/client-go/tools/events/eventseries_test.go
+++ b/staging/src/k8s.io/client-go/tools/events/eventseries_test.go
@@ -299,7 +299,7 @@ func TestFinishSeries(t *testing.T) {
 	cache := map[eventKey]*eventsv1.Event{}
 	eventBroadcaster := newBroadcaster(&testEvents, 0, cache).(*eventBroadcasterImpl)
 	recorder := eventBroadcaster.NewRecorder(scheme.Scheme, "k8s.io/kube-foo").(*recorderImplLogger)
-	cachedEvent := recorder.makeEvent(regarding, related, metav1.MicroTime{Time: time.Now()}, v1.EventTypeNormal, "test", "some verbose message: 1", "eventTest", "eventTest-"+hostname, "started")
+	cachedEvent := recorder.makeEvent(regarding, related, metav1.MicroTime{Time: time.Now()}, nil, v1.EventTypeNormal, "test", "some verbose message: 1", "eventTest", "eventTest-"+hostname, "started")
 	nonFinishedEvent := cachedEvent.DeepCopy()
 	nonFinishedEvent.ReportingController = "nonFinished-controller"
 	cachedEvent.Series = &eventsv1.EventSeries{
@@ -386,7 +386,7 @@ func TestRefreshExistingEventSeries(t *testing.T) {
 		cache := map[eventKey]*eventsv1.Event{}
 		eventBroadcaster := newBroadcaster(&testEvents, 0, cache).(*eventBroadcasterImpl)
 		recorder := eventBroadcaster.NewRecorder(scheme.Scheme, "k8s.io/kube-foo").(*recorderImplLogger)
-		cachedEvent := recorder.makeEvent(regarding, related, metav1.MicroTime{Time: time.Now()}, v1.EventTypeNormal, "test", "some verbose message: 1", "eventTest", "eventTest-"+hostname, "started")
+		cachedEvent := recorder.makeEvent(regarding, related, metav1.MicroTime{Time: time.Now()}, nil, v1.EventTypeNormal, "test", "some verbose message: 1", "eventTest", "eventTest-"+hostname, "started")
 		cachedEvent.Series = &eventsv1.EventSeries{
 			Count:            10,
 			LastObservedTime: LastObservedTime,

--- a/staging/src/k8s.io/client-go/tools/events/fake.go
+++ b/staging/src/k8s.io/client-go/tools/events/fake.go
@@ -34,6 +34,14 @@ var _ EventRecorderLogger = &FakeRecorder{}
 
 // Eventf emits an event
 func (f *FakeRecorder) Eventf(regarding runtime.Object, related runtime.Object, eventtype, reason, action, note string, args ...interface{}) {
+	f.writeEvent(eventtype, reason, note, args...)
+}
+
+func (f *FakeRecorder) AnnotatedEventf(regarding runtime.Object, related runtime.Object, annotations map[string]string, eventtype, reason, action, note string, args ...interface{}) {
+	f.writeEvent(eventtype, reason, note, args...)
+}
+
+func (f *FakeRecorder) writeEvent(eventtype, reason, note string, args ...any) {
 	if f.Events != nil {
 		f.Events <- fmt.Sprintf(eventtype+" "+reason+" "+note, args...)
 	}

--- a/staging/src/k8s.io/client-go/tools/internal/events/interfaces.go
+++ b/staging/src/k8s.io/client-go/tools/internal/events/interfaces.go
@@ -41,6 +41,9 @@ type EventRecorder interface {
 	// take in regarding's name; it should be in UpperCamelCase format (starting with a capital letter).
 	// 'note' is intended to be human readable.
 	Eventf(regarding runtime.Object, related runtime.Object, eventtype, reason, action, note string, args ...interface{})
+
+	// AnnotatedEventf is just like Eventf, but with annotations attached.
+	AnnotatedEventf(regarding runtime.Object, related runtime.Object, annotations map[string]string, eventtype, reason, action, note string, args ...interface{})
 }
 
 // EventRecorderLogger extends EventRecorder such that a logger can

--- a/staging/src/k8s.io/client-go/tools/record/event.go
+++ b/staging/src/k8s.io/client-go/tools/record/event.go
@@ -176,6 +176,11 @@ func (a *EventRecorderAdapter) Eventf(regarding, _ runtime.Object, eventtype, re
 	a.recorder.Eventf(regarding, eventtype, reason, note, args...)
 }
 
+// AnnotatedEventf is a wrapper around v1 AnnotatedEventf
+func (a *EventRecorderAdapter) AnnotatedEventf(regarding, _ runtime.Object, annotations map[string]string, eventtype, reason, action, note string, args ...interface{}) {
+	a.recorder.AnnotatedEventf(regarding, annotations, eventtype, reason, note, args...)
+}
+
 func (a *EventRecorderAdapter) WithLogger(logger klog.Logger) internalevents.EventRecorderLogger {
 	return &EventRecorderAdapter{
 		recorder: a.recorder.WithLogger(logger),


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Unlike `EventRecorder` interface in `tools/record` package, `EventRecorder` interface in `tools/events` package has no `AnnotatedEventf` method. Due to the lack of this method, clients are unable to record annotations on `events/v1.Event` through the recorder interface.

This PR adds `AnnotatedEventf` to `EventRecorder` interface` in `tools/events` package to allow clients to record `events/v1.Event` with annotations.

#### Which issue(s) this PR fixes:

- https://github.com/kubernetes/client-go/issues/1163

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
