### PR TITLE
remove unneeded func SyncReconstructedVolume from ActualStateOfWorld

### DIFF
--- a/pkg/kubelet/volumemanager/cache/actual_state_of_world.go
+++ b/pkg/kubelet/volumemanager/cache/actual_state_of_world.go
@@ -168,10 +168,6 @@ type ActualStateOfWorld interface {
 	// or have a mount/unmount operation pending.
 	GetAttachedVolumes() []AttachedVolume
 
-	// SyncReconstructedVolume check the volume.outerVolumeSpecName in asw and
-	// the one populated from dsw, if they do not match, update this field from the value from dsw.
-	SyncReconstructedVolume(volumeName v1.UniqueVolumeName, podName volumetypes.UniquePodName, outerVolumeSpecName string)
-
 	// Add the specified volume to ASW as uncertainly attached.
 	AddAttachUncertainReconstructedVolume(volumeName v1.UniqueVolumeName, volumeSpec *volume.Spec, nodeName types.NodeName, devicePath string) error
 
@@ -1117,19 +1113,6 @@ func (asw *actualStateOfWorld) GetUnmountedVolumes() []AttachedVolume {
 	}
 
 	return unmountedVolumes
-}
-
-func (asw *actualStateOfWorld) SyncReconstructedVolume(volumeName v1.UniqueVolumeName, podName volumetypes.UniquePodName, outerVolumeSpecName string) {
-	asw.Lock()
-	defer asw.Unlock()
-	if volumeObj, volumeExists := asw.attachedVolumes[volumeName]; volumeExists {
-		if podObj, podExists := volumeObj.mountedPods[podName]; podExists {
-			if podObj.outerVolumeSpecName != outerVolumeSpecName {
-				podObj.outerVolumeSpecName = outerVolumeSpecName
-				asw.attachedVolumes[volumeName].mountedPods[podName] = podObj
-			}
-		}
-	}
 }
 
 func (asw *actualStateOfWorld) newAttachedVolume(

--- a/pkg/kubelet/volumemanager/reconciler/reconciler.go
+++ b/pkg/kubelet/volumemanager/reconciler/reconciler.go
@@ -24,10 +24,10 @@ import (
 func (rc *reconciler) Run(stopCh <-chan struct{}) {
 	rc.reconstructVolumes()
 	klog.InfoS("Reconciler: start to sync state")
-	wait.Until(rc.reconcileNew, rc.loopSleepDuration, stopCh)
+	wait.Until(rc.reconcile, rc.loopSleepDuration, stopCh)
 }
 
-func (rc *reconciler) reconcileNew() {
+func (rc *reconciler) reconcile() {
 	readyToUnmount := rc.readyToUnmount()
 	if readyToUnmount {
 		// Unmounts are triggered before mounts so that a volume that was

--- a/pkg/kubelet/volumemanager/reconciler/reconciler_test.go
+++ b/pkg/kubelet/volumemanager/reconciler/reconciler_test.go
@@ -2382,7 +2382,7 @@ func TestReconcileWithUpdateReconstructedFromAPIServer(t *testing.T) {
 	reconciler.volumesNeedUpdateFromNodeStatus = append(reconciler.volumesNeedUpdateFromNodeStatus, volumeName1, volumeName2)
 	// Act - run reconcile loop just once.
 	// "volumesNeedUpdateFromNodeStatus" is not empty, so no unmount will be triggered.
-	reconciler.reconcileNew()
+	reconciler.reconcile()
 
 	// Assert
 	assert.True(t, reconciler.StatesHasBeenSynced())

--- a/pkg/kubelet/volumemanager/reconciler/reconstruct.go
+++ b/pkg/kubelet/volumemanager/reconciler/reconstruct.go
@@ -91,7 +91,7 @@ func (rc *reconciler) reconstructVolumes() {
 
 	if len(reconstructedVolumes) > 0 {
 		// Add the volumes to ASW
-		rc.updateStatesNew(reconstructedVolumes)
+		rc.updateStates(reconstructedVolumes)
 
 		// The reconstructed volumes are mounted, hence a previous kubelet must have already put it into node.status.volumesInUse.
 		// Remember to update DSW with this information.
@@ -102,7 +102,7 @@ func (rc *reconciler) reconstructVolumes() {
 	klog.V(2).InfoS("Volume reconstruction finished")
 }
 
-func (rc *reconciler) updateStatesNew(reconstructedVolumes map[v1.UniqueVolumeName]*globalVolumeInfo) {
+func (rc *reconciler) updateStates(reconstructedVolumes map[v1.UniqueVolumeName]*globalVolumeInfo) {
 	for _, gvl := range reconstructedVolumes {
 		err := rc.actualStateOfWorld.AddAttachUncertainReconstructedVolume(
 			//TODO: the devicePath might not be correct for some volume plugins: see issue #54108

--- a/pkg/kubelet/volumemanager/reconciler/reconstruct_common.go
+++ b/pkg/kubelet/volumemanager/reconciler/reconstruct_common.go
@@ -385,8 +385,8 @@ func (rc *reconciler) reconstructVolume(volume podVolume) (rvolume *reconstructe
 		volumeSpec: volumeSpec,
 		// volume.volumeSpecName is actually InnerVolumeSpecName. It will not be used
 		// for volume cleanup.
-		// in case pod is added back to desired state, outerVolumeSpecName will be updated from dsw information.
-		// See issue #103143 and its fix for details.
+		// in case reconciler calls mountOrAttachVolumes, outerVolumeSpecName will
+		// be updated from dsw information in ASW.MarkVolumeAsMounted().
 		outerVolumeSpecName: volume.volumeSpecName,
 		pod:                 pod,
 		deviceMounter:       deviceMounter,

--- a/pkg/kubelet/volumemanager/reconciler/reconstruct_test.go
+++ b/pkg/kubelet/volumemanager/reconciler/reconstruct_test.go
@@ -344,7 +344,7 @@ func TestReconstructVolumesMount(t *testing.T) {
 			rcInstance.volumesNeedUpdateFromNodeStatus = nil
 
 			// Act 2 - reconcile once
-			rcInstance.reconcileNew()
+			rcInstance.reconcile()
 
 			// Assert 2
 			// MountDevice was attempted


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The SyncReconstructedVolume func was added by https://github.com/kubernetes/kubernetes/pull/103181 which fixes https://github.com/kubernetes/kubernetes/issues/103143. 

Since the NewVolumeManagerReconstruction feature is GA in v1.30, the old reconstruction is removed and the SyncReconstructedVolume func is no longer used. So this PR removes the SyncReconstructedVolume func.

BTW, this PR also renames some functions to make the code more readable.

i.e. reconcileNew --> reconcile

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
