### PR TITLE
Allow bookmark events in between delete/modify in testSimpleCRUD

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/basic_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/basic_test.go
@@ -243,6 +243,10 @@ func testSimpleCRUD(t *testing.T, ns string, noxuDefinition *apiextensionsv1.Cus
 							t.Fatal(err)
 						}
 
+						if watchEvent.Type == watch.Bookmark {
+							continue
+						}
+
 						if watchEvent.Type != watch.Modified {
 							t.Errorf("expected modified event, got %v", watchEvent.Type)
 							break
@@ -283,6 +287,10 @@ func testSimpleCRUD(t *testing.T, ns string, noxuDefinition *apiextensionsv1.Cus
 				eventMetadata, err := meta.Accessor(watchEvent.Object)
 				if err != nil {
 					t.Fatal(err)
+				}
+
+				if watchEvent.Type == watch.Bookmark {
+					continue
 				}
 
 				if watchEvent.Type != watch.Deleted {


### PR DESCRIPTION
/kind feature

Spinning out of https://github.com/kubernetes/kubernetes/pull/123513

The `testSimpleCRUD` validates exact events on watch, however it assumes that there will be no bookmarks. This is sensible assumption as by default bookmarks are send only once every 10s. However with https://github.com/kubernetes/enhancements/issues/2340 watch cache will request progress notification, that might be converted into a bookmark, as part of normal read. 

This PR removes the assumption that there are no bookmarks within watch stream from `testSimpleCRUD` by simply ignoring them in validation.

```release-note
NONE
```
/assign @wojtek-t 
