### PR TITLE
Automated cherry pick of #124528: Fix PersistentVolumeLabel admission plugin on Azure

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_managedDiskController.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_managedDiskController.go
@@ -364,6 +364,11 @@ func (c *Cloud) GetAzureDiskLabels(diskURI string) (map[string]string, error) {
 		return nil, err
 	}
 
+	if c.Location == "" {
+		// The cloud provider is not initialized and cannot get the topology labels.
+		return nil, nil
+	}
+
 	labels := map[string]string{
 		v1.LabelTopologyRegion: c.Location,
 	}


### PR DESCRIPTION
Cherry pick of #124528 on release-1.27.

#124528: Fix PersistentVolumeLabel admission plugin on Azure

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```