### PR TITLE
kubelet/eviction: improve unit test coverage

### DIFF
--- a/pkg/kubelet/eviction/helpers_test.go
+++ b/pkg/kubelet/eviction/helpers_test.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -46,7 +47,10 @@ func quantityMustParse(value string) *resource.Quantity {
 
 func TestGetReclaimableThreshold(t *testing.T) {
 	testCases := map[string]struct {
-		thresholds []evictionapi.Threshold
+		thresholds                   []evictionapi.Threshold
+		expectedThreshold            evictionapi.Threshold
+		expectedResourceName         v1.ResourceName
+		expectedReclaimableToBeFound bool
 	}{
 		"": {
 			thresholds: []evictionapi.Threshold{
@@ -101,14 +105,40 @@ func TestGetReclaimableThreshold(t *testing.T) {
 					},
 				},
 			},
+			expectedThreshold: evictionapi.Threshold{
+				Signal:   evictionapi.Signal("memory.available"),
+				Operator: evictionapi.OpLessThan,
+				Value: evictionapi.ThresholdValue{
+					Quantity: quantityMustParse("150Mi"),
+				},
+			},
+			expectedResourceName:         v1.ResourceName("memory"),
+			expectedReclaimableToBeFound: true,
+		},
+		"no thresholds": {
+			thresholds:           []evictionapi.Threshold{},
+			expectedThreshold:    evictionapi.Threshold{},
+			expectedResourceName: v1.ResourceName(""),
+		},
+		"threshold was crossed but reclaim not implemented (invalid signal)": {
+			thresholds: []evictionapi.Threshold{
+				{
+					Signal: "mem.available",
+				},
+			},
+			expectedThreshold:    evictionapi.Threshold{},
+			expectedResourceName: v1.ResourceName(""),
 		},
 	}
-	for testName, testCase := range testCases {
+	for _, testCase := range testCases {
 		sort.Sort(byEvictionPriority(testCase.thresholds))
-		_, _, ok := getReclaimableThreshold(testCase.thresholds)
-		if !ok {
-			t.Errorf("Didn't find reclaimable threshold, test: %v", testName)
-		}
+		threshold, ressourceName, found := getReclaimableThreshold(testCase.thresholds)
+		assert.Equal(t, testCase.expectedReclaimableToBeFound, found)
+		assert.Equal(t, testCase.expectedResourceName, ressourceName)
+		assert.Equal(t, testCase.expectedThreshold.Signal, threshold.Signal)
+		assert.Equal(t, testCase.expectedThreshold.Operator, threshold.Operator)
+		assert.Equal(t, testCase.expectedThreshold.Value.Quantity.String(), threshold.Value.Quantity.String())
+		assert.Equal(t, testCase.expectedThreshold.GracePeriod, threshold.GracePeriod)
 	}
 }
 
@@ -455,6 +485,78 @@ func TestParseThresholdConfig(t *testing.T) {
 			expectErr:               true,
 			expectThresholds:        []evictionapi.Threshold{},
 		},
+		"min-reclaim-invalid-signal": {
+			allocatableConfig:       []string{},
+			evictionHard:            map[string]string{},
+			evictionSoft:            map[string]string{},
+			evictionSoftGracePeriod: map[string]string{},
+			evictionMinReclaim:      map[string]string{"mem.available": "300Mi"},
+			expectErr:               true,
+			expectThresholds:        []evictionapi.Threshold{},
+		},
+		"min-reclaim-empty-value": {
+			allocatableConfig:       []string{},
+			evictionHard:            map[string]string{},
+			evictionSoft:            map[string]string{},
+			evictionSoftGracePeriod: map[string]string{},
+			evictionMinReclaim:      map[string]string{"memory.available": ""},
+			expectErr:               true,
+			expectThresholds:        []evictionapi.Threshold{},
+		},
+		"min-reclaim-negative-percentage": {
+			allocatableConfig:       []string{},
+			evictionHard:            map[string]string{},
+			evictionSoft:            map[string]string{},
+			evictionSoftGracePeriod: map[string]string{},
+			evictionMinReclaim:      map[string]string{"memory.available": "-15%"},
+			expectErr:               true,
+			expectThresholds:        []evictionapi.Threshold{},
+		},
+		"min-reclaim-invalid-percentage": {
+			allocatableConfig:       []string{},
+			evictionHard:            map[string]string{},
+			evictionSoft:            map[string]string{},
+			evictionSoftGracePeriod: map[string]string{},
+			evictionMinReclaim:      map[string]string{"memory.available": "10..5%"},
+			expectErr:               true,
+			expectThresholds:        []evictionapi.Threshold{},
+		},
+		"hard-signal-empty-eviction-value": {
+			allocatableConfig:       []string{},
+			evictionHard:            map[string]string{"memory.available": ""},
+			evictionSoft:            map[string]string{},
+			evictionSoftGracePeriod: map[string]string{},
+			evictionMinReclaim:      map[string]string{},
+			expectErr:               true,
+			expectThresholds:        []evictionapi.Threshold{},
+		},
+		"hard-signal-invalid-float-percentage": {
+			allocatableConfig:       []string{},
+			evictionHard:            map[string]string{"memory.available": "10..5%"},
+			evictionSoft:            map[string]string{},
+			evictionSoftGracePeriod: map[string]string{},
+			evictionMinReclaim:      map[string]string{},
+			expectErr:               true,
+			expectThresholds:        []evictionapi.Threshold{},
+		},
+		"soft-grace-period-invalid-signal": {
+			allocatableConfig:       []string{},
+			evictionHard:            map[string]string{},
+			evictionSoft:            map[string]string{"memory.available": "150Mi"},
+			evictionSoftGracePeriod: map[string]string{"mem.available": "30s"},
+			evictionMinReclaim:      map[string]string{},
+			expectErr:               true,
+			expectThresholds:        []evictionapi.Threshold{},
+		},
+		"soft-invalid-grace-period": {
+			allocatableConfig:       []string{},
+			evictionHard:            map[string]string{},
+			evictionSoft:            map[string]string{"memory.available": "150Mi"},
+			evictionSoftGracePeriod: map[string]string{"memory.available": "30mins"},
+			evictionMinReclaim:      map[string]string{},
+			expectErr:               true,
+			expectThresholds:        []evictionapi.Threshold{},
+		},
 	}
 	for testName, testCase := range testCases {
 		thresholds, err := ParseThresholdConfig(testCase.allocatableConfig, testCase.evictionHard, testCase.evictionSoft, testCase.evictionSoftGracePeriod, testCase.evictionMinReclaim)
@@ -644,6 +746,47 @@ func TestAddAllocatableThresholds(t *testing.T) {
 			if !thresholdsEqual(testCase.expected, addAllocatableThresholds(testCase.thresholds)) {
 				t.Errorf("Err not as expected, test: %v, Unexpected data: %s", testName, cmp.Diff(testCase.expected, addAllocatableThresholds(testCase.thresholds)))
 			}
+		})
+	}
+}
+
+func TestFallbackResourcesUsage(t *testing.T) {
+	for _, test := range []struct {
+		description   string
+		usageFuncName string
+		usageFunc     func() int64
+	}{
+		{
+			description:   "disk usage, fallback value",
+			usageFuncName: "diskUsage",
+			usageFunc: func() int64 {
+				return diskUsage(&statsapi.FsStats{}).Value()
+			},
+		},
+		{
+			description:   "inode usage, fallback value",
+			usageFuncName: "inodeUsage",
+			usageFunc: func() int64 {
+				return inodeUsage(&statsapi.FsStats{}).Value()
+			},
+		},
+		{
+			description:   "memory usage, fallback value",
+			usageFuncName: "memoryUsage",
+			usageFunc: func() int64 {
+				return memoryUsage(&statsapi.MemoryStats{}).Value()
+			},
+		},
+		{
+			description:   "process usage, fallback value",
+			usageFuncName: "processUsage",
+			usageFunc: func() int64 {
+				return int64(processUsage(&statsapi.ProcessStats{}))
+			},
+		},
+	} {
+		t.Run(test.description, func(t *testing.T) {
+			assert.NotEqual(t, 0, test.usageFunc(), fmt.Sprintf("%s: unexpected fallback value", test.usageFuncName))
 		})
 	}
 }
@@ -3256,6 +3399,52 @@ func TestEvictonMessageWithResourceResize(t *testing.T) {
 					t.Errorf("Found 'exceeds memory' eviction message which was not expected.")
 				}
 			}
+		})
+	}
+}
+
+func TestStatsNotFoundForPod(t *testing.T) {
+	pod1 := newPod("fake-pod1", defaultPriority, []v1.Container{
+		newContainer("fake-container1", newResourceList("", "", ""), newResourceList("", "", "")),
+	}, nil)
+	pod2 := newPod("fake-pod2", defaultPriority, []v1.Container{
+		newContainer("fake-container2", newResourceList("", "", ""), newResourceList("", "", "")),
+	}, nil)
+	statsFn := func(pod *v1.Pod) (statsapi.PodStats, bool) {
+		return statsapi.PodStats{}, false
+	}
+
+	for _, test := range []struct {
+		description string
+		compFunc    func(stats statsFunc) cmpFunc
+	}{
+		{
+			description: "process",
+			compFunc:    process,
+		},
+		{
+			description: "memory",
+			compFunc:    memory,
+		},
+		{
+			description: "exceedMemoryRequests",
+			compFunc:    exceedMemoryRequests,
+		},
+		{
+			description: "exceedDiskRequests",
+			compFunc: func(stats statsFunc) cmpFunc {
+				return exceedDiskRequests(stats, nil, "")
+			},
+		},
+		{
+			description: "disk",
+			compFunc: func(stats statsFunc) cmpFunc {
+				return disk(stats, nil, "")
+			},
+		},
+	} {
+		t.Run(test.description, func(t *testing.T) {
+			assert.Equal(t, 0, test.compFunc(statsFn)(pod1, pod2), "unexpected default result")
 		})
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

If applied this commit will improve the unit test coverage of `pkg/kubelet/eviction`.

- before

<img width="735" alt="Screenshot 2024-05-21 at 07 47 16" src="https://github.com/kubernetes/kubernetes/assets/9576370/663969fc-cceb-4627-9671-ba5df1ae4a10">

- after

<img width="736" alt="Screenshot 2024-05-22 at 17 15 02" src="https://github.com/kubernetes/kubernetes/assets/9576370/f1049b0e-de6e-4540-b9a2-5cab43041d08">


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
