### PR TITLE
kubelet/volumeManager: improve unit test coverage

### DIFF
--- a/pkg/kubelet/volumemanager/cache/desired_state_of_world_test.go
+++ b/pkg/kubelet/volumemanager/cache/desired_state_of_world_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cache
 
 import (
+	"slices"
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
@@ -976,6 +977,66 @@ func Test_AddPodToVolume_Negative_ExistingPodDifferentSELinuxRWOP(t *testing.T) 
 	}
 	// Verify the original SELinux context is still in DSW
 	verifyPodExistsInVolumeDsw(t, podName, generatedVolumeName, "system_u:object_r:container_file_t:s0:c1,c2", dsw)
+}
+
+func Test_GetPods_with_and_without_errors(t *testing.T) {
+	volumePluginMgr, _ := volumetesting.GetTestKubeletVolumePluginMgr(t)
+	seLinuxTranslator := util.NewFakeSELinuxLabelTranslator()
+	dsw := NewDesiredStateOfWorld(volumePluginMgr, seLinuxTranslator)
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pod3",
+			UID:  "pod3uid",
+		},
+		Spec: v1.PodSpec{
+			Volumes: []v1.Volume{
+				{
+					Name: "volume-name",
+					VolumeSource: v1.VolumeSource{
+						GCEPersistentDisk: &v1.GCEPersistentDiskVolumeSource{
+							PDName: "fake-device1",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	volumeSpec := &volume.Spec{Volume: &pod.Spec.Volumes[0]}
+	podName := util.GetUniquePodName(pod)
+
+	generatedVolumeName, err := dsw.AddPodToVolume(
+		podName, pod, volumeSpec, volumeSpec.Name(), "" /* volumeGidValue */, nil /* seLinuxContainerContexts */)
+	if err != nil {
+		t.Fatalf("AddPodToVolume failed. Expected: <no error> Actual: <%v>", err)
+	}
+
+	verifyVolumeExistsDsw(t, generatedVolumeName, "" /* SELinuxContext */, dsw)
+	verifyVolumeExistsInVolumesToMount(t, generatedVolumeName, false /* expectReportedInUse */, dsw)
+	verifyPodExistsInVolumeDsw(t, podName, generatedVolumeName, "" /* SELinuxContext */, dsw)
+	verifyVolumeExistsWithSpecNameInVolumeDsw(t, podName, volumeSpec.Name(), dsw)
+
+	m := dsw.GetPods()
+	if len(m) != 1 {
+		t.Errorf("GetPods failed. Expected: <1> in desired state of world, Actual: <%d> in desired state of world", len(m))
+	}
+
+	dsw.AddErrorToPod(podName, "fake-error")
+	podsWithErrors := dsw.GetPodsWithErrors()
+	if len(podsWithErrors) != 1 {
+		t.Fatalf("GetPodsWithErrors failed. Expected <1> pod with error in desired state of world, Actual <%d>", len(podsWithErrors))
+	}
+	if podsWithErrors[0] != podName {
+		t.Errorf("expected pod errored %s but got %s", podName, podsWithErrors[0])
+	}
+	accumulatedErrors := dsw.PopPodErrors(podName)
+	if !slices.Equal(accumulatedErrors, []string{"fake-error"}) {
+		t.Errorf("expected accumulated errors %v on pod %s but got %v", []string{"fake-error"}, podName, accumulatedErrors)
+	}
+	podsWithErrors = dsw.GetPodsWithErrors()
+	if len(podsWithErrors) > 0 {
+		t.Errorf("GetPodsWithErrors failed. Expected <0> pod with error in desired state of world, Actual <%d>", len(podsWithErrors))
+	}
 }
 
 func verifyVolumeExistsDsw(

--- a/pkg/kubelet/volumemanager/metrics/metrics_test.go
+++ b/pkg/kubelet/volumemanager/metrics/metrics_test.go
@@ -17,12 +17,12 @@ limitations under the License.
 package metrics
 
 import (
-	"k8s.io/klog/v2/ktesting"
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2/ktesting"
 	"k8s.io/kubernetes/pkg/kubelet/volumemanager/cache"
 	"k8s.io/kubernetes/pkg/volume"
 
@@ -124,5 +124,12 @@ func TestMetricCollection(t *testing.T) {
 	if fakePluginCount != 1 {
 		t.Errorf("getVolumeCount failed. Expected <1> fake-plugin volume in ActualStateOfWorld, got <%d>",
 			fakePluginCount)
+	}
+
+	// detach volume from the node and ensure metric collector is correctly updated
+	dsw.DeletePodFromVolume(podName, generatedVolumeName)
+	asw.MarkVolumeAsDetached(generatedVolumeName, k8stypes.NodeName("node-name"))
+	if count := metricCollector.getVolumeCount(); len(count) != 1 {
+		t.Errorf("getVolumeCount failed. Expected <1> state, got <%d>", len(count))
 	}
 }

--- a/pkg/kubelet/volumemanager/reconciler/reconstruct_test.go
+++ b/pkg/kubelet/volumemanager/reconciler/reconstruct_test.go
@@ -263,6 +263,7 @@ func TestReconstructVolumesMount(t *testing.T) {
 		expectMount     bool
 		volumeMode      v1.PersistentVolumeMode
 		deviceMountPath string
+		podNotAdded     bool
 	}{
 		{
 			name:       "reconstructed volume is mounted",
@@ -283,6 +284,13 @@ func TestReconstructVolumesMount(t *testing.T) {
 			volumePath:      filepath.Join("pod1uid", "volumeDevices", "fake-plugin", volumetesting.FailMountDeviceVolumeName),
 			volumeMode:      v1.PersistentVolumeBlock,
 			deviceMountPath: filepath.Join("plugins", "fake-plugin", "volumeDevices", "pluginDependentPath"),
+		},
+		{
+			name:            "reconstructed volume, pod hasn't been added",
+			volumePath:      filepath.Join("pod1uid", "volumeDevices", "fake-plugin", volumetesting.FailMountDeviceVolumeName),
+			volumeMode:      v1.PersistentVolumeBlock,
+			deviceMountPath: filepath.Join("plugins", "fake-plugin", "volumeDevices", "pluginDependentPath"),
+			podNotAdded:     true,
 		},
 	}
 	for _, tc := range tests {
@@ -338,7 +346,7 @@ func TestReconstructVolumesMount(t *testing.T) {
 
 			rcInstance.populatorHasAddedPods = func() bool {
 				// Mark DSW populated to allow unmounting of volumes.
-				return true
+				return !tc.podNotAdded
 			}
 			// Mark devices paths as reconciled to allow unmounting of volumes.
 			rcInstance.volumesNeedUpdateFromNodeStatus = nil


### PR DESCRIPTION

/kind cleanup

#### What this PR does / why we need it:

If applied this commit will improve unit test coverage of `pkg/kubelet/volumemanager`.

- before
<img width="740" alt="Screenshot 2024-05-14 at 17 39 35" src="https://github.com/kubernetes/kubernetes/assets/9576370/707f3701-7e1f-4187-a0d4-5e0383158d04">

- after
<img width="739" alt="Screenshot 2024-05-16 at 18 31 07" src="https://github.com/kubernetes/kubernetes/assets/9576370/cf77bdca-5757-44aa-88bc-274384266ed0">


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
