### PR TITLE
Remove the `JobReadyPods` feature flag

### DIFF
--- a/pkg/controller/job/job_controller.go
+++ b/pkg/controller/job/job_controller.go
@@ -827,10 +827,7 @@ func (jm *Controller) syncJob(ctx context.Context, key string) (rErr error) {
 	newSucceededPods, newFailedPods := getNewFinishedPods(jobCtx)
 	jobCtx.succeeded = job.Status.Succeeded + int32(len(newSucceededPods)) + int32(len(jobCtx.uncounted.succeeded))
 	jobCtx.failed = job.Status.Failed + int32(nonIgnoredFailedPodsCount(jobCtx, newFailedPods)) + int32(len(jobCtx.uncounted.failed))
-	var ready *int32
-	if feature.DefaultFeatureGate.Enabled(features.JobReadyPods) {
-		ready = ptr.To(countReadyPods(jobCtx.activePods))
-	}
+	ready := ptr.To(countReadyPods(jobCtx.activePods))
 
 	// Job first start. Set StartTime only if the job is not in the suspended state.
 	if job.Status.StartTime == nil && !jobSuspended(&job) {

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -345,13 +345,6 @@ const (
 	// based on the set of succeeded pods.
 	JobSuccessPolicy featuregate.Feature = "JobSuccessPolicy"
 
-	// owner: @alculquicondor
-	// alpha: v1.23
-	// beta: v1.24
-	//
-	// Track the number of pods with Ready condition in the Job status.
-	JobReadyPods featuregate.Feature = "JobReadyPods"
-
 	// owner: @marquiz
 	// kep: http://kep.k8s.io/4033
 	// alpha: v1.28
@@ -1040,8 +1033,6 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	JobPodReplacementPolicy: {Default: true, PreRelease: featuregate.Beta},
 
 	JobSuccessPolicy: {Default: false, PreRelease: featuregate.Alpha},
-
-	JobReadyPods: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.31
 
 	KubeletCgroupDriverFromCRI: {Default: false, PreRelease: featuregate.Alpha},
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

As depicted in the  [KEP-2879](https://github.com/kubernetes/enhancements/tree/master/keps/sig-apps/2879-ready-pods-job-status), the `JobReadyPods` feature flag will be considered deprecated in v1.31 (GA + 2). It graduated to GA in v1.29 (#121302).

This PR deprecates the flag according to the [Graduation Criteria](https://github.com/kubernetes/enhancements/tree/master/keps/sig-apps/2879-ready-pods-job-status#deprecation).




#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

Graduation Criteria from the [KEP](https://github.com/kubernetes/enhancements/tree/master/keps/sig-apps/2879-ready-pods-job-status#deprecation):

**Deprecation** 

In GA+2 release:

- [X] Remove the feature gate definition
- [X] Job controller ignores the feature gate


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
job-controller: the `JobReadyPods` feature flag has been removed (deprecated since v1.31)
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
[KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-apps/2879-ready-pods-job-status
```
