### PR TITLE
volumebinding: scheduler queueing hints - CSIStorageCapacity

### DIFF
--- a/pkg/scheduler/framework/plugins/volumebinding/binder.go
+++ b/pkg/scheduler/framework/plugins/volumebinding/binder.go
@@ -1054,9 +1054,6 @@ func capacitySufficient(capacity *storagev1.CSIStorageCapacity, sizeInBytes int6
 }
 
 func volumeLimit(capacity *storagev1.CSIStorageCapacity) *resource.Quantity {
-	if capacity == nil {
-		return nil
-	}
 	if capacity.MaximumVolumeSize != nil {
 		// Prefer MaximumVolumeSize if available, it is more precise.
 		return capacity.MaximumVolumeSize

--- a/pkg/scheduler/framework/plugins/volumebinding/binder.go
+++ b/pkg/scheduler/framework/plugins/volumebinding/binder.go
@@ -27,6 +27,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -1048,12 +1049,19 @@ func (b *volumeBinder) hasEnoughCapacity(logger klog.Logger, provisioner string,
 }
 
 func capacitySufficient(capacity *storagev1.CSIStorageCapacity, sizeInBytes int64) bool {
-	limit := capacity.Capacity
+	limit := volumeLimit(capacity)
+	return limit != nil && limit.Value() >= sizeInBytes
+}
+
+func volumeLimit(capacity *storagev1.CSIStorageCapacity) *resource.Quantity {
+	if capacity == nil {
+		return nil
+	}
 	if capacity.MaximumVolumeSize != nil {
 		// Prefer MaximumVolumeSize if available, it is more precise.
-		limit = capacity.MaximumVolumeSize
+		return capacity.MaximumVolumeSize
 	}
-	return limit != nil && limit.Value() >= sizeInBytes
+	return capacity.Capacity
 }
 
 func (b *volumeBinder) nodeHasAccess(logger klog.Logger, node *v1.Node, capacity *storagev1.CSIStorageCapacity) bool {

--- a/pkg/scheduler/framework/plugins/volumebinding/volume_binding.go
+++ b/pkg/scheduler/framework/plugins/volumebinding/volume_binding.go
@@ -240,6 +240,15 @@ func (pl *VolumeBinding) isSchedulableAfterCSIStorageCapacityChange(logger klog.
 		return framework.Queue, err
 	}
 
+	if oldCap == nil {
+		logger.V(5).Info(
+			"A new CSIStorageCapacity was created, which could make a Pod schedulable",
+			"Pod", klog.KObj(pod),
+			"CSIStorageCapacity", klog.KObj(newCap),
+		)
+		return framework.Queue, nil
+	}
+
 	oldLimit := volumeLimit(oldCap)
 	newLimit := volumeLimit(newCap)
 
@@ -250,11 +259,6 @@ func (pl *VolumeBinding) isSchedulableAfterCSIStorageCapacityChange(logger klog.
 		"volumeLimit(new)", newLimit,
 		"volumeLimit(old)", oldLimit,
 	)
-
-	if oldCap == nil {
-		logger.V(5).Info("A new CSIStorageCapacity was created, which could make a Pod schedulable")
-		return framework.Queue, nil
-	}
 
 	if newLimit != nil && (oldLimit == nil || newLimit.Value() > oldLimit.Value()) {
 		logger.V(5).Info("VolumeLimit was increased, which could make a Pod schedulable", "volumeLimit(new)", newLimit, "volumeLimit(old)", oldLimit)

--- a/pkg/scheduler/framework/plugins/volumebinding/volume_binding.go
+++ b/pkg/scheduler/framework/plugins/volumebinding/volume_binding.go
@@ -265,7 +265,7 @@ func (pl *VolumeBinding) isSchedulableAfterCSIStorageCapacityChange(logger klog.
 		return framework.Queue, nil
 	}
 
-	logger.V(5).Info("CSIStorageCapacity was updated, But it doesn't make this pod schedulable")
+	logger.V(5).Info("CSIStorageCapacity was updated, but it doesn't make this pod schedulable")
 	return framework.QueueSkip, nil
 }
 

--- a/pkg/scheduler/framework/plugins/volumebinding/volume_binding.go
+++ b/pkg/scheduler/framework/plugins/volumebinding/volume_binding.go
@@ -261,7 +261,7 @@ func (pl *VolumeBinding) isSchedulableAfterCSIStorageCapacityChange(logger klog.
 	)
 
 	if newLimit != nil && (oldLimit == nil || newLimit.Value() > oldLimit.Value()) {
-		logger.V(5).Info("VolumeLimit was increased, which could make a Pod schedulable", "volumeLimit(new)", newLimit, "volumeLimit(old)", oldLimit)
+		logger.V(5).Info("VolumeLimit was increased, which could make a Pod schedulable")
 		return framework.Queue, nil
 	}
 

--- a/pkg/scheduler/framework/plugins/volumebinding/volume_binding_test.go
+++ b/pkg/scheduler/framework/plugins/volumebinding/volume_binding_test.go
@@ -1204,7 +1204,7 @@ func TestIsSchedulableAfterCSIStorageCapacityChange(t *testing.T) {
 			expect:  framework.Queue,
 		},
 		{
-			name: "When the Capacity is set, it returns Queue",
+			name: "When the volume limit is increase(Capacity set), it returns Queue",
 			pod:  makePod("pod-a").Pod,
 			oldCap: &storagev1.CSIStorageCapacity{
 				ObjectMeta: metav1.ObjectMeta{
@@ -1221,48 +1221,12 @@ func TestIsSchedulableAfterCSIStorageCapacityChange(t *testing.T) {
 			expect:  framework.Queue,
 		},
 		{
-			name: "When the Capacity is increase, it returns Queue",
+			name: "When the volume limit is increase(MaximumVolumeSize set), it returns Queue",
 			pod:  makePod("pod-a").Pod,
 			oldCap: &storagev1.CSIStorageCapacity{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cap-a",
 				},
-				Capacity: resource.NewQuantity(50, resource.DecimalSI),
-			},
-			newCap: &storagev1.CSIStorageCapacity{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "cap-a",
-				},
-				Capacity: resource.NewQuantity(100, resource.DecimalSI),
-			},
-			wantErr: false,
-			expect:  framework.Queue,
-		},
-		{
-			name: "When the MaximumVolumeSize is changed to nil, it returns Queue",
-			pod:  makePod("pod-a").Pod,
-			oldCap: &storagev1.CSIStorageCapacity{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "cap-a",
-				},
-				MaximumVolumeSize: resource.NewQuantity(50, resource.DecimalSI),
-			},
-			newCap: &storagev1.CSIStorageCapacity{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "cap-a",
-				},
-			},
-			wantErr: false,
-			expect:  framework.Queue,
-		},
-		{
-			name: "When the MaximumVolumeSize is increased, it returns Queue",
-			pod:  makePod("pod-a").Pod,
-			oldCap: &storagev1.CSIStorageCapacity{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "cap-a",
-				},
-				MaximumVolumeSize: resource.NewQuantity(50, resource.DecimalSI),
 			},
 			newCap: &storagev1.CSIStorageCapacity{
 				ObjectMeta: metav1.ObjectMeta{
@@ -1274,23 +1238,84 @@ func TestIsSchedulableAfterCSIStorageCapacityChange(t *testing.T) {
 			expect:  framework.Queue,
 		},
 		{
+			name: "When the volume limit is increase(Capacity increase), it returns Queue",
+			pod:  makePod("pod-a").Pod,
+			oldCap: &storagev1.CSIStorageCapacity{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cap-a",
+				},
+				Capacity: resource.NewQuantity(50, resource.DecimalSI),
+			},
+			newCap: &storagev1.CSIStorageCapacity{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cap-a",
+				},
+				Capacity: resource.NewQuantity(100, resource.DecimalSI),
+			},
+			wantErr: false,
+			expect:  framework.Queue,
+		},
+		{
+			name: "When the volume limit is increase(MaximumVolumeSize unset), it returns Queue",
+			pod:  makePod("pod-a").Pod,
+			oldCap: &storagev1.CSIStorageCapacity{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cap-a",
+				},
+				Capacity:          resource.NewQuantity(100, resource.DecimalSI),
+				MaximumVolumeSize: resource.NewQuantity(50, resource.DecimalSI),
+			},
+			newCap: &storagev1.CSIStorageCapacity{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cap-a",
+				},
+				Capacity: resource.NewQuantity(100, resource.DecimalSI),
+			},
+			wantErr: false,
+			expect:  framework.Queue,
+		},
+		{
+			name: "When the volume limit is increase(MaximumVolumeSize increase), it returns Queue",
+			pod:  makePod("pod-a").Pod,
+			oldCap: &storagev1.CSIStorageCapacity{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cap-a",
+				},
+				Capacity:          resource.NewQuantity(100, resource.DecimalSI),
+				MaximumVolumeSize: resource.NewQuantity(50, resource.DecimalSI),
+			},
+			newCap: &storagev1.CSIStorageCapacity{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cap-a",
+				},
+				Capacity:          resource.NewQuantity(100, resource.DecimalSI),
+				MaximumVolumeSize: resource.NewQuantity(60, resource.DecimalSI),
+			},
+			wantErr: false,
+			expect:  framework.Queue,
+		},
+		{
 			name: "When there are no changes to the CSIStorageCapacity, it returns QueueSkip",
 			pod:  makePod("pod-a").Pod,
 			oldCap: &storagev1.CSIStorageCapacity{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cap-a",
 				},
+				Capacity:          resource.NewQuantity(100, resource.DecimalSI),
+				MaximumVolumeSize: resource.NewQuantity(50, resource.DecimalSI),
 			},
 			newCap: &storagev1.CSIStorageCapacity{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cap-a",
 				},
+				Capacity:          resource.NewQuantity(100, resource.DecimalSI),
+				MaximumVolumeSize: resource.NewQuantity(50, resource.DecimalSI),
 			},
 			wantErr: false,
 			expect:  framework.QueueSkip,
 		},
 		{
-			name: "When the Capacity is equal, it returns QueueSkip",
+			name: "When the volume limit is equal(Capacity), it returns QueueSkip",
 			pod:  makePod("pod-a").Pod,
 			oldCap: &storagev1.CSIStorageCapacity{
 				ObjectMeta: metav1.ObjectMeta{
@@ -1308,13 +1333,14 @@ func TestIsSchedulableAfterCSIStorageCapacityChange(t *testing.T) {
 			expect:  framework.QueueSkip,
 		},
 		{
-			name: "When the Capacity is decrease, it returns QueueSkip",
+			name: "When the volume limit is equal(MaximumVolumeSize unset), it returns QueueSkip",
 			pod:  makePod("pod-a").Pod,
 			oldCap: &storagev1.CSIStorageCapacity{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cap-a",
 				},
-				Capacity: resource.NewQuantity(100, resource.DecimalSI),
+				Capacity:          resource.NewQuantity(100, resource.DecimalSI),
+				MaximumVolumeSize: resource.NewQuantity(50, resource.DecimalSI),
 			},
 			newCap: &storagev1.CSIStorageCapacity{
 				ObjectMeta: metav1.ObjectMeta{
@@ -1326,7 +1352,7 @@ func TestIsSchedulableAfterCSIStorageCapacityChange(t *testing.T) {
 			expect:  framework.QueueSkip,
 		},
 		{
-			name: "When the Capacity is nil, it returns QueueSkip",
+			name: "When the volume limit is decrease(Capacity), it returns QueueSkip",
 			pod:  makePod("pod-a").Pod,
 			oldCap: &storagev1.CSIStorageCapacity{
 				ObjectMeta: metav1.ObjectMeta{
@@ -1338,59 +1364,25 @@ func TestIsSchedulableAfterCSIStorageCapacityChange(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cap-a",
 				},
+				Capacity: resource.NewQuantity(90, resource.DecimalSI),
 			},
 			wantErr: false,
 			expect:  framework.QueueSkip,
 		},
 		{
-			name: "When the MaximumVolumeSize is equal, it returns QueueSkip",
+			name: "When the volume limit is decrease(MaximumVolumeSize), it returns QueueSkip",
 			pod:  makePod("pod-a").Pod,
 			oldCap: &storagev1.CSIStorageCapacity{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cap-a",
 				},
-				MaximumVolumeSize: resource.NewQuantity(50, resource.DecimalSI),
+				MaximumVolumeSize: resource.NewQuantity(100, resource.DecimalSI),
 			},
 			newCap: &storagev1.CSIStorageCapacity{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cap-a",
 				},
-				MaximumVolumeSize: resource.NewQuantity(50, resource.DecimalSI),
-			},
-			wantErr: false,
-			expect:  framework.QueueSkip,
-		},
-		{
-			name: "When the MaximumVolumeSize is decreased, it returns QueueSkip",
-			pod:  makePod("pod-a").Pod,
-			oldCap: &storagev1.CSIStorageCapacity{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "cap-a",
-				},
-				MaximumVolumeSize: resource.NewQuantity(50, resource.DecimalSI),
-			},
-			newCap: &storagev1.CSIStorageCapacity{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "cap-a",
-				},
-				MaximumVolumeSize: resource.NewQuantity(40, resource.DecimalSI),
-			},
-			wantErr: false,
-			expect:  framework.QueueSkip,
-		},
-		{
-			name: "When the MaximumVolumeSize is set, it returns QueueSkip",
-			pod:  makePod("pod-a").Pod,
-			oldCap: &storagev1.CSIStorageCapacity{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "cap-a",
-				},
-			},
-			newCap: &storagev1.CSIStorageCapacity{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "cap-a",
-				},
-				MaximumVolumeSize: resource.NewQuantity(50, resource.DecimalSI),
+				MaximumVolumeSize: resource.NewQuantity(90, resource.DecimalSI),
 			},
 			wantErr: false,
 			expect:  framework.QueueSkip,

--- a/pkg/scheduler/framework/plugins/volumebinding/volume_binding_test.go
+++ b/pkg/scheduler/framework/plugins/volumebinding/volume_binding_test.go
@@ -1402,7 +1402,7 @@ func TestIsSchedulableAfterCSIStorageCapacityChange(t *testing.T) {
 			logger, _ := ktesting.NewTestContext(t)
 			qhint, err := pl.isSchedulableAfterCSIStorageCapacityChange(logger, item.pod, item.oldCap, item.newCap)
 			if (err != nil) != item.wantErr {
-				t.Errorf("isSchedulableAfterCSIStorageCapacityChange failed - got: %q", err)
+				t.Errorf("error is unexpectedly returned or not returned from isSchedulableAfterCSIStorageCapacityChange. wantErr: %v actual error: %q", item.wantErr, err)
 			}
 			if qhint != item.expect {
 				t.Errorf("QHint does not match: %v, want: %v", qhint, item.expect)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

#### What this PR does / why we need it:

kube-scheduler implements scheduling hints for the VolumeBinding plugin.
The scheduling hints allow the scheduler to determine whether to retry or skip scheduling a Pod based on the changes made to the CSIStorageCapacity resource referenced by the plugin.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of https://github.com/kubernetes/kubernetes/issues/118893
KEP: https://github.com/kubernetes/enhancements/blob/master/keps/sig-scheduling/4247-queueinghint/README.md
Base PR: https://github.com/kubernetes/kubernetes/pull/124939

#### Special notes for your reviewer:

<details><summary>Fields Impacting QueueingHintFn</summary>
<p>
<strong>PersistentVolume (PV)</strong> is not included in this table because it can undergo extensive changes when a conversion is performed by csi-translation-lib.
</p>

| resource | field | Referenced in PreFilter+Filter? | Admission Overwrite Prevention Config | Need to Check Changes in QHint? |
| ---- | ---- | ---- | --- | --- |
| CSIStorageCapacity | .metadata.labels  | x | x | x |
| CSIStorageCapacity | .metadata.annotations  | x | x | x |
| CSIStorageCapacity | .nodeTopology | o | o | x |
| CSIStorageCapacity | .storageClassName | o | o | x |
| CSIStorageCapacity | .capacity | o | x | o |
| CSIStorageCapacity | .maximumVolumeSize | o | x | o |

ref(ja): https://zenn.dev/bells17/scraps/65bd6891012bdc

</details> 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kube-scheduler implements scheduling hints for the VolumeBinding plugin.
The scheduling hints allow the scheduler to retry scheduling a Pod that was previously rejected by the VolumeBinding plugin only if a new resource referenced by the plugin was created or an existing resource referenced by the plugin was updated.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
