### PR TITLE
Move public key serviceaccount getter to interface, filter by key id

### DIFF
--- a/pkg/kubeapiserver/authenticator/config.go
+++ b/pkg/kubeapiserver/authenticator/config.go
@@ -62,7 +62,6 @@ type Config struct {
 	AuthenticationConfig        *apiserver.AuthenticationConfiguration
 	AuthenticationConfigData    string
 	OIDCSigningAlgs             []string
-	ServiceAccountKeyFiles      []string
 	ServiceAccountLookup        bool
 	ServiceAccountIssuers       []string
 	APIAudiences                authenticator.Audiences
@@ -79,7 +78,9 @@ type Config struct {
 
 	RequestHeaderConfig *authenticatorfactory.RequestHeaderConfig
 
-	// TODO, this is the only non-serializable part of the entire config.  Factor it out into a clientconfig
+	// ServiceAccountPublicKeysGetter returns public keys for verifying service account tokens.
+	ServiceAccountPublicKeysGetter serviceaccount.PublicKeysGetter
+	// ServiceAccountTokenGetter fetches API objects used to verify bound objects in service account token claims.
 	ServiceAccountTokenGetter   serviceaccount.ServiceAccountTokenGetter
 	SecretsWriter               typedv1core.SecretsGetter
 	BootstrapTokenAuthenticator authenticator.Token
@@ -127,15 +128,15 @@ func (config Config) New(serverLifecycle context.Context) (authenticator.Request
 		}
 		tokenAuthenticators = append(tokenAuthenticators, authenticator.WrapAudienceAgnosticToken(config.APIAudiences, tokenAuth))
 	}
-	if len(config.ServiceAccountKeyFiles) > 0 {
-		serviceAccountAuth, err := newLegacyServiceAccountAuthenticator(config.ServiceAccountKeyFiles, config.ServiceAccountLookup, config.APIAudiences, config.ServiceAccountTokenGetter, config.SecretsWriter)
+	if config.ServiceAccountPublicKeysGetter != nil {
+		serviceAccountAuth, err := newLegacyServiceAccountAuthenticator(config.ServiceAccountPublicKeysGetter, config.ServiceAccountLookup, config.APIAudiences, config.ServiceAccountTokenGetter, config.SecretsWriter)
 		if err != nil {
 			return nil, nil, nil, nil, err
 		}
 		tokenAuthenticators = append(tokenAuthenticators, serviceAccountAuth)
 	}
 	if len(config.ServiceAccountIssuers) > 0 {
-		serviceAccountAuth, err := newServiceAccountAuthenticator(config.ServiceAccountIssuers, config.ServiceAccountKeyFiles, config.APIAudiences, config.ServiceAccountTokenGetter)
+		serviceAccountAuth, err := newServiceAccountAuthenticator(config.ServiceAccountIssuers, config.ServiceAccountPublicKeysGetter, config.APIAudiences, config.ServiceAccountTokenGetter)
 		if err != nil {
 			return nil, nil, nil, nil, err
 		}
@@ -338,36 +339,25 @@ func newAuthenticatorFromTokenFile(tokenAuthFile string) (authenticator.Token, e
 }
 
 // newLegacyServiceAccountAuthenticator returns an authenticator.Token or an error
-func newLegacyServiceAccountAuthenticator(keyfiles []string, lookup bool, apiAudiences authenticator.Audiences, serviceAccountGetter serviceaccount.ServiceAccountTokenGetter, secretsWriter typedv1core.SecretsGetter) (authenticator.Token, error) {
-	allPublicKeys := []interface{}{}
-	for _, keyfile := range keyfiles {
-		publicKeys, err := keyutil.PublicKeysFromFile(keyfile)
-		if err != nil {
-			return nil, err
-		}
-		allPublicKeys = append(allPublicKeys, publicKeys...)
+func newLegacyServiceAccountAuthenticator(publicKeysGetter serviceaccount.PublicKeysGetter, lookup bool, apiAudiences authenticator.Audiences, serviceAccountGetter serviceaccount.ServiceAccountTokenGetter, secretsWriter typedv1core.SecretsGetter) (authenticator.Token, error) {
+	if publicKeysGetter == nil {
+		return nil, fmt.Errorf("no public key getter provided")
 	}
 	validator, err := serviceaccount.NewLegacyValidator(lookup, serviceAccountGetter, secretsWriter)
 	if err != nil {
 		return nil, fmt.Errorf("while creating legacy validator, err: %w", err)
 	}
 
-	tokenAuthenticator := serviceaccount.JWTTokenAuthenticator([]string{serviceaccount.LegacyIssuer}, allPublicKeys, apiAudiences, validator)
+	tokenAuthenticator := serviceaccount.JWTTokenAuthenticator([]string{serviceaccount.LegacyIssuer}, publicKeysGetter, apiAudiences, validator)
 	return tokenAuthenticator, nil
 }
 
 // newServiceAccountAuthenticator returns an authenticator.Token or an error
-func newServiceAccountAuthenticator(issuers []string, keyfiles []string, apiAudiences authenticator.Audiences, serviceAccountGetter serviceaccount.ServiceAccountTokenGetter) (authenticator.Token, error) {
-	allPublicKeys := []interface{}{}
-	for _, keyfile := range keyfiles {
-		publicKeys, err := keyutil.PublicKeysFromFile(keyfile)
-		if err != nil {
-			return nil, err
-		}
-		allPublicKeys = append(allPublicKeys, publicKeys...)
+func newServiceAccountAuthenticator(issuers []string, publicKeysGetter serviceaccount.PublicKeysGetter, apiAudiences authenticator.Audiences, serviceAccountGetter serviceaccount.ServiceAccountTokenGetter) (authenticator.Token, error) {
+	if publicKeysGetter == nil {
+		return nil, fmt.Errorf("no public key getter provided")
 	}
-
-	tokenAuthenticator := serviceaccount.JWTTokenAuthenticator(issuers, allPublicKeys, apiAudiences, serviceaccount.NewValidator(serviceAccountGetter))
+	tokenAuthenticator := serviceaccount.JWTTokenAuthenticator(issuers, publicKeysGetter, apiAudiences, serviceaccount.NewValidator(serviceAccountGetter))
 	return tokenAuthenticator, nil
 }
 

--- a/pkg/kubeapiserver/options/authentication.go
+++ b/pkg/kubeapiserver/options/authentication.go
@@ -47,6 +47,7 @@ import (
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	v1listers "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/util/keyutil"
 	cliflag "k8s.io/component-base/cli/flag"
 	"k8s.io/klog/v2"
 	openapicommon "k8s.io/kube-openapi/pkg/common"
@@ -54,6 +55,7 @@ import (
 	"k8s.io/kubernetes/pkg/features"
 	kubeauthenticator "k8s.io/kubernetes/pkg/kubeapiserver/authenticator"
 	authzmodes "k8s.io/kubernetes/pkg/kubeapiserver/authorizer/modes"
+	"k8s.io/kubernetes/pkg/serviceaccount"
 	"k8s.io/kubernetes/pkg/util/filesystem"
 	"k8s.io/kubernetes/plugin/pkg/auth/authenticator/token/bootstrap"
 	"k8s.io/utils/pointer"
@@ -559,7 +561,21 @@ func (o *BuiltInAuthenticationOptions) ToAuthenticationConfig() (kubeauthenticat
 		if len(o.ServiceAccounts.Issuers) != 0 && len(o.APIAudiences) == 0 {
 			ret.APIAudiences = authenticator.Audiences(o.ServiceAccounts.Issuers)
 		}
-		ret.ServiceAccountKeyFiles = o.ServiceAccounts.KeyFiles
+		if len(o.ServiceAccounts.KeyFiles) > 0 {
+			allPublicKeys := []interface{}{}
+			for _, keyfile := range o.ServiceAccounts.KeyFiles {
+				publicKeys, err := keyutil.PublicKeysFromFile(keyfile)
+				if err != nil {
+					return kubeauthenticator.Config{}, err
+				}
+				allPublicKeys = append(allPublicKeys, publicKeys...)
+			}
+			keysGetter, err := serviceaccount.StaticPublicKeysGetter(allPublicKeys)
+			if err != nil {
+				return kubeauthenticator.Config{}, fmt.Errorf("failed to set up public service account keys: %w", err)
+			}
+			ret.ServiceAccountPublicKeysGetter = keysGetter
+		}
 		ret.ServiceAccountIssuers = o.ServiceAccounts.Issuers
 		ret.ServiceAccountLookup = o.ServiceAccounts.Lookup
 	}

--- a/pkg/routes/openidmetadata.go
+++ b/pkg/routes/openidmetadata.go
@@ -17,6 +17,7 @@ limitations under the License.
 package routes
 
 import (
+	"fmt"
 	"net/http"
 
 	restful "github.com/emicklei/go-restful/v3"
@@ -34,7 +35,8 @@ const (
 	// cacheControl is the value of the Cache-Control header. Overrides the
 	// global `private, no-cache` setting.
 	headerCacheControl = "Cache-Control"
-	cacheControl       = "public, max-age=3600" // 1 hour
+
+	cacheControlTemplate = "public, max-age=%d"
 
 	// mimeJWKS is the content type of the keyset response
 	mimeJWKS = "application/jwk-set+json"
@@ -42,18 +44,14 @@ const (
 
 // OpenIDMetadataServer is an HTTP server for metadata of the KSA token issuer.
 type OpenIDMetadataServer struct {
-	configJSON []byte
-	keysetJSON []byte
+	provider serviceaccount.OpenIDMetadataProvider
 }
 
 // NewOpenIDMetadataServer creates a new OpenIDMetadataServer.
 // The issuer is the OIDC issuer; keys are the keys that may be used to sign
 // KSA tokens.
-func NewOpenIDMetadataServer(configJSON, keysetJSON []byte) *OpenIDMetadataServer {
-	return &OpenIDMetadataServer{
-		configJSON: configJSON,
-		keysetJSON: keysetJSON,
-	}
+func NewOpenIDMetadataServer(provider serviceaccount.OpenIDMetadataProvider) *OpenIDMetadataServer {
+	return &OpenIDMetadataServer{provider: provider}
 }
 
 // Install adds this server to the request router c.
@@ -95,19 +93,21 @@ func fromStandard(h http.HandlerFunc) restful.RouteFunction {
 }
 
 func (s *OpenIDMetadataServer) serveConfiguration(w http.ResponseWriter, req *http.Request) {
+	configJSON, maxAge := s.provider.GetConfigJSON()
 	w.Header().Set(restful.HEADER_ContentType, restful.MIME_JSON)
-	w.Header().Set(headerCacheControl, cacheControl)
-	if _, err := w.Write(s.configJSON); err != nil {
+	w.Header().Set(headerCacheControl, fmt.Sprintf(cacheControlTemplate, maxAge))
+	if _, err := w.Write(configJSON); err != nil {
 		klog.Errorf("failed to write service account issuer metadata response: %v", err)
 		return
 	}
 }
 
 func (s *OpenIDMetadataServer) serveKeys(w http.ResponseWriter, req *http.Request) {
+	keysetJSON, maxAge := s.provider.GetKeysetJSON()
 	// Per RFC7517 : https://tools.ietf.org/html/rfc7517#section-8.5.1
 	w.Header().Set(restful.HEADER_ContentType, mimeJWKS)
-	w.Header().Set(headerCacheControl, cacheControl)
-	if _, err := w.Write(s.keysetJSON); err != nil {
+	w.Header().Set(headerCacheControl, fmt.Sprintf(cacheControlTemplate, maxAge))
+	if _, err := w.Write(keysetJSON); err != nil {
 		klog.Errorf("failed to write service account issuer JWKS response: %v", err)
 		return
 	}

--- a/pkg/serviceaccount/keyid_test.go
+++ b/pkg/serviceaccount/keyid_test.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package serviceaccount
+
+import (
+	"testing"
+
+	"k8s.io/client-go/util/keyutil"
+)
+
+const rsaPublicKey = `-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA249XwEo9k4tM8fMxV7zx
+OhcrP+WvXn917koM5Qr2ZXs4vo26e4ytdlrV0bQ9SlcLpQVSYjIxNfhTZdDt+ecI
+zshKuv1gKIxbbLQMOuK1eA/4HALyEkFgmS/tleLJrhc65tKPMGD+pKQ/xhmzRuCG
+51RoiMgbQxaCyYxGfNLpLAZK9L0Tctv9a0mJmGIYnIOQM4kC1A1I1n3EsXMWmeJU
+j7OTh/AjjCnMnkgvKT2tpKxYQ59PgDgU8Ssc7RDSmSkLxnrv+OrN80j6xrw0OjEi
+B4Ycr0PqfzZcvy8efTtFQ/Jnc4Bp1zUtFXt7+QeevePtQ2EcyELXE0i63T1CujRM
+WwIDAQAB
+-----END PUBLIC KEY-----
+`
+
+func TestKeyIDStability(t *testing.T) {
+	keys, err := keyutil.ParsePublicKeysPEM([]byte(rsaPublicKey))
+	if err != nil {
+		t.Fatal(err)
+	}
+	keyID, err := keyIDFromPublicKey(keys[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The derived key id for a given public key must not change or validation of previously issued tokens will fail to find associated keys
+	if expected, actual := "JHJehTTTZlsspKHT-GaJxK7Kd1NQgZJu3fyK6K_QDYU", keyID; expected != actual {
+		t.Fatalf("expected stable key id %q, got %q", expected, actual)
+	}
+}

--- a/pkg/serviceaccount/openidmetadata_test.go
+++ b/pkg/serviceaccount/openidmetadata_test.go
@@ -39,7 +39,7 @@ const (
 	exampleIssuer = "https://issuer.example.com"
 )
 
-func setupServer(t *testing.T, iss string, keys []interface{}) (*httptest.Server, string) {
+func setupServer(t *testing.T, iss string, keys serviceaccount.PublicKeysGetter) (*httptest.Server, string) {
 	t.Helper()
 
 	c := restful.NewContainer()
@@ -53,13 +53,13 @@ func setupServer(t *testing.T, iss string, keys []interface{}) (*httptest.Server
 	jwksURI.Scheme = "https"
 	jwksURI.Path = serviceaccount.JWKSPath
 
-	md, err := serviceaccount.NewOpenIDMetadata(
+	md, err := serviceaccount.NewOpenIDMetadataProvider(
 		iss, jwksURI.String(), "", keys)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	srv := routes.NewOpenIDMetadataServer(md.ConfigJSON, md.PublicKeysetJSON)
+	srv := routes.NewOpenIDMetadataServer(md)
 	srv.Install(c)
 
 	return s, jwksURI.String()
@@ -77,20 +77,59 @@ type Configuration struct {
 	SubjectTypes  []string `json:"subject_types_supported"`
 }
 
+type proxyKeyGetter struct {
+	serviceaccount.PublicKeysGetter
+	listeners []serviceaccount.Listener
+}
+
+func (p *proxyKeyGetter) AddListener(listener serviceaccount.Listener) {
+	p.listeners = append(p.listeners, listener)
+	p.PublicKeysGetter.AddListener(listener)
+}
+
 func TestServeConfiguration(t *testing.T) {
-	s, jwksURI := setupServer(t, exampleIssuer, defaultKeys)
+	ecKeysGetter, err := serviceaccount.StaticPublicKeysGetter([]interface{}{getPublicKey(ecdsaPublicKey)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	rsaKeysGetter, err := serviceaccount.StaticPublicKeysGetter([]interface{}{getPublicKey(rsaPublicKey)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	keysGetter := &proxyKeyGetter{PublicKeysGetter: ecKeysGetter}
+	s, jwksURI := setupServer(t, exampleIssuer, keysGetter)
 	defer s.Close()
 
-	want := Configuration{
+	wantEC := Configuration{
 		Issuer:        exampleIssuer,
 		JWKSURI:       jwksURI,
 		ResponseTypes: []string{"id_token"},
 		SubjectTypes:  []string{"public"},
-		SigningAlgs:   []string{"ES256", "RS256"},
+		SigningAlgs:   []string{"ES256"},
 	}
-
+	wantRSA := Configuration{
+		Issuer:        exampleIssuer,
+		JWKSURI:       jwksURI,
+		ResponseTypes: []string{"id_token"},
+		SubjectTypes:  []string{"public"},
+		SigningAlgs:   []string{"RS256"},
+	}
 	reqURL := s.URL + "/.well-known/openid-configuration"
 
+	expectConfiguration(t, reqURL, wantEC)
+
+	// modify the underlying keys, expect the same response
+	keysGetter.PublicKeysGetter = rsaKeysGetter
+	expectConfiguration(t, reqURL, wantEC)
+
+	// notify the metadata the keys changed, expected a modified response
+	for _, listener := range keysGetter.listeners {
+		listener.Enqueue()
+	}
+	expectConfiguration(t, reqURL, wantRSA)
+}
+
+func expectConfiguration(t *testing.T, reqURL string, want Configuration) {
 	resp, err := http.Get(reqURL)
 	if err != nil {
 		t.Fatalf("Get(%s) = %v, %v want: <response>, <nil>", reqURL, resp, err)
@@ -185,47 +224,82 @@ func TestServeKeys(t *testing.T) {
 
 	for _, tt := range serveKeysTests {
 		t.Run(tt.Name, func(t *testing.T) {
-			s, _ := setupServer(t, exampleIssuer, tt.Keys)
+			initialKeysGetter, err := serviceaccount.StaticPublicKeysGetter(tt.Keys)
+			if err != nil {
+				t.Fatal(err)
+			}
+			updatedKeysGetter, err := serviceaccount.StaticPublicKeysGetter([]interface{}{wantPubRSA})
+			if err != nil {
+				t.Fatal(err)
+			}
+			keysGetter := &proxyKeyGetter{PublicKeysGetter: initialKeysGetter}
+			s, _ := setupServer(t, exampleIssuer, keysGetter)
 			defer s.Close()
 
 			reqURL := s.URL + "/openid/v1/jwks"
+			expectKeys(t, reqURL, tt.WantKeys)
 
-			resp, err := http.Get(reqURL)
-			if err != nil {
-				t.Fatalf("Get(%s) = %v, %v want: <response>, <nil>", reqURL, resp, err)
-			}
-			defer resp.Body.Close()
+			// modify the underlying keys, expect the same response
+			keysGetter.PublicKeysGetter = updatedKeysGetter
+			expectKeys(t, reqURL, tt.WantKeys)
 
-			if resp.StatusCode != http.StatusOK {
-				t.Errorf("Get(%s) = %v, _ want: %v, _", reqURL, resp.StatusCode, http.StatusOK)
+			// notify the metadata the keys changed, expected a modified response
+			for _, listener := range keysGetter.listeners {
+				listener.Enqueue()
 			}
-
-			if got, want := resp.Header.Get("Content-Type"), "application/jwk-set+json"; got != want {
-				t.Errorf("Get(%s) Content-Type = %q, _ want: %q, _", reqURL, got, want)
-			}
-			if got, want := resp.Header.Get("Cache-Control"), "public, max-age=3600"; got != want {
-				t.Errorf("Get(%s) Cache-Control = %q, _ want: %q, _", reqURL, got, want)
-			}
-
-			ks := &jose.JSONWebKeySet{}
-			if err := json.NewDecoder(resp.Body).Decode(ks); err != nil {
-				t.Fatalf("Decode(_) = %v, want: <nil>", err)
-			}
-
-			bigIntComparer := cmp.Comparer(
-				func(x, y *big.Int) bool {
-					return x.Cmp(y) == 0
-				})
-			if !cmp.Equal(tt.WantKeys, ks.Keys, bigIntComparer) {
-				t.Errorf("unexpected diff in JWKS keys (-want, +got): %v",
-					cmp.Diff(tt.WantKeys, ks.Keys, bigIntComparer))
-			}
+			expectKeys(t, reqURL, []jose.JSONWebKey{{
+				Algorithm:                   "RS256",
+				Key:                         wantPubRSA,
+				KeyID:                       rsaKeyID,
+				Use:                         "sig",
+				Certificates:                []*x509.Certificate{},
+				CertificateThumbprintSHA1:   []uint8{},
+				CertificateThumbprintSHA256: []uint8{},
+			}})
 		})
+	}
+}
+func expectKeys(t *testing.T, reqURL string, wantKeys []jose.JSONWebKey) {
+	resp, err := http.Get(reqURL)
+	if err != nil {
+		t.Fatalf("Get(%s) = %v, %v want: <response>, <nil>", reqURL, resp, err)
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("Get(%s) = %v, _ want: %v, _", reqURL, resp.StatusCode, http.StatusOK)
+	}
+
+	if got, want := resp.Header.Get("Content-Type"), "application/jwk-set+json"; got != want {
+		t.Errorf("Get(%s) Content-Type = %q, _ want: %q, _", reqURL, got, want)
+	}
+	if got, want := resp.Header.Get("Cache-Control"), "public, max-age=3600"; got != want {
+		t.Errorf("Get(%s) Cache-Control = %q, _ want: %q, _", reqURL, got, want)
+	}
+
+	ks := &jose.JSONWebKeySet{}
+	if err := json.NewDecoder(resp.Body).Decode(ks); err != nil {
+		t.Fatalf("Decode(_) = %v, want: <nil>", err)
+	}
+
+	bigIntComparer := cmp.Comparer(
+		func(x, y *big.Int) bool {
+			return x.Cmp(y) == 0
+		})
+	if !cmp.Equal(wantKeys, ks.Keys, bigIntComparer) {
+		t.Errorf("unexpected diff in JWKS keys (-want, +got): %v",
+			cmp.Diff(wantKeys, ks.Keys, bigIntComparer))
 	}
 }
 
 func TestURLBoundaries(t *testing.T) {
-	s, _ := setupServer(t, exampleIssuer, defaultKeys)
+	keysGetter, err := serviceaccount.StaticPublicKeysGetter(defaultKeys)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s, _ := setupServer(t, exampleIssuer, keysGetter)
 	defer s.Close()
 
 	for _, tt := range []struct {
@@ -380,7 +454,11 @@ func TestNewOpenIDMetadata(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			md, err := serviceaccount.NewOpenIDMetadata(tc.issuerURL, tc.jwksURI, tc.externalAddress, tc.keys)
+			keysGetter, err := serviceaccount.StaticPublicKeysGetter(tc.keys)
+			if err != nil {
+				t.Fatal(err)
+			}
+			md, err := serviceaccount.NewOpenIDMetadataProvider(tc.issuerURL, tc.jwksURI, tc.externalAddress, keysGetter)
 			if tc.err {
 				if err == nil {
 					t.Fatalf("got <nil>, want error")
@@ -390,13 +468,13 @@ func TestNewOpenIDMetadata(t *testing.T) {
 				t.Fatalf("got error %v, want <nil>", err)
 			}
 
-			config := string(md.ConfigJSON)
-			keyset := string(md.PublicKeysetJSON)
-			if config != tc.wantConfig {
-				t.Errorf("got metadata %s, want %s", config, tc.wantConfig)
+			config, _ := md.GetConfigJSON()
+			keyset, _ := md.GetKeysetJSON()
+			if string(config) != tc.wantConfig {
+				t.Errorf("got metadata %s, want %s", string(config), tc.wantConfig)
 			}
-			if keyset != tc.wantKeyset {
-				t.Errorf("got keyset %s, want %s", keyset, tc.wantKeyset)
+			if string(keyset) != tc.wantKeyset {
+				t.Errorf("got keyset %s, want %s", string(keyset), tc.wantKeyset)
 			}
 		})
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This moves the public key getter for service account token authentication to an interface.

This immediately addresses a long-standing TODO in the code to look up the public key by key id, if possible.

This also paves the way for two future improvements:
1. dynamic reloading of public key files
2. dynamic fetching of public keys from an external signer (https://github.com/kubernetes/enhancements/tree/master/keps/sig-auth/740-service-account-external-signing)

```release-note
NONE
```

/sig auth
/cc @enj
/cc @ahmedtd 