### PR TITLE
kubeadm: only add the klog flags that are still supported for kubeadm, rather than disabling the unwanted flags

### DIFF
--- a/cmd/kubeadm/app/kubeadm.go
+++ b/cmd/kubeadm/app/kubeadm.go
@@ -30,23 +30,18 @@ import (
 
 // Run creates and executes new kubeadm command
 func Run() error {
-	klog.InitFlags(nil)
+	var allFlags flag.FlagSet
+	klog.InitFlags(&allFlags)
+	// only add the flags that are still supported for kubeadm
+	allFlags.VisitAll(func(f *flag.Flag) {
+		switch f.Name {
+		case "v", "add_dir_header", "skip_headers":
+			flag.CommandLine.Var(f.Value, f.Name, f.Usage)
+		}
+	})
+
 	pflag.CommandLine.SetNormalizeFunc(cliflag.WordSepNormalizeFunc)
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
-
-	pflag.Set("logtostderr", "true")
-	// We do not want these flags to show up in --help
-	// These MarkHidden calls must be after the lines above
-	pflag.CommandLine.MarkHidden("alsologtostderr")
-	pflag.CommandLine.MarkHidden("log-backtrace-at")
-	pflag.CommandLine.MarkHidden("log-dir")
-	pflag.CommandLine.MarkHidden("logtostderr")
-	pflag.CommandLine.MarkHidden("log-file")          //nolint:errcheck
-	pflag.CommandLine.MarkHidden("log-file-max-size") //nolint:errcheck
-	pflag.CommandLine.MarkHidden("one-output")        //nolint:errcheck
-	pflag.CommandLine.MarkHidden("skip-log-headers")  //nolint:errcheck
-	pflag.CommandLine.MarkHidden("stderrthreshold")
-	pflag.CommandLine.MarkHidden("vmodule")
 
 	cmd := cmd.NewKubeadmCommand(os.Stdin, os.Stdout, os.Stderr)
 	return cmd.Execute()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Inspired by https://github.com/kubernetes/kubernetes/blob/bc8ec4f9aaaeee7de285c0207bd8eb793ecf3307/staging/src/k8s.io/component-base/logs/klogflags/klogflags.go#L25-L41 we can only add the `klog` flags that are still supported for kubeadm.

The other `klog` flags are already hidden, so they do not seem to be used. IMO, it is safe to make this change.

This prevents the unexpected introduction of some unwanted flags when the `klog` flags change.

Also, `logtostderr` flag is already defaulted to be `true`, https://github.com/kubernetes/kubernetes/blob/bc8ec4f9aaaeee7de285c0207bd8eb793ecf3307/vendor/k8s.io/klog/v2/klog.go#L424


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubeadm: only enable the klog flags that are still supported for kubeadm, rather than hiding the unwanted flags. This means that the previously unrecommended hidden flags about klog (including `--alsologtostderr`, `--log-backtrace-at`, `--log-dir`, `--logtostderr`, `--log-file`, `--log-file-max-size`, `--one-output`, `--skip-log-headers`, `--stderrthreshold` and `--vmodule`) are no longer allowed to be used.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
