### PR TITLE
Expose /readyz & /livez in kube-controller-manager

### DIFF
--- a/test/integration/controllermanager/serving/healthcheck_test.go
+++ b/test/integration/controllermanager/serving/healthcheck_test.go
@@ -1,0 +1,235 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package serving
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path"
+	"strings"
+	"testing"
+
+	"k8s.io/klog/v2/ktesting"
+	kubeapiservertesting "k8s.io/kubernetes/cmd/kube-apiserver/app/testing"
+	kubecontrollermanageresting "k8s.io/kubernetes/cmd/kube-controller-manager/app/testing"
+	"k8s.io/kubernetes/test/integration/framework"
+)
+
+func TestHealthEndpoints(t *testing.T) {
+	server, configStr, _, err := startTestAPIServer(t)
+	if err != nil {
+		t.Fatalf("Failed to start kube-apiserver server: %v", err)
+	}
+	defer server.TearDownFn()
+
+	apiserverConfig, err := os.CreateTemp("", "kubeconfig")
+	if err != nil {
+		t.Fatalf("Failed to create config file: %v", err)
+	}
+	defer func() {
+		_ = os.Remove(apiserverConfig.Name())
+	}()
+	if _, err = apiserverConfig.WriteString(configStr); err != nil {
+		t.Fatalf("Failed to write config file: %v", err)
+	}
+
+	brokenConfigStr := strings.ReplaceAll(configStr, "127.0.0.1", "127.0.0.2")
+	brokenConfig, err := os.CreateTemp("", "kubeconfig")
+	if err != nil {
+		t.Fatalf("Failed to create config file: %v", err)
+	}
+	if _, err := brokenConfig.WriteString(brokenConfigStr); err != nil {
+		t.Fatalf("Failed to write config file: %v", err)
+	}
+	defer func() {
+		_ = os.Remove(brokenConfig.Name())
+	}()
+
+	tests := []struct {
+		name             string
+		path             string
+		useBrokenConfig  bool
+		wantResponseCode int
+	}{
+		{
+			"/healthz",
+			"/healthz",
+			false,
+			http.StatusOK,
+		},
+		{
+			"/livez",
+			"/livez",
+			false,
+			http.StatusOK,
+		},
+		{
+			"/livez with ping check",
+			"/livez/ping",
+			false,
+			http.StatusOK,
+		},
+		{
+			"/readyz",
+			"/readyz",
+			false,
+			http.StatusOK,
+		},
+		{
+			"/readyz with sched-handler-sync",
+			"/readyz/kcm-handler-sync",
+			false,
+			http.StatusOK,
+		},
+		{
+			"/readyz with shutdown",
+			"/readyz/shutdown",
+			false,
+			http.StatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt := tt
+			_, ctx := ktesting.NewTestContext(t)
+
+			configFile := apiserverConfig.Name()
+			if tt.useBrokenConfig {
+				configFile = brokenConfig.Name()
+			}
+			result, err := kubecontrollermanageresting.StartTestServer(
+				ctx,
+				[]string{"--controllers=", "--kubeconfig", configFile, "--leader-elect=false", "--authorization-always-allow-paths", tt.path},
+			)
+
+			if err != nil {
+				t.Fatalf("Failed to start kube-controller-manager server: %v", err)
+			}
+			if result.TearDownFn != nil {
+				defer result.TearDownFn()
+			}
+
+			client, base, err := clientAndURLFromTestServer(result)
+			if err != nil {
+				t.Fatalf("Failed to get client from test server: %v", err)
+			}
+			req, err := http.NewRequest("GET", base+tt.path, nil)
+			if err != nil {
+				t.Fatalf("failed to request: %v", err)
+			}
+			r, err := client.Do(req)
+			if err != nil {
+				t.Fatalf("failed to GET %s from component: %v", tt.path, err)
+			}
+
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("failed to read response body: %v", err)
+			}
+			if err = r.Body.Close(); err != nil {
+				t.Fatalf("failed to close response body: %v", err)
+			}
+			if got, expected := r.StatusCode, tt.wantResponseCode; got != expected {
+				t.Fatalf("expected http %d at %s of component, got: %d %q", expected, tt.path, got, string(body))
+			}
+		})
+	}
+}
+
+// TODO: Make this a util function once there is a unified way to start a testing apiserver so that we can reuse it.
+func startTestAPIServer(t *testing.T) (server *kubeapiservertesting.TestServer, apiserverConfig, token string, err error) {
+	// Insulate this test from picking up in-cluster config when run inside a pod
+	// We can't assume we have permissions to write to /var/run/secrets/... from a unit test to mock in-cluster config for testing
+	originalHost := os.Getenv("KUBERNETES_SERVICE_HOST")
+	if len(originalHost) > 0 {
+		if err = os.Setenv("KUBERNETES_SERVICE_HOST", ""); err != nil {
+			return
+		}
+		defer func() {
+			err = os.Setenv("KUBERNETES_SERVICE_HOST", originalHost)
+		}()
+	}
+
+	// authenticate to apiserver via bearer token
+	token = "flwqkenfjasasdfmwerasd" // Fake token for testing.
+	var tokenFile *os.File
+	tokenFile, err = os.CreateTemp("", "kubeconfig")
+	if err != nil {
+		return
+	}
+	if _, err = tokenFile.WriteString(fmt.Sprintf(`%s,system:kube-controller-manager,system:kube-controller-manager,""`, token)); err != nil {
+		return
+	}
+	if err = tokenFile.Close(); err != nil {
+		return
+	}
+
+	// start apiserver
+	server = kubeapiservertesting.StartTestServerOrDie(t, nil, []string{
+		"--token-auth-file", tokenFile.Name(),
+		"--authorization-mode", "AlwaysAllow",
+	}, framework.SharedEtcd())
+
+	apiserverConfig = fmt.Sprintf(`
+apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: %s
+    certificate-authority: %s
+  name: integration
+contexts:
+- context:
+    cluster: integration
+    user: kube-controller-manager
+  name: default-context
+current-context: default-context
+users:
+- name: kube-controller-manager
+  user:
+    token: %s
+`, server.ClientConfig.Host, server.ServerOpts.SecureServing.ServerCert.CertKey.CertFile, token)
+	return server, apiserverConfig, token, nil
+}
+
+func clientAndURLFromTestServer(s kubecontrollermanageresting.TestServer) (*http.Client, string, error) {
+	secureInfo := s.Config.SecureServing
+	secureOptions := s.Options.SecureServing
+	url := fmt.Sprintf("https://%s", secureInfo.Listener.Addr().String())
+	url = strings.ReplaceAll(url, "[::]", "127.0.0.1") // switch to IPv4 because the self-signed cert does not support [::]
+
+	// read self-signed server cert disk
+	pool := x509.NewCertPool()
+	serverCertPath := path.Join(secureOptions.ServerCert.CertDirectory, secureOptions.ServerCert.PairName+".crt")
+	serverCert, err := os.ReadFile(serverCertPath)
+	if err != nil {
+		return nil, "", fmt.Errorf("Failed to read component server cert %q: %w", serverCertPath, err)
+	}
+	pool.AppendCertsFromPEM(serverCert)
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{
+			RootCAs: pool,
+		},
+	}
+	client := &http.Client{Transport: tr}
+	return client, url, nil
+}

--- a/test/integration/controllermanager/serving/main_test.go
+++ b/test/integration/controllermanager/serving/main_test.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package serving
+
+import (
+	"testing"
+
+	"k8s.io/kubernetes/test/integration/framework"
+)
+
+func TestMain(m *testing.M) {
+	framework.EtcdMain(m.Run)
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Adds a proper liveness and readiness endpoints to the kube-controller-manager.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/118158

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
The kube-controller-manager exposes /livez and /readz for health checks that are in compliance with https://kubernetes.io/docs/reference/using-api/health-checks/#api-endpoints-for-health
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
