### PR TITLE
Fix assertion for host network hostname e2e test

### DIFF
--- a/test/e2e/network/dns.go
+++ b/test/e2e/network/dns.go
@@ -686,8 +686,8 @@ var _ = common.SIGDescribe("DNS HostNetwork", func() {
 		stdout, err := e2eoutput.RunHostCmd(testAgnhostPod.Namespace, testAgnhostPod.Name, "hostname")
 		framework.ExpectNoError(err, "failed to run command hostname: %s", stdout)
 		hostname := strings.TrimSpace(stdout)
-		if node.Name != hostname {
-			framework.Failf("expected hostname: %s, got: %s", node.Name, hostname)
+		if dnsTestPodHostName == hostname {
+			framework.Failf("https://issues.k8s.io/67019 expected spec.Hostname %s to be ignored", hostname)
 		}
 	})
 


### PR DESCRIPTION
#### What type of PR is this?


/kind failing-test


#### What this PR does / why we need it:

The original assumption is wrong, as the node name may not match the hostname of the host in some circumstances.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/cri-o/cri-o/issues/8167
Follow-up on https://github.com/kubernetes/kubernetes/pull/124428
#### Special notes for your reviewer:
cc @aojea @yashsingh74 @aroradaman
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
