### PR TITLE
e2e/network: dump iptables and conntrack flows for debugging

### DIFF
--- a/test/e2e/framework/network/utils.go
+++ b/test/e2e/framework/network/utils.go
@@ -347,21 +347,17 @@ func (config *NetworkingTestConfig) DialFromContainer(ctx context.Context, proto
 				LabelSelector: "k8s-app=kube-proxy",
 			})
 			for _, pod := range podList.Items {
-				// dump only for the node running test-container-pod
-				if pod.Status.HostIP == config.TestContainerPod.Status.HostIP {
-					output, _, _ := e2epod.ExecWithOptions(config.f, e2epod.ExecOptions{
-						Namespace:          "kube-system",
-						PodName:            pod.Name,
-						ContainerName:      "kube-proxy",
-						Command:            []string{"sh", "-c", fmt.Sprintf(`echo "IPTables Dump: " && iptables-save | grep "%s/%s:http" && echo "Conntrack flows: " && conntrack -Ln -p tcp | grep %d`, config.Namespace, config.NodePortService.Name, EndpointHTTPPort)},
-						Stdin:              nil,
-						CaptureStdout:      true,
-						CaptureStderr:      true,
-						PreserveWhitespace: false,
-					})
-					framework.Logf("Dump iptables and connntrack flows\n%s", output)
-					break
-				}
+				output, _, _ := e2epod.ExecWithOptions(config.f, e2epod.ExecOptions{
+					Namespace:          "kube-system",
+					PodName:            pod.Name,
+					ContainerName:      "kube-proxy",
+					Command:            []string{"sh", "-c", fmt.Sprintf(`echo "IPTables Dump: " && iptables-save | grep "%s/%s:http" && echo "Conntrack flows: " && conntrack -Ln -p tcp | grep %d`, config.Namespace, config.NodePortService.Name, EndpointHTTPPort)},
+					Stdin:              nil,
+					CaptureStdout:      true,
+					CaptureStderr:      true,
+					PreserveWhitespace: false,
+				})
+				framework.Logf("Dump iptables and connntrack flows from pod: %s \n%s", pod.Name, output)
 			}
 			return returnMsg
 		}


### PR DESCRIPTION
Follow up of https://github.com/kubernetes/kubernetes/pull/124865.

The last two flakes of **"Networking Granular Checks: Services should update endpoints: http"**  didn't capture the iptables and conntrack dump.
https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-containerd-e2e-ubuntu-gce/1794739072934088704
https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-containerd-e2e-ubuntu-gce/1794418456712450048


Not 100% sure but it might be because the following (pod.host-ip == testpod.host-ip) condition is not met for any kube-proxy pods in the cluster (It works perfectly in local kind cluster)
```go
podList, _ := config.f.ClientSet.CoreV1().Pods("kube-system").List(ctx, metav1.ListOptions{
	LabelSelector: "k8s-app=kube-proxy",
})
for _, pod := range podList.Items {
	if pod.Status.HostIP == config.TestContainerPod.Status.HostIP
```

Removing this condition in this PR.

/kind flake
/sig network
