### PR TITLE
add logging on e2e loadbalancer test

### DIFF
--- a/test/e2e/network/loadbalancer.go
+++ b/test/e2e/network/loadbalancer.go
@@ -356,7 +356,7 @@ var _ = common.SIGDescribe("LoadBalancers", feature.LoadBalancer, func() {
 		testReachableUDP(ctx, udpIngressIP, svcPort, loadBalancerLagTimeout)
 
 		// Change the services' main ports.
-
+		framework.Logf("Service Status: %v", udpService.Status)
 		ginkgo.By("changing the UDP service's port")
 		udpService, err = udpJig.UpdateService(ctx, func(s *v1.Service) {
 			s.Spec.Ports[0].Port++
@@ -370,6 +370,7 @@ var _ = common.SIGDescribe("LoadBalancers", feature.LoadBalancer, func() {
 		if int(udpService.Spec.Ports[0].NodePort) != udpNodePort {
 			framework.Failf("UDP Spec.Ports[0].NodePort (%d) changed", udpService.Spec.Ports[0].NodePort)
 		}
+		framework.Logf("Service Status: %v", udpService.Status)
 		if e2eservice.GetIngressPoint(&udpService.Status.LoadBalancer.Ingress[0]) != udpIngressIP {
 			framework.Failf("UDP Status.LoadBalancer.Ingress changed (%s -> %s) when not expected", udpIngressIP, e2eservice.GetIngressPoint(&udpService.Status.LoadBalancer.Ingress[0]))
 		}


### PR DESCRIPTION
/kind flake

```release-note
NONE
```

The test flakes https://github.com/kubernetes-sigs/cloud-provider-kind/issues/71 because it panics in https://github.com/kubernetes/kubernetes/blob/8361522b40cc8b569efdd6ee2456fa514071cad1/test/e2e/network/loadbalancer.go#L373 

so it is possible something is wiping out the status? Let's add logging to make this is easier to debug so we can get it in the existing jobs failures https://testgrid.k8s.io/sig-network-kind#sig-network-kind,%20loadbalancer

Issue https://github.com/kubernetes-sigs/cloud-provider-kind/issues/71