### PR TITLE
Revert "Run `controlplane/transformation` integration tests in parallel"

### DIFF
--- a/test/integration/controlplane/transformation/secrets_transformation_test.go
+++ b/test/integration/controlplane/transformation/secrets_transformation_test.go
@@ -85,20 +85,17 @@ func TestSecretsShouldBeTransformed(t *testing.T) {
 		// TODO: add secretbox
 	}
 	for _, tt := range testCases {
-		tt := tt
-		t.Run(tt.transformerPrefix, func(t *testing.T) {
-			t.Parallel()
-			test, err := newTransformTest(t, tt.transformerConfigContent, false, "", nil)
-			if err != nil {
-				t.Fatalf("failed to setup test for envelop %s, error was %v", tt.transformerPrefix, err)
-			}
-			test.secret, err = test.createSecret(testSecret, testNamespace)
-			if err != nil {
-				t.Fatalf("Failed to create test secret, error: %v", err)
-			}
-			test.runResource(test.logger, tt.unSealFunc, tt.transformerPrefix, "", "v1", "secrets", test.secret.Name, test.secret.Namespace)
-			test.cleanUp()
-		})
+		test, err := newTransformTest(t, tt.transformerConfigContent, false, "", nil)
+		if err != nil {
+			t.Fatalf("failed to setup test for envelop %s, error was %v", tt.transformerPrefix, err)
+			continue
+		}
+		test.secret, err = test.createSecret(testSecret, testNamespace)
+		if err != nil {
+			t.Fatalf("Failed to create test secret, error: %v", err)
+		}
+		test.runResource(test.logger, tt.unSealFunc, tt.transformerPrefix, "", "v1", "secrets", test.secret.Name, test.secret.Namespace)
+		test.cleanUp()
 	}
 }
 

--- a/test/integration/controlplane/transformation/transformation_test.go
+++ b/test/integration/controlplane/transformation/transformation_test.go
@@ -37,7 +37,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/wait"
 	apiserverv1 "k8s.io/apiserver/pkg/apis/apiserver/v1"
 	"k8s.io/apiserver/pkg/storage/storagebackend"
@@ -638,8 +637,4 @@ func getLivez(checkName string, clientConfig *rest.Config, excludes ...string) (
 	}
 	body, err := req.DoRaw(context.TODO()) // we can still have a response body during an error case
 	return string(body), err == nil, nil
-}
-
-func getSocketPath() string {
-	return fmt.Sprintf("@%s.sock", rand.String(10))
 }


### PR DESCRIPTION
/kind flake

This reverts https://github.com/kubernetes/kubernetes/pull/124250. The integration tests use a shared global state and running some of the tests in parallel causes failures because of incorrect state.

/sig auth
/assign enj

fixes https://github.com/kubernetes/kubernetes/issues/124476

```release-note
NONE
```