### PR TITLE
client-go: data consistency checker for list requests

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1/customresourcedefinition.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1/customresourcedefinition.go
@@ -31,6 +31,7 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 )
 
 // CustomResourceDefinitionsGetter has a method to return a CustomResourceDefinitionInterface.
@@ -81,6 +82,16 @@ func (c *customResourceDefinitions) Get(ctx context.Context, name string, option
 
 // List takes label and field selectors, and returns the list of CustomResourceDefinitions that match those selectors.
 func (c *customResourceDefinitions) List(ctx context.Context, opts v1.ListOptions) (result *v1beta1.CustomResourceDefinitionList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for customresourcedefinitions", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of CustomResourceDefinitions that match those selectors.
+func (c *customResourceDefinitions) list(ctx context.Context, opts v1.ListOptions) (result *v1beta1.CustomResourceDefinitionList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1/mutatingwebhookconfiguration.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1/mutatingwebhookconfiguration.go
@@ -31,6 +31,7 @@ import (
 	admissionregistrationv1 "k8s.io/client-go/applyconfigurations/admissionregistration/v1"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 )
 
 // MutatingWebhookConfigurationsGetter has a method to return a MutatingWebhookConfigurationInterface.
@@ -79,6 +80,16 @@ func (c *mutatingWebhookConfigurations) Get(ctx context.Context, name string, op
 
 // List takes label and field selectors, and returns the list of MutatingWebhookConfigurations that match those selectors.
 func (c *mutatingWebhookConfigurations) List(ctx context.Context, opts metav1.ListOptions) (result *v1.MutatingWebhookConfigurationList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for mutatingwebhookconfigurations", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of MutatingWebhookConfigurations that match those selectors.
+func (c *mutatingWebhookConfigurations) list(ctx context.Context, opts metav1.ListOptions) (result *v1.MutatingWebhookConfigurationList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1/validatingadmissionpolicy.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1/validatingadmissionpolicy.go
@@ -31,6 +31,7 @@ import (
 	admissionregistrationv1 "k8s.io/client-go/applyconfigurations/admissionregistration/v1"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 )
 
 // ValidatingAdmissionPoliciesGetter has a method to return a ValidatingAdmissionPolicyInterface.
@@ -81,6 +82,16 @@ func (c *validatingAdmissionPolicies) Get(ctx context.Context, name string, opti
 
 // List takes label and field selectors, and returns the list of ValidatingAdmissionPolicies that match those selectors.
 func (c *validatingAdmissionPolicies) List(ctx context.Context, opts metav1.ListOptions) (result *v1.ValidatingAdmissionPolicyList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for validatingadmissionpolicies", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of ValidatingAdmissionPolicies that match those selectors.
+func (c *validatingAdmissionPolicies) list(ctx context.Context, opts metav1.ListOptions) (result *v1.ValidatingAdmissionPolicyList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1/validatingadmissionpolicybinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1/validatingadmissionpolicybinding.go
@@ -31,6 +31,7 @@ import (
 	admissionregistrationv1 "k8s.io/client-go/applyconfigurations/admissionregistration/v1"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 )
 
 // ValidatingAdmissionPolicyBindingsGetter has a method to return a ValidatingAdmissionPolicyBindingInterface.
@@ -79,6 +80,16 @@ func (c *validatingAdmissionPolicyBindings) Get(ctx context.Context, name string
 
 // List takes label and field selectors, and returns the list of ValidatingAdmissionPolicyBindings that match those selectors.
 func (c *validatingAdmissionPolicyBindings) List(ctx context.Context, opts metav1.ListOptions) (result *v1.ValidatingAdmissionPolicyBindingList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for validatingadmissionpolicybindings", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of ValidatingAdmissionPolicyBindings that match those selectors.
+func (c *validatingAdmissionPolicyBindings) list(ctx context.Context, opts metav1.ListOptions) (result *v1.ValidatingAdmissionPolicyBindingList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1/validatingwebhookconfiguration.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1/validatingwebhookconfiguration.go
@@ -31,6 +31,7 @@ import (
 	admissionregistrationv1 "k8s.io/client-go/applyconfigurations/admissionregistration/v1"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 )
 
 // ValidatingWebhookConfigurationsGetter has a method to return a ValidatingWebhookConfigurationInterface.
@@ -79,6 +80,16 @@ func (c *validatingWebhookConfigurations) Get(ctx context.Context, name string, 
 
 // List takes label and field selectors, and returns the list of ValidatingWebhookConfigurations that match those selectors.
 func (c *validatingWebhookConfigurations) List(ctx context.Context, opts metav1.ListOptions) (result *v1.ValidatingWebhookConfigurationList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for validatingwebhookconfigurations", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of ValidatingWebhookConfigurations that match those selectors.
+func (c *validatingWebhookConfigurations) list(ctx context.Context, opts metav1.ListOptions) (result *v1.ValidatingWebhookConfigurationList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1alpha1/validatingadmissionpolicy.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1alpha1/validatingadmissionpolicy.go
@@ -31,6 +31,7 @@ import (
 	admissionregistrationv1alpha1 "k8s.io/client-go/applyconfigurations/admissionregistration/v1alpha1"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 )
 
 // ValidatingAdmissionPoliciesGetter has a method to return a ValidatingAdmissionPolicyInterface.
@@ -81,6 +82,16 @@ func (c *validatingAdmissionPolicies) Get(ctx context.Context, name string, opti
 
 // List takes label and field selectors, and returns the list of ValidatingAdmissionPolicies that match those selectors.
 func (c *validatingAdmissionPolicies) List(ctx context.Context, opts v1.ListOptions) (result *v1alpha1.ValidatingAdmissionPolicyList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for validatingadmissionpolicies", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of ValidatingAdmissionPolicies that match those selectors.
+func (c *validatingAdmissionPolicies) list(ctx context.Context, opts v1.ListOptions) (result *v1alpha1.ValidatingAdmissionPolicyList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1alpha1/validatingadmissionpolicybinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1alpha1/validatingadmissionpolicybinding.go
@@ -31,6 +31,7 @@ import (
 	admissionregistrationv1alpha1 "k8s.io/client-go/applyconfigurations/admissionregistration/v1alpha1"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 )
 
 // ValidatingAdmissionPolicyBindingsGetter has a method to return a ValidatingAdmissionPolicyBindingInterface.
@@ -79,6 +80,16 @@ func (c *validatingAdmissionPolicyBindings) Get(ctx context.Context, name string
 
 // List takes label and field selectors, and returns the list of ValidatingAdmissionPolicyBindings that match those selectors.
 func (c *validatingAdmissionPolicyBindings) List(ctx context.Context, opts v1.ListOptions) (result *v1alpha1.ValidatingAdmissionPolicyBindingList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for validatingadmissionpolicybindings", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of ValidatingAdmissionPolicyBindings that match those selectors.
+func (c *validatingAdmissionPolicyBindings) list(ctx context.Context, opts v1.ListOptions) (result *v1alpha1.ValidatingAdmissionPolicyBindingList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1/validatingadmissionpolicy.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1/validatingadmissionpolicy.go
@@ -31,6 +31,7 @@ import (
 	admissionregistrationv1beta1 "k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 )
 
 // ValidatingAdmissionPoliciesGetter has a method to return a ValidatingAdmissionPolicyInterface.
@@ -81,6 +82,16 @@ func (c *validatingAdmissionPolicies) Get(ctx context.Context, name string, opti
 
 // List takes label and field selectors, and returns the list of ValidatingAdmissionPolicies that match those selectors.
 func (c *validatingAdmissionPolicies) List(ctx context.Context, opts v1.ListOptions) (result *v1beta1.ValidatingAdmissionPolicyList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for validatingadmissionpolicies", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of ValidatingAdmissionPolicies that match those selectors.
+func (c *validatingAdmissionPolicies) list(ctx context.Context, opts v1.ListOptions) (result *v1beta1.ValidatingAdmissionPolicyList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1/validatingadmissionpolicybinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1/validatingadmissionpolicybinding.go
@@ -31,6 +31,7 @@ import (
 	admissionregistrationv1beta1 "k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 )
 
 // ValidatingAdmissionPolicyBindingsGetter has a method to return a ValidatingAdmissionPolicyBindingInterface.
@@ -79,6 +80,16 @@ func (c *validatingAdmissionPolicyBindings) Get(ctx context.Context, name string
 
 // List takes label and field selectors, and returns the list of ValidatingAdmissionPolicyBindings that match those selectors.
 func (c *validatingAdmissionPolicyBindings) List(ctx context.Context, opts v1.ListOptions) (result *v1beta1.ValidatingAdmissionPolicyBindingList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for validatingadmissionpolicybindings", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of ValidatingAdmissionPolicyBindings that match those selectors.
+func (c *validatingAdmissionPolicyBindings) list(ctx context.Context, opts v1.ListOptions) (result *v1beta1.ValidatingAdmissionPolicyBindingList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1/validatingwebhookconfiguration.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1/validatingwebhookconfiguration.go
@@ -31,6 +31,7 @@ import (
 	admissionregistrationv1beta1 "k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 )
 
 // ValidatingWebhookConfigurationsGetter has a method to return a ValidatingWebhookConfigurationInterface.
@@ -79,6 +80,16 @@ func (c *validatingWebhookConfigurations) Get(ctx context.Context, name string, 
 
 // List takes label and field selectors, and returns the list of ValidatingWebhookConfigurations that match those selectors.
 func (c *validatingWebhookConfigurations) List(ctx context.Context, opts v1.ListOptions) (result *v1beta1.ValidatingWebhookConfigurationList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for validatingwebhookconfigurations", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of ValidatingWebhookConfigurations that match those selectors.
+func (c *validatingWebhookConfigurations) list(ctx context.Context, opts v1.ListOptions) (result *v1beta1.ValidatingWebhookConfigurationList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/daemonset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/daemonset.go
@@ -31,6 +31,7 @@ import (
 	appsv1 "k8s.io/client-go/applyconfigurations/apps/v1"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 )
 
 // DaemonSetsGetter has a method to return a DaemonSetInterface.
@@ -84,6 +85,16 @@ func (c *daemonSets) Get(ctx context.Context, name string, options metav1.GetOpt
 
 // List takes label and field selectors, and returns the list of DaemonSets that match those selectors.
 func (c *daemonSets) List(ctx context.Context, opts metav1.ListOptions) (result *v1.DaemonSetList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for daemonsets", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of DaemonSets that match those selectors.
+func (c *daemonSets) list(ctx context.Context, opts metav1.ListOptions) (result *v1.DaemonSetList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/deployment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/deployment.go
@@ -33,6 +33,7 @@ import (
 	applyconfigurationsautoscalingv1 "k8s.io/client-go/applyconfigurations/autoscaling/v1"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 )
 
 // DeploymentsGetter has a method to return a DeploymentInterface.
@@ -90,6 +91,16 @@ func (c *deployments) Get(ctx context.Context, name string, options metav1.GetOp
 
 // List takes label and field selectors, and returns the list of Deployments that match those selectors.
 func (c *deployments) List(ctx context.Context, opts metav1.ListOptions) (result *v1.DeploymentList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for deployments", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of Deployments that match those selectors.
+func (c *deployments) list(ctx context.Context, opts metav1.ListOptions) (result *v1.DeploymentList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/statefulset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/statefulset.go
@@ -33,6 +33,7 @@ import (
 	applyconfigurationsautoscalingv1 "k8s.io/client-go/applyconfigurations/autoscaling/v1"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 )
 
 // StatefulSetsGetter has a method to return a StatefulSetInterface.
@@ -90,6 +91,16 @@ func (c *statefulSets) Get(ctx context.Context, name string, options metav1.GetO
 
 // List takes label and field selectors, and returns the list of StatefulSets that match those selectors.
 func (c *statefulSets) List(ctx context.Context, opts metav1.ListOptions) (result *v1.StatefulSetList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for statefulsets", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of StatefulSets that match those selectors.
+func (c *statefulSets) list(ctx context.Context, opts metav1.ListOptions) (result *v1.StatefulSetList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/controllerrevision.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/controllerrevision.go
@@ -31,6 +31,7 @@ import (
 	appsv1beta1 "k8s.io/client-go/applyconfigurations/apps/v1beta1"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 )
 
 // ControllerRevisionsGetter has a method to return a ControllerRevisionInterface.
@@ -82,6 +83,16 @@ func (c *controllerRevisions) Get(ctx context.Context, name string, options v1.G
 
 // List takes label and field selectors, and returns the list of ControllerRevisions that match those selectors.
 func (c *controllerRevisions) List(ctx context.Context, opts v1.ListOptions) (result *v1beta1.ControllerRevisionList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for controllerrevisions", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of ControllerRevisions that match those selectors.
+func (c *controllerRevisions) list(ctx context.Context, opts v1.ListOptions) (result *v1beta1.ControllerRevisionList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/statefulset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/statefulset.go
@@ -31,6 +31,7 @@ import (
 	appsv1beta1 "k8s.io/client-go/applyconfigurations/apps/v1beta1"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 )
 
 // StatefulSetsGetter has a method to return a StatefulSetInterface.
@@ -84,6 +85,16 @@ func (c *statefulSets) Get(ctx context.Context, name string, options v1.GetOptio
 
 // List takes label and field selectors, and returns the list of StatefulSets that match those selectors.
 func (c *statefulSets) List(ctx context.Context, opts v1.ListOptions) (result *v1beta1.StatefulSetList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for statefulsets", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of StatefulSets that match those selectors.
+func (c *statefulSets) list(ctx context.Context, opts v1.ListOptions) (result *v1beta1.StatefulSetList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/controllerrevision.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/controllerrevision.go
@@ -31,6 +31,7 @@ import (
 	appsv1beta2 "k8s.io/client-go/applyconfigurations/apps/v1beta2"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 )
 
 // ControllerRevisionsGetter has a method to return a ControllerRevisionInterface.
@@ -82,6 +83,16 @@ func (c *controllerRevisions) Get(ctx context.Context, name string, options v1.G
 
 // List takes label and field selectors, and returns the list of ControllerRevisions that match those selectors.
 func (c *controllerRevisions) List(ctx context.Context, opts v1.ListOptions) (result *v1beta2.ControllerRevisionList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for controllerrevisions", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of ControllerRevisions that match those selectors.
+func (c *controllerRevisions) list(ctx context.Context, opts v1.ListOptions) (result *v1beta2.ControllerRevisionList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/daemonset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/daemonset.go
@@ -31,6 +31,7 @@ import (
 	appsv1beta2 "k8s.io/client-go/applyconfigurations/apps/v1beta2"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 )
 
 // DaemonSetsGetter has a method to return a DaemonSetInterface.
@@ -84,6 +85,16 @@ func (c *daemonSets) Get(ctx context.Context, name string, options v1.GetOptions
 
 // List takes label and field selectors, and returns the list of DaemonSets that match those selectors.
 func (c *daemonSets) List(ctx context.Context, opts v1.ListOptions) (result *v1beta2.DaemonSetList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for daemonsets", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of DaemonSets that match those selectors.
+func (c *daemonSets) list(ctx context.Context, opts v1.ListOptions) (result *v1beta2.DaemonSetList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/deployment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/deployment.go
@@ -31,6 +31,7 @@ import (
 	appsv1beta2 "k8s.io/client-go/applyconfigurations/apps/v1beta2"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 )
 
 // DeploymentsGetter has a method to return a DeploymentInterface.
@@ -84,6 +85,16 @@ func (c *deployments) Get(ctx context.Context, name string, options v1.GetOption
 
 // List takes label and field selectors, and returns the list of Deployments that match those selectors.
 func (c *deployments) List(ctx context.Context, opts v1.ListOptions) (result *v1beta2.DeploymentList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for deployments", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of Deployments that match those selectors.
+func (c *deployments) list(ctx context.Context, opts v1.ListOptions) (result *v1beta2.DeploymentList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/statefulset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/statefulset.go
@@ -31,6 +31,7 @@ import (
 	appsv1beta2 "k8s.io/client-go/applyconfigurations/apps/v1beta2"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 )
 
 // StatefulSetsGetter has a method to return a StatefulSetInterface.
@@ -88,6 +89,16 @@ func (c *statefulSets) Get(ctx context.Context, name string, options v1.GetOptio
 
 // List takes label and field selectors, and returns the list of StatefulSets that match those selectors.
 func (c *statefulSets) List(ctx context.Context, opts v1.ListOptions) (result *v1beta2.StatefulSetList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for statefulsets", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of StatefulSets that match those selectors.
+func (c *statefulSets) list(ctx context.Context, opts v1.ListOptions) (result *v1beta2.StatefulSetList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v1/horizontalpodautoscaler.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v1/horizontalpodautoscaler.go
@@ -31,6 +31,7 @@ import (
 	autoscalingv1 "k8s.io/client-go/applyconfigurations/autoscaling/v1"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 )
 
 // HorizontalPodAutoscalersGetter has a method to return a HorizontalPodAutoscalerInterface.
@@ -84,6 +85,16 @@ func (c *horizontalPodAutoscalers) Get(ctx context.Context, name string, options
 
 // List takes label and field selectors, and returns the list of HorizontalPodAutoscalers that match those selectors.
 func (c *horizontalPodAutoscalers) List(ctx context.Context, opts metav1.ListOptions) (result *v1.HorizontalPodAutoscalerList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for horizontalpodautoscalers", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of HorizontalPodAutoscalers that match those selectors.
+func (c *horizontalPodAutoscalers) list(ctx context.Context, opts metav1.ListOptions) (result *v1.HorizontalPodAutoscalerList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2beta1/horizontalpodautoscaler.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2beta1/horizontalpodautoscaler.go
@@ -31,6 +31,7 @@ import (
 	autoscalingv2beta1 "k8s.io/client-go/applyconfigurations/autoscaling/v2beta1"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 )
 
 // HorizontalPodAutoscalersGetter has a method to return a HorizontalPodAutoscalerInterface.
@@ -84,6 +85,16 @@ func (c *horizontalPodAutoscalers) Get(ctx context.Context, name string, options
 
 // List takes label and field selectors, and returns the list of HorizontalPodAutoscalers that match those selectors.
 func (c *horizontalPodAutoscalers) List(ctx context.Context, opts v1.ListOptions) (result *v2beta1.HorizontalPodAutoscalerList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for horizontalpodautoscalers", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of HorizontalPodAutoscalers that match those selectors.
+func (c *horizontalPodAutoscalers) list(ctx context.Context, opts v1.ListOptions) (result *v2beta1.HorizontalPodAutoscalerList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2beta2/horizontalpodautoscaler.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2beta2/horizontalpodautoscaler.go
@@ -31,6 +31,7 @@ import (
 	autoscalingv2beta2 "k8s.io/client-go/applyconfigurations/autoscaling/v2beta2"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 )
 
 // HorizontalPodAutoscalersGetter has a method to return a HorizontalPodAutoscalerInterface.
@@ -84,6 +85,16 @@ func (c *horizontalPodAutoscalers) Get(ctx context.Context, name string, options
 
 // List takes label and field selectors, and returns the list of HorizontalPodAutoscalers that match those selectors.
 func (c *horizontalPodAutoscalers) List(ctx context.Context, opts v1.ListOptions) (result *v2beta2.HorizontalPodAutoscalerList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for horizontalpodautoscalers", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of HorizontalPodAutoscalers that match those selectors.
+func (c *horizontalPodAutoscalers) list(ctx context.Context, opts v1.ListOptions) (result *v2beta2.HorizontalPodAutoscalerList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1/job.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1/job.go
@@ -31,6 +31,7 @@ import (
 	batchv1 "k8s.io/client-go/applyconfigurations/batch/v1"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 )
 
 // JobsGetter has a method to return a JobInterface.
@@ -84,6 +85,16 @@ func (c *jobs) Get(ctx context.Context, name string, options metav1.GetOptions) 
 
 // List takes label and field selectors, and returns the list of Jobs that match those selectors.
 func (c *jobs) List(ctx context.Context, opts metav1.ListOptions) (result *v1.JobList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for jobs", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of Jobs that match those selectors.
+func (c *jobs) list(ctx context.Context, opts metav1.ListOptions) (result *v1.JobList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1beta1/cronjob.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1beta1/cronjob.go
@@ -31,6 +31,7 @@ import (
 	batchv1beta1 "k8s.io/client-go/applyconfigurations/batch/v1beta1"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 )
 
 // CronJobsGetter has a method to return a CronJobInterface.
@@ -84,6 +85,16 @@ func (c *cronJobs) Get(ctx context.Context, name string, options v1.GetOptions) 
 
 // List takes label and field selectors, and returns the list of CronJobs that match those selectors.
 func (c *cronJobs) List(ctx context.Context, opts v1.ListOptions) (result *v1beta1.CronJobList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for cronjobs", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of CronJobs that match those selectors.
+func (c *cronJobs) list(ctx context.Context, opts v1.ListOptions) (result *v1beta1.CronJobList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1/certificatesigningrequest.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1/certificatesigningrequest.go
@@ -31,6 +31,7 @@ import (
 	certificatesv1 "k8s.io/client-go/applyconfigurations/certificates/v1"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 )
 
 // CertificateSigningRequestsGetter has a method to return a CertificateSigningRequestInterface.
@@ -83,6 +84,16 @@ func (c *certificateSigningRequests) Get(ctx context.Context, name string, optio
 
 // List takes label and field selectors, and returns the list of CertificateSigningRequests that match those selectors.
 func (c *certificateSigningRequests) List(ctx context.Context, opts metav1.ListOptions) (result *v1.CertificateSigningRequestList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for certificatesigningrequests", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of CertificateSigningRequests that match those selectors.
+func (c *certificateSigningRequests) list(ctx context.Context, opts metav1.ListOptions) (result *v1.CertificateSigningRequestList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1alpha1/clustertrustbundle.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1alpha1/clustertrustbundle.go
@@ -31,6 +31,7 @@ import (
 	certificatesv1alpha1 "k8s.io/client-go/applyconfigurations/certificates/v1alpha1"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 )
 
 // ClusterTrustBundlesGetter has a method to return a ClusterTrustBundleInterface.
@@ -79,6 +80,16 @@ func (c *clusterTrustBundles) Get(ctx context.Context, name string, options v1.G
 
 // List takes label and field selectors, and returns the list of ClusterTrustBundles that match those selectors.
 func (c *clusterTrustBundles) List(ctx context.Context, opts v1.ListOptions) (result *v1alpha1.ClusterTrustBundleList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for clustertrustbundles", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of ClusterTrustBundles that match those selectors.
+func (c *clusterTrustBundles) list(ctx context.Context, opts v1.ListOptions) (result *v1alpha1.ClusterTrustBundleList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/client-go/kubernetes/typed/coordination/v1beta1/lease.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/coordination/v1beta1/lease.go
@@ -31,6 +31,7 @@ import (
 	coordinationv1beta1 "k8s.io/client-go/applyconfigurations/coordination/v1beta1"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 )
 
 // LeasesGetter has a method to return a LeaseInterface.
@@ -82,6 +83,16 @@ func (c *leases) Get(ctx context.Context, name string, options v1.GetOptions) (r
 
 // List takes label and field selectors, and returns the list of Leases that match those selectors.
 func (c *leases) List(ctx context.Context, opts v1.ListOptions) (result *v1beta1.LeaseList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for leases", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of Leases that match those selectors.
+func (c *leases) list(ctx context.Context, opts v1.ListOptions) (result *v1beta1.LeaseList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/componentstatus.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/componentstatus.go
@@ -31,6 +31,7 @@ import (
 	corev1 "k8s.io/client-go/applyconfigurations/core/v1"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 )
 
 // ComponentStatusesGetter has a method to return a ComponentStatusInterface.
@@ -79,6 +80,16 @@ func (c *componentStatuses) Get(ctx context.Context, name string, options metav1
 
 // List takes label and field selectors, and returns the list of ComponentStatuses that match those selectors.
 func (c *componentStatuses) List(ctx context.Context, opts metav1.ListOptions) (result *v1.ComponentStatusList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for componentstatuses", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of ComponentStatuses that match those selectors.
+func (c *componentStatuses) list(ctx context.Context, opts metav1.ListOptions) (result *v1.ComponentStatusList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/configmap.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/configmap.go
@@ -31,6 +31,7 @@ import (
 	corev1 "k8s.io/client-go/applyconfigurations/core/v1"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 )
 
 // ConfigMapsGetter has a method to return a ConfigMapInterface.
@@ -82,6 +83,16 @@ func (c *configMaps) Get(ctx context.Context, name string, options metav1.GetOpt
 
 // List takes label and field selectors, and returns the list of ConfigMaps that match those selectors.
 func (c *configMaps) List(ctx context.Context, opts metav1.ListOptions) (result *v1.ConfigMapList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for configmaps", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of ConfigMaps that match those selectors.
+func (c *configMaps) list(ctx context.Context, opts metav1.ListOptions) (result *v1.ConfigMapList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/endpoints.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/endpoints.go
@@ -31,6 +31,7 @@ import (
 	corev1 "k8s.io/client-go/applyconfigurations/core/v1"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 )
 
 // EndpointsGetter has a method to return a EndpointsInterface.
@@ -82,6 +83,16 @@ func (c *endpoints) Get(ctx context.Context, name string, options metav1.GetOpti
 
 // List takes label and field selectors, and returns the list of Endpoints that match those selectors.
 func (c *endpoints) List(ctx context.Context, opts metav1.ListOptions) (result *v1.EndpointsList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for endpoints", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of Endpoints that match those selectors.
+func (c *endpoints) list(ctx context.Context, opts metav1.ListOptions) (result *v1.EndpointsList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/event.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/event.go
@@ -31,6 +31,7 @@ import (
 	corev1 "k8s.io/client-go/applyconfigurations/core/v1"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 )
 
 // EventsGetter has a method to return a EventInterface.
@@ -82,6 +83,16 @@ func (c *events) Get(ctx context.Context, name string, options metav1.GetOptions
 
 // List takes label and field selectors, and returns the list of Events that match those selectors.
 func (c *events) List(ctx context.Context, opts metav1.ListOptions) (result *v1.EventList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for events", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of Events that match those selectors.
+func (c *events) list(ctx context.Context, opts metav1.ListOptions) (result *v1.EventList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/limitrange.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/limitrange.go
@@ -31,6 +31,7 @@ import (
 	corev1 "k8s.io/client-go/applyconfigurations/core/v1"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 )
 
 // LimitRangesGetter has a method to return a LimitRangeInterface.
@@ -82,6 +83,16 @@ func (c *limitRanges) Get(ctx context.Context, name string, options metav1.GetOp
 
 // List takes label and field selectors, and returns the list of LimitRanges that match those selectors.
 func (c *limitRanges) List(ctx context.Context, opts metav1.ListOptions) (result *v1.LimitRangeList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for limitranges", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of LimitRanges that match those selectors.
+func (c *limitRanges) list(ctx context.Context, opts metav1.ListOptions) (result *v1.LimitRangeList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/node.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/node.go
@@ -31,6 +31,7 @@ import (
 	corev1 "k8s.io/client-go/applyconfigurations/core/v1"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 )
 
 // NodesGetter has a method to return a NodeInterface.
@@ -81,6 +82,16 @@ func (c *nodes) Get(ctx context.Context, name string, options metav1.GetOptions)
 
 // List takes label and field selectors, and returns the list of Nodes that match those selectors.
 func (c *nodes) List(ctx context.Context, opts metav1.ListOptions) (result *v1.NodeList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for nodes", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of Nodes that match those selectors.
+func (c *nodes) list(ctx context.Context, opts metav1.ListOptions) (result *v1.NodeList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/persistentvolumeclaim.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/persistentvolumeclaim.go
@@ -31,6 +31,7 @@ import (
 	corev1 "k8s.io/client-go/applyconfigurations/core/v1"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 )
 
 // PersistentVolumeClaimsGetter has a method to return a PersistentVolumeClaimInterface.
@@ -84,6 +85,16 @@ func (c *persistentVolumeClaims) Get(ctx context.Context, name string, options m
 
 // List takes label and field selectors, and returns the list of PersistentVolumeClaims that match those selectors.
 func (c *persistentVolumeClaims) List(ctx context.Context, opts metav1.ListOptions) (result *v1.PersistentVolumeClaimList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for persistentvolumeclaims", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of PersistentVolumeClaims that match those selectors.
+func (c *persistentVolumeClaims) list(ctx context.Context, opts metav1.ListOptions) (result *v1.PersistentVolumeClaimList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/pod.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/pod.go
@@ -31,6 +31,7 @@ import (
 	corev1 "k8s.io/client-go/applyconfigurations/core/v1"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 )
 
 // PodsGetter has a method to return a PodInterface.
@@ -86,6 +87,16 @@ func (c *pods) Get(ctx context.Context, name string, options metav1.GetOptions) 
 
 // List takes label and field selectors, and returns the list of Pods that match those selectors.
 func (c *pods) List(ctx context.Context, opts metav1.ListOptions) (result *v1.PodList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for pods", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of Pods that match those selectors.
+func (c *pods) list(ctx context.Context, opts metav1.ListOptions) (result *v1.PodList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/podtemplate.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/podtemplate.go
@@ -31,6 +31,7 @@ import (
 	corev1 "k8s.io/client-go/applyconfigurations/core/v1"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 )
 
 // PodTemplatesGetter has a method to return a PodTemplateInterface.
@@ -82,6 +83,16 @@ func (c *podTemplates) Get(ctx context.Context, name string, options metav1.GetO
 
 // List takes label and field selectors, and returns the list of PodTemplates that match those selectors.
 func (c *podTemplates) List(ctx context.Context, opts metav1.ListOptions) (result *v1.PodTemplateList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for podtemplates", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of PodTemplates that match those selectors.
+func (c *podTemplates) list(ctx context.Context, opts metav1.ListOptions) (result *v1.PodTemplateList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/secret.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/secret.go
@@ -31,6 +31,7 @@ import (
 	corev1 "k8s.io/client-go/applyconfigurations/core/v1"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 )
 
 // SecretsGetter has a method to return a SecretInterface.
@@ -82,6 +83,16 @@ func (c *secrets) Get(ctx context.Context, name string, options metav1.GetOption
 
 // List takes label and field selectors, and returns the list of Secrets that match those selectors.
 func (c *secrets) List(ctx context.Context, opts metav1.ListOptions) (result *v1.SecretList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for secrets", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of Secrets that match those selectors.
+func (c *secrets) list(ctx context.Context, opts metav1.ListOptions) (result *v1.SecretList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/client-go/kubernetes/typed/discovery/v1/endpointslice.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/discovery/v1/endpointslice.go
@@ -31,6 +31,7 @@ import (
 	discoveryv1 "k8s.io/client-go/applyconfigurations/discovery/v1"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 )
 
 // EndpointSlicesGetter has a method to return a EndpointSliceInterface.
@@ -82,6 +83,16 @@ func (c *endpointSlices) Get(ctx context.Context, name string, options metav1.Ge
 
 // List takes label and field selectors, and returns the list of EndpointSlices that match those selectors.
 func (c *endpointSlices) List(ctx context.Context, opts metav1.ListOptions) (result *v1.EndpointSliceList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for endpointslices", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of EndpointSlices that match those selectors.
+func (c *endpointSlices) list(ctx context.Context, opts metav1.ListOptions) (result *v1.EndpointSliceList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/client-go/kubernetes/typed/discovery/v1beta1/endpointslice.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/discovery/v1beta1/endpointslice.go
@@ -31,6 +31,7 @@ import (
 	discoveryv1beta1 "k8s.io/client-go/applyconfigurations/discovery/v1beta1"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 )
 
 // EndpointSlicesGetter has a method to return a EndpointSliceInterface.
@@ -82,6 +83,16 @@ func (c *endpointSlices) Get(ctx context.Context, name string, options v1.GetOpt
 
 // List takes label and field selectors, and returns the list of EndpointSlices that match those selectors.
 func (c *endpointSlices) List(ctx context.Context, opts v1.ListOptions) (result *v1beta1.EndpointSliceList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for endpointslices", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of EndpointSlices that match those selectors.
+func (c *endpointSlices) list(ctx context.Context, opts v1.ListOptions) (result *v1beta1.EndpointSliceList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/client-go/kubernetes/typed/events/v1/event.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/events/v1/event.go
@@ -31,6 +31,7 @@ import (
 	eventsv1 "k8s.io/client-go/applyconfigurations/events/v1"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 )
 
 // EventsGetter has a method to return a EventInterface.
@@ -82,6 +83,16 @@ func (c *events) Get(ctx context.Context, name string, options metav1.GetOptions
 
 // List takes label and field selectors, and returns the list of Events that match those selectors.
 func (c *events) List(ctx context.Context, opts metav1.ListOptions) (result *v1.EventList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for events", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of Events that match those selectors.
+func (c *events) list(ctx context.Context, opts metav1.ListOptions) (result *v1.EventList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/daemonset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/daemonset.go
@@ -31,6 +31,7 @@ import (
 	extensionsv1beta1 "k8s.io/client-go/applyconfigurations/extensions/v1beta1"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 )
 
 // DaemonSetsGetter has a method to return a DaemonSetInterface.
@@ -84,6 +85,16 @@ func (c *daemonSets) Get(ctx context.Context, name string, options v1.GetOptions
 
 // List takes label and field selectors, and returns the list of DaemonSets that match those selectors.
 func (c *daemonSets) List(ctx context.Context, opts v1.ListOptions) (result *v1beta1.DaemonSetList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for daemonsets", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of DaemonSets that match those selectors.
+func (c *daemonSets) list(ctx context.Context, opts v1.ListOptions) (result *v1beta1.DaemonSetList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/deployment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/deployment.go
@@ -31,6 +31,7 @@ import (
 	extensionsv1beta1 "k8s.io/client-go/applyconfigurations/extensions/v1beta1"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 )
 
 // DeploymentsGetter has a method to return a DeploymentInterface.
@@ -88,6 +89,16 @@ func (c *deployments) Get(ctx context.Context, name string, options v1.GetOption
 
 // List takes label and field selectors, and returns the list of Deployments that match those selectors.
 func (c *deployments) List(ctx context.Context, opts v1.ListOptions) (result *v1beta1.DeploymentList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for deployments", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of Deployments that match those selectors.
+func (c *deployments) list(ctx context.Context, opts v1.ListOptions) (result *v1beta1.DeploymentList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/ingress.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/ingress.go
@@ -31,6 +31,7 @@ import (
 	extensionsv1beta1 "k8s.io/client-go/applyconfigurations/extensions/v1beta1"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 )
 
 // IngressesGetter has a method to return a IngressInterface.
@@ -84,6 +85,16 @@ func (c *ingresses) Get(ctx context.Context, name string, options v1.GetOptions)
 
 // List takes label and field selectors, and returns the list of Ingresses that match those selectors.
 func (c *ingresses) List(ctx context.Context, opts v1.ListOptions) (result *v1beta1.IngressList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for ingresses", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of Ingresses that match those selectors.
+func (c *ingresses) list(ctx context.Context, opts v1.ListOptions) (result *v1beta1.IngressList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/networkpolicy.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/networkpolicy.go
@@ -31,6 +31,7 @@ import (
 	extensionsv1beta1 "k8s.io/client-go/applyconfigurations/extensions/v1beta1"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 )
 
 // NetworkPoliciesGetter has a method to return a NetworkPolicyInterface.
@@ -82,6 +83,16 @@ func (c *networkPolicies) Get(ctx context.Context, name string, options v1.GetOp
 
 // List takes label and field selectors, and returns the list of NetworkPolicies that match those selectors.
 func (c *networkPolicies) List(ctx context.Context, opts v1.ListOptions) (result *v1beta1.NetworkPolicyList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for networkpolicies", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of NetworkPolicies that match those selectors.
+func (c *networkPolicies) list(ctx context.Context, opts v1.ListOptions) (result *v1beta1.NetworkPolicyList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/replicaset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/replicaset.go
@@ -31,6 +31,7 @@ import (
 	extensionsv1beta1 "k8s.io/client-go/applyconfigurations/extensions/v1beta1"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 )
 
 // ReplicaSetsGetter has a method to return a ReplicaSetInterface.
@@ -88,6 +89,16 @@ func (c *replicaSets) Get(ctx context.Context, name string, options v1.GetOption
 
 // List takes label and field selectors, and returns the list of ReplicaSets that match those selectors.
 func (c *replicaSets) List(ctx context.Context, opts v1.ListOptions) (result *v1beta1.ReplicaSetList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for replicasets", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of ReplicaSets that match those selectors.
+func (c *replicaSets) list(ctx context.Context, opts v1.ListOptions) (result *v1beta1.ReplicaSetList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1/flowschema.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1/flowschema.go
@@ -31,6 +31,7 @@ import (
 	flowcontrolv1 "k8s.io/client-go/applyconfigurations/flowcontrol/v1"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 )
 
 // FlowSchemasGetter has a method to return a FlowSchemaInterface.
@@ -81,6 +82,16 @@ func (c *flowSchemas) Get(ctx context.Context, name string, options metav1.GetOp
 
 // List takes label and field selectors, and returns the list of FlowSchemas that match those selectors.
 func (c *flowSchemas) List(ctx context.Context, opts metav1.ListOptions) (result *v1.FlowSchemaList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for flowschemas", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of FlowSchemas that match those selectors.
+func (c *flowSchemas) list(ctx context.Context, opts metav1.ListOptions) (result *v1.FlowSchemaList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1/prioritylevelconfiguration.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1/prioritylevelconfiguration.go
@@ -31,6 +31,7 @@ import (
 	flowcontrolv1 "k8s.io/client-go/applyconfigurations/flowcontrol/v1"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 )
 
 // PriorityLevelConfigurationsGetter has a method to return a PriorityLevelConfigurationInterface.
@@ -81,6 +82,16 @@ func (c *priorityLevelConfigurations) Get(ctx context.Context, name string, opti
 
 // List takes label and field selectors, and returns the list of PriorityLevelConfigurations that match those selectors.
 func (c *priorityLevelConfigurations) List(ctx context.Context, opts metav1.ListOptions) (result *v1.PriorityLevelConfigurationList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for prioritylevelconfigurations", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of PriorityLevelConfigurations that match those selectors.
+func (c *priorityLevelConfigurations) list(ctx context.Context, opts metav1.ListOptions) (result *v1.PriorityLevelConfigurationList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta1/prioritylevelconfiguration.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta1/prioritylevelconfiguration.go
@@ -31,6 +31,7 @@ import (
 	flowcontrolv1beta1 "k8s.io/client-go/applyconfigurations/flowcontrol/v1beta1"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 )
 
 // PriorityLevelConfigurationsGetter has a method to return a PriorityLevelConfigurationInterface.
@@ -81,6 +82,16 @@ func (c *priorityLevelConfigurations) Get(ctx context.Context, name string, opti
 
 // List takes label and field selectors, and returns the list of PriorityLevelConfigurations that match those selectors.
 func (c *priorityLevelConfigurations) List(ctx context.Context, opts v1.ListOptions) (result *v1beta1.PriorityLevelConfigurationList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for prioritylevelconfigurations", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of PriorityLevelConfigurations that match those selectors.
+func (c *priorityLevelConfigurations) list(ctx context.Context, opts v1.ListOptions) (result *v1beta1.PriorityLevelConfigurationList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta2/flowschema.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta2/flowschema.go
@@ -31,6 +31,7 @@ import (
 	flowcontrolv1beta2 "k8s.io/client-go/applyconfigurations/flowcontrol/v1beta2"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 )
 
 // FlowSchemasGetter has a method to return a FlowSchemaInterface.
@@ -81,6 +82,16 @@ func (c *flowSchemas) Get(ctx context.Context, name string, options v1.GetOption
 
 // List takes label and field selectors, and returns the list of FlowSchemas that match those selectors.
 func (c *flowSchemas) List(ctx context.Context, opts v1.ListOptions) (result *v1beta2.FlowSchemaList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for flowschemas", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of FlowSchemas that match those selectors.
+func (c *flowSchemas) list(ctx context.Context, opts v1.ListOptions) (result *v1beta2.FlowSchemaList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta2/prioritylevelconfiguration.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta2/prioritylevelconfiguration.go
@@ -31,6 +31,7 @@ import (
 	flowcontrolv1beta2 "k8s.io/client-go/applyconfigurations/flowcontrol/v1beta2"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 )
 
 // PriorityLevelConfigurationsGetter has a method to return a PriorityLevelConfigurationInterface.
@@ -81,6 +82,16 @@ func (c *priorityLevelConfigurations) Get(ctx context.Context, name string, opti
 
 // List takes label and field selectors, and returns the list of PriorityLevelConfigurations that match those selectors.
 func (c *priorityLevelConfigurations) List(ctx context.Context, opts v1.ListOptions) (result *v1beta2.PriorityLevelConfigurationList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for prioritylevelconfigurations", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of PriorityLevelConfigurations that match those selectors.
+func (c *priorityLevelConfigurations) list(ctx context.Context, opts v1.ListOptions) (result *v1beta2.PriorityLevelConfigurationList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta3/flowschema.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta3/flowschema.go
@@ -31,6 +31,7 @@ import (
 	flowcontrolv1beta3 "k8s.io/client-go/applyconfigurations/flowcontrol/v1beta3"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 )
 
 // FlowSchemasGetter has a method to return a FlowSchemaInterface.
@@ -81,6 +82,16 @@ func (c *flowSchemas) Get(ctx context.Context, name string, options v1.GetOption
 
 // List takes label and field selectors, and returns the list of FlowSchemas that match those selectors.
 func (c *flowSchemas) List(ctx context.Context, opts v1.ListOptions) (result *v1beta3.FlowSchemaList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for flowschemas", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of FlowSchemas that match those selectors.
+func (c *flowSchemas) list(ctx context.Context, opts v1.ListOptions) (result *v1beta3.FlowSchemaList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta3/prioritylevelconfiguration.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta3/prioritylevelconfiguration.go
@@ -31,6 +31,7 @@ import (
 	flowcontrolv1beta3 "k8s.io/client-go/applyconfigurations/flowcontrol/v1beta3"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 )
 
 // PriorityLevelConfigurationsGetter has a method to return a PriorityLevelConfigurationInterface.
@@ -81,6 +82,16 @@ func (c *priorityLevelConfigurations) Get(ctx context.Context, name string, opti
 
 // List takes label and field selectors, and returns the list of PriorityLevelConfigurations that match those selectors.
 func (c *priorityLevelConfigurations) List(ctx context.Context, opts v1.ListOptions) (result *v1beta3.PriorityLevelConfigurationList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for prioritylevelconfigurations", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of PriorityLevelConfigurations that match those selectors.
+func (c *priorityLevelConfigurations) list(ctx context.Context, opts v1.ListOptions) (result *v1beta3.PriorityLevelConfigurationList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1/ingress.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1/ingress.go
@@ -31,6 +31,7 @@ import (
 	networkingv1 "k8s.io/client-go/applyconfigurations/networking/v1"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 )
 
 // IngressesGetter has a method to return a IngressInterface.
@@ -84,6 +85,16 @@ func (c *ingresses) Get(ctx context.Context, name string, options metav1.GetOpti
 
 // List takes label and field selectors, and returns the list of Ingresses that match those selectors.
 func (c *ingresses) List(ctx context.Context, opts metav1.ListOptions) (result *v1.IngressList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for ingresses", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of Ingresses that match those selectors.
+func (c *ingresses) list(ctx context.Context, opts metav1.ListOptions) (result *v1.IngressList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1/networkpolicy.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1/networkpolicy.go
@@ -31,6 +31,7 @@ import (
 	networkingv1 "k8s.io/client-go/applyconfigurations/networking/v1"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 )
 
 // NetworkPoliciesGetter has a method to return a NetworkPolicyInterface.
@@ -82,6 +83,16 @@ func (c *networkPolicies) Get(ctx context.Context, name string, options metav1.G
 
 // List takes label and field selectors, and returns the list of NetworkPolicies that match those selectors.
 func (c *networkPolicies) List(ctx context.Context, opts metav1.ListOptions) (result *v1.NetworkPolicyList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for networkpolicies", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of NetworkPolicies that match those selectors.
+func (c *networkPolicies) list(ctx context.Context, opts metav1.ListOptions) (result *v1.NetworkPolicyList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1alpha1/servicecidr.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1alpha1/servicecidr.go
@@ -31,6 +31,7 @@ import (
 	networkingv1alpha1 "k8s.io/client-go/applyconfigurations/networking/v1alpha1"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 )
 
 // ServiceCIDRsGetter has a method to return a ServiceCIDRInterface.
@@ -81,6 +82,16 @@ func (c *serviceCIDRs) Get(ctx context.Context, name string, options v1.GetOptio
 
 // List takes label and field selectors, and returns the list of ServiceCIDRs that match those selectors.
 func (c *serviceCIDRs) List(ctx context.Context, opts v1.ListOptions) (result *v1alpha1.ServiceCIDRList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for servicecidrs", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of ServiceCIDRs that match those selectors.
+func (c *serviceCIDRs) list(ctx context.Context, opts v1.ListOptions) (result *v1alpha1.ServiceCIDRList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1beta1/ingress.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1beta1/ingress.go
@@ -31,6 +31,7 @@ import (
 	networkingv1beta1 "k8s.io/client-go/applyconfigurations/networking/v1beta1"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 )
 
 // IngressesGetter has a method to return a IngressInterface.
@@ -84,6 +85,16 @@ func (c *ingresses) Get(ctx context.Context, name string, options v1.GetOptions)
 
 // List takes label and field selectors, and returns the list of Ingresses that match those selectors.
 func (c *ingresses) List(ctx context.Context, opts v1.ListOptions) (result *v1beta1.IngressList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for ingresses", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of Ingresses that match those selectors.
+func (c *ingresses) list(ctx context.Context, opts v1.ListOptions) (result *v1beta1.IngressList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1beta1/ingressclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1beta1/ingressclass.go
@@ -31,6 +31,7 @@ import (
 	networkingv1beta1 "k8s.io/client-go/applyconfigurations/networking/v1beta1"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 )
 
 // IngressClassesGetter has a method to return a IngressClassInterface.
@@ -79,6 +80,16 @@ func (c *ingressClasses) Get(ctx context.Context, name string, options v1.GetOpt
 
 // List takes label and field selectors, and returns the list of IngressClasses that match those selectors.
 func (c *ingressClasses) List(ctx context.Context, opts v1.ListOptions) (result *v1beta1.IngressClassList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for ingressclasses", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of IngressClasses that match those selectors.
+func (c *ingressClasses) list(ctx context.Context, opts v1.ListOptions) (result *v1beta1.IngressClassList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/client-go/kubernetes/typed/node/v1/runtimeclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/node/v1/runtimeclass.go
@@ -31,6 +31,7 @@ import (
 	nodev1 "k8s.io/client-go/applyconfigurations/node/v1"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 )
 
 // RuntimeClassesGetter has a method to return a RuntimeClassInterface.
@@ -79,6 +80,16 @@ func (c *runtimeClasses) Get(ctx context.Context, name string, options metav1.Ge
 
 // List takes label and field selectors, and returns the list of RuntimeClasses that match those selectors.
 func (c *runtimeClasses) List(ctx context.Context, opts metav1.ListOptions) (result *v1.RuntimeClassList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for runtimeclasses", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of RuntimeClasses that match those selectors.
+func (c *runtimeClasses) list(ctx context.Context, opts metav1.ListOptions) (result *v1.RuntimeClassList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/client-go/kubernetes/typed/node/v1alpha1/runtimeclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/node/v1alpha1/runtimeclass.go
@@ -31,6 +31,7 @@ import (
 	nodev1alpha1 "k8s.io/client-go/applyconfigurations/node/v1alpha1"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 )
 
 // RuntimeClassesGetter has a method to return a RuntimeClassInterface.
@@ -79,6 +80,16 @@ func (c *runtimeClasses) Get(ctx context.Context, name string, options v1.GetOpt
 
 // List takes label and field selectors, and returns the list of RuntimeClasses that match those selectors.
 func (c *runtimeClasses) List(ctx context.Context, opts v1.ListOptions) (result *v1alpha1.RuntimeClassList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for runtimeclasses", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of RuntimeClasses that match those selectors.
+func (c *runtimeClasses) list(ctx context.Context, opts v1.ListOptions) (result *v1alpha1.RuntimeClassList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/client-go/kubernetes/typed/node/v1beta1/runtimeclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/node/v1beta1/runtimeclass.go
@@ -31,6 +31,7 @@ import (
 	nodev1beta1 "k8s.io/client-go/applyconfigurations/node/v1beta1"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 )
 
 // RuntimeClassesGetter has a method to return a RuntimeClassInterface.
@@ -79,6 +80,16 @@ func (c *runtimeClasses) Get(ctx context.Context, name string, options v1.GetOpt
 
 // List takes label and field selectors, and returns the list of RuntimeClasses that match those selectors.
 func (c *runtimeClasses) List(ctx context.Context, opts v1.ListOptions) (result *v1beta1.RuntimeClassList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for runtimeclasses", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of RuntimeClasses that match those selectors.
+func (c *runtimeClasses) list(ctx context.Context, opts v1.ListOptions) (result *v1beta1.RuntimeClassList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1/poddisruptionbudget.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1/poddisruptionbudget.go
@@ -31,6 +31,7 @@ import (
 	policyv1 "k8s.io/client-go/applyconfigurations/policy/v1"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 )
 
 // PodDisruptionBudgetsGetter has a method to return a PodDisruptionBudgetInterface.
@@ -84,6 +85,16 @@ func (c *podDisruptionBudgets) Get(ctx context.Context, name string, options met
 
 // List takes label and field selectors, and returns the list of PodDisruptionBudgets that match those selectors.
 func (c *podDisruptionBudgets) List(ctx context.Context, opts metav1.ListOptions) (result *v1.PodDisruptionBudgetList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for poddisruptionbudgets", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of PodDisruptionBudgets that match those selectors.
+func (c *podDisruptionBudgets) list(ctx context.Context, opts metav1.ListOptions) (result *v1.PodDisruptionBudgetList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/clusterrole.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/clusterrole.go
@@ -31,6 +31,7 @@ import (
 	rbacv1 "k8s.io/client-go/applyconfigurations/rbac/v1"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 )
 
 // ClusterRolesGetter has a method to return a ClusterRoleInterface.
@@ -79,6 +80,16 @@ func (c *clusterRoles) Get(ctx context.Context, name string, options metav1.GetO
 
 // List takes label and field selectors, and returns the list of ClusterRoles that match those selectors.
 func (c *clusterRoles) List(ctx context.Context, opts metav1.ListOptions) (result *v1.ClusterRoleList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for clusterroles", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of ClusterRoles that match those selectors.
+func (c *clusterRoles) list(ctx context.Context, opts metav1.ListOptions) (result *v1.ClusterRoleList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/clusterrolebinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/clusterrolebinding.go
@@ -31,6 +31,7 @@ import (
 	rbacv1 "k8s.io/client-go/applyconfigurations/rbac/v1"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 )
 
 // ClusterRoleBindingsGetter has a method to return a ClusterRoleBindingInterface.
@@ -79,6 +80,16 @@ func (c *clusterRoleBindings) Get(ctx context.Context, name string, options meta
 
 // List takes label and field selectors, and returns the list of ClusterRoleBindings that match those selectors.
 func (c *clusterRoleBindings) List(ctx context.Context, opts metav1.ListOptions) (result *v1.ClusterRoleBindingList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for clusterrolebindings", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of ClusterRoleBindings that match those selectors.
+func (c *clusterRoleBindings) list(ctx context.Context, opts metav1.ListOptions) (result *v1.ClusterRoleBindingList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/role.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/role.go
@@ -31,6 +31,7 @@ import (
 	rbacv1 "k8s.io/client-go/applyconfigurations/rbac/v1"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 )
 
 // RolesGetter has a method to return a RoleInterface.
@@ -82,6 +83,16 @@ func (c *roles) Get(ctx context.Context, name string, options metav1.GetOptions)
 
 // List takes label and field selectors, and returns the list of Roles that match those selectors.
 func (c *roles) List(ctx context.Context, opts metav1.ListOptions) (result *v1.RoleList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for roles", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of Roles that match those selectors.
+func (c *roles) list(ctx context.Context, opts metav1.ListOptions) (result *v1.RoleList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/rolebinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/rolebinding.go
@@ -31,6 +31,7 @@ import (
 	rbacv1 "k8s.io/client-go/applyconfigurations/rbac/v1"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 )
 
 // RoleBindingsGetter has a method to return a RoleBindingInterface.
@@ -82,6 +83,16 @@ func (c *roleBindings) Get(ctx context.Context, name string, options metav1.GetO
 
 // List takes label and field selectors, and returns the list of RoleBindings that match those selectors.
 func (c *roleBindings) List(ctx context.Context, opts metav1.ListOptions) (result *v1.RoleBindingList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for rolebindings", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of RoleBindings that match those selectors.
+func (c *roleBindings) list(ctx context.Context, opts metav1.ListOptions) (result *v1.RoleBindingList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/clusterrolebinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/clusterrolebinding.go
@@ -31,6 +31,7 @@ import (
 	rbacv1alpha1 "k8s.io/client-go/applyconfigurations/rbac/v1alpha1"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 )
 
 // ClusterRoleBindingsGetter has a method to return a ClusterRoleBindingInterface.
@@ -79,6 +80,16 @@ func (c *clusterRoleBindings) Get(ctx context.Context, name string, options v1.G
 
 // List takes label and field selectors, and returns the list of ClusterRoleBindings that match those selectors.
 func (c *clusterRoleBindings) List(ctx context.Context, opts v1.ListOptions) (result *v1alpha1.ClusterRoleBindingList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for clusterrolebindings", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of ClusterRoleBindings that match those selectors.
+func (c *clusterRoleBindings) list(ctx context.Context, opts v1.ListOptions) (result *v1alpha1.ClusterRoleBindingList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/role.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/role.go
@@ -31,6 +31,7 @@ import (
 	rbacv1alpha1 "k8s.io/client-go/applyconfigurations/rbac/v1alpha1"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 )
 
 // RolesGetter has a method to return a RoleInterface.
@@ -82,6 +83,16 @@ func (c *roles) Get(ctx context.Context, name string, options v1.GetOptions) (re
 
 // List takes label and field selectors, and returns the list of Roles that match those selectors.
 func (c *roles) List(ctx context.Context, opts v1.ListOptions) (result *v1alpha1.RoleList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for roles", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of Roles that match those selectors.
+func (c *roles) list(ctx context.Context, opts v1.ListOptions) (result *v1alpha1.RoleList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/rolebinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/rolebinding.go
@@ -31,6 +31,7 @@ import (
 	rbacv1alpha1 "k8s.io/client-go/applyconfigurations/rbac/v1alpha1"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 )
 
 // RoleBindingsGetter has a method to return a RoleBindingInterface.
@@ -82,6 +83,16 @@ func (c *roleBindings) Get(ctx context.Context, name string, options v1.GetOptio
 
 // List takes label and field selectors, and returns the list of RoleBindings that match those selectors.
 func (c *roleBindings) List(ctx context.Context, opts v1.ListOptions) (result *v1alpha1.RoleBindingList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for rolebindings", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of RoleBindings that match those selectors.
+func (c *roleBindings) list(ctx context.Context, opts v1.ListOptions) (result *v1alpha1.RoleBindingList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/clusterrole.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/clusterrole.go
@@ -31,6 +31,7 @@ import (
 	rbacv1beta1 "k8s.io/client-go/applyconfigurations/rbac/v1beta1"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 )
 
 // ClusterRolesGetter has a method to return a ClusterRoleInterface.
@@ -79,6 +80,16 @@ func (c *clusterRoles) Get(ctx context.Context, name string, options v1.GetOptio
 
 // List takes label and field selectors, and returns the list of ClusterRoles that match those selectors.
 func (c *clusterRoles) List(ctx context.Context, opts v1.ListOptions) (result *v1beta1.ClusterRoleList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for clusterroles", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of ClusterRoles that match those selectors.
+func (c *clusterRoles) list(ctx context.Context, opts v1.ListOptions) (result *v1beta1.ClusterRoleList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/clusterrolebinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/clusterrolebinding.go
@@ -31,6 +31,7 @@ import (
 	rbacv1beta1 "k8s.io/client-go/applyconfigurations/rbac/v1beta1"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 )
 
 // ClusterRoleBindingsGetter has a method to return a ClusterRoleBindingInterface.
@@ -79,6 +80,16 @@ func (c *clusterRoleBindings) Get(ctx context.Context, name string, options v1.G
 
 // List takes label and field selectors, and returns the list of ClusterRoleBindings that match those selectors.
 func (c *clusterRoleBindings) List(ctx context.Context, opts v1.ListOptions) (result *v1beta1.ClusterRoleBindingList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for clusterrolebindings", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of ClusterRoleBindings that match those selectors.
+func (c *clusterRoleBindings) list(ctx context.Context, opts v1.ListOptions) (result *v1beta1.ClusterRoleBindingList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/role.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/role.go
@@ -31,6 +31,7 @@ import (
 	rbacv1beta1 "k8s.io/client-go/applyconfigurations/rbac/v1beta1"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 )
 
 // RolesGetter has a method to return a RoleInterface.
@@ -82,6 +83,16 @@ func (c *roles) Get(ctx context.Context, name string, options v1.GetOptions) (re
 
 // List takes label and field selectors, and returns the list of Roles that match those selectors.
 func (c *roles) List(ctx context.Context, opts v1.ListOptions) (result *v1beta1.RoleList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for roles", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of Roles that match those selectors.
+func (c *roles) list(ctx context.Context, opts v1.ListOptions) (result *v1beta1.RoleList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/rolebinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/rolebinding.go
@@ -31,6 +31,7 @@ import (
 	rbacv1beta1 "k8s.io/client-go/applyconfigurations/rbac/v1beta1"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 )
 
 // RoleBindingsGetter has a method to return a RoleBindingInterface.
@@ -82,6 +83,16 @@ func (c *roleBindings) Get(ctx context.Context, name string, options v1.GetOptio
 
 // List takes label and field selectors, and returns the list of RoleBindings that match those selectors.
 func (c *roleBindings) List(ctx context.Context, opts v1.ListOptions) (result *v1beta1.RoleBindingList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for rolebindings", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of RoleBindings that match those selectors.
+func (c *roleBindings) list(ctx context.Context, opts v1.ListOptions) (result *v1beta1.RoleBindingList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/client-go/kubernetes/typed/resource/v1alpha2/podschedulingcontext.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/resource/v1alpha2/podschedulingcontext.go
@@ -31,6 +31,7 @@ import (
 	resourcev1alpha2 "k8s.io/client-go/applyconfigurations/resource/v1alpha2"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 )
 
 // PodSchedulingContextsGetter has a method to return a PodSchedulingContextInterface.
@@ -84,6 +85,16 @@ func (c *podSchedulingContexts) Get(ctx context.Context, name string, options v1
 
 // List takes label and field selectors, and returns the list of PodSchedulingContexts that match those selectors.
 func (c *podSchedulingContexts) List(ctx context.Context, opts v1.ListOptions) (result *v1alpha2.PodSchedulingContextList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for podschedulingcontexts", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of PodSchedulingContexts that match those selectors.
+func (c *podSchedulingContexts) list(ctx context.Context, opts v1.ListOptions) (result *v1alpha2.PodSchedulingContextList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/client-go/kubernetes/typed/resource/v1alpha2/resourceclaim.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/resource/v1alpha2/resourceclaim.go
@@ -31,6 +31,7 @@ import (
 	resourcev1alpha2 "k8s.io/client-go/applyconfigurations/resource/v1alpha2"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 )
 
 // ResourceClaimsGetter has a method to return a ResourceClaimInterface.
@@ -84,6 +85,16 @@ func (c *resourceClaims) Get(ctx context.Context, name string, options v1.GetOpt
 
 // List takes label and field selectors, and returns the list of ResourceClaims that match those selectors.
 func (c *resourceClaims) List(ctx context.Context, opts v1.ListOptions) (result *v1alpha2.ResourceClaimList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for resourceclaims", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of ResourceClaims that match those selectors.
+func (c *resourceClaims) list(ctx context.Context, opts v1.ListOptions) (result *v1alpha2.ResourceClaimList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/client-go/kubernetes/typed/resource/v1alpha2/resourceclaimparameters.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/resource/v1alpha2/resourceclaimparameters.go
@@ -31,6 +31,7 @@ import (
 	resourcev1alpha2 "k8s.io/client-go/applyconfigurations/resource/v1alpha2"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 )
 
 // ResourceClaimParametersGetter has a method to return a ResourceClaimParametersInterface.
@@ -82,6 +83,16 @@ func (c *resourceClaimParameters) Get(ctx context.Context, name string, options 
 
 // List takes label and field selectors, and returns the list of ResourceClaimParameters that match those selectors.
 func (c *resourceClaimParameters) List(ctx context.Context, opts v1.ListOptions) (result *v1alpha2.ResourceClaimParametersList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for resourceclaimparameters", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of ResourceClaimParameters that match those selectors.
+func (c *resourceClaimParameters) list(ctx context.Context, opts v1.ListOptions) (result *v1alpha2.ResourceClaimParametersList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/client-go/kubernetes/typed/resource/v1alpha2/resourceclaimtemplate.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/resource/v1alpha2/resourceclaimtemplate.go
@@ -31,6 +31,7 @@ import (
 	resourcev1alpha2 "k8s.io/client-go/applyconfigurations/resource/v1alpha2"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 )
 
 // ResourceClaimTemplatesGetter has a method to return a ResourceClaimTemplateInterface.
@@ -82,6 +83,16 @@ func (c *resourceClaimTemplates) Get(ctx context.Context, name string, options v
 
 // List takes label and field selectors, and returns the list of ResourceClaimTemplates that match those selectors.
 func (c *resourceClaimTemplates) List(ctx context.Context, opts v1.ListOptions) (result *v1alpha2.ResourceClaimTemplateList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for resourceclaimtemplates", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of ResourceClaimTemplates that match those selectors.
+func (c *resourceClaimTemplates) list(ctx context.Context, opts v1.ListOptions) (result *v1alpha2.ResourceClaimTemplateList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/client-go/kubernetes/typed/resource/v1alpha2/resourceclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/resource/v1alpha2/resourceclass.go
@@ -31,6 +31,7 @@ import (
 	resourcev1alpha2 "k8s.io/client-go/applyconfigurations/resource/v1alpha2"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 )
 
 // ResourceClassesGetter has a method to return a ResourceClassInterface.
@@ -79,6 +80,16 @@ func (c *resourceClasses) Get(ctx context.Context, name string, options v1.GetOp
 
 // List takes label and field selectors, and returns the list of ResourceClasses that match those selectors.
 func (c *resourceClasses) List(ctx context.Context, opts v1.ListOptions) (result *v1alpha2.ResourceClassList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for resourceclasses", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of ResourceClasses that match those selectors.
+func (c *resourceClasses) list(ctx context.Context, opts v1.ListOptions) (result *v1alpha2.ResourceClassList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/client-go/kubernetes/typed/resource/v1alpha2/resourceclassparameters.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/resource/v1alpha2/resourceclassparameters.go
@@ -31,6 +31,7 @@ import (
 	resourcev1alpha2 "k8s.io/client-go/applyconfigurations/resource/v1alpha2"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 )
 
 // ResourceClassParametersGetter has a method to return a ResourceClassParametersInterface.
@@ -82,6 +83,16 @@ func (c *resourceClassParameters) Get(ctx context.Context, name string, options 
 
 // List takes label and field selectors, and returns the list of ResourceClassParameters that match those selectors.
 func (c *resourceClassParameters) List(ctx context.Context, opts v1.ListOptions) (result *v1alpha2.ResourceClassParametersList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for resourceclassparameters", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of ResourceClassParameters that match those selectors.
+func (c *resourceClassParameters) list(ctx context.Context, opts v1.ListOptions) (result *v1alpha2.ResourceClassParametersList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1alpha1/priorityclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1alpha1/priorityclass.go
@@ -31,6 +31,7 @@ import (
 	schedulingv1alpha1 "k8s.io/client-go/applyconfigurations/scheduling/v1alpha1"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 )
 
 // PriorityClassesGetter has a method to return a PriorityClassInterface.
@@ -79,6 +80,16 @@ func (c *priorityClasses) Get(ctx context.Context, name string, options v1.GetOp
 
 // List takes label and field selectors, and returns the list of PriorityClasses that match those selectors.
 func (c *priorityClasses) List(ctx context.Context, opts v1.ListOptions) (result *v1alpha1.PriorityClassList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for priorityclasses", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of PriorityClasses that match those selectors.
+func (c *priorityClasses) list(ctx context.Context, opts v1.ListOptions) (result *v1alpha1.PriorityClassList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1beta1/priorityclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1beta1/priorityclass.go
@@ -31,6 +31,7 @@ import (
 	schedulingv1beta1 "k8s.io/client-go/applyconfigurations/scheduling/v1beta1"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 )
 
 // PriorityClassesGetter has a method to return a PriorityClassInterface.
@@ -79,6 +80,16 @@ func (c *priorityClasses) Get(ctx context.Context, name string, options v1.GetOp
 
 // List takes label and field selectors, and returns the list of PriorityClasses that match those selectors.
 func (c *priorityClasses) List(ctx context.Context, opts v1.ListOptions) (result *v1beta1.PriorityClassList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for priorityclasses", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of PriorityClasses that match those selectors.
+func (c *priorityClasses) list(ctx context.Context, opts v1.ListOptions) (result *v1beta1.PriorityClassList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/csidriver.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/csidriver.go
@@ -31,6 +31,7 @@ import (
 	storagev1 "k8s.io/client-go/applyconfigurations/storage/v1"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 )
 
 // CSIDriversGetter has a method to return a CSIDriverInterface.
@@ -79,6 +80,16 @@ func (c *cSIDrivers) Get(ctx context.Context, name string, options metav1.GetOpt
 
 // List takes label and field selectors, and returns the list of CSIDrivers that match those selectors.
 func (c *cSIDrivers) List(ctx context.Context, opts metav1.ListOptions) (result *v1.CSIDriverList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for csidrivers", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of CSIDrivers that match those selectors.
+func (c *cSIDrivers) list(ctx context.Context, opts metav1.ListOptions) (result *v1.CSIDriverList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/csinode.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/csinode.go
@@ -31,6 +31,7 @@ import (
 	storagev1 "k8s.io/client-go/applyconfigurations/storage/v1"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 )
 
 // CSINodesGetter has a method to return a CSINodeInterface.
@@ -79,6 +80,16 @@ func (c *cSINodes) Get(ctx context.Context, name string, options metav1.GetOptio
 
 // List takes label and field selectors, and returns the list of CSINodes that match those selectors.
 func (c *cSINodes) List(ctx context.Context, opts metav1.ListOptions) (result *v1.CSINodeList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for csinodes", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of CSINodes that match those selectors.
+func (c *cSINodes) list(ctx context.Context, opts metav1.ListOptions) (result *v1.CSINodeList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/csistoragecapacity.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/csistoragecapacity.go
@@ -31,6 +31,7 @@ import (
 	storagev1 "k8s.io/client-go/applyconfigurations/storage/v1"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 )
 
 // CSIStorageCapacitiesGetter has a method to return a CSIStorageCapacityInterface.
@@ -82,6 +83,16 @@ func (c *cSIStorageCapacities) Get(ctx context.Context, name string, options met
 
 // List takes label and field selectors, and returns the list of CSIStorageCapacities that match those selectors.
 func (c *cSIStorageCapacities) List(ctx context.Context, opts metav1.ListOptions) (result *v1.CSIStorageCapacityList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for csistoragecapacities", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of CSIStorageCapacities that match those selectors.
+func (c *cSIStorageCapacities) list(ctx context.Context, opts metav1.ListOptions) (result *v1.CSIStorageCapacityList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/storageclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/storageclass.go
@@ -31,6 +31,7 @@ import (
 	storagev1 "k8s.io/client-go/applyconfigurations/storage/v1"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 )
 
 // StorageClassesGetter has a method to return a StorageClassInterface.
@@ -79,6 +80,16 @@ func (c *storageClasses) Get(ctx context.Context, name string, options metav1.Ge
 
 // List takes label and field selectors, and returns the list of StorageClasses that match those selectors.
 func (c *storageClasses) List(ctx context.Context, opts metav1.ListOptions) (result *v1.StorageClassList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for storageclasses", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of StorageClasses that match those selectors.
+func (c *storageClasses) list(ctx context.Context, opts metav1.ListOptions) (result *v1.StorageClassList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1alpha1/csistoragecapacity.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1alpha1/csistoragecapacity.go
@@ -31,6 +31,7 @@ import (
 	storagev1alpha1 "k8s.io/client-go/applyconfigurations/storage/v1alpha1"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 )
 
 // CSIStorageCapacitiesGetter has a method to return a CSIStorageCapacityInterface.
@@ -82,6 +83,16 @@ func (c *cSIStorageCapacities) Get(ctx context.Context, name string, options v1.
 
 // List takes label and field selectors, and returns the list of CSIStorageCapacities that match those selectors.
 func (c *cSIStorageCapacities) List(ctx context.Context, opts v1.ListOptions) (result *v1alpha1.CSIStorageCapacityList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for csistoragecapacities", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of CSIStorageCapacities that match those selectors.
+func (c *cSIStorageCapacities) list(ctx context.Context, opts v1.ListOptions) (result *v1alpha1.CSIStorageCapacityList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1alpha1/volumeattachment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1alpha1/volumeattachment.go
@@ -31,6 +31,7 @@ import (
 	storagev1alpha1 "k8s.io/client-go/applyconfigurations/storage/v1alpha1"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 )
 
 // VolumeAttachmentsGetter has a method to return a VolumeAttachmentInterface.
@@ -81,6 +82,16 @@ func (c *volumeAttachments) Get(ctx context.Context, name string, options v1.Get
 
 // List takes label and field selectors, and returns the list of VolumeAttachments that match those selectors.
 func (c *volumeAttachments) List(ctx context.Context, opts v1.ListOptions) (result *v1alpha1.VolumeAttachmentList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for volumeattachments", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of VolumeAttachments that match those selectors.
+func (c *volumeAttachments) list(ctx context.Context, opts v1.ListOptions) (result *v1alpha1.VolumeAttachmentList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1alpha1/volumeattributesclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1alpha1/volumeattributesclass.go
@@ -31,6 +31,7 @@ import (
 	storagev1alpha1 "k8s.io/client-go/applyconfigurations/storage/v1alpha1"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 )
 
 // VolumeAttributesClassesGetter has a method to return a VolumeAttributesClassInterface.
@@ -79,6 +80,16 @@ func (c *volumeAttributesClasses) Get(ctx context.Context, name string, options 
 
 // List takes label and field selectors, and returns the list of VolumeAttributesClasses that match those selectors.
 func (c *volumeAttributesClasses) List(ctx context.Context, opts v1.ListOptions) (result *v1alpha1.VolumeAttributesClassList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for volumeattributesclasses", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of VolumeAttributesClasses that match those selectors.
+func (c *volumeAttributesClasses) list(ctx context.Context, opts v1.ListOptions) (result *v1alpha1.VolumeAttributesClassList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/csidriver.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/csidriver.go
@@ -31,6 +31,7 @@ import (
 	storagev1beta1 "k8s.io/client-go/applyconfigurations/storage/v1beta1"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 )
 
 // CSIDriversGetter has a method to return a CSIDriverInterface.
@@ -79,6 +80,16 @@ func (c *cSIDrivers) Get(ctx context.Context, name string, options v1.GetOptions
 
 // List takes label and field selectors, and returns the list of CSIDrivers that match those selectors.
 func (c *cSIDrivers) List(ctx context.Context, opts v1.ListOptions) (result *v1beta1.CSIDriverList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for csidrivers", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of CSIDrivers that match those selectors.
+func (c *cSIDrivers) list(ctx context.Context, opts v1.ListOptions) (result *v1beta1.CSIDriverList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/csinode.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/csinode.go
@@ -31,6 +31,7 @@ import (
 	storagev1beta1 "k8s.io/client-go/applyconfigurations/storage/v1beta1"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 )
 
 // CSINodesGetter has a method to return a CSINodeInterface.
@@ -79,6 +80,16 @@ func (c *cSINodes) Get(ctx context.Context, name string, options v1.GetOptions) 
 
 // List takes label and field selectors, and returns the list of CSINodes that match those selectors.
 func (c *cSINodes) List(ctx context.Context, opts v1.ListOptions) (result *v1beta1.CSINodeList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for csinodes", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of CSINodes that match those selectors.
+func (c *cSINodes) list(ctx context.Context, opts v1.ListOptions) (result *v1beta1.CSINodeList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/csistoragecapacity.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/csistoragecapacity.go
@@ -31,6 +31,7 @@ import (
 	storagev1beta1 "k8s.io/client-go/applyconfigurations/storage/v1beta1"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 )
 
 // CSIStorageCapacitiesGetter has a method to return a CSIStorageCapacityInterface.
@@ -82,6 +83,16 @@ func (c *cSIStorageCapacities) Get(ctx context.Context, name string, options v1.
 
 // List takes label and field selectors, and returns the list of CSIStorageCapacities that match those selectors.
 func (c *cSIStorageCapacities) List(ctx context.Context, opts v1.ListOptions) (result *v1beta1.CSIStorageCapacityList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for csistoragecapacities", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of CSIStorageCapacities that match those selectors.
+func (c *cSIStorageCapacities) list(ctx context.Context, opts v1.ListOptions) (result *v1beta1.CSIStorageCapacityList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/volumeattachment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/volumeattachment.go
@@ -31,6 +31,7 @@ import (
 	storagev1beta1 "k8s.io/client-go/applyconfigurations/storage/v1beta1"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 )
 
 // VolumeAttachmentsGetter has a method to return a VolumeAttachmentInterface.
@@ -81,6 +82,16 @@ func (c *volumeAttachments) Get(ctx context.Context, name string, options v1.Get
 
 // List takes label and field selectors, and returns the list of VolumeAttachments that match those selectors.
 func (c *volumeAttachments) List(ctx context.Context, opts v1.ListOptions) (result *v1beta1.VolumeAttachmentList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for volumeattachments", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of VolumeAttachments that match those selectors.
+func (c *volumeAttachments) list(ctx context.Context, opts v1.ListOptions) (result *v1beta1.VolumeAttachmentList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storagemigration/v1alpha1/storageversionmigration.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storagemigration/v1alpha1/storageversionmigration.go
@@ -31,6 +31,7 @@ import (
 	storagemigrationv1alpha1 "k8s.io/client-go/applyconfigurations/storagemigration/v1alpha1"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 )
 
 // StorageVersionMigrationsGetter has a method to return a StorageVersionMigrationInterface.
@@ -81,6 +82,16 @@ func (c *storageVersionMigrations) Get(ctx context.Context, name string, options
 
 // List takes label and field selectors, and returns the list of StorageVersionMigrations that match those selectors.
 func (c *storageVersionMigrations) List(ctx context.Context, opts v1.ListOptions) (result *v1alpha1.StorageVersionMigrationList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for storageversionmigrations", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of StorageVersionMigrations that match those selectors.
+func (c *storageVersionMigrations) list(ctx context.Context, opts v1.ListOptions) (result *v1alpha1.StorageVersionMigrationList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/code-generator/examples/HyphenGroup/clientset/versioned/typed/example/v1/clustertesttype.go
+++ b/staging/src/k8s.io/code-generator/examples/HyphenGroup/clientset/versioned/typed/example/v1/clustertesttype.go
@@ -29,6 +29,7 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 	v1 "k8s.io/code-generator/examples/HyphenGroup/apis/example/v1"
 	examplev1 "k8s.io/code-generator/examples/HyphenGroup/applyconfiguration/example/v1"
 	scheme "k8s.io/code-generator/examples/HyphenGroup/clientset/versioned/scheme"
@@ -85,6 +86,16 @@ func (c *clusterTestTypes) Get(ctx context.Context, name string, options metav1.
 
 // List takes label and field selectors, and returns the list of ClusterTestTypes that match those selectors.
 func (c *clusterTestTypes) List(ctx context.Context, opts metav1.ListOptions) (result *v1.ClusterTestTypeList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for clustertesttypes", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of ClusterTestTypes that match those selectors.
+func (c *clusterTestTypes) list(ctx context.Context, opts metav1.ListOptions) (result *v1.ClusterTestTypeList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/code-generator/examples/HyphenGroup/clientset/versioned/typed/example/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/HyphenGroup/clientset/versioned/typed/example/v1/testtype.go
@@ -28,6 +28,7 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 	v1 "k8s.io/code-generator/examples/HyphenGroup/apis/example/v1"
 	examplev1 "k8s.io/code-generator/examples/HyphenGroup/applyconfiguration/example/v1"
 	scheme "k8s.io/code-generator/examples/HyphenGroup/clientset/versioned/scheme"
@@ -84,6 +85,16 @@ func (c *testTypes) Get(ctx context.Context, name string, options metav1.GetOpti
 
 // List takes label and field selectors, and returns the list of TestTypes that match those selectors.
 func (c *testTypes) List(ctx context.Context, opts metav1.ListOptions) (result *v1.TestTypeList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for testtypes", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of TestTypes that match those selectors.
+func (c *testTypes) list(ctx context.Context, opts metav1.ListOptions) (result *v1.TestTypeList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/code-generator/examples/MixedCase/clientset/versioned/typed/example/v1/clustertesttype.go
+++ b/staging/src/k8s.io/code-generator/examples/MixedCase/clientset/versioned/typed/example/v1/clustertesttype.go
@@ -29,6 +29,7 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 	v1 "k8s.io/code-generator/examples/MixedCase/apis/example/v1"
 	examplev1 "k8s.io/code-generator/examples/MixedCase/applyconfiguration/example/v1"
 	scheme "k8s.io/code-generator/examples/MixedCase/clientset/versioned/scheme"
@@ -86,6 +87,16 @@ func (c *clusterTestTypes) Get(ctx context.Context, name string, options metav1.
 
 // List takes label and field selectors, and returns the list of ClusterTestTypes that match those selectors.
 func (c *clusterTestTypes) List(ctx context.Context, opts metav1.ListOptions) (result *v1.ClusterTestTypeList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for clustertesttypes", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of ClusterTestTypes that match those selectors.
+func (c *clusterTestTypes) list(ctx context.Context, opts metav1.ListOptions) (result *v1.ClusterTestTypeList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/code-generator/examples/MixedCase/clientset/versioned/typed/example/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/MixedCase/clientset/versioned/typed/example/v1/testtype.go
@@ -28,6 +28,7 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 	v1 "k8s.io/code-generator/examples/MixedCase/apis/example/v1"
 	examplev1 "k8s.io/code-generator/examples/MixedCase/applyconfiguration/example/v1"
 	scheme "k8s.io/code-generator/examples/MixedCase/clientset/versioned/scheme"
@@ -84,6 +85,16 @@ func (c *testTypes) Get(ctx context.Context, name string, options metav1.GetOpti
 
 // List takes label and field selectors, and returns the list of TestTypes that match those selectors.
 func (c *testTypes) List(ctx context.Context, opts metav1.ListOptions) (result *v1.TestTypeList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for testtypes", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of TestTypes that match those selectors.
+func (c *testTypes) list(ctx context.Context, opts metav1.ListOptions) (result *v1.TestTypeList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/code-generator/examples/apiserver/clientset/versioned/typed/example/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/clientset/versioned/typed/example/v1/testtype.go
@@ -26,6 +26,7 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 	v1 "k8s.io/code-generator/examples/apiserver/apis/example/v1"
 	scheme "k8s.io/code-generator/examples/apiserver/clientset/versioned/scheme"
 )
@@ -79,6 +80,16 @@ func (c *testTypes) Get(ctx context.Context, name string, options metav1.GetOpti
 
 // List takes label and field selectors, and returns the list of TestTypes that match those selectors.
 func (c *testTypes) List(ctx context.Context, opts metav1.ListOptions) (result *v1.TestTypeList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for testtypes", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of TestTypes that match those selectors.
+func (c *testTypes) list(ctx context.Context, opts metav1.ListOptions) (result *v1.TestTypeList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/code-generator/examples/apiserver/clientset/versioned/typed/example2/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/clientset/versioned/typed/example2/v1/testtype.go
@@ -26,6 +26,7 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 	v1 "k8s.io/code-generator/examples/apiserver/apis/example2/v1"
 	scheme "k8s.io/code-generator/examples/apiserver/clientset/versioned/scheme"
 )
@@ -79,6 +80,16 @@ func (c *testTypes) Get(ctx context.Context, name string, options metav1.GetOpti
 
 // List takes label and field selectors, and returns the list of TestTypes that match those selectors.
 func (c *testTypes) List(ctx context.Context, opts metav1.ListOptions) (result *v1.TestTypeList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for testtypes", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of TestTypes that match those selectors.
+func (c *testTypes) list(ctx context.Context, opts metav1.ListOptions) (result *v1.TestTypeList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/code-generator/examples/apiserver/clientset/versioned/typed/example3.io/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/clientset/versioned/typed/example3.io/v1/testtype.go
@@ -26,6 +26,7 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 	v1 "k8s.io/code-generator/examples/apiserver/apis/example3.io/v1"
 	scheme "k8s.io/code-generator/examples/apiserver/clientset/versioned/scheme"
 )
@@ -79,6 +80,16 @@ func (c *testTypes) Get(ctx context.Context, name string, options metav1.GetOpti
 
 // List takes label and field selectors, and returns the list of TestTypes that match those selectors.
 func (c *testTypes) List(ctx context.Context, opts metav1.ListOptions) (result *v1.TestTypeList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for testtypes", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of TestTypes that match those selectors.
+func (c *testTypes) list(ctx context.Context, opts metav1.ListOptions) (result *v1.TestTypeList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/code-generator/examples/crd/clientset/versioned/typed/example/v1/clustertesttype.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/clientset/versioned/typed/example/v1/clustertesttype.go
@@ -29,6 +29,7 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 	v1 "k8s.io/code-generator/examples/crd/apis/example/v1"
 	examplev1 "k8s.io/code-generator/examples/crd/applyconfiguration/example/v1"
 	scheme "k8s.io/code-generator/examples/crd/clientset/versioned/scheme"
@@ -85,6 +86,16 @@ func (c *clusterTestTypes) Get(ctx context.Context, name string, options metav1.
 
 // List takes label and field selectors, and returns the list of ClusterTestTypes that match those selectors.
 func (c *clusterTestTypes) List(ctx context.Context, opts metav1.ListOptions) (result *v1.ClusterTestTypeList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for clustertesttypes", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of ClusterTestTypes that match those selectors.
+func (c *clusterTestTypes) list(ctx context.Context, opts metav1.ListOptions) (result *v1.ClusterTestTypeList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/code-generator/examples/crd/clientset/versioned/typed/example/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/clientset/versioned/typed/example/v1/testtype.go
@@ -28,6 +28,7 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 	v1 "k8s.io/code-generator/examples/crd/apis/example/v1"
 	examplev1 "k8s.io/code-generator/examples/crd/applyconfiguration/example/v1"
 	scheme "k8s.io/code-generator/examples/crd/clientset/versioned/scheme"
@@ -84,6 +85,16 @@ func (c *testTypes) Get(ctx context.Context, name string, options metav1.GetOpti
 
 // List takes label and field selectors, and returns the list of TestTypes that match those selectors.
 func (c *testTypes) List(ctx context.Context, opts metav1.ListOptions) (result *v1.TestTypeList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for testtypes", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of TestTypes that match those selectors.
+func (c *testTypes) list(ctx context.Context, opts metav1.ListOptions) (result *v1.TestTypeList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/code-generator/examples/crd/clientset/versioned/typed/example2/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/clientset/versioned/typed/example2/v1/testtype.go
@@ -28,6 +28,7 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 	v1 "k8s.io/code-generator/examples/crd/apis/example2/v1"
 	example2v1 "k8s.io/code-generator/examples/crd/applyconfiguration/example2/v1"
 	scheme "k8s.io/code-generator/examples/crd/clientset/versioned/scheme"
@@ -84,6 +85,16 @@ func (c *testTypes) Get(ctx context.Context, name string, options metav1.GetOpti
 
 // List takes label and field selectors, and returns the list of TestTypes that match those selectors.
 func (c *testTypes) List(ctx context.Context, opts metav1.ListOptions) (result *v1.TestTypeList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for testtypes", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of TestTypes that match those selectors.
+func (c *testTypes) list(ctx context.Context, opts metav1.ListOptions) (result *v1.TestTypeList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1/apiservice.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1/apiservice.go
@@ -26,6 +26,7 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 	v1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 	scheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
 )
@@ -76,6 +77,16 @@ func (c *aPIServices) Get(ctx context.Context, name string, options metav1.GetOp
 
 // List takes label and field selectors, and returns the list of APIServices that match those selectors.
 func (c *aPIServices) List(ctx context.Context, opts metav1.ListOptions) (result *v1.APIServiceList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for apiservices", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of APIServices that match those selectors.
+func (c *aPIServices) list(ctx context.Context, opts metav1.ListOptions) (result *v1.APIServiceList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1alpha1/podmetrics.go
+++ b/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1alpha1/podmetrics.go
@@ -25,6 +25,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 	v1alpha1 "k8s.io/metrics/pkg/apis/metrics/v1alpha1"
 	scheme "k8s.io/metrics/pkg/client/clientset/versioned/scheme"
 )
@@ -72,6 +73,16 @@ func (c *podMetricses) Get(ctx context.Context, name string, options v1.GetOptio
 
 // List takes label and field selectors, and returns the list of PodMetricses that match those selectors.
 func (c *podMetricses) List(ctx context.Context, opts v1.ListOptions) (result *v1alpha1.PodMetricsList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for pods", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of PodMetricses that match those selectors.
+func (c *podMetricses) list(ctx context.Context, opts v1.ListOptions) (result *v1alpha1.PodMetricsList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1beta1/nodemetrics.go
+++ b/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1beta1/nodemetrics.go
@@ -25,6 +25,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 	v1beta1 "k8s.io/metrics/pkg/apis/metrics/v1beta1"
 	scheme "k8s.io/metrics/pkg/client/clientset/versioned/scheme"
 )
@@ -69,6 +70,16 @@ func (c *nodeMetricses) Get(ctx context.Context, name string, options v1.GetOpti
 
 // List takes label and field selectors, and returns the list of NodeMetricses that match those selectors.
 func (c *nodeMetricses) List(ctx context.Context, opts v1.ListOptions) (result *v1beta1.NodeMetricsList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for nodes", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of NodeMetricses that match those selectors.
+func (c *nodeMetricses) list(ctx context.Context, opts v1.ListOptions) (result *v1beta1.NodeMetricsList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1alpha1/fischer.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1alpha1/fischer.go
@@ -28,6 +28,7 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 	v1alpha1 "k8s.io/sample-apiserver/pkg/apis/wardle/v1alpha1"
 	wardlev1alpha1 "k8s.io/sample-apiserver/pkg/generated/applyconfiguration/wardle/v1alpha1"
 	scheme "k8s.io/sample-apiserver/pkg/generated/clientset/versioned/scheme"
@@ -79,6 +80,16 @@ func (c *fischers) Get(ctx context.Context, name string, options v1.GetOptions) 
 
 // List takes label and field selectors, and returns the list of Fischers that match those selectors.
 func (c *fischers) List(ctx context.Context, opts v1.ListOptions) (result *v1alpha1.FischerList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for fischers", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of Fischers that match those selectors.
+func (c *fischers) list(ctx context.Context, opts v1.ListOptions) (result *v1alpha1.FischerList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1beta1/flunder.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1beta1/flunder.go
@@ -28,6 +28,7 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
+	consistencydetector "k8s.io/client-go/util/consistencydetector"
 	v1beta1 "k8s.io/sample-apiserver/pkg/apis/wardle/v1beta1"
 	wardlev1beta1 "k8s.io/sample-apiserver/pkg/generated/applyconfiguration/wardle/v1beta1"
 	scheme "k8s.io/sample-apiserver/pkg/generated/clientset/versioned/scheme"
@@ -84,6 +85,16 @@ func (c *flunders) Get(ctx context.Context, name string, options v1.GetOptions) 
 
 // List takes label and field selectors, and returns the list of Flunders that match those selectors.
 func (c *flunders) List(ctx context.Context, opts v1.ListOptions) (result *v1beta1.FlunderList, err error) {
+	defer func() {
+		if err == nil {
+			consistencydetector.CheckListFromCacheDataConsistencyIfRequested(ctx, "list request for flunders", c.list, opts, result)
+		}
+	}()
+	return c.list(ctx, opts)
+}
+
+// list takes label and field selectors, and returns the list of Flunders that match those selectors.
+func (c *flunders) list(ctx context.Context, opts v1.ListOptions) (result *v1beta1.FlunderList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Adds data consistency checker to client-go for checking data retrieved via list requests from the cache and directly from etcd. The detector can be enabled by setting `KUBE_LIST_FROM_CACHE_INCONSISTENCY_DETECTOR` env var.

// CheckListFromCacheDataConsistencyIfRequested performs a data consistency check only when
// the KUBE_LIST_FROM_CACHE_INCONSISTENCY_DETECTOR environment variable was set during a binary startup
// for requests that have a high chance of being served from the watch-cache.
//
// The consistency check is meant to be enforced only in the CI, not in production.
// The check ensures that data retrieved by a list api call from the watch-cache
// is exactly the same as data received by the list api call from etcd.
//
// Note that this function will panic when data inconsistency is detected.
// This is intentional because we want to catch it in the CI.
//
// Note that this function doesn't examine the ListOptions to determine
// if the original request has hit the cache because it would be challenging
// to maintain consistency with the server-side implementation.
// For simplicity, we assume that the first request retrieved data from
// the cache (even though this might not be true for some requests)
// and issue the second call to get data from etcd for comparison.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
