### PR TITLE
e2e/storage: Add missing GinkgoRecover call

### DIFF
--- a/test/e2e/storage/in_tree_volumes.go
+++ b/test/e2e/storage/in_tree_volumes.go
@@ -19,6 +19,8 @@ package storage
 import (
 	"os"
 
+	"github.com/onsi/ginkgo/v2"
+
 	"k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/e2e/storage/drivers"
 	storageframework "k8s.io/kubernetes/test/e2e/storage/framework"
@@ -49,6 +51,8 @@ var testDrivers = []func() storageframework.TestDriver{
 
 // This executes testSuites for in-tree volumes.
 var _ = utils.SIGDescribe("In-tree Volumes", func() {
+	defer ginkgo.GinkgoRecover()
+
 	gceEnabled := false
 	for _, driver := range framework.TestContext.EnabledVolumeDrivers {
 		switch driver {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

If you pass an invalid value for `-enabled-volume-drivers` then the test suite currently panics rather than failing correctly. Fix this.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:

Example reproducer. Build and run tests that derive from this suite. For example:

```
❯ make all WHAT=test/e2e/e2e.test
❯ ginkgo run --succinct --focus '\[Driver: cinder.csi.openstack.org\] .* topology should fail to schedule a pod which has topologies that conflict with AllowedTopologies' _output/bin/e2e.test -- -enabled-volume-drivers invalid
```

Without this patch, this panics like so:

```
Assertion or Panic detected during tree construction
k8s.io/kubernetes/test/e2e/storage/in_tree_volumes.go:51
  Ginkgo detected a panic while constructing the spec tree.
  You may be trying to make an assertion in the body of a container node
  (i.e. Describe, Context, or When).

  Please ensure all assertions are inside leaf nodes such as BeforeEach,
  It, etc.

  Here's the content of the panic that was caught:
  Your Test Panicked
  k8s.io/kubernetes/test/e2e/storage/in_tree_volumes.go:63
    When you, or your assertion library, calls Ginkgo's Fail(),
    Ginkgo panics to prevent subsequent assertions from running.

    Normally Ginkgo rescues this panic so you shouldn't see it.

    However, if you make an assertion in a goroutine, Ginkgo can't capture the
    panic.
    To circumvent this, you should call

        defer GinkgoRecover()

    at the top of the goroutine that caused this panic.

    Alternatively, you may have made an assertion outside of a Ginkgo
    leaf node (e.g. in a container node or some out-of-band function) - please
    move your assertion to
    an appropriate Ginkgo node (e.g. a BeforeSuite, BeforeEach, It, etc...).

    Learn more at:
    http://onsi.github.io/ginkgo/#mental-model-how-ginkgo-handles-failure


  Learn more at: http://onsi.github.io/ginkgo/#no-assertions-in-container-nodes


Ginkgo ran 1 suite in 61.625393ms

Test Suite Failed
```

With this patch applied, it fails "correctly":

```
  I0520 14:19:29.308283 65846 test_context.go:561] The --provider flag is not set. Continuing as if --provider=skeleton had been used.
  I0520 14:19:29.308389   65846 e2e.go:109] Starting e2e run "9ee17e68-4e0b-4c42-814e-83b0cecebf27" on Ginkgo node 1
[1716211169] Kubernetes e2e suite - 0/2126 specs 
------------------------------
[ReportBeforeSuite] [FAILED] [0.000 seconds]
[ReportBeforeSuite] 
k8s.io/kubernetes/test/e2e/e2e_test.go:154

  [FAILED] Invalid volume type invalid in [invalid]
  In [ReportBeforeSuite] at: k8s.io/kubernetes/test/e2e/storage/in_tree_volumes.go:67 @ 05/20/24 14:19:29.338
------------------------------

Summarizing 1 Failure:
  [FAIL] [ReportBeforeSuite] 
  k8s.io/kubernetes/test/e2e/storage/in_tree_volumes.go:67

Ran 0 of 2126 Specs in 0.000 seconds
FAIL! -- 0 Passed | 0 Failed | 0 Pending | 0 Skipped
--- FAIL: TestE2E (0.03s)
FAIL

Ginkgo ran 1 suite in 107.686932ms

Test Suite Failed
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
