### PR TITLE
build: don't copy GOPATH out of docker container

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -714,6 +714,7 @@ function kube::build::copy_output() {
     --filter='+ /vendor/' \
     --filter='+ /staging/***/Godeps/**' \
     --filter='+ /_output/dockerized/bin/**' \
+    --filter='- /_output/dockerized/go/**' \
     --filter='+ zz_generated.*' \
     --filter='+ generated.proto' \
     --filter='+ *.pb.go' \


### PR DESCRIPTION


#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When using GOTOOLCHAIN with make verify the build results copied out of the dockerized environment contains a go toolchain  folder that is write protected. In order to prevent failures during the cleanup step opt-out of copying $GOPATH to the host.

#### Which issue(s) this PR fixes:

Fixes #125010

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
