### PR TITLE
[WIP] Fix race conditions and deadlocks in Reflector

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/watch/watch.go
+++ b/staging/src/k8s.io/apimachinery/pkg/watch/watch.go
@@ -114,6 +114,7 @@ func (f *FakeWatcher) Stop() {
 	defer f.Unlock()
 	if !f.stopped {
 		klog.V(4).Infof("Stopping fake watcher.")
+		// TODO: make the producer close the result channel after confirming that cleanup is complete
 		close(f.result)
 		f.stopped = true
 	}
@@ -321,4 +322,22 @@ func (pw *ProxyWatcher) ResultChan() <-chan Event {
 // StopChan returns stop channel
 func (pw *ProxyWatcher) StopChan() <-chan struct{} {
 	return pw.stopCh
+}
+
+// MockWatcher implements watch.Interface with mockable functions.
+type MockWatcher struct {
+	StopFunc       func()
+	ResultChanFunc func() <-chan Event
+}
+
+var _ Interface = &MockWatcher{}
+
+// Stop calls StopFunc
+func (mw MockWatcher) Stop() {
+	mw.StopFunc()
+}
+
+// ResultChan calls ResultChanFunc
+func (mw MockWatcher) ResultChan() <-chan Event {
+	return mw.ResultChanFunc()
 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache_test.go
@@ -18,6 +18,7 @@ package cacher
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -26,7 +27,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
@@ -276,7 +277,8 @@ func TestEvents(t *testing.T) {
 		if err == nil {
 			t.Errorf("expected error too old")
 		}
-		if _, ok := err.(*errors.StatusError); !ok {
+		var statusErr *apierrors.StatusError
+		if !errors.As(err, &statusErr) {
 			t.Errorf("expected error to be of type StatusError")
 		}
 	}
@@ -615,7 +617,7 @@ func TestWaitUntilFreshAndListTimeout(t *testing.T) {
 			}()
 
 			_, _, _, err := store.WaitUntilFreshAndList(ctx, 4, nil)
-			if !errors.IsTimeout(err) {
+			if !apierrors.IsTimeout(err) {
 				t.Errorf("expected timeout error but got: %v", err)
 			}
 			if !storage.IsTooLargeResourceVersion(err) {

--- a/staging/src/k8s.io/client-go/tools/cache/reflector_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/reflector_test.go
@@ -28,6 +28,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	v1 "k8s.io/api/core/v1"
@@ -97,19 +98,35 @@ func TestRunUntil(t *testing.T) {
 			return &v1.PodList{ListMeta: metav1.ListMeta{ResourceVersion: "1"}}, nil
 		},
 	}
-	go r.Run(stopCh)
+	doneCh := make(chan struct{})
+	go func() {
+		defer close(doneCh)
+		r.Run(stopCh)
+	}()
 	// Synchronously add a dummy pod into the watch channel so we
 	// know the RunUntil go routine is in the watch handler.
 	fw.Add(&v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "bar"}})
+
 	close(stopCh)
-	select {
-	case _, ok := <-fw.ResultChan():
-		if ok {
-			t.Errorf("Watch channel left open after stopping the watch")
+	resultCh := fw.ResultChan()
+	for {
+		select {
+		case <-doneCh:
+			if resultCh == nil {
+				return // both closed
+			}
+			doneCh = nil
+		case _, ok := <-resultCh:
+			if ok {
+				t.Fatalf("Watch channel left open after stopping the watch")
+			}
+			if doneCh == nil {
+				return // both closed
+			}
+			resultCh = nil
+		case <-time.After(wait.ForeverTestTimeout):
+			t.Fatalf("the cancellation is at least %s late", wait.ForeverTestTimeout.String())
 		}
-	case <-time.After(wait.ForeverTestTimeout):
-		t.Errorf("the cancellation is at least %s late", wait.ForeverTestTimeout.String())
-		break
 	}
 }
 
@@ -126,24 +143,59 @@ func TestReflectorResyncChan(t *testing.T) {
 	}
 }
 
-// TestEstablishedWatchStoppedAfterStopCh ensures that
-// an established watch will be closed right after
-// the StopCh was also closed.
-func TestEstablishedWatchStoppedAfterStopCh(t *testing.T) {
-	ctx, ctxCancel := context.WithCancel(context.TODO())
-	ctxCancel()
-	w := watch.NewFake()
-	require.False(t, w.IsStopped())
+// TestReflectorWatchStoppedBefore ensures that neither List nor Watch are
+// called if the stop channel is closed before Reflector.watch is called.
+func TestReflectorWatchStoppedBefore(t *testing.T) {
+	stopCh := make(chan struct{})
+	close(stopCh)
 
-	// w is stopped when the stopCh is closed
-	target := NewReflector(nil, &v1.Pod{}, nil, 0)
-	err := target.watch(w, ctx.Done(), nil)
-	require.NoError(t, err)
-	require.True(t, w.IsStopped())
+	lw := &ListWatch{
+		ListFunc: func(_ metav1.ListOptions) (runtime.Object, error) {
+			t.Fatal("ListFunc called unexpectedly")
+			return nil, nil
+		},
+		WatchFunc: func(_ metav1.ListOptions) (watch.Interface, error) {
+			// If WatchFunc is never called, the watcher it returns doesn't need to be stopped.
+			t.Fatal("WatchFunc called unexpectedly")
+			return nil, nil
+		},
+	}
+	target := NewReflector(lw, &v1.Pod{}, nil, 0)
 
-	// noop when the w is nil and the ctx is closed
-	err = target.watch(nil, ctx.Done(), nil)
+	err := target.watch(nil, stopCh, nil)
 	require.NoError(t, err)
+}
+
+// TestReflectorWatchStoppedAfter ensures that neither the watcher is stopped if
+// the stop channel is closed after Reflector.watch has started watching.
+func TestReflectorWatchStoppedAfter(t *testing.T) {
+	stopCh := make(chan struct{})
+
+	var watchers []*watch.FakeWatcher
+
+	lw := &ListWatch{
+		ListFunc: func(_ metav1.ListOptions) (runtime.Object, error) {
+			t.Fatal("ListFunc called unexpectedly")
+			return nil, nil
+		},
+		WatchFunc: func(_ metav1.ListOptions) (watch.Interface, error) {
+			// Simulate the stop channel being closed after watching has started
+			go func() {
+				time.Sleep(10 * time.Millisecond)
+				close(stopCh)
+			}()
+			// Use a fake watcher that never sends events
+			w := watch.NewFake()
+			watchers = append(watchers, w)
+			return w, nil
+		},
+	}
+	target := NewReflector(lw, &v1.Pod{}, nil, 0)
+
+	err := target.watch(nil, stopCh, nil)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(watchers))
+	require.True(t, watchers[0].IsStopped())
 }
 
 func BenchmarkReflectorResyncChanMany(b *testing.B) {
@@ -158,22 +210,140 @@ func BenchmarkReflectorResyncChanMany(b *testing.B) {
 	}
 }
 
-func TestReflectorWatchHandlerError(t *testing.T) {
+// TestReflectorHandleWatchStoppedBefore ensures that handleWatch stops when
+// stopCh is already closed before handleWatch was called. It also ensures that
+// ResultChan is only called once and that Stop is called after ResultChan.
+func TestReflectorHandleWatchStoppedBefore(t *testing.T) {
 	s := NewStore(MetaNamespaceKeyFunc)
 	g := NewReflector(&testLW{}, &v1.Pod{}, s, 0)
-	fw := watch.NewFake()
-	go func() {
-		fw.Stop()
-	}()
-	err := watchHandler(time.Now(), fw, s, g.expectedType, g.expectedGVK, g.name, g.typeDescription, g.setLastSyncResourceVersion, nil, g.clock, nevererrc, wait.NeverStop)
+	stopCh := make(chan struct{})
+	// Simulate the watch channel being closed before the watchHandler is called
+	close(stopCh)
+	var calls []string
+	resultCh := make(chan watch.Event)
+	fw := watch.MockWatcher{
+		StopFunc: func() {
+			calls = append(calls, "Stop")
+			close(resultCh)
+		},
+		ResultChanFunc: func() <-chan watch.Event {
+			calls = append(calls, "ResultChan")
+			return resultCh
+		},
+	}
+	err := handleWatch(time.Now(), fw, s, g.expectedType, g.expectedGVK, g.name, g.typeDescription, g.setLastSyncResourceVersion, g.clock, nevererrc, stopCh)
 	if err == nil {
 		t.Errorf("unexpected non-error")
 	}
+	// Ensure the watcher methods are called exactly once in this exact order.
+	assert.Equal(t, []string{"ResultChan", "Stop"}, calls)
+}
+
+// TestReflectorHandleWatchStoppedAfter ensures that handleWatch stops when
+// stopCh is closed after handleWatch was called. It also ensures that
+// ResultChan is only called once and that Stop is called after ResultChan.
+func TestReflectorHandleWatchStoppedAfter(t *testing.T) {
+	s := NewStore(MetaNamespaceKeyFunc)
+	g := NewReflector(&testLW{}, &v1.Pod{}, s, 0)
+	var calls []string
+	stopCh := make(chan struct{})
+	resultCh := make(chan watch.Event)
+	fw := watch.MockWatcher{
+		StopFunc: func() {
+			calls = append(calls, "Stop")
+			close(resultCh)
+		},
+		ResultChanFunc: func() <-chan watch.Event {
+			calls = append(calls, "ResultChan")
+			resultCh = make(chan watch.Event)
+			// Simulate the watch handler being stopped asynchronously by the
+			// caller, after watching has started.
+			go func() {
+				time.Sleep(10 * time.Millisecond)
+				close(stopCh)
+			}()
+			return resultCh
+		},
+	}
+	err := handleWatch(time.Now(), fw, s, g.expectedType, g.expectedGVK, g.name, g.typeDescription, g.setLastSyncResourceVersion, g.clock, nevererrc, stopCh)
+	if err == nil {
+		t.Errorf("unexpected non-error")
+	}
+	// Ensure the watcher methods are called exactly once in this exact order.
+	assert.Equal(t, []string{"ResultChan", "Stop"}, calls)
+}
+
+// TestReflectorHandleWatchResultChanClosedBefore ensures that handleWatch
+// stops when the result channel is closed before handleWatch was called.
+func TestReflectorHandleWatchResultChanClosedBefore(t *testing.T) {
+	s := NewStore(MetaNamespaceKeyFunc)
+	g := NewReflector(&testLW{}, &v1.Pod{}, s, 0)
+	var calls []string
+	resultCh := make(chan watch.Event)
+	fw := watch.MockWatcher{
+		StopFunc: func() {
+			calls = append(calls, "Stop")
+		},
+		ResultChanFunc: func() <-chan watch.Event {
+			calls = append(calls, "ResultChan")
+			return resultCh
+		},
+	}
+	// Simulate the result channel being closed by the producer before handleWatch is called.
+	close(resultCh)
+	err := handleWatch(time.Now(), fw, s, g.expectedType, g.expectedGVK, g.name, g.typeDescription, g.setLastSyncResourceVersion, g.clock, nevererrc, wait.NeverStop)
+	if err == nil {
+		t.Errorf("unexpected non-error")
+	}
+	// Ensure the watcher methods are called exactly once in this exact order.
+	assert.Equal(t, []string{"ResultChan", "Stop"}, calls)
+}
+
+// TestReflectorHandleWatchResultChanClosedAfter ensures that handleWatch
+// stops when the result channel is closed after handleWatch has started watching.
+func TestReflectorHandleWatchResultChanClosedAfter(t *testing.T) {
+	s := NewStore(MetaNamespaceKeyFunc)
+	g := NewReflector(&testLW{}, &v1.Pod{}, s, 0)
+	var calls []string
+	resultCh := make(chan watch.Event)
+	fw := watch.MockWatcher{
+		StopFunc: func() {
+			calls = append(calls, "Stop")
+		},
+		ResultChanFunc: func() <-chan watch.Event {
+			calls = append(calls, "ResultChan")
+			resultCh = make(chan watch.Event)
+			// Simulate the result channel being closed by the producer, after
+			// watching has started.
+			go func() {
+				time.Sleep(10 * time.Millisecond)
+				close(resultCh)
+			}()
+			return resultCh
+		},
+	}
+	err := handleWatch(time.Now(), fw, s, g.expectedType, g.expectedGVK, g.name, g.typeDescription, g.setLastSyncResourceVersion, g.clock, nevererrc, wait.NeverStop)
+	if err == nil {
+		t.Errorf("unexpected non-error")
+	}
+	// Ensure the watcher methods are called exactly once in this exact order.
+	assert.Equal(t, []string{"ResultChan", "Stop"}, calls)
 }
 
 func TestReflectorWatchHandler(t *testing.T) {
 	s := NewStore(MetaNamespaceKeyFunc)
 	g := NewReflector(&testLW{}, &v1.Pod{}, s, 0)
+	// Wrap setLastSyncResourceVersion so we can tell the watchHandler to stop
+	// watching after all the events have been consumed. This avoids race
+	// conditions which can happen if the producer calls Stop(), instead of the
+	// consumer.
+	stopCh := make(chan struct{})
+	setLastSyncResourceVersion := func(rv string) {
+		g.setLastSyncResourceVersion(rv)
+		if rv == "32" {
+			close(stopCh)
+		}
+	}
 	fw := watch.NewFake()
 	s.Add(&v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "foo"}})
 	s.Add(&v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "bar"}})
@@ -184,8 +354,8 @@ func TestReflectorWatchHandler(t *testing.T) {
 		fw.Add(&v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "baz", ResourceVersion: "32"}})
 		fw.Stop()
 	}()
-	err := watchHandler(time.Now(), fw, s, g.expectedType, g.expectedGVK, g.name, g.typeDescription, g.setLastSyncResourceVersion, nil, g.clock, nevererrc, wait.NeverStop)
-	if err != nil {
+	err := handleWatch(time.Now(), fw, s, g.expectedType, g.expectedGVK, g.name, g.typeDescription, setLastSyncResourceVersion, g.clock, nevererrc, stopCh)
+	if !errors.Is(err, errorStopRequested) {
 		t.Errorf("unexpected error %v", err)
 	}
 
@@ -193,6 +363,7 @@ func TestReflectorWatchHandler(t *testing.T) {
 		return &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: id, ResourceVersion: rv}}
 	}
 
+	// Validate that the Store was updated by the events
 	table := []struct {
 		Pod    *v1.Pod
 		exists bool
@@ -215,12 +386,7 @@ func TestReflectorWatchHandler(t *testing.T) {
 		}
 	}
 
-	// RV should send the last version we see.
-	if e, a := "32", g.LastSyncResourceVersion(); e != a {
-		t.Errorf("expected %v, got %v", e, a)
-	}
-
-	// last sync resource version should be the last version synced with store
+	// Validate that setLastSyncResourceVersion was called with the RV from the last event.
 	if e, a := "32", g.LastSyncResourceVersion(); e != a {
 		t.Errorf("expected %v, got %v", e, a)
 	}
@@ -230,9 +396,9 @@ func TestReflectorStopWatch(t *testing.T) {
 	s := NewStore(MetaNamespaceKeyFunc)
 	g := NewReflector(&testLW{}, &v1.Pod{}, s, 0)
 	fw := watch.NewFake()
-	stopWatch := make(chan struct{}, 1)
-	stopWatch <- struct{}{}
-	err := watchHandler(time.Now(), fw, s, g.expectedType, g.expectedGVK, g.name, g.typeDescription, g.setLastSyncResourceVersion, nil, g.clock, nevererrc, stopWatch)
+	stopWatch := make(chan struct{})
+	close(stopWatch)
+	err := handleWatch(time.Now(), fw, s, g.expectedType, g.expectedGVK, g.name, g.typeDescription, g.setLastSyncResourceVersion, g.clock, nevererrc, stopWatch)
 	if err != errorStopRequested {
 		t.Errorf("expected stop error, got %q", err)
 	}
@@ -361,6 +527,7 @@ func TestReflectorListAndWatchWithErrors(t *testing.T) {
 			}
 		}
 		watchRet, watchErr := item.events, item.watchErr
+		stopCh := make(chan struct{})
 		lw := &testLW{
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				if watchErr != nil {
@@ -372,7 +539,13 @@ func TestReflectorListAndWatchWithErrors(t *testing.T) {
 					for _, e := range watchRet {
 						fw.Action(e.Type, e.Object)
 					}
-					fw.Stop()
+					// Because FakeWatcher doesn't buffer events, it's safe to
+					// close the stop channel immediately without missing events.
+					// But usually, the event producer would instead close the
+					// result channel, and wait for the consumer to stop the
+					// watcher, to avoid race conditions.
+					// TODO: Fix the FakeWatcher to separate watcher.Stop from close(resultCh)
+					close(stopCh)
 				}()
 				return fw, nil
 			},
@@ -381,7 +554,16 @@ func TestReflectorListAndWatchWithErrors(t *testing.T) {
 			},
 		}
 		r := NewReflector(lw, &v1.Pod{}, s, 0)
-		r.ListAndWatch(wait.NeverStop)
+		err := r.ListAndWatch(stopCh)
+		if item.listErr != nil && !errors.Is(err, item.listErr) {
+			t.Errorf("unexpected ListAndWatch error: %v", err)
+		}
+		if item.watchErr != nil && !errors.Is(err, item.watchErr) {
+			t.Errorf("unexpected ListAndWatch error: %v", err)
+		}
+		if item.listErr == nil && item.watchErr == nil {
+			assert.NoError(t, err)
+		}
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind flake

#### What & Why?

- Ensure watcher.Stop() is called after the consumer is done consuming
  events from the watcher. This is a signal to the producer that it
  should stop trying to send events on the result channel. Without it,
  a producer that sends on an unbuffered channel can get stuck waiting
  for an event to be read by a consumer who is no longer reading.
- Add extra checks to exit early when the stop channel has been closed,
  to avoid unnecessary API calls.
- Refactor watchHandler to be easier to read. Use input and output
  bools, instead of a bool pointer.
- Fix some of the unit tests to use the stop channel to stop ListAndWatch,
  as a real user would, instead of relying on the quirk that
  FakeWatcher.Stop() happens to close the result channel.
- Add additional unit tests to confirm that the watch handler works
  correctly in various permutations where the result channel or stop
  channel is closed, before and after watching has started.
- Add a MockWatcher for more explicit testing, including order of
  operations and result channel closure.
- Remove a duplicate assertion in TestReflectorWatchHandler
- Use assert instead of require in a few cases where debugging a failed
  test is easier if you can see all the failed assertions at once.
- Fix some lint errors regarding error comparison (use errors.Is & As)

These changes make the informer/reflector safer to use with third-party watchers, which are often faked for testing controllers.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
