### PR TITLE
Remove missing extended resources from init containers

### DIFF
--- a/pkg/kubelet/lifecycle/predicate.go
+++ b/pkg/kubelet/lifecycle/predicate.go
@@ -215,21 +215,26 @@ func rejectPodAdmissionBasedOnOSField(pod *v1.Pod) bool {
 }
 
 func removeMissingExtendedResources(pod *v1.Pod, nodeInfo *schedulerframework.NodeInfo) *v1.Pod {
-	podCopy := pod.DeepCopy()
-	for i, c := range pod.Spec.Containers {
-		// We only handle requests in Requests but not Limits because the
-		// PodFitsResources predicate, to which the result pod will be passed,
-		// does not use Limits.
-		podCopy.Spec.Containers[i].Resources.Requests = make(v1.ResourceList)
-		for rName, rQuant := range c.Resources.Requests {
-			if v1helper.IsExtendedResourceName(rName) {
-				if _, found := nodeInfo.Allocatable.ScalarResources[rName]; !found {
-					continue
+	filterExtendedResources := func(containers []v1.Container) {
+		for i, c := range containers {
+			// We only handle requests in Requests but not Limits because the
+			// PodFitsResources predicate, to which the result pod will be passed,
+			// does not use Limits.
+			filteredResources := make(v1.ResourceList)
+			for rName, rQuant := range c.Resources.Requests {
+				if v1helper.IsExtendedResourceName(rName) {
+					if _, found := nodeInfo.Allocatable.ScalarResources[rName]; !found {
+						continue
+					}
 				}
+				filteredResources[rName] = rQuant
 			}
-			podCopy.Spec.Containers[i].Resources.Requests[rName] = rQuant
+			containers[i].Resources.Requests = filteredResources
 		}
 	}
+	podCopy := pod.DeepCopy()
+	filterExtendedResources(podCopy.Spec.Containers)
+	filterExtendedResources(podCopy.Spec.InitContainers)
 	return podCopy
 }
 

--- a/pkg/kubelet/lifecycle/predicate_test.go
+++ b/pkg/kubelet/lifecycle/predicate_test.go
@@ -106,6 +106,14 @@ func makeTestPod(requests, limits v1.ResourceList) *v1.Pod {
 					},
 				},
 			},
+			InitContainers: []v1.Container{
+				{
+					Resources: v1.ResourceRequirements{
+						Requests: requests,
+						Limits:   limits,
+					},
+				},
+			},
 		},
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
The function removeMissingExtendedResources() located at pkg/kubelet/lifecycle/predicate.go:217, is designed to remove any extended resources from a container’s requests that are not found in nodeInfo.Allocatable before the pod is admitted. 
This is necessary to support cluster-level resources, which are extended resources that are unknown to nodes.
However, this function only removes missingExtendedResources from the container’s requests, and does not process the requests of initContainers. 
This could lead to issues, as initContainers might request resources that do not exist on the node, which could result in the pod failing to be admitted or other unforeseen issues. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #124255  

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
