### PR TITLE
Fix: Fail admission check upon empty overhead map

### DIFF
--- a/plugin/pkg/admission/runtimeclass/admission.go
+++ b/plugin/pkg/admission/runtimeclass/admission.go
@@ -228,7 +228,7 @@ func validateOverhead(a admission.Attributes, pod *api.Pod, runtimeClass *nodev1
 		}
 	} else {
 		// If RuntimeClass with Overhead is not defined but an Overhead is set for pod, reject the pod
-		if pod.Spec.Overhead != nil {
+		if pod.Spec.Overhead != nil && len(pod.Spec.Overhead) > 0 {
 			return admission.NewForbidden(a, fmt.Errorf("pod rejected: Pod Overhead set without corresponding RuntimeClass defined Overhead"))
 		}
 	}

--- a/plugin/pkg/admission/runtimeclass/admission.go
+++ b/plugin/pkg/admission/runtimeclass/admission.go
@@ -217,6 +217,9 @@ func setScheduling(a admission.Attributes, pod *api.Pod, runtimeClass *nodev1.Ru
 }
 
 func validateOverhead(a admission.Attributes, pod *api.Pod, runtimeClass *nodev1.RuntimeClass) (err error) {
+	if len(pod.Spec.Overhead) == 0 {
+		return nil
+	}
 	if runtimeClass != nil && runtimeClass.Overhead != nil {
 		// If the Overhead set doesn't match what is provided in the RuntimeClass definition, reject the pod
 		nodeOverhead := &node.Overhead{}
@@ -228,9 +231,7 @@ func validateOverhead(a admission.Attributes, pod *api.Pod, runtimeClass *nodev1
 		}
 	} else {
 		// If RuntimeClass with Overhead is not defined but an Overhead is set for pod, reject the pod
-		if pod.Spec.Overhead != nil && len(pod.Spec.Overhead) > 0 {
-			return admission.NewForbidden(a, fmt.Errorf("pod rejected: Pod Overhead set without corresponding RuntimeClass defined Overhead"))
-		}
+		return admission.NewForbidden(a, fmt.Errorf("pod rejected: Pod Overhead set without corresponding RuntimeClass defined Overhead"))
 	}
 
 	return nil

--- a/plugin/pkg/admission/runtimeclass/admission.go
+++ b/plugin/pkg/admission/runtimeclass/admission.go
@@ -217,10 +217,7 @@ func setScheduling(a admission.Attributes, pod *api.Pod, runtimeClass *nodev1.Ru
 }
 
 func validateOverhead(a admission.Attributes, pod *api.Pod, runtimeClass *nodev1.RuntimeClass) (err error) {
-	if len(pod.Spec.Overhead) == 0 {
-		return nil
-	}
-	if runtimeClass != nil && runtimeClass.Overhead != nil {
+	if runtimeClass != nil && runtimeClass.Overhead != nil && len(pod.Spec.Overhead) > 0 {
 		// If the Overhead set doesn't match what is provided in the RuntimeClass definition, reject the pod
 		nodeOverhead := &node.Overhead{}
 		if err := apinodev1.Convert_v1_Overhead_To_node_Overhead(runtimeClass.Overhead, nodeOverhead, nil); err != nil {
@@ -231,7 +228,9 @@ func validateOverhead(a admission.Attributes, pod *api.Pod, runtimeClass *nodev1
 		}
 	} else {
 		// If RuntimeClass with Overhead is not defined but an Overhead is set for pod, reject the pod
-		return admission.NewForbidden(a, fmt.Errorf("pod rejected: Pod Overhead set without corresponding RuntimeClass defined Overhead"))
+		if pod.Spec.Overhead != nil && len(pod.Spec.Overhead) > 0 {
+			return admission.NewForbidden(a, fmt.Errorf("pod rejected: Pod Overhead set without corresponding RuntimeClass defined Overhead"))
+		}
 	}
 
 	return nil

--- a/plugin/pkg/admission/runtimeclass/admission.go
+++ b/plugin/pkg/admission/runtimeclass/admission.go
@@ -217,7 +217,7 @@ func setScheduling(a admission.Attributes, pod *api.Pod, runtimeClass *nodev1.Ru
 }
 
 func validateOverhead(a admission.Attributes, pod *api.Pod, runtimeClass *nodev1.RuntimeClass) (err error) {
-	if runtimeClass != nil && runtimeClass.Overhead != nil && len(pod.Spec.Overhead) > 0 {
+	if runtimeClass != nil && runtimeClass.Overhead != nil && len(runtimeClass.Overhead.PodFixed) > 0 {
 		// If the Overhead set doesn't match what is provided in the RuntimeClass definition, reject the pod
 		nodeOverhead := &node.Overhead{}
 		if err := apinodev1.Convert_v1_Overhead_To_node_Overhead(runtimeClass.Overhead, nodeOverhead, nil); err != nil {
@@ -228,7 +228,7 @@ func validateOverhead(a admission.Attributes, pod *api.Pod, runtimeClass *nodev1
 		}
 	} else {
 		// If RuntimeClass with Overhead is not defined but an Overhead is set for pod, reject the pod
-		if pod.Spec.Overhead != nil && len(pod.Spec.Overhead) > 0 {
+		if len(pod.Spec.Overhead) > 0 {
 			return admission.NewForbidden(a, fmt.Errorf("pod rejected: Pod Overhead set without corresponding RuntimeClass defined Overhead"))
 		}
 	}

--- a/plugin/pkg/admission/runtimeclass/admission_test.go
+++ b/plugin/pkg/admission/runtimeclass/admission_test.go
@@ -51,6 +51,8 @@ func newOverheadValidPod(name string, numContainers int, resources core.Resource
 		})
 	}
 
+	pod.Spec.Overhead = core.ResourceList{}
+
 	if setOverhead {
 		pod.Spec.Overhead = core.ResourceList{
 			core.ResourceName(core.ResourceCPU):    resource.MustParse("100m"),

--- a/plugin/pkg/admission/runtimeclass/admission_test.go
+++ b/plugin/pkg/admission/runtimeclass/admission_test.go
@@ -530,7 +530,7 @@ func TestValidateOverhead(t *testing.T) {
 				},
 			},
 			pod:         newOverheadValidPod("no-requirements", 1, core.ResourceRequirements{}, false),
-			expectError: false,
+			expectError: true,
 		},
 		{
 			name: "No Overhead in RuntimeClass, Overhead set in pod",
@@ -587,7 +587,7 @@ func TestValidateOverhead(t *testing.T) {
 				},
 			},
 			pod:         setEmptyOverhead(newOverheadValidPod("no-resource-req-no-overhead", 1, core.ResourceRequirements{}, false)),
-			expectError: false,
+			expectError: true,
 		},
 		{
 			name: "RuntimeClass is set, Overhead is nil in pod",
@@ -602,7 +602,7 @@ func TestValidateOverhead(t *testing.T) {
 				},
 			},
 			pod:         newOverheadValidPod("no-resource-req-no-overhead", 1, core.ResourceRequirements{}, false),
-			expectError: false,
+			expectError: true,
 		},
 		{
 			name: "Matching Overheads",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
the runtime class admission has a validation check against pod's `.spec.overhead` field. This validation is not correctly implemented because it's still failing requests if the request payload just has an empty map e.g.:
```
apiVersion: v1
kind: Pod
metadata:
  name: nginx
spec:
  containers:
  - name: nginx
    image: nginx:1.14.2
    ports:
    - containerPort: 80
  overhead: {}
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #https://github.com/kubernetes-client/java/issues/3076

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```