### PR TITLE
Use a mirror for registry.k8s.io to avoid hitting 5k request per minute limit in K8s scalability tests

### DIFF
--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -3280,6 +3280,8 @@ oom_score = -999
 # See: https://github.com/kubernetes/k8s.io/issues/3411
 [plugins."io.containerd.grpc.v1.cri".registry.mirrors."k8s.gcr.io"]
   endpoint = ["https://registry.k8s.io", "https://k8s.gcr.io",]
+[plugins."io.containerd.grpc.v1.cri".registry.mirrors."registry.k8s.io"]
+  endpoint = ["https://mirror.gcr.io"]
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
   SystemdCgroup = ${systemdCgroup}
 EOF


### PR DESCRIPTION
#### What type of PR is this?
/kind flake

#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes/kubernetes/issues/123672

#### Special notes for your reviewer:

```release-note
NONE
```

/assign @BenTheElder 