### PR TITLE
KEP-4193: promote ServiceAccountTokenNodeBinding feature to beta

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -699,6 +699,7 @@ const (
 	// owner: @munnerz
 	// kep: http://kep.k8s.io/4193
 	// alpha: v1.29
+	// beta: v1.31
 	//
 	// Controls whether the apiserver supports binding service account tokens to Node objects.
 	ServiceAccountTokenNodeBinding featuregate.Feature = "ServiceAccountTokenNodeBinding"
@@ -1139,7 +1140,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 
 	ServiceAccountTokenPodNodeInfo: {Default: true, PreRelease: featuregate.Beta},
 
-	ServiceAccountTokenNodeBinding: {Default: false, PreRelease: featuregate.Alpha},
+	ServiceAccountTokenNodeBinding: {Default: true, PreRelease: featuregate.Beta},
 
 	ServiceAccountTokenNodeBindingValidation: {Default: true, PreRelease: featuregate.Beta},
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_token.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_token.go
@@ -19,7 +19,6 @@ package create
 import (
 	"context"
 	"fmt"
-	"os"
 	"strings"
 	"time"
 
@@ -103,10 +102,9 @@ func boundObjectKindToAPIVersions() map[string]string {
 	kinds := map[string]string{
 		"Pod":    "v1",
 		"Secret": "v1",
+		"Node":   "v1",
 	}
-	if os.Getenv("KUBECTL_NODE_BOUND_TOKENS") == "true" {
-		kinds["Node"] = "v1"
-	}
+
 	return kinds
 }
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_token_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_token_test.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
-	"os"
 	"reflect"
 	"testing"
 	"time"
@@ -53,8 +52,6 @@ func TestCreateToken(t *testing.T) {
 		boundObjectUID  string
 		audiences       []string
 		duration        time.Duration
-
-		enableNodeBindingFeature bool
 
 		serverResponseToken string
 		serverResponseError string
@@ -118,14 +115,13 @@ status:
 			test:            "bad bound object kind",
 			name:            "mysa",
 			boundObjectKind: "Foo",
-			expectStderr:    `error: supported --bound-object-kind values are Pod, Secret`,
+			expectStderr:    `error: supported --bound-object-kind values are Node, Pod, Secret`,
 		},
 		{
-			test:                     "bad bound object kind (node feature enabled)",
-			name:                     "mysa",
-			enableNodeBindingFeature: true,
-			boundObjectKind:          "Foo",
-			expectStderr:             `error: supported --bound-object-kind values are Node, Pod, Secret`,
+			test:            "bad bound object kind (node feature enabled)",
+			name:            "mysa",
+			boundObjectKind: "Foo",
+			expectStderr:    `error: supported --bound-object-kind values are Node, Pod, Secret`,
 		},
 		{
 			test:            "missing bound object name",
@@ -172,10 +168,9 @@ status:
 			test: "valid bound object (Node)",
 			name: "mysa",
 
-			enableNodeBindingFeature: true,
-			boundObjectKind:          "Node",
-			boundObjectName:          "mynode",
-			boundObjectUID:           "myuid",
+			boundObjectKind: "Node",
+			boundObjectName: "mynode",
+			boundObjectUID:  "myuid",
 
 			expectRequestPath: "/api/v1/namespaces/test/serviceaccounts/mysa/token",
 			expectTokenRequest: &authenticationv1.TokenRequest{
@@ -366,10 +361,6 @@ status:
 			}
 			if test.duration != 0 {
 				cmd.Flags().Set("duration", test.duration.String())
-			}
-			if test.enableNodeBindingFeature {
-				os.Setenv("KUBECTL_NODE_BOUND_TOKENS", "true")
-				defer os.Unsetenv("KUBECTL_NODE_BOUND_TOKENS")
 			}
 			cmd.Run(cmd, []string{test.name})
 


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Promotes the ServiceAccountTokenNodeBinding feature to beta as per [the KEP](https://github.com/kubernetes/enhancements/issues/4193)

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:


#### Does this PR introduce a user-facing change?

```release-note
Allow creating ServiceAccount tokens bound to Node objects.
This allows users to bind a service account token's validity to a named Node object, similar to Pod bound tokens.
Use with `kubectl create token <serviceaccount-name> --bound-object-kind=Node --bound-object-node=<node-name>`.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [KEP]: https://kep.k8s.io/4193
- [Usage]: <link>
- [Other doc]: <link>
```
