### PR TITLE
Workqueue: Add generic versions that are properly typed

### DIFF
--- a/staging/src/k8s.io/client-go/util/workqueue/default_rate_limiters.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/default_rate_limiters.go
@@ -24,49 +24,66 @@ import (
 	"golang.org/x/time/rate"
 )
 
-type RateLimiter interface {
+// Deprecated: RateLimiter is deprecated, use TypedRateLimiter instead.
+type RateLimiter TypedRateLimiter[any]
+
+type TypedRateLimiter[T comparable] interface {
 	// When gets an item and gets to decide how long that item should wait
-	When(item interface{}) time.Duration
+	When(item T) time.Duration
 	// Forget indicates that an item is finished being retried.  Doesn't matter whether it's for failing
 	// or for success, we'll stop tracking it
-	Forget(item interface{})
+	Forget(item T)
 	// NumRequeues returns back how many failures the item has had
-	NumRequeues(item interface{}) int
+	NumRequeues(item T) int
 }
 
 // DefaultControllerRateLimiter is a no-arg constructor for a default rate limiter for a workqueue.  It has
 // both overall and per-item rate limiting.  The overall is a token bucket and the per-item is exponential
+//
+// Deprecated: Use DefaultTypedControllerRateLimiter instead.
 func DefaultControllerRateLimiter() RateLimiter {
-	return NewMaxOfRateLimiter(
-		NewItemExponentialFailureRateLimiter(5*time.Millisecond, 1000*time.Second),
+	return DefaultTypedControllerRateLimiter[any]()
+}
+
+// DefaultTypedControllerRateLimiter is a no-arg constructor for a default rate limiter for a workqueue.  It has
+// both overall and per-item rate limiting.  The overall is a token bucket and the per-item is exponential
+func DefaultTypedControllerRateLimiter[T comparable]() TypedRateLimiter[T] {
+	return NewTypedMaxOfRateLimiter(
+		NewTypedItemExponentialFailureRateLimiter[T](5*time.Millisecond, 1000*time.Second),
 		// 10 qps, 100 bucket size.  This is only for retry speed and its only the overall factor (not per item)
-		&BucketRateLimiter{Limiter: rate.NewLimiter(rate.Limit(10), 100)},
+		&TypedBucketRateLimiter[T]{Limiter: rate.NewLimiter(rate.Limit(10), 100)},
 	)
 }
 
-// BucketRateLimiter adapts a standard bucket to the workqueue ratelimiter API
-type BucketRateLimiter struct {
+// Deprecated: BucketRateLimiter is deprecated, use TypedBucketRateLimiter instead.
+type BucketRateLimiter = TypedBucketRateLimiter[any]
+
+// TypedBucketRateLimiter adapts a standard bucket to the workqueue ratelimiter API
+type TypedBucketRateLimiter[T comparable] struct {
 	*rate.Limiter
 }
 
 var _ RateLimiter = &BucketRateLimiter{}
 
-func (r *BucketRateLimiter) When(item interface{}) time.Duration {
+func (r *TypedBucketRateLimiter[T]) When(item T) time.Duration {
 	return r.Limiter.Reserve().Delay()
 }
 
-func (r *BucketRateLimiter) NumRequeues(item interface{}) int {
+func (r *TypedBucketRateLimiter[T]) NumRequeues(item T) int {
 	return 0
 }
 
-func (r *BucketRateLimiter) Forget(item interface{}) {
+func (r *TypedBucketRateLimiter[T]) Forget(item T) {
 }
 
-// ItemExponentialFailureRateLimiter does a simple baseDelay*2^<num-failures> limit
+// Deprecated: ItemExponentialFailureRateLimiter is deprecated, use TypedItemExponentialFailureRateLimiter instead.
+type ItemExponentialFailureRateLimiter = TypedItemExponentialFailureRateLimiter[any]
+
+// TypedItemExponentialFailureRateLimiter does a simple baseDelay*2^<num-failures> limit
 // dealing with max failures and expiration are up to the caller
-type ItemExponentialFailureRateLimiter struct {
+type TypedItemExponentialFailureRateLimiter[T comparable] struct {
 	failuresLock sync.Mutex
-	failures     map[interface{}]int
+	failures     map[T]int
 
 	baseDelay time.Duration
 	maxDelay  time.Duration
@@ -74,19 +91,29 @@ type ItemExponentialFailureRateLimiter struct {
 
 var _ RateLimiter = &ItemExponentialFailureRateLimiter{}
 
+// Deprecated: NewItemExponentialFailureRateLimiter is deprecated, use NewTypedItemExponentialFailureRateLimiter instead.
 func NewItemExponentialFailureRateLimiter(baseDelay time.Duration, maxDelay time.Duration) RateLimiter {
-	return &ItemExponentialFailureRateLimiter{
-		failures:  map[interface{}]int{},
+	return NewTypedItemExponentialFailureRateLimiter[any](baseDelay, maxDelay)
+}
+
+func NewTypedItemExponentialFailureRateLimiter[T comparable](baseDelay time.Duration, maxDelay time.Duration) TypedRateLimiter[T] {
+	return &TypedItemExponentialFailureRateLimiter[T]{
+		failures:  map[T]int{},
 		baseDelay: baseDelay,
 		maxDelay:  maxDelay,
 	}
 }
 
+// Deprecated: DefaultItemBasedRateLimiter is deprecated, use DefaultTypedItemBasedRateLimiter instead.
 func DefaultItemBasedRateLimiter() RateLimiter {
-	return NewItemExponentialFailureRateLimiter(time.Millisecond, 1000*time.Second)
+	return DefaultTypedItemBasedRateLimiter[any]()
 }
 
-func (r *ItemExponentialFailureRateLimiter) When(item interface{}) time.Duration {
+func DefaultTypedItemBasedRateLimiter[T comparable]() TypedRateLimiter[T] {
+	return NewTypedItemExponentialFailureRateLimiter[T](time.Millisecond, 1000*time.Second)
+}
+
+func (r *TypedItemExponentialFailureRateLimiter[T]) When(item T) time.Duration {
 	r.failuresLock.Lock()
 	defer r.failuresLock.Unlock()
 
@@ -107,14 +134,14 @@ func (r *ItemExponentialFailureRateLimiter) When(item interface{}) time.Duration
 	return calculated
 }
 
-func (r *ItemExponentialFailureRateLimiter) NumRequeues(item interface{}) int {
+func (r *TypedItemExponentialFailureRateLimiter[T]) NumRequeues(item T) int {
 	r.failuresLock.Lock()
 	defer r.failuresLock.Unlock()
 
 	return r.failures[item]
 }
 
-func (r *ItemExponentialFailureRateLimiter) Forget(item interface{}) {
+func (r *TypedItemExponentialFailureRateLimiter[T]) Forget(item T) {
 	r.failuresLock.Lock()
 	defer r.failuresLock.Unlock()
 
@@ -122,9 +149,13 @@ func (r *ItemExponentialFailureRateLimiter) Forget(item interface{}) {
 }
 
 // ItemFastSlowRateLimiter does a quick retry for a certain number of attempts, then a slow retry after that
-type ItemFastSlowRateLimiter struct {
+// Deprecated: Use TypedItemFastSlowRateLimiter instead.
+type ItemFastSlowRateLimiter = TypedItemFastSlowRateLimiter[any]
+
+// TypedItemFastSlowRateLimiter does a quick retry for a certain number of attempts, then a slow retry after that
+type TypedItemFastSlowRateLimiter[T comparable] struct {
 	failuresLock sync.Mutex
-	failures     map[interface{}]int
+	failures     map[T]int
 
 	maxFastAttempts int
 	fastDelay       time.Duration
@@ -133,16 +164,21 @@ type ItemFastSlowRateLimiter struct {
 
 var _ RateLimiter = &ItemFastSlowRateLimiter{}
 
+// Deprecated: NewItemFastSlowRateLimiter is deprecated, use NewTypedItemFastSlowRateLimiter instead.
 func NewItemFastSlowRateLimiter(fastDelay, slowDelay time.Duration, maxFastAttempts int) RateLimiter {
-	return &ItemFastSlowRateLimiter{
-		failures:        map[interface{}]int{},
+	return NewTypedItemFastSlowRateLimiter[any](fastDelay, slowDelay, maxFastAttempts)
+}
+
+func NewTypedItemFastSlowRateLimiter[T comparable](fastDelay, slowDelay time.Duration, maxFastAttempts int) TypedRateLimiter[T] {
+	return &TypedItemFastSlowRateLimiter[T]{
+		failures:        map[T]int{},
 		fastDelay:       fastDelay,
 		slowDelay:       slowDelay,
 		maxFastAttempts: maxFastAttempts,
 	}
 }
 
-func (r *ItemFastSlowRateLimiter) When(item interface{}) time.Duration {
+func (r *TypedItemFastSlowRateLimiter[T]) When(item T) time.Duration {
 	r.failuresLock.Lock()
 	defer r.failuresLock.Unlock()
 
@@ -155,14 +191,14 @@ func (r *ItemFastSlowRateLimiter) When(item interface{}) time.Duration {
 	return r.slowDelay
 }
 
-func (r *ItemFastSlowRateLimiter) NumRequeues(item interface{}) int {
+func (r *TypedItemFastSlowRateLimiter[T]) NumRequeues(item T) int {
 	r.failuresLock.Lock()
 	defer r.failuresLock.Unlock()
 
 	return r.failures[item]
 }
 
-func (r *ItemFastSlowRateLimiter) Forget(item interface{}) {
+func (r *TypedItemFastSlowRateLimiter[T]) Forget(item T) {
 	r.failuresLock.Lock()
 	defer r.failuresLock.Unlock()
 
@@ -172,11 +208,18 @@ func (r *ItemFastSlowRateLimiter) Forget(item interface{}) {
 // MaxOfRateLimiter calls every RateLimiter and returns the worst case response
 // When used with a token bucket limiter, the burst could be apparently exceeded in cases where particular items
 // were separately delayed a longer time.
-type MaxOfRateLimiter struct {
-	limiters []RateLimiter
+//
+// Deprecated: Use TypedMaxOfRateLimiter instead.
+type MaxOfRateLimiter = TypedMaxOfRateLimiter[any]
+
+// TypedMaxOfRateLimiter calls every RateLimiter and returns the worst case response
+// When used with a token bucket limiter, the burst could be apparently exceeded in cases where particular items
+// were separately delayed a longer time.
+type TypedMaxOfRateLimiter[T comparable] struct {
+	limiters []TypedRateLimiter[T]
 }
 
-func (r *MaxOfRateLimiter) When(item interface{}) time.Duration {
+func (r *TypedMaxOfRateLimiter[T]) When(item T) time.Duration {
 	ret := time.Duration(0)
 	for _, limiter := range r.limiters {
 		curr := limiter.When(item)
@@ -188,11 +231,16 @@ func (r *MaxOfRateLimiter) When(item interface{}) time.Duration {
 	return ret
 }
 
-func NewMaxOfRateLimiter(limiters ...RateLimiter) RateLimiter {
-	return &MaxOfRateLimiter{limiters: limiters}
+// Deprecated: NewMaxOfRateLimiter is deprecated, use NewTypedMaxOfRateLimiter instead.
+func NewMaxOfRateLimiter(limiters ...TypedRateLimiter[any]) RateLimiter {
+	return NewTypedMaxOfRateLimiter(limiters...)
 }
 
-func (r *MaxOfRateLimiter) NumRequeues(item interface{}) int {
+func NewTypedMaxOfRateLimiter[T comparable](limiters ...TypedRateLimiter[T]) TypedRateLimiter[T] {
+	return &TypedMaxOfRateLimiter[T]{limiters: limiters}
+}
+
+func (r *TypedMaxOfRateLimiter[T]) NumRequeues(item T) int {
 	ret := 0
 	for _, limiter := range r.limiters {
 		curr := limiter.NumRequeues(item)
@@ -204,23 +252,32 @@ func (r *MaxOfRateLimiter) NumRequeues(item interface{}) int {
 	return ret
 }
 
-func (r *MaxOfRateLimiter) Forget(item interface{}) {
+func (r *TypedMaxOfRateLimiter[T]) Forget(item T) {
 	for _, limiter := range r.limiters {
 		limiter.Forget(item)
 	}
 }
 
 // WithMaxWaitRateLimiter have maxDelay which avoids waiting too long
-type WithMaxWaitRateLimiter struct {
-	limiter  RateLimiter
+// Deprecated: Use TypedWithMaxWaitRateLimiter instead.
+type WithMaxWaitRateLimiter = TypedWithMaxWaitRateLimiter[any]
+
+// TypedWithMaxWaitRateLimiter have maxDelay which avoids waiting too long
+type TypedWithMaxWaitRateLimiter[T comparable] struct {
+	limiter  TypedRateLimiter[T]
 	maxDelay time.Duration
 }
 
+// Deprecated: NewWithMaxWaitRateLimiter is deprecated, use NewTypedWithMaxWaitRateLimiter instead.
 func NewWithMaxWaitRateLimiter(limiter RateLimiter, maxDelay time.Duration) RateLimiter {
-	return &WithMaxWaitRateLimiter{limiter: limiter, maxDelay: maxDelay}
+	return NewTypedWithMaxWaitRateLimiter[any](limiter, maxDelay)
 }
 
-func (w WithMaxWaitRateLimiter) When(item interface{}) time.Duration {
+func NewTypedWithMaxWaitRateLimiter[T comparable](limiter TypedRateLimiter[T], maxDelay time.Duration) TypedRateLimiter[T] {
+	return &TypedWithMaxWaitRateLimiter[T]{limiter: limiter, maxDelay: maxDelay}
+}
+
+func (w TypedWithMaxWaitRateLimiter[T]) When(item T) time.Duration {
 	delay := w.limiter.When(item)
 	if delay > w.maxDelay {
 		return w.maxDelay
@@ -229,10 +286,10 @@ func (w WithMaxWaitRateLimiter) When(item interface{}) time.Duration {
 	return delay
 }
 
-func (w WithMaxWaitRateLimiter) Forget(item interface{}) {
+func (w TypedWithMaxWaitRateLimiter[T]) Forget(item T) {
 	w.limiter.Forget(item)
 }
 
-func (w WithMaxWaitRateLimiter) NumRequeues(item interface{}) int {
+func (w TypedWithMaxWaitRateLimiter[T]) NumRequeues(item T) int {
 	return w.limiter.NumRequeues(item)
 }

--- a/staging/src/k8s.io/client-go/util/workqueue/delaying_queue.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/delaying_queue.go
@@ -27,14 +27,25 @@ import (
 
 // DelayingInterface is an Interface that can Add an item at a later time. This makes it easier to
 // requeue items after failures without ending up in a hot-loop.
-type DelayingInterface interface {
-	Interface
+//
+// Deprecated: use TypedDelayingInterface instead.
+type DelayingInterface TypedDelayingInterface[any]
+
+// TypedDelayingInterface is an Interface that can Add an item at a later time. This makes it easier to
+// requeue items after failures without ending up in a hot-loop.
+type TypedDelayingInterface[T comparable] interface {
+	TypedInterface[T]
 	// AddAfter adds an item to the workqueue after the indicated duration has passed
-	AddAfter(item interface{}, duration time.Duration)
+	AddAfter(item T, duration time.Duration)
 }
 
 // DelayingQueueConfig specifies optional configurations to customize a DelayingInterface.
-type DelayingQueueConfig struct {
+//
+// Deprecated: use TypedDelayingQueueConfig instead.
+type DelayingQueueConfig = TypedDelayingQueueConfig[any]
+
+// TypedDelayingQueueConfig specifies optional configurations to customize a DelayingInterface.
+type TypedDelayingQueueConfig[T comparable] struct {
 	// Name for the queue. If unnamed, the metrics will not be registered.
 	Name string
 
@@ -46,25 +57,42 @@ type DelayingQueueConfig struct {
 	Clock clock.WithTicker
 
 	// Queue optionally allows injecting custom queue Interface instead of the default one.
-	Queue Interface
+	Queue TypedInterface[T]
 }
 
 // NewDelayingQueue constructs a new workqueue with delayed queuing ability.
 // NewDelayingQueue does not emit metrics. For use with a MetricsProvider, please use
 // NewDelayingQueueWithConfig instead and specify a name.
+//
+// Deprecated: use TypedNewDelayingQueue instead.
 func NewDelayingQueue() DelayingInterface {
 	return NewDelayingQueueWithConfig(DelayingQueueConfig{})
 }
 
+// TypedNewDelayingQueue constructs a new workqueue with delayed queuing ability.
+// TypedNewDelayingQueue does not emit metrics. For use with a MetricsProvider, please use
+// TypedNewDelayingQueueWithConfig instead and specify a name.
+func TypedNewDelayingQueue[T comparable]() TypedDelayingInterface[T] {
+	return NewTypedDelayingQueueWithConfig(TypedDelayingQueueConfig[T]{})
+}
+
 // NewDelayingQueueWithConfig constructs a new workqueue with options to
 // customize different properties.
+//
+// Deprecated: use TypedNewDelayingQueueWithConfig instead.
 func NewDelayingQueueWithConfig(config DelayingQueueConfig) DelayingInterface {
+	return NewTypedDelayingQueueWithConfig[any](config)
+}
+
+// NewTypedDelayingQueueWithConfig constructs a new workqueue with options to
+// customize different properties.
+func NewTypedDelayingQueueWithConfig[T comparable](config TypedDelayingQueueConfig[T]) TypedDelayingInterface[T] {
 	if config.Clock == nil {
 		config.Clock = clock.RealClock{}
 	}
 
 	if config.Queue == nil {
-		config.Queue = NewWithConfig(QueueConfig{
+		config.Queue = NewTypedWithConfig[T](TypedQueueConfig[T]{
 			Name:            config.Name,
 			MetricsProvider: config.MetricsProvider,
 			Clock:           config.Clock,
@@ -100,9 +128,9 @@ func NewDelayingQueueWithCustomClock(clock clock.WithTicker, name string) Delayi
 	})
 }
 
-func newDelayingQueue(clock clock.WithTicker, q Interface, name string, provider MetricsProvider) *delayingType {
-	ret := &delayingType{
-		Interface:       q,
+func newDelayingQueue[T comparable](clock clock.WithTicker, q TypedInterface[T], name string, provider MetricsProvider) *delayingType[T] {
+	ret := &delayingType[T]{
+		TypedInterface:  q,
 		clock:           clock,
 		heartbeat:       clock.NewTicker(maxWait),
 		stopCh:          make(chan struct{}),
@@ -115,8 +143,8 @@ func newDelayingQueue(clock clock.WithTicker, q Interface, name string, provider
 }
 
 // delayingType wraps an Interface and provides delayed re-enquing
-type delayingType struct {
-	Interface
+type delayingType[T comparable] struct {
+	TypedInterface[T]
 
 	// clock tracks time for delayed firing
 	clock clock.Clock
@@ -193,16 +221,16 @@ func (pq waitForPriorityQueue) Peek() interface{} {
 
 // ShutDown stops the queue. After the queue drains, the returned shutdown bool
 // on Get() will be true. This method may be invoked more than once.
-func (q *delayingType) ShutDown() {
+func (q *delayingType[T]) ShutDown() {
 	q.stopOnce.Do(func() {
-		q.Interface.ShutDown()
+		q.TypedInterface.ShutDown()
 		close(q.stopCh)
 		q.heartbeat.Stop()
 	})
 }
 
 // AddAfter adds the given item to the work queue after the given delay
-func (q *delayingType) AddAfter(item interface{}, duration time.Duration) {
+func (q *delayingType[T]) AddAfter(item T, duration time.Duration) {
 	// don't add if we're already shutting down
 	if q.ShuttingDown() {
 		return
@@ -229,7 +257,7 @@ func (q *delayingType) AddAfter(item interface{}, duration time.Duration) {
 const maxWait = 10 * time.Second
 
 // waitingLoop runs until the workqueue is shutdown and keeps a check on the list of items to be added.
-func (q *delayingType) waitingLoop() {
+func (q *delayingType[T]) waitingLoop() {
 	defer utilruntime.HandleCrash()
 
 	// Make a placeholder channel to use when there are no items in our list
@@ -244,7 +272,7 @@ func (q *delayingType) waitingLoop() {
 	waitingEntryByData := map[t]*waitFor{}
 
 	for {
-		if q.Interface.ShuttingDown() {
+		if q.TypedInterface.ShuttingDown() {
 			return
 		}
 
@@ -258,7 +286,7 @@ func (q *delayingType) waitingLoop() {
 			}
 
 			entry = heap.Pop(waitingForQueue).(*waitFor)
-			q.Add(entry.data)
+			q.Add(entry.data.(T))
 			delete(waitingEntryByData, entry.data)
 		}
 
@@ -287,7 +315,7 @@ func (q *delayingType) waitingLoop() {
 			if waitEntry.readyAt.After(q.clock.Now()) {
 				insert(waitingForQueue, waitingEntryByData, waitEntry)
 			} else {
-				q.Add(waitEntry.data)
+				q.Add(waitEntry.data.(T))
 			}
 
 			drained := false
@@ -297,7 +325,7 @@ func (q *delayingType) waitingLoop() {
 					if waitEntry.readyAt.After(q.clock.Now()) {
 						insert(waitingForQueue, waitingEntryByData, waitEntry)
 					} else {
-						q.Add(waitEntry.data)
+						q.Add(waitEntry.data.(T))
 					}
 				default:
 					drained = true

--- a/staging/src/k8s.io/client-go/util/workqueue/delaying_queue_test.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/delaying_queue_test.go
@@ -241,7 +241,7 @@ func waitForAdded(q DelayingInterface, depth int) error {
 
 func waitForWaitingQueueToFill(q DelayingInterface) error {
 	return wait.Poll(1*time.Millisecond, 10*time.Second, func() (done bool, err error) {
-		if len(q.(*delayingType).waitingForAddCh) == 0 {
+		if len(q.(*delayingType[any]).waitingForAddCh) == 0 {
 			return true, nil
 		}
 

--- a/staging/src/k8s.io/client-go/util/workqueue/metrics_test.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/metrics_test.go
@@ -41,7 +41,7 @@ func TestMetricShutdown(t *testing.T) {
 		updateCalled: ch,
 	}
 	c := testingclock.NewFakeClock(time.Now())
-	q := newQueue(c, DefaultQueue(), m, time.Millisecond)
+	q := newQueue[any](c, DefaultQueue[any](), m, time.Millisecond)
 	for !c.HasWaiters() {
 		// Wait for the go routine to call NewTicker()
 		time.Sleep(time.Millisecond)
@@ -176,7 +176,7 @@ func TestMetrics(t *testing.T) {
 		Clock:           c,
 		MetricsProvider: &mp,
 	}
-	q := newQueueWithConfig(config, time.Millisecond)
+	q := newQueueWithConfig[any](config, time.Millisecond)
 	defer q.ShutDown()
 	for !c.HasWaiters() {
 		// Wait for the go routine to call NewTicker()

--- a/staging/src/k8s.io/client-go/util/workqueue/queue_test.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/queue_test.go
@@ -29,7 +29,7 @@ import (
 
 // traceQueue traces whether items are touched
 type traceQueue struct {
-	workqueue.Queue
+	workqueue.Queue[any]
 
 	touched map[interface{}]struct{}
 }
@@ -42,7 +42,7 @@ func (t *traceQueue) Touch(item interface{}) {
 	t.touched[item] = struct{}{}
 }
 
-var _ workqueue.Queue = &traceQueue{}
+var _ workqueue.Queue[any] = &traceQueue{}
 
 func TestBasic(t *testing.T) {
 	tests := []struct {
@@ -215,7 +215,7 @@ func TestReinsert(t *testing.T) {
 }
 
 func TestCollapse(t *testing.T) {
-	tq := &traceQueue{Queue: workqueue.DefaultQueue()}
+	tq := &traceQueue{Queue: workqueue.DefaultQueue[any]()}
 	q := workqueue.NewWithConfig(workqueue.QueueConfig{
 		Name:  "",
 		Queue: tq,
@@ -244,7 +244,7 @@ func TestCollapse(t *testing.T) {
 }
 
 func TestCollapseWhileProcessing(t *testing.T) {
-	tq := &traceQueue{Queue: workqueue.DefaultQueue()}
+	tq := &traceQueue{Queue: workqueue.DefaultQueue[any]()}
 	q := workqueue.NewWithConfig(workqueue.QueueConfig{
 		Name:  "",
 		Queue: tq,

--- a/staging/src/k8s.io/client-go/util/workqueue/rate_limiting_queue_test.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/rate_limiting_queue_test.go
@@ -25,17 +25,17 @@ import (
 
 func TestRateLimitingQueue(t *testing.T) {
 	limiter := NewItemExponentialFailureRateLimiter(1*time.Millisecond, 1*time.Second)
-	queue := NewRateLimitingQueue(limiter).(*rateLimitingType)
+	queue := NewRateLimitingQueue(limiter).(*rateLimitingType[any])
 	fakeClock := testingclock.NewFakeClock(time.Now())
-	delayingQueue := &delayingType{
-		Interface:       New(),
+	delayingQueue := &delayingType[any]{
+		TypedInterface:  New(),
 		clock:           fakeClock,
 		heartbeat:       fakeClock.NewTicker(maxWait),
 		stopCh:          make(chan struct{}),
 		waitingForAddCh: make(chan *waitFor, 1000),
 		metrics:         newRetryMetrics("", nil),
 	}
-	queue.DelayingInterface = delayingQueue
+	queue.TypedDelayingInterface = delayingQueue
 
 	queue.AddRateLimited("one")
 	waitEntry := <-delayingQueue.waitingForAddCh


### PR DESCRIPTION
This change adds a generic version of the various workqueue types while
retaining compatibility for the existing exported symbols and constructors.
The generic variants are prefixed with `Typed` and the existing ones are
marked as deprecated to nudge people to transition without breaking
them.

The first commit is the changes in the workqueue itself, the second changes the Customresource Discovery Controller to use a typed queue in order to demonstrate it.

/sig api-machinery
/kind cleanup

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
