### PR TITLE
Wait for volume to be detached before taking a snapshot in e2e tests

### DIFF
--- a/test/e2e/storage/csimock/csi_attach_volume.go
+++ b/test/e2e/storage/csimock/csi_attach_volume.go
@@ -90,7 +90,7 @@ var _ = utils.SIGDescribe("CSI Mock volume attach", func() {
 
 				ginkgo.By("Checking if VolumeAttachment was created for the pod")
 				testConfig := storageframework.ConvertTestConfig(m.config)
-				attachmentName := e2evolume.GetVolumeAttachmentName(ctx, m.cs, testConfig, m.provisioner, claim.Name, claim.Namespace)
+				attachmentName := e2evolume.GetVolumeAttachmentName(ctx, m.cs, testConfig.ClientNodeSelection.Name, m.provisioner, claim.Name, claim.Namespace)
 				_, err = m.cs.StorageV1().VolumeAttachments().Get(context.TODO(), attachmentName, metav1.GetOptions{})
 				if err != nil {
 					if apierrors.IsNotFound(err) {
@@ -141,7 +141,7 @@ var _ = utils.SIGDescribe("CSI Mock volume attach", func() {
 			// VolumeAttachment should be created because the default value for CSI attachable is true
 			ginkgo.By("Checking if VolumeAttachment was created for the pod")
 			testConfig := storageframework.ConvertTestConfig(m.config)
-			attachmentName := e2evolume.GetVolumeAttachmentName(ctx, m.cs, testConfig, m.provisioner, claim.Name, claim.Namespace)
+			attachmentName := e2evolume.GetVolumeAttachmentName(ctx, m.cs, testConfig.ClientNodeSelection.Name, m.provisioner, claim.Name, claim.Namespace)
 			_, err = m.cs.StorageV1().VolumeAttachments().Get(context.TODO(), attachmentName, metav1.GetOptions{})
 			if err != nil {
 				if apierrors.IsNotFound(err) {

--- a/test/e2e/storage/drivers/csi.go
+++ b/test/e2e/storage/drivers/csi.go
@@ -846,6 +846,7 @@ func InitGcePDCSIDriver() storageframework.TestDriver {
 				storageframework.CapReadWriteOncePod:               true,
 				storageframework.CapMultiplePVsSameID:              true,
 				storageframework.CapFSResizeFromSourceNotSupported: true, //TODO: remove when CI tests use the fixed driver with: https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/972
+				storageframework.CapOfflineSnapshotClone:           true,
 			},
 			RequiredAccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
 			TopologyKeys:        []string{GCEPDCSIZoneTopologyKey},

--- a/test/e2e/storage/framework/testdriver.go
+++ b/test/e2e/storage/framework/testdriver.go
@@ -149,13 +149,14 @@ type Capability string
 
 // Constants related to capabilities and behavior of the driver.
 const (
-	CapPersistence        Capability = "persistence"        // data is persisted across pod restarts
-	CapBlock              Capability = "block"              // raw block mode
-	CapFsGroup            Capability = "fsGroup"            // volume ownership via fsGroup
-	CapVolumeMountGroup   Capability = "volumeMountGroup"   // Driver has the VolumeMountGroup CSI node capability. Because this is a FSGroup feature, the fsGroup capability must also be set to true.
-	CapExec               Capability = "exec"               // exec a file in the volume
-	CapSnapshotDataSource Capability = "snapshotDataSource" // support populate data from snapshot
-	CapPVCDataSource      Capability = "pvcDataSource"      // support populate data from pvc
+	CapPersistence          Capability = "persistence"          // data is persisted across pod restarts
+	CapBlock                Capability = "block"                // raw block mode
+	CapFsGroup              Capability = "fsGroup"              // volume ownership via fsGroup
+	CapVolumeMountGroup     Capability = "volumeMountGroup"     // Driver has the VolumeMountGroup CSI node capability. Because this is a FSGroup feature, the fsGroup capability must also be set to true.
+	CapExec                 Capability = "exec"                 // exec a file in the volume
+	CapSnapshotDataSource   Capability = "snapshotDataSource"   // support populate data from snapshot
+	CapPVCDataSource        Capability = "pvcDataSource"        // support populate data from pvc
+	CapOfflineSnapshotClone Capability = "offlineSnapshotClone" // offlineSnapshotClone indicates this CSI volume driver does not support snapshotting/cloning while attaching/detaching.
 
 	// multiple pods on a node can use the same volume concurrently;
 	// for CSI, see:

--- a/test/e2e/storage/testsuites/multivolume.go
+++ b/test/e2e/storage/testsuites/multivolume.go
@@ -344,7 +344,7 @@ func (t *multiVolumeTestSuite) DefineTests(driver storageframework.TestDriver, p
 		}
 		testConfig := storageframework.ConvertTestConfig(l.config)
 		dc := l.config.Framework.DynamicClient
-		dataSourceRef := prepareSnapshotDataSourceForProvisioning(ctx, f, testConfig, l.config, pattern, l.cs, dc, resource.Pvc, resource.Sc, sDriver, pattern.VolMode, expectedContent)
+		dataSourceRef := prepareSnapshotDataSourceForProvisioning(ctx, f, dInfo, testConfig, l.config, pattern, l.cs, dc, resource.Pvc, resource.Sc, sDriver, pattern.VolMode, expectedContent)
 
 		// Create 2nd PVC for testing
 		pvc2 := &v1.PersistentVolumeClaim{
@@ -386,7 +386,7 @@ func (t *multiVolumeTestSuite) DefineTests(driver storageframework.TestDriver, p
 		l.resources = append(l.resources, resource)
 		pvcs := []*v1.PersistentVolumeClaim{resource.Pvc}
 		testConfig := storageframework.ConvertTestConfig(l.config)
-		dataSourceRef := preparePVCDataSourceForProvisioning(ctx, f, testConfig, l.cs, resource.Pvc, resource.Sc, pattern.VolMode, expectedContent)
+		dataSourceRef := preparePVCDataSourceForProvisioning(ctx, f, dInfo, testConfig, l.cs, resource.Pvc, resource.Sc, pattern.VolMode, expectedContent)
 
 		// Create 2nd PVC for testing
 		pvc2 := &v1.PersistentVolumeClaim{

--- a/test/e2e/storage/testsuites/provisioning.go
+++ b/test/e2e/storage/testsuites/provisioning.go
@@ -219,7 +219,7 @@ func (p *provisioningTestSuite) DefineTests(driver storageframework.TestDriver, 
 		dc := l.config.Framework.DynamicClient
 		testConfig := storageframework.ConvertTestConfig(l.config)
 		expectedContent := fmt.Sprintf("Hello from namespace %s", f.Namespace.Name)
-		dataSourceRef := prepareSnapshotDataSourceForProvisioning(ctx, f, testConfig, l.config, pattern, l.cs, dc, l.pvc, l.sc, sDriver, pattern.VolMode, expectedContent)
+		dataSourceRef := prepareSnapshotDataSourceForProvisioning(ctx, f, dInfo, testConfig, l.config, pattern, l.cs, dc, l.pvc, l.sc, sDriver, pattern.VolMode, expectedContent)
 
 		l.pvc.Spec.DataSourceRef = dataSourceRef
 		l.testCase.PvCheck = func(ctx context.Context, claim *v1.PersistentVolumeClaim) {
@@ -258,7 +258,7 @@ func (p *provisioningTestSuite) DefineTests(driver storageframework.TestDriver, 
 		dc := l.config.Framework.DynamicClient
 		testConfig := storageframework.ConvertTestConfig(l.config)
 		expectedContent := fmt.Sprintf("Hello from namespace %s", f.Namespace.Name)
-		dataSourceRef := prepareSnapshotDataSourceForProvisioning(ctx, f, testConfig, l.config, pattern, l.cs, dc, l.pvc, l.sc, sDriver, pattern.VolMode, expectedContent)
+		dataSourceRef := prepareSnapshotDataSourceForProvisioning(ctx, f, dInfo, testConfig, l.config, pattern, l.cs, dc, l.pvc, l.sc, sDriver, pattern.VolMode, expectedContent)
 
 		l.pvc.Spec.DataSourceRef = dataSourceRef
 		l.pvc.Spec.AccessModes = []v1.PersistentVolumeAccessMode{
@@ -483,7 +483,7 @@ func (p *provisioningTestSuite) DefineTests(driver storageframework.TestDriver, 
 		l.pvc.Name = "pvc-origin"
 		dc := l.config.Framework.DynamicClient
 		testConfig := storageframework.ConvertTestConfig(l.config)
-		dataSourceRef := prepareSnapshotDataSourceForProvisioning(ctx, f, testConfig, l.config, pattern, l.cs, dc, l.pvc, l.sc, sDriver, pattern.VolMode, "")
+		dataSourceRef := prepareSnapshotDataSourceForProvisioning(ctx, f, dInfo, testConfig, l.config, pattern, l.cs, dc, l.pvc, l.sc, sDriver, pattern.VolMode, "")
 
 		// Get the created PVC and record the actual size of the pv (from pvc status).
 		c, err := l.testCase.Client.CoreV1().PersistentVolumeClaims(l.pvc.Namespace).Get(ctx, l.pvc.Name, metav1.GetOptions{})
@@ -551,7 +551,7 @@ func (p *provisioningTestSuite) DefineTests(driver storageframework.TestDriver, 
 		}
 		testConfig := storageframework.ConvertTestConfig(l.config)
 		expectedContent := fmt.Sprintf("Hello from namespace %s", f.Namespace.Name)
-		dataSourceRef := preparePVCDataSourceForProvisioning(ctx, f, testConfig, l.cs, l.sourcePVC, l.sc, pattern.VolMode, expectedContent)
+		dataSourceRef := preparePVCDataSourceForProvisioning(ctx, f, dInfo, testConfig, l.cs, l.sourcePVC, l.sc, pattern.VolMode, expectedContent)
 		l.pvc.Spec.DataSourceRef = dataSourceRef
 		l.testCase.NodeSelection = testConfig.ClientNodeSelection
 		l.testCase.PvCheck = func(ctx context.Context, claim *v1.PersistentVolumeClaim) {
@@ -566,9 +566,6 @@ func (p *provisioningTestSuite) DefineTests(driver storageframework.TestDriver, 
 			}
 			e2evolume.TestVolumeClientSlow(ctx, f, testConfig, nil, "", tests)
 		}
-		// Cloning fails if the source disk is still in the process of detaching, so we wait for the VolumeAttachment to be removed before cloning.
-		volumeAttachment := e2evolume.GetVolumeAttachmentName(ctx, f.ClientSet, testConfig, l.testCase.Provisioner, dataSourceRef.Name, l.sourcePVC.Namespace)
-		framework.ExpectNoError(e2evolume.WaitForVolumeAttachmentTerminated(ctx, volumeAttachment, f.ClientSet, f.Timeouts.DataSourceProvision))
 		l.testCase.TestDynamicProvisioning(ctx)
 	})
 
@@ -590,7 +587,7 @@ func (p *provisioningTestSuite) DefineTests(driver storageframework.TestDriver, 
 		}
 		testConfig := storageframework.ConvertTestConfig(l.config)
 		expectedContent := fmt.Sprintf("Hello from namespace %s", f.Namespace.Name)
-		dataSourceRef := preparePVCDataSourceForProvisioning(ctx, f, testConfig, l.cs, l.sourcePVC, l.sc, pattern.VolMode, expectedContent)
+		dataSourceRef := preparePVCDataSourceForProvisioning(ctx, f, dInfo, testConfig, l.cs, l.sourcePVC, l.sc, pattern.VolMode, expectedContent)
 		l.pvc.Spec.DataSourceRef = dataSourceRef
 		l.pvc.Spec.AccessModes = []v1.PersistentVolumeAccessMode{
 			v1.PersistentVolumeAccessMode(v1.ReadOnlyMany),
@@ -608,9 +605,6 @@ func (p *provisioningTestSuite) DefineTests(driver storageframework.TestDriver, 
 			}
 			e2evolume.TestVolumeClientSlow(ctx, f, testConfig, nil, "", tests)
 		}
-		// Cloning fails if the source disk is still in the process of detaching, so we wait for the VolumeAttachment to be removed before cloning.
-		volumeAttachment := e2evolume.GetVolumeAttachmentName(ctx, f.ClientSet, testConfig, l.testCase.Provisioner, dataSourceRef.Name, l.sourcePVC.Namespace)
-		framework.ExpectNoError(e2evolume.WaitForVolumeAttachmentTerminated(ctx, volumeAttachment, f.ClientSet, f.Timeouts.DataSourceProvision))
 		l.testCase.TestDynamicProvisioning(ctx)
 	})
 
@@ -634,7 +628,7 @@ func (p *provisioningTestSuite) DefineTests(driver storageframework.TestDriver, 
 		}
 		testConfig := storageframework.ConvertTestConfig(l.config)
 		expectedContent := fmt.Sprintf("Hello from namespace %s", f.Namespace.Name)
-		dataSourceRef := preparePVCDataSourceForProvisioning(ctx, f, testConfig, l.cs, l.sourcePVC, l.sc, pattern.VolMode, expectedContent)
+		dataSourceRef := preparePVCDataSourceForProvisioning(ctx, f, dInfo, testConfig, l.cs, l.sourcePVC, l.sc, pattern.VolMode, expectedContent)
 		l.pvc.Spec.DataSourceRef = dataSourceRef
 
 		var wg sync.WaitGroup
@@ -662,9 +656,6 @@ func (p *provisioningTestSuite) DefineTests(driver storageframework.TestDriver, 
 					}
 					e2evolume.TestVolumeClientSlow(ctx, f, myTestConfig, nil, "", tests)
 				}
-				// Cloning fails if the source disk is still in the process of detaching, so we wait for the VolumeAttachment to be removed before cloning.
-				volumeAttachment := e2evolume.GetVolumeAttachmentName(ctx, f.ClientSet, testConfig, l.testCase.Provisioner, dataSourceRef.Name, l.sourcePVC.Namespace)
-				framework.ExpectNoError(e2evolume.WaitForVolumeAttachmentTerminated(ctx, volumeAttachment, f.ClientSet, f.Timeouts.DataSourceProvision))
 				t.TestDynamicProvisioning(ctx)
 			}(i)
 		}
@@ -1204,6 +1195,7 @@ func verifyPVCsPending(ctx context.Context, client clientset.Interface, pvcs []*
 func prepareSnapshotDataSourceForProvisioning(
 	ctx context.Context,
 	f *framework.Framework,
+	dInfo *storageframework.DriverInfo,
 	config e2evolume.TestConfig,
 	perTestConfig *storageframework.PerTestConfig,
 	pattern storageframework.TestPattern,
@@ -1238,7 +1230,8 @@ func prepareSnapshotDataSourceForProvisioning(
 			ExpectedContent: injectContent,
 		},
 	}
-	e2evolume.InjectContent(ctx, f, config, nil, "", tests)
+	verifyDetach := dInfo.Capabilities[storageframework.CapOfflineSnapshotClone]
+	e2evolume.InjectContent(ctx, f, config, nil, "", tests, initClaim, class.Provisioner, verifyDetach)
 
 	parameters := map[string]string{}
 	snapshotResource := storageframework.CreateSnapshotResource(ctx, sDriver, perTestConfig, pattern, initClaim.GetName(), initClaim.GetNamespace(), f.Timeouts, parameters)
@@ -1267,6 +1260,7 @@ func prepareSnapshotDataSourceForProvisioning(
 func preparePVCDataSourceForProvisioning(
 	ctx context.Context,
 	f *framework.Framework,
+	dInfo *storageframework.DriverInfo,
 	config e2evolume.TestConfig,
 	client clientset.Interface,
 	source *v1.PersistentVolumeClaim,
@@ -1293,7 +1287,8 @@ func preparePVCDataSourceForProvisioning(
 			ExpectedContent: injectContent,
 		},
 	}
-	e2evolume.InjectContent(ctx, f, config, nil, "", tests)
+	verifyDetach := dInfo.Capabilities[storageframework.CapOfflineSnapshotClone]
+	e2evolume.InjectContent(ctx, f, config, nil, "", tests, source, class.Provisioner, verifyDetach)
 
 	dataSourceRef := &v1.TypedObjectReference{
 		Kind: "PersistentVolumeClaim",

--- a/test/e2e/storage/testsuites/volumes.go
+++ b/test/e2e/storage/testsuites/volumes.go
@@ -178,7 +178,7 @@ func (t *volumesTestSuite) DefineTests(driver storageframework.TestDriver, patte
 		// local), plugin skips setting fsGroup if volume is already mounted
 		// and we don't have reliable way to detect volumes are unmounted or
 		// not before starting the second pod.
-		e2evolume.InjectContent(ctx, f, config, fsGroup, pattern.FsType, tests)
+		e2evolume.InjectContent(ctx, f, config, fsGroup, pattern.FsType, tests, nil, "", false /* verifyDetach */)
 		if driver.GetDriverInfo().Capabilities[storageframework.CapPersistence] {
 			e2evolume.TestVolumeClient(ctx, f, config, fsGroup, pattern.FsType, tests)
 		} else {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind failing-test


#### What this PR does / why we need it:
The VolumeSnapshotDataSource tests for the  GCE PD Driver  are flaky. They occasionally fail because of a race condition between detaching the disk and taking a snapshot. If a disk detaches while taking a snapshot, GCE will error with "Disk attachment changed while trying to make a snapshot."  To fix, we should wait for the disk to be detached before taking the snapshot.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
