### PR TITLE
Update applyconfiguration generator for packages where paths differ in name

### DIFF
--- a/staging/src/k8s.io/code-generator/cmd/applyconfiguration-gen/generators/applyconfiguration.go
+++ b/staging/src/k8s.io/code-generator/cmd/applyconfiguration-gen/generators/applyconfiguration.go
@@ -35,6 +35,7 @@ type applyConfigurationGenerator struct {
 	generator.GoGenerator
 	// outPkgBase is the base package, under which the "internal" and GV-specific subdirs live
 	outPkgBase   string // must be a Go import-path
+	localPkg     string
 	groupVersion clientgentypes.GroupVersion
 	applyConfig  applyConfig
 	imports      namer.ImportTracker
@@ -49,9 +50,8 @@ func (g *applyConfigurationGenerator) Filter(_ *generator.Context, t *types.Type
 }
 
 func (g *applyConfigurationGenerator) Namers(*generator.Context) namer.NameSystems {
-	localPkg := path.Join(g.outPkgBase, g.groupVersion.Group.PackageName(), g.groupVersion.Version.PackageName())
 	return namer.NameSystems{
-		"raw":          namer.NewRawNamer(localPkg, g.imports),
+		"raw":          namer.NewRawNamer(g.localPkg, g.imports),
 		"singularKind": namer.NewPublicNamer(0),
 	}
 }
@@ -336,7 +336,7 @@ func (b *$.ApplyConfig.ApplyConfiguration|public$) ensure$.MemberType.Elem|publi
 
 var clientgenTypeConstructorNamespaced = `
 // $.ApplyConfig.Type|public$ constructs an declarative configuration of the $.ApplyConfig.Type|public$ type for use with
-// apply. 
+// apply.
 func $.ApplyConfig.Type|public$(name, namespace string) *$.ApplyConfig.ApplyConfiguration|public$ {
   b := &$.ApplyConfig.ApplyConfiguration|public${}
   b.WithName(name)

--- a/staging/src/k8s.io/code-generator/cmd/applyconfiguration-gen/generators/targets.go
+++ b/staging/src/k8s.io/code-generator/cmd/applyconfiguration-gen/generators/targets.go
@@ -185,6 +185,7 @@ func targetForApplyConfigurationsPackage(outputDirBase, outputPkgBase, pkgSubdir
 						OutputFilename: strings.ToLower(toGenerate.Type.Name.Name) + ".go",
 					},
 					outPkgBase:   outputPkgBase,
+					localPkg:     outputPkg,
 					groupVersion: gv,
 					applyConfig:  toGenerate,
 					imports:      generator.NewImportTracker(),


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind regression

#### What this PR does / why we need it:
It is possible that package paths might differ from the group name, see https://github.com/openshift/api/blob/master/operatorcontrolplane/v1alpha1/doc.go notice that pacakge name is `operatorcontrolplane` whereas the group is `controlplane.operator...`. This confuses the generator since it tries to extrapolate the name of the package based on the group name. Whereas the `ImportTracker` can properly recognize the import path. This leads to cyclical imports in packages where the group name is different from the actual import path.

Example of a bad generated code:
generated file is `operatorcontrolplane/applyconfigurations/operatorcontrolplane/v1alpha1/outageentry.go` 
with code as follows:
```golang
package v1alpha1

import (
	v1alpha1 "github.com/openshift/client-go/operatorcontrolplane/applyconfigurations/operatorcontrolplane/v1alpha1"
	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
)

// OutageEntryApplyConfiguration represents an declarative configuration of the OutageEntry type for use
// with apply.
type OutageEntryApplyConfiguration struct {
	Start     *v1.Time                              `json:"start,omitempty"`
	End       *v1.Time                              `json:"end,omitempty"`
	StartLogs []v1alpha1.LogEntryApplyConfiguration `json:"startLogs,omitempty"`
	EndLogs   []v1alpha1.LogEntryApplyConfiguration `json:"endLogs,omitempty"`
	Message   *string                               `json:"message,omitempty"`
}
...
```
This is generated from https://github.com/openshift/api/blob/master/operatorcontrolplane/v1alpha1/. 

Notice that the group name is `controlplane.operator.openshift.io` but the import path is `github.com/openshift/client-go/operatorcontrolplane/applyconfigurations/operatorcontrolplane/v1alpha1`, since they differ the import isn't excluded as local and thus fails compilation.

#### Special notes for your reviewer:
/assign @thockin 

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
