### PR TITLE
Make the output of `kubectl describe service` more informative

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/describe/describe.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/describe.go
@@ -3058,6 +3058,9 @@ func describeService(service *corev1.Service, endpointSlices []discoveryv1.Endpo
 		if service.Spec.ExternalTrafficPolicy != "" {
 			w.Write(LEVEL_0, "External Traffic Policy:\t%s\n", service.Spec.ExternalTrafficPolicy)
 		}
+		if service.Spec.InternalTrafficPolicy != nil {
+			w.Write(LEVEL_0, "Internal Traffic Policy:\t%s\n", *service.Spec.InternalTrafficPolicy)
+		}
 		if service.Spec.HealthCheckNodePort != 0 {
 			w.Write(LEVEL_0, "HealthCheck NodePort:\t%d\n", service.Spec.HealthCheckNodePort)
 		}

--- a/staging/src/k8s.io/kubectl/pkg/describe/describe.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/describe.go
@@ -2984,6 +2984,9 @@ func buildIngressString(ingress []corev1.LoadBalancerIngress) string {
 		}
 		if ingress[i].IP != "" {
 			buffer.WriteString(ingress[i].IP)
+			if ingress[i].IPMode != nil {
+				buffer.WriteString(fmt.Sprintf(" (%s)", *ingress[i].IPMode))
+			}
 		} else {
 			buffer.WriteString(ingress[i].Hostname)
 		}

--- a/staging/src/k8s.io/kubectl/pkg/describe/describe.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/describe.go
@@ -3030,7 +3030,7 @@ func describeService(service *corev1.Service, endpointSlices []discoveryv1.Endpo
 			w.Write(LEVEL_0, "External IPs:\t%v\n", strings.Join(service.Spec.ExternalIPs, ","))
 		}
 		if service.Spec.LoadBalancerIP != "" {
-			w.Write(LEVEL_0, "IP:\t%s\n", service.Spec.LoadBalancerIP)
+			w.Write(LEVEL_0, "Desired LoadBalancer IP:\t%s\n", service.Spec.LoadBalancerIP)
 		}
 		if service.Spec.ExternalName != "" {
 			w.Write(LEVEL_0, "External Name:\t%s\n", service.Spec.ExternalName)

--- a/staging/src/k8s.io/kubectl/pkg/describe/describe_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/describe_test.go
@@ -684,6 +684,16 @@ func TestDescribeService(t *testing.T) {
 					InternalTrafficPolicy: ptr.To(corev1.ServiceInternalTrafficPolicyCluster),
 					HealthCheckNodePort:   32222,
 				},
+				Status: corev1.ServiceStatus{
+					LoadBalancer: corev1.LoadBalancerStatus{
+						Ingress: []corev1.LoadBalancerIngress{
+							{
+								IP:     "5.6.7.8",
+								IPMode: ptr.To(corev1.LoadBalancerIPModeVIP),
+							},
+						},
+					},
+				},
 			},
 			endpointSlices: []*discoveryv1.EndpointSlice{{
 				ObjectMeta: metav1.ObjectMeta{
@@ -715,6 +725,7 @@ func TestDescribeService(t *testing.T) {
 				IP:                       1.2.3.4
 				IPs:                      <none>
 				IP:                       5.6.7.8
+				LoadBalancer Ingress:     5.6.7.8 (VIP)
 				Port:                     port-tcp  8080/TCP
 				TargetPort:               9527/TCP
 				NodePort:                 port-tcp  31111/TCP
@@ -750,6 +761,15 @@ func TestDescribeService(t *testing.T) {
 					ExternalTrafficPolicy: corev1.ServiceExternalTrafficPolicyLocal,
 					InternalTrafficPolicy: ptr.To(corev1.ServiceInternalTrafficPolicyLocal),
 					HealthCheckNodePort:   32222,
+				},
+				Status: corev1.ServiceStatus{
+					LoadBalancer: corev1.LoadBalancerStatus{
+						Ingress: []corev1.LoadBalancerIngress{
+							{
+								IP: "5.6.7.8",
+							},
+						},
+					},
 				},
 			},
 			endpointSlices: []*discoveryv1.EndpointSlice{
@@ -802,6 +822,7 @@ func TestDescribeService(t *testing.T) {
 				IP:                       1.2.3.4
 				IPs:                      <none>
 				IP:                       5.6.7.8
+				LoadBalancer Ingress:     5.6.7.8
 				Port:                     port-tcp  8080/TCP
 				TargetPort:               targetPort/TCP
 				NodePort:                 port-tcp  31111/TCP

--- a/staging/src/k8s.io/kubectl/pkg/describe/describe_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/describe_test.go
@@ -681,6 +681,7 @@ func TestDescribeService(t *testing.T) {
 					LoadBalancerIP:        "5.6.7.8",
 					SessionAffinity:       corev1.ServiceAffinityNone,
 					ExternalTrafficPolicy: corev1.ServiceExternalTrafficPolicyLocal,
+					InternalTrafficPolicy: ptr.To(corev1.ServiceInternalTrafficPolicyCluster),
 					HealthCheckNodePort:   32222,
 				},
 			},
@@ -720,6 +721,7 @@ func TestDescribeService(t *testing.T) {
 				Endpoints:                10.244.0.1:9527,10.244.0.2:9527,10.244.0.3:9527
 				Session Affinity:         None
 				External Traffic Policy:  Local
+				Internal Traffic Policy:  Cluster
 				HealthCheck NodePort:     32222
 				Events:                   <none>
 			`)[1:],
@@ -746,6 +748,7 @@ func TestDescribeService(t *testing.T) {
 					LoadBalancerIP:        "5.6.7.8",
 					SessionAffinity:       corev1.ServiceAffinityNone,
 					ExternalTrafficPolicy: corev1.ServiceExternalTrafficPolicyLocal,
+					InternalTrafficPolicy: ptr.To(corev1.ServiceInternalTrafficPolicyLocal),
 					HealthCheckNodePort:   32222,
 				},
 			},
@@ -805,6 +808,7 @@ func TestDescribeService(t *testing.T) {
 				Endpoints:                10.244.0.1:9527,10.244.0.2:9527,10.244.0.3:9527 + 2 more...
 				Session Affinity:         None
 				External Traffic Policy:  Local
+				Internal Traffic Policy:  Local
 				HealthCheck NodePort:     32222
 				Events:                   <none>
 			`)[1:],

--- a/staging/src/k8s.io/kubectl/pkg/describe/describe_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/describe_test.go
@@ -724,7 +724,7 @@ func TestDescribeService(t *testing.T) {
 				IP Families:              IPv4
 				IP:                       1.2.3.4
 				IPs:                      <none>
-				IP:                       5.6.7.8
+				Desired LoadBalancer IP:  5.6.7.8
 				LoadBalancer Ingress:     5.6.7.8 (VIP)
 				Port:                     port-tcp  8080/TCP
 				TargetPort:               9527/TCP
@@ -821,7 +821,7 @@ func TestDescribeService(t *testing.T) {
 				IP Families:              IPv4
 				IP:                       1.2.3.4
 				IPs:                      <none>
-				IP:                       5.6.7.8
+				Desired LoadBalancer IP:  5.6.7.8
 				LoadBalancer Ingress:     5.6.7.8
 				Port:                     port-tcp  8080/TCP
 				TargetPort:               targetPort/TCP
@@ -886,7 +886,7 @@ func TestDescribeService(t *testing.T) {
 				IP Families:              IPv4
 				IP:                       1.2.3.4
 				IPs:                      <none>
-				IP:                       5.6.7.8
+				Desired LoadBalancer IP:  5.6.7.8
 				Port:                     port-tcp  8080/TCP
 				TargetPort:               targetPort/TCP
 				NodePort:                 port-tcp  31111/TCP
@@ -935,7 +935,7 @@ func TestDescribeService(t *testing.T) {
 				IP Families:              IPv4
 				IP:                       1.2.3.4
 				IPs:                      1.2.3.4
-				IP:                       5.6.7.8
+				Desired LoadBalancer IP:  5.6.7.8
 				Port:                     port-tcp  8080/TCP
 				TargetPort:               targetPort/TCP
 				NodePort:                 port-tcp  31111/TCP


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

InternalTrafficPolicy has been GA and LoadBalancerIPMode has been beta and enabled by default. Adding them to the output of `kubectl describe service` to make it more informative.

In addition, for a LoadBalancer Service, there were two "IP" fields in the output of `kubectl describe service` if its loadBalancerIP is not empty, which looks confusing. The second "IP" is the loadBalancer IP in spec.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
`kubectl describe service` now shows internal traffic policy and ip mode of load balancer IP
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
