### PR TITLE
mark volume.beta.kubernetes.io/mount-options as deprecated

### DIFF
--- a/pkg/api/persistentvolume/util.go
+++ b/pkg/api/persistentvolume/util.go
@@ -27,10 +27,6 @@ import (
 	"k8s.io/kubernetes/pkg/features"
 )
 
-const (
-	deprecatedStorageClassAnnotationsMsg = `deprecated since v1.8; use "storageClassName" attribute instead`
-)
-
 // DropDisabledSpecFields removes disabled fields from the pv spec.
 // This should be called from PrepareForCreate/PrepareForUpdate for all resources containing a pv spec.
 func DropDisabledSpecFields(pvSpec *api.PersistentVolumeSpec, oldPVSpec *api.PersistentVolumeSpec) {
@@ -56,17 +52,28 @@ func GetWarningsForPersistentVolume(pv *api.PersistentVolume) []string {
 	return warningsForPersistentVolumeSpecAndMeta(nil, &pv.Spec, &pv.ObjectMeta)
 }
 
+var deprecatedAnnotations = []struct {
+	key     string
+	message string
+}{
+	{
+		key:     `volume.beta.kubernetes.io/storage-class`,
+		message: `deprecated since v1.8; use "storageClassName" attribute instead`,
+	},
+	{
+		key:     `volume.beta.kubernetes.io/mount-options`,
+		message: `deprecated since v1.31; use "mountOptions" attribute instead`,
+	},
+}
+
 func warningsForPersistentVolumeSpecAndMeta(fieldPath *field.Path, pvSpec *api.PersistentVolumeSpec, pvMeta *metav1.ObjectMeta) []string {
 	var warnings []string
 
-	if _, ok := pvMeta.Annotations[api.BetaStorageClassAnnotation]; ok {
-		warnings = append(warnings,
-			fmt.Sprintf(
-				"%s: %s",
-				fieldPath.Child("metadata", "annotations").Key(api.BetaStorageClassAnnotation),
-				deprecatedStorageClassAnnotationsMsg,
-			),
-		)
+	// use of deprecated annotations
+	for _, deprecated := range deprecatedAnnotations {
+		if _, exists := pvMeta.Annotations[deprecated.key]; exists {
+			warnings = append(warnings, fmt.Sprintf("%s: %s", fieldPath.Child("metadata", "annotations").Key(deprecated.key), deprecated.message))
+		}
 	}
 
 	if pvSpec.PersistentVolumeReclaimPolicy == api.PersistentVolumeReclaimRecycle {

--- a/pkg/api/persistentvolume/util_test.go
+++ b/pkg/api/persistentvolume/util_test.go
@@ -146,6 +146,7 @@ func TestWarnings(t *testing.T) {
 					Name: "foo",
 					Annotations: map[string]string{
 						api.BetaStorageClassAnnotation: "",
+						api.MountOptionAnnotation:      "",
 					},
 				},
 				Spec: api.PersistentVolumeSpec{
@@ -171,6 +172,7 @@ func TestWarnings(t *testing.T) {
 			},
 			expected: []string{
 				`metadata.annotations[volume.beta.kubernetes.io/storage-class]: deprecated since v1.8; use "storageClassName" attribute instead`,
+				`metadata.annotations[volume.beta.kubernetes.io/mount-options]: deprecated since v1.31; use "mountOptions" attribute instead`,
 				`spec.nodeAffinity.required.nodeSelectorTerms[0].matchExpressions[0].key: beta.kubernetes.io/os is deprecated since v1.14; use "kubernetes.io/os" instead`,
 			},
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup
/kind deprecation

#### What this PR does / why we need it:

`pv.spec.mountOptions` supports this feature. let's deprecate the annotation and send a warning first. 

FYI: https://kubernetes.io/docs/concepts/storage/persistent-volumes/#mount-options. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added a warning when creating or updating a PV with the deprecated annotation `volume.beta.kubernetes.io/mount-options`
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
