### PR TITLE
Optimize `exec.createExecutor` func, there is no need to create a SPDY executor every time

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/exec/exec.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/exec/exec.go
@@ -135,11 +135,7 @@ func (*DefaultRemoteExecutor) Execute(url *url.URL, config *restclient.Config, s
 }
 
 // createExecutor returns the Executor or an error if one occurred.
-func createExecutor(url *url.URL, config *restclient.Config) (remotecommand.Executor, error) {
-	exec, err := remotecommand.NewSPDYExecutor(config, "POST", url)
-	if err != nil {
-		return nil, err
-	}
+func createExecutor(url *url.URL, config *restclient.Config) (exec remotecommand.Executor, err error) {
 	// Fallback executor is default, unless feature flag is explicitly disabled.
 	if !cmdutil.RemoteCommandWebsockets.IsDisabled() {
 		// WebSocketExecutor must be "GET" method as described in RFC 6455 Sec. 4.1 (page 17).
@@ -151,8 +147,13 @@ func createExecutor(url *url.URL, config *restclient.Config) (remotecommand.Exec
 		if err != nil {
 			return nil, err
 		}
+	} else {
+		exec, err = remotecommand.NewSPDYExecutor(config, "POST", url)
+		if err != nil {
+			return nil, err
+		}
 	}
-	return exec, nil
+	return
 }
 
 type StreamOptions struct {


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind cleanup
-->

#### What this PR does / why we need it:
Optimize `exec.createExecutor` func, there is no need to create a SPDY executor every time. usually it is enough to create a websocket executor

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```
