### PR TITLE
Delete volumeattachment with resourceVersion in pv Detach operation

### DIFF
--- a/pkg/volume/csi/csi_plugin_test.go
+++ b/pkg/volume/csi/csi_plugin_test.go
@@ -47,15 +47,19 @@ const (
 )
 
 func newTestPlugin(t *testing.T, client *fakeclient.Clientset) (*csiPlugin, string) {
-	return newTestPluginWithVolumeHost(t, client, kubeletVolumeHostType)
+	return newTestPluginWithVolumeHost(t, client, CsiResyncPeriod, kubeletVolumeHostType)
 }
 
 func newTestPluginWithAttachDetachVolumeHost(t *testing.T, client *fakeclient.Clientset) (*csiPlugin, string) {
-	return newTestPluginWithVolumeHost(t, client, attachDetachVolumeHostType)
+	return newTestPluginWithVolumeHost(t, client, CsiResyncPeriod, attachDetachVolumeHostType)
+}
+
+func newTestPluginWithAttachDetachVolumeHostWithResyncPeriod(t *testing.T, client *fakeclient.Clientset, resyncPeriod time.Duration) (*csiPlugin, string) {
+	return newTestPluginWithVolumeHost(t, client, resyncPeriod, attachDetachVolumeHostType)
 }
 
 // create a plugin mgr to load plugins and setup a fake client
-func newTestPluginWithVolumeHost(t *testing.T, client *fakeclient.Clientset, hostType int) (*csiPlugin, string) {
+func newTestPluginWithVolumeHost(t *testing.T, client *fakeclient.Clientset, resyncPeriod time.Duration, hostType int) (*csiPlugin, string) {
 	tmpDir, err := utiltesting.MkTmpdir("csi-test")
 	if err != nil {
 		t.Fatalf("can't create temp dir: %v", err)
@@ -73,7 +77,7 @@ func newTestPluginWithVolumeHost(t *testing.T, client *fakeclient.Clientset, hos
 	})
 
 	// Start informer for CSIDrivers.
-	factory := informers.NewSharedInformerFactory(client, CsiResyncPeriod)
+	factory := informers.NewSharedInformerFactory(client, resyncPeriod)
 	csiDriverInformer := factory.Storage().V1().CSIDrivers()
 	csiDriverLister := csiDriverInformer.Lister()
 	volumeAttachmentInformer := factory.Storage().V1().VolumeAttachments()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
When va finalizers patch operation and va deletion operation are performed at the same time, deletion with resourceVersion can avoid accidental deletion of va when finalizers patch operation is successful.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #124749

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Volumeattachment deletion in the csi detach will pass resourceVersion to deleteOptions.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
