### PR TITLE
dynamic client: add support for API streaming 

### DIFF
--- a/test/e2e/apimachinery/watchlist.go
+++ b/test/e2e/apimachinery/watchlist.go
@@ -35,6 +35,7 @@ import (
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	clientfeatures "k8s.io/client-go/features"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/consistencydetector"
 	"k8s.io/component-base/featuregate"
@@ -103,14 +104,7 @@ var _ = SIGDescribe("API Streaming (aka. WatchList)", framework.WithSerial(), fu
 			expectedSecrets = append(expectedSecrets, *secret)
 		}
 
-		var actualRequestsMadeByKubeClient []string
-		clientConfig := f.ClientConfig()
-		clientConfig.Wrap(func(rt http.RoundTripper) http.RoundTripper {
-			return roundTripFunc(func(req *http.Request) (*http.Response, error) {
-				actualRequestsMadeByKubeClient = append(actualRequestsMadeByKubeClient, req.URL.RawQuery)
-				return rt.RoundTrip(req)
-			})
-		})
+		rt, clientConfig := clientConfigWithRoundTripper(f)
 		wrappedKubeClient, err := kubernetes.NewForConfig(clientConfig)
 		framework.ExpectNoError(err)
 
@@ -120,26 +114,35 @@ var _ = SIGDescribe("API Streaming (aka. WatchList)", framework.WithSerial(), fu
 
 		ginkgo.By("Verifying if the secret list was properly streamed")
 		streamedSecrets := secretList.Items
-		sort.Sort(byName(expectedSecrets))
 		gomega.Expect(cmp.Equal(expectedSecrets, streamedSecrets)).To(gomega.BeTrueBecause("data received via watchlist must match the added data"))
 
 		ginkgo.By("Verifying if expected requests were sent to the server")
-		expectedRequestMadeByKubeClient := []string{
-			// corresponds to a streaming request made by the kube client to stream the secrets
-			"allowWatchBookmarks=true&resourceVersionMatch=NotOlderThan&sendInitialEvents=true&watch=true",
-		}
-		if consistencydetector.IsDataConsistencyDetectionForWatchListEnabled() {
-			// corresponds to a standard list request made by the consistency detector build in into the kube client
-			expectedRequestMadeByKubeClient = append(expectedRequestMadeByKubeClient, fmt.Sprintf("resourceVersion=%s&resourceVersionMatch=Exact", secretList.ResourceVersion))
-		}
-		gomega.Expect(actualRequestsMadeByKubeClient).To(gomega.Equal(expectedRequestMadeByKubeClient))
+		expectedRequestMadeByKubeClient := getExpectedRequestMadeByClientFor(secretList.ResourceVersion)
+		gomega.Expect(rt.actualRequests).To(gomega.Equal(expectedRequestMadeByKubeClient))
 	})
 })
 
-type roundTripFunc func(req *http.Request) (*http.Response, error)
+type roundTripper struct {
+	actualRequests []string
+	delegate       http.RoundTripper
+}
 
-func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
-	return f(req)
+func (r *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	r.actualRequests = append(r.actualRequests, req.URL.RawQuery)
+	return r.delegate.RoundTrip(req)
+}
+
+func (r *roundTripper) Wrap(delegate http.RoundTripper) http.RoundTripper {
+	r.delegate = delegate
+	return r
+}
+
+func clientConfigWithRoundTripper(f *framework.Framework) (*roundTripper, *rest.Config) {
+	clientConfig := f.ClientConfig()
+	rt := &roundTripper{}
+	clientConfig.Wrap(rt.Wrap)
+
+	return rt, clientConfig
 }
 
 func verifyStore(ctx context.Context, expectedSecrets []v1.Secret, store cache.Store) {
@@ -155,6 +158,18 @@ func verifyStore(ctx context.Context, expectedSecrets []v1.Secret, store cache.S
 		return cmp.Equal(expectedSecrets, streamedSecrets), nil
 	})
 	framework.ExpectNoError(err)
+}
+
+func getExpectedRequestMadeByClientFor(rv string) []string {
+	expectedRequestMadeByClient := []string{
+		// corresponds to a streaming request made by the client to stream the secrets
+		"allowWatchBookmarks=true&resourceVersionMatch=NotOlderThan&sendInitialEvents=true&watch=true",
+	}
+	if consistencydetector.IsDataConsistencyDetectionForWatchListEnabled() {
+		// corresponds to a standard list request made by the consistency detector build in into the client
+		expectedRequestMadeByClient = append(expectedRequestMadeByClient, fmt.Sprintf("resourceVersion=%s&resourceVersionMatch=Exact", rv))
+	}
+	return expectedRequestMadeByClient
 }
 
 type byName []v1.Secret


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This pull request introduces new functionality to the dynamic-client's List method, allowing users to enable API streaming. To activate this feature, users can set the client-go.WatchListClient feature gate.

It is important to note that the server must support streaming for this feature to function properly. If streaming is not supported by the server, the client will revert to using the normal LIST method to obtain data.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Introduces new functionality to the dynamic client's `List` method, allowing users to enable API streaming. To activate this feature, users can set the `client-go.WatchListClient` feature gate.

It is important to note that the server must support streaming for this feature to function properly. If streaming is not supported by the server, the client will revert to using the normal `LIST` method to obtain data.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
