### PR TITLE
Update publishing-bot rules to Go 1.21.10/1.22.3

### DIFF
--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -7,31 +7,31 @@ rules:
       dirs:
       - staging/src/k8s.io/apimachinery
   - name: release-1.26
-    go: 1.21.9
+    go: 1.21.10
     source:
       branch: release-1.26
       dirs:
       - staging/src/k8s.io/apimachinery
   - name: release-1.27
-    go: 1.21.9
+    go: 1.21.10
     source:
       branch: release-1.27
       dirs:
       - staging/src/k8s.io/apimachinery
   - name: release-1.28
-    go: 1.21.9
+    go: 1.21.10
     source:
       branch: release-1.28
       dirs:
       - staging/src/k8s.io/apimachinery
   - name: release-1.29
-    go: 1.21.9
+    go: 1.21.10
     source:
       branch: release-1.29
       dirs:
       - staging/src/k8s.io/apimachinery
   - name: release-1.30
-    go: 1.22.2
+    go: 1.22.3
     source:
       branch: release-1.30
       dirs:
@@ -48,7 +48,7 @@ rules:
       dirs:
       - staging/src/k8s.io/api
   - name: release-1.26
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -57,7 +57,7 @@ rules:
       dirs:
       - staging/src/k8s.io/api
   - name: release-1.27
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -66,7 +66,7 @@ rules:
       dirs:
       - staging/src/k8s.io/api
   - name: release-1.28
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -75,7 +75,7 @@ rules:
       dirs:
       - staging/src/k8s.io/api
   - name: release-1.29
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -84,7 +84,7 @@ rules:
       dirs:
       - staging/src/k8s.io/api
   - name: release-1.30
-    go: 1.22.2
+    go: 1.22.3
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -110,7 +110,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.26
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -125,7 +125,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.27
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -140,7 +140,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.28
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -155,7 +155,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.29
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -170,7 +170,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.30
-    go: 1.22.2
+    go: 1.22.3
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -196,31 +196,31 @@ rules:
       dirs:
       - staging/src/k8s.io/code-generator
   - name: release-1.26
-    go: 1.21.9
+    go: 1.21.10
     source:
       branch: release-1.26
       dirs:
       - staging/src/k8s.io/code-generator
   - name: release-1.27
-    go: 1.21.9
+    go: 1.21.10
     source:
       branch: release-1.27
       dirs:
       - staging/src/k8s.io/code-generator
   - name: release-1.28
-    go: 1.21.9
+    go: 1.21.10
     source:
       branch: release-1.28
       dirs:
       - staging/src/k8s.io/code-generator
   - name: release-1.29
-    go: 1.21.9
+    go: 1.21.10
     source:
       branch: release-1.29
       dirs:
       - staging/src/k8s.io/code-generator
   - name: release-1.30
-    go: 1.22.2
+    go: 1.22.3
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -243,7 +243,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-base
   - name: release-1.26
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -256,7 +256,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-base
   - name: release-1.27
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -269,7 +269,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-base
   - name: release-1.28
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -282,7 +282,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-base
   - name: release-1.29
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -295,7 +295,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-base
   - name: release-1.30
-    go: 1.22.2
+    go: 1.22.3
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -323,7 +323,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-helpers
   - name: release-1.26
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -336,7 +336,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-helpers
   - name: release-1.27
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -349,7 +349,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-helpers
   - name: release-1.28
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -362,7 +362,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-helpers
   - name: release-1.29
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -375,7 +375,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-helpers
   - name: release-1.30
-    go: 1.22.2
+    go: 1.22.3
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -399,13 +399,13 @@ rules:
       dirs:
       - staging/src/k8s.io/kms
   - name: release-1.26
-    go: 1.21.9
+    go: 1.21.10
     source:
       branch: release-1.26
       dirs:
       - staging/src/k8s.io/kms
   - name: release-1.27
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -418,7 +418,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kms
   - name: release-1.28
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -431,7 +431,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kms
   - name: release-1.29
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -440,7 +440,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kms
   - name: release-1.30
-    go: 1.22.2
+    go: 1.22.3
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -468,7 +468,7 @@ rules:
       dirs:
       - staging/src/k8s.io/apiserver
   - name: release-1.26
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -485,7 +485,7 @@ rules:
       dirs:
       - staging/src/k8s.io/apiserver
   - name: release-1.27
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -502,7 +502,7 @@ rules:
       dirs:
       - staging/src/k8s.io/apiserver
   - name: release-1.28
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -519,7 +519,7 @@ rules:
       dirs:
       - staging/src/k8s.io/apiserver
   - name: release-1.29
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -536,7 +536,7 @@ rules:
       dirs:
       - staging/src/k8s.io/apiserver
   - name: release-1.30
-    go: 1.22.2
+    go: 1.22.3
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -576,7 +576,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-aggregator
   - name: release-1.26
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -597,7 +597,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-aggregator
   - name: release-1.27
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -618,7 +618,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-aggregator
   - name: release-1.28
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -639,7 +639,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-aggregator
   - name: release-1.29
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -660,7 +660,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-aggregator
   - name: release-1.30
-    go: 1.22.2
+    go: 1.22.3
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -708,7 +708,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.26
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -734,7 +734,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.27
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -760,7 +760,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.28
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -786,7 +786,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.29
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -812,7 +812,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.30
-    go: 1.22.2
+    go: 1.22.3
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -859,7 +859,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.26
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -879,7 +879,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.27
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -899,7 +899,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.28
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -919,7 +919,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.29
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -939,7 +939,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.30
-    go: 1.22.2
+    go: 1.22.3
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -983,7 +983,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.26
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -1006,7 +1006,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.27
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -1029,7 +1029,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.28
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -1052,7 +1052,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.29
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -1075,7 +1075,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.30
-    go: 1.22.2
+    go: 1.22.3
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -1114,7 +1114,7 @@ rules:
       dirs:
       - staging/src/k8s.io/metrics
   - name: release-1.26
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -1129,7 +1129,7 @@ rules:
       dirs:
       - staging/src/k8s.io/metrics
   - name: release-1.27
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -1144,7 +1144,7 @@ rules:
       dirs:
       - staging/src/k8s.io/metrics
   - name: release-1.28
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -1159,7 +1159,7 @@ rules:
       dirs:
       - staging/src/k8s.io/metrics
   - name: release-1.29
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -1174,7 +1174,7 @@ rules:
       dirs:
       - staging/src/k8s.io/metrics
   - name: release-1.30
-    go: 1.22.2
+    go: 1.22.3
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -1204,7 +1204,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cli-runtime
   - name: release-1.26
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: api
       branch: release-1.26
@@ -1217,7 +1217,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cli-runtime
   - name: release-1.27
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: api
       branch: release-1.27
@@ -1230,7 +1230,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cli-runtime
   - name: release-1.28
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: api
       branch: release-1.28
@@ -1243,7 +1243,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cli-runtime
   - name: release-1.29
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: api
       branch: release-1.29
@@ -1256,7 +1256,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cli-runtime
   - name: release-1.30
-    go: 1.22.2
+    go: 1.22.3
     dependencies:
     - repository: api
       branch: release-1.30
@@ -1286,7 +1286,7 @@ rules:
       dirs:
       - staging/src/k8s.io/sample-cli-plugin
   - name: release-1.26
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: api
       branch: release-1.26
@@ -1301,7 +1301,7 @@ rules:
       dirs:
       - staging/src/k8s.io/sample-cli-plugin
   - name: release-1.27
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: api
       branch: release-1.27
@@ -1316,7 +1316,7 @@ rules:
       dirs:
       - staging/src/k8s.io/sample-cli-plugin
   - name: release-1.28
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: api
       branch: release-1.28
@@ -1331,7 +1331,7 @@ rules:
       dirs:
       - staging/src/k8s.io/sample-cli-plugin
   - name: release-1.29
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: api
       branch: release-1.29
@@ -1346,7 +1346,7 @@ rules:
       dirs:
       - staging/src/k8s.io/sample-cli-plugin
   - name: release-1.30
-    go: 1.22.2
+    go: 1.22.3
     dependencies:
     - repository: api
       branch: release-1.30
@@ -1377,7 +1377,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-proxy
   - name: release-1.26
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -1392,7 +1392,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-proxy
   - name: release-1.27
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -1407,7 +1407,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-proxy
   - name: release-1.28
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -1422,7 +1422,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-proxy
   - name: release-1.29
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -1437,7 +1437,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-proxy
   - name: release-1.30
-    go: 1.22.2
+    go: 1.22.3
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -1460,31 +1460,31 @@ rules:
       dirs:
       - staging/src/k8s.io/cri-api
   - name: release-1.26
-    go: 1.21.9
+    go: 1.21.10
     source:
       branch: release-1.26
       dirs:
       - staging/src/k8s.io/cri-api
   - name: release-1.27
-    go: 1.21.9
+    go: 1.21.10
     source:
       branch: release-1.27
       dirs:
       - staging/src/k8s.io/cri-api
   - name: release-1.28
-    go: 1.21.9
+    go: 1.21.10
     source:
       branch: release-1.28
       dirs:
       - staging/src/k8s.io/cri-api
   - name: release-1.29
-    go: 1.21.9
+    go: 1.21.10
     source:
       branch: release-1.29
       dirs:
       - staging/src/k8s.io/cri-api
   - name: release-1.30
-    go: 1.22.2
+    go: 1.22.3
     source:
       branch: release-1.30
       dirs:
@@ -1521,7 +1521,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubelet
   - name: release-1.26
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -1536,7 +1536,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubelet
   - name: release-1.27
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -1551,7 +1551,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubelet
   - name: release-1.28
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -1572,7 +1572,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubelet
   - name: release-1.29
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -1593,7 +1593,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubelet
   - name: release-1.30
-    go: 1.22.2
+    go: 1.22.3
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -1631,7 +1631,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-scheduler
   - name: release-1.26
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -1646,7 +1646,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-scheduler
   - name: release-1.27
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -1661,7 +1661,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-scheduler
   - name: release-1.28
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -1676,7 +1676,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-scheduler
   - name: release-1.29
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -1691,7 +1691,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-scheduler
   - name: release-1.30
-    go: 1.22.2
+    go: 1.22.3
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -1727,7 +1727,7 @@ rules:
       dirs:
       - staging/src/k8s.io/controller-manager
   - name: release-1.26
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: api
       branch: release-1.26
@@ -1746,7 +1746,7 @@ rules:
       dirs:
       - staging/src/k8s.io/controller-manager
   - name: release-1.27
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: api
       branch: release-1.27
@@ -1765,7 +1765,7 @@ rules:
       dirs:
       - staging/src/k8s.io/controller-manager
   - name: release-1.28
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: api
       branch: release-1.28
@@ -1784,7 +1784,7 @@ rules:
       dirs:
       - staging/src/k8s.io/controller-manager
   - name: release-1.29
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: api
       branch: release-1.29
@@ -1803,7 +1803,7 @@ rules:
       dirs:
       - staging/src/k8s.io/controller-manager
   - name: release-1.30
-    go: 1.22.2
+    go: 1.22.3
     dependencies:
     - repository: api
       branch: release-1.30
@@ -1847,7 +1847,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cloud-provider
   - name: release-1.26
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: api
       branch: release-1.26
@@ -1870,7 +1870,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cloud-provider
   - name: release-1.27
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: api
       branch: release-1.27
@@ -1893,7 +1893,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cloud-provider
   - name: release-1.28
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: api
       branch: release-1.28
@@ -1916,7 +1916,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cloud-provider
   - name: release-1.29
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: api
       branch: release-1.29
@@ -1939,7 +1939,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cloud-provider
   - name: release-1.30
-    go: 1.22.2
+    go: 1.22.3
     dependencies:
     - repository: api
       branch: release-1.30
@@ -1989,7 +1989,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-controller-manager
   - name: release-1.26
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -2014,7 +2014,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-controller-manager
   - name: release-1.27
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -2039,7 +2039,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-controller-manager
   - name: release-1.28
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -2064,7 +2064,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-controller-manager
   - name: release-1.29
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -2089,7 +2089,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-controller-manager
   - name: release-1.30
-    go: 1.22.2
+    go: 1.22.3
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -2127,7 +2127,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cluster-bootstrap
   - name: release-1.26
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -2138,7 +2138,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cluster-bootstrap
   - name: release-1.27
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -2149,7 +2149,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cluster-bootstrap
   - name: release-1.28
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -2160,7 +2160,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cluster-bootstrap
   - name: release-1.29
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -2171,7 +2171,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cluster-bootstrap
   - name: release-1.30
-    go: 1.22.2
+    go: 1.22.3
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -2195,7 +2195,7 @@ rules:
       dirs:
       - staging/src/k8s.io/csi-translation-lib
   - name: release-1.26
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: api
       branch: release-1.26
@@ -2206,7 +2206,7 @@ rules:
       dirs:
       - staging/src/k8s.io/csi-translation-lib
   - name: release-1.27
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: api
       branch: release-1.27
@@ -2217,7 +2217,7 @@ rules:
       dirs:
       - staging/src/k8s.io/csi-translation-lib
   - name: release-1.28
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: api
       branch: release-1.28
@@ -2228,7 +2228,7 @@ rules:
       dirs:
       - staging/src/k8s.io/csi-translation-lib
   - name: release-1.29
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: api
       branch: release-1.29
@@ -2239,7 +2239,7 @@ rules:
       dirs:
       - staging/src/k8s.io/csi-translation-lib
   - name: release-1.30
-    go: 1.22.2
+    go: 1.22.3
     dependencies:
     - repository: api
       branch: release-1.30
@@ -2258,31 +2258,31 @@ rules:
       dirs:
       - staging/src/k8s.io/mount-utils
   - name: release-1.26
-    go: 1.21.9
+    go: 1.21.10
     source:
       branch: release-1.26
       dirs:
       - staging/src/k8s.io/mount-utils
   - name: release-1.27
-    go: 1.21.9
+    go: 1.21.10
     source:
       branch: release-1.27
       dirs:
       - staging/src/k8s.io/mount-utils
   - name: release-1.28
-    go: 1.21.9
+    go: 1.21.10
     source:
       branch: release-1.28
       dirs:
       - staging/src/k8s.io/mount-utils
   - name: release-1.29
-    go: 1.21.9
+    go: 1.21.10
     source:
       branch: release-1.29
       dirs:
       - staging/src/k8s.io/mount-utils
   - name: release-1.30
-    go: 1.22.2
+    go: 1.22.3
     source:
       branch: release-1.30
       dirs:
@@ -2315,7 +2315,7 @@ rules:
       dirs:
       - staging/src/k8s.io/legacy-cloud-providers
   - name: release-1.26
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: api
       branch: release-1.26
@@ -2344,7 +2344,7 @@ rules:
       dirs:
       - staging/src/k8s.io/legacy-cloud-providers
   - name: release-1.27
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: api
       branch: release-1.27
@@ -2369,7 +2369,7 @@ rules:
       dirs:
       - staging/src/k8s.io/legacy-cloud-providers
   - name: release-1.28
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: api
       branch: release-1.28
@@ -2394,7 +2394,7 @@ rules:
       dirs:
       - staging/src/k8s.io/legacy-cloud-providers
   - name: release-1.29
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: api
       branch: release-1.29
@@ -2419,7 +2419,7 @@ rules:
       dirs:
       - staging/src/k8s.io/legacy-cloud-providers
   - name: release-1.30
-    go: 1.22.2
+    go: 1.22.3
     dependencies:
     - repository: api
       branch: release-1.30
@@ -2469,7 +2469,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubectl
   - name: release-1.26
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: api
       branch: release-1.26
@@ -2492,7 +2492,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubectl
   - name: release-1.27
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: api
       branch: release-1.27
@@ -2515,7 +2515,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubectl
   - name: release-1.28
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: api
       branch: release-1.28
@@ -2538,7 +2538,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubectl
   - name: release-1.29
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: api
       branch: release-1.29
@@ -2561,7 +2561,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubectl
   - name: release-1.30
-    go: 1.22.2
+    go: 1.22.3
     dependencies:
     - repository: api
       branch: release-1.30
@@ -2605,7 +2605,7 @@ rules:
       dirs:
       - staging/src/k8s.io/pod-security-admission
   - name: release-1.26
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: api
       branch: release-1.26
@@ -2624,7 +2624,7 @@ rules:
       dirs:
       - staging/src/k8s.io/pod-security-admission
   - name: release-1.27
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: api
       branch: release-1.27
@@ -2643,7 +2643,7 @@ rules:
       dirs:
       - staging/src/k8s.io/pod-security-admission
   - name: release-1.28
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: api
       branch: release-1.28
@@ -2662,7 +2662,7 @@ rules:
       dirs:
       - staging/src/k8s.io/pod-security-admission
   - name: release-1.29
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: api
       branch: release-1.29
@@ -2681,7 +2681,7 @@ rules:
       dirs:
       - staging/src/k8s.io/pod-security-admission
   - name: release-1.30
-    go: 1.22.2
+    go: 1.22.3
     dependencies:
     - repository: api
       branch: release-1.30
@@ -2725,7 +2725,7 @@ rules:
       dirs:
       - staging/src/k8s.io/dynamic-resource-allocation
   - name: release-1.26
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -2742,7 +2742,7 @@ rules:
       dirs:
       - staging/src/k8s.io/dynamic-resource-allocation
   - name: release-1.27
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -2759,7 +2759,7 @@ rules:
       dirs:
       - staging/src/k8s.io/dynamic-resource-allocation
   - name: release-1.28
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -2780,7 +2780,7 @@ rules:
       dirs:
       - staging/src/k8s.io/dynamic-resource-allocation
   - name: release-1.29
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -2801,7 +2801,7 @@ rules:
       dirs:
       - staging/src/k8s.io/dynamic-resource-allocation
   - name: release-1.30
-    go: 1.22.2
+    go: 1.22.3
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -2840,7 +2840,7 @@ rules:
       dirs:
       - staging/src/k8s.io/endpointslice
   - name: release-1.28
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: api
       branch: release-1.28
@@ -2855,7 +2855,7 @@ rules:
       dirs:
       - staging/src/k8s.io/endpointslice
   - name: release-1.29
-    go: 1.21.9
+    go: 1.21.10
     dependencies:
     - repository: api
       branch: release-1.29
@@ -2870,7 +2870,7 @@ rules:
       dirs:
       - staging/src/k8s.io/endpointslice
   - name: release-1.30
-    go: 1.22.2
+    go: 1.22.3
     dependencies:
     - repository: api
       branch: release-1.30


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

- Update publishing-bot rules to Go 1.21.10/1.22.3

/assign @dims @puerco @xmudrii @Verolop 
cc @kubernetes/release-engineering 

#### Which issue(s) this PR fixes:

xref https://github.com/kubernetes/release/issues/3597

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
