### PR TITLE
EventedPLEG: Stop waiting for cache update when it is not expected

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1959,6 +1959,12 @@ func (kl *Kubelet) SyncPod(ctx context.Context, updateType kubetypes.SyncPodType
 	sctx := context.WithoutCancel(ctx)
 	result := kl.containerRuntime.SyncPod(sctx, pod, podStatus, pullSecrets, kl.backOff)
 	kl.reasonCache.Update(pod.UID, result)
+	if utilfeature.DefaultFeatureGate.Enabled(features.EventedPLEG) {
+		if err := kl.syncPLEGCache(pod, podStatus, &result); err != nil {
+			klog.ErrorS(err, "Failed to update pod cache", "pod", klog.KObj(pod))
+			return false, err
+		}
+	}
 	if err := result.Error(); err != nil {
 		// Do not return error if the only failures were pods in backoff
 		for _, r := range result.SyncResults {
@@ -1982,6 +1988,27 @@ func (kl *Kubelet) SyncPod(ctx context.Context, updateType kubetypes.SyncPodType
 	}
 
 	return false, nil
+}
+
+// syncPLEGCache updates PLEG cache after pod lifecycle actions are completed
+// so that pod worker actions and PLEG cache are synced.
+func (kl *Kubelet) syncPLEGCache(pod *v1.Pod, podStatus *kubecontainer.PodStatus, result *kubecontainer.PodSyncResult) error {
+	needsUpdate := false
+	for _, r := range result.SyncResults {
+		if r.Error == nil && (r.Action == kubecontainer.StartContainer || r.Action == kubecontainer.KillContainer) {
+			needsUpdate = true
+			break
+		}
+	}
+	if !needsUpdate {
+		return nil
+	}
+
+	runtimePod := kubecontainer.ConvertPodStatusToRunningPod(kl.getRuntime().Type(), podStatus)
+	if err, _ := kl.pleg.UpdateCache(&runtimePod, pod.UID); err != nil {
+		return err
+	}
+	return nil
 }
 
 // SyncTerminatingPod is expected to terminate all running containers in a pod. Once this method
@@ -2039,10 +2066,27 @@ func (kl *Kubelet) SyncTerminatingPod(_ context.Context, pod *v1.Pod, podStatus 
 	// catch race conditions introduced by callers updating pod status out of order.
 	// TODO: have KillPod return the terminal status of stopped containers and write that into the
 	//  cache immediately
-	stoppedPodStatus, err := kl.containerRuntime.GetPodStatus(ctx, pod.UID, pod.Name, pod.Namespace)
-	if err != nil {
-		klog.ErrorS(err, "Unable to read pod status prior to final pod termination", "pod", klog.KObj(pod), "podUID", pod.UID)
-		return err
+	var stoppedPodStatus *kubecontainer.PodStatus
+	if utilfeature.DefaultFeatureGate.Enabled(features.EventedPLEG) {
+		// Update the PLEG cache so that podworker actions and PLEG cache are synched.
+		runtimePod := kubecontainer.ConvertPodStatusToRunningPod(kl.getRuntime().Type(), podStatus)
+		if err, _ := kl.pleg.UpdateCache(&runtimePod, pod.UID); err != nil {
+			klog.ErrorS(err, "Unable to read pod status prior to final pod termination", "pod", klog.KObj(pod), "podUID", pod.UID)
+			return err
+		}
+		var err error
+		stoppedPodStatus, err = kl.podCache.Get(pod.UID)
+		if err != nil {
+			klog.ErrorS(err, "Unable to read pod status prior to final pod termination", "pod", klog.KObj(pod), "podUID", pod.UID)
+			return err
+		}
+	} else {
+		var err error
+		stoppedPodStatus, err = kl.containerRuntime.GetPodStatus(ctx, pod.UID, pod.Name, pod.Namespace)
+		if err != nil {
+			klog.ErrorS(err, "Unable to read pod status prior to final pod termination", "pod", klog.KObj(pod), "podUID", pod.UID)
+			return err
+		}
 	}
 	preserveDataFromBeforeStopping(stoppedPodStatus, podStatus)
 	var runningContainers []string

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -1500,6 +1500,7 @@ func (m *kubeGenericRuntimeManager) GeneratePodStatus(event *runtimeapi.Containe
 		IPs:               podIPs,
 		SandboxStatuses:   []*runtimeapi.PodSandboxStatus{event.PodSandboxStatus},
 		ContainerStatuses: kubeContainerStatuses,
+		TimeStamp:         time.Unix(0, event.GetCreatedAt()),
 	}, nil
 }
 

--- a/pkg/kubelet/pleg/generic.go
+++ b/pkg/kubelet/pleg/generic.go
@@ -475,7 +475,7 @@ func (g *GenericPLEG) updateCache(ctx context.Context, pod *kubecontainer.Pod, p
 	// Evented PLEG after the event has been received by the Kubelet.
 	// For more details refer to:
 	// https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/3386-kubelet-evented-pleg#timestamp-of-the-pod-status
-	if utilfeature.DefaultFeatureGate.Enabled(features.EventedPLEG) && isEventedPLEGInUse() && status != nil {
+	if utilfeature.DefaultFeatureGate.Enabled(features.EventedPLEG) && isEventedPLEGInUse() && status != nil && !status.TimeStamp.IsZero() {
 		timestamp = status.TimeStamp
 	}
 

--- a/pkg/kubelet/pleg/generic.go
+++ b/pkg/kubelet/pleg/generic.go
@@ -475,8 +475,12 @@ func (g *GenericPLEG) updateCache(ctx context.Context, pod *kubecontainer.Pod, p
 	// Evented PLEG after the event has been received by the Kubelet.
 	// For more details refer to:
 	// https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/3386-kubelet-evented-pleg#timestamp-of-the-pod-status
-	if utilfeature.DefaultFeatureGate.Enabled(features.EventedPLEG) && isEventedPLEGInUse() && status != nil && !status.TimeStamp.IsZero() {
-		timestamp = status.TimeStamp
+	if utilfeature.DefaultFeatureGate.Enabled(features.EventedPLEG) && isEventedPLEGInUse() && status != nil {
+		if status.TimeStamp.IsZero() {
+			status.TimeStamp = timestamp
+		} else {
+			timestamp = status.TimeStamp
+		}
 	}
 
 	return err, g.cache.Set(pod.ID, status, err, timestamp)

--- a/pkg/kubelet/pod_workers.go
+++ b/pkg/kubelet/pod_workers.go
@@ -1249,6 +1249,9 @@ func (p *podWorkers) podWorkerLoop(podUID types.UID, podUpdates <-chan struct{})
 			default:
 				if utilfeature.DefaultFeatureGate.Enabled(features.EventedPLEG) {
 					status, err = p.podCache.Get(update.Options.Pod.UID)
+					if err == nil && status.TimeStamp.Before(lastSyncTime) {
+						status, err = p.podCache.GetNewerThan(update.Options.Pod.UID, lastSyncTime)
+					}
 				} else {
 					// wait until we see the next refresh from the PLEG via the cache (max 2s)
 					// TODO: this adds ~1s of latency on all transitions from sync to terminating


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:
This fix replaces `podCache.GetNewerThan()` with `podCache.Get()` at the main loop of pod workers.

Currently, a pod worker waits for the PLEG to update cache along with a PLEG event by calling `GetNewerThan()` at every time syncing a pod:
https://github.com/kubernetes/kubernetes/blob/93f82d25a5b10577116e4a72f77fb5e635e65490/pkg/kubelet/pod_workers.go#L1256

However, there are some cases where the pod worker syncs the pod triggered by other events than PLEG events such as probe failures and pod termination. In these cases, the pod worker gets unnecessarily blocked at `GetNewerThan()` till the PLEG updates the global timestamp of the cache. With `EventedPLEG` enabled, the global timestamp is updated every five seconds. This delay is too long to ignore.

In this PR, a pod worker asks the PLEG to update a cached status of a pod after it requested actions to cause pod lifecycle events such as starting and stopping containers. Then, the pod worker will not need to wait at `podCache.GetNewerThan()` before the next sync because the cache has been updated.

In order to verify this PR, run `pull-kubernetes-node-crio-cgrpv1-evented-pleg-e2e` and confirm the following failures don't appear:
```
E2eNode Suite: [It] [sig-node] [NodeFeature:SidecarContainers] Containers Lifecycle [It] should not hang in termination if terminated during initialization [sig-node, NodeFeature:SidecarContainers]
{ failed [FAILED] should delete in < 5 seconds, took 10.071795
Expected
    <float64>: 10.071794756
to be <
    <int64>: 5
In [It] at: k8s.io/kubernetes/test/e2e_node/container_lifecycle_test.go:3470 @ 09/10/24 08:54:31.819
}

E2eNode Suite.[It] [sig-node] [NodeConformance] Containers Lifecycle when a pod is terminating because its liveness probe fails should continue running liveness probes for restartable init containers and restart them while in preStop [NodeConformance]
{ failed [FAILED] Expected an error to have occurred.  Got:
    <nil>: nil
In [It] at: k8s.io/kubernetes/test/e2e_node/container_lifecycle_test.go:903 @ 08/23/24 18:16:25.131
}
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #124704, Fixes #127312

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
