### PR TITLE
1.29: Fix PersistentVolumeLabel admission plugin on Azure

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_managedDiskController.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_managedDiskController.go
@@ -364,6 +364,11 @@ func (c *Cloud) GetAzureDiskLabels(diskURI string) (map[string]string, error) {
 		return nil, err
 	}
 
+	if c.Location == "" {
+		// The cloud provider is not initialized and cannot get the topology labels.
+		return nil, nil
+	}
+
 	labels := map[string]string{
 		v1.LabelTopologyRegion: c.Location,
 	}


### PR DESCRIPTION
**This is a manual patch for v1.29. The whole Azure cloud provider was removed in v1.30 and master, so I cannot fix it there and cherry pick it to older branches.** I will backport it to 1.28 and older (if they're still supported).

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

Do not provide any topology labels for PVs when the Azure cloud provider is not initialized. Providing `topology.kubernetes.io/region: ""` is wrong, because such region does not exist and PVs with this label would not be usable by any node.

This affects only in-tree PVs. We have CSI migration in place that makes sure newly provisioned PVs already have correct nodeAffinity, so topology labels are not necessary. And for manually provisioned PVs, no topology label is better that a wrong one, because users can add the label later, but they can't update PV spec.nodeAffinity that would be created from wrong PV label during PersistentVolumeLabel admission.

Note that the whole Azure cloud provider is removed in v1.30, so I'm using just a minimal patch.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #124525

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed PersistentolumeLabel providing wrong topology labels to Azure Disk PersistentVolumes when the external Azure cloud provider is used.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
