### PR TITLE
add tests to assert on expected behavior of  wrapped ResponseWriter objects

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/audit_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/audit_test.go
@@ -111,6 +111,15 @@ func TestAuditResponseWriterDecoratorWithFake(t *testing.T) {
 	})
 }
 
+func TestAuditResponseWriterDecoratorWithHTTPServer(t *testing.T) {
+	responsewritertesting.VerifyResponseWriterDecoratorWithHTTPServer(t, func(verifier http.Handler) http.Handler {
+		fakeRuleEvaluator := policy.NewFakePolicyRuleEvaluator(auditinternal.LevelMetadata, nil)
+		handler := WithAudit(verifier, &fakeAuditSink{}, fakeRuleEvaluator, nil)
+		handler = WithAuditInit(handler)
+		return handler
+	})
+}
+
 func TestDecorateResponseWriterWithoutChannel(t *testing.T) {
 	ev := &auditinternal.Event{}
 	actual := decorateResponseWriter(context.Background(), &responsewritertesting.FakeResponseWriter{}, ev, nil, nil)

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/audit_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/audit_test.go
@@ -86,8 +86,10 @@ func TestConstructResponseWriter(t *testing.T) {
 	if innerGot := actual.(responsewriter.UserProvidedDecorator).Unwrap(); inner != innerGot {
 		t.Errorf("Expected the decorator to return the inner http.ResponseWriter object")
 	}
+}
 
-	actual = decorateResponseWriter(context.Background(), &responsewritertesting.FakeResponseWriterFlusherCloseNotifier{}, nil, nil, nil)
+func TestConstructResponseWriterWithFake(t *testing.T) {
+	actual := decorateResponseWriter(context.Background(), &responsewritertesting.FakeResponseWriterFlusherCloseNotifier{}, nil, nil, nil)
 	//lint:file-ignore SA1019 Keep supporting deprecated http.CloseNotifier
 	if _, ok := actual.(http.CloseNotifier); !ok {
 		t.Errorf("Expected http.ResponseWriter to implement http.CloseNotifier")

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/webhook_duration_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/webhook_duration_test.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package filters
+
+import (
+	"testing"
+
+	"k8s.io/apiserver/pkg/endpoints/responsewriter"
+	responsewritertesting "k8s.io/apiserver/pkg/endpoints/responsewriter/testing"
+)
+
+func TestLatencyTrackerResponseWriterDecoratorConstruction(t *testing.T) {
+	inner := &responsewritertesting.FakeResponseWriter{}
+	middle := &writeLatencyTracker{ResponseWriter: inner}
+	outer := responsewriter.WrapForHTTP1Or2(middle)
+
+	// FakeResponseWriter does not implement http.Flusher, FlusherError,
+	// http.CloseNotifier, or http.Hijacker; so WrapForHTTP1Or2 is not
+	// expected to return an outer object.
+	if outer != middle {
+		t.Errorf("did not expect a new outer object, but got %v", outer)
+	}
+
+	decorator, ok := outer.(responsewriter.UserProvidedDecorator)
+	if !ok {
+		t.Fatal("expected the middle to implement UserProvidedDecorator")
+	}
+	if want, got := inner, decorator.Unwrap(); want != got {
+		t.Errorf("expected the decorator to return the inner http.ResponseWriter object")
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/webhook_duration_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/webhook_duration_test.go
@@ -47,3 +47,7 @@ func TestLatencyTrackerResponseWriterDecoratorConstruction(t *testing.T) {
 func TestLatencyTrackerResponseWriterWithFake(t *testing.T) {
 	responsewritertesting.VerifyResponseWriterDecoratorWithFake(t, WithLatencyTrackers)
 }
+
+func TestLatencyTrackerResponseWriterDecoratorWithHTTPServer(t *testing.T) {
+	responsewritertesting.VerifyResponseWriterDecoratorWithHTTPServer(t, WithLatencyTrackers)
+}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/webhook_duration_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/webhook_duration_test.go
@@ -43,3 +43,7 @@ func TestLatencyTrackerResponseWriterDecoratorConstruction(t *testing.T) {
 		t.Errorf("expected the decorator to return the inner http.ResponseWriter object")
 	}
 }
+
+func TestLatencyTrackerResponseWriterWithFake(t *testing.T) {
+	responsewritertesting.VerifyResponseWriterDecoratorWithFake(t, WithLatencyTrackers)
+}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics_test.go
@@ -378,6 +378,12 @@ func TestMetricsResponseWriterDecoratorConstruction(t *testing.T) {
 	}
 }
 
+func TestMetricsResponseWriterDecoratorWithFake(t *testing.T) {
+	responsewritertesting.VerifyResponseWriterDecoratorWithFake(t, func(verifier http.Handler) http.Handler {
+		return InstrumentHandlerFunc("", "", "", "", "", "", "", false, "", verifier.ServeHTTP)
+	})
+}
+
 func TestRecordDroppedRequests(t *testing.T) {
 	testedMetrics := []string{
 		"apiserver_request_total",

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics_test.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/endpoints/responsewriter"
+	responsewritertesting "k8s.io/apiserver/pkg/endpoints/responsewriter/testing"
 	"k8s.io/component-base/metrics/legacyregistry"
 	"k8s.io/component-base/metrics/testutil"
 )
@@ -358,7 +359,7 @@ func TestCleanFieldValidation(t *testing.T) {
 
 func TestResponseWriterDecorator(t *testing.T) {
 	decorator := &ResponseWriterDelegator{
-		ResponseWriter: &responsewriter.FakeResponseWriter{},
+		ResponseWriter: &responsewritertesting.FakeResponseWriter{},
 	}
 	var w http.ResponseWriter = decorator
 

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics_test.go
@@ -384,6 +384,12 @@ func TestMetricsResponseWriterDecoratorWithFake(t *testing.T) {
 	})
 }
 
+func TestMetricsResponseWriterDecoratorWithHTTPServer(t *testing.T) {
+	responsewritertesting.VerifyResponseWriterDecoratorWithHTTPServer(t, func(verifier http.Handler) http.Handler {
+		return InstrumentHandlerFunc("", "", "", "", "", "", "", false, "", verifier.ServeHTTP)
+	})
+}
+
 func TestRecordDroppedRequests(t *testing.T) {
 	testedMetrics := []string{
 		"apiserver_request_total",

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/responsewriter/testing/fake.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/responsewriter/testing/fake.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package responsewriter
+package testing
 
 import (
 	"bufio"

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/responsewriter/testing/fake.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/responsewriter/testing/fake.go
@@ -89,3 +89,26 @@ func AssertResponseWriterInterfaceCompatibility(t *testing.T, inner, outer http.
 		t.Errorf("Expected the inner and outer http.ResponseWriter object to be compatible with http.Hijacker, but got - inner: %t, outer: %t", innerHijackable, outerHijackable)
 	}
 }
+
+func AssertResponseWriterImplementsExtendedInterfaces(t *testing.T, w http.ResponseWriter, req *http.Request) {
+	t.Helper()
+
+	_, flushable := w.(http.Flusher)
+	if !flushable {
+		t.Errorf("Expected the http.ResponseWriter object of type: %T to implement http.Flusher", w)
+	}
+
+	//nolint:staticcheck // SA1019
+	_, closeNotifiable := w.(http.CloseNotifier)
+	if !closeNotifiable {
+		t.Errorf("Expected the http.ResponseWriter object of type: %T to implement http.CloseNotifier", w)
+	}
+
+	// only http/1.x implements http.Hijacker
+	if req.Proto == "HTTP/1.1" {
+		_, hijackable := w.(http.Hijacker)
+		if !hijackable {
+			t.Errorf("Expected the http.ResponseWriter object of type: %T to implement http.Hijacker", w)
+		}
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/responsewriter/testing/verify_decorator.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/responsewriter/testing/verify_decorator.go
@@ -18,8 +18,11 @@ package testing
 
 import (
 	"net/http"
+	"net/http/httptest"
 	"testing"
+	"time"
 
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/endpoints/responsewriter"
 )
@@ -106,6 +109,123 @@ func VerifyResponseWriterDecoratorWithFake(t *testing.T, chain func(http.Handler
 
 			if !invoked {
 				t.Errorf("the user provided handler did not invoke the verifier handler")
+			}
+		})
+	}
+}
+
+// VerifyResponseWriterDecoratorWithHTTPServer verifies that the ResponseWriter
+// decorator built with this package adheres to interface compatibility as expected.
+// NOTE: each ResponseWriter decorator used by the apiserver is expected to run
+// the following test, and thus it is a shared test.
+func VerifyResponseWriterDecoratorWithHTTPServer(t *testing.T, chain func(http.Handler) http.Handler) {
+	for _, proto := range []string{"HTTP/1.1", "HTTP/2.0"} {
+		t.Run(proto, func(t *testing.T) {
+
+			// this handler should run first, so it should be
+			// appended to the chain:
+			// - it saves the original ResponseWriter object passed
+			// to the request handler by net/http
+			// - assert that the original ResponseWriter implements
+			// the expected interfaces
+			var inner http.ResponseWriter
+			first := func(h http.Handler) http.Handler {
+				return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+					inner = w
+					t.Logf("got the ResponseWriter object passed by net/http: original=%T", w)
+
+					if req.Proto != proto {
+						t.Errorf("expected protocol: %q, but got: %q", proto, req.Proto)
+					}
+					AssertResponseWriterImplementsExtendedInterfaces(t, inner, req)
+
+					ri := &request.RequestInfo{}
+					req = req.WithContext(request.WithRequestInfo(req.Context(), ri))
+					h.ServeHTTP(w, req)
+				})
+			}
+
+			// this handler should run last in the chain - it
+			// receives the wrapped ResponseWriter object
+			doneCh := make(chan struct{})
+			last := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				defer close(doneCh)
+				// a wrapped ResponseWriter object is nested, as shown below:
+				//   outer
+				//     |
+				//     |-- middle (user defined decorator)
+				//           |
+				//           |-- inner
+				//
+				// a) inner: this is the ResponseWriter that is being wrapped
+				// b) middle: it takes the inner ResponseWriter object and decorates
+				// it, for example, it can override the `Flush` method, the decorator
+				// does not need to maintain interface compatibility with the inner
+				// ResponseWriter.
+				// c) outer: it maintains interface compatibility with the inner, and
+				// delegates calls to the decorator as appropriate
+				outer := w
+				t.Logf("the outer ResponseWriter object is of type: %T", outer)
+				if inner == nil || outer == inner {
+					t.Errorf("the user provided handler did not wrap the ResponseWriter object")
+					return
+				}
+
+				AssertResponseWriterImplementsExtendedInterfaces(t, outer, r)
+				AssertResponseWriterInterfaceCompatibility(t, inner, outer)
+
+				accessor, ok := outer.(interface {
+					GetUserProvidedDecorator() responsewriter.UserProvidedDecorator
+				})
+				if !ok {
+					t.Errorf("the wrapped ResponseWriter is not compatible: %T", outer)
+					return
+				}
+				middle := accessor.GetUserProvidedDecorator()
+				t.Logf("got the user defined decorator - decorator=%T", middle)
+
+				// we expect the wrapped ResponseWriter to be a UserProvidedDecorator
+				decorator, ok := outer.(responsewriter.UserProvidedDecorator)
+				if !ok {
+					t.Errorf("expected a UserProvidedDecorator: %T", outer)
+					return
+				}
+
+				if want, got := inner, decorator.Unwrap(); want != got {
+					t.Errorf("expected Unwrap to return the original ResponseWriter")
+				}
+				if want, got := responsewriter.GetOriginal(outer), decorator.Unwrap(); want != got {
+					t.Errorf("expected Unwrap to return the original ResponseWriter")
+				}
+			})
+
+			// the handler chain is constructed as follows:
+			//   first -> user provided handler -> last
+			handler := chain(last)
+			handler = first(handler)
+
+			server := httptest.NewUnstartedServer(handler)
+			defer server.Close()
+			if proto == "HTTP/2.0" {
+				server.EnableHTTP2 = true
+			}
+			server.StartTLS()
+
+			client := server.Client()
+			client.Timeout = wait.ForeverTestTimeout
+			resp, err := client.Get(server.URL)
+			if err != nil {
+				t.Errorf("unexpected error from client.Get: %v", err)
+				return
+			}
+			if resp.StatusCode != http.StatusOK {
+				t.Errorf("Expected an OK response from the server, but got: %v", resp)
+			}
+
+			select {
+			case <-doneCh:
+			case <-time.After(wait.ForeverTestTimeout):
+				t.Errorf("expected the request handler to have terminated")
 			}
 		})
 	}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/responsewriter/testing/verify_decorator.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/responsewriter/testing/verify_decorator.go
@@ -1,0 +1,112 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"net/http"
+	"testing"
+
+	"k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/apiserver/pkg/endpoints/responsewriter"
+)
+
+// The user defined handler wraps the ResponseWriter object, this shared test
+// verifies that the wrapped ResponseWriter object produced by the handler
+// maintains interface compatibility with the original ResponseWriter
+// object passed to it.
+// NOTE: this test uses fake ResponseWriter implementation
+func VerifyResponseWriterDecoratorWithFake(t *testing.T, chain func(http.Handler) http.Handler) {
+	tests := []struct {
+		name      string
+		w         http.ResponseWriter
+		decorator func(w http.ResponseWriter) http.ResponseWriter
+	}{
+		{
+			name: "http/2.0",
+			w: &FakeResponseWriterFlusherCloseNotifier{
+				FakeResponseWriter: &FakeResponseWriter{},
+			},
+		},
+		{
+			name: "http/1x",
+			w: &FakeResponseWriterFlusherCloseNotifierHijacker{
+				FakeResponseWriterFlusherCloseNotifier: &FakeResponseWriterFlusherCloseNotifier{
+					FakeResponseWriter: &FakeResponseWriter{},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			req, err := http.NewRequest("GET", "http://example.com", nil)
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+
+			ri := &request.RequestInfo{}
+			req = req.WithContext(request.WithRequestInfo(req.Context(), ri))
+
+			// the verifier handler verifies the ResponseWriter
+			// wrapped by the user defined handler
+			var invoked bool
+			verifier := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				invoked = true
+
+				// test.w is the original ResponseWriter passed
+				// to the user defined handler
+				// w is the wrapped ResponseWriter object
+				inner, outer := test.w, w
+				t.Logf("verifier handler being invoked, ResponseWriter - original: %T, wrapped: %T", inner, outer)
+
+				if inner == w {
+					t.Errorf("the user provided handler did not wrap the ResponseWriter object")
+					return
+				}
+
+				decorator, ok := outer.(responsewriter.UserProvidedDecorator)
+				if !ok {
+					t.Errorf("expected the outer ResponseWriter object to implement responsewriter.UserProvidedDecorator")
+					return
+				}
+				if want, got := inner, decorator.Unwrap(); want != got {
+					t.Errorf("expected the decorator to return the correct inner ResponseWriter object")
+				}
+
+				AssertResponseWriterInterfaceCompatibility(t, inner, outer)
+			})
+
+			// we build a handler chain that looks like this:
+			//      func(w http.ResponseWriter, r *http.Request) {
+			//         // this is the user defined handler that wraps
+			//         // the ResponseWriter object passed to it.
+			//         w = wrap(w)
+			//
+			//         // invoke the verifier handler defined above,
+			//         // the wrapped ResponseWriter gets passed to
+			//         // the verifier handler.
+			//         verifier.ServeHTTP(w, r)
+			//      }
+			handler := chain(verifier)
+			handler.ServeHTTP(test.w, req)
+
+			if !invoked {
+				t.Errorf("the user provided handler did not invoke the verifier handler")
+			}
+		})
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/responsewriter/wrapper.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/responsewriter/wrapper.go
@@ -154,6 +154,11 @@ func (wr outerWithCloseNotifyAndFlush) Flush() {
 	wr.InnerCloseNotifierFlusher.Flush()
 }
 
+// GetUserProvidedDecorator returns the user provided ResponseWriter decorator
+func (wr outerWithCloseNotifyAndFlush) GetUserProvidedDecorator() UserProvidedDecorator {
+	return wr.UserProvidedDecorator
+}
+
 //lint:file-ignore SA1019 Keep supporting deprecated http.CloseNotifier
 var _ http.CloseNotifier = outerWithCloseNotifyFlushAndHijack{}
 var _ http.Flusher = outerWithCloseNotifyFlushAndHijack{}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/responsewriter/wrapper_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/responsewriter/wrapper_test.go
@@ -24,6 +24,8 @@ import (
 	"net/url"
 	"testing"
 	"time"
+
+	responsewritertesting "k8s.io/apiserver/pkg/endpoints/responsewriter/testing"
 )
 
 func TestWithHTTP1(t *testing.T) {
@@ -139,14 +141,14 @@ func TestGetOriginal(t *testing.T) {
 		{
 			name: "not wrapped",
 			wrap: func() (http.ResponseWriter, http.ResponseWriter) {
-				original := &FakeResponseWriter{}
+				original := &responsewritertesting.FakeResponseWriter{}
 				return original, original
 			},
 		},
 		{
 			name: "wrapped once",
 			wrap: func() (http.ResponseWriter, http.ResponseWriter) {
-				original := &FakeResponseWriter{}
+				original := &responsewritertesting.FakeResponseWriter{}
 				return original, &fakeResponseWriterDecorator{
 					ResponseWriter: original,
 				}
@@ -155,7 +157,7 @@ func TestGetOriginal(t *testing.T) {
 		{
 			name: "wrapped multiple times",
 			wrap: func() (http.ResponseWriter, http.ResponseWriter) {
-				original := &FakeResponseWriter{}
+				original := &responsewritertesting.FakeResponseWriter{}
 				return original, &fakeResponseWriterDecorator{
 					ResponseWriter: &fakeResponseWriterDecorator{
 						ResponseWriter: &fakeResponseWriterDecorator{

--- a/staging/src/k8s.io/apiserver/pkg/server/filters/timeout_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/timeout_test.go
@@ -540,6 +540,18 @@ func TestTimeoutResponseWriterDecoratorConstruction(t *testing.T) {
 	}
 }
 
+func TestTimeoutResponseWriterDecoratorWithFake(t *testing.T) {
+	responsewritertesting.VerifyResponseWriterDecoratorWithFake(t, func(verifier http.Handler) http.Handler {
+		return WithTimeout(
+			http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				verifier.ServeHTTP(w, req)
+			}),
+			func(req *http.Request) (*http.Request, bool, func(), *apierrors.StatusError) {
+				return req, false, func() {}, nil
+			})
+	})
+}
+
 func isStackTraceLoggedByRuntime(message string) bool {
 	// Check the captured output for the following patterns to find out if the
 	// stack trace is included in the log:

--- a/staging/src/k8s.io/apiserver/pkg/server/filters/timeout_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/timeout_test.go
@@ -44,6 +44,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/endpoints/responsewriter"
+	responsewritertesting "k8s.io/apiserver/pkg/endpoints/responsewriter/testing"
 	"k8s.io/klog/v2"
 )
 
@@ -520,7 +521,7 @@ func TestErrConnKilledHTTP2(t *testing.T) {
 
 func TestResponseWriterDecorator(t *testing.T) {
 	decorator := &baseTimeoutWriter{
-		w: &responsewriter.FakeResponseWriter{},
+		w: &responsewritertesting.FakeResponseWriter{},
 	}
 	var w http.ResponseWriter = decorator
 

--- a/staging/src/k8s.io/apiserver/pkg/server/filters/timeout_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/timeout_test.go
@@ -552,6 +552,18 @@ func TestTimeoutResponseWriterDecoratorWithFake(t *testing.T) {
 	})
 }
 
+func TestTimeoutResponseWriterDecoratorWithHTTPServer(t *testing.T) {
+	responsewritertesting.VerifyResponseWriterDecoratorWithHTTPServer(t, func(verifier http.Handler) http.Handler {
+		return WithTimeout(
+			http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				verifier.ServeHTTP(w, req)
+			}),
+			func(req *http.Request) (*http.Request, bool, func(), *apierrors.StatusError) {
+				return req, false, func() {}, nil
+			})
+	})
+}
+
 func isStackTraceLoggedByRuntime(message string) bool {
 	// Check the captured output for the following patterns to find out if the
 	// stack trace is included in the log:

--- a/staging/src/k8s.io/apiserver/pkg/server/filters/timeout_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/timeout_test.go
@@ -519,14 +519,24 @@ func TestErrConnKilledHTTP2(t *testing.T) {
 	}
 }
 
-func TestResponseWriterDecorator(t *testing.T) {
-	decorator := &baseTimeoutWriter{
-		w: &responsewritertesting.FakeResponseWriter{},
-	}
-	var w http.ResponseWriter = decorator
+func TestTimeoutResponseWriterDecoratorConstruction(t *testing.T) {
+	inner := &responsewritertesting.FakeResponseWriter{}
+	middle := &baseTimeoutWriter{w: inner}
+	outer := responsewriter.WrapForHTTP1Or2(middle)
 
-	if inner := w.(responsewriter.UserProvidedDecorator).Unwrap(); inner != decorator.w {
-		t.Errorf("Expected the decorator to return the inner http.ResponseWriter object")
+	// FakeResponseWriter does not implement http.Flusher, FlusherError,
+	// http.CloseNotifier, or http.Hijacker; so WrapForHTTP1Or2 is not
+	// expected to return an outer object.
+	if outer != middle {
+		t.Errorf("did not expect a new outer object, but got %v", outer)
+	}
+
+	decorator, ok := outer.(responsewriter.UserProvidedDecorator)
+	if !ok {
+		t.Fatal("expected the middle to implement UserProvidedDecorator")
+	}
+	if want, got := inner, decorator.Unwrap(); want != got {
+		t.Errorf("expected the decorator to return the inner http.ResponseWriter object")
 	}
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/server/httplog/httplog_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/httplog/httplog_test.go
@@ -193,3 +193,9 @@ func TestHTTPLogResponseWriterDecoratorConstruction(t *testing.T) {
 		t.Errorf("expected the decorator to return the inner http.ResponseWriter object")
 	}
 }
+
+func TestHTTPLogResponseWriterDecoratorWithHTTPServer(t *testing.T) {
+	responsewritertesting.VerifyResponseWriterDecoratorWithHTTPServer(t, func(h http.Handler) http.Handler {
+		return withLogging(h, DefaultStacktracePred, func() bool { return true })
+	})
+}

--- a/staging/src/k8s.io/apiserver/pkg/server/httplog/httplog_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/httplog/httplog_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"k8s.io/apiserver/pkg/endpoints/responsewriter"
+	responsewritertesting "k8s.io/apiserver/pkg/endpoints/responsewriter/testing"
 )
 
 func TestDefaultStacktracePred(t *testing.T) {
@@ -148,7 +149,7 @@ func TestLoggedStatus(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 
-	var tw http.ResponseWriter = new(responsewriter.FakeResponseWriter)
+	var tw http.ResponseWriter = new(responsewritertesting.FakeResponseWriter)
 	logger := newLogged(req, tw)
 	logger.Write(nil)
 
@@ -156,7 +157,7 @@ func TestLoggedStatus(t *testing.T) {
 		t.Errorf("expected status after write to be %v, got %v", http.StatusOK, logger.status)
 	}
 
-	tw = new(responsewriter.FakeResponseWriter)
+	tw = new(responsewritertesting.FakeResponseWriter)
 	logger = newLogged(req, tw)
 	logger.WriteHeader(http.StatusForbidden)
 	logger.Write(nil)
@@ -175,14 +176,14 @@ func TestRespLoggerWithDecoratedResponseWriter(t *testing.T) {
 		{
 			name: "http2",
 			r: func() http.ResponseWriter {
-				return &responsewriter.FakeResponseWriterFlusherCloseNotifier{}
+				return &responsewritertesting.FakeResponseWriterFlusherCloseNotifier{}
 			},
 			hijackable: false,
 		},
 		{
 			name: "http/1.x",
 			r: func() http.ResponseWriter {
-				return &responsewriter.FakeResponseWriterFlusherCloseNotifierHijacker{}
+				return &responsewritertesting.FakeResponseWriterFlusherCloseNotifierHijacker{}
 			},
 			hijackable: true,
 		},
@@ -224,7 +225,7 @@ func TestRespLoggerWithDecoratedResponseWriter(t *testing.T) {
 
 func TestResponseWriterDecorator(t *testing.T) {
 	decorator := &respLogger{
-		w: &responsewriter.FakeResponseWriter{},
+		w: &responsewritertesting.FakeResponseWriter{},
 	}
 	var w http.ResponseWriter = decorator
 

--- a/staging/src/k8s.io/apiserver/pkg/server/httplog/httplog_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/httplog/httplog_test.go
@@ -223,13 +223,23 @@ func TestRespLoggerWithDecoratedResponseWriter(t *testing.T) {
 	}
 }
 
-func TestResponseWriterDecorator(t *testing.T) {
-	decorator := &respLogger{
-		w: &responsewritertesting.FakeResponseWriter{},
-	}
-	var w http.ResponseWriter = decorator
+func TestHTTPLogResponseWriterDecoratorConstruction(t *testing.T) {
+	inner := &responsewritertesting.FakeResponseWriter{}
+	middle := &respLogger{w: inner} // middle is the decorator
+	outer := responsewriter.WrapForHTTP1Or2(middle)
 
-	if inner := w.(responsewriter.UserProvidedDecorator).Unwrap(); inner != decorator.w {
-		t.Errorf("Expected the decorator to return the inner http.ResponseWriter object")
+	// FakeResponseWriter does not implement http.Flusher, FlusherError,
+	// http.CloseNotifier, or http.Hijacker; so WrapForHTTP1Or2 is not
+	// expected to return an outer object.
+	if outer != middle {
+		t.Errorf("did not expect a new outer object, but got %v", outer)
+	}
+
+	decorator, ok := outer.(responsewriter.UserProvidedDecorator)
+	if !ok {
+		t.Fatal("expected the middle to implement UserProvidedDecorator")
+	}
+	if want, got := inner, decorator.Unwrap(); want != got {
+		t.Errorf("expected the decorator to return the inner http.ResponseWriter object")
 	}
 }

--- a/staging/src/k8s.io/apiserver/pkg/server/responsewriter_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/responsewriter_test.go
@@ -1,0 +1,185 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import (
+	"flag"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apiserver/pkg/endpoints/metrics"
+	"k8s.io/apiserver/pkg/endpoints/responsewriter"
+	responsewritertesting "k8s.io/apiserver/pkg/endpoints/responsewriter/testing"
+	"k8s.io/klog/v2"
+)
+
+func TestWrappedResponseWriterWithFullHandlerChain(t *testing.T) {
+	for _, proto := range []string{"HTTP/1.1", "HTTP/2.0"} {
+		t.Run(proto, func(t *testing.T) {
+			fakeAudit := &fakeAudit{}
+			config, _ := setUp(t)
+			config.AuditPolicyRuleEvaluator = fakeAudit
+			config.AuditBackend = fakeAudit
+			config.RequestTimeout = time.Minute
+
+			// build the full handler chain of the generic apiserver
+			s, err := config.Complete(nil).New("test", NewEmptyDelegate())
+			if err != nil {
+				t.Fatalf("Error in setting up a GenericAPIServer object: %v", err)
+			}
+
+			// this handler should run first, so it should be
+			// appended to the chain
+			var original http.ResponseWriter
+			first := func(h http.Handler) http.Handler {
+				return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					// save the original ResponseWriter
+					// object passed by net/http
+					original = w
+					t.Logf("got the ResponseWriter object passed by net/http: original=%T", original)
+
+					h.ServeHTTP(w, r)
+				})
+			}
+
+			// this handler should run last in the chain
+			handlerDoneCh := make(chan struct{})
+			handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				defer close(handlerDoneCh)
+
+				if r.Proto != proto {
+					t.Errorf("expected protocol: %q, but got: %q", proto, r.Proto)
+					return
+				}
+				if original == nil {
+					t.Errorf("wrong test setup - original ResponseWriter object has not been set")
+					return
+				}
+
+				// the server handler chain has wrapped the ResponseWriter object,
+				// let's ensure that the wrapped ResponseWriter is interface
+				// compatible with the original ResponseWriter passed by net/http
+				responsewritertesting.AssertResponseWriterImplementsExtendedInterfaces(t, w, r)
+				responsewritertesting.AssertResponseWriterInterfaceCompatibility(t, original, w)
+
+				// a wrapped ResponseWriter object is nested, as shown below:
+				//   outer
+				//     |
+				//     |-- middle (user defined decorator)
+				//           |
+				//           |-- inner
+				//
+				// a) inner: this is the ResponseWriter that is being wrapped
+				// b) middle: it takes the inner ResponseWriter object and decorates
+				// it, for example, it can override the `Flush` method, the decorator
+				// does not need to maintain interface compatibility with the inner
+				// ResponseWriter.
+				// c) outer: it maintains interface compatibility with the inner, and
+				// delegates calls to the decorator as appropriate
+				//
+				// when a ResponseWriter is wrapped multiple times, the outer object
+				// is passed as an inner to the next handler
+
+				// let's unwrap the wrapped ResponseWriter, we start with the final
+				// ResponseWriter object passed to this handler, and work our way
+				// back to the original ResponseWriter handed to us by net/http.
+				t.Logf("unwrapping our way back to the original ResponseWriter")
+				for outer := w; ; {
+					if outer == original {
+						t.Logf("we have reached the original ResponseWriter object - outer=%T", outer)
+						break
+					}
+					t.Logf("unwrapping ResponseWriter: outer=%T", outer)
+
+					// decorators from the kube-apiserver filters
+					// is expected to implement the following interface
+					if accessor, ok := outer.(interface {
+						GetUserProvidedDecorator() responsewriter.UserProvidedDecorator
+					}); ok {
+						middle := accessor.GetUserProvidedDecorator()
+						t.Logf("found a decorator (known) - decorator=%T", middle)
+					} else {
+						t.Logf("found a decorator (unknown, possibly wrapped by a third party library) decorator=%T", outer)
+					}
+
+					// all decorators must have 'Unwrap() http.ResponseWriter' method
+					unwrapper, ok := outer.(interface{ Unwrap() http.ResponseWriter })
+					if !ok {
+						t.Errorf("the wrapped ResponseWriter is not compatible: outer=%T", outer)
+						break
+					}
+
+					inner := unwrapper.Unwrap()
+					if inner == nil {
+						t.Errorf("expected the decorator to hold an inner ResponseWriter object")
+						break
+					}
+					responsewritertesting.AssertResponseWriterInterfaceCompatibility(t, inner, outer)
+
+					// let's unwrap this inner ResponseWriter
+					outer = inner
+				}
+			})
+
+			// httplog is enabled only when we run in -v=3 or greater
+			// TODO: does it have impact on other tests running in parallel?
+			state := klog.CaptureState()
+			t.Cleanup(state.Restore)
+			var fs flag.FlagSet
+			klog.InitFlags(&fs)
+			if err := fs.Set("v", "3"); err != nil {
+				t.Errorf("unexpected error while setting klog flags: %v", err)
+				return
+			}
+
+			// add the metrics handler
+			// TODO: register a fake type with the generic apiserver
+			var chain http.Handler = metrics.InstrumentHandlerFunc("", "", "", "", "", "", "", false, "", http.HandlerFunc(s.Handler.FullHandlerChain.ServeHTTP))
+
+			chain = first(chain)
+			s.Handler.FullHandlerChain = chain
+
+			s.Handler.NonGoRestfulMux.Handle("/ping", handler)
+			server := httptest.NewUnstartedServer(s.Handler)
+			defer server.Close()
+			if proto == "HTTP/2.0" {
+				server.EnableHTTP2 = true
+			}
+			server.StartTLS()
+
+			client := server.Client()
+			client.Timeout = wait.ForeverTestTimeout
+			resp, err := client.Get(server.URL + "/ping")
+			if err != nil {
+				t.Errorf("unexpected error from client.Get: %v", err)
+				return
+			}
+			if resp.StatusCode != http.StatusOK {
+				t.Errorf("Expected an OK response from the server, but got: %v", resp)
+			}
+
+			select {
+			case <-handlerDoneCh:
+			case <-time.After(wait.ForeverTestTimeout):
+				t.Errorf("expected the request handler to have terminated")
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
Add tests to verify expected behavior of the `ResponseWriter` object(s) wrapped by the handlers in the handler chain

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [KEP]: https://github.com/kubernetes/enhancements/pull/4462
```
