### PR TITLE
ignore cert issues in grpc probes

### DIFF
--- a/pkg/probe/grpc/grpc.go
+++ b/pkg/probe/grpc/grpc.go
@@ -18,13 +18,15 @@ package grpc
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"net"
 	"time"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/credentials/insecure"
+
+	"google.golang.org/grpc/credentials"
 	grpchealth "google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
@@ -56,7 +58,7 @@ func (p grpcProber) Probe(host, service string, port int, timeout time.Duration)
 	opts := []grpc.DialOption{
 		grpc.WithUserAgent(fmt.Sprintf("kube-probe/%s.%s", v.Major, v.Minor)),
 		grpc.WithBlock(),
-		grpc.WithTransportCredentials(insecure.NewCredentials()), //credentials are currently not supported
+		grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{InsecureSkipVerify: true})), // ignore certificate errors
 		grpc.WithContextDialer(func(ctx context.Context, addr string) (net.Conn, error) {
 			return probe.ProbeDialer().DialContext(ctx, "tcp", addr)
 		}),

--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -228,7 +228,7 @@ const (
 
 func initImageConfigs(list RegistryList) (map[ImageID]Config, map[ImageID]Config) {
 	configs := map[ImageID]Config{}
-	configs[Agnhost] = Config{list.PromoterE2eRegistry, "agnhost", "2.47"}
+	configs[Agnhost] = Config{list.PromoterE2eRegistry, "agnhost", "2.50"}
 	configs[AgnhostPrivate] = Config{list.PrivateRegistry, "agnhost", "2.6"}
 	configs[AuthenticatedAlpine] = Config{list.GcAuthenticatedRegistry, "alpine", "3.7"}
 	configs[AuthenticatedWindowsNanoServer] = Config{list.GcAuthenticatedRegistry, "windows-nanoserver", "v1"}


### PR DESCRIPTION

#### What type of PR is this?

/kind bug
/sig node

/kind regression

#### What this PR does / why we need it:

This PR broke gRPC probes behavior of ignoring certificate errors: https://github.com/kubernetes/kubernetes/pull/109778/files#diff-554e4ab6aa427de1dca207fa4dcead9be87f53da0eeb859a043bda0bc3654a86

Fixing and adding test.

#### Which issue(s) this PR fixes:
Fixes #119093

#### Special notes for your reviewer:

This must be rare occasion and there is almost zero chance anybody took dependency on the regressed behavior.

#### Does this PR introduce a user-facing change?
```release-note
Fix bug in gRPC probe - now probes are ignoring certificate issue.
```