### PR TITLE
pkg/registry: drop pointer wrapper functions.

### DIFF
--- a/pkg/registry/batch/cronjob/strategy_test.go
+++ b/pkg/registry/batch/cronjob/strategy_test.go
@@ -24,7 +24,7 @@ import (
 	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/kubernetes/pkg/apis/batch"
 	api "k8s.io/kubernetes/pkg/apis/core"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 var (
@@ -38,20 +38,20 @@ var (
 	validCronjobSpec = batch.CronJobSpec{
 		Schedule:          "5 5 * * ?",
 		ConcurrencyPolicy: batch.AllowConcurrent,
-		TimeZone:          pointer.String("Asia/Shanghai"),
+		TimeZone:          ptr.To("Asia/Shanghai"),
 		JobTemplate: batch.JobTemplateSpec{
 			Spec: batch.JobSpec{
 				Template:       validPodTemplateSpec,
 				CompletionMode: completionModePtr(batch.IndexedCompletion),
-				Completions:    pointer.Int32(10),
-				Parallelism:    pointer.Int32(10),
+				Completions:    ptr.To[int32](10),
+				Parallelism:    ptr.To[int32](10),
 			},
 		},
 	}
 	cronjobSpecWithTZinSchedule = batch.CronJobSpec{
 		Schedule:          "CRON_TZ=UTC 5 5 * * ?",
 		ConcurrencyPolicy: batch.AllowConcurrent,
-		TimeZone:          pointer.String("Asia/DoesNotExist"),
+		TimeZone:          ptr.To("Asia/DoesNotExist"),
 		JobTemplate: batch.JobTemplateSpec{
 			Spec: batch.JobSpec{
 				Template: validPodTemplateSpec,

--- a/pkg/registry/batch/job/storage/storage_test.go
+++ b/pkg/registry/batch/job/storage/storage_test.go
@@ -17,8 +17,9 @@ limitations under the License.
 package storage
 
 import (
-	"k8s.io/utils/pointer"
 	"testing"
+
+	"k8s.io/utils/ptr"
 
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -138,7 +139,7 @@ func TestCreate(t *testing.T) {
 		// invalid (empty selector)
 		&batch.Job{
 			Spec: batch.JobSpec{
-				ManualSelector: pointer.Bool(false),
+				ManualSelector: ptr.To(false),
 				Completions:    validJob.Spec.Completions,
 				Selector:       &metav1.LabelSelector{},
 				Template:       validJob.Spec.Template,

--- a/pkg/registry/batch/job/strategy_test.go
+++ b/pkg/registry/batch/job/strategy_test.go
@@ -35,7 +35,6 @@ import (
 	_ "k8s.io/kubernetes/pkg/apis/batch/install"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/features"
-	"k8s.io/utils/pointer"
 	"k8s.io/utils/ptr"
 )
 
@@ -51,7 +50,7 @@ func TestJobStrategy_PrepareForUpdate(t *testing.T) {
 			{
 				Action: batch.PodFailurePolicyActionFailJob,
 				OnExitCodes: &batch.PodFailurePolicyOnExitCodesRequirement{
-					ContainerName: pointer.String("container-name"),
+					ContainerName: ptr.To("container-name"),
 					Operator:      batch.PodFailurePolicyOnExitCodesOpIn,
 					Values:        []int32{1},
 				},
@@ -63,7 +62,7 @@ func TestJobStrategy_PrepareForUpdate(t *testing.T) {
 			{
 				Action: batch.PodFailurePolicyActionIgnore,
 				OnExitCodes: &batch.PodFailurePolicyOnExitCodesRequirement{
-					ContainerName: pointer.String("updated-container-name"),
+					ContainerName: ptr.To("updated-container-name"),
 					Operator:      batch.PodFailurePolicyOnExitCodesOpIn,
 					Values:        []int32{2},
 				},
@@ -220,8 +219,8 @@ func TestJobStrategy_PrepareForUpdate(t *testing.T) {
 				Spec: batch.JobSpec{
 					Selector:             validSelector,
 					Template:             validPodTemplateSpec,
-					BackoffLimitPerIndex: pointer.Int32(1),
-					MaxFailedIndexes:     pointer.Int32(1),
+					BackoffLimitPerIndex: ptr.To[int32](1),
+					MaxFailedIndexes:     ptr.To[int32](1),
 				},
 			},
 			wantJob: batch.Job{
@@ -229,8 +228,8 @@ func TestJobStrategy_PrepareForUpdate(t *testing.T) {
 				Spec: batch.JobSpec{
 					Selector:             validSelector,
 					Template:             validPodTemplateSpec,
-					BackoffLimitPerIndex: pointer.Int32(1),
-					MaxFailedIndexes:     pointer.Int32(1),
+					BackoffLimitPerIndex: ptr.To[int32](1),
+					MaxFailedIndexes:     ptr.To[int32](1),
 				},
 			},
 		},
@@ -250,8 +249,8 @@ func TestJobStrategy_PrepareForUpdate(t *testing.T) {
 				Spec: batch.JobSpec{
 					Selector:             validSelector,
 					Template:             validPodTemplateSpec,
-					BackoffLimitPerIndex: pointer.Int32(1),
-					MaxFailedIndexes:     pointer.Int32(1),
+					BackoffLimitPerIndex: ptr.To[int32](1),
+					MaxFailedIndexes:     ptr.To[int32](1),
 				},
 			},
 			wantJob: batch.Job{
@@ -520,7 +519,7 @@ func TestJobStrategy_PrepareForUpdate(t *testing.T) {
 				Spec: batch.JobSpec{
 					Selector: validSelector,
 					Template: validPodTemplateSpec,
-					Suspend:  pointer.Bool(false),
+					Suspend:  ptr.To(false),
 				},
 			},
 			updatedJob: batch.Job{
@@ -528,7 +527,7 @@ func TestJobStrategy_PrepareForUpdate(t *testing.T) {
 				Spec: batch.JobSpec{
 					Selector: validSelector,
 					Template: validPodTemplateSpec,
-					Suspend:  pointer.Bool(true),
+					Suspend:  ptr.To(true),
 				},
 			},
 			wantJob: batch.Job{
@@ -536,7 +535,7 @@ func TestJobStrategy_PrepareForUpdate(t *testing.T) {
 				Spec: batch.JobSpec{
 					Selector: validSelector,
 					Template: validPodTemplateSpec,
-					Suspend:  pointer.Bool(true),
+					Suspend:  ptr.To(true),
 				},
 			},
 		},
@@ -553,7 +552,7 @@ func TestJobStrategy_PrepareForUpdate(t *testing.T) {
 				Spec: batch.JobSpec{
 					Selector: validSelector,
 					Template: validPodTemplateSpec,
-					Suspend:  pointer.Bool(true),
+					Suspend:  ptr.To(true),
 				},
 			},
 			wantJob: batch.Job{
@@ -561,7 +560,7 @@ func TestJobStrategy_PrepareForUpdate(t *testing.T) {
 				Spec: batch.JobSpec{
 					Selector: validSelector,
 					Template: validPodTemplateSpec,
-					Suspend:  pointer.Bool(true),
+					Suspend:  ptr.To(true),
 				},
 			},
 		},
@@ -596,7 +595,7 @@ func TestJobStrategy_PrepareForCreate(t *testing.T) {
 			{
 				Action: batch.PodFailurePolicyActionFailJob,
 				OnExitCodes: &batch.PodFailurePolicyOnExitCodesRequirement{
-					ContainerName: pointer.String("container-name"),
+					ContainerName: ptr.To("container-name"),
 					Operator:      batch.PodFailurePolicyOnExitCodesOpIn,
 					Values:        []int32{1},
 				},
@@ -626,7 +625,7 @@ func TestJobStrategy_PrepareForCreate(t *testing.T) {
 				ObjectMeta: getValidObjectMeta(0),
 				Spec: batch.JobSpec{
 					Selector:       validSelector,
-					ManualSelector: pointer.Bool(false),
+					ManualSelector: ptr.To(false),
 					Template:       validPodTemplateSpec,
 				},
 			},
@@ -634,7 +633,7 @@ func TestJobStrategy_PrepareForCreate(t *testing.T) {
 				ObjectMeta: getValidObjectMeta(1),
 				Spec: batch.JobSpec{
 					Selector:       validSelector,
-					ManualSelector: pointer.Bool(false),
+					ManualSelector: ptr.To(false),
 					Template:       expectedPodTemplateSpec,
 				},
 			},
@@ -687,20 +686,20 @@ func TestJobStrategy_PrepareForCreate(t *testing.T) {
 				ObjectMeta: getValidObjectMeta(0),
 				Spec: batch.JobSpec{
 					Selector:             validSelector,
-					ManualSelector:       pointer.Bool(false),
+					ManualSelector:       ptr.To(false),
 					Template:             validPodTemplateSpec,
-					BackoffLimitPerIndex: pointer.Int32(1),
-					MaxFailedIndexes:     pointer.Int32(1),
+					BackoffLimitPerIndex: ptr.To[int32](1),
+					MaxFailedIndexes:     ptr.To[int32](1),
 				},
 			},
 			wantJob: batch.Job{
 				ObjectMeta: getValidObjectMeta(1),
 				Spec: batch.JobSpec{
 					Selector:             validSelector,
-					ManualSelector:       pointer.Bool(false),
+					ManualSelector:       ptr.To(false),
 					Template:             expectedPodTemplateSpec,
-					BackoffLimitPerIndex: pointer.Int32(1),
-					MaxFailedIndexes:     pointer.Int32(1),
+					BackoffLimitPerIndex: ptr.To[int32](1),
+					MaxFailedIndexes:     ptr.To[int32](1),
 				},
 			},
 		},
@@ -710,17 +709,17 @@ func TestJobStrategy_PrepareForCreate(t *testing.T) {
 				ObjectMeta: getValidObjectMeta(0),
 				Spec: batch.JobSpec{
 					Selector:             validSelector,
-					ManualSelector:       pointer.Bool(false),
+					ManualSelector:       ptr.To(false),
 					Template:             validPodTemplateSpec,
-					BackoffLimitPerIndex: pointer.Int32(1),
-					MaxFailedIndexes:     pointer.Int32(1),
+					BackoffLimitPerIndex: ptr.To[int32](1),
+					MaxFailedIndexes:     ptr.To[int32](1),
 				},
 			},
 			wantJob: batch.Job{
 				ObjectMeta: getValidObjectMeta(1),
 				Spec: batch.JobSpec{
 					Selector:             validSelector,
-					ManualSelector:       pointer.Bool(false),
+					ManualSelector:       ptr.To(false),
 					Template:             expectedPodTemplateSpec,
 					BackoffLimitPerIndex: nil,
 					MaxFailedIndexes:     nil,
@@ -733,7 +732,7 @@ func TestJobStrategy_PrepareForCreate(t *testing.T) {
 				ObjectMeta: getValidObjectMeta(0),
 				Spec: batch.JobSpec{
 					Selector:         validSelector,
-					ManualSelector:   pointer.Bool(false),
+					ManualSelector:   ptr.To(false),
 					Template:         validPodTemplateSpec,
 					PodFailurePolicy: podFailurePolicy,
 				},
@@ -742,7 +741,7 @@ func TestJobStrategy_PrepareForCreate(t *testing.T) {
 				ObjectMeta: getValidObjectMeta(1),
 				Spec: batch.JobSpec{
 					Selector:         validSelector,
-					ManualSelector:   pointer.Bool(false),
+					ManualSelector:   ptr.To(false),
 					Template:         expectedPodTemplateSpec,
 					PodFailurePolicy: podFailurePolicy,
 				},
@@ -754,7 +753,7 @@ func TestJobStrategy_PrepareForCreate(t *testing.T) {
 				ObjectMeta: getValidObjectMeta(0),
 				Spec: batch.JobSpec{
 					Selector:             validSelector,
-					ManualSelector:       pointer.Bool(false),
+					ManualSelector:       ptr.To(false),
 					Template:             validPodTemplateSpec,
 					PodReplacementPolicy: podReplacementPolicy(batch.Failed),
 				},
@@ -763,7 +762,7 @@ func TestJobStrategy_PrepareForCreate(t *testing.T) {
 				ObjectMeta: getValidObjectMeta(1),
 				Spec: batch.JobSpec{
 					Selector:             validSelector,
-					ManualSelector:       pointer.Bool(false),
+					ManualSelector:       ptr.To(false),
 					Template:             expectedPodTemplateSpec,
 					PodReplacementPolicy: podReplacementPolicy(batch.Failed),
 				},
@@ -775,7 +774,7 @@ func TestJobStrategy_PrepareForCreate(t *testing.T) {
 				ObjectMeta: getValidObjectMeta(0),
 				Spec: batch.JobSpec{
 					Selector:             validSelector,
-					ManualSelector:       pointer.Bool(false),
+					ManualSelector:       ptr.To(false),
 					Template:             validPodTemplateSpec,
 					PodReplacementPolicy: podReplacementPolicy(batch.Failed),
 				},
@@ -784,7 +783,7 @@ func TestJobStrategy_PrepareForCreate(t *testing.T) {
 				ObjectMeta: getValidObjectMeta(1),
 				Spec: batch.JobSpec{
 					Selector:             validSelector,
-					ManualSelector:       pointer.Bool(false),
+					ManualSelector:       ptr.To(false),
 					Template:             expectedPodTemplateSpec,
 					PodReplacementPolicy: nil,
 				},
@@ -796,7 +795,7 @@ func TestJobStrategy_PrepareForCreate(t *testing.T) {
 				ObjectMeta: getValidObjectMeta(0),
 				Spec: batch.JobSpec{
 					Selector:         validSelector,
-					ManualSelector:   pointer.Bool(false),
+					ManualSelector:   ptr.To(false),
 					Template:         validPodTemplateSpec,
 					PodFailurePolicy: podFailurePolicy,
 				},
@@ -805,7 +804,7 @@ func TestJobStrategy_PrepareForCreate(t *testing.T) {
 				ObjectMeta: getValidObjectMeta(1),
 				Spec: batch.JobSpec{
 					Selector:         validSelector,
-					ManualSelector:   pointer.Bool(false),
+					ManualSelector:   ptr.To(false),
 					Template:         expectedPodTemplateSpec,
 					PodFailurePolicy: nil,
 				},
@@ -816,7 +815,7 @@ func TestJobStrategy_PrepareForCreate(t *testing.T) {
 				ObjectMeta: getValidObjectMeta(0),
 				Spec: batch.JobSpec{
 					Selector:       validSelector,
-					ManualSelector: pointer.Bool(false),
+					ManualSelector: ptr.To(false),
 					Template:       validPodTemplateSpec,
 				},
 				Status: batch.JobStatus{
@@ -827,7 +826,7 @@ func TestJobStrategy_PrepareForCreate(t *testing.T) {
 				ObjectMeta: getValidObjectMeta(1),
 				Spec: batch.JobSpec{
 					Selector:       validSelector,
-					ManualSelector: pointer.Bool(false),
+					ManualSelector: ptr.To(false),
 					Template:       expectedPodTemplateSpec,
 				},
 			},
@@ -839,9 +838,9 @@ func TestJobStrategy_PrepareForCreate(t *testing.T) {
 				ObjectMeta: getValidObjectMeta(0),
 				Spec: batch.JobSpec{
 					Selector:             validSelector,
-					ManualSelector:       pointer.Bool(false),
+					ManualSelector:       ptr.To(false),
 					Template:             validPodTemplateSpec,
-					BackoffLimitPerIndex: pointer.Int32(1),
+					BackoffLimitPerIndex: ptr.To[int32](1),
 					PodFailurePolicy: &batch.PodFailurePolicy{
 						Rules: []batch.PodFailurePolicyRule{
 							{
@@ -859,7 +858,7 @@ func TestJobStrategy_PrepareForCreate(t *testing.T) {
 				ObjectMeta: getValidObjectMeta(1),
 				Spec: batch.JobSpec{
 					Selector:       validSelector,
-					ManualSelector: pointer.Bool(false),
+					ManualSelector: ptr.To(false),
 					Template:       expectedPodTemplateSpec,
 					PodFailurePolicy: &batch.PodFailurePolicy{
 						Rules: []batch.PodFailurePolicyRule{},
@@ -874,9 +873,9 @@ func TestJobStrategy_PrepareForCreate(t *testing.T) {
 				ObjectMeta: getValidObjectMeta(0),
 				Spec: batch.JobSpec{
 					Selector:             validSelector,
-					ManualSelector:       pointer.Bool(false),
+					ManualSelector:       ptr.To(false),
 					Template:             validPodTemplateSpec,
-					BackoffLimitPerIndex: pointer.Int32(1),
+					BackoffLimitPerIndex: ptr.To[int32](1),
 					PodFailurePolicy: &batch.PodFailurePolicy{
 						Rules: []batch.PodFailurePolicyRule{
 							{
@@ -908,7 +907,7 @@ func TestJobStrategy_PrepareForCreate(t *testing.T) {
 				ObjectMeta: getValidObjectMeta(1),
 				Spec: batch.JobSpec{
 					Selector:       validSelector,
-					ManualSelector: pointer.Bool(false),
+					ManualSelector: ptr.To(false),
 					Template:       expectedPodTemplateSpec,
 					PodFailurePolicy: &batch.PodFailurePolicy{
 						Rules: []batch.PodFailurePolicyRule{
@@ -937,7 +936,7 @@ func TestJobStrategy_PrepareForCreate(t *testing.T) {
 				ObjectMeta: getValidObjectMeta(0),
 				Spec: batch.JobSpec{
 					Selector:       validSelector,
-					ManualSelector: pointer.Bool(false),
+					ManualSelector: ptr.To(false),
 					Template:       validPodTemplateSpec,
 					ManagedBy:      ptr.To("custom-controller-name"),
 				},
@@ -946,7 +945,7 @@ func TestJobStrategy_PrepareForCreate(t *testing.T) {
 				ObjectMeta: getValidObjectMeta(1),
 				Spec: batch.JobSpec{
 					Selector:       validSelector,
-					ManualSelector: pointer.Bool(false),
+					ManualSelector: ptr.To(false),
 					Template:       expectedPodTemplateSpec,
 				},
 			},
@@ -957,7 +956,7 @@ func TestJobStrategy_PrepareForCreate(t *testing.T) {
 				ObjectMeta: getValidObjectMeta(0),
 				Spec: batch.JobSpec{
 					Selector:       validSelector,
-					ManualSelector: pointer.Bool(false),
+					ManualSelector: ptr.To(false),
 					Template:       validPodTemplateSpec,
 					ManagedBy:      ptr.To("custom-controller-name"),
 				},
@@ -966,7 +965,7 @@ func TestJobStrategy_PrepareForCreate(t *testing.T) {
 				ObjectMeta: getValidObjectMeta(1),
 				Spec: batch.JobSpec{
 					Selector:       validSelector,
-					ManualSelector: pointer.Bool(false),
+					ManualSelector: ptr.To(false),
 					Template:       expectedPodTemplateSpec,
 					ManagedBy:      ptr.To("custom-controller-name"),
 				},
@@ -1047,12 +1046,12 @@ func TestJobStrategy_ValidateUpdate(t *testing.T) {
 				Spec: batch.JobSpec{
 					Selector:       validSelector,
 					Template:       validPodTemplateSpec,
-					ManualSelector: pointer.BoolPtr(true),
-					Parallelism:    pointer.Int32Ptr(1),
+					ManualSelector: ptr.To(true),
+					Parallelism:    ptr.To[int32](1),
 				},
 			},
 			update: func(job *batch.Job) {
-				job.Spec.Parallelism = pointer.Int32Ptr(2)
+				job.Spec.Parallelism = ptr.To[int32](2)
 			},
 		},
 		"update completions disallowed": {
@@ -1065,13 +1064,13 @@ func TestJobStrategy_ValidateUpdate(t *testing.T) {
 				Spec: batch.JobSpec{
 					Selector:       validSelector,
 					Template:       validPodTemplateSpec,
-					ManualSelector: pointer.BoolPtr(true),
-					Parallelism:    pointer.Int32Ptr(1),
-					Completions:    pointer.Int32Ptr(1),
+					ManualSelector: ptr.To(true),
+					Parallelism:    ptr.To[int32](1),
+					Completions:    ptr.To[int32](1),
 				},
 			},
 			update: func(job *batch.Job) {
-				job.Spec.Completions = pointer.Int32Ptr(2)
+				job.Spec.Completions = ptr.To[int32](2)
 			},
 			wantErrs: field.ErrorList{
 				{Type: field.ErrorTypeInvalid, Field: "spec.completions"},
@@ -1090,8 +1089,8 @@ func TestJobStrategy_ValidateUpdate(t *testing.T) {
 				Spec: batch.JobSpec{
 					Selector:       validSelector,
 					Template:       validPodTemplateSpec,
-					ManualSelector: pointer.BoolPtr(true),
-					Parallelism:    pointer.Int32Ptr(1),
+					ManualSelector: ptr.To(true),
+					Parallelism:    ptr.To[int32](1),
 				},
 			},
 			update: func(job *batch.Job) {
@@ -1112,8 +1111,8 @@ func TestJobStrategy_ValidateUpdate(t *testing.T) {
 				Spec: batch.JobSpec{
 					Selector:       validSelector,
 					Template:       validPodTemplateSpec,
-					ManualSelector: pointer.BoolPtr(true),
-					Parallelism:    pointer.Int32Ptr(1),
+					ManualSelector: ptr.To(true),
+					Parallelism:    ptr.To[int32](1),
 				},
 			},
 			update: func(job *batch.Job) {
@@ -1131,8 +1130,8 @@ func TestJobStrategy_ValidateUpdate(t *testing.T) {
 				Spec: batch.JobSpec{
 					Selector:       validSelector,
 					Template:       validPodTemplateSpec,
-					ManualSelector: pointer.BoolPtr(true),
-					Parallelism:    pointer.Int32Ptr(1),
+					ManualSelector: ptr.To(true),
+					Parallelism:    ptr.To[int32](1),
 				},
 			},
 			update: func(job *batch.Job) {
@@ -1153,9 +1152,9 @@ func TestJobStrategy_ValidateUpdate(t *testing.T) {
 				Spec: batch.JobSpec{
 					Selector:       validSelector,
 					Template:       validPodTemplateSpec,
-					ManualSelector: pointer.BoolPtr(true),
-					Parallelism:    pointer.Int32Ptr(1),
-					Suspend:        pointer.BoolPtr(true),
+					ManualSelector: ptr.To(true),
+					Parallelism:    ptr.To[int32](1),
+					Suspend:        ptr.To(true),
 				},
 				Status: batch.JobStatus{
 					StartTime: &now,
@@ -1179,9 +1178,9 @@ func TestJobStrategy_ValidateUpdate(t *testing.T) {
 				Spec: batch.JobSpec{
 					Selector:       validSelector,
 					Template:       validPodTemplateSpec,
-					ManualSelector: pointer.BoolPtr(true),
-					Parallelism:    pointer.Int32Ptr(1),
-					Suspend:        pointer.BoolPtr(true),
+					ManualSelector: ptr.To(true),
+					Parallelism:    ptr.To[int32](1),
+					Suspend:        ptr.To(true),
 				},
 			},
 			update: func(job *batch.Job) {
@@ -1201,7 +1200,7 @@ func TestJobStrategy_ValidateUpdate(t *testing.T) {
 						MatchLabels:      map[string]string{"a": "b"},
 						MatchExpressions: []metav1.LabelSelectorRequirement{{Key: "key", Operator: metav1.LabelSelectorOpNotIn, Values: []string{"bad value"}}},
 					},
-					ManualSelector: pointer.BoolPtr(true),
+					ManualSelector: ptr.To(true),
 					Template:       validPodTemplateSpec,
 				},
 			},
@@ -1222,7 +1221,7 @@ func TestJobStrategy_ValidateUpdate(t *testing.T) {
 					Selector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{batch.LegacyControllerUidLabel: "test"},
 					},
-					Parallelism: pointer.Int32(4),
+					Parallelism: ptr.To[int32](4),
 					Template: api.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: map[string]string{batch.LegacyJobNameLabel: "myjob", batch.LegacyControllerUidLabel: "test"},
@@ -1252,7 +1251,7 @@ func TestJobStrategy_ValidateUpdate(t *testing.T) {
 					Selector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{batch.ControllerUidLabel: "test"},
 					},
-					Parallelism: pointer.Int32(4),
+					Parallelism: ptr.To[int32](4),
 					Template: api.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: map[string]string{batch.LegacyJobNameLabel: "myjob", batch.JobNameLabel: "myjob", batch.LegacyControllerUidLabel: "test", batch.ControllerUidLabel: "test"},
@@ -1281,10 +1280,10 @@ func TestJobStrategy_ValidateUpdate(t *testing.T) {
 				},
 				Spec: batch.JobSpec{
 					CompletionMode:       completionModePtr(batch.IndexedCompletion),
-					Completions:          pointer.Int32(2),
-					BackoffLimitPerIndex: pointer.Int32(1),
+					Completions:          ptr.To[int32](2),
+					BackoffLimitPerIndex: ptr.To[int32](1),
 					Selector:             validSelector,
-					ManualSelector:       pointer.Bool(true),
+					ManualSelector:       ptr.To(true),
 					Template:             validPodTemplateSpecNever,
 					PodFailurePolicy: &batch.PodFailurePolicy{
 						Rules: []batch.PodFailurePolicyRule{
@@ -1349,8 +1348,8 @@ func TestJobStrategy_WarningsOnUpdate(t *testing.T) {
 				Spec: batch.JobSpec{
 					Selector:       validSelector,
 					Template:       validPodTemplateSpec,
-					ManualSelector: pointer.BoolPtr(true),
-					Parallelism:    pointer.Int32Ptr(1),
+					ManualSelector: ptr.To(true),
+					Parallelism:    ptr.To[int32](1),
 				},
 			},
 
@@ -1364,8 +1363,8 @@ func TestJobStrategy_WarningsOnUpdate(t *testing.T) {
 				Spec: batch.JobSpec{
 					Selector:       validSelector,
 					Template:       validPodTemplateSpec,
-					ManualSelector: pointer.BoolPtr(true),
-					Parallelism:    pointer.Int32Ptr(1),
+					ManualSelector: ptr.To(true),
+					Parallelism:    ptr.To[int32](1),
 				},
 			},
 		},
@@ -1380,8 +1379,8 @@ func TestJobStrategy_WarningsOnUpdate(t *testing.T) {
 				Spec: batch.JobSpec{
 					Selector:       validSelector,
 					Template:       validPodTemplateSpec,
-					ManualSelector: pointer.BoolPtr(true),
-					Parallelism:    pointer.Int32Ptr(1),
+					ManualSelector: ptr.To(true),
+					Parallelism:    ptr.To[int32](1),
 				},
 			},
 
@@ -1395,8 +1394,8 @@ func TestJobStrategy_WarningsOnUpdate(t *testing.T) {
 				Spec: batch.JobSpec{
 					Selector:       validSelector,
 					Template:       validPodTemplateSpec,
-					ManualSelector: pointer.BoolPtr(true),
-					Parallelism:    pointer.Int32Ptr(1),
+					ManualSelector: ptr.To(true),
+					Parallelism:    ptr.To[int32](1),
 				},
 			},
 		},
@@ -1413,8 +1412,8 @@ func TestJobStrategy_WarningsOnUpdate(t *testing.T) {
 					Template: api.PodTemplateSpec{
 						Spec: api.PodSpec{ImagePullSecrets: []api.LocalObjectReference{{Name: ""}}},
 					},
-					ManualSelector: pointer.BoolPtr(true),
-					Parallelism:    pointer.Int32Ptr(1),
+					ManualSelector: ptr.To(true),
+					Parallelism:    ptr.To[int32](1),
 				},
 			},
 
@@ -1428,8 +1427,8 @@ func TestJobStrategy_WarningsOnUpdate(t *testing.T) {
 				Spec: batch.JobSpec{
 					Selector:       validSelector,
 					Template:       validPodTemplateSpec,
-					ManualSelector: pointer.BoolPtr(true),
-					Parallelism:    pointer.Int32Ptr(1),
+					ManualSelector: ptr.To(true),
+					Parallelism:    ptr.To[int32](1),
 				},
 			},
 			wantWarningsCount: 1,
@@ -1445,8 +1444,8 @@ func TestJobStrategy_WarningsOnUpdate(t *testing.T) {
 				},
 				Spec: batch.JobSpec{
 					CompletionMode: completionModePtr(batch.IndexedCompletion),
-					Completions:    pointer.Int32(100_001),
-					Parallelism:    pointer.Int32(10_001),
+					Completions:    ptr.To[int32](100_001),
+					Parallelism:    ptr.To[int32](10_001),
 					Template:       validPodTemplateSpec,
 				},
 			},
@@ -1459,8 +1458,8 @@ func TestJobStrategy_WarningsOnUpdate(t *testing.T) {
 				},
 				Spec: batch.JobSpec{
 					CompletionMode: completionModePtr(batch.IndexedCompletion),
-					Completions:    pointer.Int32(100_001),
-					Parallelism:    pointer.Int32(10_000),
+					Completions:    ptr.To[int32](100_001),
+					Parallelism:    ptr.To[int32](10_000),
 					Template:       validPodTemplateSpec,
 				},
 			},
@@ -1533,8 +1532,8 @@ func TestJobStrategy_WarningsOnCreate(t *testing.T) {
 				},
 				Spec: batch.JobSpec{
 					CompletionMode: completionModePtr(batch.IndexedCompletion),
-					Parallelism:    pointer.Int32(100_001),
-					Completions:    pointer.Int32(100_001),
+					Parallelism:    ptr.To[int32](100_001),
+					Completions:    ptr.To[int32](100_001),
 					Template:       validPodTemplate,
 				},
 			},
@@ -1577,7 +1576,7 @@ func TestJobStrategy_Validate(t *testing.T) {
 				ObjectMeta: validObjectMeta,
 				Spec: batch.JobSpec{
 					Selector:       defaultSelector,
-					ManualSelector: pointer.Bool(false),
+					ManualSelector: ptr.To(false),
 					Template: api.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: batchLabels,
@@ -1589,7 +1588,7 @@ func TestJobStrategy_Validate(t *testing.T) {
 				ObjectMeta: validObjectMeta,
 				Spec: batch.JobSpec{
 					Selector:       defaultSelector,
-					ManualSelector: pointer.Bool(false),
+					ManualSelector: ptr.To(false),
 					Template: api.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: batchLabels,
@@ -1603,7 +1602,7 @@ func TestJobStrategy_Validate(t *testing.T) {
 				ObjectMeta: validObjectMeta,
 				Spec: batch.JobSpec{
 					Selector:       defaultSelector,
-					ManualSelector: pointer.Bool(false),
+					ManualSelector: ptr.To(false),
 					Template: api.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: labelsWithNonBatch,
@@ -1615,7 +1614,7 @@ func TestJobStrategy_Validate(t *testing.T) {
 				ObjectMeta: validObjectMeta,
 				Spec: batch.JobSpec{
 					Selector:       defaultSelector,
-					ManualSelector: pointer.Bool(false),
+					ManualSelector: ptr.To(false),
 					Template: api.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: labelsWithNonBatch,
@@ -1629,7 +1628,7 @@ func TestJobStrategy_Validate(t *testing.T) {
 				ObjectMeta: validObjectMeta,
 				Spec: batch.JobSpec{
 					Selector:       defaultSelector,
-					ManualSelector: pointer.Bool(false),
+					ManualSelector: ptr.To(false),
 					Template: api.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: map[string]string{},
@@ -1641,7 +1640,7 @@ func TestJobStrategy_Validate(t *testing.T) {
 				ObjectMeta: validObjectMeta,
 				Spec: batch.JobSpec{
 					Selector:       defaultSelector,
-					ManualSelector: pointer.Bool(false),
+					ManualSelector: ptr.To(false),
 					Template: api.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: map[string]string{},
@@ -1681,8 +1680,8 @@ func TestJobStrategy_Validate(t *testing.T) {
 						},
 						Spec: validPodSpec,
 					},
-					Completions:    pointer.Int32Ptr(2),
-					ManualSelector: pointer.BoolPtr(true),
+					Completions:    ptr.To[int32](2),
+					ManualSelector: ptr.To(true),
 				},
 			},
 			wantJob: &batch.Job{
@@ -1695,8 +1694,8 @@ func TestJobStrategy_Validate(t *testing.T) {
 						},
 						Spec: validPodSpec,
 					},
-					Completions:    pointer.Int32Ptr(2),
-					ManualSelector: pointer.BoolPtr(true),
+					Completions:    ptr.To[int32](2),
+					ManualSelector: ptr.To(true),
 				},
 			},
 		},
@@ -1705,16 +1704,16 @@ func TestJobStrategy_Validate(t *testing.T) {
 				ObjectMeta: validObjectMeta,
 				Spec: batch.JobSpec{
 					Selector:       defaultSelector,
-					ManualSelector: pointer.Bool(false),
+					ManualSelector: ptr.To(false),
 					Template: api.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: labelsWithNonBatch,
 						},
 						Spec: validPodSpec,
 					},
-					Completions:             pointer.Int32Ptr(2),
-					Suspend:                 pointer.BoolPtr(true),
-					TTLSecondsAfterFinished: pointer.Int32Ptr(0),
+					Completions:             ptr.To[int32](2),
+					Suspend:                 ptr.To(true),
+					TTLSecondsAfterFinished: ptr.To[int32](0),
 					CompletionMode:          completionModePtr(batch.IndexedCompletion),
 				},
 			},
@@ -1722,16 +1721,16 @@ func TestJobStrategy_Validate(t *testing.T) {
 				ObjectMeta: validObjectMeta,
 				Spec: batch.JobSpec{
 					Selector:       defaultSelector,
-					ManualSelector: pointer.Bool(false),
+					ManualSelector: ptr.To(false),
 					Template: api.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: labelsWithNonBatch,
 						},
 						Spec: validPodSpec,
 					},
-					Completions:             pointer.Int32Ptr(2),
-					Suspend:                 pointer.BoolPtr(true),
-					TTLSecondsAfterFinished: pointer.Int32Ptr(0),
+					Completions:             ptr.To[int32](2),
+					Suspend:                 ptr.To(true),
+					TTLSecondsAfterFinished: ptr.To[int32](0),
 					CompletionMode:          completionModePtr(batch.IndexedCompletion),
 				},
 			},
@@ -1741,7 +1740,7 @@ func TestJobStrategy_Validate(t *testing.T) {
 				ObjectMeta: validObjectMeta,
 				Spec: batch.JobSpec{
 					Selector:       defaultSelector,
-					ManualSelector: pointer.Bool(false),
+					ManualSelector: ptr.To(false),
 					Template: api.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: labelsWithNonBatch,
@@ -1759,7 +1758,7 @@ func TestJobStrategy_Validate(t *testing.T) {
 				ObjectMeta: validObjectMeta,
 				Spec: batch.JobSpec{
 					Selector:       defaultSelector,
-					ManualSelector: pointer.Bool(false),
+					ManualSelector: ptr.To(false),
 					Template: api.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: labelsWithNonBatch,
@@ -1782,7 +1781,7 @@ func TestJobStrategy_Validate(t *testing.T) {
 				ObjectMeta: validObjectMeta,
 				Spec: batch.JobSpec{
 					Selector:       validSelector,
-					ManualSelector: pointer.Bool(true),
+					ManualSelector: ptr.To(true),
 					Template: api.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: validSelector.MatchLabels,
@@ -1806,7 +1805,7 @@ func TestJobStrategy_Validate(t *testing.T) {
 				ObjectMeta: validObjectMeta,
 				Spec: batch.JobSpec{
 					Selector:       validSelector,
-					ManualSelector: pointer.Bool(true),
+					ManualSelector: ptr.To(true),
 					Template: api.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: validSelector.MatchLabels,
@@ -1835,7 +1834,7 @@ func TestJobStrategy_Validate(t *testing.T) {
 				ObjectMeta: validObjectMeta,
 				Spec: batch.JobSpec{
 					Selector:       validSelector,
-					ManualSelector: pointer.Bool(true),
+					ManualSelector: ptr.To(true),
 					Template: api.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: validSelector.MatchLabels,
@@ -1859,7 +1858,7 @@ func TestJobStrategy_Validate(t *testing.T) {
 				ObjectMeta: validObjectMeta,
 				Spec: batch.JobSpec{
 					Selector:       validSelector,
-					ManualSelector: pointer.Bool(true),
+					ManualSelector: ptr.To(true),
 					Template: api.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: validSelector.MatchLabels,
@@ -1888,10 +1887,10 @@ func TestJobStrategy_Validate(t *testing.T) {
 				ObjectMeta: validObjectMeta,
 				Spec: batch.JobSpec{
 					CompletionMode:       completionModePtr(batch.IndexedCompletion),
-					Completions:          pointer.Int32(2),
-					BackoffLimitPerIndex: pointer.Int32(1),
+					Completions:          ptr.To[int32](2),
+					BackoffLimitPerIndex: ptr.To[int32](1),
 					Selector:             validSelector,
-					ManualSelector:       pointer.Bool(true),
+					ManualSelector:       ptr.To(true),
 					Template: api.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: validSelector.MatchLabels,
@@ -1915,10 +1914,10 @@ func TestJobStrategy_Validate(t *testing.T) {
 				ObjectMeta: validObjectMeta,
 				Spec: batch.JobSpec{
 					CompletionMode:       completionModePtr(batch.IndexedCompletion),
-					Completions:          pointer.Int32(2),
-					BackoffLimitPerIndex: pointer.Int32(1),
+					Completions:          ptr.To[int32](2),
+					BackoffLimitPerIndex: ptr.To[int32](1),
 					Selector:             validSelector,
-					ManualSelector:       pointer.Bool(true),
+					ManualSelector:       ptr.To(true),
 					Template: api.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: validSelector.MatchLabels,
@@ -2001,7 +2000,7 @@ func TestStatusStrategy_PrepareForUpdate(t *testing.T) {
 				Spec: batch.JobSpec{
 					Selector:    validSelector,
 					Template:    validPodTemplateSpec,
-					Parallelism: pointer.Int32(4),
+					Parallelism: ptr.To[int32](4),
 				},
 				Status: batch.JobStatus{
 					Active: 11,
@@ -2012,7 +2011,7 @@ func TestStatusStrategy_PrepareForUpdate(t *testing.T) {
 				Spec: batch.JobSpec{
 					Selector:    validSelector,
 					Template:    validPodTemplateSpec,
-					Parallelism: pointer.Int32(4),
+					Parallelism: ptr.To[int32](4),
 				},
 				Status: batch.JobStatus{
 					Active: 12,
@@ -2023,7 +2022,7 @@ func TestStatusStrategy_PrepareForUpdate(t *testing.T) {
 				Spec: batch.JobSpec{
 					Selector:    validSelector,
 					Template:    validPodTemplateSpec,
-					Parallelism: pointer.Int32(4),
+					Parallelism: ptr.To[int32](4),
 				},
 				Status: batch.JobStatus{
 					Active: 12,
@@ -2036,7 +2035,7 @@ func TestStatusStrategy_PrepareForUpdate(t *testing.T) {
 				Spec: batch.JobSpec{
 					Selector:    validSelector,
 					Template:    validPodTemplateSpec,
-					Parallelism: pointer.Int32(3),
+					Parallelism: ptr.To[int32](3),
 				},
 			},
 			newJob: &batch.Job{
@@ -2044,7 +2043,7 @@ func TestStatusStrategy_PrepareForUpdate(t *testing.T) {
 				Spec: batch.JobSpec{
 					Selector:    validSelector,
 					Template:    validPodTemplateSpec,
-					Parallelism: pointer.Int32(4),
+					Parallelism: ptr.To[int32](4),
 				},
 			},
 			wantJob: &batch.Job{
@@ -2052,7 +2051,7 @@ func TestStatusStrategy_PrepareForUpdate(t *testing.T) {
 				Spec: batch.JobSpec{
 					Selector:    validSelector,
 					Template:    validPodTemplateSpec,
-					Parallelism: pointer.Int32(3),
+					Parallelism: ptr.To[int32](3),
 				},
 			},
 		},
@@ -2114,7 +2113,7 @@ func TestStatusStrategy_ValidateUpdate(t *testing.T) {
 				Spec: batch.JobSpec{
 					Selector:    validSelector,
 					Template:    validPodTemplateSpec,
-					Parallelism: pointer.Int32(4),
+					Parallelism: ptr.To[int32](4),
 				},
 			},
 			newJob: &batch.Job{
@@ -2126,7 +2125,7 @@ func TestStatusStrategy_ValidateUpdate(t *testing.T) {
 				Spec: batch.JobSpec{
 					Selector:    validSelector,
 					Template:    validPodTemplateSpec,
-					Parallelism: pointer.Int32(4),
+					Parallelism: ptr.To[int32](4),
 				},
 			},
 			wantJob: &batch.Job{
@@ -2138,7 +2137,7 @@ func TestStatusStrategy_ValidateUpdate(t *testing.T) {
 				Spec: batch.JobSpec{
 					Selector:    validSelector,
 					Template:    validPodTemplateSpec,
-					Parallelism: pointer.Int32(4),
+					Parallelism: ptr.To[int32](4),
 				},
 			},
 		},
@@ -2882,7 +2881,7 @@ func TestStatusStrategy_ValidateUpdate(t *testing.T) {
 				Spec: batch.JobSpec{
 					Completions:          ptr.To[int32](5),
 					CompletionMode:       completionModePtr(batch.IndexedCompletion),
-					BackoffLimitPerIndex: pointer.Int32(1),
+					BackoffLimitPerIndex: ptr.To[int32](1),
 				},
 			},
 			newJob: &batch.Job{
@@ -2890,7 +2889,7 @@ func TestStatusStrategy_ValidateUpdate(t *testing.T) {
 				Spec: batch.JobSpec{
 					Completions:          ptr.To[int32](5),
 					CompletionMode:       completionModePtr(batch.IndexedCompletion),
-					BackoffLimitPerIndex: pointer.Int32(1),
+					BackoffLimitPerIndex: ptr.To[int32](1),
 				},
 				Status: batch.JobStatus{
 					FailedIndexes: ptr.To("invalid format"),
@@ -2907,7 +2906,7 @@ func TestStatusStrategy_ValidateUpdate(t *testing.T) {
 				Spec: batch.JobSpec{
 					Completions:          ptr.To[int32](5),
 					CompletionMode:       completionModePtr(batch.IndexedCompletion),
-					BackoffLimitPerIndex: pointer.Int32(1),
+					BackoffLimitPerIndex: ptr.To[int32](1),
 				},
 				Status: batch.JobStatus{
 					FailedIndexes: ptr.To("invalid format"),
@@ -2918,7 +2917,7 @@ func TestStatusStrategy_ValidateUpdate(t *testing.T) {
 				Spec: batch.JobSpec{
 					Completions:          ptr.To[int32](5),
 					CompletionMode:       completionModePtr(batch.IndexedCompletion),
-					BackoffLimitPerIndex: pointer.Int32(1),
+					BackoffLimitPerIndex: ptr.To[int32](1),
 				},
 				Status: batch.JobStatus{
 					FailedIndexes: ptr.To("invalid format"),
@@ -3460,8 +3459,8 @@ func TestJobStrategy_GetAttrs(t *testing.T) {
 				Spec: batch.JobSpec{
 					Selector:       validSelector,
 					Template:       validPodTemplateSpec,
-					ManualSelector: pointer.BoolPtr(true),
-					Parallelism:    pointer.Int32Ptr(1),
+					ManualSelector: ptr.To(true),
+					Parallelism:    ptr.To[int32](1),
 				},
 			},
 		},
@@ -3476,8 +3475,8 @@ func TestJobStrategy_GetAttrs(t *testing.T) {
 				Spec: batch.JobSpec{
 					Selector:       validSelector,
 					Template:       validPodTemplateSpec,
-					ManualSelector: pointer.BoolPtr(true),
-					Parallelism:    pointer.Int32Ptr(1),
+					ManualSelector: ptr.To(true),
+					Parallelism:    ptr.To[int32](1),
 				},
 			},
 		},

--- a/pkg/registry/certificates/certificates/storage/metrics_test.go
+++ b/pkg/registry/certificates/certificates/storage/metrics_test.go
@@ -34,7 +34,7 @@ import (
 	"k8s.io/client-go/util/certificate/csr"
 	"k8s.io/component-base/metrics"
 	"k8s.io/kubernetes/pkg/apis/certificates"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func Test_countCSRDurationMetric(t *testing.T) {
@@ -66,7 +66,7 @@ func Test_countCSRDurationMetric(t *testing.T) {
 			old: &certificates.CertificateSigningRequest{
 				Spec: certificates.CertificateSigningRequestSpec{
 					SignerName:        "fancy",
-					ExpirationSeconds: pointer.Int32(77),
+					ExpirationSeconds: ptr.To[int32](77),
 				},
 			},
 			options:       &metav1.UpdateOptions{},

--- a/pkg/registry/certificates/certificates/strategy_test.go
+++ b/pkg/registry/certificates/certificates/strategy_test.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/apiserver/pkg/authentication/user"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	certapi "k8s.io/kubernetes/pkg/apis/certificates"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 func TestStrategyCreate(t *testing.T) {
@@ -119,12 +119,12 @@ func TestStrategyCreate(t *testing.T) {
 			ctx: genericapirequest.NewContext(),
 			obj: &certapi.CertificateSigningRequest{
 				Spec: certapi.CertificateSigningRequestSpec{
-					ExpirationSeconds: pointer.Int32(1234),
+					ExpirationSeconds: ptr.To[int32](1234),
 				},
 			},
 			expectedObj: &certapi.CertificateSigningRequest{
 				Spec: certapi.CertificateSigningRequestSpec{
-					ExpirationSeconds: pointer.Int32(1234),
+					ExpirationSeconds: ptr.To[int32](1234),
 				},
 				Status: certapi.CertificateSigningRequestStatus{Conditions: []certapi.CertificateSigningRequestCondition{}},
 			},

--- a/pkg/registry/core/pod/strategy_test.go
+++ b/pkg/registry/core/pod/strategy_test.go
@@ -41,7 +41,7 @@ import (
 	"k8s.io/apiserver/pkg/warning"
 	"k8s.io/client-go/tools/cache"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
-	utilpointer "k8s.io/utils/pointer"
+	ptr "k8s.io/utils/ptr"
 
 	apitesting "k8s.io/kubernetes/pkg/api/testing"
 	api "k8s.io/kubernetes/pkg/apis/core"
@@ -418,7 +418,7 @@ func TestCheckGracefulDelete(t *testing.T) {
 			pod: &api.Pod{
 				Spec: api.PodSpec{
 					NodeName:                      "something",
-					TerminationGracePeriodSeconds: utilpointer.Int64(-1),
+					TerminationGracePeriodSeconds: ptr.To[int64](-1),
 				},
 				Status: api.PodStatus{},
 			},
@@ -429,7 +429,7 @@ func TestCheckGracefulDelete(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			out := &metav1.DeleteOptions{}
 			if tc.deleteGracePeriod != nil {
-				out.GracePeriodSeconds = utilpointer.Int64(*tc.deleteGracePeriod)
+				out.GracePeriodSeconds = ptr.To[int64](*tc.deleteGracePeriod)
 			}
 			Strategy.CheckGracefulDelete(genericapirequest.NewContext(), tc.pod, out)
 			if out.GracePeriodSeconds == nil {

--- a/pkg/registry/core/service/strategy_test.go
+++ b/pkg/registry/core/service/strategy_test.go
@@ -31,7 +31,6 @@ import (
 	api "k8s.io/kubernetes/pkg/apis/core"
 	_ "k8s.io/kubernetes/pkg/apis/core/install"
 	"k8s.io/kubernetes/pkg/features"
-	utilpointer "k8s.io/utils/pointer"
 	"k8s.io/utils/ptr"
 )
 
@@ -564,22 +563,22 @@ func TestDropTypeDependentFields(t *testing.T) {
 		}
 	}
 	setAllocateLoadBalancerNodePortsTrue := func(svc *api.Service) {
-		svc.Spec.AllocateLoadBalancerNodePorts = utilpointer.BoolPtr(true)
+		svc.Spec.AllocateLoadBalancerNodePorts = ptr.To[bool](true)
 	}
 	setAllocateLoadBalancerNodePortsFalse := func(svc *api.Service) {
-		svc.Spec.AllocateLoadBalancerNodePorts = utilpointer.BoolPtr(false)
+		svc.Spec.AllocateLoadBalancerNodePorts = ptr.To[bool](false)
 	}
 	clearAllocateLoadBalancerNodePorts := func(svc *api.Service) {
 		svc.Spec.AllocateLoadBalancerNodePorts = nil
 	}
 	setLoadBalancerClass := func(svc *api.Service) {
-		svc.Spec.LoadBalancerClass = utilpointer.String("test-load-balancer-class")
+		svc.Spec.LoadBalancerClass = ptr.To("test-load-balancer-class")
 	}
 	clearLoadBalancerClass := func(svc *api.Service) {
 		svc.Spec.LoadBalancerClass = nil
 	}
 	changeLoadBalancerClass := func(svc *api.Service) {
-		svc.Spec.LoadBalancerClass = utilpointer.String("test-load-balancer-class-changed")
+		svc.Spec.LoadBalancerClass = ptr.To("test-load-balancer-class-changed")
 	}
 
 	testCases := []struct {

--- a/pkg/registry/core/service/strategy_test.go
+++ b/pkg/registry/core/service/strategy_test.go
@@ -563,10 +563,10 @@ func TestDropTypeDependentFields(t *testing.T) {
 		}
 	}
 	setAllocateLoadBalancerNodePortsTrue := func(svc *api.Service) {
-		svc.Spec.AllocateLoadBalancerNodePorts = ptr.To[bool](true)
+		svc.Spec.AllocateLoadBalancerNodePorts = ptr.To(true)
 	}
 	setAllocateLoadBalancerNodePortsFalse := func(svc *api.Service) {
-		svc.Spec.AllocateLoadBalancerNodePorts = ptr.To[bool](false)
+		svc.Spec.AllocateLoadBalancerNodePorts = ptr.To(false)
 	}
 	clearAllocateLoadBalancerNodePorts := func(svc *api.Service) {
 		svc.Spec.AllocateLoadBalancerNodePorts = nil

--- a/pkg/registry/discovery/endpointslice/strategy_test.go
+++ b/pkg/registry/discovery/endpointslice/strategy_test.go
@@ -29,7 +29,7 @@ import (
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/kubernetes/pkg/apis/discovery"
 	"k8s.io/kubernetes/pkg/features"
-	utilpointer "k8s.io/utils/pointer"
+	ptr "k8s.io/utils/ptr"
 )
 
 func Test_dropDisabledFieldsOnCreate(t *testing.T) {
@@ -44,20 +44,20 @@ func Test_dropDisabledFieldsOnCreate(t *testing.T) {
 			eps: &discovery.EndpointSlice{
 				Endpoints: []discovery.Endpoint{
 					{
-						NodeName: utilpointer.String("node-1"),
+						NodeName: ptr.To("node-1"),
 					},
 					{
-						NodeName: utilpointer.String("node-2"),
+						NodeName: ptr.To("node-2"),
 					},
 				},
 			},
 			expectedEPS: &discovery.EndpointSlice{
 				Endpoints: []discovery.Endpoint{
 					{
-						NodeName: utilpointer.String("node-1"),
+						NodeName: ptr.To("node-1"),
 					},
 					{
-						NodeName: utilpointer.String("node-2"),
+						NodeName: ptr.To("node-2"),
 					},
 				},
 			},
@@ -101,20 +101,20 @@ func Test_dropDisabledFieldsOnUpdate(t *testing.T) {
 			newEPS: &discovery.EndpointSlice{
 				Endpoints: []discovery.Endpoint{
 					{
-						NodeName: utilpointer.String("node-1"),
+						NodeName: ptr.To("node-1"),
 					},
 					{
-						NodeName: utilpointer.String("node-2"),
+						NodeName: ptr.To("node-2"),
 					},
 				},
 			},
 			expectedEPS: &discovery.EndpointSlice{
 				Endpoints: []discovery.Endpoint{
 					{
-						NodeName: utilpointer.String("node-1"),
+						NodeName: ptr.To("node-1"),
 					},
 					{
-						NodeName: utilpointer.String("node-2"),
+						NodeName: ptr.To("node-2"),
 					},
 				},
 			},
@@ -124,30 +124,30 @@ func Test_dropDisabledFieldsOnUpdate(t *testing.T) {
 			oldEPS: &discovery.EndpointSlice{
 				Endpoints: []discovery.Endpoint{
 					{
-						NodeName: utilpointer.String("node-1-old"),
+						NodeName: ptr.To("node-1-old"),
 					},
 					{
-						NodeName: utilpointer.String("node-2-old"),
+						NodeName: ptr.To("node-2-old"),
 					},
 				},
 			},
 			newEPS: &discovery.EndpointSlice{
 				Endpoints: []discovery.Endpoint{
 					{
-						NodeName: utilpointer.String("node-1"),
+						NodeName: ptr.To("node-1"),
 					},
 					{
-						NodeName: utilpointer.String("node-2"),
+						NodeName: ptr.To("node-2"),
 					},
 				},
 			},
 			expectedEPS: &discovery.EndpointSlice{
 				Endpoints: []discovery.Endpoint{
 					{
-						NodeName: utilpointer.String("node-1"),
+						NodeName: ptr.To("node-1"),
 					},
 					{
-						NodeName: utilpointer.String("node-2"),
+						NodeName: ptr.To("node-2"),
 					},
 				},
 			},
@@ -398,14 +398,14 @@ func Test_dropTopologyOnV1(t *testing.T) {
 			v1Request: true,
 			newEPS: &discovery.EndpointSlice{
 				Endpoints: []discovery.Endpoint{
-					{Hostname: utilpointer.String("hostname-1")},
-					{Hostname: utilpointer.String("hostname-1")},
+					{Hostname: ptr.To("hostname-1")},
+					{Hostname: ptr.To("hostname-1")},
 				},
 			},
 			expectedEPS: &discovery.EndpointSlice{
 				Endpoints: []discovery.Endpoint{
-					{Hostname: utilpointer.String("hostname-1")},
-					{Hostname: utilpointer.String("hostname-1")},
+					{Hostname: ptr.To("hostname-1")},
+					{Hostname: ptr.To("hostname-1")},
 				},
 			},
 		},
@@ -413,14 +413,14 @@ func Test_dropTopologyOnV1(t *testing.T) {
 			name: "v1beta1 request, without deprecated topology",
 			newEPS: &discovery.EndpointSlice{
 				Endpoints: []discovery.Endpoint{
-					{Hostname: utilpointer.String("hostname-1")},
-					{Hostname: utilpointer.String("hostname-1")},
+					{Hostname: ptr.To("hostname-1")},
+					{Hostname: ptr.To("hostname-1")},
 				},
 			},
 			expectedEPS: &discovery.EndpointSlice{
 				Endpoints: []discovery.Endpoint{
-					{Hostname: utilpointer.String("hostname-1")},
-					{Hostname: utilpointer.String("hostname-1")},
+					{Hostname: ptr.To("hostname-1")},
+					{Hostname: ptr.To("hostname-1")},
 				},
 			},
 		},
@@ -458,11 +458,11 @@ func Test_dropTopologyOnV1(t *testing.T) {
 			originalEPS: &discovery.EndpointSlice{
 				Endpoints: []discovery.Endpoint{
 					{
-						NodeName:           utilpointer.String("node-1"),
+						NodeName:           ptr.To("node-1"),
 						DeprecatedTopology: map[string]string{"key": "value"},
 					},
 					{
-						NodeName:           utilpointer.String("node-1"),
+						NodeName:           ptr.To("node-1"),
 						DeprecatedTopology: map[string]string{"key": "value"},
 					},
 				},
@@ -473,11 +473,11 @@ func Test_dropTopologyOnV1(t *testing.T) {
 				},
 				Endpoints: []discovery.Endpoint{
 					{
-						NodeName:           utilpointer.String("node-1"),
+						NodeName:           ptr.To("node-1"),
 						DeprecatedTopology: map[string]string{"key": "value"},
 					},
 					{
-						NodeName:           utilpointer.String("node-1"),
+						NodeName:           ptr.To("node-1"),
 						DeprecatedTopology: map[string]string{"key": "value"},
 					},
 				},
@@ -488,11 +488,11 @@ func Test_dropTopologyOnV1(t *testing.T) {
 				},
 				Endpoints: []discovery.Endpoint{
 					{
-						NodeName:           utilpointer.String("node-1"),
+						NodeName:           ptr.To("node-1"),
 						DeprecatedTopology: map[string]string{"key": "value"},
 					},
 					{
-						NodeName:           utilpointer.String("node-1"),
+						NodeName:           ptr.To("node-1"),
 						DeprecatedTopology: map[string]string{"key": "value"},
 					},
 				},
@@ -503,11 +503,11 @@ func Test_dropTopologyOnV1(t *testing.T) {
 			originalEPS: &discovery.EndpointSlice{
 				Endpoints: []discovery.Endpoint{
 					{
-						NodeName:           utilpointer.String("node-1"),
+						NodeName:           ptr.To("node-1"),
 						DeprecatedTopology: map[string]string{"key": "value"},
 					},
 					{
-						NodeName:           utilpointer.String("node-1"),
+						NodeName:           ptr.To("node-1"),
 						DeprecatedTopology: map[string]string{"key": "value"},
 					},
 				},
@@ -518,11 +518,11 @@ func Test_dropTopologyOnV1(t *testing.T) {
 				},
 				Endpoints: []discovery.Endpoint{
 					{
-						NodeName:           utilpointer.String("node-1"),
+						NodeName:           ptr.To("node-1"),
 						DeprecatedTopology: map[string]string{"key": "value"},
 					},
 					{
-						NodeName:           utilpointer.String("node-1"),
+						NodeName:           ptr.To("node-1"),
 						DeprecatedTopology: map[string]string{"key": "value"},
 					},
 				},
@@ -533,11 +533,11 @@ func Test_dropTopologyOnV1(t *testing.T) {
 				},
 				Endpoints: []discovery.Endpoint{
 					{
-						NodeName:           utilpointer.String("node-1"),
+						NodeName:           ptr.To("node-1"),
 						DeprecatedTopology: map[string]string{"key": "value"},
 					},
 					{
-						NodeName:           utilpointer.String("node-1"),
+						NodeName:           ptr.To("node-1"),
 						DeprecatedTopology: map[string]string{"key": "value"},
 					},
 				},
@@ -555,19 +555,19 @@ func Test_dropTopologyOnV1(t *testing.T) {
 			newEPS: &discovery.EndpointSlice{
 				Endpoints: []discovery.Endpoint{
 					{
-						Hostname:           utilpointer.String("hostname-1"),
+						Hostname:           ptr.To("hostname-1"),
 						DeprecatedTopology: map[string]string{corev1.LabelHostname: "node-1"},
 					},
 					{
-						Hostname:           utilpointer.String("hostname-1"),
+						Hostname:           ptr.To("hostname-1"),
 						DeprecatedTopology: map[string]string{corev1.LabelHostname: "node-1"},
 					},
 				},
 			},
 			expectedEPS: &discovery.EndpointSlice{
 				Endpoints: []discovery.Endpoint{
-					{Hostname: utilpointer.String("hostname-1")},
-					{Hostname: utilpointer.String("hostname-1")},
+					{Hostname: ptr.To("hostname-1")},
+					{Hostname: ptr.To("hostname-1")},
 				},
 			},
 		},
@@ -582,11 +582,11 @@ func Test_dropTopologyOnV1(t *testing.T) {
 			newEPS: &discovery.EndpointSlice{
 				Endpoints: []discovery.Endpoint{
 					{
-						Hostname:           utilpointer.String("hostname-1"),
+						Hostname:           ptr.To("hostname-1"),
 						DeprecatedTopology: map[string]string{corev1.LabelHostname: "node-1"},
 					},
 					{
-						Hostname:           utilpointer.String("hostname-1"),
+						Hostname:           ptr.To("hostname-1"),
 						DeprecatedTopology: map[string]string{corev1.LabelHostname: "node-1"},
 					},
 				},
@@ -594,11 +594,11 @@ func Test_dropTopologyOnV1(t *testing.T) {
 			expectedEPS: &discovery.EndpointSlice{
 				Endpoints: []discovery.Endpoint{
 					{
-						Hostname:           utilpointer.String("hostname-1"),
+						Hostname:           ptr.To("hostname-1"),
 						DeprecatedTopology: map[string]string{corev1.LabelHostname: "node-1"},
 					},
 					{
-						Hostname:           utilpointer.String("hostname-1"),
+						Hostname:           ptr.To("hostname-1"),
 						DeprecatedTopology: map[string]string{corev1.LabelHostname: "node-1"},
 					},
 				},
@@ -610,11 +610,11 @@ func Test_dropTopologyOnV1(t *testing.T) {
 			originalEPS: &discovery.EndpointSlice{
 				Endpoints: []discovery.Endpoint{
 					{
-						Hostname:           utilpointer.String("hostname-1"),
+						Hostname:           ptr.To("hostname-1"),
 						DeprecatedTopology: map[string]string{corev1.LabelHostname: "node-1", "other": "value"},
 					},
 					{
-						Hostname:           utilpointer.String("hostname-1"),
+						Hostname:           ptr.To("hostname-1"),
 						DeprecatedTopology: map[string]string{corev1.LabelHostname: "node-1", "foo": "bar"},
 					},
 				},
@@ -622,11 +622,11 @@ func Test_dropTopologyOnV1(t *testing.T) {
 			newEPS: &discovery.EndpointSlice{
 				Endpoints: []discovery.Endpoint{
 					{
-						Hostname:           utilpointer.String("hostname-1a"),
+						Hostname:           ptr.To("hostname-1a"),
 						DeprecatedTopology: map[string]string{corev1.LabelHostname: "node-1", "other": "value"},
 					},
 					{
-						Hostname:           utilpointer.String("hostname-1b"),
+						Hostname:           ptr.To("hostname-1b"),
 						DeprecatedTopology: map[string]string{corev1.LabelHostname: "node-1", "foo": "bar"},
 					},
 				},
@@ -634,12 +634,12 @@ func Test_dropTopologyOnV1(t *testing.T) {
 			expectedEPS: &discovery.EndpointSlice{
 				Endpoints: []discovery.Endpoint{
 					{
-						Hostname: utilpointer.String("hostname-1a"),
-						NodeName: utilpointer.String("node-1"),
+						Hostname: ptr.To("hostname-1a"),
+						NodeName: ptr.To("node-1"),
 					},
 					{
-						Hostname: utilpointer.String("hostname-1b"),
-						NodeName: utilpointer.String("node-1"),
+						Hostname: ptr.To("hostname-1b"),
+						NodeName: ptr.To("node-1"),
 					},
 				},
 			},
@@ -650,11 +650,11 @@ func Test_dropTopologyOnV1(t *testing.T) {
 			originalEPS: &discovery.EndpointSlice{
 				Endpoints: []discovery.Endpoint{
 					{
-						Hostname:           utilpointer.String("hostname-1"),
+						Hostname:           ptr.To("hostname-1"),
 						DeprecatedTopology: map[string]string{corev1.LabelHostname: "node-1"},
 					},
 					{
-						Hostname:           utilpointer.String("hostname-1"),
+						Hostname:           ptr.To("hostname-1"),
 						DeprecatedTopology: map[string]string{corev1.LabelHostname: "node-1"},
 					},
 				},
@@ -662,11 +662,11 @@ func Test_dropTopologyOnV1(t *testing.T) {
 			newEPS: &discovery.EndpointSlice{
 				Endpoints: []discovery.Endpoint{
 					{
-						Hostname:           utilpointer.String("hostname-1a"),
+						Hostname:           ptr.To("hostname-1a"),
 						DeprecatedTopology: map[string]string{corev1.LabelHostname: "node-1"},
 					},
 					{
-						Hostname:           utilpointer.String("hostname-1b"),
+						Hostname:           ptr.To("hostname-1b"),
 						DeprecatedTopology: map[string]string{corev1.LabelHostname: "node-1"},
 					},
 				},
@@ -674,12 +674,12 @@ func Test_dropTopologyOnV1(t *testing.T) {
 			expectedEPS: &discovery.EndpointSlice{
 				Endpoints: []discovery.Endpoint{
 					{
-						Hostname: utilpointer.String("hostname-1a"),
-						NodeName: utilpointer.String("node-1"),
+						Hostname: ptr.To("hostname-1a"),
+						NodeName: ptr.To("node-1"),
 					},
 					{
-						Hostname: utilpointer.String("hostname-1b"),
-						NodeName: utilpointer.String("node-1"),
+						Hostname: ptr.To("hostname-1b"),
+						NodeName: ptr.To("node-1"),
 					},
 				},
 			},
@@ -690,11 +690,11 @@ func Test_dropTopologyOnV1(t *testing.T) {
 			originalEPS: &discovery.EndpointSlice{
 				Endpoints: []discovery.Endpoint{
 					{
-						Hostname:           utilpointer.String("hostname-1"),
+						Hostname:           ptr.To("hostname-1"),
 						DeprecatedTopology: map[string]string{corev1.LabelHostname: "node-1"},
 					},
 					{
-						Hostname:           utilpointer.String("hostname-1"),
+						Hostname:           ptr.To("hostname-1"),
 						DeprecatedTopology: map[string]string{corev1.LabelHostname: "node-2"},
 					},
 				},
@@ -702,11 +702,11 @@ func Test_dropTopologyOnV1(t *testing.T) {
 			newEPS: &discovery.EndpointSlice{
 				Endpoints: []discovery.Endpoint{
 					{
-						Hostname:           utilpointer.String("hostname-1a"),
+						Hostname:           ptr.To("hostname-1a"),
 						DeprecatedTopology: map[string]string{corev1.LabelHostname: "node-2"},
 					},
 					{
-						Hostname:           utilpointer.String("hostname-1b"),
+						Hostname:           ptr.To("hostname-1b"),
 						DeprecatedTopology: map[string]string{corev1.LabelHostname: "node-1"},
 					},
 				},
@@ -714,12 +714,12 @@ func Test_dropTopologyOnV1(t *testing.T) {
 			expectedEPS: &discovery.EndpointSlice{
 				Endpoints: []discovery.Endpoint{
 					{
-						Hostname: utilpointer.String("hostname-1a"),
-						NodeName: utilpointer.String("node-2"),
+						Hostname: ptr.To("hostname-1a"),
+						NodeName: ptr.To("node-2"),
 					},
 					{
-						Hostname: utilpointer.String("hostname-1b"),
-						NodeName: utilpointer.String("node-1"),
+						Hostname: ptr.To("hostname-1b"),
+						NodeName: ptr.To("node-1"),
 					},
 				},
 			},
@@ -730,11 +730,11 @@ func Test_dropTopologyOnV1(t *testing.T) {
 			originalEPS: &discovery.EndpointSlice{
 				Endpoints: []discovery.Endpoint{
 					{
-						Hostname:           utilpointer.String("hostname-1"),
+						Hostname:           ptr.To("hostname-1"),
 						DeprecatedTopology: map[string]string{corev1.LabelHostname: "node-1"},
 					},
 					{
-						Hostname:           utilpointer.String("hostname-1"),
+						Hostname:           ptr.To("hostname-1"),
 						DeprecatedTopology: map[string]string{corev1.LabelHostname: "node-2"},
 					},
 				},
@@ -742,12 +742,12 @@ func Test_dropTopologyOnV1(t *testing.T) {
 			newEPS: &discovery.EndpointSlice{
 				Endpoints: []discovery.Endpoint{
 					{
-						Hostname: utilpointer.String("hostname-1a"),
+						Hostname: ptr.To("hostname-1a"),
 						// Invalid node name because it did not exist in previous version of EndpointSlice
 						DeprecatedTopology: map[string]string{corev1.LabelHostname: "node-3"},
 					},
 					{
-						Hostname:           utilpointer.String("hostname-1b"),
+						Hostname:           ptr.To("hostname-1b"),
 						DeprecatedTopology: map[string]string{corev1.LabelHostname: "node-1"},
 					},
 				},
@@ -755,11 +755,11 @@ func Test_dropTopologyOnV1(t *testing.T) {
 			expectedEPS: &discovery.EndpointSlice{
 				Endpoints: []discovery.Endpoint{
 					{
-						Hostname: utilpointer.String("hostname-1a"),
+						Hostname: ptr.To("hostname-1a"),
 					},
 					{
-						Hostname: utilpointer.String("hostname-1b"),
-						NodeName: utilpointer.String("node-1"),
+						Hostname: ptr.To("hostname-1b"),
+						NodeName: ptr.To("node-1"),
 					},
 				},
 			},
@@ -770,11 +770,11 @@ func Test_dropTopologyOnV1(t *testing.T) {
 			originalEPS: &discovery.EndpointSlice{
 				Endpoints: []discovery.Endpoint{
 					{
-						Hostname:           utilpointer.String("hostname-1"),
+						Hostname:           ptr.To("hostname-1"),
 						DeprecatedTopology: map[string]string{corev1.LabelHostname: "node-1"},
 					},
 					{
-						Hostname:           utilpointer.String("hostname-1"),
+						Hostname:           ptr.To("hostname-1"),
 						DeprecatedTopology: map[string]string{corev1.LabelHostname: "node-1"},
 					},
 				},
@@ -782,12 +782,12 @@ func Test_dropTopologyOnV1(t *testing.T) {
 			newEPS: &discovery.EndpointSlice{
 				Endpoints: []discovery.Endpoint{
 					{
-						Hostname:           utilpointer.String("hostname-1a"),
+						Hostname:           ptr.To("hostname-1a"),
 						DeprecatedTopology: map[string]string{corev1.LabelHostname: "node-1"},
 					},
 					{
-						Hostname:           utilpointer.String("hostname-1b"),
-						NodeName:           utilpointer.String("node-2"),
+						Hostname:           ptr.To("hostname-1b"),
+						NodeName:           ptr.To("node-2"),
 						DeprecatedTopology: map[string]string{corev1.LabelHostname: "node-1"},
 					},
 				},
@@ -795,12 +795,12 @@ func Test_dropTopologyOnV1(t *testing.T) {
 			expectedEPS: &discovery.EndpointSlice{
 				Endpoints: []discovery.Endpoint{
 					{
-						Hostname: utilpointer.String("hostname-1a"),
-						NodeName: utilpointer.String("node-1"),
+						Hostname: ptr.To("hostname-1a"),
+						NodeName: ptr.To("node-1"),
 					},
 					{
-						Hostname: utilpointer.String("hostname-1b"),
-						NodeName: utilpointer.String("node-2"),
+						Hostname: ptr.To("hostname-1b"),
+						NodeName: ptr.To("node-2"),
 					},
 				},
 			},
@@ -811,11 +811,11 @@ func Test_dropTopologyOnV1(t *testing.T) {
 			originalEPS: &discovery.EndpointSlice{
 				Endpoints: []discovery.Endpoint{
 					{
-						Hostname:           utilpointer.String("hostname-1"),
+						Hostname:           ptr.To("hostname-1"),
 						DeprecatedTopology: map[string]string{corev1.LabelHostname: "node-1"},
 					},
 					{
-						Hostname:           utilpointer.String("hostname-1"),
+						Hostname:           ptr.To("hostname-1"),
 						DeprecatedTopology: map[string]string{corev1.LabelHostname: "node-1"},
 					},
 				},
@@ -823,13 +823,13 @@ func Test_dropTopologyOnV1(t *testing.T) {
 			newEPS: &discovery.EndpointSlice{
 				Endpoints: []discovery.Endpoint{
 					{
-						Hostname:           utilpointer.String("hostname-1a"),
+						Hostname:           ptr.To("hostname-1a"),
 						DeprecatedTopology: map[string]string{corev1.LabelHostname: "node-1"},
-						NodeName:           utilpointer.String("node-1"),
+						NodeName:           ptr.To("node-1"),
 					},
 					{
-						Hostname:           utilpointer.String("hostname-1b"),
-						NodeName:           utilpointer.String("node-2"),
+						Hostname:           ptr.To("hostname-1b"),
+						NodeName:           ptr.To("node-2"),
 						DeprecatedTopology: map[string]string{corev1.LabelHostname: "node-1"},
 					},
 				},
@@ -837,12 +837,12 @@ func Test_dropTopologyOnV1(t *testing.T) {
 			expectedEPS: &discovery.EndpointSlice{
 				Endpoints: []discovery.Endpoint{
 					{
-						Hostname: utilpointer.String("hostname-1a"),
-						NodeName: utilpointer.String("node-1"),
+						Hostname: ptr.To("hostname-1a"),
+						NodeName: ptr.To("node-1"),
 					},
 					{
-						Hostname: utilpointer.String("hostname-1b"),
-						NodeName: utilpointer.String("node-2"),
+						Hostname: ptr.To("hostname-1b"),
+						NodeName: ptr.To("node-2"),
 					},
 				},
 			},
@@ -853,19 +853,19 @@ func Test_dropTopologyOnV1(t *testing.T) {
 			originalEPS: &discovery.EndpointSlice{
 				Endpoints: []discovery.Endpoint{
 					{
-						Hostname:           utilpointer.String("hostname-1"),
+						Hostname:           ptr.To("hostname-1"),
 						DeprecatedTopology: map[string]string{corev1.LabelHostname: "valid-node-1"},
 					},
 					{
-						Hostname:           utilpointer.String("hostname-2"),
+						Hostname:           ptr.To("hostname-2"),
 						DeprecatedTopology: map[string]string{corev1.LabelHostname: "invalid node-2"},
 					},
 					{
-						Hostname:           utilpointer.String("hostname-3"),
+						Hostname:           ptr.To("hostname-3"),
 						DeprecatedTopology: map[string]string{corev1.LabelHostname: "valid-node-3"},
 					},
 					{
-						Hostname:           utilpointer.String("hostname-4"),
+						Hostname:           ptr.To("hostname-4"),
 						DeprecatedTopology: map[string]string{corev1.LabelHostname: "invalid node-4"},
 					},
 				},
@@ -873,39 +873,39 @@ func Test_dropTopologyOnV1(t *testing.T) {
 			newEPS: &discovery.EndpointSlice{
 				Endpoints: []discovery.Endpoint{
 					{
-						Hostname:           utilpointer.String("hostname-1"),
+						Hostname:           ptr.To("hostname-1"),
 						DeprecatedTopology: map[string]string{corev1.LabelHostname: "valid-node-1"},
 					},
 					{
-						Hostname:           utilpointer.String("hostname-2"),
+						Hostname:           ptr.To("hostname-2"),
 						DeprecatedTopology: map[string]string{corev1.LabelHostname: "invalid node-2"},
 					},
 					{
-						Hostname: utilpointer.String("hostname-3"),
-						NodeName: utilpointer.String("node-3"),
+						Hostname: ptr.To("hostname-3"),
+						NodeName: ptr.To("node-3"),
 					},
 					{
-						Hostname: utilpointer.String("hostname-4"),
-						NodeName: utilpointer.String("node-4"),
+						Hostname: ptr.To("hostname-4"),
+						NodeName: ptr.To("node-4"),
 					},
 				},
 			},
 			expectedEPS: &discovery.EndpointSlice{
 				Endpoints: []discovery.Endpoint{
 					{
-						Hostname: utilpointer.String("hostname-1"),
-						NodeName: utilpointer.String("valid-node-1"),
+						Hostname: ptr.To("hostname-1"),
+						NodeName: ptr.To("valid-node-1"),
 					},
 					{
-						Hostname: utilpointer.String("hostname-2"),
+						Hostname: ptr.To("hostname-2"),
 					},
 					{
-						Hostname: utilpointer.String("hostname-3"),
-						NodeName: utilpointer.String("node-3"),
+						Hostname: ptr.To("hostname-3"),
+						NodeName: ptr.To("node-3"),
 					},
 					{
-						Hostname: utilpointer.String("hostname-4"),
-						NodeName: utilpointer.String("node-4"),
+						Hostname: ptr.To("hostname-4"),
+						NodeName: ptr.To("node-4"),
 					},
 				},
 			},

--- a/pkg/registry/flowcontrol/ensurer/prioritylevelconfiguration_test.go
+++ b/pkg/registry/flowcontrol/ensurer/prioritylevelconfiguration_test.go
@@ -29,7 +29,6 @@ import (
 	flowcontrollisters "k8s.io/client-go/listers/flowcontrol/v1"
 	toolscache "k8s.io/client-go/tools/cache"
 	flowcontrolapisv1 "k8s.io/kubernetes/pkg/apis/flowcontrol/v1"
-	"k8s.io/utils/pointer"
 	"k8s.io/utils/ptr"
 
 	"github.com/google/go-cmp/cmp"
@@ -39,8 +38,8 @@ func TestEnsurePriorityLevel(t *testing.T) {
 	validExemptPL := func() *flowcontrolv1.PriorityLevelConfiguration {
 		copy := bootstrap.MandatoryPriorityLevelConfigurationExempt.DeepCopy()
 		copy.Annotations[flowcontrolv1.AutoUpdateAnnotationKey] = "true"
-		copy.Spec.Exempt.NominalConcurrencyShares = pointer.Int32(10)
-		copy.Spec.Exempt.LendablePercent = pointer.Int32(50)
+		copy.Spec.Exempt.NominalConcurrencyShares = ptr.To[int32](10)
+		copy.Spec.Exempt.LendablePercent = ptr.To[int32](50)
 		return copy
 	}()
 
@@ -275,7 +274,7 @@ func TestPriorityLevelSpecChanged(t *testing.T) {
 			Type: flowcontrolv1.PriorityLevelEnablementLimited,
 			Limited: &flowcontrolv1.LimitedPriorityLevelConfiguration{
 				NominalConcurrencyShares: ptr.To(flowcontrolapisv1.PriorityLevelConfigurationDefaultNominalConcurrencyShares),
-				LendablePercent:          pointer.Int32(0),
+				LendablePercent:          ptr.To[int32](0),
 				LimitResponse: flowcontrolv1.LimitResponse{
 					Type: flowcontrolv1.LimitResponseTypeReject,
 				},
@@ -287,8 +286,8 @@ func TestPriorityLevelSpecChanged(t *testing.T) {
 		Spec: flowcontrolv1.PriorityLevelConfigurationSpec{
 			Type: flowcontrolv1.PriorityLevelEnablementExempt,
 			Exempt: &flowcontrolv1.ExemptPriorityLevelConfiguration{
-				NominalConcurrencyShares: pointer.Int32(42),
-				LendablePercent:          pointer.Int32(33),
+				NominalConcurrencyShares: ptr.To[int32](42),
+				LendablePercent:          ptr.To[int32](33),
 			},
 		},
 	}
@@ -297,8 +296,8 @@ func TestPriorityLevelSpecChanged(t *testing.T) {
 		Spec: flowcontrolv1.PriorityLevelConfigurationSpec{
 			Type: flowcontrolv1.PriorityLevelEnablementExempt,
 			Exempt: &flowcontrolv1.ExemptPriorityLevelConfiguration{
-				NominalConcurrencyShares: pointer.Int32(24),
-				LendablePercent:          pointer.Int32(86),
+				NominalConcurrencyShares: ptr.To[int32](24),
+				LendablePercent:          ptr.To[int32](86),
 			},
 		},
 	}
@@ -488,7 +487,7 @@ func (b *plBuilder) WithLimited(nominalConcurrencyShares int32) *plBuilder {
 	b.object.Spec.Type = flowcontrolv1.PriorityLevelEnablementLimited
 	b.object.Spec.Limited = &flowcontrolv1.LimitedPriorityLevelConfiguration{
 		NominalConcurrencyShares: ptr.To(nominalConcurrencyShares),
-		LendablePercent:          pointer.Int32(0),
+		LendablePercent:          ptr.To[int32](0),
 		LimitResponse: flowcontrolv1.LimitResponse{
 			Type: flowcontrolv1.LimitResponseTypeReject,
 		},

--- a/pkg/registry/storage/csinode/strategy_test.go
+++ b/pkg/registry/storage/csinode/strategy_test.go
@@ -24,7 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/kubernetes/pkg/apis/storage"
-	utilpointer "k8s.io/utils/pointer"
+	ptr "k8s.io/utils/ptr"
 )
 
 func TestPrepareForCreate(t *testing.T) {
@@ -92,7 +92,7 @@ func TestPrepareForUpdate(t *testing.T) {
 					Name:         "valid-driver-name",
 					NodeID:       "valid-node",
 					TopologyKeys: []string{"company.com/zone1", "company.com/zone2"},
-					Allocatable:  &storage.VolumeNodeResources{Count: utilpointer.Int32Ptr(20)},
+					Allocatable:  &storage.VolumeNodeResources{Count: ptr.To[int32](20)},
 				},
 			},
 		},
@@ -251,7 +251,7 @@ func TestCSINodeValidation(t *testing.T) {
 							Name:         "$csi-driver@",
 							NodeID:       "valid-node",
 							TopologyKeys: []string{"company.com/zone1", "company.com/zone2"},
-							Allocatable:  &storage.VolumeNodeResources{Count: utilpointer.Int32Ptr(10)},
+							Allocatable:  &storage.VolumeNodeResources{Count: ptr.To[int32](10)},
 						},
 					},
 				},
@@ -270,7 +270,7 @@ func TestCSINodeValidation(t *testing.T) {
 							Name:         "valid-driver-name",
 							NodeID:       "",
 							TopologyKeys: []string{"company.com/zone1", "company.com/zone2"},
-							Allocatable:  &storage.VolumeNodeResources{Count: utilpointer.Int32Ptr(10)},
+							Allocatable:  &storage.VolumeNodeResources{Count: ptr.To[int32](10)},
 						},
 					},
 				},
@@ -289,7 +289,7 @@ func TestCSINodeValidation(t *testing.T) {
 							Name:         "valid-driver-name",
 							NodeID:       "valid-node",
 							TopologyKeys: []string{"company.com/zone1", "company.com/zone2"},
-							Allocatable:  &storage.VolumeNodeResources{Count: utilpointer.Int32Ptr(-1)},
+							Allocatable:  &storage.VolumeNodeResources{Count: ptr.To[int32](-1)},
 						},
 					},
 				},
@@ -308,7 +308,7 @@ func TestCSINodeValidation(t *testing.T) {
 							Name:         "valid-driver-name",
 							NodeID:       "valid-node",
 							TopologyKeys: []string{"company.com/zone1", ""},
-							Allocatable:  &storage.VolumeNodeResources{Count: utilpointer.Int32Ptr(10)},
+							Allocatable:  &storage.VolumeNodeResources{Count: ptr.To[int32](10)},
 						},
 					},
 				},
@@ -351,7 +351,7 @@ func getValidCSINode(name string) *storage.CSINode {
 					Name:         "valid-driver-name",
 					NodeID:       "valid-node",
 					TopologyKeys: []string{"company.com/zone1", "company.com/zone2"},
-					Allocatable:  &storage.VolumeNodeResources{Count: utilpointer.Int32Ptr(10)},
+					Allocatable:  &storage.VolumeNodeResources{Count: ptr.To[int32](10)},
 				},
 			},
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup
#### What this PR does / why we need it:

pkg/registry: drop pointer wrapper functions.
    
The new k8s.io/utils/ptr package provides generic wrapper functions,
which can be used instead of type-specific pointer wrapper functions.
This replaces the latter with the former, and migrates other uses of
the deprecated pointer package to ptr in affacted files.

See kubernetes/utils#283 for details.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
