### PR TITLE
Revert "agnhost: update README"

### DIFF
--- a/test/images/agnhost/README.md
+++ b/test/images/agnhost/README.md
@@ -84,11 +84,11 @@ Tries to open a TCP or SCTP connection to the given host and port. On error it
 prints an error message prefixed with a specific fixed string that
 test cases can check for:
 
-* `UNKNOWN` - Generic/unknown (non-network) error (e.g. bad arguments)
+* `UNKNOWN` - Generic/unknown (non-network) error (eg, bad arguments)
 * `TIMEOUT` - The connection attempt timed out
 * `DNS` - An error in DNS resolution
 * `REFUSED` - Connection refused
-* `OTHER` - Other networking error (e.g. "no route to host")
+* `OTHER` - Other networking error (eg, "no route to host")
 
 (Theoretically it would be nicer for it to distinguish these by exit
 code, but it's much easier for test programs to compare strings in the


### PR DESCRIPTION
Reverts kubernetes/kubernetes#124498 to trigger image promotion with changes from https://github.com/kubernetes/kubernetes/pull/124508

follow up from: https://kubernetes.slack.com/archives/CCK68P2Q2/p1713765201337499

/assign @aojea 
/release-note-none
/kind cleanup

