### PR TITLE
AD controller remove this behavior: call SetNodeUpdateStatusNeeded whenever nodeAdd event is received

### DIFF
--- a/pkg/controller/volume/attachdetach/attach_detach_controller.go
+++ b/pkg/controller/volume/attachdetach/attach_detach_controller.go
@@ -555,24 +555,13 @@ func (adc *attachDetachController) nodeAdd(logger klog.Logger, obj interface{}) 
 		return
 	}
 	nodeName := types.NodeName(node.Name)
-	adc.nodeUpdate(logger, nil, obj)
-	// kubernetes/kubernetes/issues/37586
-	// This is to workaround the case when a node add causes to wipe out
-	// the attached volumes field. This function ensures that we sync with
-	// the actual status.
-	adc.actualStateOfWorld.SetNodeStatusUpdateNeeded(logger, nodeName)
-}
-
-func (adc *attachDetachController) nodeUpdate(logger klog.Logger, oldObj, newObj interface{}) {
-	node, ok := newObj.(*v1.Node)
-	// TODO: investigate if nodeName is empty then if we can return
-	if node == nil || !ok {
-		return
-	}
-
-	nodeName := types.NodeName(node.Name)
 	adc.addNodeToDswp(node, nodeName)
 	adc.processVolumesInUse(logger, nodeName, node.Status.VolumesInUse)
+}
+
+func (adc *attachDetachController) nodeUpdate(logger klog.Logger, _, newObj interface{}) {
+	// The flow for update is the same as add.
+	adc.nodeAdd(logger, newObj)
 }
 
 func (adc *attachDetachController) nodeDelete(logger klog.Logger, obj interface{}) {

--- a/pkg/controller/volume/attachdetach/cache/actual_state_of_world.go
+++ b/pkg/controller/volume/attachdetach/cache/actual_state_of_world.go
@@ -136,9 +136,6 @@ type ActualStateOfWorld interface {
 	// attached for the given node. It reports a boolean indicating if there is an update for that
 	// node and the corresponding attachedVolumes list.
 	GetVolumesToReportAttachedForNode(logger klog.Logger, name types.NodeName) (bool, []v1.AttachedVolume)
-
-	// GetNodesToUpdateStatusFor returns the map of nodeNames to nodeToUpdateStatusFor
-	GetNodesToUpdateStatusFor() map[types.NodeName]nodeToUpdateStatusFor
 }
 
 // AttachedVolume represents a volume that is attached to a node.
@@ -706,10 +703,6 @@ func (asw *actualStateOfWorld) GetVolumesToReportAttachedForNode(logger klog.Log
 	}
 
 	return true, volumesToReportAttached
-}
-
-func (asw *actualStateOfWorld) GetNodesToUpdateStatusFor() map[types.NodeName]nodeToUpdateStatusFor {
-	return asw.nodesToUpdateStatusFor
 }
 
 func (asw *actualStateOfWorld) getAttachedVolumeFromUpdateObject(volumesToReportAsAttached map[v1.UniqueVolumeName]v1.UniqueVolumeName) []v1.AttachedVolume {

--- a/pkg/controller/volume/attachdetach/cache/actual_state_of_world_test.go
+++ b/pkg/controller/volume/attachdetach/cache/actual_state_of_world_test.go
@@ -1347,7 +1347,7 @@ func Test_SetNodeStatusUpdateNeededError(t *testing.T) {
 	asw.SetNodeStatusUpdateNeeded(logger, nodeName)
 
 	// Assert
-	nodesToUpdateStatusFor := asw.GetNodesToUpdateStatusFor()
+	nodesToUpdateStatusFor := asw.(*actualStateOfWorld).nodesToUpdateStatusFor
 	if len(nodesToUpdateStatusFor) != 0 {
 		t.Fatalf("nodesToUpdateStatusFor should be empty as nodeName does not exist")
 	}
@@ -1378,8 +1378,8 @@ func Test_updateNodeStatusUpdateNeeded(t *testing.T) {
 	if err != nil {
 		t.Fatalf("updateNodeStatusUpdateNeeded should not return error, but got: %v", err)
 	}
-	nodesToUpdateStatusFor := asw.GetNodesToUpdateStatusFor()
-	if nodesToUpdateStatusFor[nodeName].statusUpdateNeeded {
+
+	if asw.nodesToUpdateStatusFor[nodeName].statusUpdateNeeded {
 		t.Fatalf("nodesToUpdateStatusFor should be updated to: false, but got: true")
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This PR almost reverts the previous PR https://github.com/kubernetes/kubernetes/pull/37727.

```shell
(base) (⎈|kind-kind:test)➜  ~ kubectl explain node.spec.externalID
KIND:       Node
VERSION:    v1

FIELD: externalID <string>

DESCRIPTION:
    Deprecated. Not all kubelets will set this field. Remove field after 1.13.
    see: https://issues.k8s.io/61966

```

The main reason for this PR is that the `externalID` field of the `Node` object was removed.

With this field removed, the `Node` object isn't deleted during the `kubelet` restart or upgrade. And the attached volumes field of the `Node` object can't be wiped out now.

FYI: 
- https://github.com/kubernetes/kubernetes/issues/37586#issuecomment-263766806
- https://github.com/kubernetes/kubernetes/blob/release-1.5/pkg/kubelet/kubelet_node_status.go#L84-L90
- https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/kubelet_node_status.go#L83-L88

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Related to https://github.com/kubernetes/kubernetes/issues/37586 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
