### PR TITLE
Define a common Node autoscaling safe-to-evict/do-not-disrupt annotation

### DIFF
--- a/staging/src/k8s.io/api/core/v1/annotation_key_constants.go
+++ b/staging/src/k8s.io/api/core/v1/annotation_key_constants.go
@@ -156,4 +156,18 @@ const (
 	// heuristics will often populate topology hints on EndpointSlices, but that
 	// is not a requirement.
 	AnnotationTopologyMode = "service.kubernetes.io/topology-mode"
+
+	nodeAutoscalingPrefix = "node-autoscaling.kubernetes.io"
+
+	// NodeAutoscalingSafeToEvictKey can be used on a Pod to control Node autoscaler drain behavior:
+	// - If the value is "false": This pod is not safe to evict, and Node autoscalers shouldn't consolidate a Node where
+	//   such a pod is present.
+	// - If the value is "true": This pod is safe to evict, and Node autoscalers should not block consolidation of a
+	//   Node because of it, when they normally would. For example, if a Node autoscaler normally blocks consolidating
+	//   Nodes on which kube-system Pods are running, this can be used to opt some pods out of the blocking.
+	NodeAutoscalingSafeToEvictKey = nodeAutoscalingPrefix + "/safe-to-evict"
+	// NodeAutoscalingSafeToEvict is the value indicating that the Pod is safe to evict.
+	NodeAutoscalingSafeToEvict = "true"
+	// NodeAutoscalingNotSafeToEvict is the value indicating that the Pod is not safe to evict.
+	NodeAutoscalingNotSafeToEvict = "false"
 )


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind api-change

#### What this PR does / why we need it:

Currently, there are 2 Node autoscalers sponsored by sig-autoscaling, each supporting a different Pod annotation with the same semantics:

* Cluster Autoscaler: `cluster-autoscaler.kubernetes.io/safe-to-evict=true/false`
* Karpenter: `karpenter.sh/do-not-disrupt=true`

The semantics for `cluster-autoscaler.kubernetes.io/safe-to-evict=false`, and `karpenter.sh/do-not-disrupt=true` are identical. Both of these annotations will be replaced by `node-autoscaling.kubernetes.io/safe-to-evict=false`.

`cluster-autoscaler.kubernetes.io/safe-to-evict=true` doesn't have an equivalent in Karpenter right now, as Karpenter doesn't have any pod-level conditions blocking consolidation. This means that the equivalent new annotation
`node-autoscaling.kubernetes.io/safe-to-evict=true` should be trivially supported by Karpenter initially (but will require caution if Karpenter ever adds any pod-level conditions blocking consolidation).

Going with the Cluster Autoscaler wording for the common annotation, as otherwise we'd have a double negation (`do-not-disrupt=false`) in the `safe-to-evict=true` case which doesn't seem ideal.

This is a part of a broader alignment between Cluster Autoscaler and Karpenter. More details about the alignment can be found in https://docs.google.com/document/d/1rHhltfLV5V1kcnKr_mKRKDC4ZFPYGP4Tde2Zy-LE72w

#### Which issue(s) this PR fixes:

Part of https://github.com/kubernetes/autoscaler/issues/6648

#### Special notes for your reviewer:

The implementation in Cluster Autoscaler and Karpenter will follow this PR. If this is a problem, I could do the implementation first with the annotation hardcoded, then submit this PR, then clean up the implementation to use the annotation from the API.

@jonathan-innis this PR goes with the Cluster Autoscaler `safe-to-evict` wording for now, instead of the Karpenter `do-not-disrupt` one. `do-not-disrupt` would have to be negated to express `safe-to-evict=true`, which would result in a double negation. Would switching to `safe-to-evict` be a problem for Karpenter? 

#### Does this PR introduce a user-facing change?

```release-note
A new Pod annotation node-autoscaling.kubernetes.io/safe-to-evict is introduced. The annotation can be used to control Node autoscaler drain behavior. Value "true" means that a Pod is safe to evict, and Node autoscalers should not block consolidation of a Node because of it, when they normally would. Value "false" means that a Pod is not safe to evict, and Node autoscalers shouldn't consolidate a Node where such a pod is present. The annotation is supported by
Cluster Autoscaler and Karpenter. The annotation is equivalent to autoscaler-specific cluster-autoscaler.kubernetes.io/safe-to-evict and karpenter.sh/do-not-disrupt annotations. The autoscaler-specific annotations are deprecated, and will be removed in a future release.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [Cluster Autoscaler/Karpenter alignment doc]: https://docs.google.com/document/d/1rHhltfLV5V1kcnKr_mKRKDC4ZFPYGP4Tde2Zy-LE72w/edit?usp=sharing
```

/assign @jonathan-innis 
/assign @MaciekPytel 
/assign @gjtempleton 
/hold
Want LGTMs from the Node autoscaling stakeholders above before unholding.