### PR TITLE
Update cloud provider gcp to with the new version

### DIFF
--- a/cluster/OWNERS
+++ b/cluster/OWNERS
@@ -4,23 +4,23 @@ options:
   # make root approval non-recursive
   no_parent_owners: true
 reviewers:
+  - aojea
   - bentheelder
   - cheftako
   - dims
   - justaugustus
   - liggitt
-  - mikedanese
-  - spiffxp
   - wojtek-t
 approvers:
+  - aojea
   - bentheelder
   - cheftako
   - dims
   - liggitt
-  - mikedanese
-  - spiffxp
   - wojtek-t
 emeritus_approvers:
+  - mikedanese
+  - spiffxp
   - eparis
   - roberthbailey # 2019-03-08
   - jbeda

--- a/cluster/gce/manifests/cloud-controller-manager.manifest
+++ b/cluster/gce/manifests/cloud-controller-manager.manifest
@@ -23,7 +23,7 @@
 "containers":[
     {
     "name": "cloud-controller-manager",
-    "image": "gcr.io/k8s-staging-cloud-provider-gcp/cloud-controller-manager:v29.0.0",
+    "image": "gcr.io/k8s-staging-cloud-provider-gcp/cloud-controller-manager:v30.0.0",
     "resources": {
       "requests": {
         "cpu": "{{cpurequest}}"


### PR DESCRIPTION
Get the latest version that contains the node controller fix https://github.com/kubernetes/cloud-provider-gcp/pull/660

Also add myself to the owners since I'm having to do much more work in this folder, specially related to the cloud provider and kube-up, and already own some of the addons like kube-network-policies

Move mikedanese and spiffxp to emeritus

/kind cleanup

/kind failing-test
/kind flake

```release-note
NONE
```

/assign @dims @liggitt @wojtek-t 
