### PR TITLE
Use Go 1.21 min/max builtins

### DIFF
--- a/pkg/controller/podautoscaler/horizontal.go
+++ b/pkg/controller/podautoscaler/horizontal.go
@@ -1275,10 +1275,10 @@ func calculateScaleUpLimitWithScalingRules(currentReplicas int32, scaleUpEvents,
 		return currentReplicas // Scaling is disabled
 	} else if *scalingRules.SelectPolicy == autoscalingv2.MinChangePolicySelect {
 		result = math.MaxInt32
-		selectPolicyFn = min // For scaling up, the lowest change ('min' policy) produces a minimum value
+		selectPolicyFn = minInt32 // For scaling up, the lowest change ('min' policy) produces a minimum value
 	} else {
 		result = math.MinInt32
-		selectPolicyFn = max // Use the default policy otherwise to produce a highest possible change
+		selectPolicyFn = maxInt32 // Use the default policy otherwise to produce a highest possible change
 	}
 	for _, policy := range scalingRules.Policies {
 		replicasAddedInCurrentPeriod := getReplicasChangePerPeriod(policy.PeriodSeconds, scaleUpEvents)
@@ -1304,10 +1304,10 @@ func calculateScaleDownLimitWithBehaviors(currentReplicas int32, scaleUpEvents, 
 		return currentReplicas // Scaling is disabled
 	} else if *scalingRules.SelectPolicy == autoscalingv2.MinChangePolicySelect {
 		result = math.MinInt32
-		selectPolicyFn = max // For scaling down, the lowest change ('min' policy) produces a maximum value
+		selectPolicyFn = maxInt32 // For scaling down, the lowest change ('min' policy) produces a maximum value
 	} else {
 		result = math.MaxInt32
-		selectPolicyFn = min // Use the default policy otherwise to produce a highest possible change
+		selectPolicyFn = minInt32 // Use the default policy otherwise to produce a highest possible change
 	}
 	for _, policy := range scalingRules.Policies {
 		replicasAddedInCurrentPeriod := getReplicasChangePerPeriod(policy.PeriodSeconds, scaleUpEvents)
@@ -1434,16 +1434,12 @@ func setConditionInList(inputList []autoscalingv2.HorizontalPodAutoscalerConditi
 	return resList
 }
 
-func max(a, b int32) int32 {
-	if a >= b {
-		return a
-	}
-	return b
+// minInt32 is a wrapper around the min builtin to be used as a function value.
+func minInt32(a, b int32) int32 {
+	return min(a, b)
 }
 
-func min(a, b int32) int32 {
-	if a <= b {
-		return a
-	}
-	return b
+// maxInt32 is a wrapper around the max builtin to be used as a function value.
+func maxInt32(a, b int32) int32 {
+	return max(a, b)
 }

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapi/v2/conversion_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapi/v2/conversion_test.go
@@ -937,10 +937,3 @@ func TestFilterOut(t *testing.T) {
 		})
 	}
 }
-
-func max(i, j int) int {
-	if i > j {
-		return i
-	}
-	return j
-}

--- a/staging/src/k8s.io/apimachinery/pkg/labels/selector_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/labels/selector_test.go
@@ -224,14 +224,6 @@ func TestLexer(t *testing.T) {
 	}
 }
 
-func min(l, r int) (m int) {
-	m = r
-	if l < r {
-		m = l
-	}
-	return m
-}
-
 func TestLexerSequence(t *testing.T) {
 	testcases := []struct {
 		s string


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The `min` and `max` builtins are available since Go 1.21[^1]. The top-level go.mod file is specifying Go 1.22, so the builtins can be used instead of implementing them multiple times across the code base.

[^1]: https://go.dev/doc/go1.21#language

#### Which issue(s) this PR fixes:

non

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
