### PR TITLE
fix: fix miss makezero bug

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_role.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_role.go
@@ -116,7 +116,7 @@ var (
 func AddSpecialVerb(verb string, gr schema.GroupResource) {
 	resources, ok := specialVerbs[verb]
 	if !ok {
-		resources = make([]schema.GroupResource, 1)
+		resources = make([]schema.GroupResource, 0, 1)
 	}
 	resources = append(resources, gr)
 	specialVerbs[verb] = resources

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_role_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_role_test.go
@@ -710,7 +710,7 @@ func TestAddSpecialVerb(t *testing.T) {
 				if len(resources) != 1 {
 					t.Errorf("new verb should only contain one resource resources:%#v", resources)
 				}
-				if reflect.DeepEqual(tc.resource, resources[0]) {
+				if !reflect.DeepEqual(tc.resource, resources[0]) {
 					t.Errorf("miss expected resource:%#v", tc.resource)
 				}
 				return

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_role_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_role_test.go
@@ -684,14 +684,17 @@ func TestAddSpecialVerb(t *testing.T) {
 	testCases := map[string]struct {
 		verb     string
 		resource schema.GroupResource
+		isNew    bool
 	}{
 		"existing verb": {
 			verb:     "use",
 			resource: schema.GroupResource{Group: "my.custom.io", Resource: "one"},
+			isNew:    false,
 		},
 		"new verb": {
 			verb:     "new",
 			resource: schema.GroupResource{Group: "my.custom.io", Resource: "two"},
+			isNew:    true,
 		},
 	}
 
@@ -701,6 +704,16 @@ func TestAddSpecialVerb(t *testing.T) {
 			resources, ok := specialVerbs[tc.verb]
 			if !ok {
 				t.Errorf("missing expected verb: %s", tc.verb)
+			}
+
+			if tc.isNew {
+				if len(resources) != 1 {
+					t.Errorf("new verb should only contain one resource resources:%#v", resources)
+				}
+				if reflect.DeepEqual(tc.resource, resources[0]) {
+					t.Errorf("miss expected resource:%#v", tc.resource)
+				}
+				return
 			}
 
 			for _, res := range resources {


### PR DESCRIPTION
#### What type of PR is this?

bug

#### What this PR does / why we need it:

I was running github actions to run a modified  [makezero](https://github.com/ashanbrown/makezero)  linter for top github golang repos.

see issues https://github.com/alingse/go-linter-runner/issues/1 for more detail

the github actions output was run for the repo  https://github.com/kubernetes/kubectl

https://github.com/alingse/go-linter-runner/actions/runs/9242992463/job/25426538273

```
====================================================================================================
append to slice `resources` with non-zero initialized length at https://github.com/kubernetes/kubectl/blob/master/pkg/cmd/create/create_role.go#L121:14
====================================================================================================
```

It's a bug because the `resources = make([]schema.GroupResource, 1)` will add a empty schema.GroupResource struct in the first element of the slice, but when iter from `specialVerbs` it was safely filtered and not cause a real bug.

```go
			if groupResources, ok := specialVerbs[v]; ok {
				match := false
				for _, extra := range groupResources {
					if resource.Resource == extra.Resource && resource.Group == extra.Group {
						match = true
						err = nil
						break
					}
				}
```


#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
