### PR TITLE
Add QueueingHintFn for pvc events in VolumeRestriction plugin

### DIFF
--- a/pkg/scheduler/framework/plugins/volumerestrictions/volume_restrictions_test.go
+++ b/pkg/scheduler/framework/plugins/volumerestrictions/volume_restrictions_test.go
@@ -667,6 +667,100 @@ func Test_isSchedulableAfterPodDeleted(t *testing.T) {
 	}
 }
 
+func Test_isSchedulableAfterPersistentVolumeClaimChange(t *testing.T) {
+	podWithOnePVC := st.MakePod().Name("pod-with-one-pvc").Namespace(metav1.NamespaceDefault).PVC("claim-with-rwx-1").Node("node-1").Obj()
+	podWithTwoPVCs := st.MakePod().Name("pod-with-two-pvcs").Namespace(metav1.NamespaceDefault).PVC("claim-with-rwx-1").PVC("claim-with-rwx-2").Node("node-1").Obj()
+	podWithNotEqualNamespace := st.MakePod().Name("pod-with-one-pvc").Namespace(metav1.NamespaceSystem).PVC("claim-with-rwx-1").Node("claim-with-rwx-2").Obj()
+
+	PVC1 := &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "claim-with-rwx-1",
+		},
+		Spec: v1.PersistentVolumeClaimSpec{
+			AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteMany},
+		},
+	}
+
+	PVC2 := &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "claim-with-rwx-2",
+		},
+		Spec: v1.PersistentVolumeClaimSpec{
+			AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteMany},
+		},
+	}
+
+	testcases := map[string]struct {
+		existingPods   []*v1.Pod
+		pod            *v1.Pod
+		oldObj, newObj interface{}
+		expectedHint   framework.QueueingHint
+		expectedErr    bool
+	}{
+		"queue-new-object-pvc-belong-pod": {
+			existingPods: []*v1.Pod{},
+			pod:          podWithTwoPVCs,
+			newObj:       PVC1,
+			expectedHint: framework.Queue,
+			expectedErr:  false,
+		},
+		"skip-new-object-unused": {
+			existingPods: []*v1.Pod{},
+			pod:          podWithOnePVC,
+			newObj:       PVC2,
+			expectedHint: framework.QueueSkip,
+			expectedErr:  false,
+		},
+		"skip-nil-old-object": {
+			existingPods: []*v1.Pod{},
+			pod:          podWithOnePVC,
+			newObj:       PVC2,
+			expectedHint: framework.QueueSkip,
+			expectedErr:  false,
+		},
+		"skip-new-object-not-belong-pod": {
+			existingPods: []*v1.Pod{},
+			pod:          podWithOnePVC,
+			newObj:       PVC2,
+			expectedHint: framework.QueueSkip,
+			expectedErr:  false,
+		},
+		"skip-new-object-namespace-not-equal-pod": {
+			existingPods: []*v1.Pod{},
+			pod:          podWithNotEqualNamespace,
+			newObj:       PVC1,
+			expectedHint: framework.QueueSkip,
+			expectedErr:  false,
+		},
+	}
+
+	for name, tc := range testcases {
+		t.Run(name, func(t *testing.T) {
+			logger, _ := ktesting.NewTestContext(t)
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			p := newPluginWithListers(ctx, t, tc.existingPods, nil, []*v1.PersistentVolumeClaim{tc.newObj.(*v1.PersistentVolumeClaim)})
+
+			actualHint, err := p.(*VolumeRestrictions).isSchedulableAfterPersistentVolumeClaimAdded(logger, tc.pod, tc.oldObj, tc.newObj)
+			if tc.expectedErr {
+				if err == nil {
+					t.Error("Expect error, but got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+			}
+
+			if diff := cmp.Diff(tc.expectedHint, actualHint); diff != "" {
+				t.Errorf("Unexpected QueueingHint (-want, +got): %s", diff)
+			}
+		})
+	}
+}
+
 func newPlugin(ctx context.Context, t *testing.T) framework.Plugin {
 	return newPluginWithListers(ctx, t, nil, nil, nil)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes Part of https://github.com/kubernetes/kubernetes/issues/118893

#### Special notes for your reviewer:
For review purposes, I splitd https://github.com/kubernetes/kubernetes/pull/119405.
this PR for adding QueueingHintFn for pvc events in VolumeRestriction plugin.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kube-scheduler implements scheduling hints for the VolumeRestriction plugin.
Scheduling hints allow the scheduler to retry scheduling Pods that were previously rejected by the VolumeRestriction plugin if a new pvc added, and the pvc belongs to pod.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
