### PR TITLE
enable kubelet server to dynamically load tls certificate files

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -671,6 +671,14 @@ const (
 	// Allow almost all printable ASCII characters in environment variables
 	RelaxedEnvironmentVariableValidation featuregate.Feature = "RelaxedEnvironmentVariableValidation"
 
+	// owner: @zhangweikop
+	// beta: v1.31
+	//
+	// Enable kubelet tls server to update certificate if the specified certificate files are changed.
+	// This feature is useful when specifying tlsCertFile & tlsPrivateKeyFile in kubelet Configuration.
+	// No effect for other cases such as using serverTLSbootstap.
+	ReloadKubeletServerCertificateFile featuregate.Feature = "ReloadKubeletServerCertificateFile"
+
 	// owner: @mikedanese
 	// alpha: v1.7
 	// beta: v1.12
@@ -1158,6 +1166,8 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	RecoverVolumeExpansionFailure: {Default: false, PreRelease: featuregate.Alpha},
 
 	RelaxedEnvironmentVariableValidation: {Default: false, PreRelease: featuregate.Alpha},
+
+	ReloadKubeletServerCertificateFile: {Default: true, PreRelease: featuregate.Beta},
 
 	RotateKubeletServerCertificate: {Default: true, PreRelease: featuregate.Beta},
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind feature

#### What this PR does / why we need it:
It enable kubelet tls server to watch and reload certificate files.

In our kubelet deployment, we don't use `ServerTLSBootstrap` or let kubelet to create a self-signed cert.
We have other mechanism (based on internal PKI & CA) to generate and rotate the certificate files for kubelet on each host.

Therefore, we want that kubelet TLS (both client and server side) can handle the certificate update. This feature is important for us when we start generating short shorter-lived certificates for kubelet

Currently in Kubelet:
 - The **client side** TLS has been handling the certificate reload very well thanks to the [client-go](https://github.com/kubernetes/client-go). 
 In our testing, the kubelet -> API server requests never encountered issues. The pod can be deployed and started correctly on the host after the kubelet certificate file expired and then regenerated.
 - But the **server side** TLS doesn't have auto-reload. Therefore, the https requests to kubelet (such as access container kubectl log or kubectl exec) would fail with following error message if the certificate loaded in kubelet server TLSconfig expired. 
 ```
Error from server: Get "https://<...hostname>.com:20250/containerLogs/....: x509: certificate has expired or is not yet valid: current time 2024-04-24T00:11:34Z is after 2024-04-12T00:52:35Z

```


#### Special notes for your reviewer:

1. The logic is expressed as  a `certificate.Manager` so that it could be used similarly to other struct in pkg/kubelet/certificate/kubelet.go.
2. The internal file watch and read implementation is based on `DynamicCertKeyPairContent` struct in [ k8s.io/apiserver/pkg/server/dynamiccertificates](https://pkg.go.dev/k8s.io/apiserver/pkg/server/dynamiccertificates).

#### Does this PR introduce a user-facing change?
```release-note
kubelet server can now dynamically load certificate files
```


