### PR TITLE
Prevent multi containers from being created in Evented PLEG with fixing a few problems

### DIFF
--- a/pkg/kubelet/container/cache.go
+++ b/pkg/kubelet/container/cache.go
@@ -21,8 +21,6 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/types"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
-	"k8s.io/kubernetes/pkg/features"
 )
 
 // Cache stores the PodStatus for the pods. It represents *all* the visible
@@ -102,14 +100,6 @@ func (c *cache) GetNewerThan(id types.UID, minTime time.Time) (*PodStatus, error
 func (c *cache) Set(id types.UID, status *PodStatus, err error, timestamp time.Time) (updated bool) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
-
-	if utilfeature.DefaultFeatureGate.Enabled(features.EventedPLEG) {
-		// Set the value in the cache only if it's not present already
-		// or the timestamp in the cache is older than the current update timestamp
-		if cachedVal, ok := c.pods[id]; ok && cachedVal.modified.After(timestamp) {
-			return false
-		}
-	}
 
 	c.pods[id] = &data{status: status, err: err, modified: timestamp}
 	c.notify(id, timestamp)

--- a/pkg/kubelet/container/helpers.go
+++ b/pkg/kubelet/container/helpers.go
@@ -91,6 +91,7 @@ func ShouldContainerBeRestarted(container *v1.Container, pod *v1.Pod, podStatus 
 		return true
 	}
 	if status.State == ContainerStateCreated {
+		klog.V(4).InfoS("Container state is Created, and it will be decided whether to restart based on the specific situation.", "pod", klog.KObj(pod), "containerName", container.Name, "restartOnCreatedState", restartOnCreatedState)
 		// we don't retart the container directly as the CREATED event will always be triggered
 		// but for next syncpod, we should handle the containers failed to be started which is in CREATED state.
 		return restartOnCreatedState

--- a/pkg/kubelet/container/helpers_test.go
+++ b/pkg/kubelet/container/helpers_test.go
@@ -460,7 +460,7 @@ func TestShouldContainerBeRestarted(t *testing.T) {
 		for i, policy := range policies {
 			pod.Spec.RestartPolicy = policy
 			e := expected[c.Name][i]
-			r := ShouldContainerBeRestarted(&c, pod, podStatus)
+			r := ShouldContainerBeRestarted(&c, pod, podStatus, true)
 			if r != e {
 				t.Errorf("Restart for container %q with restart policy %q expected %t, got %t",
 					c.Name, policy, e, r)
@@ -481,7 +481,7 @@ func TestShouldContainerBeRestarted(t *testing.T) {
 		for i, policy := range policies {
 			pod.Spec.RestartPolicy = policy
 			e := expected[c.Name][i]
-			r := ShouldContainerBeRestarted(&c, pod, podStatus)
+			r := ShouldContainerBeRestarted(&c, pod, podStatus, true)
 			if r != e {
 				t.Errorf("Restart for container %q with restart policy %q expected %t, got %t",
 					c.Name, policy, e, r)

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -2297,7 +2297,7 @@ func (kl *Kubelet) convertToAPIContainerStatuses(pod *v1.Pod, podStatus *kubecon
 			}
 		}
 		// If a container should be restarted in next syncpod, it is *Waiting*.
-		if !kubecontainer.ShouldContainerBeRestarted(&container, pod, podStatus) {
+		if !kubecontainer.ShouldContainerBeRestarted(&container, pod, podStatus, true) {
 			continue
 		}
 		status := statuses[container.Name]

--- a/pkg/kubelet/kuberuntime/kuberuntime_termination_order.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_termination_order.go
@@ -17,6 +17,7 @@ limitations under the License.
 package kuberuntime
 
 import (
+	"sync"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -34,6 +35,8 @@ type terminationOrdering struct {
 	// prereqs is a map from container name to a list of channel that the container
 	// must wait on to ensure termination ordering
 	prereqs map[string][]chan struct{}
+
+	lock sync.Mutex
 }
 
 // newTerminationOrdering constructs a terminationOrdering based on the pod spec and the currently running containers.
@@ -108,7 +111,10 @@ func (o *terminationOrdering) waitForTurn(name string, gracePeriod int64) float6
 
 // containerTerminated should be called once the container with the speecified name has exited.
 func (o *terminationOrdering) containerTerminated(name string) {
+	o.lock.Lock()
+	defer o.lock.Unlock()
 	if ch, ok := o.terminated[name]; ok {
 		close(ch)
+		delete(o.terminated, name)
 	}
 }

--- a/pkg/kubelet/pleg/evented.go
+++ b/pkg/kubelet/pleg/evented.go
@@ -34,7 +34,7 @@ import (
 // The frequency with which global timestamp of the cache is to
 // is to be updated periodically. If pod workers get stuck at cache.GetNewerThan
 // call, after this period it will be unblocked.
-const globalCacheUpdatePeriod = 5 * time.Second
+const globalCacheUpdatePeriod = 1 * time.Second
 
 var (
 	eventedPLEGUsage   = false

--- a/pkg/kubelet/pleg/evented.go
+++ b/pkg/kubelet/pleg/evented.go
@@ -41,11 +41,11 @@ var (
 	eventedPLEGUsageMu = sync.RWMutex{}
 )
 
-// isEventedPLEGInUse indicates whether Evented PLEG is in use. Even after enabling
+// IsEventedPLEGInUse indicates whether Evented PLEG is in use. Even after enabling
 // the Evented PLEG feature gate, there could be several reasons it may not be in use.
 // e.g. Streaming data issues from the runtime or the runtime does not implement the
 // container events stream.
-func isEventedPLEGInUse() bool {
+func IsEventedPLEGInUse() bool {
 	eventedPLEGUsageMu.RLock()
 	defer eventedPLEGUsageMu.RUnlock()
 	return eventedPLEGUsage
@@ -118,7 +118,7 @@ func (e *EventedPLEG) Relist() {
 func (e *EventedPLEG) Start() {
 	e.runningMu.Lock()
 	defer e.runningMu.Unlock()
-	if isEventedPLEGInUse() {
+	if IsEventedPLEGInUse() {
 		return
 	}
 	setEventedPLEGUsage(true)
@@ -132,7 +132,7 @@ func (e *EventedPLEG) Start() {
 func (e *EventedPLEG) Stop() {
 	e.runningMu.Lock()
 	defer e.runningMu.Unlock()
-	if !isEventedPLEGInUse() {
+	if !IsEventedPLEGInUse() {
 		return
 	}
 	setEventedPLEGUsage(false)
@@ -181,7 +181,7 @@ func (e *EventedPLEG) watchEventsChannel() {
 		numAttempts := 0
 		for {
 			if numAttempts >= e.eventedPlegMaxStreamRetries {
-				if isEventedPLEGInUse() {
+				if IsEventedPLEGInUse() {
 					// Fall back to Generic PLEG relisting since Evented PLEG is not working.
 					klog.V(4).InfoS("Fall back to Generic PLEG relisting since Evented PLEG is not working")
 					e.Stop()
@@ -204,7 +204,7 @@ func (e *EventedPLEG) watchEventsChannel() {
 		}
 	}()
 
-	if isEventedPLEGInUse() {
+	if IsEventedPLEGInUse() {
 		e.processCRIEvents(containerEventsResponseCh)
 	}
 }

--- a/pkg/kubelet/pleg/evented.go
+++ b/pkg/kubelet/pleg/evented.go
@@ -266,7 +266,7 @@ func (e *EventedPLEG) processCRIEvents(containerEventsResponseCh chan *runtimeap
 			}
 			shouldSendPLEGEvent = true
 		} else {
-			if e.cache.Set(podID, status, err, time.Unix(event.GetCreatedAt(), 0)) {
+			if e.cache.Set(podID, status, err, time.Unix(0, event.GetCreatedAt())) {
 				shouldSendPLEGEvent = true
 			}
 		}

--- a/pkg/kubelet/pleg/generic.go
+++ b/pkg/kubelet/pleg/generic.go
@@ -26,10 +26,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/klog/v2"
-	"k8s.io/kubernetes/pkg/features"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/kubelet/metrics"
 	"k8s.io/utils/clock"
@@ -293,7 +291,7 @@ func (g *GenericPLEG) Relist() {
 				// from the list (we don't want the reinspection code below to inspect it a second time in
 				// this relist execution)
 				delete(g.podsToReinspect, pid)
-				if utilfeature.DefaultFeatureGate.Enabled(features.EventedPLEG) {
+				if IsEventedPLEGInUse() {
 					if !updated {
 						continue
 					}
@@ -475,7 +473,7 @@ func (g *GenericPLEG) updateCache(ctx context.Context, pod *kubecontainer.Pod, p
 	// Evented PLEG after the event has been received by the Kubelet.
 	// For more details refer to:
 	// https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/3386-kubelet-evented-pleg#timestamp-of-the-pod-status
-	if utilfeature.DefaultFeatureGate.Enabled(features.EventedPLEG) && isEventedPLEGInUse() && status != nil {
+	if IsEventedPLEGInUse() && status != nil {
 		timestamp = status.TimeStamp
 	}
 

--- a/test/e2e/common/node/init_container.go
+++ b/test/e2e/common/node/init_container.go
@@ -530,7 +530,7 @@ var _ = SIGDescribe("InitContainer", framework.WithNodeConformance(), func() {
 						}
 						status := t.Status.InitContainerStatuses[0]
 						if status.State.Terminated == nil {
-							if status.State.Waiting != nil && status.State.Waiting.Reason != "PodInitializing" {
+							if status.State.Waiting != nil && status.State.Waiting.Reason != "" && status.State.Waiting.Reason != "PodInitializing" {
 								return false, fmt.Errorf("second init container should have reason PodInitializing: %s", toDebugJSON(status))
 							}
 							return false, nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

This PR is a combination of #122778 and #124297 created in response to this [comment](https://github.com/kubernetes/kubernetes/issues/124704#issuecomment-2119592065).

Firstly, this PR fixes two simple problems in Evented PLEG (#124297):
  - A timestamp is passed wrongly to the cache.
  - The global cache timestamp is updated less frequently than Generic PLEG.

Secondly, this PR fixes a problem where multiple containers are started (#122778).

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #124704
Fixes #122778

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
