### PR TITLE
[FG:InPlacePodVerticalScaling] Add extended resources to ContainerStatuses[i].Resources

### DIFF
--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -2148,8 +2148,7 @@ func (kl *Kubelet) convertToAPIContainerStatuses(pod *v1.Pod, podStatus *kubecon
 
 			convertCustomResources(status.AllocatedResources, requests)
 		}
-		//TODO(vinaykul,derekwaynecarr,InPlacePodVerticalScaling): Update this to include extended resources in
-		// addition to CPU, memory, ephemeral storage. Add test case for extended resources.
+
 		resources := &v1.ResourceRequirements{
 			Limits:   limits,
 			Requests: requests,

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -2096,13 +2096,13 @@ func (kl *Kubelet) convertToAPIContainerStatuses(pod *v1.Pod, podStatus *kubecon
 		}
 
 		convertCustomResources := func(inResources, outResources v1.ResourceList) {
-			for extendedResourceName, extendedResourceQuantity := range inResources {
-				if extendedResourceName == v1.ResourceCPU || extendedResourceName == v1.ResourceMemory ||
-					extendedResourceName == v1.ResourceStorage || extendedResourceName == v1.ResourceEphemeralStorage {
+			for resourceName, resourceQuantity := range inResources {
+				if resourceName == v1.ResourceCPU || resourceName == v1.ResourceMemory ||
+					resourceName == v1.ResourceStorage || resourceName == v1.ResourceEphemeralStorage {
 					continue
 				}
 
-				outResources[extendedResourceName] = extendedResourceQuantity.DeepCopy()
+				outResources[resourceName] = resourceQuantity.DeepCopy()
 			}
 		}
 

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -2122,6 +2122,9 @@ func (kl *Kubelet) convertToAPIContainerStatuses(pod *v1.Pod, podStatus *kubecon
 			if ephemeralStorage, found := container.Resources.Limits[v1.ResourceEphemeralStorage]; found {
 				limits[v1.ResourceEphemeralStorage] = ephemeralStorage.DeepCopy()
 			}
+			if storage, found := container.Resources.Limits[v1.ResourceStorage]; found {
+				limits[v1.ResourceStorage] = storage.DeepCopy()
+			}
 
 			convertCustomResources(container.Resources.Limits, limits)
 		}
@@ -2138,6 +2141,9 @@ func (kl *Kubelet) convertToAPIContainerStatuses(pod *v1.Pod, podStatus *kubecon
 			}
 			if ephemeralStorage, found := status.AllocatedResources[v1.ResourceEphemeralStorage]; found {
 				requests[v1.ResourceEphemeralStorage] = ephemeralStorage.DeepCopy()
+			}
+			if storage, found := status.AllocatedResources[v1.ResourceStorage]; found {
+				requests[v1.ResourceStorage] = storage.DeepCopy()
 			}
 
 			convertCustomResources(status.AllocatedResources, requests)

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -2110,6 +2110,15 @@ func (kl *Kubelet) convertToAPIContainerStatuses(pod *v1.Pod, podStatus *kubecon
 			if ephemeralStorage, found := container.Resources.Limits[v1.ResourceEphemeralStorage]; found {
 				limits[v1.ResourceEphemeralStorage] = ephemeralStorage.DeepCopy()
 			}
+
+			for extendedResourceName, extendedResourceQuantity := range container.Resources.Limits {
+				if extendedResourceName == v1.ResourceCPU || extendedResourceName == v1.ResourceMemory ||
+					extendedResourceName == v1.ResourceStorage || extendedResourceName == v1.ResourceEphemeralStorage {
+					continue
+				}
+
+				limits[extendedResourceName] = extendedResourceQuantity.DeepCopy()
+			}
 		}
 		// Convert Requests
 		if status.AllocatedResources != nil {
@@ -2124,6 +2133,15 @@ func (kl *Kubelet) convertToAPIContainerStatuses(pod *v1.Pod, podStatus *kubecon
 			}
 			if ephemeralStorage, found := status.AllocatedResources[v1.ResourceEphemeralStorage]; found {
 				requests[v1.ResourceEphemeralStorage] = ephemeralStorage.DeepCopy()
+			}
+
+			for extendedResourceName, extendedResourceQuantity := range status.AllocatedResources {
+				if extendedResourceName == v1.ResourceCPU || extendedResourceName == v1.ResourceMemory ||
+					extendedResourceName == v1.ResourceStorage || extendedResourceName == v1.ResourceEphemeralStorage {
+					continue
+				}
+
+				requests[extendedResourceName] = extendedResourceQuantity.DeepCopy()
 			}
 		}
 		//TODO(vinaykul,derekwaynecarr,InPlacePodVerticalScaling): Update this to include extended resources in

--- a/pkg/kubelet/kubelet_pods_test.go
+++ b/pkg/kubelet/kubelet_pods_test.go
@@ -4585,8 +4585,10 @@ func TestConvertToAPIContainerStatusesForResources(t *testing.T) {
 	CPU2AndMem2G := v1.ResourceList{v1.ResourceCPU: resource.MustParse("2"), v1.ResourceMemory: resource.MustParse("2Gi")}
 	CPU1AndMem1GAndStorage2G := CPU1AndMem1G.DeepCopy()
 	CPU1AndMem1GAndStorage2G[v1.ResourceEphemeralStorage] = resource.MustParse("2Gi")
+	CPU1AndMem1GAndStorage2G[v1.ResourceStorage] = resource.MustParse("2Gi")
 	CPU2AndMem2GAndStorage2G := CPU2AndMem2G.DeepCopy()
 	CPU2AndMem2GAndStorage2G[v1.ResourceEphemeralStorage] = resource.MustParse("2Gi")
+	CPU2AndMem2GAndStorage2G[v1.ResourceStorage] = resource.MustParse("2Gi")
 
 	addExtendedResource := func(list v1.ResourceList) v1.ResourceList {
 		const stubCustomResource = v1.ResourceName("dummy.io/dummy")
@@ -4791,6 +4793,29 @@ func TestConvertToAPIContainerStatusesForResources(t *testing.T) {
 					State:              v1.ContainerState{Running: &v1.ContainerStateRunning{StartedAt: metav1.NewTime(nowTime)}},
 					AllocatedResources: addExtendedResource(CPU1AndMem1G),
 					Resources:          &v1.ResourceRequirements{Requests: addExtendedResource(CPU1AndMem1G)},
+				},
+			},
+		},
+		"BurstableQoSPod with storage, ephemeral storage and extended resources": {
+			Resources: []v1.ResourceRequirements{{Requests: addExtendedResource(CPU1AndMem1GAndStorage2G)}},
+			OldStatus: []v1.ContainerStatus{
+				{
+					Name:      testContainerName,
+					Image:     "img",
+					ImageID:   "img1234",
+					State:     v1.ContainerState{Running: &v1.ContainerStateRunning{}},
+					Resources: &v1.ResourceRequirements{},
+				},
+			},
+			Expected: []v1.ContainerStatus{
+				{
+					Name:               testContainerName,
+					ContainerID:        testContainerID.String(),
+					Image:              "img",
+					ImageID:            "img1234",
+					State:              v1.ContainerState{Running: &v1.ContainerStateRunning{StartedAt: metav1.NewTime(nowTime)}},
+					AllocatedResources: addExtendedResource(CPU1AndMem1GAndStorage2G),
+					Resources:          &v1.ResourceRequirements{Requests: addExtendedResource(CPU1AndMem1GAndStorage2G)},
 				},
 			},
 		},


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
/sig node

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
In-place pod resize feature adds Resources field to ContainerStatuses struct. This is used to report CPU and memory requests & limits configured for the containers.

After this PR, extended resources would also be reflected as part of `ContainerStatuses[i].Resources`.

#### Sample output:
Add a dummy extended resource to the node:
```bash
> k describe node | grep Allocatable -w -A5
Allocatable:
  cpu:                40
  dummy.com/dummy:    4  # <---- Extended resource
  ephemeral-storage:  1293695812Ki
  hugepages-1Gi:      0
  hugepages-2Mi:      0
```

Add a pod using this resource:
```yaml
apiVersion: v1
kind: Pod
metadata:
  name: dummy-pod
spec:
  containers:
  - name: dummy-container
    image: k8s.gcr.io/pause:2.0
    resources:
      requests:
        cpu: 100m
        dummy.com/dummy: 1
      limits:
        dummy.com/dummy: 1
```

Create the pod and check its `ContainerStatuses[i].Resources`:
```bash
> k get pod -o yaml | grep containerstatus -i -A40
    containerStatuses:
    - allocatedResources:
        cpu: 100m
        dummy.com/dummy: "1"
      # ....
      resources:
        limits:
          dummy.com/dummy: "1"
        requests:
          cpu: 100m
          dummy.com/dummy: "1"
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #114159

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added status for extended Pod resources within the `status.containerStatuses[].resources` field.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- KEP: https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/1287-in-place-update-pod-resources
```
