### PR TITLE
support `scheduler_plugin_execution_duration_seconds` in scheduler_perf

### DIFF
--- a/pkg/scheduler/metrics/metrics.go
+++ b/pkg/scheduler/metrics/metrics.go
@@ -38,7 +38,24 @@ const (
 	Binding = "binding"
 )
 
-// Below are possible values for the extension_point label.
+// ExtentionPoints is a list of possible values for the extension_point label.
+var ExtentionPoints = []string{
+	PreFilter,
+	Filter,
+	PreFilterExtensionAddPod,
+	PreFilterExtensionRemovePod,
+	PostFilter,
+	PreScore,
+	Score,
+	ScoreExtensionNormalize,
+	PreBind,
+	Bind,
+	PostBind,
+	Reserve,
+	Unreserve,
+	Permit,
+}
+
 const (
 	PreFilter                   = "PreFilter"
 	Filter                      = "Filter"

--- a/test/integration/scheduler_perf/util_test.go
+++ b/test/integration/scheduler_perf/util_test.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package benchmark
+
+import (
+	"reflect"
+	"testing"
+)
+
+func Test_uniqueLVCombos(t *testing.T) {
+	type args struct {
+		lvs []*labelValues
+	}
+	tests := []struct {
+		name string
+		args args
+		want []map[string]string
+	}{
+		{
+			name: "empty input",
+			args: args{
+				lvs: []*labelValues{},
+			},
+			want: []map[string]string{{}},
+		},
+		{
+			name: "single label, multiple values",
+			args: args{
+				lvs: []*labelValues{
+					{"A", []string{"a1", "a2"}},
+				},
+			},
+			want: []map[string]string{
+				{"A": "a1"},
+				{"A": "a2"},
+			},
+		},
+		{
+			name: "multiple labels, single value each",
+			args: args{
+				lvs: []*labelValues{
+					{"A", []string{"a1"}},
+					{"B", []string{"b1"}},
+				},
+			},
+			want: []map[string]string{
+				{"A": "a1", "B": "b1"},
+			},
+		},
+		{
+			name: "multiple labels, multiple values",
+			args: args{
+				lvs: []*labelValues{
+					{"A", []string{"a1", "a2"}},
+					{"B", []string{"b1", "b2"}},
+				},
+			},
+			want: []map[string]string{
+				{"A": "a1", "B": "b1"},
+				{"A": "a1", "B": "b2"},
+				{"A": "a2", "B": "b1"},
+				{"A": "a2", "B": "b2"},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := uniqueLVCombos(tt.args.lvs); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("uniqueLVCombos() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

support `scheduler_plugin_execution_duration_seconds` in scheduler_perf, which visualizes which plugin is how much slower. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

I confirmed that it's working expectedly at local machine. The output would be like following.

```json
....
    {
      "data": {
        "Average": 0.00032820000000000006,
        "Perc50": 0.005,
        "Perc90": 0.009000000000000001,
        "Perc95": 0.0095,
        "Perc99": 0.0099
      },
      "unit": "ms",
      "labels": {
        "Metric": "scheduler_plugin_execution_duration_seconds",
        "Name": "SchedulingBasic/500Nodes/namespace-2",
        "extension_point": "Score",
        "plugin": "ImageLocality",
        "result": "not applicable"
      }
    },
    {
      "data": {
        "Average": 0.0047445000000000005,
        "Perc50": 0.005,
        "Perc90": 0.009000000000000001,
        "Perc95": 0.0095,
        "Perc99": 0.0099
      },
      "unit": "ms",
      "labels": {
        "Metric": "scheduler_plugin_execution_duration_seconds",
        "Name": "SchedulingBasic/500Nodes/namespace-2",
        "extension_point": "PreFilter",
        "plugin": "InterPodAffinity",
        "result": "not applicable"
      }
    },
.....
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
