### PR TITLE
feature: support remove ephemeral container

### DIFF
--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -5438,9 +5438,7 @@ func ValidatePodEphemeralContainersUpdate(newPod, oldPod *core.Pod, opts PodVali
 		newContainerIndex[newPod.Spec.EphemeralContainers[i].Name] = &newPod.Spec.EphemeralContainers[i]
 	}
 	for _, old := range oldPod.Spec.EphemeralContainers {
-		if new, ok := newContainerIndex[old.Name]; !ok {
-			allErrs = append(allErrs, field.Forbidden(specPath, fmt.Sprintf("existing ephemeral containers %q may not be removed\n", old.Name)))
-		} else if !apiequality.Semantic.DeepEqual(old, *new) {
+		if new, ok := newContainerIndex[old.Name]; ok && !apiequality.Semantic.DeepEqual(old, *new) {
 			specDiff := cmp.Diff(old, *new)
 			allErrs = append(allErrs, field.Forbidden(specPath, fmt.Sprintf("existing ephemeral containers %q may not be changed\n%v", old.Name, specDiff)))
 		}

--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -16778,9 +16778,9 @@ func TestValidatePodEphemeralContainersUpdate(t *testing.T) {
 				TerminationMessagePolicy: "File",
 			},
 		}}),
-		"may not be removed",
+		"",
 	}, {
-		"Replace an Ephemeral Container",
+		"Replace an Ephemeral Container, old will be removed, new will be added",
 		makePod([]core.EphemeralContainer{{
 			EphemeralContainerCommon: core.EphemeralContainerCommon{
 				Name:                     "firstone",
@@ -16797,7 +16797,7 @@ func TestValidatePodEphemeralContainersUpdate(t *testing.T) {
 				TerminationMessagePolicy: "File",
 			},
 		}}),
-		"may not be removed",
+		"",
 	}, {
 		"Change an Ephemeral Containers",
 		makePod([]core.EphemeralContainer{{


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
-->

#### What this PR does / why we need it:
#124270 

Supports deleting ephemeral containers after debugging is completed

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
ephemeral container could be removed
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

[KEP-277: Ephemeral Containers](https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/277-ephemeral-containers#container-spec-in-podstatus)
