### PR TITLE
kubeadm: don't mount /etc/pki for apiserver and KCM

### DIFF
--- a/cmd/kubeadm/app/phases/controlplane/volumes.go
+++ b/cmd/kubeadm/app/phases/controlplane/volumes.go
@@ -40,7 +40,7 @@ const (
 // caCertsExtraVolumePaths specifies the paths that can be conditionally mounted into the apiserver and controller-manager containers
 // as /etc/ssl/certs might be or contain a symlink to them. It's a variable since it may be changed in unit testing. This var MUST
 // NOT be changed in normal codepaths during runtime.
-var caCertsExtraVolumePaths = []string{"/etc/pki", "/usr/share/ca-certificates", "/usr/local/share/ca-certificates", "/etc/ca-certificates"}
+var caCertsExtraVolumePaths = []string{"/etc/pki/ca-trust", "/etc/pki/tls/certs", "/etc/ca-certificates", "/usr/share/ca-certificates", "/usr/local/share/ca-certificates"}
 
 // getHostPathVolumesForTheControlPlane gets the required hostPath volumes and mounts for the control plane
 func getHostPathVolumesForTheControlPlane(cfg *kubeadmapi.ClusterConfiguration) controlPlaneHostPathMounts {
@@ -83,7 +83,7 @@ func getHostPathVolumesForTheControlPlane(cfg *kubeadmapi.ClusterConfiguration) 
 	schedulerKubeConfigFile := filepath.Join(kubeadmconstants.KubernetesDir, kubeadmconstants.SchedulerKubeConfigFileName)
 	mounts.NewHostPathMount(kubeadmconstants.KubeScheduler, kubeadmconstants.KubeConfigVolumeName, schedulerKubeConfigFile, schedulerKubeConfigFile, true, &hostPathFileOrCreate)
 
-	// On some systems were we host-mount /etc/ssl/certs, it is also required to mount additional directories.
+	// On some systems where we host-mount /etc/ssl/certs, it is also required to mount additional directories.
 	// This is needed due to symlinks pointing from files in /etc/ssl/certs to these directories.
 	for _, caCertsExtraVolumePath := range caCertsExtraVolumePaths {
 		if isExtraVolumeMountNeeded(caCertsExtraVolumePath) {
@@ -179,7 +179,7 @@ func getEtcdCertVolumes(etcdCfg *kubeadmapi.ExternalEtcd, k8sCertificatesDir str
 	for _, certPath := range certPaths {
 		certDir := filepath.ToSlash(filepath.Dir(certPath))
 		// Ignore ".", which is the result of passing an empty path.
-		// Also ignore the cert directories that already may be mounted; /etc/ssl/certs, /etc/pki or Kubernetes CertificatesDir
+		// Also ignore the cert directories that already may be mounted; /etc/ssl/certs, /etc/pki/ca-trust/ or Kubernetes CertificatesDir
 		// If the etcd certs are in there, it's okay, we don't have to do anything
 		extraVolumePath := false
 		for _, caCertsExtraVolumePath := range caCertsExtraVolumePaths {
@@ -219,9 +219,9 @@ func getEtcdCertVolumes(etcdCfg *kubeadmapi.ExternalEtcd, k8sCertificatesDir str
 	return volumes, volumeMounts
 }
 
-// isExtraVolumeMountNeeded specifies whether /etc/pki should be host-mounted into the containers
-// On some systems were we host-mount /etc/ssl/certs, it is also required to mount /etc/pki. This is needed
-// due to symlinks pointing from files in /etc/ssl/certs into /etc/pki/
+// isExtraVolumeMountNeeded specifies whether /etc/pki/ca-trust/ should be host-mounted into the containers
+// On some systems were we host-mount /etc/ssl/certs, it is also required to mount /etc/pki/ca-trust/. This is needed
+// due to symlinks pointing from files in /etc/ssl/certs into /etc/pki/ca-trust/
 func isExtraVolumeMountNeeded(caCertsExtraVolumePath string) bool {
 	if _, err := os.Stat(caCertsExtraVolumePath); err == nil {
 		return true

--- a/cmd/kubeadm/app/phases/controlplane/volumes_test.go
+++ b/cmd/kubeadm/app/phases/controlplane/volumes_test.go
@@ -57,10 +57,10 @@ func TestGetEtcdCertVolumes(t *testing.T) {
 			volMount: []v1.VolumeMount{},
 		},
 		{
-			name:     "Should ignore files in /etc/pki",
-			ca:       "/etc/pki/my-etcd-ca.crt",
-			cert:     "/etc/pki/my-etcd.crt",
-			key:      "/etc/pki/my-etcd.key",
+			name:     "Should ignore files in /etc/pki/ca-trust",
+			ca:       "/etc/pki/ca-trust/my-etcd-ca.crt",
+			cert:     "/etc/pki/ca-trust/my-etcd.crt",
+			key:      "/etc/pki/ca-trust/my-etcd.key",
 			vol:      []v1.Volume{},
 			volMount: []v1.VolumeMount{},
 		},
@@ -519,8 +519,9 @@ func TestGetHostPathVolumesForTheControlPlane(t *testing.T) {
 	defer os.RemoveAll(tmpdir)
 
 	// set up tmp caCertsExtraVolumePaths for testing
-	caCertsExtraVolumePaths = []string{fmt.Sprintf("%s/etc/pki", tmpdir), fmt.Sprintf("%s/usr/share/ca-certificates", tmpdir)}
-	defer func() { caCertsExtraVolumePaths = []string{"/etc/pki", "/usr/share/ca-certificates"} }()
+	originalCACertsExtraVolumePaths := caCertsExtraVolumePaths
+	caCertsExtraVolumePaths = []string{fmt.Sprintf("%s/etc/pki/ca-trust", tmpdir), fmt.Sprintf("%s/usr/share/ca-certificates", tmpdir)}
+	defer func() { caCertsExtraVolumePaths = originalCACertsExtraVolumePaths }()
 
 	for _, rt := range tests {
 		t.Run(rt.name, func(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug cleanup

#### What this PR does / why we need it:

According to kubeadm repo ticket 1665, /etc/pki
can contain subdirectories with private keys on some distros.
Avoid mounting the entire /etc/pki and mount /etc/pki/ca-trust
and /etc/pki/tls/certs instead. These directories are mounted
as an extra locations which can be used to search
for additional system CAs.

i can't find additional information about these private keys, but mounting /etc/pki/ca-trust, /etc/pki/tls/certs  and /etc/ca-certificates from etc should suffice. we are already mounting other locations too.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubeadm/issues/1665

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubeadm: don't mount /etc/pki in kube-apisever and kube-controller-manager pods as an additional Linux system CA location. Mount /etc/pki/ca-trust and /etc/pki/tls/certs instead. /etc/ca-certificate, /usr/share/ca-certificates, /usr/local/share/ca-certificates and /etc/ssl/certs continue to be mounted.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
