### PR TITLE
Automated cherry pick of #124289: e2e node: fix -v support

### DIFF
--- a/test/e2e/framework/ginkgologger.go
+++ b/test/e2e/framework/ginkgologger.go
@@ -49,14 +49,16 @@ var (
 
 func init() {
 	// ktesting and testinit already registered the -v and -vmodule
-	// command line flags. To configure the textlogger instead, we
-	// need to swap out the flag.Value for those.
+	// command line flags. To configure the textlogger and klog
+	// consistently, we need to intercept the Set call. This
+	// can be done by swapping out the flag.Value for the -v and
+	// -vmodule flags with a wrapper which calls both.
 	var fs flag.FlagSet
 	logConfig.AddFlags(&fs)
 	fs.VisitAll(func(loggerFlag *flag.Flag) {
 		klogFlag := flag.CommandLine.Lookup(loggerFlag.Name)
 		if klogFlag != nil {
-			klogFlag.Value = loggerFlag.Value
+			klogFlag.Value = &valueChain{Value: loggerFlag.Value, parentValue: klogFlag.Value}
 		}
 	})
 
@@ -73,6 +75,21 @@ func init() {
 		klog.WriteKlogBuffer(writer.WriteKlogBuffer),
 	}
 	klog.SetLoggerWithOptions(ginkgoLogger, opts...)
+}
+
+type valueChain struct {
+	flag.Value
+	parentValue flag.Value
+}
+
+func (v *valueChain) Set(value string) error {
+	if err := v.Value.Set(value); err != nil {
+		return err
+	}
+	if err := v.parentValue.Set(value); err != nil {
+		return err
+	}
+	return nil
 }
 
 func unwind(skip int) (string, int) {

--- a/test/e2e_node/e2e_node_suite_test.go
+++ b/test/e2e_node/e2e_node_suite_test.go
@@ -41,7 +41,6 @@ import (
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	clientset "k8s.io/client-go/kubernetes"
 	cliflag "k8s.io/component-base/cli/flag"
-	"k8s.io/component-base/logs"
 	"k8s.io/kubernetes/pkg/util/rlimit"
 	commontest "k8s.io/kubernetes/test/e2e/common"
 	"k8s.io/kubernetes/test/e2e/framework"
@@ -123,7 +122,6 @@ func TestMain(m *testing.M) {
 	e2econfig.CopyFlags(e2econfig.Flags, flag.CommandLine)
 	framework.RegisterCommonFlags(flag.CommandLine)
 	registerNodeFlags(flag.CommandLine)
-	logs.AddFlags(pflag.CommandLine)
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 	// Mark the run-services-mode flag as hidden to prevent user from using it.
 	pflag.CommandLine.MarkHidden("run-services-mode")


### PR DESCRIPTION
Cherry pick of #124289 on release-1.30.

#124289: e2e node: fix -v support

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```