### PR TITLE
Support Dev Containers / Github Codespaces

### DIFF
--- a/.devcontainer/OWNERS
+++ b/.devcontainer/OWNERS
@@ -1,0 +1,14 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+  - cblecker
+  - jberkus
+  - kaslin
+  - MadhavJivrajani
+  - mrbobbytables
+  - Nikhita
+  - Priyankasaggu11929
+approvers:
+  - sig-contributor-experience-approvers
+labels:
+  - sig/contributor-experience

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,27 @@
+// For format details, see https://containers.dev
+{
+  "name": "Kubernetes environment from dev container",
+  // Image to pull when not building from scratch. See .devcontainer/build/devcontainer.json
+  // and .github/devcontainer-build-and-push.yml for the instructions on how this image is built
+  "image": "registry.k8s.io/build-image/kube-cross:v1.29.0-go1.21.3-bullseye.0",
+  // Setup the go environment and mount into the dev container at the expected location
+  "workspaceFolder": "/go/src/k8s.io/kubernetes",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/go/src/k8s.io/kubernetes,type=bind,consistency=cached",
+  // Ensure that the host machine has enough resources to build and test Kubernetes
+  // "hack/verify-typecheck.sh" test requires more CPUs, ensure you have larger machine type (e.g. 16 cores) to pass this test
+  "hostRequirements": {
+      "cpus": 4
+  },
+  // Copy over welcome message and install pyyaml
+  "onCreateCommand": "bash .devcontainer/setup.sh",
+  // for Kubernetes testing, suppress extraneous forwarding messages
+  "otherPortsAttributes": {
+      "onAutoForward": "silent"
+  },
+  "remoteUser": "root"
+  // Configure tool-specific properties.
+  // "customizations": {
+  // },
+  // Use 'forwardPorts' to make a list of ports inside the container available locally.
+  // "forwardPorts": [],
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,27 +1,46 @@
 // For format details, see https://containers.dev
 {
-  "name": "Kubernetes environment from dev container",
-  // Image to pull when not building from scratch. See .devcontainer/build/devcontainer.json
-  // and .github/devcontainer-build-and-push.yml for the instructions on how this image is built
-  "image": "registry.k8s.io/build-image/kube-cross:v1.29.0-go1.21.3-bullseye.0",
-  // Setup the go environment and mount into the dev container at the expected location
-  "workspaceFolder": "/go/src/k8s.io/kubernetes",
-  "workspaceMount": "source=${localWorkspaceFolder},target=/go/src/k8s.io/kubernetes,type=bind,consistency=cached",
-  // Ensure that the host machine has enough resources to build and test Kubernetes
-  // "hack/verify-typecheck.sh" test requires more CPUs, ensure you have larger machine type (e.g. 16 cores) to pass this test
-  "hostRequirements": {
-      "cpus": 4
-  },
-  // Copy over welcome message and install pyyaml
-  "onCreateCommand": "bash .devcontainer/setup.sh",
-  // for Kubernetes testing, suppress extraneous forwarding messages
-  "otherPortsAttributes": {
-      "onAutoForward": "silent"
-  },
-  "remoteUser": "root"
-  // Configure tool-specific properties.
-  // "customizations": {
-  // },
-  // Use 'forwardPorts' to make a list of ports inside the container available locally.
-  // "forwardPorts": [],
+    "name": "Kubernetes environment from dev container",
+
+    // For details about this image:
+    // https://github.com/kubernetes/release/tree/master/images/build/cross
+    "image": "registry.k8s.io/build-image/kube-cross:v1.30.0-go1.22.2-bullseye.0",
+    "remoteUser": "root",
+
+    // Setup the go environment and mount into the dev container at the expected location
+    "workspaceFolder": "/go/src/k8s.io/kubernetes",
+    "workspaceMount": "source=${localWorkspaceFolder},target=/go/src/k8s.io/kubernetes,type=bind,consistency=cached",
+
+    // Install the features based on the software required for Kubernetes development
+    // https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#installing-required-software
+    // https://containers.dev/features
+    "features": {
+        // The first-run-notice.txt is displayed by a script within
+        // ghcr.io/devcontainers/features/common-utils:2
+        // Although it might be installed by other features,
+        // we are explicitly installing it to ensure it's included
+        "ghcr.io/devcontainers/features/common-utils:2": {},
+        "ghcr.io/devcontainers/features/docker-in-docker:2": {},
+        "ghcr.io/devcontainers/features/python:1": {}
+    },
+
+    // Setup the dev container environment
+    "onCreateCommand": "./.devcontainer/setup.sh",
+
+    // Add etcd & _output/bin path to PATH
+    "remoteEnv": {
+        "PATH": "${containerEnv:PATH}:${containerWorkspaceFolder}/third_party/etcd:${containerWorkspaceFolder}/_output/bin"
+    },
+
+    // Configure the hostRequirements based on the Kubernetes Hardware Requirements
+    // https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#hardware-requirements
+    "hostRequirements": {
+        "memory": "8gb",
+        "storage": "50gb"
+    },
+
+    // for Kubernetes testing, suppress extraneous forwarding messages
+    "otherPortsAttributes": {
+        "onAutoForward": "silent"
+    }
 }

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2023 The Kubernetes Authors.
+# Copyright 2024 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,11 +16,42 @@
 
 set -eux
 
-
-
 # Copies over welcome message
+mkdir -p /usr/local/etc/vscode-dev-containers
 cp .devcontainer/welcome-message.txt /usr/local/etc/vscode-dev-containers/first-run-notice.txt
 
-git remote add upstream https://github.com/kubernetes/kubernetes.git
+# Ensure that the upstream remote is set, and configure it if it's not
+if ! git remote | grep -q "^upstream$"; then
+    git remote add upstream https://github.com/kubernetes/kubernetes.git
+else
+    if [ "$(git remote get-url upstream)" != "https://github.com/kubernetes/kubernetes.git" ]; then
+      git remote set-url upstream https://github.com/kubernetes/kubernetes.git
+    fi
+fi
+
 # Never push to upstream master
 git remote set-url --push upstream no_push
+
+# To ensure success in hack/print-workspace-status.sh,
+# execute git fetch upstream beforehand
+# The information retrieved in hack/print-workspace-status.sh is necessary
+# to execute the 'kind build node-image' command successfully through kubetest2
+# https://github.com/kubernetes-sigs/kind/blob/v0.22.0/pkg/build/nodeimage/internal/kube/source.go#L71-L104
+git fetch upstream
+
+# Install etcd
+./hack/install-etcd.sh
+
+# Install gcloud command
+curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
+echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
+apt-get update
+apt-get install -yq google-cloud-cli
+rm -f /etc/apt/sources.list.d/google-cloud-sdk.list
+
+# Install PyYAML
+pip3 install pyyaml
+
+# Install kind & kubetest2 for e2e testing
+go install sigs.k8s.io/kind@latest
+go install sigs.k8s.io/kubetest2/...@latest

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# Copyright 2023 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eux
+
+
+
+# Copies over welcome message
+cp .devcontainer/welcome-message.txt /usr/local/etc/vscode-dev-containers/first-run-notice.txt
+
+git remote add upstream https://github.com/kubernetes/kubernetes.git
+# Never push to upstream master
+git remote set-url --push upstream no_push

--- a/.devcontainer/welcome-message.txt
+++ b/.devcontainer/welcome-message.txt
@@ -1,0 +1,20 @@
+👋 Welcome to Kubernetes contribution in a dev container!
+     Works in GitHub Codespaces, VS Code, or in docker using the devcontainer cli
+
+See https://www.kubernetes.dev/docs/onboarding/ for guidance on contributing to Kuberentes
+
+This debian dev container image satisfies https://github.com/kubernetes/community/blob/master/contributors/devel/development.md and includes:
+ - kubernetes/kubernetes repository
+ - Docker
+ - go
+ - kubectl, etcd, kubetest2, and kind
+For details about dev containers and the debian dev container base image see https://containers.dev and https://github.com/devcontainers/images/tree/main/src/base-debian.
+The configuration for the dev container is in the .github/.devcontainer folder. (will be moved to prow)
+🎵 By default in Codespaces this environment uses a 4-core machine. Some tests may require a larger machine. In Codespaces you can change the machine type.
+   See https://docs.github.com/en/codespaces/customizing-your-codespace/changing-the-machine-type-for-your-codespace
+
+⚙️ If you are working in Codespaces on your own fork, this environment is automatically configured to support the GitHub
+   workflow https://www.kubernetes.dev/docs/guide/github-workflow/ (omit the clone step)
+↪️ Otherwise Codespaces will automatically fork the repository for you when you make your first push
+
+🔍 To explore VS Code to its fullest, search using the Command Palette (Cmd/Ctrl + Shift + P or F1).

--- a/.devcontainer/welcome-message.txt
+++ b/.devcontainer/welcome-message.txt
@@ -1,20 +1,34 @@
 👋 Welcome to Kubernetes contribution in a dev container!
-     Works in GitHub Codespaces, VS Code, or in docker using the devcontainer cli
+   Works in GitHub Codespaces, VS Code, or in docker using the devcontainer cli.
 
-See https://www.kubernetes.dev/docs/onboarding/ for guidance on contributing to Kuberentes
+See https://www.kubernetes.dev/docs/onboarding/ for guidance on contributing to Kubernetes.
 
-This debian dev container image satisfies https://github.com/kubernetes/community/blob/master/contributors/devel/development.md and includes:
+This dev container environment satisfies the requirements found at https://github.com/kubernetes/community/blob/master/contributors/devel/development.md and includes:
  - kubernetes/kubernetes repository
  - Docker
- - go
- - kubectl, etcd, kubetest2, and kind
-For details about dev containers and the debian dev container base image see https://containers.dev and https://github.com/devcontainers/images/tree/main/src/base-debian.
-The configuration for the dev container is in the .github/.devcontainer folder. (will be moved to prow)
-🎵 By default in Codespaces this environment uses a 4-core machine. Some tests may require a larger machine. In Codespaces you can change the machine type.
+ - Go
+ - build-essential/rsync/jq/gcloud/PyYAML/etcd
+ - kind/kubetest2
+
+For details about dev containers and the container image, see https://containers.dev and https://github.com/kubernetes/release/tree/master/images/build/cross.
+The configuration for the dev container is in the .github/.devcontainer folder.
+🎵 By default in Codespaces this environment uses a 8-core machine. Some tests may require a larger machine. In Codespaces you can change the machine type.
    See https://docs.github.com/en/codespaces/customizing-your-codespace/changing-the-machine-type-for-your-codespace
 
-⚙️ If you are working in Codespaces on your own fork, this environment is automatically configured to support the GitHub
-   workflow https://www.kubernetes.dev/docs/guide/github-workflow/ (omit the clone step)
-↪️ Otherwise Codespaces will automatically fork the repository for you when you make your first push
+⚙️ If you are working in Codespaces on your own fork, this environment is automatically configured to support the GitHub workflow found at https://www.kubernetes.dev/docs/guide/github-workflow/ (omit the clone step).
+↪️ Otherwise, Codespaces will automatically fork the repository for you when you make your first push.
 
 🔍 To explore VS Code to its fullest, search using the Command Palette (Cmd/Ctrl + Shift + P or F1).
+
+🤖 Run e2e test command example:
+  $ make
+  $ KUBETEST2_RUN_DIR=$(pwd)/_output/local/go/bin/ kubetest2 kind -v 2 \
+      --build \
+      --up \
+      --down \
+      --test=ginkgo \
+      -- \
+      --parallel 4 \
+      --focus-regex='TTLAfterFinished'
+
+For details about kubetest2, see https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/e2e-tests-kubetest2.md and https://github.com/kubernetes-sigs/kubetest2.


### PR DESCRIPTION
Based on:
- https://github.com/kubernetes/kubernetes/pull/121561
- https://github.com/craiglpeters/kubernetes-devcontainer

https://kubernetes.slack.com/archives/C1TU9EB9S/p1714223550391479?thread_ts=1713701062.612009&cid=C1TU9EB9S

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature
/sig architecture
/sig contributor-experience

#### What this PR does / why we need it:

This PR adds configuration files for running dev containers.

Currently, I am developing on Mac OS X, but sometimes I encounter errors like the one mentioned below:
https://github.com/kubernetes/kubernetes/pull/124156

By enabling the use of dev containers in the k/k repository, I can reduce the discrepancies in the development environment caused by differences in operating systems, and decrease the occurrence of errors like the one mentioned above.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #113019

#### Special notes for your reviewer:

To ensure that all tools mentioned in the [Development Guide](https://github.com/kubernetes/community/blob/master/contributors/devel/development.md) are installed, I use [the dev container feature](https://containers.dev/implementors/features/) and `setup.sh` to install any tools that are not already included in [the kube-cross Dockerfile](https://github.com/kubernetes/release/blob/master/images/build/cross/default/Dockerfile).

The following commands have been confirmed to work successfully in VSCode Dev Containers / Github Codespaces:

- `make`
- `make verify`
- `make update`
- `make test`
- `make test-integration`
- Running e2e tests with kubetest2:

  ```
  KUBETEST2_RUN_DIR=$(pwd)/_output/local/go/bin/ kubetest2 kind -v 2 \
      --build \
      --up \
      --down \
      --test=ginkgo \
      -- \
      --parallel 4 \
      --focus-regex='TTLAfterFinished'
  ```


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added support for using a [devcontainer](https://containers.dev/) when developing Kubernetes.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [Usage]: https://github.com/features/codespaces
- [More Info]: https://containers.dev/
```

cc @craiglpeters