### PR TITLE
leaderelection: Keep SwitchMetric for compatibility

### DIFF
--- a/staging/src/k8s.io/client-go/tools/leaderelection/metrics.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/metrics.go
@@ -29,10 +29,17 @@ type leaderMetricsAdapter interface {
 	slowpathExercised(name string)
 }
 
-// LeaderMetric instruments metrics used in leader election.
-type LeaderMetric interface {
+// SwitchMetric represents a single numerical value that can arbitrarily go up
+// and down.
+// Deprecated: Use LeaderMetric instead.
+type SwitchMetric interface {
 	On(name string)
 	Off(name string)
+}
+
+// LeaderMetric instruments metrics used in leader election.
+type LeaderMetric interface {
+	SwitchMetric
 	SlowpathExercised(name string)
 }
 


### PR DESCRIPTION

#### What type of PR is this?

/kind cleanup
/kind api-change

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Mark interface `leaderelection.SwitchMetric` deprecated in favor of `leaderelection.LeaderMetric`
```
