### PR TITLE
Automated cherry pick of #124906: Fix printPod panic with spurious container statuses

### DIFF
--- a/pkg/printers/internalversion/printers.go
+++ b/pkg/printers/internalversion/printers.go
@@ -3048,6 +3048,9 @@ func (list SortableResourceNames) Less(i, j int) bool {
 }
 
 func isRestartableInitContainer(initContainer *api.Container) bool {
+	if initContainer == nil {
+		return false
+	}
 	if initContainer.RestartPolicy == nil {
 		return false
 	}


### PR DESCRIPTION
Cherry pick of #124906 on release-1.29.

#124906: Fix printPod panic with spurious container statuses

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.


```release-note
kube-apiserver: fixes a 1.28 regression printing pods with invalid initContainer status
```