### PR TITLE
Add cronjobs/finalizers in edit role

### DIFF
--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
@@ -314,7 +314,7 @@ func ClusterRoles() []rbacv1.ClusterRole {
 
 				rbacv1helpers.NewRule(Write...).Groups(autoscalingGroup).Resources("horizontalpodautoscalers").RuleOrDie(),
 
-				rbacv1helpers.NewRule(Write...).Groups(batchGroup).Resources("jobs", "cronjobs").RuleOrDie(),
+				rbacv1helpers.NewRule(Write...).Groups(batchGroup).Resources("jobs", "cronjobs", "cronjobs/finalizers").RuleOrDie(),
 
 				rbacv1helpers.NewRule(Write...).Groups(extensionsGroup).Resources("daemonsets",
 					"deployments", "deployments/scale", "deployments/rollback", "ingresses",


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
After https://github.com/kubernetes/kubernetes/pull/118530 has merged, cronjob starts needing the edit access to `cronjobs/finalizers`. Otherwise, it gets `is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers`. Users should manage this in their custom roles by adding `cronjobs/finalizers`. However, for the `admin` role, the expectation is this edit access to `cronjobs/finalizers` is already builtin.

This PR adds edit access to `cronjobs/finalizers` to `aggregate-to-edit`.

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Add edit access to `cronjobs/finalizers` in `aggregate-to-edit` (and admin role which is derived from it)
```