### PR TITLE
Fix networking feature tags in Windows hybrid network e2e

### DIFF
--- a/test/e2e/windows/hybrid_network.go
+++ b/test/e2e/windows/hybrid_network.go
@@ -77,7 +77,7 @@ var _ = sigDescribe("Hybrid cluster network", skipUnlessWindows(func() {
 
 		})
 
-		f.It("should provide Internet connection for Linux containers using DNS", feature.NetworkingDNS, func(ctx context.Context) {
+		f.It("should provide Internet connection for Linux containers", feature.NetworkingIPv4, func(ctx context.Context) {
 			linuxPod := createTestPod(f, linuxBusyBoxImage, linuxOS)
 			ginkgo.By("creating a linux pod and waiting for it to be running")
 			linuxPod = e2epod.NewPodClient(f).CreateSync(ctx, linuxPod)
@@ -88,7 +88,7 @@ var _ = sigDescribe("Hybrid cluster network", skipUnlessWindows(func() {
 			assertConsistentConnectivity(ctx, f, linuxPod.ObjectMeta.Name, linuxOS, linuxCheck("8.8.8.8", 53), externalMaxTries)
 		})
 
-		f.It("should provide Internet connection for Windows containers using DNS", feature.NetworkingDNS, func(ctx context.Context) {
+		f.It("should provide Internet connection and DNS for Windows containers", feature.NetworkingIPv4, feature.NetworkingDNS, func(ctx context.Context) {
 			windowsPod := createTestPod(f, windowsBusyBoximage, windowsOS)
 			ginkgo.By("creating a windows pod and waiting for it to be running")
 			windowsPod = e2epod.NewPodClient(f).CreateSync(ctx, windowsPod)
@@ -136,7 +136,7 @@ func linuxCheck(address string, port int) []string {
 }
 
 func windowsCheck(address string) []string {
-	curl := fmt.Sprintf("curl.exe %s --connect-timeout %v --fail", address, timeoutSeconds)
+	curl := fmt.Sprintf("curl.exe -4 %s --connect-timeout %v --fail", address, timeoutSeconds)
 	cmd := []string{"cmd", "/c", curl}
 	return cmd
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/sig network
/sig windows

#### What this PR does / why we need it:
(Noticed while trying to document sig-network e2e feature tags.)

#107132 added feature tags to the Windows hybrid networking tests, but they were the wrong tags.

The test "`should provide Internet connection for Linux containers using DNS`" tries to make a connection to `8.8.8.8:53`, but was tagged `[Feature:Networking-DNS]` rather than `[Feature:Networking-IPv4]` which is actually the relevant requirement. (`NetworkingDNS` means "requires that DNS requests for external hosts succeed", but that test doesn't make any DNS requests.)

OTOH, the test "`should provide Internet connection for Windows containers using DNS`" tries to connect to `www.google.com` (and so `[Feature:Networking-DNS]` is correct), but it needs `[Feature:Networking-IPv4]` too. Well... the original test might use IPv4 or IPv6, but we don't have a tag that means "needs internet connectivity of an unspecified IP family", and so since the other test explicitly uses IPv4, I just made this always use IPv4 too.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
