### PR TITLE
kube_codegen: smarter grepping of codegen tags

### DIFF
--- a/staging/src/k8s.io/code-generator/kube_codegen.sh
+++ b/staging/src/k8s.io/code-generator/kube_codegen.sh
@@ -121,7 +121,7 @@ function kube::codegen::gen_helpers() {
         input_pkgs+=("${pkg}")
     done < <(
         ( kube::codegen::internal::grep -l --null \
-            -e '+k8s:deepcopy-gen=' \
+            -e '^\s*//\s*+k8s:deepcopy-gen=' \
             -r "${in_dir}" \
             --include '*.go' \
             || true \
@@ -153,7 +153,7 @@ function kube::codegen::gen_helpers() {
         input_pkgs+=("${pkg}")
     done < <(
         ( kube::codegen::internal::grep -l --null \
-            -e '+k8s:defaulter-gen=' \
+            -e '^\s*//\s*+k8s:defaulter-gen=' \
             -r "${in_dir}" \
             --include '*.go' \
             || true \
@@ -185,7 +185,7 @@ function kube::codegen::gen_helpers() {
         input_pkgs+=("${pkg}")
     done < <(
         ( kube::codegen::internal::grep -l --null \
-            -e '+k8s:conversion-gen=' \
+            -e '^\s*//\s*+k8s:conversion-gen=' \
             -r "${in_dir}" \
             --include '*.go' \
             || true \
@@ -338,7 +338,7 @@ function kube::codegen::gen_openapi() {
         input_pkgs+=("${pkg}")
     done < <(
         ( kube::codegen::internal::grep -l --null \
-            -e '+k8s:openapi-gen=' \
+            -e '^\s*//\s*+k8s:openapi-gen=' \
             -r "${in_dir}" \
             --include '*.go' \
             || true \
@@ -568,7 +568,7 @@ function kube::codegen::gen_client() {
         fi
     done < <(
         ( kube::codegen::internal::grep -l --null \
-            -e '+genclient' \
+            -e '^\s*//\s*+genclient' \
             -r "${in_dir}${one_input_api}" \
             --include '*.go' \
             || true \


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Be smarter about finding the input packages for genclient et al.  The
previous grep patterns were too generic. This caused code-generator, for
example, to pick up it's own auto-generated packages. In this particular
case having a status field in the type adds a comment to the
autogenerated code like:

    // Add a +genclient:noStatus comment above the type...

This, in turn causes problems in some scenarios where the input (api)
and the target package for the auto-generated code reside in separate go
modules

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
