### PR TITLE
kubeadm: remove the deprecated "update-status" phase of "join"

### DIFF
--- a/cmd/kubeadm/app/cmd/phases/join/controlplanejoin.go
+++ b/cmd/kubeadm/app/cmd/phases/join/controlplanejoin.go
@@ -25,7 +25,6 @@ import (
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/options"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/workflow"
 	cmdutil "k8s.io/kubernetes/cmd/kubeadm/app/cmd/util"
-	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	etcdphase "k8s.io/kubernetes/cmd/kubeadm/app/phases/etcd"
 	markcontrolplanephase "k8s.io/kubernetes/cmd/kubeadm/app/phases/markcontrolplane"
 	etcdutil "k8s.io/kubernetes/cmd/kubeadm/app/util/etcd"
@@ -69,7 +68,6 @@ func NewControlPlaneJoinPhase() workflow.Phase {
 				ArgsValidator:  cobra.NoArgs,
 			},
 			newEtcdLocalSubphase(),
-			newUpdateStatusSubphase(),
 			newMarkControlPlaneSubphase(),
 		},
 	}
@@ -81,19 +79,6 @@ func newEtcdLocalSubphase() workflow.Phase {
 		Short:         "Add a new local etcd member",
 		Run:           runEtcdPhase,
 		InheritFlags:  getControlPlaneJoinPhaseFlags("etcd"),
-		ArgsValidator: cobra.NoArgs,
-	}
-}
-
-func newUpdateStatusSubphase() workflow.Phase {
-	return workflow.Phase{
-		Name: "update-status",
-		Short: fmt.Sprintf(
-			"Register the new control-plane node into the ClusterStatus maintained in the %s ConfigMap (DEPRECATED)",
-			kubeadmconstants.KubeadmConfigConfigMap,
-		),
-		Run:           runUpdateStatusPhase,
-		InheritFlags:  getControlPlaneJoinPhaseFlags("update-status"),
 		ArgsValidator: cobra.NoArgs,
 	}
 }
@@ -156,19 +141,6 @@ func runEtcdPhase(c workflow.RunData) error {
 		return errors.Wrap(err, "error creating local etcd static pod manifest file")
 	}
 
-	return nil
-}
-
-func runUpdateStatusPhase(c workflow.RunData) error {
-	data, ok := c.(JoinData)
-	if !ok {
-		return errors.New("control-plane-join phase invoked with an invalid data struct")
-	}
-
-	if data.Cfg().ControlPlane != nil {
-		fmt.Println("The 'update-status' phase is deprecated and will be removed in a future release. " +
-			"Currently it performs no operation")
-	}
 	return nil
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:

The phase has been deprecated and a NO-OP for 3+ years.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
NONE

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubeadm: remove the deprecated and NO-OP "kubeadm join control-plane-join update-status"  phase.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
