### PR TITLE
document kubelet --node-ip and external cloud provider node addresses logic

### DIFF
--- a/test/integration/cloudprovider/ccm_test.go
+++ b/test/integration/cloudprovider/ccm_test.go
@@ -96,6 +96,10 @@ func Test_RemoveExternalCloudProviderTaint(t *testing.T) {
 				Address: "10.0.0.1",
 			},
 			{
+				Type:    v1.NodeInternalIP,
+				Address: "192.168.0.1",
+			},
+			{
 				Type:    v1.NodeExternalIP,
 				Address: "132.143.154.163",
 			},
@@ -124,6 +128,9 @@ func Test_RemoveExternalCloudProviderTaint(t *testing.T) {
 			return false, nil
 		}
 		if n.Spec.Taints[0].Key != v1.TaintNodeNotReady {
+			return false, nil
+		}
+		if len(n.Status.Addresses) != 4 {
 			return false, nil
 		}
 		return true, nil


### PR DESCRIPTION
/kind bug
/kind api-change

#### What this PR does / why we need it:

  document kubelet node-ip with cloud provider external
    
    The node.status.addresses logic grew organically and with weird
    semantics, this commit try to document existing semantics when
    the kubelet uses an external cloud provider.
    
    The node.status.addresses can be populated by the kubelet at startup or
    delegated to the external cloud provider.
    
    If the --node-ip flag is set to an IP in the node, the kubelet will add
    an annotation to the Node object that will be respected by the external
    cloud providers, no new IP addresses will be added for the same address
    type.
    
    If the IP set in the --node-ip flag is `0.0.0.0` or `::`, the kubelet
    will initialize the node with the default address of the corresponding
    IP family of the unspecified address, and the cloud-provider will override
    it later.

This behavior is inherited from these PRs 
- https://github.com/kubernetes/kubernetes/pull/107750 , fixed https://github.com/kubernetes/cloud-provider/issues/56 that says
> Legacy cloud provider: kubelet filters NodeAddresses before writing them to the Node. It ensures that the IP given in --node-ip is present in the list of NodeAddresses, and then it removes all other NodeAddresses of that type.
- https://github.com/kubernetes/kubernetes/pull/80003

> For example, if nodeIP is 10.0.0.1 and cloud provider returns an InternalIP 10.0.0.1, then other InternalIPs are discarded from enforcedNodeAddresses, as expected. But this bug makes it so that the cloud provider's hostname is overridden too.

- https://github.com/kubernetes/kubernetes/pull/65594
- 
This seems when it originated the filtering behavior, however, but there is need to apply the same legacy behavior to the external cloud provider, as implementations should rely on the order of the addresses returned



#### Which issue(s) this PR fixes:
Fixes #

```release-note
NONE
```

/sig cloud-provider
/sig network