### PR TITLE
pkg/util/coverage: update fakeTestDeps methods

### DIFF
--- a/pkg/util/coverage/fake_test_deps.go
+++ b/pkg/util/coverage/fake_test_deps.go
@@ -105,3 +105,8 @@ func (fakeTestDeps) ResetCoverage() {}
 
 //nolint:unused // U1000 see comment above, we know it's unused normally.
 func (fakeTestDeps) SnapshotCoverage() {}
+
+//nolint:unused // U1000 see comment above, we know it's unused normally.
+func (fakeTestDeps) InitRuntimeCoverage() (mode string, tearDown func(string, string) (string, error), snapcov func() float64) {
+	return "", nil, nil
+}


### PR DESCRIPTION


#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Go 1.23 changed the signature of the testDeps interface so we need to add a blank implementation for InitRuntimeCoverage to fakeTestDeps.

#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes/kubernetes/issues/125170

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
