### PR TITLE
Automated cherry pick of #124516: Fix behavior with external cloud provider and

### DIFF
--- a/pkg/kubelet/nodestatus/setters.go
+++ b/pkg/kubelet/nodestatus/setters.go
@@ -136,6 +136,9 @@ func NodeAddress(nodeIPs []net.IP, // typically Kubelet.nodeIPs
 			// in https://github.com/kubernetes/kubernetes/issues/120720.
 			// We are already hinting the external cloud provider via the annotation AnnotationAlphaProvidedIPAddr.
 			if !nodeIPSpecified {
+				node.Status.Addresses = []v1.NodeAddress{
+					{Type: v1.NodeHostName, Address: hostname},
+				}
 				return nil
 			}
 		}

--- a/pkg/kubelet/nodestatus/setters_test.go
+++ b/pkg/kubelet/nodestatus/setters_test.go
@@ -240,15 +240,19 @@ func TestNodeAddress(t *testing.T) {
 			nodeIP:            netutils.ParseIPSloppy("::"),
 			nodeAddresses:     []v1.NodeAddress{},
 			cloudProviderType: cloudProviderExternal,
-			expectedAddresses: []v1.NodeAddress{},
-			shouldError:       false,
+			expectedAddresses: []v1.NodeAddress{
+				{Type: v1.NodeHostName, Address: testKubeletHostname},
+			},
+			shouldError: false,
 		},
 		{
 			name:              "cloud provider is external and no nodeIP",
 			nodeAddresses:     []v1.NodeAddress{},
 			cloudProviderType: cloudProviderExternal,
-			expectedAddresses: []v1.NodeAddress{},
-			shouldError:       false,
+			expectedAddresses: []v1.NodeAddress{
+				{Type: v1.NodeHostName, Address: testKubeletHostname},
+			},
+			shouldError: false,
 		},
 		{
 			name: "cloud doesn't report hostname, no override, detected hostname mismatch",


### PR DESCRIPTION
Cherry pick of #124516 on release-1.30.

#124516: Fix behavior with external cloud provider and

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```