### PR TITLE
kubeadm: update the IsPriviligedUser preflight check on Windows

### DIFF
--- a/cmd/kubeadm/app/preflight/checks_windows.go
+++ b/cmd/kubeadm/app/preflight/checks_windows.go
@@ -20,34 +20,17 @@ limitations under the License.
 package preflight
 
 import (
-	"os/user"
-
 	"github.com/pkg/errors"
+	"golang.org/x/sys/windows"
 )
-
-// The "Well-known SID" of Administrator group
-// https://support.microsoft.com/en-us/help/243330/well-known-security-identifiers-in-windows-operating-systems
-const administratorSID = "S-1-5-32-544"
 
 // Check validates if a user has elevated (administrator) privileges.
 func (ipuc IsPrivilegedUserCheck) Check() (warnings, errorList []error) {
-	currUser, err := user.Current()
-	if err != nil {
-		return nil, []error{errors.Wrap(err, "cannot get current user")}
+	hProcessToken := windows.GetCurrentProcessToken()
+	if hProcessToken.IsElevated() {
+		return nil, nil
 	}
-
-	groupIds, err := currUser.GroupIds()
-	if err != nil {
-		return nil, []error{errors.Wrap(err, "cannot get group IDs for current user")}
-	}
-
-	for _, sid := range groupIds {
-		if sid == administratorSID {
-			return nil, nil
-		}
-	}
-
-	return nil, []error{errors.New("user is not running as administrator")}
+	return nil, []error{errors.New("the kubeadm process must be run by a user with elevated privileges")}
 }
 
 // Check number of memory required by kubeadm


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

    Use GetCurrentProcessToken() instead of checking the groups of a user.

    The Go stdlib way of fetching the groups of an user appears
    to be failing on some Windows setups. Which could be a regression
    in later Go versions, or simply the code does not work on certain
    setups.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubeadm/issues/3053

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubeadm: improve the "IsPriviledgedUser" preflight check to not fail on certain Windows setups.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
