### PR TITLE
cacher: dispatchEvents is synced to watchCache.listResourceVersion

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
@@ -912,10 +912,10 @@ func (c *Cacher) dispatchEvents() {
 	// The first successful sync with the underlying store.
 	// The cache must wait until this first sync is completed to be deemed ready.
 	// Since we cannot send a bookmark when the lastProcessedResourceVersion is 0,
-	// we poll aggressively for the first RV before entering the dispatch loop.
+	// we poll aggressively for the first list RV before entering the dispatch loop.
 	lastProcessedResourceVersion := uint64(0)
 	if err := wait.PollUntilContextCancel(wait.ContextForChannel(c.stopCh), 10*time.Millisecond, true, func(_ context.Context) (bool, error) {
-		if rv := c.watchCache.getResourceVersion(); rv != 0 {
+		if rv := c.watchCache.getListResourceVersion(); rv != 0 {
 			lastProcessedResourceVersion = rv
 			return true, nil
 		}

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache.go
@@ -644,10 +644,10 @@ func (w *watchCache) Resync() error {
 	return nil
 }
 
-func (w *watchCache) getResourceVersion() uint64 {
+func (w *watchCache) getListResourceVersion() uint64 {
 	w.RLock()
 	defer w.RUnlock()
-	return w.resourceVersion
+	return w.listResourceVersion
 }
 
 func (w *watchCache) currentCapacity() int {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
```
❯ go run -mod=readonly golang.org/x/tools/cmd/stress ./cacher.test -test.run TestWatchBookmarksWithCorrectResourceVersion
5s: 0 runs so far, 0 failures
10s: 11 runs so far, 0 failures
15s: 22 runs so far, 0 failures
20s: 33 runs so far, 0 failures
25s: 43 runs so far, 0 failures
30s: 56 runs so far, 0 failures
35s: 67 runs so far, 0 failures
40s: 77 runs so far, 0 failures
45s: 88 runs so far, 0 failures
50s: 98 runs so far, 0 failures
55s: 109 runs so far, 0 failures
1m0s: 119 runs so far, 0 failures
1m5s: 129 runs so far, 0 failures
1m10s: 139 runs so far, 0 failures
1m15s: 149 runs so far, 0 failures
1m20s: 159 runs so far, 0 failures
1m25s: 169 runs so far, 0 failures
1m30s: 179 runs so far, 0 failures
1m35s: 189 runs so far, 0 failures
1m40s: 200 runs so far, 0 failures
1m45s: 210 runs so far, 0 failures
1m50s: 221 runs so far, 0 failures
1m55s: 231 runs so far, 0 failures
2m0s: 241 runs so far, 0 failures
2m5s: 252 runs so far, 0 failures
2m10s: 262 runs so far, 0 failures
2m15s: 273 runs so far, 0 failures
2m20s: 283 runs so far, 0 failures
2m25s: 294 runs so far, 0 failures
2m30s: 305 runs so far, 0 failures
2m35s: 315 runs so far, 0 failures
2m40s: 326 runs so far, 0 failures
2m45s: 336 runs so far, 0 failures
2m50s: 347 runs so far, 0 failures
2m55s: 358 runs so far, 0 failures
3m0s: 368 runs so far, 0 failures
3m5s: 378 runs so far, 0 failures
3m10s: 389 runs so far, 0 failures
3m15s: 401 runs so far, 0 failures
3m20s: 411 runs so far, 0 failures
3m25s: 421 runs so far, 0 failures
3m30s: 431 runs so far, 0 failures
3m35s: 441 runs so far, 0 failures
3m40s: 451 runs so far, 0 failures
3m45s: 461 runs so far, 0 failures
3m50s: 471 runs so far, 0 failures
3m55s: 481 runs so far, 0 failures
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #125244

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
