### PR TITLE
add field and label selectors to authorization attributes

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -1206,6 +1206,8 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 
 	genericfeatures.APIServingWithRoutine: {Default: true, PreRelease: featuregate.Beta},
 
+	genericfeatures.AuthorizeWithSelectors: {Default: false, PreRelease: featuregate.Alpha},
+
 	genericfeatures.ConsistentListFromCache: {Default: false, PreRelease: featuregate.Alpha},
 
 	genericfeatures.CustomResourceValidationExpressions: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.31

--- a/plugin/pkg/auth/authorizer/rbac/rbac_test.go
+++ b/plugin/pkg/auth/authorizer/rbac/rbac_test.go
@@ -279,12 +279,12 @@ func TestRuleMatches(t *testing.T) {
 		name string
 		rule rbacv1.PolicyRule
 
-		requestsToExpected []requestToTest
+		requestsToExpected []*requestToTest
 	}{
 		{
 			name: "star verb, exact match other",
 			rule: rbacv1helpers.NewRule("*").Groups("group1").Resources("resource1").RuleOrDie(),
-			requestsToExpected: []requestToTest{
+			requestsToExpected: []*requestToTest{
 				{resourceRequest("verb1").Group("group1").Resource("resource1").New(), true},
 				{resourceRequest("verb1").Group("group2").Resource("resource1").New(), false},
 				{resourceRequest("verb1").Group("group1").Resource("resource2").New(), false},
@@ -298,7 +298,7 @@ func TestRuleMatches(t *testing.T) {
 		{
 			name: "star group, exact match other",
 			rule: rbacv1helpers.NewRule("verb1").Groups("*").Resources("resource1").RuleOrDie(),
-			requestsToExpected: []requestToTest{
+			requestsToExpected: []*requestToTest{
 				{resourceRequest("verb1").Group("group1").Resource("resource1").New(), true},
 				{resourceRequest("verb1").Group("group2").Resource("resource1").New(), true},
 				{resourceRequest("verb1").Group("group1").Resource("resource2").New(), false},
@@ -312,7 +312,7 @@ func TestRuleMatches(t *testing.T) {
 		{
 			name: "star resource, exact match other",
 			rule: rbacv1helpers.NewRule("verb1").Groups("group1").Resources("*").RuleOrDie(),
-			requestsToExpected: []requestToTest{
+			requestsToExpected: []*requestToTest{
 				{resourceRequest("verb1").Group("group1").Resource("resource1").New(), true},
 				{resourceRequest("verb1").Group("group2").Resource("resource1").New(), false},
 				{resourceRequest("verb1").Group("group1").Resource("resource2").New(), true},
@@ -326,7 +326,7 @@ func TestRuleMatches(t *testing.T) {
 		{
 			name: "tuple expansion",
 			rule: rbacv1helpers.NewRule("verb1", "verb2").Groups("group1", "group2").Resources("resource1", "resource2").RuleOrDie(),
-			requestsToExpected: []requestToTest{
+			requestsToExpected: []*requestToTest{
 				{resourceRequest("verb1").Group("group1").Resource("resource1").New(), true},
 				{resourceRequest("verb1").Group("group2").Resource("resource1").New(), true},
 				{resourceRequest("verb1").Group("group1").Resource("resource2").New(), true},
@@ -340,7 +340,7 @@ func TestRuleMatches(t *testing.T) {
 		{
 			name: "subresource expansion",
 			rule: rbacv1helpers.NewRule("*").Groups("*").Resources("resource1/subresource1").RuleOrDie(),
-			requestsToExpected: []requestToTest{
+			requestsToExpected: []*requestToTest{
 				{resourceRequest("verb1").Group("group1").Resource("resource1").Subresource("subresource1").New(), true},
 				{resourceRequest("verb1").Group("group2").Resource("resource1").Subresource("subresource2").New(), false},
 				{resourceRequest("verb1").Group("group1").Resource("resource2").Subresource("subresource1").New(), false},
@@ -354,7 +354,7 @@ func TestRuleMatches(t *testing.T) {
 		{
 			name: "star nonresource, exact match other",
 			rule: rbacv1helpers.NewRule("verb1").URLs("*").RuleOrDie(),
-			requestsToExpected: []requestToTest{
+			requestsToExpected: []*requestToTest{
 				{nonresourceRequest("verb1").URL("/foo").New(), true},
 				{nonresourceRequest("verb1").URL("/foo/bar").New(), true},
 				{nonresourceRequest("verb1").URL("/foo/baz").New(), true},
@@ -370,7 +370,7 @@ func TestRuleMatches(t *testing.T) {
 		{
 			name: "star nonresource subpath",
 			rule: rbacv1helpers.NewRule("verb1").URLs("/foo/*").RuleOrDie(),
-			requestsToExpected: []requestToTest{
+			requestsToExpected: []*requestToTest{
 				{nonresourceRequest("verb1").URL("/foo").New(), false},
 				{nonresourceRequest("verb1").URL("/foo/bar").New(), true},
 				{nonresourceRequest("verb1").URL("/foo/baz").New(), true},
@@ -386,7 +386,7 @@ func TestRuleMatches(t *testing.T) {
 		{
 			name: "star verb, exact nonresource",
 			rule: rbacv1helpers.NewRule("*").URLs("/foo", "/foo/bar/one").RuleOrDie(),
-			requestsToExpected: []requestToTest{
+			requestsToExpected: []*requestToTest{
 				{nonresourceRequest("verb1").URL("/foo").New(), true},
 				{nonresourceRequest("verb1").URL("/foo/bar").New(), false},
 				{nonresourceRequest("verb1").URL("/foo/baz").New(), false},

--- a/plugin/pkg/auth/authorizer/rbac/rbac_test.go
+++ b/plugin/pkg/auth/authorizer/rbac/rbac_test.go
@@ -24,6 +24,8 @@ import (
 
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 	rbacv1helpers "k8s.io/kubernetes/pkg/apis/rbac/v1"
@@ -135,6 +137,12 @@ func (d *defaultAttributes) GetAPIGroup() string     { return d.apiGroup }
 func (d *defaultAttributes) GetAPIVersion() string   { return "" }
 func (d *defaultAttributes) IsResourceRequest() bool { return true }
 func (d *defaultAttributes) GetPath() string         { return "" }
+func (d *defaultAttributes) ParseFieldSelector() (fields.Selector, error) {
+	panic("not supported for RBAC")
+}
+func (d *defaultAttributes) ParseLabelSelector() (labels.Selector, error) {
+	panic("not supported for RBAC")
+}
 
 func TestAuthorizer(t *testing.T) {
 	tests := []struct {
@@ -263,135 +271,139 @@ func TestAuthorizer(t *testing.T) {
 }
 
 func TestRuleMatches(t *testing.T) {
+	type requestToTest struct {
+		request  authorizer.AttributesRecord
+		expected bool
+	}
 	tests := []struct {
 		name string
 		rule rbacv1.PolicyRule
 
-		requestsToExpected map[authorizer.AttributesRecord]bool
+		requestsToExpected []requestToTest
 	}{
 		{
 			name: "star verb, exact match other",
 			rule: rbacv1helpers.NewRule("*").Groups("group1").Resources("resource1").RuleOrDie(),
-			requestsToExpected: map[authorizer.AttributesRecord]bool{
-				resourceRequest("verb1").Group("group1").Resource("resource1").New(): true,
-				resourceRequest("verb1").Group("group2").Resource("resource1").New(): false,
-				resourceRequest("verb1").Group("group1").Resource("resource2").New(): false,
-				resourceRequest("verb1").Group("group2").Resource("resource2").New(): false,
-				resourceRequest("verb2").Group("group1").Resource("resource1").New(): true,
-				resourceRequest("verb2").Group("group2").Resource("resource1").New(): false,
-				resourceRequest("verb2").Group("group1").Resource("resource2").New(): false,
-				resourceRequest("verb2").Group("group2").Resource("resource2").New(): false,
+			requestsToExpected: []requestToTest{
+				{resourceRequest("verb1").Group("group1").Resource("resource1").New(), true},
+				{resourceRequest("verb1").Group("group2").Resource("resource1").New(), false},
+				{resourceRequest("verb1").Group("group1").Resource("resource2").New(), false},
+				{resourceRequest("verb1").Group("group2").Resource("resource2").New(), false},
+				{resourceRequest("verb2").Group("group1").Resource("resource1").New(), true},
+				{resourceRequest("verb2").Group("group2").Resource("resource1").New(), false},
+				{resourceRequest("verb2").Group("group1").Resource("resource2").New(), false},
+				{resourceRequest("verb2").Group("group2").Resource("resource2").New(), false},
 			},
 		},
 		{
 			name: "star group, exact match other",
 			rule: rbacv1helpers.NewRule("verb1").Groups("*").Resources("resource1").RuleOrDie(),
-			requestsToExpected: map[authorizer.AttributesRecord]bool{
-				resourceRequest("verb1").Group("group1").Resource("resource1").New(): true,
-				resourceRequest("verb1").Group("group2").Resource("resource1").New(): true,
-				resourceRequest("verb1").Group("group1").Resource("resource2").New(): false,
-				resourceRequest("verb1").Group("group2").Resource("resource2").New(): false,
-				resourceRequest("verb2").Group("group1").Resource("resource1").New(): false,
-				resourceRequest("verb2").Group("group2").Resource("resource1").New(): false,
-				resourceRequest("verb2").Group("group1").Resource("resource2").New(): false,
-				resourceRequest("verb2").Group("group2").Resource("resource2").New(): false,
+			requestsToExpected: []requestToTest{
+				{resourceRequest("verb1").Group("group1").Resource("resource1").New(), true},
+				{resourceRequest("verb1").Group("group2").Resource("resource1").New(), true},
+				{resourceRequest("verb1").Group("group1").Resource("resource2").New(), false},
+				{resourceRequest("verb1").Group("group2").Resource("resource2").New(), false},
+				{resourceRequest("verb2").Group("group1").Resource("resource1").New(), false},
+				{resourceRequest("verb2").Group("group2").Resource("resource1").New(), false},
+				{resourceRequest("verb2").Group("group1").Resource("resource2").New(), false},
+				{resourceRequest("verb2").Group("group2").Resource("resource2").New(), false},
 			},
 		},
 		{
 			name: "star resource, exact match other",
 			rule: rbacv1helpers.NewRule("verb1").Groups("group1").Resources("*").RuleOrDie(),
-			requestsToExpected: map[authorizer.AttributesRecord]bool{
-				resourceRequest("verb1").Group("group1").Resource("resource1").New(): true,
-				resourceRequest("verb1").Group("group2").Resource("resource1").New(): false,
-				resourceRequest("verb1").Group("group1").Resource("resource2").New(): true,
-				resourceRequest("verb1").Group("group2").Resource("resource2").New(): false,
-				resourceRequest("verb2").Group("group1").Resource("resource1").New(): false,
-				resourceRequest("verb2").Group("group2").Resource("resource1").New(): false,
-				resourceRequest("verb2").Group("group1").Resource("resource2").New(): false,
-				resourceRequest("verb2").Group("group2").Resource("resource2").New(): false,
+			requestsToExpected: []requestToTest{
+				{resourceRequest("verb1").Group("group1").Resource("resource1").New(), true},
+				{resourceRequest("verb1").Group("group2").Resource("resource1").New(), false},
+				{resourceRequest("verb1").Group("group1").Resource("resource2").New(), true},
+				{resourceRequest("verb1").Group("group2").Resource("resource2").New(), false},
+				{resourceRequest("verb2").Group("group1").Resource("resource1").New(), false},
+				{resourceRequest("verb2").Group("group2").Resource("resource1").New(), false},
+				{resourceRequest("verb2").Group("group1").Resource("resource2").New(), false},
+				{resourceRequest("verb2").Group("group2").Resource("resource2").New(), false},
 			},
 		},
 		{
 			name: "tuple expansion",
 			rule: rbacv1helpers.NewRule("verb1", "verb2").Groups("group1", "group2").Resources("resource1", "resource2").RuleOrDie(),
-			requestsToExpected: map[authorizer.AttributesRecord]bool{
-				resourceRequest("verb1").Group("group1").Resource("resource1").New(): true,
-				resourceRequest("verb1").Group("group2").Resource("resource1").New(): true,
-				resourceRequest("verb1").Group("group1").Resource("resource2").New(): true,
-				resourceRequest("verb1").Group("group2").Resource("resource2").New(): true,
-				resourceRequest("verb2").Group("group1").Resource("resource1").New(): true,
-				resourceRequest("verb2").Group("group2").Resource("resource1").New(): true,
-				resourceRequest("verb2").Group("group1").Resource("resource2").New(): true,
-				resourceRequest("verb2").Group("group2").Resource("resource2").New(): true,
+			requestsToExpected: []requestToTest{
+				{resourceRequest("verb1").Group("group1").Resource("resource1").New(), true},
+				{resourceRequest("verb1").Group("group2").Resource("resource1").New(), true},
+				{resourceRequest("verb1").Group("group1").Resource("resource2").New(), true},
+				{resourceRequest("verb1").Group("group2").Resource("resource2").New(), true},
+				{resourceRequest("verb2").Group("group1").Resource("resource1").New(), true},
+				{resourceRequest("verb2").Group("group2").Resource("resource1").New(), true},
+				{resourceRequest("verb2").Group("group1").Resource("resource2").New(), true},
+				{resourceRequest("verb2").Group("group2").Resource("resource2").New(), true},
 			},
 		},
 		{
 			name: "subresource expansion",
 			rule: rbacv1helpers.NewRule("*").Groups("*").Resources("resource1/subresource1").RuleOrDie(),
-			requestsToExpected: map[authorizer.AttributesRecord]bool{
-				resourceRequest("verb1").Group("group1").Resource("resource1").Subresource("subresource1").New(): true,
-				resourceRequest("verb1").Group("group2").Resource("resource1").Subresource("subresource2").New(): false,
-				resourceRequest("verb1").Group("group1").Resource("resource2").Subresource("subresource1").New(): false,
-				resourceRequest("verb1").Group("group2").Resource("resource2").Subresource("subresource1").New(): false,
-				resourceRequest("verb2").Group("group1").Resource("resource1").Subresource("subresource1").New(): true,
-				resourceRequest("verb2").Group("group2").Resource("resource1").Subresource("subresource2").New(): false,
-				resourceRequest("verb2").Group("group1").Resource("resource2").Subresource("subresource1").New(): false,
-				resourceRequest("verb2").Group("group2").Resource("resource2").Subresource("subresource1").New(): false,
+			requestsToExpected: []requestToTest{
+				{resourceRequest("verb1").Group("group1").Resource("resource1").Subresource("subresource1").New(), true},
+				{resourceRequest("verb1").Group("group2").Resource("resource1").Subresource("subresource2").New(), false},
+				{resourceRequest("verb1").Group("group1").Resource("resource2").Subresource("subresource1").New(), false},
+				{resourceRequest("verb1").Group("group2").Resource("resource2").Subresource("subresource1").New(), false},
+				{resourceRequest("verb2").Group("group1").Resource("resource1").Subresource("subresource1").New(), true},
+				{resourceRequest("verb2").Group("group2").Resource("resource1").Subresource("subresource2").New(), false},
+				{resourceRequest("verb2").Group("group1").Resource("resource2").Subresource("subresource1").New(), false},
+				{resourceRequest("verb2").Group("group2").Resource("resource2").Subresource("subresource1").New(), false},
 			},
 		},
 		{
 			name: "star nonresource, exact match other",
 			rule: rbacv1helpers.NewRule("verb1").URLs("*").RuleOrDie(),
-			requestsToExpected: map[authorizer.AttributesRecord]bool{
-				nonresourceRequest("verb1").URL("/foo").New():         true,
-				nonresourceRequest("verb1").URL("/foo/bar").New():     true,
-				nonresourceRequest("verb1").URL("/foo/baz").New():     true,
-				nonresourceRequest("verb1").URL("/foo/bar/one").New(): true,
-				nonresourceRequest("verb1").URL("/foo/baz/one").New(): true,
-				nonresourceRequest("verb2").URL("/foo").New():         false,
-				nonresourceRequest("verb2").URL("/foo/bar").New():     false,
-				nonresourceRequest("verb2").URL("/foo/baz").New():     false,
-				nonresourceRequest("verb2").URL("/foo/bar/one").New(): false,
-				nonresourceRequest("verb2").URL("/foo/baz/one").New(): false,
+			requestsToExpected: []requestToTest{
+				{nonresourceRequest("verb1").URL("/foo").New(), true},
+				{nonresourceRequest("verb1").URL("/foo/bar").New(), true},
+				{nonresourceRequest("verb1").URL("/foo/baz").New(), true},
+				{nonresourceRequest("verb1").URL("/foo/bar/one").New(), true},
+				{nonresourceRequest("verb1").URL("/foo/baz/one").New(), true},
+				{nonresourceRequest("verb2").URL("/foo").New(), false},
+				{nonresourceRequest("verb2").URL("/foo/bar").New(), false},
+				{nonresourceRequest("verb2").URL("/foo/baz").New(), false},
+				{nonresourceRequest("verb2").URL("/foo/bar/one").New(), false},
+				{nonresourceRequest("verb2").URL("/foo/baz/one").New(), false},
 			},
 		},
 		{
 			name: "star nonresource subpath",
 			rule: rbacv1helpers.NewRule("verb1").URLs("/foo/*").RuleOrDie(),
-			requestsToExpected: map[authorizer.AttributesRecord]bool{
-				nonresourceRequest("verb1").URL("/foo").New():            false,
-				nonresourceRequest("verb1").URL("/foo/bar").New():        true,
-				nonresourceRequest("verb1").URL("/foo/baz").New():        true,
-				nonresourceRequest("verb1").URL("/foo/bar/one").New():    true,
-				nonresourceRequest("verb1").URL("/foo/baz/one").New():    true,
-				nonresourceRequest("verb1").URL("/notfoo").New():         false,
-				nonresourceRequest("verb1").URL("/notfoo/bar").New():     false,
-				nonresourceRequest("verb1").URL("/notfoo/baz").New():     false,
-				nonresourceRequest("verb1").URL("/notfoo/bar/one").New(): false,
-				nonresourceRequest("verb1").URL("/notfoo/baz/one").New(): false,
+			requestsToExpected: []requestToTest{
+				{nonresourceRequest("verb1").URL("/foo").New(), false},
+				{nonresourceRequest("verb1").URL("/foo/bar").New(), true},
+				{nonresourceRequest("verb1").URL("/foo/baz").New(), true},
+				{nonresourceRequest("verb1").URL("/foo/bar/one").New(), true},
+				{nonresourceRequest("verb1").URL("/foo/baz/one").New(), true},
+				{nonresourceRequest("verb1").URL("/notfoo").New(), false},
+				{nonresourceRequest("verb1").URL("/notfoo/bar").New(), false},
+				{nonresourceRequest("verb1").URL("/notfoo/baz").New(), false},
+				{nonresourceRequest("verb1").URL("/notfoo/bar/one").New(), false},
+				{nonresourceRequest("verb1").URL("/notfoo/baz/one").New(), false},
 			},
 		},
 		{
 			name: "star verb, exact nonresource",
 			rule: rbacv1helpers.NewRule("*").URLs("/foo", "/foo/bar/one").RuleOrDie(),
-			requestsToExpected: map[authorizer.AttributesRecord]bool{
-				nonresourceRequest("verb1").URL("/foo").New():         true,
-				nonresourceRequest("verb1").URL("/foo/bar").New():     false,
-				nonresourceRequest("verb1").URL("/foo/baz").New():     false,
-				nonresourceRequest("verb1").URL("/foo/bar/one").New(): true,
-				nonresourceRequest("verb1").URL("/foo/baz/one").New(): false,
-				nonresourceRequest("verb2").URL("/foo").New():         true,
-				nonresourceRequest("verb2").URL("/foo/bar").New():     false,
-				nonresourceRequest("verb2").URL("/foo/baz").New():     false,
-				nonresourceRequest("verb2").URL("/foo/bar/one").New(): true,
-				nonresourceRequest("verb2").URL("/foo/baz/one").New(): false,
+			requestsToExpected: []requestToTest{
+				{nonresourceRequest("verb1").URL("/foo").New(), true},
+				{nonresourceRequest("verb1").URL("/foo/bar").New(), false},
+				{nonresourceRequest("verb1").URL("/foo/baz").New(), false},
+				{nonresourceRequest("verb1").URL("/foo/bar/one").New(), true},
+				{nonresourceRequest("verb1").URL("/foo/baz/one").New(), false},
+				{nonresourceRequest("verb2").URL("/foo").New(), true},
+				{nonresourceRequest("verb2").URL("/foo/bar").New(), false},
+				{nonresourceRequest("verb2").URL("/foo/baz").New(), false},
+				{nonresourceRequest("verb2").URL("/foo/bar/one").New(), true},
+				{nonresourceRequest("verb2").URL("/foo/baz/one").New(), false},
 			},
 		},
 	}
 	for _, tc := range tests {
-		for request, expected := range tc.requestsToExpected {
-			if e, a := expected, RuleAllows(request, &tc.rule); e != a {
-				t.Errorf("%q: expected %v, got %v for %v", tc.name, e, a, request)
+		for _, requestToTest := range tc.requestsToExpected {
+			if e, a := requestToTest.expected, RuleAllows(requestToTest.request, &tc.rule); e != a {
+				t.Errorf("%q: expected %v, got %v for %v", tc.name, e, a, requestToTest.request)
 			}
 		}
 	}

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/validating/caching_authorizer_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/validating/caching_authorizer_test.go
@@ -19,6 +19,9 @@ package validating
 import (
 	"context"
 	"fmt"
+	genericfeatures "k8s.io/apiserver/pkg/features"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"testing"
 
 	"k8s.io/apiserver/pkg/authentication/user"
@@ -26,6 +29,8 @@ import (
 )
 
 func TestCachingAuthorizer(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.AuthorizeWithSelectors, true)
+
 	type result struct {
 		decision authorizer.Decision
 		reason   string
@@ -213,6 +218,261 @@ func TestCachingAuthorizer(t *testing.T) {
 					decision: authorizer.DecisionDeny,
 					reason:   "test reason beta",
 					error:    fmt.Errorf("test error beta"),
+				},
+			},
+		},
+		{
+			name: "honor good field selector",
+			calls: []invocation{
+				{
+					attributes: authorizer.AttributesRecord{
+						Name:          "test name",
+						FieldSelector: "foo=bar",
+					},
+					expected: result{
+						decision: authorizer.DecisionAllow,
+						reason:   "test reason",
+						error:    fmt.Errorf("test error"),
+					},
+				},
+				{
+					attributes: authorizer.AttributesRecord{
+						Name: "test name",
+					},
+					expected: result{
+						decision: authorizer.DecisionAllow,
+						reason:   "test reason 2",
+						error:    fmt.Errorf("test error 2"),
+					},
+				},
+				{
+					// now this should be cached
+					attributes: authorizer.AttributesRecord{
+						Name:          "test name",
+						FieldSelector: "foo=bar",
+					},
+					expected: result{
+						decision: authorizer.DecisionAllow,
+						reason:   "test reason",
+						error:    fmt.Errorf("test error"),
+					},
+				},
+			},
+			backend: []result{
+				{
+					decision: authorizer.DecisionAllow,
+					reason:   "test reason",
+					error:    fmt.Errorf("test error"),
+				},
+				{
+					decision: authorizer.DecisionAllow,
+					reason:   "test reason 2",
+					error:    fmt.Errorf("test error 2"),
+				},
+			},
+		},
+		{
+			name: "ignore malformed field selector first",
+			calls: []invocation{
+				{
+					attributes: authorizer.AttributesRecord{
+						Name:          "test name",
+						FieldSelector: "malformed",
+					},
+					expected: result{
+						decision: authorizer.DecisionAllow,
+						reason:   "test reason",
+						error:    fmt.Errorf("test error"),
+					},
+				},
+				{
+					// notice that this does not have the malformed field selector.
+					// it should use the cached result
+					attributes: authorizer.AttributesRecord{
+						Name: "test name",
+					},
+					expected: result{
+						decision: authorizer.DecisionAllow,
+						reason:   "test reason",
+						error:    fmt.Errorf("test error"),
+					},
+				},
+			},
+			backend: []result{
+				{
+					decision: authorizer.DecisionAllow,
+					reason:   "test reason",
+					error:    fmt.Errorf("test error"),
+				},
+			},
+		},
+		{
+			name: "ignore malformed field selector second",
+			calls: []invocation{
+				{
+					attributes: authorizer.AttributesRecord{
+						Name: "test name",
+					},
+					expected: result{
+						decision: authorizer.DecisionAllow,
+						reason:   "test reason",
+						error:    fmt.Errorf("test error"),
+					},
+				},
+				{
+					// this should use the broader cached value because the selector will be ignored
+					attributes: authorizer.AttributesRecord{
+						Name:          "test name",
+						FieldSelector: "malformed",
+					},
+					expected: result{
+						decision: authorizer.DecisionAllow,
+						reason:   "test reason",
+						error:    fmt.Errorf("test error"),
+					},
+				},
+			},
+			backend: []result{
+				{
+					decision: authorizer.DecisionAllow,
+					reason:   "test reason",
+					error:    fmt.Errorf("test error"),
+				},
+			},
+		},
+
+		{
+			name: "honor good label selector",
+			calls: []invocation{
+				{
+					attributes: authorizer.AttributesRecord{
+						Name:          "test name",
+						LabelSelector: "foo=bar",
+					},
+					expected: result{
+						decision: authorizer.DecisionAllow,
+						reason:   "test reason",
+						error:    fmt.Errorf("test error"),
+					},
+				},
+				{
+					attributes: authorizer.AttributesRecord{
+						Name: "test name",
+					},
+					expected: result{
+						decision: authorizer.DecisionAllow,
+						reason:   "test reason 2",
+						error:    fmt.Errorf("test error 2"),
+					},
+				},
+				{
+					// now this should be cached
+					attributes: authorizer.AttributesRecord{
+						Name:          "test name",
+						LabelSelector: "foo=bar",
+					},
+					expected: result{
+						decision: authorizer.DecisionAllow,
+						reason:   "test reason",
+						error:    fmt.Errorf("test error"),
+					},
+				},
+				{
+					attributes: authorizer.AttributesRecord{
+						Name:          "test name",
+						LabelSelector: "diff=zero",
+					},
+					expected: result{
+						decision: authorizer.DecisionAllow,
+						reason:   "test reason 3",
+						error:    fmt.Errorf("test error 3"),
+					},
+				},
+			},
+			backend: []result{
+				{
+					decision: authorizer.DecisionAllow,
+					reason:   "test reason",
+					error:    fmt.Errorf("test error"),
+				},
+				{
+					decision: authorizer.DecisionAllow,
+					reason:   "test reason 2",
+					error:    fmt.Errorf("test error 2"),
+				},
+				{
+					decision: authorizer.DecisionAllow,
+					reason:   "test reason 3",
+					error:    fmt.Errorf("test error 3"),
+				},
+			},
+		},
+		{
+			name: "ignore malformed label selector first",
+			calls: []invocation{
+				{
+					attributes: authorizer.AttributesRecord{
+						Name:          "test name",
+						LabelSelector: "malformed mess",
+					},
+					expected: result{
+						decision: authorizer.DecisionAllow,
+						reason:   "test reason",
+						error:    fmt.Errorf("test error"),
+					},
+				},
+				{
+					// notice that this does not have the malformed field selector.
+					// it should use the cached result
+					attributes: authorizer.AttributesRecord{
+						Name: "test name",
+					},
+					expected: result{
+						decision: authorizer.DecisionAllow,
+						reason:   "test reason",
+						error:    fmt.Errorf("test error"),
+					},
+				},
+			},
+			backend: []result{
+				{
+					decision: authorizer.DecisionAllow,
+					reason:   "test reason",
+					error:    fmt.Errorf("test error"),
+				},
+			},
+		},
+		{
+			name: "ignore malformed label selector second",
+			calls: []invocation{
+				{
+					attributes: authorizer.AttributesRecord{
+						Name: "test name",
+					},
+					expected: result{
+						decision: authorizer.DecisionAllow,
+						reason:   "test reason",
+						error:    fmt.Errorf("test error"),
+					},
+				},
+				{
+					// this should use the broader cached value because the selector will be ignored
+					attributes: authorizer.AttributesRecord{
+						Name:          "test name",
+						LabelSelector: "malformed mess",
+					},
+					expected: result{
+						decision: authorizer.DecisionAllow,
+						reason:   "test reason",
+						error:    fmt.Errorf("test error"),
+					},
+				},
+			},
+			backend: []result{
+				{
+					decision: authorizer.DecisionAllow,
+					reason:   "test reason",
+					error:    fmt.Errorf("test error"),
 				},
 			},
 		},

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/authorization.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/authorization.go
@@ -19,6 +19,8 @@ package filters
 import (
 	"context"
 	"errors"
+	genericfeatures "k8s.io/apiserver/pkg/features"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"net/http"
 	"time"
 
@@ -116,6 +118,11 @@ func GetAuthorizerAttributes(ctx context.Context) (authorizer.Attributes, error)
 	attribs.Subresource = requestInfo.Subresource
 	attribs.Namespace = requestInfo.Namespace
 	attribs.Name = requestInfo.Name
+
+	if utilfeature.DefaultFeatureGate.Enabled(genericfeatures.AuthorizeWithSelectors) {
+		attribs.FieldSelector = requestInfo.FieldSelector
+		attribs.LabelSelector = requestInfo.LabelSelector
+	}
 
 	return &attribs, nil
 }

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/request/requestinfo.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/request/requestinfo.go
@@ -19,6 +19,8 @@ package request
 import (
 	"context"
 	"fmt"
+	genericfeatures "k8s.io/apiserver/pkg/features"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"net/http"
 	"strings"
 
@@ -62,6 +64,13 @@ type RequestInfo struct {
 	Name string
 	// Parts are the path parts for the request, always starting with /{resource}/{name}
 	Parts []string
+
+	// FieldSelector contains the unparsed field selector from a request.  It is only present if the kube-apiserver
+	// honors field selectors for the verb this request is associated with.
+	FieldSelector string
+	// LabelSelector contains the unparsed field selector from a request.  It is only present if the kube-apiserver
+	// honors field selectors for the verb this request is associated with.
+	LabelSelector string
 }
 
 // specialVerbs contains just strings which are used in REST paths for special actions that don't fall under the normal
@@ -238,9 +247,25 @@ func (r *RequestInfoFactory) NewRequestInfo(req *http.Request) (*RequestInfo, er
 			}
 		}
 	}
+
 	// if there's no name on the request and we thought it was a delete before, then the actual verb is deletecollection
 	if len(requestInfo.Name) == 0 && requestInfo.Verb == "delete" {
 		requestInfo.Verb = "deletecollection"
+	}
+
+	if utilfeature.DefaultFeatureGate.Enabled(genericfeatures.AuthorizeWithSelectors) {
+		switch {
+		case requestInfo.Verb == "list" || requestInfo.Verb == "watch":
+			// interestingly these are parsed above, but the current structure there means that if one (or anything) in the
+			// listOptions fails to decode, the field and label selectors are lost.
+			// therefore, do the straight query param read here.
+			if vals := req.URL.Query()["fieldSelector"]; len(vals) > 0 {
+				requestInfo.FieldSelector = vals[0]
+			}
+			if vals := req.URL.Query()["labelSelector"]; len(vals) > 0 {
+				requestInfo.LabelSelector = vals[0]
+			}
+		}
 	}
 
 	return &requestInfo, nil

--- a/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
+++ b/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
@@ -98,6 +98,13 @@ const (
 	// Enables serving watch requests in separate goroutines.
 	APIServingWithRoutine featuregate.Feature = "APIServingWithRoutine"
 
+	// owner: @deads2k
+	// kep: https://kep.k8s.io/4601
+	// alpha: v1.31
+	//
+	// Allows authorization to use field and label selectors.
+	AuthorizeWithSelectors featuregate.Feature = "AuthorizeWithSelectors"
+
 	// owner: @cici37 @jpbetz
 	// kep: http://kep.k8s.io/3488
 	// alpha: v1.26
@@ -336,6 +343,8 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	APIServerTracing: {Default: true, PreRelease: featuregate.Beta},
 
 	APIServingWithRoutine: {Default: true, PreRelease: featuregate.Beta},
+
+	AuthorizeWithSelectors: {Default: false, PreRelease: featuregate.Alpha},
 
 	ValidatingAdmissionPolicy: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.32
 


### PR DESCRIPTION
Start of interface work for https://github.com/kubernetes/enhancements/pull/4600.

1. introduces featuregates
2. adds the field and label selector methods to authorizer.attributes
3. adds field and label selector tracking from requestInfoResolver
4. adds mapping from requestInfoResolver to authorizer.attributes

does NOT
1. change the SAR types
2. change the SAR REST handler.

/sig auth
/priority important-soon
/assign @liggitt 

```release-note
NONE
```