### PR TITLE
support SV API for CRDs (using workqueue and wait channel)

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/apiserver.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/apiserver.go
@@ -35,6 +35,7 @@ import (
 	openapiv3controller "k8s.io/apiextensions-apiserver/pkg/controller/openapiv3"
 	"k8s.io/apiextensions-apiserver/pkg/controller/status"
 	"k8s.io/apiextensions-apiserver/pkg/registry/customresourcedefinition"
+	"k8s.io/apiextensions-apiserver/pkg/storageversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -43,11 +44,19 @@ import (
 	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/apiserver/pkg/endpoints/discovery"
 	"k8s.io/apiserver/pkg/endpoints/discovery/aggregated"
+	"k8s.io/apiserver/pkg/features"
 	genericregistry "k8s.io/apiserver/pkg/registry/generic"
 	"k8s.io/apiserver/pkg/registry/rest"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	serverstorage "k8s.io/apiserver/pkg/server/storage"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/apiserver/pkg/util/webhook"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	storageversionUpdateWorkers = 5
 )
 
 var (
@@ -108,6 +117,8 @@ type CustomResourceDefinitions struct {
 
 	// provided for easier embedding
 	Informers externalinformers.SharedInformerFactory
+
+	StorageVersionInformers informers.SharedInformerFactory
 }
 
 // Complete fills in any fields not set that are required to have valid data. It's mutating the receiver.
@@ -174,6 +185,12 @@ func (c completedConfig) New(delegationTarget genericapiserver.DelegationTarget)
 	}
 	s.Informers = externalinformers.NewSharedInformerFactory(crdClient, 5*time.Minute)
 
+	kubeclientset, err := kubernetes.NewForConfig(s.GenericAPIServer.LoopbackClientConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create clientset for storage versions: %w", err)
+	}
+	s.StorageVersionInformers = informers.NewSharedInformerFactory(kubeclientset, time.Second)
+
 	delegateHandler := delegationTarget.UnprotectedHandler()
 	if delegateHandler == nil {
 		delegateHandler = http.NotFoundHandler()
@@ -188,10 +205,21 @@ func (c completedConfig) New(delegationTarget genericapiserver.DelegationTarget)
 		delegate:  delegateHandler,
 	}
 	establishingController := establish.NewEstablishingController(s.Informers.Apiextensions().V1().CustomResourceDefinitions(), crdClient.ApiextensionsV1())
+
+	crdInformer := s.Informers.Apiextensions().V1().CustomResourceDefinitions()
+	svInformer := s.StorageVersionInformers.Internal().V1alpha1().StorageVersions()
+
+	var storageVersionManager *storageversion.Manager
+	if utilfeature.DefaultFeatureGate.Enabled(features.StorageVersionAPI) &&
+		utilfeature.DefaultFeatureGate.Enabled(features.APIServerIdentity) {
+		sc := kubeclientset.InternalV1alpha1().StorageVersions()
+		storageVersionManager = storageversion.NewManager(sc, c.GenericConfig.APIServerID, crdInformer, svInformer)
+	}
+
 	crdHandler, err := NewCustomResourceDefinitionHandler(
 		versionDiscoveryHandler,
 		groupDiscoveryHandler,
-		s.Informers.Apiextensions().V1().CustomResourceDefinitions(),
+		crdInformer,
 		delegateHandler,
 		c.ExtraConfig.CRDRESTOptionsGetter,
 		c.GenericConfig.AdmissionControl,
@@ -204,6 +232,7 @@ func (c completedConfig) New(delegationTarget genericapiserver.DelegationTarget)
 		time.Duration(c.GenericConfig.MinRequestTimeout)*time.Second,
 		apiGroupInfo.StaticOpenAPISpec,
 		c.GenericConfig.MaxRequestBodyBytes,
+		storageVersionManager,
 	)
 	if err != nil {
 		return nil, err
@@ -228,6 +257,10 @@ func (c completedConfig) New(delegationTarget genericapiserver.DelegationTarget)
 
 	s.GenericAPIServer.AddPostStartHookOrDie("start-apiextensions-informers", func(context genericapiserver.PostStartHookContext) error {
 		s.Informers.Start(context.StopCh)
+		if utilfeature.DefaultFeatureGate.Enabled(features.StorageVersionAPI) &&
+			utilfeature.DefaultFeatureGate.Enabled(features.APIServerIdentity) {
+			s.StorageVersionInformers.Start(context.StopCh)
+		}
 		return nil
 	})
 	s.GenericAPIServer.AddPostStartHookOrDie("start-apiextensions-controllers", func(context genericapiserver.PostStartHookContext) error {
@@ -252,6 +285,11 @@ func (c completedConfig) New(delegationTarget genericapiserver.DelegationTarget)
 		go nonStructuralSchemaController.Run(5, context.StopCh)
 		go apiApprovalController.Run(5, context.StopCh)
 		go finalizingController.Run(5, context.StopCh)
+
+		if utilfeature.DefaultFeatureGate.Enabled(features.StorageVersionAPI) &&
+			utilfeature.DefaultFeatureGate.Enabled(features.APIServerIdentity) {
+			go crdHandler.storageVersionManager.Sync(context.StopCh, storageversionUpdateWorkers)
+		}
 
 		discoverySyncedCh := make(chan struct{})
 		go discoveryController.Run(context.StopCh, discoverySyncedCh)

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler.go
@@ -36,7 +36,7 @@ import (
 	schemaobjectmeta "k8s.io/apiextensions-apiserver/pkg/apiserver/schema/objectmeta"
 	structuralpruning "k8s.io/apiextensions-apiserver/pkg/apiserver/schema/pruning"
 	apiservervalidation "k8s.io/apiextensions-apiserver/pkg/apiserver/validation"
-	informers "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/apiextensions/v1"
+	crdinformers "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/apiextensions/v1"
 	listers "k8s.io/apiextensions-apiserver/pkg/client/listers/apiextensions/v1"
 	"k8s.io/apiextensions-apiserver/pkg/controller/establish"
 	"k8s.io/apiextensions-apiserver/pkg/controller/finalizer"
@@ -44,6 +44,7 @@ import (
 	"k8s.io/apiextensions-apiserver/pkg/crdserverscheme"
 	"k8s.io/apiextensions-apiserver/pkg/registry/customresource"
 	"k8s.io/apiextensions-apiserver/pkg/registry/customresource/tableconvertor"
+	"k8s.io/apiextensions-apiserver/pkg/storageversion"
 
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -69,8 +70,10 @@ import (
 	"k8s.io/apiserver/pkg/endpoints/handlers/responsewriters"
 	"k8s.io/apiserver/pkg/endpoints/metrics"
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/apiserver/pkg/features"
 	"k8s.io/apiserver/pkg/registry/generic"
 	genericfilters "k8s.io/apiserver/pkg/server/filters"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/apiserver/pkg/util/webhook"
 	"k8s.io/apiserver/pkg/warning"
 	"k8s.io/client-go/scale"
@@ -125,10 +128,15 @@ type crdHandler struct {
 	// The limit on the request size that would be accepted and decoded in a write request
 	// 0 means no limit.
 	maxRequestBodyBytes int64
+
+	// storageVersionManager manages CRD StorageVersion updates.
+	storageVersionManager *storageversion.Manager
 }
 
 // crdInfo stores enough information to serve the storage for the custom resource
 type crdInfo struct {
+	// name of the CRD.
+	name string
 	// spec and acceptedNames are used to compare against if a change is made on a CRD. We only update
 	// the storage if one of these changes.
 	spec          *apiextensionsv1.CustomResourceDefinitionSpec
@@ -156,6 +164,8 @@ type crdInfo struct {
 	storageVersion string
 
 	waitGroup *utilwaitgroup.SafeWaitGroup
+
+	storageVersionProcessed chan struct{}
 }
 
 // crdStorageMap goes from customresourcedefinition to its storage
@@ -164,7 +174,7 @@ type crdStorageMap map[types.UID]*crdInfo
 func NewCustomResourceDefinitionHandler(
 	versionDiscoveryHandler *versionDiscoveryHandler,
 	groupDiscoveryHandler *groupDiscoveryHandler,
-	crdInformer informers.CustomResourceDefinitionInformer,
+	crdInformer crdinformers.CustomResourceDefinitionInformer,
 	delegate http.Handler,
 	restOptionsGetter generic.RESTOptionsGetter,
 	admission admission.Interface,
@@ -176,7 +186,8 @@ func NewCustomResourceDefinitionHandler(
 	requestTimeout time.Duration,
 	minRequestTimeout time.Duration,
 	staticOpenAPISpec map[string]*spec.Schema,
-	maxRequestBodyBytes int64) (*crdHandler, error) {
+	maxRequestBodyBytes int64,
+	storageVersionManager *storageversion.Manager) (*crdHandler, error) {
 	ret := &crdHandler{
 		versionDiscoveryHandler: versionDiscoveryHandler,
 		groupDiscoveryHandler:   groupDiscoveryHandler,
@@ -192,14 +203,14 @@ func NewCustomResourceDefinitionHandler(
 		minRequestTimeout:       minRequestTimeout,
 		staticOpenAPISpec:       staticOpenAPISpec,
 		maxRequestBodyBytes:     maxRequestBodyBytes,
+		storageVersionManager:   storageVersionManager,
 	}
 	crdInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    ret.createCustomResourceDefinition,
 		UpdateFunc: ret.updateCustomResourceDefinition,
-		DeleteFunc: func(obj interface{}) {
-			ret.removeDeadStorage()
-		},
+		DeleteFunc: ret.deleteCustomResourceDefinition,
 	})
+
 	crConverterFactory, err := conversion.NewCRConverterFactory(serviceResolver, authResolverWrapper)
 	if err != nil {
 		return nil, err
@@ -207,7 +218,6 @@ func NewCustomResourceDefinitionHandler(
 	ret.converterFactory = crConverterFactory
 
 	ret.customStorage.Store(crdStorageMap{})
-
 	return ret, nil
 }
 
@@ -290,8 +300,6 @@ func (r *crdHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	terminating := apiextensionshelpers.IsCRDConditionTrue(crd, apiextensionsv1.Terminating)
-
 	crdInfo, err := r.getOrCreateServingInfoFor(crd.UID, crd.Name)
 	if apierrors.IsNotFound(err) {
 		r.delegate.ServeHTTP(w, req)
@@ -337,11 +345,11 @@ func (r *crdHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	}
 	switch {
 	case subresource == "status" && subresources != nil && subresources.Status != nil:
-		handlerFunc = r.serveStatus(w, req, requestInfo, crdInfo, terminating, supportedTypes)
+		handlerFunc = r.serveStatus(w, req, requestInfo, crdInfo, crd, supportedTypes)
 	case subresource == "scale" && subresources != nil && subresources.Scale != nil:
-		handlerFunc = r.serveScale(w, req, requestInfo, crdInfo, terminating, supportedTypes)
+		handlerFunc = r.serveScale(w, req, requestInfo, crdInfo, crd, supportedTypes)
 	case len(subresource) == 0:
-		handlerFunc = r.serveResource(w, req, requestInfo, crdInfo, crd, terminating, supportedTypes)
+		handlerFunc = r.serveResource(w, req, requestInfo, crdInfo, crd, supportedTypes)
 	default:
 		responsewriters.ErrorNegotiated(
 			apierrors.NewNotFound(schema.GroupResource{Group: requestInfo.APIGroup, Resource: requestInfo.Resource}, requestInfo.Name),
@@ -357,7 +365,7 @@ func (r *crdHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	}
 }
 
-func (r *crdHandler) serveResource(w http.ResponseWriter, req *http.Request, requestInfo *apirequest.RequestInfo, crdInfo *crdInfo, crd *apiextensionsv1.CustomResourceDefinition, terminating bool, supportedTypes []string) http.HandlerFunc {
+func (r *crdHandler) serveResource(w http.ResponseWriter, req *http.Request, requestInfo *apirequest.RequestInfo, crdInfo *crdInfo, crd *apiextensionsv1.CustomResourceDefinition, supportedTypes []string) http.HandlerFunc {
 	requestScope := crdInfo.requestScopes[requestInfo.APIVersion]
 	storage := crdInfo.storages[requestInfo.APIVersion].CustomResource
 
@@ -378,21 +386,52 @@ func (r *crdHandler) serveResource(w http.ResponseWriter, req *http.Request, req
 		if justCreated {
 			time.Sleep(2 * time.Second)
 		}
-		if terminating {
+		if apiextensionshelpers.IsCRDConditionTrue(crd, apiextensionsv1.Terminating) {
 			err := apierrors.NewMethodNotSupported(schema.GroupResource{Group: requestInfo.APIGroup, Resource: requestInfo.Resource}, requestInfo.Verb)
 			err.ErrStatus.Message = fmt.Sprintf("%v not allowed while custom resource definition is terminating", requestInfo.Verb)
 			responsewriters.ErrorNegotiated(err, Codecs, schema.GroupVersion{Group: requestInfo.APIGroup, Version: requestInfo.APIVersion}, w, req)
 			return nil
 		}
+
+		if !allowMutationRequest(crdInfo) {
+			err := apierrors.NewMethodNotSupported(schema.GroupResource{Group: requestInfo.APIGroup, Resource: requestInfo.Resource}, requestInfo.Verb)
+			err.ErrStatus.Message = fmt.Sprintf("%v not allowed while storageversion is not yet published", requestInfo.Verb)
+			responsewriters.ErrorNegotiated(err, Codecs, schema.GroupVersion{Group: requestInfo.APIGroup, Version: requestInfo.APIVersion}, w, req)
+			return nil
+		}
 		return handlers.CreateResource(storage, requestScope, r.admission)
 	case "update":
+		if !allowMutationRequest(crdInfo) {
+			err := apierrors.NewMethodNotSupported(schema.GroupResource{Group: requestInfo.APIGroup, Resource: requestInfo.Resource}, requestInfo.Verb)
+			err.ErrStatus.Message = fmt.Sprintf("%v not allowed while storageversion is not yet published", requestInfo.Verb)
+			responsewriters.ErrorNegotiated(err, Codecs, schema.GroupVersion{Group: requestInfo.APIGroup, Version: requestInfo.APIVersion}, w, req)
+			return nil
+		}
 		return handlers.UpdateResource(storage, requestScope, r.admission)
 	case "patch":
+		if !allowMutationRequest(crdInfo) {
+			err := apierrors.NewMethodNotSupported(schema.GroupResource{Group: requestInfo.APIGroup, Resource: requestInfo.Resource}, requestInfo.Verb)
+			err.ErrStatus.Message = fmt.Sprintf("%v not allowed while storageversion is not yet published", requestInfo.Verb)
+			responsewriters.ErrorNegotiated(err, Codecs, schema.GroupVersion{Group: requestInfo.APIGroup, Version: requestInfo.APIVersion}, w, req)
+			return nil
+		}
 		return handlers.PatchResource(storage, requestScope, r.admission, supportedTypes)
 	case "delete":
+		if !allowMutationRequest(crdInfo) {
+			err := apierrors.NewMethodNotSupported(schema.GroupResource{Group: requestInfo.APIGroup, Resource: requestInfo.Resource}, requestInfo.Verb)
+			err.ErrStatus.Message = fmt.Sprintf("%v not allowed while storageversion is not yet published", requestInfo.Verb)
+			responsewriters.ErrorNegotiated(err, Codecs, schema.GroupVersion{Group: requestInfo.APIGroup, Version: requestInfo.APIVersion}, w, req)
+			return nil
+		}
 		allowsOptions := true
 		return handlers.DeleteResource(storage, allowsOptions, requestScope, r.admission)
 	case "deletecollection":
+		if !allowMutationRequest(crdInfo) {
+			err := apierrors.NewMethodNotSupported(schema.GroupResource{Group: requestInfo.APIGroup, Resource: requestInfo.Resource}, requestInfo.Verb)
+			err.ErrStatus.Message = fmt.Sprintf("%v not allowed while storageversion is not yet published", requestInfo.Verb)
+			responsewriters.ErrorNegotiated(err, Codecs, schema.GroupVersion{Group: requestInfo.APIGroup, Version: requestInfo.APIVersion}, w, req)
+			return nil
+		}
 		checkBody := true
 		return handlers.DeleteCollection(storage, checkBody, requestScope, r.admission)
 	default:
@@ -404,7 +443,7 @@ func (r *crdHandler) serveResource(w http.ResponseWriter, req *http.Request, req
 	}
 }
 
-func (r *crdHandler) serveStatus(w http.ResponseWriter, req *http.Request, requestInfo *apirequest.RequestInfo, crdInfo *crdInfo, terminating bool, supportedTypes []string) http.HandlerFunc {
+func (r *crdHandler) serveStatus(w http.ResponseWriter, req *http.Request, requestInfo *apirequest.RequestInfo, crdInfo *crdInfo, crd *apiextensionsv1.CustomResourceDefinition, supportedTypes []string) http.HandlerFunc {
 	requestScope := crdInfo.statusRequestScopes[requestInfo.APIVersion]
 	storage := crdInfo.storages[requestInfo.APIVersion].Status
 
@@ -412,8 +451,20 @@ func (r *crdHandler) serveStatus(w http.ResponseWriter, req *http.Request, reque
 	case "get":
 		return handlers.GetResource(storage, requestScope)
 	case "update":
+		if !allowMutationRequest(crdInfo) {
+			err := apierrors.NewMethodNotSupported(schema.GroupResource{Group: requestInfo.APIGroup, Resource: requestInfo.Resource}, requestInfo.Verb)
+			err.ErrStatus.Message = fmt.Sprintf("%v not allowed while storageversion is not yet published", requestInfo.Verb)
+			responsewriters.ErrorNegotiated(err, Codecs, schema.GroupVersion{Group: requestInfo.APIGroup, Version: requestInfo.APIVersion}, w, req)
+			return nil
+		}
 		return handlers.UpdateResource(storage, requestScope, r.admission)
 	case "patch":
+		if !allowMutationRequest(crdInfo) {
+			err := apierrors.NewMethodNotSupported(schema.GroupResource{Group: requestInfo.APIGroup, Resource: requestInfo.Resource}, requestInfo.Verb)
+			err.ErrStatus.Message = fmt.Sprintf("%v not allowed while storageversion is not yet published", requestInfo.Verb)
+			responsewriters.ErrorNegotiated(err, Codecs, schema.GroupVersion{Group: requestInfo.APIGroup, Version: requestInfo.APIVersion}, w, req)
+			return nil
+		}
 		return handlers.PatchResource(storage, requestScope, r.admission, supportedTypes)
 	default:
 		responsewriters.ErrorNegotiated(
@@ -424,7 +475,7 @@ func (r *crdHandler) serveStatus(w http.ResponseWriter, req *http.Request, reque
 	}
 }
 
-func (r *crdHandler) serveScale(w http.ResponseWriter, req *http.Request, requestInfo *apirequest.RequestInfo, crdInfo *crdInfo, terminating bool, supportedTypes []string) http.HandlerFunc {
+func (r *crdHandler) serveScale(w http.ResponseWriter, req *http.Request, requestInfo *apirequest.RequestInfo, crdInfo *crdInfo, crd *apiextensionsv1.CustomResourceDefinition, supportedTypes []string) http.HandlerFunc {
 	requestScope := crdInfo.scaleRequestScopes[requestInfo.APIVersion]
 	storage := crdInfo.storages[requestInfo.APIVersion].Scale
 
@@ -432,8 +483,20 @@ func (r *crdHandler) serveScale(w http.ResponseWriter, req *http.Request, reques
 	case "get":
 		return handlers.GetResource(storage, requestScope)
 	case "update":
+		if !allowMutationRequest(crdInfo) {
+			err := apierrors.NewMethodNotSupported(schema.GroupResource{Group: requestInfo.APIGroup, Resource: requestInfo.Resource}, requestInfo.Verb)
+			err.ErrStatus.Message = fmt.Sprintf("%v not allowed while storageversion is not yet published", requestInfo.Verb)
+			responsewriters.ErrorNegotiated(err, Codecs, schema.GroupVersion{Group: requestInfo.APIGroup, Version: requestInfo.APIVersion}, w, req)
+			return nil
+		}
 		return handlers.UpdateResource(storage, requestScope, r.admission)
 	case "patch":
+		if !allowMutationRequest(crdInfo) {
+			err := apierrors.NewMethodNotSupported(schema.GroupResource{Group: requestInfo.APIGroup, Resource: requestInfo.Resource}, requestInfo.Verb)
+			err.ErrStatus.Message = fmt.Sprintf("%v not allowed while storageversion is not yet published", requestInfo.Verb)
+			responsewriters.ErrorNegotiated(err, Codecs, schema.GroupVersion{Group: requestInfo.APIGroup, Version: requestInfo.APIVersion}, w, req)
+			return nil
+		}
 		return handlers.PatchResource(storage, requestScope, r.admission, supportedTypes)
 	default:
 		responsewriters.ErrorNegotiated(
@@ -441,6 +504,22 @@ func (r *crdHandler) serveScale(w http.ResponseWriter, req *http.Request, reques
 			Codecs, schema.GroupVersion{Group: requestInfo.APIGroup, Version: requestInfo.APIVersion}, w, req,
 		)
 		return nil
+	}
+}
+
+// allowMutationRequest checks if the handler is allowed to serve without waiting for latest storageversion udpate.
+func allowMutationRequest(crdInfo *crdInfo) bool {
+	if !utilfeature.DefaultFeatureGate.Enabled(features.StorageVersionAPI) ||
+		!utilfeature.DefaultFeatureGate.Enabled(features.APIServerIdentity) {
+		klog.V(4).Infof("not checking if handler is allowed to serve since StorageVersionAPI and/or APIServerIdentity feature are disabled.")
+		return true
+	}
+
+	select {
+	case <-crdInfo.storageVersionProcessed:
+		return true
+	default:
+		return false
 	}
 }
 
@@ -453,6 +532,13 @@ func (r *crdHandler) createCustomResourceDefinition(obj interface{}) {
 	storageMap := r.customStorage.Load().(crdStorageMap)
 	oldInfo, found := storageMap[crd.UID]
 	if !found {
+		crdInfo, err := r.createServingInfoFor(crd.Name)
+		if err != nil {
+			klog.Errorf("createCustomResourceDefinition failed, error creating new handler: %v", err)
+			return
+		}
+		crdInfo.storageVersionProcessed = make(chan struct{})
+		r.queueCRDForSVUpdate(crd, crdInfo.storageVersionProcessed)
 		return
 	}
 	if apiequality.Semantic.DeepEqual(&crd.Spec, oldInfo.spec) && apiequality.Semantic.DeepEqual(&crd.Status.AcceptedNames, oldInfo.acceptedNames) {
@@ -460,7 +546,17 @@ func (r *crdHandler) createCustomResourceDefinition(obj interface{}) {
 			crd.Name)
 		return
 	}
-	r.removeStorage_locked(crd.UID)
+	// Tear down the old storage
+	r.removeStorageLockedAndQueueSVUpdate(crd.UID, crd)
+
+	// Create new handler.
+	crdInfo, err := r.createServingInfoFor(crd.Name)
+	if err != nil {
+		klog.Errorf("createCustomResourceDefinition failed, error creating new handler: %v", err)
+		return
+	}
+	crdInfo.storageVersionProcessed = make(chan struct{})
+	r.queueCRDForSVUpdate(crd, crdInfo.storageVersionProcessed)
 }
 
 // updateCustomResourceDefinition removes potentially stale storage so it gets re-created
@@ -485,39 +581,76 @@ func (r *crdHandler) updateCustomResourceDefinition(oldObj, newObj interface{}) 
 	}
 
 	if oldCRD.UID != newCRD.UID {
-		r.removeStorage_locked(oldCRD.UID)
+		r.removeStorageLockedAndQueueSVUpdate(oldCRD.UID, nil)
 	}
 
 	storageMap := r.customStorage.Load().(crdStorageMap)
 	oldInfo, found := storageMap[newCRD.UID]
 	if !found {
+		crdInfo, err := r.createServingInfoFor(newCRD.Name)
+		if err != nil {
+			klog.Errorf("updateCustomResourceDefinition failed, error creating new handler: %v", err)
+		}
+		crdInfo.storageVersionProcessed = make(chan struct{})
+		r.queueCRDForSVUpdate(newCRD, crdInfo.storageVersionProcessed)
 		return
 	}
 	if apiequality.Semantic.DeepEqual(&newCRD.Spec, oldInfo.spec) && apiequality.Semantic.DeepEqual(&newCRD.Status.AcceptedNames, oldInfo.acceptedNames) {
-		klog.V(6).Infof("Ignoring customresourcedefinition %s update because neither spec, nor accepted names changed", oldCRD.Name)
+		klog.V(6).Infof("Ignoring updateCustomResourceDefinition %s update because neither spec, nor accepted names changed", oldCRD.Name)
+		return
+	}
+	// Tear down the old storage
+	r.removeStorageLockedAndQueueSVUpdate(newCRD.UID, newCRD)
+
+	// Create new handler.
+	crdInfo, err := r.createServingInfoFor(newCRD.Name)
+	if err != nil {
+		klog.Errorf("updateCustomResourceDefinition failed, error creating new handler: %v", err)
+	}
+	crdInfo.storageVersionProcessed = make(chan struct{})
+	r.queueCRDForSVUpdate(newCRD, crdInfo.storageVersionProcessed)
+}
+
+func (r *crdHandler) queueCRDForSVUpdate(crd *apiextensionsv1.CustomResourceDefinition, svProcessed chan struct{}) {
+	if crd == nil {
 		return
 	}
 
-	klog.V(4).Infof("Updating customresourcedefinition %s", newCRD.Name)
-	r.removeStorage_locked(newCRD.UID)
+	if utilfeature.DefaultFeatureGate.Enabled(features.StorageVersionAPI) &&
+		utilfeature.DefaultFeatureGate.Enabled(features.APIServerIdentity) {
+		r.storageVersionManager.UpdateSVUpdateInfoAndEnqueue(crd, svProcessed)
+	}
 }
 
-// removeStorage_locked removes the cached storage with the given uid as key from the storage map. This function
-// updates r.customStorage with the cleaned-up storageMap and tears down the old storage.
+func (r *crdHandler) deleteStorageVersionUpdateInfo(crdName string) {
+	if utilfeature.DefaultFeatureGate.Enabled(features.StorageVersionAPI) &&
+		utilfeature.DefaultFeatureGate.Enabled(features.APIServerIdentity) {
+		r.storageVersionManager.DeleteSVUpdateInfo(crdName)
+	}
+}
+
+func (r *crdHandler) deleteCustomResourceDefinition(obj interface{}) {
+	r.removeDeadStorage()
+}
+
+// removeStorageLockedAndQueueSVUpdate removes the cached storage with the given uid as key from the storage map.
+// This function updates r.customStorage with the cleaned-up storageMap and tears down
+// the old storage.
+// Afer the teardown finishes, it enqueues the specified CRD for SV update.
 // NOTE: Caller MUST hold r.customStorageLock to write r.customStorage thread-safely.
-func (r *crdHandler) removeStorage_locked(uid types.UID) {
+func (r *crdHandler) removeStorageLockedAndQueueSVUpdate(oldUID types.UID, newCRD *apiextensionsv1.CustomResourceDefinition) {
 	storageMap := r.customStorage.Load().(crdStorageMap)
-	if oldInfo, ok := storageMap[uid]; ok {
+	if oldInfo, ok := storageMap[oldUID]; ok {
 		// Copy because we cannot write to storageMap without a race
 		// as it is used without locking elsewhere.
 		storageMap2 := storageMap.clone()
 
 		// Remove from the CRD info map and store the map
-		delete(storageMap2, uid)
+		delete(storageMap2, oldUID)
 		r.customStorage.Store(storageMap2)
 
 		// Tear down the old storage
-		go r.tearDown(oldInfo)
+		go r.tearDownAndQueueSVUpdate(oldInfo, newCRD)
 	}
 }
 
@@ -545,13 +678,22 @@ func (r *crdHandler) removeDeadStorage() {
 	for uid, crdInfo := range storageMap {
 		if _, ok := storageMap2[uid]; !ok {
 			klog.V(4).Infof("Removing dead CRD storage for %s/%s", crdInfo.spec.Group, crdInfo.spec.Names.Kind)
-			go r.tearDown(crdInfo)
+			go r.tearDownAndQueueSVUpdate(crdInfo, nil)
 		}
 	}
 }
 
 // Wait up to a minute for requests to drain, then tear down storage
-func (r *crdHandler) tearDown(oldInfo *crdInfo) {
+func (r *crdHandler) tearDownAndQueueSVUpdate(oldInfo *crdInfo, newCRD *apiextensionsv1.CustomResourceDefinition) {
+	r.updateActiveTeardownsCount(oldInfo.name, 1)
+	defer r.updateActiveTeardownsCount(oldInfo.name, -1)
+
+	if newCRD != nil {
+		defer r.queueCRDForSVUpdate(newCRD, nil)
+	} else {
+		defer r.deleteStorageVersionUpdateInfo(oldInfo.name)
+	}
+
 	requestsDrained := make(chan struct{})
 	go func() {
 		defer close(requestsDrained)
@@ -570,6 +712,26 @@ func (r *crdHandler) tearDown(oldInfo *crdInfo) {
 	for _, storage := range oldInfo.storages {
 		// destroy only the main storage. Those for the subresources share cacher and etcd clients.
 		storage.CustomResource.DestroyFunc()
+	}
+}
+
+func (r *crdHandler) deleteTeardownsCountEntry(crdName string) {
+	if utilfeature.DefaultFeatureGate.Enabled(features.StorageVersionAPI) &&
+		utilfeature.DefaultFeatureGate.Enabled(features.APIServerIdentity) {
+		r.storageVersionManager.DeleteSVUpdateInfo(crdName)
+	}
+}
+
+func (r *crdHandler) updateActiveTeardownsCount(crdName string, value int) {
+	if crdName == "" {
+		return
+	}
+
+	if utilfeature.DefaultFeatureGate.Enabled(features.StorageVersionAPI) &&
+		utilfeature.DefaultFeatureGate.Enabled(features.APIServerIdentity) {
+		if err := r.storageVersionManager.UpdateActiveTeardownsCount(crdName, value); err != nil {
+			klog.Infof("error while tearing down old storage for crd: %s", crdName)
+		}
 	}
 }
 
@@ -610,6 +772,10 @@ func (r *crdHandler) getOrCreateServingInfoFor(uid types.UID, name string) (*crd
 
 	r.customStorageLock.Lock()
 	defer r.customStorageLock.Unlock()
+	return r.createServingInfoFor(name)
+}
+
+func (r *crdHandler) createServingInfoFor(name string) (*crdInfo, error) {
 
 	// Get the up-to-date CRD when we have the lock, to avoid racing with updateCustomResourceDefinition.
 	// If updateCustomResourceDefinition sees an update and happens later, the storage will be deleted and
@@ -619,10 +785,7 @@ func (r *crdHandler) getOrCreateServingInfoFor(uid types.UID, name string) (*crd
 	if err != nil {
 		return nil, err
 	}
-	storageMap = r.customStorage.Load().(crdStorageMap)
-	if ret, ok := storageMap[crd.UID]; ok {
-		return ret, nil
-	}
+	storageMap := r.customStorage.Load().(crdStorageMap)
 
 	storageVersion, err := apiextensionshelpers.GetCRDStorageVersion(crd)
 	if err != nil {
@@ -654,13 +817,13 @@ func (r *crdHandler) getOrCreateServingInfoFor(uid types.UID, name string) (*crd
 			return nil, fmt.Errorf("failed converting CRD validation to internal version: %v", err)
 		}
 		s, err := structuralschema.NewStructural(internalValidation.OpenAPIV3Schema)
-		if crd.Spec.PreserveUnknownFields == false && err != nil {
+		if !crd.Spec.PreserveUnknownFields && err != nil {
 			// This should never happen. If it does, it is a programming error.
 			utilruntime.HandleError(fmt.Errorf("failed to convert schema to structural: %v", err))
 			return nil, fmt.Errorf("the server could not properly serve the CR schema") // validation should avoid this
 		}
 
-		if crd.Spec.PreserveUnknownFields == false {
+		if !crd.Spec.PreserveUnknownFields {
 			// we don't own s completely, e.g. defaults are not deep-copied. So better make a copy here.
 			s = s.DeepCopy()
 
@@ -1012,6 +1175,7 @@ func (r *crdHandler) getOrCreateServingInfoFor(uid types.UID, name string) (*crd
 	}
 
 	ret := &crdInfo{
+		name:                crd.Name,
 		spec:                &crd.Spec,
 		acceptedNames:       &crd.Status.AcceptedNames,
 		storages:            storages,

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler_test.go
@@ -509,7 +509,8 @@ func testHandlerConversion(t *testing.T, enableWatchCache bool) {
 		func(r webhook.AuthenticationInfoResolver) webhook.AuthenticationInfoResolver { return r },
 		1,
 		dummyAuthorizerImpl{},
-		time.Minute, time.Minute, nil, 3*1024*1024)
+		time.Minute, time.Minute, nil, 3*1024*1024,
+		nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/storageversion/manager.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/storageversion/manager.go
@@ -1,0 +1,268 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storageversion
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
+
+	apiserverinternalv1alpha1 "k8s.io/api/apiserverinternal/v1alpha1"
+	apiextensionshelpers "k8s.io/apiextensions-apiserver/pkg/apihelpers"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	crdinformers "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	genericstorageversion "k8s.io/apiserver/pkg/storageversion"
+	svInformers "k8s.io/client-go/informers/apiserverinternal/v1alpha1"
+)
+
+var (
+	// workerFrequency is the frequency at which the worker for updating storageversion for a CRD
+	// will be called.
+	workerFrequency = 1 * time.Second
+)
+
+// Manager maintains necessary structures needed for updating
+// StorageVersion for CRDs. It does goroutine management to allow CRD
+// storage version updates running in the background and not blocking the caller.
+type Manager struct {
+	// client is the client interface that manager uses to update
+	// StorageVersion objects.
+	client genericstorageversion.Client
+	// apiserverID is the ID of the apiserver that invokes this manager.
+	apiserverID string
+	crdInformer crdinformers.CustomResourceDefinitionInformer
+	svInformer  svInformers.StorageVersionInformer
+	// workqueue to process storageversion updates for this CRD.
+	queue *workqueue.Type
+	// map from crd.Name -> number of active teardowns for this CRD.
+	storageVersionUpdateInfoMap sync.Map
+}
+
+type storageVersionUpdateInfo struct {
+	crd *apiextensionsv1.CustomResourceDefinition
+	// processedCh is closed by the storage version manager after the
+	// storage version update gets processed successfully.
+	// The API server will unblock and allow CR write requests if this
+	// channel is closed.
+	processedCh chan struct{}
+
+	// teardownFinishedCh is closed when the teardown of a previous
+	// storageversion completes. This is used by the storageversion manager
+	// to unblock publishing of the latest storageversion.
+	teardownCount int
+}
+
+// NewManager creates a CRD StorageVersion Manager.
+func NewManager(svClient genericstorageversion.Client, apiserverID string,
+	crdInformer crdinformers.CustomResourceDefinitionInformer, svInformer svInformers.StorageVersionInformer) *Manager {
+	return &Manager{
+		client:                      svClient,
+		apiserverID:                 apiserverID,
+		crdInformer:                 crdInformer,
+		svInformer:                  svInformer,
+		queue:                       workqueue.NewNamed("storageversion-updater"),
+		storageVersionUpdateInfoMap: sync.Map{},
+	}
+}
+
+// UpdateActiveTeardownsCount updates the teardown count of the CRD in sync.Map.
+func (m *Manager) UpdateActiveTeardownsCount(crdName string, value int) error {
+	val, ok := m.storageVersionUpdateInfoMap.Load(crdName)
+	if !ok {
+		return fmt.Errorf("error while trying to update number of teardowns. No entry found in sync.Map for %v", crdName)
+	}
+	svInfo := val.(*storageVersionUpdateInfo)
+	svInfo.teardownCount += value
+	return nil
+}
+
+func (m *Manager) UpdateSVUpdateInfoAndEnqueue(crd *apiextensionsv1.CustomResourceDefinition, processedCh chan struct{}) {
+	val, _ := m.storageVersionUpdateInfoMap.LoadOrStore(crd.Name, &storageVersionUpdateInfo{})
+	svInfo := val.(*storageVersionUpdateInfo)
+	svInfo.crd = crd
+	if processedCh != nil {
+		svInfo.processedCh = processedCh
+	}
+	m.enqueue(crd.Name)
+}
+
+// enqueue adds the CRD name to the SV upadte queue.
+func (m *Manager) enqueue(crdName string) {
+	if crdName == "" {
+		return
+	}
+	klog.V(4).Infof("enqueueing crd %s for storageversion update", crdName)
+	m.queue.Add(crdName)
+}
+
+// Sync runs a goroutine over the SV updater queue to indefinitely
+// process any queued storageversion updates unless stopCh is invoked.
+func (m *Manager) Sync(stopCh <-chan struct{}, workers int) {
+	defer m.queue.ShutDownWithDrain()
+	klog.V(2).Infof("starting storageversion sync loop")
+	for i := 0; i < workers; i++ {
+		go wait.Until(func() {
+			m.worker()
+		}, workerFrequency, stopCh)
+	}
+
+	<-stopCh
+}
+
+// DeleteTeardownCountInfo deletes specified key from the sync.Map.
+func (m *Manager) DeleteSVUpdateInfo(crdName string) {
+	m.storageVersionUpdateInfoMap.Delete(crdName)
+}
+
+func (m *Manager) worker() {
+	for m.processLatestUpdateFor() {
+	}
+}
+
+func (m *Manager) processLatestUpdateFor() bool {
+	ctx := context.TODO()
+	key, quit := m.queue.Get()
+	defer m.queue.Done(key)
+	if quit {
+		return false
+	}
+
+	// Fetch the latest CRD from storageVersionUpdateInfoMap to update the storageversion for it.
+	val, ok := m.storageVersionUpdateInfoMap.Load(key)
+	if !ok {
+		klog.V(4).Infof("No pending storageversion update found for crdUID: %s, returning", key)
+		return true
+	}
+	latestSVUpdateInfo := val.(*storageVersionUpdateInfo)
+
+	skip, reason := m.shouldSkipSVUpdate(latestSVUpdateInfo)
+	if skip {
+		klog.V(4).Infof("skipping storagversion update for crd: %s, reason: %s ", latestSVUpdateInfo.crd.Name, reason)
+		return true
+	}
+
+	klog.V(4).Infof("starting storageversion update for crd: %s", latestSVUpdateInfo.crd.Name)
+	err := m.updateStorageVersion(ctx, latestSVUpdateInfo.crd)
+	if err == nil {
+		klog.V(4).Infof("successfully updated storage version for %s", latestSVUpdateInfo.crd.Name)
+		close(latestSVUpdateInfo.processedCh)
+		return true
+	}
+
+	// TODO: indefinitely requeue on error?
+	m.enqueue(latestSVUpdateInfo.crd.Name)
+	return true
+}
+
+func (m *Manager) shouldSkipSVUpdate(svUpdateInfo *storageVersionUpdateInfo) (bool, string) {
+	skip, teardownCount := m.teardownInProgress(svUpdateInfo.crd.Name)
+	if skip {
+		return true, fmt.Sprintf("%d active teardowns", teardownCount)
+	}
+
+	if m.alreadyPublishedLatestSV(svUpdateInfo) {
+		return true, "already at latest storageversion"
+	}
+
+	return false, ""
+}
+
+func (m *Manager) alreadyPublishedLatestSV(svUpdateInfo *storageVersionUpdateInfo) bool {
+	select {
+	case <-svUpdateInfo.processedCh:
+		klog.V(4).Infof("Storageversion is already updated to the latest value for crd: %s, returning", svUpdateInfo.crd.Name)
+		return true
+	default:
+		return false
+	}
+}
+
+func (m *Manager) teardownInProgress(crdName string) (bool, int) {
+	val, _ := m.storageVersionUpdateInfoMap.LoadOrStore(crdName, 0)
+	svUpdateInfo := val.(*storageVersionUpdateInfo)
+	activeTeardownsCount := svUpdateInfo.teardownCount
+	if svUpdateInfo.teardownCount > 0 {
+		return true, activeTeardownsCount
+	}
+
+	return false, activeTeardownsCount
+}
+
+// updateStorageVersion updates a StorageVersion for the given CRD.
+func (m *Manager) updateStorageVersion(ctx context.Context, crd *apiextensionsv1.CustomResourceDefinition) error {
+	if err := m.updateCRDStorageVersion(ctx, crd); err != nil {
+		return fmt.Errorf("error while updating storage version for crd %v: %w", crd, err)
+	}
+
+	return nil
+}
+
+func (m *Manager) updateCRDStorageVersion(ctx context.Context, crd *apiextensionsv1.CustomResourceDefinition) error {
+	gr := schema.GroupResource{
+		Group:    crd.Spec.Group,
+		Resource: crd.Spec.Names.Plural,
+	}
+	storageVersion, err := apiextensionshelpers.GetCRDStorageVersion(crd)
+
+	if err != nil {
+		// This should never happen if crd is valid, which is true since we
+		// only update storage version for CRDs that have been written to the
+		// storage.
+		return err
+	}
+
+	encodingVersion := crd.Spec.Group + "/" + storageVersion
+	var servedVersions, decodableVersions []string
+	for _, v := range crd.Spec.Versions {
+		decodableVersions = append(decodableVersions, crd.Spec.Group+"/"+v.Name)
+		if v.Served {
+			servedVersions = append(servedVersions, crd.Spec.Group+"/"+v.Name)
+		}
+	}
+
+	appendOwnerRefFunc := func(sv *apiserverinternalv1alpha1.StorageVersion) error {
+		ref := metav1.OwnerReference{
+			APIVersion: apiextensionsv1.SchemeGroupVersion.String(),
+			Kind:       "CustomResourceDefinition",
+			Name:       crd.Name,
+			UID:        crd.UID,
+		}
+		for _, r := range sv.OwnerReferences {
+			if r == ref {
+				return nil
+			}
+		}
+		sv.OwnerReferences = append(sv.OwnerReferences, ref)
+		return nil
+	}
+	return genericstorageversion.UpdateStorageVersionFor(
+		ctx,
+		m.client,
+		m.apiserverID,
+		gr,
+		encodingVersion,
+		decodableVersions,
+		servedVersions,
+		appendOwnerRefFunc)
+}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/storageversion/manager_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/storageversion/manager_test.go
@@ -1,0 +1,192 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storageversion
+
+import (
+	"fmt"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientsetfake "k8s.io/client-go/kubernetes/fake"
+)
+
+const (
+	apiserverID = "test-server"
+)
+
+func TestUpdateActiveTeardownsCount(t *testing.T) {
+	crdName := "foo"
+	testcases := map[string]struct {
+		crdInfo           *StorageVersionUpdateInfo
+		addTeardownCount  int
+		wantErr           bool
+		wantTeardownCount int
+	}{
+		"increment_teardown_count": {
+			crdInfo: &StorageVersionUpdateInfo{
+				Crd: testCRD("example", crdName, "v1"),
+			},
+			addTeardownCount:  2,
+			wantTeardownCount: 2,
+		},
+		"decrement_teardown_count": {
+			crdInfo: &StorageVersionUpdateInfo{
+				Crd:           testCRD("example", crdName, "v1"),
+				teardownCount: 1,
+			},
+			addTeardownCount:  -1,
+			wantTeardownCount: 0,
+		},
+		"err_if_CRD_not_found": {
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range testcases {
+		stopCh := make(chan struct{})
+		manager := fakeManager()
+		go manager.Sync(stopCh, 1)
+
+		if tc.crdInfo != nil && tc.crdInfo.Crd != nil {
+			manager.storageVersionUpdateInfoMap.Store(crdName, tc.crdInfo)
+		}
+
+		err := manager.UpdateActiveTeardownsCount(crdName, tc.addTeardownCount)
+		if tc.wantErr != (err != nil) {
+			t.Fatalf("result mismatch, got err:%v, want:%v", err, tc.wantErr)
+		}
+
+		if err == nil {
+			val, ok := manager.storageVersionUpdateInfoMap.Load(crdName)
+			if !ok {
+				t.Fatalf("svUpdateInfo not found for crd:%v", crdName)
+			}
+			svUpdateInfo := val.(*StorageVersionUpdateInfo)
+			gotTeardownCount := svUpdateInfo.teardownCount
+			if gotTeardownCount != tc.wantTeardownCount {
+				t.Errorf("reason mismatch, got teardown count:%v, want:%v", gotTeardownCount, tc.wantTeardownCount)
+			}
+		}
+
+		// cleanup
+		close(stopCh)
+	}
+}
+
+func TestShouldSkipSVUpdate(t *testing.T) {
+	processedFinishedCh := make(chan struct{})
+	close(processedFinishedCh)
+
+	testcases := map[string]struct {
+		crdInfo    *StorageVersionUpdateInfo
+		wantSkip   bool
+		wantReason string
+	}{
+		"true_if_teardown_in_progress": {
+			crdInfo: &StorageVersionUpdateInfo{
+				Crd:           testCRD("example", "foo", "v1"),
+				teardownCount: 1,
+			},
+			wantSkip:   true,
+			wantReason: "1 active teardowns",
+		},
+		"true_if_SV_already_processed": {
+			crdInfo: &StorageVersionUpdateInfo{
+				Crd:         testCRD("example", "foo", "v1"),
+				ProcessedCh: processedFinishedCh,
+			},
+			wantSkip:   true,
+			wantReason: "already at latest storageversion",
+		},
+		"false_if_SV_not_processed": {
+			crdInfo: &StorageVersionUpdateInfo{
+				Crd: testCRD("example", "foo", "v1"),
+			},
+			wantSkip: false,
+		},
+	}
+
+	for _, tc := range testcases {
+		stopCh := make(chan struct{})
+		manager := fakeManager()
+		go manager.Sync(stopCh, 1)
+
+		manager.storageVersionUpdateInfoMap.Store(tc.crdInfo.Crd.Name, tc.crdInfo)
+
+		skip, reason := manager.shouldSkipSVUpdate(tc.crdInfo)
+		if tc.wantSkip != skip {
+			t.Fatalf("result mismatch, got skip:%v, want:%v", skip, tc.wantSkip)
+		}
+
+		if skip {
+			if tc.wantReason != reason {
+				t.Errorf("reason mismatch, got skip:%v, want:%v", reason, tc.wantReason)
+			}
+		}
+
+		// cleanup
+		close(stopCh)
+	}
+}
+
+func fakeManager() *Manager {
+	svClient := clientsetfake.NewSimpleClientset().InternalV1alpha1().StorageVersions()
+	return NewManager(svClient, apiserverID)
+}
+
+func testCRD(group string, name string, version string) *v1.CustomResourceDefinition {
+	crd := &v1.CustomResourceDefinition{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "apiextensions.k8s.io/v1",
+			Kind:       "CustomResourceDefinition",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			UID:  types.UID(name),
+		},
+		Spec: v1.CustomResourceDefinitionSpec{
+			Names: v1.CustomResourceDefinitionNames{
+				Plural: fmt.Sprintf("%ss", name),
+			},
+			Group: group,
+			Scope: v1.ClusterScoped,
+		},
+		Status: v1.CustomResourceDefinitionStatus{
+			Conditions: []v1.CustomResourceDefinitionCondition{
+				{
+					Type:   v1.Established,
+					Status: v1.ConditionTrue,
+				},
+			},
+		},
+	}
+
+	if version != "" {
+		crd.Spec.Versions = []v1.CustomResourceDefinitionVersion{
+			{
+				Name:    version,
+				Served:  true,
+				Storage: true,
+			},
+		}
+	}
+
+	return crd
+}

--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/apiserver.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/apiserver.go
@@ -415,7 +415,7 @@ func (c completedConfig) NewWithDelegate(delegationTarget genericapiserver.Deleg
 				// All apiservers (aggregator-apiserver, kube-apiserver, apiextensions-apiserver)
 				// share the same generic apiserver config. The same StorageVersion manager is used
 				// to register all built-in resources when the generic apiservers install APIs.
-				s.GenericAPIServer.StorageVersionManager.UpdateStorageVersions(hookContext.LoopbackClientConfig, s.GenericAPIServer.APIServerID)
+				s.GenericAPIServer.StorageVersionManager.UpdateStorageVersions(context.TODO(), hookContext.LoopbackClientConfig, s.GenericAPIServer.APIServerID)
 				return false, nil
 			}, hookContext.StopCh)
 			// Once the storage version updater finishes the first round of update,

--- a/test/integration/storageversion/storage_version_crd_test.go
+++ b/test/integration/storageversion/storage_version_crd_test.go
@@ -34,7 +34,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/integration/etcd"
 	"k8s.io/kubernetes/test/integration/framework"
-	"k8s.io/kubernetes/test/utils/ktesting"
 
 	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -44,9 +43,8 @@ import (
 )
 
 func TestStorageVersionCustomResource(t *testing.T) {
-	ktesting.SetDefaultVerbosity(1)
-	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.StorageVersionAPI, true)()
-	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.APIServerIdentity, true)()
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.StorageVersionAPI, true)
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.APIServerIdentity, true)
 	etcdConfig := framework.SharedEtcd()
 	server := kubeapiservertesting.StartTestServerOrDie(t, nil,
 		[]string{
@@ -152,8 +150,8 @@ func TestStorageVersionCustomResource(t *testing.T) {
 }
 
 func TestStorageVersionMultipleCRDs(t *testing.T) {
-	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.StorageVersionAPI, true)()
-	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.APIServerIdentity, true)()
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.StorageVersionAPI, true)
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.APIServerIdentity, true)
 	etcdConfig := framework.SharedEtcd()
 	server := kubeapiservertesting.StartTestServerOrDie(t, nil,
 		[]string{
@@ -257,8 +255,8 @@ func TestStorageVersionMultipleCRDs(t *testing.T) {
 }
 
 func TestWatchAndMutateStorageVersionCRDs(t *testing.T) {
-	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.StorageVersionAPI, true)()
-	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.APIServerIdentity, true)()
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.StorageVersionAPI, true)
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.APIServerIdentity, true)
 	etcdConfig := framework.SharedEtcd()
 	server := kubeapiservertesting.StartTestServerOrDie(t, nil,
 		[]string{

--- a/test/integration/storageversion/storage_version_crd_test.go
+++ b/test/integration/storageversion/storage_version_crd_test.go
@@ -1,0 +1,329 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storageversion
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	apiserverinternalv1alpha1 "k8s.io/api/apiserverinternal/v1alpha1"
+	"k8s.io/apiextensions-apiserver/test/integration/fixtures"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apiserver/pkg/features"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/integration/etcd"
+	"k8s.io/kubernetes/test/integration/framework"
+	"k8s.io/kubernetes/test/utils/ktesting"
+
+	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	kubeapiservertesting "k8s.io/kubernetes/cmd/kube-apiserver/app/testing"
+)
+
+func TestStorageVersionCustomResource(t *testing.T) {
+	ktesting.SetDefaultVerbosity(1)
+	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.StorageVersionAPI, true)()
+	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.APIServerIdentity, true)()
+	etcdConfig := framework.SharedEtcd()
+	server := kubeapiservertesting.StartTestServerOrDie(t, nil,
+		[]string{
+			"--runtime-config=internal.apiserver.k8s.io/v1alpha1=true",
+		},
+		etcdConfig)
+	crdClient := apiextensionsclientset.NewForConfigOrDie(server.ClientConfig)
+	crd := etcd.GetCustomResourceDefinitionData()[0]
+	etcd.CreateTestCRDs(t, crdClient, false, crd)
+	defer server.TearDownFn()
+
+	kubeclient := kubernetes.NewForConfigOrDie(server.ClientConfig)
+	gr := crd.Spec.Group + "." + crd.Spec.Names.Plural
+	createdCRD, err := crdClient.ApiextensionsV1().CustomResourceDefinitions().Get(context.TODO(), crd.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to get crd: %v", err)
+	}
+
+	var lastErr error
+	var storageVersion apiserverinternalv1alpha1.ServerStorageVersion
+
+	if err := wait.PollUntilContextTimeout(context.TODO(), 100*time.Millisecond, 10*time.Second, true, func(ctx context.Context) (bool, error) {
+		sv, err := kubeclient.InternalV1alpha1().StorageVersions().Get(context.TODO(), gr, metav1.GetOptions{})
+		if err != nil {
+			lastErr = fmt.Errorf("failed to get storage version: %w", err)
+			return false, nil
+		}
+		ref := metav1.OwnerReference{
+			APIVersion: "apiextensions.k8s.io/v1",
+			Kind:       "CustomResourceDefinition",
+			Name:       createdCRD.Name,
+			UID:        createdCRD.UID,
+		}
+		if len(sv.OwnerReferences) == 0 || sv.OwnerReferences[0] != ref {
+			return false, fmt.Errorf("apiserver failed to set crd owner references, expect: %v, got: %v", ref, sv.OwnerReferences)
+		}
+		if len(sv.Status.StorageVersions) != 1 {
+			lastErr = fmt.Errorf("apiserver failed to set one storage version record in the status, got: %v", sv.Status.StorageVersions)
+			return false, nil
+		}
+		storageVersion = sv.Status.StorageVersions[0]
+		return true, nil
+	}); err != nil {
+		t.Fatalf("failed to wait for storage version creation: %v, last error: %v", err, lastErr)
+	}
+
+	if !strings.HasPrefix(storageVersion.APIServerID, "apiserver-") {
+		t.Errorf("apiserver ID doesn't contain apiserver- prefix, has: %v", storageVersion.APIServerID)
+	}
+	expectedVersion := crd.Spec.Group + "/" + crd.Spec.Versions[0].Name
+	if storageVersion.EncodingVersion != expectedVersion {
+		t.Errorf("unexpected encoding version, expected: %v, got: %v", expectedVersion, storageVersion.EncodingVersion)
+	}
+	if len(storageVersion.DecodableVersions) != 1 {
+		t.Errorf("unexpected number of decodable versions, expected 1 version, got: %v", storageVersion.DecodableVersions)
+	}
+	if storageVersion.DecodableVersions[0] != expectedVersion {
+		t.Errorf("unexpected decodable version, expected %v, got: %v", expectedVersion, storageVersion.DecodableVersions[0])
+	}
+
+	// add a new version v2 to the CRD and make it the storage version
+	newVersion := createdCRD.Spec.Versions[0]
+	newVersion.Name = "v2"
+	createdCRD.Spec.Versions[0].Storage = false
+	createdCRD.Spec.Versions = append(createdCRD.Spec.Versions, newVersion)
+	if _, err := crdClient.ApiextensionsV1().CustomResourceDefinitions().Update(context.TODO(), createdCRD, metav1.UpdateOptions{}); err != nil {
+		t.Fatalf("failed to update crd: %v", err)
+	}
+
+	expectedNewVersion := crd.Spec.Group + "/" + newVersion.Name
+	expectedDecodableVersions := []string{expectedVersion, expectedNewVersion}
+	lastErr = nil
+	if err := wait.PollUntilContextTimeout(context.TODO(), 100*time.Millisecond, 10*time.Second, true, func(ctx context.Context) (bool, error) {
+		sv, err := kubeclient.InternalV1alpha1().StorageVersions().Get(context.TODO(), gr, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		storageVersion := sv.Status.StorageVersions[0]
+		if len(storageVersion.DecodableVersions) != 2 {
+			lastErr = fmt.Errorf("unexpected number of decodable versions, expected 2 versions, got: %v", len(sv.Status.StorageVersions))
+			return false, nil
+		}
+		if !reflect.DeepEqual(storageVersion.DecodableVersions, expectedDecodableVersions) {
+			lastErr = fmt.Errorf("unexpected decodable versions, expected %v, got: %v", expectedDecodableVersions, storageVersion.DecodableVersions)
+			return false, nil
+		}
+		if storageVersion.EncodingVersion != expectedNewVersion {
+			lastErr = fmt.Errorf("unexpected encoding version, expected: %v, got: %v", expectedNewVersion, storageVersion.EncodingVersion)
+			return false, nil
+		}
+		return true, nil
+	}); err != nil {
+		t.Fatalf("failed to wait for storage version update: %v, last error: %v", err, lastErr)
+	}
+
+	// cleanup
+	if err := fixtures.DeleteV1CustomResourceDefinition(crd, crdClient); err != nil {
+		t.Fatal(err)
+	}
+	if err := kubeclient.InternalV1alpha1().StorageVersions().Delete(context.TODO(), gr, metav1.DeleteOptions{}); err != nil {
+		t.Errorf("failed to delete storage version: %v", err)
+	}
+}
+
+func TestStorageVersionMultipleCRDs(t *testing.T) {
+	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.StorageVersionAPI, true)()
+	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.APIServerIdentity, true)()
+	etcdConfig := framework.SharedEtcd()
+	server := kubeapiservertesting.StartTestServerOrDie(t, nil,
+		[]string{
+			"--runtime-config=internal.apiserver.k8s.io/v1alpha1=true",
+		},
+		etcdConfig)
+	crdClient := apiextensionsclientset.NewForConfigOrDie(server.ClientConfig)
+	crd := etcd.GetCustomResourceDefinitionData()[0]
+	etcd.CreateTestCRDs(t, crdClient, false, crd)
+	defer server.TearDownFn()
+	dynamicClient, err := dynamic.NewForConfig(server.ClientConfig)
+	if err != nil {
+		t.Fatalf("unexpected error creating dynamic client: %v", err)
+	}
+	gvr := schema.GroupVersionResource{Group: crd.Spec.Group, Version: crd.Spec.Versions[0].Name, Resource: crd.Spec.Names.Plural}
+	errCh := make(chan error)
+	// keep flipping the storage version of the CRD and create new CRs
+	go func() {
+		for i := 0; i < 10; i++ {
+			createdCRD, err := crdClient.ApiextensionsV1().CustomResourceDefinitions().Get(context.TODO(), crd.Name, metav1.GetOptions{})
+			if err != nil {
+				errCh <- fmt.Errorf("failed to get crd: %w", err)
+				return
+			}
+
+			// add a new version to the CRD and set it as the storage version
+			newVersion := createdCRD.Spec.Versions[i]
+			newVersion.Name = fmt.Sprintf("v%d", i+2)
+			createdCRD.Spec.Versions[i].Storage = false
+			createdCRD.Spec.Versions = append(createdCRD.Spec.Versions, newVersion)
+			if _, err := crdClient.ApiextensionsV1().CustomResourceDefinitions().Update(context.TODO(), createdCRD, metav1.UpdateOptions{}); err != nil {
+				errCh <- fmt.Errorf("failed to update crd: %w", err)
+				return
+			}
+			cr := &unstructured.Unstructured{}
+			cr.SetName(newVersion.Name)
+			cr.SetAPIVersion(fmt.Sprintf("%s/v1", crd.Spec.Group))
+			cr.SetKind(crd.Spec.Names.Kind)
+			if _, err = dynamicClient.Resource(gvr).Namespace("default").Create(context.TODO(), cr, metav1.CreateOptions{}); err != nil {
+				fmt.Printf("\nerror creating cr for version %v: %v\n", newVersion.Name, err)
+				// errCh <- fmt.Errorf("error creating cr for version %v: %v", newVersion.Name, err)
+				// return
+			}
+		}
+	}()
+
+	// verify new CRD creation is not blocked by the watch event.
+	newCRD := etcd.GetCustomResourceDefinitionData()[1]
+	etcd.CreateTestCRDs(t, crdClient, false, newCRD)
+
+	// verify that the storage version of the first CRD eventually stablize to the expected version
+	kubeclient := kubernetes.NewForConfigOrDie(server.ClientConfig)
+	gr := crd.Spec.Group + "." + crd.Spec.Names.Plural
+	var lastErr error
+	if err := wait.PollUntilContextTimeout(context.TODO(), 100*time.Millisecond, 60*time.Second, true, func(ctx context.Context) (bool, error) {
+		select {
+		case err := <-errCh:
+			return false, err
+		default:
+		}
+
+		sv, err := kubeclient.InternalV1alpha1().StorageVersions().Get(context.TODO(), gr, metav1.GetOptions{})
+		if err != nil {
+			lastErr = fmt.Errorf("failed to get storage version: %w", err)
+			return false, nil
+		}
+		if len(sv.Status.StorageVersions) != 1 {
+			lastErr = fmt.Errorf("apiserver failed to set one storage version record in the status, got: %v", sv.Status.StorageVersions)
+			return false, nil
+		}
+		storageVersion := sv.Status.StorageVersions[0]
+		if len(storageVersion.DecodableVersions) != 11 {
+			lastErr = fmt.Errorf("unexpected number of decodable versions, expected 11 versions, got: %v", len(sv.Status.StorageVersions))
+			return false, nil
+		}
+		expectedNewVersion := fmt.Sprintf("%s/v11", crd.Spec.Group)
+		if storageVersion.EncodingVersion != expectedNewVersion {
+			lastErr = fmt.Errorf("unexpected encoding version, expected: %v, got: %v", expectedNewVersion, storageVersion.EncodingVersion)
+			return false, nil
+		}
+		return true, nil
+	}); err != nil {
+		t.Errorf("failed to wait for storage version update: %v, last error: %v", err, lastErr)
+	}
+
+	// cleanup
+	if err := fixtures.DeleteV1CustomResourceDefinition(crd, crdClient); err != nil {
+		t.Fatal(err)
+	}
+	if err := kubeclient.InternalV1alpha1().StorageVersions().Delete(context.TODO(), gr, metav1.DeleteOptions{}); err != nil {
+		t.Errorf("failed to delete storage version: %v", err)
+	}
+	if err := fixtures.DeleteV1CustomResourceDefinition(newCRD, crdClient); err != nil {
+		t.Fatal(err)
+	}
+	gr = newCRD.Spec.Group + "." + newCRD.Spec.Names.Plural
+	if err := kubeclient.InternalV1alpha1().StorageVersions().Delete(context.TODO(), gr, metav1.DeleteOptions{}); err != nil {
+		t.Errorf("failed to delete storage version: %v", err)
+	}
+
+}
+
+func TestWatchAndMutateStorageVersionCRDs(t *testing.T) {
+	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.StorageVersionAPI, true)()
+	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.APIServerIdentity, true)()
+	etcdConfig := framework.SharedEtcd()
+	server := kubeapiservertesting.StartTestServerOrDie(t, nil,
+		[]string{
+			"--runtime-config=internal.apiserver.k8s.io/v1alpha1=true",
+		},
+		etcdConfig)
+	defer server.TearDownFn()
+
+	crdClient := apiextensionsclientset.NewForConfigOrDie(server.ClientConfig)
+
+	// create a watch on CRDs
+	w, err := crdClient.ApiextensionsV1().CustomResourceDefinitions().Watch(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer w.Stop()
+
+	select {
+	case <-w.ResultChan():
+		t.Fatal("Watch closed before mutation requests were made")
+	default:
+	}
+
+	// verify new CRD creation is not blocked by watch event
+	crd := etcd.GetCustomResourceDefinitionData()[0]
+	etcd.CreateTestCRDs(t, crdClient, false, crd)
+
+	errCh := make(chan error)
+
+	kubeclient := kubernetes.NewForConfigOrDie(server.ClientConfig)
+	gr := crd.Spec.Group + "." + crd.Spec.Names.Plural
+	var lastErr error
+	if err := wait.PollUntilContextTimeout(context.TODO(), 100*time.Millisecond, 10*time.Second, true, func(ctx context.Context) (bool, error) {
+		select {
+		case err := <-errCh:
+			return false, err
+		default:
+		}
+
+		sv, err := kubeclient.InternalV1alpha1().StorageVersions().Get(context.TODO(), gr, metav1.GetOptions{})
+		if err != nil {
+			lastErr = fmt.Errorf("failed to get storage version: %w", err)
+			return false, nil
+		}
+		storageVersion := sv.Status.StorageVersions[0]
+		expectedVersion := crd.Spec.Group + "/" + crd.Spec.Versions[0].Name
+		if storageVersion.EncodingVersion != expectedVersion {
+			t.Errorf("unexpected encoding version, expected: %v, got: %v", expectedVersion, storageVersion.EncodingVersion)
+		}
+		if len(storageVersion.DecodableVersions) != 1 {
+			t.Errorf("unexpected number of decodable versions, expected 1 version, got: %v", storageVersion.DecodableVersions)
+		}
+		if storageVersion.DecodableVersions[0] != expectedVersion {
+			t.Errorf("unexpected decodable version, expected %v, got: %v", expectedVersion, storageVersion.DecodableVersions[0])
+		}
+		return true, nil
+	}); err != nil {
+		t.Errorf("failed to wait for storage version creation: %v, last error: %v", err, lastErr)
+	}
+
+	// cleanup
+	if err := fixtures.DeleteV1CustomResourceDefinition(crd, crdClient); err != nil {
+		t.Fatal(err)
+	}
+	if err := kubeclient.InternalV1alpha1().StorageVersions().Delete(context.TODO(), gr, metav1.DeleteOptions{}); err != nil {
+		t.Errorf("failed to delete storage version: %v", err)
+	}
+}

--- a/test/integration/storageversion/storage_version_filter_test.go
+++ b/test/integration/storageversion/storage_version_filter_test.go
@@ -52,9 +52,9 @@ type wrappedStorageVersionManager struct {
 	completed      <-chan struct{}
 }
 
-func (w *wrappedStorageVersionManager) UpdateStorageVersions(loopbackClientConfig *rest.Config, serverID string) {
+func (w *wrappedStorageVersionManager) UpdateStorageVersions(ctx context.Context, loopbackClientConfig *rest.Config, serverID string) {
 	<-w.startUpdateSV
-	w.Manager.UpdateStorageVersions(loopbackClientConfig, serverID)
+	w.Manager.UpdateStorageVersions(ctx, loopbackClientConfig, serverID)
 	close(w.updateFinished)
 	<-w.finishUpdateSV
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
This PR is based off of https://github.com/kubernetes/kubernetes/pull/120582. 

Pseudocode

1. In `createCustomResourceDefinition` and `updateCustomResourceDefinition` methods, create an `svUpdateInfo` object that stores the crd, a wait channel that indicates whether SV update for this CRD is finished, and some other metadata. Store this  `svUpdateInfo` in `manager.storageVersionUpdateInfoMap`
2. In getOrCreateServingInfoFor(), read the latest CRD from `manager.storageVersionUpdateInfoMap` and also store svUpdateInfo.storageVersionProcessedCh inside crdInfo
3. While serving CR writes, check if crdInfo.storageVersionProcessedCh is closed -> if so, only then serve the request else fail with 405(StatusMethodNotAllowed).
4. In `createCustomResourceDefinition` and `updateCustomResourceDefinition`, after the teardown of old handlers is completed, queue new CRDs (names) for SV updates.
5. Manager processes SV updates of queued CRDs, for every crd.Name polled from the queue - find whats the latest CRD from `storageVersionUpdateInfoMap` and use that to update the SV. 
6. Manager abandons SV updates if there're active teardowns of previous handlers ongoing (tracked via storageVersionUpdateInfoMap.teardownCount). Once the teardown of previous handlers completes, re-enqueue the new CRD to try for SV update.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/enhancements/issues/2339

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/2339-storageversion-api-for-ha-api-servers
```