### PR TITLE
e2e/network: stream pod logs for debugging

### DIFF
--- a/test/e2e/network/networking.go
+++ b/test/e2e/network/networking.go
@@ -17,6 +17,7 @@ limitations under the License.
 package network
 
 import (
+	"bufio"
 	"context"
 	"fmt"
 	"strconv"
@@ -327,6 +328,37 @@ var _ = common.SIGDescribe("Networking", func() {
 
 		ginkgo.It("should update endpoints: http", func(ctx context.Context) {
 			config := e2enetwork.NewNetworkingTestConfig(ctx, f)
+
+			// start of intermittent code snippet to understand the reason for flaky behaviour
+			// TODO @aroradaman @aojea remove this once issue #123760 is resolved
+			// streaming logs for netserver-0 which will be deleted during the test
+			// (ref: https://github.com/kubernetes/kubernetes/issues/123760)
+			pod0name := config.EndpointPods[0].Name
+			go func() {
+				defer ginkgo.GinkgoRecover()
+				readCloser, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).GetLogs(pod0name, &v1.PodLogOptions{
+					Follow: true,
+				}).Stream(ctx)
+
+				// silently ignoring error, we don't want to disturb the original test
+				if err != nil {
+					return
+				}
+				defer func() {
+					_ = readCloser.Close()
+				}()
+
+				scanner := bufio.NewScanner(readCloser)
+				var lines []string
+				for scanner.Scan() {
+					lines = append(lines, "\t\t"+scanner.Text())
+				}
+				framework.Logf("================ start of pod log for %s ================", pod0name)
+				framework.Logf("\n%s", strings.Join(lines, "\n"))
+				framework.Logf("================ end of pod log for %s ================", pod0name)
+			}()
+			// end of intermittent code snippet
+
 			ginkgo.By(fmt.Sprintf("dialing(http) %v --> %v:%v (config.clusterIP)", config.TestContainerPod.Name, config.ClusterIP, e2enetwork.ClusterHTTPPort))
 			err := config.DialFromTestContainer(ctx, "http", config.ClusterIP, e2enetwork.ClusterHTTPPort, config.MaxTries, 0, config.EndpointHostnames())
 			if err != nil {


### PR DESCRIPTION
Intermittent logging to understand the root cause of https://github.com/kubernetes/kubernetes/issues/123760
```
  I0501 00:55:58.906442 48549 networking.go:353] ================ start of pod log for netserver-0 ================
  I0501 00:55:58.906541 48549 networking.go:354] 
  		I0430 19:25:28.023397       1 log.go:245] Started HTTP server on port 8083
  		I0430 19:25:28.023548       1 log.go:245] Started UDP server on port  8081
  		I0430 19:25:47.883592       1 log.go:245] GET /healthz
  		I0430 19:25:47.883689       1 log.go:245] GET /healthz
  		I0430 19:25:57.883767       1 log.go:245] GET /healthz
  		I0430 19:25:57.883992       1 log.go:245] GET /healthz
  		I0430 19:25:57.967560       1 log.go:245] GET /hostname
  		I0430 19:25:57.967598       1 log.go:245] hostname: netserver-0
  I0501 00:55:58.906697 48549 networking.go:355] ================ end of pod log for netserver-0 ================
```
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/kind flake
/sig network
/release-note-none
/assign @aojea 
