### PR TITLE
client-go/transport: fix memory leak when using rest.Config Dial function

### DIFF
--- a/staging/src/k8s.io/client-go/rest/transport.go
+++ b/staging/src/k8s.io/client-go/rest/transport.go
@@ -112,7 +112,7 @@ func (c *Config) TransportConfig() (*transport.Config, error) {
 	}
 
 	if c.Dial != nil {
-		conf.DialHolder = &transport.DialHolder{Dial: c.Dial}
+		conf.DialHolder = &transport.DialHolder{Dial: c.Dial, DisableCache: true}
 	}
 
 	if c.ExecProvider != nil && c.AuthProvider != nil {

--- a/staging/src/k8s.io/client-go/transport/cache.go
+++ b/staging/src/k8s.io/client-go/transport/cache.go
@@ -156,6 +156,10 @@ func tlsConfigKey(c *Config) (tlsCacheKey, bool, error) {
 		return tlsCacheKey{}, false, nil
 	}
 
+	if c.DialHolder != nil && c.DialHolder.DisableCache {
+		return tlsCacheKey{}, false, nil
+	}
+
 	k := tlsCacheKey{
 		insecure:           c.TLS.Insecure,
 		caData:             string(c.TLS.CAData),

--- a/staging/src/k8s.io/client-go/transport/cache_test.go
+++ b/staging/src/k8s.io/client-go/transport/cache_test.go
@@ -71,13 +71,14 @@ func TestTLSConfigKey(t *testing.T) {
 	dialer := net.Dialer{}
 	getCert := &GetCertHolder{GetCert: func() (*tls.Certificate, error) { return nil, nil }}
 	uniqueConfigurations := map[string]*Config{
-		"proxy":    {Proxy: func(request *http.Request) (*url.URL, error) { return nil, nil }},
-		"no tls":   {},
-		"dialer":   {DialHolder: &DialHolder{Dial: dialer.DialContext}},
-		"dialer2":  {DialHolder: &DialHolder{Dial: func(ctx context.Context, network, address string) (net.Conn, error) { return nil, nil }}},
-		"insecure": {TLS: TLSConfig{Insecure: true}},
-		"cadata 1": {TLS: TLSConfig{CAData: []byte{1}}},
-		"cadata 2": {TLS: TLSConfig{CAData: []byte{2}}},
+		"proxy":                      {Proxy: func(request *http.Request) (*url.URL, error) { return nil, nil }},
+		"no tls":                     {},
+		"dialer":                     {DialHolder: &DialHolder{Dial: dialer.DialContext}},
+		"dialer with cache disabled": {DialHolder: &DialHolder{DisableCache: true, Dial: dialer.DialContext}},
+		"dialer2":                    {DialHolder: &DialHolder{Dial: func(ctx context.Context, network, address string) (net.Conn, error) { return nil, nil }}},
+		"insecure":                   {TLS: TLSConfig{Insecure: true}},
+		"cadata 1":                   {TLS: TLSConfig{CAData: []byte{1}}},
+		"cadata 2":                   {TLS: TLSConfig{CAData: []byte{2}}},
 		"cert 1, key 1": {
 			TLS: TLSConfig{
 				CertData: []byte{1},
@@ -157,7 +158,7 @@ func TestTLSConfigKey(t *testing.T) {
 				continue
 			}
 
-			shouldCacheA := valueA.Proxy == nil
+			shouldCacheA := valueA.Proxy == nil && (valueA.DialHolder == nil || !valueA.DialHolder.DisableCache)
 			if shouldCacheA != canCacheA {
 				t.Errorf("Unexpected canCache=false for " + nameA)
 			}

--- a/staging/src/k8s.io/client-go/transport/config.go
+++ b/staging/src/k8s.io/client-go/transport/config.go
@@ -82,6 +82,9 @@ type Config struct {
 // DialHolder is used to make the wrapped function comparable so that it can be used as a map key.
 type DialHolder struct {
 	Dial func(ctx context.Context, network, address string) (net.Conn, error)
+
+	// DisableCache disables TLS config caching for this DialHolder.
+	DisableCache bool
 }
 
 // ImpersonationConfig has all the available impersonation options


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
When using a rest.Config `Dial` function and constructing a client with `client.New()` or `kubernetes.NewForConfig()`, the `tlsConfigCache` is ineffective because the `Dial` function is wrapped in a new `DialHolder` instance every time. This leads to a memory leak since the `tlsConfigCache` grows unbounded with unique keys. This change allows skipping the `tlsConfigCache` for this case.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #118703

#### Special notes for your reviewer:
Here are graphs showing the change in memory usage before & after this fix. I have marked this as not having a user facing change, since unless the user has taken care to reuse `DialHolder` instances when creating clients, they would not have seen the benefits of the `tlsConfigCache`.

**before**
![image (3)](https://github.com/kubernetes/kubernetes/assets/727952/f5d92370-d5ae-47b9-b5af-634940d058ca)

**after**
<img width="1245" alt="Screenshot 2024-05-15 at 10 26 40 AM" src="https://github.com/kubernetes/kubernetes/assets/727952/8b3a51b0-928c-40e8-9468-0d5addc87445">


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
