### PR TITLE
[WIP] added EtcdGrpcHealthcheck feature gate

### DIFF
--- a/pkg/features/versioned_kube_features.go
+++ b/pkg/features/versioned_kube_features.go
@@ -269,6 +269,10 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 		{Version: version.MustParse("1.24"), Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 	},
 
+	genericfeatures.EtcdGrpcHealthcheck: {
+		{Version: version.MustParse("1.32"), Default: false, PreRelease: featuregate.Alpha},
+	},
+
 	genericfeatures.KMSv1: {
 		{Version: version.MustParse("1.28"), Default: true, PreRelease: featuregate.Deprecated},
 		{Version: version.MustParse("1.29"), Default: false, PreRelease: featuregate.Deprecated},

--- a/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
+++ b/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
@@ -238,6 +238,17 @@ const (
 	//
 	// Allow the API server to serve consistent lists from cache
 	ConsistentListFromCache featuregate.Feature = "ConsistentListFromCache"
+
+	// owner: @lavacat
+	//
+	// enable etcd grpc client health checking
+	// see https://grpc.io/docs/guides/health-checking/#enabling-client-health-checking
+	//
+	// etcd has server side health service enabled since 3.5.0
+	// https://github.com/etcd-io/etcd/commit/c1e3172e3a7157e812c5c76eaedc9a97fe257716
+	// etcd 3.5.14 added `--experimental-stop-grpc-service-on-defrag` that will set NOT_SERVING during defragmentation
+	// https://github.com/etcd-io/etcd/blob/main/CHANGELOG/CHANGELOG-3.5.md#v3514-2024-05-29
+	EtcdGrpcHealthcheck featuregate.Feature = "EtcdGrpcHealthcheck"
 )
 
 func init() {
@@ -324,6 +335,10 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 		{Version: version.MustParse("1.20"), Default: false, PreRelease: featuregate.Alpha},
 		{Version: version.MustParse("1.21"), Default: true, PreRelease: featuregate.Beta},
 		{Version: version.MustParse("1.24"), Default: true, PreRelease: featuregate.GA, LockToDefault: true},
+	},
+
+	EtcdGrpcHealthcheck: {
+		{Version: version.MustParse("1.32"), Default: false, PreRelease: featuregate.Alpha},
 	},
 
 	KMSv1: {

--- a/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/etcd3.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/etcd3.go
@@ -45,7 +45,7 @@ import (
 	utilnet "k8s.io/apimachinery/pkg/util/net"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
-	genericfeatures "k8s.io/apiserver/pkg/features"
+	"k8s.io/apiserver/pkg/features"
 	"k8s.io/apiserver/pkg/server/egressselector"
 	"k8s.io/apiserver/pkg/storage"
 	"k8s.io/apiserver/pkg/storage/etcd3"
@@ -55,6 +55,12 @@ import (
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/component-base/metrics/legacyregistry"
 	tracing "k8s.io/component-base/tracing"
+
+	// This import sets internal.HealthCheckFunc
+	// but function won't be used unless EtcdGrpcHealthcheck feature gate is set
+	//https://github.com/grpc/grpc-go/blob/master/examples/features/health/README.md#client
+	//https://github.com/grpc/grpc-go/blob/v1.64.x/clientconn.go#L1428
+	_ "google.golang.org/grpc/health"
 )
 
 const (
@@ -69,6 +75,17 @@ const (
 	dialTimeout = 20 * time.Second
 
 	dbMetricsMonitorJitter = 0.5
+
+	// grpcServiceConfigWithHealthcheck is used to enable etcd grpc client health check.
+	// See https://grpc.io/docs/guides/health-checking/#enabling-client-health-checking
+	//
+	// Need to specify loadBalancingPolicy because internally etcd sets `round_robin`.
+	// Using config without policy will revert to default `pick_first`
+	// https://grpc.io/docs/guides/custom-load-balancing/#implementing-your-own-policy
+	//
+	// serviceName is set to "" because etcd server uses empty string to represent the health of the whole server
+	// See https://grpc.io/docs/guides/health-checking/#the-server-side-health-service
+	grpcServiceConfigWithHealthcheck = `{"loadBalancingPolicy": "round_robin", "healthCheckConfig": {"serviceName": ""}}`
 )
 
 // TODO(negz): Stop using a package scoped logger. At the time of writing we're
@@ -316,7 +333,7 @@ var newETCD3Client = func(c storagebackend.TransportConfig) (*kubernetes.Client,
 		grpc.WithChainUnaryInterceptor(grpcprom.UnaryClientInterceptor),
 		grpc.WithChainStreamInterceptor(grpcprom.StreamClientInterceptor),
 	}
-	if utilfeature.DefaultFeatureGate.Enabled(genericfeatures.APIServerTracing) {
+	if utilfeature.DefaultFeatureGate.Enabled(features.APIServerTracing) {
 		tracingOpts := []otelgrpc.Option{
 			otelgrpc.WithMessageEvents(otelgrpc.ReceivedEvents, otelgrpc.SentEvents),
 			otelgrpc.WithPropagators(tracing.Propagators()),
@@ -341,6 +358,11 @@ var newETCD3Client = func(c storagebackend.TransportConfig) (*kubernetes.Client,
 			return egressDialer(ctx, "tcp", addr)
 		}
 		dialOptions = append(dialOptions, grpc.WithContextDialer(dialer))
+	}
+	if utilfeature.DefaultFeatureGate.Enabled(features.EtcdGrpcHealthcheck) {
+		// ignore config set by etcd manual resolver inside etcd client
+		dialOptions = append(dialOptions, grpc.WithDisableServiceConfig())
+		dialOptions = append(dialOptions, grpc.WithDefaultServiceConfig(grpcServiceConfigWithHealthcheck))
 	}
 
 	cfg := clientv3.Config{

--- a/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/etcd3_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/etcd3_test.go
@@ -17,10 +17,31 @@ limitations under the License.
 package factory
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"net"
+
+	"k8s.io/apiserver/pkg/storage/etcd3/testserver"
+
+	"k8s.io/apiserver/pkg/features"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
+
+	pb "go.etcd.io/etcd/api/v3/etcdserverpb"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/health"
+	"k8s.io/apiserver/pkg/apis/example"
+
 	"testing"
 	"time"
+
+	"k8s.io/apimachinery/pkg/api/apitesting"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	examplev1 "k8s.io/apiserver/pkg/apis/example/v1"
+	"k8s.io/apiserver/pkg/storage/storagebackend"
+
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 )
 
 func Test_atomicLastError(t *testing.T) {
@@ -45,4 +66,173 @@ func Test_atomicLastError(t *testing.T) {
 	if err.Error() != "now error" {
 		t.Fatalf("Expected: \"now error\" got: %s", err.Error())
 	}
+}
+
+func TestClientWithGrpcHealthcheckWithRealServer(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.EtcdGrpcHealthcheck, true)
+
+	client := testserver.RunEtcd(t, testserver.NewTestConfig(t))
+	_, err := client.Put(context.Background(), "/somekey", "data")
+	if err != nil {
+		t.Fatalf("Put failed: %v", err)
+	}
+}
+
+func TestClientWithGrpcHealthcheckWithMockServer(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.EtcdGrpcHealthcheck, true)
+
+	etcdMock1 := startEtcdMockServer(t)
+	defer etcdMock1.Stop(t)
+	etcdMock2 := startEtcdMockServer(t)
+	defer etcdMock2.Stop(t)
+
+	cfg := storagebackend.Config{
+		Type: storagebackend.StorageTypeETCD3,
+		Transport: storagebackend.TransportConfig{
+			ServerList: []string{etcdMock1.Listener.Addr().String(), etcdMock2.Listener.Addr().String()},
+		},
+		// reusing codecs for tls_test
+		Codec: apitesting.TestCodec(codecs, examplev1.SchemeGroupVersion),
+	}
+
+	storage, destroyFunc, err := newETCD3Storage(*cfg.ForResource(schema.GroupResource{Resource: "pods"}), nil, nil, "")
+	defer destroyFunc()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	maxCreates := 10
+	for range maxCreates {
+		err = storage.Create(context.TODO(), "/abc", &example.Pod{}, nil, 0)
+		if err != nil {
+			t.Fatalf("Create failed: %v", err)
+		}
+	}
+
+	if (etcdMock1.MockKVServer.TxnCounter != maxCreates/2) && (etcdMock2.MockKVServer.TxnCounter != maxCreates/2) {
+		t.Fatalf("Etcd client round robin balancer should balance equally. Got %d vs %d",
+			etcdMock1.MockKVServer.TxnCounter, etcdMock2.MockKVServer.TxnCounter)
+	}
+
+	etcdMock1.HealthServer.SetServingStatus("", healthpb.HealthCheckResponse_NOT_SERVING)
+
+	for range maxCreates {
+		err = storage.Create(context.TODO(), "/abc", &example.Pod{}, nil, 0)
+		if err != nil {
+			t.Fatalf("Create failed: %v", err)
+		}
+	}
+
+	if etcdMock1.MockKVServer.TxnCounter > maxCreates/2+1 {
+		t.Fatalf("Etcd client grpc healthcheck isn't working. Max 1 extra request is expected. Got %d vs %d",
+			etcdMock1.MockKVServer.TxnCounter, etcdMock2.MockKVServer.TxnCounter)
+	}
+
+	if etcdMock2.MockKVServer.TxnCounter < maxCreates {
+		t.Fatalf("Etcd client grpc healthcheck isn't working. Most of the requests should go to second server. Got %d vs %d",
+			etcdMock1.MockKVServer.TxnCounter, etcdMock2.MockKVServer.TxnCounter)
+	}
+}
+
+type mockEtcdServer struct {
+	Listener     net.Listener
+	GrpcServer   *grpc.Server
+	MockKVServer *mockKVServer
+	HealthServer *health.Server
+}
+
+func startEtcdMockServer(t *testing.T) *mockEtcdServer {
+	lis, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	svr := grpc.NewServer()
+	kv := &mockKVServer{}
+	ms := &mockMaintenanceServer{}
+	hs := health.NewServer()
+
+	pb.RegisterKVServer(svr, kv)
+	pb.RegisterMaintenanceServer(svr, ms)
+	healthpb.RegisterHealthServer(svr, hs)
+
+	go func() {
+		_ = svr.Serve(lis)
+	}()
+
+	return &mockEtcdServer{
+		Listener:     lis,
+		GrpcServer:   svr,
+		MockKVServer: kv,
+		HealthServer: hs,
+	}
+}
+
+func (m *mockEtcdServer) Stop(t *testing.T) {
+	err := m.Listener.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+	m.GrpcServer.Stop()
+}
+
+type mockKVServer struct {
+	TxnCounter int
+}
+
+func (m *mockKVServer) Range(context.Context, *pb.RangeRequest) (*pb.RangeResponse, error) {
+	return &pb.RangeResponse{}, nil
+}
+
+func (m *mockKVServer) Put(context.Context, *pb.PutRequest) (*pb.PutResponse, error) {
+	return &pb.PutResponse{}, nil
+}
+
+func (m *mockKVServer) DeleteRange(context.Context, *pb.DeleteRangeRequest) (*pb.DeleteRangeResponse, error) {
+	return &pb.DeleteRangeResponse{}, nil
+}
+
+func (m *mockKVServer) Txn(context.Context, *pb.TxnRequest) (*pb.TxnResponse, error) {
+	m.TxnCounter += 1
+	// minimal response to make create call succeed
+	return &pb.TxnResponse{Succeeded: true, Header: &pb.ResponseHeader{Revision: 0}}, nil
+}
+
+func (m *mockKVServer) Compact(context.Context, *pb.CompactionRequest) (*pb.CompactionResponse, error) {
+	return &pb.CompactionResponse{}, nil
+}
+
+type mockMaintenanceServer struct{}
+
+func (m *mockMaintenanceServer) Alarm(context.Context, *pb.AlarmRequest) (*pb.AlarmResponse, error) {
+	return &pb.AlarmResponse{}, nil
+}
+
+func (m *mockMaintenanceServer) Status(context.Context, *pb.StatusRequest) (*pb.StatusResponse, error) {
+	// used to pass feature_support_checker
+	return &pb.StatusResponse{Version: "3.5.13"}, nil
+}
+
+func (m *mockMaintenanceServer) Defragment(context.Context, *pb.DefragmentRequest) (*pb.DefragmentResponse, error) {
+	return &pb.DefragmentResponse{}, nil
+}
+
+func (m *mockMaintenanceServer) Hash(context.Context, *pb.HashRequest) (*pb.HashResponse, error) {
+	return &pb.HashResponse{}, nil
+}
+
+func (m *mockMaintenanceServer) HashKV(context.Context, *pb.HashKVRequest) (*pb.HashKVResponse, error) {
+	return &pb.HashKVResponse{}, nil
+}
+
+func (m *mockMaintenanceServer) Snapshot(*pb.SnapshotRequest, pb.Maintenance_SnapshotServer) error {
+	return nil
+}
+
+func (m *mockMaintenanceServer) MoveLeader(context.Context, *pb.MoveLeaderRequest) (*pb.MoveLeaderResponse, error) {
+	return &pb.MoveLeaderResponse{}, nil
+}
+
+func (m *mockMaintenanceServer) Downgrade(context.Context, *pb.DowngradeRequest) (*pb.DowngradeResponse, error) {
+	return &pb.DowngradeResponse{}, nil
 }

--- a/test/featuregates_linter/test_data/versioned_feature_list.yaml
+++ b/test/featuregates_linter/test_data/versioned_feature_list.yaml
@@ -440,6 +440,12 @@
     lockToDefault: true
     preRelease: GA
     version: "1.31"
+- name: EtcdGrpcHealthcheck
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.32"
 - name: EventedPLEG
   versionedSpecs:
   - default: false


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

#### What this PR does / why we need it:
Enable etcd client grpc health checks.
See https://grpc.io/docs/guides/health-checking/#enabling-client-health-checking

Etcd recently enabled grpc health checks on the server https://github.com/etcd-io/etcd/pull/17914. Use-case is to notify clients when etcd member is doing defrag and can't serve client traffic.
Etcd client inside apiserver will be able to preemptively switch to healthy etcd endpoint and avoid queuing up requests (causes "too many requests" etcd error under large load). 

This also helps with existing apiserver etcd healthcheck. Current default healthcheck timeout is 2s. Etcd server side request timeout is 5s + 1s(default election timeout). If defrag > 2s, healthcheck fails before etcd client switches to new endpoint.

Note: in etcd healtcheck service is enabled by default, but defrag notification is behind feature flag.
This is backward compatible with current etcd version.

Adding full e2e test that triggers defrag of non-trivial length is difficult. Etcd e2e test uses `failpoints` to insert delay in defrag. Please suggest ideas on e2e test.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
https://github.com/kubernetes/kubernetes/issues/124763

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
added EtcdGrpcHealthcheck feature gate that enables etcd grpc client health checks calls against individual etcd members
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
https://grpc.io/docs/guides/health-checking/#enabling-client-health-checking
```
