### PR TITLE
Avoid cycle imports for multiple token group names.

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1/customresourcedefinitionspec.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1/customresourcedefinitionspec.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1
 
 import (
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 )
 
 // CustomResourceDefinitionSpecApplyConfiguration represents an declarative configuration of the CustomResourceDefinitionSpec type for use
@@ -27,7 +27,7 @@ import (
 type CustomResourceDefinitionSpecApplyConfiguration struct {
 	Group                 *string                                             `json:"group,omitempty"`
 	Names                 *CustomResourceDefinitionNamesApplyConfiguration    `json:"names,omitempty"`
-	Scope                 *apiextensionsv1.ResourceScope                      `json:"scope,omitempty"`
+	Scope                 *v1.ResourceScope                                   `json:"scope,omitempty"`
 	Versions              []CustomResourceDefinitionVersionApplyConfiguration `json:"versions,omitempty"`
 	Conversion            *CustomResourceConversionApplyConfiguration         `json:"conversion,omitempty"`
 	PreserveUnknownFields *bool                                               `json:"preserveUnknownFields,omitempty"`
@@ -58,7 +58,7 @@ func (b *CustomResourceDefinitionSpecApplyConfiguration) WithNames(value *Custom
 // WithScope sets the Scope field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the Scope field is set to the value of the last call.
-func (b *CustomResourceDefinitionSpecApplyConfiguration) WithScope(value apiextensionsv1.ResourceScope) *CustomResourceDefinitionSpecApplyConfiguration {
+func (b *CustomResourceDefinitionSpecApplyConfiguration) WithScope(value v1.ResourceScope) *CustomResourceDefinitionSpecApplyConfiguration {
 	b.Scope = &value
 	return b
 }

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1beta1/customresourcedefinitionspec.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/applyconfiguration/apiextensions/v1beta1/customresourcedefinitionspec.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1beta1
 
 import (
-	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	v1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 )
 
 // CustomResourceDefinitionSpecApplyConfiguration represents an declarative configuration of the CustomResourceDefinitionSpec type for use
@@ -28,7 +28,7 @@ type CustomResourceDefinitionSpecApplyConfiguration struct {
 	Group                    *string                                             `json:"group,omitempty"`
 	Version                  *string                                             `json:"version,omitempty"`
 	Names                    *CustomResourceDefinitionNamesApplyConfiguration    `json:"names,omitempty"`
-	Scope                    *apiextensionsv1beta1.ResourceScope                 `json:"scope,omitempty"`
+	Scope                    *v1beta1.ResourceScope                              `json:"scope,omitempty"`
 	Validation               *CustomResourceValidationApplyConfiguration         `json:"validation,omitempty"`
 	Subresources             *CustomResourceSubresourcesApplyConfiguration       `json:"subresources,omitempty"`
 	Versions                 []CustomResourceDefinitionVersionApplyConfiguration `json:"versions,omitempty"`
@@ -71,7 +71,7 @@ func (b *CustomResourceDefinitionSpecApplyConfiguration) WithNames(value *Custom
 // WithScope sets the Scope field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the Scope field is set to the value of the last call.
-func (b *CustomResourceDefinitionSpecApplyConfiguration) WithScope(value apiextensionsv1beta1.ResourceScope) *CustomResourceDefinitionSpecApplyConfiguration {
+func (b *CustomResourceDefinitionSpecApplyConfiguration) WithScope(value v1beta1.ResourceScope) *CustomResourceDefinitionSpecApplyConfiguration {
 	b.Scope = &value
 	return b
 }

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/matchresources.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/matchresources.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1
 
 import (
-	apiadmissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	v1 "k8s.io/client-go/applyconfigurations/meta/v1"
 )
 
@@ -30,7 +30,7 @@ type MatchResourcesApplyConfiguration struct {
 	ObjectSelector       *v1.LabelSelectorApplyConfiguration         `json:"objectSelector,omitempty"`
 	ResourceRules        []NamedRuleWithOperationsApplyConfiguration `json:"resourceRules,omitempty"`
 	ExcludeResourceRules []NamedRuleWithOperationsApplyConfiguration `json:"excludeResourceRules,omitempty"`
-	MatchPolicy          *apiadmissionregistrationv1.MatchPolicyType `json:"matchPolicy,omitempty"`
+	MatchPolicy          *admissionregistrationv1.MatchPolicyType    `json:"matchPolicy,omitempty"`
 }
 
 // MatchResourcesApplyConfiguration constructs an declarative configuration of the MatchResources type for use with
@@ -84,7 +84,7 @@ func (b *MatchResourcesApplyConfiguration) WithExcludeResourceRules(values ...*N
 // WithMatchPolicy sets the MatchPolicy field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the MatchPolicy field is set to the value of the last call.
-func (b *MatchResourcesApplyConfiguration) WithMatchPolicy(value apiadmissionregistrationv1.MatchPolicyType) *MatchResourcesApplyConfiguration {
+func (b *MatchResourcesApplyConfiguration) WithMatchPolicy(value admissionregistrationv1.MatchPolicyType) *MatchResourcesApplyConfiguration {
 	b.MatchPolicy = &value
 	return b
 }

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/mutatingwebhook.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/mutatingwebhook.go
@@ -19,25 +19,25 @@ limitations under the License.
 package v1
 
 import (
-	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	v1 "k8s.io/api/admissionregistration/v1"
 	metav1 "k8s.io/client-go/applyconfigurations/meta/v1"
 )
 
 // MutatingWebhookApplyConfiguration represents an declarative configuration of the MutatingWebhook type for use
 // with apply.
 type MutatingWebhookApplyConfiguration struct {
-	Name                    *string                                         `json:"name,omitempty"`
-	ClientConfig            *WebhookClientConfigApplyConfiguration          `json:"clientConfig,omitempty"`
-	Rules                   []RuleWithOperationsApplyConfiguration          `json:"rules,omitempty"`
-	FailurePolicy           *admissionregistrationv1.FailurePolicyType      `json:"failurePolicy,omitempty"`
-	MatchPolicy             *admissionregistrationv1.MatchPolicyType        `json:"matchPolicy,omitempty"`
-	NamespaceSelector       *metav1.LabelSelectorApplyConfiguration         `json:"namespaceSelector,omitempty"`
-	ObjectSelector          *metav1.LabelSelectorApplyConfiguration         `json:"objectSelector,omitempty"`
-	SideEffects             *admissionregistrationv1.SideEffectClass        `json:"sideEffects,omitempty"`
-	TimeoutSeconds          *int32                                          `json:"timeoutSeconds,omitempty"`
-	AdmissionReviewVersions []string                                        `json:"admissionReviewVersions,omitempty"`
-	ReinvocationPolicy      *admissionregistrationv1.ReinvocationPolicyType `json:"reinvocationPolicy,omitempty"`
-	MatchConditions         []MatchConditionApplyConfiguration              `json:"matchConditions,omitempty"`
+	Name                    *string                                 `json:"name,omitempty"`
+	ClientConfig            *WebhookClientConfigApplyConfiguration  `json:"clientConfig,omitempty"`
+	Rules                   []RuleWithOperationsApplyConfiguration  `json:"rules,omitempty"`
+	FailurePolicy           *v1.FailurePolicyType                   `json:"failurePolicy,omitempty"`
+	MatchPolicy             *v1.MatchPolicyType                     `json:"matchPolicy,omitempty"`
+	NamespaceSelector       *metav1.LabelSelectorApplyConfiguration `json:"namespaceSelector,omitempty"`
+	ObjectSelector          *metav1.LabelSelectorApplyConfiguration `json:"objectSelector,omitempty"`
+	SideEffects             *v1.SideEffectClass                     `json:"sideEffects,omitempty"`
+	TimeoutSeconds          *int32                                  `json:"timeoutSeconds,omitempty"`
+	AdmissionReviewVersions []string                                `json:"admissionReviewVersions,omitempty"`
+	ReinvocationPolicy      *v1.ReinvocationPolicyType              `json:"reinvocationPolicy,omitempty"`
+	MatchConditions         []MatchConditionApplyConfiguration      `json:"matchConditions,omitempty"`
 }
 
 // MutatingWebhookApplyConfiguration constructs an declarative configuration of the MutatingWebhook type for use with
@@ -78,7 +78,7 @@ func (b *MutatingWebhookApplyConfiguration) WithRules(values ...*RuleWithOperati
 // WithFailurePolicy sets the FailurePolicy field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the FailurePolicy field is set to the value of the last call.
-func (b *MutatingWebhookApplyConfiguration) WithFailurePolicy(value admissionregistrationv1.FailurePolicyType) *MutatingWebhookApplyConfiguration {
+func (b *MutatingWebhookApplyConfiguration) WithFailurePolicy(value v1.FailurePolicyType) *MutatingWebhookApplyConfiguration {
 	b.FailurePolicy = &value
 	return b
 }
@@ -86,7 +86,7 @@ func (b *MutatingWebhookApplyConfiguration) WithFailurePolicy(value admissionreg
 // WithMatchPolicy sets the MatchPolicy field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the MatchPolicy field is set to the value of the last call.
-func (b *MutatingWebhookApplyConfiguration) WithMatchPolicy(value admissionregistrationv1.MatchPolicyType) *MutatingWebhookApplyConfiguration {
+func (b *MutatingWebhookApplyConfiguration) WithMatchPolicy(value v1.MatchPolicyType) *MutatingWebhookApplyConfiguration {
 	b.MatchPolicy = &value
 	return b
 }
@@ -110,7 +110,7 @@ func (b *MutatingWebhookApplyConfiguration) WithObjectSelector(value *metav1.Lab
 // WithSideEffects sets the SideEffects field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the SideEffects field is set to the value of the last call.
-func (b *MutatingWebhookApplyConfiguration) WithSideEffects(value admissionregistrationv1.SideEffectClass) *MutatingWebhookApplyConfiguration {
+func (b *MutatingWebhookApplyConfiguration) WithSideEffects(value v1.SideEffectClass) *MutatingWebhookApplyConfiguration {
 	b.SideEffects = &value
 	return b
 }
@@ -136,7 +136,7 @@ func (b *MutatingWebhookApplyConfiguration) WithAdmissionReviewVersions(values .
 // WithReinvocationPolicy sets the ReinvocationPolicy field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the ReinvocationPolicy field is set to the value of the last call.
-func (b *MutatingWebhookApplyConfiguration) WithReinvocationPolicy(value admissionregistrationv1.ReinvocationPolicyType) *MutatingWebhookApplyConfiguration {
+func (b *MutatingWebhookApplyConfiguration) WithReinvocationPolicy(value v1.ReinvocationPolicyType) *MutatingWebhookApplyConfiguration {
 	b.ReinvocationPolicy = &value
 	return b
 }

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/mutatingwebhookconfiguration.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/mutatingwebhookconfiguration.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1
 
 import (
-	apiadmissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -56,18 +56,18 @@ func MutatingWebhookConfiguration(name string) *MutatingWebhookConfigurationAppl
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractMutatingWebhookConfiguration(mutatingWebhookConfiguration *apiadmissionregistrationv1.MutatingWebhookConfiguration, fieldManager string) (*MutatingWebhookConfigurationApplyConfiguration, error) {
+func ExtractMutatingWebhookConfiguration(mutatingWebhookConfiguration *admissionregistrationv1.MutatingWebhookConfiguration, fieldManager string) (*MutatingWebhookConfigurationApplyConfiguration, error) {
 	return extractMutatingWebhookConfiguration(mutatingWebhookConfiguration, fieldManager, "")
 }
 
 // ExtractMutatingWebhookConfigurationStatus is the same as ExtractMutatingWebhookConfiguration except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractMutatingWebhookConfigurationStatus(mutatingWebhookConfiguration *apiadmissionregistrationv1.MutatingWebhookConfiguration, fieldManager string) (*MutatingWebhookConfigurationApplyConfiguration, error) {
+func ExtractMutatingWebhookConfigurationStatus(mutatingWebhookConfiguration *admissionregistrationv1.MutatingWebhookConfiguration, fieldManager string) (*MutatingWebhookConfigurationApplyConfiguration, error) {
 	return extractMutatingWebhookConfiguration(mutatingWebhookConfiguration, fieldManager, "status")
 }
 
-func extractMutatingWebhookConfiguration(mutatingWebhookConfiguration *apiadmissionregistrationv1.MutatingWebhookConfiguration, fieldManager string, subresource string) (*MutatingWebhookConfigurationApplyConfiguration, error) {
+func extractMutatingWebhookConfiguration(mutatingWebhookConfiguration *admissionregistrationv1.MutatingWebhookConfiguration, fieldManager string, subresource string) (*MutatingWebhookConfigurationApplyConfiguration, error) {
 	b := &MutatingWebhookConfigurationApplyConfiguration{}
 	err := managedfields.ExtractInto(mutatingWebhookConfiguration, internal.Parser().Type("io.k8s.api.admissionregistration.v1.MutatingWebhookConfiguration"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/namedrulewithoperations.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/namedrulewithoperations.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1
 
 import (
-	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	v1 "k8s.io/api/admissionregistration/v1"
 )
 
 // NamedRuleWithOperationsApplyConfiguration represents an declarative configuration of the NamedRuleWithOperations type for use
@@ -48,7 +48,7 @@ func (b *NamedRuleWithOperationsApplyConfiguration) WithResourceNames(values ...
 // WithOperations adds the given value to the Operations field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Operations field.
-func (b *NamedRuleWithOperationsApplyConfiguration) WithOperations(values ...admissionregistrationv1.OperationType) *NamedRuleWithOperationsApplyConfiguration {
+func (b *NamedRuleWithOperationsApplyConfiguration) WithOperations(values ...v1.OperationType) *NamedRuleWithOperationsApplyConfiguration {
 	for i := range values {
 		b.Operations = append(b.Operations, values[i])
 	}
@@ -88,7 +88,7 @@ func (b *NamedRuleWithOperationsApplyConfiguration) WithResources(values ...stri
 // WithScope sets the Scope field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the Scope field is set to the value of the last call.
-func (b *NamedRuleWithOperationsApplyConfiguration) WithScope(value admissionregistrationv1.ScopeType) *NamedRuleWithOperationsApplyConfiguration {
+func (b *NamedRuleWithOperationsApplyConfiguration) WithScope(value v1.ScopeType) *NamedRuleWithOperationsApplyConfiguration {
 	b.Scope = &value
 	return b
 }

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/validatingadmissionpolicy.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/validatingadmissionpolicy.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1
 
 import (
-	apiadmissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -57,18 +57,18 @@ func ValidatingAdmissionPolicy(name string) *ValidatingAdmissionPolicyApplyConfi
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractValidatingAdmissionPolicy(validatingAdmissionPolicy *apiadmissionregistrationv1.ValidatingAdmissionPolicy, fieldManager string) (*ValidatingAdmissionPolicyApplyConfiguration, error) {
+func ExtractValidatingAdmissionPolicy(validatingAdmissionPolicy *admissionregistrationv1.ValidatingAdmissionPolicy, fieldManager string) (*ValidatingAdmissionPolicyApplyConfiguration, error) {
 	return extractValidatingAdmissionPolicy(validatingAdmissionPolicy, fieldManager, "")
 }
 
 // ExtractValidatingAdmissionPolicyStatus is the same as ExtractValidatingAdmissionPolicy except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractValidatingAdmissionPolicyStatus(validatingAdmissionPolicy *apiadmissionregistrationv1.ValidatingAdmissionPolicy, fieldManager string) (*ValidatingAdmissionPolicyApplyConfiguration, error) {
+func ExtractValidatingAdmissionPolicyStatus(validatingAdmissionPolicy *admissionregistrationv1.ValidatingAdmissionPolicy, fieldManager string) (*ValidatingAdmissionPolicyApplyConfiguration, error) {
 	return extractValidatingAdmissionPolicy(validatingAdmissionPolicy, fieldManager, "status")
 }
 
-func extractValidatingAdmissionPolicy(validatingAdmissionPolicy *apiadmissionregistrationv1.ValidatingAdmissionPolicy, fieldManager string, subresource string) (*ValidatingAdmissionPolicyApplyConfiguration, error) {
+func extractValidatingAdmissionPolicy(validatingAdmissionPolicy *admissionregistrationv1.ValidatingAdmissionPolicy, fieldManager string, subresource string) (*ValidatingAdmissionPolicyApplyConfiguration, error) {
 	b := &ValidatingAdmissionPolicyApplyConfiguration{}
 	err := managedfields.ExtractInto(validatingAdmissionPolicy, internal.Parser().Type("io.k8s.api.admissionregistration.v1.ValidatingAdmissionPolicy"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/validatingadmissionpolicybinding.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/validatingadmissionpolicybinding.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1
 
 import (
-	apiadmissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -56,18 +56,18 @@ func ValidatingAdmissionPolicyBinding(name string) *ValidatingAdmissionPolicyBin
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractValidatingAdmissionPolicyBinding(validatingAdmissionPolicyBinding *apiadmissionregistrationv1.ValidatingAdmissionPolicyBinding, fieldManager string) (*ValidatingAdmissionPolicyBindingApplyConfiguration, error) {
+func ExtractValidatingAdmissionPolicyBinding(validatingAdmissionPolicyBinding *admissionregistrationv1.ValidatingAdmissionPolicyBinding, fieldManager string) (*ValidatingAdmissionPolicyBindingApplyConfiguration, error) {
 	return extractValidatingAdmissionPolicyBinding(validatingAdmissionPolicyBinding, fieldManager, "")
 }
 
 // ExtractValidatingAdmissionPolicyBindingStatus is the same as ExtractValidatingAdmissionPolicyBinding except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractValidatingAdmissionPolicyBindingStatus(validatingAdmissionPolicyBinding *apiadmissionregistrationv1.ValidatingAdmissionPolicyBinding, fieldManager string) (*ValidatingAdmissionPolicyBindingApplyConfiguration, error) {
+func ExtractValidatingAdmissionPolicyBindingStatus(validatingAdmissionPolicyBinding *admissionregistrationv1.ValidatingAdmissionPolicyBinding, fieldManager string) (*ValidatingAdmissionPolicyBindingApplyConfiguration, error) {
 	return extractValidatingAdmissionPolicyBinding(validatingAdmissionPolicyBinding, fieldManager, "status")
 }
 
-func extractValidatingAdmissionPolicyBinding(validatingAdmissionPolicyBinding *apiadmissionregistrationv1.ValidatingAdmissionPolicyBinding, fieldManager string, subresource string) (*ValidatingAdmissionPolicyBindingApplyConfiguration, error) {
+func extractValidatingAdmissionPolicyBinding(validatingAdmissionPolicyBinding *admissionregistrationv1.ValidatingAdmissionPolicyBinding, fieldManager string, subresource string) (*ValidatingAdmissionPolicyBindingApplyConfiguration, error) {
 	b := &ValidatingAdmissionPolicyBindingApplyConfiguration{}
 	err := managedfields.ExtractInto(validatingAdmissionPolicyBinding, internal.Parser().Type("io.k8s.api.admissionregistration.v1.ValidatingAdmissionPolicyBinding"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/validatingadmissionpolicybindingspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/validatingadmissionpolicybindingspec.go
@@ -19,16 +19,16 @@ limitations under the License.
 package v1
 
 import (
-	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	v1 "k8s.io/api/admissionregistration/v1"
 )
 
 // ValidatingAdmissionPolicyBindingSpecApplyConfiguration represents an declarative configuration of the ValidatingAdmissionPolicyBindingSpec type for use
 // with apply.
 type ValidatingAdmissionPolicyBindingSpecApplyConfiguration struct {
-	PolicyName        *string                                    `json:"policyName,omitempty"`
-	ParamRef          *ParamRefApplyConfiguration                `json:"paramRef,omitempty"`
-	MatchResources    *MatchResourcesApplyConfiguration          `json:"matchResources,omitempty"`
-	ValidationActions []admissionregistrationv1.ValidationAction `json:"validationActions,omitempty"`
+	PolicyName        *string                           `json:"policyName,omitempty"`
+	ParamRef          *ParamRefApplyConfiguration       `json:"paramRef,omitempty"`
+	MatchResources    *MatchResourcesApplyConfiguration `json:"matchResources,omitempty"`
+	ValidationActions []v1.ValidationAction             `json:"validationActions,omitempty"`
 }
 
 // ValidatingAdmissionPolicyBindingSpecApplyConfiguration constructs an declarative configuration of the ValidatingAdmissionPolicyBindingSpec type for use with
@@ -64,7 +64,7 @@ func (b *ValidatingAdmissionPolicyBindingSpecApplyConfiguration) WithMatchResour
 // WithValidationActions adds the given value to the ValidationActions field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the ValidationActions field.
-func (b *ValidatingAdmissionPolicyBindingSpecApplyConfiguration) WithValidationActions(values ...admissionregistrationv1.ValidationAction) *ValidatingAdmissionPolicyBindingSpecApplyConfiguration {
+func (b *ValidatingAdmissionPolicyBindingSpecApplyConfiguration) WithValidationActions(values ...v1.ValidationAction) *ValidatingAdmissionPolicyBindingSpecApplyConfiguration {
 	for i := range values {
 		b.ValidationActions = append(b.ValidationActions, values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/validatingadmissionpolicyspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/validatingadmissionpolicyspec.go
@@ -19,19 +19,19 @@ limitations under the License.
 package v1
 
 import (
-	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	v1 "k8s.io/api/admissionregistration/v1"
 )
 
 // ValidatingAdmissionPolicySpecApplyConfiguration represents an declarative configuration of the ValidatingAdmissionPolicySpec type for use
 // with apply.
 type ValidatingAdmissionPolicySpecApplyConfiguration struct {
-	ParamKind        *ParamKindApplyConfiguration               `json:"paramKind,omitempty"`
-	MatchConstraints *MatchResourcesApplyConfiguration          `json:"matchConstraints,omitempty"`
-	Validations      []ValidationApplyConfiguration             `json:"validations,omitempty"`
-	FailurePolicy    *admissionregistrationv1.FailurePolicyType `json:"failurePolicy,omitempty"`
-	AuditAnnotations []AuditAnnotationApplyConfiguration        `json:"auditAnnotations,omitempty"`
-	MatchConditions  []MatchConditionApplyConfiguration         `json:"matchConditions,omitempty"`
-	Variables        []VariableApplyConfiguration               `json:"variables,omitempty"`
+	ParamKind        *ParamKindApplyConfiguration        `json:"paramKind,omitempty"`
+	MatchConstraints *MatchResourcesApplyConfiguration   `json:"matchConstraints,omitempty"`
+	Validations      []ValidationApplyConfiguration      `json:"validations,omitempty"`
+	FailurePolicy    *v1.FailurePolicyType               `json:"failurePolicy,omitempty"`
+	AuditAnnotations []AuditAnnotationApplyConfiguration `json:"auditAnnotations,omitempty"`
+	MatchConditions  []MatchConditionApplyConfiguration  `json:"matchConditions,omitempty"`
+	Variables        []VariableApplyConfiguration        `json:"variables,omitempty"`
 }
 
 // ValidatingAdmissionPolicySpecApplyConfiguration constructs an declarative configuration of the ValidatingAdmissionPolicySpec type for use with
@@ -72,7 +72,7 @@ func (b *ValidatingAdmissionPolicySpecApplyConfiguration) WithValidations(values
 // WithFailurePolicy sets the FailurePolicy field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the FailurePolicy field is set to the value of the last call.
-func (b *ValidatingAdmissionPolicySpecApplyConfiguration) WithFailurePolicy(value admissionregistrationv1.FailurePolicyType) *ValidatingAdmissionPolicySpecApplyConfiguration {
+func (b *ValidatingAdmissionPolicySpecApplyConfiguration) WithFailurePolicy(value v1.FailurePolicyType) *ValidatingAdmissionPolicySpecApplyConfiguration {
 	b.FailurePolicy = &value
 	return b
 }

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/validatingadmissionpolicystatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/validatingadmissionpolicystatus.go
@@ -19,15 +19,15 @@ limitations under the License.
 package v1
 
 import (
-	metav1 "k8s.io/client-go/applyconfigurations/meta/v1"
+	v1 "k8s.io/client-go/applyconfigurations/meta/v1"
 )
 
 // ValidatingAdmissionPolicyStatusApplyConfiguration represents an declarative configuration of the ValidatingAdmissionPolicyStatus type for use
 // with apply.
 type ValidatingAdmissionPolicyStatusApplyConfiguration struct {
-	ObservedGeneration *int64                               `json:"observedGeneration,omitempty"`
-	TypeChecking       *TypeCheckingApplyConfiguration      `json:"typeChecking,omitempty"`
-	Conditions         []metav1.ConditionApplyConfiguration `json:"conditions,omitempty"`
+	ObservedGeneration *int64                           `json:"observedGeneration,omitempty"`
+	TypeChecking       *TypeCheckingApplyConfiguration  `json:"typeChecking,omitempty"`
+	Conditions         []v1.ConditionApplyConfiguration `json:"conditions,omitempty"`
 }
 
 // ValidatingAdmissionPolicyStatusApplyConfiguration constructs an declarative configuration of the ValidatingAdmissionPolicyStatus type for use with
@@ -55,7 +55,7 @@ func (b *ValidatingAdmissionPolicyStatusApplyConfiguration) WithTypeChecking(val
 // WithConditions adds the given value to the Conditions field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Conditions field.
-func (b *ValidatingAdmissionPolicyStatusApplyConfiguration) WithConditions(values ...*metav1.ConditionApplyConfiguration) *ValidatingAdmissionPolicyStatusApplyConfiguration {
+func (b *ValidatingAdmissionPolicyStatusApplyConfiguration) WithConditions(values ...*v1.ConditionApplyConfiguration) *ValidatingAdmissionPolicyStatusApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithConditions")

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/validatingwebhook.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/validatingwebhook.go
@@ -19,24 +19,24 @@ limitations under the License.
 package v1
 
 import (
-	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	v1 "k8s.io/api/admissionregistration/v1"
 	metav1 "k8s.io/client-go/applyconfigurations/meta/v1"
 )
 
 // ValidatingWebhookApplyConfiguration represents an declarative configuration of the ValidatingWebhook type for use
 // with apply.
 type ValidatingWebhookApplyConfiguration struct {
-	Name                    *string                                    `json:"name,omitempty"`
-	ClientConfig            *WebhookClientConfigApplyConfiguration     `json:"clientConfig,omitempty"`
-	Rules                   []RuleWithOperationsApplyConfiguration     `json:"rules,omitempty"`
-	FailurePolicy           *admissionregistrationv1.FailurePolicyType `json:"failurePolicy,omitempty"`
-	MatchPolicy             *admissionregistrationv1.MatchPolicyType   `json:"matchPolicy,omitempty"`
-	NamespaceSelector       *metav1.LabelSelectorApplyConfiguration    `json:"namespaceSelector,omitempty"`
-	ObjectSelector          *metav1.LabelSelectorApplyConfiguration    `json:"objectSelector,omitempty"`
-	SideEffects             *admissionregistrationv1.SideEffectClass   `json:"sideEffects,omitempty"`
-	TimeoutSeconds          *int32                                     `json:"timeoutSeconds,omitempty"`
-	AdmissionReviewVersions []string                                   `json:"admissionReviewVersions,omitempty"`
-	MatchConditions         []MatchConditionApplyConfiguration         `json:"matchConditions,omitempty"`
+	Name                    *string                                 `json:"name,omitempty"`
+	ClientConfig            *WebhookClientConfigApplyConfiguration  `json:"clientConfig,omitempty"`
+	Rules                   []RuleWithOperationsApplyConfiguration  `json:"rules,omitempty"`
+	FailurePolicy           *v1.FailurePolicyType                   `json:"failurePolicy,omitempty"`
+	MatchPolicy             *v1.MatchPolicyType                     `json:"matchPolicy,omitempty"`
+	NamespaceSelector       *metav1.LabelSelectorApplyConfiguration `json:"namespaceSelector,omitempty"`
+	ObjectSelector          *metav1.LabelSelectorApplyConfiguration `json:"objectSelector,omitempty"`
+	SideEffects             *v1.SideEffectClass                     `json:"sideEffects,omitempty"`
+	TimeoutSeconds          *int32                                  `json:"timeoutSeconds,omitempty"`
+	AdmissionReviewVersions []string                                `json:"admissionReviewVersions,omitempty"`
+	MatchConditions         []MatchConditionApplyConfiguration      `json:"matchConditions,omitempty"`
 }
 
 // ValidatingWebhookApplyConfiguration constructs an declarative configuration of the ValidatingWebhook type for use with
@@ -77,7 +77,7 @@ func (b *ValidatingWebhookApplyConfiguration) WithRules(values ...*RuleWithOpera
 // WithFailurePolicy sets the FailurePolicy field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the FailurePolicy field is set to the value of the last call.
-func (b *ValidatingWebhookApplyConfiguration) WithFailurePolicy(value admissionregistrationv1.FailurePolicyType) *ValidatingWebhookApplyConfiguration {
+func (b *ValidatingWebhookApplyConfiguration) WithFailurePolicy(value v1.FailurePolicyType) *ValidatingWebhookApplyConfiguration {
 	b.FailurePolicy = &value
 	return b
 }
@@ -85,7 +85,7 @@ func (b *ValidatingWebhookApplyConfiguration) WithFailurePolicy(value admissionr
 // WithMatchPolicy sets the MatchPolicy field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the MatchPolicy field is set to the value of the last call.
-func (b *ValidatingWebhookApplyConfiguration) WithMatchPolicy(value admissionregistrationv1.MatchPolicyType) *ValidatingWebhookApplyConfiguration {
+func (b *ValidatingWebhookApplyConfiguration) WithMatchPolicy(value v1.MatchPolicyType) *ValidatingWebhookApplyConfiguration {
 	b.MatchPolicy = &value
 	return b
 }
@@ -109,7 +109,7 @@ func (b *ValidatingWebhookApplyConfiguration) WithObjectSelector(value *metav1.L
 // WithSideEffects sets the SideEffects field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the SideEffects field is set to the value of the last call.
-func (b *ValidatingWebhookApplyConfiguration) WithSideEffects(value admissionregistrationv1.SideEffectClass) *ValidatingWebhookApplyConfiguration {
+func (b *ValidatingWebhookApplyConfiguration) WithSideEffects(value v1.SideEffectClass) *ValidatingWebhookApplyConfiguration {
 	b.SideEffects = &value
 	return b
 }

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/validatingwebhookconfiguration.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1/validatingwebhookconfiguration.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1
 
 import (
-	apiadmissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -56,18 +56,18 @@ func ValidatingWebhookConfiguration(name string) *ValidatingWebhookConfiguration
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractValidatingWebhookConfiguration(validatingWebhookConfiguration *apiadmissionregistrationv1.ValidatingWebhookConfiguration, fieldManager string) (*ValidatingWebhookConfigurationApplyConfiguration, error) {
+func ExtractValidatingWebhookConfiguration(validatingWebhookConfiguration *admissionregistrationv1.ValidatingWebhookConfiguration, fieldManager string) (*ValidatingWebhookConfigurationApplyConfiguration, error) {
 	return extractValidatingWebhookConfiguration(validatingWebhookConfiguration, fieldManager, "")
 }
 
 // ExtractValidatingWebhookConfigurationStatus is the same as ExtractValidatingWebhookConfiguration except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractValidatingWebhookConfigurationStatus(validatingWebhookConfiguration *apiadmissionregistrationv1.ValidatingWebhookConfiguration, fieldManager string) (*ValidatingWebhookConfigurationApplyConfiguration, error) {
+func ExtractValidatingWebhookConfigurationStatus(validatingWebhookConfiguration *admissionregistrationv1.ValidatingWebhookConfiguration, fieldManager string) (*ValidatingWebhookConfigurationApplyConfiguration, error) {
 	return extractValidatingWebhookConfiguration(validatingWebhookConfiguration, fieldManager, "status")
 }
 
-func extractValidatingWebhookConfiguration(validatingWebhookConfiguration *apiadmissionregistrationv1.ValidatingWebhookConfiguration, fieldManager string, subresource string) (*ValidatingWebhookConfigurationApplyConfiguration, error) {
+func extractValidatingWebhookConfiguration(validatingWebhookConfiguration *admissionregistrationv1.ValidatingWebhookConfiguration, fieldManager string, subresource string) (*ValidatingWebhookConfigurationApplyConfiguration, error) {
 	b := &ValidatingWebhookConfigurationApplyConfiguration{}
 	err := managedfields.ExtractInto(validatingWebhookConfiguration, internal.Parser().Type("io.k8s.api.admissionregistration.v1.ValidatingWebhookConfiguration"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1alpha1/matchresources.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1alpha1/matchresources.go
@@ -19,18 +19,18 @@ limitations under the License.
 package v1alpha1
 
 import (
-	admissionregistrationv1alpha1 "k8s.io/api/admissionregistration/v1alpha1"
+	v1alpha1 "k8s.io/api/admissionregistration/v1alpha1"
 	v1 "k8s.io/client-go/applyconfigurations/meta/v1"
 )
 
 // MatchResourcesApplyConfiguration represents an declarative configuration of the MatchResources type for use
 // with apply.
 type MatchResourcesApplyConfiguration struct {
-	NamespaceSelector    *v1.LabelSelectorApplyConfiguration            `json:"namespaceSelector,omitempty"`
-	ObjectSelector       *v1.LabelSelectorApplyConfiguration            `json:"objectSelector,omitempty"`
-	ResourceRules        []NamedRuleWithOperationsApplyConfiguration    `json:"resourceRules,omitempty"`
-	ExcludeResourceRules []NamedRuleWithOperationsApplyConfiguration    `json:"excludeResourceRules,omitempty"`
-	MatchPolicy          *admissionregistrationv1alpha1.MatchPolicyType `json:"matchPolicy,omitempty"`
+	NamespaceSelector    *v1.LabelSelectorApplyConfiguration         `json:"namespaceSelector,omitempty"`
+	ObjectSelector       *v1.LabelSelectorApplyConfiguration         `json:"objectSelector,omitempty"`
+	ResourceRules        []NamedRuleWithOperationsApplyConfiguration `json:"resourceRules,omitempty"`
+	ExcludeResourceRules []NamedRuleWithOperationsApplyConfiguration `json:"excludeResourceRules,omitempty"`
+	MatchPolicy          *v1alpha1.MatchPolicyType                   `json:"matchPolicy,omitempty"`
 }
 
 // MatchResourcesApplyConfiguration constructs an declarative configuration of the MatchResources type for use with
@@ -84,7 +84,7 @@ func (b *MatchResourcesApplyConfiguration) WithExcludeResourceRules(values ...*N
 // WithMatchPolicy sets the MatchPolicy field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the MatchPolicy field is set to the value of the last call.
-func (b *MatchResourcesApplyConfiguration) WithMatchPolicy(value admissionregistrationv1alpha1.MatchPolicyType) *MatchResourcesApplyConfiguration {
+func (b *MatchResourcesApplyConfiguration) WithMatchPolicy(value v1alpha1.MatchPolicyType) *MatchResourcesApplyConfiguration {
 	b.MatchPolicy = &value
 	return b
 }

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1alpha1/validatingadmissionpolicy.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1alpha1/validatingadmissionpolicy.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	admissionregistrationv1alpha1 "k8s.io/api/admissionregistration/v1alpha1"
+	v1alpha1 "k8s.io/api/admissionregistration/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -57,18 +57,18 @@ func ValidatingAdmissionPolicy(name string) *ValidatingAdmissionPolicyApplyConfi
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractValidatingAdmissionPolicy(validatingAdmissionPolicy *admissionregistrationv1alpha1.ValidatingAdmissionPolicy, fieldManager string) (*ValidatingAdmissionPolicyApplyConfiguration, error) {
+func ExtractValidatingAdmissionPolicy(validatingAdmissionPolicy *v1alpha1.ValidatingAdmissionPolicy, fieldManager string) (*ValidatingAdmissionPolicyApplyConfiguration, error) {
 	return extractValidatingAdmissionPolicy(validatingAdmissionPolicy, fieldManager, "")
 }
 
 // ExtractValidatingAdmissionPolicyStatus is the same as ExtractValidatingAdmissionPolicy except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractValidatingAdmissionPolicyStatus(validatingAdmissionPolicy *admissionregistrationv1alpha1.ValidatingAdmissionPolicy, fieldManager string) (*ValidatingAdmissionPolicyApplyConfiguration, error) {
+func ExtractValidatingAdmissionPolicyStatus(validatingAdmissionPolicy *v1alpha1.ValidatingAdmissionPolicy, fieldManager string) (*ValidatingAdmissionPolicyApplyConfiguration, error) {
 	return extractValidatingAdmissionPolicy(validatingAdmissionPolicy, fieldManager, "status")
 }
 
-func extractValidatingAdmissionPolicy(validatingAdmissionPolicy *admissionregistrationv1alpha1.ValidatingAdmissionPolicy, fieldManager string, subresource string) (*ValidatingAdmissionPolicyApplyConfiguration, error) {
+func extractValidatingAdmissionPolicy(validatingAdmissionPolicy *v1alpha1.ValidatingAdmissionPolicy, fieldManager string, subresource string) (*ValidatingAdmissionPolicyApplyConfiguration, error) {
 	b := &ValidatingAdmissionPolicyApplyConfiguration{}
 	err := managedfields.ExtractInto(validatingAdmissionPolicy, internal.Parser().Type("io.k8s.api.admissionregistration.v1alpha1.ValidatingAdmissionPolicy"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1alpha1/validatingadmissionpolicybinding.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1alpha1/validatingadmissionpolicybinding.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	admissionregistrationv1alpha1 "k8s.io/api/admissionregistration/v1alpha1"
+	v1alpha1 "k8s.io/api/admissionregistration/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -56,18 +56,18 @@ func ValidatingAdmissionPolicyBinding(name string) *ValidatingAdmissionPolicyBin
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractValidatingAdmissionPolicyBinding(validatingAdmissionPolicyBinding *admissionregistrationv1alpha1.ValidatingAdmissionPolicyBinding, fieldManager string) (*ValidatingAdmissionPolicyBindingApplyConfiguration, error) {
+func ExtractValidatingAdmissionPolicyBinding(validatingAdmissionPolicyBinding *v1alpha1.ValidatingAdmissionPolicyBinding, fieldManager string) (*ValidatingAdmissionPolicyBindingApplyConfiguration, error) {
 	return extractValidatingAdmissionPolicyBinding(validatingAdmissionPolicyBinding, fieldManager, "")
 }
 
 // ExtractValidatingAdmissionPolicyBindingStatus is the same as ExtractValidatingAdmissionPolicyBinding except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractValidatingAdmissionPolicyBindingStatus(validatingAdmissionPolicyBinding *admissionregistrationv1alpha1.ValidatingAdmissionPolicyBinding, fieldManager string) (*ValidatingAdmissionPolicyBindingApplyConfiguration, error) {
+func ExtractValidatingAdmissionPolicyBindingStatus(validatingAdmissionPolicyBinding *v1alpha1.ValidatingAdmissionPolicyBinding, fieldManager string) (*ValidatingAdmissionPolicyBindingApplyConfiguration, error) {
 	return extractValidatingAdmissionPolicyBinding(validatingAdmissionPolicyBinding, fieldManager, "status")
 }
 
-func extractValidatingAdmissionPolicyBinding(validatingAdmissionPolicyBinding *admissionregistrationv1alpha1.ValidatingAdmissionPolicyBinding, fieldManager string, subresource string) (*ValidatingAdmissionPolicyBindingApplyConfiguration, error) {
+func extractValidatingAdmissionPolicyBinding(validatingAdmissionPolicyBinding *v1alpha1.ValidatingAdmissionPolicyBinding, fieldManager string, subresource string) (*ValidatingAdmissionPolicyBindingApplyConfiguration, error) {
 	b := &ValidatingAdmissionPolicyBindingApplyConfiguration{}
 	err := managedfields.ExtractInto(validatingAdmissionPolicyBinding, internal.Parser().Type("io.k8s.api.admissionregistration.v1alpha1.ValidatingAdmissionPolicyBinding"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1alpha1/validatingadmissionpolicybindingspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1alpha1/validatingadmissionpolicybindingspec.go
@@ -19,16 +19,16 @@ limitations under the License.
 package v1alpha1
 
 import (
-	admissionregistrationv1alpha1 "k8s.io/api/admissionregistration/v1alpha1"
+	v1alpha1 "k8s.io/api/admissionregistration/v1alpha1"
 )
 
 // ValidatingAdmissionPolicyBindingSpecApplyConfiguration represents an declarative configuration of the ValidatingAdmissionPolicyBindingSpec type for use
 // with apply.
 type ValidatingAdmissionPolicyBindingSpecApplyConfiguration struct {
-	PolicyName        *string                                          `json:"policyName,omitempty"`
-	ParamRef          *ParamRefApplyConfiguration                      `json:"paramRef,omitempty"`
-	MatchResources    *MatchResourcesApplyConfiguration                `json:"matchResources,omitempty"`
-	ValidationActions []admissionregistrationv1alpha1.ValidationAction `json:"validationActions,omitempty"`
+	PolicyName        *string                           `json:"policyName,omitempty"`
+	ParamRef          *ParamRefApplyConfiguration       `json:"paramRef,omitempty"`
+	MatchResources    *MatchResourcesApplyConfiguration `json:"matchResources,omitempty"`
+	ValidationActions []v1alpha1.ValidationAction       `json:"validationActions,omitempty"`
 }
 
 // ValidatingAdmissionPolicyBindingSpecApplyConfiguration constructs an declarative configuration of the ValidatingAdmissionPolicyBindingSpec type for use with
@@ -64,7 +64,7 @@ func (b *ValidatingAdmissionPolicyBindingSpecApplyConfiguration) WithMatchResour
 // WithValidationActions adds the given value to the ValidationActions field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the ValidationActions field.
-func (b *ValidatingAdmissionPolicyBindingSpecApplyConfiguration) WithValidationActions(values ...admissionregistrationv1alpha1.ValidationAction) *ValidatingAdmissionPolicyBindingSpecApplyConfiguration {
+func (b *ValidatingAdmissionPolicyBindingSpecApplyConfiguration) WithValidationActions(values ...v1alpha1.ValidationAction) *ValidatingAdmissionPolicyBindingSpecApplyConfiguration {
 	for i := range values {
 		b.ValidationActions = append(b.ValidationActions, values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1alpha1/validatingadmissionpolicyspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1alpha1/validatingadmissionpolicyspec.go
@@ -19,19 +19,19 @@ limitations under the License.
 package v1alpha1
 
 import (
-	admissionregistrationv1alpha1 "k8s.io/api/admissionregistration/v1alpha1"
+	v1alpha1 "k8s.io/api/admissionregistration/v1alpha1"
 )
 
 // ValidatingAdmissionPolicySpecApplyConfiguration represents an declarative configuration of the ValidatingAdmissionPolicySpec type for use
 // with apply.
 type ValidatingAdmissionPolicySpecApplyConfiguration struct {
-	ParamKind        *ParamKindApplyConfiguration                     `json:"paramKind,omitempty"`
-	MatchConstraints *MatchResourcesApplyConfiguration                `json:"matchConstraints,omitempty"`
-	Validations      []ValidationApplyConfiguration                   `json:"validations,omitempty"`
-	FailurePolicy    *admissionregistrationv1alpha1.FailurePolicyType `json:"failurePolicy,omitempty"`
-	AuditAnnotations []AuditAnnotationApplyConfiguration              `json:"auditAnnotations,omitempty"`
-	MatchConditions  []MatchConditionApplyConfiguration               `json:"matchConditions,omitempty"`
-	Variables        []VariableApplyConfiguration                     `json:"variables,omitempty"`
+	ParamKind        *ParamKindApplyConfiguration        `json:"paramKind,omitempty"`
+	MatchConstraints *MatchResourcesApplyConfiguration   `json:"matchConstraints,omitempty"`
+	Validations      []ValidationApplyConfiguration      `json:"validations,omitempty"`
+	FailurePolicy    *v1alpha1.FailurePolicyType         `json:"failurePolicy,omitempty"`
+	AuditAnnotations []AuditAnnotationApplyConfiguration `json:"auditAnnotations,omitempty"`
+	MatchConditions  []MatchConditionApplyConfiguration  `json:"matchConditions,omitempty"`
+	Variables        []VariableApplyConfiguration        `json:"variables,omitempty"`
 }
 
 // ValidatingAdmissionPolicySpecApplyConfiguration constructs an declarative configuration of the ValidatingAdmissionPolicySpec type for use with
@@ -72,7 +72,7 @@ func (b *ValidatingAdmissionPolicySpecApplyConfiguration) WithValidations(values
 // WithFailurePolicy sets the FailurePolicy field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the FailurePolicy field is set to the value of the last call.
-func (b *ValidatingAdmissionPolicySpecApplyConfiguration) WithFailurePolicy(value admissionregistrationv1alpha1.FailurePolicyType) *ValidatingAdmissionPolicySpecApplyConfiguration {
+func (b *ValidatingAdmissionPolicySpecApplyConfiguration) WithFailurePolicy(value v1alpha1.FailurePolicyType) *ValidatingAdmissionPolicySpecApplyConfiguration {
 	b.FailurePolicy = &value
 	return b
 }

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/matchresources.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/matchresources.go
@@ -19,18 +19,18 @@ limitations under the License.
 package v1beta1
 
 import (
-	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	v1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	v1 "k8s.io/client-go/applyconfigurations/meta/v1"
 )
 
 // MatchResourcesApplyConfiguration represents an declarative configuration of the MatchResources type for use
 // with apply.
 type MatchResourcesApplyConfiguration struct {
-	NamespaceSelector    *v1.LabelSelectorApplyConfiguration           `json:"namespaceSelector,omitempty"`
-	ObjectSelector       *v1.LabelSelectorApplyConfiguration           `json:"objectSelector,omitempty"`
-	ResourceRules        []NamedRuleWithOperationsApplyConfiguration   `json:"resourceRules,omitempty"`
-	ExcludeResourceRules []NamedRuleWithOperationsApplyConfiguration   `json:"excludeResourceRules,omitempty"`
-	MatchPolicy          *admissionregistrationv1beta1.MatchPolicyType `json:"matchPolicy,omitempty"`
+	NamespaceSelector    *v1.LabelSelectorApplyConfiguration         `json:"namespaceSelector,omitempty"`
+	ObjectSelector       *v1.LabelSelectorApplyConfiguration         `json:"objectSelector,omitempty"`
+	ResourceRules        []NamedRuleWithOperationsApplyConfiguration `json:"resourceRules,omitempty"`
+	ExcludeResourceRules []NamedRuleWithOperationsApplyConfiguration `json:"excludeResourceRules,omitempty"`
+	MatchPolicy          *v1beta1.MatchPolicyType                    `json:"matchPolicy,omitempty"`
 }
 
 // MatchResourcesApplyConfiguration constructs an declarative configuration of the MatchResources type for use with
@@ -84,7 +84,7 @@ func (b *MatchResourcesApplyConfiguration) WithExcludeResourceRules(values ...*N
 // WithMatchPolicy sets the MatchPolicy field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the MatchPolicy field is set to the value of the last call.
-func (b *MatchResourcesApplyConfiguration) WithMatchPolicy(value admissionregistrationv1beta1.MatchPolicyType) *MatchResourcesApplyConfiguration {
+func (b *MatchResourcesApplyConfiguration) WithMatchPolicy(value v1beta1.MatchPolicyType) *MatchResourcesApplyConfiguration {
 	b.MatchPolicy = &value
 	return b
 }

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/mutatingwebhook.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/mutatingwebhook.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1beta1
 
 import (
-	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	v1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	v1 "k8s.io/client-go/applyconfigurations/admissionregistration/v1"
 	metav1 "k8s.io/client-go/applyconfigurations/meta/v1"
 )
@@ -27,18 +27,18 @@ import (
 // MutatingWebhookApplyConfiguration represents an declarative configuration of the MutatingWebhook type for use
 // with apply.
 type MutatingWebhookApplyConfiguration struct {
-	Name                    *string                                              `json:"name,omitempty"`
-	ClientConfig            *WebhookClientConfigApplyConfiguration               `json:"clientConfig,omitempty"`
-	Rules                   []v1.RuleWithOperationsApplyConfiguration            `json:"rules,omitempty"`
-	FailurePolicy           *admissionregistrationv1beta1.FailurePolicyType      `json:"failurePolicy,omitempty"`
-	MatchPolicy             *admissionregistrationv1beta1.MatchPolicyType        `json:"matchPolicy,omitempty"`
-	NamespaceSelector       *metav1.LabelSelectorApplyConfiguration              `json:"namespaceSelector,omitempty"`
-	ObjectSelector          *metav1.LabelSelectorApplyConfiguration              `json:"objectSelector,omitempty"`
-	SideEffects             *admissionregistrationv1beta1.SideEffectClass        `json:"sideEffects,omitempty"`
-	TimeoutSeconds          *int32                                               `json:"timeoutSeconds,omitempty"`
-	AdmissionReviewVersions []string                                             `json:"admissionReviewVersions,omitempty"`
-	ReinvocationPolicy      *admissionregistrationv1beta1.ReinvocationPolicyType `json:"reinvocationPolicy,omitempty"`
-	MatchConditions         []MatchConditionApplyConfiguration                   `json:"matchConditions,omitempty"`
+	Name                    *string                                   `json:"name,omitempty"`
+	ClientConfig            *WebhookClientConfigApplyConfiguration    `json:"clientConfig,omitempty"`
+	Rules                   []v1.RuleWithOperationsApplyConfiguration `json:"rules,omitempty"`
+	FailurePolicy           *v1beta1.FailurePolicyType                `json:"failurePolicy,omitempty"`
+	MatchPolicy             *v1beta1.MatchPolicyType                  `json:"matchPolicy,omitempty"`
+	NamespaceSelector       *metav1.LabelSelectorApplyConfiguration   `json:"namespaceSelector,omitempty"`
+	ObjectSelector          *metav1.LabelSelectorApplyConfiguration   `json:"objectSelector,omitempty"`
+	SideEffects             *v1beta1.SideEffectClass                  `json:"sideEffects,omitempty"`
+	TimeoutSeconds          *int32                                    `json:"timeoutSeconds,omitempty"`
+	AdmissionReviewVersions []string                                  `json:"admissionReviewVersions,omitempty"`
+	ReinvocationPolicy      *v1beta1.ReinvocationPolicyType           `json:"reinvocationPolicy,omitempty"`
+	MatchConditions         []MatchConditionApplyConfiguration        `json:"matchConditions,omitempty"`
 }
 
 // MutatingWebhookApplyConfiguration constructs an declarative configuration of the MutatingWebhook type for use with
@@ -79,7 +79,7 @@ func (b *MutatingWebhookApplyConfiguration) WithRules(values ...*v1.RuleWithOper
 // WithFailurePolicy sets the FailurePolicy field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the FailurePolicy field is set to the value of the last call.
-func (b *MutatingWebhookApplyConfiguration) WithFailurePolicy(value admissionregistrationv1beta1.FailurePolicyType) *MutatingWebhookApplyConfiguration {
+func (b *MutatingWebhookApplyConfiguration) WithFailurePolicy(value v1beta1.FailurePolicyType) *MutatingWebhookApplyConfiguration {
 	b.FailurePolicy = &value
 	return b
 }
@@ -87,7 +87,7 @@ func (b *MutatingWebhookApplyConfiguration) WithFailurePolicy(value admissionreg
 // WithMatchPolicy sets the MatchPolicy field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the MatchPolicy field is set to the value of the last call.
-func (b *MutatingWebhookApplyConfiguration) WithMatchPolicy(value admissionregistrationv1beta1.MatchPolicyType) *MutatingWebhookApplyConfiguration {
+func (b *MutatingWebhookApplyConfiguration) WithMatchPolicy(value v1beta1.MatchPolicyType) *MutatingWebhookApplyConfiguration {
 	b.MatchPolicy = &value
 	return b
 }
@@ -111,7 +111,7 @@ func (b *MutatingWebhookApplyConfiguration) WithObjectSelector(value *metav1.Lab
 // WithSideEffects sets the SideEffects field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the SideEffects field is set to the value of the last call.
-func (b *MutatingWebhookApplyConfiguration) WithSideEffects(value admissionregistrationv1beta1.SideEffectClass) *MutatingWebhookApplyConfiguration {
+func (b *MutatingWebhookApplyConfiguration) WithSideEffects(value v1beta1.SideEffectClass) *MutatingWebhookApplyConfiguration {
 	b.SideEffects = &value
 	return b
 }
@@ -137,7 +137,7 @@ func (b *MutatingWebhookApplyConfiguration) WithAdmissionReviewVersions(values .
 // WithReinvocationPolicy sets the ReinvocationPolicy field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the ReinvocationPolicy field is set to the value of the last call.
-func (b *MutatingWebhookApplyConfiguration) WithReinvocationPolicy(value admissionregistrationv1beta1.ReinvocationPolicyType) *MutatingWebhookApplyConfiguration {
+func (b *MutatingWebhookApplyConfiguration) WithReinvocationPolicy(value v1beta1.ReinvocationPolicyType) *MutatingWebhookApplyConfiguration {
 	b.ReinvocationPolicy = &value
 	return b
 }

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/mutatingwebhookconfiguration.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/mutatingwebhookconfiguration.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1beta1
 
 import (
-	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	v1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -56,18 +56,18 @@ func MutatingWebhookConfiguration(name string) *MutatingWebhookConfigurationAppl
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractMutatingWebhookConfiguration(mutatingWebhookConfiguration *admissionregistrationv1beta1.MutatingWebhookConfiguration, fieldManager string) (*MutatingWebhookConfigurationApplyConfiguration, error) {
+func ExtractMutatingWebhookConfiguration(mutatingWebhookConfiguration *v1beta1.MutatingWebhookConfiguration, fieldManager string) (*MutatingWebhookConfigurationApplyConfiguration, error) {
 	return extractMutatingWebhookConfiguration(mutatingWebhookConfiguration, fieldManager, "")
 }
 
 // ExtractMutatingWebhookConfigurationStatus is the same as ExtractMutatingWebhookConfiguration except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractMutatingWebhookConfigurationStatus(mutatingWebhookConfiguration *admissionregistrationv1beta1.MutatingWebhookConfiguration, fieldManager string) (*MutatingWebhookConfigurationApplyConfiguration, error) {
+func ExtractMutatingWebhookConfigurationStatus(mutatingWebhookConfiguration *v1beta1.MutatingWebhookConfiguration, fieldManager string) (*MutatingWebhookConfigurationApplyConfiguration, error) {
 	return extractMutatingWebhookConfiguration(mutatingWebhookConfiguration, fieldManager, "status")
 }
 
-func extractMutatingWebhookConfiguration(mutatingWebhookConfiguration *admissionregistrationv1beta1.MutatingWebhookConfiguration, fieldManager string, subresource string) (*MutatingWebhookConfigurationApplyConfiguration, error) {
+func extractMutatingWebhookConfiguration(mutatingWebhookConfiguration *v1beta1.MutatingWebhookConfiguration, fieldManager string, subresource string) (*MutatingWebhookConfigurationApplyConfiguration, error) {
 	b := &MutatingWebhookConfigurationApplyConfiguration{}
 	err := managedfields.ExtractInto(mutatingWebhookConfiguration, internal.Parser().Type("io.k8s.api.admissionregistration.v1beta1.MutatingWebhookConfiguration"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/validatingadmissionpolicy.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/validatingadmissionpolicy.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1beta1
 
 import (
-	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	v1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -57,18 +57,18 @@ func ValidatingAdmissionPolicy(name string) *ValidatingAdmissionPolicyApplyConfi
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractValidatingAdmissionPolicy(validatingAdmissionPolicy *admissionregistrationv1beta1.ValidatingAdmissionPolicy, fieldManager string) (*ValidatingAdmissionPolicyApplyConfiguration, error) {
+func ExtractValidatingAdmissionPolicy(validatingAdmissionPolicy *v1beta1.ValidatingAdmissionPolicy, fieldManager string) (*ValidatingAdmissionPolicyApplyConfiguration, error) {
 	return extractValidatingAdmissionPolicy(validatingAdmissionPolicy, fieldManager, "")
 }
 
 // ExtractValidatingAdmissionPolicyStatus is the same as ExtractValidatingAdmissionPolicy except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractValidatingAdmissionPolicyStatus(validatingAdmissionPolicy *admissionregistrationv1beta1.ValidatingAdmissionPolicy, fieldManager string) (*ValidatingAdmissionPolicyApplyConfiguration, error) {
+func ExtractValidatingAdmissionPolicyStatus(validatingAdmissionPolicy *v1beta1.ValidatingAdmissionPolicy, fieldManager string) (*ValidatingAdmissionPolicyApplyConfiguration, error) {
 	return extractValidatingAdmissionPolicy(validatingAdmissionPolicy, fieldManager, "status")
 }
 
-func extractValidatingAdmissionPolicy(validatingAdmissionPolicy *admissionregistrationv1beta1.ValidatingAdmissionPolicy, fieldManager string, subresource string) (*ValidatingAdmissionPolicyApplyConfiguration, error) {
+func extractValidatingAdmissionPolicy(validatingAdmissionPolicy *v1beta1.ValidatingAdmissionPolicy, fieldManager string, subresource string) (*ValidatingAdmissionPolicyApplyConfiguration, error) {
 	b := &ValidatingAdmissionPolicyApplyConfiguration{}
 	err := managedfields.ExtractInto(validatingAdmissionPolicy, internal.Parser().Type("io.k8s.api.admissionregistration.v1beta1.ValidatingAdmissionPolicy"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/validatingadmissionpolicybinding.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/validatingadmissionpolicybinding.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1beta1
 
 import (
-	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	v1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -56,18 +56,18 @@ func ValidatingAdmissionPolicyBinding(name string) *ValidatingAdmissionPolicyBin
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractValidatingAdmissionPolicyBinding(validatingAdmissionPolicyBinding *admissionregistrationv1beta1.ValidatingAdmissionPolicyBinding, fieldManager string) (*ValidatingAdmissionPolicyBindingApplyConfiguration, error) {
+func ExtractValidatingAdmissionPolicyBinding(validatingAdmissionPolicyBinding *v1beta1.ValidatingAdmissionPolicyBinding, fieldManager string) (*ValidatingAdmissionPolicyBindingApplyConfiguration, error) {
 	return extractValidatingAdmissionPolicyBinding(validatingAdmissionPolicyBinding, fieldManager, "")
 }
 
 // ExtractValidatingAdmissionPolicyBindingStatus is the same as ExtractValidatingAdmissionPolicyBinding except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractValidatingAdmissionPolicyBindingStatus(validatingAdmissionPolicyBinding *admissionregistrationv1beta1.ValidatingAdmissionPolicyBinding, fieldManager string) (*ValidatingAdmissionPolicyBindingApplyConfiguration, error) {
+func ExtractValidatingAdmissionPolicyBindingStatus(validatingAdmissionPolicyBinding *v1beta1.ValidatingAdmissionPolicyBinding, fieldManager string) (*ValidatingAdmissionPolicyBindingApplyConfiguration, error) {
 	return extractValidatingAdmissionPolicyBinding(validatingAdmissionPolicyBinding, fieldManager, "status")
 }
 
-func extractValidatingAdmissionPolicyBinding(validatingAdmissionPolicyBinding *admissionregistrationv1beta1.ValidatingAdmissionPolicyBinding, fieldManager string, subresource string) (*ValidatingAdmissionPolicyBindingApplyConfiguration, error) {
+func extractValidatingAdmissionPolicyBinding(validatingAdmissionPolicyBinding *v1beta1.ValidatingAdmissionPolicyBinding, fieldManager string, subresource string) (*ValidatingAdmissionPolicyBindingApplyConfiguration, error) {
 	b := &ValidatingAdmissionPolicyBindingApplyConfiguration{}
 	err := managedfields.ExtractInto(validatingAdmissionPolicyBinding, internal.Parser().Type("io.k8s.api.admissionregistration.v1beta1.ValidatingAdmissionPolicyBinding"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/validatingadmissionpolicybindingspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/validatingadmissionpolicybindingspec.go
@@ -19,16 +19,16 @@ limitations under the License.
 package v1beta1
 
 import (
-	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	v1beta1 "k8s.io/api/admissionregistration/v1beta1"
 )
 
 // ValidatingAdmissionPolicyBindingSpecApplyConfiguration represents an declarative configuration of the ValidatingAdmissionPolicyBindingSpec type for use
 // with apply.
 type ValidatingAdmissionPolicyBindingSpecApplyConfiguration struct {
-	PolicyName        *string                                         `json:"policyName,omitempty"`
-	ParamRef          *ParamRefApplyConfiguration                     `json:"paramRef,omitempty"`
-	MatchResources    *MatchResourcesApplyConfiguration               `json:"matchResources,omitempty"`
-	ValidationActions []admissionregistrationv1beta1.ValidationAction `json:"validationActions,omitempty"`
+	PolicyName        *string                           `json:"policyName,omitempty"`
+	ParamRef          *ParamRefApplyConfiguration       `json:"paramRef,omitempty"`
+	MatchResources    *MatchResourcesApplyConfiguration `json:"matchResources,omitempty"`
+	ValidationActions []v1beta1.ValidationAction        `json:"validationActions,omitempty"`
 }
 
 // ValidatingAdmissionPolicyBindingSpecApplyConfiguration constructs an declarative configuration of the ValidatingAdmissionPolicyBindingSpec type for use with
@@ -64,7 +64,7 @@ func (b *ValidatingAdmissionPolicyBindingSpecApplyConfiguration) WithMatchResour
 // WithValidationActions adds the given value to the ValidationActions field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the ValidationActions field.
-func (b *ValidatingAdmissionPolicyBindingSpecApplyConfiguration) WithValidationActions(values ...admissionregistrationv1beta1.ValidationAction) *ValidatingAdmissionPolicyBindingSpecApplyConfiguration {
+func (b *ValidatingAdmissionPolicyBindingSpecApplyConfiguration) WithValidationActions(values ...v1beta1.ValidationAction) *ValidatingAdmissionPolicyBindingSpecApplyConfiguration {
 	for i := range values {
 		b.ValidationActions = append(b.ValidationActions, values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/validatingadmissionpolicyspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/validatingadmissionpolicyspec.go
@@ -19,19 +19,19 @@ limitations under the License.
 package v1beta1
 
 import (
-	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	v1beta1 "k8s.io/api/admissionregistration/v1beta1"
 )
 
 // ValidatingAdmissionPolicySpecApplyConfiguration represents an declarative configuration of the ValidatingAdmissionPolicySpec type for use
 // with apply.
 type ValidatingAdmissionPolicySpecApplyConfiguration struct {
-	ParamKind        *ParamKindApplyConfiguration                    `json:"paramKind,omitempty"`
-	MatchConstraints *MatchResourcesApplyConfiguration               `json:"matchConstraints,omitempty"`
-	Validations      []ValidationApplyConfiguration                  `json:"validations,omitempty"`
-	FailurePolicy    *admissionregistrationv1beta1.FailurePolicyType `json:"failurePolicy,omitempty"`
-	AuditAnnotations []AuditAnnotationApplyConfiguration             `json:"auditAnnotations,omitempty"`
-	MatchConditions  []MatchConditionApplyConfiguration              `json:"matchConditions,omitempty"`
-	Variables        []VariableApplyConfiguration                    `json:"variables,omitempty"`
+	ParamKind        *ParamKindApplyConfiguration        `json:"paramKind,omitempty"`
+	MatchConstraints *MatchResourcesApplyConfiguration   `json:"matchConstraints,omitempty"`
+	Validations      []ValidationApplyConfiguration      `json:"validations,omitempty"`
+	FailurePolicy    *v1beta1.FailurePolicyType          `json:"failurePolicy,omitempty"`
+	AuditAnnotations []AuditAnnotationApplyConfiguration `json:"auditAnnotations,omitempty"`
+	MatchConditions  []MatchConditionApplyConfiguration  `json:"matchConditions,omitempty"`
+	Variables        []VariableApplyConfiguration        `json:"variables,omitempty"`
 }
 
 // ValidatingAdmissionPolicySpecApplyConfiguration constructs an declarative configuration of the ValidatingAdmissionPolicySpec type for use with
@@ -72,7 +72,7 @@ func (b *ValidatingAdmissionPolicySpecApplyConfiguration) WithValidations(values
 // WithFailurePolicy sets the FailurePolicy field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the FailurePolicy field is set to the value of the last call.
-func (b *ValidatingAdmissionPolicySpecApplyConfiguration) WithFailurePolicy(value admissionregistrationv1beta1.FailurePolicyType) *ValidatingAdmissionPolicySpecApplyConfiguration {
+func (b *ValidatingAdmissionPolicySpecApplyConfiguration) WithFailurePolicy(value v1beta1.FailurePolicyType) *ValidatingAdmissionPolicySpecApplyConfiguration {
 	b.FailurePolicy = &value
 	return b
 }

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/validatingwebhook.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/validatingwebhook.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1beta1
 
 import (
-	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	v1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	v1 "k8s.io/client-go/applyconfigurations/admissionregistration/v1"
 	metav1 "k8s.io/client-go/applyconfigurations/meta/v1"
 )
@@ -27,17 +27,17 @@ import (
 // ValidatingWebhookApplyConfiguration represents an declarative configuration of the ValidatingWebhook type for use
 // with apply.
 type ValidatingWebhookApplyConfiguration struct {
-	Name                    *string                                         `json:"name,omitempty"`
-	ClientConfig            *WebhookClientConfigApplyConfiguration          `json:"clientConfig,omitempty"`
-	Rules                   []v1.RuleWithOperationsApplyConfiguration       `json:"rules,omitempty"`
-	FailurePolicy           *admissionregistrationv1beta1.FailurePolicyType `json:"failurePolicy,omitempty"`
-	MatchPolicy             *admissionregistrationv1beta1.MatchPolicyType   `json:"matchPolicy,omitempty"`
-	NamespaceSelector       *metav1.LabelSelectorApplyConfiguration         `json:"namespaceSelector,omitempty"`
-	ObjectSelector          *metav1.LabelSelectorApplyConfiguration         `json:"objectSelector,omitempty"`
-	SideEffects             *admissionregistrationv1beta1.SideEffectClass   `json:"sideEffects,omitempty"`
-	TimeoutSeconds          *int32                                          `json:"timeoutSeconds,omitempty"`
-	AdmissionReviewVersions []string                                        `json:"admissionReviewVersions,omitempty"`
-	MatchConditions         []MatchConditionApplyConfiguration              `json:"matchConditions,omitempty"`
+	Name                    *string                                   `json:"name,omitempty"`
+	ClientConfig            *WebhookClientConfigApplyConfiguration    `json:"clientConfig,omitempty"`
+	Rules                   []v1.RuleWithOperationsApplyConfiguration `json:"rules,omitempty"`
+	FailurePolicy           *v1beta1.FailurePolicyType                `json:"failurePolicy,omitempty"`
+	MatchPolicy             *v1beta1.MatchPolicyType                  `json:"matchPolicy,omitempty"`
+	NamespaceSelector       *metav1.LabelSelectorApplyConfiguration   `json:"namespaceSelector,omitempty"`
+	ObjectSelector          *metav1.LabelSelectorApplyConfiguration   `json:"objectSelector,omitempty"`
+	SideEffects             *v1beta1.SideEffectClass                  `json:"sideEffects,omitempty"`
+	TimeoutSeconds          *int32                                    `json:"timeoutSeconds,omitempty"`
+	AdmissionReviewVersions []string                                  `json:"admissionReviewVersions,omitempty"`
+	MatchConditions         []MatchConditionApplyConfiguration        `json:"matchConditions,omitempty"`
 }
 
 // ValidatingWebhookApplyConfiguration constructs an declarative configuration of the ValidatingWebhook type for use with
@@ -78,7 +78,7 @@ func (b *ValidatingWebhookApplyConfiguration) WithRules(values ...*v1.RuleWithOp
 // WithFailurePolicy sets the FailurePolicy field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the FailurePolicy field is set to the value of the last call.
-func (b *ValidatingWebhookApplyConfiguration) WithFailurePolicy(value admissionregistrationv1beta1.FailurePolicyType) *ValidatingWebhookApplyConfiguration {
+func (b *ValidatingWebhookApplyConfiguration) WithFailurePolicy(value v1beta1.FailurePolicyType) *ValidatingWebhookApplyConfiguration {
 	b.FailurePolicy = &value
 	return b
 }
@@ -86,7 +86,7 @@ func (b *ValidatingWebhookApplyConfiguration) WithFailurePolicy(value admissionr
 // WithMatchPolicy sets the MatchPolicy field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the MatchPolicy field is set to the value of the last call.
-func (b *ValidatingWebhookApplyConfiguration) WithMatchPolicy(value admissionregistrationv1beta1.MatchPolicyType) *ValidatingWebhookApplyConfiguration {
+func (b *ValidatingWebhookApplyConfiguration) WithMatchPolicy(value v1beta1.MatchPolicyType) *ValidatingWebhookApplyConfiguration {
 	b.MatchPolicy = &value
 	return b
 }
@@ -110,7 +110,7 @@ func (b *ValidatingWebhookApplyConfiguration) WithObjectSelector(value *metav1.L
 // WithSideEffects sets the SideEffects field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the SideEffects field is set to the value of the last call.
-func (b *ValidatingWebhookApplyConfiguration) WithSideEffects(value admissionregistrationv1beta1.SideEffectClass) *ValidatingWebhookApplyConfiguration {
+func (b *ValidatingWebhookApplyConfiguration) WithSideEffects(value v1beta1.SideEffectClass) *ValidatingWebhookApplyConfiguration {
 	b.SideEffects = &value
 	return b
 }

--- a/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/validatingwebhookconfiguration.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1/validatingwebhookconfiguration.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1beta1
 
 import (
-	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	v1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -56,18 +56,18 @@ func ValidatingWebhookConfiguration(name string) *ValidatingWebhookConfiguration
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractValidatingWebhookConfiguration(validatingWebhookConfiguration *admissionregistrationv1beta1.ValidatingWebhookConfiguration, fieldManager string) (*ValidatingWebhookConfigurationApplyConfiguration, error) {
+func ExtractValidatingWebhookConfiguration(validatingWebhookConfiguration *v1beta1.ValidatingWebhookConfiguration, fieldManager string) (*ValidatingWebhookConfigurationApplyConfiguration, error) {
 	return extractValidatingWebhookConfiguration(validatingWebhookConfiguration, fieldManager, "")
 }
 
 // ExtractValidatingWebhookConfigurationStatus is the same as ExtractValidatingWebhookConfiguration except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractValidatingWebhookConfigurationStatus(validatingWebhookConfiguration *admissionregistrationv1beta1.ValidatingWebhookConfiguration, fieldManager string) (*ValidatingWebhookConfigurationApplyConfiguration, error) {
+func ExtractValidatingWebhookConfigurationStatus(validatingWebhookConfiguration *v1beta1.ValidatingWebhookConfiguration, fieldManager string) (*ValidatingWebhookConfigurationApplyConfiguration, error) {
 	return extractValidatingWebhookConfiguration(validatingWebhookConfiguration, fieldManager, "status")
 }
 
-func extractValidatingWebhookConfiguration(validatingWebhookConfiguration *admissionregistrationv1beta1.ValidatingWebhookConfiguration, fieldManager string, subresource string) (*ValidatingWebhookConfigurationApplyConfiguration, error) {
+func extractValidatingWebhookConfiguration(validatingWebhookConfiguration *v1beta1.ValidatingWebhookConfiguration, fieldManager string, subresource string) (*ValidatingWebhookConfigurationApplyConfiguration, error) {
 	b := &ValidatingWebhookConfigurationApplyConfiguration{}
 	err := managedfields.ExtractInto(validatingWebhookConfiguration, internal.Parser().Type("io.k8s.api.admissionregistration.v1beta1.ValidatingWebhookConfiguration"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/daemonset.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/daemonset.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1
 
 import (
-	apiappsv1 "k8s.io/api/apps/v1"
+	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -58,18 +58,18 @@ func DaemonSet(name, namespace string) *DaemonSetApplyConfiguration {
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractDaemonSet(daemonSet *apiappsv1.DaemonSet, fieldManager string) (*DaemonSetApplyConfiguration, error) {
+func ExtractDaemonSet(daemonSet *appsv1.DaemonSet, fieldManager string) (*DaemonSetApplyConfiguration, error) {
 	return extractDaemonSet(daemonSet, fieldManager, "")
 }
 
 // ExtractDaemonSetStatus is the same as ExtractDaemonSet except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractDaemonSetStatus(daemonSet *apiappsv1.DaemonSet, fieldManager string) (*DaemonSetApplyConfiguration, error) {
+func ExtractDaemonSetStatus(daemonSet *appsv1.DaemonSet, fieldManager string) (*DaemonSetApplyConfiguration, error) {
 	return extractDaemonSet(daemonSet, fieldManager, "status")
 }
 
-func extractDaemonSet(daemonSet *apiappsv1.DaemonSet, fieldManager string, subresource string) (*DaemonSetApplyConfiguration, error) {
+func extractDaemonSet(daemonSet *appsv1.DaemonSet, fieldManager string, subresource string) (*DaemonSetApplyConfiguration, error) {
 	b := &DaemonSetApplyConfiguration{}
 	err := managedfields.ExtractInto(daemonSet, internal.Parser().Type("io.k8s.api.apps.v1.DaemonSet"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/deployment.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/deployment.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1
 
 import (
-	apiappsv1 "k8s.io/api/apps/v1"
+	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -58,18 +58,18 @@ func Deployment(name, namespace string) *DeploymentApplyConfiguration {
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractDeployment(deployment *apiappsv1.Deployment, fieldManager string) (*DeploymentApplyConfiguration, error) {
+func ExtractDeployment(deployment *appsv1.Deployment, fieldManager string) (*DeploymentApplyConfiguration, error) {
 	return extractDeployment(deployment, fieldManager, "")
 }
 
 // ExtractDeploymentStatus is the same as ExtractDeployment except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractDeploymentStatus(deployment *apiappsv1.Deployment, fieldManager string) (*DeploymentApplyConfiguration, error) {
+func ExtractDeploymentStatus(deployment *appsv1.Deployment, fieldManager string) (*DeploymentApplyConfiguration, error) {
 	return extractDeployment(deployment, fieldManager, "status")
 }
 
-func extractDeployment(deployment *apiappsv1.Deployment, fieldManager string, subresource string) (*DeploymentApplyConfiguration, error) {
+func extractDeployment(deployment *appsv1.Deployment, fieldManager string, subresource string) (*DeploymentApplyConfiguration, error) {
 	b := &DeploymentApplyConfiguration{}
 	err := managedfields.ExtractInto(deployment, internal.Parser().Type("io.k8s.api.apps.v1.Deployment"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/replicaset.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/replicaset.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1
 
 import (
-	apiappsv1 "k8s.io/api/apps/v1"
+	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -58,18 +58,18 @@ func ReplicaSet(name, namespace string) *ReplicaSetApplyConfiguration {
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractReplicaSet(replicaSet *apiappsv1.ReplicaSet, fieldManager string) (*ReplicaSetApplyConfiguration, error) {
+func ExtractReplicaSet(replicaSet *appsv1.ReplicaSet, fieldManager string) (*ReplicaSetApplyConfiguration, error) {
 	return extractReplicaSet(replicaSet, fieldManager, "")
 }
 
 // ExtractReplicaSetStatus is the same as ExtractReplicaSet except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractReplicaSetStatus(replicaSet *apiappsv1.ReplicaSet, fieldManager string) (*ReplicaSetApplyConfiguration, error) {
+func ExtractReplicaSetStatus(replicaSet *appsv1.ReplicaSet, fieldManager string) (*ReplicaSetApplyConfiguration, error) {
 	return extractReplicaSet(replicaSet, fieldManager, "status")
 }
 
-func extractReplicaSet(replicaSet *apiappsv1.ReplicaSet, fieldManager string, subresource string) (*ReplicaSetApplyConfiguration, error) {
+func extractReplicaSet(replicaSet *appsv1.ReplicaSet, fieldManager string, subresource string) (*ReplicaSetApplyConfiguration, error) {
 	b := &ReplicaSetApplyConfiguration{}
 	err := managedfields.ExtractInto(replicaSet, internal.Parser().Type("io.k8s.api.apps.v1.ReplicaSet"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/statefulset.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1/statefulset.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1
 
 import (
-	apiappsv1 "k8s.io/api/apps/v1"
+	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -58,18 +58,18 @@ func StatefulSet(name, namespace string) *StatefulSetApplyConfiguration {
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractStatefulSet(statefulSet *apiappsv1.StatefulSet, fieldManager string) (*StatefulSetApplyConfiguration, error) {
+func ExtractStatefulSet(statefulSet *appsv1.StatefulSet, fieldManager string) (*StatefulSetApplyConfiguration, error) {
 	return extractStatefulSet(statefulSet, fieldManager, "")
 }
 
 // ExtractStatefulSetStatus is the same as ExtractStatefulSet except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractStatefulSetStatus(statefulSet *apiappsv1.StatefulSet, fieldManager string) (*StatefulSetApplyConfiguration, error) {
+func ExtractStatefulSetStatus(statefulSet *appsv1.StatefulSet, fieldManager string) (*StatefulSetApplyConfiguration, error) {
 	return extractStatefulSet(statefulSet, fieldManager, "status")
 }
 
-func extractStatefulSet(statefulSet *apiappsv1.StatefulSet, fieldManager string, subresource string) (*StatefulSetApplyConfiguration, error) {
+func extractStatefulSet(statefulSet *appsv1.StatefulSet, fieldManager string, subresource string) (*StatefulSetApplyConfiguration, error) {
 	b := &StatefulSetApplyConfiguration{}
 	err := managedfields.ExtractInto(statefulSet, internal.Parser().Type("io.k8s.api.apps.v1.StatefulSet"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta1/deployment.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta1/deployment.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1beta1
 
 import (
-	appsv1beta1 "k8s.io/api/apps/v1beta1"
+	v1beta1 "k8s.io/api/apps/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -58,18 +58,18 @@ func Deployment(name, namespace string) *DeploymentApplyConfiguration {
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractDeployment(deployment *appsv1beta1.Deployment, fieldManager string) (*DeploymentApplyConfiguration, error) {
+func ExtractDeployment(deployment *v1beta1.Deployment, fieldManager string) (*DeploymentApplyConfiguration, error) {
 	return extractDeployment(deployment, fieldManager, "")
 }
 
 // ExtractDeploymentStatus is the same as ExtractDeployment except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractDeploymentStatus(deployment *appsv1beta1.Deployment, fieldManager string) (*DeploymentApplyConfiguration, error) {
+func ExtractDeploymentStatus(deployment *v1beta1.Deployment, fieldManager string) (*DeploymentApplyConfiguration, error) {
 	return extractDeployment(deployment, fieldManager, "status")
 }
 
-func extractDeployment(deployment *appsv1beta1.Deployment, fieldManager string, subresource string) (*DeploymentApplyConfiguration, error) {
+func extractDeployment(deployment *v1beta1.Deployment, fieldManager string, subresource string) (*DeploymentApplyConfiguration, error) {
 	b := &DeploymentApplyConfiguration{}
 	err := managedfields.ExtractInto(deployment, internal.Parser().Type("io.k8s.api.apps.v1beta1.Deployment"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta1/statefulset.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta1/statefulset.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1beta1
 
 import (
-	appsv1beta1 "k8s.io/api/apps/v1beta1"
+	v1beta1 "k8s.io/api/apps/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -58,18 +58,18 @@ func StatefulSet(name, namespace string) *StatefulSetApplyConfiguration {
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractStatefulSet(statefulSet *appsv1beta1.StatefulSet, fieldManager string) (*StatefulSetApplyConfiguration, error) {
+func ExtractStatefulSet(statefulSet *v1beta1.StatefulSet, fieldManager string) (*StatefulSetApplyConfiguration, error) {
 	return extractStatefulSet(statefulSet, fieldManager, "")
 }
 
 // ExtractStatefulSetStatus is the same as ExtractStatefulSet except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractStatefulSetStatus(statefulSet *appsv1beta1.StatefulSet, fieldManager string) (*StatefulSetApplyConfiguration, error) {
+func ExtractStatefulSetStatus(statefulSet *v1beta1.StatefulSet, fieldManager string) (*StatefulSetApplyConfiguration, error) {
 	return extractStatefulSet(statefulSet, fieldManager, "status")
 }
 
-func extractStatefulSet(statefulSet *appsv1beta1.StatefulSet, fieldManager string, subresource string) (*StatefulSetApplyConfiguration, error) {
+func extractStatefulSet(statefulSet *v1beta1.StatefulSet, fieldManager string, subresource string) (*StatefulSetApplyConfiguration, error) {
 	b := &StatefulSetApplyConfiguration{}
 	err := managedfields.ExtractInto(statefulSet, internal.Parser().Type("io.k8s.api.apps.v1beta1.StatefulSet"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/daemonset.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/daemonset.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1beta2
 
 import (
-	appsv1beta2 "k8s.io/api/apps/v1beta2"
+	v1beta2 "k8s.io/api/apps/v1beta2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -58,18 +58,18 @@ func DaemonSet(name, namespace string) *DaemonSetApplyConfiguration {
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractDaemonSet(daemonSet *appsv1beta2.DaemonSet, fieldManager string) (*DaemonSetApplyConfiguration, error) {
+func ExtractDaemonSet(daemonSet *v1beta2.DaemonSet, fieldManager string) (*DaemonSetApplyConfiguration, error) {
 	return extractDaemonSet(daemonSet, fieldManager, "")
 }
 
 // ExtractDaemonSetStatus is the same as ExtractDaemonSet except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractDaemonSetStatus(daemonSet *appsv1beta2.DaemonSet, fieldManager string) (*DaemonSetApplyConfiguration, error) {
+func ExtractDaemonSetStatus(daemonSet *v1beta2.DaemonSet, fieldManager string) (*DaemonSetApplyConfiguration, error) {
 	return extractDaemonSet(daemonSet, fieldManager, "status")
 }
 
-func extractDaemonSet(daemonSet *appsv1beta2.DaemonSet, fieldManager string, subresource string) (*DaemonSetApplyConfiguration, error) {
+func extractDaemonSet(daemonSet *v1beta2.DaemonSet, fieldManager string, subresource string) (*DaemonSetApplyConfiguration, error) {
 	b := &DaemonSetApplyConfiguration{}
 	err := managedfields.ExtractInto(daemonSet, internal.Parser().Type("io.k8s.api.apps.v1beta2.DaemonSet"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/deployment.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/deployment.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1beta2
 
 import (
-	appsv1beta2 "k8s.io/api/apps/v1beta2"
+	v1beta2 "k8s.io/api/apps/v1beta2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -58,18 +58,18 @@ func Deployment(name, namespace string) *DeploymentApplyConfiguration {
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractDeployment(deployment *appsv1beta2.Deployment, fieldManager string) (*DeploymentApplyConfiguration, error) {
+func ExtractDeployment(deployment *v1beta2.Deployment, fieldManager string) (*DeploymentApplyConfiguration, error) {
 	return extractDeployment(deployment, fieldManager, "")
 }
 
 // ExtractDeploymentStatus is the same as ExtractDeployment except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractDeploymentStatus(deployment *appsv1beta2.Deployment, fieldManager string) (*DeploymentApplyConfiguration, error) {
+func ExtractDeploymentStatus(deployment *v1beta2.Deployment, fieldManager string) (*DeploymentApplyConfiguration, error) {
 	return extractDeployment(deployment, fieldManager, "status")
 }
 
-func extractDeployment(deployment *appsv1beta2.Deployment, fieldManager string, subresource string) (*DeploymentApplyConfiguration, error) {
+func extractDeployment(deployment *v1beta2.Deployment, fieldManager string, subresource string) (*DeploymentApplyConfiguration, error) {
 	b := &DeploymentApplyConfiguration{}
 	err := managedfields.ExtractInto(deployment, internal.Parser().Type("io.k8s.api.apps.v1beta2.Deployment"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/replicaset.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/replicaset.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1beta2
 
 import (
-	appsv1beta2 "k8s.io/api/apps/v1beta2"
+	v1beta2 "k8s.io/api/apps/v1beta2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -58,18 +58,18 @@ func ReplicaSet(name, namespace string) *ReplicaSetApplyConfiguration {
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractReplicaSet(replicaSet *appsv1beta2.ReplicaSet, fieldManager string) (*ReplicaSetApplyConfiguration, error) {
+func ExtractReplicaSet(replicaSet *v1beta2.ReplicaSet, fieldManager string) (*ReplicaSetApplyConfiguration, error) {
 	return extractReplicaSet(replicaSet, fieldManager, "")
 }
 
 // ExtractReplicaSetStatus is the same as ExtractReplicaSet except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractReplicaSetStatus(replicaSet *appsv1beta2.ReplicaSet, fieldManager string) (*ReplicaSetApplyConfiguration, error) {
+func ExtractReplicaSetStatus(replicaSet *v1beta2.ReplicaSet, fieldManager string) (*ReplicaSetApplyConfiguration, error) {
 	return extractReplicaSet(replicaSet, fieldManager, "status")
 }
 
-func extractReplicaSet(replicaSet *appsv1beta2.ReplicaSet, fieldManager string, subresource string) (*ReplicaSetApplyConfiguration, error) {
+func extractReplicaSet(replicaSet *v1beta2.ReplicaSet, fieldManager string, subresource string) (*ReplicaSetApplyConfiguration, error) {
 	b := &ReplicaSetApplyConfiguration{}
 	err := managedfields.ExtractInto(replicaSet, internal.Parser().Type("io.k8s.api.apps.v1beta2.ReplicaSet"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/statefulset.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/apps/v1beta2/statefulset.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1beta2
 
 import (
-	appsv1beta2 "k8s.io/api/apps/v1beta2"
+	v1beta2 "k8s.io/api/apps/v1beta2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -58,18 +58,18 @@ func StatefulSet(name, namespace string) *StatefulSetApplyConfiguration {
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractStatefulSet(statefulSet *appsv1beta2.StatefulSet, fieldManager string) (*StatefulSetApplyConfiguration, error) {
+func ExtractStatefulSet(statefulSet *v1beta2.StatefulSet, fieldManager string) (*StatefulSetApplyConfiguration, error) {
 	return extractStatefulSet(statefulSet, fieldManager, "")
 }
 
 // ExtractStatefulSetStatus is the same as ExtractStatefulSet except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractStatefulSetStatus(statefulSet *appsv1beta2.StatefulSet, fieldManager string) (*StatefulSetApplyConfiguration, error) {
+func ExtractStatefulSetStatus(statefulSet *v1beta2.StatefulSet, fieldManager string) (*StatefulSetApplyConfiguration, error) {
 	return extractStatefulSet(statefulSet, fieldManager, "status")
 }
 
-func extractStatefulSet(statefulSet *appsv1beta2.StatefulSet, fieldManager string, subresource string) (*StatefulSetApplyConfiguration, error) {
+func extractStatefulSet(statefulSet *v1beta2.StatefulSet, fieldManager string, subresource string) (*StatefulSetApplyConfiguration, error) {
 	b := &StatefulSetApplyConfiguration{}
 	err := managedfields.ExtractInto(statefulSet, internal.Parser().Type("io.k8s.api.apps.v1beta2.StatefulSet"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v1/horizontalpodautoscaler.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v1/horizontalpodautoscaler.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1
 
 import (
-	apiautoscalingv1 "k8s.io/api/autoscaling/v1"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -58,18 +58,18 @@ func HorizontalPodAutoscaler(name, namespace string) *HorizontalPodAutoscalerApp
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractHorizontalPodAutoscaler(horizontalPodAutoscaler *apiautoscalingv1.HorizontalPodAutoscaler, fieldManager string) (*HorizontalPodAutoscalerApplyConfiguration, error) {
+func ExtractHorizontalPodAutoscaler(horizontalPodAutoscaler *autoscalingv1.HorizontalPodAutoscaler, fieldManager string) (*HorizontalPodAutoscalerApplyConfiguration, error) {
 	return extractHorizontalPodAutoscaler(horizontalPodAutoscaler, fieldManager, "")
 }
 
 // ExtractHorizontalPodAutoscalerStatus is the same as ExtractHorizontalPodAutoscaler except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractHorizontalPodAutoscalerStatus(horizontalPodAutoscaler *apiautoscalingv1.HorizontalPodAutoscaler, fieldManager string) (*HorizontalPodAutoscalerApplyConfiguration, error) {
+func ExtractHorizontalPodAutoscalerStatus(horizontalPodAutoscaler *autoscalingv1.HorizontalPodAutoscaler, fieldManager string) (*HorizontalPodAutoscalerApplyConfiguration, error) {
 	return extractHorizontalPodAutoscaler(horizontalPodAutoscaler, fieldManager, "status")
 }
 
-func extractHorizontalPodAutoscaler(horizontalPodAutoscaler *apiautoscalingv1.HorizontalPodAutoscaler, fieldManager string, subresource string) (*HorizontalPodAutoscalerApplyConfiguration, error) {
+func extractHorizontalPodAutoscaler(horizontalPodAutoscaler *autoscalingv1.HorizontalPodAutoscaler, fieldManager string, subresource string) (*HorizontalPodAutoscalerApplyConfiguration, error) {
 	b := &HorizontalPodAutoscalerApplyConfiguration{}
 	err := managedfields.ExtractInto(horizontalPodAutoscaler, internal.Parser().Type("io.k8s.api.autoscaling.v1.HorizontalPodAutoscaler"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2/horizontalpodautoscaler.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2/horizontalpodautoscaler.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v2
 
 import (
-	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	v2 "k8s.io/api/autoscaling/v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -58,18 +58,18 @@ func HorizontalPodAutoscaler(name, namespace string) *HorizontalPodAutoscalerApp
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractHorizontalPodAutoscaler(horizontalPodAutoscaler *autoscalingv2.HorizontalPodAutoscaler, fieldManager string) (*HorizontalPodAutoscalerApplyConfiguration, error) {
+func ExtractHorizontalPodAutoscaler(horizontalPodAutoscaler *v2.HorizontalPodAutoscaler, fieldManager string) (*HorizontalPodAutoscalerApplyConfiguration, error) {
 	return extractHorizontalPodAutoscaler(horizontalPodAutoscaler, fieldManager, "")
 }
 
 // ExtractHorizontalPodAutoscalerStatus is the same as ExtractHorizontalPodAutoscaler except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractHorizontalPodAutoscalerStatus(horizontalPodAutoscaler *autoscalingv2.HorizontalPodAutoscaler, fieldManager string) (*HorizontalPodAutoscalerApplyConfiguration, error) {
+func ExtractHorizontalPodAutoscalerStatus(horizontalPodAutoscaler *v2.HorizontalPodAutoscaler, fieldManager string) (*HorizontalPodAutoscalerApplyConfiguration, error) {
 	return extractHorizontalPodAutoscaler(horizontalPodAutoscaler, fieldManager, "status")
 }
 
-func extractHorizontalPodAutoscaler(horizontalPodAutoscaler *autoscalingv2.HorizontalPodAutoscaler, fieldManager string, subresource string) (*HorizontalPodAutoscalerApplyConfiguration, error) {
+func extractHorizontalPodAutoscaler(horizontalPodAutoscaler *v2.HorizontalPodAutoscaler, fieldManager string, subresource string) (*HorizontalPodAutoscalerApplyConfiguration, error) {
 	b := &HorizontalPodAutoscalerApplyConfiguration{}
 	err := managedfields.ExtractInto(horizontalPodAutoscaler, internal.Parser().Type("io.k8s.api.autoscaling.v2.HorizontalPodAutoscaler"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta1/horizontalpodautoscaler.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta1/horizontalpodautoscaler.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v2beta1
 
 import (
-	autoscalingv2beta1 "k8s.io/api/autoscaling/v2beta1"
+	v2beta1 "k8s.io/api/autoscaling/v2beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -58,18 +58,18 @@ func HorizontalPodAutoscaler(name, namespace string) *HorizontalPodAutoscalerApp
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractHorizontalPodAutoscaler(horizontalPodAutoscaler *autoscalingv2beta1.HorizontalPodAutoscaler, fieldManager string) (*HorizontalPodAutoscalerApplyConfiguration, error) {
+func ExtractHorizontalPodAutoscaler(horizontalPodAutoscaler *v2beta1.HorizontalPodAutoscaler, fieldManager string) (*HorizontalPodAutoscalerApplyConfiguration, error) {
 	return extractHorizontalPodAutoscaler(horizontalPodAutoscaler, fieldManager, "")
 }
 
 // ExtractHorizontalPodAutoscalerStatus is the same as ExtractHorizontalPodAutoscaler except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractHorizontalPodAutoscalerStatus(horizontalPodAutoscaler *autoscalingv2beta1.HorizontalPodAutoscaler, fieldManager string) (*HorizontalPodAutoscalerApplyConfiguration, error) {
+func ExtractHorizontalPodAutoscalerStatus(horizontalPodAutoscaler *v2beta1.HorizontalPodAutoscaler, fieldManager string) (*HorizontalPodAutoscalerApplyConfiguration, error) {
 	return extractHorizontalPodAutoscaler(horizontalPodAutoscaler, fieldManager, "status")
 }
 
-func extractHorizontalPodAutoscaler(horizontalPodAutoscaler *autoscalingv2beta1.HorizontalPodAutoscaler, fieldManager string, subresource string) (*HorizontalPodAutoscalerApplyConfiguration, error) {
+func extractHorizontalPodAutoscaler(horizontalPodAutoscaler *v2beta1.HorizontalPodAutoscaler, fieldManager string, subresource string) (*HorizontalPodAutoscalerApplyConfiguration, error) {
 	b := &HorizontalPodAutoscalerApplyConfiguration{}
 	err := managedfields.ExtractInto(horizontalPodAutoscaler, internal.Parser().Type("io.k8s.api.autoscaling.v2beta1.HorizontalPodAutoscaler"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta2/horizontalpodautoscaler.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/autoscaling/v2beta2/horizontalpodautoscaler.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v2beta2
 
 import (
-	autoscalingv2beta2 "k8s.io/api/autoscaling/v2beta2"
+	v2beta2 "k8s.io/api/autoscaling/v2beta2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -58,18 +58,18 @@ func HorizontalPodAutoscaler(name, namespace string) *HorizontalPodAutoscalerApp
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractHorizontalPodAutoscaler(horizontalPodAutoscaler *autoscalingv2beta2.HorizontalPodAutoscaler, fieldManager string) (*HorizontalPodAutoscalerApplyConfiguration, error) {
+func ExtractHorizontalPodAutoscaler(horizontalPodAutoscaler *v2beta2.HorizontalPodAutoscaler, fieldManager string) (*HorizontalPodAutoscalerApplyConfiguration, error) {
 	return extractHorizontalPodAutoscaler(horizontalPodAutoscaler, fieldManager, "")
 }
 
 // ExtractHorizontalPodAutoscalerStatus is the same as ExtractHorizontalPodAutoscaler except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractHorizontalPodAutoscalerStatus(horizontalPodAutoscaler *autoscalingv2beta2.HorizontalPodAutoscaler, fieldManager string) (*HorizontalPodAutoscalerApplyConfiguration, error) {
+func ExtractHorizontalPodAutoscalerStatus(horizontalPodAutoscaler *v2beta2.HorizontalPodAutoscaler, fieldManager string) (*HorizontalPodAutoscalerApplyConfiguration, error) {
 	return extractHorizontalPodAutoscaler(horizontalPodAutoscaler, fieldManager, "status")
 }
 
-func extractHorizontalPodAutoscaler(horizontalPodAutoscaler *autoscalingv2beta2.HorizontalPodAutoscaler, fieldManager string, subresource string) (*HorizontalPodAutoscalerApplyConfiguration, error) {
+func extractHorizontalPodAutoscaler(horizontalPodAutoscaler *v2beta2.HorizontalPodAutoscaler, fieldManager string, subresource string) (*HorizontalPodAutoscalerApplyConfiguration, error) {
 	b := &HorizontalPodAutoscalerApplyConfiguration{}
 	err := managedfields.ExtractInto(horizontalPodAutoscaler, internal.Parser().Type("io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscaler"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/batch/v1/cronjob.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/batch/v1/cronjob.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1
 
 import (
-	apibatchv1 "k8s.io/api/batch/v1"
+	batchv1 "k8s.io/api/batch/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -58,18 +58,18 @@ func CronJob(name, namespace string) *CronJobApplyConfiguration {
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractCronJob(cronJob *apibatchv1.CronJob, fieldManager string) (*CronJobApplyConfiguration, error) {
+func ExtractCronJob(cronJob *batchv1.CronJob, fieldManager string) (*CronJobApplyConfiguration, error) {
 	return extractCronJob(cronJob, fieldManager, "")
 }
 
 // ExtractCronJobStatus is the same as ExtractCronJob except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractCronJobStatus(cronJob *apibatchv1.CronJob, fieldManager string) (*CronJobApplyConfiguration, error) {
+func ExtractCronJobStatus(cronJob *batchv1.CronJob, fieldManager string) (*CronJobApplyConfiguration, error) {
 	return extractCronJob(cronJob, fieldManager, "status")
 }
 
-func extractCronJob(cronJob *apibatchv1.CronJob, fieldManager string, subresource string) (*CronJobApplyConfiguration, error) {
+func extractCronJob(cronJob *batchv1.CronJob, fieldManager string, subresource string) (*CronJobApplyConfiguration, error) {
 	b := &CronJobApplyConfiguration{}
 	err := managedfields.ExtractInto(cronJob, internal.Parser().Type("io.k8s.api.batch.v1.CronJob"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/batch/v1/job.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/batch/v1/job.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1
 
 import (
-	apibatchv1 "k8s.io/api/batch/v1"
+	batchv1 "k8s.io/api/batch/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -58,18 +58,18 @@ func Job(name, namespace string) *JobApplyConfiguration {
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractJob(job *apibatchv1.Job, fieldManager string) (*JobApplyConfiguration, error) {
+func ExtractJob(job *batchv1.Job, fieldManager string) (*JobApplyConfiguration, error) {
 	return extractJob(job, fieldManager, "")
 }
 
 // ExtractJobStatus is the same as ExtractJob except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractJobStatus(job *apibatchv1.Job, fieldManager string) (*JobApplyConfiguration, error) {
+func ExtractJobStatus(job *batchv1.Job, fieldManager string) (*JobApplyConfiguration, error) {
 	return extractJob(job, fieldManager, "status")
 }
 
-func extractJob(job *apibatchv1.Job, fieldManager string, subresource string) (*JobApplyConfiguration, error) {
+func extractJob(job *batchv1.Job, fieldManager string, subresource string) (*JobApplyConfiguration, error) {
 	b := &JobApplyConfiguration{}
 	err := managedfields.ExtractInto(job, internal.Parser().Type("io.k8s.api.batch.v1.Job"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/batch/v1/jobspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/batch/v1/jobspec.go
@@ -21,7 +21,7 @@ package v1
 import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/client-go/applyconfigurations/core/v1"
-	metav1 "k8s.io/client-go/applyconfigurations/meta/v1"
+	v1 "k8s.io/client-go/applyconfigurations/meta/v1"
 )
 
 // JobSpecApplyConfiguration represents an declarative configuration of the JobSpec type for use
@@ -35,7 +35,7 @@ type JobSpecApplyConfiguration struct {
 	BackoffLimit            *int32                                    `json:"backoffLimit,omitempty"`
 	BackoffLimitPerIndex    *int32                                    `json:"backoffLimitPerIndex,omitempty"`
 	MaxFailedIndexes        *int32                                    `json:"maxFailedIndexes,omitempty"`
-	Selector                *metav1.LabelSelectorApplyConfiguration   `json:"selector,omitempty"`
+	Selector                *v1.LabelSelectorApplyConfiguration       `json:"selector,omitempty"`
 	ManualSelector          *bool                                     `json:"manualSelector,omitempty"`
 	Template                *corev1.PodTemplateSpecApplyConfiguration `json:"template,omitempty"`
 	TTLSecondsAfterFinished *int32                                    `json:"ttlSecondsAfterFinished,omitempty"`
@@ -118,7 +118,7 @@ func (b *JobSpecApplyConfiguration) WithMaxFailedIndexes(value int32) *JobSpecAp
 // WithSelector sets the Selector field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the Selector field is set to the value of the last call.
-func (b *JobSpecApplyConfiguration) WithSelector(value *metav1.LabelSelectorApplyConfiguration) *JobSpecApplyConfiguration {
+func (b *JobSpecApplyConfiguration) WithSelector(value *v1.LabelSelectorApplyConfiguration) *JobSpecApplyConfiguration {
 	b.Selector = value
 	return b
 }

--- a/staging/src/k8s.io/client-go/applyconfigurations/batch/v1/jobstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/batch/v1/jobstatus.go
@@ -19,15 +19,15 @@ limitations under the License.
 package v1
 
 import (
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // JobStatusApplyConfiguration represents an declarative configuration of the JobStatus type for use
 // with apply.
 type JobStatusApplyConfiguration struct {
 	Conditions              []JobConditionApplyConfiguration           `json:"conditions,omitempty"`
-	StartTime               *metav1.Time                               `json:"startTime,omitempty"`
-	CompletionTime          *metav1.Time                               `json:"completionTime,omitempty"`
+	StartTime               *v1.Time                                   `json:"startTime,omitempty"`
+	CompletionTime          *v1.Time                                   `json:"completionTime,omitempty"`
 	Active                  *int32                                     `json:"active,omitempty"`
 	Succeeded               *int32                                     `json:"succeeded,omitempty"`
 	Failed                  *int32                                     `json:"failed,omitempty"`
@@ -60,7 +60,7 @@ func (b *JobStatusApplyConfiguration) WithConditions(values ...*JobConditionAppl
 // WithStartTime sets the StartTime field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the StartTime field is set to the value of the last call.
-func (b *JobStatusApplyConfiguration) WithStartTime(value metav1.Time) *JobStatusApplyConfiguration {
+func (b *JobStatusApplyConfiguration) WithStartTime(value v1.Time) *JobStatusApplyConfiguration {
 	b.StartTime = &value
 	return b
 }
@@ -68,7 +68,7 @@ func (b *JobStatusApplyConfiguration) WithStartTime(value metav1.Time) *JobStatu
 // WithCompletionTime sets the CompletionTime field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the CompletionTime field is set to the value of the last call.
-func (b *JobStatusApplyConfiguration) WithCompletionTime(value metav1.Time) *JobStatusApplyConfiguration {
+func (b *JobStatusApplyConfiguration) WithCompletionTime(value v1.Time) *JobStatusApplyConfiguration {
 	b.CompletionTime = &value
 	return b
 }

--- a/staging/src/k8s.io/client-go/applyconfigurations/batch/v1beta1/cronjob.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/batch/v1beta1/cronjob.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1beta1
 
 import (
-	batchv1beta1 "k8s.io/api/batch/v1beta1"
+	v1beta1 "k8s.io/api/batch/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -58,18 +58,18 @@ func CronJob(name, namespace string) *CronJobApplyConfiguration {
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractCronJob(cronJob *batchv1beta1.CronJob, fieldManager string) (*CronJobApplyConfiguration, error) {
+func ExtractCronJob(cronJob *v1beta1.CronJob, fieldManager string) (*CronJobApplyConfiguration, error) {
 	return extractCronJob(cronJob, fieldManager, "")
 }
 
 // ExtractCronJobStatus is the same as ExtractCronJob except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractCronJobStatus(cronJob *batchv1beta1.CronJob, fieldManager string) (*CronJobApplyConfiguration, error) {
+func ExtractCronJobStatus(cronJob *v1beta1.CronJob, fieldManager string) (*CronJobApplyConfiguration, error) {
 	return extractCronJob(cronJob, fieldManager, "status")
 }
 
-func extractCronJob(cronJob *batchv1beta1.CronJob, fieldManager string, subresource string) (*CronJobApplyConfiguration, error) {
+func extractCronJob(cronJob *v1beta1.CronJob, fieldManager string, subresource string) (*CronJobApplyConfiguration, error) {
 	b := &CronJobApplyConfiguration{}
 	err := managedfields.ExtractInto(cronJob, internal.Parser().Type("io.k8s.api.batch.v1beta1.CronJob"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/certificates/v1/certificatesigningrequest.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/certificates/v1/certificatesigningrequest.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1
 
 import (
-	apicertificatesv1 "k8s.io/api/certificates/v1"
+	certificatesv1 "k8s.io/api/certificates/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -57,18 +57,18 @@ func CertificateSigningRequest(name string) *CertificateSigningRequestApplyConfi
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractCertificateSigningRequest(certificateSigningRequest *apicertificatesv1.CertificateSigningRequest, fieldManager string) (*CertificateSigningRequestApplyConfiguration, error) {
+func ExtractCertificateSigningRequest(certificateSigningRequest *certificatesv1.CertificateSigningRequest, fieldManager string) (*CertificateSigningRequestApplyConfiguration, error) {
 	return extractCertificateSigningRequest(certificateSigningRequest, fieldManager, "")
 }
 
 // ExtractCertificateSigningRequestStatus is the same as ExtractCertificateSigningRequest except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractCertificateSigningRequestStatus(certificateSigningRequest *apicertificatesv1.CertificateSigningRequest, fieldManager string) (*CertificateSigningRequestApplyConfiguration, error) {
+func ExtractCertificateSigningRequestStatus(certificateSigningRequest *certificatesv1.CertificateSigningRequest, fieldManager string) (*CertificateSigningRequestApplyConfiguration, error) {
 	return extractCertificateSigningRequest(certificateSigningRequest, fieldManager, "status")
 }
 
-func extractCertificateSigningRequest(certificateSigningRequest *apicertificatesv1.CertificateSigningRequest, fieldManager string, subresource string) (*CertificateSigningRequestApplyConfiguration, error) {
+func extractCertificateSigningRequest(certificateSigningRequest *certificatesv1.CertificateSigningRequest, fieldManager string, subresource string) (*CertificateSigningRequestApplyConfiguration, error) {
 	b := &CertificateSigningRequestApplyConfiguration{}
 	err := managedfields.ExtractInto(certificateSigningRequest, internal.Parser().Type("io.k8s.api.certificates.v1.CertificateSigningRequest"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/certificates/v1alpha1/clustertrustbundle.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/certificates/v1alpha1/clustertrustbundle.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	certificatesv1alpha1 "k8s.io/api/certificates/v1alpha1"
+	v1alpha1 "k8s.io/api/certificates/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -56,18 +56,18 @@ func ClusterTrustBundle(name string) *ClusterTrustBundleApplyConfiguration {
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractClusterTrustBundle(clusterTrustBundle *certificatesv1alpha1.ClusterTrustBundle, fieldManager string) (*ClusterTrustBundleApplyConfiguration, error) {
+func ExtractClusterTrustBundle(clusterTrustBundle *v1alpha1.ClusterTrustBundle, fieldManager string) (*ClusterTrustBundleApplyConfiguration, error) {
 	return extractClusterTrustBundle(clusterTrustBundle, fieldManager, "")
 }
 
 // ExtractClusterTrustBundleStatus is the same as ExtractClusterTrustBundle except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractClusterTrustBundleStatus(clusterTrustBundle *certificatesv1alpha1.ClusterTrustBundle, fieldManager string) (*ClusterTrustBundleApplyConfiguration, error) {
+func ExtractClusterTrustBundleStatus(clusterTrustBundle *v1alpha1.ClusterTrustBundle, fieldManager string) (*ClusterTrustBundleApplyConfiguration, error) {
 	return extractClusterTrustBundle(clusterTrustBundle, fieldManager, "status")
 }
 
-func extractClusterTrustBundle(clusterTrustBundle *certificatesv1alpha1.ClusterTrustBundle, fieldManager string, subresource string) (*ClusterTrustBundleApplyConfiguration, error) {
+func extractClusterTrustBundle(clusterTrustBundle *v1alpha1.ClusterTrustBundle, fieldManager string, subresource string) (*ClusterTrustBundleApplyConfiguration, error) {
 	b := &ClusterTrustBundleApplyConfiguration{}
 	err := managedfields.ExtractInto(clusterTrustBundle, internal.Parser().Type("io.k8s.api.certificates.v1alpha1.ClusterTrustBundle"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/certificates/v1beta1/certificatesigningrequest.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/certificates/v1beta1/certificatesigningrequest.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1beta1
 
 import (
-	certificatesv1beta1 "k8s.io/api/certificates/v1beta1"
+	v1beta1 "k8s.io/api/certificates/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -57,18 +57,18 @@ func CertificateSigningRequest(name string) *CertificateSigningRequestApplyConfi
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractCertificateSigningRequest(certificateSigningRequest *certificatesv1beta1.CertificateSigningRequest, fieldManager string) (*CertificateSigningRequestApplyConfiguration, error) {
+func ExtractCertificateSigningRequest(certificateSigningRequest *v1beta1.CertificateSigningRequest, fieldManager string) (*CertificateSigningRequestApplyConfiguration, error) {
 	return extractCertificateSigningRequest(certificateSigningRequest, fieldManager, "")
 }
 
 // ExtractCertificateSigningRequestStatus is the same as ExtractCertificateSigningRequest except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractCertificateSigningRequestStatus(certificateSigningRequest *certificatesv1beta1.CertificateSigningRequest, fieldManager string) (*CertificateSigningRequestApplyConfiguration, error) {
+func ExtractCertificateSigningRequestStatus(certificateSigningRequest *v1beta1.CertificateSigningRequest, fieldManager string) (*CertificateSigningRequestApplyConfiguration, error) {
 	return extractCertificateSigningRequest(certificateSigningRequest, fieldManager, "status")
 }
 
-func extractCertificateSigningRequest(certificateSigningRequest *certificatesv1beta1.CertificateSigningRequest, fieldManager string, subresource string) (*CertificateSigningRequestApplyConfiguration, error) {
+func extractCertificateSigningRequest(certificateSigningRequest *v1beta1.CertificateSigningRequest, fieldManager string, subresource string) (*CertificateSigningRequestApplyConfiguration, error) {
 	b := &CertificateSigningRequestApplyConfiguration{}
 	err := managedfields.ExtractInto(certificateSigningRequest, internal.Parser().Type("io.k8s.api.certificates.v1beta1.CertificateSigningRequest"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/coordination/v1/lease.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/coordination/v1/lease.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1
 
 import (
-	apicoordinationv1 "k8s.io/api/coordination/v1"
+	coordinationv1 "k8s.io/api/coordination/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -57,18 +57,18 @@ func Lease(name, namespace string) *LeaseApplyConfiguration {
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractLease(lease *apicoordinationv1.Lease, fieldManager string) (*LeaseApplyConfiguration, error) {
+func ExtractLease(lease *coordinationv1.Lease, fieldManager string) (*LeaseApplyConfiguration, error) {
 	return extractLease(lease, fieldManager, "")
 }
 
 // ExtractLeaseStatus is the same as ExtractLease except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractLeaseStatus(lease *apicoordinationv1.Lease, fieldManager string) (*LeaseApplyConfiguration, error) {
+func ExtractLeaseStatus(lease *coordinationv1.Lease, fieldManager string) (*LeaseApplyConfiguration, error) {
 	return extractLease(lease, fieldManager, "status")
 }
 
-func extractLease(lease *apicoordinationv1.Lease, fieldManager string, subresource string) (*LeaseApplyConfiguration, error) {
+func extractLease(lease *coordinationv1.Lease, fieldManager string, subresource string) (*LeaseApplyConfiguration, error) {
 	b := &LeaseApplyConfiguration{}
 	err := managedfields.ExtractInto(lease, internal.Parser().Type("io.k8s.api.coordination.v1.Lease"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/coordination/v1beta1/lease.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/coordination/v1beta1/lease.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1beta1
 
 import (
-	coordinationv1beta1 "k8s.io/api/coordination/v1beta1"
+	v1beta1 "k8s.io/api/coordination/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -57,18 +57,18 @@ func Lease(name, namespace string) *LeaseApplyConfiguration {
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractLease(lease *coordinationv1beta1.Lease, fieldManager string) (*LeaseApplyConfiguration, error) {
+func ExtractLease(lease *v1beta1.Lease, fieldManager string) (*LeaseApplyConfiguration, error) {
 	return extractLease(lease, fieldManager, "")
 }
 
 // ExtractLeaseStatus is the same as ExtractLease except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractLeaseStatus(lease *coordinationv1beta1.Lease, fieldManager string) (*LeaseApplyConfiguration, error) {
+func ExtractLeaseStatus(lease *v1beta1.Lease, fieldManager string) (*LeaseApplyConfiguration, error) {
 	return extractLease(lease, fieldManager, "status")
 }
 
-func extractLease(lease *coordinationv1beta1.Lease, fieldManager string, subresource string) (*LeaseApplyConfiguration, error) {
+func extractLease(lease *v1beta1.Lease, fieldManager string, subresource string) (*LeaseApplyConfiguration, error) {
 	b := &LeaseApplyConfiguration{}
 	err := managedfields.ExtractInto(lease, internal.Parser().Type("io.k8s.api.coordination.v1beta1.Lease"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/componentstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/componentstatus.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1
 
 import (
-	apicorev1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -56,18 +56,18 @@ func ComponentStatus(name string) *ComponentStatusApplyConfiguration {
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractComponentStatus(componentStatus *apicorev1.ComponentStatus, fieldManager string) (*ComponentStatusApplyConfiguration, error) {
+func ExtractComponentStatus(componentStatus *corev1.ComponentStatus, fieldManager string) (*ComponentStatusApplyConfiguration, error) {
 	return extractComponentStatus(componentStatus, fieldManager, "")
 }
 
 // ExtractComponentStatusStatus is the same as ExtractComponentStatus except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractComponentStatusStatus(componentStatus *apicorev1.ComponentStatus, fieldManager string) (*ComponentStatusApplyConfiguration, error) {
+func ExtractComponentStatusStatus(componentStatus *corev1.ComponentStatus, fieldManager string) (*ComponentStatusApplyConfiguration, error) {
 	return extractComponentStatus(componentStatus, fieldManager, "status")
 }
 
-func extractComponentStatus(componentStatus *apicorev1.ComponentStatus, fieldManager string, subresource string) (*ComponentStatusApplyConfiguration, error) {
+func extractComponentStatus(componentStatus *corev1.ComponentStatus, fieldManager string, subresource string) (*ComponentStatusApplyConfiguration, error) {
 	b := &ComponentStatusApplyConfiguration{}
 	err := managedfields.ExtractInto(componentStatus, internal.Parser().Type("io.k8s.api.core.v1.ComponentStatus"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/container.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/container.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1
 
 import (
-	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 )
 
 // ContainerApplyConfiguration represents an declarative configuration of the Container type for use
@@ -35,7 +35,7 @@ type ContainerApplyConfiguration struct {
 	Env                      []EnvVarApplyConfiguration                `json:"env,omitempty"`
 	Resources                *ResourceRequirementsApplyConfiguration   `json:"resources,omitempty"`
 	ResizePolicy             []ContainerResizePolicyApplyConfiguration `json:"resizePolicy,omitempty"`
-	RestartPolicy            *corev1.ContainerRestartPolicy            `json:"restartPolicy,omitempty"`
+	RestartPolicy            *v1.ContainerRestartPolicy                `json:"restartPolicy,omitempty"`
 	VolumeMounts             []VolumeMountApplyConfiguration           `json:"volumeMounts,omitempty"`
 	VolumeDevices            []VolumeDeviceApplyConfiguration          `json:"volumeDevices,omitempty"`
 	LivenessProbe            *ProbeApplyConfiguration                  `json:"livenessProbe,omitempty"`
@@ -43,8 +43,8 @@ type ContainerApplyConfiguration struct {
 	StartupProbe             *ProbeApplyConfiguration                  `json:"startupProbe,omitempty"`
 	Lifecycle                *LifecycleApplyConfiguration              `json:"lifecycle,omitempty"`
 	TerminationMessagePath   *string                                   `json:"terminationMessagePath,omitempty"`
-	TerminationMessagePolicy *corev1.TerminationMessagePolicy          `json:"terminationMessagePolicy,omitempty"`
-	ImagePullPolicy          *corev1.PullPolicy                        `json:"imagePullPolicy,omitempty"`
+	TerminationMessagePolicy *v1.TerminationMessagePolicy              `json:"terminationMessagePolicy,omitempty"`
+	ImagePullPolicy          *v1.PullPolicy                            `json:"imagePullPolicy,omitempty"`
 	SecurityContext          *SecurityContextApplyConfiguration        `json:"securityContext,omitempty"`
 	Stdin                    *bool                                     `json:"stdin,omitempty"`
 	StdinOnce                *bool                                     `json:"stdinOnce,omitempty"`
@@ -164,7 +164,7 @@ func (b *ContainerApplyConfiguration) WithResizePolicy(values ...*ContainerResiz
 // WithRestartPolicy sets the RestartPolicy field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the RestartPolicy field is set to the value of the last call.
-func (b *ContainerApplyConfiguration) WithRestartPolicy(value corev1.ContainerRestartPolicy) *ContainerApplyConfiguration {
+func (b *ContainerApplyConfiguration) WithRestartPolicy(value v1.ContainerRestartPolicy) *ContainerApplyConfiguration {
 	b.RestartPolicy = &value
 	return b
 }
@@ -238,7 +238,7 @@ func (b *ContainerApplyConfiguration) WithTerminationMessagePath(value string) *
 // WithTerminationMessagePolicy sets the TerminationMessagePolicy field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the TerminationMessagePolicy field is set to the value of the last call.
-func (b *ContainerApplyConfiguration) WithTerminationMessagePolicy(value corev1.TerminationMessagePolicy) *ContainerApplyConfiguration {
+func (b *ContainerApplyConfiguration) WithTerminationMessagePolicy(value v1.TerminationMessagePolicy) *ContainerApplyConfiguration {
 	b.TerminationMessagePolicy = &value
 	return b
 }
@@ -246,7 +246,7 @@ func (b *ContainerApplyConfiguration) WithTerminationMessagePolicy(value corev1.
 // WithImagePullPolicy sets the ImagePullPolicy field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the ImagePullPolicy field is set to the value of the last call.
-func (b *ContainerApplyConfiguration) WithImagePullPolicy(value corev1.PullPolicy) *ContainerApplyConfiguration {
+func (b *ContainerApplyConfiguration) WithImagePullPolicy(value v1.PullPolicy) *ContainerApplyConfiguration {
 	b.ImagePullPolicy = &value
 	return b
 }

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/containerstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/containerstatus.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1
 
 import (
-	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 )
 
 // ContainerStatusApplyConfiguration represents an declarative configuration of the ContainerStatus type for use
@@ -34,7 +34,7 @@ type ContainerStatusApplyConfiguration struct {
 	ImageID              *string                                 `json:"imageID,omitempty"`
 	ContainerID          *string                                 `json:"containerID,omitempty"`
 	Started              *bool                                   `json:"started,omitempty"`
-	AllocatedResources   *corev1.ResourceList                    `json:"allocatedResources,omitempty"`
+	AllocatedResources   *v1.ResourceList                        `json:"allocatedResources,omitempty"`
 	Resources            *ResourceRequirementsApplyConfiguration `json:"resources,omitempty"`
 	VolumeMounts         []VolumeMountStatusApplyConfiguration   `json:"volumeMounts,omitempty"`
 }
@@ -120,7 +120,7 @@ func (b *ContainerStatusApplyConfiguration) WithStarted(value bool) *ContainerSt
 // WithAllocatedResources sets the AllocatedResources field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the AllocatedResources field is set to the value of the last call.
-func (b *ContainerStatusApplyConfiguration) WithAllocatedResources(value corev1.ResourceList) *ContainerStatusApplyConfiguration {
+func (b *ContainerStatusApplyConfiguration) WithAllocatedResources(value v1.ResourceList) *ContainerStatusApplyConfiguration {
 	b.AllocatedResources = &value
 	return b
 }

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/endpoints.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/endpoints.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1
 
 import (
-	apicorev1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -57,18 +57,18 @@ func Endpoints(name, namespace string) *EndpointsApplyConfiguration {
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractEndpoints(endpoints *apicorev1.Endpoints, fieldManager string) (*EndpointsApplyConfiguration, error) {
+func ExtractEndpoints(endpoints *corev1.Endpoints, fieldManager string) (*EndpointsApplyConfiguration, error) {
 	return extractEndpoints(endpoints, fieldManager, "")
 }
 
 // ExtractEndpointsStatus is the same as ExtractEndpoints except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractEndpointsStatus(endpoints *apicorev1.Endpoints, fieldManager string) (*EndpointsApplyConfiguration, error) {
+func ExtractEndpointsStatus(endpoints *corev1.Endpoints, fieldManager string) (*EndpointsApplyConfiguration, error) {
 	return extractEndpoints(endpoints, fieldManager, "status")
 }
 
-func extractEndpoints(endpoints *apicorev1.Endpoints, fieldManager string, subresource string) (*EndpointsApplyConfiguration, error) {
+func extractEndpoints(endpoints *corev1.Endpoints, fieldManager string, subresource string) (*EndpointsApplyConfiguration, error) {
 	b := &EndpointsApplyConfiguration{}
 	err := managedfields.ExtractInto(endpoints, internal.Parser().Type("io.k8s.api.core.v1.Endpoints"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/ephemeralcontainer.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/ephemeralcontainer.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1
 
 import (
-	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 )
 
 // EphemeralContainerApplyConfiguration represents an declarative configuration of the EphemeralContainer type for use
@@ -142,7 +142,7 @@ func (b *EphemeralContainerApplyConfiguration) WithResizePolicy(values ...*Conta
 // WithRestartPolicy sets the RestartPolicy field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the RestartPolicy field is set to the value of the last call.
-func (b *EphemeralContainerApplyConfiguration) WithRestartPolicy(value corev1.ContainerRestartPolicy) *EphemeralContainerApplyConfiguration {
+func (b *EphemeralContainerApplyConfiguration) WithRestartPolicy(value v1.ContainerRestartPolicy) *EphemeralContainerApplyConfiguration {
 	b.RestartPolicy = &value
 	return b
 }
@@ -216,7 +216,7 @@ func (b *EphemeralContainerApplyConfiguration) WithTerminationMessagePath(value 
 // WithTerminationMessagePolicy sets the TerminationMessagePolicy field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the TerminationMessagePolicy field is set to the value of the last call.
-func (b *EphemeralContainerApplyConfiguration) WithTerminationMessagePolicy(value corev1.TerminationMessagePolicy) *EphemeralContainerApplyConfiguration {
+func (b *EphemeralContainerApplyConfiguration) WithTerminationMessagePolicy(value v1.TerminationMessagePolicy) *EphemeralContainerApplyConfiguration {
 	b.TerminationMessagePolicy = &value
 	return b
 }
@@ -224,7 +224,7 @@ func (b *EphemeralContainerApplyConfiguration) WithTerminationMessagePolicy(valu
 // WithImagePullPolicy sets the ImagePullPolicy field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the ImagePullPolicy field is set to the value of the last call.
-func (b *EphemeralContainerApplyConfiguration) WithImagePullPolicy(value corev1.PullPolicy) *EphemeralContainerApplyConfiguration {
+func (b *EphemeralContainerApplyConfiguration) WithImagePullPolicy(value v1.PullPolicy) *EphemeralContainerApplyConfiguration {
 	b.ImagePullPolicy = &value
 	return b
 }

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/ephemeralcontainercommon.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/ephemeralcontainercommon.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1
 
 import (
-	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 )
 
 // EphemeralContainerCommonApplyConfiguration represents an declarative configuration of the EphemeralContainerCommon type for use
@@ -35,7 +35,7 @@ type EphemeralContainerCommonApplyConfiguration struct {
 	Env                      []EnvVarApplyConfiguration                `json:"env,omitempty"`
 	Resources                *ResourceRequirementsApplyConfiguration   `json:"resources,omitempty"`
 	ResizePolicy             []ContainerResizePolicyApplyConfiguration `json:"resizePolicy,omitempty"`
-	RestartPolicy            *corev1.ContainerRestartPolicy            `json:"restartPolicy,omitempty"`
+	RestartPolicy            *v1.ContainerRestartPolicy                `json:"restartPolicy,omitempty"`
 	VolumeMounts             []VolumeMountApplyConfiguration           `json:"volumeMounts,omitempty"`
 	VolumeDevices            []VolumeDeviceApplyConfiguration          `json:"volumeDevices,omitempty"`
 	LivenessProbe            *ProbeApplyConfiguration                  `json:"livenessProbe,omitempty"`
@@ -43,8 +43,8 @@ type EphemeralContainerCommonApplyConfiguration struct {
 	StartupProbe             *ProbeApplyConfiguration                  `json:"startupProbe,omitempty"`
 	Lifecycle                *LifecycleApplyConfiguration              `json:"lifecycle,omitempty"`
 	TerminationMessagePath   *string                                   `json:"terminationMessagePath,omitempty"`
-	TerminationMessagePolicy *corev1.TerminationMessagePolicy          `json:"terminationMessagePolicy,omitempty"`
-	ImagePullPolicy          *corev1.PullPolicy                        `json:"imagePullPolicy,omitempty"`
+	TerminationMessagePolicy *v1.TerminationMessagePolicy              `json:"terminationMessagePolicy,omitempty"`
+	ImagePullPolicy          *v1.PullPolicy                            `json:"imagePullPolicy,omitempty"`
 	SecurityContext          *SecurityContextApplyConfiguration        `json:"securityContext,omitempty"`
 	Stdin                    *bool                                     `json:"stdin,omitempty"`
 	StdinOnce                *bool                                     `json:"stdinOnce,omitempty"`
@@ -164,7 +164,7 @@ func (b *EphemeralContainerCommonApplyConfiguration) WithResizePolicy(values ...
 // WithRestartPolicy sets the RestartPolicy field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the RestartPolicy field is set to the value of the last call.
-func (b *EphemeralContainerCommonApplyConfiguration) WithRestartPolicy(value corev1.ContainerRestartPolicy) *EphemeralContainerCommonApplyConfiguration {
+func (b *EphemeralContainerCommonApplyConfiguration) WithRestartPolicy(value v1.ContainerRestartPolicy) *EphemeralContainerCommonApplyConfiguration {
 	b.RestartPolicy = &value
 	return b
 }
@@ -238,7 +238,7 @@ func (b *EphemeralContainerCommonApplyConfiguration) WithTerminationMessagePath(
 // WithTerminationMessagePolicy sets the TerminationMessagePolicy field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the TerminationMessagePolicy field is set to the value of the last call.
-func (b *EphemeralContainerCommonApplyConfiguration) WithTerminationMessagePolicy(value corev1.TerminationMessagePolicy) *EphemeralContainerCommonApplyConfiguration {
+func (b *EphemeralContainerCommonApplyConfiguration) WithTerminationMessagePolicy(value v1.TerminationMessagePolicy) *EphemeralContainerCommonApplyConfiguration {
 	b.TerminationMessagePolicy = &value
 	return b
 }
@@ -246,7 +246,7 @@ func (b *EphemeralContainerCommonApplyConfiguration) WithTerminationMessagePolic
 // WithImagePullPolicy sets the ImagePullPolicy field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the ImagePullPolicy field is set to the value of the last call.
-func (b *EphemeralContainerCommonApplyConfiguration) WithImagePullPolicy(value corev1.PullPolicy) *EphemeralContainerCommonApplyConfiguration {
+func (b *EphemeralContainerCommonApplyConfiguration) WithImagePullPolicy(value v1.PullPolicy) *EphemeralContainerCommonApplyConfiguration {
 	b.ImagePullPolicy = &value
 	return b
 }

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/event.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/event.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1
 
 import (
-	apicorev1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -70,18 +70,18 @@ func Event(name, namespace string) *EventApplyConfiguration {
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractEvent(event *apicorev1.Event, fieldManager string) (*EventApplyConfiguration, error) {
+func ExtractEvent(event *corev1.Event, fieldManager string) (*EventApplyConfiguration, error) {
 	return extractEvent(event, fieldManager, "")
 }
 
 // ExtractEventStatus is the same as ExtractEvent except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractEventStatus(event *apicorev1.Event, fieldManager string) (*EventApplyConfiguration, error) {
+func ExtractEventStatus(event *corev1.Event, fieldManager string) (*EventApplyConfiguration, error) {
 	return extractEvent(event, fieldManager, "status")
 }
 
-func extractEvent(event *apicorev1.Event, fieldManager string, subresource string) (*EventApplyConfiguration, error) {
+func extractEvent(event *corev1.Event, fieldManager string, subresource string) (*EventApplyConfiguration, error) {
 	b := &EventApplyConfiguration{}
 	err := managedfields.ExtractInto(event, internal.Parser().Type("io.k8s.api.core.v1.Event"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/limitrange.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/limitrange.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1
 
 import (
-	apicorev1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -57,18 +57,18 @@ func LimitRange(name, namespace string) *LimitRangeApplyConfiguration {
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractLimitRange(limitRange *apicorev1.LimitRange, fieldManager string) (*LimitRangeApplyConfiguration, error) {
+func ExtractLimitRange(limitRange *corev1.LimitRange, fieldManager string) (*LimitRangeApplyConfiguration, error) {
 	return extractLimitRange(limitRange, fieldManager, "")
 }
 
 // ExtractLimitRangeStatus is the same as ExtractLimitRange except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractLimitRangeStatus(limitRange *apicorev1.LimitRange, fieldManager string) (*LimitRangeApplyConfiguration, error) {
+func ExtractLimitRangeStatus(limitRange *corev1.LimitRange, fieldManager string) (*LimitRangeApplyConfiguration, error) {
 	return extractLimitRange(limitRange, fieldManager, "status")
 }
 
-func extractLimitRange(limitRange *apicorev1.LimitRange, fieldManager string, subresource string) (*LimitRangeApplyConfiguration, error) {
+func extractLimitRange(limitRange *corev1.LimitRange, fieldManager string, subresource string) (*LimitRangeApplyConfiguration, error) {
 	b := &LimitRangeApplyConfiguration{}
 	err := managedfields.ExtractInto(limitRange, internal.Parser().Type("io.k8s.api.core.v1.LimitRange"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/namespace.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/namespace.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1
 
 import (
-	apicorev1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -57,18 +57,18 @@ func Namespace(name string) *NamespaceApplyConfiguration {
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractNamespace(namespace *apicorev1.Namespace, fieldManager string) (*NamespaceApplyConfiguration, error) {
+func ExtractNamespace(namespace *corev1.Namespace, fieldManager string) (*NamespaceApplyConfiguration, error) {
 	return extractNamespace(namespace, fieldManager, "")
 }
 
 // ExtractNamespaceStatus is the same as ExtractNamespace except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractNamespaceStatus(namespace *apicorev1.Namespace, fieldManager string) (*NamespaceApplyConfiguration, error) {
+func ExtractNamespaceStatus(namespace *corev1.Namespace, fieldManager string) (*NamespaceApplyConfiguration, error) {
 	return extractNamespace(namespace, fieldManager, "status")
 }
 
-func extractNamespace(namespace *apicorev1.Namespace, fieldManager string, subresource string) (*NamespaceApplyConfiguration, error) {
+func extractNamespace(namespace *corev1.Namespace, fieldManager string, subresource string) (*NamespaceApplyConfiguration, error) {
 	b := &NamespaceApplyConfiguration{}
 	err := managedfields.ExtractInto(namespace, internal.Parser().Type("io.k8s.api.core.v1.Namespace"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/node.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/node.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1
 
 import (
-	apicorev1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -57,18 +57,18 @@ func Node(name string) *NodeApplyConfiguration {
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractNode(node *apicorev1.Node, fieldManager string) (*NodeApplyConfiguration, error) {
+func ExtractNode(node *corev1.Node, fieldManager string) (*NodeApplyConfiguration, error) {
 	return extractNode(node, fieldManager, "")
 }
 
 // ExtractNodeStatus is the same as ExtractNode except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractNodeStatus(node *apicorev1.Node, fieldManager string) (*NodeApplyConfiguration, error) {
+func ExtractNodeStatus(node *corev1.Node, fieldManager string) (*NodeApplyConfiguration, error) {
 	return extractNode(node, fieldManager, "status")
 }
 
-func extractNode(node *apicorev1.Node, fieldManager string, subresource string) (*NodeApplyConfiguration, error) {
+func extractNode(node *corev1.Node, fieldManager string, subresource string) (*NodeApplyConfiguration, error) {
 	b := &NodeApplyConfiguration{}
 	err := managedfields.ExtractInto(node, internal.Parser().Type("io.k8s.api.core.v1.Node"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/persistentvolume.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/persistentvolume.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1
 
 import (
-	apicorev1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -57,18 +57,18 @@ func PersistentVolume(name string) *PersistentVolumeApplyConfiguration {
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractPersistentVolume(persistentVolume *apicorev1.PersistentVolume, fieldManager string) (*PersistentVolumeApplyConfiguration, error) {
+func ExtractPersistentVolume(persistentVolume *corev1.PersistentVolume, fieldManager string) (*PersistentVolumeApplyConfiguration, error) {
 	return extractPersistentVolume(persistentVolume, fieldManager, "")
 }
 
 // ExtractPersistentVolumeStatus is the same as ExtractPersistentVolume except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractPersistentVolumeStatus(persistentVolume *apicorev1.PersistentVolume, fieldManager string) (*PersistentVolumeApplyConfiguration, error) {
+func ExtractPersistentVolumeStatus(persistentVolume *corev1.PersistentVolume, fieldManager string) (*PersistentVolumeApplyConfiguration, error) {
 	return extractPersistentVolume(persistentVolume, fieldManager, "status")
 }
 
-func extractPersistentVolume(persistentVolume *apicorev1.PersistentVolume, fieldManager string, subresource string) (*PersistentVolumeApplyConfiguration, error) {
+func extractPersistentVolume(persistentVolume *corev1.PersistentVolume, fieldManager string, subresource string) (*PersistentVolumeApplyConfiguration, error) {
 	b := &PersistentVolumeApplyConfiguration{}
 	err := managedfields.ExtractInto(persistentVolume, internal.Parser().Type("io.k8s.api.core.v1.PersistentVolume"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/persistentvolumeclaim.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/persistentvolumeclaim.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1
 
 import (
-	apicorev1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -58,18 +58,18 @@ func PersistentVolumeClaim(name, namespace string) *PersistentVolumeClaimApplyCo
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractPersistentVolumeClaim(persistentVolumeClaim *apicorev1.PersistentVolumeClaim, fieldManager string) (*PersistentVolumeClaimApplyConfiguration, error) {
+func ExtractPersistentVolumeClaim(persistentVolumeClaim *corev1.PersistentVolumeClaim, fieldManager string) (*PersistentVolumeClaimApplyConfiguration, error) {
 	return extractPersistentVolumeClaim(persistentVolumeClaim, fieldManager, "")
 }
 
 // ExtractPersistentVolumeClaimStatus is the same as ExtractPersistentVolumeClaim except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractPersistentVolumeClaimStatus(persistentVolumeClaim *apicorev1.PersistentVolumeClaim, fieldManager string) (*PersistentVolumeClaimApplyConfiguration, error) {
+func ExtractPersistentVolumeClaimStatus(persistentVolumeClaim *corev1.PersistentVolumeClaim, fieldManager string) (*PersistentVolumeClaimApplyConfiguration, error) {
 	return extractPersistentVolumeClaim(persistentVolumeClaim, fieldManager, "status")
 }
 
-func extractPersistentVolumeClaim(persistentVolumeClaim *apicorev1.PersistentVolumeClaim, fieldManager string, subresource string) (*PersistentVolumeClaimApplyConfiguration, error) {
+func extractPersistentVolumeClaim(persistentVolumeClaim *corev1.PersistentVolumeClaim, fieldManager string, subresource string) (*PersistentVolumeClaimApplyConfiguration, error) {
 	b := &PersistentVolumeClaimApplyConfiguration{}
 	err := managedfields.ExtractInto(persistentVolumeClaim, internal.Parser().Type("io.k8s.api.core.v1.PersistentVolumeClaim"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/pod.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/pod.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1
 
 import (
-	apicorev1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -58,18 +58,18 @@ func Pod(name, namespace string) *PodApplyConfiguration {
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractPod(pod *apicorev1.Pod, fieldManager string) (*PodApplyConfiguration, error) {
+func ExtractPod(pod *corev1.Pod, fieldManager string) (*PodApplyConfiguration, error) {
 	return extractPod(pod, fieldManager, "")
 }
 
 // ExtractPodStatus is the same as ExtractPod except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractPodStatus(pod *apicorev1.Pod, fieldManager string) (*PodApplyConfiguration, error) {
+func ExtractPodStatus(pod *corev1.Pod, fieldManager string) (*PodApplyConfiguration, error) {
 	return extractPod(pod, fieldManager, "status")
 }
 
-func extractPod(pod *apicorev1.Pod, fieldManager string, subresource string) (*PodApplyConfiguration, error) {
+func extractPod(pod *corev1.Pod, fieldManager string, subresource string) (*PodApplyConfiguration, error) {
 	b := &PodApplyConfiguration{}
 	err := managedfields.ExtractInto(pod, internal.Parser().Type("io.k8s.api.core.v1.Pod"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/podsecuritycontext.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/podsecuritycontext.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1
 
 import (
-	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 )
 
 // PodSecurityContextApplyConfiguration represents an declarative configuration of the PodSecurityContext type for use
@@ -33,7 +33,7 @@ type PodSecurityContextApplyConfiguration struct {
 	SupplementalGroups  []int64                                          `json:"supplementalGroups,omitempty"`
 	FSGroup             *int64                                           `json:"fsGroup,omitempty"`
 	Sysctls             []SysctlApplyConfiguration                       `json:"sysctls,omitempty"`
-	FSGroupChangePolicy *corev1.PodFSGroupChangePolicy                   `json:"fsGroupChangePolicy,omitempty"`
+	FSGroupChangePolicy *v1.PodFSGroupChangePolicy                       `json:"fsGroupChangePolicy,omitempty"`
 	SeccompProfile      *SeccompProfileApplyConfiguration                `json:"seccompProfile,omitempty"`
 	AppArmorProfile     *AppArmorProfileApplyConfiguration               `json:"appArmorProfile,omitempty"`
 }
@@ -118,7 +118,7 @@ func (b *PodSecurityContextApplyConfiguration) WithSysctls(values ...*SysctlAppl
 // WithFSGroupChangePolicy sets the FSGroupChangePolicy field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the FSGroupChangePolicy field is set to the value of the last call.
-func (b *PodSecurityContextApplyConfiguration) WithFSGroupChangePolicy(value corev1.PodFSGroupChangePolicy) *PodSecurityContextApplyConfiguration {
+func (b *PodSecurityContextApplyConfiguration) WithFSGroupChangePolicy(value v1.PodFSGroupChangePolicy) *PodSecurityContextApplyConfiguration {
 	b.FSGroupChangePolicy = &value
 	return b
 }

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/podspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/podspec.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1
 
 import (
-	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 )
 
 // PodSpecApplyConfiguration represents an declarative configuration of the PodSpec type for use
@@ -29,10 +29,10 @@ type PodSpecApplyConfiguration struct {
 	InitContainers                []ContainerApplyConfiguration                `json:"initContainers,omitempty"`
 	Containers                    []ContainerApplyConfiguration                `json:"containers,omitempty"`
 	EphemeralContainers           []EphemeralContainerApplyConfiguration       `json:"ephemeralContainers,omitempty"`
-	RestartPolicy                 *corev1.RestartPolicy                        `json:"restartPolicy,omitempty"`
+	RestartPolicy                 *v1.RestartPolicy                            `json:"restartPolicy,omitempty"`
 	TerminationGracePeriodSeconds *int64                                       `json:"terminationGracePeriodSeconds,omitempty"`
 	ActiveDeadlineSeconds         *int64                                       `json:"activeDeadlineSeconds,omitempty"`
-	DNSPolicy                     *corev1.DNSPolicy                            `json:"dnsPolicy,omitempty"`
+	DNSPolicy                     *v1.DNSPolicy                                `json:"dnsPolicy,omitempty"`
 	NodeSelector                  map[string]string                            `json:"nodeSelector,omitempty"`
 	ServiceAccountName            *string                                      `json:"serviceAccountName,omitempty"`
 	DeprecatedServiceAccount      *string                                      `json:"serviceAccount,omitempty"`
@@ -56,8 +56,8 @@ type PodSpecApplyConfiguration struct {
 	ReadinessGates                []PodReadinessGateApplyConfiguration         `json:"readinessGates,omitempty"`
 	RuntimeClassName              *string                                      `json:"runtimeClassName,omitempty"`
 	EnableServiceLinks            *bool                                        `json:"enableServiceLinks,omitempty"`
-	PreemptionPolicy              *corev1.PreemptionPolicy                     `json:"preemptionPolicy,omitempty"`
-	Overhead                      *corev1.ResourceList                         `json:"overhead,omitempty"`
+	PreemptionPolicy              *v1.PreemptionPolicy                         `json:"preemptionPolicy,omitempty"`
+	Overhead                      *v1.ResourceList                             `json:"overhead,omitempty"`
 	TopologySpreadConstraints     []TopologySpreadConstraintApplyConfiguration `json:"topologySpreadConstraints,omitempty"`
 	SetHostnameAsFQDN             *bool                                        `json:"setHostnameAsFQDN,omitempty"`
 	OS                            *PodOSApplyConfiguration                     `json:"os,omitempty"`
@@ -127,7 +127,7 @@ func (b *PodSpecApplyConfiguration) WithEphemeralContainers(values ...*Ephemeral
 // WithRestartPolicy sets the RestartPolicy field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the RestartPolicy field is set to the value of the last call.
-func (b *PodSpecApplyConfiguration) WithRestartPolicy(value corev1.RestartPolicy) *PodSpecApplyConfiguration {
+func (b *PodSpecApplyConfiguration) WithRestartPolicy(value v1.RestartPolicy) *PodSpecApplyConfiguration {
 	b.RestartPolicy = &value
 	return b
 }
@@ -151,7 +151,7 @@ func (b *PodSpecApplyConfiguration) WithActiveDeadlineSeconds(value int64) *PodS
 // WithDNSPolicy sets the DNSPolicy field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the DNSPolicy field is set to the value of the last call.
-func (b *PodSpecApplyConfiguration) WithDNSPolicy(value corev1.DNSPolicy) *PodSpecApplyConfiguration {
+func (b *PodSpecApplyConfiguration) WithDNSPolicy(value v1.DNSPolicy) *PodSpecApplyConfiguration {
 	b.DNSPolicy = &value
 	return b
 }
@@ -369,7 +369,7 @@ func (b *PodSpecApplyConfiguration) WithEnableServiceLinks(value bool) *PodSpecA
 // WithPreemptionPolicy sets the PreemptionPolicy field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the PreemptionPolicy field is set to the value of the last call.
-func (b *PodSpecApplyConfiguration) WithPreemptionPolicy(value corev1.PreemptionPolicy) *PodSpecApplyConfiguration {
+func (b *PodSpecApplyConfiguration) WithPreemptionPolicy(value v1.PreemptionPolicy) *PodSpecApplyConfiguration {
 	b.PreemptionPolicy = &value
 	return b
 }
@@ -377,7 +377,7 @@ func (b *PodSpecApplyConfiguration) WithPreemptionPolicy(value corev1.Preemption
 // WithOverhead sets the Overhead field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the Overhead field is set to the value of the last call.
-func (b *PodSpecApplyConfiguration) WithOverhead(value corev1.ResourceList) *PodSpecApplyConfiguration {
+func (b *PodSpecApplyConfiguration) WithOverhead(value v1.ResourceList) *PodSpecApplyConfiguration {
 	b.Overhead = &value
 	return b
 }

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/podtemplate.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/podtemplate.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1
 
 import (
-	apicorev1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -57,18 +57,18 @@ func PodTemplate(name, namespace string) *PodTemplateApplyConfiguration {
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractPodTemplate(podTemplate *apicorev1.PodTemplate, fieldManager string) (*PodTemplateApplyConfiguration, error) {
+func ExtractPodTemplate(podTemplate *corev1.PodTemplate, fieldManager string) (*PodTemplateApplyConfiguration, error) {
 	return extractPodTemplate(podTemplate, fieldManager, "")
 }
 
 // ExtractPodTemplateStatus is the same as ExtractPodTemplate except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractPodTemplateStatus(podTemplate *apicorev1.PodTemplate, fieldManager string) (*PodTemplateApplyConfiguration, error) {
+func ExtractPodTemplateStatus(podTemplate *corev1.PodTemplate, fieldManager string) (*PodTemplateApplyConfiguration, error) {
 	return extractPodTemplate(podTemplate, fieldManager, "status")
 }
 
-func extractPodTemplate(podTemplate *apicorev1.PodTemplate, fieldManager string, subresource string) (*PodTemplateApplyConfiguration, error) {
+func extractPodTemplate(podTemplate *corev1.PodTemplate, fieldManager string, subresource string) (*PodTemplateApplyConfiguration, error) {
 	b := &PodTemplateApplyConfiguration{}
 	err := managedfields.ExtractInto(podTemplate, internal.Parser().Type("io.k8s.api.core.v1.PodTemplate"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/replicationcontroller.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/replicationcontroller.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1
 
 import (
-	apicorev1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -58,18 +58,18 @@ func ReplicationController(name, namespace string) *ReplicationControllerApplyCo
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractReplicationController(replicationController *apicorev1.ReplicationController, fieldManager string) (*ReplicationControllerApplyConfiguration, error) {
+func ExtractReplicationController(replicationController *corev1.ReplicationController, fieldManager string) (*ReplicationControllerApplyConfiguration, error) {
 	return extractReplicationController(replicationController, fieldManager, "")
 }
 
 // ExtractReplicationControllerStatus is the same as ExtractReplicationController except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractReplicationControllerStatus(replicationController *apicorev1.ReplicationController, fieldManager string) (*ReplicationControllerApplyConfiguration, error) {
+func ExtractReplicationControllerStatus(replicationController *corev1.ReplicationController, fieldManager string) (*ReplicationControllerApplyConfiguration, error) {
 	return extractReplicationController(replicationController, fieldManager, "status")
 }
 
-func extractReplicationController(replicationController *apicorev1.ReplicationController, fieldManager string, subresource string) (*ReplicationControllerApplyConfiguration, error) {
+func extractReplicationController(replicationController *corev1.ReplicationController, fieldManager string, subresource string) (*ReplicationControllerApplyConfiguration, error) {
 	b := &ReplicationControllerApplyConfiguration{}
 	err := managedfields.ExtractInto(replicationController, internal.Parser().Type("io.k8s.api.core.v1.ReplicationController"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/resourcequota.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/resourcequota.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1
 
 import (
-	apicorev1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -58,18 +58,18 @@ func ResourceQuota(name, namespace string) *ResourceQuotaApplyConfiguration {
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractResourceQuota(resourceQuota *apicorev1.ResourceQuota, fieldManager string) (*ResourceQuotaApplyConfiguration, error) {
+func ExtractResourceQuota(resourceQuota *corev1.ResourceQuota, fieldManager string) (*ResourceQuotaApplyConfiguration, error) {
 	return extractResourceQuota(resourceQuota, fieldManager, "")
 }
 
 // ExtractResourceQuotaStatus is the same as ExtractResourceQuota except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractResourceQuotaStatus(resourceQuota *apicorev1.ResourceQuota, fieldManager string) (*ResourceQuotaApplyConfiguration, error) {
+func ExtractResourceQuotaStatus(resourceQuota *corev1.ResourceQuota, fieldManager string) (*ResourceQuotaApplyConfiguration, error) {
 	return extractResourceQuota(resourceQuota, fieldManager, "status")
 }
 
-func extractResourceQuota(resourceQuota *apicorev1.ResourceQuota, fieldManager string, subresource string) (*ResourceQuotaApplyConfiguration, error) {
+func extractResourceQuota(resourceQuota *corev1.ResourceQuota, fieldManager string, subresource string) (*ResourceQuotaApplyConfiguration, error) {
 	b := &ResourceQuotaApplyConfiguration{}
 	err := managedfields.ExtractInto(resourceQuota, internal.Parser().Type("io.k8s.api.core.v1.ResourceQuota"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/securitycontext.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/securitycontext.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1
 
 import (
-	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 )
 
 // SecurityContextApplyConfiguration represents an declarative configuration of the SecurityContext type for use
@@ -34,7 +34,7 @@ type SecurityContextApplyConfiguration struct {
 	RunAsNonRoot             *bool                                            `json:"runAsNonRoot,omitempty"`
 	ReadOnlyRootFilesystem   *bool                                            `json:"readOnlyRootFilesystem,omitempty"`
 	AllowPrivilegeEscalation *bool                                            `json:"allowPrivilegeEscalation,omitempty"`
-	ProcMount                *corev1.ProcMountType                            `json:"procMount,omitempty"`
+	ProcMount                *v1.ProcMountType                                `json:"procMount,omitempty"`
 	SeccompProfile           *SeccompProfileApplyConfiguration                `json:"seccompProfile,omitempty"`
 	AppArmorProfile          *AppArmorProfileApplyConfiguration               `json:"appArmorProfile,omitempty"`
 }
@@ -120,7 +120,7 @@ func (b *SecurityContextApplyConfiguration) WithAllowPrivilegeEscalation(value b
 // WithProcMount sets the ProcMount field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the ProcMount field is set to the value of the last call.
-func (b *SecurityContextApplyConfiguration) WithProcMount(value corev1.ProcMountType) *SecurityContextApplyConfiguration {
+func (b *SecurityContextApplyConfiguration) WithProcMount(value v1.ProcMountType) *SecurityContextApplyConfiguration {
 	b.ProcMount = &value
 	return b
 }

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/service.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/service.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1
 
 import (
-	apicorev1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -58,18 +58,18 @@ func Service(name, namespace string) *ServiceApplyConfiguration {
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractService(service *apicorev1.Service, fieldManager string) (*ServiceApplyConfiguration, error) {
+func ExtractService(service *corev1.Service, fieldManager string) (*ServiceApplyConfiguration, error) {
 	return extractService(service, fieldManager, "")
 }
 
 // ExtractServiceStatus is the same as ExtractService except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractServiceStatus(service *apicorev1.Service, fieldManager string) (*ServiceApplyConfiguration, error) {
+func ExtractServiceStatus(service *corev1.Service, fieldManager string) (*ServiceApplyConfiguration, error) {
 	return extractService(service, fieldManager, "status")
 }
 
-func extractService(service *apicorev1.Service, fieldManager string, subresource string) (*ServiceApplyConfiguration, error) {
+func extractService(service *corev1.Service, fieldManager string, subresource string) (*ServiceApplyConfiguration, error) {
 	b := &ServiceApplyConfiguration{}
 	err := managedfields.ExtractInto(service, internal.Parser().Type("io.k8s.api.core.v1.Service"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/serviceaccount.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/serviceaccount.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1
 
 import (
-	apicorev1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -59,18 +59,18 @@ func ServiceAccount(name, namespace string) *ServiceAccountApplyConfiguration {
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractServiceAccount(serviceAccount *apicorev1.ServiceAccount, fieldManager string) (*ServiceAccountApplyConfiguration, error) {
+func ExtractServiceAccount(serviceAccount *corev1.ServiceAccount, fieldManager string) (*ServiceAccountApplyConfiguration, error) {
 	return extractServiceAccount(serviceAccount, fieldManager, "")
 }
 
 // ExtractServiceAccountStatus is the same as ExtractServiceAccount except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractServiceAccountStatus(serviceAccount *apicorev1.ServiceAccount, fieldManager string) (*ServiceAccountApplyConfiguration, error) {
+func ExtractServiceAccountStatus(serviceAccount *corev1.ServiceAccount, fieldManager string) (*ServiceAccountApplyConfiguration, error) {
 	return extractServiceAccount(serviceAccount, fieldManager, "status")
 }
 
-func extractServiceAccount(serviceAccount *apicorev1.ServiceAccount, fieldManager string, subresource string) (*ServiceAccountApplyConfiguration, error) {
+func extractServiceAccount(serviceAccount *corev1.ServiceAccount, fieldManager string, subresource string) (*ServiceAccountApplyConfiguration, error) {
 	b := &ServiceAccountApplyConfiguration{}
 	err := managedfields.ExtractInto(serviceAccount, internal.Parser().Type("io.k8s.api.core.v1.ServiceAccount"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/servicespec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/servicespec.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1
 
 import (
-	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 )
 
 // ServiceSpecApplyConfiguration represents an declarative configuration of the ServiceSpec type for use
@@ -29,21 +29,21 @@ type ServiceSpecApplyConfiguration struct {
 	Selector                      map[string]string                        `json:"selector,omitempty"`
 	ClusterIP                     *string                                  `json:"clusterIP,omitempty"`
 	ClusterIPs                    []string                                 `json:"clusterIPs,omitempty"`
-	Type                          *corev1.ServiceType                      `json:"type,omitempty"`
+	Type                          *v1.ServiceType                          `json:"type,omitempty"`
 	ExternalIPs                   []string                                 `json:"externalIPs,omitempty"`
-	SessionAffinity               *corev1.ServiceAffinity                  `json:"sessionAffinity,omitempty"`
+	SessionAffinity               *v1.ServiceAffinity                      `json:"sessionAffinity,omitempty"`
 	LoadBalancerIP                *string                                  `json:"loadBalancerIP,omitempty"`
 	LoadBalancerSourceRanges      []string                                 `json:"loadBalancerSourceRanges,omitempty"`
 	ExternalName                  *string                                  `json:"externalName,omitempty"`
-	ExternalTrafficPolicy         *corev1.ServiceExternalTrafficPolicy     `json:"externalTrafficPolicy,omitempty"`
+	ExternalTrafficPolicy         *v1.ServiceExternalTrafficPolicy         `json:"externalTrafficPolicy,omitempty"`
 	HealthCheckNodePort           *int32                                   `json:"healthCheckNodePort,omitempty"`
 	PublishNotReadyAddresses      *bool                                    `json:"publishNotReadyAddresses,omitempty"`
 	SessionAffinityConfig         *SessionAffinityConfigApplyConfiguration `json:"sessionAffinityConfig,omitempty"`
-	IPFamilies                    []corev1.IPFamily                        `json:"ipFamilies,omitempty"`
-	IPFamilyPolicy                *corev1.IPFamilyPolicy                   `json:"ipFamilyPolicy,omitempty"`
+	IPFamilies                    []v1.IPFamily                            `json:"ipFamilies,omitempty"`
+	IPFamilyPolicy                *v1.IPFamilyPolicy                       `json:"ipFamilyPolicy,omitempty"`
 	AllocateLoadBalancerNodePorts *bool                                    `json:"allocateLoadBalancerNodePorts,omitempty"`
 	LoadBalancerClass             *string                                  `json:"loadBalancerClass,omitempty"`
-	InternalTrafficPolicy         *corev1.ServiceInternalTrafficPolicy     `json:"internalTrafficPolicy,omitempty"`
+	InternalTrafficPolicy         *v1.ServiceInternalTrafficPolicy         `json:"internalTrafficPolicy,omitempty"`
 	TrafficDistribution           *string                                  `json:"trafficDistribution,omitempty"`
 }
 
@@ -101,7 +101,7 @@ func (b *ServiceSpecApplyConfiguration) WithClusterIPs(values ...string) *Servic
 // WithType sets the Type field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the Type field is set to the value of the last call.
-func (b *ServiceSpecApplyConfiguration) WithType(value corev1.ServiceType) *ServiceSpecApplyConfiguration {
+func (b *ServiceSpecApplyConfiguration) WithType(value v1.ServiceType) *ServiceSpecApplyConfiguration {
 	b.Type = &value
 	return b
 }
@@ -119,7 +119,7 @@ func (b *ServiceSpecApplyConfiguration) WithExternalIPs(values ...string) *Servi
 // WithSessionAffinity sets the SessionAffinity field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the SessionAffinity field is set to the value of the last call.
-func (b *ServiceSpecApplyConfiguration) WithSessionAffinity(value corev1.ServiceAffinity) *ServiceSpecApplyConfiguration {
+func (b *ServiceSpecApplyConfiguration) WithSessionAffinity(value v1.ServiceAffinity) *ServiceSpecApplyConfiguration {
 	b.SessionAffinity = &value
 	return b
 }
@@ -153,7 +153,7 @@ func (b *ServiceSpecApplyConfiguration) WithExternalName(value string) *ServiceS
 // WithExternalTrafficPolicy sets the ExternalTrafficPolicy field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the ExternalTrafficPolicy field is set to the value of the last call.
-func (b *ServiceSpecApplyConfiguration) WithExternalTrafficPolicy(value corev1.ServiceExternalTrafficPolicy) *ServiceSpecApplyConfiguration {
+func (b *ServiceSpecApplyConfiguration) WithExternalTrafficPolicy(value v1.ServiceExternalTrafficPolicy) *ServiceSpecApplyConfiguration {
 	b.ExternalTrafficPolicy = &value
 	return b
 }
@@ -185,7 +185,7 @@ func (b *ServiceSpecApplyConfiguration) WithSessionAffinityConfig(value *Session
 // WithIPFamilies adds the given value to the IPFamilies field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the IPFamilies field.
-func (b *ServiceSpecApplyConfiguration) WithIPFamilies(values ...corev1.IPFamily) *ServiceSpecApplyConfiguration {
+func (b *ServiceSpecApplyConfiguration) WithIPFamilies(values ...v1.IPFamily) *ServiceSpecApplyConfiguration {
 	for i := range values {
 		b.IPFamilies = append(b.IPFamilies, values[i])
 	}
@@ -195,7 +195,7 @@ func (b *ServiceSpecApplyConfiguration) WithIPFamilies(values ...corev1.IPFamily
 // WithIPFamilyPolicy sets the IPFamilyPolicy field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the IPFamilyPolicy field is set to the value of the last call.
-func (b *ServiceSpecApplyConfiguration) WithIPFamilyPolicy(value corev1.IPFamilyPolicy) *ServiceSpecApplyConfiguration {
+func (b *ServiceSpecApplyConfiguration) WithIPFamilyPolicy(value v1.IPFamilyPolicy) *ServiceSpecApplyConfiguration {
 	b.IPFamilyPolicy = &value
 	return b
 }
@@ -219,7 +219,7 @@ func (b *ServiceSpecApplyConfiguration) WithLoadBalancerClass(value string) *Ser
 // WithInternalTrafficPolicy sets the InternalTrafficPolicy field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the InternalTrafficPolicy field is set to the value of the last call.
-func (b *ServiceSpecApplyConfiguration) WithInternalTrafficPolicy(value corev1.ServiceInternalTrafficPolicy) *ServiceSpecApplyConfiguration {
+func (b *ServiceSpecApplyConfiguration) WithInternalTrafficPolicy(value v1.ServiceInternalTrafficPolicy) *ServiceSpecApplyConfiguration {
 	b.InternalTrafficPolicy = &value
 	return b
 }

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/servicestatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/servicestatus.go
@@ -19,14 +19,14 @@ limitations under the License.
 package v1
 
 import (
-	metav1 "k8s.io/client-go/applyconfigurations/meta/v1"
+	v1 "k8s.io/client-go/applyconfigurations/meta/v1"
 )
 
 // ServiceStatusApplyConfiguration represents an declarative configuration of the ServiceStatus type for use
 // with apply.
 type ServiceStatusApplyConfiguration struct {
 	LoadBalancer *LoadBalancerStatusApplyConfiguration `json:"loadBalancer,omitempty"`
-	Conditions   []metav1.ConditionApplyConfiguration  `json:"conditions,omitempty"`
+	Conditions   []v1.ConditionApplyConfiguration      `json:"conditions,omitempty"`
 }
 
 // ServiceStatusApplyConfiguration constructs an declarative configuration of the ServiceStatus type for use with
@@ -46,7 +46,7 @@ func (b *ServiceStatusApplyConfiguration) WithLoadBalancer(value *LoadBalancerSt
 // WithConditions adds the given value to the Conditions field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Conditions field.
-func (b *ServiceStatusApplyConfiguration) WithConditions(values ...*metav1.ConditionApplyConfiguration) *ServiceStatusApplyConfiguration {
+func (b *ServiceStatusApplyConfiguration) WithConditions(values ...*v1.ConditionApplyConfiguration) *ServiceStatusApplyConfiguration {
 	for i := range values {
 		if values[i] == nil {
 			panic("nil value passed to WithConditions")

--- a/staging/src/k8s.io/client-go/applyconfigurations/discovery/v1/endpoint.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/discovery/v1/endpoint.go
@@ -19,20 +19,20 @@ limitations under the License.
 package v1
 
 import (
-	corev1 "k8s.io/client-go/applyconfigurations/core/v1"
+	v1 "k8s.io/client-go/applyconfigurations/core/v1"
 )
 
 // EndpointApplyConfiguration represents an declarative configuration of the Endpoint type for use
 // with apply.
 type EndpointApplyConfiguration struct {
-	Addresses          []string                                  `json:"addresses,omitempty"`
-	Conditions         *EndpointConditionsApplyConfiguration     `json:"conditions,omitempty"`
-	Hostname           *string                                   `json:"hostname,omitempty"`
-	TargetRef          *corev1.ObjectReferenceApplyConfiguration `json:"targetRef,omitempty"`
-	DeprecatedTopology map[string]string                         `json:"deprecatedTopology,omitempty"`
-	NodeName           *string                                   `json:"nodeName,omitempty"`
-	Zone               *string                                   `json:"zone,omitempty"`
-	Hints              *EndpointHintsApplyConfiguration          `json:"hints,omitempty"`
+	Addresses          []string                              `json:"addresses,omitempty"`
+	Conditions         *EndpointConditionsApplyConfiguration `json:"conditions,omitempty"`
+	Hostname           *string                               `json:"hostname,omitempty"`
+	TargetRef          *v1.ObjectReferenceApplyConfiguration `json:"targetRef,omitempty"`
+	DeprecatedTopology map[string]string                     `json:"deprecatedTopology,omitempty"`
+	NodeName           *string                               `json:"nodeName,omitempty"`
+	Zone               *string                               `json:"zone,omitempty"`
+	Hints              *EndpointHintsApplyConfiguration      `json:"hints,omitempty"`
 }
 
 // EndpointApplyConfiguration constructs an declarative configuration of the Endpoint type for use with
@@ -70,7 +70,7 @@ func (b *EndpointApplyConfiguration) WithHostname(value string) *EndpointApplyCo
 // WithTargetRef sets the TargetRef field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the TargetRef field is set to the value of the last call.
-func (b *EndpointApplyConfiguration) WithTargetRef(value *corev1.ObjectReferenceApplyConfiguration) *EndpointApplyConfiguration {
+func (b *EndpointApplyConfiguration) WithTargetRef(value *v1.ObjectReferenceApplyConfiguration) *EndpointApplyConfiguration {
 	b.TargetRef = value
 	return b
 }

--- a/staging/src/k8s.io/client-go/applyconfigurations/events/v1/event.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/events/v1/event.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1
 
 import (
-	apieventsv1 "k8s.io/api/events/v1"
+	eventsv1 "k8s.io/api/events/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -71,18 +71,18 @@ func Event(name, namespace string) *EventApplyConfiguration {
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractEvent(event *apieventsv1.Event, fieldManager string) (*EventApplyConfiguration, error) {
+func ExtractEvent(event *eventsv1.Event, fieldManager string) (*EventApplyConfiguration, error) {
 	return extractEvent(event, fieldManager, "")
 }
 
 // ExtractEventStatus is the same as ExtractEvent except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractEventStatus(event *apieventsv1.Event, fieldManager string) (*EventApplyConfiguration, error) {
+func ExtractEventStatus(event *eventsv1.Event, fieldManager string) (*EventApplyConfiguration, error) {
 	return extractEvent(event, fieldManager, "status")
 }
 
-func extractEvent(event *apieventsv1.Event, fieldManager string, subresource string) (*EventApplyConfiguration, error) {
+func extractEvent(event *eventsv1.Event, fieldManager string, subresource string) (*EventApplyConfiguration, error) {
 	b := &EventApplyConfiguration{}
 	err := managedfields.ExtractInto(event, internal.Parser().Type("io.k8s.api.events.v1.Event"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/events/v1beta1/event.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/events/v1beta1/event.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1beta1
 
 import (
-	eventsv1beta1 "k8s.io/api/events/v1beta1"
+	v1beta1 "k8s.io/api/events/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -71,18 +71,18 @@ func Event(name, namespace string) *EventApplyConfiguration {
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractEvent(event *eventsv1beta1.Event, fieldManager string) (*EventApplyConfiguration, error) {
+func ExtractEvent(event *v1beta1.Event, fieldManager string) (*EventApplyConfiguration, error) {
 	return extractEvent(event, fieldManager, "")
 }
 
 // ExtractEventStatus is the same as ExtractEvent except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractEventStatus(event *eventsv1beta1.Event, fieldManager string) (*EventApplyConfiguration, error) {
+func ExtractEventStatus(event *v1beta1.Event, fieldManager string) (*EventApplyConfiguration, error) {
 	return extractEvent(event, fieldManager, "status")
 }
 
-func extractEvent(event *eventsv1beta1.Event, fieldManager string, subresource string) (*EventApplyConfiguration, error) {
+func extractEvent(event *v1beta1.Event, fieldManager string, subresource string) (*EventApplyConfiguration, error) {
 	b := &EventApplyConfiguration{}
 	err := managedfields.ExtractInto(event, internal.Parser().Type("io.k8s.api.events.v1beta1.Event"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/daemonset.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/daemonset.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1beta1
 
 import (
-	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
+	v1beta1 "k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -58,18 +58,18 @@ func DaemonSet(name, namespace string) *DaemonSetApplyConfiguration {
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractDaemonSet(daemonSet *extensionsv1beta1.DaemonSet, fieldManager string) (*DaemonSetApplyConfiguration, error) {
+func ExtractDaemonSet(daemonSet *v1beta1.DaemonSet, fieldManager string) (*DaemonSetApplyConfiguration, error) {
 	return extractDaemonSet(daemonSet, fieldManager, "")
 }
 
 // ExtractDaemonSetStatus is the same as ExtractDaemonSet except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractDaemonSetStatus(daemonSet *extensionsv1beta1.DaemonSet, fieldManager string) (*DaemonSetApplyConfiguration, error) {
+func ExtractDaemonSetStatus(daemonSet *v1beta1.DaemonSet, fieldManager string) (*DaemonSetApplyConfiguration, error) {
 	return extractDaemonSet(daemonSet, fieldManager, "status")
 }
 
-func extractDaemonSet(daemonSet *extensionsv1beta1.DaemonSet, fieldManager string, subresource string) (*DaemonSetApplyConfiguration, error) {
+func extractDaemonSet(daemonSet *v1beta1.DaemonSet, fieldManager string, subresource string) (*DaemonSetApplyConfiguration, error) {
 	b := &DaemonSetApplyConfiguration{}
 	err := managedfields.ExtractInto(daemonSet, internal.Parser().Type("io.k8s.api.extensions.v1beta1.DaemonSet"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/deployment.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/deployment.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1beta1
 
 import (
-	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
+	v1beta1 "k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -58,18 +58,18 @@ func Deployment(name, namespace string) *DeploymentApplyConfiguration {
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractDeployment(deployment *extensionsv1beta1.Deployment, fieldManager string) (*DeploymentApplyConfiguration, error) {
+func ExtractDeployment(deployment *v1beta1.Deployment, fieldManager string) (*DeploymentApplyConfiguration, error) {
 	return extractDeployment(deployment, fieldManager, "")
 }
 
 // ExtractDeploymentStatus is the same as ExtractDeployment except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractDeploymentStatus(deployment *extensionsv1beta1.Deployment, fieldManager string) (*DeploymentApplyConfiguration, error) {
+func ExtractDeploymentStatus(deployment *v1beta1.Deployment, fieldManager string) (*DeploymentApplyConfiguration, error) {
 	return extractDeployment(deployment, fieldManager, "status")
 }
 
-func extractDeployment(deployment *extensionsv1beta1.Deployment, fieldManager string, subresource string) (*DeploymentApplyConfiguration, error) {
+func extractDeployment(deployment *v1beta1.Deployment, fieldManager string, subresource string) (*DeploymentApplyConfiguration, error) {
 	b := &DeploymentApplyConfiguration{}
 	err := managedfields.ExtractInto(deployment, internal.Parser().Type("io.k8s.api.extensions.v1beta1.Deployment"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/ingress.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/ingress.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1beta1
 
 import (
-	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
+	v1beta1 "k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -58,18 +58,18 @@ func Ingress(name, namespace string) *IngressApplyConfiguration {
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractIngress(ingress *extensionsv1beta1.Ingress, fieldManager string) (*IngressApplyConfiguration, error) {
+func ExtractIngress(ingress *v1beta1.Ingress, fieldManager string) (*IngressApplyConfiguration, error) {
 	return extractIngress(ingress, fieldManager, "")
 }
 
 // ExtractIngressStatus is the same as ExtractIngress except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractIngressStatus(ingress *extensionsv1beta1.Ingress, fieldManager string) (*IngressApplyConfiguration, error) {
+func ExtractIngressStatus(ingress *v1beta1.Ingress, fieldManager string) (*IngressApplyConfiguration, error) {
 	return extractIngress(ingress, fieldManager, "status")
 }
 
-func extractIngress(ingress *extensionsv1beta1.Ingress, fieldManager string, subresource string) (*IngressApplyConfiguration, error) {
+func extractIngress(ingress *v1beta1.Ingress, fieldManager string, subresource string) (*IngressApplyConfiguration, error) {
 	b := &IngressApplyConfiguration{}
 	err := managedfields.ExtractInto(ingress, internal.Parser().Type("io.k8s.api.extensions.v1beta1.Ingress"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/networkpolicy.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/networkpolicy.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1beta1
 
 import (
-	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
+	v1beta1 "k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -57,18 +57,18 @@ func NetworkPolicy(name, namespace string) *NetworkPolicyApplyConfiguration {
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractNetworkPolicy(networkPolicy *extensionsv1beta1.NetworkPolicy, fieldManager string) (*NetworkPolicyApplyConfiguration, error) {
+func ExtractNetworkPolicy(networkPolicy *v1beta1.NetworkPolicy, fieldManager string) (*NetworkPolicyApplyConfiguration, error) {
 	return extractNetworkPolicy(networkPolicy, fieldManager, "")
 }
 
 // ExtractNetworkPolicyStatus is the same as ExtractNetworkPolicy except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractNetworkPolicyStatus(networkPolicy *extensionsv1beta1.NetworkPolicy, fieldManager string) (*NetworkPolicyApplyConfiguration, error) {
+func ExtractNetworkPolicyStatus(networkPolicy *v1beta1.NetworkPolicy, fieldManager string) (*NetworkPolicyApplyConfiguration, error) {
 	return extractNetworkPolicy(networkPolicy, fieldManager, "status")
 }
 
-func extractNetworkPolicy(networkPolicy *extensionsv1beta1.NetworkPolicy, fieldManager string, subresource string) (*NetworkPolicyApplyConfiguration, error) {
+func extractNetworkPolicy(networkPolicy *v1beta1.NetworkPolicy, fieldManager string, subresource string) (*NetworkPolicyApplyConfiguration, error) {
 	b := &NetworkPolicyApplyConfiguration{}
 	err := managedfields.ExtractInto(networkPolicy, internal.Parser().Type("io.k8s.api.extensions.v1beta1.NetworkPolicy"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/networkpolicyspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/networkpolicyspec.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1beta1
 
 import (
-	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
+	v1beta1 "k8s.io/api/extensions/v1beta1"
 	v1 "k8s.io/client-go/applyconfigurations/meta/v1"
 )
 
@@ -29,7 +29,7 @@ type NetworkPolicySpecApplyConfiguration struct {
 	PodSelector *v1.LabelSelectorApplyConfiguration          `json:"podSelector,omitempty"`
 	Ingress     []NetworkPolicyIngressRuleApplyConfiguration `json:"ingress,omitempty"`
 	Egress      []NetworkPolicyEgressRuleApplyConfiguration  `json:"egress,omitempty"`
-	PolicyTypes []extensionsv1beta1.PolicyType               `json:"policyTypes,omitempty"`
+	PolicyTypes []v1beta1.PolicyType                         `json:"policyTypes,omitempty"`
 }
 
 // NetworkPolicySpecApplyConfiguration constructs an declarative configuration of the NetworkPolicySpec type for use with
@@ -75,7 +75,7 @@ func (b *NetworkPolicySpecApplyConfiguration) WithEgress(values ...*NetworkPolic
 // WithPolicyTypes adds the given value to the PolicyTypes field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the PolicyTypes field.
-func (b *NetworkPolicySpecApplyConfiguration) WithPolicyTypes(values ...extensionsv1beta1.PolicyType) *NetworkPolicySpecApplyConfiguration {
+func (b *NetworkPolicySpecApplyConfiguration) WithPolicyTypes(values ...v1beta1.PolicyType) *NetworkPolicySpecApplyConfiguration {
 	for i := range values {
 		b.PolicyTypes = append(b.PolicyTypes, values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/replicaset.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/extensions/v1beta1/replicaset.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1beta1
 
 import (
-	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
+	v1beta1 "k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -58,18 +58,18 @@ func ReplicaSet(name, namespace string) *ReplicaSetApplyConfiguration {
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractReplicaSet(replicaSet *extensionsv1beta1.ReplicaSet, fieldManager string) (*ReplicaSetApplyConfiguration, error) {
+func ExtractReplicaSet(replicaSet *v1beta1.ReplicaSet, fieldManager string) (*ReplicaSetApplyConfiguration, error) {
 	return extractReplicaSet(replicaSet, fieldManager, "")
 }
 
 // ExtractReplicaSetStatus is the same as ExtractReplicaSet except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractReplicaSetStatus(replicaSet *extensionsv1beta1.ReplicaSet, fieldManager string) (*ReplicaSetApplyConfiguration, error) {
+func ExtractReplicaSetStatus(replicaSet *v1beta1.ReplicaSet, fieldManager string) (*ReplicaSetApplyConfiguration, error) {
 	return extractReplicaSet(replicaSet, fieldManager, "status")
 }
 
-func extractReplicaSet(replicaSet *extensionsv1beta1.ReplicaSet, fieldManager string, subresource string) (*ReplicaSetApplyConfiguration, error) {
+func extractReplicaSet(replicaSet *v1beta1.ReplicaSet, fieldManager string, subresource string) (*ReplicaSetApplyConfiguration, error) {
 	b := &ReplicaSetApplyConfiguration{}
 	err := managedfields.ExtractInto(replicaSet, internal.Parser().Type("io.k8s.api.extensions.v1beta1.ReplicaSet"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1/flowschema.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1/flowschema.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1
 
 import (
-	apiflowcontrolv1 "k8s.io/api/flowcontrol/v1"
+	flowcontrolv1 "k8s.io/api/flowcontrol/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -57,18 +57,18 @@ func FlowSchema(name string) *FlowSchemaApplyConfiguration {
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractFlowSchema(flowSchema *apiflowcontrolv1.FlowSchema, fieldManager string) (*FlowSchemaApplyConfiguration, error) {
+func ExtractFlowSchema(flowSchema *flowcontrolv1.FlowSchema, fieldManager string) (*FlowSchemaApplyConfiguration, error) {
 	return extractFlowSchema(flowSchema, fieldManager, "")
 }
 
 // ExtractFlowSchemaStatus is the same as ExtractFlowSchema except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractFlowSchemaStatus(flowSchema *apiflowcontrolv1.FlowSchema, fieldManager string) (*FlowSchemaApplyConfiguration, error) {
+func ExtractFlowSchemaStatus(flowSchema *flowcontrolv1.FlowSchema, fieldManager string) (*FlowSchemaApplyConfiguration, error) {
 	return extractFlowSchema(flowSchema, fieldManager, "status")
 }
 
-func extractFlowSchema(flowSchema *apiflowcontrolv1.FlowSchema, fieldManager string, subresource string) (*FlowSchemaApplyConfiguration, error) {
+func extractFlowSchema(flowSchema *flowcontrolv1.FlowSchema, fieldManager string, subresource string) (*FlowSchemaApplyConfiguration, error) {
 	b := &FlowSchemaApplyConfiguration{}
 	err := managedfields.ExtractInto(flowSchema, internal.Parser().Type("io.k8s.api.flowcontrol.v1.FlowSchema"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1/prioritylevelconfiguration.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1/prioritylevelconfiguration.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1
 
 import (
-	apiflowcontrolv1 "k8s.io/api/flowcontrol/v1"
+	flowcontrolv1 "k8s.io/api/flowcontrol/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -57,18 +57,18 @@ func PriorityLevelConfiguration(name string) *PriorityLevelConfigurationApplyCon
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractPriorityLevelConfiguration(priorityLevelConfiguration *apiflowcontrolv1.PriorityLevelConfiguration, fieldManager string) (*PriorityLevelConfigurationApplyConfiguration, error) {
+func ExtractPriorityLevelConfiguration(priorityLevelConfiguration *flowcontrolv1.PriorityLevelConfiguration, fieldManager string) (*PriorityLevelConfigurationApplyConfiguration, error) {
 	return extractPriorityLevelConfiguration(priorityLevelConfiguration, fieldManager, "")
 }
 
 // ExtractPriorityLevelConfigurationStatus is the same as ExtractPriorityLevelConfiguration except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractPriorityLevelConfigurationStatus(priorityLevelConfiguration *apiflowcontrolv1.PriorityLevelConfiguration, fieldManager string) (*PriorityLevelConfigurationApplyConfiguration, error) {
+func ExtractPriorityLevelConfigurationStatus(priorityLevelConfiguration *flowcontrolv1.PriorityLevelConfiguration, fieldManager string) (*PriorityLevelConfigurationApplyConfiguration, error) {
 	return extractPriorityLevelConfiguration(priorityLevelConfiguration, fieldManager, "status")
 }
 
-func extractPriorityLevelConfiguration(priorityLevelConfiguration *apiflowcontrolv1.PriorityLevelConfiguration, fieldManager string, subresource string) (*PriorityLevelConfigurationApplyConfiguration, error) {
+func extractPriorityLevelConfiguration(priorityLevelConfiguration *flowcontrolv1.PriorityLevelConfiguration, fieldManager string, subresource string) (*PriorityLevelConfigurationApplyConfiguration, error) {
 	b := &PriorityLevelConfigurationApplyConfiguration{}
 	err := managedfields.ExtractInto(priorityLevelConfiguration, internal.Parser().Type("io.k8s.api.flowcontrol.v1.PriorityLevelConfiguration"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta1/flowschema.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta1/flowschema.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1beta1
 
 import (
-	flowcontrolv1beta1 "k8s.io/api/flowcontrol/v1beta1"
+	v1beta1 "k8s.io/api/flowcontrol/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -57,18 +57,18 @@ func FlowSchema(name string) *FlowSchemaApplyConfiguration {
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractFlowSchema(flowSchema *flowcontrolv1beta1.FlowSchema, fieldManager string) (*FlowSchemaApplyConfiguration, error) {
+func ExtractFlowSchema(flowSchema *v1beta1.FlowSchema, fieldManager string) (*FlowSchemaApplyConfiguration, error) {
 	return extractFlowSchema(flowSchema, fieldManager, "")
 }
 
 // ExtractFlowSchemaStatus is the same as ExtractFlowSchema except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractFlowSchemaStatus(flowSchema *flowcontrolv1beta1.FlowSchema, fieldManager string) (*FlowSchemaApplyConfiguration, error) {
+func ExtractFlowSchemaStatus(flowSchema *v1beta1.FlowSchema, fieldManager string) (*FlowSchemaApplyConfiguration, error) {
 	return extractFlowSchema(flowSchema, fieldManager, "status")
 }
 
-func extractFlowSchema(flowSchema *flowcontrolv1beta1.FlowSchema, fieldManager string, subresource string) (*FlowSchemaApplyConfiguration, error) {
+func extractFlowSchema(flowSchema *v1beta1.FlowSchema, fieldManager string, subresource string) (*FlowSchemaApplyConfiguration, error) {
 	b := &FlowSchemaApplyConfiguration{}
 	err := managedfields.ExtractInto(flowSchema, internal.Parser().Type("io.k8s.api.flowcontrol.v1beta1.FlowSchema"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta1/prioritylevelconfiguration.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta1/prioritylevelconfiguration.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1beta1
 
 import (
-	flowcontrolv1beta1 "k8s.io/api/flowcontrol/v1beta1"
+	v1beta1 "k8s.io/api/flowcontrol/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -57,18 +57,18 @@ func PriorityLevelConfiguration(name string) *PriorityLevelConfigurationApplyCon
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractPriorityLevelConfiguration(priorityLevelConfiguration *flowcontrolv1beta1.PriorityLevelConfiguration, fieldManager string) (*PriorityLevelConfigurationApplyConfiguration, error) {
+func ExtractPriorityLevelConfiguration(priorityLevelConfiguration *v1beta1.PriorityLevelConfiguration, fieldManager string) (*PriorityLevelConfigurationApplyConfiguration, error) {
 	return extractPriorityLevelConfiguration(priorityLevelConfiguration, fieldManager, "")
 }
 
 // ExtractPriorityLevelConfigurationStatus is the same as ExtractPriorityLevelConfiguration except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractPriorityLevelConfigurationStatus(priorityLevelConfiguration *flowcontrolv1beta1.PriorityLevelConfiguration, fieldManager string) (*PriorityLevelConfigurationApplyConfiguration, error) {
+func ExtractPriorityLevelConfigurationStatus(priorityLevelConfiguration *v1beta1.PriorityLevelConfiguration, fieldManager string) (*PriorityLevelConfigurationApplyConfiguration, error) {
 	return extractPriorityLevelConfiguration(priorityLevelConfiguration, fieldManager, "status")
 }
 
-func extractPriorityLevelConfiguration(priorityLevelConfiguration *flowcontrolv1beta1.PriorityLevelConfiguration, fieldManager string, subresource string) (*PriorityLevelConfigurationApplyConfiguration, error) {
+func extractPriorityLevelConfiguration(priorityLevelConfiguration *v1beta1.PriorityLevelConfiguration, fieldManager string, subresource string) (*PriorityLevelConfigurationApplyConfiguration, error) {
 	b := &PriorityLevelConfigurationApplyConfiguration{}
 	err := managedfields.ExtractInto(priorityLevelConfiguration, internal.Parser().Type("io.k8s.api.flowcontrol.v1beta1.PriorityLevelConfiguration"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta2/flowschema.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta2/flowschema.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1beta2
 
 import (
-	flowcontrolv1beta2 "k8s.io/api/flowcontrol/v1beta2"
+	v1beta2 "k8s.io/api/flowcontrol/v1beta2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -57,18 +57,18 @@ func FlowSchema(name string) *FlowSchemaApplyConfiguration {
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractFlowSchema(flowSchema *flowcontrolv1beta2.FlowSchema, fieldManager string) (*FlowSchemaApplyConfiguration, error) {
+func ExtractFlowSchema(flowSchema *v1beta2.FlowSchema, fieldManager string) (*FlowSchemaApplyConfiguration, error) {
 	return extractFlowSchema(flowSchema, fieldManager, "")
 }
 
 // ExtractFlowSchemaStatus is the same as ExtractFlowSchema except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractFlowSchemaStatus(flowSchema *flowcontrolv1beta2.FlowSchema, fieldManager string) (*FlowSchemaApplyConfiguration, error) {
+func ExtractFlowSchemaStatus(flowSchema *v1beta2.FlowSchema, fieldManager string) (*FlowSchemaApplyConfiguration, error) {
 	return extractFlowSchema(flowSchema, fieldManager, "status")
 }
 
-func extractFlowSchema(flowSchema *flowcontrolv1beta2.FlowSchema, fieldManager string, subresource string) (*FlowSchemaApplyConfiguration, error) {
+func extractFlowSchema(flowSchema *v1beta2.FlowSchema, fieldManager string, subresource string) (*FlowSchemaApplyConfiguration, error) {
 	b := &FlowSchemaApplyConfiguration{}
 	err := managedfields.ExtractInto(flowSchema, internal.Parser().Type("io.k8s.api.flowcontrol.v1beta2.FlowSchema"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta2/prioritylevelconfiguration.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta2/prioritylevelconfiguration.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1beta2
 
 import (
-	flowcontrolv1beta2 "k8s.io/api/flowcontrol/v1beta2"
+	v1beta2 "k8s.io/api/flowcontrol/v1beta2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -57,18 +57,18 @@ func PriorityLevelConfiguration(name string) *PriorityLevelConfigurationApplyCon
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractPriorityLevelConfiguration(priorityLevelConfiguration *flowcontrolv1beta2.PriorityLevelConfiguration, fieldManager string) (*PriorityLevelConfigurationApplyConfiguration, error) {
+func ExtractPriorityLevelConfiguration(priorityLevelConfiguration *v1beta2.PriorityLevelConfiguration, fieldManager string) (*PriorityLevelConfigurationApplyConfiguration, error) {
 	return extractPriorityLevelConfiguration(priorityLevelConfiguration, fieldManager, "")
 }
 
 // ExtractPriorityLevelConfigurationStatus is the same as ExtractPriorityLevelConfiguration except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractPriorityLevelConfigurationStatus(priorityLevelConfiguration *flowcontrolv1beta2.PriorityLevelConfiguration, fieldManager string) (*PriorityLevelConfigurationApplyConfiguration, error) {
+func ExtractPriorityLevelConfigurationStatus(priorityLevelConfiguration *v1beta2.PriorityLevelConfiguration, fieldManager string) (*PriorityLevelConfigurationApplyConfiguration, error) {
 	return extractPriorityLevelConfiguration(priorityLevelConfiguration, fieldManager, "status")
 }
 
-func extractPriorityLevelConfiguration(priorityLevelConfiguration *flowcontrolv1beta2.PriorityLevelConfiguration, fieldManager string, subresource string) (*PriorityLevelConfigurationApplyConfiguration, error) {
+func extractPriorityLevelConfiguration(priorityLevelConfiguration *v1beta2.PriorityLevelConfiguration, fieldManager string, subresource string) (*PriorityLevelConfigurationApplyConfiguration, error) {
 	b := &PriorityLevelConfigurationApplyConfiguration{}
 	err := managedfields.ExtractInto(priorityLevelConfiguration, internal.Parser().Type("io.k8s.api.flowcontrol.v1beta2.PriorityLevelConfiguration"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta3/flowschema.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta3/flowschema.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1beta3
 
 import (
-	flowcontrolv1beta3 "k8s.io/api/flowcontrol/v1beta3"
+	v1beta3 "k8s.io/api/flowcontrol/v1beta3"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -57,18 +57,18 @@ func FlowSchema(name string) *FlowSchemaApplyConfiguration {
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractFlowSchema(flowSchema *flowcontrolv1beta3.FlowSchema, fieldManager string) (*FlowSchemaApplyConfiguration, error) {
+func ExtractFlowSchema(flowSchema *v1beta3.FlowSchema, fieldManager string) (*FlowSchemaApplyConfiguration, error) {
 	return extractFlowSchema(flowSchema, fieldManager, "")
 }
 
 // ExtractFlowSchemaStatus is the same as ExtractFlowSchema except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractFlowSchemaStatus(flowSchema *flowcontrolv1beta3.FlowSchema, fieldManager string) (*FlowSchemaApplyConfiguration, error) {
+func ExtractFlowSchemaStatus(flowSchema *v1beta3.FlowSchema, fieldManager string) (*FlowSchemaApplyConfiguration, error) {
 	return extractFlowSchema(flowSchema, fieldManager, "status")
 }
 
-func extractFlowSchema(flowSchema *flowcontrolv1beta3.FlowSchema, fieldManager string, subresource string) (*FlowSchemaApplyConfiguration, error) {
+func extractFlowSchema(flowSchema *v1beta3.FlowSchema, fieldManager string, subresource string) (*FlowSchemaApplyConfiguration, error) {
 	b := &FlowSchemaApplyConfiguration{}
 	err := managedfields.ExtractInto(flowSchema, internal.Parser().Type("io.k8s.api.flowcontrol.v1beta3.FlowSchema"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta3/prioritylevelconfiguration.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/flowcontrol/v1beta3/prioritylevelconfiguration.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1beta3
 
 import (
-	flowcontrolv1beta3 "k8s.io/api/flowcontrol/v1beta3"
+	v1beta3 "k8s.io/api/flowcontrol/v1beta3"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -57,18 +57,18 @@ func PriorityLevelConfiguration(name string) *PriorityLevelConfigurationApplyCon
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractPriorityLevelConfiguration(priorityLevelConfiguration *flowcontrolv1beta3.PriorityLevelConfiguration, fieldManager string) (*PriorityLevelConfigurationApplyConfiguration, error) {
+func ExtractPriorityLevelConfiguration(priorityLevelConfiguration *v1beta3.PriorityLevelConfiguration, fieldManager string) (*PriorityLevelConfigurationApplyConfiguration, error) {
 	return extractPriorityLevelConfiguration(priorityLevelConfiguration, fieldManager, "")
 }
 
 // ExtractPriorityLevelConfigurationStatus is the same as ExtractPriorityLevelConfiguration except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractPriorityLevelConfigurationStatus(priorityLevelConfiguration *flowcontrolv1beta3.PriorityLevelConfiguration, fieldManager string) (*PriorityLevelConfigurationApplyConfiguration, error) {
+func ExtractPriorityLevelConfigurationStatus(priorityLevelConfiguration *v1beta3.PriorityLevelConfiguration, fieldManager string) (*PriorityLevelConfigurationApplyConfiguration, error) {
 	return extractPriorityLevelConfiguration(priorityLevelConfiguration, fieldManager, "status")
 }
 
-func extractPriorityLevelConfiguration(priorityLevelConfiguration *flowcontrolv1beta3.PriorityLevelConfiguration, fieldManager string, subresource string) (*PriorityLevelConfigurationApplyConfiguration, error) {
+func extractPriorityLevelConfiguration(priorityLevelConfiguration *v1beta3.PriorityLevelConfiguration, fieldManager string, subresource string) (*PriorityLevelConfigurationApplyConfiguration, error) {
 	b := &PriorityLevelConfigurationApplyConfiguration{}
 	err := managedfields.ExtractInto(priorityLevelConfiguration, internal.Parser().Type("io.k8s.api.flowcontrol.v1beta3.PriorityLevelConfiguration"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/imagepolicy/v1alpha1/imagereview.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/imagepolicy/v1alpha1/imagereview.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	imagepolicyv1alpha1 "k8s.io/api/imagepolicy/v1alpha1"
+	v1alpha1 "k8s.io/api/imagepolicy/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -57,18 +57,18 @@ func ImageReview(name string) *ImageReviewApplyConfiguration {
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractImageReview(imageReview *imagepolicyv1alpha1.ImageReview, fieldManager string) (*ImageReviewApplyConfiguration, error) {
+func ExtractImageReview(imageReview *v1alpha1.ImageReview, fieldManager string) (*ImageReviewApplyConfiguration, error) {
 	return extractImageReview(imageReview, fieldManager, "")
 }
 
 // ExtractImageReviewStatus is the same as ExtractImageReview except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractImageReviewStatus(imageReview *imagepolicyv1alpha1.ImageReview, fieldManager string) (*ImageReviewApplyConfiguration, error) {
+func ExtractImageReviewStatus(imageReview *v1alpha1.ImageReview, fieldManager string) (*ImageReviewApplyConfiguration, error) {
 	return extractImageReview(imageReview, fieldManager, "status")
 }
 
-func extractImageReview(imageReview *imagepolicyv1alpha1.ImageReview, fieldManager string, subresource string) (*ImageReviewApplyConfiguration, error) {
+func extractImageReview(imageReview *v1alpha1.ImageReview, fieldManager string, subresource string) (*ImageReviewApplyConfiguration, error) {
 	b := &ImageReviewApplyConfiguration{}
 	err := managedfields.ExtractInto(imageReview, internal.Parser().Type("io.k8s.api.imagepolicy.v1alpha1.ImageReview"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/meta/v1/deleteoptions.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/meta/v1/deleteoptions.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1
 
 import (
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // DeleteOptionsApplyConfiguration represents an declarative configuration of the DeleteOptions type for use
@@ -29,7 +29,7 @@ type DeleteOptionsApplyConfiguration struct {
 	GracePeriodSeconds         *int64                           `json:"gracePeriodSeconds,omitempty"`
 	Preconditions              *PreconditionsApplyConfiguration `json:"preconditions,omitempty"`
 	OrphanDependents           *bool                            `json:"orphanDependents,omitempty"`
-	PropagationPolicy          *metav1.DeletionPropagation      `json:"propagationPolicy,omitempty"`
+	PropagationPolicy          *v1.DeletionPropagation          `json:"propagationPolicy,omitempty"`
 	DryRun                     []string                         `json:"dryRun,omitempty"`
 }
 
@@ -85,7 +85,7 @@ func (b *DeleteOptionsApplyConfiguration) WithOrphanDependents(value bool) *Dele
 // WithPropagationPolicy sets the PropagationPolicy field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the PropagationPolicy field is set to the value of the last call.
-func (b *DeleteOptionsApplyConfiguration) WithPropagationPolicy(value metav1.DeletionPropagation) *DeleteOptionsApplyConfiguration {
+func (b *DeleteOptionsApplyConfiguration) WithPropagationPolicy(value v1.DeletionPropagation) *DeleteOptionsApplyConfiguration {
 	b.PropagationPolicy = &value
 	return b
 }

--- a/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/ingress.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/ingress.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1
 
 import (
-	apinetworkingv1 "k8s.io/api/networking/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -58,18 +58,18 @@ func Ingress(name, namespace string) *IngressApplyConfiguration {
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractIngress(ingress *apinetworkingv1.Ingress, fieldManager string) (*IngressApplyConfiguration, error) {
+func ExtractIngress(ingress *networkingv1.Ingress, fieldManager string) (*IngressApplyConfiguration, error) {
 	return extractIngress(ingress, fieldManager, "")
 }
 
 // ExtractIngressStatus is the same as ExtractIngress except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractIngressStatus(ingress *apinetworkingv1.Ingress, fieldManager string) (*IngressApplyConfiguration, error) {
+func ExtractIngressStatus(ingress *networkingv1.Ingress, fieldManager string) (*IngressApplyConfiguration, error) {
 	return extractIngress(ingress, fieldManager, "status")
 }
 
-func extractIngress(ingress *apinetworkingv1.Ingress, fieldManager string, subresource string) (*IngressApplyConfiguration, error) {
+func extractIngress(ingress *networkingv1.Ingress, fieldManager string, subresource string) (*IngressApplyConfiguration, error) {
 	b := &IngressApplyConfiguration{}
 	err := managedfields.ExtractInto(ingress, internal.Parser().Type("io.k8s.api.networking.v1.Ingress"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/ingressbackend.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/ingressbackend.go
@@ -19,14 +19,14 @@ limitations under the License.
 package v1
 
 import (
-	corev1 "k8s.io/client-go/applyconfigurations/core/v1"
+	v1 "k8s.io/client-go/applyconfigurations/core/v1"
 )
 
 // IngressBackendApplyConfiguration represents an declarative configuration of the IngressBackend type for use
 // with apply.
 type IngressBackendApplyConfiguration struct {
-	Service  *IngressServiceBackendApplyConfiguration            `json:"service,omitempty"`
-	Resource *corev1.TypedLocalObjectReferenceApplyConfiguration `json:"resource,omitempty"`
+	Service  *IngressServiceBackendApplyConfiguration        `json:"service,omitempty"`
+	Resource *v1.TypedLocalObjectReferenceApplyConfiguration `json:"resource,omitempty"`
 }
 
 // IngressBackendApplyConfiguration constructs an declarative configuration of the IngressBackend type for use with
@@ -46,7 +46,7 @@ func (b *IngressBackendApplyConfiguration) WithService(value *IngressServiceBack
 // WithResource sets the Resource field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the Resource field is set to the value of the last call.
-func (b *IngressBackendApplyConfiguration) WithResource(value *corev1.TypedLocalObjectReferenceApplyConfiguration) *IngressBackendApplyConfiguration {
+func (b *IngressBackendApplyConfiguration) WithResource(value *v1.TypedLocalObjectReferenceApplyConfiguration) *IngressBackendApplyConfiguration {
 	b.Resource = value
 	return b
 }

--- a/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/ingressclass.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/ingressclass.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1
 
 import (
-	apinetworkingv1 "k8s.io/api/networking/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -56,18 +56,18 @@ func IngressClass(name string) *IngressClassApplyConfiguration {
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractIngressClass(ingressClass *apinetworkingv1.IngressClass, fieldManager string) (*IngressClassApplyConfiguration, error) {
+func ExtractIngressClass(ingressClass *networkingv1.IngressClass, fieldManager string) (*IngressClassApplyConfiguration, error) {
 	return extractIngressClass(ingressClass, fieldManager, "")
 }
 
 // ExtractIngressClassStatus is the same as ExtractIngressClass except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractIngressClassStatus(ingressClass *apinetworkingv1.IngressClass, fieldManager string) (*IngressClassApplyConfiguration, error) {
+func ExtractIngressClassStatus(ingressClass *networkingv1.IngressClass, fieldManager string) (*IngressClassApplyConfiguration, error) {
 	return extractIngressClass(ingressClass, fieldManager, "status")
 }
 
-func extractIngressClass(ingressClass *apinetworkingv1.IngressClass, fieldManager string, subresource string) (*IngressClassApplyConfiguration, error) {
+func extractIngressClass(ingressClass *networkingv1.IngressClass, fieldManager string, subresource string) (*IngressClassApplyConfiguration, error) {
 	b := &IngressClassApplyConfiguration{}
 	err := managedfields.ExtractInto(ingressClass, internal.Parser().Type("io.k8s.api.networking.v1.IngressClass"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/networkpolicy.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/networkpolicy.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1
 
 import (
-	apinetworkingv1 "k8s.io/api/networking/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -57,18 +57,18 @@ func NetworkPolicy(name, namespace string) *NetworkPolicyApplyConfiguration {
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractNetworkPolicy(networkPolicy *apinetworkingv1.NetworkPolicy, fieldManager string) (*NetworkPolicyApplyConfiguration, error) {
+func ExtractNetworkPolicy(networkPolicy *networkingv1.NetworkPolicy, fieldManager string) (*NetworkPolicyApplyConfiguration, error) {
 	return extractNetworkPolicy(networkPolicy, fieldManager, "")
 }
 
 // ExtractNetworkPolicyStatus is the same as ExtractNetworkPolicy except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractNetworkPolicyStatus(networkPolicy *apinetworkingv1.NetworkPolicy, fieldManager string) (*NetworkPolicyApplyConfiguration, error) {
+func ExtractNetworkPolicyStatus(networkPolicy *networkingv1.NetworkPolicy, fieldManager string) (*NetworkPolicyApplyConfiguration, error) {
 	return extractNetworkPolicy(networkPolicy, fieldManager, "status")
 }
 
-func extractNetworkPolicy(networkPolicy *apinetworkingv1.NetworkPolicy, fieldManager string, subresource string) (*NetworkPolicyApplyConfiguration, error) {
+func extractNetworkPolicy(networkPolicy *networkingv1.NetworkPolicy, fieldManager string, subresource string) (*NetworkPolicyApplyConfiguration, error) {
 	b := &NetworkPolicyApplyConfiguration{}
 	err := managedfields.ExtractInto(networkPolicy, internal.Parser().Type("io.k8s.api.networking.v1.NetworkPolicy"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/networkpolicyspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/networking/v1/networkpolicyspec.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1
 
 import (
-	apinetworkingv1 "k8s.io/api/networking/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	v1 "k8s.io/client-go/applyconfigurations/meta/v1"
 )
 
@@ -29,7 +29,7 @@ type NetworkPolicySpecApplyConfiguration struct {
 	PodSelector *v1.LabelSelectorApplyConfiguration          `json:"podSelector,omitempty"`
 	Ingress     []NetworkPolicyIngressRuleApplyConfiguration `json:"ingress,omitempty"`
 	Egress      []NetworkPolicyEgressRuleApplyConfiguration  `json:"egress,omitempty"`
-	PolicyTypes []apinetworkingv1.PolicyType                 `json:"policyTypes,omitempty"`
+	PolicyTypes []networkingv1.PolicyType                    `json:"policyTypes,omitempty"`
 }
 
 // NetworkPolicySpecApplyConfiguration constructs an declarative configuration of the NetworkPolicySpec type for use with
@@ -75,7 +75,7 @@ func (b *NetworkPolicySpecApplyConfiguration) WithEgress(values ...*NetworkPolic
 // WithPolicyTypes adds the given value to the PolicyTypes field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the PolicyTypes field.
-func (b *NetworkPolicySpecApplyConfiguration) WithPolicyTypes(values ...apinetworkingv1.PolicyType) *NetworkPolicySpecApplyConfiguration {
+func (b *NetworkPolicySpecApplyConfiguration) WithPolicyTypes(values ...networkingv1.PolicyType) *NetworkPolicySpecApplyConfiguration {
 	for i := range values {
 		b.PolicyTypes = append(b.PolicyTypes, values[i])
 	}

--- a/staging/src/k8s.io/client-go/applyconfigurations/networking/v1alpha1/ipaddress.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/networking/v1alpha1/ipaddress.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	networkingv1alpha1 "k8s.io/api/networking/v1alpha1"
+	v1alpha1 "k8s.io/api/networking/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -56,18 +56,18 @@ func IPAddress(name string) *IPAddressApplyConfiguration {
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractIPAddress(iPAddress *networkingv1alpha1.IPAddress, fieldManager string) (*IPAddressApplyConfiguration, error) {
+func ExtractIPAddress(iPAddress *v1alpha1.IPAddress, fieldManager string) (*IPAddressApplyConfiguration, error) {
 	return extractIPAddress(iPAddress, fieldManager, "")
 }
 
 // ExtractIPAddressStatus is the same as ExtractIPAddress except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractIPAddressStatus(iPAddress *networkingv1alpha1.IPAddress, fieldManager string) (*IPAddressApplyConfiguration, error) {
+func ExtractIPAddressStatus(iPAddress *v1alpha1.IPAddress, fieldManager string) (*IPAddressApplyConfiguration, error) {
 	return extractIPAddress(iPAddress, fieldManager, "status")
 }
 
-func extractIPAddress(iPAddress *networkingv1alpha1.IPAddress, fieldManager string, subresource string) (*IPAddressApplyConfiguration, error) {
+func extractIPAddress(iPAddress *v1alpha1.IPAddress, fieldManager string, subresource string) (*IPAddressApplyConfiguration, error) {
 	b := &IPAddressApplyConfiguration{}
 	err := managedfields.ExtractInto(iPAddress, internal.Parser().Type("io.k8s.api.networking.v1alpha1.IPAddress"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/networking/v1alpha1/servicecidr.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/networking/v1alpha1/servicecidr.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	networkingv1alpha1 "k8s.io/api/networking/v1alpha1"
+	v1alpha1 "k8s.io/api/networking/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -57,18 +57,18 @@ func ServiceCIDR(name string) *ServiceCIDRApplyConfiguration {
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractServiceCIDR(serviceCIDR *networkingv1alpha1.ServiceCIDR, fieldManager string) (*ServiceCIDRApplyConfiguration, error) {
+func ExtractServiceCIDR(serviceCIDR *v1alpha1.ServiceCIDR, fieldManager string) (*ServiceCIDRApplyConfiguration, error) {
 	return extractServiceCIDR(serviceCIDR, fieldManager, "")
 }
 
 // ExtractServiceCIDRStatus is the same as ExtractServiceCIDR except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractServiceCIDRStatus(serviceCIDR *networkingv1alpha1.ServiceCIDR, fieldManager string) (*ServiceCIDRApplyConfiguration, error) {
+func ExtractServiceCIDRStatus(serviceCIDR *v1alpha1.ServiceCIDR, fieldManager string) (*ServiceCIDRApplyConfiguration, error) {
 	return extractServiceCIDR(serviceCIDR, fieldManager, "status")
 }
 
-func extractServiceCIDR(serviceCIDR *networkingv1alpha1.ServiceCIDR, fieldManager string, subresource string) (*ServiceCIDRApplyConfiguration, error) {
+func extractServiceCIDR(serviceCIDR *v1alpha1.ServiceCIDR, fieldManager string, subresource string) (*ServiceCIDRApplyConfiguration, error) {
 	b := &ServiceCIDRApplyConfiguration{}
 	err := managedfields.ExtractInto(serviceCIDR, internal.Parser().Type("io.k8s.api.networking.v1alpha1.ServiceCIDR"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/networking/v1beta1/ingress.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/networking/v1beta1/ingress.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1beta1
 
 import (
-	networkingv1beta1 "k8s.io/api/networking/v1beta1"
+	v1beta1 "k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -58,18 +58,18 @@ func Ingress(name, namespace string) *IngressApplyConfiguration {
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractIngress(ingress *networkingv1beta1.Ingress, fieldManager string) (*IngressApplyConfiguration, error) {
+func ExtractIngress(ingress *v1beta1.Ingress, fieldManager string) (*IngressApplyConfiguration, error) {
 	return extractIngress(ingress, fieldManager, "")
 }
 
 // ExtractIngressStatus is the same as ExtractIngress except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractIngressStatus(ingress *networkingv1beta1.Ingress, fieldManager string) (*IngressApplyConfiguration, error) {
+func ExtractIngressStatus(ingress *v1beta1.Ingress, fieldManager string) (*IngressApplyConfiguration, error) {
 	return extractIngress(ingress, fieldManager, "status")
 }
 
-func extractIngress(ingress *networkingv1beta1.Ingress, fieldManager string, subresource string) (*IngressApplyConfiguration, error) {
+func extractIngress(ingress *v1beta1.Ingress, fieldManager string, subresource string) (*IngressApplyConfiguration, error) {
 	b := &IngressApplyConfiguration{}
 	err := managedfields.ExtractInto(ingress, internal.Parser().Type("io.k8s.api.networking.v1beta1.Ingress"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/networking/v1beta1/ingressclass.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/networking/v1beta1/ingressclass.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1beta1
 
 import (
-	networkingv1beta1 "k8s.io/api/networking/v1beta1"
+	v1beta1 "k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -56,18 +56,18 @@ func IngressClass(name string) *IngressClassApplyConfiguration {
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractIngressClass(ingressClass *networkingv1beta1.IngressClass, fieldManager string) (*IngressClassApplyConfiguration, error) {
+func ExtractIngressClass(ingressClass *v1beta1.IngressClass, fieldManager string) (*IngressClassApplyConfiguration, error) {
 	return extractIngressClass(ingressClass, fieldManager, "")
 }
 
 // ExtractIngressClassStatus is the same as ExtractIngressClass except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractIngressClassStatus(ingressClass *networkingv1beta1.IngressClass, fieldManager string) (*IngressClassApplyConfiguration, error) {
+func ExtractIngressClassStatus(ingressClass *v1beta1.IngressClass, fieldManager string) (*IngressClassApplyConfiguration, error) {
 	return extractIngressClass(ingressClass, fieldManager, "status")
 }
 
-func extractIngressClass(ingressClass *networkingv1beta1.IngressClass, fieldManager string, subresource string) (*IngressClassApplyConfiguration, error) {
+func extractIngressClass(ingressClass *v1beta1.IngressClass, fieldManager string, subresource string) (*IngressClassApplyConfiguration, error) {
 	b := &IngressClassApplyConfiguration{}
 	err := managedfields.ExtractInto(ingressClass, internal.Parser().Type("io.k8s.api.networking.v1beta1.IngressClass"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/node/v1/runtimeclass.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/node/v1/runtimeclass.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1
 
 import (
-	apinodev1 "k8s.io/api/node/v1"
+	nodev1 "k8s.io/api/node/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -58,18 +58,18 @@ func RuntimeClass(name string) *RuntimeClassApplyConfiguration {
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractRuntimeClass(runtimeClass *apinodev1.RuntimeClass, fieldManager string) (*RuntimeClassApplyConfiguration, error) {
+func ExtractRuntimeClass(runtimeClass *nodev1.RuntimeClass, fieldManager string) (*RuntimeClassApplyConfiguration, error) {
 	return extractRuntimeClass(runtimeClass, fieldManager, "")
 }
 
 // ExtractRuntimeClassStatus is the same as ExtractRuntimeClass except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractRuntimeClassStatus(runtimeClass *apinodev1.RuntimeClass, fieldManager string) (*RuntimeClassApplyConfiguration, error) {
+func ExtractRuntimeClassStatus(runtimeClass *nodev1.RuntimeClass, fieldManager string) (*RuntimeClassApplyConfiguration, error) {
 	return extractRuntimeClass(runtimeClass, fieldManager, "status")
 }
 
-func extractRuntimeClass(runtimeClass *apinodev1.RuntimeClass, fieldManager string, subresource string) (*RuntimeClassApplyConfiguration, error) {
+func extractRuntimeClass(runtimeClass *nodev1.RuntimeClass, fieldManager string, subresource string) (*RuntimeClassApplyConfiguration, error) {
 	b := &RuntimeClassApplyConfiguration{}
 	err := managedfields.ExtractInto(runtimeClass, internal.Parser().Type("io.k8s.api.node.v1.RuntimeClass"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/node/v1alpha1/runtimeclass.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/node/v1alpha1/runtimeclass.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	nodev1alpha1 "k8s.io/api/node/v1alpha1"
+	v1alpha1 "k8s.io/api/node/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -56,18 +56,18 @@ func RuntimeClass(name string) *RuntimeClassApplyConfiguration {
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractRuntimeClass(runtimeClass *nodev1alpha1.RuntimeClass, fieldManager string) (*RuntimeClassApplyConfiguration, error) {
+func ExtractRuntimeClass(runtimeClass *v1alpha1.RuntimeClass, fieldManager string) (*RuntimeClassApplyConfiguration, error) {
 	return extractRuntimeClass(runtimeClass, fieldManager, "")
 }
 
 // ExtractRuntimeClassStatus is the same as ExtractRuntimeClass except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractRuntimeClassStatus(runtimeClass *nodev1alpha1.RuntimeClass, fieldManager string) (*RuntimeClassApplyConfiguration, error) {
+func ExtractRuntimeClassStatus(runtimeClass *v1alpha1.RuntimeClass, fieldManager string) (*RuntimeClassApplyConfiguration, error) {
 	return extractRuntimeClass(runtimeClass, fieldManager, "status")
 }
 
-func extractRuntimeClass(runtimeClass *nodev1alpha1.RuntimeClass, fieldManager string, subresource string) (*RuntimeClassApplyConfiguration, error) {
+func extractRuntimeClass(runtimeClass *v1alpha1.RuntimeClass, fieldManager string, subresource string) (*RuntimeClassApplyConfiguration, error) {
 	b := &RuntimeClassApplyConfiguration{}
 	err := managedfields.ExtractInto(runtimeClass, internal.Parser().Type("io.k8s.api.node.v1alpha1.RuntimeClass"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/node/v1beta1/runtimeclass.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/node/v1beta1/runtimeclass.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1beta1
 
 import (
-	nodev1beta1 "k8s.io/api/node/v1beta1"
+	v1beta1 "k8s.io/api/node/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -58,18 +58,18 @@ func RuntimeClass(name string) *RuntimeClassApplyConfiguration {
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractRuntimeClass(runtimeClass *nodev1beta1.RuntimeClass, fieldManager string) (*RuntimeClassApplyConfiguration, error) {
+func ExtractRuntimeClass(runtimeClass *v1beta1.RuntimeClass, fieldManager string) (*RuntimeClassApplyConfiguration, error) {
 	return extractRuntimeClass(runtimeClass, fieldManager, "")
 }
 
 // ExtractRuntimeClassStatus is the same as ExtractRuntimeClass except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractRuntimeClassStatus(runtimeClass *nodev1beta1.RuntimeClass, fieldManager string) (*RuntimeClassApplyConfiguration, error) {
+func ExtractRuntimeClassStatus(runtimeClass *v1beta1.RuntimeClass, fieldManager string) (*RuntimeClassApplyConfiguration, error) {
 	return extractRuntimeClass(runtimeClass, fieldManager, "status")
 }
 
-func extractRuntimeClass(runtimeClass *nodev1beta1.RuntimeClass, fieldManager string, subresource string) (*RuntimeClassApplyConfiguration, error) {
+func extractRuntimeClass(runtimeClass *v1beta1.RuntimeClass, fieldManager string, subresource string) (*RuntimeClassApplyConfiguration, error) {
 	b := &RuntimeClassApplyConfiguration{}
 	err := managedfields.ExtractInto(runtimeClass, internal.Parser().Type("io.k8s.api.node.v1beta1.RuntimeClass"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/policy/v1/poddisruptionbudget.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/policy/v1/poddisruptionbudget.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1
 
 import (
-	apipolicyv1 "k8s.io/api/policy/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -58,18 +58,18 @@ func PodDisruptionBudget(name, namespace string) *PodDisruptionBudgetApplyConfig
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractPodDisruptionBudget(podDisruptionBudget *apipolicyv1.PodDisruptionBudget, fieldManager string) (*PodDisruptionBudgetApplyConfiguration, error) {
+func ExtractPodDisruptionBudget(podDisruptionBudget *policyv1.PodDisruptionBudget, fieldManager string) (*PodDisruptionBudgetApplyConfiguration, error) {
 	return extractPodDisruptionBudget(podDisruptionBudget, fieldManager, "")
 }
 
 // ExtractPodDisruptionBudgetStatus is the same as ExtractPodDisruptionBudget except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractPodDisruptionBudgetStatus(podDisruptionBudget *apipolicyv1.PodDisruptionBudget, fieldManager string) (*PodDisruptionBudgetApplyConfiguration, error) {
+func ExtractPodDisruptionBudgetStatus(podDisruptionBudget *policyv1.PodDisruptionBudget, fieldManager string) (*PodDisruptionBudgetApplyConfiguration, error) {
 	return extractPodDisruptionBudget(podDisruptionBudget, fieldManager, "status")
 }
 
-func extractPodDisruptionBudget(podDisruptionBudget *apipolicyv1.PodDisruptionBudget, fieldManager string, subresource string) (*PodDisruptionBudgetApplyConfiguration, error) {
+func extractPodDisruptionBudget(podDisruptionBudget *policyv1.PodDisruptionBudget, fieldManager string, subresource string) (*PodDisruptionBudgetApplyConfiguration, error) {
 	b := &PodDisruptionBudgetApplyConfiguration{}
 	err := managedfields.ExtractInto(podDisruptionBudget, internal.Parser().Type("io.k8s.api.policy.v1.PodDisruptionBudget"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/policy/v1beta1/poddisruptionbudget.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/policy/v1beta1/poddisruptionbudget.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1beta1
 
 import (
-	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	v1beta1 "k8s.io/api/policy/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -58,18 +58,18 @@ func PodDisruptionBudget(name, namespace string) *PodDisruptionBudgetApplyConfig
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractPodDisruptionBudget(podDisruptionBudget *policyv1beta1.PodDisruptionBudget, fieldManager string) (*PodDisruptionBudgetApplyConfiguration, error) {
+func ExtractPodDisruptionBudget(podDisruptionBudget *v1beta1.PodDisruptionBudget, fieldManager string) (*PodDisruptionBudgetApplyConfiguration, error) {
 	return extractPodDisruptionBudget(podDisruptionBudget, fieldManager, "")
 }
 
 // ExtractPodDisruptionBudgetStatus is the same as ExtractPodDisruptionBudget except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractPodDisruptionBudgetStatus(podDisruptionBudget *policyv1beta1.PodDisruptionBudget, fieldManager string) (*PodDisruptionBudgetApplyConfiguration, error) {
+func ExtractPodDisruptionBudgetStatus(podDisruptionBudget *v1beta1.PodDisruptionBudget, fieldManager string) (*PodDisruptionBudgetApplyConfiguration, error) {
 	return extractPodDisruptionBudget(podDisruptionBudget, fieldManager, "status")
 }
 
-func extractPodDisruptionBudget(podDisruptionBudget *policyv1beta1.PodDisruptionBudget, fieldManager string, subresource string) (*PodDisruptionBudgetApplyConfiguration, error) {
+func extractPodDisruptionBudget(podDisruptionBudget *v1beta1.PodDisruptionBudget, fieldManager string, subresource string) (*PodDisruptionBudgetApplyConfiguration, error) {
 	b := &PodDisruptionBudgetApplyConfiguration{}
 	err := managedfields.ExtractInto(podDisruptionBudget, internal.Parser().Type("io.k8s.api.policy.v1beta1.PodDisruptionBudget"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1/clusterrole.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1/clusterrole.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1
 
 import (
-	apirbacv1 "k8s.io/api/rbac/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -57,18 +57,18 @@ func ClusterRole(name string) *ClusterRoleApplyConfiguration {
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractClusterRole(clusterRole *apirbacv1.ClusterRole, fieldManager string) (*ClusterRoleApplyConfiguration, error) {
+func ExtractClusterRole(clusterRole *rbacv1.ClusterRole, fieldManager string) (*ClusterRoleApplyConfiguration, error) {
 	return extractClusterRole(clusterRole, fieldManager, "")
 }
 
 // ExtractClusterRoleStatus is the same as ExtractClusterRole except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractClusterRoleStatus(clusterRole *apirbacv1.ClusterRole, fieldManager string) (*ClusterRoleApplyConfiguration, error) {
+func ExtractClusterRoleStatus(clusterRole *rbacv1.ClusterRole, fieldManager string) (*ClusterRoleApplyConfiguration, error) {
 	return extractClusterRole(clusterRole, fieldManager, "status")
 }
 
-func extractClusterRole(clusterRole *apirbacv1.ClusterRole, fieldManager string, subresource string) (*ClusterRoleApplyConfiguration, error) {
+func extractClusterRole(clusterRole *rbacv1.ClusterRole, fieldManager string, subresource string) (*ClusterRoleApplyConfiguration, error) {
 	b := &ClusterRoleApplyConfiguration{}
 	err := managedfields.ExtractInto(clusterRole, internal.Parser().Type("io.k8s.api.rbac.v1.ClusterRole"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1/clusterrolebinding.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1/clusterrolebinding.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1
 
 import (
-	apirbacv1 "k8s.io/api/rbac/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -57,18 +57,18 @@ func ClusterRoleBinding(name string) *ClusterRoleBindingApplyConfiguration {
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractClusterRoleBinding(clusterRoleBinding *apirbacv1.ClusterRoleBinding, fieldManager string) (*ClusterRoleBindingApplyConfiguration, error) {
+func ExtractClusterRoleBinding(clusterRoleBinding *rbacv1.ClusterRoleBinding, fieldManager string) (*ClusterRoleBindingApplyConfiguration, error) {
 	return extractClusterRoleBinding(clusterRoleBinding, fieldManager, "")
 }
 
 // ExtractClusterRoleBindingStatus is the same as ExtractClusterRoleBinding except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractClusterRoleBindingStatus(clusterRoleBinding *apirbacv1.ClusterRoleBinding, fieldManager string) (*ClusterRoleBindingApplyConfiguration, error) {
+func ExtractClusterRoleBindingStatus(clusterRoleBinding *rbacv1.ClusterRoleBinding, fieldManager string) (*ClusterRoleBindingApplyConfiguration, error) {
 	return extractClusterRoleBinding(clusterRoleBinding, fieldManager, "status")
 }
 
-func extractClusterRoleBinding(clusterRoleBinding *apirbacv1.ClusterRoleBinding, fieldManager string, subresource string) (*ClusterRoleBindingApplyConfiguration, error) {
+func extractClusterRoleBinding(clusterRoleBinding *rbacv1.ClusterRoleBinding, fieldManager string, subresource string) (*ClusterRoleBindingApplyConfiguration, error) {
 	b := &ClusterRoleBindingApplyConfiguration{}
 	err := managedfields.ExtractInto(clusterRoleBinding, internal.Parser().Type("io.k8s.api.rbac.v1.ClusterRoleBinding"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1/role.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1/role.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1
 
 import (
-	apirbacv1 "k8s.io/api/rbac/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -57,18 +57,18 @@ func Role(name, namespace string) *RoleApplyConfiguration {
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractRole(role *apirbacv1.Role, fieldManager string) (*RoleApplyConfiguration, error) {
+func ExtractRole(role *rbacv1.Role, fieldManager string) (*RoleApplyConfiguration, error) {
 	return extractRole(role, fieldManager, "")
 }
 
 // ExtractRoleStatus is the same as ExtractRole except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractRoleStatus(role *apirbacv1.Role, fieldManager string) (*RoleApplyConfiguration, error) {
+func ExtractRoleStatus(role *rbacv1.Role, fieldManager string) (*RoleApplyConfiguration, error) {
 	return extractRole(role, fieldManager, "status")
 }
 
-func extractRole(role *apirbacv1.Role, fieldManager string, subresource string) (*RoleApplyConfiguration, error) {
+func extractRole(role *rbacv1.Role, fieldManager string, subresource string) (*RoleApplyConfiguration, error) {
 	b := &RoleApplyConfiguration{}
 	err := managedfields.ExtractInto(role, internal.Parser().Type("io.k8s.api.rbac.v1.Role"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1/rolebinding.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1/rolebinding.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1
 
 import (
-	apirbacv1 "k8s.io/api/rbac/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -58,18 +58,18 @@ func RoleBinding(name, namespace string) *RoleBindingApplyConfiguration {
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractRoleBinding(roleBinding *apirbacv1.RoleBinding, fieldManager string) (*RoleBindingApplyConfiguration, error) {
+func ExtractRoleBinding(roleBinding *rbacv1.RoleBinding, fieldManager string) (*RoleBindingApplyConfiguration, error) {
 	return extractRoleBinding(roleBinding, fieldManager, "")
 }
 
 // ExtractRoleBindingStatus is the same as ExtractRoleBinding except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractRoleBindingStatus(roleBinding *apirbacv1.RoleBinding, fieldManager string) (*RoleBindingApplyConfiguration, error) {
+func ExtractRoleBindingStatus(roleBinding *rbacv1.RoleBinding, fieldManager string) (*RoleBindingApplyConfiguration, error) {
 	return extractRoleBinding(roleBinding, fieldManager, "status")
 }
 
-func extractRoleBinding(roleBinding *apirbacv1.RoleBinding, fieldManager string, subresource string) (*RoleBindingApplyConfiguration, error) {
+func extractRoleBinding(roleBinding *rbacv1.RoleBinding, fieldManager string, subresource string) (*RoleBindingApplyConfiguration, error) {
 	b := &RoleBindingApplyConfiguration{}
 	err := managedfields.ExtractInto(roleBinding, internal.Parser().Type("io.k8s.api.rbac.v1.RoleBinding"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1alpha1/clusterrole.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1alpha1/clusterrole.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	rbacv1alpha1 "k8s.io/api/rbac/v1alpha1"
+	v1alpha1 "k8s.io/api/rbac/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -57,18 +57,18 @@ func ClusterRole(name string) *ClusterRoleApplyConfiguration {
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractClusterRole(clusterRole *rbacv1alpha1.ClusterRole, fieldManager string) (*ClusterRoleApplyConfiguration, error) {
+func ExtractClusterRole(clusterRole *v1alpha1.ClusterRole, fieldManager string) (*ClusterRoleApplyConfiguration, error) {
 	return extractClusterRole(clusterRole, fieldManager, "")
 }
 
 // ExtractClusterRoleStatus is the same as ExtractClusterRole except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractClusterRoleStatus(clusterRole *rbacv1alpha1.ClusterRole, fieldManager string) (*ClusterRoleApplyConfiguration, error) {
+func ExtractClusterRoleStatus(clusterRole *v1alpha1.ClusterRole, fieldManager string) (*ClusterRoleApplyConfiguration, error) {
 	return extractClusterRole(clusterRole, fieldManager, "status")
 }
 
-func extractClusterRole(clusterRole *rbacv1alpha1.ClusterRole, fieldManager string, subresource string) (*ClusterRoleApplyConfiguration, error) {
+func extractClusterRole(clusterRole *v1alpha1.ClusterRole, fieldManager string, subresource string) (*ClusterRoleApplyConfiguration, error) {
 	b := &ClusterRoleApplyConfiguration{}
 	err := managedfields.ExtractInto(clusterRole, internal.Parser().Type("io.k8s.api.rbac.v1alpha1.ClusterRole"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1alpha1/clusterrolebinding.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1alpha1/clusterrolebinding.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	rbacv1alpha1 "k8s.io/api/rbac/v1alpha1"
+	v1alpha1 "k8s.io/api/rbac/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -57,18 +57,18 @@ func ClusterRoleBinding(name string) *ClusterRoleBindingApplyConfiguration {
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractClusterRoleBinding(clusterRoleBinding *rbacv1alpha1.ClusterRoleBinding, fieldManager string) (*ClusterRoleBindingApplyConfiguration, error) {
+func ExtractClusterRoleBinding(clusterRoleBinding *v1alpha1.ClusterRoleBinding, fieldManager string) (*ClusterRoleBindingApplyConfiguration, error) {
 	return extractClusterRoleBinding(clusterRoleBinding, fieldManager, "")
 }
 
 // ExtractClusterRoleBindingStatus is the same as ExtractClusterRoleBinding except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractClusterRoleBindingStatus(clusterRoleBinding *rbacv1alpha1.ClusterRoleBinding, fieldManager string) (*ClusterRoleBindingApplyConfiguration, error) {
+func ExtractClusterRoleBindingStatus(clusterRoleBinding *v1alpha1.ClusterRoleBinding, fieldManager string) (*ClusterRoleBindingApplyConfiguration, error) {
 	return extractClusterRoleBinding(clusterRoleBinding, fieldManager, "status")
 }
 
-func extractClusterRoleBinding(clusterRoleBinding *rbacv1alpha1.ClusterRoleBinding, fieldManager string, subresource string) (*ClusterRoleBindingApplyConfiguration, error) {
+func extractClusterRoleBinding(clusterRoleBinding *v1alpha1.ClusterRoleBinding, fieldManager string, subresource string) (*ClusterRoleBindingApplyConfiguration, error) {
 	b := &ClusterRoleBindingApplyConfiguration{}
 	err := managedfields.ExtractInto(clusterRoleBinding, internal.Parser().Type("io.k8s.api.rbac.v1alpha1.ClusterRoleBinding"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1alpha1/role.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1alpha1/role.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	rbacv1alpha1 "k8s.io/api/rbac/v1alpha1"
+	v1alpha1 "k8s.io/api/rbac/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -57,18 +57,18 @@ func Role(name, namespace string) *RoleApplyConfiguration {
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractRole(role *rbacv1alpha1.Role, fieldManager string) (*RoleApplyConfiguration, error) {
+func ExtractRole(role *v1alpha1.Role, fieldManager string) (*RoleApplyConfiguration, error) {
 	return extractRole(role, fieldManager, "")
 }
 
 // ExtractRoleStatus is the same as ExtractRole except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractRoleStatus(role *rbacv1alpha1.Role, fieldManager string) (*RoleApplyConfiguration, error) {
+func ExtractRoleStatus(role *v1alpha1.Role, fieldManager string) (*RoleApplyConfiguration, error) {
 	return extractRole(role, fieldManager, "status")
 }
 
-func extractRole(role *rbacv1alpha1.Role, fieldManager string, subresource string) (*RoleApplyConfiguration, error) {
+func extractRole(role *v1alpha1.Role, fieldManager string, subresource string) (*RoleApplyConfiguration, error) {
 	b := &RoleApplyConfiguration{}
 	err := managedfields.ExtractInto(role, internal.Parser().Type("io.k8s.api.rbac.v1alpha1.Role"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1alpha1/rolebinding.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1alpha1/rolebinding.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	rbacv1alpha1 "k8s.io/api/rbac/v1alpha1"
+	v1alpha1 "k8s.io/api/rbac/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -58,18 +58,18 @@ func RoleBinding(name, namespace string) *RoleBindingApplyConfiguration {
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractRoleBinding(roleBinding *rbacv1alpha1.RoleBinding, fieldManager string) (*RoleBindingApplyConfiguration, error) {
+func ExtractRoleBinding(roleBinding *v1alpha1.RoleBinding, fieldManager string) (*RoleBindingApplyConfiguration, error) {
 	return extractRoleBinding(roleBinding, fieldManager, "")
 }
 
 // ExtractRoleBindingStatus is the same as ExtractRoleBinding except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractRoleBindingStatus(roleBinding *rbacv1alpha1.RoleBinding, fieldManager string) (*RoleBindingApplyConfiguration, error) {
+func ExtractRoleBindingStatus(roleBinding *v1alpha1.RoleBinding, fieldManager string) (*RoleBindingApplyConfiguration, error) {
 	return extractRoleBinding(roleBinding, fieldManager, "status")
 }
 
-func extractRoleBinding(roleBinding *rbacv1alpha1.RoleBinding, fieldManager string, subresource string) (*RoleBindingApplyConfiguration, error) {
+func extractRoleBinding(roleBinding *v1alpha1.RoleBinding, fieldManager string, subresource string) (*RoleBindingApplyConfiguration, error) {
 	b := &RoleBindingApplyConfiguration{}
 	err := managedfields.ExtractInto(roleBinding, internal.Parser().Type("io.k8s.api.rbac.v1alpha1.RoleBinding"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1beta1/clusterrole.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1beta1/clusterrole.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1beta1
 
 import (
-	rbacv1beta1 "k8s.io/api/rbac/v1beta1"
+	v1beta1 "k8s.io/api/rbac/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -57,18 +57,18 @@ func ClusterRole(name string) *ClusterRoleApplyConfiguration {
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractClusterRole(clusterRole *rbacv1beta1.ClusterRole, fieldManager string) (*ClusterRoleApplyConfiguration, error) {
+func ExtractClusterRole(clusterRole *v1beta1.ClusterRole, fieldManager string) (*ClusterRoleApplyConfiguration, error) {
 	return extractClusterRole(clusterRole, fieldManager, "")
 }
 
 // ExtractClusterRoleStatus is the same as ExtractClusterRole except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractClusterRoleStatus(clusterRole *rbacv1beta1.ClusterRole, fieldManager string) (*ClusterRoleApplyConfiguration, error) {
+func ExtractClusterRoleStatus(clusterRole *v1beta1.ClusterRole, fieldManager string) (*ClusterRoleApplyConfiguration, error) {
 	return extractClusterRole(clusterRole, fieldManager, "status")
 }
 
-func extractClusterRole(clusterRole *rbacv1beta1.ClusterRole, fieldManager string, subresource string) (*ClusterRoleApplyConfiguration, error) {
+func extractClusterRole(clusterRole *v1beta1.ClusterRole, fieldManager string, subresource string) (*ClusterRoleApplyConfiguration, error) {
 	b := &ClusterRoleApplyConfiguration{}
 	err := managedfields.ExtractInto(clusterRole, internal.Parser().Type("io.k8s.api.rbac.v1beta1.ClusterRole"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1beta1/clusterrolebinding.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1beta1/clusterrolebinding.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1beta1
 
 import (
-	rbacv1beta1 "k8s.io/api/rbac/v1beta1"
+	v1beta1 "k8s.io/api/rbac/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -57,18 +57,18 @@ func ClusterRoleBinding(name string) *ClusterRoleBindingApplyConfiguration {
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractClusterRoleBinding(clusterRoleBinding *rbacv1beta1.ClusterRoleBinding, fieldManager string) (*ClusterRoleBindingApplyConfiguration, error) {
+func ExtractClusterRoleBinding(clusterRoleBinding *v1beta1.ClusterRoleBinding, fieldManager string) (*ClusterRoleBindingApplyConfiguration, error) {
 	return extractClusterRoleBinding(clusterRoleBinding, fieldManager, "")
 }
 
 // ExtractClusterRoleBindingStatus is the same as ExtractClusterRoleBinding except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractClusterRoleBindingStatus(clusterRoleBinding *rbacv1beta1.ClusterRoleBinding, fieldManager string) (*ClusterRoleBindingApplyConfiguration, error) {
+func ExtractClusterRoleBindingStatus(clusterRoleBinding *v1beta1.ClusterRoleBinding, fieldManager string) (*ClusterRoleBindingApplyConfiguration, error) {
 	return extractClusterRoleBinding(clusterRoleBinding, fieldManager, "status")
 }
 
-func extractClusterRoleBinding(clusterRoleBinding *rbacv1beta1.ClusterRoleBinding, fieldManager string, subresource string) (*ClusterRoleBindingApplyConfiguration, error) {
+func extractClusterRoleBinding(clusterRoleBinding *v1beta1.ClusterRoleBinding, fieldManager string, subresource string) (*ClusterRoleBindingApplyConfiguration, error) {
 	b := &ClusterRoleBindingApplyConfiguration{}
 	err := managedfields.ExtractInto(clusterRoleBinding, internal.Parser().Type("io.k8s.api.rbac.v1beta1.ClusterRoleBinding"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1beta1/role.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1beta1/role.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1beta1
 
 import (
-	rbacv1beta1 "k8s.io/api/rbac/v1beta1"
+	v1beta1 "k8s.io/api/rbac/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -57,18 +57,18 @@ func Role(name, namespace string) *RoleApplyConfiguration {
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractRole(role *rbacv1beta1.Role, fieldManager string) (*RoleApplyConfiguration, error) {
+func ExtractRole(role *v1beta1.Role, fieldManager string) (*RoleApplyConfiguration, error) {
 	return extractRole(role, fieldManager, "")
 }
 
 // ExtractRoleStatus is the same as ExtractRole except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractRoleStatus(role *rbacv1beta1.Role, fieldManager string) (*RoleApplyConfiguration, error) {
+func ExtractRoleStatus(role *v1beta1.Role, fieldManager string) (*RoleApplyConfiguration, error) {
 	return extractRole(role, fieldManager, "status")
 }
 
-func extractRole(role *rbacv1beta1.Role, fieldManager string, subresource string) (*RoleApplyConfiguration, error) {
+func extractRole(role *v1beta1.Role, fieldManager string, subresource string) (*RoleApplyConfiguration, error) {
 	b := &RoleApplyConfiguration{}
 	err := managedfields.ExtractInto(role, internal.Parser().Type("io.k8s.api.rbac.v1beta1.Role"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1beta1/rolebinding.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/rbac/v1beta1/rolebinding.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1beta1
 
 import (
-	rbacv1beta1 "k8s.io/api/rbac/v1beta1"
+	v1beta1 "k8s.io/api/rbac/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -58,18 +58,18 @@ func RoleBinding(name, namespace string) *RoleBindingApplyConfiguration {
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractRoleBinding(roleBinding *rbacv1beta1.RoleBinding, fieldManager string) (*RoleBindingApplyConfiguration, error) {
+func ExtractRoleBinding(roleBinding *v1beta1.RoleBinding, fieldManager string) (*RoleBindingApplyConfiguration, error) {
 	return extractRoleBinding(roleBinding, fieldManager, "")
 }
 
 // ExtractRoleBindingStatus is the same as ExtractRoleBinding except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractRoleBindingStatus(roleBinding *rbacv1beta1.RoleBinding, fieldManager string) (*RoleBindingApplyConfiguration, error) {
+func ExtractRoleBindingStatus(roleBinding *v1beta1.RoleBinding, fieldManager string) (*RoleBindingApplyConfiguration, error) {
 	return extractRoleBinding(roleBinding, fieldManager, "status")
 }
 
-func extractRoleBinding(roleBinding *rbacv1beta1.RoleBinding, fieldManager string, subresource string) (*RoleBindingApplyConfiguration, error) {
+func extractRoleBinding(roleBinding *v1beta1.RoleBinding, fieldManager string, subresource string) (*RoleBindingApplyConfiguration, error) {
 	b := &RoleBindingApplyConfiguration{}
 	err := managedfields.ExtractInto(roleBinding, internal.Parser().Type("io.k8s.api.rbac.v1beta1.RoleBinding"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1alpha2/podschedulingcontext.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1alpha2/podschedulingcontext.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1alpha2
 
 import (
-	resourcev1alpha2 "k8s.io/api/resource/v1alpha2"
+	v1alpha2 "k8s.io/api/resource/v1alpha2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -58,18 +58,18 @@ func PodSchedulingContext(name, namespace string) *PodSchedulingContextApplyConf
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractPodSchedulingContext(podSchedulingContext *resourcev1alpha2.PodSchedulingContext, fieldManager string) (*PodSchedulingContextApplyConfiguration, error) {
+func ExtractPodSchedulingContext(podSchedulingContext *v1alpha2.PodSchedulingContext, fieldManager string) (*PodSchedulingContextApplyConfiguration, error) {
 	return extractPodSchedulingContext(podSchedulingContext, fieldManager, "")
 }
 
 // ExtractPodSchedulingContextStatus is the same as ExtractPodSchedulingContext except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractPodSchedulingContextStatus(podSchedulingContext *resourcev1alpha2.PodSchedulingContext, fieldManager string) (*PodSchedulingContextApplyConfiguration, error) {
+func ExtractPodSchedulingContextStatus(podSchedulingContext *v1alpha2.PodSchedulingContext, fieldManager string) (*PodSchedulingContextApplyConfiguration, error) {
 	return extractPodSchedulingContext(podSchedulingContext, fieldManager, "status")
 }
 
-func extractPodSchedulingContext(podSchedulingContext *resourcev1alpha2.PodSchedulingContext, fieldManager string, subresource string) (*PodSchedulingContextApplyConfiguration, error) {
+func extractPodSchedulingContext(podSchedulingContext *v1alpha2.PodSchedulingContext, fieldManager string, subresource string) (*PodSchedulingContextApplyConfiguration, error) {
 	b := &PodSchedulingContextApplyConfiguration{}
 	err := managedfields.ExtractInto(podSchedulingContext, internal.Parser().Type("io.k8s.api.resource.v1alpha2.PodSchedulingContext"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1alpha2/resourceclaim.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1alpha2/resourceclaim.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1alpha2
 
 import (
-	resourcev1alpha2 "k8s.io/api/resource/v1alpha2"
+	v1alpha2 "k8s.io/api/resource/v1alpha2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -58,18 +58,18 @@ func ResourceClaim(name, namespace string) *ResourceClaimApplyConfiguration {
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractResourceClaim(resourceClaim *resourcev1alpha2.ResourceClaim, fieldManager string) (*ResourceClaimApplyConfiguration, error) {
+func ExtractResourceClaim(resourceClaim *v1alpha2.ResourceClaim, fieldManager string) (*ResourceClaimApplyConfiguration, error) {
 	return extractResourceClaim(resourceClaim, fieldManager, "")
 }
 
 // ExtractResourceClaimStatus is the same as ExtractResourceClaim except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractResourceClaimStatus(resourceClaim *resourcev1alpha2.ResourceClaim, fieldManager string) (*ResourceClaimApplyConfiguration, error) {
+func ExtractResourceClaimStatus(resourceClaim *v1alpha2.ResourceClaim, fieldManager string) (*ResourceClaimApplyConfiguration, error) {
 	return extractResourceClaim(resourceClaim, fieldManager, "status")
 }
 
-func extractResourceClaim(resourceClaim *resourcev1alpha2.ResourceClaim, fieldManager string, subresource string) (*ResourceClaimApplyConfiguration, error) {
+func extractResourceClaim(resourceClaim *v1alpha2.ResourceClaim, fieldManager string, subresource string) (*ResourceClaimApplyConfiguration, error) {
 	b := &ResourceClaimApplyConfiguration{}
 	err := managedfields.ExtractInto(resourceClaim, internal.Parser().Type("io.k8s.api.resource.v1alpha2.ResourceClaim"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1alpha2/resourceclaimparameters.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1alpha2/resourceclaimparameters.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1alpha2
 
 import (
-	resourcev1alpha2 "k8s.io/api/resource/v1alpha2"
+	v1alpha2 "k8s.io/api/resource/v1alpha2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -59,18 +59,18 @@ func ResourceClaimParameters(name, namespace string) *ResourceClaimParametersApp
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractResourceClaimParameters(resourceClaimParameters *resourcev1alpha2.ResourceClaimParameters, fieldManager string) (*ResourceClaimParametersApplyConfiguration, error) {
+func ExtractResourceClaimParameters(resourceClaimParameters *v1alpha2.ResourceClaimParameters, fieldManager string) (*ResourceClaimParametersApplyConfiguration, error) {
 	return extractResourceClaimParameters(resourceClaimParameters, fieldManager, "")
 }
 
 // ExtractResourceClaimParametersStatus is the same as ExtractResourceClaimParameters except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractResourceClaimParametersStatus(resourceClaimParameters *resourcev1alpha2.ResourceClaimParameters, fieldManager string) (*ResourceClaimParametersApplyConfiguration, error) {
+func ExtractResourceClaimParametersStatus(resourceClaimParameters *v1alpha2.ResourceClaimParameters, fieldManager string) (*ResourceClaimParametersApplyConfiguration, error) {
 	return extractResourceClaimParameters(resourceClaimParameters, fieldManager, "status")
 }
 
-func extractResourceClaimParameters(resourceClaimParameters *resourcev1alpha2.ResourceClaimParameters, fieldManager string, subresource string) (*ResourceClaimParametersApplyConfiguration, error) {
+func extractResourceClaimParameters(resourceClaimParameters *v1alpha2.ResourceClaimParameters, fieldManager string, subresource string) (*ResourceClaimParametersApplyConfiguration, error) {
 	b := &ResourceClaimParametersApplyConfiguration{}
 	err := managedfields.ExtractInto(resourceClaimParameters, internal.Parser().Type("io.k8s.api.resource.v1alpha2.ResourceClaimParameters"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1alpha2/resourceclaimspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1alpha2/resourceclaimspec.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1alpha2
 
 import (
-	resourcev1alpha2 "k8s.io/api/resource/v1alpha2"
+	v1alpha2 "k8s.io/api/resource/v1alpha2"
 )
 
 // ResourceClaimSpecApplyConfiguration represents an declarative configuration of the ResourceClaimSpec type for use
@@ -27,7 +27,7 @@ import (
 type ResourceClaimSpecApplyConfiguration struct {
 	ResourceClassName *string                                             `json:"resourceClassName,omitempty"`
 	ParametersRef     *ResourceClaimParametersReferenceApplyConfiguration `json:"parametersRef,omitempty"`
-	AllocationMode    *resourcev1alpha2.AllocationMode                    `json:"allocationMode,omitempty"`
+	AllocationMode    *v1alpha2.AllocationMode                            `json:"allocationMode,omitempty"`
 }
 
 // ResourceClaimSpecApplyConfiguration constructs an declarative configuration of the ResourceClaimSpec type for use with
@@ -55,7 +55,7 @@ func (b *ResourceClaimSpecApplyConfiguration) WithParametersRef(value *ResourceC
 // WithAllocationMode sets the AllocationMode field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the AllocationMode field is set to the value of the last call.
-func (b *ResourceClaimSpecApplyConfiguration) WithAllocationMode(value resourcev1alpha2.AllocationMode) *ResourceClaimSpecApplyConfiguration {
+func (b *ResourceClaimSpecApplyConfiguration) WithAllocationMode(value v1alpha2.AllocationMode) *ResourceClaimSpecApplyConfiguration {
 	b.AllocationMode = &value
 	return b
 }

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1alpha2/resourceclaimtemplate.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1alpha2/resourceclaimtemplate.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1alpha2
 
 import (
-	resourcev1alpha2 "k8s.io/api/resource/v1alpha2"
+	v1alpha2 "k8s.io/api/resource/v1alpha2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -57,18 +57,18 @@ func ResourceClaimTemplate(name, namespace string) *ResourceClaimTemplateApplyCo
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractResourceClaimTemplate(resourceClaimTemplate *resourcev1alpha2.ResourceClaimTemplate, fieldManager string) (*ResourceClaimTemplateApplyConfiguration, error) {
+func ExtractResourceClaimTemplate(resourceClaimTemplate *v1alpha2.ResourceClaimTemplate, fieldManager string) (*ResourceClaimTemplateApplyConfiguration, error) {
 	return extractResourceClaimTemplate(resourceClaimTemplate, fieldManager, "")
 }
 
 // ExtractResourceClaimTemplateStatus is the same as ExtractResourceClaimTemplate except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractResourceClaimTemplateStatus(resourceClaimTemplate *resourcev1alpha2.ResourceClaimTemplate, fieldManager string) (*ResourceClaimTemplateApplyConfiguration, error) {
+func ExtractResourceClaimTemplateStatus(resourceClaimTemplate *v1alpha2.ResourceClaimTemplate, fieldManager string) (*ResourceClaimTemplateApplyConfiguration, error) {
 	return extractResourceClaimTemplate(resourceClaimTemplate, fieldManager, "status")
 }
 
-func extractResourceClaimTemplate(resourceClaimTemplate *resourcev1alpha2.ResourceClaimTemplate, fieldManager string, subresource string) (*ResourceClaimTemplateApplyConfiguration, error) {
+func extractResourceClaimTemplate(resourceClaimTemplate *v1alpha2.ResourceClaimTemplate, fieldManager string, subresource string) (*ResourceClaimTemplateApplyConfiguration, error) {
 	b := &ResourceClaimTemplateApplyConfiguration{}
 	err := managedfields.ExtractInto(resourceClaimTemplate, internal.Parser().Type("io.k8s.api.resource.v1alpha2.ResourceClaimTemplate"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1alpha2/resourceclass.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1alpha2/resourceclass.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1alpha2
 
 import (
-	resourcev1alpha2 "k8s.io/api/resource/v1alpha2"
+	v1alpha2 "k8s.io/api/resource/v1alpha2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -60,18 +60,18 @@ func ResourceClass(name string) *ResourceClassApplyConfiguration {
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractResourceClass(resourceClass *resourcev1alpha2.ResourceClass, fieldManager string) (*ResourceClassApplyConfiguration, error) {
+func ExtractResourceClass(resourceClass *v1alpha2.ResourceClass, fieldManager string) (*ResourceClassApplyConfiguration, error) {
 	return extractResourceClass(resourceClass, fieldManager, "")
 }
 
 // ExtractResourceClassStatus is the same as ExtractResourceClass except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractResourceClassStatus(resourceClass *resourcev1alpha2.ResourceClass, fieldManager string) (*ResourceClassApplyConfiguration, error) {
+func ExtractResourceClassStatus(resourceClass *v1alpha2.ResourceClass, fieldManager string) (*ResourceClassApplyConfiguration, error) {
 	return extractResourceClass(resourceClass, fieldManager, "status")
 }
 
-func extractResourceClass(resourceClass *resourcev1alpha2.ResourceClass, fieldManager string, subresource string) (*ResourceClassApplyConfiguration, error) {
+func extractResourceClass(resourceClass *v1alpha2.ResourceClass, fieldManager string, subresource string) (*ResourceClassApplyConfiguration, error) {
 	b := &ResourceClassApplyConfiguration{}
 	err := managedfields.ExtractInto(resourceClass, internal.Parser().Type("io.k8s.api.resource.v1alpha2.ResourceClass"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1alpha2/resourceclassparameters.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1alpha2/resourceclassparameters.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1alpha2
 
 import (
-	resourcev1alpha2 "k8s.io/api/resource/v1alpha2"
+	v1alpha2 "k8s.io/api/resource/v1alpha2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -59,18 +59,18 @@ func ResourceClassParameters(name, namespace string) *ResourceClassParametersApp
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractResourceClassParameters(resourceClassParameters *resourcev1alpha2.ResourceClassParameters, fieldManager string) (*ResourceClassParametersApplyConfiguration, error) {
+func ExtractResourceClassParameters(resourceClassParameters *v1alpha2.ResourceClassParameters, fieldManager string) (*ResourceClassParametersApplyConfiguration, error) {
 	return extractResourceClassParameters(resourceClassParameters, fieldManager, "")
 }
 
 // ExtractResourceClassParametersStatus is the same as ExtractResourceClassParameters except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractResourceClassParametersStatus(resourceClassParameters *resourcev1alpha2.ResourceClassParameters, fieldManager string) (*ResourceClassParametersApplyConfiguration, error) {
+func ExtractResourceClassParametersStatus(resourceClassParameters *v1alpha2.ResourceClassParameters, fieldManager string) (*ResourceClassParametersApplyConfiguration, error) {
 	return extractResourceClassParameters(resourceClassParameters, fieldManager, "status")
 }
 
-func extractResourceClassParameters(resourceClassParameters *resourcev1alpha2.ResourceClassParameters, fieldManager string, subresource string) (*ResourceClassParametersApplyConfiguration, error) {
+func extractResourceClassParameters(resourceClassParameters *v1alpha2.ResourceClassParameters, fieldManager string, subresource string) (*ResourceClassParametersApplyConfiguration, error) {
 	b := &ResourceClassParametersApplyConfiguration{}
 	err := managedfields.ExtractInto(resourceClassParameters, internal.Parser().Type("io.k8s.api.resource.v1alpha2.ResourceClassParameters"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1alpha2/resourceslice.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1alpha2/resourceslice.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1alpha2
 
 import (
-	resourcev1alpha2 "k8s.io/api/resource/v1alpha2"
+	v1alpha2 "k8s.io/api/resource/v1alpha2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -58,18 +58,18 @@ func ResourceSlice(name string) *ResourceSliceApplyConfiguration {
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractResourceSlice(resourceSlice *resourcev1alpha2.ResourceSlice, fieldManager string) (*ResourceSliceApplyConfiguration, error) {
+func ExtractResourceSlice(resourceSlice *v1alpha2.ResourceSlice, fieldManager string) (*ResourceSliceApplyConfiguration, error) {
 	return extractResourceSlice(resourceSlice, fieldManager, "")
 }
 
 // ExtractResourceSliceStatus is the same as ExtractResourceSlice except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractResourceSliceStatus(resourceSlice *resourcev1alpha2.ResourceSlice, fieldManager string) (*ResourceSliceApplyConfiguration, error) {
+func ExtractResourceSliceStatus(resourceSlice *v1alpha2.ResourceSlice, fieldManager string) (*ResourceSliceApplyConfiguration, error) {
 	return extractResourceSlice(resourceSlice, fieldManager, "status")
 }
 
-func extractResourceSlice(resourceSlice *resourcev1alpha2.ResourceSlice, fieldManager string, subresource string) (*ResourceSliceApplyConfiguration, error) {
+func extractResourceSlice(resourceSlice *v1alpha2.ResourceSlice, fieldManager string, subresource string) (*ResourceSliceApplyConfiguration, error) {
 	b := &ResourceSliceApplyConfiguration{}
 	err := managedfields.ExtractInto(resourceSlice, internal.Parser().Type("io.k8s.api.resource.v1alpha2.ResourceSlice"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/storage/v1/csidriver.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storage/v1/csidriver.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1
 
 import (
-	apistoragev1 "k8s.io/api/storage/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -56,18 +56,18 @@ func CSIDriver(name string) *CSIDriverApplyConfiguration {
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractCSIDriver(cSIDriver *apistoragev1.CSIDriver, fieldManager string) (*CSIDriverApplyConfiguration, error) {
+func ExtractCSIDriver(cSIDriver *storagev1.CSIDriver, fieldManager string) (*CSIDriverApplyConfiguration, error) {
 	return extractCSIDriver(cSIDriver, fieldManager, "")
 }
 
 // ExtractCSIDriverStatus is the same as ExtractCSIDriver except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractCSIDriverStatus(cSIDriver *apistoragev1.CSIDriver, fieldManager string) (*CSIDriverApplyConfiguration, error) {
+func ExtractCSIDriverStatus(cSIDriver *storagev1.CSIDriver, fieldManager string) (*CSIDriverApplyConfiguration, error) {
 	return extractCSIDriver(cSIDriver, fieldManager, "status")
 }
 
-func extractCSIDriver(cSIDriver *apistoragev1.CSIDriver, fieldManager string, subresource string) (*CSIDriverApplyConfiguration, error) {
+func extractCSIDriver(cSIDriver *storagev1.CSIDriver, fieldManager string, subresource string) (*CSIDriverApplyConfiguration, error) {
 	b := &CSIDriverApplyConfiguration{}
 	err := managedfields.ExtractInto(cSIDriver, internal.Parser().Type("io.k8s.api.storage.v1.CSIDriver"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/storage/v1/csinode.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storage/v1/csinode.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1
 
 import (
-	apistoragev1 "k8s.io/api/storage/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -56,18 +56,18 @@ func CSINode(name string) *CSINodeApplyConfiguration {
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractCSINode(cSINode *apistoragev1.CSINode, fieldManager string) (*CSINodeApplyConfiguration, error) {
+func ExtractCSINode(cSINode *storagev1.CSINode, fieldManager string) (*CSINodeApplyConfiguration, error) {
 	return extractCSINode(cSINode, fieldManager, "")
 }
 
 // ExtractCSINodeStatus is the same as ExtractCSINode except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractCSINodeStatus(cSINode *apistoragev1.CSINode, fieldManager string) (*CSINodeApplyConfiguration, error) {
+func ExtractCSINodeStatus(cSINode *storagev1.CSINode, fieldManager string) (*CSINodeApplyConfiguration, error) {
 	return extractCSINode(cSINode, fieldManager, "status")
 }
 
-func extractCSINode(cSINode *apistoragev1.CSINode, fieldManager string, subresource string) (*CSINodeApplyConfiguration, error) {
+func extractCSINode(cSINode *storagev1.CSINode, fieldManager string, subresource string) (*CSINodeApplyConfiguration, error) {
 	b := &CSINodeApplyConfiguration{}
 	err := managedfields.ExtractInto(cSINode, internal.Parser().Type("io.k8s.api.storage.v1.CSINode"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/storage/v1/volumeattachment.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storage/v1/volumeattachment.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1
 
 import (
-	apistoragev1 "k8s.io/api/storage/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -57,18 +57,18 @@ func VolumeAttachment(name string) *VolumeAttachmentApplyConfiguration {
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractVolumeAttachment(volumeAttachment *apistoragev1.VolumeAttachment, fieldManager string) (*VolumeAttachmentApplyConfiguration, error) {
+func ExtractVolumeAttachment(volumeAttachment *storagev1.VolumeAttachment, fieldManager string) (*VolumeAttachmentApplyConfiguration, error) {
 	return extractVolumeAttachment(volumeAttachment, fieldManager, "")
 }
 
 // ExtractVolumeAttachmentStatus is the same as ExtractVolumeAttachment except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractVolumeAttachmentStatus(volumeAttachment *apistoragev1.VolumeAttachment, fieldManager string) (*VolumeAttachmentApplyConfiguration, error) {
+func ExtractVolumeAttachmentStatus(volumeAttachment *storagev1.VolumeAttachment, fieldManager string) (*VolumeAttachmentApplyConfiguration, error) {
 	return extractVolumeAttachment(volumeAttachment, fieldManager, "status")
 }
 
-func extractVolumeAttachment(volumeAttachment *apistoragev1.VolumeAttachment, fieldManager string, subresource string) (*VolumeAttachmentApplyConfiguration, error) {
+func extractVolumeAttachment(volumeAttachment *storagev1.VolumeAttachment, fieldManager string, subresource string) (*VolumeAttachmentApplyConfiguration, error) {
 	b := &VolumeAttachmentApplyConfiguration{}
 	err := managedfields.ExtractInto(volumeAttachment, internal.Parser().Type("io.k8s.api.storage.v1.VolumeAttachment"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/storage/v1alpha1/volumeattachment.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storage/v1alpha1/volumeattachment.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	storagev1alpha1 "k8s.io/api/storage/v1alpha1"
+	v1alpha1 "k8s.io/api/storage/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -57,18 +57,18 @@ func VolumeAttachment(name string) *VolumeAttachmentApplyConfiguration {
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractVolumeAttachment(volumeAttachment *storagev1alpha1.VolumeAttachment, fieldManager string) (*VolumeAttachmentApplyConfiguration, error) {
+func ExtractVolumeAttachment(volumeAttachment *v1alpha1.VolumeAttachment, fieldManager string) (*VolumeAttachmentApplyConfiguration, error) {
 	return extractVolumeAttachment(volumeAttachment, fieldManager, "")
 }
 
 // ExtractVolumeAttachmentStatus is the same as ExtractVolumeAttachment except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractVolumeAttachmentStatus(volumeAttachment *storagev1alpha1.VolumeAttachment, fieldManager string) (*VolumeAttachmentApplyConfiguration, error) {
+func ExtractVolumeAttachmentStatus(volumeAttachment *v1alpha1.VolumeAttachment, fieldManager string) (*VolumeAttachmentApplyConfiguration, error) {
 	return extractVolumeAttachment(volumeAttachment, fieldManager, "status")
 }
 
-func extractVolumeAttachment(volumeAttachment *storagev1alpha1.VolumeAttachment, fieldManager string, subresource string) (*VolumeAttachmentApplyConfiguration, error) {
+func extractVolumeAttachment(volumeAttachment *v1alpha1.VolumeAttachment, fieldManager string, subresource string) (*VolumeAttachmentApplyConfiguration, error) {
 	b := &VolumeAttachmentApplyConfiguration{}
 	err := managedfields.ExtractInto(volumeAttachment, internal.Parser().Type("io.k8s.api.storage.v1alpha1.VolumeAttachment"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/storage/v1beta1/csidriver.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storage/v1beta1/csidriver.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1beta1
 
 import (
-	storagev1beta1 "k8s.io/api/storage/v1beta1"
+	v1beta1 "k8s.io/api/storage/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -56,18 +56,18 @@ func CSIDriver(name string) *CSIDriverApplyConfiguration {
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractCSIDriver(cSIDriver *storagev1beta1.CSIDriver, fieldManager string) (*CSIDriverApplyConfiguration, error) {
+func ExtractCSIDriver(cSIDriver *v1beta1.CSIDriver, fieldManager string) (*CSIDriverApplyConfiguration, error) {
 	return extractCSIDriver(cSIDriver, fieldManager, "")
 }
 
 // ExtractCSIDriverStatus is the same as ExtractCSIDriver except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractCSIDriverStatus(cSIDriver *storagev1beta1.CSIDriver, fieldManager string) (*CSIDriverApplyConfiguration, error) {
+func ExtractCSIDriverStatus(cSIDriver *v1beta1.CSIDriver, fieldManager string) (*CSIDriverApplyConfiguration, error) {
 	return extractCSIDriver(cSIDriver, fieldManager, "status")
 }
 
-func extractCSIDriver(cSIDriver *storagev1beta1.CSIDriver, fieldManager string, subresource string) (*CSIDriverApplyConfiguration, error) {
+func extractCSIDriver(cSIDriver *v1beta1.CSIDriver, fieldManager string, subresource string) (*CSIDriverApplyConfiguration, error) {
 	b := &CSIDriverApplyConfiguration{}
 	err := managedfields.ExtractInto(cSIDriver, internal.Parser().Type("io.k8s.api.storage.v1beta1.CSIDriver"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/storage/v1beta1/csinode.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storage/v1beta1/csinode.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1beta1
 
 import (
-	storagev1beta1 "k8s.io/api/storage/v1beta1"
+	v1beta1 "k8s.io/api/storage/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -56,18 +56,18 @@ func CSINode(name string) *CSINodeApplyConfiguration {
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractCSINode(cSINode *storagev1beta1.CSINode, fieldManager string) (*CSINodeApplyConfiguration, error) {
+func ExtractCSINode(cSINode *v1beta1.CSINode, fieldManager string) (*CSINodeApplyConfiguration, error) {
 	return extractCSINode(cSINode, fieldManager, "")
 }
 
 // ExtractCSINodeStatus is the same as ExtractCSINode except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractCSINodeStatus(cSINode *storagev1beta1.CSINode, fieldManager string) (*CSINodeApplyConfiguration, error) {
+func ExtractCSINodeStatus(cSINode *v1beta1.CSINode, fieldManager string) (*CSINodeApplyConfiguration, error) {
 	return extractCSINode(cSINode, fieldManager, "status")
 }
 
-func extractCSINode(cSINode *storagev1beta1.CSINode, fieldManager string, subresource string) (*CSINodeApplyConfiguration, error) {
+func extractCSINode(cSINode *v1beta1.CSINode, fieldManager string, subresource string) (*CSINodeApplyConfiguration, error) {
 	b := &CSINodeApplyConfiguration{}
 	err := managedfields.ExtractInto(cSINode, internal.Parser().Type("io.k8s.api.storage.v1beta1.CSINode"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/storage/v1beta1/volumeattachment.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storage/v1beta1/volumeattachment.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1beta1
 
 import (
-	storagev1beta1 "k8s.io/api/storage/v1beta1"
+	v1beta1 "k8s.io/api/storage/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -57,18 +57,18 @@ func VolumeAttachment(name string) *VolumeAttachmentApplyConfiguration {
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractVolumeAttachment(volumeAttachment *storagev1beta1.VolumeAttachment, fieldManager string) (*VolumeAttachmentApplyConfiguration, error) {
+func ExtractVolumeAttachment(volumeAttachment *v1beta1.VolumeAttachment, fieldManager string) (*VolumeAttachmentApplyConfiguration, error) {
 	return extractVolumeAttachment(volumeAttachment, fieldManager, "")
 }
 
 // ExtractVolumeAttachmentStatus is the same as ExtractVolumeAttachment except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractVolumeAttachmentStatus(volumeAttachment *storagev1beta1.VolumeAttachment, fieldManager string) (*VolumeAttachmentApplyConfiguration, error) {
+func ExtractVolumeAttachmentStatus(volumeAttachment *v1beta1.VolumeAttachment, fieldManager string) (*VolumeAttachmentApplyConfiguration, error) {
 	return extractVolumeAttachment(volumeAttachment, fieldManager, "status")
 }
 
-func extractVolumeAttachment(volumeAttachment *storagev1beta1.VolumeAttachment, fieldManager string, subresource string) (*VolumeAttachmentApplyConfiguration, error) {
+func extractVolumeAttachment(volumeAttachment *v1beta1.VolumeAttachment, fieldManager string, subresource string) (*VolumeAttachmentApplyConfiguration, error) {
 	b := &VolumeAttachmentApplyConfiguration{}
 	err := managedfields.ExtractInto(volumeAttachment, internal.Parser().Type("io.k8s.api.storage.v1beta1.VolumeAttachment"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/applyconfigurations/storagemigration/v1alpha1/storageversionmigration.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storagemigration/v1alpha1/storageversionmigration.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	storagemigrationv1alpha1 "k8s.io/api/storagemigration/v1alpha1"
+	v1alpha1 "k8s.io/api/storagemigration/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	managedfields "k8s.io/apimachinery/pkg/util/managedfields"
@@ -57,18 +57,18 @@ func StorageVersionMigration(name string) *StorageVersionMigrationApplyConfigura
 // Note that an extracted apply configuration will contain fewer fields than what the fieldManager previously
 // applied if another fieldManager has updated or force applied any of the previously applied fields.
 // Experimental!
-func ExtractStorageVersionMigration(storageVersionMigration *storagemigrationv1alpha1.StorageVersionMigration, fieldManager string) (*StorageVersionMigrationApplyConfiguration, error) {
+func ExtractStorageVersionMigration(storageVersionMigration *v1alpha1.StorageVersionMigration, fieldManager string) (*StorageVersionMigrationApplyConfiguration, error) {
 	return extractStorageVersionMigration(storageVersionMigration, fieldManager, "")
 }
 
 // ExtractStorageVersionMigrationStatus is the same as ExtractStorageVersionMigration except
 // that it extracts the status subresource applied configuration.
 // Experimental!
-func ExtractStorageVersionMigrationStatus(storageVersionMigration *storagemigrationv1alpha1.StorageVersionMigration, fieldManager string) (*StorageVersionMigrationApplyConfiguration, error) {
+func ExtractStorageVersionMigrationStatus(storageVersionMigration *v1alpha1.StorageVersionMigration, fieldManager string) (*StorageVersionMigrationApplyConfiguration, error) {
 	return extractStorageVersionMigration(storageVersionMigration, fieldManager, "status")
 }
 
-func extractStorageVersionMigration(storageVersionMigration *storagemigrationv1alpha1.StorageVersionMigration, fieldManager string, subresource string) (*StorageVersionMigrationApplyConfiguration, error) {
+func extractStorageVersionMigration(storageVersionMigration *v1alpha1.StorageVersionMigration, fieldManager string, subresource string) (*StorageVersionMigrationApplyConfiguration, error) {
 	b := &StorageVersionMigrationApplyConfiguration{}
 	err := managedfields.ExtractInto(storageVersionMigration, internal.Parser().Type("io.k8s.api.storagemigration.v1alpha1.StorageVersionMigration"), fieldManager, b, subresource)
 	if err != nil {

--- a/staging/src/k8s.io/code-generator/cmd/applyconfiguration-gen/generators/targets.go
+++ b/staging/src/k8s.io/code-generator/cmd/applyconfiguration-gen/generators/targets.go
@@ -187,7 +187,7 @@ func targetForApplyConfigurationsPackage(outputDirBase, outputPkgBase, pkgSubdir
 					outPkgBase:   outputPkgBase,
 					groupVersion: gv,
 					applyConfig:  toGenerate,
-					imports:      generator.NewImportTracker(),
+					imports:      generator.NewImportTrackerForPackage(outputPkg),
 					refGraph:     refs,
 					openAPIType:  openAPIType,
 				})

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/applyconfiguration/wardle/v1alpha1/flunder.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/applyconfiguration/wardle/v1alpha1/flunder.go
@@ -22,7 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	v1 "k8s.io/client-go/applyconfigurations/meta/v1"
-	wardlev1alpha1 "k8s.io/sample-apiserver/pkg/apis/wardle/v1alpha1"
+	v1alpha1 "k8s.io/sample-apiserver/pkg/apis/wardle/v1alpha1"
 )
 
 // FlunderApplyConfiguration represents an declarative configuration of the Flunder type for use
@@ -31,7 +31,7 @@ type FlunderApplyConfiguration struct {
 	v1.TypeMetaApplyConfiguration    `json:",inline"`
 	*v1.ObjectMetaApplyConfiguration `json:"metadata,omitempty"`
 	Spec                             *FlunderSpecApplyConfiguration `json:"spec,omitempty"`
-	Status                           *wardlev1alpha1.FlunderStatus  `json:"status,omitempty"`
+	Status                           *v1alpha1.FlunderStatus        `json:"status,omitempty"`
 }
 
 // Flunder constructs an declarative configuration of the Flunder type for use with
@@ -214,7 +214,7 @@ func (b *FlunderApplyConfiguration) WithSpec(value *FlunderSpecApplyConfiguratio
 // WithStatus sets the Status field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the Status field is set to the value of the last call.
-func (b *FlunderApplyConfiguration) WithStatus(value wardlev1alpha1.FlunderStatus) *FlunderApplyConfiguration {
+func (b *FlunderApplyConfiguration) WithStatus(value v1alpha1.FlunderStatus) *FlunderApplyConfiguration {
 	b.Status = &value
 	return b
 }

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/applyconfiguration/wardle/v1beta1/flunder.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/applyconfiguration/wardle/v1beta1/flunder.go
@@ -22,7 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	v1 "k8s.io/client-go/applyconfigurations/meta/v1"
-	wardlev1beta1 "k8s.io/sample-apiserver/pkg/apis/wardle/v1beta1"
+	v1beta1 "k8s.io/sample-apiserver/pkg/apis/wardle/v1beta1"
 )
 
 // FlunderApplyConfiguration represents an declarative configuration of the Flunder type for use
@@ -31,7 +31,7 @@ type FlunderApplyConfiguration struct {
 	v1.TypeMetaApplyConfiguration    `json:",inline"`
 	*v1.ObjectMetaApplyConfiguration `json:"metadata,omitempty"`
 	Spec                             *FlunderSpecApplyConfiguration `json:"spec,omitempty"`
-	Status                           *wardlev1beta1.FlunderStatus   `json:"status,omitempty"`
+	Status                           *v1beta1.FlunderStatus         `json:"status,omitempty"`
 }
 
 // Flunder constructs an declarative configuration of the Flunder type for use with
@@ -214,7 +214,7 @@ func (b *FlunderApplyConfiguration) WithSpec(value *FlunderSpecApplyConfiguratio
 // WithStatus sets the Status field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the Status field is set to the value of the last call.
-func (b *FlunderApplyConfiguration) WithStatus(value wardlev1beta1.FlunderStatus) *FlunderApplyConfiguration {
+func (b *FlunderApplyConfiguration) WithStatus(value v1beta1.FlunderStatus) *FlunderApplyConfiguration {
 	b.Status = &value
 	return b
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This PR fixes cycle import situation when generating configuration for CRD with group name which consists of more than 1 tokens (e.g. usefulcrd.io). In this scenario `applyconfig-gen` would generate config files with imports to "self"

Fixes https://github.com/kubernetes/kubernetes/issues/124192

#### Special notes for your reviewer:

Incomplete until https://github.com/kubernetes/gengo/pull/268 change is available within a used `gengo` version

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/assign jpbetz