### PR TITLE
Step 3 – prefactoring: generic controlplane: split out SystemNamespaces

### DIFF
--- a/cmd/kube-apiserver/app/options/options.go
+++ b/cmd/kube-apiserver/app/options/options.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"time"
 
+	v1 "k8s.io/api/core/v1"
 	utilnet "k8s.io/apimachinery/pkg/util/net"
 	cliflag "k8s.io/component-base/cli/flag"
 
@@ -91,6 +92,8 @@ func NewServerRunOptions() *ServerRunOptions {
 			MasterCount:          1,
 		},
 	}
+
+	s.Options.SystemNamespaces = append(s.Options.SystemNamespaces, v1.NamespaceNodeLease)
 
 	return &s
 }

--- a/cmd/kube-apiserver/app/options/options_test.go
+++ b/cmd/kube-apiserver/app/options/options_test.go
@@ -291,6 +291,7 @@ func TestAddFlags(t *testing.T) {
 				ConfigFile: "/var/run/kubernetes/tracing_config.yaml",
 			},
 			AggregatorRejectForwardingRedirects: true,
+			SystemNamespaces:                    []string{"kube-system", "kube-public", "default", "kube-node-lease"},
 		},
 
 		Extra: Extra{

--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -239,6 +239,7 @@ func CreateKubeAPIServerConfig(opts options.CompletedOptions) (
 				EventTTL:                opts.EventTTL,
 				EnableLogsSupport:       opts.EnableLogsHandler,
 				ProxyTransport:          proxyTransport,
+				SystemNamespaces:        opts.SystemNamespaces,
 
 				ServiceAccountIssuer:        opts.ServiceAccountIssuer,
 				ServiceAccountMaxExpiration: opts.ServiceAccountTokenMaxExpiration,

--- a/pkg/controlplane/apiserver/config.go
+++ b/pkg/controlplane/apiserver/config.go
@@ -76,6 +76,8 @@ type Extra struct {
 	ServiceAccountJWKSURI    string
 	ServiceAccountPublicKeys []interface{}
 
+	SystemNamespaces []string
+
 	VersionedInformers clientgoinformers.SharedInformerFactory
 }
 

--- a/pkg/controlplane/apiserver/options/options.go
+++ b/pkg/controlplane/apiserver/options/options.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"time"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	peerreconcilers "k8s.io/apiserver/pkg/reconcilers"
 	genericoptions "k8s.io/apiserver/pkg/server/options"
 	"k8s.io/apiserver/pkg/storage/storagebackend"
@@ -83,6 +84,8 @@ type Options struct {
 	ServiceAccountTokenMaxExpiration time.Duration
 
 	ShowHiddenMetricsForVersion string
+
+	SystemNamespaces []string
 }
 
 // completedServerRunOptions is a private wrapper that enforces a call of Complete() before Run can be invoked.
@@ -115,6 +118,7 @@ func NewOptions() *Options {
 		EnableLogsHandler:                   true,
 		EventTTL:                            1 * time.Hour,
 		AggregatorRejectForwardingRedirects: true,
+		SystemNamespaces:                    []string{metav1.NamespaceSystem, metav1.NamespacePublic, metav1.NamespaceDefault},
 	}
 
 	// Overwrite the default for storage data format.

--- a/pkg/controlplane/apiserver/options/options_test.go
+++ b/pkg/controlplane/apiserver/options/options_test.go
@@ -277,6 +277,7 @@ func TestAddFlags(t *testing.T) {
 			ConfigFile: "/var/run/kubernetes/tracing_config.yaml",
 		},
 		AggregatorRejectForwardingRedirects: true,
+		SystemNamespaces:                    []string{"kube-system", "kube-public", "default"},
 	}
 
 	expected.Authentication.OIDC.UsernameClaim = "sub"

--- a/pkg/controlplane/controller/systemnamespaces/system_namespaces_controller.go
+++ b/pkg/controlplane/controller/systemnamespaces/system_namespaces_controller.go
@@ -46,8 +46,7 @@ type Controller struct {
 }
 
 // NewController creates a new Controller to ensure system namespaces exist.
-func NewController(clientset kubernetes.Interface, namespaceInformer coreinformers.NamespaceInformer) *Controller {
-	systemNamespaces := []string{metav1.NamespaceSystem, metav1.NamespacePublic, v1.NamespaceNodeLease, metav1.NamespaceDefault}
+func NewController(systemNamespaces []string, clientset kubernetes.Interface, namespaceInformer coreinformers.NamespaceInformer) *Controller {
 	interval := 1 * time.Minute
 
 	return &Controller{

--- a/pkg/controlplane/controller/systemnamespaces/system_namespaces_controller_test.go
+++ b/pkg/controlplane/controller/systemnamespaces/system_namespaces_controller_test.go
@@ -30,8 +30,6 @@ import (
 
 // Test_Controller validates the garbage collection logic for the apiserverleasegc controller.
 func Test_Controller(t *testing.T) {
-	systemNamespaces := []string{metav1.NamespaceSystem, metav1.NamespacePublic, v1.NamespaceNodeLease}
-
 	tests := []struct {
 		name       string
 		namespaces []string
@@ -107,7 +105,8 @@ func Test_Controller(t *testing.T) {
 				namespaceInformer.Informer().GetIndexer().Add(obj)
 			}
 
-			controller := NewController(clientset, namespaceInformer)
+			systemNamespaces := []string{metav1.NamespaceSystem, metav1.NamespacePublic, v1.NamespaceNodeLease, metav1.NamespaceDefault}
+			controller := NewController(systemNamespaces, clientset, namespaceInformer)
 
 			clientset.PrependReactor("create", "namespaces", func(action k8stesting.Action) (bool, runtime.Object, error) {
 				create := action.(k8stesting.CreateAction)

--- a/pkg/controlplane/instance.go
+++ b/pkg/controlplane/instance.go
@@ -465,7 +465,7 @@ func (c CompletedConfig) New(delegationTarget genericapiserver.DelegationTarget)
 	}
 
 	m.GenericAPIServer.AddPostStartHookOrDie("start-system-namespaces-controller", func(hookContext genericapiserver.PostStartHookContext) error {
-		go systemnamespaces.NewController(client, c.ControlPlane.Extra.VersionedInformers.Core().V1().Namespaces()).Run(hookContext.StopCh)
+		go systemnamespaces.NewController(c.ControlPlane.SystemNamespaces, client, c.ControlPlane.Extra.VersionedInformers.Core().V1().Namespaces()).Run(hookContext.StopCh)
 		return nil
 	})
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

A generic controlplane will have system namespaces, but just a subset of the kube ones (`kube-node-lease` is left out). This PR split the configuration of the set of system namespaces out such that a generic controlplane can customize the set.

Part of https://github.com/kubernetes/kubernetes/pull/124530.

#### Which issue(s) this PR fixes:

Towards https://github.com/kubernetes/enhancements/issues/4080.

#### Special notes for your reviewer:

This has zero behaviour changes for kube-apiserver.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```