### PR TITLE
client-go: add metric for waitingForQueue depth

### DIFF
--- a/staging/src/k8s.io/client-go/util/workqueue/delaying_queue_test.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/delaying_queue_test.go
@@ -38,8 +38,8 @@ func TestSimpleQueue(t *testing.T) {
 	if err := waitForWaitingQueueToFill(q); err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
-	if mp.waitingForDepth.getInc() != 1 {
-		t.Fatalf("expected %v, got %v", 1, mp.waitingForDepth.inc)
+	if val := mp.waitingForDepth.gaugeValue(); val != 1 {
+		t.Fatalf("expected %v, got %v", 1, val)
 	}
 
 	if q.Len() != 0 {
@@ -51,8 +51,8 @@ func TestSimpleQueue(t *testing.T) {
 	if err := waitForAdded(q, 1); err != nil {
 		t.Errorf("should have added")
 	}
-	if mp.waitingForDepth.getDec() != 1 {
-		t.Fatalf("expected %v, got %v", 1, mp.waitingForDepth.dec)
+	if val := mp.waitingForDepth.gaugeValue(); val != 0 {
+		t.Fatalf("expected %v, got %v", 0, val)
 	}
 	item, _ := q.Get()
 	q.Done(item)
@@ -91,8 +91,8 @@ func TestDeduping(t *testing.T) {
 	if err := waitForWaitingQueueToFill(q); err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
-	if mp.waitingForDepth.getInc() != 1 {
-		t.Fatalf("expected %v, got %v", 1, mp.waitingForDepth.inc)
+	if val := mp.waitingForDepth.gaugeValue(); val != 1 {
+		t.Fatalf("expected %v, got %v", 1, val)
 	}
 	if q.Len() != 0 {
 		t.Errorf("should not have added")
@@ -103,8 +103,8 @@ func TestDeduping(t *testing.T) {
 	if err := waitForAdded(q, 1); err != nil {
 		t.Errorf("should have added")
 	}
-	if mp.waitingForDepth.getDec() != 1 {
-		t.Fatalf("expected %v, got %v", 1, mp.waitingForDepth.dec)
+	if val := mp.waitingForDepth.gaugeValue(); val != 0 {
+		t.Fatalf("expected %v, got %v", 0, val)
 	}
 	item, _ := q.Get()
 	q.Done(item)
@@ -121,8 +121,8 @@ func TestDeduping(t *testing.T) {
 	if err := waitForWaitingQueueToFill(q); err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
-	if mp.waitingForDepth.getInc() != 2 {
-		t.Fatalf("expected %v, got %v", 2, mp.waitingForDepth.inc)
+	if val := mp.waitingForDepth.gaugeValue(); val != 1 {
+		t.Fatalf("expected %v, got %v", 1, val)
 	}
 	if q.Len() != 0 {
 		t.Errorf("should not have added")
@@ -132,8 +132,8 @@ func TestDeduping(t *testing.T) {
 	if err := waitForAdded(q, 1); err != nil {
 		t.Errorf("should have added")
 	}
-	if mp.waitingForDepth.getDec() != 2 {
-		t.Fatalf("expected %v, got %v", 2, mp.waitingForDepth.dec)
+	if val := mp.waitingForDepth.gaugeValue(); val != 0 {
+		t.Fatalf("expected %v, got %v", 0, val)
 	}
 	item, _ = q.Get()
 	q.Done(item)
@@ -159,8 +159,8 @@ func TestAddTwoFireEarly(t *testing.T) {
 	if err := waitForWaitingQueueToFill(q); err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
-	if mp.waitingForDepth.getInc() != 2 {
-		t.Fatalf("expected %v, got %v", 2, mp.waitingForDepth.inc)
+	if val := mp.waitingForDepth.gaugeValue(); val != 2 {
+		t.Fatalf("expected %v, got %v", 2, val)
 	}
 
 	if q.Len() != 0 {
@@ -172,8 +172,8 @@ func TestAddTwoFireEarly(t *testing.T) {
 	if err := waitForAdded(q, 1); err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
-	if mp.waitingForDepth.getDec() != 1 {
-		t.Fatalf("expected %v, got %v", 1, mp.waitingForDepth.dec)
+	if val := mp.waitingForDepth.gaugeValue(); val != 1 {
+		t.Fatalf("expected %v, got %v", 1, val)
 	}
 	item, _ := q.Get()
 	if !reflect.DeepEqual(item, second) {
@@ -186,11 +186,8 @@ func TestAddTwoFireEarly(t *testing.T) {
 	if err := waitForAdded(q, 1); err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
-	if mp.waitingForDepth.getInc() != 3 {
-		t.Fatalf("expected %v, got %v", 3, mp.waitingForDepth.inc)
-	}
-	if mp.waitingForDepth.getDec() != 2 {
-		t.Fatalf("expected %v, got %v", 2, mp.waitingForDepth.dec)
+	if val := mp.waitingForDepth.gaugeValue(); val != 1 {
+		t.Fatalf("expected %v, got %v", 1, val)
 	}
 	item, _ = q.Get()
 	if !reflect.DeepEqual(item, first) {
@@ -201,8 +198,8 @@ func TestAddTwoFireEarly(t *testing.T) {
 	if err := waitForAdded(q, 1); err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
-	if mp.waitingForDepth.getDec() != 3 {
-		t.Fatalf("expected %v, got %v", 3, mp.waitingForDepth.dec)
+	if val := mp.waitingForDepth.gaugeValue(); val != 0 {
+		t.Fatalf("expected %v, got %v", 3, val)
 	}
 	item, _ = q.Get()
 	if !reflect.DeepEqual(item, third) {
@@ -225,8 +222,8 @@ func TestCopyShifting(t *testing.T) {
 	if err := waitForWaitingQueueToFill(q); err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
-	if mp.waitingForDepth.getInc() != 3 {
-		t.Fatalf("expected %v, got %v", 3, mp.waitingForDepth.inc)
+	if val := mp.waitingForDepth.gaugeValue(); val != 3 {
+		t.Fatalf("expected %v, got %v", 3, val)
 	}
 
 	if q.Len() != 0 {
@@ -238,8 +235,8 @@ func TestCopyShifting(t *testing.T) {
 	if err := waitForAdded(q, 3); err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
-	if mp.waitingForDepth.getDec() != 3 {
-		t.Fatalf("expected %v, got %v", 3, mp.waitingForDepth.dec)
+	if val := mp.waitingForDepth.gaugeValue(); val != 0 {
+		t.Fatalf("expected %v, got %v", 0, val)
 	}
 	actualFirst, _ := q.Get()
 	if !reflect.DeepEqual(actualFirst, third) {

--- a/staging/src/k8s.io/client-go/util/workqueue/delaying_queue_test.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/delaying_queue_test.go
@@ -29,13 +29,17 @@ import (
 
 func TestSimpleQueue(t *testing.T) {
 	fakeClock := testingclock.NewFakeClock(time.Now())
-	q := NewDelayingQueueWithConfig(DelayingQueueConfig{Clock: fakeClock})
+	mp := &testMetricsProvider{}
+	q := NewDelayingQueueWithConfig(DelayingQueueConfig{Name: "test-simple", Clock: fakeClock, MetricsProvider: mp})
 
 	first := "foo"
 
 	q.AddAfter(first, 50*time.Millisecond)
 	if err := waitForWaitingQueueToFill(q); err != nil {
 		t.Fatalf("unexpected err: %v", err)
+	}
+	if mp.waitingForDepth.inc != 1 {
+		t.Fatalf("expected %v, got %v", 1, mp.waitingForDepth.inc)
 	}
 
 	if q.Len() != 0 {
@@ -46,6 +50,9 @@ func TestSimpleQueue(t *testing.T) {
 
 	if err := waitForAdded(q, 1); err != nil {
 		t.Errorf("should have added")
+	}
+	if mp.waitingForDepth.dec != 1 {
+		t.Fatalf("expected %v, got %v", 1, mp.waitingForDepth.dec)
 	}
 	item, _ := q.Get()
 	q.Done(item)
@@ -71,7 +78,8 @@ func TestSimpleQueue(t *testing.T) {
 
 func TestDeduping(t *testing.T) {
 	fakeClock := testingclock.NewFakeClock(time.Now())
-	q := NewDelayingQueueWithConfig(DelayingQueueConfig{Clock: fakeClock})
+	mp := &testMetricsProvider{}
+	q := NewDelayingQueueWithConfig(DelayingQueueConfig{Name: "test-dedupe", Clock: fakeClock, MetricsProvider: mp})
 
 	first := "foo"
 
@@ -83,6 +91,9 @@ func TestDeduping(t *testing.T) {
 	if err := waitForWaitingQueueToFill(q); err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
+	if mp.waitingForDepth.inc != 1 {
+		t.Fatalf("expected %v, got %v", 1, mp.waitingForDepth.inc)
+	}
 	if q.Len() != 0 {
 		t.Errorf("should not have added")
 	}
@@ -91,6 +102,9 @@ func TestDeduping(t *testing.T) {
 	fakeClock.Step(60 * time.Millisecond)
 	if err := waitForAdded(q, 1); err != nil {
 		t.Errorf("should have added")
+	}
+	if mp.waitingForDepth.dec != 1 {
+		t.Fatalf("expected %v, got %v", 1, mp.waitingForDepth.dec)
 	}
 	item, _ := q.Get()
 	q.Done(item)
@@ -107,6 +121,9 @@ func TestDeduping(t *testing.T) {
 	if err := waitForWaitingQueueToFill(q); err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
+	if mp.waitingForDepth.inc != 2 {
+		t.Fatalf("expected %v, got %v", 2, mp.waitingForDepth.inc)
+	}
 	if q.Len() != 0 {
 		t.Errorf("should not have added")
 	}
@@ -114,6 +131,9 @@ func TestDeduping(t *testing.T) {
 	fakeClock.Step(40 * time.Millisecond)
 	if err := waitForAdded(q, 1); err != nil {
 		t.Errorf("should have added")
+	}
+	if mp.waitingForDepth.dec != 2 {
+		t.Fatalf("expected %v, got %v", 2, mp.waitingForDepth.dec)
 	}
 	item, _ = q.Get()
 	q.Done(item)
@@ -127,7 +147,8 @@ func TestDeduping(t *testing.T) {
 
 func TestAddTwoFireEarly(t *testing.T) {
 	fakeClock := testingclock.NewFakeClock(time.Now())
-	q := NewDelayingQueueWithConfig(DelayingQueueConfig{Clock: fakeClock})
+	mp := &testMetricsProvider{}
+	q := NewDelayingQueueWithConfig(DelayingQueueConfig{Name: "test-addtwofireeearly", Clock: fakeClock, MetricsProvider: mp})
 
 	first := "foo"
 	second := "bar"
@@ -138,6 +159,9 @@ func TestAddTwoFireEarly(t *testing.T) {
 	if err := waitForWaitingQueueToFill(q); err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
+	if mp.waitingForDepth.inc != 2 {
+		t.Fatalf("expected %v, got %v", 2, mp.waitingForDepth.inc)
+	}
 
 	if q.Len() != 0 {
 		t.Errorf("should not have added")
@@ -147,6 +171,9 @@ func TestAddTwoFireEarly(t *testing.T) {
 
 	if err := waitForAdded(q, 1); err != nil {
 		t.Fatalf("unexpected err: %v", err)
+	}
+	if mp.waitingForDepth.dec != 1 {
+		t.Fatalf("expected %v, got %v", 1, mp.waitingForDepth.dec)
 	}
 	item, _ := q.Get()
 	if !reflect.DeepEqual(item, second) {
@@ -159,6 +186,12 @@ func TestAddTwoFireEarly(t *testing.T) {
 	if err := waitForAdded(q, 1); err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
+	if mp.waitingForDepth.inc != 3 {
+		t.Fatalf("expected %v, got %v", 3, mp.waitingForDepth.inc)
+	}
+	if mp.waitingForDepth.dec != 2 {
+		t.Fatalf("expected %v, got %v", 2, mp.waitingForDepth.dec)
+	}
 	item, _ = q.Get()
 	if !reflect.DeepEqual(item, first) {
 		t.Errorf("expected %v, got %v", first, item)
@@ -168,6 +201,9 @@ func TestAddTwoFireEarly(t *testing.T) {
 	if err := waitForAdded(q, 1); err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
+	if mp.waitingForDepth.dec != 3 {
+		t.Fatalf("expected %v, got %v", 3, mp.waitingForDepth.dec)
+	}
 	item, _ = q.Get()
 	if !reflect.DeepEqual(item, third) {
 		t.Errorf("expected %v, got %v", third, item)
@@ -176,7 +212,8 @@ func TestAddTwoFireEarly(t *testing.T) {
 
 func TestCopyShifting(t *testing.T) {
 	fakeClock := testingclock.NewFakeClock(time.Now())
-	q := NewDelayingQueueWithConfig(DelayingQueueConfig{Clock: fakeClock})
+	mp := &testMetricsProvider{}
+	q := NewDelayingQueueWithConfig(DelayingQueueConfig{Name: "test-copyshift", Clock: fakeClock, MetricsProvider: mp})
 
 	first := "foo"
 	second := "bar"
@@ -188,6 +225,9 @@ func TestCopyShifting(t *testing.T) {
 	if err := waitForWaitingQueueToFill(q); err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
+	if mp.waitingForDepth.inc != 3 {
+		t.Fatalf("expected %v, got %v", 3, mp.waitingForDepth.inc)
+	}
 
 	if q.Len() != 0 {
 		t.Errorf("should not have added")
@@ -197,6 +237,9 @@ func TestCopyShifting(t *testing.T) {
 
 	if err := waitForAdded(q, 3); err != nil {
 		t.Fatalf("unexpected err: %v", err)
+	}
+	if mp.waitingForDepth.dec != 3 {
+		t.Fatalf("expected %v, got %v", 3, mp.waitingForDepth.dec)
 	}
 	actualFirst, _ := q.Get()
 	if !reflect.DeepEqual(actualFirst, third) {

--- a/staging/src/k8s.io/client-go/util/workqueue/delaying_queue_test.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/delaying_queue_test.go
@@ -38,7 +38,7 @@ func TestSimpleQueue(t *testing.T) {
 	if err := waitForWaitingQueueToFill(q); err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
-	if mp.waitingForDepth.inc != 1 {
+	if mp.waitingForDepth.getInc() != 1 {
 		t.Fatalf("expected %v, got %v", 1, mp.waitingForDepth.inc)
 	}
 
@@ -51,7 +51,7 @@ func TestSimpleQueue(t *testing.T) {
 	if err := waitForAdded(q, 1); err != nil {
 		t.Errorf("should have added")
 	}
-	if mp.waitingForDepth.dec != 1 {
+	if mp.waitingForDepth.getDec() != 1 {
 		t.Fatalf("expected %v, got %v", 1, mp.waitingForDepth.dec)
 	}
 	item, _ := q.Get()
@@ -91,7 +91,7 @@ func TestDeduping(t *testing.T) {
 	if err := waitForWaitingQueueToFill(q); err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
-	if mp.waitingForDepth.inc != 1 {
+	if mp.waitingForDepth.getInc() != 1 {
 		t.Fatalf("expected %v, got %v", 1, mp.waitingForDepth.inc)
 	}
 	if q.Len() != 0 {
@@ -103,7 +103,7 @@ func TestDeduping(t *testing.T) {
 	if err := waitForAdded(q, 1); err != nil {
 		t.Errorf("should have added")
 	}
-	if mp.waitingForDepth.dec != 1 {
+	if mp.waitingForDepth.getDec() != 1 {
 		t.Fatalf("expected %v, got %v", 1, mp.waitingForDepth.dec)
 	}
 	item, _ := q.Get()
@@ -121,7 +121,7 @@ func TestDeduping(t *testing.T) {
 	if err := waitForWaitingQueueToFill(q); err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
-	if mp.waitingForDepth.inc != 2 {
+	if mp.waitingForDepth.getInc() != 2 {
 		t.Fatalf("expected %v, got %v", 2, mp.waitingForDepth.inc)
 	}
 	if q.Len() != 0 {
@@ -132,7 +132,7 @@ func TestDeduping(t *testing.T) {
 	if err := waitForAdded(q, 1); err != nil {
 		t.Errorf("should have added")
 	}
-	if mp.waitingForDepth.dec != 2 {
+	if mp.waitingForDepth.getDec() != 2 {
 		t.Fatalf("expected %v, got %v", 2, mp.waitingForDepth.dec)
 	}
 	item, _ = q.Get()
@@ -159,7 +159,7 @@ func TestAddTwoFireEarly(t *testing.T) {
 	if err := waitForWaitingQueueToFill(q); err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
-	if mp.waitingForDepth.inc != 2 {
+	if mp.waitingForDepth.getInc() != 2 {
 		t.Fatalf("expected %v, got %v", 2, mp.waitingForDepth.inc)
 	}
 
@@ -172,7 +172,7 @@ func TestAddTwoFireEarly(t *testing.T) {
 	if err := waitForAdded(q, 1); err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
-	if mp.waitingForDepth.dec != 1 {
+	if mp.waitingForDepth.getDec() != 1 {
 		t.Fatalf("expected %v, got %v", 1, mp.waitingForDepth.dec)
 	}
 	item, _ := q.Get()
@@ -186,10 +186,10 @@ func TestAddTwoFireEarly(t *testing.T) {
 	if err := waitForAdded(q, 1); err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
-	if mp.waitingForDepth.inc != 3 {
+	if mp.waitingForDepth.getInc() != 3 {
 		t.Fatalf("expected %v, got %v", 3, mp.waitingForDepth.inc)
 	}
-	if mp.waitingForDepth.dec != 2 {
+	if mp.waitingForDepth.getDec() != 2 {
 		t.Fatalf("expected %v, got %v", 2, mp.waitingForDepth.dec)
 	}
 	item, _ = q.Get()
@@ -201,7 +201,7 @@ func TestAddTwoFireEarly(t *testing.T) {
 	if err := waitForAdded(q, 1); err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
-	if mp.waitingForDepth.dec != 3 {
+	if mp.waitingForDepth.getDec() != 3 {
 		t.Fatalf("expected %v, got %v", 3, mp.waitingForDepth.dec)
 	}
 	item, _ = q.Get()
@@ -225,7 +225,7 @@ func TestCopyShifting(t *testing.T) {
 	if err := waitForWaitingQueueToFill(q); err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
-	if mp.waitingForDepth.inc != 3 {
+	if mp.waitingForDepth.getInc() != 3 {
 		t.Fatalf("expected %v, got %v", 3, mp.waitingForDepth.inc)
 	}
 
@@ -238,7 +238,7 @@ func TestCopyShifting(t *testing.T) {
 	if err := waitForAdded(q, 3); err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
-	if mp.waitingForDepth.dec != 3 {
+	if mp.waitingForDepth.getDec() != 3 {
 		t.Fatalf("expected %v, got %v", 3, mp.waitingForDepth.dec)
 	}
 	actualFirst, _ := q.Get()

--- a/staging/src/k8s.io/client-go/util/workqueue/metrics.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/metrics.go
@@ -156,13 +156,12 @@ func (m *defaultQueueMetrics) sinceInSeconds(start time.Time) float64 {
 type delayQueueMetrics interface {
 	retry()
 
-	addToWaitingForQueue()
-	removeFromWaitingForQueue()
+	setWaitingForQueueSize(n float64)
 }
 
 type defaultDelayQueueMetrics struct {
 	retries              CounterMetric
-	waitingForQueueDepth GaugeMetric
+	waitingForQueueDepth SettableGaugeMetric
 }
 
 func (m *defaultDelayQueueMetrics) retry() {
@@ -173,19 +172,11 @@ func (m *defaultDelayQueueMetrics) retry() {
 	m.retries.Inc()
 }
 
-func (m *defaultDelayQueueMetrics) addToWaitingForQueue() {
+func (m *defaultDelayQueueMetrics) setWaitingForQueueSize(n float64) {
 	if m == nil {
 		return
 	}
-	m.waitingForQueueDepth.Inc()
-}
-
-func (m *defaultDelayQueueMetrics) removeFromWaitingForQueue() {
-	if m == nil {
-		return
-	}
-
-	m.waitingForQueueDepth.Dec()
+	m.waitingForQueueDepth.Set(n)
 }
 
 // MetricsProvider generates various metrics used by the queue.
@@ -197,7 +188,7 @@ type MetricsProvider interface {
 	NewUnfinishedWorkSecondsMetric(name string) SettableGaugeMetric
 	NewLongestRunningProcessorSecondsMetric(name string) SettableGaugeMetric
 	NewRetriesMetric(name string) CounterMetric
-	NewWaitingForQueueDepthMetric(name string) GaugeMetric
+	NewWaitingForQueueDepthMetric(name string) SettableGaugeMetric
 }
 
 type noopMetricsProvider struct{}
@@ -230,7 +221,7 @@ func (_ noopMetricsProvider) NewRetriesMetric(name string) CounterMetric {
 	return noopMetric{}
 }
 
-func (noopMetricsProvider) NewWaitingForQueueDepthMetric(name string) GaugeMetric {
+func (noopMetricsProvider) NewWaitingForQueueDepthMetric(name string) SettableGaugeMetric {
 	return noopMetric{}
 }
 

--- a/staging/src/k8s.io/client-go/util/workqueue/metrics.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/metrics.go
@@ -230,7 +230,7 @@ func (_ noopMetricsProvider) NewRetriesMetric(name string) CounterMetric {
 	return noopMetric{}
 }
 
-func (_ noopMetricsProvider) NewWaitingForQueueDepthMetric(name string) GaugeMetric {
+func (noopMetricsProvider) NewWaitingForQueueDepthMetric(name string) GaugeMetric {
 	return noopMetric{}
 }
 

--- a/staging/src/k8s.io/client-go/util/workqueue/metrics_test.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/metrics_test.go
@@ -80,11 +80,23 @@ func (m *testMetric) Inc() {
 	m.notify()
 }
 
+func (m *testMetric) getInc() int64 {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	return m.inc
+}
+
 func (m *testMetric) Dec() {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 	m.dec++
 	m.notify()
+}
+
+func (m *testMetric) getDec() int64 {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	return m.dec
 }
 
 func (m *testMetric) Set(f float64) {

--- a/staging/src/k8s.io/client-go/util/workqueue/metrics_test.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/metrics_test.go
@@ -80,23 +80,11 @@ func (m *testMetric) Inc() {
 	m.notify()
 }
 
-func (m *testMetric) getInc() int64 {
-	m.lock.Lock()
-	defer m.lock.Unlock()
-	return m.inc
-}
-
 func (m *testMetric) Dec() {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 	m.dec++
 	m.notify()
-}
-
-func (m *testMetric) getDec() int64 {
-	m.lock.Lock()
-	defer m.lock.Unlock()
-	return m.dec
 }
 
 func (m *testMetric) Set(f float64) {
@@ -180,7 +168,7 @@ func (m *testMetricsProvider) NewRetriesMetric(name string) CounterMetric {
 	return &m.retries
 }
 
-func (m *testMetricsProvider) NewWaitingForQueueDepthMetric(name string) GaugeMetric {
+func (m *testMetricsProvider) NewWaitingForQueueDepthMetric(name string) SettableGaugeMetric {
 	return &m.waitingForDepth
 }
 

--- a/staging/src/k8s.io/client-go/util/workqueue/metrics_test.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/metrics_test.go
@@ -130,13 +130,14 @@ func (m *testMetric) notify() {
 }
 
 type testMetricsProvider struct {
-	depth      testMetric
-	adds       testMetric
-	latency    testMetric
-	duration   testMetric
-	unfinished testMetric
-	longest    testMetric
-	retries    testMetric
+	depth           testMetric
+	adds            testMetric
+	latency         testMetric
+	duration        testMetric
+	unfinished      testMetric
+	longest         testMetric
+	retries         testMetric
+	waitingForDepth testMetric
 }
 
 func (m *testMetricsProvider) NewDepthMetric(name string) GaugeMetric {
@@ -165,6 +166,10 @@ func (m *testMetricsProvider) NewLongestRunningProcessorSecondsMetric(name strin
 
 func (m *testMetricsProvider) NewRetriesMetric(name string) CounterMetric {
 	return &m.retries
+}
+
+func (m *testMetricsProvider) NewWaitingForQueueDepthMetric(name string) GaugeMetric {
+	return &m.waitingForDepth
 }
 
 func TestMetrics(t *testing.T) {

--- a/staging/src/k8s.io/client-go/util/workqueue/rate_limiting_queue_test.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/rate_limiting_queue_test.go
@@ -33,7 +33,7 @@ func TestRateLimitingQueue(t *testing.T) {
 		heartbeat:       fakeClock.NewTicker(maxWait),
 		stopCh:          make(chan struct{}),
 		waitingForAddCh: make(chan *waitFor, 1000),
-		metrics:         newRetryMetrics("", nil),
+		metrics:         newDelayQueueMetrics("", nil),
 	}
 	queue.TypedDelayingInterface = delayingQueue
 

--- a/staging/src/k8s.io/component-base/metrics/prometheus/workqueue/metrics.go
+++ b/staging/src/k8s.io/component-base/metrics/prometheus/workqueue/metrics.go
@@ -35,6 +35,7 @@ const (
 	UnfinishedWorkKey          = "unfinished_work_seconds"
 	LongestRunningProcessorKey = "longest_running_processor_seconds"
 	RetriesKey                 = "retries_total"
+	WaitingForQueueDepthKey    = "waitingfor_depth"
 )
 
 var (
@@ -93,8 +94,15 @@ var (
 		Help:           "Total number of retries handled by workqueue",
 	}, []string{"name"})
 
+	waitingForQueueDepth = k8smetrics.NewGaugeVec(&k8smetrics.GaugeOpts{
+		Subsystem:      WorkQueueSubsystem,
+		Name:           WaitingForQueueDepthKey,
+		StabilityLevel: k8smetrics.ALPHA,
+		Help:           "Current depth of the waiting-for queue",
+	}, []string{"name"})
+
 	metrics = []k8smetrics.Registerable{
-		depth, adds, latency, workDuration, unfinished, longestRunningProcessor, retries,
+		depth, adds, latency, workDuration, unfinished, longestRunningProcessor, retries, waitingForQueueDepth,
 	}
 )
 
@@ -134,4 +142,8 @@ func (prometheusMetricsProvider) NewLongestRunningProcessorSecondsMetric(name st
 
 func (prometheusMetricsProvider) NewRetriesMetric(name string) workqueue.CounterMetric {
 	return retries.WithLabelValues(name)
+}
+
+func (prometheusMetricsProvider) NewWaitingForQueueDepthMetric(name string) workqueue.GaugeMetric {
+	return waitingForQueueDepth.WithLabelValues(name)
 }

--- a/staging/src/k8s.io/component-base/metrics/prometheus/workqueue/metrics.go
+++ b/staging/src/k8s.io/component-base/metrics/prometheus/workqueue/metrics.go
@@ -144,6 +144,6 @@ func (prometheusMetricsProvider) NewRetriesMetric(name string) workqueue.Counter
 	return retries.WithLabelValues(name)
 }
 
-func (prometheusMetricsProvider) NewWaitingForQueueDepthMetric(name string) workqueue.GaugeMetric {
+func (prometheusMetricsProvider) NewWaitingForQueueDepthMetric(name string) workqueue.SettableGaugeMetric {
 	return waitingForQueueDepth.WithLabelValues(name)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

The workqueue package provides an abstraction for items to be added after a delay. This is done by maintaining a min heap, called the waitingForQueue that orders items by their delay time. A goroutine polls this heap and feeds the items which are ready to be worked on to the main queue.

This PR introduces a gauge metric for the waitingForQueue depth. While a metric already exists for the depth of the main queue, it doesn't provide observability to track how many items will be enqueued in the future. Adding this metric would help downstream users of the library, such as controller-runtime, with a large waitingForQueue depth and a low main queue depth help alert on long delays due to aggressive rate limiting.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added a metric in client-go's workqueue package to track the number of items waiting to be scheduled in future.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
