### PR TITLE
Debug E2e network test flake

### DIFF
--- a/test/e2e/framework/network/utils.go
+++ b/test/e2e/framework/network/utils.go
@@ -46,6 +46,7 @@ import (
 	e2epodoutput "k8s.io/kubernetes/test/e2e/framework/pod/output"
 	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 	e2essh "k8s.io/kubernetes/test/e2e/framework/ssh"
+	storageutils "k8s.io/kubernetes/test/e2e/storage/utils"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 	netutils "k8s.io/utils/net"
 )
@@ -327,7 +328,20 @@ func (config *NetworkingTestConfig) DialFromContainer(ctx context.Context, proto
 		}
 		if responses.Difference(expectedResponses).Len() > 0 {
 			returnMsg := fmt.Errorf("received unexpected responses... \nAttempt %d\nCommand %v\nretrieved %v\nexpected %v", i, cmd, responses, expectedResponses)
+			// TODO(aojea) Remove once issues.k8s.io/123760 is solved
+			// Dump the nodes network routes and addresses for troubleshooting #123760
 			framework.Logf("encountered error during dial (%v)", returnMsg)
+			hostExec := storageutils.NewHostExec(config.f)
+			ginkgo.DeferCleanup(hostExec.Cleanup)
+			cmd := `echo "IP routes: " && ip route && echo "IP addresses:" && ip addr && echo "Open sockets: " && ss -anp --socket=tcp`
+			for _, node := range config.Nodes {
+				result, err := hostExec.IssueCommandWithResult(ctx, cmd, &node)
+				if err != nil {
+					framework.Logf("error occurred while executing command %s on node: %v", cmd, err)
+					continue
+				}
+				framework.Logf("Dump network information for node %s:\n%s", node.Name, result)
+			}
 			return returnMsg
 		}
 


### PR DESCRIPTION

/kind flake
```release-note
NONE
```

We no longer need https://github.com/kubernetes/kubernetes/commit/d70f96fe220007cd2b87497f74afc6ac24f9be00 as it was verified in https://github.com/kubernetes/kubernetes/issues/123760 the pods is not the one replying the request.

We want to validate the new hypothesis that the IP address of the Pod is present in the host and is the hostNetwork pod that replies 