### PR TITLE
volumezone: scheduler queueing hints: pv

### DIFF
--- a/pkg/scheduler/framework/plugins/volumezone/volume_zone.go
+++ b/pkg/scheduler/framework/plugins/volumezone/volume_zone.go
@@ -370,6 +370,9 @@ func (pl *VolumeZone) isSchedulableAfterPersistentVolumeChange(logger klog.Logge
 }
 
 // getPVTopologies retrieves pvTopology from a given PV and returns the array
+// This function doesn't check spec.nodeAffinity
+// because it's read-only after creation and thus cannot be updated
+// and nodeAffinity is being handled in node affinity plugin
 func (pl *VolumeZone) getPVTopologies(logger klog.Logger, pv *v1.PersistentVolume) []pvTopology {
 	podPVTopologies := make([]pvTopology, 0)
 	for _, key := range topologyLabels {

--- a/pkg/scheduler/framework/plugins/volumezone/volume_zone_test.go
+++ b/pkg/scheduler/framework/plugins/volumezone/volume_zone_test.go
@@ -675,6 +675,105 @@ func TestIsSchedulableAfterStorageClassAdded(t *testing.T) {
 	}
 }
 
+func TestIsSchedulableAfterPersistentVolumeChange(t *testing.T) {
+	testcases := map[string]struct {
+		pod            *v1.Pod
+		oldObj, newObj interface{}
+		expectedHint   framework.QueueingHint
+		expectedErr    bool
+	}{
+		"error-wrong-new-object": {
+			pod:          createPodWithVolume("pod_1", "PVC_1"),
+			newObj:       "not-a-pv",
+			expectedHint: framework.Queue,
+			expectedErr:  true,
+		},
+		"error-wrong-old-object": {
+			pod:          createPodWithVolume("pod_1", "PVC_1"),
+			oldObj:       "not-a-pv",
+			newObj:       st.MakePersistentVolume().Name("Vol_1").Obj(),
+			expectedHint: framework.Queue,
+			expectedErr:  true,
+		},
+		"new-pv-was-added": {
+			pod: createPodWithVolume("pod_1", "PVC_1"),
+			newObj: &v1.PersistentVolume{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "Vol_1",
+					Labels: map[string]string{v1.LabelFailureDomainBetaZone: "us-west1-b"},
+				},
+			},
+			expectedHint: framework.Queue,
+		},
+		"pv-was-updated-and-changed-topology": {
+			pod: createPodWithVolume("pod_1", "PVC_1"),
+			oldObj: &v1.PersistentVolume{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "Vol_1",
+					Labels: map[string]string{v1.LabelFailureDomainBetaZone: "us-west1-a"},
+				},
+			},
+			newObj: &v1.PersistentVolume{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "Vol_1",
+					Labels: map[string]string{v1.LabelFailureDomainBetaZone: "us-west1-b"},
+				},
+			},
+			expectedHint: framework.Queue,
+		},
+		"pv-was-updated-and-added-topology-label": {
+			pod: createPodWithVolume("pod_1", "PVC_1"),
+			oldObj: &v1.PersistentVolume{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "Vol_1",
+					Labels: map[string]string{v1.LabelFailureDomainBetaZone: "us-west1-a"},
+				},
+			},
+			newObj: &v1.PersistentVolume{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "Vol_1",
+					Labels: map[string]string{v1.LabelFailureDomainBetaZone: "us-west1-a",
+						v1.LabelTopologyZone: "zone"},
+				},
+			},
+			expectedHint: framework.Queue,
+		},
+		"pv-was-updated-but-no-topology-is-changed": {
+			pod: createPodWithVolume("pod_1", "PVC_1"),
+			oldObj: &v1.PersistentVolume{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "Vol_1",
+					Labels: map[string]string{v1.LabelFailureDomainBetaZone: "us-west1-a",
+						v1.LabelTopologyZone: "zone"},
+				},
+			},
+			newObj: &v1.PersistentVolume{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "Vol_1",
+					Labels: map[string]string{v1.LabelFailureDomainBetaZone: "us-west1-a",
+						v1.LabelTopologyZone: "zone"},
+				},
+			},
+			expectedHint: framework.QueueSkip,
+		},
+	}
+
+	for name, tc := range testcases {
+		t.Run(name, func(t *testing.T) {
+			logger, _ := ktesting.NewTestContext(t)
+			p := &VolumeZone{}
+
+			got, err := p.isSchedulableAfterPersistentVolumeChange(logger, tc.pod, tc.oldObj, tc.newObj)
+			if err != nil && !tc.expectedErr {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if got != tc.expectedHint {
+				t.Errorf("isSchedulableAfterPersistentVolumeChange() = %v, want %v", got, tc.expectedHint)
+			}
+		})
+	}
+}
+
 func BenchmarkVolumeZone(b *testing.B) {
 	tests := []struct {
 		Name      string


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Added scheduler queueing hints to volume zone plugin.
This PR covers pv.

I divided #119373 into following 4 PRs.
https://github.com/kubernetes/kubernetes/pull/125000
https://github.com/kubernetes/kubernetes/pull/125001
https://github.com/kubernetes/kubernetes/pull/124996
https://github.com/kubernetes/kubernetes/pull/124998

#### Which issue(s) this PR fixes:
Part of #118893 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
kube-scheduler implements scheduling hints for the VolumeZone plugin.
The scheduling hints allow the scheduler to only retry scheduling a Pod
that was previously rejected by the VolemeZone plugin if  addition/update of node, 
addition/update of PV, addition/update of PVC, or addition of SC matches pod's topology settings.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
