### PR TITLE
simplify EndpointSliceCache caching

### DIFF
--- a/pkg/proxy/endpointslicecache_test.go
+++ b/pkg/proxy/endpointslicecache_test.go
@@ -370,7 +370,7 @@ func TestEsDataChanged(t *testing.T) {
 				ObjectMeta: objMeta,
 				Ports:      []discovery.EndpointPort{port80, port443},
 			},
-			expectChanged: false,
+			expectChanged: true,
 		},
 		"port removed": {
 			cache: NewEndpointSliceCache("", v1.IPv4Protocol, nil, nil),
@@ -422,7 +422,7 @@ func TestEsDataChanged(t *testing.T) {
 				Ports:      []discovery.EndpointPort{port443},
 				Endpoints:  []discovery.Endpoint{endpoint2, endpoint1},
 			},
-			expectChanged: false,
+			expectChanged: true,
 		},
 		"identical with endpoint added": {
 			cache: NewEndpointSliceCache("", v1.IPv4Protocol, nil, nil),

--- a/pkg/proxy/endpointslicecache_test.go
+++ b/pkg/proxy/endpointslicecache_test.go
@@ -454,7 +454,7 @@ func TestEsDataChanged(t *testing.T) {
 				t.Fatalf("Expected no error calling endpointSliceCacheKeys(): %v", err)
 			}
 
-			esData := newEndpointSliceData(tc.updatedSlice, false)
+			esData := &endpointSliceData{tc.updatedSlice, false}
 			changed := tc.cache.esDataChanged(serviceKey, sliceKey, esData)
 
 			if tc.expectChanged != changed {


### PR DESCRIPTION
#### What this PR does / why we need it:
Reduces proxy memory usage (and simplifies EndpointSliceCache) by caching EndpointSlices directly rather than caching copies of them

(Part of belatedly getting back to #114757...)

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/kind cleanup
/sig network
/assign @aojea @robscott 