### PR TITLE
Add integration tests for policy secondary authz runtime cost limit.

### DIFF
--- a/test/integration/apiserver/cel/validatingadmissionpolicy_test.go
+++ b/test/integration/apiserver/cel/validatingadmissionpolicy_test.go
@@ -2363,6 +2363,39 @@ func Test_ValidateSecondaryAuthorization(t *testing.T) {
 			allowed:    true,
 		},
 		{
+			name: "more than 28 checks exceeds per-policy runtime cost budget",
+			rbac: &rbacv1.PolicyRule{
+				Verbs:         []string{"create"},
+				APIGroups:     []string{"apps"},
+				Resources:     []string{"deployments/status"},
+				ResourceNames: []string{"charmander"},
+			},
+			expression: "[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29].all(x, authorizer.group('apps').resource('deployments').subresource('status').namespace('default').namespace('default').name('charmander').check('create').allowed())",
+			allowed:    false,
+		},
+		{
+			name: "more than 2 checks exceeds per-expression runtime cost budget",
+			rbac: &rbacv1.PolicyRule{
+				Verbs:         []string{"create"},
+				APIGroups:     []string{"apps"},
+				Resources:     []string{"deployments/status"},
+				ResourceNames: []string{"charmander"},
+			},
+			expression: "[1, 2, 3].all(x, authorizer.group('apps').resource('deployments').subresource('status').namespace('default').namespace('default').name('charmander').check('create').allowed())",
+			allowed:    false,
+		},
+		{
+			name: "fewer than 3 checks meets per-expression runtime cost budget",
+			rbac: &rbacv1.PolicyRule{
+				Verbs:         []string{"create"},
+				APIGroups:     []string{"apps"},
+				Resources:     []string{"deployments/status"},
+				ResourceNames: []string{"charmander"},
+			},
+			expression: "[1, 2].all(x, authorizer.group('apps').resource('deployments').subresource('status').namespace('default').namespace('default').name('charmander').check('create').allowed())",
+			allowed:    true,
+		},
+		{
 			name:       "principal is not allowed to create a specific deployment",
 			expression: "authorizer.group('apps').resource('deployments').subresource('status').namespace('default').name('charmander').check('create').allowed()",
 			allowed:    false,


### PR DESCRIPTION
We intentionally gave secondary authorization a high runtime cost. Only two checks per expression and 28 per policy should be allowed if that cost is being counted.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup
/sig api-machinery

#### What this PR does / why we need it:

Adds integration tests demonstrating that we have wired up the cost calculations for the our CEL library functions and that the runtime cost budgets are being enforced.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
