### PR TITLE
client-go: only filter PATCH events by default

### DIFF
--- a/staging/src/k8s.io/client-go/tools/record/event.go
+++ b/staging/src/k8s.io/client-go/tools/record/event.go
@@ -85,7 +85,7 @@ type CorrelatorOptions struct {
 	// If not specified (zero value), clock.RealClock{} will be used
 	Clock clock.PassiveClock
 	// The func used by EventFilterFunc, which returns a key for given event, based on which filtering will take place
-	// If not specified (zero value), getSpamKey will be used
+	// If not specified (zero value), each aggregated event will be filtered individually
 	SpamKeyFunc EventSpamKeyFunc
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

PR #47367 introduced client side event spam filtering to reduce the API server/etcd pressure of processing repeated events.  However, it use only Source and InvolvedObject as key, so it can also drop important and unique events. Slowing down the diagnosing significantly.

PR #103918 try to resolve this by adding a new SpamKeyFunc to customize the key used. But this is still not ideal, because every user needs to dig into the code of client-go to figure out why his event does not appear. If the EventBroadcaster is initialized in a library, it may be even harder to set the SpamKeyFunc.

I propose to only drop PATCH events by default, which is the intent of the original proposal.  For the users who don't set SpamKeyFunc, they should get exactly more events.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

Please consider the same use case of #103918. In our case, we found [csi-provisioner](https://github.com/kubernetes-csi/external-provisioner) always issue a `Provisioning` event just before `ProvisioningFailed` event. The `ProvisioningFailed` event is then always dropped by client-go and disappear after a while.
And the event is issued from a lib used by csi-provisioner. That would require changes to multiple repo to enable SpamKeyFunc, which is annoying.

I think this case is so common that we should change the default behavior to reduce confusing to developers and cluster admins.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
client-go event spam filtering now only drops PATCH requests by default.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/cc @derekwaynecarr @smarterclayton @olagacek @serathius
The author and reviewers of the previously mentioned PRs