### PR TITLE
kubeadm: use etcd 3.5.11's /livez and /readyz endpoints for probes

### DIFF
--- a/cmd/kubeadm/app/constants/constants.go
+++ b/cmd/kubeadm/app/constants/constants.go
@@ -317,7 +317,7 @@ const (
 	KubeletHealthzPort = 10248
 
 	// MinExternalEtcdVersion indicates minimum external etcd version which kubeadm supports
-	MinExternalEtcdVersion = "3.4.13-4"
+	MinExternalEtcdVersion = "3.5.11-0"
 
 	// DefaultEtcdVersion indicates the default etcd version that kubeadm uses
 	DefaultEtcdVersion = "3.5.13-0"
@@ -479,13 +479,6 @@ var (
 
 	// SupportedEtcdVersion lists officially supported etcd versions with corresponding Kubernetes releases
 	SupportedEtcdVersion = map[uint8]string{
-		22: "3.5.13-0",
-		23: "3.5.13-0",
-		24: "3.5.13-0",
-		25: "3.5.13-0",
-		26: "3.5.13-0",
-		27: "3.5.13-0",
-		28: "3.5.13-0",
 		29: "3.5.13-0",
 		30: "3.5.13-0",
 		31: "3.5.13-0",

--- a/cmd/kubeadm/app/constants/constants_test.go
+++ b/cmd/kubeadm/app/constants/constants_test.go
@@ -124,11 +124,15 @@ func TestGetStaticPodFilepath(t *testing.T) {
 	}
 }
 
+func TestEtcdSupportedVersionLength(t *testing.T) {
+	const max = 3
+	if len(SupportedEtcdVersion) > max {
+		t.Fatalf("SupportedEtcdVersion must not include more than %d versions", max)
+	}
+}
+
 func TestEtcdSupportedVersion(t *testing.T) {
 	var supportedEtcdVersion = map[uint8]string{
-		13: "3.2.24",
-		14: "3.3.10",
-		15: "3.3.10",
 		16: "3.3.17-0",
 		17: "3.4.3-0",
 		18: "3.4.3-0",
@@ -147,7 +151,7 @@ func TestEtcdSupportedVersion(t *testing.T) {
 		},
 		{
 			kubernetesVersion: "1.10.1",
-			expectedVersion:   version.MustParseSemantic("3.2.24"),
+			expectedVersion:   version.MustParseSemantic("3.3.17-0"),
 			expectedWarning:   true,
 			expectedError:     false,
 		},

--- a/cmd/kubeadm/app/phases/etcd/local.go
+++ b/cmd/kubeadm/app/phases/etcd/local.go
@@ -224,9 +224,12 @@ func GetEtcdPodSpec(cfg *kubeadmapi.ClusterConfiguration, endpoint *kubeadmapi.A
 					v1.ResourceMemory: resource.MustParse("100Mi"),
 				},
 			},
-			LivenessProbe: staticpodutil.LivenessProbe(probeHostname, "/health?exclude=NOSPACE&serializable=true", probePort, probeScheme),
-			StartupProbe:  staticpodutil.StartupProbe(probeHostname, "/health?serializable=false", probePort, probeScheme, componentHealthCheckTimeout),
-			Env:           kubeadmutil.MergeKubeadmEnvVars(cfg.Etcd.Local.ExtraEnvs),
+			// The etcd probe endpoints are explained here:
+			// https://github.com/kubernetes/kubeadm/issues/3039
+			LivenessProbe:  staticpodutil.LivenessProbe(probeHostname, "/livez", probePort, probeScheme),
+			ReadinessProbe: staticpodutil.ReadinessProbe(probeHostname, "/readyz", probePort, probeScheme),
+			StartupProbe:   staticpodutil.StartupProbe(probeHostname, "/readyz", probePort, probeScheme, componentHealthCheckTimeout),
+			Env:            kubeadmutil.MergeKubeadmEnvVars(cfg.Etcd.Local.ExtraEnvs),
 		},
 		etcdMounts,
 		// etcd will listen on the advertise address of the API server, in a different port (2379)

--- a/cmd/kubeadm/app/phases/etcd/local_test.go
+++ b/cmd/kubeadm/app/phases/etcd/local_test.go
@@ -129,13 +129,22 @@ spec:
       failureThreshold: 8
       httpGet:
         host: 127.0.0.1
-        path: /health?exclude=NOSPACE&serializable=true
+        path: /livez
         port: 2381
         scheme: HTTP
       initialDelaySeconds: 10
       periodSeconds: 10
       timeoutSeconds: 15
     name: etcd
+    readinessProbe:
+      failureThreshold: 3
+      httpGet:
+        host: 127.0.0.1
+        path: /readyz
+        port: 2381
+        scheme: HTTP
+      periodSeconds: 1
+      timeoutSeconds: 15
     resources:
       requests:
         cpu: 100m
@@ -144,7 +153,7 @@ spec:
       failureThreshold: 24
       httpGet:
         host: 127.0.0.1
-        path: /health?serializable=false
+        path: /readyz
         port: 2381
         scheme: HTTP
       initialDelaySeconds: 10


### PR DESCRIPTION
#### What type of PR is this?

Add a unit test to block on this.

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

etcd >= 3.5.11 includes new endpoints for liveness, startup
and readyness probes. Use them in 1.31.

there is another commit here:

There is no point to track more than 3 etcd versions at a time
where each etcd versions maps to a k8s CP version.

It's 3 instead of 2 (k8s CP / kubeadm version skew size) because
there is a period of time where the 3rd version (newest) will
be WIP at k/k master - e.g. at the time of this commit it's 1.31.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubeadm/issues/3039

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubeadm: switch to using the new etcd endpoints introduced in 3.5.11 - /livez (for liveness probe) and /readyz (for readyness and startup probe). With this change it is no longer possible to deploy a custom etcd version older than 3.5.11 with kubeadm 1.31. If so, please upgrade.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
