### PR TITLE
[WIP] Refactor FakeWatcher to be thread-safe & race-free

### DIFF
--- a/cmd/kube-proxy/app/server_linux_test.go
+++ b/cmd/kube-proxy/app/server_linux_test.go
@@ -569,6 +569,7 @@ func Test_waitForPodCIDR(t *testing.T) {
 		fakeWatch.Delete(oldNode)
 		// set the PodCIDRs on the new node
 		fakeWatch.Modify(updatedNode)
+		fakeWatch.Close()
 	}()
 	got, err := waitForPodCIDR(ctx, client, node.Name)
 	if err != nil {

--- a/pkg/controller/job/job_controller_test.go
+++ b/pkg/controller/job/job_controller_test.go
@@ -5522,6 +5522,7 @@ func TestWatchJobs(t *testing.T) {
 	_, ctx := ktesting.NewTestContext(t)
 	clientset := fake.NewSimpleClientset()
 	fakeWatch := watch.NewFake()
+	defer fakeWatch.Close()
 	clientset.PrependWatchReactor("jobs", core.DefaultWatchReactor(fakeWatch, nil))
 	manager, sharedInformerFactory := newControllerFromClient(ctx, t, clientset, controller.NoResyncPeriodFunc)
 	manager.podStoreSynced = alwaysReady
@@ -5568,6 +5569,7 @@ func TestWatchPods(t *testing.T) {
 	testJob := newJob(2, 2, 6, batch.NonIndexedCompletion)
 	clientset := fake.NewSimpleClientset(testJob)
 	fakeWatch := watch.NewFake()
+	defer fakeWatch.Close()
 	clientset.PrependWatchReactor("pods", core.DefaultWatchReactor(fakeWatch, nil))
 	manager, sharedInformerFactory := newControllerFromClient(ctx, t, clientset, controller.NoResyncPeriodFunc)
 	manager.podStoreSynced = alwaysReady

--- a/pkg/controller/podautoscaler/horizontal_test.go
+++ b/pkg/controller/podautoscaler/horizontal_test.go
@@ -500,6 +500,7 @@ func (tc *testCase) prepareTestClient(t *testing.T) (*fake.Clientset, *metricsfa
 	})
 
 	fakeWatch := watch.NewFake()
+	defer fakeWatch.Close()
 	fakeClient.AddWatchReactor("*", core.DefaultWatchReactor(fakeWatch, nil))
 
 	fakeMetricsClient := &metricsfake.Clientset{}

--- a/pkg/controller/replicaset/replica_set_test.go
+++ b/pkg/controller/replicaset/replica_set_test.go
@@ -623,6 +623,7 @@ func TestRelatedPodsLookup(t *testing.T) {
 func TestWatchControllers(t *testing.T) {
 
 	fakeWatch := watch.NewFake()
+	defer fakeWatch.Close()
 	client := fake.NewSimpleClientset()
 	client.PrependWatchReactor("replicasets", core.DefaultWatchReactor(fakeWatch, nil))
 	stopCh := make(chan struct{})
@@ -676,6 +677,7 @@ func TestWatchPods(t *testing.T) {
 	client := fake.NewSimpleClientset()
 
 	fakeWatch := watch.NewFake()
+	defer fakeWatch.Close()
 	client.PrependWatchReactor("pods", core.DefaultWatchReactor(fakeWatch, nil))
 
 	stopCh := make(chan struct{})

--- a/pkg/controller/testutil/test_utils.go
+++ b/pkg/controller/testutil/test_utils.go
@@ -281,6 +281,7 @@ func (m *FakeNodeHandler) PatchStatus(ctx context.Context, nodeName string, data
 
 // Watch watches Nodes in a fake store.
 func (m *FakeNodeHandler) Watch(_ context.Context, opts metav1.ListOptions) (watch.Interface, error) {
+	// TODO: fakeWatch.Close()
 	return watch.NewFake(), nil
 }
 

--- a/pkg/controller/volume/attachdetach/testing/testvolumespec.go
+++ b/pkg/controller/volume/attachdetach/testing/testvolumespec.go
@@ -200,6 +200,7 @@ func CreateTestClient() *fake.Clientset {
 	})
 
 	fakeWatch := watch.NewFake()
+	// TODO: fakeWatch.Close()
 	fakeClient.AddWatchReactor("*", core.DefaultWatchReactor(fakeWatch, nil))
 
 	return fakeClient

--- a/pkg/kubelet/certificate/bootstrap/bootstrap_test.go
+++ b/pkg/kubelet/certificate/bootstrap/bootstrap_test.go
@@ -435,9 +435,12 @@ func newClientset(opts fakeClient) *fake.Clientset {
 		f.PrependWatchReactor("certificatesigningrequests", func(action clienttesting.Action) (handled bool, ret watch.Interface, err error) {
 			switch action.GetResource().Version {
 			case "v1":
-				w := watch.NewFakeWithChanSize(1, false)
-				w.Add(opts.generateCSR())
-				w.Stop()
+				w := watch.NewFake()
+				go func() {
+					defer w.Close()
+					w.Add(opts.generateCSR())
+					<-w.StopChan()
+				}()
 				return true, w, nil
 
 			default:

--- a/pkg/kubelet/config/apiserver_test.go
+++ b/pkg/kubelet/config/apiserver_test.go
@@ -19,7 +19,7 @@ package config
 import (
 	"testing"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -56,6 +56,7 @@ func TestNewSourceApiserver_UpdatesAndMultiplePods(t *testing.T) {
 
 	// Setup fake api client.
 	fakeWatch := watch.NewFake()
+	defer fakeWatch.Close()
 	lw := fakePodLW{
 		listResp:  &v1.PodList{Items: []v1.Pod{*pod1v1}},
 		watchResp: fakeWatch,
@@ -139,6 +140,7 @@ func TestNewSourceApiserver_TwoNamespacesSameName(t *testing.T) {
 
 	// Setup fake api client.
 	fakeWatch := watch.NewFake()
+	defer fakeWatch.Close()
 	lw := fakePodLW{
 		listResp:  &v1.PodList{Items: []v1.Pod{pod1, pod2}},
 		watchResp: fakeWatch,
@@ -173,6 +175,7 @@ func TestNewSourceApiserver_TwoNamespacesSameName(t *testing.T) {
 func TestNewSourceApiserverInitialEmptySendsEmptyPodUpdate(t *testing.T) {
 	// Setup fake api client.
 	fakeWatch := watch.NewFake()
+	defer fakeWatch.Close()
 	lw := fakePodLW{
 		listResp:  &v1.PodList{Items: []v1.Pod{}},
 		watchResp: fakeWatch,

--- a/pkg/kubelet/util/manager/watch_based_manager_test.go
+++ b/pkg/kubelet/util/manager/watch_based_manager_test.go
@@ -89,6 +89,7 @@ func TestSecretCache(t *testing.T) {
 	}
 	fakeClient.AddReactor("list", "secrets", listReactor)
 	fakeWatch := watch.NewFake()
+	defer fakeWatch.Close()
 	fakeClient.AddWatchReactor("secrets", core.DefaultWatchReactor(fakeWatch, nil))
 
 	fakeClock := testingclock.NewFakeClock(time.Now())
@@ -159,6 +160,7 @@ func TestSecretCacheMultipleRegistrations(t *testing.T) {
 	}
 	fakeClient.AddReactor("list", "secrets", listReactor)
 	fakeWatch := watch.NewFake()
+	defer fakeWatch.Close()
 	fakeClient.AddWatchReactor("secrets", core.DefaultWatchReactor(fakeWatch, nil))
 
 	fakeClock := testingclock.NewFakeClock(time.Now())
@@ -265,6 +267,7 @@ func TestImmutableSecretStopsTheReflector(t *testing.T) {
 			}
 			fakeClient.AddReactor("list", "secrets", listReactor)
 			fakeWatch := watch.NewFake()
+			defer fakeWatch.Close()
 			fakeClient.AddWatchReactor("secrets", core.DefaultWatchReactor(fakeWatch, nil))
 
 			fakeClock := testingclock.NewFakeClock(time.Now())
@@ -353,6 +356,7 @@ func TestMaxIdleTimeStopsTheReflector(t *testing.T) {
 
 	fakeClient.AddReactor("list", "secrets", listReactor)
 	fakeWatch := watch.NewFake()
+	defer fakeWatch.Close()
 	fakeClient.AddWatchReactor("secrets", core.DefaultWatchReactor(fakeWatch, nil))
 	fakeClock := testingclock.NewFakeClock(time.Now())
 	store := newSecretCache(fakeClient, fakeClock, time.Minute)
@@ -436,6 +440,7 @@ func TestReflectorNotStoppedOnSlowInitialization(t *testing.T) {
 
 	fakeClient.AddReactor("list", "secrets", listReactor)
 	fakeWatch := watch.NewFake()
+	defer fakeWatch.Close()
 	fakeClient.AddWatchReactor("secrets", core.DefaultWatchReactor(fakeWatch, nil))
 	store := newSecretCache(fakeClient, fakeClock, time.Minute)
 
@@ -591,6 +596,7 @@ func TestRefMapHandlesReferencesCorrectly(t *testing.T) {
 			}
 			fakeClient.AddReactor("list", "secrets", listReactor)
 			fakeWatch := watch.NewFake()
+			defer fakeWatch.Close()
 			fakeClient.AddWatchReactor("secrets", core.DefaultWatchReactor(fakeWatch, nil))
 			fakeClock := testingclock.NewFakeClock(time.Now())
 			store := newSecretCache(fakeClient, fakeClock, time.Minute)

--- a/pkg/proxy/config/api_test.go
+++ b/pkg/proxy/config/api_test.go
@@ -49,6 +49,7 @@ func TestNewServicesSourceApi_UpdatesAndMultipleServices(t *testing.T) {
 	// Setup fake api client.
 	client := fake.NewSimpleClientset()
 	fakeWatch := watch.NewFake()
+	defer fakeWatch.Close()
 	client.PrependWatchReactor("services", ktesting.DefaultWatchReactor(fakeWatch, nil))
 
 	stopCh := make(chan struct{})
@@ -130,6 +131,7 @@ func TestNewEndpointsSourceApi_UpdatesAndMultipleEndpoints(t *testing.T) {
 	// Setup fake api client.
 	client := fake.NewSimpleClientset()
 	fakeWatch := watch.NewFake()
+	defer fakeWatch.Close()
 	client.PrependWatchReactor("endpointslices", ktesting.DefaultWatchReactor(fakeWatch, nil))
 
 	stopCh := make(chan struct{})

--- a/pkg/proxy/config/config_test.go
+++ b/pkg/proxy/config/config_test.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -230,6 +230,7 @@ func TestNewServiceAddedAndNotified(t *testing.T) {
 	_, ctx := klogtesting.NewTestContext(t)
 	client := fake.NewSimpleClientset()
 	fakeWatch := watch.NewFake()
+	defer fakeWatch.Close()
 	client.PrependWatchReactor("services", ktesting.DefaultWatchReactor(fakeWatch, nil))
 
 	stopCh := make(chan struct{})
@@ -255,6 +256,7 @@ func TestServiceAddedRemovedSetAndNotified(t *testing.T) {
 	_, ctx := klogtesting.NewTestContext(t)
 	client := fake.NewSimpleClientset()
 	fakeWatch := watch.NewFake()
+	defer fakeWatch.Close()
 	client.PrependWatchReactor("services", ktesting.DefaultWatchReactor(fakeWatch, nil))
 
 	stopCh := make(chan struct{})
@@ -292,6 +294,7 @@ func TestNewServicesMultipleHandlersAddedAndNotified(t *testing.T) {
 	_, ctx := klogtesting.NewTestContext(t)
 	client := fake.NewSimpleClientset()
 	fakeWatch := watch.NewFake()
+	defer fakeWatch.Close()
 	client.PrependWatchReactor("services", ktesting.DefaultWatchReactor(fakeWatch, nil))
 
 	stopCh := make(chan struct{})
@@ -327,6 +330,7 @@ func TestNewEndpointsMultipleHandlersAddedAndNotified(t *testing.T) {
 	_, ctx := klogtesting.NewTestContext(t)
 	client := fake.NewSimpleClientset()
 	fakeWatch := watch.NewFake()
+	defer fakeWatch.Close()
 	client.PrependWatchReactor("endpointslices", ktesting.DefaultWatchReactor(fakeWatch, nil))
 
 	stopCh := make(chan struct{})
@@ -374,6 +378,7 @@ func TestNewEndpointsMultipleHandlersAddRemoveSetAndNotified(t *testing.T) {
 	_, ctx := klogtesting.NewTestContext(t)
 	client := fake.NewSimpleClientset()
 	fakeWatch := watch.NewFake()
+	defer fakeWatch.Close()
 	client.PrependWatchReactor("endpointslices", ktesting.DefaultWatchReactor(fakeWatch, nil))
 
 	stopCh := make(chan struct{})

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/negotiate.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/negotiate.go
@@ -48,7 +48,7 @@ func (n *clientNegotiator) Encoder(contentType string, params map[string]string)
 	info, ok := SerializerInfoForMediaType(mediaTypes, contentType)
 	if !ok {
 		if len(contentType) != 0 || len(mediaTypes) == 0 {
-			return nil, NegotiateError{ContentType: contentType}
+			return nil, fmt.Errorf("encoding: %w", NegotiateError{ContentType: contentType})
 		}
 		info = mediaTypes[0]
 	}
@@ -60,7 +60,7 @@ func (n *clientNegotiator) Decoder(contentType string, params map[string]string)
 	info, ok := SerializerInfoForMediaType(mediaTypes, contentType)
 	if !ok {
 		if len(contentType) != 0 || len(mediaTypes) == 0 {
-			return nil, NegotiateError{ContentType: contentType}
+			return nil, fmt.Errorf("decoding: %w", NegotiateError{ContentType: contentType})
 		}
 		info = mediaTypes[0]
 	}
@@ -72,12 +72,12 @@ func (n *clientNegotiator) StreamDecoder(contentType string, params map[string]s
 	info, ok := SerializerInfoForMediaType(mediaTypes, contentType)
 	if !ok {
 		if len(contentType) != 0 || len(mediaTypes) == 0 {
-			return nil, nil, nil, NegotiateError{ContentType: contentType, Stream: true}
+			return nil, nil, nil, fmt.Errorf("stream decoding: %w", NegotiateError{ContentType: contentType, Stream: true})
 		}
 		info = mediaTypes[0]
 	}
 	if info.StreamSerializer == nil {
-		return nil, nil, nil, NegotiateError{ContentType: info.MediaType, Stream: true}
+		return nil, nil, nil, fmt.Errorf("stream decoding: %w", NegotiateError{ContentType: info.MediaType, Stream: true})
 	}
 	return n.serializer.DecoderToVersion(info.Serializer, n.decode), info.StreamSerializer.Serializer, info.StreamSerializer.Framer, nil
 }

--- a/staging/src/k8s.io/apimachinery/pkg/watch/watch.go
+++ b/staging/src/k8s.io/apimachinery/pkg/watch/watch.go
@@ -114,6 +114,7 @@ func (f *FakeWatcher) Stop() {
 	defer f.Unlock()
 	if !f.stopped {
 		klog.V(4).Infof("Stopping fake watcher.")
+		// TODO: make the producer close the result channel after confirming that cleanup is complete
 		close(f.result)
 		f.stopped = true
 	}
@@ -321,4 +322,22 @@ func (pw *ProxyWatcher) ResultChan() <-chan Event {
 // StopChan returns stop channel
 func (pw *ProxyWatcher) StopChan() <-chan struct{} {
 	return pw.stopCh
+}
+
+// MockWatcher implements watch.Interface with mockable functions.
+type MockWatcher struct {
+	StopFunc       func()
+	ResultChanFunc func() <-chan Event
+}
+
+var _ Interface = &MockWatcher{}
+
+// Stop calls StopFunc
+func (mw MockWatcher) Stop() {
+	mw.StopFunc()
+}
+
+// ResultChan calls ResultChanFunc
+func (mw MockWatcher) ResultChan() <-chan Event {
+	return mw.ResultChanFunc()
 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
@@ -675,19 +675,24 @@ func TestCacherDontMissEventsOnReinitialization(t *testing.T) {
 			var err error
 			switch watchCalls {
 			case 0:
-				w = watch.NewFakeWithChanSize(10, false)
-				for i := 2; i < 8; i++ {
-					w.Add(makePod(i))
-				}
-				// Emit an error to force relisting.
-				w.Error(nil)
-				w.Stop()
+				w = watch.NewFake()
+				go func() {
+					defer w.Close()
+					for i := 2; i < 8; i++ {
+						w.Add(makePod(i))
+					}
+					// Emit an error to force relisting.
+					w.Error(nil)
+				}()
 			case 1:
-				w = watch.NewFakeWithChanSize(10, false)
-				for i := 12; i < 18; i++ {
-					w.Add(makePod(i))
-				}
-				w.Stop()
+				w = watch.NewFake()
+				go func() {
+					defer w.Close()
+					for i := 12; i < 18; i++ {
+						w.Add(makePod(i))
+					}
+					<-w.StopChan()
+				}()
 			default:
 				err = fmt.Errorf("unexpected watch call")
 			}

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache_test.go
@@ -18,6 +18,7 @@ package cacher
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -26,7 +27,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
@@ -287,7 +288,8 @@ func TestEvents(t *testing.T) {
 		if err == nil {
 			t.Errorf("expected error too old")
 		}
-		if _, ok := err.(*errors.StatusError); !ok {
+		var statusErr *apierrors.StatusError
+		if !errors.As(err, &statusErr) {
 			t.Errorf("expected error to be of type StatusError")
 		}
 	}
@@ -626,7 +628,7 @@ func TestWaitUntilFreshAndListTimeout(t *testing.T) {
 			}()
 
 			_, _, _, err := store.WaitUntilFreshAndList(ctx, 4, nil)
-			if !errors.IsTimeout(err) {
+			if !apierrors.IsTimeout(err) {
 				t.Errorf("expected timeout error but got: %v", err)
 			}
 			if !storage.IsTooLargeResourceVersion(err) {

--- a/staging/src/k8s.io/client-go/rest/request.go
+++ b/staging/src/k8s.io/client-go/rest/request.go
@@ -865,11 +865,13 @@ func (r *Request) handleWatchList(ctx context.Context, w watch.Interface) WatchL
 	var lastKey string
 	var items []runtime.Object
 
+	doneCh := ctx.Done()
+	resultCh := w.ResultChan()
 	for {
 		select {
-		case <-ctx.Done():
+		case <-doneCh:
 			return WatchListResult{err: ctx.Err()}
-		case event, ok := <-w.ResultChan():
+		case event, ok := <-resultCh:
 			if !ok {
 				return WatchListResult{err: fmt.Errorf("unexpected watch close")}
 			}

--- a/staging/src/k8s.io/client-go/tools/cache/reflector.go
+++ b/staging/src/k8s.io/client-go/tools/cache/reflector.go
@@ -346,15 +346,18 @@ func (r *Reflector) ListAndWatch(stopCh <-chan struct{}) error {
 
 	if useWatchList {
 		w, err = r.watchList(stopCh)
-		if w == nil && err == nil {
-			// stopCh was closed
-			return nil
-		}
-		if err != nil {
+		switch {
+		case err != nil:
 			klog.Warningf("The watchlist request ended with an error, falling back to the standard LIST/WATCH semantics because making progress is better than deadlocking, err = %v", err)
 			fallbackToList = true
 			// ensure that we won't accidentally pass some garbage down the watch.
 			w = nil
+		case w == nil:
+			// stopCh was closed
+			return nil
+		default:
+			// Ensure watcher is stopped
+			defer w.Stop()
 		}
 	}
 
@@ -366,12 +369,7 @@ func (r *Reflector) ListAndWatch(stopCh <-chan struct{}) error {
 	}
 
 	klog.V(2).Infof("Caches populated for %v from %s", r.typeDescription, r.name)
-
-	resyncerrc := make(chan error, 1)
-	cancelCh := make(chan struct{})
-	defer close(cancelCh)
-	go r.startResync(stopCh, cancelCh, resyncerrc)
-	return r.watch(w, stopCh, resyncerrc)
+	return r.watchWithResync(w, stopCh)
 }
 
 // startResync periodically calls r.store.Resync() method.
@@ -402,8 +400,32 @@ func (r *Reflector) startResync(stopCh <-chan struct{}, cancelCh <-chan struct{}
 	}
 }
 
+// watchWithResync runs watch with startResync in the background.
+func (r *Reflector) watchWithResync(w watch.Interface, stopCh <-chan struct{}) error {
+	// Skip watching, if already stopped
+	select {
+	case <-stopCh:
+		return nil
+	default:
+	}
+	resyncerrc := make(chan error, 1)
+	cancelCh := make(chan struct{})
+	defer close(cancelCh)
+	go r.startResync(stopCh, cancelCh, resyncerrc)
+	return r.watch(w, stopCh, resyncerrc)
+}
+
 // watch simply starts a watch request with the server.
 func (r *Reflector) watch(w watch.Interface, stopCh <-chan struct{}, resyncerrc chan error) error {
+	// Put the initial watcher on the heap, so we can close it in a defer without it being nil after removal from the stack.
+	watcher := w
+	// Ensure the initial watcher is stopped on exit, in case of error or stopCh closure.
+	// All subsequent watchers will be closed by handleWatch.
+	defer func() {
+		if watcher != nil {
+			watcher.Stop()
+		}
+	}()
 	var err error
 	retry := NewRetryWithDeadline(r.MaxInternalErrorRetryDuration, time.Minute, apierrors.IsInternalError, r.clock)
 
@@ -411,11 +433,6 @@ func (r *Reflector) watch(w watch.Interface, stopCh <-chan struct{}, resyncerrc 
 		// give the stopCh a chance to stop the loop, even in case of continue statements further down on errors
 		select {
 		case <-stopCh:
-			// we can only end up here when the stopCh
-			// was closed after a successful watchlist or list request
-			if w != nil {
-				w.Stop()
-			}
 			return nil
 		default:
 		}
@@ -451,13 +468,13 @@ func (r *Reflector) watch(w watch.Interface, stopCh <-chan struct{}, resyncerrc 
 			}
 		}
 
-		err = watchHandler(start, w, r.store, r.expectedType, r.expectedGVK, r.name, r.typeDescription, r.setLastSyncResourceVersion, nil, r.clock, resyncerrc, stopCh)
+		err = handleWatch(start, w, r.store, r.expectedType, r.expectedGVK, r.name, r.typeDescription, r.setLastSyncResourceVersion,
+			r.clock, resyncerrc, stopCh)
 		// Ensure that watch will not be reused across iterations.
-		w.Stop()
 		w = nil
 		retry.After(err)
 		if err != nil {
-			if err != errorStopRequested {
+			if !errors.Is(err, errorStopRequested) {
 				switch {
 				case isExpiredError(err):
 					// Don't set LastSyncResourceVersionUnavailable - LIST call with ResourceVersion=RV already
@@ -487,6 +504,12 @@ func (r *Reflector) watch(w watch.Interface, stopCh <-chan struct{}, resyncerrc 
 // list simply lists all items and records a resource version obtained from the server at the moment of the call.
 // the resource version can be used for further progress notification (aka. watch).
 func (r *Reflector) list(stopCh <-chan struct{}) error {
+	// Skip listing, if already stopped
+	select {
+	case <-stopCh:
+		return nil
+	default:
+	}
 	var resourceVersion string
 	options := metav1.ListOptions{ResourceVersion: r.relistResourceVersion()}
 
@@ -612,8 +635,16 @@ func (r *Reflector) list(stopCh <-chan struct{}) error {
 // It replaces its internal store with the collected items and
 // reuses the current watch requests for getting further events.
 func (r *Reflector) watchList(stopCh <-chan struct{}) (watch.Interface, error) {
-	var w watch.Interface
-	var err error
+	success := false
+	var watcher watch.Interface
+	// Ensure watcher is stopped when not successful (ex: error or closed stopCh).
+	// When successful, the watcher is left open to continue watching, after
+	// receiving the full set of objects on the cluster.
+	defer func() {
+		if watcher != nil && !success {
+			watcher.Stop()
+		}
+	}()
 	var temporaryStore Store
 	var resourceVersion string
 	// TODO(#115478): see if this function could be turned
@@ -661,21 +692,18 @@ func (r *Reflector) watchList(stopCh <-chan struct{}) (watch.Interface, error) {
 		}
 		start := r.clock.Now()
 
-		w, err = r.listerWatcher.Watch(options)
+		w, err := r.listerWatcher.Watch(options)
 		if err != nil {
 			if isErrorRetriableWithSideEffectsFn(err) {
 				continue
 			}
 			return nil, err
 		}
-		bookmarkReceived := pointer.Bool(false)
-		err = watchHandler(start, w, temporaryStore, r.expectedType, r.expectedGVK, r.name, r.typeDescription,
+		watchListBookmarkReceived, err := handleListWatch(start, w, temporaryStore, r.expectedType, r.expectedGVK, r.name, r.typeDescription,
 			func(rv string) { resourceVersion = rv },
-			bookmarkReceived,
 			r.clock, make(chan error), stopCh)
 		if err != nil {
-			w.Stop() // stop and retry with clean state
-			if err == errorStopRequested {
+			if errors.Is(err, errorStopRequested) {
 				return nil, nil
 			}
 			if isErrorRetriableWithSideEffectsFn(err) {
@@ -683,7 +711,8 @@ func (r *Reflector) watchList(stopCh <-chan struct{}) (watch.Interface, error) {
 			}
 			return nil, err
 		}
-		if *bookmarkReceived {
+		if watchListBookmarkReceived {
+			watcher = w
 			break
 		}
 	}
@@ -697,13 +726,14 @@ func (r *Reflector) watchList(stopCh <-chan struct{}) (watch.Interface, error) {
 	// component as soon as it finishes replacing the content.
 	checkWatchListDataConsistencyIfRequested(wait.ContextForChannel(stopCh), r.name, resourceVersion, wrapListFuncWithContext(r.listerWatcher.List), temporaryStore.List)
 
-	if err = r.store.Replace(temporaryStore.List(), resourceVersion); err != nil {
-		return nil, fmt.Errorf("unable to sync watch-list result: %v", err)
+	if err := r.store.Replace(temporaryStore.List(), resourceVersion); err != nil {
+		return nil, fmt.Errorf("unable to sync watch-list result: %w", err)
 	}
 	initTrace.Step("SyncWith done")
 	r.setLastSyncResourceVersion(resourceVersion)
 
-	return w, nil
+	success = true
+	return watcher, nil
 }
 
 // syncWith replaces the store's items with the given list.
@@ -715,8 +745,12 @@ func (r *Reflector) syncWith(items []runtime.Object, resourceVersion string) err
 	return r.store.Replace(found, resourceVersion)
 }
 
-// watchHandler watches w and sets setLastSyncResourceVersion
-func watchHandler(start time.Time,
+// handleListWatch consumes events from w, updates the Store, and records the
+// last seen ResourceVersion, to allow continuing from that ResourceVersion on
+// retry. If successful, the watcher will be left open after receiving the
+// initial set of objects, to allow watching for future events.
+func handleListWatch(
+	start time.Time,
 	w watch.Interface,
 	store Store,
 	expectedType reflect.Type,
@@ -724,33 +758,88 @@ func watchHandler(start time.Time,
 	name string,
 	expectedTypeName string,
 	setLastSyncResourceVersion func(string),
-	exitOnInitialEventsEndBookmark *bool,
 	clock clock.Clock,
-	errc chan error,
+	errCh chan error,
+	stopCh <-chan struct{},
+) (bool, error) {
+	exitOnWatchListBookmarkReceived := true
+	return handleAnyWatch(start, w, store, expectedType, expectedGVK, name, expectedTypeName,
+		setLastSyncResourceVersion, exitOnWatchListBookmarkReceived, clock, errCh, stopCh)
+}
+
+// handleListWatch consumes events from w, updates the Store, and records the
+// last seen ResourceVersion, to allow continuing from that ResourceVersion on
+// retry. The watcher will always be stopped on exit.
+func handleWatch(
+	start time.Time,
+	w watch.Interface,
+	store Store,
+	expectedType reflect.Type,
+	expectedGVK *schema.GroupVersionKind,
+	name string,
+	expectedTypeName string,
+	setLastSyncResourceVersion func(string),
+	clock clock.Clock,
+	errCh chan error,
 	stopCh <-chan struct{},
 ) error {
+	exitOnWatchListBookmarkReceived := false
+	_, err := handleAnyWatch(start, w, store, expectedType, expectedGVK, name, expectedTypeName,
+		setLastSyncResourceVersion, exitOnWatchListBookmarkReceived, clock, errCh, stopCh)
+	return err
+}
+
+// handleAnyWatch consumes events from w, updates the Store, and records the last
+// seen ResourceVersion, to allow continuing from that ResourceVersion on retry.
+// If exitOnWatchListBookmarkReceived is true, the watch events will be consumed
+// until a bookmark event is received with the WatchList annotation present.
+// Returns true (watchListBookmarkReceived) if the WatchList bookmark was
+// received, even if exitOnWatchListBookmarkReceived is false.
+// The watcher will always be stopped, unless exitOnWatchListBookmarkReceived is
+// true and watchListBookmarkReceived is true. This allows the same watch stream
+// to be re-used by the caller to continue watching for new events.
+func handleAnyWatch(start time.Time,
+	w watch.Interface,
+	store Store,
+	expectedType reflect.Type,
+	expectedGVK *schema.GroupVersionKind,
+	name string,
+	expectedTypeName string,
+	setLastSyncResourceVersion func(string),
+	exitOnWatchListBookmarkReceived bool,
+	clock clock.Clock,
+	errCh chan error,
+	stopCh <-chan struct{},
+) (bool, error) {
+	watchListBookmarkReceived := false
+	// When exiting, tell the producer that the consumer is done consuming.
+	// This avoids the producer blocking forever, waiting for events to be consumed.
+	// If the watchlist bookmark was received, leave the watcher open to read future events.
+	defer func() {
+		if !exitOnWatchListBookmarkReceived || !watchListBookmarkReceived {
+			w.Stop()
+		}
+	}()
 	eventCount := 0
-	initialEventsEndBookmarkWarningTicker := newInitialEventsEndBookmarkTicker(name, clock, start, exitOnInitialEventsEndBookmark != nil)
+	initialEventsEndBookmarkWarningTicker := newInitialEventsEndBookmarkTicker(name, clock, start, exitOnWatchListBookmarkReceived)
 	defer initialEventsEndBookmarkWarningTicker.Stop()
-	if exitOnInitialEventsEndBookmark != nil {
-		// set it to false just in case somebody
-		// made it positive
-		*exitOnInitialEventsEndBookmark = false
-	}
+	// Get the result channel once, instead of once for every loop iteration.
+	// This allows using lock-free watch.Interface implementations.
+	resultCh := w.ResultChan()
 
 loop:
 	for {
 		select {
 		case <-stopCh:
-			return errorStopRequested
-		case err := <-errc:
-			return err
-		case event, ok := <-w.ResultChan():
+			return watchListBookmarkReceived, errorStopRequested
+		case err := <-errCh:
+			return watchListBookmarkReceived, err
+		case event, ok := <-resultCh:
 			if !ok {
 				break loop
 			}
 			if event.Type == watch.Error {
-				return apierrors.FromObject(event.Object)
+				return watchListBookmarkReceived, apierrors.FromObject(event.Object)
 			}
 			if expectedType != nil {
 				if e, a := expectedType, reflect.TypeOf(event.Object); e != a {
@@ -790,11 +879,9 @@ loop:
 					utilruntime.HandleError(fmt.Errorf("%s: unable to delete watch event object (%#v) from store: %v", name, event.Object, err))
 				}
 			case watch.Bookmark:
-				// A `Bookmark` means watch has synced here, just update the resourceVersion
+				// A `Bookmark` means watch has synced here, just update the resourceVersion.
 				if meta.GetAnnotations()[metav1.InitialEventsAnnotationKey] == "true" {
-					if exitOnInitialEventsEndBookmark != nil {
-						*exitOnInitialEventsEndBookmark = true
-					}
+					watchListBookmarkReceived = true
 				}
 			default:
 				utilruntime.HandleError(fmt.Errorf("%s: unable to understand watch event %#v", name, event))
@@ -804,10 +891,10 @@ loop:
 				rvu.UpdateResourceVersion(resourceVersion)
 			}
 			eventCount++
-			if exitOnInitialEventsEndBookmark != nil && *exitOnInitialEventsEndBookmark {
+			if exitOnWatchListBookmarkReceived && watchListBookmarkReceived {
 				watchDuration := clock.Since(start)
 				klog.V(4).Infof("exiting %v Watch because received the bookmark that marks the end of initial events stream, total %v items received in %v", name, eventCount, watchDuration)
-				return nil
+				return watchListBookmarkReceived, nil
 			}
 			initialEventsEndBookmarkWarningTicker.observeLastEventTimeStamp(clock.Now())
 		case <-initialEventsEndBookmarkWarningTicker.C():
@@ -817,10 +904,10 @@ loop:
 
 	watchDuration := clock.Since(start)
 	if watchDuration < 1*time.Second && eventCount == 0 {
-		return fmt.Errorf("very short watch: %s: Unexpected watch close - watch lasted less than a second and no items received", name)
+		return watchListBookmarkReceived, fmt.Errorf("very short watch: %s: Unexpected watch close - watch lasted less than a second and no items received", name)
 	}
 	klog.V(4).Infof("%s: Watch close - %v total %v items received", name, expectedTypeName, eventCount)
-	return nil
+	return watchListBookmarkReceived, nil
 }
 
 // LastSyncResourceVersion is the resource version observed when last sync with the underlying store
@@ -962,14 +1049,14 @@ type initialEventsEndBookmarkTicker struct {
 // Note that the caller controls whether to call t.C() and t.Stop().
 //
 // In practice, the reflector exits the watchHandler as soon as the bookmark event is received and calls the t.C() method.
-func newInitialEventsEndBookmarkTicker(name string, c clock.Clock, watchStart time.Time, exitOnInitialEventsEndBookmarkRequested bool) *initialEventsEndBookmarkTicker {
-	return newInitialEventsEndBookmarkTickerInternal(name, c, watchStart, 10*time.Second, exitOnInitialEventsEndBookmarkRequested)
+func newInitialEventsEndBookmarkTicker(name string, c clock.Clock, watchStart time.Time, exitOnWatchListBookmarkReceived bool) *initialEventsEndBookmarkTicker {
+	return newInitialEventsEndBookmarkTickerInternal(name, c, watchStart, 10*time.Second, exitOnWatchListBookmarkReceived)
 }
 
-func newInitialEventsEndBookmarkTickerInternal(name string, c clock.Clock, watchStart time.Time, tickInterval time.Duration, exitOnInitialEventsEndBookmarkRequested bool) *initialEventsEndBookmarkTicker {
+func newInitialEventsEndBookmarkTickerInternal(name string, c clock.Clock, watchStart time.Time, tickInterval time.Duration, exitOnWatchListBookmarkReceived bool) *initialEventsEndBookmarkTicker {
 	clockWithTicker, ok := c.(clock.WithTicker)
-	if !ok || !exitOnInitialEventsEndBookmarkRequested {
-		if exitOnInitialEventsEndBookmarkRequested {
+	if !ok || !exitOnWatchListBookmarkReceived {
+		if exitOnWatchListBookmarkReceived {
 			klog.Warningf("clock does not support WithTicker interface but exitOnInitialEventsEndBookmark was requested")
 		}
 		return &initialEventsEndBookmarkTicker{

--- a/staging/src/k8s.io/client-go/tools/cache/reflector_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/reflector_test.go
@@ -28,6 +28,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	v1 "k8s.io/api/core/v1"
@@ -97,19 +98,35 @@ func TestRunUntil(t *testing.T) {
 			return &v1.PodList{ListMeta: metav1.ListMeta{ResourceVersion: "1"}}, nil
 		},
 	}
-	go r.Run(stopCh)
+	doneCh := make(chan struct{})
+	go func() {
+		defer close(doneCh)
+		r.Run(stopCh)
+	}()
 	// Synchronously add a dummy pod into the watch channel so we
 	// know the RunUntil go routine is in the watch handler.
 	fw.Add(&v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "bar"}})
+
 	close(stopCh)
-	select {
-	case _, ok := <-fw.ResultChan():
-		if ok {
-			t.Errorf("Watch channel left open after stopping the watch")
+	resultCh := fw.ResultChan()
+	for {
+		select {
+		case <-doneCh:
+			if resultCh == nil {
+				return // both closed
+			}
+			doneCh = nil
+		case _, ok := <-resultCh:
+			if ok {
+				t.Fatalf("Watch channel left open after stopping the watch")
+			}
+			if doneCh == nil {
+				return // both closed
+			}
+			resultCh = nil
+		case <-time.After(wait.ForeverTestTimeout):
+			t.Fatalf("the cancellation is at least %s late", wait.ForeverTestTimeout.String())
 		}
-	case <-time.After(wait.ForeverTestTimeout):
-		t.Errorf("the cancellation is at least %s late", wait.ForeverTestTimeout.String())
-		break
 	}
 }
 
@@ -126,24 +143,59 @@ func TestReflectorResyncChan(t *testing.T) {
 	}
 }
 
-// TestEstablishedWatchStoppedAfterStopCh ensures that
-// an established watch will be closed right after
-// the StopCh was also closed.
-func TestEstablishedWatchStoppedAfterStopCh(t *testing.T) {
-	ctx, ctxCancel := context.WithCancel(context.TODO())
-	ctxCancel()
-	w := watch.NewFake()
-	require.False(t, w.IsStopped())
+// TestReflectorWatchStoppedBefore ensures that neither List nor Watch are
+// called if the stop channel is closed before Reflector.watch is called.
+func TestReflectorWatchStoppedBefore(t *testing.T) {
+	stopCh := make(chan struct{})
+	close(stopCh)
 
-	// w is stopped when the stopCh is closed
-	target := NewReflector(nil, &v1.Pod{}, nil, 0)
-	err := target.watch(w, ctx.Done(), nil)
-	require.NoError(t, err)
-	require.True(t, w.IsStopped())
+	lw := &ListWatch{
+		ListFunc: func(_ metav1.ListOptions) (runtime.Object, error) {
+			t.Fatal("ListFunc called unexpectedly")
+			return nil, nil
+		},
+		WatchFunc: func(_ metav1.ListOptions) (watch.Interface, error) {
+			// If WatchFunc is never called, the watcher it returns doesn't need to be stopped.
+			t.Fatal("WatchFunc called unexpectedly")
+			return nil, nil
+		},
+	}
+	target := NewReflector(lw, &v1.Pod{}, nil, 0)
 
-	// noop when the w is nil and the ctx is closed
-	err = target.watch(nil, ctx.Done(), nil)
+	err := target.watch(nil, stopCh, nil)
 	require.NoError(t, err)
+}
+
+// TestReflectorWatchStoppedAfter ensures that neither the watcher is stopped if
+// the stop channel is closed after Reflector.watch has started watching.
+func TestReflectorWatchStoppedAfter(t *testing.T) {
+	stopCh := make(chan struct{})
+
+	var watchers []*watch.FakeWatcher
+
+	lw := &ListWatch{
+		ListFunc: func(_ metav1.ListOptions) (runtime.Object, error) {
+			t.Fatal("ListFunc called unexpectedly")
+			return nil, nil
+		},
+		WatchFunc: func(_ metav1.ListOptions) (watch.Interface, error) {
+			// Simulate the stop channel being closed after watching has started
+			go func() {
+				time.Sleep(10 * time.Millisecond)
+				close(stopCh)
+			}()
+			// Use a fake watcher that never sends events
+			w := watch.NewFake()
+			watchers = append(watchers, w)
+			return w, nil
+		},
+	}
+	target := NewReflector(lw, &v1.Pod{}, nil, 0)
+
+	err := target.watch(nil, stopCh, nil)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(watchers))
+	require.True(t, watchers[0].IsStopped())
 }
 
 func BenchmarkReflectorResyncChanMany(b *testing.B) {
@@ -158,22 +210,140 @@ func BenchmarkReflectorResyncChanMany(b *testing.B) {
 	}
 }
 
-func TestReflectorWatchHandlerError(t *testing.T) {
+// TestReflectorHandleWatchStoppedBefore ensures that handleWatch stops when
+// stopCh is already closed before handleWatch was called. It also ensures that
+// ResultChan is only called once and that Stop is called after ResultChan.
+func TestReflectorHandleWatchStoppedBefore(t *testing.T) {
 	s := NewStore(MetaNamespaceKeyFunc)
 	g := NewReflector(&testLW{}, &v1.Pod{}, s, 0)
-	fw := watch.NewFake()
-	go func() {
-		fw.Stop()
-	}()
-	err := watchHandler(time.Now(), fw, s, g.expectedType, g.expectedGVK, g.name, g.typeDescription, g.setLastSyncResourceVersion, nil, g.clock, nevererrc, wait.NeverStop)
+	stopCh := make(chan struct{})
+	// Simulate the watch channel being closed before the watchHandler is called
+	close(stopCh)
+	var calls []string
+	resultCh := make(chan watch.Event)
+	fw := watch.MockWatcher{
+		StopFunc: func() {
+			calls = append(calls, "Stop")
+			close(resultCh)
+		},
+		ResultChanFunc: func() <-chan watch.Event {
+			calls = append(calls, "ResultChan")
+			return resultCh
+		},
+	}
+	err := handleWatch(time.Now(), fw, s, g.expectedType, g.expectedGVK, g.name, g.typeDescription, g.setLastSyncResourceVersion, g.clock, nevererrc, stopCh)
 	if err == nil {
 		t.Errorf("unexpected non-error")
 	}
+	// Ensure the watcher methods are called exactly once in this exact order.
+	assert.Equal(t, []string{"ResultChan", "Stop"}, calls)
+}
+
+// TestReflectorHandleWatchStoppedAfter ensures that handleWatch stops when
+// stopCh is closed after handleWatch was called. It also ensures that
+// ResultChan is only called once and that Stop is called after ResultChan.
+func TestReflectorHandleWatchStoppedAfter(t *testing.T) {
+	s := NewStore(MetaNamespaceKeyFunc)
+	g := NewReflector(&testLW{}, &v1.Pod{}, s, 0)
+	var calls []string
+	stopCh := make(chan struct{})
+	resultCh := make(chan watch.Event)
+	fw := watch.MockWatcher{
+		StopFunc: func() {
+			calls = append(calls, "Stop")
+			close(resultCh)
+		},
+		ResultChanFunc: func() <-chan watch.Event {
+			calls = append(calls, "ResultChan")
+			resultCh = make(chan watch.Event)
+			// Simulate the watch handler being stopped asynchronously by the
+			// caller, after watching has started.
+			go func() {
+				time.Sleep(10 * time.Millisecond)
+				close(stopCh)
+			}()
+			return resultCh
+		},
+	}
+	err := handleWatch(time.Now(), fw, s, g.expectedType, g.expectedGVK, g.name, g.typeDescription, g.setLastSyncResourceVersion, g.clock, nevererrc, stopCh)
+	if err == nil {
+		t.Errorf("unexpected non-error")
+	}
+	// Ensure the watcher methods are called exactly once in this exact order.
+	assert.Equal(t, []string{"ResultChan", "Stop"}, calls)
+}
+
+// TestReflectorHandleWatchResultChanClosedBefore ensures that handleWatch
+// stops when the result channel is closed before handleWatch was called.
+func TestReflectorHandleWatchResultChanClosedBefore(t *testing.T) {
+	s := NewStore(MetaNamespaceKeyFunc)
+	g := NewReflector(&testLW{}, &v1.Pod{}, s, 0)
+	var calls []string
+	resultCh := make(chan watch.Event)
+	fw := watch.MockWatcher{
+		StopFunc: func() {
+			calls = append(calls, "Stop")
+		},
+		ResultChanFunc: func() <-chan watch.Event {
+			calls = append(calls, "ResultChan")
+			return resultCh
+		},
+	}
+	// Simulate the result channel being closed by the producer before handleWatch is called.
+	close(resultCh)
+	err := handleWatch(time.Now(), fw, s, g.expectedType, g.expectedGVK, g.name, g.typeDescription, g.setLastSyncResourceVersion, g.clock, nevererrc, wait.NeverStop)
+	if err == nil {
+		t.Errorf("unexpected non-error")
+	}
+	// Ensure the watcher methods are called exactly once in this exact order.
+	assert.Equal(t, []string{"ResultChan", "Stop"}, calls)
+}
+
+// TestReflectorHandleWatchResultChanClosedAfter ensures that handleWatch
+// stops when the result channel is closed after handleWatch has started watching.
+func TestReflectorHandleWatchResultChanClosedAfter(t *testing.T) {
+	s := NewStore(MetaNamespaceKeyFunc)
+	g := NewReflector(&testLW{}, &v1.Pod{}, s, 0)
+	var calls []string
+	resultCh := make(chan watch.Event)
+	fw := watch.MockWatcher{
+		StopFunc: func() {
+			calls = append(calls, "Stop")
+		},
+		ResultChanFunc: func() <-chan watch.Event {
+			calls = append(calls, "ResultChan")
+			resultCh = make(chan watch.Event)
+			// Simulate the result channel being closed by the producer, after
+			// watching has started.
+			go func() {
+				time.Sleep(10 * time.Millisecond)
+				close(resultCh)
+			}()
+			return resultCh
+		},
+	}
+	err := handleWatch(time.Now(), fw, s, g.expectedType, g.expectedGVK, g.name, g.typeDescription, g.setLastSyncResourceVersion, g.clock, nevererrc, wait.NeverStop)
+	if err == nil {
+		t.Errorf("unexpected non-error")
+	}
+	// Ensure the watcher methods are called exactly once in this exact order.
+	assert.Equal(t, []string{"ResultChan", "Stop"}, calls)
 }
 
 func TestReflectorWatchHandler(t *testing.T) {
 	s := NewStore(MetaNamespaceKeyFunc)
 	g := NewReflector(&testLW{}, &v1.Pod{}, s, 0)
+	// Wrap setLastSyncResourceVersion so we can tell the watchHandler to stop
+	// watching after all the events have been consumed. This avoids race
+	// conditions which can happen if the producer calls Stop(), instead of the
+	// consumer.
+	stopCh := make(chan struct{})
+	setLastSyncResourceVersion := func(rv string) {
+		g.setLastSyncResourceVersion(rv)
+		if rv == "32" {
+			close(stopCh)
+		}
+	}
 	fw := watch.NewFake()
 	s.Add(&v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "foo"}})
 	s.Add(&v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "bar"}})
@@ -184,8 +354,8 @@ func TestReflectorWatchHandler(t *testing.T) {
 		fw.Add(&v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "baz", ResourceVersion: "32"}})
 		fw.Stop()
 	}()
-	err := watchHandler(time.Now(), fw, s, g.expectedType, g.expectedGVK, g.name, g.typeDescription, g.setLastSyncResourceVersion, nil, g.clock, nevererrc, wait.NeverStop)
-	if err != nil {
+	err := handleWatch(time.Now(), fw, s, g.expectedType, g.expectedGVK, g.name, g.typeDescription, setLastSyncResourceVersion, g.clock, nevererrc, stopCh)
+	if !errors.Is(err, errorStopRequested) {
 		t.Errorf("unexpected error %v", err)
 	}
 
@@ -193,6 +363,7 @@ func TestReflectorWatchHandler(t *testing.T) {
 		return &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: id, ResourceVersion: rv}}
 	}
 
+	// Validate that the Store was updated by the events
 	table := []struct {
 		Pod    *v1.Pod
 		exists bool
@@ -215,12 +386,7 @@ func TestReflectorWatchHandler(t *testing.T) {
 		}
 	}
 
-	// RV should send the last version we see.
-	if e, a := "32", g.LastSyncResourceVersion(); e != a {
-		t.Errorf("expected %v, got %v", e, a)
-	}
-
-	// last sync resource version should be the last version synced with store
+	// Validate that setLastSyncResourceVersion was called with the RV from the last event.
 	if e, a := "32", g.LastSyncResourceVersion(); e != a {
 		t.Errorf("expected %v, got %v", e, a)
 	}
@@ -230,9 +396,9 @@ func TestReflectorStopWatch(t *testing.T) {
 	s := NewStore(MetaNamespaceKeyFunc)
 	g := NewReflector(&testLW{}, &v1.Pod{}, s, 0)
 	fw := watch.NewFake()
-	stopWatch := make(chan struct{}, 1)
-	stopWatch <- struct{}{}
-	err := watchHandler(time.Now(), fw, s, g.expectedType, g.expectedGVK, g.name, g.typeDescription, g.setLastSyncResourceVersion, nil, g.clock, nevererrc, stopWatch)
+	stopWatch := make(chan struct{})
+	close(stopWatch)
+	err := handleWatch(time.Now(), fw, s, g.expectedType, g.expectedGVK, g.name, g.typeDescription, g.setLastSyncResourceVersion, g.clock, nevererrc, stopWatch)
 	if err != errorStopRequested {
 		t.Errorf("expected stop error, got %q", err)
 	}
@@ -361,6 +527,7 @@ func TestReflectorListAndWatchWithErrors(t *testing.T) {
 			}
 		}
 		watchRet, watchErr := item.events, item.watchErr
+		stopCh := make(chan struct{})
 		lw := &testLW{
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				if watchErr != nil {
@@ -372,7 +539,13 @@ func TestReflectorListAndWatchWithErrors(t *testing.T) {
 					for _, e := range watchRet {
 						fw.Action(e.Type, e.Object)
 					}
-					fw.Stop()
+					// Because FakeWatcher doesn't buffer events, it's safe to
+					// close the stop channel immediately without missing events.
+					// But usually, the event producer would instead close the
+					// result channel, and wait for the consumer to stop the
+					// watcher, to avoid race conditions.
+					// TODO: Fix the FakeWatcher to separate watcher.Stop from close(resultCh)
+					close(stopCh)
 				}()
 				return fw, nil
 			},
@@ -381,7 +554,16 @@ func TestReflectorListAndWatchWithErrors(t *testing.T) {
 			},
 		}
 		r := NewReflector(lw, &v1.Pod{}, s, 0)
-		r.ListAndWatch(wait.NeverStop)
+		err := r.ListAndWatch(stopCh)
+		if item.listErr != nil && !errors.Is(err, item.listErr) {
+			t.Errorf("unexpected ListAndWatch error: %v", err)
+		}
+		if item.watchErr != nil && !errors.Is(err, item.watchErr) {
+			t.Errorf("unexpected ListAndWatch error: %v", err)
+		}
+		if item.listErr == nil && item.watchErr == nil {
+			assert.NoError(t, err)
+		}
 	}
 }
 

--- a/staging/src/k8s.io/client-go/tools/watch/until_test.go
+++ b/staging/src/k8s.io/client-go/tools/watch/until_test.go
@@ -47,6 +47,8 @@ func TestUntil(t *testing.T) {
 		var obj *fakePod
 		fw.Add(obj)
 		fw.Modify(obj)
+		<-fw.StopChan()
+		fw.Close()
 	}()
 	conditions := []ConditionFunc{
 		func(event watch.Event) (bool, error) { return event.Type == watch.Added, nil },
@@ -69,6 +71,18 @@ func TestUntil(t *testing.T) {
 	if got, isPod := lastEvent.Object.(*fakePod); !isPod {
 		t.Fatalf("expected a pod event, got %#v", got)
 	}
+
+	// Validate the UntilWithoutRetry stopped the watcher on condition or error
+	select {
+	case _, ok := <-fw.StopChan():
+		if !ok {
+			// closed as expected
+			break
+		}
+		t.Fatalf("Unexpected stop channel event")
+	case <-time.After(wait.ForeverTestTimeout):
+		t.Fatalf("Expected watcher to be stopped")
+	}
 }
 
 func TestUntilMultipleConditions(t *testing.T) {
@@ -76,6 +90,8 @@ func TestUntilMultipleConditions(t *testing.T) {
 	go func() {
 		var obj *fakePod
 		fw.Add(obj)
+		<-fw.StopChan()
+		fw.Close()
 	}()
 	conditions := []ConditionFunc{
 		func(event watch.Event) (bool, error) { return event.Type == watch.Added, nil },
@@ -98,6 +114,18 @@ func TestUntilMultipleConditions(t *testing.T) {
 	if got, isPod := lastEvent.Object.(*fakePod); !isPod {
 		t.Fatalf("expected a pod event, got %#v", got)
 	}
+
+	// Validate the UntilWithoutRetry stopped the watcher on condition or error
+	select {
+	case _, ok := <-fw.StopChan():
+		if !ok {
+			// closed as expected
+			break
+		}
+		t.Fatalf("Unexpected stop channel event")
+	case <-time.After(wait.ForeverTestTimeout):
+		t.Fatalf("Expected watcher to be stopped")
+	}
 }
 
 func TestUntilMultipleConditionsFail(t *testing.T) {
@@ -105,6 +133,8 @@ func TestUntilMultipleConditionsFail(t *testing.T) {
 	go func() {
 		var obj *fakePod
 		fw.Add(obj)
+		<-fw.StopChan()
+		fw.Close()
 	}()
 	conditions := []ConditionFunc{
 		func(event watch.Event) (bool, error) { return event.Type == watch.Added, nil },
@@ -128,6 +158,18 @@ func TestUntilMultipleConditionsFail(t *testing.T) {
 	if got, isPod := lastEvent.Object.(*fakePod); !isPod {
 		t.Fatalf("expected a pod event, got %#v", got)
 	}
+
+	// Validate the UntilWithoutRetry stopped the watcher on condition or error
+	select {
+	case _, ok := <-fw.StopChan():
+		if !ok {
+			// closed as expected
+			break
+		}
+		t.Fatalf("Unexpected stop channel event")
+	case <-time.After(wait.ForeverTestTimeout):
+		t.Fatalf("Expected watcher to be stopped")
+	}
 }
 
 func TestUntilTimeout(t *testing.T) {
@@ -136,6 +178,8 @@ func TestUntilTimeout(t *testing.T) {
 		var obj *fakePod
 		fw.Add(obj)
 		fw.Modify(obj)
+		<-fw.StopChan()
+		fw.Close()
 	}()
 	conditions := []ConditionFunc{
 		func(event watch.Event) (bool, error) {
@@ -159,6 +203,18 @@ func TestUntilTimeout(t *testing.T) {
 	if got, isPod := lastEvent.Object.(*fakePod); !isPod {
 		t.Fatalf("expected a pod event, got %#v", got)
 	}
+
+	// Validate the UntilWithoutRetry stopped the watcher on condition or error
+	select {
+	case _, ok := <-fw.StopChan():
+		if !ok {
+			// closed as expected
+			break
+		}
+		t.Fatalf("Unexpected stop channel event")
+	case <-time.After(wait.ForeverTestTimeout):
+		t.Fatalf("Expected watcher to be stopped")
+	}
 }
 
 func TestUntilErrorCondition(t *testing.T) {
@@ -166,6 +222,8 @@ func TestUntilErrorCondition(t *testing.T) {
 	go func() {
 		var obj *fakePod
 		fw.Add(obj)
+		<-fw.StopChan()
+		fw.Close()
 	}()
 	expected := "something bad"
 	conditions := []ConditionFunc{
@@ -182,6 +240,18 @@ func TestUntilErrorCondition(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), expected) {
 		t.Fatalf("expected %q in error string, got %q", expected, err.Error())
+	}
+
+	// Validate the UntilWithoutRetry stopped the watcher on condition or error
+	select {
+	case _, ok := <-fw.StopChan():
+		if !ok {
+			// closed as expected
+			break
+		}
+		t.Fatalf("Unexpected stop channel event")
+	case <-time.After(wait.ForeverTestTimeout):
+		t.Fatalf("Expected watcher to be stopped")
 	}
 }
 


### PR DESCRIPTION
/kind cleanup
/kind flake

#### What & Why

The FakeWatcher doesn't expose the result channel or stop channel, which makes it impossible to use correctly by the event producer. This has made every test that uses the FakeWatcher effectively invalid, because it cannot correctly simulate the way the client and server negotiate how to stop. Plus, while the comments say it's thread-safe, it's not actually, and has several possible race conditions. In the past, alternative watcher implementations have been added to use instead of FakeWatcher, but because of its name, FakeWatcher is used all over the place in k/k and for testing 3rd party controllers. 

This PR refactors the FakeWatcher to be thread-safe & race-free. It also updates all the tests in k/k to use FakeWatcher correctly.

- Add FakeWatcher methods: StopChan, Close, IsClosed.
  These allow the event producer to close the result channel, which
  signals to the event consumer that the producer is done sending
  events. Stop() should only be called by the event consumer, to
  signal to the producer that it's done receiving events.
  This allows for bidirectional communication between the producer
  and consumer, with cleanup on both sides.
- Modify all tests using FakeWatcher to correctly Stop & Close.
  This should fix quite a few race conditions.
  It also uncovered a few bugs.
- Fix WatchServer.HandleHTTP to Stop the watcher when done reading
  events from the result channel, even on errors before reading from
  the result channel has started.
- Fix WatchServer.HandleHTTP to cleanup the TimeoutFactory in the
  rare case of some early Flusher and FrameWriter errors.
- Fix multiple instances where watcher.ResultChan() is being called
  from inside a for loop. Moving this outside the for loop allows
  these consumers to work with watch.Interface implementations that
  return a new result channel every time ResultChan() is called,
  even though we don't have any current examples.
- Remove FakeWatcher.Reset(). It was unused and causes problems with
  thread-safety. The better approach is to Close() the current
  watcher and create a new one for the next call to Watch.
- Add testing in numerous places to validate that the watcher is
  correctly stopped and closed. This uncovered a few test bugs.
- Fix TestNewInformerWatcher to test with the WatchListClient feature
  both enabled and disabled.

#### Dependencies

- https://github.com/kubernetes/kubernetes/pull/125107
- https://github.com/kubernetes/kubernetes/pull/123974
- https://github.com/kubernetes/kubernetes/pull/125302

#### Does this PR introduce a user-facing change?

```release-note
[client-go] Refactor FakeWatcher to be thread-safe & race-free.
```
