### PR TITLE
volumebinding: scheduler queueing hints - PersistentVolume

### DIFF
--- a/pkg/scheduler/framework/plugins/volumebinding/volume_binding.go
+++ b/pkg/scheduler/framework/plugins/volumebinding/volume_binding.go
@@ -100,7 +100,7 @@ func (pl *VolumeBinding) EventsToRegister() []framework.ClusterEventWithHint {
 		{Event: framework.ClusterEvent{Resource: framework.StorageClass, ActionType: framework.Add | framework.Update}},
 		// We bind PVCs with PVs, so any changes may make the pods schedulable.
 		{Event: framework.ClusterEvent{Resource: framework.PersistentVolumeClaim, ActionType: framework.Add | framework.Update}},
-		{Event: framework.ClusterEvent{Resource: framework.PersistentVolume, ActionType: framework.Add | framework.Update}, QueueingHintFn: pl.isSchedulableAfterPersistentVolumeAddOrChange},
+		{Event: framework.ClusterEvent{Resource: framework.PersistentVolume, ActionType: framework.Add | framework.Update}, QueueingHintFn: pl.isSchedulableAfterPersistentVolumeChange},
 		// Pods may fail to find available PVs because the node labels do not
 		// match the storage class's allowed topologies or PV's node affinity.
 		// A new or updated node may make pods schedulable.
@@ -171,7 +171,7 @@ func (pl *VolumeBinding) podHasPVCs(pod *v1.Pod) (bool, error) {
 	return hasPVC, nil
 }
 
-func (pl *VolumeBinding) isSchedulableAfterPersistentVolumeAddOrChange(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (framework.QueueingHint, error) {
+func (pl *VolumeBinding) isSchedulableAfterPersistentVolumeChange(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (framework.QueueingHint, error) {
 	_, newPV, err := util.As[*v1.PersistentVolume](oldObj, newObj)
 	if err != nil {
 		return framework.Queue, err
@@ -190,7 +190,7 @@ func (pl *VolumeBinding) isSchedulableAfterPersistentVolumeAddOrChange(logger kl
 		}
 	}
 
-	logger.V(4).Info("PersistentVolumeClaim was created or updated, but it doesn't make this pod schedulable")
+	logger.V(4).Info("PersistentVolume was created or updated, but it doesn't make this pod schedulable")
 	return framework.QueueSkip, nil
 }
 

--- a/pkg/scheduler/framework/plugins/volumebinding/volume_binding_test.go
+++ b/pkg/scheduler/framework/plugins/volumebinding/volume_binding_test.go
@@ -891,7 +891,7 @@ func TestVolumeBinding(t *testing.T) {
 	}
 }
 
-func TestIsSchedulableAfterPersistentVolumeAddOrChange(t *testing.T) {
+func TestIsSchedulableAfterPersistentVolumeChange(t *testing.T) {
 	table := []struct {
 		name           string
 		pod            *v1.Pod
@@ -980,13 +980,13 @@ func TestIsSchedulableAfterPersistentVolumeAddOrChange(t *testing.T) {
 			var qhint framework.QueueingHint
 			var err error
 			if item.useEmptyStruct {
-				qhint, err = pl.isSchedulableAfterPersistentVolumeAddOrChange(logger, item.pod, new(struct{}), new(struct{}))
+				qhint, err = pl.isSchedulableAfterPersistentVolumeChange(logger, item.pod, new(struct{}), new(struct{}))
 			} else {
-				qhint, err = pl.isSchedulableAfterPersistentVolumeAddOrChange(logger, item.pod, item.oldPV, item.newPV)
+				qhint, err = pl.isSchedulableAfterPersistentVolumeChange(logger, item.pod, item.oldPV, item.newPV)
 			}
 
 			if (item.err && err == nil) || (!item.err && err != nil) {
-				t.Errorf("isSchedulableAfterPersistentVolumeAddOrChange failed - got: %q", err)
+				t.Errorf("isSchedulableAfterPersistentVolumeChange failed - got: %q", err)
 			}
 			if qhint != item.expect {
 				t.Errorf("QHint does not match: %v, want: %v", qhint, item.expect)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

#### What this PR does / why we need it:

kube-scheduler implements scheduling hints for the VolumeBinding plugin.
The scheduling hints allow the scheduler to determine whether to retry or skip scheduling a Pod based on the changes made to the PersistentVolume resource referenced by the plugin.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of https://github.com/kubernetes/kubernetes/issues/118893
KEP: https://github.com/kubernetes/enhancements/blob/master/keps/sig-scheduling/4247-queueinghint/README.md
Base PR: https://github.com/kubernetes/kubernetes/pull/124939

#### Special notes for your reviewer:

<details><summary>Fields Impacting QueueingHintFn</summary>
<p>
<strong>PersistentVolume (PV)</strong> is not included in this table because it can undergo extensive changes when a conversion is performed by csi-translation-lib.
</p>

| resource | field | Referenced in PreFilter+Filter? | Admission Overwrite Prevention Config | Need to Check Changes in QHint? |
| ---- | ---- | ---- | --- | --- |
| PersistentVolume(PV) | .metadata.labels  | o | x | o |
| PersistentVolume(PV) | .metadata.annotations  | o | x | o |
| PersistentVolume(PV) | .spec.capacity | o | x | o |
| PersistentVolume(PV) | .spec.(PersistentVolumeSource) | o | o | x |
| PersistentVolume(PV) | .spec.accessModes | o | x | o |
| PersistentVolume(PV) | .spec.claimRef | o | x | o |
| PersistentVolume(PV) | .spec.persistentVolumeReclaimPolicy | o | x | o |
| PersistentVolume(PV) | .spec.storageClassName | o | x | o |
| PersistentVolume(PV) | .spec.mountOptions | o | x | o |
| PersistentVolume(PV) | .spec.volumeMode | o | o | x |
| PersistentVolume(PV) | .spec.nodeAffinity | o | o | o |
| PersistentVolume(PV) | .spec.volumeAttributesClassName | o | o | x |
| PersistentVolume(PV) | .status.phase | o | x | o |
| PersistentVolume(PV) | .status.message | o | x | o |
| PersistentVolume(PV) | .status.reason | o | x | o |
| PersistentVolume(PV) | .status.lastPhaseTransitionTime | o | x | o |

ref(ja): https://zenn.dev/bells17/scraps/65bd6891012bdc

</details> 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kube-scheduler implements scheduling hints for the VolumeBinding plugin.
The scheduling hints allow the scheduler to retry scheduling a Pod that was previously rejected by the VolumeBinding plugin only if a new resource referenced by the plugin was created or an existing resource referenced by the plugin was updated.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
