### PR TITLE
[KEP-2400]: Restrict access to swap for containers in high priority Pods

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_container_linux.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_linux.go
@@ -180,6 +180,11 @@ func (m *kubeGenericRuntimeManager) configureContainerSwapResources(lcr *runtime
 		return
 	}
 
+	if kubelettypes.IsCriticalPod(pod) {
+		swapConfigurationHelper.ConfigureNoSwap(lcr)
+		return
+	}
+
 	// NOTE(ehashman): Behavior is defined in the opencontainers runtime spec:
 	// https://github.com/opencontainers/runtime-spec/blob/1c3f411f041711bbeecf35ff7e93461ea6789220/config-linux.md#memory
 	switch m.memorySwapBehavior {


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Exclude critical pods from gaining swap access.

I believe this is valuable for two main reasons:
1. Critical pods are assumed to not tolerate performance derogations which could be impacted swap access.
2. This provides another way of opting-out burstable pods from swap access.

p.s. currently, it is possible to opt-out of swap for burstable pods by setting `requests.memory == limits.memory`. However, this approach forces the workload owner to set limits which is unacceptable for certain workloads. With this, an administrator can choose to classify such burstable pods as critical to opt-out of swap.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Changed Linux swap handling to restrict access to swap for containers in high priority Pods.
New Pods that have a node- or cluster-critical priority are prohibited from accessing swap on Linux,
even if your cluster and node configuration could otherwise allow this.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- KEP: https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/2400-node-swap
```
