### PR TITLE
kubeadm: support image pull mode and policy in UpgradeConfiguration 

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/fuzzer/fuzzer.go
+++ b/cmd/kubeadm/app/apis/kubeadm/fuzzer/fuzzer.go
@@ -162,8 +162,14 @@ func fuzzUpgradeConfiguration(obj *kubeadm.UpgradeConfiguration, c fuzz.Continue
 
 	// Pinning values for fields that get defaults if fuzz value is empty string or nil (thus making the round trip test fail)
 	obj.Node.EtcdUpgrade = ptr.To(true)
+	obj.Node.CertificateRenewal = ptr.To(false)
+	obj.Node.ImagePullPolicy = corev1.PullIfNotPresent
+	obj.Node.ImagePullSerial = ptr.To(true)
+
 	obj.Apply.EtcdUpgrade = ptr.To(true)
 	obj.Apply.CertificateRenewal = ptr.To(false)
-	obj.Node.CertificateRenewal = ptr.To(false)
+	obj.Apply.ImagePullPolicy = corev1.PullIfNotPresent
+	obj.Apply.ImagePullSerial = ptr.To(true)
+
 	kubeadm.SetDefaultTimeouts(&obj.Timeouts)
 }

--- a/cmd/kubeadm/app/apis/kubeadm/types.go
+++ b/cmd/kubeadm/app/apis/kubeadm/types.go
@@ -588,6 +588,14 @@ type UpgradeApplyConfiguration struct {
 	// SkipPhases is a list of phases to skip during command execution.
 	// NOTE: This field is currently ignored for "kubeadm upgrade apply", but in the future it will be supported.
 	SkipPhases []string
+
+	// ImagePullPolicy specifies the policy for image pulling during kubeadm "upgrade apply" operations.
+	// The value of this field must be one of "Always", "IfNotPresent" or "Never".
+	// If this field is unset kubeadm will default it to "IfNotPresent", or pull the required images if not present on the host.
+	ImagePullPolicy v1.PullPolicy `json:"imagePullPolicy,omitempty"`
+
+	// ImagePullSerial specifies if image pulling performed by kubeadm must be done serially or in parallel.
+	ImagePullSerial *bool
 }
 
 // UpgradeDiffConfiguration contains a list of configurable options which are specific to the "kubeadm upgrade diff" command.
@@ -620,6 +628,14 @@ type UpgradeNodeConfiguration struct {
 
 	// Patches contains options related to applying patches to components deployed by kubeadm during "kubeadm upgrade".
 	Patches *Patches
+
+	// ImagePullPolicy specifies the policy for image pulling during kubeadm "upgrade node" operations.
+	// The value of this field must be one of "Always", "IfNotPresent" or "Never".
+	// If this field is unset kubeadm will default it to "IfNotPresent", or pull the required images if not present on the host.
+	ImagePullPolicy v1.PullPolicy `json:"imagePullPolicy,omitempty"`
+
+	// ImagePullSerial specifies if image pulling performed by kubeadm must be done serially or in parallel.
+	ImagePullSerial *bool
 }
 
 // UpgradePlanConfiguration contains a list of configurable options which are specific to the "kubeadm upgrade plan" command.

--- a/cmd/kubeadm/app/apis/kubeadm/v1beta4/defaults.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1beta4/defaults.go
@@ -278,18 +278,29 @@ func SetDefaults_UpgradeConfiguration(obj *UpgradeConfiguration) {
 	if obj.Node.EtcdUpgrade == nil {
 		obj.Node.EtcdUpgrade = ptr.To(true)
 	}
-
 	if obj.Node.CertificateRenewal == nil {
 		obj.Node.CertificateRenewal = ptr.To(true)
+	}
+	if len(obj.Node.ImagePullPolicy) == 0 {
+		obj.Node.ImagePullPolicy = DefaultImagePullPolicy
+	}
+	if obj.Node.ImagePullSerial == nil {
+		obj.Node.ImagePullSerial = ptr.To(true)
 	}
 
 	if obj.Apply.EtcdUpgrade == nil {
 		obj.Apply.EtcdUpgrade = ptr.To(true)
 	}
-
 	if obj.Apply.CertificateRenewal == nil {
 		obj.Apply.CertificateRenewal = ptr.To(true)
 	}
+	if len(obj.Apply.ImagePullPolicy) == 0 {
+		obj.Apply.ImagePullPolicy = DefaultImagePullPolicy
+	}
+	if obj.Apply.ImagePullSerial == nil {
+		obj.Apply.ImagePullSerial = ptr.To(true)
+	}
+
 	if obj.Timeouts == nil {
 		obj.Timeouts = &Timeouts{}
 	}

--- a/cmd/kubeadm/app/apis/kubeadm/v1beta4/types.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1beta4/types.go
@@ -663,6 +663,17 @@ type UpgradeApplyConfiguration struct {
 	// SkipPhases is a list of phases to skip during command execution.
 	// NOTE: This field is currently ignored for "kubeadm upgrade apply", but in the future it will be supported.
 	SkipPhases []string
+
+	// ImagePullPolicy specifies the policy for image pulling during kubeadm "upgrade apply" operations.
+	// The value of this field must be one of "Always", "IfNotPresent" or "Never".
+	// If this field is unset kubeadm will default it to "IfNotPresent", or pull the required images if not present on the host.
+	// +optional
+	ImagePullPolicy corev1.PullPolicy `json:"imagePullPolicy,omitempty"`
+
+	// ImagePullSerial specifies if image pulling performed by kubeadm must be done serially or in parallel.
+	// Default: true
+	// +optional
+	ImagePullSerial *bool `json:"imagePullSerial,omitempty"`
 }
 
 // UpgradeDiffConfiguration contains a list of configurable options which are specific to the "kubeadm upgrade diff" command.
@@ -705,6 +716,17 @@ type UpgradeNodeConfiguration struct {
 	// Patches contains options related to applying patches to components deployed by kubeadm during "kubeadm upgrade".
 	// +optional
 	Patches *Patches `json:"patches,omitempty"`
+
+	// ImagePullPolicy specifies the policy for image pulling during kubeadm "upgrade node" operations.
+	// The value of this field must be one of "Always", "IfNotPresent" or "Never".
+	// If this field is unset kubeadm will default it to "IfNotPresent", or pull the required images if not present on the host.
+	// +optional
+	ImagePullPolicy corev1.PullPolicy `json:"imagePullPolicy,omitempty"`
+
+	// ImagePullSerial specifies if image pulling performed by kubeadm must be done serially or in parallel.
+	// Default: true
+	// +optional
+	ImagePullSerial *bool `json:"imagePullSerial,omitempty"`
 }
 
 // UpgradePlanConfiguration contains a list of configurable options which are specific to the "kubeadm upgrade plan" command.

--- a/cmd/kubeadm/app/apis/kubeadm/v1beta4/zz_generated.conversion.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1beta4/zz_generated.conversion.go
@@ -1009,6 +1009,8 @@ func autoConvert_v1beta4_UpgradeApplyConfiguration_To_kubeadm_UpgradeApplyConfig
 	out.Patches = (*kubeadm.Patches)(unsafe.Pointer(in.Patches))
 	out.PrintConfig = (*bool)(unsafe.Pointer(in.PrintConfig))
 	out.SkipPhases = *(*[]string)(unsafe.Pointer(&in.SkipPhases))
+	out.ImagePullPolicy = corev1.PullPolicy(in.ImagePullPolicy)
+	out.ImagePullSerial = (*bool)(unsafe.Pointer(in.ImagePullSerial))
 	return nil
 }
 
@@ -1029,6 +1031,8 @@ func autoConvert_kubeadm_UpgradeApplyConfiguration_To_v1beta4_UpgradeApplyConfig
 	out.Patches = (*Patches)(unsafe.Pointer(in.Patches))
 	out.PrintConfig = (*bool)(unsafe.Pointer(in.PrintConfig))
 	out.SkipPhases = *(*[]string)(unsafe.Pointer(&in.SkipPhases))
+	out.ImagePullPolicy = corev1.PullPolicy(in.ImagePullPolicy)
+	out.ImagePullSerial = (*bool)(unsafe.Pointer(in.ImagePullSerial))
 	return nil
 }
 
@@ -1110,6 +1114,8 @@ func autoConvert_v1beta4_UpgradeNodeConfiguration_To_kubeadm_UpgradeNodeConfigur
 	out.IgnorePreflightErrors = *(*[]string)(unsafe.Pointer(&in.IgnorePreflightErrors))
 	out.SkipPhases = *(*[]string)(unsafe.Pointer(&in.SkipPhases))
 	out.Patches = (*kubeadm.Patches)(unsafe.Pointer(in.Patches))
+	out.ImagePullPolicy = corev1.PullPolicy(in.ImagePullPolicy)
+	out.ImagePullSerial = (*bool)(unsafe.Pointer(in.ImagePullSerial))
 	return nil
 }
 
@@ -1125,6 +1131,8 @@ func autoConvert_kubeadm_UpgradeNodeConfiguration_To_v1beta4_UpgradeNodeConfigur
 	out.IgnorePreflightErrors = *(*[]string)(unsafe.Pointer(&in.IgnorePreflightErrors))
 	out.SkipPhases = *(*[]string)(unsafe.Pointer(&in.SkipPhases))
 	out.Patches = (*Patches)(unsafe.Pointer(in.Patches))
+	out.ImagePullPolicy = corev1.PullPolicy(in.ImagePullPolicy)
+	out.ImagePullSerial = (*bool)(unsafe.Pointer(in.ImagePullSerial))
 	return nil
 }
 

--- a/cmd/kubeadm/app/apis/kubeadm/v1beta4/zz_generated.deepcopy.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1beta4/zz_generated.deepcopy.go
@@ -727,6 +727,11 @@ func (in *UpgradeApplyConfiguration) DeepCopyInto(out *UpgradeApplyConfiguration
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.ImagePullSerial != nil {
+		in, out := &in.ImagePullSerial, &out.ImagePullSerial
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 
@@ -821,6 +826,11 @@ func (in *UpgradeNodeConfiguration) DeepCopyInto(out *UpgradeNodeConfiguration) 
 	if in.Patches != nil {
 		in, out := &in.Patches, &out.Patches
 		*out = new(Patches)
+		**out = **in
+	}
+	if in.ImagePullSerial != nil {
+		in, out := &in.ImagePullSerial, &out.ImagePullSerial
+		*out = new(bool)
 		**out = **in
 	}
 	return

--- a/cmd/kubeadm/app/apis/kubeadm/zz_generated.deepcopy.go
+++ b/cmd/kubeadm/app/apis/kubeadm/zz_generated.deepcopy.go
@@ -767,6 +767,11 @@ func (in *UpgradeApplyConfiguration) DeepCopyInto(out *UpgradeApplyConfiguration
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.ImagePullSerial != nil {
+		in, out := &in.ImagePullSerial, &out.ImagePullSerial
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 
@@ -861,6 +866,11 @@ func (in *UpgradeNodeConfiguration) DeepCopyInto(out *UpgradeNodeConfiguration) 
 	if in.Patches != nil {
 		in, out := &in.Patches, &out.Patches
 		*out = new(Patches)
+		**out = **in
+	}
+	if in.ImagePullSerial != nil {
+		in, out := &in.ImagePullSerial, &out.ImagePullSerial
+		*out = new(bool)
 		**out = **in
 	}
 	return

--- a/cmd/kubeadm/app/cmd/upgrade/common.go
+++ b/cmd/kubeadm/app/cmd/upgrade/common.go
@@ -106,6 +106,13 @@ func enforceRequirements(flagSet *pflag.FlagSet, flags *applyPlanFlags, args []s
 		return nil, nil, nil, nil, errors.Wrap(err, "[upgrade/init config] FATAL")
 	}
 
+	// Set the ImagePullPolicy and ImagePullSerial from the UpgradeApplyConfiguration to the InitConfiguration.
+	// These are used by preflight.RunPullImagesCheck() when running 'apply'.
+	if upgradeApply {
+		initCfg.NodeRegistration.ImagePullPolicy = upgradeCfg.Apply.ImagePullPolicy
+		initCfg.NodeRegistration.ImagePullSerial = upgradeCfg.Apply.ImagePullSerial
+	}
+
 	newK8sVersion := upgradeCfg.Plan.KubernetesVersion
 	if upgradeApply {
 		newK8sVersion = upgradeCfg.Apply.KubernetesVersion

--- a/cmd/kubeadm/app/cmd/upgrade/node.go
+++ b/cmd/kubeadm/app/cmd/upgrade/node.go
@@ -180,11 +180,11 @@ func newNodeData(cmd *cobra.Command, args []string, nodeOptions *nodeOptions, ou
 		return nil, errors.Wrap(err, "unable to fetch the kubeadm-config ConfigMap")
 	}
 
-	ignorePreflightErrorsSet, err := validation.ValidateIgnorePreflightErrors(nodeOptions.ignorePreflightErrors, initCfg.NodeRegistration.IgnorePreflightErrors)
+	ignorePreflightErrorsSet, err := validation.ValidateIgnorePreflightErrors(nodeOptions.ignorePreflightErrors, upgradeCfg.Node.IgnorePreflightErrors)
 	if err != nil {
 		return nil, err
 	}
-	// Also set the union of pre-flight errors to JoinConfiguration, to provide a consistent view of the runtime configuration:
+	// Also set the union of pre-flight errors to InitConfiguration, to provide a consistent view of the runtime configuration:
 	initCfg.NodeRegistration.IgnorePreflightErrors = sets.List(ignorePreflightErrorsSet)
 
 	var patchesDir string

--- a/cmd/kubeadm/app/util/config/upgradeconfiguration_test.go
+++ b/cmd/kubeadm/app/util/config/upgradeconfiguration_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/lithammer/dedent"
 
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/yaml"
@@ -53,10 +54,14 @@ func TestDocMapToUpgradeConfiguration(t *testing.T) {
 				Apply: kubeadmapi.UpgradeApplyConfiguration{
 					CertificateRenewal: ptr.To(true),
 					EtcdUpgrade:        ptr.To(true),
+					ImagePullPolicy:    v1.PullIfNotPresent,
+					ImagePullSerial:    ptr.To(true),
 				},
 				Node: kubeadmapi.UpgradeNodeConfiguration{
 					CertificateRenewal: ptr.To(true),
 					EtcdUpgrade:        ptr.To(true),
+					ImagePullPolicy:    v1.PullIfNotPresent,
+					ImagePullSerial:    ptr.To(true),
 				},
 			},
 		},
@@ -78,10 +83,14 @@ func TestDocMapToUpgradeConfiguration(t *testing.T) {
 				Apply: kubeadmapi.UpgradeApplyConfiguration{
 					CertificateRenewal: ptr.To(false),
 					EtcdUpgrade:        ptr.To(true),
+					ImagePullPolicy:    v1.PullIfNotPresent,
+					ImagePullSerial:    ptr.To(true),
 				},
 				Node: kubeadmapi.UpgradeNodeConfiguration{
 					CertificateRenewal: ptr.To(true),
 					EtcdUpgrade:        ptr.To(false),
+					ImagePullPolicy:    v1.PullIfNotPresent,
+					ImagePullSerial:    ptr.To(true),
 				},
 			},
 		},
@@ -162,10 +171,14 @@ func TestLoadUpgradeConfigurationFromFile(t *testing.T) {
 				Apply: kubeadmapi.UpgradeApplyConfiguration{
 					CertificateRenewal: ptr.To(true),
 					EtcdUpgrade:        ptr.To(true),
+					ImagePullPolicy:    v1.PullIfNotPresent,
+					ImagePullSerial:    ptr.To(true),
 				},
 				Node: kubeadmapi.UpgradeNodeConfiguration{
 					CertificateRenewal: ptr.To(true),
 					EtcdUpgrade:        ptr.To(true),
+					ImagePullPolicy:    v1.PullIfNotPresent,
+					ImagePullSerial:    ptr.To(true),
 				},
 			},
 			wantErr: false,
@@ -214,10 +227,14 @@ func TestDefaultedUpgradeConfiguration(t *testing.T) {
 				Apply: kubeadmapi.UpgradeApplyConfiguration{
 					CertificateRenewal: ptr.To(true),
 					EtcdUpgrade:        ptr.To(true),
+					ImagePullPolicy:    v1.PullIfNotPresent,
+					ImagePullSerial:    ptr.To(true),
 				},
 				Node: kubeadmapi.UpgradeNodeConfiguration{
 					CertificateRenewal: ptr.To(true),
 					EtcdUpgrade:        ptr.To(true),
+					ImagePullPolicy:    v1.PullIfNotPresent,
+					ImagePullSerial:    ptr.To(true),
 				},
 			},
 		},
@@ -226,9 +243,13 @@ func TestDefaultedUpgradeConfiguration(t *testing.T) {
 			cfg: &kubeadmapiv1.UpgradeConfiguration{
 				Apply: kubeadmapiv1.UpgradeApplyConfiguration{
 					CertificateRenewal: ptr.To(false),
+					ImagePullPolicy:    v1.PullAlways,
+					ImagePullSerial:    ptr.To(false),
 				},
 				Node: kubeadmapiv1.UpgradeNodeConfiguration{
-					EtcdUpgrade: ptr.To(false),
+					EtcdUpgrade:     ptr.To(false),
+					ImagePullPolicy: v1.PullAlways,
+					ImagePullSerial: ptr.To(false),
 				},
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: kubeadmapiv1.SchemeGroupVersion.String(),
@@ -239,10 +260,14 @@ func TestDefaultedUpgradeConfiguration(t *testing.T) {
 				Apply: kubeadmapi.UpgradeApplyConfiguration{
 					CertificateRenewal: ptr.To(false),
 					EtcdUpgrade:        ptr.To(true),
+					ImagePullPolicy:    v1.PullAlways,
+					ImagePullSerial:    ptr.To(false),
 				},
 				Node: kubeadmapi.UpgradeNodeConfiguration{
 					CertificateRenewal: ptr.To(true),
 					EtcdUpgrade:        ptr.To(false),
+					ImagePullPolicy:    v1.PullAlways,
+					ImagePullSerial:    ptr.To(false),
 				},
 			},
 		},
@@ -269,15 +294,6 @@ func TestLoadOrDefaultUpgradeConfiguration(t *testing.T) {
 	}()
 	filename := "kubeadmConfig"
 	filePath := filepath.Join(tmpdir, filename)
-	fileContents := dedent.Dedent(`
-				apiVersion: kubeadm.k8s.io/v1beta4
-				kind: UpgradeConfiguration
-			`)
-	err = os.WriteFile(filePath, []byte(fileContents), 0644)
-	if err != nil {
-		t.Fatalf("Couldn't write content to file: %v", err)
-	}
-
 	options := LoadOrDefaultConfigurationOptions{}
 
 	tests := []struct {
@@ -305,10 +321,14 @@ func TestLoadOrDefaultUpgradeConfiguration(t *testing.T) {
 				Apply: kubeadmapi.UpgradeApplyConfiguration{
 					CertificateRenewal: ptr.To(false),
 					EtcdUpgrade:        ptr.To(true),
+					ImagePullPolicy:    v1.PullIfNotPresent,
+					ImagePullSerial:    ptr.To(true),
 				},
 				Node: kubeadmapi.UpgradeNodeConfiguration{
 					CertificateRenewal: ptr.To(true),
 					EtcdUpgrade:        ptr.To(false),
+					ImagePullPolicy:    v1.PullIfNotPresent,
+					ImagePullSerial:    ptr.To(true),
 				},
 			},
 		},
@@ -318,9 +338,15 @@ func TestLoadOrDefaultUpgradeConfiguration(t *testing.T) {
 			cfg: &kubeadmapiv1.UpgradeConfiguration{
 				Apply: kubeadmapiv1.UpgradeApplyConfiguration{
 					CertificateRenewal: ptr.To(false),
+					EtcdUpgrade:        ptr.To(false),
+					ImagePullPolicy:    v1.PullNever,
+					ImagePullSerial:    ptr.To(false),
 				},
 				Node: kubeadmapiv1.UpgradeNodeConfiguration{
-					EtcdUpgrade: ptr.To(false),
+					CertificateRenewal: ptr.To(false),
+					EtcdUpgrade:        ptr.To(false),
+					ImagePullPolicy:    v1.PullNever,
+					ImagePullSerial:    ptr.To(false),
 				},
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: kubeadmapiv1.SchemeGroupVersion.String(),
@@ -329,18 +355,31 @@ func TestLoadOrDefaultUpgradeConfiguration(t *testing.T) {
 			},
 			want: &kubeadmapi.UpgradeConfiguration{
 				Apply: kubeadmapi.UpgradeApplyConfiguration{
-					CertificateRenewal: ptr.To(true),
-					EtcdUpgrade:        ptr.To(true),
+					CertificateRenewal: ptr.To(false),
+					EtcdUpgrade:        ptr.To(false),
+					ImagePullPolicy:    v1.PullNever,
+					ImagePullSerial:    ptr.To(false),
 				},
 				Node: kubeadmapi.UpgradeNodeConfiguration{
-					CertificateRenewal: ptr.To(true),
-					EtcdUpgrade:        ptr.To(true),
+					CertificateRenewal: ptr.To(false),
+					EtcdUpgrade:        ptr.To(false),
+					ImagePullPolicy:    v1.PullNever,
+					ImagePullSerial:    ptr.To(false),
 				},
 			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			bytes, err := yaml.Marshal(tt.cfg)
+			if err != nil {
+				t.Fatalf("Could not marshal test config: %v", err)
+			}
+			err = os.WriteFile(filePath, bytes, 0644)
+			if err != nil {
+				t.Fatalf("Couldn't write content to file: %v", err)
+			}
+
 			got, _ := LoadOrDefaultUpgradeConfiguration(tt.cfgPath, tt.cfg, options)
 			if diff := cmp.Diff(got, tt.want, cmpopts.IgnoreFields(kubeadmapi.UpgradeConfiguration{}, "Timeouts")); diff != "" {
 				t.Errorf("LoadOrDefaultUpgradeConfiguration returned unexpected diff (-want,+got):\n%s", diff)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Add Upgrade{Apply|Node}Configuration.{ImagePullPolicy|ImagePullSerial}.
The same feature already exists in NodeRegistrationOptions for Init and JoinConfiguraiton.

also fix a bug in a separate commit:

When using UpgradeNodeConfiguration.IgnorePreflightErrors the field
is currently ignored in favor of the "defualted" field created
by configutil.FetchInitConfigurationFromCluster.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

fixes https://github.com/kubernetes/kubeadm/issues/2780

xref
- https://github.com/kubernetes/kubeadm/issues/2890
- https://github.com/kubernetes/kubeadm/issues/2489

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
