### PR TITLE
Revert "remove legacycloudproviders from staging"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -248,6 +248,7 @@ replace (
 	k8s.io/kube-scheduler => ./staging/src/k8s.io/kube-scheduler
 	k8s.io/kubectl => ./staging/src/k8s.io/kubectl
 	k8s.io/kubelet => ./staging/src/k8s.io/kubelet
+	k8s.io/legacy-cloud-providers => ./staging/src/k8s.io/legacy-cloud-providers
 	k8s.io/metrics => ./staging/src/k8s.io/metrics
 	k8s.io/mount-utils => ./staging/src/k8s.io/mount-utils
 	k8s.io/pod-security-admission => ./staging/src/k8s.io/pod-security-admission

--- a/go.work
+++ b/go.work
@@ -28,6 +28,7 @@ use (
 	./staging/src/k8s.io/kube-scheduler
 	./staging/src/k8s.io/kubectl
 	./staging/src/k8s.io/kubelet
+	./staging/src/k8s.io/legacy-cloud-providers
 	./staging/src/k8s.io/metrics
 	./staging/src/k8s.io/mount-utils
 	./staging/src/k8s.io/pod-security-admission

--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -141,6 +141,7 @@ linters-settings: # please keep this alphabetized
           contextual k8s.io/kube-controller-manager/.*
           contextual k8s.io/kube-proxy/.*
           contextual k8s.io/kube-scheduler/.*
+          contextual k8s.io/legacy-cloud-providers/.*
           contextual k8s.io/sample-apiserver/.*
           contextual k8s.io/sample-cli-plugin/.*
           contextual k8s.io/sample-controller/.*

--- a/hack/golangci-strict.yaml
+++ b/hack/golangci-strict.yaml
@@ -187,6 +187,7 @@ linters-settings: # please keep this alphabetized
           contextual k8s.io/kube-controller-manager/.*
           contextual k8s.io/kube-proxy/.*
           contextual k8s.io/kube-scheduler/.*
+          contextual k8s.io/legacy-cloud-providers/.*
           contextual k8s.io/sample-apiserver/.*
           contextual k8s.io/sample-cli-plugin/.*
           contextual k8s.io/sample-controller/.*

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -190,6 +190,7 @@ linters-settings: # please keep this alphabetized
           contextual k8s.io/kube-controller-manager/.*
           contextual k8s.io/kube-proxy/.*
           contextual k8s.io/kube-scheduler/.*
+          contextual k8s.io/legacy-cloud-providers/.*
           contextual k8s.io/sample-apiserver/.*
           contextual k8s.io/sample-cli-plugin/.*
           contextual k8s.io/sample-controller/.*

--- a/hack/logcheck.conf
+++ b/hack/logcheck.conf
@@ -38,6 +38,7 @@ contextual k8s.io/kms/.*
 contextual k8s.io/kube-controller-manager/.*
 contextual k8s.io/kube-proxy/.*
 contextual k8s.io/kube-scheduler/.*
+contextual k8s.io/legacy-cloud-providers/.*
 contextual k8s.io/sample-apiserver/.*
 contextual k8s.io/sample-cli-plugin/.*
 contextual k8s.io/sample-controller/.*

--- a/staging/README.md
+++ b/staging/README.md
@@ -29,6 +29,7 @@ Repositories currently staged here:
 - [`k8s.io/kube-scheduler`](https://github.com/kubernetes/kube-scheduler)
 - [`k8s.io/kubectl`](https://github.com/kubernetes/kubectl)
 - [`k8s.io/kubelet`](https://github.com/kubernetes/kubelet)
+- [`k8s.io/legacy-cloud-providers`](https://github.com/kubernetes/legacy-cloud-providers)
 - [`k8s.io/metrics`](https://github.com/kubernetes/metrics)
 - [`k8s.io/mount-utils`](https://github.com/kubernetes/mount-utils)
 - [`k8s.io/pod-security-admission`](https://github.com/kubernetes/pod-security-admission)

--- a/staging/publishing/import-restrictions.yaml
+++ b/staging/publishing/import-restrictions.yaml
@@ -261,6 +261,22 @@
   - k8s.io/kubelet
   - k8s.io/utils
 
+- baseImportPath: "./staging/src/k8s.io/legacy-cloud-providers"
+  allowedImports:
+  - k8s.io/api
+  - k8s.io/apimachinery
+  - k8s.io/client-go
+  - k8s.io/cloud-provider
+  - k8s.io/csi-translation-lib
+  - k8s.io/klog
+  - k8s.io/legacy-cloud-providers
+  - k8s.io/mount-utils
+  - k8s.io/utils
+  - k8s.io/apiserver/pkg/util/feature
+  - k8s.io/component-base/featuregate
+  - k8s.io/component-base/metrics
+  - k8s.io/component-base/metrics/legacyregistry
+
 - baseImportPath: "./staging/src/k8s.io/csi-translation-lib"
   allowedImports:
   - k8s.io/api

--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -2290,6 +2290,30 @@ rules:
   library: true
 - destination: legacy-cloud-providers
   branches:
+  - name: master
+    dependencies:
+    - repository: api
+      branch: master
+    - repository: apimachinery
+      branch: master
+    - repository: client-go
+      branch: master
+    - repository: cloud-provider
+      branch: master
+    - repository: apiserver
+      branch: master
+    - repository: component-base
+      branch: master
+    - repository: controller-manager
+      branch: master
+    - repository: component-helpers
+      branch: master
+    - repository: kms
+      branch: master
+    source:
+      branch: master
+      dirs:
+      - staging/src/k8s.io/legacy-cloud-providers
   - name: release-1.26
     go: 1.21.9
     dependencies:

--- a/staging/src/k8s.io/legacy-cloud-providers/.github/PULL_REQUEST_TEMPLATE.md
+++ b/staging/src/k8s.io/legacy-cloud-providers/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,2 @@
+Sorry, we do not accept changes directly against this repository. Please see
+CONTRIBUTING.md for information on where and how to contribute instead.

--- a/staging/src/k8s.io/legacy-cloud-providers/LICENSE
+++ b/staging/src/k8s.io/legacy-cloud-providers/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/staging/src/k8s.io/legacy-cloud-providers/OWNERS
+++ b/staging/src/k8s.io/legacy-cloud-providers/OWNERS
@@ -1,0 +1,22 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+# We are no longer accepting features into k8s.io/legacy-cloud-providers.
+# Any kind/feature PRs must be approved by SIG Cloud Provider going forward.
+options:
+  no_parent_owners: true
+approvers:
+  - bridgetkromhout # SIG Cloud Provider chair, for approving bug fixes only
+  - elmiko # SIG Cloud Provider chair, for approving bug fixes only
+  - andrewsykim # SIG Cloud Provider TL, for approving bug fixes only
+  - nckturner # SIG Cloud Provider TL, for approving bug fixes only
+  - cheftako # SIG Cloud Provider TL, for approving bug fixes only
+  - dims # For code organization / dependency updates only
+  - liggitt # For code organization / dependency updates only
+reviewers:
+  - andrewsykim
+  - cheftako
+emeritus_approvers:
+  - mikedanese
+  - mcrute
+labels:
+  - sig/cloud-provider
+  - area/cloudprovider

--- a/staging/src/k8s.io/legacy-cloud-providers/README.md
+++ b/staging/src/k8s.io/legacy-cloud-providers/README.md
@@ -1,0 +1,30 @@
+# legacy-cloud-providers
+
+This repository hosts the legacy cloud providers that were previously hosted under
+`k8s.io/kubernetes/pkg/cloudprovider/providers`. Out-of-tree cloud providers can consume
+packages in this repo to support legacy implementations of their Kubernetes cloud provider.
+
+**Note:** go-get or vendor this package as `k8s.io/legacy-cloud-providers`.
+
+## Purpose
+
+To be consumed by out-of-tree cloud providers that wish to support legacy behavior
+from their in-tree equivalents.
+
+## Compatibility
+
+The legacy providers here follow the same compatibility rules as cloud providers that
+were previously in `k8s.io/kubernetes/pkg/cloudprovider/providers`.
+
+## Where does it come from?
+
+`legacy-cloud-providers` is synced from https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/legacy-cloud-providers.
+Code changes are made in that location, merged into `k8s.io/kubernetes` and later synced here.
+
+## Things you should NOT do
+
+ 1. Add a new cloud provider here.
+ 2. Directly modify anything under this repo. Those are driven from `k8s.io/kubernetes/staging/src/k8s.io/legacy-cloud-providers`.
+    sig-cloudprovider.
+ 3. Add new features/integrations to a cloud provider in this repo. Changes sync here should only be incremental bug fixes.
+

--- a/staging/src/k8s.io/legacy-cloud-providers/SECURITY_CONTACTS
+++ b/staging/src/k8s.io/legacy-cloud-providers/SECURITY_CONTACTS
@@ -1,0 +1,20 @@
+# Defined below are the security contacts for this repo.
+#
+# They are the contact point for the Product Security Committee to reach out
+# to for triaging and handling of incoming issues.
+#
+# The below names agree to abide by the
+# [Embargo Policy](https://git.k8s.io/security/private-distributors-list.md#embargo-policy)
+# and will be removed and replaced if they violate that agreement.
+#
+# DO NOT REPORT SECURITY VULNERABILITIES DIRECTLY TO THESE NAMES, FOLLOW THE
+# INSTRUCTIONS AT https://kubernetes.io/security/
+
+cheftako
+andrewsykim
+dims
+cjcullen
+joelsmith
+liggitt
+philips
+tallclair

--- a/staging/src/k8s.io/legacy-cloud-providers/code-of-conduct.md
+++ b/staging/src/k8s.io/legacy-cloud-providers/code-of-conduct.md
@@ -1,0 +1,3 @@
+# Kubernetes Community Code of Conduct
+
+Please refer to our [Kubernetes Community Code of Conduct](https://git.k8s.io/community/code-of-conduct.md)

--- a/staging/src/k8s.io/legacy-cloud-providers/doc.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/doc.go
@@ -1,0 +1,17 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package legacycloudproviders // import "k8s.io/legacy-cloud-providers"

--- a/staging/src/k8s.io/legacy-cloud-providers/go.mod
+++ b/staging/src/k8s.io/legacy-cloud-providers/go.mod
@@ -1,0 +1,7 @@
+// This is a generated file. Do not edit directly.
+
+module k8s.io/legacy-cloud-providers
+
+go 1.22.0
+
+replace k8s.io/legacy-cloud-providers => ../legacy-cloud-providers


### PR DESCRIPTION
This reverts commit 07c8d35681dcab9dab3770545339ccc15a8fe449.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
/kind failing-test
/kind regression

#### What this PR does / why we need it:

The publishing bot doesn't support to remove the master rule from the staging directory when the repository is being used by supported releases. so I have to revert the changes made by https://github.com/kubernetes/kubernetes/pull/124862 in order to not break the `pull-publishing-bot-validate` job, see https://github.com/kubernetes/kubernetes/pull/124829.

The reverted PR is expected to be merged after 1.30 goes out of support. I add a to-do item to https://github.com/kubernetes/kubernetes/issues/124771 to remind us to do so.



#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Ref https://github.com/kubernetes/kubernetes/pull/124829
Ref https://github.com/kubernetes/kubernetes/pull/124862

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Revert "remove legacycloudproviders from staging"
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
