### PR TITLE
[code-generator]: add register-gen to helper script kube_codegen.sh

### DIFF
--- a/staging/src/k8s.io/code-generator/kube_codegen.sh
+++ b/staging/src/k8s.io/code-generator/kube_codegen.sh
@@ -659,3 +659,89 @@ function kube::codegen::gen_client() {
             "${input_pkgs[@]}"
     fi
 }
+
+# Generate register code
+#
+# USAGE: kube::codegen::gen_register [FLAGS] <input-dir>
+#
+# <input-dir>
+#   The root directory under which to search for Go files which request code to
+#   be generated.  This must be a local path, not a Go package.
+#
+#   See note at the top about package structure below that.
+#
+# FLAGS:
+#
+#   --boilerplate <string = path_to_kube_codegen_boilerplate>
+#     An optional override for the header file to insert into generated files.
+#
+function kube::codegen::gen_register() {
+    local in_dir=""
+    local boilerplate="${KUBE_CODEGEN_ROOT}/hack/boilerplate.go.txt"
+    local v="${KUBE_VERBOSE:-0}"
+
+    while [ "$#" -gt 0 ]; do
+        case "$1" in
+            "--boilerplate")
+                boilerplate="$2"
+                shift 2
+                ;;
+            *)
+                if [[ "$1" =~ ^-- ]]; then
+                    echo "unknown argument: $1" >&2
+                    return 1
+                fi
+                if [ -n "$in_dir" ]; then
+                    echo "too many arguments: $1 (already have $in_dir)" >&2
+                    return 1
+                fi
+                in_dir="$1"
+                shift
+                ;;
+        esac
+    done
+
+    if [ -z "${in_dir}" ]; then
+        echo "input-dir argument is required" >&2
+        return 1
+    fi
+
+    (
+        # To support running this from anywhere, first cd into this directory,
+        # and then install with forced module mode on and fully qualified name.
+        cd "${KUBE_CODEGEN_ROOT}"
+
+        GO111MODULE=on go install "k8s.io/code-generator/cmd/register-gen"
+    )
+    # Go installs in $GOBIN if defined, and $GOPATH/bin otherwise
+    gobin="${GOBIN:-$(go env GOPATH)/bin}"
+
+    local input_pkgs=()
+    while read -r dir; do
+        pkg="$(cd "${dir}" && GO111MODULE=on go list -find .)"
+        input_pkgs+=("${pkg}")
+    done < <(
+        ( kube::codegen::internal::grep -l --null \
+            -r "${in_dir}" \
+            --include '*.go' \
+            || true \
+        ) | while read -r -d $'\0' F; do dirname "${F}"; done \
+          | LC_ALL=C sort -u
+    )
+
+    if [ "${#input_pkgs[@]}" != 0 ]; then
+        echo "Generating register code for ${#input_pkgs[@]} targets"
+
+        kube::codegen::internal::findz \
+            "${in_dir}" \
+            -type f \
+            -name zz_generated.register.go \
+            | xargs -0 rm -f
+
+        "${gobin}/register-gen" \
+            -v "${v}" \
+            --output-file zz_generated.register.go \
+            --go-header-file "${boilerplate}" \
+            "${input_pkgs[@]}"
+    fi
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Register code is just as common as deepcopy, client, informer, defaulter (and so on) in CRD development.
However, the helper script kube_codegen.sh within the code-generator does not include a function for registration.
This pull request attempts to add it.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/code-generator/issues/169

#### Special notes for your reviewer:

I am aware that some subsequent changes may also be necessary, such as replacing the manually created register file (e.g., ·examples/crd/apis/example/v1/register.go·) with the generated register version.

But I need your confirmation on this matter. Additionally, if any other subsequent changes need to be made, please also let me know.


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
the `kube_codegen.sh` helper script of `code-generator` added `kube::codegen::gen_register` function for generating register code.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
