### PR TITLE
kubelet: fix potential resource leak and double file close.

### DIFF
--- a/staging/src/k8s.io/cri-client/pkg/logs/logs.go
+++ b/staging/src/k8s.io/cri-client/pkg/logs/logs.go
@@ -299,7 +299,11 @@ func ReadLogs(ctx context.Context, logger *klog.Logger, path, containerID string
 	if err != nil {
 		return fmt.Errorf("failed to open log file %q: %v", path, err)
 	}
-	defer f.Close()
+	// Let the closure capture the variable f, so it can close the last opened file.
+	defer func() {
+		//nolint:errcheck
+		f.Close()
+	}()
 
 	// Search start point based on tail line.
 	start, err := findTailLineStartIndex(f, opts.tail)
@@ -371,7 +375,8 @@ func ReadLogs(ctx context.Context, logger *klog.Logger, path, containerID string
 						}
 						return fmt.Errorf("failed to open log file %q: %v", path, err)
 					}
-					defer newF.Close()
+					internal.Log(logger, 6, "Opened new log file", "path", path)
+
 					f.Close()
 					f = newF
 					r = bufio.NewReader(f)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test

/kind regression
-->
/kind flake

#### What this PR does / why we need it:
A sample code mimic the function `ReadLogs`
It may cause resource leaks and close the file twice.
```
func closeFileTwice() {
	fn := "/tmp/abc.txt"
	f, _ := os.Open(fn)
	defer f.Close()

	for i := 0; i < 10; i++ {
		newF, _ := os.Open(fn)
		defer func(f *os.File) {
			if err := f.Close(); err != nil {
				panic(err)
			}
		}(newF)

		f.Close()
		f = newF
	}
}

```


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
