### PR TITLE
[KEP-2400]: Add a NodeSwapnode condition

### DIFF
--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -6234,6 +6234,8 @@ const (
 	NodePIDPressure NodeConditionType = "PIDPressure"
 	// NodeNetworkUnavailable means that network for the node is not correctly configured.
 	NodeNetworkUnavailable NodeConditionType = "NetworkUnavailable"
+	// NodeSwap means that swap is provisioned on the node some workloads are able to use it.
+	NodeSwap NodeConditionType = "NodeSwap"
 )
 
 // NodeCondition contains condition information for a node.


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
/sig node

#### What this PR does / why we need it:
This PR adds a `NodeSwap` node condition that indicates if swap is enabled on the node.

The condition will be true if all of the following is true:
- Swap is provisioned on the node.
- SwapBehavior is different than NoSwap.
- The NodeSwap feature-gate is enabled.

In addition, a condition message will outline which of the above caused swap to be disabled, alongside to the swap behavior that is currently being used.

#### Sample output:
```bash
> k describe node
...
Conditions:
  Type              Status  LastHeartbeatTime                 LastTransitionTime                Reason                       Message
  ----              ------  -----------------                 ------------------                ------                       -------
  MemoryPressure    False   Sun, 02 Jun 2024 16:09:51 +0300   Sun, 02 Jun 2024 16:09:44 +0300   KubeletHasSufficientMemory   kubelet has sufficient memory available
  DiskPressure      False   Sun, 02 Jun 2024 16:09:51 +0300   Sun, 02 Jun 2024 16:09:44 +0300   KubeletHasNoDiskPressure     kubelet has no disk pressure
  PIDPressure       False   Sun, 02 Jun 2024 16:09:51 +0300   Sun, 02 Jun 2024 16:09:44 +0300   KubeletHasSufficientPID      kubelet has sufficient PID available
  NodeSwap          True    Sun, 02 Jun 2024 16:09:51 +0300   Sun, 02 Jun 2024 16:09:44 +0300   SwapEnabled                  is swap provisioned on node: true. swapBehavior: LimitedSwap
  Ready             True    Sun, 02 Jun 2024 16:09:51 +0300   Sun, 02 Jun 2024 16:09:51 +0300   KubeletReady                 kubelet is posting ready status
```

When swap is disabled, the user would immediately know what's the reason for it being disabled.
When swap is enabled, the user would immediately know what's the current swap behavior. Currently we have only LimitedSwap and NoSwap, but I believe this would be extended in the future.

#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/kubernetes/issues/123962

#### Special notes for your reviewer:
This is a replacement for https://github.com/kubernetes/kubernetes/pull/123963.
See these comments for more context:
* https://github.com/kubernetes/enhancements/pull/4401#discussion_r1479124963
* https://github.com/kubernetes/kubernetes/pull/123963#issuecomment-2029660630
* https://github.com/kubernetes/kubernetes/pull/123963#issuecomment-2130401050
* https://github.com/kubernetes/kubernetes/pull/123963#issuecomment-2130605373

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added a NodeSwap node condition
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- KEP: https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/2400-node-swap/README.md
```
