### PR TITLE
pkg/controller: drop pointer wrapper functions

### DIFF
--- a/pkg/controller/endpointslice/endpointslice_controller_test.go
+++ b/pkg/controller/endpointslice/endpointslice_controller_test.go
@@ -45,7 +45,7 @@ import (
 	"k8s.io/klog/v2/ktesting"
 	"k8s.io/kubernetes/pkg/controller"
 	endpointslicepkg "k8s.io/kubernetes/pkg/controller/util/endpointslice"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 // Most of the tests related to EndpointSlice allocation can be found in reconciler_test.go
@@ -643,41 +643,41 @@ func TestSyncService(t *testing.T) {
 			},
 			expectedEndpointPorts: []discovery.EndpointPort{
 				{
-					Name:     pointer.String("sctp-example"),
-					Protocol: protoPtr(v1.ProtocolSCTP),
-					Port:     pointer.Int32(3456),
+					Name:     ptr.To("sctp-example"),
+					Protocol: ptr.To(v1.ProtocolSCTP),
+					Port:     ptr.To[int32](3456),
 				},
 				{
-					Name:     pointer.String("udp-example"),
-					Protocol: protoPtr(v1.ProtocolUDP),
-					Port:     pointer.Int32(161),
+					Name:     ptr.To("udp-example"),
+					Protocol: ptr.To(v1.ProtocolUDP),
+					Port:     ptr.To[int32](161),
 				},
 				{
-					Name:     pointer.String("tcp-example"),
-					Protocol: protoPtr(v1.ProtocolTCP),
-					Port:     pointer.Int32(80),
+					Name:     ptr.To("tcp-example"),
+					Protocol: ptr.To(v1.ProtocolTCP),
+					Port:     ptr.To[int32](80),
 				},
 			},
 			expectedEndpoints: []discovery.Endpoint{
 				{
 					Conditions: discovery.EndpointConditions{
-						Ready:       pointer.Bool(true),
-						Serving:     pointer.Bool(true),
-						Terminating: pointer.Bool(false),
+						Ready:       ptr.To(true),
+						Serving:     ptr.To(true),
+						Terminating: ptr.To(false),
 					},
 					Addresses: []string{"10.0.0.1"},
 					TargetRef: &v1.ObjectReference{Kind: "Pod", Namespace: "default", Name: "pod0"},
-					NodeName:  pointer.String("node-1"),
+					NodeName:  ptr.To("node-1"),
 				},
 				{
 					Conditions: discovery.EndpointConditions{
-						Ready:       pointer.Bool(true),
-						Serving:     pointer.Bool(true),
-						Terminating: pointer.Bool(false),
+						Ready:       ptr.To(true),
+						Serving:     ptr.To(true),
+						Terminating: ptr.To(false),
 					},
 					Addresses: []string{"10.0.0.2"},
 					TargetRef: &v1.ObjectReference{Kind: "Pod", Namespace: "default", Name: "pod1"},
-					NodeName:  pointer.String("node-1"),
+					NodeName:  ptr.To("node-1"),
 				},
 			},
 		},
@@ -760,31 +760,31 @@ func TestSyncService(t *testing.T) {
 			},
 			expectedEndpointPorts: []discovery.EndpointPort{
 				{
-					Name:     pointer.String("sctp-example"),
-					Protocol: protoPtr(v1.ProtocolSCTP),
-					Port:     pointer.Int32(3456),
+					Name:     ptr.To("sctp-example"),
+					Protocol: ptr.To(v1.ProtocolSCTP),
+					Port:     ptr.To[int32](3456),
 				},
 				{
-					Name:     pointer.String("udp-example"),
-					Protocol: protoPtr(v1.ProtocolUDP),
-					Port:     pointer.Int32(161),
+					Name:     ptr.To("udp-example"),
+					Protocol: ptr.To(v1.ProtocolUDP),
+					Port:     ptr.To[int32](161),
 				},
 				{
-					Name:     pointer.String("tcp-example"),
-					Protocol: protoPtr(v1.ProtocolTCP),
-					Port:     pointer.Int32(80),
+					Name:     ptr.To("tcp-example"),
+					Protocol: ptr.To(v1.ProtocolTCP),
+					Port:     ptr.To[int32](80),
 				},
 			},
 			expectedEndpoints: []discovery.Endpoint{
 				{
 					Conditions: discovery.EndpointConditions{
-						Ready:       pointer.Bool(true),
-						Serving:     pointer.Bool(true),
-						Terminating: pointer.Bool(false),
+						Ready:       ptr.To(true),
+						Serving:     ptr.To(true),
+						Terminating: ptr.To(false),
 					},
 					Addresses: []string{"fd08::5678:0000:0000:9abc:def0"},
 					TargetRef: &v1.ObjectReference{Kind: "Pod", Namespace: "default", Name: "pod1"},
-					NodeName:  pointer.String("node-1"),
+					NodeName:  ptr.To("node-1"),
 				},
 			},
 		},
@@ -865,41 +865,41 @@ func TestSyncService(t *testing.T) {
 			},
 			expectedEndpointPorts: []discovery.EndpointPort{
 				{
-					Name:     pointer.String("sctp-example"),
-					Protocol: protoPtr(v1.ProtocolSCTP),
-					Port:     pointer.Int32(3456),
+					Name:     ptr.To("sctp-example"),
+					Protocol: ptr.To(v1.ProtocolSCTP),
+					Port:     ptr.To[int32](3456),
 				},
 				{
-					Name:     pointer.String("udp-example"),
-					Protocol: protoPtr(v1.ProtocolUDP),
-					Port:     pointer.Int32(161),
+					Name:     ptr.To("udp-example"),
+					Protocol: ptr.To(v1.ProtocolUDP),
+					Port:     ptr.To[int32](161),
 				},
 				{
-					Name:     pointer.String("tcp-example"),
-					Protocol: protoPtr(v1.ProtocolTCP),
-					Port:     pointer.Int32(80),
+					Name:     ptr.To("tcp-example"),
+					Protocol: ptr.To(v1.ProtocolTCP),
+					Port:     ptr.To[int32](80),
 				},
 			},
 			expectedEndpoints: []discovery.Endpoint{
 				{
 					Conditions: discovery.EndpointConditions{
-						Ready:       pointer.Bool(true),
-						Serving:     pointer.Bool(true),
-						Terminating: pointer.Bool(false),
+						Ready:       ptr.To(true),
+						Serving:     ptr.To(true),
+						Terminating: ptr.To(false),
 					},
 					Addresses: []string{"10.0.0.1"},
 					TargetRef: &v1.ObjectReference{Kind: "Pod", Namespace: "default", Name: "pod0"},
-					NodeName:  pointer.String("node-1"),
+					NodeName:  ptr.To("node-1"),
 				},
 				{
 					Conditions: discovery.EndpointConditions{
-						Ready:       pointer.Bool(false),
-						Serving:     pointer.Bool(true),
-						Terminating: pointer.Bool(true),
+						Ready:       ptr.To(false),
+						Serving:     ptr.To(true),
+						Terminating: ptr.To(true),
 					},
 					Addresses: []string{"10.0.0.2"},
 					TargetRef: &v1.ObjectReference{Kind: "Pod", Namespace: "default", Name: "pod1"},
-					NodeName:  pointer.String("node-1"),
+					NodeName:  ptr.To("node-1"),
 				},
 			},
 		},
@@ -980,41 +980,41 @@ func TestSyncService(t *testing.T) {
 			},
 			expectedEndpointPorts: []discovery.EndpointPort{
 				{
-					Name:     pointer.String("sctp-example"),
-					Protocol: protoPtr(v1.ProtocolSCTP),
-					Port:     pointer.Int32(3456),
+					Name:     ptr.To("sctp-example"),
+					Protocol: ptr.To(v1.ProtocolSCTP),
+					Port:     ptr.To[int32](3456),
 				},
 				{
-					Name:     pointer.String("udp-example"),
-					Protocol: protoPtr(v1.ProtocolUDP),
-					Port:     pointer.Int32(161),
+					Name:     ptr.To("udp-example"),
+					Protocol: ptr.To(v1.ProtocolUDP),
+					Port:     ptr.To[int32](161),
 				},
 				{
-					Name:     pointer.String("tcp-example"),
-					Protocol: protoPtr(v1.ProtocolTCP),
-					Port:     pointer.Int32(80),
+					Name:     ptr.To("tcp-example"),
+					Protocol: ptr.To(v1.ProtocolTCP),
+					Port:     ptr.To[int32](80),
 				},
 			},
 			expectedEndpoints: []discovery.Endpoint{
 				{
 					Conditions: discovery.EndpointConditions{
-						Ready:       pointer.Bool(true),
-						Serving:     pointer.Bool(true),
-						Terminating: pointer.Bool(false),
+						Ready:       ptr.To(true),
+						Serving:     ptr.To(true),
+						Terminating: ptr.To(false),
 					},
 					Addresses: []string{"10.0.0.1"},
 					TargetRef: &v1.ObjectReference{Kind: "Pod", Namespace: "default", Name: "pod0"},
-					NodeName:  pointer.String("node-1"),
+					NodeName:  ptr.To("node-1"),
 				},
 				{
 					Conditions: discovery.EndpointConditions{
-						Ready:       pointer.Bool(false),
-						Serving:     pointer.Bool(false),
-						Terminating: pointer.Bool(true),
+						Ready:       ptr.To(false),
+						Serving:     ptr.To(false),
+						Terminating: ptr.To(true),
 					},
 					Addresses: []string{"10.0.0.2"},
 					TargetRef: &v1.ObjectReference{Kind: "Pod", Namespace: "default", Name: "pod1"},
-					NodeName:  pointer.String("node-1"),
+					NodeName:  ptr.To("node-1"),
 				},
 			},
 		},
@@ -1110,41 +1110,41 @@ func TestSyncService(t *testing.T) {
 			},
 			expectedEndpointPorts: []discovery.EndpointPort{
 				{
-					Name:     pointer.StringPtr("sctp-example"),
-					Protocol: protoPtr(v1.ProtocolSCTP),
-					Port:     pointer.Int32Ptr(int32(3456)),
+					Name:     ptr.To("sctp-example"),
+					Protocol: ptr.To(v1.ProtocolSCTP),
+					Port:     ptr.To[int32](3456),
 				},
 				{
-					Name:     pointer.StringPtr("udp-example"),
-					Protocol: protoPtr(v1.ProtocolUDP),
-					Port:     pointer.Int32Ptr(int32(161)),
+					Name:     ptr.To("udp-example"),
+					Protocol: ptr.To(v1.ProtocolUDP),
+					Port:     ptr.To[int32](161),
 				},
 				{
-					Name:     pointer.StringPtr("tcp-example"),
-					Protocol: protoPtr(v1.ProtocolTCP),
-					Port:     pointer.Int32Ptr(int32(80)),
+					Name:     ptr.To("tcp-example"),
+					Protocol: ptr.To(v1.ProtocolTCP),
+					Port:     ptr.To[int32](80),
 				},
 			},
 			expectedEndpoints: []discovery.Endpoint{
 				{
 					Conditions: discovery.EndpointConditions{
-						Ready:       pointer.BoolPtr(true),
-						Serving:     pointer.BoolPtr(true),
-						Terminating: pointer.BoolPtr(false),
+						Ready:       ptr.To(true),
+						Serving:     ptr.To(true),
+						Terminating: ptr.To(false),
 					},
 					Addresses: []string{"10.0.0.1"},
 					TargetRef: &v1.ObjectReference{Kind: "Pod", Namespace: "default", Name: "pod0"},
-					NodeName:  pointer.StringPtr("node-1"),
+					NodeName:  ptr.To("node-1"),
 				},
 				{
 					Conditions: discovery.EndpointConditions{
-						Ready:       pointer.BoolPtr(false),
-						Serving:     pointer.BoolPtr(false),
-						Terminating: pointer.BoolPtr(false),
+						Ready:       ptr.To(false),
+						Serving:     ptr.To(false),
+						Terminating: ptr.To(false),
 					},
 					Addresses: []string{"10.0.0.1"},
 					TargetRef: &v1.ObjectReference{Kind: "Pod", Namespace: "default", Name: "pod1"},
-					NodeName:  pointer.StringPtr("node-1"),
+					NodeName:  ptr.To("node-1"),
 				},
 			},
 		},
@@ -1242,41 +1242,41 @@ func TestSyncService(t *testing.T) {
 			},
 			expectedEndpointPorts: []discovery.EndpointPort{
 				{
-					Name:     pointer.StringPtr("sctp-example"),
-					Protocol: protoPtr(v1.ProtocolSCTP),
-					Port:     pointer.Int32Ptr(int32(3456)),
+					Name:     ptr.To("sctp-example"),
+					Protocol: ptr.To(v1.ProtocolSCTP),
+					Port:     ptr.To[int32](3456),
 				},
 				{
-					Name:     pointer.StringPtr("udp-example"),
-					Protocol: protoPtr(v1.ProtocolUDP),
-					Port:     pointer.Int32Ptr(int32(161)),
+					Name:     ptr.To("udp-example"),
+					Protocol: ptr.To(v1.ProtocolUDP),
+					Port:     ptr.To[int32](161),
 				},
 				{
-					Name:     pointer.StringPtr("tcp-example"),
-					Protocol: protoPtr(v1.ProtocolTCP),
-					Port:     pointer.Int32Ptr(int32(80)),
+					Name:     ptr.To("tcp-example"),
+					Protocol: ptr.To(v1.ProtocolTCP),
+					Port:     ptr.To[int32](80),
 				},
 			},
 			expectedEndpoints: []discovery.Endpoint{
 				{
 					Conditions: discovery.EndpointConditions{
-						Ready:       pointer.BoolPtr(true),
-						Serving:     pointer.BoolPtr(true),
-						Terminating: pointer.BoolPtr(false),
+						Ready:       ptr.To(true),
+						Serving:     ptr.To(true),
+						Terminating: ptr.To(false),
 					},
 					Addresses: []string{"10.0.0.1"},
 					TargetRef: &v1.ObjectReference{Kind: "Pod", Namespace: "default", Name: "pod0"},
-					NodeName:  pointer.StringPtr("node-1"),
+					NodeName:  ptr.To("node-1"),
 				},
 				{
 					Conditions: discovery.EndpointConditions{
-						Ready:       pointer.BoolPtr(true),
-						Serving:     pointer.BoolPtr(true),
-						Terminating: pointer.BoolPtr(false),
+						Ready:       ptr.To(true),
+						Serving:     ptr.To(true),
+						Terminating: ptr.To(false),
 					},
 					Addresses: []string{"10.0.0.1"},
 					TargetRef: &v1.ObjectReference{Kind: "Pod", Namespace: "default", Name: "pod1"},
-					NodeName:  pointer.StringPtr("node-1"),
+					NodeName:  ptr.To("node-1"),
 				},
 			},
 		},
@@ -1983,13 +1983,13 @@ func TestUpdateNode(t *testing.T) {
 				Endpoints: []discovery.Endpoint{
 					{
 						Addresses:  []string{"172.18.0.2"},
-						Zone:       pointer.String("zone-a"),
-						Conditions: discovery.EndpointConditions{Ready: pointer.Bool(true)},
+						Zone:       ptr.To("zone-a"),
+						Conditions: discovery.EndpointConditions{Ready: ptr.To(true)},
 					},
 					{
 						Addresses:  []string{"172.18.1.2"},
-						Zone:       pointer.String("zone-b"),
-						Conditions: discovery.EndpointConditions{Ready: pointer.Bool(true)},
+						Zone:       ptr.To("zone-b"),
+						Conditions: discovery.EndpointConditions{Ready: ptr.To(true)},
 					},
 				},
 				AddressType: discovery.AddressTypeIPv4,
@@ -2088,11 +2088,6 @@ func expectAction(t *testing.T, actions []k8stesting.Action, index int, verb, re
 	if action.GetResource().Resource != resource {
 		t.Errorf("Expected action %d resource to be %s, got %s", index, resource, action.GetResource().Resource)
 	}
-}
-
-// protoPtr takes a Protocol and returns a pointer to it.
-func protoPtr(proto v1.Protocol) *v1.Protocol {
-	return &proto
 }
 
 // cacheMutationCheck helps ensure that cached objects have not been changed

--- a/pkg/controller/job/job_controller_test.go
+++ b/pkg/controller/job/job_controller_test.go
@@ -3875,7 +3875,7 @@ func TestSyncJobWithJobSuccessPolicy(t *testing.T) {
 				Spec: batch.JobSpec{
 					Selector:       validSelector,
 					Template:       validTemplate,
-					CompletionMode: completionModePtr(batch.IndexedCompletion),
+					CompletionMode: ptr.To(batch.IndexedCompletion),
 					Parallelism:    ptr.To[int32](3),
 					Completions:    ptr.To[int32](3),
 					BackoffLimit:   ptr.To[int32](math.MaxInt32),
@@ -3924,7 +3924,7 @@ func TestSyncJobWithJobSuccessPolicy(t *testing.T) {
 				Spec: batch.JobSpec{
 					Selector:       validSelector,
 					Template:       validTemplate,
-					CompletionMode: completionModePtr(batch.IndexedCompletion),
+					CompletionMode: ptr.To(batch.IndexedCompletion),
 					Parallelism:    ptr.To[int32](3),
 					Completions:    ptr.To[int32](3),
 					BackoffLimit:   ptr.To[int32](math.MaxInt32),
@@ -3973,7 +3973,7 @@ func TestSyncJobWithJobSuccessPolicy(t *testing.T) {
 				Spec: batch.JobSpec{
 					Selector:       validSelector,
 					Template:       validTemplate,
-					CompletionMode: completionModePtr(batch.IndexedCompletion),
+					CompletionMode: ptr.To(batch.IndexedCompletion),
 					Parallelism:    ptr.To[int32](2),
 					Completions:    ptr.To[int32](2),
 					BackoffLimit:   ptr.To[int32](math.MaxInt32),
@@ -4031,7 +4031,7 @@ func TestSyncJobWithJobSuccessPolicy(t *testing.T) {
 				Spec: batch.JobSpec{
 					Selector:       validSelector,
 					Template:       validTemplate,
-					CompletionMode: completionModePtr(batch.IndexedCompletion),
+					CompletionMode: ptr.To(batch.IndexedCompletion),
 					Parallelism:    ptr.To[int32](2),
 					Completions:    ptr.To[int32](2),
 					BackoffLimit:   ptr.To[int32](math.MaxInt32),
@@ -4088,7 +4088,7 @@ func TestSyncJobWithJobSuccessPolicy(t *testing.T) {
 				Spec: batch.JobSpec{
 					Selector:             validSelector,
 					Template:             validTemplate,
-					CompletionMode:       completionModePtr(batch.IndexedCompletion),
+					CompletionMode:       ptr.To(batch.IndexedCompletion),
 					Parallelism:          ptr.To[int32](2),
 					Completions:          ptr.To[int32](2),
 					BackoffLimit:         ptr.To[int32](math.MaxInt32),
@@ -4138,7 +4138,7 @@ func TestSyncJobWithJobSuccessPolicy(t *testing.T) {
 				Spec: batch.JobSpec{
 					Selector:             validSelector,
 					Template:             validTemplate,
-					CompletionMode:       completionModePtr(batch.IndexedCompletion),
+					CompletionMode:       ptr.To(batch.IndexedCompletion),
 					Parallelism:          ptr.To[int32](2),
 					Completions:          ptr.To[int32](2),
 					BackoffLimit:         ptr.To[int32](math.MaxInt32),
@@ -4201,7 +4201,7 @@ func TestSyncJobWithJobSuccessPolicy(t *testing.T) {
 				Spec: batch.JobSpec{
 					Selector:             validSelector,
 					Template:             validTemplate,
-					CompletionMode:       completionModePtr(batch.IndexedCompletion),
+					CompletionMode:       ptr.To(batch.IndexedCompletion),
 					Parallelism:          ptr.To[int32](3),
 					Completions:          ptr.To[int32](3),
 					BackoffLimit:         ptr.To[int32](math.MaxInt32),
@@ -4262,7 +4262,7 @@ func TestSyncJobWithJobSuccessPolicy(t *testing.T) {
 				Spec: batch.JobSpec{
 					Selector:       validSelector,
 					Template:       validTemplate,
-					CompletionMode: completionModePtr(batch.IndexedCompletion),
+					CompletionMode: ptr.To(batch.IndexedCompletion),
 					Parallelism:    ptr.To[int32](2),
 					Completions:    ptr.To[int32](2),
 					BackoffLimit:   ptr.To[int32](math.MaxInt32),
@@ -4326,7 +4326,7 @@ func TestSyncJobWithJobSuccessPolicy(t *testing.T) {
 				Spec: batch.JobSpec{
 					Selector:             validSelector,
 					Template:             validTemplate,
-					CompletionMode:       completionModePtr(batch.IndexedCompletion),
+					CompletionMode:       ptr.To(batch.IndexedCompletion),
 					Parallelism:          ptr.To[int32](2),
 					Completions:          ptr.To[int32](2),
 					BackoffLimit:         ptr.To[int32](math.MaxInt32),
@@ -4369,7 +4369,7 @@ func TestSyncJobWithJobSuccessPolicy(t *testing.T) {
 				Spec: batch.JobSpec{
 					Selector:       validSelector,
 					Template:       validTemplate,
-					CompletionMode: completionModePtr(batch.IndexedCompletion),
+					CompletionMode: ptr.To(batch.IndexedCompletion),
 					Parallelism:    ptr.To[int32](2),
 					Completions:    ptr.To[int32](2),
 					BackoffLimit:   ptr.To[int32](1),
@@ -4412,7 +4412,7 @@ func TestSyncJobWithJobSuccessPolicy(t *testing.T) {
 				Spec: batch.JobSpec{
 					Selector:       validSelector,
 					Template:       validTemplate,
-					CompletionMode: completionModePtr(batch.IndexedCompletion),
+					CompletionMode: ptr.To(batch.IndexedCompletion),
 					Parallelism:    ptr.To[int32](2),
 					Completions:    ptr.To[int32](2),
 					BackoffLimit:   ptr.To[int32](math.MaxInt32),
@@ -4489,7 +4489,7 @@ func TestSyncJobWithJobSuccessPolicy(t *testing.T) {
 				Spec: batch.JobSpec{
 					Selector:             validSelector,
 					Template:             validTemplate,
-					CompletionMode:       completionModePtr(batch.IndexedCompletion),
+					CompletionMode:       ptr.To(batch.IndexedCompletion),
 					Parallelism:          ptr.To[int32](2),
 					Completions:          ptr.To[int32](2),
 					BackoffLimit:         ptr.To[int32](math.MaxInt32),
@@ -4552,7 +4552,7 @@ func TestSyncJobWithJobSuccessPolicy(t *testing.T) {
 				Spec: batch.JobSpec{
 					Selector:       validSelector,
 					Template:       validTemplate,
-					CompletionMode: completionModePtr(batch.IndexedCompletion),
+					CompletionMode: ptr.To(batch.IndexedCompletion),
 					Parallelism:    ptr.To[int32](2),
 					Completions:    ptr.To[int32](2),
 					BackoffLimit:   ptr.To[int32](1),
@@ -4615,7 +4615,7 @@ func TestSyncJobWithJobSuccessPolicy(t *testing.T) {
 				Spec: batch.JobSpec{
 					Selector:       validSelector,
 					Template:       validTemplate,
-					CompletionMode: completionModePtr(batch.IndexedCompletion),
+					CompletionMode: ptr.To(batch.IndexedCompletion),
 					Parallelism:    ptr.To[int32](2),
 					Completions:    ptr.To[int32](2),
 					BackoffLimit:   ptr.To[int32](math.MaxInt32),
@@ -4690,7 +4690,7 @@ func TestSyncJobWithJobSuccessPolicy(t *testing.T) {
 				Spec: batch.JobSpec{
 					Selector:       validSelector,
 					Template:       validTemplate,
-					CompletionMode: completionModePtr(batch.IndexedCompletion),
+					CompletionMode: ptr.To(batch.IndexedCompletion),
 					Parallelism:    ptr.To[int32](3),
 					Completions:    ptr.To[int32](3),
 					BackoffLimit:   ptr.To[int32](math.MaxInt32),
@@ -4804,7 +4804,7 @@ func TestSyncJobWithJobBackoffLimitPerIndex(t *testing.T) {
 					Parallelism:          ptr.To[int32](2),
 					Completions:          ptr.To[int32](2),
 					BackoffLimit:         ptr.To[int32](math.MaxInt32),
-					CompletionMode:       completionModePtr(batch.IndexedCompletion),
+					CompletionMode:       ptr.To(batch.IndexedCompletion),
 					BackoffLimitPerIndex: ptr.To[int32](1),
 				},
 			},
@@ -4839,7 +4839,7 @@ func TestSyncJobWithJobBackoffLimitPerIndex(t *testing.T) {
 					Parallelism:          ptr.To[int32](2),
 					Completions:          ptr.To[int32](2),
 					BackoffLimit:         ptr.To[int32](math.MaxInt32),
-					CompletionMode:       completionModePtr(batch.IndexedCompletion),
+					CompletionMode:       ptr.To(batch.IndexedCompletion),
 					BackoffLimitPerIndex: ptr.To[int32](1),
 				},
 			},
@@ -4864,7 +4864,7 @@ func TestSyncJobWithJobBackoffLimitPerIndex(t *testing.T) {
 					Parallelism:          ptr.To[int32](2),
 					Completions:          ptr.To[int32](2),
 					BackoffLimit:         ptr.To[int32](math.MaxInt32),
-					CompletionMode:       completionModePtr(batch.IndexedCompletion),
+					CompletionMode:       ptr.To(batch.IndexedCompletion),
 					BackoffLimitPerIndex: ptr.To[int32](1),
 				},
 			},
@@ -4891,7 +4891,7 @@ func TestSyncJobWithJobBackoffLimitPerIndex(t *testing.T) {
 					Parallelism:          ptr.To[int32](2),
 					Completions:          ptr.To[int32](2),
 					BackoffLimit:         ptr.To[int32](math.MaxInt32),
-					CompletionMode:       completionModePtr(batch.IndexedCompletion),
+					CompletionMode:       ptr.To(batch.IndexedCompletion),
 					BackoffLimitPerIndex: ptr.To[int32](1),
 				},
 			},
@@ -4918,7 +4918,7 @@ func TestSyncJobWithJobBackoffLimitPerIndex(t *testing.T) {
 					Parallelism:          ptr.To[int32](2),
 					Completions:          ptr.To[int32](2),
 					BackoffLimit:         ptr.To[int32](math.MaxInt32),
-					CompletionMode:       completionModePtr(batch.IndexedCompletion),
+					CompletionMode:       ptr.To(batch.IndexedCompletion),
 					BackoffLimitPerIndex: ptr.To[int32](1),
 					PodFailurePolicy: &batch.PodFailurePolicy{
 						Rules: []batch.PodFailurePolicyRule{
@@ -4967,7 +4967,7 @@ func TestSyncJobWithJobBackoffLimitPerIndex(t *testing.T) {
 					Parallelism:          ptr.To[int32](2),
 					Completions:          ptr.To[int32](2),
 					BackoffLimit:         ptr.To[int32](6),
-					CompletionMode:       completionModePtr(batch.IndexedCompletion),
+					CompletionMode:       ptr.To(batch.IndexedCompletion),
 					BackoffLimitPerIndex: ptr.To[int32](1),
 					PodFailurePolicy: &batch.PodFailurePolicy{
 						Rules: []batch.PodFailurePolicyRule{
@@ -5031,7 +5031,7 @@ func TestSyncJobWithJobBackoffLimitPerIndex(t *testing.T) {
 					Parallelism:          ptr.To[int32](2),
 					Completions:          ptr.To[int32](2),
 					BackoffLimit:         ptr.To[int32](6),
-					CompletionMode:       completionModePtr(batch.IndexedCompletion),
+					CompletionMode:       ptr.To(batch.IndexedCompletion),
 					BackoffLimitPerIndex: ptr.To[int32](1),
 					PodFailurePolicy: &batch.PodFailurePolicy{
 						Rules: []batch.PodFailurePolicyRule{
@@ -5080,7 +5080,7 @@ func TestSyncJobWithJobBackoffLimitPerIndex(t *testing.T) {
 					Parallelism:          ptr.To[int32](2),
 					Completions:          ptr.To[int32](2),
 					BackoffLimit:         ptr.To[int32](1),
-					CompletionMode:       completionModePtr(batch.IndexedCompletion),
+					CompletionMode:       ptr.To(batch.IndexedCompletion),
 					BackoffLimitPerIndex: ptr.To[int32](1),
 				},
 			},
@@ -5115,7 +5115,7 @@ func TestSyncJobWithJobBackoffLimitPerIndex(t *testing.T) {
 					Parallelism:          ptr.To[int32](2),
 					Completions:          ptr.To[int32](2),
 					BackoffLimit:         ptr.To[int32](math.MaxInt32),
-					CompletionMode:       completionModePtr(batch.IndexedCompletion),
+					CompletionMode:       ptr.To(batch.IndexedCompletion),
 					BackoffLimitPerIndex: ptr.To[int32](1),
 				},
 			},
@@ -5151,7 +5151,7 @@ func TestSyncJobWithJobBackoffLimitPerIndex(t *testing.T) {
 					Parallelism:          ptr.To[int32](4),
 					Completions:          ptr.To[int32](4),
 					BackoffLimit:         ptr.To[int32](math.MaxInt32),
-					CompletionMode:       completionModePtr(batch.IndexedCompletion),
+					CompletionMode:       ptr.To(batch.IndexedCompletion),
 					BackoffLimitPerIndex: ptr.To[int32](1),
 					MaxFailedIndexes:     ptr.To[int32](1),
 				},
@@ -5190,7 +5190,7 @@ func TestSyncJobWithJobBackoffLimitPerIndex(t *testing.T) {
 					Parallelism:          ptr.To[int32](3),
 					Completions:          ptr.To[int32](3),
 					BackoffLimit:         ptr.To[int32](math.MaxInt32),
-					CompletionMode:       completionModePtr(batch.IndexedCompletion),
+					CompletionMode:       ptr.To(batch.IndexedCompletion),
 					BackoffLimitPerIndex: ptr.To[int32](1),
 				},
 				Status: batch.JobStatus{
@@ -7223,10 +7223,6 @@ func (pb podBuilder) deletionTimestamp() podBuilder {
 func (pb podBuilder) customDeletionTimestamp(t time.Time) podBuilder {
 	pb.DeletionTimestamp = &metav1.Time{Time: t}
 	return pb
-}
-
-func completionModePtr(m batch.CompletionMode) *batch.CompletionMode {
-	return &m
 }
 
 func setDurationDuringTest(val *time.Duration, newVal time.Duration) func() {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The new k8s.io/utils/ptr package provides generic wrapper functions, which can be used instead of type-specific pointer wrapper functions. This replaces the latter with the former, and migrates other uses of the deprecated pointer package to ptr in affected files.

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
