### PR TITLE
chore/refactor(e2e tests): Solidify Contract for and Cleanup WaitForPodsRunningReady

### DIFF
--- a/test/e2e/cloud/gcp/node_lease.go
+++ b/test/e2e/cloud/gcp/node_lease.go
@@ -38,7 +38,7 @@ import (
 var _ = SIGDescribe(framework.WithDisruptive(), "NodeLease", func() {
 	f := framework.NewDefaultFramework("node-lease-test")
 	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
-	var systemPodsNo int32
+	var systemPodsNo int
 	var c clientset.Interface
 	var ns string
 	var group string
@@ -48,7 +48,7 @@ var _ = SIGDescribe(framework.WithDisruptive(), "NodeLease", func() {
 		ns = f.Namespace.Name
 		systemPods, err := e2epod.GetPodsInNamespace(ctx, c, ns, map[string]string{})
 		framework.ExpectNoError(err)
-		systemPodsNo = int32(len(systemPods))
+		systemPodsNo = len(systemPods)
 		if strings.Contains(framework.TestContext.CloudConfig.NodeInstanceGroup, ",") {
 			framework.Failf("Test dose not support cluster setup with more than one MIG: %s", framework.TestContext.CloudConfig.NodeInstanceGroup)
 		} else {
@@ -97,7 +97,7 @@ var _ = SIGDescribe(framework.WithDisruptive(), "NodeLease", func() {
 			// Many e2e tests assume that the cluster is fully healthy before they start.  Wait until
 			// the cluster is restored to health.
 			ginkgo.By("waiting for system pods to successfully restart")
-			err := e2epod.WaitForPodsRunningReady(ctx, c, metav1.NamespaceSystem, systemPodsNo, 0, framework.PodReadyBeforeTimeout)
+			err := e2epod.WaitForPodsRunningReady(ctx, c, metav1.NamespaceSystem, systemPodsNo, framework.PodReadyBeforeTimeout)
 			framework.ExpectNoError(err)
 		})
 

--- a/test/e2e/cloud/gcp/resize_nodes.go
+++ b/test/e2e/cloud/gcp/resize_nodes.go
@@ -47,7 +47,7 @@ func resizeRC(ctx context.Context, c clientset.Interface, ns, name string, repli
 var _ = SIGDescribe("Nodes", framework.WithDisruptive(), func() {
 	f := framework.NewDefaultFramework("resize-nodes")
 	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
-	var systemPodsNo int32
+	var systemPodsNo int
 	var c clientset.Interface
 	var ns string
 	var group string
@@ -57,7 +57,7 @@ var _ = SIGDescribe("Nodes", framework.WithDisruptive(), func() {
 		ns = f.Namespace.Name
 		systemPods, err := e2epod.GetPodsInNamespace(ctx, c, ns, map[string]string{})
 		framework.ExpectNoError(err)
-		systemPodsNo = int32(len(systemPods))
+		systemPodsNo = len(systemPods)
 		if strings.Contains(framework.TestContext.CloudConfig.NodeInstanceGroup, ",") {
 			framework.Failf("Test dose not support cluster setup with more than one MIG: %s", framework.TestContext.CloudConfig.NodeInstanceGroup)
 		} else {
@@ -99,7 +99,7 @@ var _ = SIGDescribe("Nodes", framework.WithDisruptive(), func() {
 				// Many e2e tests assume that the cluster is fully healthy before they start.  Wait until
 				// the cluster is restored to health.
 				ginkgo.By("waiting for system pods to successfully restart")
-				err := e2epod.WaitForPodsRunningReady(ctx, c, metav1.NamespaceSystem, systemPodsNo, 0, framework.PodReadyBeforeTimeout)
+				err := e2epod.WaitForPodsRunningReady(ctx, c, metav1.NamespaceSystem, systemPodsNo, framework.PodReadyBeforeTimeout)
 				framework.ExpectNoError(err)
 			})
 		})

--- a/test/e2e/common/node/container_probe.go
+++ b/test/e2e/common/node/container_probe.go
@@ -612,7 +612,7 @@ done
 		})
 
 		// verify pods are running and ready
-		err := e2epod.WaitForPodsRunningReady(ctx, f.ClientSet, f.Namespace.Name, 1, 0, f.Timeouts.PodStart)
+		err := e2epod.WaitForPodsRunningReady(ctx, f.ClientSet, f.Namespace.Name, 1, f.Timeouts.PodStart)
 		framework.ExpectNoError(err)
 
 		// Shutdown pod. Readiness should change to false
@@ -694,7 +694,7 @@ done
 		})
 
 		// verify pods are running and ready
-		err := e2epod.WaitForPodsRunningReady(ctx, f.ClientSet, f.Namespace.Name, 1, 0, f.Timeouts.PodStart)
+		err := e2epod.WaitForPodsRunningReady(ctx, f.ClientSet, f.Namespace.Name, 1, f.Timeouts.PodStart)
 		framework.ExpectNoError(err)
 
 		// Shutdown pod. Readiness should change to false
@@ -1359,7 +1359,7 @@ done
 		})
 
 		// verify pods are running and ready
-		err := e2epod.WaitForPodsRunningReady(ctx, f.ClientSet, f.Namespace.Name, 1, 0, f.Timeouts.PodStart)
+		err := e2epod.WaitForPodsRunningReady(ctx, f.ClientSet, f.Namespace.Name, 1, f.Timeouts.PodStart)
 		framework.ExpectNoError(err)
 
 		// Shutdown pod. Readiness should change to false
@@ -1452,7 +1452,7 @@ done
 		})
 
 		// verify pods are running and ready
-		err := e2epod.WaitForPodsRunningReady(ctx, f.ClientSet, f.Namespace.Name, 1, 0, f.Timeouts.PodStart)
+		err := e2epod.WaitForPodsRunningReady(ctx, f.ClientSet, f.Namespace.Name, 1, f.Timeouts.PodStart)
 		framework.ExpectNoError(err)
 
 		// Shutdown pod. Readiness should change to false

--- a/test/e2e/common/node/pods.go
+++ b/test/e2e/common/node/pods.go
@@ -873,7 +873,7 @@ var _ = SIGDescribe("Pods", func() {
 
 		// wait as required for all 3 pods to be running
 		ginkgo.By("waiting for all 3 pods to be running")
-		err := e2epod.WaitForPodsRunningReady(ctx, f.ClientSet, f.Namespace.Name, 3, 0, f.Timeouts.PodStart)
+		err := e2epod.WaitForPodsRunningReady(ctx, f.ClientSet, f.Namespace.Name, 3, f.Timeouts.PodStart)
 		framework.ExpectNoError(err, "3 pods not found running.")
 
 		// delete Collection of pods with a label in the current namespace

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -226,7 +226,7 @@ func setupSuite(ctx context.Context) {
 	// #41007. To avoid those pods preventing the whole test runs (and just
 	// wasting the whole run), we allow for some not-ready pods (with the
 	// number equal to the number of allowed not-ready nodes).
-	if err := e2epod.WaitForPodsRunningReady(ctx, c, metav1.NamespaceSystem, int32(framework.TestContext.MinStartupPods), int32(framework.TestContext.AllowedNotReadyNodes), timeouts.SystemPodsStartup); err != nil {
+	if err := e2epod.WaitForAlmostAllPodsReady(ctx, c, metav1.NamespaceSystem, framework.TestContext.MinStartupPods, framework.TestContext.AllowedNotReadyNodes, timeouts.SystemPodsStartup); err != nil {
 		e2edebug.DumpAllNamespaceInfo(ctx, c, metav1.NamespaceSystem)
 		e2ekubectl.LogFailedContainers(ctx, c, metav1.NamespaceSystem, framework.Logf)
 		framework.Failf("Error waiting for all pods to be running and ready: %v", err)

--- a/test/e2e/framework/pod/wait.go
+++ b/test/e2e/framework/pod/wait.go
@@ -104,17 +104,11 @@ func BeInPhase(phase v1.PodPhase) types.GomegaMatcher {
 // 2. All Pods in Namespace ns are either Ready or Succeeded
 // 3. All Pods part of a ReplicaSet or ReplicationController in Namespace ns are Ready
 //
-// After the timeout has elapsed, an error is returned if and only if either of
-// the following conditions hold:
-//  1. The number of Pods in Namespace ns that are not Succeeded or Failed is less than minPods
-//  2. The number of Pods in Namespace ns that are not Ready, Succeeded, or Failed
-//     is greater than to allowedNotReadyPods
-//
-// Roughly speaking, this means that not "too many" Pods are not Ready, where the tolerance
-// for "too many" is controlled by allowedNotReadyPods.
+// After the timeout has elapsed, an error is returned if the number of Pods in a Pending Phase
+// is greater than allowedNotReadyPods.
 //
 // It is generally recommended to use WaitForPodsRunningReady instead of this function
-// whenever possible, because it is easier to understand. Similar to WaitForPodsRunningReady,
+// whenever possible, because its behavior is more intuitive. Similar to WaitForPodsRunningReady,
 // this function requests the list of pods on every iteration, making it useful for situations
 // where the set of Pods is likely changing, such as during cluster startup.
 //
@@ -218,7 +212,7 @@ func WaitForAlmostAllPodsReady(ctx context.Context, c clientset.Interface, ns st
 	}))
 
 	// An error might not be fatal.
-	if nOk+len(otherPods) >= minPods && len(otherPods) <= allowedNotReadyPods {
+	if len(otherPods) <= allowedNotReadyPods {
 		return nil
 	}
 	return err

--- a/test/e2e/scheduling/priorities.go
+++ b/test/e2e/scheduling/priorities.go
@@ -109,7 +109,7 @@ var _ = SIGDescribe("SchedulerPriorities", framework.WithSerial(), func() {
 
 		err = framework.CheckTestingNSDeletedExcept(ctx, cs, ns)
 		framework.ExpectNoError(err)
-		err = e2epod.WaitForPodsRunningReady(ctx, cs, metav1.NamespaceSystem, int32(systemPodsNo), 0, framework.PodReadyBeforeTimeout)
+		err = e2epod.WaitForPodsRunningReady(ctx, cs, metav1.NamespaceSystem, systemPodsNo, framework.PodReadyBeforeTimeout)
 		framework.ExpectNoError(err)
 
 		// skip if the most utilized node has less than the cri-o minMemLimit available

--- a/test/e2e/windows/host_process.go
+++ b/test/e2e/windows/host_process.go
@@ -657,7 +657,8 @@ var _ = sigDescribe(feature.WindowsHostProcessContainers, "[MinimumKubeletVersio
 
 		ginkgo.By("Waiting for the pod to start running")
 		timeout := 3 * time.Minute
-		e2epod.WaitForPodsRunningReady(ctx, f.ClientSet, f.Namespace.Name, 1, timeout)
+		err = e2epod.WaitForPodsRunningReady(ctx, f.ClientSet, f.Namespace.Name, 1, timeout)
+		framework.ExpectNoError(err)
 
 		ginkgo.By("Getting container stats for pod")
 		statsChecked := false
@@ -711,7 +712,8 @@ var _ = sigDescribe(feature.WindowsHostProcessContainers, "[MinimumKubeletVersio
 		pc.Create(ctx, pod)
 
 		ginkgo.By("Waiting for pod to run")
-		e2epod.WaitForPodsRunningReady(ctx, f.ClientSet, f.Namespace.Name, 1, 3*time.Minute)
+		err := e2epod.WaitForPodsRunningReady(ctx, f.ClientSet, f.Namespace.Name, 1, 3*time.Minute)
+		framework.ExpectNoError(err)
 
 		ginkgo.By("Waiting for 60 seconds")
 		// We wait an additional 60 seconds after the pod is Running because the

--- a/test/e2e/windows/host_process.go
+++ b/test/e2e/windows/host_process.go
@@ -657,7 +657,7 @@ var _ = sigDescribe(feature.WindowsHostProcessContainers, "[MinimumKubeletVersio
 
 		ginkgo.By("Waiting for the pod to start running")
 		timeout := 3 * time.Minute
-		e2epod.WaitForPodsRunningReady(ctx, f.ClientSet, f.Namespace.Name, 1, 0, timeout)
+		e2epod.WaitForPodsRunningReady(ctx, f.ClientSet, f.Namespace.Name, 1, timeout)
 
 		ginkgo.By("Getting container stats for pod")
 		statsChecked := false
@@ -711,7 +711,7 @@ var _ = sigDescribe(feature.WindowsHostProcessContainers, "[MinimumKubeletVersio
 		pc.Create(ctx, pod)
 
 		ginkgo.By("Waiting for pod to run")
-		e2epod.WaitForPodsRunningReady(ctx, f.ClientSet, f.Namespace.Name, 1, 0, 3*time.Minute)
+		e2epod.WaitForPodsRunningReady(ctx, f.ClientSet, f.Namespace.Name, 1, 3*time.Minute)
 
 		ginkgo.By("Waiting for 60 seconds")
 		// We wait an additional 60 seconds after the pod is Running because the

--- a/test/e2e/windows/hyperv.go
+++ b/test/e2e/windows/hyperv.go
@@ -95,7 +95,7 @@ var _ = sigDescribe(feature.WindowsHyperVContainers, "HyperV containers", skipUn
 		pc.Create(ctx, hypervPod)
 		ginkgo.By("waiting for the pod to be running")
 		timeout := 3 * time.Minute
-		e2epod.WaitForPodsRunningReady(ctx, f.ClientSet, f.Namespace.Name, 1, 0, timeout)
+		e2epod.WaitForPodsRunningReady(ctx, f.ClientSet, f.Namespace.Name, 1, timeout)
 
 		ginkgo.By("creating a host process container in another pod to verify the pod is running hyperv isolated containers")
 

--- a/test/e2e/windows/hyperv.go
+++ b/test/e2e/windows/hyperv.go
@@ -95,7 +95,8 @@ var _ = sigDescribe(feature.WindowsHyperVContainers, "HyperV containers", skipUn
 		pc.Create(ctx, hypervPod)
 		ginkgo.By("waiting for the pod to be running")
 		timeout := 3 * time.Minute
-		e2epod.WaitForPodsRunningReady(ctx, f.ClientSet, f.Namespace.Name, 1, timeout)
+		err = e2epod.WaitForPodsRunningReady(ctx, f.ClientSet, f.Namespace.Name, 1, timeout)
+		framework.ExpectNoError(err)
 
 		ginkgo.By("creating a host process container in another pod to verify the pod is running hyperv isolated containers")
 

--- a/test/e2e/windows/kubelet_stats.go
+++ b/test/e2e/windows/kubelet_stats.go
@@ -60,7 +60,7 @@ var _ = sigDescribe(feature.Windows, "Kubelet-Stats", framework.WithSerial(), sk
 
 				ginkgo.By("Waiting up to 3 minutes for pods to be running")
 				timeout := 3 * time.Minute
-				err = e2epod.WaitForPodsRunningReady(ctx, f.ClientSet, f.Namespace.Name, 10, 0, timeout)
+				err = e2epod.WaitForPodsRunningReady(ctx, f.ClientSet, f.Namespace.Name, 10, timeout)
 				framework.ExpectNoError(err)
 
 				ginkgo.By("Getting kubelet stats 5 times and checking average duration")
@@ -152,7 +152,7 @@ var _ = sigDescribe(feature.Windows, "Kubelet-Stats", skipUnlessWindows(func() {
 
 				ginkgo.By("Waiting up to 3 minutes for pods to be running")
 				timeout := 3 * time.Minute
-				err = e2epod.WaitForPodsRunningReady(ctx, f.ClientSet, f.Namespace.Name, 3, 0, timeout)
+				err = e2epod.WaitForPodsRunningReady(ctx, f.ClientSet, f.Namespace.Name, 3, timeout)
 				framework.ExpectNoError(err)
 
 				ginkgo.By("Getting kubelet stats 1 time")


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/kind flake

#### What this PR does / why we need it:

This cleans up the the test helper function `WaitForPodsRunningReady`. In particular, concretely defines the expected behavior for this function, rewrite to follow this expected behavior, and remove the log message that caused the original confusion.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #111092

#### Special notes for your reviewer:

This is an extremely simple issue that's remained open for a quite a while. With this being my first K8s PR, the simplicity was appealing to me! PRs have been opened to address this issue, but closed because agreement wasn't reached on how exactly to approach it. Of course, to agree on what to log, there needs to be clarity on what this function is doing. Unfortunately, I don't think the contract for this function has ever been well-defined.

Firstly, what exactly does it mean to have one parameter specify the minimum of Ready Pods, another specify the maximum number of Pods that are allowed to not be Ready, but also document that this function waits for all Pods are either Ready or Failed? I have no idea how that's supposed to work before reading the code! However, reading the code doesn't clarify much.

The clearest way to see the problem with the previous code is to consider: "What happens if every Pod in this Namespace fails?" The code will remain polling for the duration of timeout. Once it exits, then `notReady` will be 0, and this function will return without an error! *Surely* this can't be the intended behavior. This code has been refactored over the past few years, but this same problem has existed since this file was created 5 years ago. This is just one example of why this code is problematic- simply incrementing `notReady` for failed Pods wouldn't completely fix things in my mind.

Ultimately, I needed to decide what the contract for this function should be. I chose one that balanced similarity to previous behavior with what I felt is expected behavior:

```

WaitForPodsRunningReady waits up to timeout for the following conditions:
 1. At least minPods Pods in Namespace ns are Running and Ready
 2. No more than allowedNotReadyPods Pods in Namespace ns are not either
    Ready, Succeeded, or Failed with a Controller.

```

Once I established this, it became clear that a bunch of the logic was entirely unecessary. In fact, I felt like that specific log line from the original Issue lost its purpose now that the presence of non-Ready Pods isn't treated as exceptional behavior, and I just removed it.

One notable consequence of establishing this contract is that this function now exits earlier than it used to in certain situations (roughly speaking, previously a single non-Ready Pod in the Namespace would make the function continue polling until `timeout`). Considering how amgiguous the contract for this function was previously, there's certainly risk that some tests in some environments implicitely rely upon this function taking longer than it needs to. All pertitent Linux e2e tests seem to be passing when run against a local WSL cluster, and I suppose we'll see about the CI tests. I assume that this sort of risk is considered acceptable?

#### Update 4/14

Based upon feedback, I split `WaitForPodsRunningReady` into two functions:

1. `WaitForPodsRunningReady` is now substantially simplied. In addition to the above simplifications, I removed `allowedNotReadyPods` entirely, since it was unused by almost all of the callers.
2. A new function, `WaitForAlmostAllPodsReady`, which is equivalent in behavior to the previous `WaitForPodsRunningReady`. I just kept some light cleanup I did.

Notably, I opted to copy-and-paste code between the functions instead of trying to make it DRY. Since we're scared to touch `WaitForAlmostAllPodsReady` but have more confidence in what the semantics of `WaitForPodsRunningReady` are, it seems best to not couple these two functions at all.

#### Does this PR introduce a user-facing change?
No
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
N/A
