### PR TITLE
[KEP-4569] Add a warning log, an event for cgroup v1 usage and a metric for cgroup version

### DIFF
--- a/pkg/kubelet/cm/cgroup_manager_unsupported.go
+++ b/pkg/kubelet/cm/cgroup_manager_unsupported.go
@@ -41,6 +41,10 @@ func NewCgroupManager(_ interface{}) CgroupManager {
 	return &unsupportedCgroupManager{}
 }
 
+func (m *unsupportedCgroupManager) Version() int {
+	return 0
+}
+
 func (m *unsupportedCgroupManager) Name(_ CgroupName) string {
 	return ""
 }

--- a/pkg/kubelet/cm/cgroup_v1_manager_linux.go
+++ b/pkg/kubelet/cm/cgroup_v1_manager_linux.go
@@ -48,6 +48,11 @@ func NewCgroupV1Manager(cs *CgroupSubsystems, cgroupDriver string) CgroupManager
 	}
 }
 
+// Version of the cgroup implementation on the host
+func (c *cgroupV1impl) Version() int {
+	return 1
+}
+
 // Validate checks if all subsystem cgroups are valid
 func (c *cgroupV1impl) Validate(name CgroupName) error {
 	// Get map of all cgroup paths on the system for the particular cgroup

--- a/pkg/kubelet/cm/cgroup_v2_manager_linux.go
+++ b/pkg/kubelet/cm/cgroup_v2_manager_linux.go
@@ -47,6 +47,11 @@ func NewCgroupV2Manager(cs *CgroupSubsystems, cgroupDriver string) CgroupManager
 	}
 }
 
+// Version of the cgroup implementation on the host
+func (c *cgroupV2impl) Version() int {
+	return 2
+}
+
 // Validate checks if all subsystem cgroups are valid
 func (c *cgroupV2impl) Validate(name CgroupName) error {
 	cgroupPath := c.buildCgroupUnifiedPath(name)

--- a/pkg/kubelet/cm/container_manager.go
+++ b/pkg/kubelet/cm/container_manager.go
@@ -42,6 +42,11 @@ import (
 	"k8s.io/utils/cpuset"
 )
 
+const (
+	// Warning message for the users still using cgroup v1
+	CgroupV1MaintenanceModeWarning = "Cgroup v1 support is in maintenance mode, please migrate to Cgroup v2."
+)
+
 type ActivePodsFunc func() []*v1.Pod
 
 // Manages the containers running on a machine.
@@ -159,6 +164,7 @@ type NodeConfig struct {
 	CPUCFSQuotaPeriod                       time.Duration
 	TopologyManagerPolicy                   string
 	TopologyManagerPolicyOptions            map[string]string
+	CgroupVersion                           int
 }
 
 type NodeAllocatableConfig struct {

--- a/pkg/kubelet/cm/container_manager_linux.go
+++ b/pkg/kubelet/cm/container_manager_linux.go
@@ -245,6 +245,7 @@ func NewContainerManager(mountUtil mount.Interface, cadvisorInterface cadvisor.I
 	// Turn CgroupRoot from a string (in cgroupfs path format) to internal CgroupName
 	cgroupRoot := ParseCgroupfsToCgroupName(nodeConfig.CgroupRoot)
 	cgroupManager := NewCgroupManager(subsystems, nodeConfig.CgroupDriver)
+	nodeConfig.CgroupVersion = cgroupManager.Version()
 	// Check if Cgroup-root actually exists on the node
 	if nodeConfig.CgroupsPerQOS {
 		// this does default to / when enabled, but this tests against regressions.

--- a/pkg/kubelet/cm/types.go
+++ b/pkg/kubelet/cm/types.go
@@ -88,6 +88,8 @@ type CgroupManager interface {
 	GetCgroupConfig(name CgroupName, resource v1.ResourceName) (*ResourceConfig, error)
 	// Set resource config for the specified resource type on the cgroup
 	SetCgroupConfig(name CgroupName, resource v1.ResourceName, resourceConfig *ResourceConfig) error
+	// Version of the cgroup implementation on the host
+	Version() int
 }
 
 // QOSContainersInfo stores the names of containers per qos

--- a/pkg/kubelet/events/event.go
+++ b/pkg/kubelet/events/event.go
@@ -76,6 +76,7 @@ const (
 	FailedMountOnFilesystemMismatch      = "FailedMountOnFilesystemMismatch"
 	FailedPrepareDynamicResources        = "FailedPrepareDynamicResources"
 	PossibleMemoryBackedVolumesOnDisk    = "PossibleMemoryBackedVolumesOnDisk"
+	CgroupV1                             = "CgroupV1"
 )
 
 // Image manager event reason list

--- a/pkg/kubelet/metrics/metrics.go
+++ b/pkg/kubelet/metrics/metrics.go
@@ -72,6 +72,7 @@ const (
 	OrphanedRuntimePodTotalKey         = "orphaned_runtime_pods_total"
 	RestartedPodTotalKey               = "restarted_pods_total"
 	ImagePullDurationKey               = "image_pull_duration_seconds"
+	CgroupVersionKey                   = "cgroup_version"
 
 	// Metrics keys of remote runtime operations
 	RuntimeOperationsKey         = "runtime_operations_total"
@@ -907,6 +908,15 @@ var (
 			StabilityLevel: metrics.ALPHA,
 		},
 	)
+
+	CgroupVersion = metrics.NewGauge(
+		&metrics.GaugeOpts{
+			Subsystem:      KubeletSubsystem,
+			Name:           CgroupVersionKey,
+			Help:           "cgroup version on the hosts.",
+			StabilityLevel: metrics.ALPHA,
+		},
+	)
 )
 
 var registerMetrics sync.Once
@@ -996,6 +1006,7 @@ func Register(collectors ...metrics.StableCollector) {
 
 		legacyregistry.MustRegister(LifecycleHandlerHTTPFallbacks)
 		legacyregistry.MustRegister(LifecycleHandlerSleepTerminated)
+		legacyregistry.MustRegister(CgroupVersion)
 	})
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it: 
Implements following items from the cgroup v1 maintenance mode KEP 
1. A warning log and an event generation in case cgroup v1 is used as described in this [KEP](https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/4569-cgroup-v1-maintenance-mode#implementing-a-warning-log-and-an-event-for-cgroup-v1-usage)
2. [cgroup version metric](https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/4569-cgroup-v1-maintenance-mode#introduction-of-cgroup-version-metric)

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Add a warning log, an event for cgroup v1 usage and a metric for cgroup version.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/4569-cgroup-v1-maintenance-mode#implementing-a-warning-log-and-an-event-for-cgroup-v1-usage
```
