### PR TITLE
Added name-only and examples in the kubectl plugin help

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/plugin/plugin.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/plugin/plugin.go
@@ -41,7 +41,7 @@ var (
 		Please refer to the documentation and examples for more information about how write your own plugins.
 
 		The easiest way to discover and install plugins is via the kubernetes sub-project krew: [krew.sigs.k8s.io].
-		To install krew, visit https://krew.sigs.k8s.io/docs/user-guide/installing-plugins/`))
+		To install krew, visit https://krew.sigs.k8s.io/docs/user-guide/setup/install`))
 
 	pluginExample = templates.Examples(i18n.T(`
 		# List all available plugins

--- a/staging/src/k8s.io/kubectl/pkg/cmd/plugin/plugin.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/plugin/plugin.go
@@ -40,15 +40,19 @@ var (
 		Plugins provide extended functionality that is not part of the major command-line distribution.
 		Please refer to the documentation and examples for more information about how write your own plugins.
 
-		The easiest way to discover and install plugins is via the kubernetes sub-project krew.
-		To install krew, visit [krew.sigs.k8s.io](https://krew.sigs.k8s.io/docs/user-guide/setup/install/)`))
+		The easiest way to discover and install plugins is via the kubernetes sub-project krew: [krew.sigs.k8s.io].
+		To install krew, visit https://krew.sigs.k8s.io/docs/user-guide/installing-plugins/`))
 
 	pluginExample = templates.Examples(i18n.T(`
 		# List all available plugins
-		kubectl plugin list`))
+		kubectl plugin list
+		
+		# List only binary names of available plugins without paths
+		kubectl plugin list --name-only`))
 
 	pluginListLong = templates.LongDesc(i18n.T(`
 		List all available plugin files on a user's PATH.
+		To see plugins binary names without the full path use --name-only flag.
 
 		Available plugin files are those that are:
 		- executable
@@ -65,6 +69,7 @@ func NewCmdPlugin(streams genericiooptions.IOStreams) *cobra.Command {
 		DisableFlagsInUseLine: true,
 		Short:                 i18n.T("Provides utilities for interacting with plugins"),
 		Long:                  pluginLong,
+		Example:               pluginExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.DefaultSubCommandRun(streams.ErrOut)(cmd, args)
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:


#### What type of PR is this?
/kind feature


#### What this PR does / why we need it:
Added name-only and examples in the kubectl plugin help

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #https://github.com/kubernetes/kubectl/issues/1432


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
