### PR TITLE
e2e/network: dump iptables and conntrack flows for debugging

### DIFF
--- a/test/e2e/framework/network/utils.go
+++ b/test/e2e/framework/network/utils.go
@@ -342,6 +342,27 @@ func (config *NetworkingTestConfig) DialFromContainer(ctx context.Context, proto
 				}
 				framework.Logf("Dump network information for node %s:\n%s", node.Name, result)
 			}
+			// Dump the node iptables rules and conntrack flows for troubleshooting #123760
+			podList, _ := config.f.ClientSet.CoreV1().Pods("kube-system").List(ctx, metav1.ListOptions{
+				LabelSelector: "k8s-app=kube-proxy",
+			})
+			for _, pod := range podList.Items {
+				// dump only for the node running test-container-pod
+				if pod.Status.HostIP == config.TestContainerPod.Status.HostIP {
+					output, _, _ := e2epod.ExecWithOptions(config.f, e2epod.ExecOptions{
+						Namespace:          "kube-system",
+						PodName:            pod.Name,
+						ContainerName:      "kube-proxy",
+						Command:            []string{"sh", "-c", fmt.Sprintf(`echo "IPTables Dump: " && iptables-save | grep "%s/%s:http" && echo "Conntrack flows: " && conntrack -Ln -p tcp | grep %d`, config.Namespace, config.NodePortService.Name, EndpointHTTPPort)},
+						Stdin:              nil,
+						CaptureStdout:      true,
+						CaptureStderr:      true,
+						PreserveWhitespace: false,
+					})
+					framework.Logf("Dump iptables and connntrack flows\n%s", output)
+					break
+				}
+			}
 			return returnMsg
 		}
 


### PR DESCRIPTION
For troubleshooting #123760

```
  I0514 15:05:27.290224 72478 networking.go:356] Dump iptables and connntrack flows for node :
  IPTables Dump: 
  -A KUBE-EXT-U7I7RVERQEPDX3Y6 -m comment --comment "masquerade traffic for nettest-7732/node-port-service:http external destinations" -j KUBE-MARK-MASQ
  -A KUBE-NODEPORTS -p tcp -m comment --comment "nettest-7732/node-port-service:http" -m tcp --dport 31800 -j KUBE-EXT-U7I7RVERQEPDX3Y6
  -A KUBE-SEP-VFVEZ5MLNGMSD7ZR -s 10.244.2.11/32 -m comment --comment "nettest-7732/node-port-service:http" -j KUBE-MARK-MASQ
  -A KUBE-SEP-VFVEZ5MLNGMSD7ZR -p tcp -m comment --comment "nettest-7732/node-port-service:http" -m tcp -j DNAT --to-destination 10.244.2.11:8083
  -A KUBE-SEP-Z3A4G5665FZF4KZI -s 10.244.1.14/32 -m comment --comment "nettest-7732/node-port-service:http" -j KUBE-MARK-MASQ
  -A KUBE-SEP-Z3A4G5665FZF4KZI -p tcp -m comment --comment "nettest-7732/node-port-service:http" -m tcp -j DNAT --to-destination 10.244.1.14:8083
  -A KUBE-SERVICES -d 10.96.63.98/32 -p tcp -m comment --comment "nettest-7732/node-port-service:http cluster IP" -m tcp --dport 80 -j KUBE-SVC-U7I7RVERQEPDX3Y6
  -A KUBE-SVC-U7I7RVERQEPDX3Y6 ! -s 10.244.0.0/16 -d 10.96.63.98/32 -p tcp -m comment --comment "nettest-7732/node-port-service:http cluster IP" -m tcp --dport 80 -j KUBE-MARK-MASQ
  -A KUBE-SVC-U7I7RVERQEPDX3Y6 -m comment --comment "nettest-7732/node-port-service:http -> 10.244.1.14:8083" -m statistic --mode random --probability 0.50000000000 -j KUBE-SEP-Z3A4G5665FZF4KZI
  -A KUBE-SVC-U7I7RVERQEPDX3Y6 -m comment --comment "nettest-7732/node-port-service:http -> 10.244.2.11:8083" -j KUBE-SEP-VFVEZ5MLNGMSD7ZR
  Conntrack flows: 
  tcp      6 100 TIME_WAIT src=10.244.1.1 dst=10.244.1.14 sport=38048 dport=8083 src=10.244.1.14 dst=10.244.1.1 sport=8083 dport=38048 [ASSURED] mark=0 use=1
  tcp      6 13 TIME_WAIT src=10.244.1.13 dst=10.96.192.168 sport=50128 dport=80 src=10.244.1.12 dst=10.244.1.13 sport=8083 dport=50128 [ASSURED] mark=0 use=1
  tcp      6 90 TIME_WAIT src=10.244.1.1 dst=10.244.1.14 sport=53144 dport=8083 src=10.244.1.14 dst=10.244.1.1 sport=8083 dport=53144 [ASSURED] mark=0 use=1
  tcp      6 97 TIME_WAIT src=10.244.1.15 dst=10.96.63.98 sport=36366 dport=80 src=10.244.3.13 dst=10.244.1.15 sport=8083 dport=36366 [ASSURED] mark=0 use=1
  tcp      6 80 TIME_WAIT src=10.244.1.1 dst=10.244.1.14 sport=57256 dport=8083 src=10.244.1.14 dst=10.244.1.1 sport=8083 dport=57256 [ASSURED] mark=0 use=1
  tcp      6 1 TIME_WAIT src=10.244.1.1 dst=10.244.1.12 sport=51984 dport=8083 src=10.244.1.12 dst=10.244.1.1 sport=8083 dport=51984 [ASSURED] mark=0 use=1
  tcp      6 107 TIME_WAIT src=10.244.1.15 dst=10.96.63.98 sport=39206 dport=80 src=10.244.1.14 dst=10.244.1.15 sport=8083 dport=39206 [ASSURED] mark=0 use=1
  tcp      6 110 TIME_WAIT src=10.244.1.1 dst=10.244.1.14 sport=42776 dport=8083 src=10.244.1.14 dst=10.244.1.1 sport=8083 dport=42776 [ASSURED] mark=0 use=1
  tcp      6 115 TIME_WAIT src=10.244.1.15 dst=10.96.63.98 sport=39222 dport=80 src=10.244.2.11 dst=10.244.1.15 sport=8083 dport=39222 [ASSURED] mark=0 use=1
  tcp      6 1 TIME_WAIT src=10.244.1.13 dst=10.96.192.168 sport=45346 dport=80 src=10.244.3.12 dst=10.244.1.13 sport=8083 dport=45346 [ASSURED] mark=0 use=1
  tcp      6 119 TIME_WAIT src=10.244.1.15 dst=10.96.63.98 sport=56162 dport=80 src=10.244.1.14 dst=10.244.1.15 sport=8083 dport=56162 [ASSURED] mark=0 use=1
  tcp      6 90 TIME_WAIT src=10.244.1.1 dst=10.244.1.14 sport=53146 dport=8083 src=10.244.1.14 dst=10.244.1.1 sport=8083 dport=53146 [ASSURED] mark=0 use=1
  tcp      6 91 TIME_WAIT src=10.244.1.15 dst=10.96.63.98 sport=38562 dport=80 src=10.244.2.11 dst=10.244.1.15 sport=8083 dport=38562 [ASSURED] mark=0 use=1
  tcp      6 11 TIME_WAIT src=10.244.1.13 dst=10.96.192.168 sport=50116 dport=80 src=10.244.2.10 dst=10.244.1.13 sport=8083 dport=50116 [ASSURED] mark=0 use=1
  tcp      6 105 TIME_WAIT src=10.244.1.15 dst=10.96.63.98 sport=36408 dport=80 src=10.244.2.11 dst=10.244.1.15 sport=8083 dport=36408 [ASSURED] mark=0 use=1
  tcp      6 3 TIME_WAIT src=10.244.1.13 dst=10.96.192.168 sport=45362 dport=80 src=10.244.2.10 dst=10.244.1.13 sport=8083 dport=45362 [ASSURED] mark=0 use=2
  tcp      6 88 TIME_WAIT src=10.244.1.15 dst=10.96.63.98 sport=38558 dport=80 src=10.244.3.13 dst=10.244.1.15 sport=8083 dport=38558 [ASSURED] mark=0 use=1
  tcp      6 99 TIME_WAIT src=10.244.1.15 dst=10.96.63.98 sport=36376 dport=80 src=10.244.3.13 dst=10.244.1.15 sport=8083 dport=36376 [ASSURED] mark=0 use=1
  tcp      6 117 TIME_WAIT src=10.244.1.15 dst=10.96.63.98 sport=56160 dport=80 src=10.244.2.11 dst=10.244.1.15 sport=8083 dport=56160 [ASSURED] mark=0 use=1
  tcp      6 103 TIME_WAIT src=10.244.1.15 dst=10.96.63.98 sport=36400 dport=80 src=10.244.2.11 dst=10.244.1.15 sport=8083 dport=36400 [ASSURED] mark=0 use=1
  tcp      6 100 TIME_WAIT src=10.244.1.1 dst=10.244.1.14 sport=38046 dport=8083 src=10.244.1.14 dst=10.244.1.1 sport=8083 dport=38046 [ASSURED] mark=0 use=1
  tcp      6 93 TIME_WAIT src=10.244.1.15 dst=10.96.63.98 sport=38574 dport=80 src=10.244.3.13 dst=10.244.1.15 sport=8083 dport=38574 [ASSURED] mark=0 use=1
  tcp      6 101 TIME_WAIT src=10.244.1.15 dst=10.96.63.98 sport=36384 dport=80 src=10.244.3.13 dst=10.244.1.15 sport=8083 dport=36384 [ASSURED] mark=0 use=1
  tcp      6 11 TIME_WAIT src=10.244.1.1 dst=10.244.1.12 sport=46330 dport=8083 src=10.244.1.12 dst=10.244.1.1 sport=8083 dport=46330 [ASSURED] mark=0 use=1
  tcp      6 80 TIME_WAIT src=10.244.1.1 dst=10.244.1.14 sport=57264 dport=8083 src=10.244.1.14 dst=10.244.1.1 sport=8083 dport=57264 [ASSURED] mark=0 use=1
  tcp      6 95 TIME_WAIT src=10.244.1.15 dst=10.96.63.98 sport=38578 dport=80 src=10.244.3.13 dst=10.244.1.15 sport=8083 dport=38578 [ASSURED] mark=0 use=1
  tcp      6 1 TIME_WAIT src=10.244.1.1 dst=10.244.1.12 sport=51976 dport=8083 src=10.244.1.12 dst=10.244.1.1 sport=8083 dport=51976 [ASSURED] mark=0 use=1
  tcp      6 86 TIME_WAIT src=10.244.1.15 dst=10.96.63.98 sport=38552 dport=80 src=10.244.3.13 dst=10.244.1.15 sport=8083 dport=38552 [ASSURED] mark=0 use=2
  tcp      6 11 TIME_WAIT src=10.244.1.1 dst=10.244.1.12 sport=46344 dport=8083 src=10.244.1.12 dst=10.244.1.1 sport=8083 dport=46344 [ASSURED] mark=0 use=1
  tcp      6 110 TIME_WAIT src=10.244.1.1 dst=10.244.1.14 sport=42782 dport=8083 src=10.244.1.14 dst=10.244.1.1 sport=8083 dport=42782 [ASSURED] mark=0 use=1
  I0514 15:05:27.290497 72478 helper.go:121] Waiting up to 7m0s for all (but 0) nodes to be ready
  STEP: Destroying namespace "nettest-7732" for this suite. @ 05/14/24 15:05:27.293
```

/kind flake
/sig network
/assign @aojea 