### PR TITLE
ReadWriteMany access mode should not be allowed with hostPath volumes. issue#123743

### DIFF
--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -25175,6 +25175,48 @@ func TestValidateNonSpecialIP(t *testing.T) {
 	}
 }
 
+func TestValidateHostPathVolumes(t *testing.T) {
+    cases := []struct {
+        name     string
+        pv       *core.PersistentVolume
+        expected bool
+    }{
+        {
+            name: "hostPath with RWX",
+            pv: &core.PersistentVolume{
+                Spec: core.PersistentVolumeSpec{
+                    PersistentVolumeSource: core.PersistentVolumeSource{
+                        HostPath: &core.HostPathVolumeSource{},
+                    },
+                    AccessModes: []core.PersistentVolumeAccessMode{core.ReadWriteMany},
+                },
+            },
+            expected: false,
+        },
+        {
+            name: "hostPath without RWX",
+            pv: &core.PersistentVolume{
+                Spec: core.PersistentVolumeSpec{
+                    PersistentVolumeSource: core.PersistentVolumeSource{
+                        HostPath: &core.HostPathVolumeSource{},
+                    },
+                    AccessModes: []core.PersistentVolumeAccessMode{core.ReadWriteOnce},
+                },
+            },
+            expected: true,
+        },
+    }
+
+    for _, c := range cases {
+        t.Run(c.name, func(t *testing.T) {
+            errs := validation.ValidatePersistentVolume(c.pv)
+            if (len(errs) == 0) != c.expected {
+                t.Errorf("TestValidateHostPathVolumes %s failed: expected %v, got errs %v", c.name, c.expected, errs)
+            }
+        })
+    }
+}
+
 func TestValidateHostUsers(t *testing.T) {
 	falseVar := false
 	trueVar := true


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
Fixing issue #123743 

<!--
Add one of the following kinds:
/kind bug

Optionally add one or more of the following kinds if applicable:
/kind api-change
-->

#### What this PR does / why we need it:
We know that hostPath doesn't support ReadWriteMany access mode from the docs[1]. But if we attempt to create a PV and PVC with hostPath option enabled and the access mode with ReadWriteMany. Kubernetes allows this to be created but when the end goal is to have a common volume shared by many pods of a deployment running on multiple nodes. This setup causes confusion to the users, as they assumed everything is setup perfectly since there was no error while creating the PV and PVC.
When the user tries to write some files from one of the pods, the data will not be accessible to the other pods, since it is mounting the hostpath and writing onto it.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #123743 `
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #123743 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
