### PR TITLE
WIP: apiserver/endpoints/installer: use storage GV for hubGV

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/installer.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/installer.go
@@ -301,6 +301,7 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 		return nil, nil, err
 	}
 
+	hubGV := schema.GroupVersion{Group: fqKindToRegister.Group, Version: runtime.APIVersionInternal}
 	versionedPtr, err := a.group.Creater.New(fqKindToRegister)
 	if err != nil {
 		return nil, nil, err
@@ -491,6 +492,7 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 		if err != nil {
 			return nil, nil, err
 		}
+		hubGV = gvk.GroupVersion()
 		apiResource.StorageVersionHash = discovery.StorageVersionHash(gvk.Group, gvk.Version, gvk.Kind)
 	}
 
@@ -675,7 +677,7 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 
 		AcceptsGroupVersionDelegate: gvAcceptor,
 
-		HubGroupVersion: schema.GroupVersion{Group: fqKindToRegister.Group, Version: runtime.APIVersionInternal},
+		HubGroupVersion: hubGV,
 
 		MetaGroupVersion: metav1.SchemeGroupVersion,
 


### PR DESCRIPTION
Strategic merge patch assumes resources should be converted to an internal resource version, presumably for etcd internal storage. It seems the example apiservice gets around this by registering versions with the internal version but this causes problems with much of the other tooling that presumes resources have a version. At any rate, it seems reasonable to allow an external apiservice to be able to choose its own `HubGroupVersion` while still being able to utilize the heavy-lifting logic in endpoints/installer.go

To achieve this, allow the rest.Storage parameter to drive what the `HubGroupVersion` is when it implements `rest.StorageVersionProvider`. The assumption here is that a hub gv is always the same as the storageVersion. (If this is not true, corrections wanted).

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
Fixes strategic merge patch for apiservice implementations that do not use/register the internal api group.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
