### PR TITLE
client-go/tools/record: fix and test Broadcaster shutdown + logging

### DIFF
--- a/staging/src/k8s.io/client-go/tools/record/event.go
+++ b/staging/src/k8s.io/client-go/tools/record/event.go
@@ -203,8 +203,8 @@ func NewBroadcaster(opts ...BroadcasterOption) EventBroadcaster {
 	// - The context was nil.
 	// - The context was context.Background() to begin with.
 	//
-	// Both cases get checked here.
-	haveCtxCancelation := ctx.Done() == nil
+	// Both cases get checked here: we have cancelation if (and only if) there is a channel.
+	haveCtxCancelation := ctx.Done() != nil
 
 	eventBroadcaster.cancelationCtx, eventBroadcaster.cancel = context.WithCancel(ctx)
 

--- a/staging/src/k8s.io/client-go/tools/record/main_test.go
+++ b/staging/src/k8s.io/client-go/tools/record/main_test.go
@@ -17,10 +17,11 @@ limitations under the License.
 package record
 
 import (
-	"os"
 	"testing"
+
+	"go.uber.org/goleak"
 )
 
 func TestMain(m *testing.M) {
-	os.Exit(m.Run())
+	goleak.VerifyTestMain(m)
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Constructing a Broadcaster already starts a watch which runs in the background. Shutdown must be called to avoid leaking the goroutine.  Providing a context was supposed to remove the need to call Shutdown, but that did not actually work because the logic for "must check for cancellation" was accidentally inverted.

#### Special notes for your reviewer:

While at it, structured log output also gets tested together with checking for goroutine leaks.

#### Does this PR introduce a user-facing change?
```release-note
client-go/tools/record.Broadcaster: fixed automatic shutdown on WithContext cancellation
```
