### PR TITLE
Automated cherry pick of #123893: kube_codegen: expose applyconfig-openapi-schema flag for
#124193: Update applyconfig-gen for pacakges where group and dir

### DIFF
--- a/staging/src/k8s.io/code-generator/cmd/applyconfiguration-gen/generators/applyconfiguration.go
+++ b/staging/src/k8s.io/code-generator/cmd/applyconfiguration-gen/generators/applyconfiguration.go
@@ -35,6 +35,7 @@ type applyConfigurationGenerator struct {
 	generator.GoGenerator
 	// outPkgBase is the base package, under which the "internal" and GV-specific subdirs live
 	outPkgBase   string // must be a Go import-path
+	localPkg     string
 	groupVersion clientgentypes.GroupVersion
 	applyConfig  applyConfig
 	imports      namer.ImportTracker
@@ -49,9 +50,8 @@ func (g *applyConfigurationGenerator) Filter(_ *generator.Context, t *types.Type
 }
 
 func (g *applyConfigurationGenerator) Namers(*generator.Context) namer.NameSystems {
-	localPkg := path.Join(g.outPkgBase, g.groupVersion.Group.PackageName(), g.groupVersion.Version.PackageName())
 	return namer.NameSystems{
-		"raw":          namer.NewRawNamer(localPkg, g.imports),
+		"raw":          namer.NewRawNamer(g.localPkg, g.imports),
 		"singularKind": namer.NewPublicNamer(0),
 	}
 }
@@ -336,7 +336,7 @@ func (b *$.ApplyConfig.ApplyConfiguration|public$) ensure$.MemberType.Elem|publi
 
 var clientgenTypeConstructorNamespaced = `
 // $.ApplyConfig.Type|public$ constructs an declarative configuration of the $.ApplyConfig.Type|public$ type for use with
-// apply. 
+// apply.
 func $.ApplyConfig.Type|public$(name, namespace string) *$.ApplyConfig.ApplyConfiguration|public$ {
   b := &$.ApplyConfig.ApplyConfiguration|public${}
   b.WithName(name)

--- a/staging/src/k8s.io/code-generator/cmd/applyconfiguration-gen/generators/targets.go
+++ b/staging/src/k8s.io/code-generator/cmd/applyconfiguration-gen/generators/targets.go
@@ -185,6 +185,7 @@ func targetForApplyConfigurationsPackage(outputDirBase, outputPkgBase, pkgSubdir
 						OutputFilename: strings.ToLower(toGenerate.Type.Name.Name) + ".go",
 					},
 					outPkgBase:   outputPkgBase,
+					localPkg:     outputPkg,
 					groupVersion: gv,
 					applyConfig:  toGenerate,
 					imports:      generator.NewImportTracker(),

--- a/staging/src/k8s.io/code-generator/kube_codegen.sh
+++ b/staging/src/k8s.io/code-generator/kube_codegen.sh
@@ -443,6 +443,7 @@ function kube::codegen::gen_client() {
     local applyconfig="false"
     local applyconfig_subdir="applyconfiguration"
     local applyconfig_external=""
+    local applyconfig_openapi_schema=""
     local watchable="false"
     local listers_subdir="listers"
     local informers_subdir="informers"
@@ -486,6 +487,10 @@ function kube::codegen::gen_client() {
                 ;;
             "--applyconfig-externals")
                 applyconfig_external="$2"
+                shift 2
+                ;;
+            "--applyconfig-openapi-schema")
+                applyconfig_openapi_schema="$2"
                 shift 2
                 ;;
             "--with-watch")
@@ -594,6 +599,7 @@ function kube::codegen::gen_client() {
             --output-dir "${out_dir}/${applyconfig_subdir}" \
             --output-pkg "${applyconfig_pkg}" \
             --external-applyconfigurations "${applyconfig_external}" \
+            --openapi-schema "${applyconfig_openapi_schema}" \
             "${input_pkgs[@]}"
     fi
 


### PR DESCRIPTION
Cherry pick of #123893 #124193 on release-1.30.

#123893: kube_codegen: expose applyconfig-openapi-schema flag for
#124193: Update applyconfig-gen for pacakges where group and dir

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fixes a 1.30 regression in code-generator functionality: Expose --applyconfig-openapi-schema flag for client generation and fix applyconfig-gen to not create import cycles
```