### PR TITLE
Fix Reflector to always close the watcher

### DIFF
--- a/staging/src/k8s.io/client-go/tools/cache/reflector_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/reflector_test.go
@@ -235,9 +235,7 @@ func TestReflectorHandleWatchStoppedBefore(t *testing.T) {
 	if err == nil {
 		t.Errorf("unexpected non-error")
 	}
-	// Ensure the watcher methods are called exactly once in this exact order.
-	// TODO(karlkfi): Fix watchHandler to call Stop()
-	// assert.Equal(t, []string{"ResultChan", "Stop"}, calls)
+	// Ensure ResultChan is called once and Stop is never called
 	assert.Equal(t, []string{"ResultChan"}, calls)
 }
 
@@ -271,9 +269,7 @@ func TestReflectorHandleWatchStoppedAfter(t *testing.T) {
 	if err == nil {
 		t.Errorf("unexpected non-error")
 	}
-	// Ensure the watcher methods are called exactly once in this exact order.
-	// TODO(karlkfi): Fix watchHandler to call Stop()
-	// assert.Equal(t, []string{"ResultChan", "Stop"}, calls)
+	// Ensure ResultChan is called once and Stop is never called
 	assert.Equal(t, []string{"ResultChan"}, calls)
 }
 
@@ -299,9 +295,7 @@ func TestReflectorHandleWatchResultChanClosedBefore(t *testing.T) {
 	if err == nil {
 		t.Errorf("unexpected non-error")
 	}
-	// Ensure the watcher methods are called exactly once in this exact order.
-	// TODO(karlkfi): Fix watchHandler to call Stop()
-	// assert.Equal(t, []string{"ResultChan", "Stop"}, calls)
+	// Ensure ResultChan is called once and Stop is never called
 	assert.Equal(t, []string{"ResultChan"}, calls)
 }
 
@@ -332,9 +326,7 @@ func TestReflectorHandleWatchResultChanClosedAfter(t *testing.T) {
 	if err == nil {
 		t.Errorf("unexpected non-error")
 	}
-	// Ensure the watcher methods are called exactly once in this exact order.
-	// TODO(karlkfi): Fix watchHandler to call Stop()
-	// assert.Equal(t, []string{"ResultChan", "Stop"}, calls)
+	// Ensure ResultChan is called once and Stop is never called
 	assert.Equal(t, []string{"ResultChan"}, calls)
 }
 


### PR DESCRIPTION
/bug

#### What/Why

- Ensure watcher.Stop() is called in all cases, including errors.

This is part of a multi-PR cleanup of code that uses `watch.Interface` to fix memory leaks and race conditions related to the closing of watcher stop and result channels.

Unfortunately, validating that this fix actually fixes the problem requires modifying `watch.FakeWatcher`, which is used by dozens of tests upstream. But modifying `watch.FakeWatcher` breaks the tests unless this `Reflector.ListAndWatch` bug is already fixed. So this change fixes the issue first, then I'll fix `watch.FakeWatcher` in a follow-up PR. Then I can add or modify the reflector tests to confirm that `Reflector.ListAndWatch` always closes the channels in the right order.

In a previous iteration, I had chosen to make watchHandler/handleWatch handle calling stop on the watcher, but after playing around with it a bit, I decided that doing that with defers using conditionals was confusing and error prone. So instead, I opted for ensuring that watchHandler/handleWatch never stops the watcher, instead delegating that back up to the caller, who can more easily do it with a defer without conditionals. This way, the lower level methods also do not need to call `w.Stop()` when the `stopCh` is closed.

Dependencies:
- https://github.com/kubernetes/kubernetes/pull/125299
- https://github.com/kubernetes/kubernetes/pull/125391
- https://github.com/kubernetes/kubernetes/pull/125472
- 
Related:
- https://github.com/kubernetes/kubernetes/pull/125107
- https://github.com/kubernetes/kubernetes/pull/125204
- https://github.com/kubernetes/kubernetes/pull/124801

#### Does this PR introduce a user-facing change?

```release-note
client-go: fix Reflector.ListAndWatch to always close the watcher
```
