### PR TITLE
Fix the field typo in statefulset patch operation

### DIFF
--- a/test/e2e/apps/statefulset.go
+++ b/test/e2e/apps/statefulset.go
@@ -987,7 +987,7 @@ var _ = SIGDescribe("StatefulSet", func() {
 					"replicas": ssPatchReplicas,
 					"template": map[string]interface{}{
 						"spec": map[string]interface{}{
-							"TerminationGracePeriodSeconds": &one,
+							"terminationGracePeriodSeconds": &one,
 							"containers": [1]map[string]interface{}{{
 								"name":  ssName,
 								"image": ssPatchImage,


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/sig testing
/sig apps

#### What this PR does / why we need it:
Noticed this while investigating https://github.com/kubernetes/kubernetes/issues/125195, I found this warning in the output:
```
W0529 00:20:43.564524   51739 warnings.go:70] unknown field "spec.template.spec.TerminationGracePeriodSeconds"
```

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
/assign @Atharva-Shinde 

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
