### PR TITLE
Remove gate DefaultHostNetworkHostPortsInPodTemplates

### DIFF
--- a/pkg/apis/core/v1/defaults.go
+++ b/pkg/apis/core/v1/defaults.go
@@ -228,12 +228,6 @@ func SetDefaults_PodSpec(obj *v1.PodSpec) {
 	if obj.RestartPolicy == "" {
 		obj.RestartPolicy = v1.RestartPolicyAlways
 	}
-	if utilfeature.DefaultFeatureGate.Enabled(features.DefaultHostNetworkHostPortsInPodTemplates) {
-		if obj.HostNetwork {
-			defaultHostNetworkPorts(&obj.Containers)
-			defaultHostNetworkPorts(&obj.InitContainers)
-		}
-	}
 	if obj.SecurityContext == nil {
 		obj.SecurityContext = &v1.PodSecurityContext{}
 	}

--- a/pkg/apis/core/v1/defaults_test.go
+++ b/pkg/apis/core/v1/defaults_test.go
@@ -208,14 +208,8 @@ func testWorkloadDefaults(t *testing.T, featuresEnabled bool) {
 				".Spec.HostNetwork":                          "true",
 				".Spec.Containers[0].Ports[0].ContainerPort": "12345",
 			}
-			if utilfeature.DefaultFeatureGate.Enabled(features.DefaultHostNetworkHostPortsInPodTemplates) {
-				m[".Spec.Containers"] = `[{"name":"","ports":[{"hostPort":12345,"containerPort":12345,"protocol":"TCP"}],"resources":{},"terminationMessagePath":"/dev/termination-log","terminationMessagePolicy":"File","imagePullPolicy":"IfNotPresent"}]`
-				m[".Spec.Containers[0].Ports"] = `[{"hostPort":12345,"containerPort":12345,"protocol":"TCP"}]`
-				m[".Spec.Containers[0].Ports[0].HostPort"] = "12345"
-			} else {
-				m[".Spec.Containers"] = `[{"name":"","ports":[{"containerPort":12345,"protocol":"TCP"}],"resources":{},"terminationMessagePath":"/dev/termination-log","terminationMessagePolicy":"File","imagePullPolicy":"IfNotPresent"}]`
-				m[".Spec.Containers[0].Ports"] = `[{"containerPort":12345,"protocol":"TCP"}]`
-			}
+			m[".Spec.Containers"] = `[{"name":"","ports":[{"containerPort":12345,"protocol":"TCP"}],"resources":{},"terminationMessagePath":"/dev/termination-log","terminationMessagePolicy":"File","imagePullPolicy":"IfNotPresent"}]`
+			m[".Spec.Containers[0].Ports"] = `[{"containerPort":12345,"protocol":"TCP"}]`
 			for k, v := range expectedDefaults {
 				if _, found := m[k]; !found {
 					m[k] = v
@@ -379,40 +373,23 @@ func testPodDefaults(t *testing.T, featuresEnabled bool) {
 func TestPodHostNetworkDefaults(t *testing.T) {
 	cases := []struct {
 		name                 string
-		gate                 bool
 		hostNet              bool
 		expectPodDefault     bool
 		expectPodSpecDefault bool
 	}{{
-		name:                 "gate disabled, hostNetwork=false",
-		gate:                 false,
+		name:                 "hostNetwork=false",
 		hostNet:              false,
 		expectPodDefault:     false,
 		expectPodSpecDefault: false,
 	}, {
-		name:                 "gate disabled, hostNetwork=true",
-		gate:                 false,
+		name:                 "hostNetwork=true",
 		hostNet:              true,
 		expectPodDefault:     true,
 		expectPodSpecDefault: false,
-	}, {
-		name:                 "gate enabled, hostNetwork=false",
-		gate:                 true,
-		hostNet:              false,
-		expectPodDefault:     false,
-		expectPodSpecDefault: false,
-	}, {
-		name:                 "gate enabled, hostNetwork=true",
-		gate:                 true,
-		hostNet:              true,
-		expectPodDefault:     true,
-		expectPodSpecDefault: true,
 	}}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.DefaultHostNetworkHostPortsInPodTemplates, tc.gate)()
-
 			const portNum = 12345
 			spec := v1.PodSpec{
 				HostNetwork: tc.hostNet,

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -187,15 +187,6 @@ const (
 	// Set the scheduled time as an annotation in the job.
 	CronJobsScheduledAnnotation featuregate.Feature = "CronJobsScheduledAnnotation"
 
-	// owner: @thockin
-	// deprecated: v1.28
-	//
-	// Changes when the default value of PodSpec.containers[].ports[].hostPort
-	// is assigned.  The default is to only set a default value in Pods.
-	// Enabling this means a default will be assigned even to embeddedPodSpecs
-	// (e.g. in a Deployment), which is the historical default.
-	DefaultHostNetworkHostPortsInPodTemplates featuregate.Feature = "DefaultHostNetworkHostPortsInPodTemplates"
-
 	// owner: @elezar
 	// kep: http://kep.k8s.io/4009
 	// alpha: v1.28
@@ -1039,8 +1030,6 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	ConsistentHTTPGetHandlers: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.31
 
 	CronJobsScheduledAnnotation: {Default: true, PreRelease: featuregate.Beta},
-
-	DefaultHostNetworkHostPortsInPodTemplates: {Default: false, PreRelease: featuregate.Deprecated},
 
 	DisableCloudProviders: {Default: true, PreRelease: featuregate.Beta},
 


### PR DESCRIPTION
This behavior was deprecated in 1.28.

/kind cleanup

```release-note
The feature gate "DefaultHostNetworkHostPortsInPodTemplates" has been removed.  This behavior was deprecated in v1.28, and has had no reports of trouble since.
```