### PR TITLE
Create NPD kubeconfig conditionally if the installation mode is standalone

### DIFF
--- a/cluster/gce/upgrade.sh
+++ b/cluster/gce/upgrade.sh
@@ -258,6 +258,7 @@ function prepare-node-upgrade() {
   KUBE_PROXY_TOKEN=$(get-env-val "${node_env}" "KUBE_PROXY_TOKEN")
   export KUBE_PROXY_TOKEN
   NODE_PROBLEM_DETECTOR_TOKEN=$(get-env-val "${node_env}" "NODE_PROBLEM_DETECTOR_TOKEN")
+  export NODE_PROBLEM_DETECTOR_TOKEN
   CA_CERT_BASE64=$(get-env-val "${node_env}" "CA_CERT")
   export CA_CERT_BASE64
   EXTRA_DOCKER_OPTS=$(get-env-val "${node_env}" "EXTRA_DOCKER_OPTS")

--- a/cluster/gce/windows/k8s-node-setup.psm1
+++ b/cluster/gce/windows/k8s-node-setup.psm1
@@ -1130,7 +1130,7 @@ function Verify-WorkerServices {
   $timeout = 12
   $retries = 0
   $retryDelayInSeconds = 5
-  
+
   Log-Output ("Testing node connection to API server...")
   do {
       $retries++
@@ -1138,17 +1138,17 @@ function Verify-WorkerServices {
       $host_status = & "${env:NODE_DIR}\kubectl.exe" get nodes (hostname) -o=custom-columns=:.status.conditions[4].type | Out-String
       Start-Sleep $retryDelayInSeconds
   } while (((-Not $nodes_list) -or (-Not $nodes_list.contains((hostname))) -or (-Not $host_status.contains("Ready")))-and ($retries -le $timeout))
-  
+
   If (-Not $nodes_list){
       Throw ("Node: '$(hostname)' failed to connect to API server")
-  
+
   }ElseIf (-Not $nodes_list.contains((hostname))) {
       Throw ("Node: '$(hostname)' failed to join the cluster; NODES: '`n $($nodes_list)'")
 
   }ELseIf (-Not $host_status.contains("Ready")) {
       Throw ("Node: '$(hostname)' is not in Ready state")
   }
-  
+
   Log-Output ("Node: $(hostname) successfully joined cluster `n NODES: `n $($nodes_list)")
   Verify_GceMetadataServerRouteIsPresent
 
@@ -1543,10 +1543,21 @@ function DownloadAndInstall-NodeProblemDetector {
 #   CA_CERT
 #   NODE_PROBLEM_DETECTOR_TOKEN
 function Create-NodeProblemDetectorKubeConfig {
-  if (-not [string]::IsNullOrEmpty(${env:NODEPROBLEMDETECTOR_KUBECONFIG_FILE})) {
-    Create-Kubeconfig -Name 'node-problem-detector' `
-      -Path ${env:NODEPROBLEMDETECTOR_KUBECONFIG_FILE} `
-      -Token ${kube_env}['NODE_PROBLEM_DETECTOR_TOKEN']
+  if ("${env:ENABLE_NODE_PROBLEM_DETECTOR}" -eq "standalone") {
+    if (-not [string]::IsNullOrEmpty(${kube_env]['NODE_PROBLEM_DETECTOR_TOKEN']})) {
+      Log-Output "Create-NodeProblemDetectorKubeConfig using Node Problem Detector token"
+      Create-Kubeconfig -Name 'node-problem-detector' `
+        -Path ${env:NODEPROBLEMDETECTOR_KUBECONFIG_FILE} `
+        -Token ${kube_env}['NODE_PROBLEM_DETECTOR_TOKEN']
+    } elseif (Test-Path ${env:BOOTSTRAP_KUBECONFIG}) {
+      Log-Output "Create-NodeProblemDetectorKubeConfig creating kubeconfig from kubelet kubeconfig"
+      Copy-Item ${env:BOOTSTRAP_KUBECONFIG} -Destination ${env:NODEPROBLEMDETECTOR_KUBECONFIG_FILE}
+      Log-Output ("node-problem-detector bootstrap kubeconfig:`n" +
+              "$(Get-Content -Raw ${env:NODEPROBLEMDETECTOR_KUBECONFIG_FILE})")
+    } else {
+      Log-Output "Either NODE_PROBLEM_DETECTOR_TOKEN or ${env:BOOTSTRAP_KUBECONFIG} must be set"
+      exit 1
+    }
   }
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Conditionally creates NPD kubeconfig if `ENABLE_NODE_PROBLEM_DETECTOR=standalone`. In the Windows startup script `ENABLE_NODE_PROBLEM_DETECTOR=none` but we'd still attempt to create it.

Ref https://github.com/kubernetes/kubernetes/issues/124047

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

/cc @AnishShah 