### PR TITLE
features: update milestone for DevicePluginCDIDevices

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -170,7 +170,7 @@ const (
 	// kep: http://kep.k8s.io/4009
 	// alpha: v1.28
 	// beta: v1.29
-	// GA: v1.30
+	// GA: v1.31
 	//
 	// Add support for CDI Device IDs in the Device Plugin API.
 	DevicePluginCDIDevices featuregate.Feature = "DevicePluginCDIDevices"


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind documentation

#### What this PR does / why we need it:

This is a followup PR for https://github.com/kubernetes/kubernetes/pull/123315
It sets correct milestone for the DevicePluginCDIDevices feature gate.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```