### PR TITLE
update metrics-server to v0.7.1

### DIFF
--- a/cluster/addons/metrics-server/metrics-server-deployment.yaml
+++ b/cluster/addons/metrics-server/metrics-server-deployment.yaml
@@ -23,23 +23,23 @@ data:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: metrics-server-v0.7.0
+  name: metrics-server-v0.7.1
   namespace: kube-system
   labels:
     k8s-app: metrics-server
     addonmanager.kubernetes.io/mode: Reconcile
-    version: v0.7.0
+    version: v0.7.1
 spec:
   selector:
     matchLabels:
       k8s-app: metrics-server
-      version: v0.7.0
+      version: v0.7.1
   template:
     metadata:
       name: metrics-server
       labels:
         k8s-app: metrics-server
-        version: v0.7.0
+        version: v0.7.1
     spec:
       securityContext:
         seccompProfile:
@@ -50,7 +50,7 @@ spec:
         kubernetes.io/os: linux
       containers:
       - name: metrics-server
-        image: registry.k8s.io/metrics-server/metrics-server:v0.7.0
+        image: registry.k8s.io/metrics-server/metrics-server:v0.7.1
         command:
         - /metrics-server
         - --metric-resolution=15s
@@ -109,7 +109,7 @@ spec:
           - --memory={{ base_metrics_server_memory }}
           - --extra-memory={{ metrics_server_memory_per_node }}Mi
           - --threshold=5
-          - --deployment=metrics-server-v0.7.0
+          - --deployment=metrics-server-v0.7.1
           - --container=metrics-server
           - --poll-period=30000
           - --estimator=exponential


### PR DESCRIPTION
https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.7.1

Main changes:



Update Golang to v1.21.8 and Kubernetes dependencies to v1.29.2
Fixed a bug causing kubectl get PodMetrics/NodeMetrics to fail

/kind cleanup

```release-note
NONE
```


```docs
NONE
```
