### PR TITLE
SIG Cloud Provider update

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -431,7 +431,7 @@ aliases:
     - pwittrock
     - soltysh
   sig-cloud-provider-api-reviewers:
-    - andrewsykim
+    - elmiko
     - cheftako
     - dims
   # sig-cluster-lifecycle-api-reviewers:


### PR DESCRIPTION
Updating feature-approvers in [OWNERS_ALIASES](https://git.k8s.io/kubernetes/OWNERS_ALIASES) in [kubernetes/kubernetes](https://github.com/kubernetes/kubernetes) for https://github.com/kubernetes/community/issues/7865.

/sig cloud-provider
