### PR TITLE
Remove ReadWriteOncePod feature gate

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -663,15 +663,6 @@ const (
 	// bursting into resources requested at higher QoS levels (memory only for now)
 	QOSReserved featuregate.Feature = "QOSReserved"
 
-	// owner: @chrishenzie
-	// kep: https://kep.k8s.io/2485
-	// alpha: v1.22
-	// beta: v1.27
-	// GA: v1.29
-	//
-	// Enables usage of the ReadWriteOncePod PersistentVolume access mode.
-	ReadWriteOncePod featuregate.Feature = "ReadWriteOncePod"
-
 	// owner: @gnufied
 	// kep: https://kep.k8s.io/1790
 	// alpha: v1.23
@@ -1171,8 +1162,6 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	ProcMountType: {Default: false, PreRelease: featuregate.Alpha},
 
 	QOSReserved: {Default: false, PreRelease: featuregate.Alpha},
-
-	ReadWriteOncePod: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.31
 
 	RecoverVolumeExpansionFailure: {Default: false, PreRelease: featuregate.Alpha},
 


### PR DESCRIPTION
/kind cleanup
/sig storage

#### What this PR does / why we need it:
Removes the `ReadWriteOncePod` feature gate. We can remove this because we no longer need it / no logic depends on checking it.

#### Does this PR introduce a user-facing change?
```release-note
Removed generally available feature gate `ReadWriteOncePod`.
```