### PR TITLE
Secrets and ConfigMaps: Manage Generation

### DIFF
--- a/pkg/registry/core/secret/strategy_test.go
+++ b/pkg/registry/core/secret/strategy_test.go
@@ -17,10 +17,13 @@ limitations under the License.
 package secret
 
 import (
+	"context"
 	"testing"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apitesting "k8s.io/kubernetes/pkg/api/testing"
 	api "k8s.io/kubernetes/pkg/apis/core"
+	"k8s.io/utils/ptr"
 
 	// ensure types are installed
 	_ "k8s.io/kubernetes/pkg/apis/core/install"
@@ -33,4 +36,42 @@ func TestSelectableFieldLabelConversions(t *testing.T) {
 		SelectableFields(&api.Secret{}),
 		nil,
 	)
+}
+
+func TestStrategy(t *testing.T) {
+	t.Parallel()
+
+	obj := &api.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo",
+			Namespace: "default",
+		},
+	}
+	Strategy.PrepareForCreate(context.Background(), obj)
+	if obj.Generation != 1 {
+		t.Errorf("expected generation to be 1, was %d", obj.Generation)
+	}
+
+	newSecret := obj.DeepCopy()
+	newSecret.Labels = map[string]string{"foo": "bar"}
+
+	Strategy.PrepareForUpdate(context.Background(), newSecret, obj)
+	if expected, got := obj.Generation, newSecret.Generation; expected != got {
+		t.Errorf("expected generation to be %d, was %d", expected, got)
+	}
+
+	newSecret.Data = map[string][]byte{"foo": []byte("bar")}
+
+	Strategy.PrepareForUpdate(context.Background(), newSecret, obj)
+	if expected, got := obj.Generation+1, newSecret.Generation; expected != got {
+		t.Errorf("expected generation to be %d, was %d", expected, got)
+	}
+
+	immutableSecret := obj.DeepCopy()
+	immutableSecret.Immutable = ptr.To(true)
+
+	Strategy.PrepareForUpdate(context.Background(), immutableSecret, obj)
+	if expected, got := obj.Generation+1, immutableSecret.Generation; expected != got {
+		t.Errorf("expected generation to be %d, was %d", expected, got)
+	}
 }

--- a/test/integration/apiserver/apply/apply_test.go
+++ b/test/integration/apiserver/apply/apply_test.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"net/http"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -890,6 +891,7 @@ func TestApplyManagedFields(t *testing.T) {
 			"namespace": "default",
 			"uid": "` + string(accessor.GetUID()) + `",
 			"resourceVersion": "` + accessor.GetResourceVersion() + `",
+			"generation": ` + strconv.Itoa(int(accessor.GetGeneration())) + `,
 			"creationTimestamp": "` + accessor.GetCreationTimestamp().UTC().Format(time.RFC3339) + `",
 			"labels": {
 				"test-label": "test"


### PR DESCRIPTION
This change makes the apiserver manage the Generation on ConfigMaps and Secets by
setting it to `1` on creation and incrementing it whenever the `Data` or
`BinaryData` changes. Changes to the object as a whole can already be
 deducted from the `ResourceVersion` changing.

The main use-case is controllers that react to `ConfigMap`/`Secret` content
changes, with this change they can get away with only watching the
ObjectMeta.

/kind feature
/sig api-machinery
(I think? Not sure)
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
The Generation on ConfigMaps and Secrets will be set to 1 on Creation and increased by 1 on non-metadata updates
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
