### PR TITLE
deflake network policies job

### DIFF
--- a/cluster/addons/kube-network-policies/kube-network-policies.yaml
+++ b/cluster/addons/kube-network-policies/kube-network-policies.yaml
@@ -27,7 +27,7 @@ spec:
       serviceAccountName: kube-network-policies
       containers:
       - name: kube-network-policies
-        image: registry.k8s.io/networking/kube-network-policies:v0.2.0
+        image: gcr.io/k8s-staging-networking/kube-network-policies:v20240518-081163b
         command:
         - /bin/sh
         - -c


### PR DESCRIPTION
/kind flake

This uses a new version with a possible fix for https://github.com/kubernetes-sigs/kube-network-policies/issues/12

It is not easy to repro and does not manifest in the CI with a high rate https://testgrid.k8s.io/sig-network-gce#network-policies,%20google-gce so I don't want to cut a new release until I'm confident the workaround in https://github.com/kubernetes-sigs/kube-network-policies/pull/24 solves the problem

```release-note
NONE
```