### PR TITLE
Include "computed QoS" instead of "status QoS" in validation error when in-place resource updates result in recalculated QoS

### DIFF
--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -5130,8 +5130,8 @@ func ValidatePodUpdate(newPod, oldPod *core.Pod, opts PodValidationOptions) fiel
 		return allErrs
 	}
 
-	if qos.GetPodQOS(oldPod) != qos.ComputePodQOS(newPod) {
-		allErrs = append(allErrs, field.Invalid(fldPath, newPod.Status.QOSClass, "Pod QoS is immutable"))
+	if computedNewQOS := qos.ComputePodQOS(newPod); qos.GetPodQOS(oldPod) != computedNewQOS {
+		allErrs = append(allErrs, field.Invalid(fldPath, computedNewQOS, "pod resource changes may not change computed pod QoS, pod QoS is immutable"))
 	}
 
 	// handle updateable fields by munging those fields prior to deep equal comparison.

--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -12573,7 +12573,7 @@ func TestValidatePodUpdate(t *testing.T) {
 						Requests: getResourceLimits("100m", "100Mi"),
 					}))),
 			),
-			err:  "Pod QoS is immutable",
+			err:  "pod resource changes may not change computed pod QoS, pod QoS is immutable",
 			test: "Pod QoS change, guaranteed -> burstable",
 		}, {
 			new: *podtest.MakePod("pod",
@@ -12589,7 +12589,7 @@ func TestValidatePodUpdate(t *testing.T) {
 						Requests: getResourceLimits("100m", "100Mi"),
 					}))),
 			),
-			err:  "Pod QoS is immutable",
+			err:  "pod resource changes may not change computed pod QoS, pod QoS is immutable",
 			test: "Pod QoS change, burstable -> guaranteed",
 		}, {
 			new: *podtest.MakePod("pod",
@@ -12600,7 +12600,7 @@ func TestValidatePodUpdate(t *testing.T) {
 					}))),
 			),
 			old:  *podtest.MakePod("pod"),
-			err:  "Pod QoS is immutable",
+			err:  "pod resource changes may not change computed pod QoS, pod QoS is immutable",
 			test: "Pod QoS change, besteffort -> burstable",
 		}, {
 			new: *podtest.MakePod("pod"),
@@ -12611,7 +12611,7 @@ func TestValidatePodUpdate(t *testing.T) {
 						Requests: getResourceLimits("100m", "100Mi"),
 					}))),
 			),
-			err:  "Pod QoS is immutable",
+			err:  "pod resource changes may not change computed pod QoS, pod QoS is immutable",
 			test: "Pod QoS change, burstable -> besteffort",
 		}, {
 			new: *podtest.MakePod("pod",

--- a/test/e2e/node/pod_resize.go
+++ b/test/e2e/node/pod_resize.go
@@ -1510,7 +1510,7 @@ func doPodResizeErrorTests() {
 			patchString: `{"spec":{"containers":[
 						{"name":"c1", "resources":{"requests":{"memory":"400Mi"}}}
 					]}}`,
-			patchError: "Pod QoS is immutable",
+			patchError: `Pod "testpod" is invalid: metadata: Invalid value: "Burstable": pod resource changes may not change computed pod QoS, pod QoS is immutable`,
 			expected: []TestContainerInfo{
 				{
 					Name: "c1",
@@ -1559,6 +1559,7 @@ func doPodResizeErrorTests() {
 				framework.ExpectNoError(pErr, "failed to patch pod for resize")
 			} else {
 				gomega.Expect(pErr).To(gomega.HaveOccurred(), tc.patchError)
+				gomega.Expect(pErr.Error()).To(gomega.Equal(tc.patchError))
 				patchedPod = newPod
 			}
 


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Currently: 
- In-place resource updates can result in Pod QoS changing due to recalculation, which causes the update to fail validation
- That validation failure error currently includes the existing QoS value from the Pod's status, rather than the new computed QoS

This PR: 
- changes the error message to output the computed QoS, so the user can know what the QoS value was recalculated to and hopefully correlate it to their attempted resource changes 

Example: 

Take this pod: 
```
apiVersion: v1
kind: Pod
metadata:
  name: sleeper
  namespace: default
spec:
  containers:
  - args:
    - -c
    - sleep infinity
    command:
    - /bin/sh
    image: registry.k8s.io/ubuntu-slim:0.1
    imagePullPolicy: IfNotPresent
    name: sleeper
    resources:
      requests:
        cpu: 25m
        memory: 100Mi
```
Remove the resources to make it recalculate to `BestEffort`: 
```
$ kubectl patch pod sleeper --type="strategic" -p'{"spec":{"containers":[{"name":"sleeper","resources":{"$patch":"delete"}}]}}'
```
Observe the validation output (the pod is already `Burstable`, but the error says `Burstable` is the invalid value): 
```
The Pod "sleeper" is invalid: 
* metadata: Invalid value: "Burstable": Pod QoS is immutable
* spec: Forbidden: pod updates may not change fields other than `spec.containers[*].image`,`spec.initContainers[*].image`,`spec.activeDeadlineSeconds`,`spec.tolerations` (only additions to existing tolerations),`spec.terminationGracePeriodSeconds` (allow it to be set to 1 if it was previously negative)
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
In-place resource updates that recalculate pod QoS now properly include the recalculated QoS value with the validation failure
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
