### PR TITLE
Enhance Event Spam Key to Preserve Important Events During Reconciliations

### DIFF
--- a/staging/src/k8s.io/client-go/tools/record/events_cache.go
+++ b/staging/src/k8s.io/client-go/tools/record/events_cache.go
@@ -77,6 +77,7 @@ func getSpamKey(event *v1.Event) string {
 		event.InvolvedObject.Name,
 		string(event.InvolvedObject.UID),
 		event.InvolvedObject.APIVersion,
+		event.Type,
 	},
 		"")
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
##### Description:
The current Kubernetes event spam key doesn't distinguish between event types and reasons. This leads to important events being lost during reconcile loops for stuck Kubernetes objects once the --event-ttl is reached (default: 1 hour)

##### Problem:
* When a controller encounters errors and retries repeatedly, it can trigger a burst of events for the same object.
* The event spam filter limits the number of events to prevent flooding the Etcd.
* If multiple event types occur during a reconcile loop (e.g., Warning and Normal), only the first event among those gets recorded.
* This can mask critical information like the reason for a service sync failure, leading to troubleshooting difficulties.

##### Example:
* The default Kubernetes service controller encounters an error during service synchronization.
* It retries and generates multiple events, including a Normal event with "EnsuringLoadBalancer" reason.
* Due to the spam filter, only the "EnsuringLoadBalancer" event gets recorded, hiding any Warning events containing the actual error details.
```
Events:
  Type     Reason                  Age                    From                Message
  ----     ------                  ----                   ----                -------
  Normal   EnsuringLoadBalancer    6m7s (x268 over 22h)   service-controller  Ensuring load balancer
```
##### Solution:
This pull request proposes modifying the default event spam key to include event.Type and event.Reason. This allows the spam filter to differentiate between events based on their type and reason, preventing the loss of crucial information in scenarios like reconcile loops.
```
Events:
  Type     Reason                  Age                    From                Message
  ----     ------                  ----                   ----                -------
  Normal   EnsuringLoadBalancer    4s (x265 over 21h)  service-controller  Ensuring load balancer
  Warning  SyncLoadBalancerFailed  1s (x256 over 21h)  service-controller  (combined from similar events): Error syncing load balancer: failed to ensure load balancer: xyz reason crucial for debugging.
```

##### Benefits:
* Improved visibility into controller behaviour during reconcile loops.
* Easier troubleshooting of service and other object failures.
* More informative event logs for debugging and analysis.

##### Possible Approaches:
* Modify the default spam key behaviour to include event.Type and event.Reason.
* Introduce overrides for specific upstream controllers (e.g., service controller) to achieve the same outcome. ([example](https://github.com/kubernetes/kubernetes/compare/master...l-technicore:kubernetes:controller_event_spam_key_optimization))

##### Impact:
This approach should have minimal impact on etcd storage since only unique events (based on type and reason) are recorded, and the recording frequency is limited to one event every 5 minutes.

This pull request aims to enhance event visibility in Kubernetes by addressing the limitations of the current spam filter during reconcile loops. By differentiating events based on type and reason, we can ensure that critical information is preserved and readily accessible for debugging purposes.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
NONE

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
