### PR TITLE
Add test to detect unintentional changes in dynamic client requests.

### DIFF
--- a/staging/src/k8s.io/client-go/dynamic/golden_test.go
+++ b/staging/src/k8s.io/client-go/dynamic/golden_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package dynamic_test
 
 import (

--- a/staging/src/k8s.io/client-go/dynamic/golden_test.go
+++ b/staging/src/k8s.io/client-go/dynamic/golden_test.go
@@ -1,0 +1,232 @@
+package dynamic_test
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/http/httputil"
+	"net/url"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
+)
+
+func TestGoldenRequest(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		do   func(context.Context, dynamic.Interface) error
+	}{
+		{
+			name: "create",
+			do: func(ctx context.Context, client dynamic.Interface) error {
+				_, err := client.Resource(schema.GroupVersionResource{Group: "flops", Version: "v1alpha1", Resource: "flips"}).Namespace("mops").Create(
+					ctx,
+					&unstructured.Unstructured{Object: map[string]interface{}{
+						"metadata": map[string]interface{}{"name": "mips"},
+					}},
+					metav1.CreateOptions{FieldValidation: "warn"},
+					"fin",
+				)
+				return err
+			},
+		},
+		{
+			name: "update",
+			do: func(ctx context.Context, client dynamic.Interface) error {
+				_, err := client.Resource(schema.GroupVersionResource{Group: "flops", Version: "v1alpha1", Resource: "flips"}).Namespace("mops").Update(
+					ctx,
+					&unstructured.Unstructured{Object: map[string]interface{}{
+						"metadata": map[string]interface{}{"name": "mips"},
+					}},
+					metav1.UpdateOptions{FieldValidation: "warn"},
+					"fin",
+				)
+				return err
+			},
+		},
+		{
+			name: "updatestatus",
+			do: func(ctx context.Context, client dynamic.Interface) error {
+				_, err := client.Resource(schema.GroupVersionResource{Group: "flops", Version: "v1alpha1", Resource: "flips"}).Namespace("mops").UpdateStatus(
+					ctx,
+					&unstructured.Unstructured{Object: map[string]interface{}{
+						"metadata": map[string]interface{}{"name": "mips"},
+					}},
+					metav1.UpdateOptions{FieldValidation: "warn"},
+				)
+				return err
+			},
+		},
+		{
+			name: "delete",
+			do: func(ctx context.Context, client dynamic.Interface) error {
+				return client.Resource(schema.GroupVersionResource{Group: "flops", Version: "v1alpha1", Resource: "flips"}).Namespace("mops").Delete(
+					ctx,
+					"mips",
+					metav1.DeleteOptions{DryRun: []string{metav1.DryRunAll}},
+					"fin",
+				)
+			},
+		},
+		{
+			name: "deletecollection",
+			do: func(ctx context.Context, client dynamic.Interface) error {
+				return client.Resource(schema.GroupVersionResource{Group: "flops", Version: "v1alpha1", Resource: "flips"}).Namespace("mops").DeleteCollection(
+					ctx,
+					metav1.DeleteOptions{DryRun: []string{metav1.DryRunAll}},
+					metav1.ListOptions{ResourceVersion: "42"},
+				)
+			},
+		},
+		{
+			name: "get",
+			do: func(ctx context.Context, client dynamic.Interface) error {
+				_, err := client.Resource(schema.GroupVersionResource{Group: "flops", Version: "v1alpha1", Resource: "flips"}).Namespace("mops").Get(
+					ctx,
+					"mips",
+					metav1.GetOptions{ResourceVersion: "42"},
+					"fin",
+				)
+				return err
+			},
+		},
+		{
+			name: "list",
+			do: func(ctx context.Context, client dynamic.Interface) error {
+				_, err := client.Resource(schema.GroupVersionResource{Group: "flops", Version: "v1alpha1", Resource: "flips"}).Namespace("mops").List(
+					ctx,
+					metav1.ListOptions{ResourceVersion: "42"},
+				)
+				return err
+			},
+		},
+		{
+			name: "watch",
+			do: func(ctx context.Context, client dynamic.Interface) error {
+				_, err := client.Resource(schema.GroupVersionResource{Group: "flops", Version: "v1alpha1", Resource: "flips"}).Namespace("mops").Watch(
+					ctx,
+					metav1.ListOptions{ResourceVersion: "42"},
+				)
+				return err
+			},
+		},
+		{
+			name: "patch",
+			do: func(ctx context.Context, client dynamic.Interface) error {
+				_, err := client.Resource(schema.GroupVersionResource{Group: "flops", Version: "v1alpha1", Resource: "flips"}).Namespace("mops").Patch(
+					ctx,
+					"mips",
+					types.StrategicMergePatchType,
+					[]byte("{\"foo\":\"bar\"}\n"),
+					metav1.PatchOptions{FieldManager: "baz"},
+					"fin",
+				)
+				return err
+			},
+		},
+		{
+			name: "apply",
+			do: func(ctx context.Context, client dynamic.Interface) error {
+				_, err := client.Resource(schema.GroupVersionResource{Group: "flops", Version: "v1alpha1", Resource: "flips"}).Namespace("mops").Apply(
+					ctx,
+					"mips",
+					&unstructured.Unstructured{Object: map[string]interface{}{
+						"metadata": map[string]interface{}{"name": "mips"},
+					}},
+					metav1.ApplyOptions{Force: true},
+					"fin",
+				)
+				return err
+			},
+		},
+		{
+			name: "applystatus",
+			do: func(ctx context.Context, client dynamic.Interface) error {
+				_, err := client.Resource(schema.GroupVersionResource{Group: "flops", Version: "v1alpha1", Resource: "flips"}).Namespace("mops").ApplyStatus(
+					ctx,
+					"mips",
+					&unstructured.Unstructured{Object: map[string]interface{}{
+						"metadata": map[string]interface{}{"name": "mips"},
+					}},
+					metav1.ApplyOptions{Force: true},
+				)
+				return err
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			handled := make(chan struct{})
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				defer close(handled)
+
+				got, err := httputil.DumpRequest(r, true)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				path := filepath.Join("testdata", filepath.FromSlash(t.Name()))
+
+				if os.Getenv("UPDATE_DYNAMIC_CLIENT_FIXTURES") == "true" {
+					err := os.WriteFile(path, got, os.FileMode(0755))
+					if err != nil {
+						t.Fatalf("failed to update fixture: %v", err)
+					}
+				}
+
+				want, err := os.ReadFile(path)
+				if err != nil {
+					t.Fatalf("failed to load fixture: %v", err)
+				}
+				if diff := cmp.Diff(got, want); diff != "" {
+					t.Errorf("unexpected difference from expected bytes:\n%s", diff)
+				}
+			}))
+			defer srv.Close()
+
+			client, err := dynamic.NewForConfig(&rest.Config{
+				Host:      "example.com",
+				UserAgent: "TestGoldenRequest",
+				Transport: &http.Transport{
+					// The client will send a static Host header while always
+					// connecting to the test server.
+					DialContext: func(ctx context.Context, network string, addr string) (net.Conn, error) {
+						u, err := url.Parse(srv.URL)
+						if err != nil {
+							return nil, fmt.Errorf("failed to parse test server url: %w", err)
+						}
+						return (&net.Dialer{}).DialContext(ctx, "tcp", u.Host)
+					},
+				},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			defer cancel()
+			if err := tc.do(ctx, client); err != nil {
+				// This test detects server-perceptible changes to the request. As
+				// long as the server receives the expected request, a non-nil error
+				// returned from a client method is not a failure.
+				t.Logf("client returned non-nil error: %v", err)
+			}
+
+			select {
+			case <-handled:
+			default:
+				t.Fatal("no request received")
+			}
+		})
+	}
+}

--- a/staging/src/k8s.io/client-go/dynamic/testdata/TestGoldenRequest/.gitattributes
+++ b/staging/src/k8s.io/client-go/dynamic/testdata/TestGoldenRequest/.gitattributes
@@ -1,0 +1,2 @@
+# disable end-of-line conversion for fixtures
+* -text

--- a/staging/src/k8s.io/client-go/dynamic/testdata/TestGoldenRequest/apply
+++ b/staging/src/k8s.io/client-go/dynamic/testdata/TestGoldenRequest/apply
@@ -1,0 +1,9 @@
+PATCH /apis/flops/v1alpha1/namespaces/mops/flips/mips/fin?force=true HTTP/1.1
+Host: example.com
+Accept: application/json
+Accept-Encoding: gzip
+Content-Length: 29
+Content-Type: application/apply-patch+yaml
+User-Agent: TestGoldenRequest
+
+{"metadata":{"name":"mips"}}

--- a/staging/src/k8s.io/client-go/dynamic/testdata/TestGoldenRequest/applystatus
+++ b/staging/src/k8s.io/client-go/dynamic/testdata/TestGoldenRequest/applystatus
@@ -1,0 +1,9 @@
+PATCH /apis/flops/v1alpha1/namespaces/mops/flips/mips/status?force=true HTTP/1.1
+Host: example.com
+Accept: application/json
+Accept-Encoding: gzip
+Content-Length: 29
+Content-Type: application/apply-patch+yaml
+User-Agent: TestGoldenRequest
+
+{"metadata":{"name":"mips"}}

--- a/staging/src/k8s.io/client-go/dynamic/testdata/TestGoldenRequest/create
+++ b/staging/src/k8s.io/client-go/dynamic/testdata/TestGoldenRequest/create
@@ -1,0 +1,9 @@
+POST /apis/flops/v1alpha1/namespaces/mops/flips/mips/fin?fieldValidation=warn HTTP/1.1
+Host: example.com
+Accept: application/json
+Accept-Encoding: gzip
+Content-Length: 29
+Content-Type: application/json
+User-Agent: TestGoldenRequest
+
+{"metadata":{"name":"mips"}}

--- a/staging/src/k8s.io/client-go/dynamic/testdata/TestGoldenRequest/delete
+++ b/staging/src/k8s.io/client-go/dynamic/testdata/TestGoldenRequest/delete
@@ -1,0 +1,9 @@
+DELETE /apis/flops/v1alpha1/namespaces/mops/flips/mips/fin HTTP/1.1
+Host: example.com
+Accept: application/json
+Accept-Encoding: gzip
+Content-Length: 60
+Content-Type: application/json
+User-Agent: TestGoldenRequest
+
+{"kind":"DeleteOptions","apiVersion":"v1","dryRun":["All"]}

--- a/staging/src/k8s.io/client-go/dynamic/testdata/TestGoldenRequest/deletecollection
+++ b/staging/src/k8s.io/client-go/dynamic/testdata/TestGoldenRequest/deletecollection
@@ -1,0 +1,9 @@
+DELETE /apis/flops/v1alpha1/namespaces/mops/flips?resourceVersion=42 HTTP/1.1
+Host: example.com
+Accept: application/json
+Accept-Encoding: gzip
+Content-Length: 60
+Content-Type: application/json
+User-Agent: TestGoldenRequest
+
+{"kind":"DeleteOptions","apiVersion":"v1","dryRun":["All"]}

--- a/staging/src/k8s.io/client-go/dynamic/testdata/TestGoldenRequest/get
+++ b/staging/src/k8s.io/client-go/dynamic/testdata/TestGoldenRequest/get
@@ -1,0 +1,6 @@
+GET /apis/flops/v1alpha1/namespaces/mops/flips/mips/fin?resourceVersion=42 HTTP/1.1
+Host: example.com
+Accept: application/json
+Accept-Encoding: gzip
+User-Agent: TestGoldenRequest
+

--- a/staging/src/k8s.io/client-go/dynamic/testdata/TestGoldenRequest/list
+++ b/staging/src/k8s.io/client-go/dynamic/testdata/TestGoldenRequest/list
@@ -1,0 +1,6 @@
+GET /apis/flops/v1alpha1/namespaces/mops/flips?resourceVersion=42 HTTP/1.1
+Host: example.com
+Accept: application/json
+Accept-Encoding: gzip
+User-Agent: TestGoldenRequest
+

--- a/staging/src/k8s.io/client-go/dynamic/testdata/TestGoldenRequest/patch
+++ b/staging/src/k8s.io/client-go/dynamic/testdata/TestGoldenRequest/patch
@@ -1,0 +1,9 @@
+PATCH /apis/flops/v1alpha1/namespaces/mops/flips/mips/fin?fieldManager=baz HTTP/1.1
+Host: example.com
+Accept: application/json
+Accept-Encoding: gzip
+Content-Length: 14
+Content-Type: application/strategic-merge-patch+json
+User-Agent: TestGoldenRequest
+
+{"foo":"bar"}

--- a/staging/src/k8s.io/client-go/dynamic/testdata/TestGoldenRequest/update
+++ b/staging/src/k8s.io/client-go/dynamic/testdata/TestGoldenRequest/update
@@ -1,0 +1,9 @@
+PUT /apis/flops/v1alpha1/namespaces/mops/flips/mips/fin?fieldValidation=warn HTTP/1.1
+Host: example.com
+Accept: application/json
+Accept-Encoding: gzip
+Content-Length: 29
+Content-Type: application/json
+User-Agent: TestGoldenRequest
+
+{"metadata":{"name":"mips"}}

--- a/staging/src/k8s.io/client-go/dynamic/testdata/TestGoldenRequest/updatestatus
+++ b/staging/src/k8s.io/client-go/dynamic/testdata/TestGoldenRequest/updatestatus
@@ -1,0 +1,9 @@
+PUT /apis/flops/v1alpha1/namespaces/mops/flips/mips/status?fieldValidation=warn HTTP/1.1
+Host: example.com
+Accept: application/json
+Accept-Encoding: gzip
+Content-Length: 29
+Content-Type: application/json
+User-Agent: TestGoldenRequest
+
+{"metadata":{"name":"mips"}}

--- a/staging/src/k8s.io/client-go/dynamic/testdata/TestGoldenRequest/watch
+++ b/staging/src/k8s.io/client-go/dynamic/testdata/TestGoldenRequest/watch
@@ -1,0 +1,6 @@
+GET /apis/flops/v1alpha1/namespaces/mops/flips?resourceVersion=42&watch=true HTTP/1.1
+Host: example.com
+Accept: application/json
+Accept-Encoding: gzip
+User-Agent: TestGoldenRequest
+


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup
/sig api-machinery

#### What this PR does / why we need it:

This adds a test that should fail if requests made by the dynamic client change. The goal is to decrease the risk of refactoring the dynamic client. Specifically, I am preparing to make the dynamic client use the REST client's content negotiation mechanisms for all methods.

Following a pattern from https://github.com/kubernetes/kubernetes/pull/36538, the test includes an environment-variable-shaped button to update test fixtures to reflect the current behavior.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

This implements the request side of this suggestion: https://github.com/kubernetes/kubernetes/pull/124059#issuecomment-2057693855

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
