### PR TITLE
WIP: volumebinding: scheduler queueing hints - phase1

### DIFF
--- a/pkg/scheduler/framework/plugins/volumebinding/volume_binding.go
+++ b/pkg/scheduler/framework/plugins/volumebinding/volume_binding.go
@@ -24,10 +24,13 @@ import (
 	"time"
 
 	v1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/component-helpers/storage/ephemeral"
+	"k8s.io/component-helpers/storage/volume"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config/validation"
@@ -35,6 +38,7 @@ import (
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/feature"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/helper"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/names"
+	"k8s.io/kubernetes/pkg/scheduler/util"
 )
 
 const (
@@ -96,10 +100,10 @@ func (pl *VolumeBinding) EventsToRegister() []framework.ClusterEventWithHint {
 		// Pods may fail because of missing or mis-configured storage class
 		// (e.g., allowedTopologies, volumeBindingMode), and hence may become
 		// schedulable upon StorageClass Add or Update events.
-		{Event: framework.ClusterEvent{Resource: framework.StorageClass, ActionType: framework.Add | framework.Update}},
+		{Event: framework.ClusterEvent{Resource: framework.StorageClass, ActionType: framework.Add | framework.Update}, QueueingHintFn: pl.isSchedulableAfterStorageClassChange},
 		// We bind PVCs with PVs, so any changes may make the pods schedulable.
-		{Event: framework.ClusterEvent{Resource: framework.PersistentVolumeClaim, ActionType: framework.Add | framework.Update}},
-		{Event: framework.ClusterEvent{Resource: framework.PersistentVolume, ActionType: framework.Add | framework.Update}},
+		{Event: framework.ClusterEvent{Resource: framework.PersistentVolumeClaim, ActionType: framework.Add | framework.Update}, QueueingHintFn: pl.isSchedulableAfterPersistentVolumeClaimChange},
+		{Event: framework.ClusterEvent{Resource: framework.PersistentVolume, ActionType: framework.Add | framework.Update}, QueueingHintFn: pl.isSchedulableAfterPersistentVolumeChange},
 		// Pods may fail to find available PVs because the node labels do not
 		// match the storage class's allowed topologies or PV's node affinity.
 		// A new or updated node may make pods schedulable.
@@ -118,9 +122,212 @@ func (pl *VolumeBinding) EventsToRegister() []framework.ClusterEventWithHint {
 		// When CSIStorageCapacity is enabled, pods may become schedulable
 		// on CSI driver & storage capacity changes.
 		{Event: framework.ClusterEvent{Resource: framework.CSIDriver, ActionType: framework.Add | framework.Update}},
-		{Event: framework.ClusterEvent{Resource: framework.CSIStorageCapacity, ActionType: framework.Add | framework.Update}},
+		{Event: framework.ClusterEvent{Resource: framework.CSIStorageCapacity, ActionType: framework.Add | framework.Update}, QueueingHintFn: pl.isSchedulableAfterCSIStorageCapacityChange},
 	}
 	return events
+}
+
+func (pl *VolumeBinding) isSchedulableAfterStorageClassChange(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (framework.QueueingHint, error) {
+	oldSC, newSC, err := util.As[*storagev1.StorageClass](oldObj, newObj)
+	if err != nil {
+		return framework.Queue, err
+	}
+
+	logger = klog.LoggerWithValues(
+		logger,
+		"Pod", klog.KObj(pod),
+		"StorageClass", klog.KObj(newSC),
+	)
+
+	result, err := processPodVolumesForQHint(pod, func(pvcName string, isEphemeral bool) (bool, error) {
+		pvc, err := pl.PVCLister.PersistentVolumeClaims(pod.Namespace).Get(pvcName)
+		if err != nil {
+			if isEphemeral && apierrors.IsNotFound(err) {
+				err = fmt.Errorf("waiting for ephemeral volume controller to create the persistentvolumeclaim %q", pvcName)
+				return false, err
+			}
+			return false, err
+		}
+
+		className := volume.GetPersistentVolumeClaimClass(pvc)
+		if className == "" {
+			return false, fmt.Errorf("no class for claim %q", pvcName)
+		}
+
+		if className == newSC.Name {
+			if oldSC == nil {
+				logger.V(4).Info("StorageClass was created")
+				return true, nil
+			}
+
+			if !apiequality.Semantic.DeepEqual(newSC.AllowedTopologies, oldSC.AllowedTopologies) {
+				logger.V(4).Info("StorageClass was created or updated, and changed Provisioner", "AllowedTopologies", newSC.AllowedTopologies)
+				return true, nil
+			}
+		}
+
+		return false, nil
+	})
+
+	if err != nil {
+		return framework.Queue, err
+	}
+
+	if result {
+		return framework.Queue, nil
+	}
+
+	logger.V(4).Info("StorageClass was created or updated, but it doesn't make this pod schedulable")
+	return framework.QueueSkip, nil
+}
+
+func (pl *VolumeBinding) isSchedulableAfterPersistentVolumeClaimChange(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (framework.QueueingHint, error) {
+	oldPVC, newPVC, err := util.As[*v1.PersistentVolumeClaim](oldObj, newObj)
+	if err != nil {
+		return framework.Queue, err
+	}
+
+	logger = klog.LoggerWithValues(
+		logger,
+		"Pod", klog.KObj(pod),
+		"PersistentVolumeClaim", klog.KObj(newPVC),
+	)
+
+	result, err := processPodVolumesForQHint(pod, func(pvcName string, isEphemeral bool) (bool, error) {
+		if pvcName == newPVC.Name {
+			if oldPVC == nil {
+				logger.V(4).Info("PersistentVolumeClaim was created")
+				return true, nil
+			}
+
+			if newPVC.Status.Phase != oldPVC.Status.Phase {
+				logger.V(4).Info("PersistentVolumeClaim referenced by the Pod was created or updated, and changed Provisioner", "Phase", newPVC.Status.Phase)
+				return true, nil
+			}
+
+			if !apiequality.Semantic.DeepEqual(newPVC.Annotations, oldPVC.Annotations) {
+				logger.V(4).Info("PersistentVolumeClaim referenced by the Pod was created or updated, and changed Annotations")
+				return true, nil
+			}
+
+			if !apiequality.Semantic.DeepEqual(newPVC.Spec, oldPVC.Spec) {
+				logger.V(4).Info("PersistentVolumeClaim referenced by the Pod was created or updated, and changed Spec")
+				return true, nil
+			}
+		}
+
+		return false, nil
+	})
+
+	if err != nil {
+		return framework.Queue, err
+	}
+
+	if result {
+		return framework.Queue, nil
+	}
+
+	logger.V(4).Info("PersistentVolumeClaim was created or updated, but it doesn't make this pod schedulable")
+	return framework.QueueSkip, nil
+}
+
+func (pl *VolumeBinding) isSchedulableAfterPersistentVolumeChange(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (framework.QueueingHint, error) {
+	_, newPV, err := util.As[*v1.PersistentVolume](oldObj, newObj)
+	if err != nil {
+		return framework.Queue, err
+	}
+
+	logger = klog.LoggerWithValues(
+		logger,
+		"Pod", klog.KObj(pod),
+		"PersistentVolume", klog.KObj(newPV),
+	)
+
+	for _, vol := range pod.Spec.Volumes {
+		if vol.Name == newPV.Name {
+			logger.V(4).Info("PersistentVolume referenced by the Pod was created or updated")
+			return framework.Queue, nil
+		}
+	}
+
+	logger.V(4).Info("PersistentVolumeClaim was created or updated, but it doesn't make this pod schedulable")
+	return framework.QueueSkip, nil
+}
+
+func (pl *VolumeBinding) isSchedulableAfterCSIStorageCapacityChange(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (framework.QueueingHint, error) {
+	oldCap, newCap, err := util.As[*storagev1.CSIStorageCapacity](oldObj, newObj)
+	if err != nil {
+		return framework.Queue, err
+	}
+
+	logger = klog.LoggerWithValues(
+		logger,
+		"Pod", klog.KObj(pod),
+		"CSIStorageCapacity", klog.KObj(newCap),
+	)
+
+	result, err := processPodVolumesForQHint(pod, func(pvcName string, isEphemeral bool) (bool, error) {
+		pvc, err := pl.PVCLister.PersistentVolumeClaims(pod.Namespace).Get(pvcName)
+		if err != nil {
+			if isEphemeral && apierrors.IsNotFound(err) {
+				err = fmt.Errorf("waiting for ephemeral volume controller to create the persistentvolumeclaim %q", pvcName)
+				return true, err
+			}
+			return true, err
+		}
+
+		className := volume.GetPersistentVolumeClaimClass(pvc)
+		if className == "" {
+			return true, fmt.Errorf("no class for claim %q", pvcName)
+		}
+
+		if newCap.StorageClassName == className {
+			if oldCap == nil {
+				logger.V(4).Info("CSIStorageCapacity was created")
+				return true, nil
+			}
+
+			if newCap.Capacity != oldCap.Capacity {
+				logger.V(4).Info("CSIStorageCapacity referenced by the Pod was created or updated, and changed Capacity", "Capacity", newCap.Capacity)
+				return true, nil
+			}
+
+			if newCap.MaximumVolumeSize != oldCap.MaximumVolumeSize {
+				logger.V(4).Info("CSIStorageCapacity referenced by the Pod was created or updated, and changed MaximumVolumeSize", "MaximumVolumeSize", newCap.MaximumVolumeSize)
+				return true, nil
+			}
+		}
+
+		return false, nil
+	})
+
+	if err != nil {
+		return framework.Queue, err
+	}
+
+	if result {
+		return framework.Queue, nil
+	}
+
+	logger.V(4).Info("CSIStorageCapacity was created or updated, but it doesn't make this pod schedulable")
+	return framework.QueueSkip, nil
+}
+
+func processPodVolumesForQHint(pod *v1.Pod, fn func(string, bool) (bool, error)) (bool, error) {
+	for _, vol := range pod.Spec.Volumes {
+		hasPVC, pvcName, isEphemeral := getVolumeClaimName(pod, &vol)
+		if !hasPVC {
+			continue
+		}
+		result, err := fn(pvcName, isEphemeral)
+		if err != nil {
+			return false, err
+		}
+		if result {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 // podHasPVCs returns 2 values:
@@ -129,16 +336,8 @@ func (pl *VolumeBinding) EventsToRegister() []framework.ClusterEventWithHint {
 func (pl *VolumeBinding) podHasPVCs(pod *v1.Pod) (bool, error) {
 	hasPVC := false
 	for _, vol := range pod.Spec.Volumes {
-		var pvcName string
-		isEphemeral := false
-		switch {
-		case vol.PersistentVolumeClaim != nil:
-			pvcName = vol.PersistentVolumeClaim.ClaimName
-		case vol.Ephemeral != nil:
-			pvcName = ephemeral.VolumeClaimName(pod, &vol)
-			isEphemeral = true
-		default:
-			// Volume is not using a PVC, ignore
+		hasPVC2, pvcName, isEphemeral := getVolumeClaimName(pod, &vol)
+		if !hasPVC2 {
 			continue
 		}
 		hasPVC = true
@@ -168,6 +367,16 @@ func (pl *VolumeBinding) podHasPVCs(pod *v1.Pod) (bool, error) {
 		}
 	}
 	return hasPVC, nil
+}
+
+func getVolumeClaimName(pod *v1.Pod, vol *v1.Volume) (bool, string, bool) {
+	switch {
+	case vol.PersistentVolumeClaim != nil:
+		return true, vol.PersistentVolumeClaim.ClaimName, false
+	case vol.Ephemeral != nil:
+		return true, ephemeral.VolumeClaimName(pod, vol), true
+	}
+	return false, "", false
 }
 
 // PreFilter invoked at the prefilter extension point to check if pod has all


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

#### What this PR does / why we need it:

kube-scheduler implements scheduling hints for the VolumeBinding plugin.
The scheduling hints allow the scheduler to retry scheduling a Pod that was previously rejected by the VolumeBinding plugin only if a new resource referenced by the plugin was created or an existing resource referenced by the plugin was updated.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of https://github.com/kubernetes/kubernetes/issues/118893
KEP: https://github.com/kubernetes/enhancements/blob/master/keps/sig-scheduling/4247-queueinghint/README.md

#### Special notes for your reviewer:

<details><summary>Fields Impacting QueueingHintFn</summary>
<p>
<strong>PersistentVolume (PV)</strong> is not included in this table because it can undergo extensive changes when a conversion is performed by csi-translation-lib.
</p>

| resource | field | Referenced in PreFilter+Filter? | Admission Overwrite Prevention Config | Need to Check Changes in QHint? |
| ---- | ---- | ---- | --- | --- |
| StorageClass | .metadata.labels  | x | x | x |
| StorageClass | .metadata.annotations  | x | x | x |
| StorageClass | .provisioner  | o | o | x |
| StorageClass | .parameters  | x | o | x |
| StorageClass | .reclaimPolicy  | x | o | x |
| StorageClass | .mountOptions  | x | o | x |
| StorageClass | .allowVolumeExpansion  | x | x | x |
| StorageClass | .volumeBindingMode  | o | x | o |
| StorageClass | .allowedTopologies  | o | x | o |
| PersistentVolumeClaim(PVC) | .metadata.labels  | x | x | x |
| PersistentVolumeClaim(PVC) | .metadata.annotations  | o | o | o |
| PersistentVolumeClaim(PVC) | .spec.accessModes | o | x | o |
| PersistentVolumeClaim(PVC) | .spec.selector | o | o | x |
| PersistentVolumeClaim(PVC) | .spec.resources | o | o | x |
| PersistentVolumeClaim(PVC) | .spec.volumeName | o | o | x |
| PersistentVolumeClaim(PVC) | .spec.storageClassName | o | x | o |
| PersistentVolumeClaim(PVC) | .spec.volumeMode | x | o | x |
| PersistentVolumeClaim(PVC) | .spec.dataSource | x | o | x |
| PersistentVolumeClaim(PVC) | .spec.dataSourceRef | x | o | x |
| PersistentVolumeClaim(PVC) | .spec.volumeAttributesClassName | x | o | x |
| PersistentVolumeClaim(PVC) | .status.phase | o | x | o |
| PersistentVolumeClaim(PVC) | .status.accessModes | x | x | x |
| PersistentVolumeClaim(PVC) | .status.capacity | x | x | x |
| PersistentVolumeClaim(PVC) | .status.conditions | x | x | x |
| PersistentVolumeClaim(PVC) | .status.allocatedResources | x | x | x |
| PersistentVolumeClaim(PVC) | .status.allocatedResourceStatuses | x | x | x |
| PersistentVolumeClaim(PVC) | .status.currentVolumeAttributesClassName | x | x | x |
| PersistentVolumeClaim(PVC) | .status.modifyVolumeStatus | x | x | x |
| Node | .metadata.labels  | o | x | o |
| Node | .metadata.annotations  | x | o | x |
| Node | .spec.podCIDR | x | x | x |
| Node | .spec.podCIDRs | x | o | x |
| Node | .spec.providerID | x | o | x |
| Node | .spec.unschedulable | x | x | x |
| Node | .spec.taints | x | x | x |
| Node | .spec.configSource | x | x | x |
| Node | .spec.externalID | x | o | x |
| Node | .status.capacity | x | x | x |
| Node | .status.allocatable | x | x | x |
| Node | .status.phase | x | x | x |
| Node | .status.conditions | x | x | x |
| Node | .status.addresses | x | o | x |
| Node | .status.daemonEndpoints | x | x | x |
| Node | .status.nodeInfo | x | x | x |
| Node | .status.images | x | x | x |
| Node | .status.volumesInUse | x | x | x |
| Node | .status.volumesAttached | x | x | x |
| Node | .status.config | x | x | x |
| Node | .status.runtimeHandlers | x | x | x |
| CSINode | .metadata.labels  | x | x | x |
| CSINode | .metadata.annotations  | o | x | o |
| CSINode | .spec.drivers.name | x | o | x |
| CSINode | .spec.drivers.nodeID | x | o | x |
| CSINode | .spec.drivers.topologyKeys | x | o | x |
| CSINode | .spec.drivers.allocatable | x | o | x |
| CSIDriver | .metadata.labels  | x | o | x |
| CSIDriver | .metadata.annotations  | o | o | x |
| CSIDriver | .spec.attachRequired | x | o | x |
| CSIDriver | .spec.podInfoOnMount | x | x | x |
| CSIDriver | .spec.VolumeLifecycleMode | x | o | x |
| CSIDriver | .spec.storageCapacity | o | x | o |
| CSIDriver | .spec.fsGroupPolicy | x | x | x |
| CSIDriver | .spec.tokenRequests | x | x | x |
| CSIDriver | .spec.requiresRepublish | x | x | x |
| CSIDriver | .spec.seLinuxMount | x | x | x |
| CSIStorageCapacity | .metadata.labels  | x | x | x |
| CSIStorageCapacity | .metadata.annotations  | x | x | x |
| CSIStorageCapacity | .nodeTopology | o | o | x |
| CSIStorageCapacity | .storageClassName | o | o | x |
| CSIStorageCapacity | .capacity | o | x | o |
| CSIStorageCapacity | .maximumVolumeSize | o | x | o |

ref(ja): https://zenn.dev/bells17/scraps/65bd6891012bdc

</details> 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kube-scheduler implements scheduling hints for the VolumeBinding plugin.
The scheduling hints allow the scheduler to retry scheduling a Pod that was previously rejected by the VolumeBinding plugin only if a new resource referenced by the plugin was created or an existing resource referenced by the plugin was updated.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
