### PR TITLE
kubeadm: check only for `RuntimeReady` condition

### DIFF
--- a/cmd/kubeadm/app/util/runtime/runtime.go
+++ b/cmd/kubeadm/app/util/runtime/runtime.go
@@ -104,7 +104,8 @@ func (runtime *CRIRuntime) IsRunning() error {
 	}
 
 	for _, condition := range res.GetStatus().GetConditions() {
-		if !condition.GetStatus() {
+		if condition.GetType() == runtimeapi.RuntimeReady && // NetworkReady will not be tested on purpose
+			!condition.GetStatus() {
 			return errors.Errorf(
 				"container runtime condition %q is not true. reason: %s, message: %s",
 				condition.GetType(), condition.GetReason(), condition.GetMessage(),

--- a/cmd/kubeadm/app/util/runtime/runtime_test.go
+++ b/cmd/kubeadm/app/util/runtime/runtime_test.go
@@ -95,6 +95,7 @@ func TestIsRunning(t *testing.T) {
 				mock.StatusReturns(&v1.StatusResponse{Status: &v1.RuntimeStatus{
 					Conditions: []*v1.RuntimeCondition{
 						{
+							Type:   v1.RuntimeReady,
 							Status: false,
 						},
 					},
@@ -102,6 +103,21 @@ func TestIsRunning(t *testing.T) {
 				}, nil)
 			},
 			shouldError: true,
+		},
+		{
+			name: "valid: runtime condition type does not match",
+			prepare: func(mock *fakeImpl) {
+				mock.StatusReturns(&v1.StatusResponse{Status: &v1.RuntimeStatus{
+					Conditions: []*v1.RuntimeCondition{
+						{
+							Type:   v1.NetworkReady,
+							Status: false,
+						},
+					},
+				},
+				}, nil)
+			},
+			shouldError: false,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION


#### What type of PR is this?

/kind regression

#### What this PR does / why we need it:
We only check for the `RuntimeReady` condition instead of anything else like the `NetworkReady` to allow kubeadm to provision the cluster.


#### Which issue(s) this PR fixes:

Refers to https://github.com/kubernetes/kubernetes/pull/124685#issuecomment-2138655482 Follow-up on: 

https://github.com/kubernetes/kubernetes/pull/124685


#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
