### PR TITLE
Automated cherry pick of #124322: Add envFrom to serviceaccount admission plugin

### DIFF
--- a/plugin/pkg/admission/serviceaccount/admission.go
+++ b/plugin/pkg/admission/serviceaccount/admission.go
@@ -337,6 +337,13 @@ func (s *Plugin) limitSecretReferences(serviceAccount *corev1.ServiceAccount, po
 				}
 			}
 		}
+		for _, envFrom := range container.EnvFrom {
+			if envFrom.SecretRef != nil {
+				if !mountableSecrets.Has(envFrom.SecretRef.Name) {
+					return fmt.Errorf("init container %s with envFrom referencing secret.secretName=\"%s\" is not allowed because service account %s does not reference that secret", container.Name, envFrom.SecretRef.Name, serviceAccount.Name)
+				}
+			}
+		}
 	}
 
 	for _, container := range pod.Spec.Containers {
@@ -344,6 +351,13 @@ func (s *Plugin) limitSecretReferences(serviceAccount *corev1.ServiceAccount, po
 			if env.ValueFrom != nil && env.ValueFrom.SecretKeyRef != nil {
 				if !mountableSecrets.Has(env.ValueFrom.SecretKeyRef.Name) {
 					return fmt.Errorf("container %s with envVar %s referencing secret.secretName=\"%s\" is not allowed because service account %s does not reference that secret", container.Name, env.Name, env.ValueFrom.SecretKeyRef.Name, serviceAccount.Name)
+				}
+			}
+		}
+		for _, envFrom := range container.EnvFrom {
+			if envFrom.SecretRef != nil {
+				if !mountableSecrets.Has(envFrom.SecretRef.Name) {
+					return fmt.Errorf("container %s with envFrom referencing secret.secretName=\"%s\" is not allowed because service account %s does not reference that secret", container.Name, envFrom.SecretRef.Name, serviceAccount.Name)
 				}
 			}
 		}
@@ -385,6 +399,13 @@ func (s *Plugin) limitEphemeralContainerSecretReferences(pod *api.Pod, a admissi
 			if env.ValueFrom != nil && env.ValueFrom.SecretKeyRef != nil {
 				if !mountableSecrets.Has(env.ValueFrom.SecretKeyRef.Name) {
 					return fmt.Errorf("ephemeral container %s with envVar %s referencing secret.secretName=\"%s\" is not allowed because service account %s does not reference that secret", container.Name, env.Name, env.ValueFrom.SecretKeyRef.Name, serviceAccount.Name)
+				}
+			}
+		}
+		for _, envFrom := range container.EnvFrom {
+			if envFrom.SecretRef != nil {
+				if !mountableSecrets.Has(envFrom.SecretRef.Name) {
+					return fmt.Errorf("ephemeral container %s with envFrom referencing secret.secretName=\"%s\" is not allowed because service account %s does not reference that secret", container.Name, envFrom.SecretRef.Name, serviceAccount.Name)
 				}
 			}
 		}

--- a/plugin/pkg/admission/serviceaccount/admission_test.go
+++ b/plugin/pkg/admission/serviceaccount/admission_test.go
@@ -523,6 +523,25 @@ func TestAllowsReferencedSecret(t *testing.T) {
 
 	pod2 = &api.Pod{
 		Spec: api.PodSpec{
+			Containers: []api.Container{
+				{
+					Name: "container-1",
+					EnvFrom: []api.EnvFromSource{
+						{
+							SecretRef: &api.SecretEnvSource{
+								LocalObjectReference: api.LocalObjectReference{
+									Name: "foo"}}}},
+				},
+			},
+		},
+	}
+	attrs = admission.NewAttributesRecord(pod2, nil, api.Kind("Pod").WithVersion("version"), ns, "myname", api.Resource("pods").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
+	if err := admissiontesting.WithReinvocationTesting(t, admit).Admit(context.TODO(), attrs, nil); err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	pod2 = &api.Pod{
+		Spec: api.PodSpec{
 			InitContainers: []api.Container{
 				{
 					Name: "container-1",
@@ -536,6 +555,25 @@ func TestAllowsReferencedSecret(t *testing.T) {
 							},
 						},
 					},
+				},
+			},
+		},
+	}
+	attrs = admission.NewAttributesRecord(pod2, nil, api.Kind("Pod").WithVersion("version"), ns, "myname", api.Resource("pods").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
+	if err := admissiontesting.WithReinvocationTesting(t, admit).Admit(context.TODO(), attrs, nil); err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	pod2 = &api.Pod{
+		Spec: api.PodSpec{
+			InitContainers: []api.Container{
+				{
+					Name: "container-1",
+					EnvFrom: []api.EnvFromSource{
+						{
+							SecretRef: &api.SecretEnvSource{
+								LocalObjectReference: api.LocalObjectReference{
+									Name: "foo"}}}},
 				},
 			},
 		},
@@ -568,6 +606,28 @@ func TestAllowsReferencedSecret(t *testing.T) {
 		},
 	}
 	// validate enforces restrictions on secret mounts when operation==create and subresource=='' or operation==update and subresource==ephemeralcontainers"
+	attrs = admission.NewAttributesRecord(pod2, nil, api.Kind("Pod").WithVersion("version"), ns, "myname", api.Resource("pods").WithVersion("version"), "ephemeralcontainers", admission.Update, &metav1.UpdateOptions{}, false, nil)
+	if err := admit.Validate(context.TODO(), attrs, nil); err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	pod2 = &api.Pod{
+		Spec: api.PodSpec{
+			ServiceAccountName: DefaultServiceAccountName,
+			EphemeralContainers: []api.EphemeralContainer{
+				{
+					EphemeralContainerCommon: api.EphemeralContainerCommon{
+						Name: "container-2",
+						EnvFrom: []api.EnvFromSource{{
+							SecretRef: &api.SecretEnvSource{
+								LocalObjectReference: api.LocalObjectReference{
+									Name: "foo"}}}},
+					},
+				},
+			},
+		},
+	}
+	// validate enforces restrictions on secret mounts when operation==update and subresource==ephemeralcontainers"
 	attrs = admission.NewAttributesRecord(pod2, nil, api.Kind("Pod").WithVersion("version"), ns, "myname", api.Resource("pods").WithVersion("version"), "ephemeralcontainers", admission.Update, &metav1.UpdateOptions{}, false, nil)
 	if err := admit.Validate(context.TODO(), attrs, nil); err != nil {
 		t.Errorf("Unexpected error: %v", err)
@@ -628,25 +688,20 @@ func TestRejectsUnreferencedSecretVolumes(t *testing.T) {
 
 	pod2 = &api.Pod{
 		Spec: api.PodSpec{
-			InitContainers: []api.Container{
+			Containers: []api.Container{
 				{
 					Name: "container-1",
-					Env: []api.EnvVar{
+					EnvFrom: []api.EnvFromSource{
 						{
-							Name: "env-1",
-							ValueFrom: &api.EnvVarSource{
-								SecretKeyRef: &api.SecretKeySelector{
-									LocalObjectReference: api.LocalObjectReference{Name: "foo"},
-								},
-							},
-						},
-					},
+							SecretRef: &api.SecretEnvSource{
+								LocalObjectReference: api.LocalObjectReference{
+									Name: "foo"}}}},
 				},
 			},
 		},
 	}
 	attrs = admission.NewAttributesRecord(pod2, nil, api.Kind("Pod").WithVersion("version"), ns, "myname", api.Resource("pods").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
-	if err := admissiontesting.WithReinvocationTesting(t, admit).Admit(context.TODO(), attrs, nil); err == nil || !strings.Contains(err.Error(), "with envVar") {
+	if err := admissiontesting.WithReinvocationTesting(t, admit).Admit(context.TODO(), attrs, nil); err == nil || !strings.Contains(err.Error(), "with envFrom") {
 		t.Errorf("Unexpected error: %v", err)
 	}
 
@@ -682,6 +737,30 @@ func TestRejectsUnreferencedSecretVolumes(t *testing.T) {
 	pod2 = &api.Pod{
 		Spec: api.PodSpec{
 			ServiceAccountName: DefaultServiceAccountName,
+			InitContainers: []api.Container{
+				{
+					Name: "container-1",
+					EnvFrom: []api.EnvFromSource{
+						{
+							SecretRef: &api.SecretEnvSource{
+								LocalObjectReference: api.LocalObjectReference{
+									Name: "foo"}}}},
+				},
+			},
+		},
+	}
+	attrs = admission.NewAttributesRecord(pod2, nil, api.Kind("Pod").WithVersion("version"), ns, "myname", api.Resource("pods").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, nil)
+	if err := admissiontesting.WithReinvocationTesting(t, admit).Admit(context.TODO(), attrs, nil); err != nil {
+		t.Errorf("admit only enforces restrictions on secret mounts when operation==create. Unexpected error: %v", err)
+	}
+	attrs = admission.NewAttributesRecord(pod2, nil, api.Kind("Pod").WithVersion("version"), ns, "myname", api.Resource("pods").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
+	if err := admit.Validate(context.TODO(), attrs, nil); err == nil || !strings.Contains(err.Error(), "with envFrom") {
+		t.Errorf("validate only enforces restrictions on secret mounts when operation==create and subresource==''. Unexpected error: %v", err)
+	}
+
+	pod2 = &api.Pod{
+		Spec: api.PodSpec{
+			ServiceAccountName: DefaultServiceAccountName,
 			EphemeralContainers: []api.EphemeralContainer{
 				{
 					EphemeralContainerCommon: api.EphemeralContainerCommon{
@@ -707,6 +786,27 @@ func TestRejectsUnreferencedSecretVolumes(t *testing.T) {
 	}
 	attrs = admission.NewAttributesRecord(pod2, nil, api.Kind("Pod").WithVersion("version"), ns, "myname", api.Resource("pods").WithVersion("version"), "ephemeralcontainers", admission.Update, &metav1.UpdateOptions{}, false, nil)
 	if err := admit.Validate(context.TODO(), attrs, nil); err == nil || !strings.Contains(err.Error(), "with envVar") {
+		t.Errorf("validate enforces restrictions on secret mounts when operation==update and subresource==ephemeralcontainers. Unexpected error: %v", err)
+	}
+
+	pod2 = &api.Pod{
+		Spec: api.PodSpec{
+			ServiceAccountName: DefaultServiceAccountName,
+			EphemeralContainers: []api.EphemeralContainer{
+				{
+					EphemeralContainerCommon: api.EphemeralContainerCommon{
+						Name: "container-2",
+						EnvFrom: []api.EnvFromSource{{
+							SecretRef: &api.SecretEnvSource{
+								LocalObjectReference: api.LocalObjectReference{
+									Name: "foo"}}}},
+					},
+				},
+			},
+		},
+	}
+	attrs = admission.NewAttributesRecord(pod2, nil, api.Kind("Pod").WithVersion("version"), ns, "myname", api.Resource("pods").WithVersion("version"), "ephemeralcontainers", admission.Update, &metav1.UpdateOptions{}, false, nil)
+	if err := admit.Validate(context.TODO(), attrs, nil); err == nil || !strings.Contains(err.Error(), "with envFrom") {
 		t.Errorf("validate enforces restrictions on secret mounts when operation==update and subresource==ephemeralcontainers. Unexpected error: %v", err)
 	}
 }


### PR DESCRIPTION
Cherry pick of #124322 on release-1.27.

#124322: Add envFrom to serviceaccount admission plugin

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```

/sig auth
/milestone v1.27