### PR TITLE
lease controller: add lease renew policies

### DIFF
--- a/pkg/controlplane/apiserver/server.go
+++ b/pkg/controlplane/apiserver/server.go
@@ -232,7 +232,8 @@ func (c completedConfig) New(name string, delegationTarget genericapiserver.Dele
 				leaseName,
 				metav1.NamespaceSystem,
 				// TODO: receive identity label value as a parameter when post start hook is moved to generic apiserver.
-				labelAPIServerHeartbeatFunc(name, peeraddress))
+				labelAPIServerHeartbeatFunc(name, peeraddress),
+				lease.FixedLeaseRenewPolicy)
 			go controller.Run(ctx)
 			return nil
 		})

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -204,6 +204,13 @@ const (
 	// that is independent of a Pod.
 	DynamicResourceAllocation featuregate.Feature = "DynamicResourceAllocation"
 
+	// owner: @linxiulei
+	// beta: v1.31
+	//
+	// Enable dynamic node lease renew interval that allows kubelet to renew leases
+	// at longer interval in first attempt and shorter interval after failures.
+	DynamicNodeLeaseRenewInterval featuregate.Feature = "DynamicNodeLeaseRenewInterval"
+
 	// owner: @harche
 	// kep: http://kep.k8s.io/3386
 	// alpha: v1.25
@@ -1000,6 +1007,8 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	DevicePluginCDIDevices: {Default: true, PreRelease: featuregate.Beta},
 
 	DynamicResourceAllocation: {Default: false, PreRelease: featuregate.Alpha},
+
+	DynamicNodeLeaseRenewInterval: {Default: true, PreRelease: featuregate.Beta},
 
 	EventedPLEG: {Default: false, PreRelease: featuregate.Alpha},
 


### PR DESCRIPTION
Lease renew policies can be used to specify how the lease renew interval is decided.

The default and previous policy is using a fixed renew interval, which updates lease for every 1/4 `nodeLeaseDurationSeconds` or `renewInterval` provided in NewController().

A new policy is added in this commit to have dynamic renew intervals, which starts with 1/2 `nodeLeaseDurationSeconds` and decreases 50% of previous interval for next retry. It decreases up to 3 times and reset the interval back to the initial.

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
Fixes #123178

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
TODO
```