### PR TITLE
Remove workarounds for https://github.com/etcd-io/etcd/issues/17507

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_test.go
@@ -177,13 +177,6 @@ func TestListWithConsistentListFromCache(t *testing.T) {
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ConsistentListFromCache, true)()
 	ctx, cacher, server, terminate := testSetupWithEtcdServer(t)
 	t.Cleanup(terminate)
-	// Wait before sending watch progress request to avoid https://github.com/etcd-io/etcd/issues/17507
-	// TODO(https://github.com/etcd-io/etcd/issues/17507): Remove the wait when etcd is upgraded to version with fix.
-	err := cacher.ready.wait(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
-	time.Sleep(time.Second)
 	storagetesting.RunTestList(ctx, t, cacher, compactStorage(cacher, server.V3Client), true)
 }
 
@@ -198,13 +191,6 @@ func TestConsistentListWithConsistentListFromCache(t *testing.T) {
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ConsistentListFromCache, true)()
 	ctx, cacher, server, terminate := testSetupWithEtcdServer(t)
 	t.Cleanup(terminate)
-	// Wait before sending watch progress request to avoid https://github.com/etcd-io/etcd/issues/17507
-	// TODO(https://github.com/etcd-io/etcd/issues/17507): Remove the wait when etcd is upgraded to version with fix.
-	err := cacher.ready.wait(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
-	time.Sleep(time.Second)
 	storagetesting.RunTestConsistentList(ctx, t, cacher, compactStorage(cacher, server.V3Client), true, true)
 }
 
@@ -219,9 +205,6 @@ func TestGetListNonRecursiveWithConsistentListFromCache(t *testing.T) {
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ConsistentListFromCache, true)()
 	ctx, cacher, server, terminate := testSetupWithEtcdServer(t)
 	t.Cleanup(terminate)
-	// Wait before sending watch progress request to avoid https://github.com/etcd-io/etcd/issues/17507
-	// TODO(https://github.com/etcd-io/etcd/issues/17507): Remove sleep when etcd is upgraded to version with fix.
-	time.Sleep(time.Second)
 	storagetesting.RunTestGetListNonRecursive(ctx, t, compactStorage(cacher, server.V3Client), cacher)
 }
 


### PR DESCRIPTION
With https://github.com/kubernetes/kubernetes/pull/124469 merged we don't need the workarounds
/kind cleanup

```release-note
NONE
```

/assign @wojtek-t 