### PR TITLE
Step 7 – kube-apiserver: split admission initializers into generic and non-generic

### DIFF
--- a/pkg/controlplane/apiserver/admission/config.go
+++ b/pkg/controlplane/apiserver/admission/config.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package admission
+
+import (
+	"net/http"
+
+	"go.opentelemetry.io/otel/trace"
+
+	"k8s.io/apiserver/pkg/admission"
+	webhookinit "k8s.io/apiserver/pkg/admission/plugin/webhook/initializer"
+	egressselector "k8s.io/apiserver/pkg/server/egressselector"
+	"k8s.io/apiserver/pkg/util/webhook"
+	externalinformers "k8s.io/client-go/informers"
+	"k8s.io/client-go/rest"
+	"k8s.io/kubernetes/pkg/kubeapiserver/admission/exclusion"
+	quotainstall "k8s.io/kubernetes/pkg/quota/v1/install"
+)
+
+// Config holds the configuration needed to for initialize the admission plugins
+type Config struct {
+	LoopbackClientConfig *rest.Config
+	ExternalInformers    externalinformers.SharedInformerFactory
+}
+
+// New sets up the plugins and admission start hooks needed for admission
+func (c *Config) New(proxyTransport *http.Transport, egressSelector *egressselector.EgressSelector, serviceResolver webhook.ServiceResolver, tp trace.TracerProvider) ([]admission.PluginInitializer, error) {
+	webhookAuthResolverWrapper := webhook.NewDefaultAuthenticationInfoResolverWrapper(proxyTransport, egressSelector, c.LoopbackClientConfig, tp)
+	webhookPluginInitializer := webhookinit.NewPluginInitializer(webhookAuthResolverWrapper, serviceResolver)
+
+	kubePluginInitializer := NewPluginInitializer(
+		quotainstall.NewQuotaConfigurationForAdmission(),
+		exclusion.Excluded(),
+	)
+
+	return []admission.PluginInitializer{webhookPluginInitializer, kubePluginInitializer}, nil
+}

--- a/pkg/controlplane/apiserver/admission/initializer.go
+++ b/pkg/controlplane/apiserver/admission/initializer.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors.
+Copyright 2024 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -17,34 +17,39 @@ limitations under the License.
 package admission
 
 import (
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/apiserver/pkg/admission/initializer"
+	quota "k8s.io/apiserver/pkg/quota/v1"
 )
 
-// TODO add a `WantsToRun` which takes a stopCh.  Might make it generic.
-
-// WantsCloudConfig defines a function which sets CloudConfig for admission plugins that need it.
-type WantsCloudConfig interface {
-	SetCloudConfig([]byte)
-}
-
-// PluginInitializer is used for initialization of the Kubernetes specific admission plugins.
+// PluginInitializer is used for initialization of the generic controlplane admission plugins.
 type PluginInitializer struct {
-	cloudConfig []byte
+	quotaConfiguration         quota.Configuration
+	excludedAdmissionResources []schema.GroupResource
 }
 
 var _ admission.PluginInitializer = &PluginInitializer{}
 
 // NewPluginInitializer constructs new instance of PluginInitializer
-func NewPluginInitializer(cloudConfig []byte) *PluginInitializer {
+func NewPluginInitializer(
+	quotaConfiguration quota.Configuration,
+	excludedAdmissionResources []schema.GroupResource,
+) *PluginInitializer {
 	return &PluginInitializer{
-		cloudConfig: cloudConfig,
+		quotaConfiguration:         quotaConfiguration,
+		excludedAdmissionResources: excludedAdmissionResources,
 	}
 }
 
 // Initialize checks the initialization interfaces implemented by each plugin
 // and provide the appropriate initialization data
 func (i *PluginInitializer) Initialize(plugin admission.Interface) {
-	if wants, ok := plugin.(WantsCloudConfig); ok {
-		wants.SetCloudConfig(i.cloudConfig)
+	if wants, ok := plugin.(initializer.WantsQuotaConfiguration); ok {
+		wants.SetQuotaConfiguration(i.quotaConfiguration)
+	}
+
+	if wants, ok := plugin.(initializer.WantsExcludedAdmissionResources); ok {
+		wants.SetExcludedAdmissionResources(i.excludedAdmissionResources)
 	}
 }

--- a/pkg/controlplane/apiserver/admission/initializer_test.go
+++ b/pkg/controlplane/apiserver/admission/initializer_test.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package admission
+
+import (
+	"context"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apiserver/pkg/admission"
+	quota "k8s.io/apiserver/pkg/quota/v1"
+)
+
+type doNothingAdmission struct{}
+
+func (doNothingAdmission) Admit(ctx context.Context, a admission.Attributes, o admission.ObjectInterfaces) error {
+	return nil
+}
+func (doNothingAdmission) Handles(o admission.Operation) bool { return false }
+func (doNothingAdmission) Validate() error                    { return nil }
+
+type doNothingPluginInitialization struct{}
+
+func (doNothingPluginInitialization) ValidateInitialization() error { return nil }
+
+type doNothingQuotaConfiguration struct{}
+
+func (doNothingQuotaConfiguration) IgnoredResources() map[schema.GroupResource]struct{} { return nil }
+
+func (doNothingQuotaConfiguration) Evaluators() []quota.Evaluator { return nil }
+
+type WantsQuotaConfigurationAdmissionPlugin struct {
+	doNothingAdmission
+	doNothingPluginInitialization
+	config quota.Configuration
+}
+
+func (p *WantsQuotaConfigurationAdmissionPlugin) SetQuotaConfiguration(config quota.Configuration) {
+	p.config = config
+}
+
+func TestQuotaConfigurationAdmissionPlugin(t *testing.T) {
+	config := doNothingQuotaConfiguration{}
+	initializer := NewPluginInitializer(config, nil)
+	wantsQuotaConfigurationAdmission := &WantsQuotaConfigurationAdmissionPlugin{}
+	initializer.Initialize(wantsQuotaConfigurationAdmission)
+
+	if wantsQuotaConfigurationAdmission.config == nil {
+		t.Errorf("Expected quota configuration to be initialized but found nil")
+	}
+}

--- a/pkg/kubeapiserver/admission/initializer_test.go
+++ b/pkg/kubeapiserver/admission/initializer_test.go
@@ -20,9 +20,7 @@ import (
 	"context"
 	"testing"
 
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/admission"
-	quota "k8s.io/apiserver/pkg/quota/v1"
 )
 
 type doNothingAdmission struct{}
@@ -32,10 +30,6 @@ func (doNothingAdmission) Admit(ctx context.Context, a admission.Attributes, o a
 }
 func (doNothingAdmission) Handles(o admission.Operation) bool { return false }
 func (doNothingAdmission) Validate() error                    { return nil }
-
-type doNothingPluginInitialization struct{}
-
-func (doNothingPluginInitialization) ValidateInitialization() error { return nil }
 
 type WantsCloudConfigAdmissionPlugin struct {
 	doNothingAdmission
@@ -48,38 +42,11 @@ func (p *WantsCloudConfigAdmissionPlugin) SetCloudConfig(cloudConfig []byte) {
 
 func TestCloudConfigAdmissionPlugin(t *testing.T) {
 	cloudConfig := []byte("cloud-configuration")
-	initializer := NewPluginInitializer(cloudConfig, nil, nil)
+	initializer := NewPluginInitializer(cloudConfig)
 	wantsCloudConfigAdmission := &WantsCloudConfigAdmissionPlugin{}
 	initializer.Initialize(wantsCloudConfigAdmission)
 
 	if wantsCloudConfigAdmission.cloudConfig == nil {
 		t.Errorf("Expected cloud config to be initialized but found nil")
-	}
-}
-
-type doNothingQuotaConfiguration struct{}
-
-func (doNothingQuotaConfiguration) IgnoredResources() map[schema.GroupResource]struct{} { return nil }
-
-func (doNothingQuotaConfiguration) Evaluators() []quota.Evaluator { return nil }
-
-type WantsQuotaConfigurationAdmissionPlugin struct {
-	doNothingAdmission
-	doNothingPluginInitialization
-	config quota.Configuration
-}
-
-func (p *WantsQuotaConfigurationAdmissionPlugin) SetQuotaConfiguration(config quota.Configuration) {
-	p.config = config
-}
-
-func TestQuotaConfigurationAdmissionPlugin(t *testing.T) {
-	config := doNothingQuotaConfiguration{}
-	initializer := NewPluginInitializer(nil, config, nil)
-	wantsQuotaConfigurationAdmission := &WantsQuotaConfigurationAdmissionPlugin{}
-	initializer.Initialize(wantsQuotaConfigurationAdmission)
-
-	if wantsQuotaConfigurationAdmission.config == nil {
-		t.Errorf("Expected quota configuration to be initialized but found nil")
 	}
 }

--- a/plugin/pkg/admission/gc/gc_admission_test.go
+++ b/plugin/pkg/admission/gc/gc_admission_test.go
@@ -28,15 +28,16 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apiserver/pkg/admission"
+	apiserveradmission "k8s.io/apiserver/pkg/admission"
 	"k8s.io/apiserver/pkg/admission/initializer"
 	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 	fakediscovery "k8s.io/client-go/discovery/fake"
 	"k8s.io/client-go/restmapper"
 	coretesting "k8s.io/client-go/testing"
+
 	api "k8s.io/kubernetes/pkg/apis/core"
-	kubeadmission "k8s.io/kubernetes/pkg/kubeapiserver/admission"
+	controlplaneadmission "k8s.io/kubernetes/pkg/controlplane/apiserver/admission"
 )
 
 type fakeAuthorizer struct{}
@@ -111,7 +112,7 @@ func newGCPermissionsEnforcement() (*gcPermissionsEnforcement, error) {
 		},
 	}
 	gcAdmit := &gcPermissionsEnforcement{
-		Handler:   admission.NewHandler(admission.Create, admission.Update),
+		Handler:   apiserveradmission.NewHandler(apiserveradmission.Create, apiserveradmission.Update),
 		whiteList: whiteList,
 	}
 
@@ -138,9 +139,8 @@ func newGCPermissionsEnforcement() (*gcPermissionsEnforcement, error) {
 	}
 	restMapper := restmapper.NewDiscoveryRESTMapper(restMapperRes)
 	genericPluginInitializer := initializer.New(nil, nil, nil, fakeAuthorizer{}, nil, nil, restMapper)
-
-	pluginInitializer := kubeadmission.NewPluginInitializer(nil, nil, nil)
-	initializersChain := admission.PluginInitializers{}
+	pluginInitializer := controlplaneadmission.NewPluginInitializer(nil, nil)
+	initializersChain := apiserveradmission.PluginInitializers{}
 	initializersChain = append(initializersChain, genericPluginInitializer)
 	initializersChain = append(initializersChain, pluginInitializer)
 
@@ -349,14 +349,14 @@ func TestGCAdmission(t *testing.T) {
 				t.Error(err)
 			}
 
-			operation := admission.Create
+			operation := apiserveradmission.Create
 			var options runtime.Object = &metav1.CreateOptions{}
 			if tc.oldObj != nil {
-				operation = admission.Update
+				operation = apiserveradmission.Update
 				options = &metav1.UpdateOptions{}
 			}
 			user := &user.DefaultInfo{Name: tc.username}
-			attributes := admission.NewAttributesRecord(tc.newObj, tc.oldObj, schema.GroupVersionKind{}, metav1.NamespaceDefault, "foo", tc.resource, tc.subresource, operation, options, false, user)
+			attributes := apiserveradmission.NewAttributesRecord(tc.newObj, tc.oldObj, schema.GroupVersionKind{}, metav1.NamespaceDefault, "foo", tc.resource, tc.subresource, operation, options, false, user)
 
 			err = gcAdmit.Validate(context.TODO(), attributes, nil)
 			if !tc.checkError(err) {
@@ -668,14 +668,14 @@ func TestBlockOwnerDeletionAdmission(t *testing.T) {
 				gcAdmit.restMapper = tc.restMapperOverride
 			}
 
-			operation := admission.Create
+			operation := apiserveradmission.Create
 			var options runtime.Object = &metav1.CreateOptions{}
 			if tc.oldObj != nil {
-				operation = admission.Update
+				operation = apiserveradmission.Update
 				options = &metav1.UpdateOptions{}
 			}
 			user := &user.DefaultInfo{Name: tc.username}
-			attributes := admission.NewAttributesRecord(tc.newObj, tc.oldObj, schema.GroupVersionKind{}, metav1.NamespaceDefault, "foo", tc.resource, tc.subresource, operation, options, false, user)
+			attributes := apiserveradmission.NewAttributesRecord(tc.newObj, tc.oldObj, schema.GroupVersionKind{}, metav1.NamespaceDefault, "foo", tc.resource, tc.subresource, operation, options, false, user)
 
 			err = gcAdmit.Validate(context.TODO(), attributes, nil)
 			if !tc.checkError(err) {

--- a/plugin/pkg/admission/resourcequota/admission_test.go
+++ b/plugin/pkg/admission/resourcequota/admission_test.go
@@ -37,7 +37,7 @@ import (
 	testcore "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
 	api "k8s.io/kubernetes/pkg/apis/core"
-	kubeapiserveradmission "k8s.io/kubernetes/pkg/kubeapiserver/admission"
+	controlplaneadmission "k8s.io/kubernetes/pkg/controlplane/apiserver/admission"
 	"k8s.io/kubernetes/pkg/quota/v1/install"
 )
 
@@ -115,7 +115,7 @@ func createHandlerWithConfig(kubeClient kubernetes.Interface, informerFactory in
 
 	initializers := admission.PluginInitializers{
 		genericadmissioninitializer.New(kubeClient, nil, informerFactory, nil, nil, stopCh, nil),
-		kubeapiserveradmission.NewPluginInitializer(nil, quotaConfiguration, nil),
+		controlplaneadmission.NewPluginInitializer(quotaConfiguration, nil),
 	}
 	initializers.Initialize(handler)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR splits up admission initializers into those that are generic (in the sense of generic controlplanes) and those that are kube-specific.

NO FUNCTIONAL CHANGE.

Part of #124530. Next step will be https://github.com/kubernetes/kubernetes/pull/124638.

#### Which issue(s) this PR fixes:

Towards kubernetes/enhancements#4080.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

Look careful that this does not change any behaviour.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```