### PR TITLE
Fix check to ignore non-semantic changes to objects to handle unstructured

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/equality.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/equality.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/conversion"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/endpoints/metrics"
@@ -51,13 +52,21 @@ func getAvoidTimestampEqualities() conversion.Equalities {
 		}
 
 		var eqs = equality.Semantic.Copy()
-		err := eqs.AddFunc(
+		err := eqs.AddFuncs(
 			func(a, b metav1.ManagedFieldsEntry) bool {
 				// Two objects' managed fields are equivalent if, ignoring timestamp,
 				//	the objects are deeply equal.
 				a.Time = nil
 				b.Time = nil
 				return reflect.DeepEqual(a, b)
+			},
+			func(a, b unstructured.Unstructured) bool {
+				// Check if the managed fields are equal by converting to structured types and leveraging the above
+				// function, then, ignoring the managed fields, equality check the rest of the unstructured data.
+				if !avoidTimestampEqualities.DeepEqual(a.GetManagedFields(), b.GetManagedFields()) {
+					return false
+				}
+				return equalIgnoringValueAtPath(a.Object, b.Object, []string{"metadata", "managedFields"})
 			},
 		)
 
@@ -68,6 +77,35 @@ func getAvoidTimestampEqualities() conversion.Equalities {
 		avoidTimestampEqualities = eqs
 	})
 	return avoidTimestampEqualities
+}
+
+func equalIgnoringValueAtPath(a, b any, path []string) bool {
+	if len(path) == 0 { // found the value to ignore
+		return true
+	}
+	aMap, aOk := a.(map[string]any)
+	bMap, bOk := b.(map[string]any)
+	if !aOk || !bOk {
+		return !avoidTimestampEqualities.DeepEqual(a, b)
+	}
+	if len(aMap) != len(bMap) {
+		return false
+	}
+	pathHead := path[0]
+	for k, aVal := range aMap {
+		bVal, ok := bMap[k]
+		if !ok {
+			return false
+		}
+		if k == pathHead {
+			if !equalIgnoringValueAtPath(aVal, bVal, path[1:]) {
+				return false
+			}
+		} else if !avoidTimestampEqualities.DeepEqual(aVal, bVal) {
+			return false
+		}
+	}
+	return true
 }
 
 // IgnoreManagedFieldsTimestampsTransformer reverts timestamp updates

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/equality.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/equality.go
@@ -86,7 +86,8 @@ func equalIgnoringValueAtPath(a, b any, path []string) bool {
 	aMap, aOk := a.(map[string]any)
 	bMap, bOk := b.(map[string]any)
 	if !aOk || !bOk {
-		return !avoidTimestampEqualities.DeepEqual(a, b)
+		// Can't traverse into non-maps, ignore
+		return true
 	}
 	if len(aMap) != len(bMap) {
 		return false

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/equality_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/equality_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 20214The Kubernetes Authors.
+Copyright 2024 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -91,7 +91,7 @@ func TestEqualIgnoringFieldValueAtPath(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "extra spec fields in object a",
+			name: "extra spec field",
 			a: map[string]any{
 				"metadata": map[string]any{
 					"labels":        map[string]any{"env": "dev"},
@@ -114,7 +114,7 @@ func TestEqualIgnoringFieldValueAtPath(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "different spec field in object b",
+			name: "different spec field",
 			a: map[string]any{
 				"metadata": map[string]any{
 					"labels":        map[string]any{"env": "dev"},
@@ -158,6 +158,26 @@ func TestEqualIgnoringFieldValueAtPath(t *testing.T) {
 			},
 			want: true,
 		},
+		{
+			name: "wrong type for metadata result in differences being ignored",
+			a: map[string]any{
+				"metadata": []any{
+					"something",
+				},
+				"spec": map[string]any{
+					"field": "value",
+				},
+			},
+			b: map[string]any{
+				"metadata": []any{
+					"something else",
+				},
+				"spec": map[string]any{
+					"field": "value",
+				},
+			},
+			want: true,
+		},
 	}
 
 	path := []string{"metadata", "managedFields"}
@@ -165,6 +185,11 @@ func TestEqualIgnoringFieldValueAtPath(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			actual := equalIgnoringValueAtPath(c.a, c.b, path)
+			if actual != c.want {
+				t.Error("Expected equality check to return ", c.want, ", but got ", actual)
+			}
+			// Check that equality is commutative
+			actual = equalIgnoringValueAtPath(c.b, c.a, path)
 			if actual != c.want {
 				t.Error("Expected equality check to return ", c.want, ", but got ", actual)
 			}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/equality_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/equality_test.go
@@ -1,0 +1,173 @@
+/*
+Copyright 20214The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fieldmanager
+
+import "testing"
+
+func TestEqualIgnoringFieldValueAtPath(t *testing.T) {
+	cases := []struct {
+		name string
+		a, b map[string]any
+		want bool
+	}{
+		{
+			name: "identical objects",
+			a: map[string]any{
+				"metadata": map[string]any{
+					"labels":        map[string]any{"env": "dev"},
+					"managedFields": []any{},
+				},
+				"spec": map[string]any{
+					"field": "value",
+				},
+			},
+			b: map[string]any{
+				"metadata": map[string]any{
+					"labels":        map[string]any{"env": "dev"},
+					"managedFields": []any{},
+				},
+				"spec": map[string]any{
+					"field": "value",
+				},
+			},
+			want: true,
+		},
+		{
+			name: "different metadata label value",
+			a: map[string]any{
+				"metadata": map[string]any{
+					"labels":        map[string]any{"env": "dev"},
+					"managedFields": []any{},
+				},
+				"spec": map[string]any{
+					"field": "value",
+				},
+			},
+			b: map[string]any{
+				"metadata": map[string]any{
+					"labels":        map[string]any{"env": "prod"},
+					"managedFields": []any{},
+				},
+				"spec": map[string]any{
+					"field": "value",
+				},
+			},
+			want: false,
+		},
+		{
+			name: "different spec value",
+			a: map[string]any{
+				"metadata": map[string]any{
+					"labels":        map[string]any{"env": "dev"},
+					"managedFields": []any{},
+				},
+				"spec": map[string]any{
+					"field": "value1",
+				},
+			},
+			b: map[string]any{
+				"metadata": map[string]any{
+					"labels":        map[string]any{"env": "dev"},
+					"managedFields": []any{},
+				},
+				"spec": map[string]any{
+					"field": "value2",
+				},
+			},
+			want: false,
+		},
+		{
+			name: "extra spec fields in object a",
+			a: map[string]any{
+				"metadata": map[string]any{
+					"labels":        map[string]any{"env": "dev"},
+					"managedFields": []any{},
+				},
+				"spec": map[string]any{
+					"field":      "value1",
+					"otherField": "other",
+				},
+			},
+			b: map[string]any{
+				"metadata": map[string]any{
+					"labels":        map[string]any{"env": "dev"},
+					"managedFields": []any{},
+				},
+				"spec": map[string]any{
+					"field": "value1",
+				},
+			},
+			want: false,
+		},
+		{
+			name: "different spec field in object b",
+			a: map[string]any{
+				"metadata": map[string]any{
+					"labels":        map[string]any{"env": "dev"},
+					"managedFields": []any{},
+				},
+				"spec": map[string]any{
+					"field": "value1",
+				},
+			},
+			b: map[string]any{
+				"metadata": map[string]any{
+					"labels":        map[string]any{"env": "dev"},
+					"managedFields": []any{},
+				},
+				"spec": map[string]any{
+					"field":      "value1",
+					"otherField": "other",
+				},
+			},
+			want: false,
+		},
+		{
+			name: "different managed fields should be ignored",
+			a: map[string]any{
+				"metadata": map[string]any{
+					"labels":        map[string]any{"env": "dev"},
+					"managedFields": []any{map[string]any{"manager": "client1"}},
+				},
+				"spec": map[string]any{
+					"field": "value",
+				},
+			},
+			b: map[string]any{
+				"metadata": map[string]any{
+					"labels":        map[string]any{"env": "dev"},
+					"managedFields": []any{map[string]any{"manager": "client2"}},
+				},
+				"spec": map[string]any{
+					"field": "value",
+				},
+			},
+			want: true,
+		},
+	}
+
+	path := []string{"metadata", "managedFields"}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			actual := equalIgnoringValueAtPath(c.a, c.b, path)
+			if actual != c.want {
+				t.Error("Expected equality check to return ", c.want, ", but got ", actual)
+			}
+		})
+	}
+}

--- a/test/integration/apiserver/apply/apply_crd_test.go
+++ b/test/integration/apiserver/apply/apply_crd_test.go
@@ -737,6 +737,7 @@ spec:
 }
 
 func TestNoOpApplyWithDefaultsSameResourceVersionCRD(t *testing.T) {
+	// https://github.com/kubernetes/kubernetes/issues/124605
 	server, err := apiservertesting.StartTestServer(t, apiservertesting.NewDefaultTestServerOptions(), nil, framework.SharedEtcd())
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

Fixes #124605

#### Special notes for your reviewer:

https://github.com/kubernetes/kubernetes/pull/106388 fixed built-in types, but the equality check in IgnoreManagedFieldsTimestampsTransformer for the slow case didn't handle unstructured as needed.

This is just a POC.  I'm looking for feedback on how to make this cleaner.  I'll add unit tests before moving out of draft.

#### Does this PR introduce a user-facing change?

```release-note
Fix bug where Server Side Apply causes spurious resourceVersion bumps on no-op patches to custom resources.
```

