### PR TITLE
Move 3 get*APIGroup endpoints to ineligible_endpoints.yaml

### DIFF
--- a/test/conformance/testdata/ineligible_endpoints.yaml
+++ b/test/conformance/testdata/ineligible_endpoints.yaml
@@ -265,3 +265,12 @@
 - endpoint: createAuthenticationV1SelfSubjectReview
   reason: Cluster providers are allowed to choose to not serve this API, and the whoami command handles unavailability gracefully.
   link: https://github.com/kubernetes/enhancements/blob/master/keps/sig-auth/3325-self-subject-attributes-review-api/README.md#ga
+- endpoint: getInternalApiserverAPIGroup
+  reason: The endpoint is part of a group that has no stable endpoints yet, reporting as a stable endpoint in apisnoop.
+  link: https://github.com/kubernetes/issues/124248
+- endpoint: getResourceAPIGroup
+  reason: The endpoint is part of a group that has no stable endpoints yet, reporting as a stable endpoint in apisnoop.
+  link: https://github.com/kubernetes/issues/124248
+- endpoint: getStoragemigrationAPIGroup
+  reason: The endpoint is part of a group that has no stable endpoints yet, reporting as a stable endpoint in apisnoop.
+  link: https://github.com/kubernetes/issues/124248

--- a/test/conformance/testdata/pending_eligible_endpoints.yaml
+++ b/test/conformance/testdata/pending_eligible_endpoints.yaml
@@ -5,9 +5,6 @@
 - deleteCoreV1Node
 - deleteStorageV1CollectionCSINode
 - deleteStorageV1CSINode
-- getInternalApiserverAPIGroup
-- getResourceAPIGroup
-- getStoragemigrationAPIGroup
 - listStorageV1CSINode
 - patchStorageV1CSINode
 - patchStorageV1VolumeAttachmentStatus


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The following api endpoints are currently in [pending_eligible_endpoints.yaml](https://github.com/kubernetes/kubernetes/blob/master/test/conformance/testdata/pending_eligible_endpoints.yaml)

-  getInternalApiserverAPIGroup
- getResourceAPIGroup
-  getStoragemigrationAPIGroup

As each group has no stable endpoints they are reported in [apisnoop.cncf.io](https://apisnoop.cncf.io/) as promoted to stable without tests. The current logic for [ineligible_endpoints.yaml](https://github.com/kubernetes/kubernetes/blob/master/test/conformance/testdata/ineligible_endpoints.yaml) endpoints will address this issue.

#### Which issue(s) this PR fixes:

Fixes #124248

#### Special notes for your reviewer:


#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
/sig architecture
/area conformance