### PR TITLE
Agnhost building fix

### DIFF
--- a/test/images/image-util.sh
+++ b/test/images/image-util.sh
@@ -127,7 +127,8 @@ build() {
 
     # Create a temporary directory for every architecture and copy the image content
     # and build the image from temporary directory
-    temp_dir="$(kube::realpath "$(mktemp -d -t "$(basename "$0").XXXXXX")")"
+    mkdir -p "${KUBE_ROOT}"/_tmp
+    temp_dir=$(mktemp -d "${KUBE_ROOT}"/_tmp/test-images-build.XXXXXX)
     kube::util::trap_add "rm -rf ${temp_dir}" EXIT
 
     cp -r "${img_folder}"/* "${temp_dir}"

--- a/test/images/image-util.sh
+++ b/test/images/image-util.sh
@@ -30,7 +30,6 @@ export DOCKER_CLI_EXPERIMENTAL="enabled"
 DOCKER_CERT_BASE_PATH="${DOCKER_CERT_BASE_PATH:-${HOME}}"
 
 KUBE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
-source "${KUBE_ROOT}/hack/lib/init.sh"
 source "${KUBE_ROOT}/hack/lib/logging.sh"
 source "${KUBE_ROOT}/hack/lib/util.sh"
 
@@ -266,16 +265,11 @@ bin() {
   fi
   for SRC in "$@";
   do
-  local -r target=${TARGET:-}
-  if [[ -z "${target}" ]]; then
-    echo "TARGET is not set"
-    exit 1
-  fi
-  docker run --rm -v "${target}:${target}:Z" -v "${KUBE_ROOT}":/go/src/k8s.io/kubernetes:Z \
+  docker run --rm -v "${TARGET}:${TARGET}:Z" -v "${KUBE_ROOT}":/go/src/k8s.io/kubernetes:Z \
         golang:"${GOLANG_VERSION}" \
         /bin/bash -c "\
                 cd /go/src/k8s.io/kubernetes/test/images/${SRC_DIR} && \
-                CGO_ENABLED=0 ${arch_prefix} GOOS=${OS} GOARCH=${ARCH} go build -a -installsuffix cgo --ldflags \"-w ${LD_FLAGS:-}\" -o ${target}/${SRC} ./$(dirname "${SRC}")"
+                CGO_ENABLED=0 ${arch_prefix} GOOS=${OS} GOARCH=${ARCH} go build -a -installsuffix cgo --ldflags \"-w ${LD_FLAGS:-}\" -o ${TARGET}/${SRC} ./$(dirname "${SRC}")"
   done
 }
 


### PR DESCRIPTION

/kind failing-test
```release-note
NONE
```

Move to the latest well known state, this script seems to be very brittle and fixing forward is not giving us to a much better place, so we revert 

![image](https://github.com/kubernetes/kubernetes/assets/6450081/01a457e4-9aba-4dbd-95f7-d24129b3387f)



