### PR TITLE
Run `controlplane/transformation` integration tests in parallel

### DIFF
--- a/test/integration/controlplane/transformation/kms_transformation_test.go
+++ b/test/integration/controlplane/transformation/kms_transformation_test.go
@@ -890,7 +890,10 @@ func TestEncryptionConfigHotReloadFilePolling(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
 			socketPath := getSocketPath()
 			encryptionConfig := fmt.Sprintf(`
 kind: EncryptionConfiguration

--- a/test/integration/controlplane/transformation/kmsv2_transformation_test.go
+++ b/test/integration/controlplane/transformation/kmsv2_transformation_test.go
@@ -412,6 +412,7 @@ func TestKMSv2ProviderKeyIDStaleness(t *testing.T) {
 }
 
 func testKMSv2ProviderKeyIDStaleness(t *testing.T) {
+	t.Parallel()
 	socketPath := getSocketPath()
 	encryptionConfig := fmt.Sprintf(`
 kind: EncryptionConfiguration
@@ -1347,6 +1348,7 @@ func TestKMSv2ProviderLegacyData(t *testing.T) {
 }
 
 func testKMSv2ProviderLegacyData(t *testing.T) {
+	t.Parallel()
 	socketPath := getSocketPath()
 	encryptionConfig := fmt.Sprintf(`
 kind: EncryptionConfiguration

--- a/test/integration/controlplane/transformation/secrets_transformation_test.go
+++ b/test/integration/controlplane/transformation/secrets_transformation_test.go
@@ -85,17 +85,20 @@ func TestSecretsShouldBeTransformed(t *testing.T) {
 		// TODO: add secretbox
 	}
 	for _, tt := range testCases {
-		test, err := newTransformTest(t, tt.transformerConfigContent, false, "", nil)
-		if err != nil {
-			t.Fatalf("failed to setup test for envelop %s, error was %v", tt.transformerPrefix, err)
-			continue
-		}
-		test.secret, err = test.createSecret(testSecret, testNamespace)
-		if err != nil {
-			t.Fatalf("Failed to create test secret, error: %v", err)
-		}
-		test.runResource(test.logger, tt.unSealFunc, tt.transformerPrefix, "", "v1", "secrets", test.secret.Name, test.secret.Namespace)
-		test.cleanUp()
+		tt := tt
+		t.Run(tt.transformerPrefix, func(t *testing.T) {
+			t.Parallel()
+			test, err := newTransformTest(t, tt.transformerConfigContent, false, "", nil)
+			if err != nil {
+				t.Fatalf("failed to setup test for envelop %s, error was %v", tt.transformerPrefix, err)
+			}
+			test.secret, err = test.createSecret(testSecret, testNamespace)
+			if err != nil {
+				t.Fatalf("Failed to create test secret, error: %v", err)
+			}
+			test.runResource(test.logger, tt.unSealFunc, tt.transformerPrefix, "", "v1", "secrets", test.secret.Name, test.secret.Namespace)
+			test.cleanUp()
+		})
 	}
 }
 

--- a/test/integration/controlplane/transformation/transformation_test.go
+++ b/test/integration/controlplane/transformation/transformation_test.go
@@ -37,6 +37,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/wait"
 	apiserverv1 "k8s.io/apiserver/pkg/apis/apiserver/v1"
 	"k8s.io/apiserver/pkg/storage/storagebackend"
@@ -637,4 +638,8 @@ func getLivez(checkName string, clientConfig *rest.Config, excludes ...string) (
 	}
 	body, err := req.DoRaw(context.TODO()) // we can still have a response body during an error case
 	return string(body), err == nil, nil
+}
+
+func getSocketPath() string {
+	return fmt.Sprintf("@%s.sock", rand.String(10))
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind flake
/kind cleanup

#### What this PR does / why we need it:
- Generate a unique UDS path for each integration test, so there are no conflicts.
- Run some of the tests in parallel.

Test runtime before the change

```shell
➜ make test-integration WHAT=./test/integration/controlplane/transformation KUBE_TEST_ARGS="-v"
...
PASS
ok    k8s.io/kubernetes/test/integration/controlplane/transformation  502.481s
```

Runtime after change 

```shell
➜ make test-integration WHAT=./test/integration/controlplane/transformation KUBE_TEST_ARGS="-v"
...
PASS
ok  	k8s.io/kubernetes/test/integration/controlplane/transformation	375.110s
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/124106

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

/sig auth
/triage accepted
/priority important-longterm
