### PR TITLE
kubelet/apis/config/validation: improve unit test coverage

### DIFF
--- a/pkg/kubelet/apis/config/validation/validation_test.go
+++ b/pkg/kubelet/apis/config/validation/validation_test.go
@@ -598,6 +598,27 @@ func TestValidateKubeletConfiguration(t *testing.T) {
 			return config
 		},
 		errMsg: `invalid configuration: pod logs path "/🧪" mut contains ASCII characters only`,
+	}, {
+		name: "invalid ContainerRuntimeEndpoint",
+		configure: func(conf *kubeletconfig.KubeletConfiguration) *kubeletconfig.KubeletConfiguration {
+			conf.ContainerRuntimeEndpoint = ""
+			return conf
+		},
+		errMsg: "invalid configuration: the containerRuntimeEndpoint was not specified or empty",
+	}, {
+		name: "invalid Logging configuration",
+		configure: func(conf *kubeletconfig.KubeletConfiguration) *kubeletconfig.KubeletConfiguration {
+			conf.Logging.Format = "invalid"
+			return conf
+		},
+		errMsg: "logging.format: Invalid value: \"invalid\": Unsupported log format",
+	}, {
+		name: "invalid FeatureGate",
+		configure: func(conf *kubeletconfig.KubeletConfiguration) *kubeletconfig.KubeletConfiguration {
+			conf.FeatureGates["invalid"] = true
+			return conf
+		},
+		errMsg: "unrecognized feature gate: invalid",
 	},
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

If applied this commit will improve the unit tests coverage of `pkg/kubelet/apis/config/validation`.

- before

<img width="737" alt="Screenshot 2024-05-23 at 11 02 07" src="https://github.com/kubernetes/kubernetes/assets/9576370/7b4bb2c8-d1f4-477a-b6c5-23896899cd3d">

- after

<img width="736" alt="Screenshot 2024-05-23 at 11 01 41" src="https://github.com/kubernetes/kubernetes/assets/9576370/c282ef46-48e6-44ae-8a8a-80ddeded89a6">

ps: Unfortunately I cannot bring it to 100% due to the `validateKubeletOSConfiguration` that returns an error only under Windows.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
