### PR TITLE
Automated cherry pick of #124283: Rename `cluster` to `storage_cluster_id` for

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/metrics/metrics.go
@@ -84,7 +84,7 @@ var (
 		},
 		[]string{"endpoint"},
 	)
-	storageSizeDescription   = compbasemetrics.NewDesc("apiserver_storage_size_bytes", "Size of the storage database file physically allocated in bytes.", []string{"cluster"}, nil, compbasemetrics.ALPHA, "")
+	storageSizeDescription   = compbasemetrics.NewDesc("apiserver_storage_size_bytes", "Size of the storage database file physically allocated in bytes.", []string{"storage_cluster_id"}, nil, compbasemetrics.ALPHA, "")
 	storageMonitor           = &monitorCollector{monitorGetter: func() ([]Monitor, error) { return nil, nil }}
 	etcdEventsReceivedCounts = compbasemetrics.NewCounterVec(
 		&compbasemetrics.CounterOpts{
@@ -274,21 +274,21 @@ func (c *monitorCollector) CollectWithStability(ch chan<- compbasemetrics.Metric
 	}
 
 	for i, m := range monitors {
-		cluster := fmt.Sprintf("etcd-%d", i)
+		storageClusterID := fmt.Sprintf("etcd-%d", i)
 
-		klog.V(4).InfoS("Start collecting storage metrics", "cluster", cluster)
+		klog.V(4).InfoS("Start collecting storage metrics", "storage_cluster_id", storageClusterID)
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 		metrics, err := m.Monitor(ctx)
 		cancel()
 		m.Close()
 		if err != nil {
-			klog.InfoS("Failed to get storage metrics", "cluster", cluster, "err", err)
+			klog.InfoS("Failed to get storage metrics", "storage_cluster_id", storageClusterID, "err", err)
 			continue
 		}
 
-		metric, err := compbasemetrics.NewConstMetric(storageSizeDescription, compbasemetrics.GaugeValue, float64(metrics.Size), cluster)
+		metric, err := compbasemetrics.NewConstMetric(storageSizeDescription, compbasemetrics.GaugeValue, float64(metrics.Size), storageClusterID)
 		if err != nil {
-			klog.ErrorS(err, "Failed to create metric", "cluster", cluster)
+			klog.ErrorS(err, "Failed to create metric", "storage_cluster_id", storageClusterID)
 		}
 		ch <- metric
 	}

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/metrics/metrics_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/metrics/metrics_test.go
@@ -199,7 +199,7 @@ func TestStorageSizeCollector(t *testing.T) {
 			err: nil,
 			want: `# HELP apiserver_storage_size_bytes [ALPHA] Size of the storage database file physically allocated in bytes.
 			# TYPE apiserver_storage_size_bytes gauge
-			apiserver_storage_size_bytes{cluster="etcd-0"} 1e+09
+			apiserver_storage_size_bytes{storage_cluster_id="etcd-0"} 1e+09
 			`,
 		},
 		{

--- a/test/instrumentation/documentation/documentation-list.yaml
+++ b/test/instrumentation/documentation/documentation-list.yaml
@@ -3082,7 +3082,7 @@
   type: Custom
   stabilityLevel: ALPHA
   labels:
-  - cluster
+  - storage_cluster_id
 - name: terminated_watchers_total
   namespace: apiserver
   help: Counter of watchers closed due to unresponsiveness broken by resource type.

--- a/test/instrumentation/documentation/documentation.md
+++ b/test/instrumentation/documentation/documentation.md
@@ -1029,7 +1029,7 @@ Alpha metrics do not have any API guarantees. These metrics must be used at your
 <td class="metric_stability_level" data-stability="alpha">ALPHA</td>
 <td class="metric_type" data-type="custom">Custom</td>
 <td class="metric_description">Size of the storage database file physically allocated in bytes.</td>
-<td class="metric_labels_varying"><div class="metric_label">cluster</div></td>
+<td class="metric_labels_varying"><div class="metric_label">storage_cluster_id</div></td>
 <td class="metric_labels_constant"></td>
 <td class="metric_deprecated_version"></td></tr>
 <tr class="metric"><td class="metric_name">apiserver_storage_transformation_duration_seconds</td>


### PR DESCRIPTION
Cherry pick of #124283 on release-1.28.

#124283: Rename `cluster` to `storage_cluster_id` for

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
For apiserver_storage_size_bytes metric, we are renaming the label for etcd to be "storage_cluster_id" instead of "cluster" to to reduce conflict and be very specific.
```