### PR TITLE
fix dra flaky test on TestPlugin

### DIFF
--- a/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources.go
@@ -1055,6 +1055,13 @@ func (pl *dynamicResources) lookupClassParameters(logger klog.Logger, class *res
 		}
 		return parameters, nil
 	default:
+		sort.Slice(objs, func(i, j int) bool {
+			obj1, obj2 := objs[i].(*resourcev1alpha2.ResourceClassParameters), objs[j].(*resourcev1alpha2.ResourceClassParameters)
+			if obj1 == nil || obj2 == nil {
+				return false
+			}
+			return obj1.Name < obj2.Name
+		})
 		return nil, statusError(logger, fmt.Errorf("multiple generated class parameters for %s.%s %s found: %s", class.ParametersRef.Kind, class.ParametersRef.APIGroup, klog.KRef(class.Namespace, class.ParametersRef.Name), klog.KObjSlice(objs)))
 	}
 }
@@ -1112,6 +1119,13 @@ func (pl *dynamicResources) lookupClaimParameters(logger klog.Logger, class *res
 		}
 		return parameters, nil
 	default:
+		sort.Slice(objs, func(i, j int) bool {
+			obj1, obj2 := objs[i].(*resourcev1alpha2.ResourceClaimParameters), objs[j].(*resourcev1alpha2.ResourceClaimParameters)
+			if obj1 == nil || obj2 == nil {
+				return false
+			}
+			return obj1.Name < obj2.Name
+		})
 		return nil, statusError(logger, fmt.Errorf("multiple generated claim parameters for %s.%s %s found: %s", claim.Spec.ParametersRef.Kind, claim.Spec.ParametersRef.APIGroup, klog.KRef(claim.Namespace, claim.Spec.ParametersRef.Name), klog.KObjSlice(objs)))
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind flake
/kind regression

#### What this PR does / why we need it:

```
{Failed;Failed;Failed;  === RUN   TestPlugin/too-many-translated-class-parameters/prefilter
    dynamicresources_test.go:1103: 
        	Error Trace:	/home/prow/go/src/k8s.io/kubernetes/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go:1221
        	            				/home/prow/go/src/k8s.io/kubernetes/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go:1103
        	Error:      	Not equal: 
        	            	expected: &framework.Status{code:1, reasons:[]string(nil), err:(*errors.errorString)(0xc0000236a0), plugin:""}
        	            	actual  : &framework.Status{code:1, reasons:[]string(nil), err:(*errors.errorString)(0xc0008c6240), plugin:""}
        	            	
        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -4,3 +4,3 @@
        	            	  err: (*errors.errorString)({
        	            	-  s: (string) (len=142) "multiple generated class parameters for ResourceClassParameters.example.com my-resource-class found: [default/my-resource-class default/other]"
        	            	+  s: (string) (len=142) "multiple generated class parameters for ResourceClassParameters.example.com my-resource-class found: [default/other default/my-resource-class]"
        	            	  }),
        	Test:       	TestPlugin/too-many-translated-class-parameters/prefilter
        --- FAIL: TestPlugin/too-many-translated-class-parameters/prefilter (0.00s)
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Related to https://github.com/kubernetes/kubernetes/pull/124630 and https://github.com/kubernetes/kubernetes/pull/125204 

Fixes https://github.com/kubernetes/kubernetes/issues/125221

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
