### PR TITLE
add apiGroup validation

### DIFF
--- a/pkg/apis/resource/validation/validation_resourceclaim_test.go
+++ b/pkg/apis/resource/validation/validation_resourceclaim_test.go
@@ -53,6 +53,8 @@ func TestValidateClaim(t *testing.T) {
 	}
 	now := metav1.Now()
 	badValue := "spaces not allowed"
+	badAPIGroup := "example.com/v1"
+	goodAPIGroup := "example.com"
 
 	scenarios := map[string]struct {
 		claim        *resource.ResourceClaim
@@ -212,6 +214,29 @@ func TestValidateClaim(t *testing.T) {
 				claim.Spec.ParametersRef = &resource.ResourceClaimParametersReference{
 					Kind: "foo",
 					Name: "bar",
+				}
+				return claim
+			}(),
+		},
+		"good-parameters-apigroup": {
+			claim: func() *resource.ResourceClaim {
+				claim := testClaim(goodName, goodNS, goodClaimSpec)
+				claim.Spec.ParametersRef = &resource.ResourceClaimParametersReference{
+					APIGroup: goodAPIGroup,
+					Kind:     "foo",
+					Name:     "bar",
+				}
+				return claim
+			}(),
+		},
+		"bad-parameters-apigroup": {
+			wantFailures: field.ErrorList{field.Invalid(field.NewPath("spec", "parametersRef", "apiGroup"), badAPIGroup, "a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')")},
+			claim: func() *resource.ResourceClaim {
+				claim := testClaim(goodName, goodNS, goodClaimSpec)
+				claim.Spec.ParametersRef = &resource.ResourceClaimParametersReference{
+					APIGroup: badAPIGroup,
+					Kind:     "foo",
+					Name:     "bar",
 				}
 				return claim
 			}(),

--- a/pkg/apis/resource/validation/validation_resourceclaimtemplate_test.go
+++ b/pkg/apis/resource/validation/validation_resourceclaimtemplate_test.go
@@ -51,6 +51,8 @@ func TestValidateClaimTemplate(t *testing.T) {
 	}
 	now := metav1.Now()
 	badValue := "spaces not allowed"
+	badAPIGroup := "example.com/v1"
+	goodAPIGroup := "example.com"
 
 	scenarios := map[string]struct {
 		template     *resource.ResourceClaimTemplate
@@ -210,6 +212,29 @@ func TestValidateClaimTemplate(t *testing.T) {
 				template.Spec.Spec.ParametersRef = &resource.ResourceClaimParametersReference{
 					Kind: "foo",
 					Name: "bar",
+				}
+				return template
+			}(),
+		},
+		"good-parameters-apigroup": {
+			template: func() *resource.ResourceClaimTemplate {
+				template := testClaimTemplate(goodName, goodNS, goodClaimSpec)
+				template.Spec.Spec.ParametersRef = &resource.ResourceClaimParametersReference{
+					APIGroup: goodAPIGroup,
+					Kind:     "foo",
+					Name:     "bar",
+				}
+				return template
+			}(),
+		},
+		"bad-parameters-apigroup": {
+			wantFailures: field.ErrorList{field.Invalid(field.NewPath("spec", "spec", "parametersRef", "apiGroup"), badAPIGroup, "a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')")},
+			template: func() *resource.ResourceClaimTemplate {
+				template := testClaimTemplate(goodName, goodNS, goodClaimSpec)
+				template.Spec.Spec.ParametersRef = &resource.ResourceClaimParametersReference{
+					APIGroup: badAPIGroup,
+					Kind:     "foo",
+					Name:     "bar",
 				}
 				return template
 			}(),

--- a/pkg/apis/resource/validation/validation_resourceclass_test.go
+++ b/pkg/apis/resource/validation/validation_resourceclass_test.go
@@ -47,6 +47,8 @@ func TestValidateClass(t *testing.T) {
 	}
 	badName := "!@#$%^"
 	badValue := "spaces not allowed"
+	badAPIGroup := "example.com/v1"
+	goodAPIGroup := "example.com"
 
 	scenarios := map[string]struct {
 		class        *resource.ResourceClass
@@ -201,6 +203,23 @@ func TestValidateClass(t *testing.T) {
 			class: func() *resource.ResourceClass {
 				class := testClass(goodName, goodName)
 				class.ParametersRef = goodParameters.DeepCopy()
+				return class
+			}(),
+		},
+		"good-parameters-apigroup": {
+			class: func() *resource.ResourceClass {
+				class := testClass(goodName, goodName)
+				class.ParametersRef = goodParameters.DeepCopy()
+				class.ParametersRef.APIGroup = goodAPIGroup
+				return class
+			}(),
+		},
+		"bad-parameters-apigroup": {
+			wantFailures: field.ErrorList{field.Invalid(field.NewPath("parametersRef", "apiGroup"), badAPIGroup, "a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')")},
+			class: func() *resource.ResourceClass {
+				class := testClass(goodName, goodName)
+				class.ParametersRef = goodParameters.DeepCopy()
+				class.ParametersRef.APIGroup = badAPIGroup
 				return class
 			}(),
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Add a validation for the `generatedFrom.apiGroup` field and the `ParametersRef.apiGroup` field. when group is not empty, it should be a valid group name. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #125216

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
DRA: enhance validation for the ResourceClaimParametersReference and ResourceClassParametersReference with the following rules:

1. `apiGroup`: If set, it must be a valid DNS subdomain (e.g. 'example.com').
2. `kind` and `name`: It must be valid path segment name. It may not be '.' or '..' and it may not contain '/' and '%' characters.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
