### PR TITLE
Ensure go.mod has consistent go patch version

### DIFF
--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -119,6 +119,7 @@ dependencies:
     version: 1.22.2
     refPaths:
     - path: .go-version
+    - path: go.mod
     - path: build/build-image/cross/VERSION
     - path: staging/publishing/rules.yaml
       match: 'default-go-version\: \d+.\d+(alpha|beta|rc)?\.?(\d+)?'

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@
 
 module k8s.io/kubernetes
 
-go 1.22.0
+go 1.22.2
 
 require (
 	bitbucket.org/bertimus9/systemstat v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -1292,8 +1292,7 @@ sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.29.0 h1:/U5vjBbQn3RCh
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.29.0/go.mod h1:z7+wmGM2dfIiLRfrC6jb5kV2Mq/sK1ZP303cxzkV5Y4=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd h1:EDPBXCAspyGV4jQlpZSudPeMmr1bNJefnuqLsRAsHZo=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd/go.mod h1:B8JuhiUyNFVKdsE8h686QcCxMaH6HrOAZj4vswFpcB0=
-sigs.k8s.io/knftables v0.0.14 h1:VzKQoDMCGBOH8c85sGrWSXSPCS0XrIpEfOlcCLBXiC0=
-sigs.k8s.io/knftables v0.0.14/go.mod h1:f/5ZLKYEUPUhVjUCg6l80ACdL7CIIyeL0DxfgojGRTk=
+sigs.k8s.io/knftables v0.0.16 h1:ZpTfNsjnidgoXdxxzcZLdSctqkpSO3QB3jo3zQ4PXqM=
 sigs.k8s.io/knftables v0.0.16/go.mod h1:f/5ZLKYEUPUhVjUCg6l80ACdL7CIIyeL0DxfgojGRTk=
 sigs.k8s.io/kustomize/api v0.13.5-0.20230601165947-6ce0bf390ce3 h1:XX3Ajgzov2RKUdc5jW3t5jwY7Bo7dcRm+tFxT+NfgY0=
 sigs.k8s.io/kustomize/api v0.13.5-0.20230601165947-6ce0bf390ce3/go.mod h1:9n16EZKMhXBNSiUC5kSdFQJkdH3zbxS/JoO619G1VAY=

--- a/go.work
+++ b/go.work
@@ -1,6 +1,6 @@
 // This is a generated file. Do not edit directly.
 
-go 1.22.0
+go 1.22.2
 
 use (
 	.

--- a/hack/tools/go.work
+++ b/hack/tools/go.work
@@ -1,6 +1,6 @@
 // This is a hack, but it prevents go from climbing further and trying to
 // reconcile the various deps across the "real" modules and this one.
 
-go 1.22.0
+go 1.22.2
 
 use .

--- a/staging/src/k8s.io/api/go.mod
+++ b/staging/src/k8s.io/api/go.mod
@@ -2,7 +2,7 @@
 
 module k8s.io/api
 
-go 1.22.0
+go 1.22.2
 
 require (
 	github.com/gogo/protobuf v1.3.2

--- a/staging/src/k8s.io/apiextensions-apiserver/go.mod
+++ b/staging/src/k8s.io/apiextensions-apiserver/go.mod
@@ -2,7 +2,7 @@
 
 module k8s.io/apiextensions-apiserver
 
-go 1.22.0
+go 1.22.2
 
 require (
 	github.com/emicklei/go-restful/v3 v3.11.0

--- a/staging/src/k8s.io/apimachinery/go.mod
+++ b/staging/src/k8s.io/apimachinery/go.mod
@@ -2,7 +2,7 @@
 
 module k8s.io/apimachinery
 
-go 1.22.0
+go 1.22.2
 
 require (
 	github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5

--- a/staging/src/k8s.io/apiserver/go.mod
+++ b/staging/src/k8s.io/apiserver/go.mod
@@ -2,7 +2,7 @@
 
 module k8s.io/apiserver
 
-go 1.22.0
+go 1.22.2
 
 require (
 	github.com/coreos/go-oidc v2.2.1+incompatible

--- a/staging/src/k8s.io/cli-runtime/go.mod
+++ b/staging/src/k8s.io/cli-runtime/go.mod
@@ -2,7 +2,7 @@
 
 module k8s.io/cli-runtime
 
-go 1.22.0
+go 1.22.2
 
 require (
 	github.com/evanphx/json-patch v4.12.0+incompatible

--- a/staging/src/k8s.io/client-go/go.mod
+++ b/staging/src/k8s.io/client-go/go.mod
@@ -2,7 +2,7 @@
 
 module k8s.io/client-go
 
-go 1.22.0
+go 1.22.2
 
 require (
 	github.com/evanphx/json-patch v4.12.0+incompatible

--- a/staging/src/k8s.io/cloud-provider/go.mod
+++ b/staging/src/k8s.io/cloud-provider/go.mod
@@ -2,7 +2,7 @@
 
 module k8s.io/cloud-provider
 
-go 1.22.0
+go 1.22.2
 
 require (
 	github.com/google/go-cmp v0.6.0

--- a/staging/src/k8s.io/cluster-bootstrap/go.mod
+++ b/staging/src/k8s.io/cluster-bootstrap/go.mod
@@ -2,7 +2,7 @@
 
 module k8s.io/cluster-bootstrap
 
-go 1.22.0
+go 1.22.2
 
 require (
 	github.com/stretchr/testify v1.8.4

--- a/staging/src/k8s.io/code-generator/examples/go.mod
+++ b/staging/src/k8s.io/code-generator/examples/go.mod
@@ -2,7 +2,7 @@
 
 module k8s.io/code-generator/examples
 
-go 1.22.0
+go 1.22.2
 
 require (
 	k8s.io/api v0.0.0

--- a/staging/src/k8s.io/code-generator/examples/go.work
+++ b/staging/src/k8s.io/code-generator/examples/go.work
@@ -1,6 +1,6 @@
 // This is a hack, but it prevents go from climbing further and trying to
 // reconcile the various deps across the "real" modules and this one.
 
-go 1.22.0
+go 1.22.2
 
 use .

--- a/staging/src/k8s.io/code-generator/go.mod
+++ b/staging/src/k8s.io/code-generator/go.mod
@@ -2,7 +2,7 @@
 
 module k8s.io/code-generator
 
-go 1.22.0
+go 1.22.2
 
 require (
 	github.com/davecgh/go-spew v1.1.1

--- a/staging/src/k8s.io/component-base/go.mod
+++ b/staging/src/k8s.io/component-base/go.mod
@@ -2,7 +2,7 @@
 
 module k8s.io/component-base
 
-go 1.22.0
+go 1.22.2
 
 require (
 	github.com/blang/semver/v4 v4.0.0

--- a/staging/src/k8s.io/component-helpers/go.mod
+++ b/staging/src/k8s.io/component-helpers/go.mod
@@ -2,7 +2,7 @@
 
 module k8s.io/component-helpers
 
-go 1.22.0
+go 1.22.2
 
 require (
 	github.com/google/go-cmp v0.6.0

--- a/staging/src/k8s.io/controller-manager/go.mod
+++ b/staging/src/k8s.io/controller-manager/go.mod
@@ -2,7 +2,7 @@
 
 module k8s.io/controller-manager
 
-go 1.22.0
+go 1.22.2
 
 require (
 	github.com/spf13/pflag v1.0.5

--- a/staging/src/k8s.io/cri-api/go.mod
+++ b/staging/src/k8s.io/cri-api/go.mod
@@ -2,7 +2,7 @@
 
 module k8s.io/cri-api
 
-go 1.22.0
+go 1.22.2
 
 require (
 	github.com/gogo/protobuf v1.3.2

--- a/staging/src/k8s.io/csi-translation-lib/go.mod
+++ b/staging/src/k8s.io/csi-translation-lib/go.mod
@@ -2,7 +2,7 @@
 
 module k8s.io/csi-translation-lib
 
-go 1.22.0
+go 1.22.2
 
 require (
 	github.com/stretchr/testify v1.8.4

--- a/staging/src/k8s.io/dynamic-resource-allocation/go.mod
+++ b/staging/src/k8s.io/dynamic-resource-allocation/go.mod
@@ -2,7 +2,7 @@
 
 module k8s.io/dynamic-resource-allocation
 
-go 1.22.0
+go 1.22.2
 
 require (
 	github.com/blang/semver/v4 v4.0.0

--- a/staging/src/k8s.io/endpointslice/go.mod
+++ b/staging/src/k8s.io/endpointslice/go.mod
@@ -2,7 +2,7 @@
 
 module k8s.io/endpointslice
 
-go 1.22.0
+go 1.22.2
 
 require (
 	github.com/davecgh/go-spew v1.1.1

--- a/staging/src/k8s.io/kms/go.mod
+++ b/staging/src/k8s.io/kms/go.mod
@@ -2,7 +2,7 @@
 
 module k8s.io/kms
 
-go 1.22.0
+go 1.22.2
 
 require (
 	github.com/gogo/protobuf v1.3.2

--- a/staging/src/k8s.io/kms/internal/plugins/_mock/go.mod
+++ b/staging/src/k8s.io/kms/internal/plugins/_mock/go.mod
@@ -1,6 +1,6 @@
 module k8s.io/kms/plugins/mock
 
-go 1.22.0
+go 1.22.2
 
 require (
 	github.com/ThalesIgnite/crypto11 v1.2.5

--- a/staging/src/k8s.io/kms/internal/plugins/_mock/go.work
+++ b/staging/src/k8s.io/kms/internal/plugins/_mock/go.work
@@ -1,6 +1,6 @@
 // This is a hack, but it prevents go from climbing further and trying to
 // reconcile the various deps across the "real" modules and this one.
 
-go 1.22.0
+go 1.22.2
 
 use .

--- a/staging/src/k8s.io/kube-aggregator/go.mod
+++ b/staging/src/k8s.io/kube-aggregator/go.mod
@@ -2,7 +2,7 @@
 
 module k8s.io/kube-aggregator
 
-go 1.22.0
+go 1.22.2
 
 require (
 	github.com/emicklei/go-restful/v3 v3.11.0

--- a/staging/src/k8s.io/kube-controller-manager/go.mod
+++ b/staging/src/k8s.io/kube-controller-manager/go.mod
@@ -2,7 +2,7 @@
 
 module k8s.io/kube-controller-manager
 
-go 1.22.0
+go 1.22.2
 
 require (
 	k8s.io/apimachinery v0.0.0

--- a/staging/src/k8s.io/kube-proxy/go.mod
+++ b/staging/src/k8s.io/kube-proxy/go.mod
@@ -2,7 +2,7 @@
 
 module k8s.io/kube-proxy
 
-go 1.22.0
+go 1.22.2
 
 require (
 	k8s.io/apimachinery v0.0.0

--- a/staging/src/k8s.io/kube-scheduler/go.mod
+++ b/staging/src/k8s.io/kube-scheduler/go.mod
@@ -2,7 +2,7 @@
 
 module k8s.io/kube-scheduler
 
-go 1.22.0
+go 1.22.2
 
 require (
 	github.com/google/go-cmp v0.6.0

--- a/staging/src/k8s.io/kubectl/go.mod
+++ b/staging/src/k8s.io/kubectl/go.mod
@@ -2,7 +2,7 @@
 
 module k8s.io/kubectl
 
-go 1.22.0
+go 1.22.2
 
 require (
 	github.com/MakeNowJust/heredoc v1.0.0

--- a/staging/src/k8s.io/kubelet/go.mod
+++ b/staging/src/k8s.io/kubelet/go.mod
@@ -2,7 +2,7 @@
 
 module k8s.io/kubelet
 
-go 1.22.0
+go 1.22.2
 
 require (
 	github.com/emicklei/go-restful/v3 v3.11.0

--- a/staging/src/k8s.io/legacy-cloud-providers/go.mod
+++ b/staging/src/k8s.io/legacy-cloud-providers/go.mod
@@ -2,7 +2,7 @@
 
 module k8s.io/legacy-cloud-providers
 
-go 1.22.0
+go 1.22.2
 
 require (
 	cloud.google.com/go/compute/metadata v0.2.3

--- a/staging/src/k8s.io/metrics/go.mod
+++ b/staging/src/k8s.io/metrics/go.mod
@@ -2,7 +2,7 @@
 
 module k8s.io/metrics
 
-go 1.22.0
+go 1.22.2
 
 require (
 	github.com/gogo/protobuf v1.3.2

--- a/staging/src/k8s.io/mount-utils/go.mod
+++ b/staging/src/k8s.io/mount-utils/go.mod
@@ -2,7 +2,7 @@
 
 module k8s.io/mount-utils
 
-go 1.22.0
+go 1.22.2
 
 require (
 	github.com/moby/sys/mountinfo v0.6.2

--- a/staging/src/k8s.io/pod-security-admission/go.mod
+++ b/staging/src/k8s.io/pod-security-admission/go.mod
@@ -2,7 +2,7 @@
 
 module k8s.io/pod-security-admission
 
-go 1.22.0
+go 1.22.2
 
 require (
 	github.com/blang/semver/v4 v4.0.0

--- a/staging/src/k8s.io/sample-apiserver/go.mod
+++ b/staging/src/k8s.io/sample-apiserver/go.mod
@@ -2,7 +2,7 @@
 
 module k8s.io/sample-apiserver
 
-go 1.22.0
+go 1.22.2
 
 require (
 	github.com/google/gofuzz v1.2.0

--- a/staging/src/k8s.io/sample-cli-plugin/go.mod
+++ b/staging/src/k8s.io/sample-cli-plugin/go.mod
@@ -2,7 +2,7 @@
 
 module k8s.io/sample-cli-plugin
 
-go 1.22.0
+go 1.22.2
 
 require (
 	github.com/spf13/cobra v1.7.0

--- a/staging/src/k8s.io/sample-controller/go.mod
+++ b/staging/src/k8s.io/sample-controller/go.mod
@@ -2,7 +2,7 @@
 
 module k8s.io/sample-controller
 
-go 1.22.0
+go 1.22.2
 
 require (
 	golang.org/x/time v0.3.0

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1187,37 +1187,37 @@ gopkg.in/yaml.v2
 ## explicit
 gopkg.in/yaml.v3
 # k8s.io/api v0.0.0 => ./staging/src/k8s.io/api
-## explicit; go 1.22.0
+## explicit; go 1.22.2
 # k8s.io/apiextensions-apiserver v0.0.0 => ./staging/src/k8s.io/apiextensions-apiserver
-## explicit; go 1.22.0
+## explicit; go 1.22.2
 # k8s.io/apimachinery v0.0.0 => ./staging/src/k8s.io/apimachinery
-## explicit; go 1.22.0
+## explicit; go 1.22.2
 # k8s.io/apiserver v0.0.0 => ./staging/src/k8s.io/apiserver
-## explicit; go 1.22.0
+## explicit; go 1.22.2
 # k8s.io/cli-runtime v0.0.0 => ./staging/src/k8s.io/cli-runtime
-## explicit; go 1.22.0
+## explicit; go 1.22.2
 # k8s.io/client-go v0.0.0 => ./staging/src/k8s.io/client-go
-## explicit; go 1.22.0
+## explicit; go 1.22.2
 # k8s.io/cloud-provider v0.0.0 => ./staging/src/k8s.io/cloud-provider
-## explicit; go 1.22.0
+## explicit; go 1.22.2
 # k8s.io/cluster-bootstrap v0.0.0 => ./staging/src/k8s.io/cluster-bootstrap
-## explicit; go 1.22.0
+## explicit; go 1.22.2
 # k8s.io/code-generator v0.0.0 => ./staging/src/k8s.io/code-generator
-## explicit; go 1.22.0
+## explicit; go 1.22.2
 # k8s.io/component-base v0.0.0 => ./staging/src/k8s.io/component-base
-## explicit; go 1.22.0
+## explicit; go 1.22.2
 # k8s.io/component-helpers v0.0.0 => ./staging/src/k8s.io/component-helpers
-## explicit; go 1.22.0
+## explicit; go 1.22.2
 # k8s.io/controller-manager v0.0.0 => ./staging/src/k8s.io/controller-manager
-## explicit; go 1.22.0
+## explicit; go 1.22.2
 # k8s.io/cri-api v0.0.0 => ./staging/src/k8s.io/cri-api
-## explicit; go 1.22.0
+## explicit; go 1.22.2
 # k8s.io/csi-translation-lib v0.0.0 => ./staging/src/k8s.io/csi-translation-lib
-## explicit; go 1.22.0
+## explicit; go 1.22.2
 # k8s.io/dynamic-resource-allocation v0.0.0 => ./staging/src/k8s.io/dynamic-resource-allocation
-## explicit; go 1.22.0
+## explicit; go 1.22.2
 # k8s.io/endpointslice v0.0.0 => ./staging/src/k8s.io/endpointslice
-## explicit; go 1.22.0
+## explicit; go 1.22.2
 # k8s.io/gengo/v2 v2.0.0-20240228010128-51d4e06bde70
 ## explicit; go 1.20
 k8s.io/gengo/v2
@@ -1240,11 +1240,11 @@ k8s.io/klog/v2/ktesting/init
 k8s.io/klog/v2/test
 k8s.io/klog/v2/textlogger
 # k8s.io/kms v0.0.0 => ./staging/src/k8s.io/kms
-## explicit; go 1.22.0
+## explicit; go 1.22.2
 # k8s.io/kube-aggregator v0.0.0 => ./staging/src/k8s.io/kube-aggregator
-## explicit; go 1.22.0
+## explicit; go 1.22.2
 # k8s.io/kube-controller-manager v0.0.0 => ./staging/src/k8s.io/kube-controller-manager
-## explicit; go 1.22.0
+## explicit; go 1.22.2
 # k8s.io/kube-openapi v0.0.0-20240228011516-70dd3763d340
 ## explicit; go 1.20
 k8s.io/kube-openapi/cmd/openapi-gen
@@ -1277,23 +1277,23 @@ k8s.io/kube-openapi/pkg/validation/strfmt
 k8s.io/kube-openapi/pkg/validation/strfmt/bson
 k8s.io/kube-openapi/pkg/validation/validate
 # k8s.io/kube-proxy v0.0.0 => ./staging/src/k8s.io/kube-proxy
-## explicit; go 1.22.0
+## explicit; go 1.22.2
 # k8s.io/kube-scheduler v0.0.0 => ./staging/src/k8s.io/kube-scheduler
-## explicit; go 1.22.0
+## explicit; go 1.22.2
 # k8s.io/kubectl v0.0.0 => ./staging/src/k8s.io/kubectl
-## explicit; go 1.22.0
+## explicit; go 1.22.2
 # k8s.io/kubelet v0.0.0 => ./staging/src/k8s.io/kubelet
-## explicit; go 1.22.0
+## explicit; go 1.22.2
 # k8s.io/legacy-cloud-providers v0.0.0 => ./staging/src/k8s.io/legacy-cloud-providers
-## explicit; go 1.22.0
+## explicit; go 1.22.2
 # k8s.io/metrics v0.0.0 => ./staging/src/k8s.io/metrics
-## explicit; go 1.22.0
+## explicit; go 1.22.2
 # k8s.io/mount-utils v0.0.0 => ./staging/src/k8s.io/mount-utils
-## explicit; go 1.22.0
+## explicit; go 1.22.2
 # k8s.io/pod-security-admission v0.0.0 => ./staging/src/k8s.io/pod-security-admission
-## explicit; go 1.22.0
+## explicit; go 1.22.2
 # k8s.io/sample-apiserver v0.0.0 => ./staging/src/k8s.io/sample-apiserver
-## explicit; go 1.22.0
+## explicit; go 1.22.2
 # k8s.io/system-validators v1.8.0
 ## explicit; go 1.16
 k8s.io/system-validators/validators


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Because go transitively propagates go.mod patch requirements, sticking on the .0 has two negative implications:
1. if any of our dependencies bumps to the latest patch, go will refuse to build us
2. if any of our dependants currently has a go version like go1.22, go will bump them to our go patch version (go1.22.0)

Since we update to latest patch versions ~immediately, keeping our go.mod in sync with .go-version will avoid both of these problems.

```release-note
NONE
```

/sig release
/area code-organization
/cc @dims @howardjohn 