### PR TITLE
e2e tests: Enables should test kubelet managed /etc/hosts file for Windows

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -2221,15 +2221,14 @@
   file: test/e2e/common/node/kubelet.go
 - testname: Kubelet, managed etc hosts
   codename: '[sig-node] KubeletManagedEtcHosts should test kubelet managed /etc/hosts
-    file [LinuxOnly] [NodeConformance] [Conformance]'
+    file [NodeConformance] [Conformance]'
   description: Create a Pod with containers with hostNetwork set to false, one of
     the containers mounts the /etc/hosts file form the host. Create a second Pod with
     hostNetwork set to true. 1. The Pod with hostNetwork=false MUST have /etc/hosts
     of containers managed by the Kubelet. 2. The Pod with hostNetwork=false but the
     container mounts /etc/hosts file from the host. The /etc/hosts file MUST not be
     managed by the Kubelet. 3. The Pod with hostNetwork=true , /etc/hosts file MUST
-    not be managed by the Kubelet. This test is marked LinuxOnly since Windows cannot
-    mount individual files in Containers.
+    not be managed by the Kubelet.
   release: v1.9
   file: test/e2e/common/node/kubelet_etc_hosts.go
 - testname: lease API should be available

--- a/test/e2e/common/node/kubelet_etc_hosts.go
+++ b/test/e2e/common/node/kubelet_etc_hosts.go
@@ -31,11 +31,13 @@ import (
 )
 
 const (
-	etcHostsPodName            = "test-pod"
-	etcHostsHostNetworkPodName = "test-host-network-pod"
-	etcHostsPartialContent     = "# Kubernetes-managed hosts file."
-	etcHostsPath               = "/etc/hosts"
-	etcHostsOriginalPath       = "/etc/hosts-original"
+	etcHostsPodName             = "test-pod"
+	etcHostsHostNetworkPodName  = "test-host-network-pod"
+	etcHostsPartialContent      = "# Kubernetes-managed hosts file."
+	etcHostsPathLinux           = "/etc/hosts"
+	etcHostsPathWindows         = `C:\Windows\System32\drivers\etc\hosts`
+	etcHostsOriginalPathLinux   = "/etc/hosts-original"
+	etcHostsOriginalPathWindows = `C:\Windows\System32\drivers\etc\hosts-original`
 )
 
 // KubeletManagedHostConfig defines the types for running managed etc hosts test cases
@@ -59,9 +61,8 @@ var _ = SIGDescribe("KubeletManagedEtcHosts", func() {
 			1. The Pod with hostNetwork=false MUST have /etc/hosts of containers managed by the Kubelet.
 			2. The Pod with hostNetwork=false but the container mounts /etc/hosts file from the host. The /etc/hosts file MUST not be managed by the Kubelet.
 			3. The Pod with hostNetwork=true , /etc/hosts file MUST not be managed by the Kubelet.
-		This test is marked LinuxOnly since Windows cannot mount individual files in Containers.
 	*/
-	framework.ConformanceIt("should test kubelet managed /etc/hosts file [LinuxOnly]", f.WithNodeConformance(), func(ctx context.Context) {
+	framework.ConformanceIt("should test kubelet managed /etc/hosts file", f.WithNodeConformance(), func(ctx context.Context) {
 		ginkgo.By("Setting up the test")
 		config.setup(ctx)
 
@@ -112,6 +113,7 @@ func assertManagedStatus(
 
 	retryCount := 0
 	etcHostsContent := ""
+	etcHostsPath, etcHostsOriginalPath := getEtcHostsPath()
 
 	for startTime := time.Now(); time.Since(startTime) < retryTimeout; {
 		etcHostsContent = config.getFileContents(podName, name, etcHostsPath)
@@ -155,6 +157,7 @@ func (config *KubeletManagedHostConfig) getFileContents(podName, containerName, 
 func (config *KubeletManagedHostConfig) createPodSpec(podName string) *v1.Pod {
 	hostPathType := new(v1.HostPathType)
 	*hostPathType = v1.HostPathType(string(v1.HostPathFileOrCreate))
+	etcHostsPath, etcHostsOriginalPath := getEtcHostsPath()
 	mounts := []v1.VolumeMount{
 		{
 			Name:      "host-etc-hosts",
@@ -198,6 +201,7 @@ func (config *KubeletManagedHostConfig) createPodSpec(podName string) *v1.Pod {
 func (config *KubeletManagedHostConfig) createPodSpecWithHostNetwork(podName string) *v1.Pod {
 	hostPathType := new(v1.HostPathType)
 	*hostPathType = v1.HostPathType(string(v1.HostPathFileOrCreate))
+	etcHostsPath, etcHostsOriginalPath := getEtcHostsPath()
 	mounts := []v1.VolumeMount{
 		{
 			Name:      "host-etc-hosts",
@@ -229,4 +233,11 @@ func (config *KubeletManagedHostConfig) createPodSpecWithHostNetwork(podName str
 		},
 	}
 	return pod
+}
+
+func getEtcHostsPath() (string, string) {
+	if framework.NodeOSDistroIs("windows") {
+		return etcHostsPathWindows, etcHostsOriginalPathWindows
+	}
+	return etcHostsPathLinux, etcHostsOriginalPathLinux
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind failing-test
/sig testing
/sig windows

#### What this PR does / why we need it:

We previously skipped this test because Docker did not support mounting individual files in Containers.

Since then, support for Docker has been removed, and containerd on Windows supports this feature. We can run this test on Windows.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Related #https://github.com/kubernetes/kubernetes/issues/124426

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
