### PR TITLE
Added a testcase to check hostname and hostNetwork

### DIFF
--- a/test/e2e/network/dns.go
+++ b/test/e2e/network/dns.go
@@ -26,7 +26,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
+	e2eoutput "k8s.io/kubernetes/test/e2e/framework/pod/output"
 	e2eservice "k8s.io/kubernetes/test/e2e/framework/service"
 	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 	"k8s.io/kubernetes/test/e2e/network/common"
@@ -640,6 +642,53 @@ var _ = common.SIGDescribe("DNS HostNetwork", func() {
 		pod.Spec.HostNetwork = true
 		pod.Spec.DNSPolicy = v1.DNSClusterFirstWithHostNet
 		validateDNSResults(ctx, f, pod, append(wheezyFileNames, jessieFileNames...))
+	})
+
+	// https://issues.k8s.io/67019
+	ginkgo.It("spec.Hostname field is not silently ignored and is used for hostname for a Pod", func(ctx context.Context) {
+		ginkgo.By("Creating a pod by setting a hostname")
+
+		testAgnhostPod := e2epod.NewAgnhostPod(f.Namespace.Name, "test-dns-hostname", nil, nil, nil)
+		testAgnhostPod.Spec.Hostname = dnsTestPodHostName
+		testAgnhostPod, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, testAgnhostPod, metav1.CreateOptions{})
+		framework.ExpectNoError(err, "failed to created pod: %s", testAgnhostPod.Name)
+
+		err = e2epod.WaitTimeoutForPodReadyInNamespace(ctx, f.ClientSet, testAgnhostPod.Name, f.Namespace.Name, framework.PodStartTimeout)
+		framework.ExpectNoError(err, "failed to wait for pod %s to be running", testAgnhostPod.Name)
+
+		stdout, err := e2eoutput.RunHostCmd(testAgnhostPod.Namespace, testAgnhostPod.Name, "hostname")
+		framework.ExpectNoError(err, "failed to run command hostname: %s", stdout)
+		hostname := strings.TrimSpace(stdout)
+		if testAgnhostPod.Spec.Hostname != hostname {
+			framework.Failf("expected hostname: %s, got: %s", testAgnhostPod.Spec.Hostname, hostname)
+		}
+	})
+
+	// https://issues.k8s.io/67019
+	ginkgo.It("spec.Hostname field is silently ignored and the node hostname is used when hostNetwork is set to true for a Pod", func(ctx context.Context) {
+		ginkgo.By("Creating a pod by setting a hostNetwork to true")
+
+		testAgnhostPod := e2epod.NewAgnhostPod(f.Namespace.Name, "test-dns-hostnetwork", nil, nil, nil)
+		testAgnhostPod.Spec.Hostname = dnsTestPodHostName
+		testAgnhostPod.Spec.HostNetwork = true
+		node, err := e2enode.GetRandomReadySchedulableNode(ctx, f.ClientSet)
+		framework.ExpectNoError(err)
+		nodeSelection := e2epod.NodeSelection{}
+		e2epod.SetAffinity(&nodeSelection, node.Name)
+		e2epod.SetNodeSelection(&testAgnhostPod.Spec, nodeSelection)
+
+		testAgnhostPod, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, testAgnhostPod, metav1.CreateOptions{})
+		framework.ExpectNoError(err, "failed to created pod: %s", testAgnhostPod.Name)
+
+		err = e2epod.WaitTimeoutForPodReadyInNamespace(ctx, f.ClientSet, testAgnhostPod.Name, f.Namespace.Name, framework.PodStartTimeout)
+		framework.ExpectNoError(err, "failed to wait for pod %s to be running", testAgnhostPod.Name)
+
+		stdout, err := e2eoutput.RunHostCmd(testAgnhostPod.Namespace, testAgnhostPod.Name, "hostname")
+		framework.ExpectNoError(err, "failed to run command hostname: %s", stdout)
+		hostname := strings.TrimSpace(stdout)
+		if node.Name != hostname {
+			framework.Failf("expected hostname: %s, got: %s", node.Name, hostname)
+		}
 	})
 
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
https://github.com/kubernetes/kubernetes/issues/67019


Fixes # https://github.com/kubernetes/kubernetes/issues/67019

#### Test result-
```
[sig-network] DNS should resolve hostname and hostNetwork for a Pod [Conformance] [sig-network, Conformance]
k8s.io/kubernetes/test/e2e/network/dns.go:132
  STEP: Creating a kubernetes client @ 04/21/24 07:33:32.982
  I0421 07:33:32.982058 3814322 util.go:506] >>> kubeConfig: /home/syash/.kube/kind-test-config
  I0421 07:33:32.982505 3814322 util.go:515] >>> kubeContext: kind-kind
  STEP: Building a namespace api object, basename dns @ 04/21/24 07:33:32.982
  STEP: Waiting for a default service account to be provisioned in namespace @ 04/21/24 07:33:32.991
  STEP: Waiting for kube-root-ca.crt to be provisioned in namespace @ 04/21/24 07:33:32.992
  STEP: Creating a pod by setting hostname @ 04/21/24 07:33:32.994
  I0421 07:33:32.994520 3814322 resource.go:361] Creating new exec pod
  I0421 07:33:35.003946 3814322 dns.go:138] Setting up hostname to: dns-querier-1
  I0421 07:33:35.004077 3814322 builder.go:121] Running '/usr/bin/kubectl --server=https://127.0.0.1:43529 --kubeconfig=/home/syash/.kube/kind-test-config --context=kind-kind --namespace=dns-319 exec dns-querier-1x
5hqm -- /bin/sh -x -c hostname'
  I0421 07:33:35.109971 3814322 builder.go:146] stderr: "+ hostname\n"
  I0421 07:33:35.110020 3814322 builder.go:147] stdout: "dns-querier-1x5hqm\n"
  I0421 07:33:35.110042 3814322 dns.go:145] The spec.hostname is not same as container hostname, expected to contain: dns-querier-1, got: dns-querier-1x5hqm

  STEP: Updating the pod spec.hostNetwork to true @ 04/21/24 07:33:35.11
  I0421 07:33:35.110085 3814322 dns.go:149] Setting up hostNetwork to: true
  I0421 07:33:35.110128 3814322 builder.go:121] Running '/usr/bin/kubectl --server=https://127.0.0.1:43529 --kubeconfig=/home/syash/.kube/kind-test-config --context=kind-kind --namespace=dns-319 exec dns-querier-1x
5hqm -- /bin/sh -x -c hostname'
  I0421 07:33:35.222393 3814322 builder.go:146] stderr: "+ hostname\n"
  I0421 07:33:35.222448 3814322 builder.go:147] stdout: "dns-querier-1x5hqm\n"
  I0421 07:33:35.222472 3814322 dns.go:157] The hostname and pod metadata are same: dns-querier-1x5hqm, got: dns-querier-1x5hqm

  I0421 07:33:35.222564 3814322 helper.go:121] Waiting up to 7m0s for all (but 0) nodes to be ready
  STEP: Destroying namespace "dns-319" for this suite. @ 04/21/24 07:33:35.225
• [2.247 seconds]
```
