### PR TITLE
Automated cherry pick of #122359: cluster/gce: upgrade cos-97-lts -> cos-109-lts

### DIFF
--- a/cluster/gce/config-default.sh
+++ b/cluster/gce/config-default.sh
@@ -86,7 +86,7 @@ fi
 # you are updating the os image versions, update this variable.
 # Also please update corresponding image for node e2e at:
 # https://github.com/kubernetes/kubernetes/blob/master/test/e2e_node/jenkins/image-config.yaml
-GCI_VERSION=${KUBE_GCI_VERSION:-cos-97-16919-103-16}
+GCI_VERSION=${KUBE_GCI_VERSION:-cos-109-17800-147-60}
 export MASTER_IMAGE=${KUBE_GCE_MASTER_IMAGE:-}
 export MASTER_IMAGE_PROJECT=${KUBE_GCE_MASTER_PROJECT:-cos-cloud}
 export NODE_IMAGE=${KUBE_GCE_NODE_IMAGE:-${GCI_VERSION}}

--- a/cluster/gce/config-test.sh
+++ b/cluster/gce/config-test.sh
@@ -99,7 +99,7 @@ ALLOWED_NOTREADY_NODES=${ALLOWED_NOTREADY_NODES:-$(($(get-num-nodes) / 100))}
 # you are updating the os image versions, update this variable.
 # Also please update corresponding image for node e2e at:
 # https://github.com/kubernetes/kubernetes/blob/master/test/e2e_node/jenkins/image-config.yaml
-GCI_VERSION=${KUBE_GCI_VERSION:-cos-97-16919-103-16}
+GCI_VERSION=${KUBE_GCI_VERSION:-cos-109-17800-147-60}
 export MASTER_IMAGE=${KUBE_GCE_MASTER_IMAGE:-}
 export MASTER_IMAGE_PROJECT=${KUBE_GCE_MASTER_PROJECT:-cos-cloud}
 export NODE_IMAGE=${KUBE_GCE_NODE_IMAGE:-${GCI_VERSION}}


### PR DESCRIPTION
Cherry pick of #122359 on release-1.27.

#122359: cluster/gce: upgrade cos-97-lts -> cos-109-lts

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```