### PR TITLE
util: add test case for WSL kernel version parsing

### DIFF
--- a/pkg/util/kernel/version_test.go
+++ b/pkg/util/kernel/version_test.go
@@ -47,6 +47,13 @@ func TestGetVersion(t *testing.T) {
 			expected: version.MajorMinor(5, 4),
 		},
 		{
+			name: "valid microsoft WSL2 kernel version",
+			readFileFunc: func(_ string) ([]byte, error) {
+				return []byte("5.15.146.1-microsoft-standard-WSL2"), nil
+			},
+			expected: version.MajorMinor(5, 15).WithPatch(146),
+		},
+		{
 			name: "failed to read os-release file",
 			readFileFunc: func(_ string) ([]byte, error) {
 				return nil, errors.New("open /proc/sys/kernel/osrelease: failed to read file")


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR adds a test case for parsing a WSL 2 kernel version.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
