### PR TITLE
feat: support GroupVersionResources with all resources inside a specific group

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/auth/cani.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/auth/cani.go
@@ -310,8 +310,13 @@ func (o *CanIOptions) RunAccessCheck() (bool, error) {
 }
 
 func (o *CanIOptions) resourceFor(mapper meta.RESTMapper, resourceArg string) schema.GroupVersionResource {
-	if resourceArg == "*" {
-		return schema.GroupVersionResource{Resource: resourceArg}
+	if strings.HasPrefix(resourceArg, "*") {
+		r := strings.Split(resourceArg, ".")
+		if len(r) == 1 {
+			return schema.GroupVersionResource{Resource: resourceArg}
+		} else {
+			return schema.GroupVersionResource{Resource: r[0], Group: r[1]}
+		}
 	}
 
 	fullySpecifiedGVR, groupResource := schema.ParseResourceArg(strings.ToLower(resourceArg))

--- a/staging/src/k8s.io/kubectl/pkg/cmd/auth/cani_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/auth/cani_test.go
@@ -64,6 +64,15 @@ func TestRunAccessCheck(t *testing.T) {
 			},
 		},
 		{
+			name:    "access all resources within a specific group",
+			o:       &CanIOptions{},
+			args:    []string{"get", "*.apps"},
+			allowed: true,
+			expectedBodyStrings: []string{
+				`{"resourceAttributes":{"namespace":"test","verb":"get","group":"apps","resource":"*"}}`,
+			},
+		},
+		{
 			name: "all namespaces",
 			o: &CanIOptions{
 				AllNamespaces: true,
@@ -246,6 +255,15 @@ func TestRunResourceFor(t *testing.T) {
 			resourceArg: "*",
 			expectGVR: schema.GroupVersionResource{
 				Resource: "*",
+			},
+		},
+		{
+			name:        "any resources inside a specific group",
+			o:           &CanIOptions{},
+			resourceArg: "*.apps",
+			expectGVR: schema.GroupVersionResource{
+				Resource: "*",
+				Group:    "apps",
 			},
 		},
 		{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

#### What this PR does / why we need it:
This PR aims to support GroupVersionsResources with all resources inside a specific group

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubectl/issues/1549

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
support GroupVersionResources with * for resources within a specific group for kubectl auth can-i command
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
N/A
```
