### PR TITLE
use latest stable version of kube-network-policies for CI

### DIFF
--- a/cluster/addons/kube-network-policies/kube-network-policies.yaml
+++ b/cluster/addons/kube-network-policies/kube-network-policies.yaml
@@ -27,7 +27,7 @@ spec:
       serviceAccountName: kube-network-policies
       containers:
       - name: kube-network-policies
-        image: registry.k8s.io/networking/kube-network-policies:v0.1.0
+        image: gcr.io/k8s-staging-networking/kube-network-policies:v20240423-88bdf40
         command:
         - /bin/sh
         - -c


### PR DESCRIPTION

/kind failing-test
/kind flake
```release-note
NONE
```

Fixes: #https://github.com/kubernetes-sigs/kube-network-policies/issues/12