### PR TITLE
e2e: enhance WithFeatureGate labels

### DIFF
--- a/test/e2e/framework/internal/unittests/bugs/bugs.go
+++ b/test/e2e/framework/internal/unittests/bugs/bugs.go
@@ -133,12 +133,12 @@ ERROR: some/relative/path/buggy.go:200: with spaces
 
 	// Used by unittests/list-labels.
 	ListLabelsOutput = `The following labels can be used with 'ginkgo run --label-filter':
-    Alpha
-    Beta
     Conformance
     Disruptive
     Environment:Linux
     Environment:no-such-env
+    Feature:Alpha
+    Feature:Beta
     Feature:feature-foo
     Feature:no-such-feature
     FeatureGate:TestAlphaFeature

--- a/test/e2e/framework/internal/unittests/list-labels/listlabels_test.go
+++ b/test/e2e/framework/internal/unittests/list-labels/listlabels_test.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/kubernetes/test/e2e/framework/internal/unittests/bugs"
 )
 
-func TestListTests(t *testing.T) {
+func TestListLabels(t *testing.T) {
 	bugs.Describe()
 	framework.CheckForBugs = false
 	output, code := unittests.GetFrameworkOutput(t, map[string]string{"list-labels": "true"})


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

We want:

- To keep test annotations simple: using both WithFeatureGate and WithFeature should only be necessary when a test really has requirements that go beyond "feature gate needs to be enabled" (example: HonorPVReclaimPolicy in https://github.com/kubernetes/kubernetes/pull/123151 only needs the feature gate).

- To run tests which depend only on feature gates being enabled in the ci-kubernetes-e2e-kind-alpha-features resp. ci-kubernetes-e2e-kind-beta-features, because otherwise we may have a proliferation of many bespoke jobs which only run very few tests. This would make testing more expensive for Kubernetes.

- To enable those tests only once in the ci-kubernetes-e2e-kind-alpha-features and ci-kubernetes-e2e-kind-beta-features definition instead of having to update those each time feature gates change.

#### Special notes for your reviewer:

This can be achieved by adding `Feature:Alpha` resp. `Feature:Beta` as Ginkgo labels instead of just `Alpha` and `Beta`. Then jobs which are configured to skip tests with feature dependencies via `--label-filter=!/^Feature:.+/` will skip tests which are labeled with just WithFeatureGate. The ci-kubernetes jobs can select to include such tests with the new set-based Ginkgo label filter (see https://github.com/kubernetes/community/pull/7824).

Note that removing WithFeature depends on first updating job definitions to use --label-filter or to skip based on the inline `[Alpha]` or `[Beta]` text, otherwise tests that were previously skipped because of WithFeature might start to run in jobs which don't have the feature gate enabled.

#### Does this PR introduce a user-facing change?
```release-note
e2e.test and e2e_node.test: tests which depend on alpha or beta feature gates now have `Feature:Alpha` or `Feature:Beta` as Ginkgo labels. The inline text is `[Alpha]` or `[Beta]`, as before.
```
