### PR TITLE
Do not lock feature gate at GA, when it was off by default in previous release

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -1303,7 +1303,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 
 	genericfeatures.UnauthenticatedHTTP2DOSMitigation: {Default: true, PreRelease: featuregate.Beta},
 
-	genericfeatures.ValidatingAdmissionPolicy: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.32
+	genericfeatures.ValidatingAdmissionPolicy: {Default: true, PreRelease: featuregate.GA, LockToDefault: false}, // remove in 1.32
 
 	genericfeatures.WatchBookmark: {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 

--- a/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
+++ b/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
@@ -319,7 +319,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 
 	APIServingWithRoutine: {Default: true, PreRelease: featuregate.Beta},
 
-	ValidatingAdmissionPolicy: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.32
+	ValidatingAdmissionPolicy: {Default: true, PreRelease: featuregate.GA, LockToDefault: false}, // remove in 1.32
 
 	CustomResourceValidationExpressions: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.31
 


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/kind regression

#### What this PR does / why we need it:
`ValidatingAdmissionPolicy` feature gate was [off by default in 1.29](https://github.com/kubernetes/kubernetes/blob/release-1.29/pkg/features/kube_features.go#L1260) and it switched to [on by default and locked in 1.30](https://github.com/kubernetes/kubernetes/pull/123405). This is potentially a problem for everyone who manually sets these flags, because during upgrade the cluster won't work with settings that worked fine in k8s 1.29. We should ensure smooth upgrade path between such transitions. In the past beta->GA transition, when the feature was already on in beta was fine to lock the feature gate, but this particular case should not have locked to default. 

#### Special notes for your reviewer:
/assign @deads2k @liggitt 

#### Does this PR introduce a user-facing change?
```release-note
Allow smooth 1.29->1.30 upgrade by not locking ValidatingAdmissionPolicy to true in 1.30. 
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/3488
```
