### PR TITLE
Add PSA for blocking `.host` on pod probes

### DIFF
--- a/staging/src/k8s.io/pod-security-admission/policy/check_hostProbesAndhostLifecycle.go
+++ b/staging/src/k8s.io/pod-security-admission/policy/check_hostProbesAndhostLifecycle.go
@@ -1,0 +1,150 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package policy
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/pod-security-admission/api"
+)
+
+/*
+Host field is restricted in the probes and lifecycle handlers.
+
+**Restricted Fields:**
+
+* spec.containers[*].livenessProbe.httpGet.host
+* spec.containers[*].readinessProbe.httpGet.host
+* spec.containers[*].startupProbe.httpGet.host
+* spec.containers[*].livenessProbe.tcpSocket.host
+* spec.containers[*].readinessProbe.tcpSocket.host
+* spec.containers[*].startupProbe.tcpSocket.host
+* spec.containers[*].lifecycle.postStart.tcpSocket.host // Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept for backward compatibility.
+* spec.containers[*].lifecycle.preStop.tcpSocket.host // Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept for backward compatibility.
+* spec.containers[*].lifecycle.postStart.httpGet.host
+* spec.containers[*].lifecycle.preStop.httpGet.host
+* spec.initContainers[*].livenessProbe.httpGet.host
+* spec.initContainers[*].readinessProbe.httpGet.host
+* spec.initContainers[*].startupProbe.httpGet.host
+* spec.initContainers[*].livenessProbe.tcpSocket.host
+* spec.initContainers[*].readinessProbe.tcpSocket.host
+* spec.initContainers[*].startupProbe.tcpSocket.host
+* spec.initContainers[*].lifecycle.postStart.tcpSocket.host // Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept for backward compatibility.
+* spec.initContainers[*].lifecycle.preStop.tcpSocket.host // Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept for backward compatibility.
+* spec.initContainers[*].lifecycle.postStart.httpGet.host
+* spec.initContainers[*].lifecycle.preStop.httpGet.host
+
+Allowed Values: "", undefined/null
+*/
+
+func init() {
+	addCheck(CheckHostProbesAndHostLifecycle)
+}
+
+// CheckHostProbesAndHostLifecycle returns a baseline level check
+// that forbids setting host field in probes and lifecycle handlers in 1.34+
+func CheckHostProbesAndHostLifecycle() Check {
+	return Check{
+		ID:    "hostProbesAndHostLifecycle",
+		Level: api.LevelBaseline,
+		Versions: []VersionedCheck{
+			{
+				MinimumVersion: api.MajorMinorVersion(1, 34),
+				CheckPod:       hostProbesAndHostLifecycleV1Dot34,
+			},
+		},
+	}
+}
+
+func hostProbesAndHostLifecycleV1Dot34(podMetadata *metav1.ObjectMeta, podSpec *corev1.PodSpec) CheckResult {
+	badContainers := sets.New[string]()
+	forbidden := sets.New[string]()
+	visitContainers(podSpec, func(container *corev1.Container) {
+		// Check probes
+		if badHosts := getForbiddenHostProbes(container.LivenessProbe); len(badHosts) > 0 {
+			badContainers.Insert(container.Name)
+			forbidden.Insert(badHosts...)
+		}
+		if badHosts := getForbiddenHostProbes(container.ReadinessProbe); len(badHosts) > 0 {
+			badContainers.Insert(container.Name)
+			forbidden.Insert(badHosts...)
+		}
+		if badHosts := getForbiddenHostProbes(container.StartupProbe); len(badHosts) > 0 {
+			badContainers.Insert(container.Name)
+			forbidden.Insert(badHosts...)
+		}
+
+		// Check lifecycle handlers
+		if container.Lifecycle != nil {
+			if badHosts := getForbiddenHostLifecycle(container.Lifecycle.PostStart); len(badHosts) > 0 {
+				badContainers.Insert(container.Name)
+				forbidden.Insert(badHosts...)
+			}
+			if badHosts := getForbiddenHostLifecycle(container.Lifecycle.PreStop); len(badHosts) > 0 {
+				badContainers.Insert(container.Name)
+				forbidden.Insert(badHosts...)
+			}
+		}
+	})
+
+	if len(badContainers) > 0 {
+		return CheckResult{
+			Allowed:         false,
+			ForbiddenReason: "probe or lifecycle host",
+			ForbiddenDetail: fmt.Sprintf(
+				"%s %s %s %s %s",
+				pluralize("container", "containers", len(badContainers)),
+				joinQuote(sets.List(badContainers)),
+				pluralize("uses", "use", len(badContainers)),
+				pluralize("probe or lifecycle host", "probe or lifecycle hosts", len(forbidden)),
+				joinQuote(sets.List(forbidden)),
+			),
+		}
+	}
+	return CheckResult{Allowed: true}
+}
+
+func getForbiddenHostProbes(probe *corev1.Probe) []string {
+	var badHosts []string
+	if probe == nil {
+		return nil
+	}
+	if probe.HTTPGet != nil && probe.HTTPGet.Host != "" {
+		badHosts = append(badHosts, probe.HTTPGet.Host)
+	}
+	if probe.TCPSocket != nil && probe.TCPSocket.Host != "" {
+		badHosts = append(badHosts, probe.TCPSocket.Host)
+	}
+	return badHosts
+}
+
+func getForbiddenHostLifecycle(handler *corev1.LifecycleHandler) []string {
+	var badHosts []string
+	if handler == nil {
+		return nil
+	}
+	if handler.HTTPGet != nil && handler.HTTPGet.Host != "" {
+		badHosts = append(badHosts, handler.HTTPGet.Host)
+	}
+	if handler.TCPSocket != nil && handler.TCPSocket.Host != "" {
+		badHosts = append(badHosts, handler.TCPSocket.Host)
+	}
+	return badHosts
+}

--- a/staging/src/k8s.io/pod-security-admission/policy/check_hostProbesAndhostLifecycle_test.go
+++ b/staging/src/k8s.io/pod-security-admission/policy/check_hostProbesAndhostLifecycle_test.go
@@ -1,0 +1,267 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package policy
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestHostProbesAndHostLifecycle(t *testing.T) {
+	tests := []struct {
+		name         string
+		pod          *corev1.Pod
+		expectReason string
+		expectDetail string
+	}{
+		{
+			name: "valid pod with unset hosts",
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name: "a",
+						LivenessProbe: &corev1.Probe{
+							ProbeHandler: corev1.ProbeHandler{
+								HTTPGet: &corev1.HTTPGetAction{}, // Host field not set (defaults to podIP)
+							},
+						},
+						ReadinessProbe: &corev1.Probe{
+							ProbeHandler: corev1.ProbeHandler{
+								TCPSocket: &corev1.TCPSocketAction{}, // Host field not set (defaults to podIP)
+							},
+						},
+						Lifecycle: &corev1.Lifecycle{
+							PostStart: &corev1.LifecycleHandler{
+								HTTPGet: &corev1.HTTPGetAction{}, // Host field not set (defaults to podIP)
+							},
+						},
+					},
+				},
+			}},
+		},
+		{
+			name: "invalid pod with local host IP as probe host",
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name: "a",
+						LivenessProbe: &corev1.Probe{
+							ProbeHandler: corev1.ProbeHandler{
+								HTTPGet: &corev1.HTTPGetAction{Host: "127.0.0.1"},
+							},
+						},
+						ReadinessProbe: &corev1.Probe{
+							ProbeHandler: corev1.ProbeHandler{
+								TCPSocket: &corev1.TCPSocketAction{Host: "::1"},
+							},
+						},
+						StartupProbe: &corev1.Probe{
+							ProbeHandler: corev1.ProbeHandler{
+								HTTPGet: &corev1.HTTPGetAction{Host: "localhost"},
+							},
+						},
+					},
+				},
+			}},
+			expectReason: "probe or lifecycle host",
+			expectDetail: `container "a" uses probe or lifecycle hosts "127.0.0.1", "::1", "localhost"`,
+		},
+		{
+			name: "invalid httpget host in liveness probe",
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name: "a",
+						LivenessProbe: &corev1.Probe{
+							ProbeHandler: corev1.ProbeHandler{
+								HTTPGet: &corev1.HTTPGetAction{Host: "invalid.host"},
+							},
+						},
+					},
+				},
+			}},
+			expectReason: "probe or lifecycle host",
+			expectDetail: `container "a" uses probe or lifecycle host "invalid.host"`,
+		},
+		{
+			name: "invalid tcpsocket host in readiness probe",
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name: "b",
+						ReadinessProbe: &corev1.Probe{
+							ProbeHandler: corev1.ProbeHandler{
+								TCPSocket: &corev1.TCPSocketAction{Host: "invalid.host"},
+							},
+						},
+					},
+				},
+			}},
+			expectReason: "probe or lifecycle host",
+			expectDetail: `container "b" uses probe or lifecycle host "invalid.host"`,
+		},
+		{
+			name: "invalid httpget host in startup probe",
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name: "c",
+						StartupProbe: &corev1.Probe{
+							ProbeHandler: corev1.ProbeHandler{
+								HTTPGet: &corev1.HTTPGetAction{Host: "invalid.host"},
+							},
+						},
+					},
+				},
+			}},
+			expectReason: "probe or lifecycle host",
+			expectDetail: `container "c" uses probe or lifecycle host "invalid.host"`,
+		},
+		{
+			name: "invalid poststart tcpsocket host",
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name: "d",
+						Lifecycle: &corev1.Lifecycle{
+							PostStart: &corev1.LifecycleHandler{
+								TCPSocket: &corev1.TCPSocketAction{Host: "invalid.host"},
+							},
+						},
+					},
+				},
+			}},
+			expectReason: "probe or lifecycle host",
+			expectDetail: `container "d" uses probe or lifecycle host "invalid.host"`,
+		},
+		{
+			name: "invalid prestop httpget host",
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name: "e",
+						Lifecycle: &corev1.Lifecycle{
+							PreStop: &corev1.LifecycleHandler{
+								HTTPGet: &corev1.HTTPGetAction{Host: "another.invalid.host"},
+							},
+						},
+					},
+				},
+			}},
+			expectReason: "probe or lifecycle host",
+			expectDetail: `container "e" uses probe or lifecycle host "another.invalid.host"`,
+		},
+		{
+			name: "multiple containers with multiple invalid hosts",
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{Name: "valid"},
+					{
+						Name: "invalid1",
+						LivenessProbe: &corev1.Probe{
+							ProbeHandler: corev1.ProbeHandler{HTTPGet: &corev1.HTTPGetAction{Host: "a.com"}},
+						},
+					},
+					{
+						Name: "invalid2",
+						Lifecycle: &corev1.Lifecycle{
+							PreStop: &corev1.LifecycleHandler{TCPSocket: &corev1.TCPSocketAction{Host: "b.com"}},
+						},
+						StartupProbe: &corev1.Probe{
+							ProbeHandler: corev1.ProbeHandler{HTTPGet: &corev1.HTTPGetAction{Host: "a.com"}},
+						},
+					},
+				},
+			}},
+			expectReason: "probe or lifecycle host",
+			expectDetail: `containers "invalid1", "invalid2" use probe or lifecycle hosts "a.com", "b.com"`,
+		},
+		{
+			name: "invalid ipv4 host in probe",
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name: "a",
+						LivenessProbe: &corev1.Probe{
+							ProbeHandler: corev1.ProbeHandler{
+								HTTPGet: &corev1.HTTPGetAction{Host: "8.8.8.8"},
+							},
+						},
+					},
+				},
+			}},
+			expectReason: "probe or lifecycle host",
+			expectDetail: `container "a" uses probe or lifecycle host "8.8.8.8"`,
+		},
+		{
+			name: "invalid ipv6 host in probe",
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name: "a",
+						LivenessProbe: &corev1.Probe{
+							ProbeHandler: corev1.ProbeHandler{
+								TCPSocket: &corev1.TCPSocketAction{Host: "2001:4860:4860::8888"},
+							},
+						},
+					},
+				},
+			}},
+			expectReason: "probe or lifecycle host",
+			expectDetail: `container "a" uses probe or lifecycle host "2001:4860:4860::8888"`,
+		},
+		{
+			name: "invalid host in initcontainer",
+			pod: &corev1.Pod{Spec: corev1.PodSpec{
+				InitContainers: []corev1.Container{
+					{
+						Name: "init",
+						LivenessProbe: &corev1.Probe{
+							ProbeHandler: corev1.ProbeHandler{
+								HTTPGet: &corev1.HTTPGetAction{Host: "invalid.init.host"},
+							},
+						},
+					},
+				},
+			}},
+			expectReason: "probe or lifecycle host",
+			expectDetail: `container "init" uses probe or lifecycle host "invalid.init.host"`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := hostProbesAndHostLifecycleV1Dot34(&tc.pod.ObjectMeta, &tc.pod.Spec)
+			if tc.expectReason == "" {
+				if !result.Allowed {
+					t.Fatalf("expected allowed, but got disallowed: %s", result.ForbiddenDetail)
+				}
+			} else {
+				if result.Allowed {
+					t.Fatal("expected disallowed, but got allowed")
+				}
+				if e, a := tc.expectReason, result.ForbiddenReason; e != a {
+					t.Errorf("expected reason\n%s\ngot\n%s", e, a)
+				}
+				if e, a := tc.expectDetail, result.ForbiddenDetail; e != a {
+					t.Errorf("expected detail\n%s\ngot\n%s", e, a)
+				}
+			}
+		})
+	}
+}

--- a/staging/src/k8s.io/pod-security-admission/test/fixtures_hostProbesAndHostLifecycle.go
+++ b/staging/src/k8s.io/pod-security-admission/test/fixtures_hostProbesAndHostLifecycle.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/pod-security-admission/api"
+)
+
+func init() {
+	fixtureDataV1Dot34 := fixtureGenerator{
+		expectErrorSubstring: "probe or lifecycle host",
+		generatePass: func(p *corev1.Pod) []*corev1.Pod {
+			return []*corev1.Pod{
+				p, // A pod with no probes should pass.
+				tweak(p, func(p *corev1.Pod) {
+					p.Spec.Containers[0].LivenessProbe = &corev1.Probe{
+						ProbeHandler: corev1.ProbeHandler{
+							HTTPGet: &corev1.HTTPGetAction{
+								Port: intstr.FromInt32(8080),
+							},
+						},
+					}
+				}),
+				tweak(p, func(p *corev1.Pod) {
+					p.Spec.Containers[0].ReadinessProbe = &corev1.Probe{
+						ProbeHandler: corev1.ProbeHandler{
+							TCPSocket: &corev1.TCPSocketAction{
+								Port: intstr.FromInt32(8080),
+							},
+						},
+					}
+				}),
+			}
+		},
+		generateFail: func(p *corev1.Pod) []*corev1.Pod {
+			return []*corev1.Pod{
+				tweak(p, func(p *corev1.Pod) {
+					p.Spec.Containers[0].LivenessProbe = &corev1.Probe{
+						ProbeHandler: corev1.ProbeHandler{
+							HTTPGet: &corev1.HTTPGetAction{
+								Host: "bad.host",
+								Port: intstr.FromInt32(8080),
+							},
+						},
+					}
+				}),
+				tweak(p, func(p *corev1.Pod) {
+					restartPolicy := corev1.ContainerRestartPolicyAlways
+					p.Spec.InitContainers[0].RestartPolicy = &restartPolicy
+					p.Spec.InitContainers[0].ReadinessProbe = &corev1.Probe{
+						ProbeHandler: corev1.ProbeHandler{
+							TCPSocket: &corev1.TCPSocketAction{
+								Host: "8.8.8.8",
+								Port: intstr.FromInt32(8080),
+							},
+						},
+					}
+				}),
+				tweak(p, func(p *corev1.Pod) {
+					p.Spec.Containers[0].Lifecycle = &corev1.Lifecycle{
+						PostStart: &corev1.LifecycleHandler{
+							HTTPGet: &corev1.HTTPGetAction{
+								Host: "bad.host",
+								Port: intstr.FromInt32(8080),
+							},
+						},
+					}
+				}),
+				tweak(p, func(p *corev1.Pod) {
+					p.Spec.Containers[0].LivenessProbe = &corev1.Probe{
+						ProbeHandler: corev1.ProbeHandler{
+							HTTPGet: &corev1.HTTPGetAction{
+								Host: "127.0.0.1",
+								Port: intstr.FromInt32(8080),
+							},
+						},
+					}
+				}),
+				tweak(p, func(p *corev1.Pod) {
+					p.Spec.Containers[0].ReadinessProbe = &corev1.Probe{
+						ProbeHandler: corev1.ProbeHandler{
+							TCPSocket: &corev1.TCPSocketAction{
+								Host: "::1",
+								Port: intstr.FromInt32(8080),
+							},
+						},
+					}
+				}),
+			}
+		},
+	}
+
+	registerFixtureGenerator(
+		fixtureKey{level: api.LevelBaseline, version: api.MajorMinorVersion(1, 34), check: "hostProbesAndHostLifecycle"},
+		fixtureDataV1Dot34,
+	)
+}

--- a/staging/src/k8s.io/pod-security-admission/test/run.go
+++ b/staging/src/k8s.io/pod-security-admission/test/run.go
@@ -37,7 +37,7 @@ import (
 )
 
 const (
-	newestMinorVersionToTest            = 32
+	newestMinorVersionToTest            = 34
 	podOSBasedRestrictionEnabledVersion = 29
 )
 

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.33/fail/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.33/fail/apparmorprofile0.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: unconfined
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.33/fail/apparmorprofile1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.33/fail/apparmorprofile1.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/initcontainer1: unconfined
+  name: apparmorprofile1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.33/fail/capabilities_baseline0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.33/fail/capabilities_baseline0.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_baseline0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      capabilities:
+        add:
+        - NET_RAW
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      capabilities: {}
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.33/fail/capabilities_baseline1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.33/fail/capabilities_baseline1.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_baseline1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      capabilities: {}
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      capabilities:
+        add:
+        - NET_RAW
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.33/fail/capabilities_baseline2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.33/fail/capabilities_baseline2.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_baseline2
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      capabilities:
+        add:
+        - chown
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      capabilities: {}
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.33/fail/capabilities_baseline3.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.33/fail/capabilities_baseline3.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_baseline3
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      capabilities:
+        add:
+        - CAP_CHOWN
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      capabilities: {}
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.33/fail/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.33/fail/hostnamespaces0.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+  hostIPC: true
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.33/fail/hostnamespaces1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.33/fail/hostnamespaces1.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+  hostNetwork: true
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.33/fail/hostnamespaces2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.33/fail/hostnamespaces2.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces2
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+  hostPID: true
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.33/fail/hostpathvolumes0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.33/fail/hostpathvolumes0.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostpathvolumes0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+  volumes:
+  - emptyDir: {}
+    name: volume-emptydir
+  - hostPath:
+      path: /a
+    name: volume-hostpath

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.33/fail/hostpathvolumes1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.33/fail/hostpathvolumes1.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostpathvolumes1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+  volumes:
+  - hostPath:
+      path: /a
+    name: volume-hostpath-a
+  - hostPath:
+      path: /b
+    name: volume-hostpath-b

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.33/fail/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.33/fail/hostports0.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.33/fail/hostports1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.33/fail/hostports1.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.33/fail/hostports2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.33/fail/hostports2.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports2
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+    - containerPort: 12347
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346
+    - containerPort: 12348

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.33/fail/privileged0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.33/fail/privileged0.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: privileged0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      privileged: true
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext: {}
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.33/fail/privileged1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.33/fail/privileged1.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: privileged1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext: {}
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      privileged: true
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.33/fail/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.33/fail/procmount0.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: procmount0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      procMount: Unmasked
+  hostUsers: false
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext: {}
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.33/fail/procmount1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.33/fail/procmount1.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: procmount1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext: {}
+  hostUsers: false
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      procMount: Unmasked
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.33/fail/seccompprofile_baseline0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.33/fail/seccompprofile_baseline0.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_baseline0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext: {}
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext: {}
+  securityContext:
+    seccompProfile:
+      type: Unconfined

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.33/fail/seccompprofile_baseline1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.33/fail/seccompprofile_baseline1.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_baseline1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      seccompProfile:
+        type: Unconfined
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext: {}
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.33/fail/seccompprofile_baseline2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.33/fail/seccompprofile_baseline2.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_baseline2
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext: {}
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      seccompProfile:
+        type: Unconfined
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.33/fail/selinuxoptions0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.33/fail/selinuxoptions0.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      seLinuxOptions: {}
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      seLinuxOptions: {}
+  securityContext:
+    seLinuxOptions:
+      type: somevalue

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.33/fail/selinuxoptions1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.33/fail/selinuxoptions1.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      seLinuxOptions:
+        type: somevalue
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      seLinuxOptions: {}
+  securityContext:
+    seLinuxOptions: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.33/fail/selinuxoptions2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.33/fail/selinuxoptions2.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions2
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      seLinuxOptions: {}
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      seLinuxOptions:
+        type: somevalue
+  securityContext:
+    seLinuxOptions: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.33/fail/selinuxoptions3.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.33/fail/selinuxoptions3.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions3
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      seLinuxOptions: {}
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      seLinuxOptions: {}
+  securityContext:
+    seLinuxOptions:
+      user: somevalue

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.33/fail/selinuxoptions4.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.33/fail/selinuxoptions4.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions4
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      seLinuxOptions: {}
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      seLinuxOptions: {}
+  securityContext:
+    seLinuxOptions:
+      role: somevalue

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.33/fail/sysctls0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.33/fail/sysctls0.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: sysctls0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+  securityContext:
+    sysctls:
+    - name: othersysctl
+      value: other

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.33/fail/windowshostprocess0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.33/fail/windowshostprocess0.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: windowshostprocess0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      windowsOptions: {}
+  hostNetwork: true
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      windowsOptions: {}
+  securityContext:
+    windowsOptions:
+      hostProcess: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.33/fail/windowshostprocess1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.33/fail/windowshostprocess1.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: windowshostprocess1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      windowsOptions:
+        hostProcess: true
+  hostNetwork: true
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      windowsOptions:
+        hostProcess: true
+  securityContext:
+    windowsOptions: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.33/pass/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.33/pass/apparmorprofile0.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: localhost/foo
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.33/pass/base.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.33/pass/base.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: base
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.33/pass/capabilities_baseline0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.33/pass/capabilities_baseline0.yaml
@@ -1,0 +1,44 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_baseline0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      capabilities:
+        add:
+        - AUDIT_WRITE
+        - CHOWN
+        - DAC_OVERRIDE
+        - FOWNER
+        - FSETID
+        - KILL
+        - MKNOD
+        - NET_BIND_SERVICE
+        - SETFCAP
+        - SETGID
+        - SETPCAP
+        - SETUID
+        - SYS_CHROOT
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      capabilities:
+        add:
+        - AUDIT_WRITE
+        - CHOWN
+        - DAC_OVERRIDE
+        - FOWNER
+        - FSETID
+        - KILL
+        - MKNOD
+        - NET_BIND_SERVICE
+        - SETFCAP
+        - SETGID
+        - SETPCAP
+        - SETUID
+        - SYS_CHROOT
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.33/pass/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.33/pass/hostports0.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.33/pass/privileged0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.33/pass/privileged0.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: privileged0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      privileged: false
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      privileged: false
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.33/pass/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.33/pass/procmount0.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: procmount0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      procMount: Default
+  hostUsers: false
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      procMount: Default
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.33/pass/seccompprofile_baseline0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.33/pass/seccompprofile_baseline0.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_baseline0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      seccompProfile:
+        type: RuntimeDefault
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext: {}
+  securityContext:
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.33/pass/selinuxoptions0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.33/pass/selinuxoptions0.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext: {}
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      seLinuxOptions: {}
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.33/pass/selinuxoptions1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.33/pass/selinuxoptions1.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      seLinuxOptions:
+        level: somevalue
+        type: container_init_t
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      seLinuxOptions:
+        type: container_kvm_t
+  securityContext:
+    seLinuxOptions:
+      type: container_t

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.33/pass/sysctls0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.33/pass/sysctls0.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: sysctls0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.33/pass/sysctls1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.33/pass/sysctls1.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: sysctls1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+  securityContext:
+    sysctls:
+    - name: net.ipv4.tcp_rmem
+      value: 4096 87380 16777216
+    - name: net.ipv4.tcp_wmem
+      value: 4096 65536 16777216

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.34/fail/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.34/fail/apparmorprofile0.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: unconfined
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.34/fail/apparmorprofile1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.34/fail/apparmorprofile1.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/initcontainer1: unconfined
+  name: apparmorprofile1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.34/fail/capabilities_baseline0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.34/fail/capabilities_baseline0.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_baseline0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      capabilities:
+        add:
+        - NET_RAW
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      capabilities: {}
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.34/fail/capabilities_baseline1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.34/fail/capabilities_baseline1.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_baseline1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      capabilities: {}
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      capabilities:
+        add:
+        - NET_RAW
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.34/fail/capabilities_baseline2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.34/fail/capabilities_baseline2.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_baseline2
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      capabilities:
+        add:
+        - chown
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      capabilities: {}
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.34/fail/capabilities_baseline3.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.34/fail/capabilities_baseline3.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_baseline3
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      capabilities:
+        add:
+        - CAP_CHOWN
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      capabilities: {}
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.34/fail/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.34/fail/hostnamespaces0.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+  hostIPC: true
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.34/fail/hostnamespaces1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.34/fail/hostnamespaces1.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+  hostNetwork: true
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.34/fail/hostnamespaces2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.34/fail/hostnamespaces2.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces2
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+  hostPID: true
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.34/fail/hostpathvolumes0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.34/fail/hostpathvolumes0.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostpathvolumes0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+  volumes:
+  - emptyDir: {}
+    name: volume-emptydir
+  - hostPath:
+      path: /a
+    name: volume-hostpath

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.34/fail/hostpathvolumes1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.34/fail/hostpathvolumes1.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostpathvolumes1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+  volumes:
+  - hostPath:
+      path: /a
+    name: volume-hostpath-a
+  - hostPath:
+      path: /b
+    name: volume-hostpath-b

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.34/fail/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.34/fail/hostports0.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.34/fail/hostports1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.34/fail/hostports1.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.34/fail/hostports2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.34/fail/hostports2.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports2
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+    - containerPort: 12347
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346
+    - containerPort: 12348

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.34/fail/hostprobesandhostlifecycle0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.34/fail/hostprobesandhostlifecycle0.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostprobesandhostlifecycle0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    livenessProbe:
+      httpGet:
+        host: bad.host
+        port: 8080
+    name: container1
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.34/fail/hostprobesandhostlifecycle1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.34/fail/hostprobesandhostlifecycle1.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostprobesandhostlifecycle1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    readinessProbe:
+      tcpSocket:
+        host: 8.8.8.8
+        port: 8080
+    restartPolicy: Always

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.34/fail/hostprobesandhostlifecycle2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.34/fail/hostprobesandhostlifecycle2.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostprobesandhostlifecycle2
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    lifecycle:
+      postStart:
+        httpGet:
+          host: bad.host
+          port: 8080
+    name: container1
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.34/fail/hostprobesandhostlifecycle3.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.34/fail/hostprobesandhostlifecycle3.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostprobesandhostlifecycle3
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    livenessProbe:
+      httpGet:
+        host: 127.0.0.1
+        port: 8080
+    name: container1
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.34/fail/hostprobesandhostlifecycle4.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.34/fail/hostprobesandhostlifecycle4.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostprobesandhostlifecycle4
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    readinessProbe:
+      tcpSocket:
+        host: ::1
+        port: 8080
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.34/fail/privileged0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.34/fail/privileged0.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: privileged0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      privileged: true
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext: {}
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.34/fail/privileged1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.34/fail/privileged1.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: privileged1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext: {}
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      privileged: true
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.34/fail/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.34/fail/procmount0.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: procmount0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      procMount: Unmasked
+  hostUsers: false
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext: {}
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.34/fail/procmount1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.34/fail/procmount1.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: procmount1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext: {}
+  hostUsers: false
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      procMount: Unmasked
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.34/fail/seccompprofile_baseline0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.34/fail/seccompprofile_baseline0.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_baseline0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext: {}
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext: {}
+  securityContext:
+    seccompProfile:
+      type: Unconfined

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.34/fail/seccompprofile_baseline1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.34/fail/seccompprofile_baseline1.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_baseline1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      seccompProfile:
+        type: Unconfined
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext: {}
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.34/fail/seccompprofile_baseline2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.34/fail/seccompprofile_baseline2.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_baseline2
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext: {}
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      seccompProfile:
+        type: Unconfined
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.34/fail/selinuxoptions0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.34/fail/selinuxoptions0.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      seLinuxOptions: {}
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      seLinuxOptions: {}
+  securityContext:
+    seLinuxOptions:
+      type: somevalue

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.34/fail/selinuxoptions1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.34/fail/selinuxoptions1.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      seLinuxOptions:
+        type: somevalue
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      seLinuxOptions: {}
+  securityContext:
+    seLinuxOptions: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.34/fail/selinuxoptions2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.34/fail/selinuxoptions2.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions2
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      seLinuxOptions: {}
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      seLinuxOptions:
+        type: somevalue
+  securityContext:
+    seLinuxOptions: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.34/fail/selinuxoptions3.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.34/fail/selinuxoptions3.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions3
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      seLinuxOptions: {}
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      seLinuxOptions: {}
+  securityContext:
+    seLinuxOptions:
+      user: somevalue

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.34/fail/selinuxoptions4.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.34/fail/selinuxoptions4.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions4
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      seLinuxOptions: {}
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      seLinuxOptions: {}
+  securityContext:
+    seLinuxOptions:
+      role: somevalue

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.34/fail/sysctls0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.34/fail/sysctls0.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: sysctls0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+  securityContext:
+    sysctls:
+    - name: othersysctl
+      value: other

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.34/fail/windowshostprocess0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.34/fail/windowshostprocess0.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: windowshostprocess0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      windowsOptions: {}
+  hostNetwork: true
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      windowsOptions: {}
+  securityContext:
+    windowsOptions:
+      hostProcess: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.34/fail/windowshostprocess1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.34/fail/windowshostprocess1.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: windowshostprocess1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      windowsOptions:
+        hostProcess: true
+  hostNetwork: true
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      windowsOptions:
+        hostProcess: true
+  securityContext:
+    windowsOptions: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.34/pass/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.34/pass/apparmorprofile0.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: localhost/foo
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.34/pass/base.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.34/pass/base.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: base
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.34/pass/capabilities_baseline0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.34/pass/capabilities_baseline0.yaml
@@ -1,0 +1,44 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_baseline0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      capabilities:
+        add:
+        - AUDIT_WRITE
+        - CHOWN
+        - DAC_OVERRIDE
+        - FOWNER
+        - FSETID
+        - KILL
+        - MKNOD
+        - NET_BIND_SERVICE
+        - SETFCAP
+        - SETGID
+        - SETPCAP
+        - SETUID
+        - SYS_CHROOT
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      capabilities:
+        add:
+        - AUDIT_WRITE
+        - CHOWN
+        - DAC_OVERRIDE
+        - FOWNER
+        - FSETID
+        - KILL
+        - MKNOD
+        - NET_BIND_SERVICE
+        - SETFCAP
+        - SETGID
+        - SETPCAP
+        - SETUID
+        - SYS_CHROOT
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.34/pass/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.34/pass/hostports0.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.34/pass/hostprobesandhostlifecycle0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.34/pass/hostprobesandhostlifecycle0.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostprobesandhostlifecycle0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.34/pass/hostprobesandhostlifecycle1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.34/pass/hostprobesandhostlifecycle1.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostprobesandhostlifecycle1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    livenessProbe:
+      httpGet:
+        port: 8080
+    name: container1
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.34/pass/hostprobesandhostlifecycle2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.34/pass/hostprobesandhostlifecycle2.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostprobesandhostlifecycle2
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    readinessProbe:
+      tcpSocket:
+        port: 8080
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.34/pass/privileged0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.34/pass/privileged0.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: privileged0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      privileged: false
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      privileged: false
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.34/pass/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.34/pass/procmount0.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: procmount0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      procMount: Default
+  hostUsers: false
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      procMount: Default
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.34/pass/seccompprofile_baseline0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.34/pass/seccompprofile_baseline0.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_baseline0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      seccompProfile:
+        type: RuntimeDefault
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext: {}
+  securityContext:
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.34/pass/selinuxoptions0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.34/pass/selinuxoptions0.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext: {}
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      seLinuxOptions: {}
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.34/pass/selinuxoptions1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.34/pass/selinuxoptions1.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      seLinuxOptions:
+        level: somevalue
+        type: container_init_t
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      seLinuxOptions:
+        type: container_kvm_t
+  securityContext:
+    seLinuxOptions:
+      type: container_t

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.34/pass/sysctls0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.34/pass/sysctls0.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: sysctls0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+  securityContext: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.34/pass/sysctls1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/baseline/v1.34/pass/sysctls1.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: sysctls1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+  securityContext:
+    sysctls:
+    - name: net.ipv4.tcp_rmem
+      value: 4096 87380 16777216
+    - name: net.ipv4.tcp_wmem
+      value: 4096 65536 16777216

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/allowprivilegeescalation0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/allowprivilegeescalation0.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: allowprivilegeescalation0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: true
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/allowprivilegeescalation1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/allowprivilegeescalation1.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: allowprivilegeescalation1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: true
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/allowprivilegeescalation2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/allowprivilegeescalation2.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: allowprivilegeescalation2
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/allowprivilegeescalation3.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/allowprivilegeescalation3.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: allowprivilegeescalation3
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/apparmorprofile0.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: unconfined
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/apparmorprofile1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/apparmorprofile1.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/initcontainer1: unconfined
+  name: apparmorprofile1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/capabilities_baseline0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/capabilities_baseline0.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_baseline0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        add:
+        - NET_RAW
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/capabilities_baseline1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/capabilities_baseline1.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_baseline1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        add:
+        - NET_RAW
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/capabilities_baseline2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/capabilities_baseline2.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_baseline2
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        add:
+        - chown
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/capabilities_baseline3.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/capabilities_baseline3.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_baseline3
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        add:
+        - CAP_CHOWN
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/capabilities_restricted0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/capabilities_restricted0.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_restricted0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities: {}
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/capabilities_restricted1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/capabilities_restricted1.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_restricted1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities: {}
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/capabilities_restricted2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/capabilities_restricted2.yaml
@@ -1,0 +1,97 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_restricted2
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - SYS_TIME
+        - SYS_MODULE
+        - SYS_RAWIO
+        - SYS_PACCT
+        - SYS_ADMIN
+        - SYS_NICE
+        - SYS_RESOURCE
+        - SYS_TIME
+        - SYS_TTY_CONFIG
+        - MKNOD
+        - AUDIT_WRITE
+        - AUDIT_CONTROL
+        - MAC_OVERRIDE
+        - MAC_ADMIN
+        - NET_ADMIN
+        - SYSLOG
+        - CHOWN
+        - NET_RAW
+        - DAC_OVERRIDE
+        - FOWNER
+        - DAC_READ_SEARCH
+        - FSETID
+        - KILL
+        - SETGID
+        - SETUID
+        - LINUX_IMMUTABLE
+        - NET_BIND_SERVICE
+        - NET_BROADCAST
+        - IPC_LOCK
+        - IPC_OWNER
+        - SYS_CHROOT
+        - SYS_PTRACE
+        - SYS_BOOT
+        - LEASE
+        - SETFCAP
+        - WAKE_ALARM
+        - BLOCK_SUSPEND
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - SYS_TIME
+        - SYS_MODULE
+        - SYS_RAWIO
+        - SYS_PACCT
+        - SYS_ADMIN
+        - SYS_NICE
+        - SYS_RESOURCE
+        - SYS_TIME
+        - SYS_TTY_CONFIG
+        - MKNOD
+        - AUDIT_WRITE
+        - AUDIT_CONTROL
+        - MAC_OVERRIDE
+        - MAC_ADMIN
+        - NET_ADMIN
+        - SYSLOG
+        - CHOWN
+        - NET_RAW
+        - DAC_OVERRIDE
+        - FOWNER
+        - DAC_READ_SEARCH
+        - FSETID
+        - KILL
+        - SETGID
+        - SETUID
+        - LINUX_IMMUTABLE
+        - NET_BIND_SERVICE
+        - NET_BROADCAST
+        - IPC_LOCK
+        - IPC_OWNER
+        - SYS_CHROOT
+        - SYS_PTRACE
+        - SYS_BOOT
+        - LEASE
+        - SETFCAP
+        - WAKE_ALARM
+        - BLOCK_SUSPEND
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/capabilities_restricted3.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/capabilities_restricted3.yaml
@@ -1,0 +1,53 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_restricted3
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        add:
+        - AUDIT_WRITE
+        - CHOWN
+        - DAC_OVERRIDE
+        - FOWNER
+        - FSETID
+        - KILL
+        - MKNOD
+        - NET_BIND_SERVICE
+        - SETFCAP
+        - SETGID
+        - SETPCAP
+        - SETUID
+        - SYS_CHROOT
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        add:
+        - AUDIT_WRITE
+        - CHOWN
+        - DAC_OVERRIDE
+        - FOWNER
+        - FSETID
+        - KILL
+        - MKNOD
+        - NET_BIND_SERVICE
+        - SETFCAP
+        - SETGID
+        - SETPCAP
+        - SETUID
+        - SYS_CHROOT
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/hostnamespaces0.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  hostIPC: true
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/hostnamespaces1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/hostnamespaces1.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  hostNetwork: true
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/hostnamespaces2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/hostnamespaces2.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces2
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  hostPID: true
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/hostpathvolumes0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/hostpathvolumes0.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostpathvolumes0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - emptyDir: {}
+    name: volume-emptydir
+  - hostPath:
+      path: /a
+    name: volume-hostpath

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/hostpathvolumes1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/hostpathvolumes1.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostpathvolumes1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - hostPath:
+      path: /a
+    name: volume-hostpath-a
+  - hostPath:
+      path: /b
+    name: volume-hostpath-b

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/hostports0.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/hostports1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/hostports1.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/hostports2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/hostports2.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports2
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+    - containerPort: 12347
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346
+    - containerPort: 12348
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/privileged0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/privileged0.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: privileged0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      capabilities:
+        drop:
+        - ALL
+      privileged: true
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/privileged1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/privileged1.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: privileged1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      capabilities:
+        drop:
+        - ALL
+      privileged: true
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/procmount0.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: procmount0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      procMount: Unmasked
+  hostUsers: false
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/procmount1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/procmount1.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: procmount1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  hostUsers: false
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      procMount: Unmasked
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/restrictedvolumes0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/restrictedvolumes0.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - gcePersistentDisk:
+      pdName: test
+    name: volume1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/restrictedvolumes1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/restrictedvolumes1.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - awsElasticBlockStore:
+      volumeID: test
+    name: volume1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/restrictedvolumes10.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/restrictedvolumes10.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes10
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - flocker:
+      datasetName: test
+    name: volume1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/restrictedvolumes11.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/restrictedvolumes11.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes11
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - fc:
+      wwids:
+      - test
+    name: volume1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/restrictedvolumes12.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/restrictedvolumes12.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes12
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - azureFile:
+      secretName: test
+      shareName: test
+    name: volume1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/restrictedvolumes13.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/restrictedvolumes13.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes13
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - name: volume1
+    vsphereVolume:
+      volumePath: test

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/restrictedvolumes14.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/restrictedvolumes14.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes14
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - name: volume1
+    quobyte:
+      registry: localhost:1234
+      volume: test

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/restrictedvolumes15.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/restrictedvolumes15.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes15
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - azureDisk:
+      diskName: test
+      diskURI: https://test.blob.core.windows.net/test/test.vhd
+    name: volume1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/restrictedvolumes16.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/restrictedvolumes16.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes16
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - name: volume1
+    portworxVolume:
+      fsType: ext4
+      volumeID: test

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/restrictedvolumes17.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/restrictedvolumes17.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes17
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - name: volume1
+    scaleIO:
+      gateway: localhost
+      secretRef: null
+      system: test
+      volumeName: test

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/restrictedvolumes18.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/restrictedvolumes18.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes18
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - name: volume1
+    storageos:
+      volumeName: test

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/restrictedvolumes19.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/restrictedvolumes19.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes19
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - hostPath:
+      path: /dev/null
+    name: volume1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/restrictedvolumes2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/restrictedvolumes2.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes2
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - gitRepo:
+      repository: github.com/kubernetes/kubernetes
+    name: volume1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/restrictedvolumes3.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/restrictedvolumes3.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes3
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - name: volume1
+    nfs:
+      path: /test
+      server: test

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/restrictedvolumes4.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/restrictedvolumes4.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes4
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - iscsi:
+      iqn: iqn.2001-04.com.example:storage.kube.sys1.xyz
+      lun: 0
+      targetPortal: test
+    name: volume1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/restrictedvolumes5.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/restrictedvolumes5.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes5
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - glusterfs:
+      endpoints: test
+      path: test
+    name: volume1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/restrictedvolumes6.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/restrictedvolumes6.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes6
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - name: volume1
+    rbd:
+      image: test
+      monitors:
+      - test

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/restrictedvolumes7.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/restrictedvolumes7.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes7
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - flexVolume:
+      driver: test
+    name: volume1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/restrictedvolumes8.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/restrictedvolumes8.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes8
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - cinder:
+      volumeID: test
+    name: volume1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/restrictedvolumes9.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/restrictedvolumes9.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes9
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - cephfs:
+      monitors:
+      - test
+    name: volume1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/runasnonroot0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/runasnonroot0.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: runasnonroot0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/runasnonroot1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/runasnonroot1.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: runasnonroot1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: false
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/runasnonroot2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/runasnonroot2.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: runasnonroot2
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      runAsNonRoot: false
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/runasnonroot3.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/runasnonroot3.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: runasnonroot3
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      runAsNonRoot: false
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/runasuser0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/runasuser0.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: runasuser0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 0
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/runasuser1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/runasuser1.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: runasuser1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      runAsUser: 0
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/runasuser2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/runasuser2.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: runasuser2
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      runAsUser: 0
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/seccompprofile_baseline0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/seccompprofile_baseline0.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_baseline0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: Unconfined

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/seccompprofile_baseline1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/seccompprofile_baseline1.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_baseline1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seccompProfile:
+        type: Unconfined
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/seccompprofile_baseline2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/seccompprofile_baseline2.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_baseline2
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seccompProfile:
+        type: Unconfined
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/seccompprofile_restricted0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/seccompprofile_restricted0.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_restricted0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/seccompprofile_restricted1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/seccompprofile_restricted1.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_restricted1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: Unconfined

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/seccompprofile_restricted2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/seccompprofile_restricted2.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_restricted2
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seccompProfile:
+        type: RuntimeDefault
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/seccompprofile_restricted3.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/seccompprofile_restricted3.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_restricted3
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seccompProfile:
+        type: RuntimeDefault
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/seccompprofile_restricted4.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/seccompprofile_restricted4.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_restricted4
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seccompProfile:
+        type: RuntimeDefault
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seccompProfile:
+        type: Unconfined
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/selinuxoptions0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/selinuxoptions0.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seLinuxOptions: {}
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seLinuxOptions: {}
+  securityContext:
+    runAsNonRoot: true
+    seLinuxOptions:
+      type: somevalue
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/selinuxoptions1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/selinuxoptions1.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seLinuxOptions:
+        type: somevalue
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seLinuxOptions: {}
+  securityContext:
+    runAsNonRoot: true
+    seLinuxOptions: {}
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/selinuxoptions2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/selinuxoptions2.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions2
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seLinuxOptions: {}
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seLinuxOptions:
+        type: somevalue
+  securityContext:
+    runAsNonRoot: true
+    seLinuxOptions: {}
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/selinuxoptions3.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/selinuxoptions3.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions3
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seLinuxOptions: {}
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seLinuxOptions: {}
+  securityContext:
+    runAsNonRoot: true
+    seLinuxOptions:
+      user: somevalue
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/selinuxoptions4.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/selinuxoptions4.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions4
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seLinuxOptions: {}
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seLinuxOptions: {}
+  securityContext:
+    runAsNonRoot: true
+    seLinuxOptions:
+      role: somevalue
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/sysctls0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/sysctls0.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: sysctls0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+    sysctls:
+    - name: othersysctl
+      value: other

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/windowshostprocess0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/windowshostprocess0.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: windowshostprocess0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      windowsOptions: {}
+  hostNetwork: true
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      windowsOptions: {}
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+    windowsOptions:
+      hostProcess: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/windowshostprocess1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/fail/windowshostprocess1.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: windowshostprocess1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      windowsOptions:
+        hostProcess: true
+  hostNetwork: true
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      windowsOptions:
+        hostProcess: true
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+    windowsOptions: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/pass/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/pass/apparmorprofile0.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: localhost/foo
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/pass/base.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/pass/base.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: base
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/pass/base_linux.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/pass/base_linux.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: base_linux
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  os:
+    name: linux
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/pass/base_windows.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/pass/base_windows.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: base_windows
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+  os:
+    name: windows
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/pass/capabilities_restricted0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/pass/capabilities_restricted0.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_restricted0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        add:
+        - NET_BIND_SERVICE
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        add:
+        - NET_BIND_SERVICE
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/pass/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/pass/hostports0.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/pass/privileged0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/pass/privileged0.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: privileged0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      privileged: false
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      privileged: false
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/pass/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/pass/procmount0.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: procmount0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      procMount: Default
+  hostUsers: false
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      procMount: Default
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/pass/restrictedvolumes0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/pass/restrictedvolumes0.yaml
@@ -1,0 +1,47 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - name: volume0
+  - emptyDir: {}
+    name: volume1
+  - name: volume2
+    secret:
+      secretName: test
+  - name: volume3
+    persistentVolumeClaim:
+      claimName: test
+  - downwardAPI:
+      items:
+      - fieldRef:
+          fieldPath: metadata.labels
+        path: labels
+    name: volume4
+  - configMap:
+      name: test
+    name: volume5
+  - name: volume6
+    projected:
+      sources: []

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/pass/runasnonroot0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/pass/runasnonroot0.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: runasnonroot0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/pass/runasnonroot1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/pass/runasnonroot1.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: runasnonroot1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      runAsNonRoot: true
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      runAsNonRoot: true
+  securityContext:
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/pass/runasuser0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/pass/runasuser0.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: runasuser0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      runAsUser: 1000
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      runAsUser: 1000
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/pass/seccompprofile_restricted0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/pass/seccompprofile_restricted0.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_restricted0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/pass/seccompprofile_restricted1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/pass/seccompprofile_restricted1.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_restricted1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      localhostProfile: testing
+      type: Localhost

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/pass/seccompprofile_restricted2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/pass/seccompprofile_restricted2.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_restricted2
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seccompProfile:
+        type: RuntimeDefault
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seccompProfile:
+        localhostProfile: testing
+        type: Localhost
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/pass/selinuxoptions0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/pass/selinuxoptions0.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seLinuxOptions: {}
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/pass/selinuxoptions1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/pass/selinuxoptions1.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seLinuxOptions:
+        level: somevalue
+        type: container_init_t
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seLinuxOptions:
+        type: container_kvm_t
+  securityContext:
+    runAsNonRoot: true
+    seLinuxOptions:
+      type: container_t
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/pass/sysctls0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/pass/sysctls0.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: sysctls0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/pass/sysctls1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.33/pass/sysctls1.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: sysctls1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+    sysctls:
+    - name: net.ipv4.tcp_rmem
+      value: 4096 87380 16777216
+    - name: net.ipv4.tcp_wmem
+      value: 4096 65536 16777216

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/allowprivilegeescalation0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/allowprivilegeescalation0.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: allowprivilegeescalation0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: true
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/allowprivilegeescalation1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/allowprivilegeescalation1.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: allowprivilegeescalation1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: true
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/allowprivilegeescalation2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/allowprivilegeescalation2.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: allowprivilegeescalation2
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/allowprivilegeescalation3.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/allowprivilegeescalation3.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: allowprivilegeescalation3
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/apparmorprofile0.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: unconfined
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/apparmorprofile1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/apparmorprofile1.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/initcontainer1: unconfined
+  name: apparmorprofile1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/capabilities_baseline0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/capabilities_baseline0.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_baseline0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        add:
+        - NET_RAW
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/capabilities_baseline1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/capabilities_baseline1.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_baseline1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        add:
+        - NET_RAW
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/capabilities_baseline2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/capabilities_baseline2.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_baseline2
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        add:
+        - chown
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/capabilities_baseline3.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/capabilities_baseline3.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_baseline3
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        add:
+        - CAP_CHOWN
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/capabilities_restricted0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/capabilities_restricted0.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_restricted0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities: {}
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/capabilities_restricted1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/capabilities_restricted1.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_restricted1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities: {}
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/capabilities_restricted2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/capabilities_restricted2.yaml
@@ -1,0 +1,97 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_restricted2
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - SYS_TIME
+        - SYS_MODULE
+        - SYS_RAWIO
+        - SYS_PACCT
+        - SYS_ADMIN
+        - SYS_NICE
+        - SYS_RESOURCE
+        - SYS_TIME
+        - SYS_TTY_CONFIG
+        - MKNOD
+        - AUDIT_WRITE
+        - AUDIT_CONTROL
+        - MAC_OVERRIDE
+        - MAC_ADMIN
+        - NET_ADMIN
+        - SYSLOG
+        - CHOWN
+        - NET_RAW
+        - DAC_OVERRIDE
+        - FOWNER
+        - DAC_READ_SEARCH
+        - FSETID
+        - KILL
+        - SETGID
+        - SETUID
+        - LINUX_IMMUTABLE
+        - NET_BIND_SERVICE
+        - NET_BROADCAST
+        - IPC_LOCK
+        - IPC_OWNER
+        - SYS_CHROOT
+        - SYS_PTRACE
+        - SYS_BOOT
+        - LEASE
+        - SETFCAP
+        - WAKE_ALARM
+        - BLOCK_SUSPEND
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - SYS_TIME
+        - SYS_MODULE
+        - SYS_RAWIO
+        - SYS_PACCT
+        - SYS_ADMIN
+        - SYS_NICE
+        - SYS_RESOURCE
+        - SYS_TIME
+        - SYS_TTY_CONFIG
+        - MKNOD
+        - AUDIT_WRITE
+        - AUDIT_CONTROL
+        - MAC_OVERRIDE
+        - MAC_ADMIN
+        - NET_ADMIN
+        - SYSLOG
+        - CHOWN
+        - NET_RAW
+        - DAC_OVERRIDE
+        - FOWNER
+        - DAC_READ_SEARCH
+        - FSETID
+        - KILL
+        - SETGID
+        - SETUID
+        - LINUX_IMMUTABLE
+        - NET_BIND_SERVICE
+        - NET_BROADCAST
+        - IPC_LOCK
+        - IPC_OWNER
+        - SYS_CHROOT
+        - SYS_PTRACE
+        - SYS_BOOT
+        - LEASE
+        - SETFCAP
+        - WAKE_ALARM
+        - BLOCK_SUSPEND
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/capabilities_restricted3.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/capabilities_restricted3.yaml
@@ -1,0 +1,53 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_restricted3
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        add:
+        - AUDIT_WRITE
+        - CHOWN
+        - DAC_OVERRIDE
+        - FOWNER
+        - FSETID
+        - KILL
+        - MKNOD
+        - NET_BIND_SERVICE
+        - SETFCAP
+        - SETGID
+        - SETPCAP
+        - SETUID
+        - SYS_CHROOT
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        add:
+        - AUDIT_WRITE
+        - CHOWN
+        - DAC_OVERRIDE
+        - FOWNER
+        - FSETID
+        - KILL
+        - MKNOD
+        - NET_BIND_SERVICE
+        - SETFCAP
+        - SETGID
+        - SETPCAP
+        - SETUID
+        - SYS_CHROOT
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/hostnamespaces0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/hostnamespaces0.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  hostIPC: true
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/hostnamespaces1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/hostnamespaces1.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  hostNetwork: true
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/hostnamespaces2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/hostnamespaces2.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnamespaces2
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  hostPID: true
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/hostpathvolumes0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/hostpathvolumes0.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostpathvolumes0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - emptyDir: {}
+    name: volume-emptydir
+  - hostPath:
+      path: /a
+    name: volume-hostpath

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/hostpathvolumes1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/hostpathvolumes1.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostpathvolumes1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - hostPath:
+      path: /a
+    name: volume-hostpath-a
+  - hostPath:
+      path: /b
+    name: volume-hostpath-b

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/hostports0.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/hostports1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/hostports1.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/hostports2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/hostports2.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports2
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+      hostPort: 12345
+    - containerPort: 12347
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+      hostPort: 12346
+    - containerPort: 12348
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/hostprobesandhostlifecycle0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/hostprobesandhostlifecycle0.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostprobesandhostlifecycle0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    livenessProbe:
+      httpGet:
+        host: bad.host
+        port: 8080
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/hostprobesandhostlifecycle1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/hostprobesandhostlifecycle1.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostprobesandhostlifecycle1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    readinessProbe:
+      tcpSocket:
+        host: 8.8.8.8
+        port: 8080
+    restartPolicy: Always
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/hostprobesandhostlifecycle2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/hostprobesandhostlifecycle2.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostprobesandhostlifecycle2
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    lifecycle:
+      postStart:
+        httpGet:
+          host: bad.host
+          port: 8080
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/hostprobesandhostlifecycle3.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/hostprobesandhostlifecycle3.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostprobesandhostlifecycle3
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    livenessProbe:
+      httpGet:
+        host: 127.0.0.1
+        port: 8080
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/hostprobesandhostlifecycle4.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/hostprobesandhostlifecycle4.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostprobesandhostlifecycle4
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    readinessProbe:
+      tcpSocket:
+        host: ::1
+        port: 8080
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/privileged0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/privileged0.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: privileged0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      capabilities:
+        drop:
+        - ALL
+      privileged: true
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/privileged1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/privileged1.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: privileged1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      capabilities:
+        drop:
+        - ALL
+      privileged: true
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/procmount0.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: procmount0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      procMount: Unmasked
+  hostUsers: false
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/procmount1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/procmount1.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: procmount1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  hostUsers: false
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      procMount: Unmasked
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/restrictedvolumes0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/restrictedvolumes0.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - gcePersistentDisk:
+      pdName: test
+    name: volume1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/restrictedvolumes1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/restrictedvolumes1.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - awsElasticBlockStore:
+      volumeID: test
+    name: volume1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/restrictedvolumes10.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/restrictedvolumes10.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes10
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - flocker:
+      datasetName: test
+    name: volume1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/restrictedvolumes11.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/restrictedvolumes11.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes11
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - fc:
+      wwids:
+      - test
+    name: volume1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/restrictedvolumes12.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/restrictedvolumes12.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes12
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - azureFile:
+      secretName: test
+      shareName: test
+    name: volume1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/restrictedvolumes13.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/restrictedvolumes13.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes13
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - name: volume1
+    vsphereVolume:
+      volumePath: test

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/restrictedvolumes14.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/restrictedvolumes14.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes14
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - name: volume1
+    quobyte:
+      registry: localhost:1234
+      volume: test

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/restrictedvolumes15.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/restrictedvolumes15.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes15
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - azureDisk:
+      diskName: test
+      diskURI: https://test.blob.core.windows.net/test/test.vhd
+    name: volume1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/restrictedvolumes16.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/restrictedvolumes16.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes16
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - name: volume1
+    portworxVolume:
+      fsType: ext4
+      volumeID: test

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/restrictedvolumes17.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/restrictedvolumes17.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes17
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - name: volume1
+    scaleIO:
+      gateway: localhost
+      secretRef: null
+      system: test
+      volumeName: test

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/restrictedvolumes18.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/restrictedvolumes18.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes18
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - name: volume1
+    storageos:
+      volumeName: test

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/restrictedvolumes19.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/restrictedvolumes19.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes19
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - hostPath:
+      path: /dev/null
+    name: volume1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/restrictedvolumes2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/restrictedvolumes2.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes2
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - gitRepo:
+      repository: github.com/kubernetes/kubernetes
+    name: volume1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/restrictedvolumes3.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/restrictedvolumes3.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes3
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - name: volume1
+    nfs:
+      path: /test
+      server: test

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/restrictedvolumes4.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/restrictedvolumes4.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes4
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - iscsi:
+      iqn: iqn.2001-04.com.example:storage.kube.sys1.xyz
+      lun: 0
+      targetPortal: test
+    name: volume1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/restrictedvolumes5.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/restrictedvolumes5.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes5
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - glusterfs:
+      endpoints: test
+      path: test
+    name: volume1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/restrictedvolumes6.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/restrictedvolumes6.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes6
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - name: volume1
+    rbd:
+      image: test
+      monitors:
+      - test

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/restrictedvolumes7.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/restrictedvolumes7.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes7
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - flexVolume:
+      driver: test
+    name: volume1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/restrictedvolumes8.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/restrictedvolumes8.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes8
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - cinder:
+      volumeID: test
+    name: volume1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/restrictedvolumes9.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/restrictedvolumes9.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes9
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - cephfs:
+      monitors:
+      - test
+    name: volume1

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/runasnonroot0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/runasnonroot0.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: runasnonroot0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/runasnonroot1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/runasnonroot1.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: runasnonroot1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: false
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/runasnonroot2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/runasnonroot2.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: runasnonroot2
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      runAsNonRoot: false
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/runasnonroot3.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/runasnonroot3.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: runasnonroot3
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      runAsNonRoot: false
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/runasuser0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/runasuser0.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: runasuser0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 0
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/runasuser1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/runasuser1.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: runasuser1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      runAsUser: 0
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/runasuser2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/runasuser2.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: runasuser2
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      runAsUser: 0
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/seccompprofile_baseline0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/seccompprofile_baseline0.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_baseline0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: Unconfined

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/seccompprofile_baseline1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/seccompprofile_baseline1.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_baseline1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seccompProfile:
+        type: Unconfined
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/seccompprofile_baseline2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/seccompprofile_baseline2.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_baseline2
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seccompProfile:
+        type: Unconfined
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/seccompprofile_restricted0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/seccompprofile_restricted0.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_restricted0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/seccompprofile_restricted1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/seccompprofile_restricted1.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_restricted1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: Unconfined

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/seccompprofile_restricted2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/seccompprofile_restricted2.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_restricted2
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seccompProfile:
+        type: RuntimeDefault
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/seccompprofile_restricted3.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/seccompprofile_restricted3.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_restricted3
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seccompProfile:
+        type: RuntimeDefault
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/seccompprofile_restricted4.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/seccompprofile_restricted4.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_restricted4
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seccompProfile:
+        type: RuntimeDefault
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seccompProfile:
+        type: Unconfined
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/selinuxoptions0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/selinuxoptions0.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seLinuxOptions: {}
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seLinuxOptions: {}
+  securityContext:
+    runAsNonRoot: true
+    seLinuxOptions:
+      type: somevalue
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/selinuxoptions1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/selinuxoptions1.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seLinuxOptions:
+        type: somevalue
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seLinuxOptions: {}
+  securityContext:
+    runAsNonRoot: true
+    seLinuxOptions: {}
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/selinuxoptions2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/selinuxoptions2.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions2
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seLinuxOptions: {}
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seLinuxOptions:
+        type: somevalue
+  securityContext:
+    runAsNonRoot: true
+    seLinuxOptions: {}
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/selinuxoptions3.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/selinuxoptions3.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions3
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seLinuxOptions: {}
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seLinuxOptions: {}
+  securityContext:
+    runAsNonRoot: true
+    seLinuxOptions:
+      user: somevalue
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/selinuxoptions4.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/selinuxoptions4.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions4
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seLinuxOptions: {}
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seLinuxOptions: {}
+  securityContext:
+    runAsNonRoot: true
+    seLinuxOptions:
+      role: somevalue
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/sysctls0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/sysctls0.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: sysctls0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+    sysctls:
+    - name: othersysctl
+      value: other

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/windowshostprocess0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/windowshostprocess0.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: windowshostprocess0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      windowsOptions: {}
+  hostNetwork: true
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      windowsOptions: {}
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+    windowsOptions:
+      hostProcess: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/windowshostprocess1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/fail/windowshostprocess1.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: windowshostprocess1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      windowsOptions:
+        hostProcess: true
+  hostNetwork: true
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      windowsOptions:
+        hostProcess: true
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+    windowsOptions: {}

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/pass/apparmorprofile0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/pass/apparmorprofile0.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/container1: localhost/foo
+  name: apparmorprofile0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/pass/base.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/pass/base.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: base
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/pass/base_linux.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/pass/base_linux.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: base_linux
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  os:
+    name: linux
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/pass/base_windows.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/pass/base_windows.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: base_windows
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+  os:
+    name: windows
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/pass/capabilities_restricted0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/pass/capabilities_restricted0.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: capabilities_restricted0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        add:
+        - NET_BIND_SERVICE
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        add:
+        - NET_BIND_SERVICE
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/pass/hostports0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/pass/hostports0.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostports0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    ports:
+    - containerPort: 12345
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    ports:
+    - containerPort: 12346
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/pass/hostprobesandhostlifecycle0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/pass/hostprobesandhostlifecycle0.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostprobesandhostlifecycle0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/pass/hostprobesandhostlifecycle1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/pass/hostprobesandhostlifecycle1.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostprobesandhostlifecycle1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    livenessProbe:
+      httpGet:
+        port: 8080
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/pass/hostprobesandhostlifecycle2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/pass/hostprobesandhostlifecycle2.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostprobesandhostlifecycle2
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    readinessProbe:
+      tcpSocket:
+        port: 8080
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/pass/privileged0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/pass/privileged0.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: privileged0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      privileged: false
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      privileged: false
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/pass/procmount0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/pass/procmount0.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: procmount0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      procMount: Default
+  hostUsers: false
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      procMount: Default
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/pass/restrictedvolumes0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/pass/restrictedvolumes0.yaml
@@ -1,0 +1,47 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: restrictedvolumes0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  volumes:
+  - name: volume0
+  - emptyDir: {}
+    name: volume1
+  - name: volume2
+    secret:
+      secretName: test
+  - name: volume3
+    persistentVolumeClaim:
+      claimName: test
+  - downwardAPI:
+      items:
+      - fieldRef:
+          fieldPath: metadata.labels
+        path: labels
+    name: volume4
+  - configMap:
+      name: test
+    name: volume5
+  - name: volume6
+    projected:
+      sources: []

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/pass/runasnonroot0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/pass/runasnonroot0.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: runasnonroot0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/pass/runasnonroot1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/pass/runasnonroot1.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: runasnonroot1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      runAsNonRoot: true
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      runAsNonRoot: true
+  securityContext:
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/pass/runasuser0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/pass/runasuser0.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: runasuser0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      runAsUser: 1000
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      runAsUser: 1000
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/pass/seccompprofile_restricted0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/pass/seccompprofile_restricted0.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_restricted0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/pass/seccompprofile_restricted1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/pass/seccompprofile_restricted1.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_restricted1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      localhostProfile: testing
+      type: Localhost

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/pass/seccompprofile_restricted2.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/pass/seccompprofile_restricted2.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seccompprofile_restricted2
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seccompProfile:
+        type: RuntimeDefault
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seccompProfile:
+        localhostProfile: testing
+        type: Localhost
+  securityContext:
+    runAsNonRoot: true

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/pass/selinuxoptions0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/pass/selinuxoptions0.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seLinuxOptions: {}
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/pass/selinuxoptions1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/pass/selinuxoptions1.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: selinuxoptions1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seLinuxOptions:
+        level: somevalue
+        type: container_init_t
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      seLinuxOptions:
+        type: container_kvm_t
+  securityContext:
+    runAsNonRoot: true
+    seLinuxOptions:
+      type: container_t
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/pass/sysctls0.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/pass/sysctls0.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: sysctls0
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/pass/sysctls1.yaml
+++ b/staging/src/k8s.io/pod-security-admission/test/testdata/restricted/v1.34/pass/sysctls1.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: sysctls1
+spec:
+  containers:
+  - image: registry.k8s.io/pause
+    name: container1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  initContainers:
+  - image: registry.k8s.io/pause
+    name: initcontainer1
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+    sysctls:
+    - name: net.ipv4.tcp_rmem
+      value: 4096 87380 16777216
+    - name: net.ipv4.tcp_wmem
+      value: 4096 65536 16777216

--- a/test/e2e/common/node/lifecycle_hook.go
+++ b/test/e2e/common/node/lifecycle_hook.go
@@ -41,7 +41,8 @@ import (
 
 var _ = SIGDescribe("Container Lifecycle Hook", func() {
 	f := framework.NewDefaultFramework("container-lifecycle-hook")
-	f.NamespacePodSecurityLevel = admissionapi.LevelBaseline
+	// FIXME: This test is being run in the privileged mode because of https://github.com/kubernetes/kubernetes/issues/133091
+	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
 	var podClient *e2epod.PodClient
 	const (
 		podCheckInterval     = 1 * time.Second
@@ -259,7 +260,8 @@ var _ = SIGDescribe("Container Lifecycle Hook", func() {
 
 var _ = SIGDescribe(feature.SidecarContainers, framework.WithFeatureGate(features.SidecarContainers), "Restartable Init Container Lifecycle Hook", func() {
 	f := framework.NewDefaultFramework("restartable-init-container-lifecycle-hook")
-	f.NamespacePodSecurityLevel = admissionapi.LevelBaseline
+	// FIXME: This test is being run in the privileged mode because of https://github.com/kubernetes/kubernetes/issues/133091
+	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
 	var podClient *e2epod.PodClient
 	const (
 		podCheckInterval     = 1 * time.Second


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind feature

#### What this PR does / why we need it:

This PR aims to add the following fields as part of PSA so that users can be blocked/warned when they create probes with the `.Host` field set.

```
* spec.containers[*].livenessProbe.httpGet.host
* spec.containers[*].readinessProbe.httpGet.host
* spec.containers[*].startupProbe.httpGet.host
* spec.containers[*].livenessProbe.tcpSocket.host
* spec.containers[*].readinessProbe.tcpSocket.host
* spec.containers[*].startupProbe.tcpSocket.host
* spec.containers[*].lifecycle.postStart.tcpSocket.host // Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept for backward compatibility.
* spec.containers[*].lifecycle.preStop.tcpSocket.host // Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept for backward compatibility.
* spec.containers[*].lifecycle.postStart.httpGet.host
* spec.containers[*].lifecycle.preStop.httpGet.host
* spec.initContainers[*].livenessProbe.httpGet.host
* spec.initContainers[*].readinessProbe.httpGet.host
* spec.initContainers[*].startupProbe.httpGet.host
* spec.initContainers[*].livenessProbe.tcpSocket.host
* spec.initContainers[*].readinessProbe.tcpSocket.host
* spec.initContainers[*].startupProbe.tcpSocket.host
* spec.initContainers[*].lifecycle.postStart.tcpSocket.host // Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept for backward compatibility.
* spec.initContainers[*].lifecycle.preStop.tcpSocket.host // Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept for backward compatibility.
* spec.initContainers[*].lifecycle.postStart.httpGet.host
* spec.initContainers[*].lifecycle.preStop.httpGet.host
```

#### Which issue(s) this PR fixes:

Fixes #99425
Fixes https://github.com/kubernetes/enhancements/issues/4940

#### Special notes for your reviewer:

This is my first PR to pod-security-admission area, so I might need some hand-holding, but I will mark the PR as draft till I get all the pieces done.

So one question I have is should I fix the tests on sig-node side like I have done here today by making them use the privileged mode? Or should I do something like https://github.com/kubernetes/kubernetes/pull/132916/commits/77fa562ae7ee3c6aec33ab1d19a2e259d1058b40

Ran the following tests locally:

- UPDATE_POD_SECURITY_FIXTURE_DATA=true go test -v ./test/... -run TestFixtures
- go test -v ./test/... -run TestFixtures
- go test -v ./policy/... -run TestHostProbesAndHostLifecycle
- go test -v ./policy/... -timeout 30s
- go test -v ./test/... -timeout 30s
- make test-integration WHAT=./test/integration/auth GOFLAGS="-v" KUBE_TEST_ARGS='-run ^TestPodSecurity$$'

#### Does this PR introduce a user-facing change?


```release-note
The `baseline` and `restricted` pod security admission levels now block setting the `host` field on probe and lifecycle handlers
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:



Please use the following format for linking documentation:
- KEP: https://github.com/kubernetes/enhancements/pull/4558 and https://github.com/kubernetes/enhancements/issues/4940
- Usage: <link>
- Other doc: https://github.com/kubernetes/website/pull/51498

```docs

```
