### PR TITLE
apiserver/endpoints/installer: allow overriding hubGV

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/rest.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/rest.go
@@ -381,6 +381,16 @@ type StorageVersionProvider interface {
 	StorageVersion() runtime.GroupVersioner
 }
 
+// HubGroupVersionProvider is an optional interface that a store can implement
+// if it wishes to override the hub group-version. Otherwise, the default is
+// the runtime.APIVersionInternal version with a matching group. This is useful
+// for non-etcd storage implementations that still utilize the common patch
+// handler: k8s.io/apiserver/pkg/endpoints/handlers/patch.go but do not use a
+// runtime.APIVersionInternal
+type HubGroupVersionProvider interface {
+	HubGroupVersion() runtime.GroupVersioner
+}
+
 // ResetFieldsStrategy is an optional interface that a storage object can
 // implement if it wishes to provide the fields reset by its strategies.
 type ResetFieldsStrategy interface {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
Strategic merge patch (k8s.io/apiserver/pkg/endpoints/handlers/patch.go) assumes resources should be converted to an internal resource version, presumably for etcd internal storage. It seems the example apiservice gets around this by registering versions with the internal version but this causes problems with much of the other tooling that presumes resources have a version. At any rate, it seems reasonable to allow an external apiservice to be able to choose its own hubGroupVersion while still being able to utilize the heavy-lifting logic in endpoints/installer.go and endpoints/handlers/patch.go.

To achieve this, allow the rest.Storage parameter to drive what the hubGroupVersion is when it implements `rest.HubGroupVersionProvider`.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

Note that a previous attempt (#124457 ) tried to utilize the existing `rest.StorageVersionProvider` but the versions for a storage version and a hub version are not aligned closely enough to be unified. Namely, the hub version uses `__internal` for all types, whereas a storage version uses `__internal` for non-external types (e.g. `statefulsets/scale`) but then uses the external group version elsewhere (e.g. `v1` for `statefulsets`).

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
