### PR TITLE
e2e-kind-cloud-provider-loadbalancer fixes, part 1

### DIFF
--- a/test/e2e/network/loadbalancer.go
+++ b/test/e2e/network/loadbalancer.go
@@ -387,8 +387,8 @@ var _ = common.SIGDescribe("LoadBalancers", feature.LoadBalancer, func() {
 		err = udpJig.Scale(ctx, 0)
 		framework.ExpectNoError(err)
 
-		ginkgo.By("looking for ICMP REJECT on the UDP service's LoadBalancer")
-		testRejectedUDP(ctx, udpIngressIP, svcPort, loadBalancerCreateTimeout)
+		ginkgo.By("checking that the UDP service's LoadBalancer is not reachable")
+		testNotReachableUDP(ctx, udpIngressIP, svcPort, loadBalancerCreateTimeout)
 
 		ginkgo.By("Scaling the pods to 1")
 		err = udpJig.Scale(ctx, 1)

--- a/test/e2e/network/loadbalancer.go
+++ b/test/e2e/network/loadbalancer.go
@@ -927,11 +927,6 @@ var _ = common.SIGDescribe("LoadBalancers", feature.LoadBalancer, func() {
 })
 
 var _ = common.SIGDescribe("LoadBalancers ExternalTrafficPolicy: Local", feature.LoadBalancer, framework.WithSlow(), func() {
-	// FIXME: What are the expected semantics of requesting an
-	// "ExternalTrafficPolicy: Local" service from a cloud provider that does not
-	// support that? What are the expected semantics of "ExternalTrafficPolicy: Local"
-	// on `IPMode: Proxy`-type LoadBalancers?
-
 	f := framework.NewDefaultFramework("esipp")
 	f.NamespacePodSecurityLevel = admissionapi.LevelBaseline
 	var loadBalancerCreateTimeout time.Duration
@@ -986,6 +981,14 @@ var _ = common.SIGDescribe("LoadBalancers ExternalTrafficPolicy: Local", feature
 			err = cs.CoreV1().Services(svc.Namespace).Delete(ctx, svc.Name, metav1.DeleteOptions{})
 			framework.ExpectNoError(err)
 		})
+
+		// FIXME: figure out the actual expected semantics for
+		// "ExternalTrafficPolicy: Local" + "IPMode: Proxy".
+		// https://issues.k8s.io/123714
+		ingress := &svc.Status.LoadBalancer.Ingress[0]
+		if ingress.IP == "" || (ingress.IPMode != nil && *ingress.IPMode == v1.LoadBalancerIPModeProxy) {
+			e2eskipper.Skipf("LoadBalancer uses 'Proxy' IPMode")
+		}
 
 		svcTCPPort := int(svc.Spec.Ports[0].Port)
 		ingressIP := e2eservice.GetIngressPoint(&svc.Status.LoadBalancer.Ingress[0])
@@ -1132,6 +1135,14 @@ var _ = common.SIGDescribe("LoadBalancers ExternalTrafficPolicy: Local", feature
 			err := cs.CoreV1().Services(svc.Namespace).Delete(ctx, svc.Name, metav1.DeleteOptions{})
 			framework.ExpectNoError(err)
 		})
+
+		// FIXME: figure out the actual expected semantics for
+		// "ExternalTrafficPolicy: Local" + "IPMode: Proxy".
+		// https://issues.k8s.io/123714
+		ingress := &svc.Status.LoadBalancer.Ingress[0]
+		if ingress.IP == "" || (ingress.IPMode != nil && *ingress.IPMode == v1.LoadBalancerIPModeProxy) {
+			e2eskipper.Skipf("LoadBalancer uses 'Proxy' IPMode")
+		}
 
 		ingressIP := e2eservice.GetIngressPoint(&svc.Status.LoadBalancer.Ingress[0])
 		port := strconv.Itoa(int(svc.Spec.Ports[0].Port))

--- a/test/e2e/network/service.go
+++ b/test/e2e/network/service.go
@@ -606,20 +606,6 @@ func testNotReachableUDP(ctx context.Context, host string, port int, timeout tim
 	}
 }
 
-// testRejectedUDP tests that the given host rejects a UDP request on the given port.
-func testRejectedUDP(ctx context.Context, host string, port int, timeout time.Duration) {
-	pollfn := func(ctx context.Context) (bool, error) {
-		result := pokeUDP(host, port, "echo hello", &UDPPokeParams{Timeout: 3 * time.Second})
-		if result.Status == UDPRefused {
-			return true, nil
-		}
-		return false, nil // caller can retry
-	}
-	if err := wait.PollUntilContextTimeout(ctx, framework.Poll, timeout, true, pollfn); err != nil {
-		framework.Failf("UDP service %v:%v not rejected: %v", host, port, err)
-	}
-}
-
 // TestHTTPHealthCheckNodePort tests a HTTP connection by the given request to the given host and port.
 func TestHTTPHealthCheckNodePort(ctx context.Context, host string, port int, request string, timeout time.Duration, expectSucceed bool, threshold int) error {
 	count := 0


### PR DESCRIPTION
#### What type of PR is this?
/kind failing-test

#### What this PR does / why we need it:
Pulling out the definitely-right parts of #124371:

1. Make the "no UDP endpoints" behavior match the "no TCP endpoints" behavior. (Only assert "not reachable" rather than "ICMP reject".)
2. Bail out on the "source IP is preserved" tests if the cloud returns "Proxy"-type load balancers.

(The latter will hopefully be improved later, KEP-4361.)

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/sig network
/priority important-soon
/triage accepted
/assign @aojea 