### PR TITLE
fix: csi_attacher should use api-server watch

### DIFF
--- a/plugin/pkg/auth/authorizer/node/node_authorizer_test.go
+++ b/plugin/pkg/auth/authorizer/node/node_authorizer_test.go
@@ -178,6 +178,21 @@ func TestAuthorizer(t *testing.T) {
 			expect: authorizer.DecisionAllow,
 		},
 		{
+			name:   "watch allowed attachment",
+			attrs:  authorizer.AttributesRecord{User: node0, ResourceRequest: true, Verb: "watch", Resource: "volumeattachments", APIGroup: "storage.k8s.io", Name: "attachment0-node0"},
+			expect: authorizer.DecisionAllow,
+		},
+		{
+			name:   "disallowed list many attachments",
+			attrs:  authorizer.AttributesRecord{User: node0, ResourceRequest: true, Verb: "list", Resource: "volumeattachments", APIGroup: "storage.k8s.io", Name: ""},
+			expect: authorizer.DecisionNoOpinion,
+		},
+		{
+			name:   "disallowed watch many attachments",
+			attrs:  authorizer.AttributesRecord{User: node0, ResourceRequest: true, Verb: "watch", Resource: "volumeattachments", APIGroup: "storage.k8s.io", Name: ""},
+			expect: authorizer.DecisionNoOpinion,
+		},
+		{
 			name:   "allowed svcacct token create",
 			attrs:  authorizer.AttributesRecord{User: node0, ResourceRequest: true, Verb: "create", Resource: "serviceaccounts", Subresource: "token", Name: "svcacct0-node0", Namespace: "ns0"},
 			expect: authorizer.DecisionAllow,

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
@@ -157,7 +157,7 @@ func NodeRules() []rbacv1.PolicyRule {
 		rbacv1helpers.NewRule("get", "create", "update", "patch", "delete").Groups("coordination.k8s.io").Resources("leases").RuleOrDie(),
 
 		// CSI
-		rbacv1helpers.NewRule("get").Groups(storageGroup).Resources("volumeattachments").RuleOrDie(),
+		rbacv1helpers.NewRule("get", "watch").Groups(storageGroup).Resources("volumeattachments").RuleOrDie(),
 
 		// Use the Node authorization to limit a node to create tokens for service accounts running on that node
 		// Use the NodeRestriction admission plugin to limit a node to create tokens bound to pods on that node

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
@@ -1051,6 +1051,7 @@ items:
     - volumeattachments
     verbs:
     - get
+    - watch
   - apiGroups:
     - ""
     resources:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

https://github.com/kubernetes/kubernetes/pull/57194 changes `waitForVolumeAttachment` to use `watch` instead of polling from api-server. It adds a unit test to cover the change, but forgot to add corresponding `watch` permission for kubelet. @cvvz found this issue and sent a [PR](https://github.com/kubernetes/kubernetes/pull/118196) to fix it. However, the PR is not merged yet. I tried to ping the PR author, but no response. So I take over it and re-send an active PR. 

https://github.com/kubernetes/kubernetes/pull/97834 refactors the csi attacher that runs in controller-manager to use informer instead of watching the api-server directly to resolve https://github.com/kubernetes/kubernetes/issues/64429. And the CSI plugin's attacher that runs in Kubelet still uses the event-based approach (API watches) and is not changed, because the Kubelet does not have access to a VolumeAttachment lister, and because using API watches is still more performant than polling via API get calls.

So, according to the above messages, the `kubelet` needs to have the `watch` permission to watch the `VolumeAttachment` resource. If we add the `watch` permission to the `kubelet` to activate the `dead` codes, what's the impact on the performance of the `kubelet` or `kube-apiserver`? Does it have any potential risk? I'm not sure about it.

BTW, https://github.com/kubernetes/kubernetes/pull/84282 is unrelated to this issue.

/cc @jsafrane @linyouchong @msau42 @ibihim @cvvz @pacoxu @chrishenzie @andyzhangx

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

If it is merged, we need to cherry-pick it into previous releases.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Remove volumeattachments permissions from the system:node clusterrole because the NodeAuthorizer plugin can handle this resource correctly without this configuration. 
 Allow a node to watch a single volumeattachment object that refers to that node. 
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
