### PR TITLE
hack/verify-e2e-suites.sh: non-zero exit code when there were errors

### DIFF
--- a/hack/verify-e2e-suites.sh
+++ b/hack/verify-e2e-suites.sh
@@ -31,6 +31,7 @@ cd "${KUBE_ROOT}"
 
 kube::util::ensure-temp-dir
 
+res=0
 for suite in $(git grep -l framework.AfterReadingAllFlags | grep -v -e ^test/e2e/framework -e ^hack | xargs -n 1 dirname | sort -u); do
     # Build a binary and run it in the root directory to get paths that are
     # relative to that instead of the package directory.
@@ -41,5 +42,7 @@ for suite in $(git grep -l framework.AfterReadingAllFlags | grep -v -e ^test/e2e
         echo >&2 "ERROR: E2E test suite invocation failed for $suite."
         # shellcheck disable=SC2001
         echo "$out" | sed -e 's/^/   /'
+        res=1
     fi
 done
+exit "$res"


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind failing-test

#### What this PR does / why we need it:

The script correctly reported errors, but did not return a non-zero exit code. Therefore errors would have been overlooked during pull-kubernetes-verify runs.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
