### PR TITLE
cherry pick #124618 to 1.27

### DIFF
--- a/pkg/scheduler/internal/queue/scheduling_queue.go
+++ b/pkg/scheduler/internal/queue/scheduling_queue.go
@@ -776,6 +776,11 @@ func (p *PriorityQueue) MoveAllToActiveOrBackoffQueue(event framework.ClusterEve
 func (p *PriorityQueue) movePodsToActiveOrBackoffQueue(podInfoList []*framework.QueuedPodInfo, event framework.ClusterEvent) {
 	activated := false
 	for _, pInfo := range podInfoList {
+		// Since there may be many gated pods and they will not move from the
+		// unschedulable pool, we skip calling the expensive isPodWorthRequeueing.
+		if pInfo.Gated {
+			continue
+		}
 		// If the event doesn't help making the Pod schedulable, continue.
 		// Note: we don't run the check if pInfo.UnschedulablePlugins is nil, which denotes
 		// either there is some abnormal error, or scheduling the pod failed by plugins other than PreFilter, Filter and Permit.


### PR DESCRIPTION
Changes to make tests compatible with 1.27
 - omit rename of "want" to "schedule" to reduce diff
 - call Scheduler.Run(), as ScheduleOne is not public interface
 - only verify pods scheduled; don't call ScheduleOne
 - Replace PodsInActiveQ check with PodSchedulingGated
 - update wait.Poll to wait.PollUntilContextTimeout
 - don't update plugin_tests.go, as relevant test no longer exists
 - don't update scheduling_queue_test.go, as QueueingHintFn tests no longer exist - **new [1]**


[1] Change is new in this PR. Changes above were originally introduced in previous PRs. See  #124848, #124849, #124851
 
#### What type of PR is this?
/kind bug

/sig scheduling
/assign @alculquicondor 

#### What this PR does / why we need it:
Cherry pick performance fix #124618
#### Which issue(s) this PR fixes:
#124384
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Improved scheduling latency when many gated pods
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
