### PR TITLE
EventedPLEG: Pass event created timestamp correctly to cache

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -184,9 +184,6 @@ const (
 	eventedPlegRelistPeriod     = time.Second * 300
 	eventedPlegRelistThreshold  = time.Minute * 10
 	eventedPlegMaxStreamRetries = 5
-	// Evented PLEG needs to update the global timestamp of the cache as frequently as Generic PLEG relisting
-	// in order to wake up pod workers that get stuck in cache.GetNewerThan().
-	eventedPlegCacheUpdatePeriod = genericPlegRelistPeriod
 
 	// backOffPeriod is the period to back off when pod syncing results in an
 	// error. It is also used as the base period for the exponential backoff
@@ -739,7 +736,7 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 			RelistThreshold: genericPlegRelistThreshold,
 		}
 		klet.eventedPleg, err = pleg.NewEventedPLEG(klet.containerRuntime, klet.runtimeService, eventChannel,
-			klet.podCache, klet.pleg, eventedPlegMaxStreamRetries, eventedRelistDuration, clock.RealClock{}, eventedPlegCacheUpdatePeriod)
+			klet.podCache, klet.pleg, eventedPlegMaxStreamRetries, eventedRelistDuration, clock.RealClock{})
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -184,6 +184,9 @@ const (
 	eventedPlegRelistPeriod     = time.Second * 300
 	eventedPlegRelistThreshold  = time.Minute * 10
 	eventedPlegMaxStreamRetries = 5
+	// Evented PLEG needs to update the global timestamp of the cache as frequently as Generic PLEG relisting
+	// in order to wake up pod workers that get stuck in cache.GetNewerThan().
+	eventedPlegCacheUpdatePeriod = genericPlegRelistPeriod
 
 	// backOffPeriod is the period to back off when pod syncing results in an
 	// error. It is also used as the base period for the exponential backoff
@@ -736,7 +739,7 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 			RelistThreshold: genericPlegRelistThreshold,
 		}
 		klet.eventedPleg, err = pleg.NewEventedPLEG(klet.containerRuntime, klet.runtimeService, eventChannel,
-			klet.podCache, klet.pleg, eventedPlegMaxStreamRetries, eventedRelistDuration, clock.RealClock{})
+			klet.podCache, klet.pleg, eventedPlegMaxStreamRetries, eventedRelistDuration, clock.RealClock{}, eventedPlegCacheUpdatePeriod)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/kubelet/pleg/evented.go
+++ b/pkg/kubelet/pleg/evented.go
@@ -34,7 +34,7 @@ import (
 // The frequency with which global timestamp of the cache is to
 // is to be updated periodically. If pod workers get stuck at cache.GetNewerThan
 // call, after this period it will be unblocked.
-const globalCacheUpdatePeriod = 1 * time.Second
+const globalCacheUpdatePeriod = 5 * time.Second
 
 var (
 	eventedPLEGUsage   = false

--- a/pkg/kubelet/pleg/evented.go
+++ b/pkg/kubelet/pleg/evented.go
@@ -34,7 +34,7 @@ import (
 // The frequency with which global timestamp of the cache is to
 // is to be updated periodically. If pod workers get stuck at cache.GetNewerThan
 // call, after this period it will be unblocked.
-const globalCacheUpdatePeriod = 5 * time.Second
+const globalCacheUpdatePeriod = 1 * time.Second
 
 var (
 	eventedPLEGUsage   = false

--- a/pkg/kubelet/pleg/evented.go
+++ b/pkg/kubelet/pleg/evented.go
@@ -31,6 +31,11 @@ import (
 	"k8s.io/utils/clock"
 )
 
+// The frequency with which global timestamp of the cache is to
+// is to be updated periodically. If pod workers get stuck at cache.GetNewerThan
+// call, after this period it will be unblocked.
+const globalCacheUpdatePeriod = 1 * time.Second
+
 var (
 	eventedPLEGUsage   = false
 	eventedPLEGUsageMu = sync.RWMutex{}
@@ -71,10 +76,6 @@ type EventedPLEG struct {
 	eventedPlegMaxStreamRetries int
 	// Indicates relisting related parameters
 	relistDuration *RelistDuration
-	// The frequency with which global timestamp of the cache is to
-	// is to be updated periodically. If pod workers get stuck at cache.GetNewerThan
-	// call, after this period it will be unblocked.
-	globalCacheUpdatePeriod time.Duration
 	// Stop the Evented PLEG by closing the channel.
 	stopCh chan struct{}
 	// Stops the periodic update of the cache global timestamp.
@@ -86,7 +87,7 @@ type EventedPLEG struct {
 // NewEventedPLEG instantiates a new EventedPLEG object and return it.
 func NewEventedPLEG(runtime kubecontainer.Runtime, runtimeService internalapi.RuntimeService, eventChannel chan *PodLifecycleEvent,
 	cache kubecontainer.Cache, genericPleg PodLifecycleEventGenerator, eventedPlegMaxStreamRetries int,
-	relistDuration *RelistDuration, clock clock.Clock, cacheUpdatePeriod time.Duration) (PodLifecycleEventGenerator, error) {
+	relistDuration *RelistDuration, clock clock.Clock) (PodLifecycleEventGenerator, error) {
 	handler, ok := genericPleg.(podLifecycleEventGeneratorHandler)
 	if !ok {
 		return nil, fmt.Errorf("%v doesn't implement podLifecycleEventGeneratorHandler interface", genericPleg)
@@ -100,7 +101,6 @@ func NewEventedPLEG(runtime kubecontainer.Runtime, runtimeService internalapi.Ru
 		eventedPlegMaxStreamRetries: eventedPlegMaxStreamRetries,
 		relistDuration:              relistDuration,
 		clock:                       clock,
-		globalCacheUpdatePeriod:     cacheUpdatePeriod,
 	}, nil
 }
 
@@ -125,7 +125,7 @@ func (e *EventedPLEG) Start() {
 	e.stopCh = make(chan struct{})
 	e.stopCacheUpdateCh = make(chan struct{})
 	go wait.Until(e.watchEventsChannel, 0, e.stopCh)
-	go wait.Until(e.updateGlobalCache, e.globalCacheUpdatePeriod, e.stopCacheUpdateCh)
+	go wait.Until(e.updateGlobalCache, globalCacheUpdatePeriod, e.stopCacheUpdateCh)
 }
 
 // Stop stops the Evented PLEG

--- a/pkg/kubelet/pleg/evented.go
+++ b/pkg/kubelet/pleg/evented.go
@@ -264,7 +264,7 @@ func (e *EventedPLEG) processCRIEvents(containerEventsResponseCh chan *runtimeap
 			}
 			shouldSendPLEGEvent = true
 		} else {
-			if e.cache.Set(podID, status, err, time.Unix(event.GetCreatedAt(), 0)) {
+			if e.cache.Set(podID, status, err, time.Unix(0, event.GetCreatedAt())) {
 				shouldSendPLEGEvent = true
 			}
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:
`CreatedAt` timestamp of `ContainerEventResponse` should be passed as nanoseconds to `time.Unix()`.

This fix may mitigate #123087. I guess this issue happens as following:
Usually, a container created event is delivered while a pod worker is creating a pod at [SyncPod()](https://github.com/kubernetes/kubernetes/blob/v1.30.0-rc.2/pkg/kubelet/pod_workers.go#L1283) and the `created` status is cached by the PLEG. After `SyncPod()`, the pod worker waits at [GetNewerThan()](https://github.com/kubernetes/kubernetes/blob/v1.30.0-rc.2/pkg/kubelet/pod_workers.go#L1253) until a next event (container started) happens because the cached container status is older than `lastSyncTime`. However, due to the bug in this PR, the `modified` time of the cached status is so much newer because a nanoseconds value is set as seconds. Then, the pod worker gets a `created` container status from the cache and goes into `SyncPod()` soon. Then, the worker creates another container.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
