### PR TITLE
[1.28]backport verify-govulncheck.sh

### DIFF
--- a/hack/verify-govulncheck.sh
+++ b/hack/verify-govulncheck.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Copyright 2023 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set +x
+
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+source "${KUBE_ROOT}/hack/lib/init.sh"
+source "${KUBE_ROOT}/hack/lib/util.sh"
+
+# make sure everything is committed
+kube::util::ensure_clean_working_dir
+
+# This sets up the environment, like GOCACHE, which keeps the worktree cleaner.
+kube::golang::setup_env
+
+# Opt into using go modules
+export GO111MODULE=on
+
+go install golang.org/x/vuln/cmd/govulncheck@v1.1.0
+
+# KUBE_VERIFY_GIT_BRANCH is populated in verify CI jobs
+# For presubmits, check if PULL_BASE_REF is set and use its value
+if [[ -n ${PULL_BASE_REF+x} ]]; then
+  KUBE_VERIFY_GIT_BRANCH="${PULL_BASE_REF}"
+fi
+BRANCH="${KUBE_VERIFY_GIT_BRANCH:-master}"
+
+kube::util::ensure-temp-dir
+WORKTREE="${KUBE_TEMP}/worktree"
+
+# Create a copy of the repo with $BRANCH checked out
+git worktree add -f "${WORKTREE}" "${BRANCH}"
+# Clean up the copy on exit
+kube::util::trap_add "git worktree remove -f ${WORKTREE}" EXIT
+
+govulncheck -scan package ./... > "${KUBE_TEMP}/head.txt" || true
+pushd "${WORKTREE}" >/dev/null
+  govulncheck -scan package ./... > "${KUBE_TEMP}/pr-base.txt" || true
+popd >/dev/null
+
+echo -e "\n HEAD: $(cat "${KUBE_TEMP}"/head.txt)"
+echo -e "\n PR_BASE: $(cat "${KUBE_TEMP}/pr-base.txt")"
+
+diff -s -u --ignore-all-space "${KUBE_TEMP}"/pr-base.txt "${KUBE_TEMP}"/head.txt || true


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR will backport verify-govulncheck.sh from master to release-1.28 branch. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #  https://github.com/kubernetes/sig-security/issues/100

#### Special notes for your reviewer:
Discussion thread: https://kubernetes.slack.com/archives/C01CUSVMHPY/p1715006609141609

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
