### PR TITLE
Add new error type for failed resource reads

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -971,6 +971,8 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 
 	genericfeatures.AdmissionWebhookMatchConditions: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.33
 
+	genericfeatures.AllowUnsafeMalformedObjectDeletion: {Default: false, PreRelease: featuregate.Alpha},
+
 	genericfeatures.AggregatedDiscoveryEndpoint: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.33
 
 	genericfeatures.APIListChunking: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.32

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/conversion/conversion_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/conversion/conversion_test.go
@@ -715,7 +715,10 @@ func expectConversionFailureMessage(id, message string) func(t *testing.T, ctc *
 				if err == nil {
 					t.Errorf("expected error with message %s, but got no error", message)
 				} else if !strings.Contains(err.Error(), message) {
-					t.Errorf("expected error with message %s, but got %v", message, err)
+					statusCause, hasCause := errors.StatusCause(err, metav1.CauseTypeUnexpectedServerResponse)
+					if !hasCause || !strings.Contains(statusCause.Message, message) {
+						t.Errorf("expected error with message %s, but got %v", message, err)
+					}
 				}
 			})
 		}

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
@@ -916,6 +916,22 @@ const (
 	// Status code 500
 	StatusReasonServerTimeout StatusReason = "ServerTimeout"
 
+	// StatusReasonStoreReadError means that the server encountered an error while
+	// retrieving resources from the backend object store.
+	// This may be due to backend database error, or because processing of the read
+	// resource failed.
+	// Details:
+	//   "kind" string - the kind attribute of the resource being acted on.
+	//   "name" string - the prefix where the reading error(s) occurred
+	//   "causes" []StatusCause
+	//      - (optional):
+	//        - "type" CauseType - CauseTypeUnexpectedServerResponse
+	//        - "message" string - the error message from the store backend
+	//        - "field" string - the full path with the key of the resource that failed reading
+	//
+	// Status code 500
+	StatusReasonStoreReadError StatusReason = "StorageReadError"
+
 	// StatusReasonTimeout means that the request could not be completed within the given time.
 	// Clients can get this response only when they specified a timeout param in the request,
 	// or if the server cannot complete the operation within a reasonable amount of time.

--- a/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
+++ b/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
@@ -53,6 +53,15 @@ const (
 	// caching with ETags containing all APIResources known to the apiserver.
 	AggregatedDiscoveryEndpoint featuregate.Feature = "AggregatedDiscoveryEndpoint"
 
+	// owner: @stlaz
+	// alpha: v1.32
+	// kep: https://kep.k8s.io/3926
+	//
+	// Enables the ability to remove objects that cannot be read, either because of
+	// errors during transformation of the data read (usually decryption), or because
+	// the object failed to be deserialized.
+	AllowUnsafeMalformedObjectDeletion featuregate.Feature = "AllowUnsafeMalformedObjectDeletion"
+
 	// owner: @vinayakankugoyal
 	// kep: https://kep.k8s.io/4633
 	// alpha: v1.31
@@ -314,6 +323,8 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 
 	AggregatedDiscoveryEndpoint: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.33
+
+	AllowUnsafeMalformedObjectDeletion: {Default: false, PreRelease: featuregate.Alpha},
 
 	AdmissionWebhookMatchConditions: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.33
 

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
@@ -179,7 +179,7 @@ func (s *store) Get(ctx context.Context, key string, opts storage.GetOptions, ou
 
 	data, _, err := s.transformer.TransformFromStorage(ctx, kv.Value, authenticatedDataString(preparedKey))
 	if err != nil {
-		return apierrors.NewStorageReadError(s.groupResource, key, map[string]error{preparedKey: err})
+		return storage.NewCorruptedDataError(map[string]error{preparedKey: err})
 	}
 
 	err = decode(s.codec, s.versioner, data, out, kv.ModRevision)
@@ -793,7 +793,7 @@ func (s *store) GetList(ctx context.Context, key string, opts storage.ListOption
 			getResp.Kvs[i] = nil
 		}
 		if len(failedKeys) > 0 {
-			return apierrors.NewStorageReadError(s.groupResource, key, failedKeys)
+			return storage.NewCorruptedDataError(failedKeys)
 		}
 
 		// no more results remain or we didn't request paging
@@ -917,7 +917,7 @@ func (s *store) getState(ctx context.Context, getResp *clientv3.GetResponse, key
 	} else {
 		data, stale, err := s.transformer.TransformFromStorage(ctx, getResp.Kvs[0].Value, authenticatedDataString(key))
 		if err != nil {
-			return nil, apierrors.NewStorageReadError(s.groupResource, key, map[string]error{key: err})
+			return nil, storage.NewCorruptedDataError(map[string]error{key: err})
 		}
 		state.rev = getResp.Kvs[0].ModRevision
 		state.meta.ResourceVersion = uint64(state.rev)

--- a/staging/src/k8s.io/apiserver/pkg/storage/testing/store_tests.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/testing/store_tests.go
@@ -2639,12 +2639,12 @@ func RunTestTransformationFailure(ctx context.Context, t *testing.T, store Inter
 		Predicate: storage.Everything,
 		Recursive: true,
 	}
-	if err := store.GetList(ctx, "/pods", storageOpts, &got); !apierrors.IsStoreReadError(err) {
+	if err := store.GetList(ctx, "/pods", storageOpts, &got); !storage.IsCorruptedData(err) {
 		t.Errorf("Unexpected error %v", err)
 	}
 
 	// Get should fail
-	if err := store.Get(ctx, preset[1].key, storage.GetOptions{}, &example.Pod{}); !apierrors.IsStoreReadError(err) {
+	if err := store.Get(ctx, preset[1].key, storage.GetOptions{}, &example.Pod{}); !storage.IsCorruptedData(err) {
 		t.Errorf("Unexpected error: %v", err)
 	}
 
@@ -2652,7 +2652,7 @@ func RunTestTransformationFailure(ctx context.Context, t *testing.T, store Inter
 		return input, nil, nil
 	}
 	// GuaranteedUpdate without suggestion should return an error
-	if err := store.GuaranteedUpdate(ctx, preset[1].key, &example.Pod{}, false, nil, updateFunc, nil); !apierrors.IsStoreReadError(err) {
+	if err := store.GuaranteedUpdate(ctx, preset[1].key, &example.Pod{}, false, nil, updateFunc, nil); !storage.IsCorruptedData(err) {
 		t.Errorf("Unexpected error: %v", err)
 	}
 	// GuaranteedUpdate with suggestion should return an error if we don't change the object
@@ -2661,10 +2661,10 @@ func RunTestTransformationFailure(ctx context.Context, t *testing.T, store Inter
 	}
 
 	// Delete fails with internal error.
-	if err := store.Delete(ctx, preset[1].key, &example.Pod{}, nil, storage.ValidateAllObjectFunc, nil); !apierrors.IsStoreReadError(err) {
+	if err := store.Delete(ctx, preset[1].key, &example.Pod{}, nil, storage.ValidateAllObjectFunc, nil); !storage.IsCorruptedData(err) {
 		t.Errorf("Unexpected error: %v", err)
 	}
-	if err := store.Get(ctx, preset[1].key, storage.GetOptions{}, &example.Pod{}); !apierrors.IsStoreReadError(err) {
+	if err := store.Get(ctx, preset[1].key, storage.GetOptions{}, &example.Pod{}); !storage.IsCorruptedData(err) {
 		t.Errorf("Unexpected error: %v", err)
 	}
 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/testing/store_tests.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/testing/store_tests.go
@@ -2639,12 +2639,12 @@ func RunTestTransformationFailure(ctx context.Context, t *testing.T, store Inter
 		Predicate: storage.Everything,
 		Recursive: true,
 	}
-	if err := store.GetList(ctx, "/pods", storageOpts, &got); !storage.IsInternalError(err) {
+	if err := store.GetList(ctx, "/pods", storageOpts, &got); !apierrors.IsStoreReadError(err) {
 		t.Errorf("Unexpected error %v", err)
 	}
 
 	// Get should fail
-	if err := store.Get(ctx, preset[1].key, storage.GetOptions{}, &example.Pod{}); !storage.IsInternalError(err) {
+	if err := store.Get(ctx, preset[1].key, storage.GetOptions{}, &example.Pod{}); !apierrors.IsStoreReadError(err) {
 		t.Errorf("Unexpected error: %v", err)
 	}
 
@@ -2652,7 +2652,7 @@ func RunTestTransformationFailure(ctx context.Context, t *testing.T, store Inter
 		return input, nil, nil
 	}
 	// GuaranteedUpdate without suggestion should return an error
-	if err := store.GuaranteedUpdate(ctx, preset[1].key, &example.Pod{}, false, nil, updateFunc, nil); !storage.IsInternalError(err) {
+	if err := store.GuaranteedUpdate(ctx, preset[1].key, &example.Pod{}, false, nil, updateFunc, nil); !apierrors.IsStoreReadError(err) {
 		t.Errorf("Unexpected error: %v", err)
 	}
 	// GuaranteedUpdate with suggestion should return an error if we don't change the object
@@ -2661,10 +2661,10 @@ func RunTestTransformationFailure(ctx context.Context, t *testing.T, store Inter
 	}
 
 	// Delete fails with internal error.
-	if err := store.Delete(ctx, preset[1].key, &example.Pod{}, nil, storage.ValidateAllObjectFunc, nil); !storage.IsInternalError(err) {
+	if err := store.Delete(ctx, preset[1].key, &example.Pod{}, nil, storage.ValidateAllObjectFunc, nil); !apierrors.IsStoreReadError(err) {
 		t.Errorf("Unexpected error: %v", err)
 	}
-	if err := store.Get(ctx, preset[1].key, storage.GetOptions{}, &example.Pod{}); !storage.IsInternalError(err) {
+	if err := store.Get(ctx, preset[1].key, storage.GetOptions{}, &example.Pod{}); !apierrors.IsStoreReadError(err) {
 		t.Errorf("Unexpected error: %v", err)
 	}
 }

--- a/test/integration/controlplane/transformation/secrets_transformation_test.go
+++ b/test/integration/controlplane/transformation/secrets_transformation_test.go
@@ -35,8 +35,11 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	apiserverv1 "k8s.io/apiserver/pkg/apis/apiserver/v1"
+	genericfeatures "k8s.io/apiserver/pkg/features"
 	"k8s.io/apiserver/pkg/storage/value"
 	aestransformer "k8s.io/apiserver/pkg/storage/value/encrypt/aes"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
 )
 
 const (
@@ -119,6 +122,8 @@ func TestSecretsShouldBeTransformed(t *testing.T) {
 //  4. check that the original secrets now cannot be read, but the new ones still can
 //  5. check that the read error has the expected format
 func TestBrokenTransformations(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.AllowUnsafeMalformedObjectDeletion, true)
+
 	test, err := newTransformTest(t, aesGCMConfigYAML, true, "", nil)
 	defer test.cleanUp()
 	if err != nil {

--- a/test/integration/controlplane/transformation/secrets_transformation_test.go
+++ b/test/integration/controlplane/transformation/secrets_transformation_test.go
@@ -21,9 +21,19 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 	"encoding/base64"
+	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
 	apiserverv1 "k8s.io/apiserver/pkg/apis/apiserver/v1"
 	"k8s.io/apiserver/pkg/storage/value"
 	aestransformer "k8s.io/apiserver/pkg/storage/value/encrypt/aes"
@@ -66,7 +76,10 @@ resources:
   - resources:
     - secrets
     providers:
-    - identity: {}
+    - aesgcm:
+        keys:
+        - name: key1
+          secret: dXBlcnByZGVscHJkZWxwCg==
 `
 )
 
@@ -97,6 +110,127 @@ func TestSecretsShouldBeTransformed(t *testing.T) {
 		test.runResource(test.TContext, tt.unSealFunc, tt.transformerPrefix, "", "v1", "secrets", test.secret.Name, test.secret.Namespace)
 		test.cleanUp()
 	}
+}
+
+// TestBrokenTransformations:
+//  1. set up etcd encryption and push a few test secrets
+//  2. override the encryption config, thus breaking decryption
+//  3. create a few more secrets
+//  4. check that the original secrets now cannot be read, but the new ones still can
+//  5. check that the read error has the expected format
+func TestBrokenTransformations(t *testing.T) {
+	test, err := newTransformTest(t, aesGCMConfigYAML, true, "", nil)
+	defer test.cleanUp()
+	if err != nil {
+		t.Errorf("failed to setup test for envelop %s, error was %v", aesGCMPrefix, err)
+		return
+	}
+
+	brokenSecrets := sets.New[string]()
+	// push a few secrets that we won't be able to read afterwards
+	for _, s := range []string{"a", "b", "c"} {
+		name := "pre-fail-" + s
+		brokenSecrets.Insert(name)
+		_, err = test.createSecret(name, testNamespace)
+		if err != nil {
+			t.Fatalf("Failed to create test secret, error: %v", err)
+		}
+	}
+	// one more secret to use in an encryption test to confirm the config was fine
+	test.secret, err = test.createSecret(testSecret, testNamespace)
+	if err != nil {
+		t.Fatalf("Failed to create test secret, error: %v", err)
+	}
+	brokenSecrets.Insert(testSecret)
+	test.runResource(test.TContext, unSealWithGCMTransformer, aesGCMPrefix, "", "v1", "secrets", test.secret.Name, test.secret.Namespace)
+
+	// override the config and break decryption of the old resources
+	encryptionConf := filepath.Join(test.configDir, encryptionConfigFileName)
+	if err := os.WriteFile(encryptionConf, []byte(identityConfigYAML), 0o644); err != nil {
+		t.Fatalf("failed to write encryption config that's going to make decryption fail")
+	}
+
+	testCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// wait for the breaking changes to take effect
+	err = wait.PollUntilContextTimeout(testCtx, 1*time.Second, 2*time.Minute, true, func(ctx context.Context) (done bool, err error) {
+		if _, err := test.restClient.CoreV1().Secrets(testNamespace).Get(ctx, testSecret, metav1.GetOptions{}); err == nil || !apierrors.IsStoreReadError(err) {
+			return false, nil
+		}
+		return true, nil
+	})
+
+	if err != nil {
+		t.Fatalf("encryption never broke: %v", err)
+	}
+
+	// push some new secrets that should be readable
+	var secretErr error
+	for _, s := range []string{"a", "b", "c"} {
+		name := "post-fail-" + s
+		_, err = test.createSecret(name, testNamespace)
+		if err != nil {
+			t.Fatalf("Failed to create test secret, error: %v", err)
+		}
+	}
+
+	checkStoreError := func(secretErr error, brokenSecrets []string) {
+		if secretErr == nil {
+			t.Errorf("listing secrets in %q should have failed", testNamespace)
+		} else if !apierrors.IsStoreReadError(secretErr) {
+			t.Errorf("listing secrets in %q failed with unexpected error: %v", testNamespace, secretErr)
+		} else {
+			var storeErr apierrors.APIStatus
+			if !errors.As(secretErr, &storeErr) {
+				t.Fatalf("how is this possible? %v", secretErr)
+			}
+
+			causes := storeErr.Status().Details.Causes
+			if len(causes) != len(brokenSecrets) {
+				t.Errorf("expected %d causes, got %d: %v", len(brokenSecrets), len(causes), causes)
+			}
+
+			brokenSecretsCopy := sets.New(brokenSecrets...)
+			for _, c := range causes {
+				splitKey := strings.Split(c.Field, "/")
+				brokenSecretsCopy.Delete(splitKey[len(splitKey)-1])
+			}
+			if brokenSecretsCopy.Len() != 0 {
+				t.Errorf("expected to find all broken secrets in the error, but these secrets' keys were missing: %v", brokenSecretsCopy.UnsortedList())
+			}
+		}
+	}
+
+	_, err = test.restClient.CoreV1().Secrets(testNamespace).Get(context.Background(), "post-fail-a", metav1.GetOptions{})
+	if err != nil {
+		t.Errorf("'%s/%s' secret should be readable but got error: %v", err, testNamespace, "post-fail-a")
+	}
+
+	_, err = test.restClient.CoreV1().Secrets(testNamespace).Get(context.Background(), "pre-fail-c", metav1.GetOptions{})
+	checkStoreError(err, []string{"pre-fail-c"})
+
+	_, secretErr = test.restClient.CoreV1().Secrets(testNamespace).List(context.Background(), metav1.ListOptions{})
+	checkStoreError(secretErr, brokenSecrets.UnsortedList())
+
+	// create a new NS where listing secrets should be fine
+	newNS, err := test.restClient.CoreV1().Namespaces().Create(context.Background(), &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "pokus"}}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("failed to create the ns: %v", err)
+	}
+
+	_, err = test.createSecret("somesecret", newNS.Name)
+	if err != nil {
+		t.Fatalf("failed to create a secret in the clean ns: %v", err)
+	}
+
+	secretList, secretErr := test.restClient.CoreV1().Secrets(newNS.Name).List(context.Background(), metav1.ListOptions{})
+	if secretErr != nil || len(secretList.Items) != 1 {
+		t.Fatalf("listing secrets in the new NS should be fine but an error appeared: %v\nsecretsList: %v", secretErr, secretList)
+	}
+
+	_, secretErr = test.restClient.CoreV1().Secrets("").List(context.Background(), metav1.ListOptions{})
+	checkStoreError(secretErr, brokenSecrets.UnsortedList())
 }
 
 // Baseline (no enveloping) - use to contrast with enveloping benchmarks.

--- a/test/integration/controlplane/transformation/transformation_test.go
+++ b/test/integration/controlplane/transformation/transformation_test.go
@@ -148,12 +148,12 @@ func newTransformTest(tb testing.TB, transformerConfigYAML string, reload bool, 
 }
 
 func (e *transformTest) cleanUp() {
-	if e.configDir != "" {
-		os.RemoveAll(e.configDir)
-	}
-
 	if e.kubeAPIServer.ClientConfig != nil {
 		e.shutdownAPIServer()
+	}
+
+	if e.configDir != "" {
+		os.RemoveAll(e.configDir)
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
This PR implements an error that allows handling specific to errors that occur when decoding/transforming data from the database during read operations.

#### Which issue(s) this PR fixes:
Related to https://github.com/kubernetes/enhancements/issues/3926

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
A new error type was added to distinguish errors that occur when decoding/transforming resource data from the backend database. This error appears as a `StatusError` having `Reason` set to "StorageReadError".

The HTTP status code for the error remains at 500, as it would for any other internal server error.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/3926
```

An example of such an error might look something like this:
```go
&errors.StatusError{
  ErrStatus: v1.Status{
    TypeMeta: v1.TypeMeta{
      Kind:       "",
      APIVersion: "",
    },
    ListMeta: v1.ListMeta{
      SelfLink:           "",
      ResourceVersion:    "",
      Continue:           "",
      RemainingItemCount: (*int64)(nil),
    },
    Status:  "Failure",
    Message: "failed to read one or more secrets from the storage; failed keys: [/ac770294-4d69-4a8e-a601-4ab7435b5d05/registry/secrets/secret-encryption-test/pre-fail-a /ac770294-4d69-4a8e-a601-4ab7435b5d05/registry/secrets/secret-encryption-test/pre-fail-b]",
    Reason:  "StorageReadError",
    Details: &v1.StatusDetails{
      Name:   "/secrets",
      Group:  "",
      Kind:   "secrets",
      UID:    "",
      Causes: []v1.StatusCause{
        v1.StatusCause{
          Type:    "UnexpectedServerResponse",
          Message: "cipher: message authentication failed",
          Field:   "/ac770294-4d69-4a8e-a601-4ab7435b5d05/registry/secrets/secret-encryption-test/pre-fail-a",
        },
        v1.StatusCause{
          Type:    "UnexpectedServerResponse",
          Message: "cipher: message authentication failed",
          Field:   "/ac770294-4d69-4a8e-a601-4ab7435b5d05/registry/secrets/secret-encryption-test/pre-fail-b",
        },
      },
      RetryAfterSeconds: 0,
    },
    Code: 500,
  },
}
```

/assign @deads2k 
/assign @dgrisonnet 
