### PR TITLE
windows: Fixes following container log rotation

### DIFF
--- a/staging/src/k8s.io/cri-client/pkg/logs/logs.go
+++ b/staging/src/k8s.io/cri-client/pkg/logs/logs.go
@@ -295,7 +295,7 @@ func ReadLogs(ctx context.Context, logger *klog.Logger, path, containerID string
 		return fmt.Errorf("failed to try resolving symlinks in path %q: %v", path, err)
 	}
 	path = evaluated
-	f, err := os.Open(path)
+	f, err := openFileShareDelete(path)
 	if err != nil {
 		return fmt.Errorf("failed to open log file %q: %v", path, err)
 	}
@@ -364,7 +364,7 @@ func ReadLogs(ctx context.Context, logger *klog.Logger, path, containerID string
 					return err
 				}
 				if recreated {
-					newF, err := os.Open(path)
+					newF, err := openFileShareDelete(path)
 					if err != nil {
 						if os.IsNotExist(err) {
 							continue

--- a/staging/src/k8s.io/cri-client/pkg/logs/logs_other.go
+++ b/staging/src/k8s.io/cri-client/pkg/logs/logs_other.go
@@ -1,0 +1,29 @@
+//go:build !windows
+// +build !windows
+
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logs
+
+import (
+	"os"
+)
+
+func openFileShareDelete(path string) (*os.File, error) {
+	// Noop. Only relevant for Windows.
+	return os.Open(path)
+}

--- a/staging/src/k8s.io/cri-client/pkg/logs/logs_test.go
+++ b/staging/src/k8s.io/cri-client/pkg/logs/logs_test.go
@@ -24,7 +24,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	goruntime "runtime"
 	"testing"
 	"time"
 
@@ -212,10 +211,6 @@ func TestReadLogs(t *testing.T) {
 }
 
 func TestReadRotatedLog(t *testing.T) {
-	if goruntime.GOOS == "windows" {
-		// TODO: remove skip once the failing test has been fixed.
-		t.Skip("Skip failing test on Windows.")
-	}
 	tmpDir := t.TempDir()
 	file, err := os.CreateTemp(tmpDir, "logfile")
 	if err != nil {
@@ -287,6 +282,10 @@ func TestReadRotatedLog(t *testing.T) {
 			time.Sleep(20 * time.Millisecond)
 		}
 	}
+
+	// Finished writing into the file, close it, so we can delete it later.
+	err = file.Close()
+	assert.NoErrorf(t, err, "could not close file.")
 
 	time.Sleep(20 * time.Millisecond)
 	// Make the function ReadLogs end.

--- a/staging/src/k8s.io/cri-client/pkg/logs/logs_windows.go
+++ b/staging/src/k8s.io/cri-client/pkg/logs/logs_windows.go
@@ -1,0 +1,49 @@
+//go:build windows
+// +build windows
+
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logs
+
+import (
+	"os"
+	"syscall"
+)
+
+// Based on Windows implementation of Windows' syscall.Open
+// https://cs.opensource.google/go/go/+/refs/tags/go1.22.2:src/syscall/syscall_windows.go;l=342
+// In addition to syscall.Open, this function also adds the syscall.FILE_SHARE_DELETE flag to sharemode,
+// which will allow us to read from the file without blocking the file from being deleted or renamed.
+// This is essential for Log Rotation which is done by renaming the open file. Without this, the file rename would fail.
+func openFileShareDelete(path string) (*os.File, error) {
+	pathp, err := syscall.UTF16PtrFromString(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var access uint32 = syscall.GENERIC_READ
+	var sharemode uint32 = syscall.FILE_SHARE_READ | syscall.FILE_SHARE_WRITE | syscall.FILE_SHARE_DELETE
+	var createmode uint32 = syscall.OPEN_EXISTING
+	var attrs uint32 = syscall.FILE_ATTRIBUTE_NORMAL
+
+	handle, err := syscall.CreateFile(pathp, access, sharemode, nil, createmode, attrs, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	return os.NewFile(uintptr(handle), path), nil
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug
/kind failing-test

/sig windows
/sig testing

#### What this PR does / why we need it:

If we're following a file, that file will remain open, and we continue to read data from it when new data becomes available.

On Windows, this can be an issue if the container logs needs to be rotated. Log rotation is done by renaming the file, but this action may fail if the file is already opened.

Setting the ``FILE_SHARE_DELETE`` flag when opening the file will prevent this issue, as documented: ``"Delete access allows both delete and rename operations"`` [1].

In golang, there's no way to set this flag [2], the ``sharemode`` is always set to: ``sharemode := uint32(FILE_SHARE_READ | FILE_SHARE_WRITE)``

Thus, we need to open the file ourselves with the right flags.

[1] https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilea?redirectedfrom=MSDN
[2] https://cs.opensource.google/go/go/+/refs/tags/go1.22.2:src/syscall/syscall_windows.go;l=366

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #124443
Related: https://github.com/kubernetes/kubernetes/issues/51540

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed issue where following Windows container logs would prevent container log rotation.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
