### PR TITLE
Disable P&F by default in the apiserver library

### DIFF
--- a/pkg/controlplane/apiserver/options/options.go
+++ b/pkg/controlplane/apiserver/options/options.go
@@ -120,6 +120,10 @@ func NewOptions() *Options {
 	// Overwrite the default for storage data format.
 	s.Etcd.DefaultStorageMediaType = "application/vnd.kubernetes.protobuf"
 
+	// Overwrite the default for Priority and Fairness to enable it by default in
+	// the kube-apiserver.
+	s.Features.EnablePriorityAndFairness = true
+
 	return &s
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/server/options/feature.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/feature.go
@@ -42,7 +42,10 @@ func NewFeatureOptions() *FeatureOptions {
 		EnableProfiling:           defaults.EnableProfiling,
 		DebugSocketPath:           defaults.DebugSocketPath,
 		EnableContentionProfiling: defaults.EnableContentionProfiling,
-		EnablePriorityAndFairness: true,
+		// Disable PriorityAndFairness by default since it only makes sense to have
+		// on by default for the kube-apiserver and not for the aggregated
+		// apiservers that are reusing this library.
+		EnablePriorityAndFairness: false,
 	}
 }
 


### PR DESCRIPTION
Priority and Fairness is currently enabled by default for any consumers of the apiserver library. This include the kube-apiserver as well as aggregated apiservers that are based on the generic apiserver library. For the latter it doesn't really make sense to have P&F enabled by default because the apiservers are for the majority not supposed to be accessed directly, but rather via the kube-apiserver. In case there is still a need to enable P&F at an aggregated apiserver level, they can continue to do it either via the `--enable-priority-and-fairness` CLI flag or by turning on the feature like we do for the kube-apiserver.

```release-note
Disable priority and fairness by default for the consumers of the apiserver library. The feature will still be enabled on the kube-apiserver by default.
```