### PR TITLE
--image-gc-high-threshold should less than 100 - imagefs.available

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -262,6 +262,12 @@ const (
 	// deletion ordering.
 	HonorPVReclaimPolicy featuregate.Feature = "HonorPVReclaimPolicy"
 
+	// owner: @olderTaoist
+	// alpha: v1.30.0
+	//
+	// --image-gc-high-threshold should less than 100 - imagefs.available.
+	ImageGCHighThresholdAccurate featuregate.Feature = "ImageGCHighThresholdAccurate"
+
 	// owner: @leakingtapan
 	// alpha: v1.21
 	//
@@ -1016,6 +1022,8 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	HonorPVReclaimPolicy: {Default: false, PreRelease: featuregate.Alpha},
 
 	ImageMaximumGCAge: {Default: true, PreRelease: featuregate.Beta},
+
+	ImageGCHighThresholdAccurate: {Default: false, PreRelease: featuregate.Alpha},
 
 	InTreePluginAWSUnregister: {Default: false, PreRelease: featuregate.Alpha},
 

--- a/pkg/kubelet/apis/config/v1beta1/defaults.go
+++ b/pkg/kubelet/apis/config/v1beta1/defaults.go
@@ -137,10 +137,10 @@ func SetDefaults_KubeletConfiguration(obj *kubeletconfigv1beta1.KubeletConfigura
 	}
 	if obj.ImageGCHighThresholdPercent == nil {
 		// default is below docker's default dm.min_free_space of 90%
-		obj.ImageGCHighThresholdPercent = utilpointer.Int32(85)
+		obj.ImageGCHighThresholdPercent = utilpointer.Int32(80)
 	}
 	if obj.ImageGCLowThresholdPercent == nil {
-		obj.ImageGCLowThresholdPercent = utilpointer.Int32(80)
+		obj.ImageGCLowThresholdPercent = utilpointer.Int32(75)
 	}
 	if obj.VolumeStatsAggPeriod == zeroDuration {
 		obj.VolumeStatsAggPeriod = metav1.Duration{Duration: time.Minute}

--- a/pkg/kubelet/apis/config/validation/validation.go
+++ b/pkg/kubelet/apis/config/validation/validation.go
@@ -88,11 +88,12 @@ func ValidateKubeletConfiguration(kc *kubeletconfig.KubeletConfiguration, featur
 	if kc.ImageGCLowThresholdPercent >= kc.ImageGCHighThresholdPercent {
 		allErrors = append(allErrors, fmt.Errorf("invalid configuration: imageGCLowThresholdPercent (--image-gc-low-threshold) %v must be less than imageGCHighThresholdPercent (--image-gc-high-threshold) %v", kc.ImageGCLowThresholdPercent, kc.ImageGCHighThresholdPercent))
 	}
-	imageFsAvailable, _ := strconv.ParseInt(strings.TrimRight(kc.EvictionHard[string(evictionapi.SignalImageFsAvailable)], "%"), 10, 32)
-	if kc.ImageGCHighThresholdPercent >= 100-int32(imageFsAvailable) {
-		allErrors = append(allErrors, fmt.Errorf("invalid configuration: imageGCHighThresholdPercent (--image-gc-high-threshold) %v must be less than evict hard (%s) 100 - %v", kc.ImageGCHighThresholdPercent, evictionapi.SignalImageFsAvailable, imageFsAvailable))
+	if localFeatureGate.Enabled(features.ImageGCHighThresholdAccurate) {
+		imageFsAvailable, _ := strconv.ParseInt(strings.TrimRight(kc.EvictionHard[string(evictionapi.SignalImageFsAvailable)], "%"), 10, 32)
+		if kc.ImageGCHighThresholdPercent >= 100-int32(imageFsAvailable) {
+			allErrors = append(allErrors, fmt.Errorf("invalid configuration: imageGCHighThresholdPercent (--image-gc-high-threshold) %v must be less than evict hard (%s) 100 - %v", kc.ImageGCHighThresholdPercent, evictionapi.SignalImageFsAvailable, imageFsAvailable))
+		}
 	}
-
 	if kc.ImageMaximumGCAge.Duration != 0 && !localFeatureGate.Enabled(features.ImageMaximumGCAge) {
 		allErrors = append(allErrors, fmt.Errorf("invalid configuration: ImageMaximumGCAge feature gate is required for Kubelet configuration option imageMaximumGCAge"))
 	}

--- a/pkg/kubelet/apis/config/validation/validation_test.go
+++ b/pkg/kubelet/apis/config/validation/validation_test.go
@@ -166,6 +166,9 @@ func TestValidateKubeletConfiguration(t *testing.T) {
 		configure: func(conf *kubeletconfig.KubeletConfiguration) *kubeletconfig.KubeletConfiguration {
 			conf.ImageGCHighThresholdPercent = 85
 			conf.EvictionHard = map[string]string{"imagefs.available": "15%"}
+			conf.FeatureGates = map[string]bool{
+				"ImageGCHighThresholdAccurate": true,
+			}
 			return conf
 		},
 		errMsg: "invalid configuration: imageGCHighThresholdPercent (--image-gc-high-threshold) 85 must be less than evict hard (imagefs.available) 100 - 15",

--- a/pkg/kubelet/apis/config/validation/validation_test.go
+++ b/pkg/kubelet/apis/config/validation/validation_test.go
@@ -162,6 +162,14 @@ func TestValidateKubeletConfiguration(t *testing.T) {
 		},
 		errMsg: "invalid configuration: imageGCHighThresholdPercent (--image-gc-high-threshold) 101 must be between 0 and 100, inclusive",
 	}, {
+		name: "invalid ImageGCHighThresholdPercent large than evict hard 100 - imagefs.available",
+		configure: func(conf *kubeletconfig.KubeletConfiguration) *kubeletconfig.KubeletConfiguration {
+			conf.ImageGCHighThresholdPercent = 85
+			conf.EvictionHard = map[string]string{"imagefs.available": "15%"}
+			return conf
+		},
+		errMsg: "invalid configuration: imageGCHighThresholdPercent (--image-gc-high-threshold) 85 must be less than evict hard (imagefs.available) 100 - 15",
+	}, {
 		name: "invalid ImageGCLowThresholdPercent",
 		configure: func(conf *kubeletconfig.KubeletConfiguration) *kubeletconfig.KubeletConfiguration {
 			conf.ImageGCLowThresholdPercent = -1


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
`ImageGCManager` garbage collect should before `Eviction Manager`

#### Which issue(s) this PR fixes:
Fixes #124868

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:


KEP: [reasonable --image-gc-high-threshold](https://github.com/kubernetes/enhancements/pull/4739)
