### PR TITLE
Remove unused field from APIGroupVersion

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/apiserver_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/apiserver_test.go
@@ -237,7 +237,6 @@ func handleInternal(storage map[string]rest.Storage, admissionControl admission.
 		Defaulter:       scheme,
 		Typer:           scheme,
 		Namer:           namer,
-		RootScopedKinds: sets.NewString("SimpleRoot"),
 
 		EquivalentResourceRegistry: runtime.NewEquivalentResourceRegistry(),
 
@@ -3311,7 +3310,6 @@ func TestParentResourceIsRequired(t *testing.T) {
 		Defaulter:       scheme,
 		Typer:           scheme,
 		Namer:           namer,
-		RootScopedKinds: sets.NewString("SimpleRoot"),
 
 		EquivalentResourceRegistry: runtime.NewEquivalentResourceRegistry(),
 

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/groupversion.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/groupversion.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/managedfields"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apiserver/pkg/admission"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 	"k8s.io/apiserver/pkg/endpoints/discovery"
@@ -70,9 +69,6 @@ type APIGroupVersion struct {
 	// common API implementations like ListOptions. Future changes will allow this to vary by group
 	// version (for when the inevitable meta/v2 group emerges).
 	MetaGroupVersion *schema.GroupVersion
-
-	// RootScopedKinds are the root scoped kinds for the primary GroupVersion
-	RootScopedKinds sets.String
 
 	// Serializer is used to determine how to convert responses from API methods into bytes to send over
 	// the wire.


### PR DESCRIPTION
RootScopedKinds is only present in unit tests, and is not referenced anywhere else.

/kind cleanup

#### What this PR does / why we need it:

Remove unused field from apiserver public api.

#### Special notes for your reviewer:


#### Does this PR introduce a user-facing change?
```release-note
NONE
```