### PR TITLE
Wire in ctx into rbac plugins

### DIFF
--- a/pkg/auth/authorizer/abac/abac.go
+++ b/pkg/auth/authorizer/abac/abac.go
@@ -239,7 +239,7 @@ func (pl PolicyList) Authorize(ctx context.Context, a authorizer.Attributes) (au
 }
 
 // RulesFor returns rules for the given user and namespace.
-func (pl PolicyList) RulesFor(user user.Info, namespace string) ([]authorizer.ResourceRuleInfo, []authorizer.NonResourceRuleInfo, bool, error) {
+func (pl PolicyList) RulesFor(ctx context.Context, user user.Info, namespace string) ([]authorizer.ResourceRuleInfo, []authorizer.NonResourceRuleInfo, bool, error) {
 	var (
 		resourceRules    []authorizer.ResourceRuleInfo
 		nonResourceRules []authorizer.NonResourceRuleInfo

--- a/pkg/auth/authorizer/abac/abac_test.go
+++ b/pkg/auth/authorizer/abac/abac_test.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/kubernetes/pkg/apis/abac"
 	"k8s.io/kubernetes/pkg/apis/abac/v0"
 	"k8s.io/kubernetes/pkg/apis/abac/v1beta1"
@@ -324,7 +325,7 @@ func TestRulesFor(t *testing.T) {
 			User:      &tc.User,
 			Namespace: tc.Namespace,
 		}
-		resourceRules, nonResourceRules, _, _ := a.RulesFor(attr.GetUser(), attr.GetNamespace())
+		resourceRules, nonResourceRules, _, _ := a.RulesFor(genericapirequest.NewContext(), attr.GetUser(), attr.GetNamespace())
 		actualResourceRules := getResourceRules(resourceRules)
 		if !reflect.DeepEqual(tc.ExpectResourceRules, actualResourceRules) {
 			t.Logf("tc: %v -> attr %v", tc, attr)

--- a/pkg/kubeapiserver/authorizer/reload.go
+++ b/pkg/kubeapiserver/authorizer/reload.go
@@ -78,8 +78,8 @@ func (r *reloadableAuthorizerResolver) Authorize(ctx context.Context, a authoriz
 	return r.current.Load().authorizer.Authorize(ctx, a)
 }
 
-func (r *reloadableAuthorizerResolver) RulesFor(user user.Info, namespace string) ([]authorizer.ResourceRuleInfo, []authorizer.NonResourceRuleInfo, bool, error) {
-	return r.current.Load().ruleResolver.RulesFor(user, namespace)
+func (r *reloadableAuthorizerResolver) RulesFor(ctx context.Context, user user.Info, namespace string) ([]authorizer.ResourceRuleInfo, []authorizer.NonResourceRuleInfo, bool, error) {
+	return r.current.Load().ruleResolver.RulesFor(ctx, user, namespace)
 }
 
 // newForConfig constructs

--- a/pkg/registry/authorization/selfsubjectrulesreview/rest.go
+++ b/pkg/registry/authorization/selfsubjectrulesreview/rest.go
@@ -78,7 +78,7 @@ func (r *REST) Create(ctx context.Context, obj runtime.Object, createValidation 
 		}
 	}
 
-	resourceInfo, nonResourceInfo, incomplete, err := r.ruleResolver.RulesFor(user, namespace)
+	resourceInfo, nonResourceInfo, incomplete, err := r.ruleResolver.RulesFor(ctx, user, namespace)
 
 	ret := &authorizationapi.SelfSubjectRulesReview{
 		Status: authorizationapi.SubjectRulesReviewStatus{

--- a/pkg/registry/rbac/clusterrole/registry.go
+++ b/pkg/registry/rbac/clusterrole/registry.go
@@ -62,6 +62,6 @@ type AuthorizerAdapter struct {
 }
 
 // GetClusterRole returns the corresponding ClusterRole by name
-func (a AuthorizerAdapter) GetClusterRole(name string) (*rbacv1.ClusterRole, error) {
-	return a.Registry.GetClusterRole(genericapirequest.NewContext(), name, &metav1.GetOptions{})
+func (a AuthorizerAdapter) GetClusterRole(ctx context.Context, name string) (*rbacv1.ClusterRole, error) {
+	return a.Registry.GetClusterRole(genericapirequest.WithNamespace(ctx, ""), name, &metav1.GetOptions{})
 }

--- a/pkg/registry/rbac/clusterrolebinding/policybased/storage.go
+++ b/pkg/registry/rbac/clusterrolebinding/policybased/storage.go
@@ -81,7 +81,7 @@ func (s *Storage) Create(ctx context.Context, obj runtime.Object, createValidati
 	if err != nil {
 		return nil, err
 	}
-	rules, err := s.ruleResolver.GetRoleReferenceRules(v1RoleRef, metav1.NamespaceNone)
+	rules, err := s.ruleResolver.GetRoleReferenceRules(ctx, v1RoleRef, metav1.NamespaceNone)
 	if err != nil {
 		return nil, err
 	}
@@ -115,7 +115,7 @@ func (s *Storage) Update(ctx context.Context, name string, obj rest.UpdatedObjec
 		if err != nil {
 			return nil, err
 		}
-		rules, err := s.ruleResolver.GetRoleReferenceRules(v1RoleRef, metav1.NamespaceNone)
+		rules, err := s.ruleResolver.GetRoleReferenceRules(ctx, v1RoleRef, metav1.NamespaceNone)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/registry/rbac/clusterrolebinding/registry.go
+++ b/pkg/registry/rbac/clusterrolebinding/registry.go
@@ -61,8 +61,8 @@ type AuthorizerAdapter struct {
 	Registry Registry
 }
 
-func (a AuthorizerAdapter) ListClusterRoleBindings() ([]*rbacv1.ClusterRoleBinding, error) {
-	list, err := a.Registry.ListClusterRoleBindings(genericapirequest.NewContext(), &metainternalversion.ListOptions{})
+func (a AuthorizerAdapter) ListClusterRoleBindings(ctx context.Context) ([]*rbacv1.ClusterRoleBinding, error) {
+	list, err := a.Registry.ListClusterRoleBindings(genericapirequest.WithNamespace(ctx, ""), &metainternalversion.ListOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/registry/rbac/role/registry.go
+++ b/pkg/registry/rbac/role/registry.go
@@ -62,6 +62,6 @@ type AuthorizerAdapter struct {
 }
 
 // GetRole returns the corresponding Role by name in specified namespace
-func (a AuthorizerAdapter) GetRole(namespace, name string) (*rbacv1.Role, error) {
-	return a.Registry.GetRole(genericapirequest.WithNamespace(genericapirequest.NewContext(), namespace), name, &metav1.GetOptions{})
+func (a AuthorizerAdapter) GetRole(ctx context.Context, namespace, name string) (*rbacv1.Role, error) {
+	return a.Registry.GetRole(genericapirequest.WithNamespace(ctx, namespace), name, &metav1.GetOptions{})
 }

--- a/pkg/registry/rbac/rolebinding/policybased/storage.go
+++ b/pkg/registry/rbac/rolebinding/policybased/storage.go
@@ -89,7 +89,7 @@ func (s *Storage) Create(ctx context.Context, obj runtime.Object, createValidati
 	if err != nil {
 		return nil, err
 	}
-	rules, err := s.ruleResolver.GetRoleReferenceRules(v1RoleRef, namespace)
+	rules, err := s.ruleResolver.GetRoleReferenceRules(ctx, v1RoleRef, namespace)
 	if err != nil {
 		return nil, err
 	}
@@ -130,7 +130,7 @@ func (s *Storage) Update(ctx context.Context, name string, obj rest.UpdatedObjec
 		if err != nil {
 			return nil, err
 		}
-		rules, err := s.ruleResolver.GetRoleReferenceRules(v1RoleRef, namespace)
+		rules, err := s.ruleResolver.GetRoleReferenceRules(ctx, v1RoleRef, namespace)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/registry/rbac/rolebinding/registry.go
+++ b/pkg/registry/rbac/rolebinding/registry.go
@@ -61,8 +61,8 @@ type AuthorizerAdapter struct {
 	Registry Registry
 }
 
-func (a AuthorizerAdapter) ListRoleBindings(namespace string) ([]*rbacv1.RoleBinding, error) {
-	list, err := a.Registry.ListRoleBindings(genericapirequest.WithNamespace(genericapirequest.NewContext(), namespace), &metainternalversion.ListOptions{})
+func (a AuthorizerAdapter) ListRoleBindings(ctx context.Context, namespace string) ([]*rbacv1.RoleBinding, error) {
+	list, err := a.Registry.ListRoleBindings(genericapirequest.WithNamespace(ctx, namespace), &metainternalversion.ListOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/registry/rbac/validation/rule_test.go
+++ b/pkg/registry/rbac/validation/rule_test.go
@@ -27,6 +27,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apiserver/pkg/authentication/user"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 )
 
 // compute a hash of a policy rule so we can sort in a deterministic order
@@ -145,7 +146,7 @@ func TestDefaultRuleResolver(t *testing.T) {
 
 	for i, tc := range tests {
 		ruleResolver := newMockRuleResolver(&tc.StaticRoles)
-		rules, err := ruleResolver.RulesFor(tc.user, tc.namespace)
+		rules, err := ruleResolver.RulesFor(genericapirequest.NewContext(), tc.user, tc.namespace)
 		if err != nil {
 			t.Errorf("case %d: GetEffectivePolicyRules(context)=%v", i, err)
 			continue

--- a/plugin/pkg/auth/authorizer/node/node_authorizer.go
+++ b/plugin/pkg/auth/authorizer/node/node_authorizer.go
@@ -95,7 +95,7 @@ var (
 	csiNodeResource       = storageapi.Resource("csinodes")
 )
 
-func (r *NodeAuthorizer) RulesFor(user user.Info, namespace string) ([]authorizer.ResourceRuleInfo, []authorizer.NonResourceRuleInfo, bool, error) {
+func (r *NodeAuthorizer) RulesFor(ctx context.Context, user user.Info, namespace string) ([]authorizer.ResourceRuleInfo, []authorizer.NonResourceRuleInfo, bool, error) {
 	if _, isNode := r.identifier.NodeIdentity(user); isNode {
 		// indicate nodes do not have fully enumerated permissions
 		return nil, nil, true, fmt.Errorf("node authorizer does not support user rule resolution")

--- a/plugin/pkg/auth/authorizer/rbac/rbac.go
+++ b/plugin/pkg/auth/authorizer/rbac/rbac.go
@@ -39,12 +39,12 @@ type RequestToRuleMapper interface {
 	// Any rule returned is still valid, since rules are deny by default.  If you can pass with the rules
 	// supplied, you do not have to fail the request.  If you cannot, you should indicate the error along
 	// with your denial.
-	RulesFor(subject user.Info, namespace string) ([]rbacv1.PolicyRule, error)
+	RulesFor(ctx context.Context, subject user.Info, namespace string) ([]rbacv1.PolicyRule, error)
 
 	// VisitRulesFor invokes visitor() with each rule that applies to a given user in a given namespace,
 	// and each error encountered resolving those rules. Rule may be nil if err is non-nil.
 	// If visitor() returns false, visiting is short-circuited.
-	VisitRulesFor(user user.Info, namespace string, visitor func(source fmt.Stringer, rule *rbacv1.PolicyRule, err error) bool)
+	VisitRulesFor(ctx context.Context, user user.Info, namespace string, visitor func(source fmt.Stringer, rule *rbacv1.PolicyRule, err error) bool)
 }
 
 type RBACAuthorizer struct {
@@ -75,7 +75,7 @@ func (v *authorizingVisitor) visit(source fmt.Stringer, rule *rbacv1.PolicyRule,
 func (r *RBACAuthorizer) Authorize(ctx context.Context, requestAttributes authorizer.Attributes) (authorizer.Decision, string, error) {
 	ruleCheckingVisitor := &authorizingVisitor{requestAttributes: requestAttributes}
 
-	r.authorizationRuleResolver.VisitRulesFor(requestAttributes.GetUser(), requestAttributes.GetNamespace(), ruleCheckingVisitor.visit)
+	r.authorizationRuleResolver.VisitRulesFor(ctx, requestAttributes.GetUser(), requestAttributes.GetNamespace(), ruleCheckingVisitor.visit)
 	if ruleCheckingVisitor.allowed {
 		return authorizer.DecisionAllow, ruleCheckingVisitor.reason, nil
 	}
@@ -126,13 +126,13 @@ func (r *RBACAuthorizer) Authorize(ctx context.Context, requestAttributes author
 	return authorizer.DecisionNoOpinion, reason, nil
 }
 
-func (r *RBACAuthorizer) RulesFor(user user.Info, namespace string) ([]authorizer.ResourceRuleInfo, []authorizer.NonResourceRuleInfo, bool, error) {
+func (r *RBACAuthorizer) RulesFor(ctx context.Context, user user.Info, namespace string) ([]authorizer.ResourceRuleInfo, []authorizer.NonResourceRuleInfo, bool, error) {
 	var (
 		resourceRules    []authorizer.ResourceRuleInfo
 		nonResourceRules []authorizer.NonResourceRuleInfo
 	)
 
-	policyRules, err := r.authorizationRuleResolver.RulesFor(user, namespace)
+	policyRules, err := r.authorizationRuleResolver.RulesFor(ctx, user, namespace)
 	for _, policyRule := range policyRules {
 		if len(policyRule.Resources) > 0 {
 			r := authorizer.DefaultResourceRuleInfo{
@@ -196,7 +196,7 @@ type RoleGetter struct {
 	Lister rbaclisters.RoleLister
 }
 
-func (g *RoleGetter) GetRole(namespace, name string) (*rbacv1.Role, error) {
+func (g *RoleGetter) GetRole(ctx context.Context, namespace, name string) (*rbacv1.Role, error) {
 	return g.Lister.Roles(namespace).Get(name)
 }
 
@@ -204,7 +204,7 @@ type RoleBindingLister struct {
 	Lister rbaclisters.RoleBindingLister
 }
 
-func (l *RoleBindingLister) ListRoleBindings(namespace string) ([]*rbacv1.RoleBinding, error) {
+func (l *RoleBindingLister) ListRoleBindings(ctx context.Context, namespace string) ([]*rbacv1.RoleBinding, error) {
 	return l.Lister.RoleBindings(namespace).List(labels.Everything())
 }
 
@@ -212,7 +212,7 @@ type ClusterRoleGetter struct {
 	Lister rbaclisters.ClusterRoleLister
 }
 
-func (g *ClusterRoleGetter) GetClusterRole(name string) (*rbacv1.ClusterRole, error) {
+func (g *ClusterRoleGetter) GetClusterRole(ctx context.Context, name string) (*rbacv1.ClusterRole, error) {
 	return g.Lister.Get(name)
 }
 
@@ -220,6 +220,6 @@ type ClusterRoleBindingLister struct {
 	Lister rbaclisters.ClusterRoleBindingLister
 }
 
-func (l *ClusterRoleBindingLister) ListClusterRoleBindings() ([]*rbacv1.ClusterRoleBinding, error) {
+func (l *ClusterRoleBindingLister) ListClusterRoleBindings(ctx context.Context) ([]*rbacv1.ClusterRoleBinding, error) {
 	return l.Lister.List(labels.Everything())
 }

--- a/plugin/pkg/auth/authorizer/rbac/subject_locator.go
+++ b/plugin/pkg/auth/authorizer/rbac/subject_locator.go
@@ -18,6 +18,8 @@ limitations under the License.
 package rbac
 
 import (
+	"context"
+
 	rbacv1 "k8s.io/api/rbac/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apiserver/pkg/authentication/user"
@@ -28,11 +30,11 @@ import (
 type RoleToRuleMapper interface {
 	// GetRoleReferenceRules attempts to resolve the role reference of a RoleBinding or ClusterRoleBinding.  The passed namespace should be the namespace
 	// of the role binding, the empty string if a cluster role binding.
-	GetRoleReferenceRules(roleRef rbacv1.RoleRef, namespace string) ([]rbacv1.PolicyRule, error)
+	GetRoleReferenceRules(ctx context.Context, roleRef rbacv1.RoleRef, namespace string) ([]rbacv1.PolicyRule, error)
 }
 
 type SubjectLocator interface {
-	AllowedSubjects(attributes authorizer.Attributes) ([]rbacv1.Subject, error)
+	AllowedSubjects(ctx context.Context, attributes authorizer.Attributes) ([]rbacv1.Subject, error)
 }
 
 var _ = SubjectLocator(&SubjectAccessEvaluator{})
@@ -59,19 +61,19 @@ func NewSubjectAccessEvaluator(roles rbacregistryvalidation.RoleGetter, roleBind
 
 // AllowedSubjects returns the subjects that can perform an action and any errors encountered while computing the list.
 // It is possible to have both subjects and errors returned if some rolebindings couldn't be resolved, but others could be.
-func (r *SubjectAccessEvaluator) AllowedSubjects(requestAttributes authorizer.Attributes) ([]rbacv1.Subject, error) {
+func (r *SubjectAccessEvaluator) AllowedSubjects(ctx context.Context, requestAttributes authorizer.Attributes) ([]rbacv1.Subject, error) {
 	subjects := []rbacv1.Subject{{Kind: rbacv1.GroupKind, APIGroup: rbacv1.GroupName, Name: user.SystemPrivilegedGroup}}
 	if len(r.superUser) > 0 {
 		subjects = append(subjects, rbacv1.Subject{Kind: rbacv1.UserKind, APIGroup: rbacv1.GroupName, Name: r.superUser})
 	}
 	errorlist := []error{}
 
-	if clusterRoleBindings, err := r.clusterRoleBindingLister.ListClusterRoleBindings(); err != nil {
+	if clusterRoleBindings, err := r.clusterRoleBindingLister.ListClusterRoleBindings(ctx); err != nil {
 		errorlist = append(errorlist, err)
 
 	} else {
 		for _, clusterRoleBinding := range clusterRoleBindings {
-			rules, err := r.roleToRuleMapper.GetRoleReferenceRules(clusterRoleBinding.RoleRef, "")
+			rules, err := r.roleToRuleMapper.GetRoleReferenceRules(ctx, clusterRoleBinding.RoleRef, "")
 			if err != nil {
 				// if we have an error, just keep track of it and keep processing.  Since rules are additive,
 				// missing a reference is bad, but we can continue with other rolebindings and still have a list
@@ -85,12 +87,12 @@ func (r *SubjectAccessEvaluator) AllowedSubjects(requestAttributes authorizer.At
 	}
 
 	if namespace := requestAttributes.GetNamespace(); len(namespace) > 0 {
-		if roleBindings, err := r.roleBindingLister.ListRoleBindings(namespace); err != nil {
+		if roleBindings, err := r.roleBindingLister.ListRoleBindings(ctx, namespace); err != nil {
 			errorlist = append(errorlist, err)
 
 		} else {
 			for _, roleBinding := range roleBindings {
-				rules, err := r.roleToRuleMapper.GetRoleReferenceRules(roleBinding.RoleRef, namespace)
+				rules, err := r.roleToRuleMapper.GetRoleReferenceRules(ctx, roleBinding.RoleRef, namespace)
 				if err != nil {
 					// if we have an error, just keep track of it and keep processing.  Since rules are additive,
 					// missing a reference is bad, but we can continue with other rolebindings and still have a list

--- a/plugin/pkg/auth/authorizer/rbac/subject_locator_test.go
+++ b/plugin/pkg/auth/authorizer/rbac/subject_locator_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package rbac
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -139,7 +140,7 @@ func TestSubjectLocator(t *testing.T) {
 		ruleResolver, lister := rbacregistryvalidation.NewTestRuleResolver(tt.roles, tt.roleBindings, tt.clusterRoles, tt.clusterRoleBindings)
 		a := SubjectAccessEvaluator{tt.superUser, lister, lister, ruleResolver}
 		for i, action := range tt.actionsToSubjects {
-			actualSubjects, err := a.AllowedSubjects(action.action)
+			actualSubjects, err := a.AllowedSubjects(context.Background(), action.action)
 			if err != nil {
 				t.Errorf("case %q %d: error %v", tt.name, i, err)
 			}

--- a/staging/src/k8s.io/apiserver/pkg/authorization/authorizer/interfaces.go
+++ b/staging/src/k8s.io/apiserver/pkg/authorization/authorizer/interfaces.go
@@ -92,7 +92,7 @@ func (f AuthorizerFunc) Authorize(ctx context.Context, a Attributes) (Decision, 
 // RuleResolver provides a mechanism for resolving the list of rules that apply to a given user within a namespace.
 type RuleResolver interface {
 	// RulesFor get the list of cluster wide rules, the list of rules in the specific namespace, incomplete status and errors.
-	RulesFor(user user.Info, namespace string) ([]ResourceRuleInfo, []NonResourceRuleInfo, bool, error)
+	RulesFor(ctx context.Context, user user.Info, namespace string) ([]ResourceRuleInfo, []NonResourceRuleInfo, bool, error)
 }
 
 // RequestAttributesGetter provides a function that extracts Attributes from an http.Request

--- a/staging/src/k8s.io/apiserver/pkg/authorization/authorizerfactory/builtin.go
+++ b/staging/src/k8s.io/apiserver/pkg/authorization/authorizerfactory/builtin.go
@@ -33,7 +33,7 @@ func (alwaysAllowAuthorizer) Authorize(ctx context.Context, a authorizer.Attribu
 	return authorizer.DecisionAllow, "", nil
 }
 
-func (alwaysAllowAuthorizer) RulesFor(user user.Info, namespace string) ([]authorizer.ResourceRuleInfo, []authorizer.NonResourceRuleInfo, bool, error) {
+func (alwaysAllowAuthorizer) RulesFor(ctx context.Context, user user.Info, namespace string) ([]authorizer.ResourceRuleInfo, []authorizer.NonResourceRuleInfo, bool, error) {
 	return []authorizer.ResourceRuleInfo{
 			&authorizer.DefaultResourceRuleInfo{
 				Verbs:     []string{"*"},
@@ -61,7 +61,7 @@ func (alwaysDenyAuthorizer) Authorize(ctx context.Context, a authorizer.Attribut
 	return authorizer.DecisionNoOpinion, "Everything is forbidden.", nil
 }
 
-func (alwaysDenyAuthorizer) RulesFor(user user.Info, namespace string) ([]authorizer.ResourceRuleInfo, []authorizer.NonResourceRuleInfo, bool, error) {
+func (alwaysDenyAuthorizer) RulesFor(ctx context.Context, user user.Info, namespace string) ([]authorizer.ResourceRuleInfo, []authorizer.NonResourceRuleInfo, bool, error) {
 	return []authorizer.ResourceRuleInfo{}, []authorizer.NonResourceRuleInfo{}, false, nil
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/authorization/union/union.go
+++ b/staging/src/k8s.io/apiserver/pkg/authorization/union/union.go
@@ -77,7 +77,7 @@ func NewRuleResolvers(authorizationHandlers ...authorizer.RuleResolver) authoriz
 }
 
 // RulesFor against a chain of authorizer.RuleResolver objects and returns nil if successful and returns error if unsuccessful
-func (authzHandler unionAuthzRulesHandler) RulesFor(user user.Info, namespace string) ([]authorizer.ResourceRuleInfo, []authorizer.NonResourceRuleInfo, bool, error) {
+func (authzHandler unionAuthzRulesHandler) RulesFor(ctx context.Context, user user.Info, namespace string) ([]authorizer.ResourceRuleInfo, []authorizer.NonResourceRuleInfo, bool, error) {
 	var (
 		errList              []error
 		resourceRulesList    []authorizer.ResourceRuleInfo
@@ -86,7 +86,7 @@ func (authzHandler unionAuthzRulesHandler) RulesFor(user user.Info, namespace st
 	incompleteStatus := false
 
 	for _, currAuthzHandler := range authzHandler {
-		resourceRules, nonResourceRules, incomplete, err := currAuthzHandler.RulesFor(user, namespace)
+		resourceRules, nonResourceRules, incomplete, err := currAuthzHandler.RulesFor(ctx, user, namespace)
 
 		if incomplete {
 			incompleteStatus = true

--- a/staging/src/k8s.io/apiserver/pkg/authorization/union/union_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/authorization/union/union_test.go
@@ -25,6 +25,7 @@ import (
 
 	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 )
 
 type mockAuthzHandler struct {
@@ -86,7 +87,7 @@ type mockAuthzRuleHandler struct {
 	err              error
 }
 
-func (mock *mockAuthzRuleHandler) RulesFor(user user.Info, namespace string) ([]authorizer.ResourceRuleInfo, []authorizer.NonResourceRuleInfo, bool, error) {
+func (mock *mockAuthzRuleHandler) RulesFor(ctx context.Context, user user.Info, namespace string) ([]authorizer.ResourceRuleInfo, []authorizer.NonResourceRuleInfo, bool, error) {
 	if mock.err != nil {
 		return []authorizer.ResourceRuleInfo{}, []authorizer.NonResourceRuleInfo{}, false, mock.err
 	}
@@ -150,7 +151,7 @@ func TestAuthorizationResourceRules(t *testing.T) {
 
 	authzRulesHandler := NewRuleResolvers(handler1, handler2)
 
-	rules, _, _, _ := authzRulesHandler.RulesFor(nil, "")
+	rules, _, _, _ := authzRulesHandler.RulesFor(genericapirequest.NewContext(), nil, "")
 	actual := getResourceRules(rules)
 	if !reflect.DeepEqual(expected, actual) {
 		t.Errorf("Expected: \n%#v\n but actual: \n%#v\n", expected, actual)
@@ -189,7 +190,7 @@ func TestAuthorizationNonResourceRules(t *testing.T) {
 
 	authzRulesHandler := NewRuleResolvers(handler1, handler2)
 
-	_, rules, _, _ := authzRulesHandler.RulesFor(nil, "")
+	_, rules, _, _ := authzRulesHandler.RulesFor(genericapirequest.NewContext(), nil, "")
 	actual := getNonResourceRules(rules)
 	if !reflect.DeepEqual(expected, actual) {
 		t.Errorf("Expected: \n%#v\n but actual: \n%#v\n", expected, actual)

--- a/staging/src/k8s.io/apiserver/plugin/pkg/authorizer/webhook/webhook.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/authorizer/webhook/webhook.go
@@ -402,7 +402,7 @@ func labelSelectorToAuthorizationAPI(attr authorizer.Attributes) ([]metav1.Label
 }
 
 // TODO: need to finish the method to get the rules when using webhook mode
-func (w *WebhookAuthorizer) RulesFor(user user.Info, namespace string) ([]authorizer.ResourceRuleInfo, []authorizer.NonResourceRuleInfo, bool, error) {
+func (w *WebhookAuthorizer) RulesFor(ctx context.Context, user user.Info, namespace string) ([]authorizer.ResourceRuleInfo, []authorizer.NonResourceRuleInfo, bool, error) {
 	var (
 		resourceRules    []authorizer.ResourceRuleInfo
 		nonResourceRules []authorizer.NonResourceRuleInfo


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

The authorizers access the rbac etcd registry and for that they need a context, created through genericapirequest.NewContext() which is just a context.TODO(). This PR wires through the context of the request properly to get rid of this TODO.


Replaces https://github.com/kubernetes/kubernetes/pull/120717  
```
func (a AuthorizerAdapter) ListRoleBindings(namespace string) ([]*rbacv1.RoleBinding, error) {
	list, err := a.Registry.ListRoleBindings(genericapirequest.WithNamespace(genericapirequest.NewContext(), namespace), &metainternalversion.ListOptions{})
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```

Replaces https://github.com/kubernetes/kubernetes/pull/120717 