### PR TITLE
Add logging to show which unexpected events were received in kubectl events e2e test

### DIFF
--- a/test/e2e/kubectl/kubectl.go
+++ b/test/e2e/kubectl/kubectl.go
@@ -2008,13 +2008,13 @@ metadata:
 			// replace multi spaces into single white space
 			eventsStr := strings.Join(strings.Fields(strings.TrimSpace(events)), " ")
 			if !strings.Contains(string(eventsStr), fmt.Sprintf("Normal Scheduled Pod/%s", podName)) {
-				framework.Failf("failed to list expected event")
+				framework.Failf("failed to list expected event with pod name: %s, got: %s", podName, events)
 			}
 
 			ginkgo.By("expect not showing any WARNING message except timeouts")
 			events = e2ekubectl.RunKubectlOrDie(ns, "events", "--types=WARNING", "--for=pod/"+podName)
 			if events != "" && !strings.Contains(events, "timed out") {
-				framework.Failf("unexpected WARNING event fired")
+				framework.Failf("unexpected non-timeout WARNING event fired, got: %s ", events)
 			}
 		})
 	})


### PR DESCRIPTION
#### What type of PR is this?
/kind flake

#### What this PR does / why we need it:
kubectl events e2e test is [occasionally flaky](https://storage.googleapis.com/k8s-triage/index.html?sig=cli#6bc9e9c5f193d7f0024c), failing with "unexpected WARNING event fired".

This PR adds additional logging to print *which* events were received, so that the underlying cause of the flake can be determined.

#### Which issue(s) this PR fixes:
Related to #125109

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
