### PR TITLE
add functions to set client-go featuregates directly for testing

### DIFF
--- a/staging/src/k8s.io/client-go/features/envvar_test.go
+++ b/staging/src/k8s.io/client-go/features/envvar_test.go
@@ -121,7 +121,7 @@ func TestEnvVarFeatureGates(t *testing.T) {
 			for k, v := range scenario.envVariables {
 				t.Setenv(k, v)
 			}
-			target := newEnvVarFeatureGates(scenario.features)
+			target := NewEnvVarFeatureGates(scenario.features)
 
 			for expectedFeature, expectedValue := range scenario.expectedFeaturesState {
 				actualValue := target.Enabled(expectedFeature)
@@ -143,12 +143,12 @@ func TestEnvVarFeatureGates(t *testing.T) {
 }
 
 func TestEnvVarFeatureGatesEnabledPanic(t *testing.T) {
-	target := newEnvVarFeatureGates(nil)
+	target := NewEnvVarFeatureGates(nil)
 	require.PanicsWithError(t, fmt.Errorf("feature %q is not registered in FeatureGates %q", "UnknownFeature", target.callSiteName).Error(), func() { target.Enabled("UnknownFeature") })
 }
 
 func TestHasAlreadyReadEnvVar(t *testing.T) {
-	target := newEnvVarFeatureGates(nil)
+	target := NewEnvVarFeatureGates(nil)
 	require.False(t, target.hasAlreadyReadEnvVar())
 
 	_ = target.getEnabledMapFromEnvVar()

--- a/staging/src/k8s.io/client-go/features/features.go
+++ b/staging/src/k8s.io/client-go/features/features.go
@@ -57,6 +57,14 @@ type Gates interface {
 	Enabled(key Feature) bool
 }
 
+type MutableGates interface {
+	Gates
+
+	// Set parses and stores flag gates for known features
+	// from a string like feature1=true,feature2=false,...
+	Set(value string) error
+}
+
 // Registry represents an external feature gates registry.
 type Registry interface {
 	// Add adds existing feature gates to the provided registry.
@@ -122,7 +130,7 @@ func replaceFeatureGatesWithWarningIndicator(newFeatureGates Gates) bool {
 }
 
 func init() {
-	envVarGates := newEnvVarFeatureGates(defaultKubernetesFeatureGates)
+	envVarGates := NewEnvVarFeatureGates(defaultKubernetesFeatureGates)
 
 	wrappedFeatureGates := &featureGatesWrapper{envVarGates}
 	featureGates.Store(wrappedFeatureGates)

--- a/staging/src/k8s.io/client-go/features/testing/feature_gate.go
+++ b/staging/src/k8s.io/client-go/features/testing/feature_gate.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+
+	"k8s.io/client-go/features"
+)
+
+// nearly direct copy from component-base with package shifting
+
+var (
+	overrideLock        sync.Mutex
+	featureFlagOverride map[features.Feature]string
+)
+
+func init() {
+	featureFlagOverride = map[features.Feature]string{}
+}
+
+// SetFeatureGateDuringTest sets the specified gate to the specified value for duration of the test.
+// Fails when it detects second call to the same flag or is unable to set or restore feature flag.
+//
+// WARNING: Can leak set variable when called in test calling t.Parallel(), however second attempt to set the same feature flag will cause fatal.
+//
+// Example use:
+//
+// featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.<FeatureName>, true)
+func SetFeatureGateDuringTest(tb testing.TB, gate features.Gates, f features.Feature, value bool) {
+	tb.Helper()
+	detectParallelOverrideCleanup := detectParallelOverride(tb, f)
+	originalValue := gate.Enabled(f)
+
+	if err := gate.(features.MutableGates).Set(fmt.Sprintf("%s=%v", f, value)); err != nil {
+		tb.Errorf("error setting %s=%v: %v", f, value, err)
+	}
+
+	tb.Cleanup(func() {
+		tb.Helper()
+		detectParallelOverrideCleanup()
+		if err := gate.(features.MutableGates).Set(fmt.Sprintf("%s=%v", f, originalValue)); err != nil {
+			tb.Errorf("error restoring %s=%v: %v", f, originalValue, err)
+		}
+	})
+}
+
+func detectParallelOverride(tb testing.TB, f features.Feature) func() {
+	tb.Helper()
+	overrideLock.Lock()
+	defer overrideLock.Unlock()
+	beforeOverrideTestName := featureFlagOverride[f]
+	if beforeOverrideTestName != "" && !sameTestOrSubtest(tb, beforeOverrideTestName) {
+		tb.Fatalf("Detected parallel setting of a feature gate by both %q and %q", beforeOverrideTestName, tb.Name())
+	}
+	featureFlagOverride[f] = tb.Name()
+
+	return func() {
+		tb.Helper()
+		overrideLock.Lock()
+		defer overrideLock.Unlock()
+		if afterOverrideTestName := featureFlagOverride[f]; afterOverrideTestName != tb.Name() {
+			tb.Fatalf("Detected parallel setting of a feature gate between both %q and %q", afterOverrideTestName, tb.Name())
+		}
+		featureFlagOverride[f] = beforeOverrideTestName
+	}
+}
+
+func sameTestOrSubtest(tb testing.TB, testName string) bool {
+	// Assumes that "/" is not used in test names.
+	return tb.Name() == testName || strings.HasPrefix(tb.Name(), testName+"/")
+}

--- a/staging/src/k8s.io/client-go/features/testing/feature_gate_test.go
+++ b/staging/src/k8s.io/client-go/features/testing/feature_gate_test.go
@@ -1,0 +1,149 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	gotest "testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/client-go/features"
+)
+
+func expect(t *gotest.T, gate features.Gates, expect map[features.Feature]bool) {
+	t.Helper()
+	for k, v := range expect {
+		if gate.Enabled(k) != v {
+			t.Errorf("Expected %v=%v, got %v", k, v, gate.Enabled(k))
+		}
+	}
+}
+
+func TestSetFeatureGateInTest(t *gotest.T) {
+	gate := features.NewEnvVarFeatureGates(map[features.Feature]features.FeatureSpec{
+		"feature": {PreRelease: features.Alpha, Default: false},
+	})
+
+	assert.False(t, gate.Enabled("feature"))
+	SetFeatureGateDuringTest(t, gate, "feature", true)
+	SetFeatureGateDuringTest(t, gate, "feature", true)
+
+	assert.True(t, gate.Enabled("feature"))
+	t.Run("Subtest", func(t *gotest.T) {
+		assert.True(t, gate.Enabled("feature"))
+	})
+
+	t.Run("ParallelSubtest", func(t *gotest.T) {
+		assert.True(t, gate.Enabled("feature"))
+		// Calling t.Parallel in subtest will resume the main test body
+		t.Parallel()
+		assert.True(t, gate.Enabled("feature"))
+	})
+	assert.True(t, gate.Enabled("feature"))
+
+	t.Run("OverwriteInSubtest", func(t *gotest.T) {
+		SetFeatureGateDuringTest(t, gate, "feature", false)
+		assert.False(t, gate.Enabled("feature"))
+	})
+	assert.True(t, gate.Enabled("feature"))
+}
+
+func TestDetectLeakToMainTest(t *gotest.T) {
+	t.Cleanup(func() {
+		featureFlagOverride = map[features.Feature]string{}
+	})
+	gate := features.NewEnvVarFeatureGates(map[features.Feature]features.FeatureSpec{
+		"feature": {PreRelease: features.Alpha, Default: false},
+	})
+
+	// Subtest setting feature gate and calling parallel will leak it out
+	t.Run("LeakingSubtest", func(t *gotest.T) {
+		fakeT := &ignoreFatalT{T: t}
+		SetFeatureGateDuringTest(fakeT, gate, "feature", true)
+		// Calling t.Parallel in subtest will resume the main test body
+		t.Parallel()
+		// Leaked false from main test
+		assert.False(t, gate.Enabled("feature"))
+	})
+	// Leaked true from subtest
+	assert.True(t, gate.Enabled("feature"))
+	fakeT := &ignoreFatalT{T: t}
+	SetFeatureGateDuringTest(fakeT, gate, "feature", false)
+	assert.True(t, fakeT.fatalRecorded)
+}
+
+func TestDetectLeakToOtherSubtest(t *gotest.T) {
+	t.Cleanup(func() {
+		featureFlagOverride = map[features.Feature]string{}
+	})
+	gate := features.NewEnvVarFeatureGates(map[features.Feature]features.FeatureSpec{
+		"feature": {PreRelease: features.Alpha, Default: false},
+	})
+
+	subtestName := "Subtest"
+	// Subtest setting feature gate and calling parallel will leak it out
+	t.Run(subtestName, func(t *gotest.T) {
+		fakeT := &ignoreFatalT{T: t}
+		SetFeatureGateDuringTest(fakeT, gate, "feature", true)
+		t.Parallel()
+	})
+	// Add suffix to name to prevent tests with the same prefix.
+	t.Run(subtestName+"Suffix", func(t *gotest.T) {
+		// Leaked true
+		assert.True(t, gate.Enabled("feature"))
+
+		fakeT := &ignoreFatalT{T: t}
+		SetFeatureGateDuringTest(fakeT, gate, "feature", false)
+		assert.True(t, fakeT.fatalRecorded)
+	})
+}
+
+func TestCannotDetectLeakFromSubtest(t *gotest.T) {
+	t.Cleanup(func() {
+		featureFlagOverride = map[features.Feature]string{}
+	})
+	gate := features.NewEnvVarFeatureGates(map[features.Feature]features.FeatureSpec{
+		"feature": {PreRelease: features.Alpha, Default: false},
+	})
+
+	SetFeatureGateDuringTest(t, gate, "feature", false)
+	// Subtest setting feature gate and calling parallel will leak it out
+	t.Run("Subtest", func(t *gotest.T) {
+		SetFeatureGateDuringTest(t, gate, "feature", true)
+		t.Parallel()
+	})
+	// Leaked true
+	assert.True(t, gate.Enabled("feature"))
+}
+
+type ignoreFatalT struct {
+	*gotest.T
+	fatalRecorded bool
+}
+
+func (f *ignoreFatalT) Fatal(args ...any) {
+	f.T.Helper()
+	f.fatalRecorded = true
+	newArgs := []any{"[IGNORED]"}
+	newArgs = append(newArgs, args...)
+	f.T.Log(newArgs...)
+}
+
+func (f *ignoreFatalT) Fatalf(format string, args ...any) {
+	f.T.Helper()
+	f.fatalRecorded = true
+	f.T.Logf("[IGNORED] "+format, args...)
+}


### PR DESCRIPTION
Example. I guess it might be good enough to merge too, but if needs more it's an option
