### PR TITLE
Allow request parameter and proto file path

### DIFF
--- a/staging/src/k8s.io/code-generator/cmd/go-to-protobuf/protoc-gen-gogo/main.go
+++ b/staging/src/k8s.io/code-generator/cmd/go-to-protobuf/protoc-gen-gogo/main.go
@@ -36,8 +36,12 @@ func main() {
 	// if we're given paths as inputs, generate .pb.go files based on those paths
 	for _, file := range request.FileToGenerate {
 		if strings.Contains(file, "/") {
-			param := "paths=source_relative"
-			request.Parameter = &param
+			if request.Parameter != nil {
+				*request.Parameter += ",paths=source_relative"
+			} else {
+				param := "paths=source_relative"
+				request.Parameter = &param
+			}
 			break
 		}
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This PR fixes a bug in the protoc-gen-gogo tool where specific command-line parameters were being overridden, resulting in missing some parameters. This fix ensures that all specified parameters are respected and properly applied.

#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes/kubernetes/issues/117080

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
allow parameter to be set along with proto file path
```
