### PR TITLE
Update cli-runtime OWNERS file to use sig-cli-maintainers/sig-cli-reviewers

### DIFF
--- a/staging/src/k8s.io/cli-runtime/OWNERS
+++ b/staging/src/k8s.io/cli-runtime/OWNERS
@@ -1,20 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-  - deads2k
-  - pwittrock
-  - seans3
-  - soltysh
-  - eddiezane
-  - brianpursley
-  - KnVerey
+  - sig-cli-maintainers
 reviewers:
-  - deads2k
-  - pwittrock
-  - seans3
-  - soltysh
-  - eddiezane
-  - brianpursley
-  - KnVerey
+  - sig-cli-reviewers
 labels:
   - sig/cli


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
OWNERS file in cli-runtime is out of date and has individual names instead of the sig-cli-maintainers/sig-cli-reviewers groups.

#### Which issue(s) this PR fixes:
n/a

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
