### PR TITLE
Replaced unsafe packages with []byte(s) as of go 1.22 - (#124656)

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/authentication/token/cache/cached_token_authenticator.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/token/cache/cached_token_authenticator.go
@@ -276,13 +276,8 @@ func writeLength(w io.Writer, b []byte, length int) {
 
 // toBytes performs unholy acts to avoid allocations
 func toBytes(s string) []byte {
-	// unsafe.StringData is unspecified for the empty string, so we provide a strict interpretation
-	if len(s) == 0 {
-		return nil
-	}
-	// Copied from go 1.20.1 os.File.WriteString
-	// https://github.com/golang/go/blob/202a1a57064127c3f19d96df57b9f9586145e21c/src/os/file.go#L246
-	return unsafe.Slice(unsafe.StringData(s), len(s))
+	//As of go 1.22, string to bytes conversion []bytes(str) is faster than using the unsafe package.
+	return []byte(s)
 }
 
 // toString performs unholy acts to avoid allocations

--- a/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/kmsv2/envelope.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/kmsv2/envelope.go
@@ -25,7 +25,6 @@ import (
 	"fmt"
 	"sort"
 	"time"
-	"unsafe"
 
 	"github.com/gogo/protobuf/proto"
 	"go.opentelemetry.io/otel/attribute"
@@ -510,13 +509,8 @@ func generateCacheKey(encryptedDEKSourceType kmstypes.EncryptedDEKSourceType, en
 
 // toBytes performs unholy acts to avoid allocations
 func toBytes(s string) []byte {
-	// unsafe.StringData is unspecified for the empty string, so we provide a strict interpretation
-	if len(s) == 0 {
-		return nil
-	}
-	// Copied from go 1.20.1 os.File.WriteString
-	// https://github.com/golang/go/blob/202a1a57064127c3f19d96df57b9f9586145e21c/src/os/file.go#L246
-	return unsafe.Slice(unsafe.StringData(s), len(s))
+	//As of go 1.22, string to bytes conversion []bytes(str) is faster than using the unsafe package.
+	return []byte(s)
 }
 
 // GetHashIfNotEmpty returns the sha256 hash of the data if it is not empty.


### PR DESCRIPTION
#### What type of PR is this?
kind/feature

#### What this PR does / why we need it:
- This PR fixes the redundancy issue as Go 1.22 now provide the typecasting from string to bytes using []byte(str) only, we don't need to use unsafe packages anymore. Hence, it also takes zero memory allocation as per the benchmarking test done by @Aden-Q

#### Which issue(s) this PR fixes:
[124656](https://github.com/kubernetes/kubernetes/issues/124656)

Fixes #
Redundancy issue

#### Special notes for your reviewer:
- Test Cases [Passed]

#### Does this PR introduce a user-facing change?
NONE