### PR TITLE
Do not clean Job tracking finalizer for Pods owned by non-batch/Job

### DIFF
--- a/pkg/controller/job/job_controller.go
+++ b/pkg/controller/job/job_controller.go
@@ -648,6 +648,10 @@ func (jm *Controller) syncOrphanPod(ctx context.Context, key string) error {
 	}
 	// Make sure the pod is still orphaned.
 	if controllerRef := metav1.GetControllerOf(sharedPod); controllerRef != nil {
+		if controllerRef.Kind != controllerKind.Kind || controllerRef.APIVersion != batch.SchemeGroupVersion.String() {
+			// The pod is controlled by an owner that is not a batch/v1 Job. Do not remove finalizer.
+			return nil
+		}
 		job := jm.resolveControllerRef(sharedPod.Namespace, controllerRef)
 		if job != nil {
 			// Skip cleanup of finalizers for pods owned by a job managed by an external controller

--- a/pkg/controller/job/job_controller_test.go
+++ b/pkg/controller/job/job_controller_test.go
@@ -5684,6 +5684,184 @@ func TestWatchOrphanPods(t *testing.T) {
 	}
 }
 
+func TestSyncOrphanPod(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
+	clientset := fake.NewSimpleClientset()
+	sharedInformers := informers.NewSharedInformerFactory(clientset, controller.NoResyncPeriodFunc())
+	manager, err := NewController(ctx, sharedInformers.Core().V1().Pods(), sharedInformers.Batch().V1().Jobs(), clientset)
+	if err != nil {
+		t.Fatalf("Error creating Job controller: %v", err)
+	}
+	manager.podStoreSynced = alwaysReady
+	manager.jobStoreSynced = alwaysReady
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	podInformer := sharedInformers.Core().V1().Pods().Informer()
+	go podInformer.Run(stopCh)
+	cache.WaitForCacheSync(stopCh, podInformer.HasSynced)
+	go manager.Run(ctx, 1)
+
+	cases := map[string]struct {
+		owner                *metav1.OwnerReference
+		job                  *batch.Job
+		inCache              bool
+		wantFinalizerRemoved bool
+	}{
+		"controlled_by_existing_running_job": {
+			owner: &metav1.OwnerReference{
+				APIVersion:         "batch/v1",
+				Kind:               "Job",
+				Name:               "j",
+				UID:                "111",
+				Controller:         ptr.To(true),
+				BlockOwnerDeletion: ptr.To(true),
+			},
+			job: func() *batch.Job {
+				j := newJob(2, 2, 6, batch.NonIndexedCompletion)
+				j.UID = "111"
+				j.Name = "j"
+				return j
+			}(),
+			inCache:              true,
+			wantFinalizerRemoved: false,
+		},
+		"controlled_by_existing_finished_job": {
+			owner: &metav1.OwnerReference{
+				APIVersion:         "batch/v1",
+				Kind:               "Job",
+				Name:               "j",
+				UID:                "111",
+				Controller:         ptr.To(true),
+				BlockOwnerDeletion: ptr.To(true),
+			},
+			job: func() *batch.Job {
+				j := newJob(2, 2, 6, batch.NonIndexedCompletion)
+				j.UID = "111"
+				j.Name = "j"
+				j.Status.Conditions = append(j.Status.Conditions, batch.JobCondition{
+					Type:   batch.JobComplete,
+					Status: v1.ConditionTrue,
+				})
+				return j
+			}(),
+			inCache:              true,
+			wantFinalizerRemoved: true,
+		},
+		"controlled_by_non_existing_job": {
+			owner: &metav1.OwnerReference{
+				APIVersion:         "batch/v1",
+				Kind:               "Job",
+				Name:               "j",
+				UID:                "111",
+				Controller:         ptr.To(true),
+				BlockOwnerDeletion: ptr.To(true),
+			},
+			wantFinalizerRemoved: true,
+		},
+		"controlled_by_cronjob": {
+			owner: &metav1.OwnerReference{
+				APIVersion:         "batch/v1",
+				Kind:               "CronJob",
+				Name:               "cj",
+				UID:                "111",
+				Controller:         ptr.To(true),
+				BlockOwnerDeletion: ptr.To(true),
+			},
+			wantFinalizerRemoved: false,
+		},
+		"not_controlled": {
+			wantFinalizerRemoved: true,
+		},
+		"controlled_by_custom_crd": {
+			owner: &metav1.OwnerReference{
+				APIVersion:         "example/v1",
+				Kind:               "Job",
+				Name:               "job",
+				UID:                "111",
+				Controller:         ptr.To(true),
+				BlockOwnerDeletion: ptr.To(true),
+			},
+			wantFinalizerRemoved: false,
+		},
+		"owned_by_existing_running_job": {
+			owner: &metav1.OwnerReference{
+				APIVersion: "batch/v1",
+				Kind:       "Job",
+				Name:       "j",
+				UID:        "111",
+			},
+			job: func() *batch.Job {
+				j := newJob(2, 2, 6, batch.NonIndexedCompletion)
+				j.UID = "111"
+				j.Name = "j"
+				return j
+			}(),
+			inCache:              true,
+			wantFinalizerRemoved: true,
+		},
+		"owned_by_custom_crd": {
+			owner: &metav1.OwnerReference{
+				APIVersion: "example/v1",
+				Kind:       "Job",
+				Name:       "job",
+				UID:        "111",
+			},
+			wantFinalizerRemoved: true,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if tc.inCache {
+				if err := sharedInformers.Batch().V1().Jobs().Informer().GetIndexer().Add(tc.job); err != nil {
+					t.Fatalf("Failed to insert job in index: %v", err)
+				}
+				t.Cleanup(func() {
+					if err := sharedInformers.Batch().V1().Jobs().Informer().GetIndexer().Delete(tc.job); err != nil {
+						t.Fatalf("Failed to delete job from index: %v", err)
+					}
+				})
+			}
+
+			podBuilder := buildPod().name(name).deletionTimestamp().trackingFinalizer()
+			if tc.owner != nil {
+				podBuilder = podBuilder.owner(*tc.owner)
+			}
+			orphanPod := podBuilder.Pod
+			orphanPod, err := clientset.CoreV1().Pods("default").Create(ctx, orphanPod, metav1.CreateOptions{})
+			if err != nil {
+				t.Fatalf("Creating orphan pod: %v", err)
+			}
+			err = manager.syncOrphanPod(ctx, cache.MetaObjectToName(orphanPod).String())
+			if err != nil {
+				t.Fatalf("Failed sync orphan pod: %v", err)
+			}
+			if tc.wantFinalizerRemoved {
+				if err := wait.PollUntilContextTimeout(ctx, 10*time.Millisecond, wait.ForeverTestTimeout, false, func(ctx context.Context) (bool, error) {
+					p, err := clientset.CoreV1().Pods(orphanPod.Namespace).Get(ctx, orphanPod.Name, metav1.GetOptions{})
+					if err != nil {
+						return false, err
+					}
+					return !hasJobTrackingFinalizer(p), nil
+				}); err != nil {
+					t.Errorf("Waiting for the Job's finalizer to be removed: %v", err)
+				}
+			} else {
+				// we sleep a little bit to give potential time for the client's
+				// cache to update after the finalizer removal.
+				time.Sleep(time.Millisecond)
+				orphanPod, err := clientset.CoreV1().Pods(orphanPod.Namespace).Get(ctx, orphanPod.Name, metav1.GetOptions{})
+				if err != nil {
+					t.Fatalf("Failed to the latest pod: %v", err)
+				}
+				if !hasJobTrackingFinalizer(orphanPod) {
+					t.Errorf("Unexpected removal of the Job's finalizer")
+				}
+			}
+		})
+	}
+}
+
 func bumpResourceVersion(obj metav1.Object) {
 	ver, _ := strconv.ParseInt(obj.GetResourceVersion(), 10, 32)
 	obj.SetResourceVersion(strconv.FormatInt(ver+1, 10))
@@ -6395,6 +6573,11 @@ func (pb podBuilder) job(j *batch.Job) podBuilder {
 	pb.Labels = j.Spec.Selector.MatchLabels
 	pb.Namespace = j.Namespace
 	pb.OwnerReferences = []metav1.OwnerReference{*metav1.NewControllerRef(j, controllerKind)}
+	return pb
+}
+
+func (pb podBuilder) owner(ownerRef metav1.OwnerReference) podBuilder {
+	pb.OwnerReferences = append(pb.OwnerReferences, ownerRef)
 	return pb
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

Discovered during https://github.com/kubernetes/kubernetes/pull/123273/, where we decided that the finalizer should not be deleted from Job, if the owner is a batch Job with a custom managedBy.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Do not remove the "batch.kubernetes.io/job-tracking" finalizer from a Pod, in a corner
case scenario, when the Pod is controlled by an API object which is not a batch Job
(e.g. when the Pod is controlled by a custom CRD).
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
