### PR TITLE
use a stable release for network policies

### DIFF
--- a/cluster/addons/kube-network-policies/kube-network-policies.yaml
+++ b/cluster/addons/kube-network-policies/kube-network-policies.yaml
@@ -27,7 +27,7 @@ spec:
       serviceAccountName: kube-network-policies
       containers:
       - name: kube-network-policies
-        image: gcr.io/k8s-staging-networking/kube-network-policies:v20240423-88bdf40
+        image: registry.k8s.io/networking/kube-network-policies:v0.2.0
         command:
         - /bin/sh
         - -c


### PR DESCRIPTION

/kind cleanup

```release-note
NONE
```

following up on previous comment from BenTheElder, we should not get artifacts from staging for CI