### PR TITLE
graduate PersistentVolumeLastPhaseTransitionTime to GA in 1.31

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -9023,7 +9023,7 @@
       "properties": {
         "lastPhaseTransitionTime": {
           "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
-          "description": "lastPhaseTransitionTime is the time the phase transitioned from one to another and automatically resets to current time everytime a volume phase transitions. This is a beta field and requires the PersistentVolumeLastPhaseTransitionTime feature to be enabled (enabled by default)."
+          "description": "lastPhaseTransitionTime is the time the phase transitioned from one to another and automatically resets to current time everytime a volume phase transitions."
         },
         "message": {
           "description": "message is a human-readable message indicating details about why the volume is in this state.",

--- a/api/openapi-spec/v3/api__v1_openapi.json
+++ b/api/openapi-spec/v3/api__v1_openapi.json
@@ -4817,7 +4817,7 @@
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
               }
             ],
-            "description": "lastPhaseTransitionTime is the time the phase transitioned from one to another and automatically resets to current time everytime a volume phase transitions. This is a beta field and requires the PersistentVolumeLastPhaseTransitionTime feature to be enabled (enabled by default)."
+            "description": "lastPhaseTransitionTime is the time the phase transitioned from one to another and automatically resets to current time everytime a volume phase transitions."
           },
           "message": {
             "description": "message is a human-readable message indicating details about why the volume is in this state.",

--- a/pkg/api/persistentvolume/util.go
+++ b/pkg/api/persistentvolume/util.go
@@ -41,14 +41,6 @@ func DropDisabledSpecFields(pvSpec *api.PersistentVolumeSpec, oldPVSpec *api.Per
 	}
 }
 
-// DropDisabledStatusFields removes disabled fields from the pv status.
-// This should be called from PrepareForUpdate for all resources containing a pv status.
-func DropDisabledStatusFields(oldStatus, newStatus *api.PersistentVolumeStatus) {
-	if !utilfeature.DefaultFeatureGate.Enabled(features.PersistentVolumeLastPhaseTransitionTime) && oldStatus.LastPhaseTransitionTime.IsZero() {
-		newStatus.LastPhaseTransitionTime = nil
-	}
-}
-
 func GetWarningsForPersistentVolume(pv *api.PersistentVolume) []string {
 	if pv == nil {
 		return nil

--- a/pkg/apis/core/types.go
+++ b/pkg/apis/core/types.go
@@ -392,8 +392,6 @@ type PersistentVolumeStatus struct {
 	Reason string
 	// LastPhaseTransitionTime is the time the phase transitioned from one to another
 	// and automatically resets to current time everytime a volume phase transitions.
-	// This is a beta field and requires the PersistentVolumeLastPhaseTransitionTime feature to be enabled (enabled by default).
-	// +featureGate=PersistentVolumeLastPhaseTransitionTime
 	// +optional
 	LastPhaseTransitionTime *metav1.Time
 }

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -534,6 +534,7 @@ const (
 	// kep: https://kep.k8s.io/3762
 	// alpha: v1.28
 	// beta: v1.29
+	// GA: v1.31
 	//
 	// Adds a new field to persistent volumes which holds a timestamp of when the volume last transitioned its phase.
 	PersistentVolumeLastPhaseTransitionTime featuregate.Feature = "PersistentVolumeLastPhaseTransitionTime"
@@ -1089,7 +1090,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 
 	PDBUnhealthyPodEvictionPolicy: {Default: true, PreRelease: featuregate.Beta},
 
-	PersistentVolumeLastPhaseTransitionTime: {Default: true, PreRelease: featuregate.Beta},
+	PersistentVolumeLastPhaseTransitionTime: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.33
 
 	PodAndContainerStatsFromCRI: {Default: false, PreRelease: featuregate.Alpha},
 

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -26072,7 +26072,7 @@ func schema_k8sio_api_core_v1_PersistentVolumeStatus(ref common.ReferenceCallbac
 					},
 					"lastPhaseTransitionTime": {
 						SchemaProps: spec.SchemaProps{
-							Description: "lastPhaseTransitionTime is the time the phase transitioned from one to another and automatically resets to current time everytime a volume phase transitions. This is a beta field and requires the PersistentVolumeLastPhaseTransitionTime feature to be enabled (enabled by default).",
+							Description: "lastPhaseTransitionTime is the time the phase transitioned from one to another and automatically resets to current time everytime a volume phase transitions.",
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Time"),
 						},
 					},

--- a/pkg/registry/core/persistentvolume/storage/storage_test.go
+++ b/pkg/registry/core/persistentvolume/storage/storage_test.go
@@ -33,10 +33,7 @@ import (
 	genericregistrytest "k8s.io/apiserver/pkg/registry/generic/testing"
 	"k8s.io/apiserver/pkg/registry/rest"
 	etcd3testing "k8s.io/apiserver/pkg/storage/etcd3/testing"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
-	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	api "k8s.io/kubernetes/pkg/apis/core"
-	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/registry/core/persistentvolume"
 	"k8s.io/kubernetes/pkg/registry/registrytest"
 )
@@ -174,7 +171,6 @@ func TestWatch(t *testing.T) {
 }
 
 func TestUpdateStatus(t *testing.T) {
-	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.PersistentVolumeLastPhaseTransitionTime, true)
 	storage, statusStorage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()

--- a/pkg/registry/core/persistentvolume/strategy_test.go
+++ b/pkg/registry/core/persistentvolume/strategy_test.go
@@ -21,11 +21,8 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
-	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	apitesting "k8s.io/kubernetes/pkg/api/testing"
 	api "k8s.io/kubernetes/pkg/apis/core"
-	"k8s.io/kubernetes/pkg/features"
 	"reflect"
 	"testing"
 	"time"
@@ -53,14 +50,12 @@ func TestStatusUpdate(t *testing.T) {
 	}()
 	tests := []struct {
 		name        string
-		fg          bool
 		oldObj      *api.PersistentVolume
 		newObj      *api.PersistentVolume
 		expectedObj *api.PersistentVolume
 	}{
 		{
-			name: "feature enabled: timestamp is updated when phase changes",
-			fg:   true,
+			name: "timestamp is updated when phase changes",
 			oldObj: &api.PersistentVolume{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "foo",
@@ -88,8 +83,7 @@ func TestStatusUpdate(t *testing.T) {
 			},
 		},
 		{
-			name: "feature enabled: timestamp is updated when phase changes and old pv has a timestamp",
-			fg:   true,
+			name: "timestamp is updated when phase changes and old pv has a timestamp",
 			oldObj: &api.PersistentVolume{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "foo",
@@ -118,8 +112,7 @@ func TestStatusUpdate(t *testing.T) {
 			},
 		},
 		{
-			name: "feature enabled: user timestamp change is respected on no phase change",
-			fg:   true,
+			name: "user timestamp change is respected on no phase change",
 			oldObj: &api.PersistentVolume{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "foo",
@@ -148,8 +141,7 @@ func TestStatusUpdate(t *testing.T) {
 			},
 		},
 		{
-			name: "feature enabled: user timestamp is respected on phase change",
-			fg:   true,
+			name: "user timestamp is respected on phase change",
 			oldObj: &api.PersistentVolume{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "foo",
@@ -179,8 +171,7 @@ func TestStatusUpdate(t *testing.T) {
 			},
 		},
 		{
-			name: "feature enabled: user timestamp change is respected on no phase change when old pv has a timestamp",
-			fg:   true,
+			name: "user timestamp change is respected on no phase change when old pv has a timestamp",
 			oldObj: &api.PersistentVolume{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "foo",
@@ -210,8 +201,7 @@ func TestStatusUpdate(t *testing.T) {
 			},
 		},
 		{
-			name: "feature enabled: timestamp is updated when phase changes and both new and old timestamp matches",
-			fg:   true,
+			name: "timestamp is updated when phase changes and both new and old timestamp matches",
 			oldObj: &api.PersistentVolume{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "foo",
@@ -237,126 +227,6 @@ func TestStatusUpdate(t *testing.T) {
 				Status: api.PersistentVolumeStatus{
 					Phase:                   api.VolumeBound,
 					LastPhaseTransitionTime: &now,
-				},
-			},
-		},
-		{
-			name: "feature disabled: timestamp is not updated",
-			fg:   false,
-			oldObj: &api.PersistentVolume{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "foo",
-				},
-				Status: api.PersistentVolumeStatus{
-					Phase: api.VolumePending,
-				},
-			},
-			newObj: &api.PersistentVolume{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "foo",
-				},
-				Status: api.PersistentVolumeStatus{
-					Phase: api.VolumeBound,
-				},
-			},
-			expectedObj: &api.PersistentVolume{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "foo",
-				},
-				Status: api.PersistentVolumeStatus{
-					Phase: api.VolumeBound,
-				},
-			},
-		},
-		{
-			name: "feature disabled: user timestamp is overwritten on phase change to nil",
-			fg:   false,
-			oldObj: &api.PersistentVolume{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "foo",
-				},
-				Status: api.PersistentVolumeStatus{
-					Phase: api.VolumePending,
-				},
-			},
-			newObj: &api.PersistentVolume{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "foo",
-				},
-				Status: api.PersistentVolumeStatus{
-					Phase:                   api.VolumePending,
-					LastPhaseTransitionTime: &later,
-				},
-			},
-			expectedObj: &api.PersistentVolume{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "foo",
-				},
-				Status: api.PersistentVolumeStatus{
-					Phase:                   api.VolumePending,
-					LastPhaseTransitionTime: nil,
-				},
-			},
-		},
-		{
-			name: "feature disabled: user timestamp change is respected on phase change",
-			fg:   false,
-			oldObj: &api.PersistentVolume{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "foo",
-				},
-				Status: api.PersistentVolumeStatus{
-					Phase:                   api.VolumePending,
-					LastPhaseTransitionTime: &origin,
-				},
-			},
-			newObj: &api.PersistentVolume{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "foo",
-				},
-				Status: api.PersistentVolumeStatus{
-					Phase:                   api.VolumeBound,
-					LastPhaseTransitionTime: &later,
-				},
-			},
-			expectedObj: &api.PersistentVolume{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "foo",
-				},
-				Status: api.PersistentVolumeStatus{
-					Phase:                   api.VolumeBound,
-					LastPhaseTransitionTime: &later,
-				},
-			},
-		},
-		{
-			name: "feature disabled: user timestamp change is respected on no phase change",
-			fg:   false,
-			oldObj: &api.PersistentVolume{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "foo",
-				},
-				Status: api.PersistentVolumeStatus{
-					Phase:                   api.VolumeBound,
-					LastPhaseTransitionTime: &origin,
-				},
-			},
-			newObj: &api.PersistentVolume{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "foo",
-				},
-				Status: api.PersistentVolumeStatus{
-					Phase:                   api.VolumeBound,
-					LastPhaseTransitionTime: &later,
-				},
-			},
-			expectedObj: &api.PersistentVolume{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "foo",
-				},
-				Status: api.PersistentVolumeStatus{
-					Phase:                   api.VolumeBound,
-					LastPhaseTransitionTime: &later,
 				},
 			},
 		},
@@ -364,7 +234,6 @@ func TestStatusUpdate(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.PersistentVolumeLastPhaseTransitionTime, tc.fg)
 
 			obj := tc.newObj.DeepCopy()
 			StatusStrategy.PrepareForUpdate(context.TODO(), obj, tc.oldObj.DeepCopy())
@@ -383,13 +252,11 @@ func TestStatusCreate(t *testing.T) {
 	}()
 	tests := []struct {
 		name        string
-		fg          bool
 		newObj      *api.PersistentVolume
 		expectedObj *api.PersistentVolume
 	}{
 		{
-			name: "feature enabled: pv is in pending phase and has a timestamp",
-			fg:   true,
+			name: "pv is in pending phase and has a timestamp",
 			newObj: &api.PersistentVolume{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "foo",
@@ -405,26 +272,11 @@ func TestStatusCreate(t *testing.T) {
 				},
 			},
 		},
-		{
-			name: "feature disabled: pv does not have phase and timestamp",
-			fg:   false,
-			newObj: &api.PersistentVolume{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "foo",
-				},
-			},
-			expectedObj: &api.PersistentVolume{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "foo",
-				},
-			},
-		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 
-			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.PersistentVolumeLastPhaseTransitionTime, tc.fg)
 			obj := tc.newObj.DeepCopy()
 			StatusStrategy.PrepareForCreate(context.TODO(), obj)
 			if !reflect.DeepEqual(obj, tc.expectedObj) {

--- a/staging/src/k8s.io/api/core/v1/generated.proto
+++ b/staging/src/k8s.io/api/core/v1/generated.proto
@@ -3406,8 +3406,6 @@ message PersistentVolumeStatus {
 
   // lastPhaseTransitionTime is the time the phase transitioned from one to another
   // and automatically resets to current time everytime a volume phase transitions.
-  // This is a beta field and requires the PersistentVolumeLastPhaseTransitionTime feature to be enabled (enabled by default).
-  // +featureGate=PersistentVolumeLastPhaseTransitionTime
   // +optional
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time lastPhaseTransitionTime = 4;
 }

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -425,8 +425,6 @@ type PersistentVolumeStatus struct {
 	Reason string `json:"reason,omitempty" protobuf:"bytes,3,opt,name=reason"`
 	// lastPhaseTransitionTime is the time the phase transitioned from one to another
 	// and automatically resets to current time everytime a volume phase transitions.
-	// This is a beta field and requires the PersistentVolumeLastPhaseTransitionTime feature to be enabled (enabled by default).
-	// +featureGate=PersistentVolumeLastPhaseTransitionTime
 	// +optional
 	LastPhaseTransitionTime *metav1.Time `json:"lastPhaseTransitionTime,omitempty" protobuf:"bytes,4,opt,name=lastPhaseTransitionTime"`
 }

--- a/staging/src/k8s.io/api/core/v1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/core/v1/types_swagger_doc_generated.go
@@ -1500,7 +1500,7 @@ var map_PersistentVolumeStatus = map[string]string{
 	"phase":                   "phase indicates if a volume is available, bound to a claim, or released by a claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#phase",
 	"message":                 "message is a human-readable message indicating details about why the volume is in this state.",
 	"reason":                  "reason is a brief CamelCase string that describes any failure and is meant for machine parsing and tidy display in the CLI.",
-	"lastPhaseTransitionTime": "lastPhaseTransitionTime is the time the phase transitioned from one to another and automatically resets to current time everytime a volume phase transitions. This is a beta field and requires the PersistentVolumeLastPhaseTransitionTime feature to be enabled (enabled by default).",
+	"lastPhaseTransitionTime": "lastPhaseTransitionTime is the time the phase transitioned from one to another and automatically resets to current time everytime a volume phase transitions.",
 }
 
 func (PersistentVolumeStatus) SwaggerDoc() map[string]string {

--- a/test/e2e/feature/feature.go
+++ b/test/e2e/feature/feature.go
@@ -243,9 +243,6 @@ var (
 	// Marks a single test that tests pod-to-pod connectivity between every pair of nodes.
 	NoSNAT = framework.WithFeature(framework.ValidFeatures.Add("NoSNAT"))
 
-	// TODO: document the feature (owning SIG, when to use this feature for a test)
-	PersistentVolumeLastPhaseTransitionTime = framework.WithFeature(framework.ValidFeatures.Add("PersistentVolumeLastPhaseTransitionTime"))
-
 	// Owner: sig-network
 	// Marks a single test that tests cluster DNS performance with many services.
 	PerformanceDNS = framework.WithFeature(framework.ValidFeatures.Add("PerformanceDNS"))

--- a/test/e2e/storage/persistent_volumes.go
+++ b/test/e2e/storage/persistent_volumes.go
@@ -34,7 +34,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/uuid"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/util/retry"
-	"k8s.io/kubernetes/test/e2e/feature"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	e2epv "k8s.io/kubernetes/test/e2e/framework/pv"
@@ -213,7 +212,7 @@ var _ = utils.SIGDescribe("PersistentVolumes", func() {
 			})
 
 			// Create new PV without claim, verify it's in Available state and LastPhaseTransitionTime is set.
-			f.It("create a PV: test phase transition timestamp is set and phase is Available", feature.PersistentVolumeLastPhaseTransitionTime, func(ctx context.Context) {
+			f.It("create a PV: test phase transition timestamp is set and phase is Available", func(ctx context.Context) {
 				pvObj := e2epv.MakePersistentVolume(pvConfig)
 				pv, err = e2epv.CreatePV(ctx, c, f.Timeouts, pvObj)
 				framework.ExpectNoError(err)
@@ -232,7 +231,7 @@ var _ = utils.SIGDescribe("PersistentVolumes", func() {
 
 			// Create PV and pre-bound PVC that matches the PV, verify that when PV and PVC bind
 			// the LastPhaseTransitionTime filed of the PV is updated.
-			f.It("create a PV and a pre-bound PVC: test phase transition timestamp is set", feature.PersistentVolumeLastPhaseTransitionTime, func(ctx context.Context) {
+			f.It("create a PV and a pre-bound PVC: test phase transition timestamp is set", func(ctx context.Context) {
 				pv, pvc, err = e2epv.CreatePVPVC(ctx, c, f.Timeouts, pvConfig, pvcConfig, ns, true)
 				framework.ExpectNoError(err)
 
@@ -252,7 +251,7 @@ var _ = utils.SIGDescribe("PersistentVolumes", func() {
 			// Create PV and pre-bound PVC that matches the PV, verify that when PV and PVC bind
 			// the LastPhaseTransitionTime field of the PV is set, then delete the PVC to change PV phase to
 			// released and validate PV LastPhaseTransitionTime correctly updated timestamp.
-			f.It("create a PV and a pre-bound PVC: test phase transition timestamp multiple updates", feature.PersistentVolumeLastPhaseTransitionTime, func(ctx context.Context) {
+			f.It("create a PV and a pre-bound PVC: test phase transition timestamp multiple updates", func(ctx context.Context) {
 				pv, pvc, err = e2epv.CreatePVPVC(ctx, c, f.Timeouts, pvConfig, pvcConfig, ns, true)
 				framework.ExpectNoError(err)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

graduate PersistentVolumeLastPhaseTransitionTime to GA in 1.31

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
PersistentVolumeLastPhaseTransitionTime feature is stable and enabled by default.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/3762
```
