### PR TITLE
Kube-Proxy: Track packets accepted on localhost nodeports

### DIFF
--- a/pkg/proxy/iptables/number_generated_rules_test.go
+++ b/pkg/proxy/iptables/number_generated_rules_test.go
@@ -162,7 +162,7 @@ func TestNumberIptablesRules(t *testing.T) {
 			services:            1,
 			epPerService:        1,
 			expectedFilterRules: 5,
-			expectedNatRules:    17,
+			expectedNatRules:    18,
 		},
 		{
 			name: "1 Services 2 EndpointPerService - LoadBalancer",
@@ -177,7 +177,7 @@ func TestNumberIptablesRules(t *testing.T) {
 			services:            1,
 			epPerService:        2,
 			expectedFilterRules: 5,
-			expectedNatRules:    20,
+			expectedNatRules:    21,
 		},
 		{
 			name: "1 Services 10 EndpointPerService - LoadBalancer",
@@ -192,7 +192,7 @@ func TestNumberIptablesRules(t *testing.T) {
 			services:            1,
 			epPerService:        10,
 			expectedFilterRules: 5,
-			expectedNatRules:    44,
+			expectedNatRules:    45,
 		},
 		{
 			name: "10 Services 0 EndpointsPerService - LoadBalancer",
@@ -222,7 +222,7 @@ func TestNumberIptablesRules(t *testing.T) {
 			services:            10,
 			epPerService:        1,
 			expectedFilterRules: 14,
-			expectedNatRules:    125,
+			expectedNatRules:    135,
 		},
 		{
 			name: "10 Services 2 EndpointPerService - LoadBalancer",
@@ -237,7 +237,7 @@ func TestNumberIptablesRules(t *testing.T) {
 			services:            10,
 			epPerService:        2,
 			expectedFilterRules: 14,
-			expectedNatRules:    155,
+			expectedNatRules:    165,
 		},
 		{
 			name: "10 Services 10 EndpointPerService - LoadBalancer",
@@ -252,7 +252,7 @@ func TestNumberIptablesRules(t *testing.T) {
 			services:            10,
 			epPerService:        10,
 			expectedFilterRules: 14,
-			expectedNatRules:    395,
+			expectedNatRules:    405,
 		},
 	}
 

--- a/pkg/proxy/metrics/metrics.go
+++ b/pkg/proxy/metrics/metrics.go
@@ -266,6 +266,15 @@ var (
 		},
 		[]string{"traffic_policy"},
 	)
+
+	// localhostNodePortsAcceptedPacketsDescription describe the metrics for the number of packets accepted
+	// by iptables which were destined for nodeports on loopback interface.
+	localhostNodePortsAcceptedPacketsDescription = metrics.NewDesc(
+		"kubeproxy_iptables_localhost_nodeports_accepted_packets_total",
+		"Number of packets accepted on nodeports of loopback interface",
+		nil, nil, metrics.ALPHA, "")
+	LocalhostNodePortAcceptedNFAcctCounter     = "localhost_nps_accepted_pkts"
+	localhostNodePortsAcceptedMetricsCollector = newNFAcctMetricCollector(LocalhostNodePortAcceptedNFAcctCounter, localhostNodePortsAcceptedPacketsDescription)
 )
 
 var registerMetricsOnce sync.Once
@@ -291,6 +300,7 @@ func RegisterMetrics(mode kubeproxyconfig.ProxyMode) {
 		switch mode {
 		case kubeproxyconfig.ProxyModeIPTables:
 			legacyregistry.CustomMustRegister(iptablesCTStateInvalidDroppedMetricCollector)
+			legacyregistry.CustomMustRegister(localhostNodePortsAcceptedMetricsCollector)
 			legacyregistry.MustRegister(SyncFullProxyRulesLatency)
 			legacyregistry.MustRegister(SyncPartialProxyRulesLatency)
 			legacyregistry.MustRegister(IPTablesRestoreFailuresTotal)

--- a/test/e2e/framework/metrics/kube_proxy_metrics.go
+++ b/test/e2e/framework/metrics/kube_proxy_metrics.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"k8s.io/component-base/metrics/testutil"
+)
+
+// KubeProxyMetrics is metrics for kube-proxy
+type KubeProxyMetrics testutil.Metrics
+
+// GetCounterMetricValue returns value for metric type counter.
+func (m *KubeProxyMetrics) GetCounterMetricValue(metricName string) float64 {
+	return float64(testutil.Metrics(*m)[metricName][0].Value)
+}
+
+func newKubeProxyMetricsMetrics() KubeProxyMetrics {
+	result := testutil.NewMetrics()
+	return KubeProxyMetrics(result)
+}
+
+func parseKubeProxyMetrics(data string) (KubeProxyMetrics, error) {
+	result := newKubeProxyMetricsMetrics()
+	if err := testutil.ParseMetrics(data, (*testutil.Metrics)(&result)); err != nil {
+		return KubeProxyMetrics{}, err
+	}
+	return result, nil
+}

--- a/test/e2e/framework/metrics/metrics_grabber.go
+++ b/test/e2e/framework/metrics/metrics_grabber.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"net"
 	"regexp"
+	"strconv"
 	"sync"
 	"time"
 
@@ -32,8 +33,9 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
-
+	"k8s.io/kubernetes/test/e2e/framework"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
+	e2epodoutput "k8s.io/kubernetes/test/e2e/framework/pod/output"
 )
 
 const (
@@ -43,6 +45,8 @@ const (
 	kubeControllerManagerPort = 10257
 	// snapshotControllerPort is the port for the snapshot controller
 	snapshotControllerPort = 9102
+	// kubeProxyPort is the default port for the kube-proxy status server.
+	kubeProxyPort = 10249
 )
 
 // MetricsGrabbingDisabledError is an error that is wrapped by the
@@ -231,6 +235,45 @@ func (g *Grabber) getMetricsFromNode(ctx context.Context, nodeName string, kubel
 		}
 		return string(rawOutput), nil
 	}
+}
+
+// GrabFromKubeProxy returns metrics from kube-proxy
+func (g *Grabber) GrabFromKubeProxy(ctx context.Context, nodeName string) (KubeProxyMetrics, error) {
+	nodes, err := g.client.CoreV1().Nodes().List(ctx, metav1.ListOptions{FieldSelector: fields.Set{"metadata.name": nodeName}.AsSelector().String()})
+	if err != nil {
+		return KubeProxyMetrics{}, err
+	}
+
+	if len(nodes.Items) != 1 {
+		return KubeProxyMetrics{}, fmt.Errorf("error listing nodes with name %v, got %v", nodeName, nodes.Items)
+	}
+	output, err := g.grabFromKubeProxy(ctx, nodeName)
+	if err != nil {
+		return KubeProxyMetrics{}, err
+	}
+	return parseKubeProxyMetrics(output)
+}
+
+func (g *Grabber) grabFromKubeProxy(ctx context.Context, nodeName string) (string, error) {
+	hostCmdPodName := fmt.Sprintf("grab-kube-proxy-metrics-%s", framework.RandomSuffix())
+	hostCmdPod := e2epod.NewExecPodSpec(metav1.NamespaceSystem, hostCmdPodName, true)
+	nodeSelection := e2epod.NodeSelection{Name: nodeName}
+	e2epod.SetNodeSelection(&hostCmdPod.Spec, nodeSelection)
+	if _, err := g.client.CoreV1().Pods(metav1.NamespaceSystem).Create(ctx, hostCmdPod, metav1.CreateOptions{}); err != nil {
+		return "", fmt.Errorf("failed to create pod to fetch metrics: %w", err)
+	}
+	if err := e2epod.WaitTimeoutForPodReadyInNamespace(ctx, g.client, hostCmdPodName, metav1.NamespaceSystem, 5*time.Minute); err != nil {
+		return "", fmt.Errorf("error waiting for pod to be up: %w", err)
+	}
+
+	host := "127.0.0.1"
+	if framework.TestContext.ClusterIsIPv6() {
+		host = "::1"
+	}
+
+	stdout, err := e2epodoutput.RunHostCmd(metav1.NamespaceSystem, hostCmdPodName, fmt.Sprintf("curl --silent %s/metrics", net.JoinHostPort(host, strconv.Itoa(kubeProxyPort))))
+	_ = g.client.CoreV1().Pods(metav1.NamespaceSystem).Delete(ctx, hostCmdPodName, metav1.DeleteOptions{})
+	return stdout, err
 }
 
 // GrabFromScheduler returns metrics from scheduler

--- a/test/e2e/network/kube_proxy.go
+++ b/test/e2e/network/kube_proxy.go
@@ -25,22 +25,25 @@ import (
 	"strings"
 	"time"
 
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
-
+	"k8s.io/kubernetes/pkg/cluster/ports"
+	"k8s.io/kubernetes/pkg/proxy/apis/config"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2emetrics "k8s.io/kubernetes/test/e2e/framework/metrics"
 	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
-	e2eoutput "k8s.io/kubernetes/test/e2e/framework/pod/output"
+	e2epodoutput "k8s.io/kubernetes/test/e2e/framework/pod/output"
 	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 	"k8s.io/kubernetes/test/e2e/network/common"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 	admissionapi "k8s.io/pod-security-admission/api"
 	netutils "k8s.io/utils/net"
-
-	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 )
 
 var kubeProxyE2eImage = imageutils.GetE2EImage(imageutils.Agnhost)
@@ -220,7 +223,7 @@ var _ = common.SIGDescribe("KubeProxy", func() {
 			"| grep -m 1 'CLOSE_WAIT.*dport=%v' ",
 			ipFamily, ip, testDaemonTCPPort)
 		if err := wait.PollImmediate(2*time.Second, epsilonSeconds*time.Second, func() (bool, error) {
-			result, err := e2eoutput.RunHostCmd(fr.Namespace.Name, "e2e-net-exec", cmd)
+			result, err := e2epodoutput.RunHostCmd(fr.Namespace.Name, "e2e-net-exec", cmd)
 			// retry if we can't obtain the conntrack entry
 			if err != nil {
 				framework.Logf("failed to obtain conntrack entry: %v %v", result, err)
@@ -242,7 +245,7 @@ var _ = common.SIGDescribe("KubeProxy", func() {
 			return false, fmt.Errorf("wrong TCP CLOSE_WAIT timeout: %v expected: %v", timeoutSeconds, expectedTimeoutSeconds)
 		}); err != nil {
 			// Dump all conntrack entries for debugging
-			result, err2 := e2eoutput.RunHostCmd(fr.Namespace.Name, "e2e-net-exec", "conntrack -L")
+			result, err2 := e2epodoutput.RunHostCmd(fr.Namespace.Name, "e2e-net-exec", "conntrack -L")
 			if err2 != nil {
 				framework.Logf("failed to obtain conntrack entry: %v %v", result, err2)
 			}
@@ -251,4 +254,115 @@ var _ = common.SIGDescribe("KubeProxy", func() {
 		}
 	})
 
+	ginkgo.It("should update metric for tracking accepted packets destined for localhost nodeports", func(ctx context.Context) {
+		if framework.TestContext.ClusterIsIPv6() {
+			e2eskipper.Skipf("test requires IPv4 cluster")
+		}
+
+		cs := fr.ClientSet
+		ns := fr.Namespace.Name
+
+		nodes, err := e2enode.GetBoundedReadySchedulableNodes(ctx, cs, 1)
+		framework.ExpectNoError(err)
+		if len(nodes.Items) < 1 {
+			e2eskipper.Skipf(
+				"Test requires >= 1 Ready nodes, but there are only %v nodes",
+				len(nodes.Items))
+		}
+		nodeName := nodes.Items[0].Name
+
+		metricName := "kubeproxy_iptables_localhost_nodeports_accepted_packets_total"
+		metricsGrabber, err := e2emetrics.NewMetricsGrabber(ctx, fr.ClientSet, nil, fr.ClientConfig(), false, false, false, false, false, false)
+		framework.ExpectNoError(err)
+
+		// create a pod with host-network for execing
+		hostExecPodName := "host-exec-pod"
+		hostExecPod := e2epod.NewExecPodSpec(fr.Namespace.Name, hostExecPodName, true)
+		nodeSelection := e2epod.NodeSelection{Name: nodeName}
+		e2epod.SetNodeSelection(&hostExecPod.Spec, nodeSelection)
+		e2epod.NewPodClient(fr).CreateSync(ctx, hostExecPod)
+
+		// get proxyMode
+		stdout, err := e2epodoutput.RunHostCmd(fr.Namespace.Name, hostExecPodName, fmt.Sprintf("curl --silent 127.0.0.1:%d/proxyMode", ports.ProxyStatusPort))
+		framework.ExpectNoError(err)
+		proxyMode := strings.TrimSpace(stdout)
+
+		// get value of route_localnet
+		stdout, err = e2epodoutput.RunHostCmd(fr.Namespace.Name, hostExecPodName, "cat /proc/sys/net/ipv4/conf/all/route_localnet")
+		framework.ExpectNoError(err)
+		routeLocalnet := strings.TrimSpace(stdout)
+
+		if !(proxyMode == string(config.ProxyModeIPTables) && routeLocalnet == "1") {
+			e2eskipper.Skipf("test requires iptables proxy mode with route_localnet set")
+		}
+
+		// get value of target metric before accessing localhost nodeports
+		metrics, err := metricsGrabber.GrabFromKubeProxy(ctx, nodeName)
+		framework.ExpectNoError(err)
+		targetMetricBefore := metrics.GetCounterMetricValue(metricName)
+
+		// create pod
+		ginkgo.By("creating test pod")
+		label := map[string]string{
+			"app": "agnhost-localhost-nodeports",
+		}
+		httpPort := []v1.ContainerPort{
+			{
+				ContainerPort: 8080,
+				Protocol:      v1.ProtocolTCP,
+			},
+		}
+		pod := e2epod.NewAgnhostPod(ns, "agnhost-localhost-nodeports", nil, nil, httpPort, "netexec")
+		pod.Labels = label
+		e2epod.NewPodClient(fr).CreateSync(ctx, pod)
+
+		// create nodeport service
+		ginkgo.By("creating test nodeport service")
+		svc := &v1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "agnhost-localhost-nodeports",
+			},
+			Spec: v1.ServiceSpec{
+				Type:     v1.ServiceTypeNodePort,
+				Selector: label,
+				Ports: []v1.ServicePort{
+					{
+						Protocol:   v1.ProtocolTCP,
+						Port:       9000,
+						TargetPort: intstr.IntOrString{Type: 0, IntVal: 8080},
+					},
+				},
+			},
+		}
+		svc, err = fr.ClientSet.CoreV1().Services(fr.Namespace.Name).Create(ctx, svc, metav1.CreateOptions{})
+		framework.ExpectNoError(err)
+
+		// wait for endpoints update
+		ginkgo.By("waiting for endpoints to be updated")
+		err = framework.WaitForServiceEndpointsNum(ctx, fr.ClientSet, ns, svc.Name, 1, time.Second, wait.ForeverTestTimeout)
+		framework.ExpectNoError(err)
+
+		ginkgo.By("accessing endpoint via localhost nodeports 10 times")
+		for i := 0; i < 10; i++ {
+			if err := wait.PollUntilContextTimeout(ctx, 1*time.Second, 10*time.Second, true, func(_ context.Context) (bool, error) {
+				_, err = e2epodoutput.RunHostCmd(fr.Namespace.Name, hostExecPodName, fmt.Sprintf("curl --silent http://localhost:%d/hostname", svc.Spec.Ports[0].NodePort))
+				if err != nil {
+					return false, nil
+				}
+				return true, nil
+			}); err != nil {
+				e2eskipper.Skipf("skipping test as localhost nodeports are not acceesible in this environment")
+			}
+		}
+
+		// our target metric should be updated by now
+		if err := wait.PollUntilContextTimeout(ctx, 10*time.Second, 2*time.Minute, true, func(_ context.Context) (bool, error) {
+			metrics, err := metricsGrabber.GrabFromKubeProxy(ctx, nodeName)
+			framework.ExpectNoError(err)
+			targetMetricAfter := metrics.GetCounterMetricValue(metricName)
+			return targetMetricAfter > targetMetricBefore, nil
+		}); err != nil {
+			framework.Failf("expected %s metric to be updated after accessing endpoints via localhost nodeports", metricName)
+		}
+	})
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
Part of nftables-todo https://github.com/kubernetes/kubernetes/issues/122572
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
The iptables mode of kube-proxy now tracks accepted packets that are destined for node-ports on localhost by introducing `kubeproxy_iptables_localhost_nodeports_accepted_packets_total` metric.
This will help users to identify if they rely on iptables.localhostNodePorts feature and ulitmately help them to migrate from iptables to nftables.

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/sig network
/assign @danwinship @aojea 


```
root@kind-worker:/# nfacct list
{ pkts = 00000000000000000000, bytes = 00000000000000000000 } = ct_state_invalid_dropped_pkts;
{ pkts = 00000000000000000000, bytes = 00000000000000000000 } = localhost_nps_accepted_pkts;

root@kind-worker:/# for i in {1..4321}; do curl --silent localhost:31490 > /dev/null; done;

root@kind-worker:/# nfacct list
{ pkts = 00000000000000000000, bytes = 00000000000000000000 } = ct_state_invalid_dropped_pkts;
{ pkts = 00000000000000004321, bytes = 00000000000000259260 } = localhost_nps_accepted_pkts;

root@kind-worker:/# curl --silent 127.0.0.1:10249/metrics | grep kubeproxy_iptables_localhost_nodeports_accepted_packets_total
# HELP kubeproxy_iptables_localhost_nodeports_accepted_packets_total [ALPHA] Number of packets accepted on nodeports of loopback interface
# TYPE kubeproxy_iptables_localhost_nodeports_accepted_packets_total counter
kubeproxy_iptables_localhost_nodeports_accepted_packets_total 4321

root@kind-worker:/# 
```