### PR TITLE
Automated cherry pick of #122489: storage e2e: update hostpath and mock images

### DIFF
--- a/test/e2e/storage/utils/create.go
+++ b/test/e2e/storage/utils/create.go
@@ -62,6 +62,10 @@ func LoadFromManifests(files ...string) ([]interface{}, error) {
 		if err := runtime.DecodeInto(scheme.Codecs.UniversalDecoder(), data, &what); err != nil {
 			return fmt.Errorf("decode TypeMeta: %w", err)
 		}
+		// Ignore empty documents.
+		if what.Kind == "" {
+			return nil
+		}
 
 		factory := factories[what]
 		if factory == nil {

--- a/test/e2e/testing-manifests/storage-csi/external-attacher/rbac.yaml
+++ b/test/e2e/testing-manifests/storage-csi/external-attacher/rbac.yaml
@@ -1,5 +1,5 @@
-# Do not edit, downloaded from https://github.com/kubernetes-csi/external-attacher/raw/v3.4.0/deploy/kubernetes//rbac.yaml
-# for csi-driver-host-path v1.8.0
+# Do not edit, downloaded from https://github.com/kubernetes-csi/external-attacher/raw/v4.5.0/deploy/kubernetes//rbac.yaml
+# for csi-driver-host-path release-1.13
 # by ./update-hostpath.sh
 #
 # This YAML file contains all RBAC objects that are necessary to run external

--- a/test/e2e/testing-manifests/storage-csi/external-health-monitor/external-health-monitor-controller/rbac.yaml
+++ b/test/e2e/testing-manifests/storage-csi/external-health-monitor/external-health-monitor-controller/rbac.yaml
@@ -1,5 +1,5 @@
-# Do not edit, downloaded from https://github.com/kubernetes-csi/external-health-monitor/raw/v0.4.0/deploy/kubernetes/external-health-monitor-controller/rbac.yaml
-# for csi-driver-host-path v1.8.0
+# Do not edit, downloaded from https://github.com/kubernetes-csi/external-health-monitor/raw/v0.11.0/deploy/kubernetes/external-health-monitor-controller/rbac.yaml
+# for csi-driver-host-path release-1.13
 # by ./update-hostpath.sh
 #
 # This YAML file contains all RBAC objects that are necessary to run external

--- a/test/e2e/testing-manifests/storage-csi/external-provisioner/rbac.yaml
+++ b/test/e2e/testing-manifests/storage-csi/external-provisioner/rbac.yaml
@@ -1,5 +1,5 @@
-# Do not edit, downloaded from https://github.com/kubernetes-csi/external-provisioner/raw/v3.1.0/deploy/kubernetes//rbac.yaml
-# for csi-driver-host-path v1.8.0
+# Do not edit, downloaded from https://github.com/kubernetes-csi/external-provisioner/raw/v4.0.0/deploy/kubernetes//rbac.yaml
+# for csi-driver-host-path release-1.13
 # by ./update-hostpath.sh
 #
 # This YAML file contains all RBAC objects that are necessary to run external
@@ -61,6 +61,13 @@ rules:
   - apiGroups: ["storage.k8s.io"]
     resources: ["volumeattachments"]
     verbs: ["get", "list", "watch"]
+  # (Alpha) Access to referencegrants is only needed when the CSI driver
+  # has the CrossNamespaceVolumeDataSource controller capability.
+  # In that case, external-provisioner requires "get", "list", "watch" 
+  # permissions  for "referencegrants" on "gateway.networking.k8s.io".
+  #- apiGroups: ["gateway.networking.k8s.io"]
+  #  resources: ["referencegrants"]
+  #  verbs: ["get", "list", "watch"]
 
 ---
 kind: ClusterRoleBinding
@@ -89,9 +96,6 @@ metadata:
 rules:
 # Only one of the following rules for endpoints or leases is required based on
 # what is set for `--leader-election-type`. Endpoints are deprecated in favor of Leases.
-- apiGroups: [""]
-  resources: ["endpoints"]
-  verbs: ["get", "watch", "list", "delete", "update", "create"]
 - apiGroups: ["coordination.k8s.io"]
   resources: ["leases"]
   verbs: ["get", "watch", "list", "delete", "update", "create"]

--- a/test/e2e/testing-manifests/storage-csi/external-resizer/rbac.yaml
+++ b/test/e2e/testing-manifests/storage-csi/external-resizer/rbac.yaml
@@ -1,5 +1,5 @@
-# Do not edit, downloaded from https://github.com/kubernetes-csi/external-resizer/raw/v1.4.0/deploy/kubernetes//rbac.yaml
-# for csi-driver-host-path v1.8.0
+# Do not edit, downloaded from https://github.com/kubernetes-csi/external-resizer/raw/v1.10.0/deploy/kubernetes//rbac.yaml
+# for csi-driver-host-path release-1.13
 # by ./update-hostpath.sh
 #
 # This YAML file contains all RBAC objects that are necessary to run external
@@ -46,6 +46,10 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["list", "watch", "create", "update", "patch"]
+  # only required if enabling the alpha volume modify feature
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattributesclasses"]
+    verbs: ["get", "list", "watch"]
 
 ---
 kind: ClusterRoleBinding
@@ -63,7 +67,7 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 
 ---
-# Resizer must be able to work with end point in current namespace
+# Resizer must be able to work with `leases` in current namespace
 # if (and only if) leadership election is enabled
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1

--- a/test/e2e/testing-manifests/storage-csi/external-snapshotter/csi-snapshotter/rbac-csi-snapshotter.yaml
+++ b/test/e2e/testing-manifests/storage-csi/external-snapshotter/csi-snapshotter/rbac-csi-snapshotter.yaml
@@ -1,5 +1,5 @@
-# Do not edit, downloaded from https://github.com/kubernetes-csi/external-snapshotter/raw/v5.0.1/deploy/kubernetes/csi-snapshotter/rbac-csi-snapshotter.yaml
-# for csi-driver-host-path v1.8.0
+# Do not edit, downloaded from https://github.com/kubernetes-csi/external-snapshotter/raw/v7.0.1/deploy/kubernetes/csi-snapshotter/rbac-csi-snapshotter.yaml
+# for csi-driver-host-path release-1.13
 # by ./update-hostpath.sh
 #
 # Together with the RBAC file for external-provisioner, this YAML file
@@ -12,6 +12,7 @@
 # - optionally rename the non-namespaced ClusterRole if there
 #   are conflicts with other deployments
 
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -38,12 +39,23 @@ rules:
     resources: ["volumesnapshotclasses"]
     verbs: ["get", "list", "watch"]
   - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots"]
+    verbs: ["get", "list", "watch", "update", "patch", "create"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotcontents"]
-    verbs: ["create", "get", "list", "watch", "update", "delete", "patch"]
+    verbs: ["get", "list", "watch", "update", "patch", "create"]
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotcontents/status"]
     verbs: ["update", "patch"]
-
+  - apiGroups: ["groupsnapshot.storage.k8s.io"]
+    resources: ["volumegroupsnapshotclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["groupsnapshot.storage.k8s.io"]
+    resources: ["volumegroupsnapshotcontents"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: ["groupsnapshot.storage.k8s.io"]
+    resources: ["volumegroupsnapshotcontents/status"]
+    verbs: ["update", "patch"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/test/e2e/testing-manifests/storage-csi/hostpath/README.md
+++ b/test/e2e/testing-manifests/storage-csi/hostpath/README.md
@@ -1,4 +1,4 @@
 The files in this directory are exact copies of "kubernetes-latest" in
-https://github.com/kubernetes-csi/csi-driver-host-path/tree/v1.8.0/deploy/
+https://github.com/kubernetes-csi/csi-driver-host-path/tree/release-1.13/deploy/
 
 Do not edit manually. Run ./update-hostpath.sh to refresh the content.

--- a/test/e2e/testing-manifests/storage-csi/hostpath/hostpath/csi-hostpath-driverinfo.yaml
+++ b/test/e2e/testing-manifests/storage-csi/hostpath/hostpath/csi-hostpath-driverinfo.yaml
@@ -15,3 +15,6 @@ spec:
   # To determine at runtime which mode a volume uses, pod info and its
   # "csi.storage.k8s.io/ephemeral" entry are needed.
   podInfoOnMount: true
+  # Kubernetes may use fsGroup to change permissions and ownership 
+  # of the volume to match user requested fsGroup in the pod's SecurityPolicy
+  fsGroupPolicy: File

--- a/test/e2e/testing-manifests/storage-csi/hostpath/hostpath/csi-hostpath-plugin.yaml
+++ b/test/e2e/testing-manifests/storage-csi/hostpath/hostpath/csi-hostpath-plugin.yaml
@@ -1,4 +1,4 @@
-# All of the individual sidecar RBAC roles get bound
+  # All of the individual sidecar RBAC roles get bound
 # to this account.
 kind: ServiceAccount
 apiVersion: v1
@@ -190,6 +190,7 @@ kind: StatefulSet
 apiVersion: apps/v1
 metadata:
   name: csi-hostpathplugin
+  namespace: default
   labels:
     app.kubernetes.io/instance: hostpath.csi.k8s.io
     app.kubernetes.io/part-of: csi-driver-host-path
@@ -218,7 +219,7 @@ spec:
       serviceAccountName: csi-hostpathplugin-sa
       containers:
         - name: hostpath
-          image: registry.k8s.io/sig-storage/hostpathplugin:v1.11.0
+          image: registry.k8s.io/sig-storage/hostpathplugin:v1.13.0
           args:
             - "--drivername=hostpath.csi.k8s.io"
             - "--v=5"
@@ -261,7 +262,7 @@ spec:
               name: dev-dir
 
         - name: csi-external-health-monitor-controller
-          image: registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.7.0
+          image: registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.11.0
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
@@ -275,7 +276,7 @@ spec:
               mountPath: /csi
 
         - name: node-driver-registrar
-          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.5.1
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.10.0
           args:
             - --v=5
             - --csi-address=/csi/csi.sock
@@ -303,13 +304,13 @@ spec:
           volumeMounts:
           - mountPath: /csi
             name: socket-dir
-          image: registry.k8s.io/sig-storage/livenessprobe:v2.7.0
+          image: registry.k8s.io/sig-storage/livenessprobe:v2.12.0
           args:
           - --csi-address=/csi/csi.sock
           - --health-port=9898
 
         - name: csi-attacher
-          image: registry.k8s.io/sig-storage/csi-attacher:v4.0.0
+          image: registry.k8s.io/sig-storage/csi-attacher:v4.5.0
           args:
             - --v=5
             - --csi-address=/csi/csi.sock
@@ -323,11 +324,12 @@ spec:
             name: socket-dir
 
         - name: csi-provisioner
-          image: registry.k8s.io/sig-storage/csi-provisioner:v3.4.0
+          image: registry.k8s.io/sig-storage/csi-provisioner:v4.0.0
           args:
             - -v=5
             - --csi-address=/csi/csi.sock
             - --feature-gates=Topology=true
+            # end csi-provisioner args
           securityContext:
             # This is necessary only for systems with SELinux, where
             # non-privileged sidecar containers cannot access unix domain socket
@@ -338,7 +340,7 @@ spec:
               name: socket-dir
 
         - name: csi-resizer
-          image: registry.k8s.io/sig-storage/csi-resizer:v1.6.0
+          image: registry.k8s.io/sig-storage/csi-resizer:v1.10.0
           args:
             - -v=5
             - -csi-address=/csi/csi.sock
@@ -352,7 +354,7 @@ spec:
               name: socket-dir
 
         - name: csi-snapshotter
-          image: registry.k8s.io/sig-storage/csi-snapshotter:v6.1.0
+          image: registry.k8s.io/sig-storage/csi-snapshotter:v7.0.1
           args:
             - -v=5
             - --csi-address=/csi/csi.sock

--- a/test/e2e/testing-manifests/storage-csi/hostpath/hostpath/csi-hostpath-testing.yaml
+++ b/test/e2e/testing-manifests/storage-csi/hostpath/hostpath/csi-hostpath-testing.yaml
@@ -11,6 +11,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: hostpath-service
+  namespace: default
   labels:
     app.kubernetes.io/instance: hostpath.csi.k8s.io
     app.kubernetes.io/part-of: csi-driver-host-path
@@ -30,6 +31,7 @@ kind: StatefulSet
 apiVersion: apps/v1
 metadata:
   name: csi-hostpath-socat
+  namespace: default
   labels:
     app.kubernetes.io/instance: hostpath.csi.k8s.io
     app.kubernetes.io/part-of: csi-driver-host-path
@@ -64,7 +66,9 @@ spec:
             topologyKey: kubernetes.io/hostname
       containers:
         - name: socat
-          image: docker.io/alpine/socat:1.7.4.3-r0
+          image: registry.k8s.io/sig-storage/hostpathplugin:v1.13.0
+          command:
+          - socat
           args:
             - tcp-listen:10000,fork,reuseaddr
             - unix-connect:/csi/csi.sock

--- a/test/e2e/testing-manifests/storage-csi/mock/csi-mock-driver-attacher.yaml
+++ b/test/e2e/testing-manifests/storage-csi/mock/csi-mock-driver-attacher.yaml
@@ -15,7 +15,7 @@ spec:
       serviceAccountName: csi-mock
       containers:
         - name: csi-attacher
-          image: registry.k8s.io/sig-storage/csi-attacher:v4.0.0
+          image: registry.k8s.io/sig-storage/csi-attacher:v4.5.0
           args:
             - --v=5
             - --csi-address=$(ADDRESS)

--- a/test/e2e/testing-manifests/storage-csi/mock/csi-mock-driver-resizer.yaml
+++ b/test/e2e/testing-manifests/storage-csi/mock/csi-mock-driver-resizer.yaml
@@ -15,7 +15,7 @@ spec:
       serviceAccountName: csi-mock
       containers:
         - name: csi-resizer
-          image: registry.k8s.io/sig-storage/csi-resizer:v1.6.0
+          image: registry.k8s.io/sig-storage/csi-resizer:v1.10.0
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"

--- a/test/e2e/testing-manifests/storage-csi/mock/csi-mock-driver-snapshotter.yaml
+++ b/test/e2e/testing-manifests/storage-csi/mock/csi-mock-driver-snapshotter.yaml
@@ -15,7 +15,7 @@ spec:
       serviceAccountName: csi-mock
       containers:
         - name: csi-snapshotter
-          image: registry.k8s.io/sig-storage/csi-snapshotter:v6.1.0
+          image: registry.k8s.io/sig-storage/csi-snapshotter:v7.0.1
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"

--- a/test/e2e/testing-manifests/storage-csi/mock/csi-mock-driver.yaml
+++ b/test/e2e/testing-manifests/storage-csi/mock/csi-mock-driver.yaml
@@ -15,7 +15,7 @@ spec:
       serviceAccountName: csi-mock
       containers:
         - name: csi-provisioner
-          image: registry.k8s.io/sig-storage/csi-provisioner:v3.4.0
+          image: registry.k8s.io/sig-storage/csi-provisioner:v4.0.0
           args:
             - "--csi-address=$(ADDRESS)"
             # Topology support is needed for the pod rescheduling test
@@ -34,7 +34,7 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: driver-registrar
-          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.5.1
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.10.0
           args:
             - --v=5
             - --csi-address=/csi/csi.sock
@@ -53,7 +53,7 @@ spec:
           - mountPath: /registration
             name: registration-dir
         - name: mock
-          image: registry.k8s.io/sig-storage/hostpathplugin:v1.9.0
+          image: registry.k8s.io/sig-storage/hostpathplugin:v1.13.0
           args:
             - "--drivername=mock.storage.k8s.io"
             - "--nodeid=$(KUBE_NODE_NAME)"

--- a/test/e2e/testing-manifests/storage-csi/mock/csi-mock-proxy.yaml
+++ b/test/e2e/testing-manifests/storage-csi/mock/csi-mock-proxy.yaml
@@ -15,7 +15,7 @@ spec:
       serviceAccountName: csi-mock
       containers:
         - name: csi-provisioner
-          image: registry.k8s.io/sig-storage/csi-provisioner:v3.4.0
+          image: registry.k8s.io/sig-storage/csi-provisioner:v4.0.0
           args:
             - "--csi-address=$(ADDRESS)"
             # Topology support is needed for the pod rescheduling test
@@ -35,7 +35,7 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: driver-registrar
-          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.5.1
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.10.0
           args:
             - --v=5
             - --csi-address=/csi/csi.sock
@@ -53,7 +53,7 @@ spec:
           - mountPath: /registration
             name: registration-dir
         - name: mock
-          image: registry.k8s.io/sig-storage/hostpathplugin:v1.9.0
+          image: registry.k8s.io/sig-storage/hostpathplugin:v1.13.0
           args:
             - -v=5
             - -nodeid=$(KUBE_NODE_NAME)

--- a/test/e2e/testing-manifests/storage-csi/update-hostpath.sh
+++ b/test/e2e/testing-manifests/storage-csi/update-hostpath.sh
@@ -137,5 +137,5 @@ done
 grep -r image: hostpath/hostpath/csi-hostpath-plugin.yaml | while read -r image; do
     version=$(echo "$image" | sed -e 's/.*:\(.*\)/\1/')
     image=$(echo "$image" | sed -e 's/.*image: \([^:]*\).*/\1/')
-    sed -i -e "s;$image:.*;$image:$version;" mock/*.yaml
+    sed -i '' -e "s;$image:.*;$image:$version;" mock/*.yaml
 done

--- a/test/utils/image/csi_manifests_test.go
+++ b/test/utils/image/csi_manifests_test.go
@@ -48,7 +48,6 @@ func TestCSIImageConfigs(t *testing.T) {
 		"gcp-compute-persistent-disk-csi-driver",
 
 		// For some hostpath tests.
-		"socat",
 		"busybox",
 
 		// For AnyVolumeDataSource feature tests.


### PR DESCRIPTION
Cherry pick of #122489 on release-1.28.

#122489: storage e2e: update hostpath and mock images

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```