### PR TITLE
ignore starting order in RunTogether, add another that does

### DIFF
--- a/test/e2e_node/container_lifecycle_pod_construction.go
+++ b/test/e2e_node/container_lifecycle_pod_construction.go
@@ -119,8 +119,18 @@ func (o containerOutputList) String() string {
 	return b.String()
 }
 
-// RunTogether returns an error the lhs and rhs run together
+// RunTogether returns an error if containers don't run together
 func (o containerOutputList) RunTogether(lhs, rhs string) error {
+	if err := o.RunTogetherLhsFirst(lhs, rhs); err != nil {
+		if err := o.RunTogetherLhsFirst(rhs, lhs); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// RunTogetherLhsFirst returns an error if containers don't run together or if rhs starts before lhs
+func (o containerOutputList) RunTogetherLhsFirst(lhs, rhs string) error {
 	lhsStart := o.findIndex(lhs, "Started", 0)
 	if lhsStart == -1 {
 		return fmt.Errorf("couldn't find that %s ever started, got\n%v", lhs, o)

--- a/test/e2e_node/container_lifecycle_test.go
+++ b/test/e2e_node/container_lifecycle_test.go
@@ -834,9 +834,9 @@ var _ = SIGDescribe(framework.WithNodeConformance(), "Containers Lifecycle", fun
 
 			ginkgo.By("Analyzing results")
 			// readiness probes are called during pod termination
-			framework.ExpectNoError(results.RunTogether(prefixedName(PreStopPrefix, regular1), prefixedName(ReadinessPrefix, regular1)))
+			framework.ExpectNoError(results.RunTogetherLhsFirst(prefixedName(PreStopPrefix, regular1), prefixedName(ReadinessPrefix, regular1)))
 			// liveness probes are not called during pod termination
-			err = results.RunTogether(prefixedName(PreStopPrefix, regular1), prefixedName(LivenessPrefix, regular1))
+			err = results.RunTogetherLhsFirst(prefixedName(PreStopPrefix, regular1), prefixedName(LivenessPrefix, regular1))
 			gomega.Expect(err).To(gomega.HaveOccurred())
 		})
 
@@ -897,11 +897,11 @@ var _ = SIGDescribe(framework.WithNodeConformance(), "Containers Lifecycle", fun
 			ginkgo.By("Analyzing results")
 			// FIXME ExpectNoError: this will be implemented in KEP 4438
 			// liveness probes are called for restartable init containers during pod termination
-			err = results.RunTogether(prefixedName(PreStopPrefix, regular1), prefixedName(LivenessPrefix, restartableInit1))
+			err = results.RunTogetherLhsFirst(prefixedName(PreStopPrefix, regular1), prefixedName(LivenessPrefix, restartableInit1))
 			gomega.Expect(err).To(gomega.HaveOccurred())
 			// FIXME ExpectNoError: this will be implemented in KEP 4438
 			// restartable init containers are restarted during pod termination
-			err = results.RunTogether(prefixedName(PreStopPrefix, regular1), restartableInit1)
+			err = results.RunTogetherLhsFirst(prefixedName(PreStopPrefix, regular1), restartableInit1)
 			gomega.Expect(err).To(gomega.HaveOccurred())
 		})
 	})
@@ -1147,12 +1147,8 @@ var _ = SIGDescribe(nodefeature.SidecarContainers, "Containers Lifecycle", func(
 			framework.ExpectNoError(results.ExitsBefore(init1, restartableInit1))
 		})
 
-		ginkgo.It("should start first restartable init container before starting second init container", func() {
-			framework.ExpectNoError(results.StartsBefore(restartableInit1, init2))
-		})
-
 		ginkgo.It("should run first init container and first restartable init container together", func() {
-			framework.ExpectNoError(results.RunTogether(restartableInit1, init2))
+			framework.ExpectNoError(results.RunTogetherLhsFirst(restartableInit1, init2))
 		})
 
 		ginkgo.It("should run second init container to completion before starting second restartable init container", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind flake
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Some tests don't need to check the starting order in `RunTogether`, and doing so creates flakes.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #125030

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
