### PR TITLE
Fix error checking in unit tests

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/label/label_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/label/label_test.go
@@ -281,8 +281,7 @@ func TestLabelFunc(t *testing.T) {
 		if test.expectErr != "" {
 			if err == nil {
 				t.Errorf("unexpected non-error: %v", test)
-			}
-			if err.Error() != test.expectErr {
+			} else if err.Error() != test.expectErr {
 				t.Errorf("error expected: %v, got: %v", test.expectErr, err.Error())
 			}
 			continue

--- a/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_restart_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_restart_test.go
@@ -112,8 +112,7 @@ func TestRolloutRestartError(t *testing.T) {
 	err = opt.RunRestart()
 	if err == nil {
 		t.Errorf("error expected but not fired")
-	}
-	if err.Error() != expectedErr {
+	} else if err.Error() != expectedErr {
 		t.Errorf("unexpected error fired %v", err)
 	}
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers_test.go
@@ -597,7 +597,9 @@ func TestGetValidationDirective(t *testing.T) {
 			t.Errorf("validation directive, expected: %v, but got: %v", tc.expectedDirective, directive)
 		}
 		if tc.expectedErr != nil {
-			if err.Error() != tc.expectedErr.Error() {
+			if err == nil {
+				t.Errorf("GetValidationDirective error, expected: %v, but got: nil", tc.expectedErr)
+			} else if err.Error() != tc.expectedErr.Error() {
 				t.Errorf("GetValidationDirective error, expected: %v, but got: %v", tc.expectedErr, err)
 			}
 		} else {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/version/version_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/version/version_test.go
@@ -41,7 +41,7 @@ func TestNewCmdVersionClientVersion(t *testing.T) {
 	if err := o.Complete(tf, &cobra.Command{}, []string{"extraParameter0"}); err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
-	if err := o.Validate(); !strings.Contains(err.Error(), "extra arguments") {
+	if err := o.Validate(); err == nil || !strings.Contains(err.Error(), "extra arguments") {
 		t.Errorf("Unexpected error: should fail to validate the args length greater than 0")
 	}
 	if err := o.Run(); err != nil {

--- a/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/helpers_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/helpers_test.go
@@ -115,6 +115,10 @@ func TestGetPodList(t *testing.T) {
 			t.Errorf("%s: expected an error", test.name)
 			continue
 		}
+		if podList == nil {
+			t.Errorf("%s: unexpected nil podList", test.name)
+			continue
+		}
 		if test.expectedNum != len(podList.Items) {
 			t.Errorf("%s: expected %d pods, got %d", test.name, test.expectedNum, len(podList.Items))
 			continue


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:

Primary motivation for this PR was to fix the `TestUnsetNonexistentConfigKey` unit, which doesn't properly check expected error, but I ended up finding and fixing some other missing nil reference checks in other unit tests.

Fix error checking in unit tests:
- check for nil error when error is expected
- prevent nil pointer dereference

#### Which issue(s) this PR fixes:
n/a

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
