### PR TITLE
Refactor e2e netpol

### DIFF
--- a/test/e2e/network/netpol/network_policy.go
+++ b/test/e2e/network/netpol/network_policy.go
@@ -1450,10 +1450,6 @@ func initializeCluster(ctx context.Context, f *framework.Framework, protocols []
 
 	framework.Logf("finished initializing cluster state")
 
-	if err := waitForHTTPServers(k8s, model); err != nil {
-		return nil, err
-	}
-
 	return k8s, nil
 }
 

--- a/test/e2e/network/netpol/test_helper.go
+++ b/test/e2e/network/netpol/test_helper.go
@@ -18,7 +18,6 @@ package netpol
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/onsi/ginkgo/v2"
@@ -63,48 +62,6 @@ func UpdatePolicy(ctx context.Context, k8s *kubeManager, policy *networkingv1.Ne
 
 	_, err := k8s.updateNetworkPolicy(ctx, namespace, policy)
 	framework.ExpectNoError(err, "Unable to update netpol %s/%s", namespace, policy.Name)
-}
-
-// waitForHTTPServers waits for all webservers to be up, on all protocols sent in the input,  and then validates them using the same probe logic as the rest of the suite.
-func waitForHTTPServers(k *kubeManager, model *Model) error {
-	const maxTries = 10
-	framework.Logf("waiting for HTTP servers (ports 80 and/or 81) to become ready")
-
-	testCases := map[string]*TestCase{}
-	for _, port := range model.Ports {
-		// Protocols is provided as input so that we can skip udp polling for windows
-		for _, protocol := range model.Protocols {
-			fromPort := 81
-			desc := fmt.Sprintf("%d->%d,%s", fromPort, port, protocol)
-			testCases[desc] = &TestCase{ToPort: int(port), Protocol: protocol}
-		}
-	}
-	notReady := map[string]bool{}
-	for caseName := range testCases {
-		notReady[caseName] = true
-	}
-
-	for i := 0; i < maxTries; i++ {
-		for caseName, testCase := range testCases {
-			if notReady[caseName] {
-				reachability := NewReachability(k.AllPodStrings(), true)
-				testCase.Reachability = reachability
-				ProbePodToPodConnectivity(k, k.AllPods(), k.DNSDomain(), testCase)
-				_, wrong, _, _ := reachability.Summary(ignoreLoopback)
-				if wrong == 0 {
-					framework.Logf("server %s is ready", caseName)
-					delete(notReady, caseName)
-				} else {
-					framework.Logf("server %s is not ready", caseName)
-				}
-			}
-		}
-		if len(notReady) == 0 {
-			return nil
-		}
-		time.Sleep(waitInterval)
-	}
-	return fmt.Errorf("after %d tries, %d HTTP servers are not ready", maxTries, len(notReady))
 }
 
 // ValidateOrFail validates connectivity


### PR DESCRIPTION
The existing e2e test for network policies exec multiple times on the Pods, this is expensive and slow, and can create flakiness since the apiserver may throttle some of the request, instead just do multiple queries in a single command.

E2e test must not validate the environment, if the environment is not ready then is ok to fail the test, waiting for the pods to be running and ready must be enough signal to start testing. This stage of validation also adds more load to the framework and the cluster under test.

Refactor the `probeConnectivity` method to return the expected results, as previous implementation returned the error and later interpreted it, with the consequence that unexpected errors could be considered as false positives.

```release-note
NONE
```