### PR TITLE
Fix behavior with external cloud provider and --hostname-override

### DIFF
--- a/pkg/kubelet/nodestatus/setters.go
+++ b/pkg/kubelet/nodestatus/setters.go
@@ -135,6 +135,9 @@ func NodeAddress(nodeIPs []net.IP, // typically Kubelet.nodeIPs
 			// in https://github.com/kubernetes/kubernetes/issues/120720.
 			// We are already hinting the external cloud provider via the annotation AnnotationAlphaProvidedIPAddr.
 			if !nodeIPSpecified {
+				node.Status.Addresses = []v1.NodeAddress{
+					{Type: v1.NodeHostName, Address: hostname},
+				}
 				return nil
 			}
 		}

--- a/pkg/kubelet/nodestatus/setters_test.go
+++ b/pkg/kubelet/nodestatus/setters_test.go
@@ -238,15 +238,19 @@ func TestNodeAddress(t *testing.T) {
 			nodeIP:            netutils.ParseIPSloppy("::"),
 			nodeAddresses:     []v1.NodeAddress{},
 			cloudProviderType: cloudProviderExternal,
-			expectedAddresses: []v1.NodeAddress{},
-			shouldError:       false,
+			expectedAddresses: []v1.NodeAddress{
+				{Type: v1.NodeHostName, Address: testKubeletHostname},
+			},
+			shouldError: false,
 		},
 		{
 			name:              "cloud provider is external and no nodeIP",
 			nodeAddresses:     []v1.NodeAddress{},
 			cloudProviderType: cloudProviderExternal,
-			expectedAddresses: []v1.NodeAddress{},
-			shouldError:       false,
+			expectedAddresses: []v1.NodeAddress{
+				{Type: v1.NodeHostName, Address: testKubeletHostname},
+			},
+			shouldError: false,
 		},
 		{
 			name: "cloud doesn't report hostname, no override, detected hostname mismatch",


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/kind regression

#### What this PR does / why we need it:
#121028 changed kubelet startup to not try to autodetect the node IP when using an external cloud provider, but accidentally also changed it to not write out the kubelet-provided hostname value.

Pre-121028, the `if !nodeIPSpecified { return nil }` wasn't there, so it ended up adding an autodetected node IP and the hostname [below](https://github.com/danwinship/kubernetes/blob/4da16d5c07d82267ada50eca20504a93856a8272/pkg/kubelet/nodestatus/setters.go#L233-L236) (whether that hostname was autodetected or overridden). This patch just revises that so we always add the hostname like before, we just don't write out the nodeIP if it wasn't user-specified.

(The 2 unit tests that this changes the behavior of are the 2 that were added in #121028.)

#### Which issue(s) this PR fixes:
Fixes #124453

#### Special notes for your reviewer:
The logic here can be simplified once we drop the legacy cloud provider case, but (a) I wasn't sure what that was waiting for, and (b) this patch needs to be backported anyway.

#### Does this PR introduce a user-facing change?
```release-note
Fixed a regression where `kubelet --hostname-override` no longer worked
correctly with an external cloud provider.
```

/cc @aojea 