### PR TITLE
Step 1 – pkg/controlplane: split up config into generic controlplane and kube-related part

### DIFF
--- a/cmd/kube-apiserver/app/config.go
+++ b/cmd/kube-apiserver/app/config.go
@@ -29,7 +29,7 @@ type Config struct {
 	Options options.CompletedOptions
 
 	Aggregator    *aggregatorapiserver.Config
-	ControlPlane  *controlplane.Config
+	KubeAPIs      *controlplane.Config
 	ApiExtensions *apiextensionsapiserver.Config
 
 	ExtraConfig
@@ -42,7 +42,7 @@ type completedConfig struct {
 	Options options.CompletedOptions
 
 	Aggregator    aggregatorapiserver.CompletedConfig
-	ControlPlane  controlplane.CompletedConfig
+	KubeAPIs      controlplane.CompletedConfig
 	ApiExtensions apiextensionsapiserver.CompletedConfig
 
 	ExtraConfig
@@ -58,7 +58,7 @@ func (c *Config) Complete() (CompletedConfig, error) {
 		Options: c.Options,
 
 		Aggregator:    c.Aggregator.Complete(),
-		ControlPlane:  c.ControlPlane.Complete(),
+		KubeAPIs:      c.KubeAPIs.Complete(),
 		ApiExtensions: c.ApiExtensions.Complete(),
 
 		ExtraConfig: c.ExtraConfig,
@@ -71,20 +71,20 @@ func NewConfig(opts options.CompletedOptions) (*Config, error) {
 		Options: opts,
 	}
 
-	controlPlane, serviceResolver, pluginInitializer, err := CreateKubeAPIServerConfig(opts)
+	kubeAPIs, serviceResolver, pluginInitializer, err := CreateKubeAPIServerConfig(opts)
 	if err != nil {
 		return nil, err
 	}
-	c.ControlPlane = controlPlane
+	c.KubeAPIs = kubeAPIs
 
-	apiExtensions, err := apiserver.CreateAPIExtensionsConfig(*controlPlane.GenericConfig, controlPlane.ExtraConfig.VersionedInformers, pluginInitializer, opts.CompletedOptions, opts.MasterCount,
-		serviceResolver, webhook.NewDefaultAuthenticationInfoResolverWrapper(controlPlane.ExtraConfig.ProxyTransport, controlPlane.GenericConfig.EgressSelector, controlPlane.GenericConfig.LoopbackClientConfig, controlPlane.GenericConfig.TracerProvider))
+	apiExtensions, err := apiserver.CreateAPIExtensionsConfig(*kubeAPIs.ControlPlane.Generic, kubeAPIs.ControlPlane.VersionedInformers, pluginInitializer, opts.CompletedOptions, opts.MasterCount,
+		serviceResolver, webhook.NewDefaultAuthenticationInfoResolverWrapper(kubeAPIs.ControlPlane.ProxyTransport, kubeAPIs.ControlPlane.Generic.EgressSelector, kubeAPIs.ControlPlane.Generic.LoopbackClientConfig, kubeAPIs.ControlPlane.Generic.TracerProvider))
 	if err != nil {
 		return nil, err
 	}
 	c.ApiExtensions = apiExtensions
 
-	aggregator, err := createAggregatorConfig(*controlPlane.GenericConfig, opts.CompletedOptions, controlPlane.ExtraConfig.VersionedInformers, serviceResolver, controlPlane.ExtraConfig.ProxyTransport, controlPlane.ExtraConfig.PeerProxy, pluginInitializer)
+	aggregator, err := createAggregatorConfig(*kubeAPIs.ControlPlane.Generic, opts.CompletedOptions, kubeAPIs.ControlPlane.VersionedInformers, serviceResolver, kubeAPIs.ControlPlane.ProxyTransport, kubeAPIs.Extra.PeerProxy, pluginInitializer)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -271,7 +271,7 @@ func CreateKubeAPIServerConfig(opts options.CompletedOptions) (
 		}
 		// build peer proxy config only if peer ca file exists
 		if opts.PeerCAFile != "" {
-			config.Extra.PeerProxy, err = controlplaneapiserver.BuildPeerProxy(versionedInformers, genericConfig.StorageVersionManager, opts.ProxyClientCertFile,
+			config.Extra.PeerProxy, err = controlplane.BuildPeerProxy(versionedInformers, genericConfig.StorageVersionManager, opts.ProxyClientCertFile,
 				opts.ProxyClientKeyFile, opts.PeerCAFile, opts.PeerAdvertiseAddress, genericConfig.APIServerID, config.Extra.PeerEndpointLeaseReconciler, config.ControlPlane.Generic.Serializer)
 			if err != nil {
 				return nil, nil, nil, err

--- a/pkg/controlplane/apiserver/completion.go
+++ b/pkg/controlplane/apiserver/completion.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apiserver
+
+import (
+	"k8s.io/apiserver/pkg/endpoints/discovery"
+	genericapiserver "k8s.io/apiserver/pkg/server"
+)
+
+type completedConfig struct {
+	Generic genericapiserver.CompletedConfig
+	*Extra
+}
+
+// CompletedConfig embeds a private pointer that cannot be instantiated outside of this package
+type CompletedConfig struct {
+	*completedConfig
+}
+
+func (c *Config) Complete() CompletedConfig {
+	cfg := completedConfig{
+		c.Generic.Complete(c.VersionedInformers),
+		&c.Extra,
+	}
+
+	discoveryAddresses := discovery.DefaultAddresses{DefaultAddress: cfg.Generic.ExternalAddress}
+	cfg.Generic.DiscoveryAddresses = discoveryAddresses
+
+	return CompletedConfig{&cfg}
+}

--- a/pkg/controlplane/apiserver/config.go
+++ b/pkg/controlplane/apiserver/config.go
@@ -31,20 +31,15 @@ import (
 	"k8s.io/apiserver/pkg/endpoints/discovery/aggregated"
 	openapinamer "k8s.io/apiserver/pkg/endpoints/openapi"
 	genericfeatures "k8s.io/apiserver/pkg/features"
-	"k8s.io/apiserver/pkg/reconcilers"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/apiserver/pkg/server/egressselector"
 	"k8s.io/apiserver/pkg/server/filters"
 	serverstorage "k8s.io/apiserver/pkg/server/storage"
-	"k8s.io/apiserver/pkg/storageversion"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/apiserver/pkg/util/openapi"
-	utilpeerproxy "k8s.io/apiserver/pkg/util/peerproxy"
 	clientgoinformers "k8s.io/client-go/informers"
 	clientgoclientset "k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/transport"
 	"k8s.io/component-base/version"
-	"k8s.io/klog/v2"
 	openapicommon "k8s.io/kube-openapi/pkg/common"
 
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
@@ -240,39 +235,4 @@ func BuildAuthorizer(ctx context.Context, s controlplaneapiserver.CompletedOptio
 	authorizer, ruleResolver, err := authorizationConfig.New(ctx, apiserverID)
 
 	return authorizer, ruleResolver, enablesRBAC, err
-}
-
-func BuildPeerProxy(versionedInformer clientgoinformers.SharedInformerFactory, svm storageversion.Manager,
-	proxyClientCertFile string, proxyClientKeyFile string, peerCAFile string, peerAdvertiseAddress reconcilers.PeerAdvertiseAddress,
-	apiServerID string, reconciler reconcilers.PeerEndpointLeaseReconciler, serializer runtime.NegotiatedSerializer) (utilpeerproxy.Interface, error) {
-	if proxyClientCertFile == "" {
-		return nil, fmt.Errorf("error building peer proxy handler, proxy-cert-file not specified")
-	}
-	if proxyClientKeyFile == "" {
-		return nil, fmt.Errorf("error building peer proxy handler, proxy-key-file not specified")
-	}
-	// create proxy client config
-	clientConfig := &transport.Config{
-		TLS: transport.TLSConfig{
-			Insecure:   false,
-			CertFile:   proxyClientCertFile,
-			KeyFile:    proxyClientKeyFile,
-			CAFile:     peerCAFile,
-			ServerName: "kubernetes.default.svc",
-		}}
-
-	// build proxy transport
-	proxyRoundTripper, transportBuildingError := transport.New(clientConfig)
-	if transportBuildingError != nil {
-		klog.Error(transportBuildingError.Error())
-		return nil, transportBuildingError
-	}
-	return utilpeerproxy.NewPeerProxyHandler(
-		versionedInformer,
-		svm,
-		proxyRoundTripper,
-		apiServerID,
-		reconciler,
-		serializer,
-	), nil
 }

--- a/pkg/controlplane/apiserver/config.go
+++ b/pkg/controlplane/apiserver/config.go
@@ -19,6 +19,7 @@ package apiserver
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"time"
 
 	oteltrace "go.opentelemetry.io/otel/trace"
@@ -47,28 +48,56 @@ import (
 	openapicommon "k8s.io/kube-openapi/pkg/common"
 
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
-	api "k8s.io/kubernetes/pkg/apis/core"
-	"k8s.io/kubernetes/pkg/controlplane"
 	controlplaneapiserver "k8s.io/kubernetes/pkg/controlplane/apiserver/options"
+	"k8s.io/kubernetes/pkg/controlplane/controller/clusterauthenticationtrust"
 	"k8s.io/kubernetes/pkg/kubeapiserver"
 	"k8s.io/kubernetes/pkg/kubeapiserver/authorizer/modes"
 	rbacrest "k8s.io/kubernetes/pkg/registry/rbac/rest"
+	"k8s.io/kubernetes/pkg/serviceaccount"
 )
+
+// Config defines configuration for the master
+type Config struct {
+	Generic *genericapiserver.Config
+	Extra
+}
+
+type Extra struct {
+	ClusterAuthenticationInfo clusterauthenticationtrust.ClusterAuthenticationInfo
+
+	APIResourceConfigSource serverstorage.APIResourceConfigSource
+	StorageFactory          serverstorage.StorageFactory
+	EventTTL                time.Duration
+
+	EnableLogsSupport bool
+	ProxyTransport    *http.Transport
+
+	ServiceAccountIssuer        serviceaccount.TokenGenerator
+	ServiceAccountMaxExpiration time.Duration
+	ExtendExpiration            bool
+
+	// ServiceAccountIssuerDiscovery
+	ServiceAccountIssuerURL  string
+	ServiceAccountJWKSURI    string
+	ServiceAccountPublicKeys []interface{}
+
+	VersionedInformers clientgoinformers.SharedInformerFactory
+}
 
 // BuildGenericConfig takes the master server options and produces the genericapiserver.Config associated with it
 func BuildGenericConfig(
 	s controlplaneapiserver.CompletedOptions,
 	schemes []*runtime.Scheme,
+	resourceConfig *serverstorage.ResourceConfig,
 	getOpenAPIDefinitions func(ref openapicommon.ReferenceCallback) map[string]openapicommon.OpenAPIDefinition,
 ) (
 	genericConfig *genericapiserver.Config,
 	versionedInformers clientgoinformers.SharedInformerFactory,
 	storageFactory *serverstorage.DefaultStorageFactory,
-
 	lastErr error,
 ) {
 	genericConfig = genericapiserver.NewConfig(legacyscheme.Codecs)
-	genericConfig.MergedResourceConfig = controlplane.DefaultAPIResourceConfigSource()
+	genericConfig.MergedResourceConfig = resourceConfig
 
 	if lastErr = s.GenericServerRunOptions.ApplyTo(genericConfig); lastErr != nil {
 		return
@@ -98,7 +127,7 @@ func BuildGenericConfig(
 	if lastErr = s.Features.ApplyTo(genericConfig, clientgoExternalClient, versionedInformers); lastErr != nil {
 		return
 	}
-	if lastErr = s.APIEnablement.ApplyTo(genericConfig, controlplane.DefaultAPIResourceConfigSource(), legacyscheme.Scheme); lastErr != nil {
+	if lastErr = s.APIEnablement.ApplyTo(genericConfig, resourceConfig, legacyscheme.Scheme); lastErr != nil {
 		return
 	}
 	if lastErr = s.EgressSelector.ApplyTo(genericConfig); lastErr != nil {
@@ -211,18 +240,6 @@ func BuildAuthorizer(ctx context.Context, s controlplaneapiserver.CompletedOptio
 	authorizer, ruleResolver, err := authorizationConfig.New(ctx, apiserverID)
 
 	return authorizer, ruleResolver, enablesRBAC, err
-}
-
-// CreatePeerEndpointLeaseReconciler creates a apiserver endpoint lease reconciliation loop
-// The peer endpoint leases are used to find network locations of apiservers for peer proxy
-func CreatePeerEndpointLeaseReconciler(c genericapiserver.Config, storageFactory serverstorage.StorageFactory) (reconcilers.PeerEndpointLeaseReconciler, error) {
-	ttl := controlplane.DefaultEndpointReconcilerTTL
-	config, err := storageFactory.NewConfig(api.Resource("apiServerPeerIPInfo"))
-	if err != nil {
-		return nil, fmt.Errorf("error creating storage factory config: %w", err)
-	}
-	reconciler, err := reconcilers.NewPeerEndpointLeaseReconciler(config, "/peerserverleases/", ttl)
-	return reconciler, err
 }
 
 func BuildPeerProxy(versionedInformer clientgoinformers.SharedInformerFactory, svm storageversion.Manager,

--- a/pkg/controlplane/apiserver/config_test.go
+++ b/pkg/controlplane/apiserver/config_test.go
@@ -17,6 +17,9 @@ limitations under the License.
 package apiserver
 
 import (
+	"net"
+	"testing"
+
 	extensionsapiserver "k8s.io/apiextensions-apiserver/pkg/apiserver"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -26,8 +29,6 @@ import (
 	"k8s.io/kubernetes/pkg/controlplane/apiserver/options"
 	generatedopenapi "k8s.io/kubernetes/pkg/generated/openapi"
 	netutils "k8s.io/utils/net"
-	"net"
-	"testing"
 )
 
 func TestBuildGenericConfig(t *testing.T) {
@@ -52,6 +53,7 @@ func TestBuildGenericConfig(t *testing.T) {
 	genericConfig, _, storageFactory, err := BuildGenericConfig(
 		completedOptions,
 		[]*runtime.Scheme{legacyscheme.Scheme, extensionsapiserver.Scheme, aggregatorscheme.Scheme},
+		nil,
 		generatedopenapi.GetOpenAPIDefinitions,
 	)
 	if err != nil {

--- a/test/integration/apiserver/apiserver_test.go
+++ b/test/integration/apiserver/apiserver_test.go
@@ -84,7 +84,7 @@ func setupWithResources(t *testing.T, groupVersions []schema.GroupVersion, resou
 				resourceConfig := controlplane.DefaultAPIResourceConfigSource()
 				resourceConfig.EnableVersions(groupVersions...)
 				resourceConfig.EnableResources(resources...)
-				config.ExtraConfig.APIResourceConfigSource = resourceConfig
+				config.ControlPlane.Extra.APIResourceConfigSource = resourceConfig
 			}
 		},
 	})

--- a/test/integration/apiserver/flowcontrol/concurrency_util_test.go
+++ b/test/integration/apiserver/flowcontrol/concurrency_util_test.go
@@ -155,7 +155,7 @@ func TestConcurrencyIsolation(t *testing.T) {
 		},
 		ModifyServerConfig: func(config *controlplane.Config) {
 			// Wrap default authorizer with one that delays requests from noxu clients
-			config.GenericConfig.Authorization.Authorizer = &noxuDelayingAuthorizer{config.GenericConfig.Authorization.Authorizer}
+			config.ControlPlane.Generic.Authorization.Authorizer = &noxuDelayingAuthorizer{config.ControlPlane.Generic.Authorization.Authorizer}
 		},
 	})
 	defer closeFn()

--- a/test/integration/apiserver/openapi/openapi_enum_test.go
+++ b/test/integration/apiserver/openapi/openapi_enum_test.go
@@ -77,8 +77,8 @@ func TestEnablingOpenAPIEnumTypes(t *testing.T) {
 
 			_, kubeConfig, tearDownFn := framework.StartTestServer(tCtx, t, framework.TestServerSetup{
 				ModifyServerConfig: func(config *controlplane.Config) {
-					config.GenericConfig.OpenAPIConfig = framework.DefaultOpenAPIConfig()
-					config.GenericConfig.OpenAPIConfig.GetDefinitions = getDefinitionsFn
+					config.ControlPlane.Generic.OpenAPIConfig = framework.DefaultOpenAPIConfig()
+					config.ControlPlane.Generic.OpenAPIConfig.GetDefinitions = getDefinitionsFn
 				},
 			})
 			defer tearDownFn()

--- a/test/integration/apiserver/watchcache_test.go
+++ b/test/integration/apiserver/watchcache_test.go
@@ -61,7 +61,7 @@ func multiEtcdSetup(ctx context.Context, t *testing.T) (clientset.Interface, fra
 		},
 		ModifyServerConfig: func(config *controlplane.Config) {
 			// Switch off endpoints reconciler to avoid unnecessary operations.
-			config.ExtraConfig.EndpointReconcilerType = reconcilers.NoneEndpointReconcilerType
+			config.Extra.EndpointReconcilerType = reconcilers.NoneEndpointReconcilerType
 		},
 	})
 
@@ -170,7 +170,7 @@ func BenchmarkListFromWatchCache(b *testing.B) {
 	c, _, tearDownFn := framework.StartTestServer(tCtx, b, framework.TestServerSetup{
 		ModifyServerConfig: func(config *controlplane.Config) {
 			// Switch off endpoints reconciler to avoid unnecessary operations.
-			config.ExtraConfig.EndpointReconcilerType = reconcilers.NoneEndpointReconcilerType
+			config.Extra.EndpointReconcilerType = reconcilers.NoneEndpointReconcilerType
 		},
 	})
 	defer tearDownFn()

--- a/test/integration/auth/accessreview_test.go
+++ b/test/integration/auth/accessreview_test.go
@@ -62,9 +62,9 @@ func TestSubjectAccessReview(t *testing.T) {
 	clientset, _, tearDownFn := framework.StartTestServer(tCtx, t, framework.TestServerSetup{
 		ModifyServerConfig: func(config *controlplane.Config) {
 			// Unset BearerToken to disable BearerToken authenticator.
-			config.GenericConfig.LoopbackClientConfig.BearerToken = ""
-			config.GenericConfig.Authentication.Authenticator = authenticator.RequestFunc(alwaysAlice)
-			config.GenericConfig.Authorization.Authorizer = sarAuthorizer{}
+			config.ControlPlane.Generic.LoopbackClientConfig.BearerToken = ""
+			config.ControlPlane.Generic.Authentication.Authenticator = authenticator.RequestFunc(alwaysAlice)
+			config.ControlPlane.Generic.Authorization.Authorizer = sarAuthorizer{}
 		},
 	})
 	defer tearDownFn()
@@ -172,9 +172,9 @@ func TestSelfSubjectAccessReview(t *testing.T) {
 	clientset, _, tearDownFn := framework.StartTestServer(tCtx, t, framework.TestServerSetup{
 		ModifyServerConfig: func(config *controlplane.Config) {
 			// Unset BearerToken to disable BearerToken authenticator.
-			config.GenericConfig.LoopbackClientConfig.BearerToken = ""
-			config.GenericConfig.Authentication.Authenticator = authenticator.RequestFunc(authenticatorFunc)
-			config.GenericConfig.Authorization.Authorizer = sarAuthorizer{}
+			config.ControlPlane.Generic.LoopbackClientConfig.BearerToken = ""
+			config.ControlPlane.Generic.Authentication.Authenticator = authenticator.RequestFunc(authenticatorFunc)
+			config.ControlPlane.Generic.Authorization.Authorizer = sarAuthorizer{}
 		},
 	})
 	defer tearDownFn()
@@ -256,9 +256,9 @@ func TestLocalSubjectAccessReview(t *testing.T) {
 	clientset, _, tearDownFn := framework.StartTestServer(tCtx, t, framework.TestServerSetup{
 		ModifyServerConfig: func(config *controlplane.Config) {
 			// Unset BearerToken to disable BearerToken authenticator.
-			config.GenericConfig.LoopbackClientConfig.BearerToken = ""
-			config.GenericConfig.Authentication.Authenticator = authenticator.RequestFunc(alwaysAlice)
-			config.GenericConfig.Authorization.Authorizer = sarAuthorizer{}
+			config.ControlPlane.Generic.LoopbackClientConfig.BearerToken = ""
+			config.ControlPlane.Generic.Authentication.Authenticator = authenticator.RequestFunc(alwaysAlice)
+			config.ControlPlane.Generic.Authorization.Authorizer = sarAuthorizer{}
 		},
 	})
 	defer tearDownFn()

--- a/test/integration/auth/auth_test.go
+++ b/test/integration/auth/auth_test.go
@@ -813,7 +813,7 @@ func TestImpersonateIsForbidden(t *testing.T) {
 		},
 		ModifyServerConfig: func(config *controlplane.Config) {
 			// Prepend an impersonation authorizer with specific opinions about alice and bob
-			config.GenericConfig.Authorization.Authorizer = unionauthz.New(impersonateAuthorizer{}, config.GenericConfig.Authorization.Authorizer)
+			config.ControlPlane.Generic.Authorization.Authorizer = unionauthz.New(impersonateAuthorizer{}, config.ControlPlane.Generic.Authorization.Authorizer)
 		},
 	})
 	defer tearDownFn()
@@ -1118,7 +1118,7 @@ func TestAuthorizationAttributeDetermination(t *testing.T) {
 			opts.Authentication.TokenFile.TokenFile = "testdata/tokens.csv"
 		},
 		ModifyServerConfig: func(config *controlplane.Config) {
-			config.GenericConfig.Authorization.Authorizer = unionauthz.New(config.GenericConfig.Authorization.Authorizer, trackingAuthorizer)
+			config.ControlPlane.Generic.Authorization.Authorizer = unionauthz.New(config.ControlPlane.Generic.Authorization.Authorizer, trackingAuthorizer)
 		},
 	})
 	defer tearDownFn()
@@ -1458,9 +1458,9 @@ func testWebhookTokenAuthenticator(customDialer bool, t *testing.T) {
 			opts.Authorization.PolicyFile = "testdata/allowalice.jsonl"
 		},
 		ModifyServerConfig: func(config *controlplane.Config) {
-			config.GenericConfig.Authentication.Authenticator = group.NewAuthenticatedGroupAdder(authenticator)
+			config.ControlPlane.Generic.Authentication.Authenticator = group.NewAuthenticatedGroupAdder(authenticator)
 			// Disable checking API audiences that is set by testserver by default.
-			config.GenericConfig.Authentication.APIAudiences = nil
+			config.ControlPlane.Generic.Authentication.APIAudiences = nil
 		},
 	})
 	defer tearDownFn()

--- a/test/integration/auth/bootstraptoken_test.go
+++ b/test/integration/auth/bootstraptoken_test.go
@@ -128,7 +128,7 @@ func TestBootstrapTokenAuth(t *testing.T) {
 					opts.Authorization.Modes = []string{"AlwaysAllow"}
 				},
 				ModifyServerConfig: func(config *controlplane.Config) {
-					config.GenericConfig.Authentication.Authenticator = authenticator
+					config.ControlPlane.Generic.Authentication.Authenticator = authenticator
 				},
 			})
 			defer tearDownFn()

--- a/test/integration/auth/rbac_test.go
+++ b/test/integration/auth/rbac_test.go
@@ -81,7 +81,7 @@ type testRESTOptionsGetter struct {
 }
 
 func (getter *testRESTOptionsGetter) GetRESTOptions(resource schema.GroupResource) (generic.RESTOptions, error) {
-	storageConfig, err := getter.config.ExtraConfig.StorageFactory.NewConfig(resource)
+	storageConfig, err := getter.config.ControlPlane.Extra.StorageFactory.NewConfig(resource)
 	if err != nil {
 		return generic.RESTOptions{}, fmt.Errorf("failed to get storage: %v", err)
 	}
@@ -556,11 +556,11 @@ func TestRBAC(t *testing.T) {
 				},
 				ModifyServerConfig: func(config *controlplane.Config) {
 					// Append our custom test authenticator
-					config.GenericConfig.Authentication.Authenticator = unionauthn.New(config.GenericConfig.Authentication.Authenticator, authenticator)
+					config.ControlPlane.Generic.Authentication.Authenticator = unionauthn.New(config.ControlPlane.Generic.Authentication.Authenticator, authenticator)
 					// Append our custom test authorizer
 					var rbacAuthz authorizer.Authorizer
 					rbacAuthz, tearDownAuthorizerFn = newRBACAuthorizer(t, config)
-					config.GenericConfig.Authorization.Authorizer = unionauthz.New(config.GenericConfig.Authorization.Authorizer, rbacAuthz)
+					config.ControlPlane.Generic.Authorization.Authorizer = unionauthz.New(config.ControlPlane.Generic.Authorization.Authorizer, rbacAuthz)
 				},
 			})
 			defer tearDownFn()

--- a/test/integration/auth/selfsubjectreview_test.go
+++ b/test/integration/auth/selfsubjectreview_test.go
@@ -101,8 +101,8 @@ func TestGetsSelfAttributes(t *testing.T) {
 		},
 		ModifyServerConfig: func(config *controlplane.Config) {
 			// Unset BearerToken to disable BearerToken authenticator.
-			config.GenericConfig.LoopbackClientConfig.BearerToken = ""
-			config.GenericConfig.Authentication.Authenticator = authenticator.RequestFunc(func(req *http.Request) (*authenticator.Response, bool, error) {
+			config.ControlPlane.Generic.LoopbackClientConfig.BearerToken = ""
+			config.ControlPlane.Generic.Authentication.Authenticator = authenticator.RequestFunc(func(req *http.Request) (*authenticator.Response, bool, error) {
 				respMu.RLock()
 				defer respMu.RUnlock()
 				return &authenticator.Response{User: response}, true, nil
@@ -215,8 +215,8 @@ func TestGetsSelfAttributesError(t *testing.T) {
 		},
 		ModifyServerConfig: func(config *controlplane.Config) {
 			// Unset BearerToken to disable BearerToken authenticator.
-			config.GenericConfig.LoopbackClientConfig.BearerToken = ""
-			config.GenericConfig.Authentication.Authenticator = authenticator.RequestFunc(func(req *http.Request) (*authenticator.Response, bool, error) {
+			config.ControlPlane.Generic.LoopbackClientConfig.BearerToken = ""
+			config.ControlPlane.Generic.Authentication.Authenticator = authenticator.RequestFunc(func(req *http.Request) (*authenticator.Response, bool, error) {
 				if toggle.Load().(bool) {
 					return &authenticator.Response{
 						User: &user.DefaultInfo{

--- a/test/integration/auth/svcaccttoken_test.go
+++ b/test/integration/auth/svcaccttoken_test.go
@@ -104,10 +104,10 @@ func TestServiceAccountTokenCreate(t *testing.T) {
 		},
 		ModifyServerConfig: func(config *controlplane.Config) {
 			// extract token generator
-			tokenGenerator = config.ExtraConfig.ServiceAccountIssuer
+			tokenGenerator = config.ControlPlane.Extra.ServiceAccountIssuer
 
-			config.ExtraConfig.ServiceAccountMaxExpiration = maxExpirationDuration
-			config.ExtraConfig.ExtendExpiration = true
+			config.ControlPlane.Extra.ServiceAccountMaxExpiration = maxExpirationDuration
+			config.ControlPlane.Extra.ExtendExpiration = true
 		},
 	})
 	defer tearDownFn()

--- a/test/integration/daemonset/daemonset_test.go
+++ b/test/integration/daemonset/daemonset_test.go
@@ -1178,7 +1178,7 @@ func TestUpdateStatusDespitePodCreationFailure(t *testing.T) {
 		limitedPodNumber := 2
 		ctx, closeFn, dc, informers, clientset := setupWithServerSetup(t, framework.TestServerSetup{
 			ModifyServerConfig: func(config *controlplane.Config) {
-				config.GenericConfig.AdmissionControl = &fakePodFailAdmission{
+				config.ControlPlane.Generic.AdmissionControl = &fakePodFailAdmission{
 					limitedPodNumber: limitedPodNumber,
 				}
 			},

--- a/test/integration/defaulttolerationseconds/defaulttolerationseconds_test.go
+++ b/test/integration/defaulttolerationseconds/defaulttolerationseconds_test.go
@@ -32,8 +32,8 @@ func TestAdmission(t *testing.T) {
 	tCtx := ktesting.Init(t)
 	client, _, tearDownFn := framework.StartTestServer(tCtx, t, framework.TestServerSetup{
 		ModifyServerConfig: func(cfg *controlplane.Config) {
-			cfg.GenericConfig.EnableProfiling = true
-			cfg.GenericConfig.AdmissionControl = defaulttolerationseconds.NewDefaultTolerationSeconds()
+			cfg.ControlPlane.Generic.EnableProfiling = true
+			cfg.ControlPlane.Generic.AdmissionControl = defaulttolerationseconds.NewDefaultTolerationSeconds()
 		},
 	})
 	defer tearDownFn()

--- a/test/integration/examples/webhook_test.go
+++ b/test/integration/examples/webhook_test.go
@@ -47,11 +47,11 @@ func TestWebhookLoopback(t *testing.T) {
 		},
 		ModifyServerConfig: func(config *controlplane.Config) {
 			// Avoid resolvable kubernetes service
-			config.ExtraConfig.EndpointReconcilerType = reconcilers.NoneEndpointReconcilerType
+			config.Extra.EndpointReconcilerType = reconcilers.NoneEndpointReconcilerType
 
 			// Hook into audit to watch requests
-			config.GenericConfig.AuditBackend = auditSinkFunc(func(events ...*auditinternal.Event) {})
-			config.GenericConfig.AuditPolicyRuleEvaluator = auditPolicyRuleEvaluator(func(attrs authorizer.Attributes) audit.RequestAuditConfig {
+			config.ControlPlane.Generic.AuditBackend = auditSinkFunc(func(events ...*auditinternal.Event) {})
+			config.ControlPlane.Generic.AuditPolicyRuleEvaluator = auditPolicyRuleEvaluator(func(attrs authorizer.Attributes) audit.RequestAuditConfig {
 				if attrs.GetPath() == webhookPath {
 					if attrs.GetUser().GetName() != "system:apiserver" {
 						t.Errorf("expected user %q, got %q", "system:apiserver", attrs.GetUser().GetName())

--- a/test/integration/framework/test_server.go
+++ b/test/integration/framework/test_server.go
@@ -182,7 +182,7 @@ func StartTestServer(ctx context.Context, t testing.TB, setup TestServerSetup) (
 	}()
 
 	// Adjust the loopback config for external use (external server name and CA)
-	kubeAPIServerClientConfig := rest.CopyConfig(kubeAPIServerConfig.GenericConfig.LoopbackClientConfig)
+	kubeAPIServerClientConfig := rest.CopyConfig(kubeAPIServerConfig.ControlPlane.Generic.LoopbackClientConfig)
 	kubeAPIServerClientConfig.CAFile = path.Join(certDir, "apiserver.crt")
 	kubeAPIServerClientConfig.CAData = nil
 	kubeAPIServerClientConfig.ServerName = ""

--- a/test/integration/network/services_test.go
+++ b/test/integration/network/services_test.go
@@ -50,7 +50,7 @@ func TestServicesFinalizersRepairLoop(t *testing.T) {
 			opts.ServiceClusterIPRanges = serviceCIDR
 		},
 		ModifyServerConfig: func(cfg *controlplane.Config) {
-			cfg.ExtraConfig.RepairServicesInterval = interval
+			cfg.Extra.RepairServicesInterval = interval
 		},
 	})
 	defer tearDownFn()

--- a/test/integration/openshift/openshift_test.go
+++ b/test/integration/openshift/openshift_test.go
@@ -21,17 +21,20 @@ import (
 
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/kubernetes/pkg/controlplane"
+	controlplaneapiserver "k8s.io/kubernetes/pkg/controlplane/apiserver"
 )
 
 // This test references methods that OpenShift uses to customize the apiserver on startup, that
 // are not referenced directly by an instance.
 func TestApiserverExportsSymbols(t *testing.T) {
 	_ = &controlplane.Config{
-		GenericConfig: &genericapiserver.Config{
-			EnableMetrics: true,
-		},
-		ExtraConfig: controlplane.ExtraConfig{
-			EnableLogsSupport: false,
+		ControlPlane: controlplaneapiserver.Config{
+			Generic: &genericapiserver.Config{
+				EnableMetrics: true,
+			},
+			Extra: controlplaneapiserver.Extra{
+				EnableLogsSupport: false,
+			},
 		},
 	}
 	_ = &controlplane.Instance{

--- a/test/integration/serviceaccount/service_account_test.go
+++ b/test/integration/serviceaccount/service_account_test.go
@@ -376,7 +376,7 @@ func startServiceAccountTestServerAndWaitForCaches(ctx context.Context, t *testi
 
 				return authorizer.DecisionNoOpinion, fmt.Sprintf("User %s is denied (ns=%s, readonly=%v, resource=%s)", username, ns, attrs.IsReadOnly(), attrs.GetResource()), nil
 			})
-			config.GenericConfig.Authorization.Authorizer = unionauthz.New(config.GenericConfig.Authorization.Authorizer, authorizer)
+			config.ControlPlane.Generic.Authorization.Authorizer = unionauthz.New(config.ControlPlane.Generic.Authorization.Authorizer, authorizer)
 		},
 	})
 

--- a/test/integration/statefulset/statefulset_test.go
+++ b/test/integration/statefulset/statefulset_test.go
@@ -381,7 +381,7 @@ func TestStatefulSetStatusWithPodFail(t *testing.T) {
 	limitedPodNumber := 2
 	c, config, closeFn := framework.StartTestServer(tCtx, t, framework.TestServerSetup{
 		ModifyServerConfig: func(config *controlplane.Config) {
-			config.GenericConfig.AdmissionControl = &fakePodFailAdmission{
+			config.ControlPlane.Generic.AdmissionControl = &fakePodFailAdmission{
 				limitedPodNumber: limitedPodNumber,
 			}
 		},

--- a/test/integration/util/util.go
+++ b/test/integration/util/util.go
@@ -518,7 +518,7 @@ func InitTestAPIServer(t *testing.T, nsPrefix string, admission admission.Interf
 		},
 		ModifyServerConfig: func(config *controlplane.Config) {
 			if admission != nil {
-				config.GenericConfig.AdmissionControl = admission
+				config.ControlPlane.Generic.AdmissionControl = admission
 			}
 		},
 	})


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Step 1 towards kubernetes/enhancements#4080, splitting the config structs into generic controlplane part and kube-related part, without changing behaviour.

Full refactoring in https://github.com/kubernetes/kubernetes/pull/124530.

#### Which issue(s) this PR fixes:

Towards kubernetes/enhancements#4080.

#### Special notes for your reviewer:

- check for everything removed being added again elsewhere.
- look for potential behaviour changes due to different order.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```