### PR TITLE
clean up, use attempt from container runtime service as restart count

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_container_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_test.go
@@ -142,7 +142,7 @@ func TestKillContainer(t *testing.T) {
 // different states.
 func TestToKubeContainerStatus(t *testing.T) {
 	cid := &kubecontainer.ContainerID{Type: "testRuntime", ID: "dummyid"}
-	meta := &runtimeapi.ContainerMetadata{Name: "cname", Attempt: 3}
+	meta := &runtimeapi.ContainerMetadata{Name: "cname", Attempt: 0}
 	imageSpec := &runtimeapi.ImageSpec{Image: "fimage"}
 	var (
 		createdAt  int64 = 327
@@ -229,7 +229,8 @@ func TestToKubeContainerStatus(t *testing.T) {
 			},
 		},
 	} {
-		actual := toKubeContainerStatus(test.input, cid.Type)
+		annotatedInfo := getContainerInfoFromAnnotations(test.input.Annotations)
+		actual := toKubeContainerStatus(test.input, cid.Type, annotatedInfo)
 		assert.Equal(t, test.expected, actual, desc)
 	}
 }
@@ -239,7 +240,7 @@ func TestToKubeContainerStatus(t *testing.T) {
 func TestToKubeContainerStatusWithResources(t *testing.T) {
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.InPlacePodVerticalScaling, true)
 	cid := &kubecontainer.ContainerID{Type: "testRuntime", ID: "dummyid"}
-	meta := &runtimeapi.ContainerMetadata{Name: "cname", Attempt: 3}
+	meta := &runtimeapi.ContainerMetadata{Name: "cname", Attempt: 0}
 	imageSpec := &runtimeapi.ImageSpec{Image: "fimage"}
 	var (
 		createdAt int64 = 327
@@ -363,7 +364,8 @@ func TestToKubeContainerStatusWithResources(t *testing.T) {
 				// TODO: remove skip once the failing test has been fixed.
 				t.Skip("Skip failing test on Windows.")
 			}
-			actual := toKubeContainerStatus(test.input, cid.Type)
+			annotatedInfo := getContainerInfoFromAnnotations(test.input.Annotations)
+			actual := toKubeContainerStatus(test.input, cid.Type, annotatedInfo)
 			assert.Equal(t, test.expected, actual, desc)
 		})
 	}

--- a/pkg/kubelet/kuberuntime/labels.go
+++ b/pkg/kubelet/kuberuntime/labels.go
@@ -62,7 +62,6 @@ type labeledContainerInfo struct {
 
 type annotatedContainerInfo struct {
 	Hash                      uint64
-	RestartCount              int
 	PodDeletionGracePeriod    *int64
 	PodTerminationGracePeriod *int64
 	TerminationMessagePath    string
@@ -193,9 +192,6 @@ func getContainerInfoFromAnnotations(annotations map[string]string) *annotatedCo
 	if containerInfo.Hash, err = getUint64ValueFromLabel(annotations, containerHashLabel); err != nil {
 		klog.ErrorS(err, "Unable to get label value from annotations", "label", containerHashLabel, "annotations", annotations)
 	}
-	if containerInfo.RestartCount, err = getIntValueFromLabel(annotations, containerRestartCountLabel); err != nil {
-		klog.ErrorS(err, "Unable to get label value from annotations", "label", containerRestartCountLabel, "annotations", annotations)
-	}
 	if containerInfo.PodDeletionGracePeriod, err = getInt64PointerFromLabel(annotations, podDeletionGracePeriodLabel); err != nil {
 		klog.ErrorS(err, "Unable to get label value from annotations", "label", podDeletionGracePeriodLabel, "annotations", annotations)
 	}
@@ -228,21 +224,6 @@ func getStringValueFromLabel(labels map[string]string, label string) string {
 	klog.V(3).InfoS("Container doesn't have requested label, it may be an old or invalid container", "label", label)
 	// Return empty string "" for these containers, the caller will get value by other ways.
 	return ""
-}
-
-func getIntValueFromLabel(labels map[string]string, label string) (int, error) {
-	if strValue, found := labels[label]; found {
-		intValue, err := strconv.Atoi(strValue)
-		if err != nil {
-			// This really should not happen. Just set value to 0 to handle this abnormal case
-			return 0, err
-		}
-		return intValue, nil
-	}
-	// Do not report error, because there should be many old containers without label now.
-	klog.V(3).InfoS("Container doesn't have requested label, it may be an old or invalid container", "label", label)
-	// Just set the value to 0
-	return 0, nil
 }
 
 func getUint64ValueFromLabel(labels map[string]string, label string) (uint64, error) {

--- a/pkg/kubelet/kuberuntime/labels_test.go
+++ b/pkg/kubelet/kuberuntime/labels_test.go
@@ -155,7 +155,6 @@ func TestContainerAnnotations(t *testing.T) {
 		PodDeletionGracePeriod:    pod.DeletionGracePeriodSeconds,
 		PodTerminationGracePeriod: pod.Spec.TerminationGracePeriodSeconds,
 		Hash:                      kubecontainer.HashContainer(container),
-		RestartCount:              restartCount,
 		TerminationMessagePath:    container.TerminationMessagePath,
 		PreStopHandler:            container.Lifecycle.PreStop,
 	}


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
use attempt from container runtime service as restart count
don't need to parse the restartCount from the container's annotation, but directly obtain it from the status returned by the cri
https://github.com/kubernetes/kubernetes/blob/2c7bda528f2344c1c9ab3c87de7958b316d16574/pkg/kubelet/kuberuntime/kuberuntime_container.go#L342-L348

#### Special notes for your reviewer:
