### PR TITLE
build/pause: add -v flag to the Windows pause binary. Add 3.10 changelog entry.

### DIFF
--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -189,11 +189,14 @@ dependencies:
     - path: build/common.sh
       match: __default_go_runner_version=
 
-  - name: "registry.k8s.io/pause"
-    version: 3.9
-    refPaths:
-    - path: build/pause/Makefile
-      match: TAG\s*\?=
+  # TODO: enable once pause 3.10 is promoted
+  # https://github.com/kubernetes/kubernetes/issues/125092
+  #
+  # - name: "registry.k8s.io/pause"
+  #   version: 3.10
+  #   refPaths:
+  #   - path: build/pause/Makefile
+  #     match: TAG\s*\?=
 
   - name: "registry.k8s.io/pause: dependents"
     version: 3.9

--- a/build/pause/CHANGELOG.md
+++ b/build/pause/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.10
+
+* Add support for the -v flag on Windows. It prints the version similarly to Linux. ([#125067](https://github.com/kubernetes/kubernetes/pull/125067), [@neolit123](https://github.com/neolit123))
+
 # 3.9
 
 * Unsupported Windows Semi-Annual Channel container images removed (OS Versions removed: 20H2). ([#112924](https://github.com/kubernetes/kubernetes/pull/112924), [@marosset](https://github.com/marosset))

--- a/build/pause/Makefile
+++ b/build/pause/Makefile
@@ -17,7 +17,7 @@
 REGISTRY ?= staging-k8s.gcr.io
 IMAGE = $(REGISTRY)/pause
 
-TAG ?= 3.9
+TAG ?= 3.10
 REV = $(shell git describe --contains --always --match='v*')
 
 # Architectures supported: amd64, arm, arm64, ppc64le and s390x

--- a/build/pause/windows/pause.c
+++ b/build/pause/windows/pause.c
@@ -16,6 +16,14 @@ limitations under the License.
 
 #include <windows.h>
 #include <stdio.h>
+#include <string.h>
+
+#define STRINGIFY(x) #x
+#define VERSION_STRING(x) STRINGIFY(x)
+
+#ifndef VERSION
+#define VERSION HEAD
+#endif
 
 BOOL WINAPI CtrlHandler(DWORD fdwCtrlType)
 {
@@ -34,8 +42,18 @@ BOOL WINAPI CtrlHandler(DWORD fdwCtrlType)
 	}
 }
 
-int main(void)
+int main(int argc, char **argv)
 {
+	int i;
+	for (i = 1; i < argc; ++i)
+	{
+		if (!_stricmp(argv[i], "-v"))
+		{
+			fprintf(stdout, "pause.c %s\n", VERSION_STRING(VERSION));
+			return 0;
+		}
+	}
+
 	if (SetConsoleCtrlHandler(CtrlHandler, TRUE))
 	{
 		Sleep(INFINITE);


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Make the Windows pause.exe have the same -v flag as the Linux pause binary.

_stricmp is documented here:
https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/strcmp-wcscmp-mbscmp?view=msvc-170

The VERSION definition is passed on compile time for both OSes in the Makefile via CFLAGS:

`  $(TRIPLE)-gcc $(CFLAGS) -o $@ $^ && \`

Add changelog entry for 3.10.
TODO promotion.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

xref:
- https://github.com/kubernetes/kubernetes/issues/125012
- https://github.com/kubernetes/kubernetes/issues/125092

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
pause: add a -v flag to the Windows variant of the pause binary, which prints the version of pause and exits. The Linux pause already has the flag.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
