### PR TITLE
Fix validation of -f or -k flag in kubectl create command to be consistent with other commands

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create.go
@@ -109,12 +109,6 @@ func NewCmdCreate(f cmdutil.Factory, ioStreams genericiooptions.IOStreams) *cobr
 		Long:                  createLong,
 		Example:               createExample,
 		Run: func(cmd *cobra.Command, args []string) {
-			if cmdutil.IsFilenameSliceEmpty(o.FilenameOptions.Filenames, o.FilenameOptions.Kustomize) {
-				ioStreams.ErrOut.Write([]byte("Error: must specify one of -f and -k\n\n"))
-				defaultRunFunc := cmdutil.DefaultSubCommandRun(ioStreams.ErrOut)
-				defaultRunFunc(cmd, args)
-				return
-			}
 			cmdutil.CheckErr(o.Complete(f, cmd, args))
 			cmdutil.CheckErr(o.Validate())
 			cmdutil.CheckErr(o.RunCreate(f, cmd))
@@ -159,8 +153,12 @@ func NewCmdCreate(f cmdutil.Factory, ioStreams genericiooptions.IOStreams) *cobr
 	return cmd
 }
 
-// Validate makes sure there is no discrepency in command options
+// Validate makes sure there is no discrepancy in command options
 func (o *CreateOptions) Validate() error {
+	if err := o.FilenameOptions.RequireFilenameOrKustomize(); err != nil {
+		return err
+	}
+
 	if len(o.Raw) > 0 {
 		if o.EditBeforeCreate {
 			return fmt.Errorf("--raw and --edit are mutually exclusive")


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
`kubectl create` without specifying `-f` or `-k` behaves inconsistently from other commands.

This PR moves the validation logic out of the cobra Run function and into the `Validate()` function and calls the preexisting `RequireFilenameOrKustomize()` cli-runtime function like other commands do.

It also no longer automatically prints the command usage, which is not a standard behavior for validation errors.

#### Which issue(s) this PR fixes:
n/a

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
