### PR TITLE
KEP-3866 kube-proxy nftables to beta

### DIFF
--- a/cluster/gce/config-test.sh
+++ b/cluster/gce/config-test.sh
@@ -532,7 +532,7 @@ KUBE_PROXY_DAEMONSET=${KUBE_PROXY_DAEMONSET:-false} # true, false
 # as an addon daemonset.
 KUBE_PROXY_DISABLE="${KUBE_PROXY_DISABLE:-false}" # true, false
 
-# Optional: Change the kube-proxy implementation. Choices are [iptables, ipvs].
+# Optional: Change the kube-proxy implementation. Choices are [iptables, ipvs, nftables].
 KUBE_PROXY_MODE=${KUBE_PROXY_MODE:-iptables}
 
 # Will be passed into the kube-proxy via `--detect-local-mode`

--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -1774,6 +1774,12 @@ function prepare-kube-proxy-manifest-variables {
       fi
       params+=" --proxy-mode=ipvs --ipvs-sync-period=1m --ipvs-min-sync-period=10s"
       ;;
+    nftables)
+      # Pass --conntrack-tcp-be-liberal so we can test that this makes the
+      # "proxy implementation should not be vulnerable to the invalid conntrack state bug"
+      # test pass. https://issues.k8s.io/122663#issuecomment-1885024015
+      params+=" --proxy-mode=nftables --conntrack-tcp-be-liberal"
+      ;;
   esac
 
   if [[ -n "${KUBEPROXY_TEST_ARGS:-}" ]]; then

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -525,6 +525,7 @@ const (
 	// owner: @danwinship
 	// kep: https://kep.k8s.io/3866
 	// alpha: v1.29
+	// beta: v1.31
 	//
 	// Allows running kube-proxy with `--mode nftables`.
 	NFTablesProxyMode featuregate.Feature = "NFTablesProxyMode"
@@ -1131,7 +1132,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 
 	NewVolumeManagerReconstruction: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.32
 
-	NFTablesProxyMode: {Default: false, PreRelease: featuregate.Alpha},
+	NFTablesProxyMode: {Default: true, PreRelease: featuregate.Beta},
 
 	NodeLogQuery: {Default: false, PreRelease: featuregate.Beta},
 

--- a/pkg/proxy/apis/config/validation/validation_test.go
+++ b/pkg/proxy/apis/config/validation/validation_test.go
@@ -827,7 +827,7 @@ func TestValidateKubeProxyConntrackConfiguration(t *testing.T) {
 func TestValidateProxyMode(t *testing.T) {
 	newPath := field.NewPath("KubeProxyConfiguration")
 	successCases := []kubeproxyconfig.ProxyMode{""}
-	expectedNonExistentErrorMsg := "must be iptables, ipvs or blank (blank means the best-available proxy [currently iptables])"
+	expectedNonExistentErrorMsg := "must be iptables, ipvs, nftables or blank (blank means the best-available proxy [currently iptables])"
 
 	if runtime.GOOS == "windows" {
 		successCases = append(successCases, kubeproxyconfig.ProxyModeKernelspace)


### PR DESCRIPTION
#### What this PR does / why we need it:
Moves kube-proxy nftables mode to beta, and adds infra for using it in GCE-based CI

#### Special notes for your reviewer:

(The KEP says we're going to implement a few more e2e tests before going to beta, but it will be simpler to implement those tests if we go to beta first...)

#### Does this PR introduce a user-facing change?
```release-note
kube-proxy's nftables mode is now beta and available by default. It
requires Linux kernel version 5.13 or later, and can be enabled by
passing `--proxy-mode=nftables` to kube-proxy.

A few features in the nftables mode behave slightly differently than
in the iptables mode:

  - By default, nftables mode only listens for NodePort connections on
    the node's primary interface, and it never listens for NodePort
    connections on 127.0.0.1.

  - If you are running a firewall on the node, nftables kube-proxy
    requires the firewall to be configured properly for service
    proxying; it will not try to poke holes in the firewall itself.

  - The nftables mode does not attempt to work around conntrack bugs
    in the kernel unless you explicitly configure it to.

Consult the documentation
(https://kubernetes.io/docs/reference/networking/virtual-ips/#proxy-mode-nftables)
for more information on how to tell if these differences affect you,
and what configuration options are available to change these behaviors.

Note that while the nftables code should be stable and fully-featured
at this point, it is still in the process of being optimized, and it
is known to have worse performance than iptables mode in a few
situations. (In particular, kube-proxy startup for a given cluster
size will be slower with nftables mode than with iptables mode.)
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/3866
```

/kind feature
/sig network
/priority important-soon
/assign @aojea 