### PR TITLE
kubelet/cm/cpumanager: Improving test coverage

### DIFF
--- a/pkg/kubelet/cm/cpumanager/policy_static_test.go
+++ b/pkg/kubelet/cm/cpumanager/policy_static_test.go
@@ -68,6 +68,16 @@ func (spt staticPolicyTest) PseudoClone() staticPolicyTest {
 	}
 }
 
+func TestSMTAlignmentError(t *testing.T) {
+	smtErr := SMTAlignmentError{RequestedCPUs: 3, CpusPerCore: 2}
+	if err := smtErr.Error(); err != "SMT Alignment Error: requested 3 cpus not multiple cpus per core = 2" {
+		t.Errorf("expected: SMT Alignment Error: requested 3 cpus not multiple cpus per core = 2, but got: %s", err)
+	}
+	if typ := smtErr.Type(); typ != "SMTAlignmentError" {
+		t.Errorf("expected: SMTAlignmentError but got: %s", typ)
+	}
+}
+
 func TestStaticPolicyName(t *testing.T) {
 	policy, _ := NewStaticPolicy(topoSingleSocketHT, 1, cpuset.New(), topologymanager.NewFakeManager(), nil)
 
@@ -1016,7 +1026,6 @@ func TestStaticPolicyStartWithResvList(t *testing.T) {
 }
 
 func TestStaticPolicyAddWithResvList(t *testing.T) {
-
 	testCases := []staticPolicyTestWithResvList{
 		{
 			description:     "GuPodSingleCore, SingleSocketHT, ExpectError",

--- a/pkg/kubelet/cm/cpumanager/topology/topology_test.go
+++ b/pkg/kubelet/cm/cpumanager/topology/topology_test.go
@@ -26,7 +26,6 @@ import (
 )
 
 func Test_Discover(t *testing.T) {
-
 	tests := []struct {
 		name        string
 		machineInfo cadvisorapi.MachineInfo
@@ -523,9 +522,7 @@ func Test_Discover(t *testing.T) {
 }
 
 func TestCPUDetailsKeepOnly(t *testing.T) {
-
-	var details CPUDetails
-	details = map[int]CPUInfo{
+	details := CPUDetails{
 		0: {},
 		1: {},
 		2: {},
@@ -559,7 +556,6 @@ func TestCPUDetailsKeepOnly(t *testing.T) {
 }
 
 func TestCPUDetailsNUMANodes(t *testing.T) {
-
 	tests := []struct {
 		name    string
 		details CPUDetails
@@ -586,9 +582,7 @@ func TestCPUDetailsNUMANodes(t *testing.T) {
 }
 
 func TestCPUDetailsNUMANodesInSockets(t *testing.T) {
-
-	var details1 CPUDetails
-	details1 = map[int]CPUInfo{
+	details1 := CPUDetails{
 		0: {SocketID: 0, NUMANodeID: 0},
 		1: {SocketID: 1, NUMANodeID: 0},
 		2: {SocketID: 2, NUMANodeID: 1},
@@ -596,8 +590,7 @@ func TestCPUDetailsNUMANodesInSockets(t *testing.T) {
 	}
 
 	// poorly designed mainboards
-	var details2 CPUDetails
-	details2 = map[int]CPUInfo{
+	details2 := CPUDetails{
 		0: {SocketID: 0, NUMANodeID: 0},
 		1: {SocketID: 0, NUMANodeID: 1},
 		2: {SocketID: 1, NUMANodeID: 2},
@@ -642,7 +635,6 @@ func TestCPUDetailsNUMANodesInSockets(t *testing.T) {
 }
 
 func TestCPUDetailsSockets(t *testing.T) {
-
 	tests := []struct {
 		name    string
 		details CPUDetails
@@ -669,9 +661,7 @@ func TestCPUDetailsSockets(t *testing.T) {
 }
 
 func TestCPUDetailsCPUsInSockets(t *testing.T) {
-
-	var details CPUDetails
-	details = map[int]CPUInfo{
+	details := CPUDetails{
 		0: {SocketID: 0},
 		1: {SocketID: 0},
 		2: {SocketID: 1},
@@ -703,9 +693,7 @@ func TestCPUDetailsCPUsInSockets(t *testing.T) {
 }
 
 func TestCPUDetailsSocketsInNUMANodes(t *testing.T) {
-
-	var details CPUDetails
-	details = map[int]CPUInfo{
+	details := CPUDetails{
 		0: {NUMANodeID: 0, SocketID: 0},
 		1: {NUMANodeID: 0, SocketID: 1},
 		2: {NUMANodeID: 1, SocketID: 2},
@@ -737,7 +725,6 @@ func TestCPUDetailsSocketsInNUMANodes(t *testing.T) {
 }
 
 func TestCPUDetailsCores(t *testing.T) {
-
 	tests := []struct {
 		name    string
 		details CPUDetails
@@ -764,9 +751,7 @@ func TestCPUDetailsCores(t *testing.T) {
 }
 
 func TestCPUDetailsCoresInNUMANodes(t *testing.T) {
-
-	var details CPUDetails
-	details = map[int]CPUInfo{
+	details := CPUDetails{
 		0: {NUMANodeID: 0, CoreID: 0},
 		1: {NUMANodeID: 0, CoreID: 1},
 		2: {NUMANodeID: 1, CoreID: 2},
@@ -798,9 +783,7 @@ func TestCPUDetailsCoresInNUMANodes(t *testing.T) {
 }
 
 func TestCPUDetailsCoresInSockets(t *testing.T) {
-
-	var details CPUDetails
-	details = map[int]CPUInfo{
+	details := CPUDetails{
 		0: {SocketID: 0, CoreID: 0},
 		1: {SocketID: 0, CoreID: 1},
 		2: {SocketID: 1, CoreID: 2},
@@ -832,7 +815,6 @@ func TestCPUDetailsCoresInSockets(t *testing.T) {
 }
 
 func TestCPUDetailsCPUs(t *testing.T) {
-
 	tests := []struct {
 		name    string
 		details CPUDetails
@@ -857,9 +839,7 @@ func TestCPUDetailsCPUs(t *testing.T) {
 }
 
 func TestCPUDetailsCPUsInNUMANodes(t *testing.T) {
-
-	var details CPUDetails
-	details = map[int]CPUInfo{
+	details := CPUDetails{
 		0: {NUMANodeID: 0},
 		1: {NUMANodeID: 0},
 		2: {NUMANodeID: 1},
@@ -891,9 +871,7 @@ func TestCPUDetailsCPUsInNUMANodes(t *testing.T) {
 }
 
 func TestCPUDetailsCPUsInCores(t *testing.T) {
-
-	var details CPUDetails
-	details = map[int]CPUInfo{
+	details := CPUDetails{
 		0: {CoreID: 0},
 		1: {CoreID: 0},
 		2: {CoreID: 1},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

If applied this commit will improve the unit testing coverage of `pkg/kubelet/cm/cpumanager`.

- before
<img width="750" alt="Screenshot 2024-05-15 at 22 49 21" src="https://github.com/kubernetes/kubernetes/assets/9576370/128f76c1-fa1f-4c4b-a838-1a0f2426b6a5">

- after
<img width="749" alt="Screenshot 2024-05-15 at 22 49 02" src="https://github.com/kubernetes/kubernetes/assets/9576370/ab3a45bb-0265-4204-9ab4-ba96cb2e6868">


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
