### PR TITLE
remove BulkVolumeVerifier interface from volume

### DIFF
--- a/pkg/volume/configmap/configmap.go
+++ b/pkg/volume/configmap/configmap.go
@@ -86,10 +86,6 @@ func (plugin *configMapPlugin) SupportsMountOption() bool {
 	return false
 }
 
-func (plugin *configMapPlugin) SupportsBulkVolumeVerification() bool {
-	return false
-}
-
 func (plugin *configMapPlugin) SupportsSELinuxContextMount(spec *volume.Spec) (bool, error) {
 	return false, nil
 }

--- a/pkg/volume/csi/csi_plugin.go
+++ b/pkg/volume/csi/csi_plugin.go
@@ -529,10 +529,6 @@ func (p *csiPlugin) SupportsMountOption() bool {
 	return true
 }
 
-func (p *csiPlugin) SupportsBulkVolumeVerification() bool {
-	return false
-}
-
 func (p *csiPlugin) SupportsSELinuxContextMount(spec *volume.Spec) (bool, error) {
 	if utilfeature.DefaultFeatureGate.Enabled(features.SELinuxMountReadWriteOncePod) {
 		driver, err := GetCSIDriverName(spec)

--- a/pkg/volume/downwardapi/downwardapi.go
+++ b/pkg/volume/downwardapi/downwardapi.go
@@ -88,10 +88,6 @@ func (plugin *downwardAPIPlugin) SupportsMountOption() bool {
 	return false
 }
 
-func (plugin *downwardAPIPlugin) SupportsBulkVolumeVerification() bool {
-	return false
-}
-
 func (plugin *downwardAPIPlugin) SupportsSELinuxContextMount(spec *volume.Spec) (bool, error) {
 	return false, nil
 }

--- a/pkg/volume/emptydir/empty_dir.go
+++ b/pkg/volume/emptydir/empty_dir.go
@@ -99,10 +99,6 @@ func (plugin *emptyDirPlugin) SupportsMountOption() bool {
 	return false
 }
 
-func (plugin *emptyDirPlugin) SupportsBulkVolumeVerification() bool {
-	return false
-}
-
 func (plugin *emptyDirPlugin) SupportsSELinuxContextMount(spec *volume.Spec) (bool, error) {
 	return false, nil
 }

--- a/pkg/volume/fc/fc.go
+++ b/pkg/volume/fc/fc.go
@@ -97,10 +97,6 @@ func (plugin *fcPlugin) SupportsMountOption() bool {
 	return true
 }
 
-func (plugin *fcPlugin) SupportsBulkVolumeVerification() bool {
-	return false
-}
-
 func (plugin *fcPlugin) SupportsSELinuxContextMount(spec *volume.Spec) (bool, error) {
 	return true, nil
 }

--- a/pkg/volume/flexvolume/plugin.go
+++ b/pkg/volume/flexvolume/plugin.go
@@ -285,10 +285,6 @@ func (plugin *flexVolumePlugin) unsupported(commands ...string) {
 	plugin.unsupportedCommands = append(plugin.unsupportedCommands, commands...)
 }
 
-func (plugin *flexVolumePlugin) SupportsBulkVolumeVerification() bool {
-	return false
-}
-
 func (plugin *flexVolumePlugin) SupportsSELinuxContextMount(spec *volume.Spec) (bool, error) {
 	return false, nil
 }

--- a/pkg/volume/git_repo/git_repo.go
+++ b/pkg/volume/git_repo/git_repo.go
@@ -85,10 +85,6 @@ func (plugin *gitRepoPlugin) SupportsMountOption() bool {
 	return false
 }
 
-func (plugin *gitRepoPlugin) SupportsBulkVolumeVerification() bool {
-	return false
-}
-
 func (plugin *gitRepoPlugin) SupportsSELinuxContextMount(spec *volume.Spec) (bool, error) {
 	return false, nil
 }

--- a/pkg/volume/hostpath/host_path.go
+++ b/pkg/volume/hostpath/host_path.go
@@ -18,9 +18,10 @@ package hostpath
 
 import (
 	"fmt"
-	"k8s.io/klog/v2"
 	"os"
 	"regexp"
+
+	"k8s.io/klog/v2"
 
 	"github.com/opencontainers/selinux/go-selinux"
 
@@ -104,10 +105,6 @@ func (plugin *hostPathPlugin) RequiresRemount(spec *volume.Spec) bool {
 }
 
 func (plugin *hostPathPlugin) SupportsMountOption() bool {
-	return false
-}
-
-func (plugin *hostPathPlugin) SupportsBulkVolumeVerification() bool {
 	return false
 }
 

--- a/pkg/volume/iscsi/iscsi.go
+++ b/pkg/volume/iscsi/iscsi.go
@@ -90,10 +90,6 @@ func (plugin *iscsiPlugin) SupportsMountOption() bool {
 	return true
 }
 
-func (plugin *iscsiPlugin) SupportsBulkVolumeVerification() bool {
-	return false
-}
-
 func (plugin *iscsiPlugin) SupportsSELinuxContextMount(spec *volume.Spec) (bool, error) {
 	return true, nil
 }

--- a/pkg/volume/local/local.go
+++ b/pkg/volume/local/local.go
@@ -92,10 +92,6 @@ func (plugin *localVolumePlugin) SupportsMountOption() bool {
 	return true
 }
 
-func (plugin *localVolumePlugin) SupportsBulkVolumeVerification() bool {
-	return false
-}
-
 func (plugin *localVolumePlugin) SupportsSELinuxContextMount(spec *volume.Spec) (bool, error) {
 	return false, nil
 }

--- a/pkg/volume/nfs/nfs.go
+++ b/pkg/volume/nfs/nfs.go
@@ -101,10 +101,6 @@ func (plugin *nfsPlugin) SupportsMountOption() bool {
 	return true
 }
 
-func (plugin *nfsPlugin) SupportsBulkVolumeVerification() bool {
-	return false
-}
-
 func (plugin *nfsPlugin) SupportsSELinuxContextMount(spec *volume.Spec) (bool, error) {
 	return false, nil
 }

--- a/pkg/volume/noop_expandable_plugin.go
+++ b/pkg/volume/noop_expandable_plugin.go
@@ -68,10 +68,6 @@ func (n *noopExpandableVolumePluginInstance) SupportsMountOption() bool {
 	return true
 }
 
-func (n *noopExpandableVolumePluginInstance) SupportsBulkVolumeVerification() bool {
-	return false
-}
-
 func (n *noopExpandableVolumePluginInstance) RequiresFSResize() bool {
 	return true
 }

--- a/pkg/volume/plugins.go
+++ b/pkg/volume/plugins.go
@@ -169,11 +169,6 @@ type VolumePlugin interface {
 	// user specified mount options will result in error creating persistent volumes
 	SupportsMountOption() bool
 
-	// SupportsBulkVolumeVerification checks if volume plugin type is capable
-	// of enabling bulk polling of all nodes. This can speed up verification of
-	// attached volumes by quite a bit, but underlying pluging must support it.
-	SupportsBulkVolumeVerification() bool
-
 	// SupportsSELinuxContextMount returns true if volume plugins supports
 	// mount -o context=XYZ for a given volume.
 	SupportsSELinuxContextMount(spec *Spec) (bool, error)

--- a/pkg/volume/plugins_test.go
+++ b/pkg/volume/plugins_test.go
@@ -83,10 +83,6 @@ func (plugin *testPlugins) SupportsMountOption() bool {
 	return false
 }
 
-func (plugin *testPlugins) SupportsBulkVolumeVerification() bool {
-	return false
-}
-
 func (plugin *testPlugins) SupportsSELinuxContextMount(spec *Spec) (bool, error) {
 	return false, nil
 }

--- a/pkg/volume/portworx/portworx.go
+++ b/pkg/volume/portworx/portworx.go
@@ -228,10 +228,6 @@ func (plugin *portworxVolumePlugin) SupportsMountOption() bool {
 	return false
 }
 
-func (plugin *portworxVolumePlugin) SupportsBulkVolumeVerification() bool {
-	return false
-}
-
 func (plugin *portworxVolumePlugin) SupportsSELinuxContextMount(spec *volume.Spec) (bool, error) {
 	return false, nil
 }

--- a/pkg/volume/projected/projected.go
+++ b/pkg/volume/projected/projected.go
@@ -103,10 +103,6 @@ func (plugin *projectedPlugin) SupportsMountOption() bool {
 	return false
 }
 
-func (plugin *projectedPlugin) SupportsBulkVolumeVerification() bool {
-	return false
-}
-
 func (plugin *projectedPlugin) SupportsSELinuxContextMount(spec *volume.Spec) (bool, error) {
 	return false, nil
 }

--- a/pkg/volume/secret/secret.go
+++ b/pkg/volume/secret/secret.go
@@ -89,10 +89,6 @@ func (plugin *secretPlugin) SupportsMountOption() bool {
 	return false
 }
 
-func (plugin *secretPlugin) SupportsBulkVolumeVerification() bool {
-	return false
-}
-
 func (plugin *secretPlugin) SupportsSELinuxContextMount(spec *volume.Spec) (bool, error) {
 	return false, nil
 }

--- a/pkg/volume/testing/testing.go
+++ b/pkg/volume/testing/testing.go
@@ -290,10 +290,6 @@ func (plugin *FakeVolumePlugin) SupportsMountOption() bool {
 	return true
 }
 
-func (plugin *FakeVolumePlugin) SupportsBulkVolumeVerification() bool {
-	return false
-}
-
 func (plugin *FakeVolumePlugin) SupportsSELinuxContextMount(spec *volume.Spec) (bool, error) {
 	return plugin.SupportsSELinux, nil
 }
@@ -564,10 +560,6 @@ func (f *FakeBasicVolumePlugin) RequiresRemount(spec *volume.Spec) bool {
 	return f.Plugin.RequiresRemount(spec)
 }
 
-func (f *FakeBasicVolumePlugin) SupportsBulkVolumeVerification() bool {
-	return f.Plugin.SupportsBulkVolumeVerification()
-}
-
 func (f *FakeBasicVolumePlugin) SupportsSELinuxContextMount(spec *volume.Spec) (bool, error) {
 	return f.Plugin.SupportsSELinuxContextMount(spec)
 }
@@ -646,10 +638,6 @@ func (plugin *FakeFileVolumePlugin) RequiresRemount(spec *volume.Spec) bool {
 }
 
 func (plugin *FakeFileVolumePlugin) SupportsMountOption() bool {
-	return false
-}
-
-func (plugin *FakeFileVolumePlugin) SupportsBulkVolumeVerification() bool {
 	return false
 }
 

--- a/pkg/volume/util/operationexecutor/fakegenerator.go
+++ b/pkg/volume/util/operationexecutor/fakegenerator.go
@@ -17,8 +17,9 @@ limitations under the License.
 package operationexecutor
 
 import (
-	"k8s.io/klog/v2"
 	"time"
+
+	"k8s.io/klog/v2"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -93,13 +94,6 @@ func (f *fakeOGCounter) GetVolumePluginMgr() *volume.VolumePluginMgr {
 
 func (f *fakeOGCounter) GetCSITranslator() InTreeToCSITranslator {
 	return csitrans.New()
-}
-
-func (f *fakeOGCounter) GenerateBulkVolumeVerifyFunc(
-	map[types.NodeName][]*volume.Spec,
-	string,
-	map[*volume.Spec]v1.UniqueVolumeName, ActualStateOfWorldAttacherUpdater) (volumetypes.GeneratedOperations, error) {
-	return f.recordFuncCall("GenerateBulkVolumeVerifyFunc"), nil
 }
 
 func (f *fakeOGCounter) GenerateExpandVolumeFunc(*v1.PersistentVolumeClaim, *v1.PersistentVolume) (volumetypes.GeneratedOperations, error) {

--- a/pkg/volume/util/operationexecutor/operation_executor_test.go
+++ b/pkg/volume/util/operationexecutor/operation_executor_test.go
@@ -18,10 +18,11 @@ package operationexecutor
 
 import (
 	"fmt"
-	"k8s.io/klog/v2"
 	"strconv"
 	"testing"
 	"time"
+
+	"k8s.io/klog/v2"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -680,20 +681,6 @@ func (fopg *fakeOperationGenerator) GenerateExpandAndRecoverVolumeFunc(pvc *v1.P
 }
 
 func (fopg *fakeOperationGenerator) GenerateExpandInUseVolumeFunc(volumeToMount VolumeToMount, actualStateOfWorld ActualStateOfWorldMounterUpdater, currentSize resource.Quantity) (volumetypes.GeneratedOperations, error) {
-	opFunc := func() volumetypes.OperationContext {
-		startOperationAndBlock(fopg.ch, fopg.quit)
-		return volumetypes.NewOperationContext(nil, nil, false)
-	}
-	return volumetypes.GeneratedOperations{
-		OperationFunc: opFunc,
-	}, nil
-}
-
-func (fopg *fakeOperationGenerator) GenerateBulkVolumeVerifyFunc(
-	pluginNodeVolumes map[types.NodeName][]*volume.Spec,
-	pluginNane string,
-	volumeSpecMap map[*volume.Spec]v1.UniqueVolumeName,
-	actualStateOfWorldAttacherUpdater ActualStateOfWorldAttacherUpdater) (volumetypes.GeneratedOperations, error) {
 	opFunc := func() volumetypes.OperationContext {
 		startOperationAndBlock(fopg.ch, fopg.quit)
 		return volumetypes.NewOperationContext(nil, nil, false)

--- a/pkg/volume/volume.go
+++ b/pkg/volume/volume.go
@@ -284,14 +284,6 @@ type DeviceMounter interface {
 	MountDevice(spec *Spec, devicePath string, deviceMountPath string, deviceMounterArgs DeviceMounterArgs) error
 }
 
-type BulkVolumeVerifier interface {
-	// BulkVerifyVolumes checks whether the list of volumes still attached to the
-	// clusters in the node. It returns a map which maps from the volume spec to the checking result.
-	// If an error occurs during check - error should be returned and volume on nodes
-	// should be assumed as still attached.
-	BulkVerifyVolumes(volumesByNode map[types.NodeName][]*Spec) (map[types.NodeName]map[*Spec]bool, error)
-}
-
 // Detacher can detach a volume from a node.
 type Detacher interface {
 	DeviceUnmounter


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

As the vsphere in-tree volume plugins removed in 1.30, the last one which supports bulk volume verification was also removed. So, this PR cleans up the remaining codes.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
