### PR TITLE
node-lifecycle-controller: Wait uninitialized nodes

### DIFF
--- a/staging/src/k8s.io/cloud-provider/controllers/nodelifecycle/node_lifecycle_controller.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/nodelifecycle/node_lifecycle_controller.go
@@ -44,12 +44,21 @@ import (
 const (
 	deleteNodeEvent       = "DeletingNode"
 	deleteNodeFailedEvent = "DeletingNodeFailed"
+
+	uninitializedNodeDelay = time.Minute
 )
 
-var ShutdownTaint = &v1.Taint{
-	Key:    cloudproviderapi.TaintNodeShutdown,
-	Effect: v1.TaintEffectNoSchedule,
-}
+var (
+	UninitializedTaint = &v1.Taint{
+		Key:    cloudproviderapi.TaintExternalCloudProvider,
+		Effect: v1.TaintEffectNoSchedule,
+	}
+
+	ShutdownTaint = &v1.Taint{
+		Key:    cloudproviderapi.TaintNodeShutdown,
+		Effect: v1.TaintEffectNoSchedule,
+	}
+)
 
 // CloudNodeLifecycleController is responsible for deleting/updating kubernetes
 // nodes that have been deleted/shutdown on the cloud provider
@@ -147,6 +156,25 @@ func (c *CloudNodeLifecycleController) MonitorNodes(ctx context.Context) {
 				klog.Errorf("error patching node taints: %v", err)
 			}
 			continue
+		}
+
+		// Wait unknown uninitialized node
+		if node.Spec.ProviderID == "" {
+			uninitialized := false
+
+			for _, taint := range node.Spec.Taints {
+				if taint.MatchTaint(UninitializedTaint) {
+					uninitialized = true
+				}
+			}
+
+			if uninitialized {
+				delay := time.Since(node.ObjectMeta.CreationTimestamp.Time)
+				if delay < time.Duration(uninitializedNodeDelay) {
+					klog.V(2).Infof("wait uninitialized node %s for %s", node.Name, delay.String())
+					continue
+				}
+			}
 		}
 
 		// At this point the node has NotReady status, we need to check if the node has been removed

--- a/staging/src/k8s.io/cloud-provider/controllers/nodelifecycle/node_lifecycle_controller_test.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/nodelifecycle/node_lifecycle_controller_test.go
@@ -35,12 +35,16 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
 	cloudprovider "k8s.io/cloud-provider"
+	cloudproviderapi "k8s.io/cloud-provider/api"
 	fakecloud "k8s.io/cloud-provider/fake"
 	"k8s.io/klog/v2"
 	"k8s.io/klog/v2/ktesting"
 )
 
 func Test_NodesDeleted(t *testing.T) {
+	createNodeTime := metav1.Now()
+	createNodeTimeOut := metav1.NewTime(createNodeTime.Add(-2 * uninitializedNodeDelay))
+
 	testcases := []struct {
 		name            string
 		fakeCloud       *fakecloud.Cloud
@@ -391,6 +395,97 @@ func Test_NodesDeleted(t *testing.T) {
 			fakeCloud: &fakecloud.Cloud{
 				EnableInstancesV2:  true,
 				ExistsByProviderID: true,
+			},
+		},
+		{
+			name: "[instancev2] node is not ready and uninitialized yet",
+			existingNode: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "node-uninitialized",
+					CreationTimestamp: createNodeTime,
+				},
+				Spec: v1.NodeSpec{
+					Taints: []v1.Taint{
+						{
+							Key:    cloudproviderapi.TaintExternalCloudProvider,
+							Value:  "true",
+							Effect: v1.TaintEffectNoSchedule,
+						},
+					},
+				},
+				Status: v1.NodeStatus{
+					Conditions: []v1.NodeCondition{
+						{
+							Type:               v1.NodeReady,
+							Status:             v1.ConditionFalse,
+							LastHeartbeatTime:  metav1.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
+							LastTransitionTime: metav1.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
+						},
+					},
+				},
+			},
+			expectedNode: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "node-uninitialized",
+					CreationTimestamp: createNodeTime,
+				},
+				Spec: v1.NodeSpec{
+					Taints: []v1.Taint{
+						{
+							Key:    cloudproviderapi.TaintExternalCloudProvider,
+							Value:  "true",
+							Effect: v1.TaintEffectNoSchedule,
+						},
+					},
+				},
+				Status: v1.NodeStatus{
+					Conditions: []v1.NodeCondition{
+						{
+							Type:               v1.NodeReady,
+							Status:             v1.ConditionFalse,
+							LastHeartbeatTime:  metav1.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
+							LastTransitionTime: metav1.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
+						},
+					},
+				},
+			},
+			expectedDeleted: false,
+			fakeCloud: &fakecloud.Cloud{
+				EnableInstancesV2: true,
+			},
+		},
+		{
+			name: "[instancev2] node is not ready condition is unknown and uninitialized timeout passed",
+			existingNode: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "node-uninitialized",
+					CreationTimestamp: createNodeTimeOut,
+				},
+				Spec: v1.NodeSpec{
+					Taints: []v1.Taint{
+						{
+							Key:    cloudproviderapi.TaintExternalCloudProvider,
+							Value:  "true",
+							Effect: v1.TaintEffectNoSchedule,
+						},
+					},
+				},
+				Status: v1.NodeStatus{
+					Conditions: []v1.NodeCondition{
+						{
+							Type:               v1.NodeReady,
+							Status:             v1.ConditionUnknown,
+							LastHeartbeatTime:  metav1.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
+							LastTransitionTime: metav1.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
+						},
+					},
+				},
+			},
+			expectedNode:    &v1.Node{},
+			expectedDeleted: true,
+			fakeCloud: &fakecloud.Cloud{
+				EnableInstancesV2:  true,
+				ExistsByProviderID: false,
 			},
 		},
 		{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Hello. 
The case that I’d like to solve here:

Imagine a scenario where a node autoscaler adds 100 instances to the cluster. When these nodes join the cluster, both the node-controller and node-lifecycle-controller run simultaneously. However, at this moment, the nodes don't yet have a ProviderID. Both controllers try to find the instance by name, which is an API-call resource-intensive task. There's a risk of hitting the rate limit imposed by the cloud provider, or in the worst case, the controller may not find the instance due to caching issues.

The node-controller performs a more complex job compared to the node-lifecycle-controller. It needs to find the node IPs, public/private DNS names, zone/region, etc. Consequently, there's a possibility that the node-lifecycle-controller deletes the node before the node-controller finishes its initialization process.

To mitigate this issue, the proposed solution is to introduce a delay in the node-lifecycle-controller after the registration of the node.


```shell
I0514 16:39:36.264846   65428 node_controller.go:425] Initializing node web-ovh-gra11a with cloud provider
# node-controller calls InstanceMetadata func.
I0514 16:39:36.264946   65428 instancesv2.go:54] openstack.Instancesv2() called
I0514 16:39:36.265072   65428 instancesv2.go:172] "openstack.getInstance() called" node="web-ovh-gra11a" providerID="" region=""
I0514 16:39:36.601663   65428 instancesv2.go:260] "openstack.getInstanceByName() called" node="web-ovh-gra11a" servers=0 region="UK1"
I0514 16:39:37.580420   65428 instancesv2.go:260] "openstack.getInstanceByName() called" node="web-ovh-gra11a" servers=0 region="GRA9"
# node-lifecycle-controller calls InstanceExists func. (node does not providerID yet)
I0514 16:39:37.704361   65428 instancesv2.go:54] openstack.Instancesv2() called
I0514 16:39:37.704416   65428 instancesv2.go:93] "openstack.InstanceExists() called" node="web-ovh-gra11a" providerID="" region=""
I0514 16:39:37.704443   65428 instancesv2.go:172] "openstack.getInstance() called" node="web-ovh-gra11a" providerID="" region=""
I0514 16:39:37.831306   65428 instancesv2.go:260] "openstack.getInstanceByName() called" node="web-ovh-gra11a" servers=0 region="UK1"
I0514 16:39:37.968281   65428 instancesv2.go:260] "openstack.getInstanceByName() called" node="web-ovh-gra11a" servers=0 region="GRA9"
I0514 16:39:38.628247   65428 instancesv2.go:260] "openstack.getInstanceByName() called" node="web-ovh-gra11a" servers=1 region="GRA11"
# node-controller finished job and sets the labels and providerID
I0514 16:39:39.015931   65428 instances.go:719] Node 'web-ovh-gra11a' returns addresses '[...]'
I0514 16:39:39.016055   65428 node_controller.go:530] Adding node label from cloud provider: beta.kubernetes.io/instance-type=b2-7
I0514 16:39:39.016069   65428 node_controller.go:531] Adding node label from cloud provider: node.kubernetes.io/instance-type=b2-7
I0514 16:39:39.016082   65428 node_controller.go:542] Adding node label from cloud provider: failure-domain.beta.kubernetes.io/zone=nova
I0514 16:39:39.016095   65428 node_controller.go:543] Adding node label from cloud provider: topology.kubernetes.io/zone=nova
I0514 16:39:39.016109   65428 node_controller.go:553] Adding node label from cloud provider: failure-domain.beta.kubernetes.io/region=GRA11
I0514 16:39:39.016123   65428 node_controller.go:554] Adding node label from cloud provider: topology.kubernetes.io/region=GRA11
# node-lifecycle-controller calls InstanceShutdown with empty providerID (it already exists in kubernetes resource)
I0514 16:39:39.096362   65428 instancesv2.go:260] "openstack.getInstanceByName() called" node="web-ovh-gra11a" servers=1 region="GRA11"
I0514 16:39:39.096496   65428 instancesv2.go:54] openstack.Instancesv2() called
I0514 16:39:39.096555   65428 instancesv2.go:112] "openstack.InstanceShutdown() called" node="web-ovh-gra11a" providerID="" region=""
I0514 16:39:39.096570   65428 instancesv2.go:172] "openstack.getInstance() called" node="web-ovh-gra11a" providerID="" region=""
I0514 16:39:39.220507   65428 instancesv2.go:260] "openstack.getInstanceByName() called" node="web-ovh-gra11a" servers=0 region="UK1"
I0514 16:39:39.241579   65428 node_controller.go:492] Successfully initialized node web-ovh-gra11a with cloud provider
I0514 16:39:39.241674   65428 event.go:389] "Event occurred" object="web-ovh-gra11a" fieldPath="" kind="Node" apiVersion="v1" type="Normal" reason="Synced" message="Node synced successfully"
I0514 16:39:39.394450   65428 instancesv2.go:260] "openstack.getInstanceByName() called" node="web-ovh-gra11a" servers=0 region="GRA9"
I0514 16:39:39.885919   65428 instancesv2.go:260] "openstack.getInstanceByName() called" node="web-ovh-gra11a" servers=1 region="GRA11"
# Only from this moment node-lifecycle-controller has properly defined ProviderID and can use cheapest function to define status of the node 
I0514 16:39:44.886913   65428 instancesv2.go:54] openstack.Instancesv2() called
I0514 16:39:44.887012   65428 instancesv2.go:93] "openstack.InstanceExists() called" node="web-ovh-gra11a" providerID="openstack://GRA11/2c47a4e6-3237-4f16-9033-009b592691f8" region="GRA11"
I0514 16:39:44.887027   65428 instancesv2.go:172] "openstack.getInstance() called" node="web-ovh-gra11a" providerID="openstack://GRA11/2c47a4e6-3237-4f16-9033-009b592691f8" region="GRA11"
```

As result we calls openstack.getInstanceByName (expensive function) - 9 times, lets say, that one call makes 5 calls to the cloud provider api.  -> 45 cals per one node. 
100 nodes scale up ->  4500 calls in ~5 second

#### Which issue(s) this PR fixes:

Related 
* https://github.com/kubernetes/cloud-provider/issues/35 
* https://github.com/kubernetes/cloud-provider-openstack/issues/2213 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
