### PR TITLE
volumebinding: scheduler queueing hints - PersistentVolumeClaim

### DIFF
--- a/pkg/scheduler/framework/plugins/volumebinding/volume_binding_test.go
+++ b/pkg/scheduler/framework/plugins/volumebinding/volume_binding_test.go
@@ -996,3 +996,100 @@ func TestIsSchedulableAfterCSINodeChange(t *testing.T) {
 		})
 	}
 }
+
+func TestIsSchedulableAfterPersistentVolumeClaimChange(t *testing.T) {
+	table := []struct {
+		name    string
+		pod     *v1.Pod
+		oldPVC  interface{}
+		newPVC  interface{}
+		wantErr bool
+		expect  framework.QueueingHint
+	}{
+		{
+			name:    "pod has no pvc or ephemeral volumes",
+			pod:     makePod("pod-a").withEmptyDirVolume().Pod,
+			oldPVC:  makePVC("pvc-b", "sc-a").PersistentVolumeClaim,
+			newPVC:  makePVC("pvc-b", "sc-a").PersistentVolumeClaim,
+			wantErr: false,
+			expect:  framework.QueueSkip,
+		},
+		{
+			name: "pvc with the same name as the one used by the pod in a different namespace is modified",
+			pod: makePod("pod-a").
+				withNamespace("ns-a").
+				withPVCVolume("pvc-a", "").
+				withPVCVolume("pvc-b", "").
+				Pod,
+			oldPVC:  nil,
+			newPVC:  makePVC("pvc-b", "").PersistentVolumeClaim,
+			wantErr: false,
+			expect:  framework.QueueSkip,
+		},
+		{
+			name: "pod has no pvc that is being modified",
+			pod: makePod("pod-a").
+				withPVCVolume("pvc-a", "").
+				withPVCVolume("pvc-c", "").
+				Pod,
+			oldPVC:  makePVC("pvc-b", "").PersistentVolumeClaim,
+			newPVC:  makePVC("pvc-b", "").PersistentVolumeClaim,
+			wantErr: false,
+			expect:  framework.QueueSkip,
+		},
+		{
+			name: "pod has no generic ephemeral volume that is being modified",
+			pod: makePod("pod-a").
+				withGenericEphemeralVolume("ephemeral-a").
+				withGenericEphemeralVolume("ephemeral-c").
+				Pod,
+			oldPVC:  makePVC("pod-a-ephemeral-b", "").PersistentVolumeClaim,
+			newPVC:  makePVC("pod-a-ephemeral-b", "").PersistentVolumeClaim,
+			wantErr: false,
+			expect:  framework.QueueSkip,
+		},
+		{
+			name: "pod has the pvc that is being modified",
+			pod: makePod("pod-a").
+				withPVCVolume("pvc-a", "").
+				withPVCVolume("pvc-b", "").
+				Pod,
+			oldPVC:  makePVC("pvc-b", "").PersistentVolumeClaim,
+			newPVC:  makePVC("pvc-b", "").PersistentVolumeClaim,
+			wantErr: false,
+			expect:  framework.Queue,
+		},
+		{
+			name: "pod has the generic ephemeral volume that is being modified",
+			pod: makePod("pod-a").
+				withGenericEphemeralVolume("ephemeral-a").
+				withGenericEphemeralVolume("ephemeral-b").
+				Pod,
+			oldPVC:  makePVC("pod-a-ephemeral-b", "").PersistentVolumeClaim,
+			newPVC:  makePVC("pod-a-ephemeral-b", "").PersistentVolumeClaim,
+			wantErr: false,
+			expect:  framework.Queue,
+		},
+		{
+			name:    "type conversion error",
+			oldPVC:  new(struct{}),
+			newPVC:  new(struct{}),
+			wantErr: true,
+			expect:  framework.Queue,
+		},
+	}
+
+	for _, item := range table {
+		t.Run(item.name, func(t *testing.T) {
+			pl := &VolumeBinding{}
+			logger, _ := ktesting.NewTestContext(t)
+			qhint, err := pl.isSchedulableAfterPersistentVolumeClaimChange(logger, item.pod, item.oldPVC, item.newPVC)
+			if (err != nil) != item.wantErr {
+				t.Errorf("isSchedulableAfterPersistentVolumeClaimChange failed - got: %q", err)
+			}
+			if qhint != item.expect {
+				t.Errorf("QHint does not match: %v, want: %v", qhint, item.expect)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

#### What this PR does / why we need it:

kube-scheduler implements scheduling hints for the VolumeBinding plugin.
The scheduling hints allow the scheduler to determine whether to retry or skip scheduling a Pod based on the changes made to the PersistentVolumeClaim resource referenced by the plugin.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of https://github.com/kubernetes/kubernetes/issues/118893
KEP: https://github.com/kubernetes/enhancements/blob/master/keps/sig-scheduling/4247-queueinghint/README.md
Base PR: https://github.com/kubernetes/kubernetes/pull/124939

#### Special notes for your reviewer:

<details><summary>Fields Impacting QueueingHintFn</summary>
<p>
<strong>PersistentVolume (PV)</strong> is not included in this table because it can undergo extensive changes when a conversion is performed by csi-translation-lib.
</p>

| resource | field | Referenced in PreFilter+Filter? | Admission Overwrite Prevention Config | Need to Check Changes in QHint? |
| ---- | ---- | ---- | --- | --- |
| PersistentVolumeClaim(PVC) | .metadata.labels  | x | x | x |
| PersistentVolumeClaim(PVC) | .metadata.annotations  | o | o | o |
| PersistentVolumeClaim(PVC) | .spec.accessModes | o | x | o |
| PersistentVolumeClaim(PVC) | .spec.selector | o | o | x |
| PersistentVolumeClaim(PVC) | .spec.resources | o | o | x |
| PersistentVolumeClaim(PVC) | .spec.volumeName | o | o | x |
| PersistentVolumeClaim(PVC) | .spec.storageClassName | o | x | o |
| PersistentVolumeClaim(PVC) | .spec.volumeMode | x | o | x |
| PersistentVolumeClaim(PVC) | .spec.dataSource | x | o | x |
| PersistentVolumeClaim(PVC) | .spec.dataSourceRef | x | o | x |
| PersistentVolumeClaim(PVC) | .spec.volumeAttributesClassName | x | o | x |
| PersistentVolumeClaim(PVC) | .status.phase | o | x | o |
| PersistentVolumeClaim(PVC) | .status.accessModes | x | x | x |
| PersistentVolumeClaim(PVC) | .status.capacity | x | x | x |
| PersistentVolumeClaim(PVC) | .status.conditions | x | x | x |
| PersistentVolumeClaim(PVC) | .status.allocatedResources | x | x | x |
| PersistentVolumeClaim(PVC) | .status.allocatedResourceStatuses | x | x | x |
| PersistentVolumeClaim(PVC) | .status.currentVolumeAttributesClassName | x | x | x |
| PersistentVolumeClaim(PVC) | .status.modifyVolumeStatus | x | x | x |

ref(ja): https://zenn.dev/bells17/scraps/65bd6891012bdc

</details> 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kube-scheduler implements scheduling hints for the VolumeBinding plugin.
The scheduling hints allow the scheduler to retry scheduling a Pod that was previously rejected by the VolumeBinding plugin only if a new resource referenced by the plugin was created or an existing resource referenced by the plugin was updated.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
