### PR TITLE
Improve performance of TestForceApply unit test (k8s.io/kubectl/pkg/cmd/apply)

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply_test.go
@@ -2087,6 +2087,9 @@ func TestForceApply(t *testing.T) {
 		"post":        1,
 	}
 
+	// Set the patch retry back off period to something low, so the test can run more quickly
+	patchRetryBackOffPeriod = 1 * time.Millisecond
+
 	for _, testingOpenAPISchema := range testingOpenAPISchemas {
 		for _, openAPIFeatureToggle := range applyFeatureToggles {
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/patcher.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/patcher.go
@@ -49,8 +49,6 @@ import (
 const (
 	// maxPatchRetry is the maximum number of conflicts retry for during a patch operation before returning failure
 	maxPatchRetry = 5
-	// backOffPeriod is the period to back off when apply patch results in error.
-	backOffPeriod = 1 * time.Second
 	// how many times we can retry before back off
 	triesBeforeBackOff = 1
 	// groupVersionKindExtensionKey is the key used to lookup the
@@ -58,6 +56,9 @@ const (
 	// definition's "extensions" map.
 	groupVersionKindExtensionKey = "x-kubernetes-group-version-kind"
 )
+
+// patchRetryBackOffPeriod is the period to back off when apply patch results in error.
+var patchRetryBackOffPeriod = 1 * time.Second
 
 var createPatchErrFormat = "creating patch with:\noriginal:\n%s\nmodified:\n%s\ncurrent:\n%s\nfor:"
 
@@ -363,7 +364,7 @@ func (p *Patcher) Patch(current runtime.Object, modified []byte, source, namespa
 	}
 	for i := 1; i <= p.Retries && apierrors.IsConflict(err); i++ {
 		if i > triesBeforeBackOff {
-			p.BackOff.Sleep(backOffPeriod)
+			p.BackOff.Sleep(patchRetryBackOffPeriod)
 		}
 		current, getErr = p.Helper.Get(namespace, name)
 		if getErr != nil {


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
The TestForceApply unit test is slow because it requires patch to fail 6 times, which involves a retry backoff sleep.

This PR changes `backOffPeriod` from a const to a var, so that it can be set lower for the unit test.

As a result, test time decreases from 17s to 1s.

Before:
```
$ go test -run TestForceApply -count 1 ./...
ok  	k8s.io/kubectl/pkg/cmd/apply	17.035s
```

After:
```
$ go test -run TestForceApply -count 1 ./...
ok  	k8s.io/kubectl/pkg/cmd/apply	0.988s
```

#### Which issue(s) this PR fixes:
Ref #123685

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
