### PR TITLE
WIP: component-base logs: update klog verbosity also at runtime

### DIFF
--- a/staging/src/k8s.io/component-base/logs/api/v1/options.go
+++ b/staging/src/k8s.io/component-base/logs/api/v1/options.go
@@ -276,10 +276,10 @@ func apply(c *LoggingConfiguration, options *LoggingOptions, featureGate feature
 		}
 		klog.SetLoggerWithOptions(log, opts...)
 	}
-	if err := loggingFlags.Lookup("v").Value.Set(VerbosityLevelPflag(&c.Verbosity).String()); err != nil {
+	if err := loggingFlags.Lookup("v").Value.Set(VerbosityLevelPflag(&c.Verbosity, nil).String()); err != nil {
 		return fmt.Errorf("internal error while setting klog verbosity: %v", err)
 	}
-	if err := loggingFlags.Lookup("vmodule").Value.Set(VModuleConfigurationPflag(&c.VModule).String()); err != nil {
+	if err := loggingFlags.Lookup("vmodule").Value.Set(VModuleConfigurationPflag(&c.VModule, nil).String()); err != nil {
 		return fmt.Errorf("internal error while setting klog vmodule: %v", err)
 	}
 	klog.StartFlushDaemon(c.FlushFrequency.Duration.Duration)
@@ -363,8 +363,8 @@ func addFlags(c *LoggingConfiguration, fs flagSet) {
 	logRegistry.freeze()
 
 	fs.DurationVar(&c.FlushFrequency.Duration.Duration, LogFlushFreqFlagName, c.FlushFrequency.Duration.Duration, "Maximum number of seconds between log flushes")
-	fs.VarP(VerbosityLevelPflag(&c.Verbosity), "v", "v", "number for the log level verbosity")
-	fs.Var(VModuleConfigurationPflag(&c.VModule), "vmodule", "comma-separated list of pattern=N settings for file-filtered logging (only works for text log format)")
+	fs.VarP(VerbosityLevelPflag(&c.Verbosity, lookupValue(&loggingFlags, "v")), "v", "v", "number for the log level verbosity")
+	fs.Var(VModuleConfigurationPflag(&c.VModule, lookupValue(&loggingFlags, "vmodule")), "vmodule", "comma-separated list of pattern=N settings for file-filtered logging (only works for text log format)")
 
 	fs.BoolVar(&c.Options.Text.SplitStream, "log-text-split-stream", false, "[Alpha] In text format, write error messages to stderr and info messages to stdout. The default is to write a single stream to stdout. Enable the LoggingAlphaOptions feature gate to use this.")
 	fs.Var(&c.Options.Text.InfoBufferSize, "log-text-info-buffer-size", "[Alpha] In text format with split output streams, the info messages can be buffered for a while to increase performance. The default value of zero bytes disables buffering. The size can be specified as number of bytes (512), multiples of 1000 (1K), multiples of 1024 (2Ki), or powers of those (3M, 4G, 5Mi, 6Gi). Enable the LoggingAlphaOptions feature gate to use this.")
@@ -375,6 +375,14 @@ func addFlags(c *LoggingConfiguration, fs flagSet) {
 		fs.BoolVar(&c.Options.JSON.SplitStream, "log-json-split-stream", false, "[Alpha] In JSON format, write error messages to stderr and info messages to stdout. The default is to write a single stream to stdout. Enable the LoggingAlphaOptions feature gate to use this.")
 		fs.Var(&c.Options.JSON.InfoBufferSize, "log-json-info-buffer-size", "[Alpha] In JSON format with split output streams, the info messages can be buffered for a while to increase performance. The default value of zero bytes disables buffering. The size can be specified as number of bytes (512), multiples of 1000 (1K), multiples of 1024 (2Ki), or powers of those (3M, 4G, 5Mi, 6Gi). Enable the LoggingAlphaOptions feature gate to use this.")
 	}
+}
+
+func lookupValue(fs *pflag.FlagSet, flagName string) pflag.Value {
+	f := fs.Lookup(flagName)
+	if f == nil {
+		return nil
+	}
+	return f.Value
 }
 
 // SetRecommendedLoggingConfiguration sets the default logging configuration

--- a/staging/src/k8s.io/component-base/logs/api/v1/text.go
+++ b/staging/src/k8s.io/component-base/logs/api/v1/text.go
@@ -65,7 +65,7 @@ func (f textFactory) Create(c LoggingConfiguration, o LoggingOptions) (logr.Logg
 	loggerConfig := textlogger.NewConfig(options...)
 
 	// This should never fail, we produce a valid string here.
-	_ = loggerConfig.VModule().Set(VModuleConfigurationPflag(&c.VModule).String())
+	_ = loggerConfig.VModule().Set(VModuleConfigurationPflag(&c.VModule, nil).String())
 
 	return textlogger.NewLogger(loggerConfig),
 		RuntimeControl{

--- a/staging/src/k8s.io/component-base/logs/api/v1/types_test.go
+++ b/staging/src/k8s.io/component-base/logs/api/v1/types_test.go
@@ -104,7 +104,7 @@ func TestVModule(t *testing.T) {
 	for _, test := range testcases {
 		t.Run(test.arg, func(t *testing.T) {
 			var actual VModuleConfiguration
-			value := VModuleConfigurationPflag(&actual)
+			value := VModuleConfigurationPflag(&actual, nil)
 			err := value.Set(test.arg)
 			if test.expectError != "" {
 				if err == nil {


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

When applying the logging configuration, verbosity settings in klog were already updated. This is important because legacy klog calls (for example, klog.V.Enabled) use the klog verbosity settings even when a logger is installed.

But when some code changes the verbosity at runtime via fs.Lookup("v").Value.Set("5"), only the component-base logger settings were updated. Now the Set call also updates klog.

#### Special notes for your reviewer:

The receiver type of the methods gets changed to pointer because:
- None of the reasons for value receiver from https://go.dev/wiki/CodeReviewComments#receiver-type apply (the struct contains a pointer and modifies the underlying value, so pointer better expresses the intent)
- Binding the value to an interface always allocates on the heap anyway, so the pointer receiver gets used.

WIP: needs tests...

#### Does this PR introduce a user-facing change?
```release-note
component-base logs: update also klog verbosity when changing verbosity at runtime through command line flags
```
