### PR TITLE
e2e: Increase preStop hook delay to deflake the test

### DIFF
--- a/test/e2e_node/container_lifecycle_test.go
+++ b/test/e2e_node/container_lifecycle_test.go
@@ -799,7 +799,7 @@ var _ = SIGDescribe(framework.WithNodeConformance(), "Containers Lifecycle", fun
 				PreStop: &v1.LifecycleHandler{
 					Exec: &v1.ExecAction{
 						Command: ExecCommand(prefixedName(PreStopPrefix, regular1), execCommand{
-							Delay:         1,
+							Delay:         10,
 							ExitCode:      0,
 							ContainerName: regular1,
 						}),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind flake
/kind failing-test
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/125073/pull-kubernetes-node-e2e-containerd/1793373424723169280
```
50) 2024-05-22 20:22:37.013 +0000 UTC Readiness-regular-1 Exiting
51) 2024-05-22 20:22:37.065 +0000 UTC PreStop-regular-1 Starting
52) 2024-05-22 20:22:37.074 +0000 UTC PreStop-regular-1 Started
53) 2024-05-22 20:22:37.081 +0000 UTC PreStop-regular-1 Delaying
54) 2024-05-22 20:22:38.065 +0000 UTC Readiness-regular-1 Starting
55) 2024-05-22 20:22:38.12 +0000 UTC PreStop-regular-1 Exiting
56) 2024-05-22 20:22:38.132 +0000 UTC Readiness-regular-1 Started
57) 2024-05-22 20:22:38.161 +0000 UTC Readiness-regular-1 Delaying
58) 2024-05-22 20:22:38.18 +0000 UTC Readiness-regular-1 Exiting
59) 2024-05-22 20:22:39.029 +0000 UTC Readiness-regular-1 Starting
60) 2024-05-22 20:22:39.067 +0000 UTC Readiness-regular-1 Started
61) 2024-05-22 20:22:39.095 +0000 UTC Readiness-regular-1 Delaying
62) 2024-05-22 20:22:39.11 +0000 UTC Readiness-regular-1 Exiting
```
Currently, the kubelet sometimes does not have enough time to execute the readiness probe during the prestop hook.

This PR delays the preStop hook to allow sufficient time for the readiness probe to be executed.



#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
xref: https://github.com/kubernetes/kubernetes/issues/124791

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
none
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
