### PR TITLE
WIP fix `e2e-kind-cloud-provider-loadbalancer`

### DIFF
--- a/test/e2e/network/loadbalancer.go
+++ b/test/e2e/network/loadbalancer.go
@@ -209,6 +209,8 @@ var _ = common.SIGDescribe("LoadBalancers", feature.LoadBalancer, func() {
 		}
 		framework.Logf("TCP node port: %d", tcpNodePort)
 
+		// FIXME: we change the NodePort but then connect via LB IP, but some LBs
+		// don't use the NodePort anyway.
 		ginkgo.By("hitting the TCP service's LoadBalancer")
 		e2eservice.TestReachableHTTP(ctx, tcpIngressIP, svcPort, loadBalancerLagTimeout)
 
@@ -246,6 +248,8 @@ var _ = common.SIGDescribe("LoadBalancers", feature.LoadBalancer, func() {
 		ginkgo.By("Scaling the pods to 1")
 		err = tcpJig.Scale(ctx, 1)
 		framework.ExpectNoError(err)
+
+		// FIXME: the UDP version below tests reachability via NodePort here as well
 
 		ginkgo.By("hitting the TCP service's LoadBalancer")
 		e2eservice.TestReachableHTTP(ctx, tcpIngressIP, svcPort, loadBalancerLagTimeout)
@@ -818,6 +822,13 @@ var _ = common.SIGDescribe("LoadBalancers", feature.LoadBalancer, func() {
 		e2epod.SetNodeSelection(&serverPod2.Spec, nodeSelection)
 		e2epod.NewPodClient(f).CreateSync(ctx, serverPod2)
 
+		// FIXME: this test is supposed to ensure that "a LoadBalancer UDP service
+		// doesn't blackhole the traffic to the node when the pod backend is
+		// destroyed and the traffic has to fall back to another pod", but it's
+		// possible that a connection to backend 2 will succeed at this point
+		// before backend 1 is deleted, in which case no further successful
+		// connections are required to pass.
+
 		// and delete the first pod
 		framework.Logf("Cleaning up %s pod", podBackend1)
 		e2epod.NewPodClient(f).DeleteSync(ctx, podBackend1, metav1.DeleteOptions{}, e2epod.DefaultPodDeletionTimeout)
@@ -949,6 +960,13 @@ var _ = common.SIGDescribe("LoadBalancers", feature.LoadBalancer, func() {
 		// use the same node as previous pod
 		e2epod.SetNodeSelection(&serverPod2.Spec, nodeSelection)
 		e2epod.NewPodClient(f).CreateSync(ctx, serverPod2)
+
+		// FIXME: this test is supposed to ensure that "a LoadBalancer UDP service
+		// doesn't blackhole the traffic to the node when the pod backend is
+		// destroyed and the traffic has to fall back to another pod", but it's
+		// possible that a connection to backend 2 will succeed at this point
+		// before backend 1 is deleted, in which case no further successful
+		// connections are required to pass.
 
 		// and delete the first pod
 		framework.Logf("Cleaning up %s pod", podBackend1)

--- a/test/e2e/network/loadbalancer.go
+++ b/test/e2e/network/loadbalancer.go
@@ -1074,38 +1074,6 @@ var _ = common.SIGDescribe("LoadBalancers ExternalTrafficPolicy: Local", feature
 		}
 	})
 
-	ginkgo.It("should work for type=NodePort", func(ctx context.Context) {
-		namespace := f.Namespace.Name
-		serviceName := "external-local-nodeport"
-		jig := e2eservice.NewTestJig(cs, namespace, serviceName)
-
-		svc, err := jig.CreateOnlyLocalNodePortService(ctx, true)
-		framework.ExpectNoError(err)
-		ginkgo.DeferCleanup(func(ctx context.Context) {
-			err := cs.CoreV1().Services(svc.Namespace).Delete(ctx, svc.Name, metav1.DeleteOptions{})
-			framework.ExpectNoError(err)
-		})
-
-		tcpNodePort := int(svc.Spec.Ports[0].NodePort)
-
-		endpointsNodeMap, err := getEndpointNodesWithInternalIP(ctx, jig)
-		framework.ExpectNoError(err)
-
-		dialCmd := "clientip"
-		config := e2enetwork.NewNetworkingTestConfig(ctx, f)
-
-		for nodeName, nodeIP := range endpointsNodeMap {
-			ginkgo.By(fmt.Sprintf("reading clientIP using the TCP service's NodePort, on node %v: %v:%v/%v", nodeName, nodeIP, tcpNodePort, dialCmd))
-			clientIP, err := GetHTTPContentFromTestContainer(ctx, config, nodeIP, tcpNodePort, e2eservice.KubeProxyLagTimeout, dialCmd)
-			framework.ExpectNoError(err)
-			framework.Logf("ClientIP detected by target pod using NodePort is %s, the ip of test container is %s", clientIP, config.TestContainerPod.Status.PodIP)
-			// the clientIP returned by agnhost contains port
-			if !strings.HasPrefix(clientIP, config.TestContainerPod.Status.PodIP) {
-				framework.Failf("Source IP was NOT preserved")
-			}
-		}
-	})
-
 	ginkgo.It("should only target nodes with endpoints", func(ctx context.Context) {
 		namespace := f.Namespace.Name
 		serviceName := "external-local-nodes"

--- a/test/e2e/network/loadbalancer.go
+++ b/test/e2e/network/loadbalancer.go
@@ -387,8 +387,8 @@ var _ = common.SIGDescribe("LoadBalancers", feature.LoadBalancer, func() {
 		err = udpJig.Scale(ctx, 0)
 		framework.ExpectNoError(err)
 
-		ginkgo.By("looking for ICMP REJECT on the UDP service's LoadBalancer")
-		testRejectedUDP(ctx, udpIngressIP, svcPort, loadBalancerCreateTimeout)
+		ginkgo.By("checking that the UDP service's LoadBalancer is not reachable")
+		testNotReachableUDP(ctx, udpIngressIP, svcPort, loadBalancerCreateTimeout)
 
 		ginkgo.By("Scaling the pods to 1")
 		err = udpJig.Scale(ctx, 1)

--- a/test/e2e/network/loadbalancer.go
+++ b/test/e2e/network/loadbalancer.go
@@ -927,11 +927,6 @@ var _ = common.SIGDescribe("LoadBalancers", feature.LoadBalancer, func() {
 })
 
 var _ = common.SIGDescribe("LoadBalancers ExternalTrafficPolicy: Local", feature.LoadBalancer, framework.WithSlow(), func() {
-	// FIXME: What are the expected semantics of requesting an
-	// "ExternalTrafficPolicy: Local" service from a cloud provider that does not
-	// support that? What are the expected semantics of "ExternalTrafficPolicy: Local"
-	// on `IPMode: Proxy`-type LoadBalancers?
-
 	f := framework.NewDefaultFramework("esipp")
 	f.NamespacePodSecurityLevel = admissionapi.LevelBaseline
 	var loadBalancerCreateTimeout time.Duration
@@ -986,6 +981,14 @@ var _ = common.SIGDescribe("LoadBalancers ExternalTrafficPolicy: Local", feature
 			err = cs.CoreV1().Services(svc.Namespace).Delete(ctx, svc.Name, metav1.DeleteOptions{})
 			framework.ExpectNoError(err)
 		})
+
+		// FIXME: figure out the actual expected semantics for
+		// "ExternalTrafficPolicy: Local" + "IPMode: Proxy".
+		// https://issues.k8s.io/123714
+		ingress := &svc.Status.LoadBalancer.Ingress[0]
+		if ingress.IP == "" || (ingress.IPMode != nil && *ingress.IPMode == v1.LoadBalancerIPModeProxy) {
+			e2eskipper.Skipf("LoadBalancer uses 'Proxy' IPMode")
+		}
 
 		svcTCPPort := int(svc.Spec.Ports[0].Port)
 		ingressIP := e2eservice.GetIngressPoint(&svc.Status.LoadBalancer.Ingress[0])
@@ -1132,6 +1135,14 @@ var _ = common.SIGDescribe("LoadBalancers ExternalTrafficPolicy: Local", feature
 			err := cs.CoreV1().Services(svc.Namespace).Delete(ctx, svc.Name, metav1.DeleteOptions{})
 			framework.ExpectNoError(err)
 		})
+
+		// FIXME: figure out the actual expected semantics for
+		// "ExternalTrafficPolicy: Local" + "IPMode: Proxy".
+		// https://issues.k8s.io/123714
+		ingress := &svc.Status.LoadBalancer.Ingress[0]
+		if ingress.IP == "" || (ingress.IPMode != nil && *ingress.IPMode == v1.LoadBalancerIPModeProxy) {
+			e2eskipper.Skipf("LoadBalancer uses 'Proxy' IPMode")
+		}
 
 		ingressIP := e2eservice.GetIngressPoint(&svc.Status.LoadBalancer.Ingress[0])
 		port := strconv.Itoa(int(svc.Spec.Ports[0].Port))

--- a/test/e2e/network/service.go
+++ b/test/e2e/network/service.go
@@ -606,20 +606,6 @@ func testNotReachableUDP(ctx context.Context, host string, port int, timeout tim
 	}
 }
 
-// testRejectedUDP tests that the given host rejects a UDP request on the given port.
-func testRejectedUDP(ctx context.Context, host string, port int, timeout time.Duration) {
-	pollfn := func(ctx context.Context) (bool, error) {
-		result := pokeUDP(host, port, "echo hello", &UDPPokeParams{Timeout: 3 * time.Second})
-		if result.Status == UDPRefused {
-			return true, nil
-		}
-		return false, nil // caller can retry
-	}
-	if err := wait.PollUntilContextTimeout(ctx, framework.Poll, timeout, true, pollfn); err != nil {
-		framework.Failf("UDP service %v:%v not rejected: %v", host, port, err)
-	}
-}
-
 // TestHTTPHealthCheckNodePort tests a HTTP connection by the given request to the given host and port.
 func TestHTTPHealthCheckNodePort(ctx context.Context, host string, port int, request string, timeout time.Duration, expectSucceed bool, threshold int) error {
 	count := 0


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/kind cleanup
/kind failing-test

#### What this PR does / why we need it:
Moved out of #124660. Once we get the loadbalancer tests running again, we will get them working with cloud-provider-kind.

Notes:
- [x] `LoadBalancers should be able to change the type and ports of a [ TCP / UDP ] service`
  - Creates a ClusterIP service, checks reachability by ClusterIP, converts to NodePort, checks reachability by NodePort, converts to LoadBalancer (requesting a static IP on GCE), checks reachability by LB, changes NodePort, checks reachability by LB, changes service port, checks reachability by LB, scales to 0, checks NON-reachability by LB, scales to 1, checks reachability by LB, converts to ClusterIP, waits, checks NON-reachability by LB.
  - was `SkipUnlessProviderIs("gce", "gke", "aws")`
  - :heavy_check_mark: passes with cpkind after removing skip and GCE-specific subtest
  - TCP version should pass on all cloud providers that support LBs. UDP version should pass on all cloud providers that support UDP LBs.
- [ ] `LoadBalancers should only allow access from service loadbalancer source ranges`
  - Creates "accept" and "drop" pods, creates LB service with `LoadBalancerSourceRanges: ${accept_pod_ip}`, checks that accept→LB works and drop→LB does not, changes LBSR to `${drop_pod_ip}`, checks that things are reversed, unsets LBSR, checks that both pods can connect.
  - was `SkipUnlessProviderIs("gce", "gke", "aws", "azure")`
  - :shrug: For VIP-type LBs this does not test the LB functionality; it only tests kube-proxy's implementation of LB short-circuiting and LBSR.
  - :x: For proxy-type LBs (like cpkind), this assumes that pod-to-LB connections will not be masqueraded, which is likely to be false.\
  - Rewriting the current test to use node IPs rather than pod IPs would fix the proxy-type LB case (assuming that the LB supports LoadBalancerSourceRanges) but wouldn't improve the VIP case.
  - Connecting from the `e2e.test` binary itself would test the LB rather than kube-proxy in both cases.
- [ ] `LoadBalancers should have session affinity work for LoadBalancer service with ESIPP [ on / off ]`
  - Creates a service with affinity and appropriate eTP, repeatedly connects (from `e2e.test`) and checks that it gets the same backend each time.
  - was `SkipIfProviderIs("aws")`
  - :x: cpkind doesn't support affinity but this still passes sometimes
- [ ] `LoadBalancers should be able to switch session affinity for LoadBalancer service with ESIPP [ on / off ]`
  - Creates a service with appropriate eTP but no affinity, repeatedly connects (from `e2e.test`) and checks that it doesn't always get the same backend, enables affinity, checks again that it now does always get the same backend
  - was `SkipIfProviderIs("aws")`
  - :x: cpkind doesn't support affinity but this still passes sometimes
- [x] `LoadBalancers should handle load balancer cleanup finalizer for service`
  - Creates LB, checks for finalizer, converts to ClusterIP, checks that finalizer is removed, converts back to LoadBalancer, checks for finalizer
  - Tests functionality from the generic cloud provider controller code; should work for all providers.
  - :heavy_check_mark: passes with cpkind
- [ ] `LoadBalancers should be able to create LoadBalancer Service without NodePort and change it`
  - Creates ClusterIP service, converts to LB-without-NodePort (requesting a static IP on GCE), checks reachability by LB, updates `AllocateLoadBalancerNodePorts`, checks that a NodePort was allocated, checks reachability by LB. 
  - was `SkipUnlessProviderIs("gce", "gke", "aws")`
  - :x: doesn't deal with clouds that require nodeports
  - :heavy_check_mark: currently skipped by `e2e-kind-cloud-provider-loadbalancer`, so doesn't cause a test failure
- [x] `LoadBalancers should be able to preserve UDP traffic when server pod cycles for a LoadBalancer service [on different nodes / on the same node]`
  - Creates UDP LoadBalancer service, spawns thread to repeatedly connect to LB with same source port, adds one pod, ensures that the other thread reached it at least once, adds another pod on different/same node, deletes the first pod, ensures that the other thread reached the new pod at least once.
  - was `SkipUnlessProviderIs("gce", "gke", "azure")`
  - :heavy_check_mark: passes with cpkind
- [x] `LoadBalancers should not have connectivity disruption during rolling update with externalTrafficPolicy=[ Cluster / Local ]`
  - Creates DaemonSet, creates LB pointing to it, spawns a thread to repeatedly connect, does 5 rolling updates of the DaemonSet, checks that number of failed connections is within tolerance.
  - :heavy_check_mark: passes with cpkind
- [ ] `LoadBalancers ESIPP should work for type=LoadBalancer`
  - Creates eTP:Local LB service, connects via LB (from `e2e.test`), checks if source IP was preserved
  - was `SkipUnlessProviderIs("gce", "gke")`
  - :x: semantics of eTP:Local via Proxy-type LBs are not well-defined?
  - :heavy_check_mark: skipped for Proxy-type LBs (with this PR)
- [ ] `LoadBalancers ESIPP should work for type=NodePort`
  - Creates eTP:Local NodePort service, connects from pod to every node's NodePort, checks if source IP was preserved
  - was `SkipUnlessProviderIs("gce", "gke")`
  - :shrug: does not actually use a LoadBalancer, but is part of LB tests
  - :x: assumes pod-to-different-node-nodeIP is unmasqueraded, which is not true for most network plugins; should use `hostNetwork` pod instead
- [x] `LoadBalancers ESIPP should only target nodes with endpoints`
  - Creates eTP:Local LB service. Picks 3 nodes. For each node: adds endpoints on that node, checks reachability via LB, checks HealthCheckNodePorts on _all_ nodes, delete endpoints.
  - was `SkipUnlessProviderIs("gce", "gke")`
  - :heavy_check_mark: passes with cpkind
- [ ] `LoadBalancers ESIPP should work from pods`
  - Creates eTP:Local LB service, connects via LB from pod, checks if source IP was preserved
  - was `SkipUnlessProviderIs("gce", "gke")`
  - :x: semantics of eTP:Local via Proxy-type LBs are not well-defined?
  - :heavy_check_mark: skipped for Proxy-type LBs (with this PR)
- [ ] `LoadBalancers ESIPP should handle updates to ExternalTrafficPolicy field`
  - Creates eTP:Local LB service, saves its HealthCheckNodePort, converts to eTP:Cluster, confirms that it's reachable on NodePorts from every node where it _doesn't_ have an endpoint, confirms that the old HealthCheckNodePort does not report healthiness on the nodes where it _does_ have an endpoint, confirms that traffic through the LB IP does not preserve source IP, converts the service back to Local (with same HCNP), confirms that the LB IP now does preserve source IP
  - (There are multiple problems with this test...)
  - was `SkipUnlessProviderIs("gce", "gke")`
  - :x: semantics of eTP:Local via Proxy-type LBs are not well-defined?
  - :x: does not pass with cpkind

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
