### PR TITLE
cleanup: Use cache.NewInformerWithOptions instead of deprecated NewIndexerInformer func

### DIFF
--- a/test/integration/apimachinery/watch_timeout_test.go
+++ b/test/integration/apimachinery/watch_timeout_test.go
@@ -288,7 +288,13 @@ func testWatchClientTimeout(t *testing.T, config *restclient.Config, timeout, ti
 			return client.CoreV1().ConfigMaps(metav1.NamespaceAll).Watch(context.TODO(), options)
 		},
 	}
-	_, informer := cache.NewIndexerInformer(listWatch, &corev1.ConfigMap{}, 30*time.Minute, cache.ResourceEventHandlerFuncs{}, cache.Indexers{})
+	_, informer := cache.NewInformerWithOptions(cache.InformerOptions{
+		ListerWatcher: listWatch,
+		ObjectType:    &corev1.ConfigMap{},
+		ResyncPeriod:  30 * time.Minute,
+		Handler:       cache.ResourceEventHandlerFuncs{},
+		Indexers:      cache.Indexers{},
+	})
 	informer.Run(stopCh)
 	select {
 	case <-stopCh:


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
The functions NewIndexerInformer in the cache package are deprecated in favor of the NewInformerWithOptions func.
https://github.com/kubernetes/kubernetes/blob/ec93d3b71a6634659b59bf435959f4befafe3796/staging/src/k8s.io/client-go/tools/cache/controller.go#L455-L465


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```
