### PR TITLE
Use broadcast broker for parallel image pulls

### DIFF
--- a/pkg/kubelet/container/testing/fake_runtime.go
+++ b/pkg/kubelet/container/testing/fake_runtime.go
@@ -68,7 +68,9 @@ type FakeRuntime struct {
 	// from container runtime.
 	BlockImagePulls      bool
 	imagePullTokenBucket chan bool
-	T                    TB
+	// Delay the image pulls by a certain amount of time.
+	DelayImagePulls time.Duration
+	T               TB
 }
 
 const FakeHost = "localhost:12345"
@@ -310,6 +312,9 @@ func (f *FakeRuntime) GetContainerLogs(_ context.Context, pod *v1.Pod, container
 
 func (f *FakeRuntime) PullImage(ctx context.Context, image kubecontainer.ImageSpec, pullSecrets []v1.Secret, podSandboxConfig *runtimeapi.PodSandboxConfig) (string, error) {
 	f.Lock()
+	if f.DelayImagePulls != 0 {
+		time.Sleep(f.DelayImagePulls)
+	}
 	f.CalledFunctions = append(f.CalledFunctions, "PullImage")
 	if f.Err == nil {
 		i := kubecontainer.Image{

--- a/pkg/kubelet/images/image_manager.go
+++ b/pkg/kubelet/images/image_manager.go
@@ -157,7 +157,7 @@ func (m *imageManager) EnsureImageExists(ctx context.Context, pod *v1.Pod, conta
 	m.logIt(ref, v1.EventTypeNormal, events.PullingImage, logPrefix, fmt.Sprintf("Pulling image %q", container.Image), klog.Info)
 	startTime := time.Now()
 	pullChan := make(chan pullResult)
-	m.puller.pullImage(ctx, spec, pullSecrets, pullChan, podSandboxConfig)
+	m.puller.pullImage(ctx, spec, pullSecrets, pullChan, podSandboxConfig, container.ImagePullPolicy)
 	imagePullResult := <-pullChan
 	if imagePullResult.err != nil {
 		m.logIt(ref, v1.EventTypeWarning, events.FailedToPullImage, logPrefix, fmt.Sprintf("Failed to pull image %q: %v", container.Image, imagePullResult.err), klog.Warning)

--- a/pkg/kubelet/images/image_manager_test.go
+++ b/pkg/kubelet/images/image_manager_test.go
@@ -238,7 +238,7 @@ func pullerTestEnv(t *testing.T, c pullerTestCase, serialized bool, maxParallelI
 	fakeClock = testingclock.NewFakeClock(time.Now())
 	backOff.Clock = fakeClock
 
-	fakeRuntime = &ctest.FakeRuntime{T: t}
+	fakeRuntime = &ctest.FakeRuntime{T: t, DelayImagePulls: time.Millisecond}
 	fakeRecorder := &record.FakeRecorder{}
 
 	fakeRuntime.ImageList = []Image{{ID: "present_image:latest"}}

--- a/pkg/kubelet/images/puller_test.go
+++ b/pkg/kubelet/images/puller_test.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package images
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
+	ctest "k8s.io/kubernetes/pkg/kubelet/container/testing"
+)
+
+func TestPullKey(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name     string
+		spec     kubecontainer.ImageSpec
+		expected string
+	}{
+		{
+			name: "image",
+			spec: kubecontainer.ImageSpec{
+				Image: "image",
+			},
+			expected: "image",
+		},
+		{
+			name: "image with runtime handler",
+			spec: kubecontainer.ImageSpec{
+				Image:          "image",
+				RuntimeHandler: "runtimeHandler",
+			},
+			expected: "image-runtimeHandler",
+		},
+		{
+			name: "image with runtime handler and annotations",
+			spec: kubecontainer.ImageSpec{
+				Image:          "image",
+				RuntimeHandler: "runtimeHandler",
+				Annotations: []kubecontainer.Annotation{
+					{Name: "name", Value: "value"},
+					{Name: "foo", Value: "bar"},
+				},
+			},
+			expected: "image-runtimeHandler-foo-bar-name-value",
+		},
+	} {
+		expected := tc.expected
+		spec := tc.spec
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			res := pullKey(spec)
+			require.Equal(t, expected, res)
+		})
+	}
+}
+
+func TestPullImageParallel(t *testing.T) {
+	const (
+		parallelPulls = 5
+		delay         = 10 * time.Millisecond
+	)
+	var (
+		maxParallelPulls int32 = parallelPulls
+		results          atomic.Uint32
+	)
+
+	fake := &ctest.FakeRuntime{T: t, DelayImagePulls: parallelPulls * delay}
+	p := newParallelImagePuller(fake, &maxParallelPulls)
+
+	for range parallelPulls {
+		resCh := make(chan pullResult)
+		p.pullImage(context.TODO(), kubecontainer.ImageSpec{Image: "image"}, nil, resCh, nil, v1.PullIfNotPresent)
+		go func() {
+			<-resCh
+			results.Add(1)
+		}()
+		time.Sleep(delay)
+	}
+	time.Sleep(delay)
+
+	fake.AssertCallCounts("PullImage", 1)
+	require.EqualValues(t, results.Load(), parallelPulls)
+}


### PR DESCRIPTION

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
The broker will limit the amount of ongoing parallel image pulls for the same image. This is being achieved using a broadcast channel to propagate the result to all subscribers when it's available.


#### Which issue(s) this PR fixes:
Fixes: https://github.com/kubernetes/kubernetes/issues/125164

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Limit the amount of maximum parallel CRI image pulls for a single image by reusing the pull result in a broadcast broker if `--serialize-image-pulls` / `serializeImagePulls` is set to `false` in the kubelet configuration.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
