### PR TITLE
Update publishing-bot rules to Go 1.21.9

### DIFF
--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -7,25 +7,25 @@ rules:
       dirs:
       - staging/src/k8s.io/apimachinery
   - name: release-1.26
-    go: 1.21.8
+    go: 1.21.9
     source:
       branch: release-1.26
       dirs:
       - staging/src/k8s.io/apimachinery
   - name: release-1.27
-    go: 1.21.8
+    go: 1.21.9
     source:
       branch: release-1.27
       dirs:
       - staging/src/k8s.io/apimachinery
   - name: release-1.28
-    go: 1.21.8
+    go: 1.21.9
     source:
       branch: release-1.28
       dirs:
       - staging/src/k8s.io/apimachinery
   - name: release-1.29
-    go: 1.21.8
+    go: 1.21.9
     source:
       branch: release-1.29
       dirs:
@@ -48,7 +48,7 @@ rules:
       dirs:
       - staging/src/k8s.io/api
   - name: release-1.26
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -57,7 +57,7 @@ rules:
       dirs:
       - staging/src/k8s.io/api
   - name: release-1.27
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -66,7 +66,7 @@ rules:
       dirs:
       - staging/src/k8s.io/api
   - name: release-1.28
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -75,7 +75,7 @@ rules:
       dirs:
       - staging/src/k8s.io/api
   - name: release-1.29
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -110,7 +110,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.26
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -125,7 +125,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.27
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -140,7 +140,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.28
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -155,7 +155,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.29
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -196,25 +196,25 @@ rules:
       dirs:
       - staging/src/k8s.io/code-generator
   - name: release-1.26
-    go: 1.21.8
+    go: 1.21.9
     source:
       branch: release-1.26
       dirs:
       - staging/src/k8s.io/code-generator
   - name: release-1.27
-    go: 1.21.8
+    go: 1.21.9
     source:
       branch: release-1.27
       dirs:
       - staging/src/k8s.io/code-generator
   - name: release-1.28
-    go: 1.21.8
+    go: 1.21.9
     source:
       branch: release-1.28
       dirs:
       - staging/src/k8s.io/code-generator
   - name: release-1.29
-    go: 1.21.8
+    go: 1.21.9
     source:
       branch: release-1.29
       dirs:
@@ -243,7 +243,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-base
   - name: release-1.26
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -256,7 +256,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-base
   - name: release-1.27
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -269,7 +269,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-base
   - name: release-1.28
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -282,7 +282,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-base
   - name: release-1.29
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -323,7 +323,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-helpers
   - name: release-1.26
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -336,7 +336,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-helpers
   - name: release-1.27
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -349,7 +349,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-helpers
   - name: release-1.28
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -362,7 +362,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-helpers
   - name: release-1.29
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -399,13 +399,13 @@ rules:
       dirs:
       - staging/src/k8s.io/kms
   - name: release-1.26
-    go: 1.21.8
+    go: 1.21.9
     source:
       branch: release-1.26
       dirs:
       - staging/src/k8s.io/kms
   - name: release-1.27
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -418,7 +418,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kms
   - name: release-1.28
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -431,7 +431,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kms
   - name: release-1.29
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -468,7 +468,7 @@ rules:
       dirs:
       - staging/src/k8s.io/apiserver
   - name: release-1.26
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -485,7 +485,7 @@ rules:
       dirs:
       - staging/src/k8s.io/apiserver
   - name: release-1.27
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -502,7 +502,7 @@ rules:
       dirs:
       - staging/src/k8s.io/apiserver
   - name: release-1.28
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -519,7 +519,7 @@ rules:
       dirs:
       - staging/src/k8s.io/apiserver
   - name: release-1.29
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -576,7 +576,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-aggregator
   - name: release-1.26
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -597,7 +597,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-aggregator
   - name: release-1.27
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -618,7 +618,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-aggregator
   - name: release-1.28
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -639,7 +639,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-aggregator
   - name: release-1.29
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -708,7 +708,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.26
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -734,7 +734,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.27
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -760,7 +760,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.28
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -786,7 +786,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.29
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -859,7 +859,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.26
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -879,7 +879,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.27
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -899,7 +899,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.28
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -919,7 +919,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.29
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -983,7 +983,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.26
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -1006,7 +1006,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.27
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -1029,7 +1029,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.28
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -1052,7 +1052,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.29
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -1114,7 +1114,7 @@ rules:
       dirs:
       - staging/src/k8s.io/metrics
   - name: release-1.26
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -1129,7 +1129,7 @@ rules:
       dirs:
       - staging/src/k8s.io/metrics
   - name: release-1.27
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -1144,7 +1144,7 @@ rules:
       dirs:
       - staging/src/k8s.io/metrics
   - name: release-1.28
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -1159,7 +1159,7 @@ rules:
       dirs:
       - staging/src/k8s.io/metrics
   - name: release-1.29
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -1204,7 +1204,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cli-runtime
   - name: release-1.26
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: api
       branch: release-1.26
@@ -1217,7 +1217,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cli-runtime
   - name: release-1.27
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: api
       branch: release-1.27
@@ -1230,7 +1230,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cli-runtime
   - name: release-1.28
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: api
       branch: release-1.28
@@ -1243,7 +1243,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cli-runtime
   - name: release-1.29
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: api
       branch: release-1.29
@@ -1286,7 +1286,7 @@ rules:
       dirs:
       - staging/src/k8s.io/sample-cli-plugin
   - name: release-1.26
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: api
       branch: release-1.26
@@ -1301,7 +1301,7 @@ rules:
       dirs:
       - staging/src/k8s.io/sample-cli-plugin
   - name: release-1.27
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: api
       branch: release-1.27
@@ -1316,7 +1316,7 @@ rules:
       dirs:
       - staging/src/k8s.io/sample-cli-plugin
   - name: release-1.28
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: api
       branch: release-1.28
@@ -1331,7 +1331,7 @@ rules:
       dirs:
       - staging/src/k8s.io/sample-cli-plugin
   - name: release-1.29
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: api
       branch: release-1.29
@@ -1377,7 +1377,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-proxy
   - name: release-1.26
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -1392,7 +1392,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-proxy
   - name: release-1.27
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -1407,7 +1407,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-proxy
   - name: release-1.28
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -1422,7 +1422,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-proxy
   - name: release-1.29
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -1460,25 +1460,25 @@ rules:
       dirs:
       - staging/src/k8s.io/cri-api
   - name: release-1.26
-    go: 1.21.8
+    go: 1.21.9
     source:
       branch: release-1.26
       dirs:
       - staging/src/k8s.io/cri-api
   - name: release-1.27
-    go: 1.21.8
+    go: 1.21.9
     source:
       branch: release-1.27
       dirs:
       - staging/src/k8s.io/cri-api
   - name: release-1.28
-    go: 1.21.8
+    go: 1.21.9
     source:
       branch: release-1.28
       dirs:
       - staging/src/k8s.io/cri-api
   - name: release-1.29
-    go: 1.21.8
+    go: 1.21.9
     source:
       branch: release-1.29
       dirs:
@@ -1513,7 +1513,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubelet
   - name: release-1.26
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -1528,7 +1528,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubelet
   - name: release-1.27
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -1543,7 +1543,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubelet
   - name: release-1.28
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -1564,7 +1564,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubelet
   - name: release-1.29
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -1623,7 +1623,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-scheduler
   - name: release-1.26
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -1638,7 +1638,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-scheduler
   - name: release-1.27
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -1653,7 +1653,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-scheduler
   - name: release-1.28
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -1668,7 +1668,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-scheduler
   - name: release-1.29
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -1719,7 +1719,7 @@ rules:
       dirs:
       - staging/src/k8s.io/controller-manager
   - name: release-1.26
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: api
       branch: release-1.26
@@ -1738,7 +1738,7 @@ rules:
       dirs:
       - staging/src/k8s.io/controller-manager
   - name: release-1.27
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: api
       branch: release-1.27
@@ -1757,7 +1757,7 @@ rules:
       dirs:
       - staging/src/k8s.io/controller-manager
   - name: release-1.28
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: api
       branch: release-1.28
@@ -1776,7 +1776,7 @@ rules:
       dirs:
       - staging/src/k8s.io/controller-manager
   - name: release-1.29
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: api
       branch: release-1.29
@@ -1839,7 +1839,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cloud-provider
   - name: release-1.26
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: api
       branch: release-1.26
@@ -1862,7 +1862,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cloud-provider
   - name: release-1.27
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: api
       branch: release-1.27
@@ -1885,7 +1885,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cloud-provider
   - name: release-1.28
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: api
       branch: release-1.28
@@ -1908,7 +1908,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cloud-provider
   - name: release-1.29
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: api
       branch: release-1.29
@@ -1981,7 +1981,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-controller-manager
   - name: release-1.26
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -2006,7 +2006,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-controller-manager
   - name: release-1.27
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -2031,7 +2031,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-controller-manager
   - name: release-1.28
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -2056,7 +2056,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-controller-manager
   - name: release-1.29
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -2119,7 +2119,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cluster-bootstrap
   - name: release-1.26
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -2130,7 +2130,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cluster-bootstrap
   - name: release-1.27
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -2141,7 +2141,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cluster-bootstrap
   - name: release-1.28
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -2152,7 +2152,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cluster-bootstrap
   - name: release-1.29
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -2187,7 +2187,7 @@ rules:
       dirs:
       - staging/src/k8s.io/csi-translation-lib
   - name: release-1.26
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: api
       branch: release-1.26
@@ -2198,7 +2198,7 @@ rules:
       dirs:
       - staging/src/k8s.io/csi-translation-lib
   - name: release-1.27
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: api
       branch: release-1.27
@@ -2209,7 +2209,7 @@ rules:
       dirs:
       - staging/src/k8s.io/csi-translation-lib
   - name: release-1.28
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: api
       branch: release-1.28
@@ -2220,7 +2220,7 @@ rules:
       dirs:
       - staging/src/k8s.io/csi-translation-lib
   - name: release-1.29
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: api
       branch: release-1.29
@@ -2250,25 +2250,25 @@ rules:
       dirs:
       - staging/src/k8s.io/mount-utils
   - name: release-1.26
-    go: 1.21.8
+    go: 1.21.9
     source:
       branch: release-1.26
       dirs:
       - staging/src/k8s.io/mount-utils
   - name: release-1.27
-    go: 1.21.8
+    go: 1.21.9
     source:
       branch: release-1.27
       dirs:
       - staging/src/k8s.io/mount-utils
   - name: release-1.28
-    go: 1.21.8
+    go: 1.21.9
     source:
       branch: release-1.28
       dirs:
       - staging/src/k8s.io/mount-utils
   - name: release-1.29
-    go: 1.21.8
+    go: 1.21.9
     source:
       branch: release-1.29
       dirs:
@@ -2307,7 +2307,7 @@ rules:
       dirs:
       - staging/src/k8s.io/legacy-cloud-providers
   - name: release-1.26
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: api
       branch: release-1.26
@@ -2336,7 +2336,7 @@ rules:
       dirs:
       - staging/src/k8s.io/legacy-cloud-providers
   - name: release-1.27
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: api
       branch: release-1.27
@@ -2361,7 +2361,7 @@ rules:
       dirs:
       - staging/src/k8s.io/legacy-cloud-providers
   - name: release-1.28
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: api
       branch: release-1.28
@@ -2386,7 +2386,7 @@ rules:
       dirs:
       - staging/src/k8s.io/legacy-cloud-providers
   - name: release-1.29
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: api
       branch: release-1.29
@@ -2461,7 +2461,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubectl
   - name: release-1.26
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: api
       branch: release-1.26
@@ -2484,7 +2484,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubectl
   - name: release-1.27
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: api
       branch: release-1.27
@@ -2507,7 +2507,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubectl
   - name: release-1.28
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: api
       branch: release-1.28
@@ -2530,7 +2530,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubectl
   - name: release-1.29
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: api
       branch: release-1.29
@@ -2597,7 +2597,7 @@ rules:
       dirs:
       - staging/src/k8s.io/pod-security-admission
   - name: release-1.26
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: api
       branch: release-1.26
@@ -2616,7 +2616,7 @@ rules:
       dirs:
       - staging/src/k8s.io/pod-security-admission
   - name: release-1.27
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: api
       branch: release-1.27
@@ -2635,7 +2635,7 @@ rules:
       dirs:
       - staging/src/k8s.io/pod-security-admission
   - name: release-1.28
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: api
       branch: release-1.28
@@ -2654,7 +2654,7 @@ rules:
       dirs:
       - staging/src/k8s.io/pod-security-admission
   - name: release-1.29
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: api
       branch: release-1.29
@@ -2717,7 +2717,7 @@ rules:
       dirs:
       - staging/src/k8s.io/dynamic-resource-allocation
   - name: release-1.26
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -2734,7 +2734,7 @@ rules:
       dirs:
       - staging/src/k8s.io/dynamic-resource-allocation
   - name: release-1.27
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -2751,7 +2751,7 @@ rules:
       dirs:
       - staging/src/k8s.io/dynamic-resource-allocation
   - name: release-1.28
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -2772,7 +2772,7 @@ rules:
       dirs:
       - staging/src/k8s.io/dynamic-resource-allocation
   - name: release-1.29
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -2832,7 +2832,7 @@ rules:
       dirs:
       - staging/src/k8s.io/endpointslice
   - name: release-1.28
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: api
       branch: release-1.28
@@ -2847,7 +2847,7 @@ rules:
       dirs:
       - staging/src/k8s.io/endpointslice
   - name: release-1.29
-    go: 1.21.8
+    go: 1.21.9
     dependencies:
     - repository: api
       branch: release-1.29


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

- Update publishing-bot rules to Go 1.21.9

should we drop the rules for `release-1.26`?

/assign @dims @puerco @xmudrii @Verolop 
cc @kubernetes/release-engineering 

#### Which issue(s) this PR fixes:

xref https://github.com/kubernetes/release/issues/3529

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
