### PR TITLE
CEL: allow multiple messageExpression strings to be returned

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation_test.go
@@ -9749,6 +9749,89 @@ func TestValidateCustomResourceDefinitionValidation(t *testing.T) {
 			},
 		},
 		{
+			name: "x-kubernetes-validation rule with multiple messageExpressions returning empty list",
+			opts: validationOptions{requireStructuralSchema: true},
+			input: apiextensions.CustomResourceValidation{
+				OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
+					Type: "object",
+					Properties: map[string]apiextensions.JSONSchemaProps{
+						"f": {
+							Type: "string",
+							XValidations: apiextensions.ValidationRules{
+								{
+									Rule:              "self == \"string value\"",
+									MessageExpression: `[]`,
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedErrors: []validationMatch{
+				{
+					path:           field.NewPath("spec.validation.openAPIV3Schema.properties[f].x-kubernetes-validations[0].messageExpression"),
+					errorType:      field.ErrorTypeInvalid,
+					containsString: "messageExpression must evaluate to a string",
+				},
+			},
+		},
+		{
+			name: "x-kubernetes-validation rule with multiple messageExpressions returning invalid type",
+			opts: validationOptions{requireStructuralSchema: true},
+			input: apiextensions.CustomResourceValidation{
+				OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
+					Type: "object",
+					Properties: map[string]apiextensions.JSONSchemaProps{
+						"f": {
+							Type: "string",
+							XValidations: apiextensions.ValidationRules{
+								{
+									Rule:              "self == \"string value\"",
+									MessageExpression: `3`,
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedErrors: []validationMatch{
+				{
+					path:           field.NewPath("spec.validation.openAPIV3Schema.properties[f].x-kubernetes-validations[0].messageExpression"),
+					errorType:      field.ErrorTypeInvalid,
+					containsString: "messageExpression must evaluate to a string",
+				},
+			},
+		},
+		{
+			name: "x-kubernetes-validations rule with multiple messageExpressions",
+			opts: validationOptions{requireStructuralSchema: true},
+			input: apiextensions.CustomResourceValidation{
+				OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
+					Type: "object",
+					Properties: map[string]apiextensions.JSONSchemaProps{
+						"f": {
+							Type: "string",
+							XValidations: apiextensions.ValidationRules{
+								{
+									Rule:              "self == \"string value\"",
+									MessageExpression: `[self + " should be \"string value\"", "another message"]`,
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedErrors: []validationMatch{
+				{
+					// This feature is introduced 1.31 and enabled for stored expressions
+					// But not for new expressions
+					path:           field.NewPath("spec.validation.openAPIV3Schema.properties[f].x-kubernetes-validations[0].messageExpression"),
+					errorType:      field.ErrorTypeInvalid,
+					containsString: "messageExpression must evaluate to a string",
+				},
+			},
+		},
+		{
 			name: "x-kubernetes-validations rule with messageExpression",
 			opts: validationOptions{requireStructuralSchema: true},
 			input: apiextensions.CustomResourceValidation{

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/compilation.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/compilation.go
@@ -253,8 +253,16 @@ func compileRule(s *schema.Structural, rule apiextensions.ValidationRule, envSet
 			compilationResult.MessageExpressionError = &apiservercel.Error{Type: apiservercel.ErrorTypeInvalid, Detail: "messageExpression compilation failed: " + issues.String()}
 			return
 		}
-		if ast.OutputType() != cel.StringType {
-			compilationResult.MessageExpressionError = &apiservercel.Error{Type: apiservercel.ErrorTypeInvalid, Detail: "messageExpression must evaluate to a string"}
+
+		supportsMultipleMessageExpressions := messageEnv.HasLibrary(library.AllowMultipleMessageExpressionName)
+		outputType := ast.OutputType()
+
+		if outputType != cel.StringType && (!supportsMultipleMessageExpressions || !outputType.IsEquivalentType(cel.ListType(cel.StringType))) {
+			detail := "messageExpression must evaluate to a string"
+			if supportsMultipleMessageExpressions {
+				detail += " or a list of strings"
+			}
+			compilationResult.MessageExpressionError = &apiservercel.Error{Type: apiservercel.ErrorTypeInvalid, Detail: detail}
 			return
 		}
 

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/validation_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/validation_test.go
@@ -2560,42 +2560,42 @@ func TestMessageExpression(t *testing.T) {
 		message                 string
 		messageExpression       string
 		expectedLogErr          string
-		expectedValidationErr   string
+		expectedValidationErrs  []string
 		expectedRemainingBudget int64
 	}{
 		{
 			name:                    "no cost error expected",
 			messageExpression:       `"static string"`,
-			expectedValidationErr:   "static string",
+			expectedValidationErrs:  []string{"static string"},
 			costBudget:              300,
 			expectedRemainingBudget: 300,
 		},
 		{
-			name:                  "messageExpression takes precedence over message",
-			message:               "invisible",
-			messageExpression:     `"this is messageExpression"`,
-			costBudget:            celconfig.RuntimeCELCostBudget,
-			expectedValidationErr: "this is messageExpression",
+			name:                   "messageExpression takes precedence over message",
+			message:                "invisible",
+			messageExpression:      `"this is messageExpression"`,
+			costBudget:             celconfig.RuntimeCELCostBudget,
+			expectedValidationErrs: []string{"this is messageExpression"},
 		},
 		{
 			name:                    "default rule message used if messageExpression does not eval to string",
 			messageExpression:       `true`,
 			costBudget:              celconfig.RuntimeCELCostBudget,
-			expectedValidationErr:   "failed rule",
+			expectedValidationErrs:  []string{"failed rule"},
 			expectedRemainingBudget: celconfig.RuntimeCELCostBudget,
 		},
 		{
 			name:                    "limit exceeded",
 			messageExpression:       `"string 1" + "string 2" + "string 3"`,
 			costBudget:              1,
-			expectedValidationErr:   "messageExpression evaluation failed due to running out of cost budget",
+			expectedValidationErrs:  []string{"messageExpression evaluation failed due to running out of cost budget"},
 			expectedRemainingBudget: -1,
 		},
 		{
 			name:                    "messageExpression budget (str concat)",
 			messageExpression:       `"str1 " + self.str`,
 			costBudget:              50,
-			expectedValidationErr:   "str1 a string",
+			expectedValidationErrs:  []string{"str1 a string"},
 			expectedRemainingBudget: 46,
 		},
 		{
@@ -2604,7 +2604,7 @@ func TestMessageExpression(t *testing.T) {
 			messageExpression:       `"str1 " + ["a", "b", "c", "d"][4]`,
 			costBudget:              50,
 			expectedLogErr:          "messageExpression evaluation failed due to: index out of bounds: 4",
-			expectedValidationErr:   "message not messageExpression",
+			expectedValidationErrs:  []string{"message not messageExpression"},
 			expectedRemainingBudget: 47,
 		},
 		{
@@ -2612,7 +2612,7 @@ func TestMessageExpression(t *testing.T) {
 			messageExpression:       `"str1 " + ["a", "b", "c", "d"][4]`,
 			costBudget:              50,
 			expectedLogErr:          "messageExpression evaluation failed due to: index out of bounds: 4",
-			expectedValidationErr:   "failed rule",
+			expectedValidationErrs:  []string{"failed rule"},
 			expectedRemainingBudget: 47,
 		},
 		{
@@ -2620,40 +2620,62 @@ func TestMessageExpression(t *testing.T) {
 			messageExpression:       `"string 1" + "string 2" + "string 3"`,
 			costBudget:              celconfig.RuntimeCELCostBudget,
 			perCallLimit:            1,
-			expectedValidationErr:   "call cost exceeds limit for messageExpression",
+			expectedValidationErrs:  []string{"call cost exceeds limit for messageExpression"},
 			expectedRemainingBudget: -1,
 		},
 		{
-			name:                  "messageExpression is not allowed to generate a string with newlines",
-			message:               "message not messageExpression",
-			messageExpression:     `"str with \na newline"`,
-			costBudget:            celconfig.RuntimeCELCostBudget,
-			expectedLogErr:        "messageExpression should not contain line breaks",
-			expectedValidationErr: "message not messageExpression",
+			name:                   "messageExpression is not allowed to generate a string with newlines",
+			message:                "message not messageExpression",
+			messageExpression:      `"str with \na newline"`,
+			costBudget:             celconfig.RuntimeCELCostBudget,
+			expectedLogErr:         "messageExpression should not contain line breaks",
+			expectedValidationErrs: []string{"message not messageExpression"},
 		},
 		{
-			name:                  "messageExpression is not allowed to generate messages >5000 characters",
-			message:               "message not messageExpression",
-			messageExpression:     fmt.Sprintf(`"%s"`, genString(5121, 'a')),
-			costBudget:            celconfig.RuntimeCELCostBudget,
-			expectedLogErr:        "messageExpression beyond allowable length of 5120",
-			expectedValidationErr: "message not messageExpression",
+			name:                   "messageExpression is not allowed to generate messages >5000 characters",
+			message:                "message not messageExpression",
+			messageExpression:      fmt.Sprintf(`"%s"`, genString(5121, 'a')),
+			costBudget:             celconfig.RuntimeCELCostBudget,
+			expectedLogErr:         "messageExpression beyond allowable length of 5120",
+			expectedValidationErrs: []string{"message not messageExpression"},
 		},
 		{
-			name:                  "messageExpression is not allowed to generate an empty string",
-			message:               "message not messageExpression",
-			messageExpression:     `string("")`,
-			costBudget:            celconfig.RuntimeCELCostBudget,
-			expectedLogErr:        "messageExpression should evaluate to a non-empty string",
-			expectedValidationErr: "message not messageExpression",
+			name:                   "messageExpression is not allowed to generate an empty string",
+			message:                "message not messageExpression",
+			messageExpression:      `string("")`,
+			costBudget:             celconfig.RuntimeCELCostBudget,
+			expectedLogErr:         "messageExpression should evaluate to a non-empty string",
+			expectedValidationErrs: []string{"message not messageExpression"},
 		},
 		{
-			name:                  "messageExpression is not allowed to generate a string with only spaces",
-			message:               "message not messageExpression",
-			messageExpression:     `string("     ")`,
-			costBudget:            celconfig.RuntimeCELCostBudget,
-			expectedLogErr:        "messageExpression should evaluate to a non-empty string",
-			expectedValidationErr: "message not messageExpression",
+			name:                   "messageExpression is not allowed to generate a string with only spaces",
+			message:                "message not messageExpression",
+			messageExpression:      `string("     ")`,
+			costBudget:             celconfig.RuntimeCELCostBudget,
+			expectedLogErr:         "messageExpression should evaluate to a non-empty string",
+			expectedValidationErrs: []string{"message not messageExpression"},
+		},
+		{
+			name:                   "multiple message expressions",
+			messageExpression:      `["error1", "error2"]`,
+			costBudget:             celconfig.RuntimeCELCostBudget,
+			expectedValidationErrs: []string{"error1", "error2"},
+		},
+		{
+			name:                   "multiple messageExpression is not allowed to generate a string with only spaces",
+			message:                "message not messageExpression",
+			messageExpression:      `["withoutspaces", string("     ")]`,
+			costBudget:             celconfig.RuntimeCELCostBudget,
+			expectedLogErr:         "messageExpression should evaluate to a non-empty string",
+			expectedValidationErrs: []string{"message not messageExpression"},
+		},
+		{
+			name:                   "multiple message expressions",
+			message:                "message not messageExpression",
+			messageExpression:      `["error1", 5]`,
+			costBudget:             celconfig.RuntimeCELCostBudget,
+			expectedValidationErrs: []string{`message not messageExpression`},
+			expectedLogErr:         ``,
 		},
 	}
 	for _, tt := range tests {
@@ -2685,8 +2707,8 @@ func TestMessageExpression(t *testing.T) {
 			errs, remainingBudget := celValidator.Validate(ctx, field.NewPath("root"), &s, obj, nil, tt.costBudget)
 			klog.Flush()
 
-			if len(errs) != 1 {
-				t.Fatalf("expected 1 error, got %d", len(errs))
+			if len(errs) != len(tt.expectedValidationErrs) {
+				t.Fatalf("expected %d error(s), got %d", len(tt.expectedValidationErrs), len(errs))
 			}
 
 			if tt.expectedLogErr != "" {
@@ -2697,9 +2719,9 @@ func TestMessageExpression(t *testing.T) {
 				t.Fatalf("expected no log output, got: %q", outputBuffer.String())
 			}
 
-			if tt.expectedValidationErr != "" {
-				if !strings.Contains(errs[0].Error(), tt.expectedValidationErr) {
-					t.Fatalf("did not find expected validation error message: %q", tt.expectedValidationErr)
+			for i, expectedValidationErr := range tt.expectedValidationErrs {
+				if !strings.Contains(errs[i].Error(), expectedValidationErr) {
+					t.Fatalf("did not find expected validation error message: %q", expectedValidationErr)
 				}
 			}
 

--- a/staging/src/k8s.io/apiserver/pkg/cel/environment/base.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/environment/base.go
@@ -132,11 +132,11 @@ var baseOptsWithoutStrictCost = []VersionedOptions{
 			library.CIDR(),
 		},
 	},
-	// Format Library
 	{
 		IntroducedVersion: version.MajorMinor(1, 31),
 		EnvOptions: []cel.EnvOption{
 			library.Format(),
+			library.AllowMultipleMessageExpression(),
 		},
 	},
 }

--- a/staging/src/k8s.io/apiserver/pkg/cel/library/multiple_message_expression.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/library/multiple_message_expression.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package library
+
+import "github.com/google/cel-go/cel"
+
+func AllowMultipleMessageExpression() cel.EnvOption {
+	return cel.Lib(allowMultipleMessageExpressionLib)
+}
+
+var allowMultipleMessageExpressionLib = &allowMultipleMessageExpression{}
+
+var AllowMultipleMessageExpressionName = "AllowMultipleMessageExpression"
+
+type allowMultipleMessageExpression struct{}
+
+func (*allowMultipleMessageExpression) LibraryName() string {
+	return AllowMultipleMessageExpressionName
+}
+
+func (*allowMultipleMessageExpression) CompileOptions() []cel.EnvOption {
+	return nil
+}
+
+func (*allowMultipleMessageExpression) ProgramOptions() []cel.ProgramOption {
+	return nil
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
Blocker for Declarative Validation for Native Types. Allows a CEL `list(string)` to be returned for `messageExpression`. Uses a CEL library to gate the feature, so it acquires ratcheting properties of other CEL libraries.

/cc @cici37 @jpbetz 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Allows for CEL `messageExpression` under `x-kubernetes-validations` to accept a `list(string)` in addition to `string` to allow multiple errors to be constructed and returned. New CRDs will be able to use this change starting in 1.32.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
