### PR TITLE
Automated cherry pick of #120291: Fix Windows credential provider cannot find binary Windows

### DIFF
--- a/pkg/credentialprovider/plugin/plugin.go
+++ b/pkg/credentialprovider/plugin/plugin.go
@@ -98,8 +98,10 @@ func RegisterCredentialProviderPlugins(pluginConfigFile, pluginBinDir string) er
 	registerMetrics()
 
 	for _, provider := range credentialProviderConfig.Providers {
-		pluginBin := filepath.Join(pluginBinDir, provider.Name)
-		if _, err := os.Stat(pluginBin); err != nil {
+		// Considering Windows binary with suffix ".exe", LookPath() helps to find the correct path.
+		// LookPath() also calls os.Stat().
+		pluginBin, err := exec.LookPath(filepath.Join(pluginBinDir, provider.Name))
+		if err != nil {
 			if os.IsNotExist(err) {
 				return fmt.Errorf("plugin binary executable %s did not exist", pluginBin)
 			}


### PR DESCRIPTION
Cherry pick of #120291 on release-1.28.

#120291: Fix Windows credential provider cannot find binary Windows

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.