### PR TITLE
Remove provider specific operations from the autoscaling tests and fix the ones that were previously failing.

### DIFF
--- a/cluster/gce/manifests/cluster-autoscaler.manifest
+++ b/cluster/gce/manifests/cluster-autoscaler.manifest
@@ -22,7 +22,7 @@
         "containers": [
             {
                 "name": "cluster-autoscaler",
-                "image": "registry.k8s.io/autoscaling/cluster-autoscaler:v1.26.1",
+                "image": "registry.k8s.io/autoscaling/cluster-autoscaler:v1.31.1",
                 "livenessProbe": {
                     "httpGet": {
                         "path": "/health-check",

--- a/test/e2e/autoscaling/autoscaling_timer.go
+++ b/test/e2e/autoscaling/autoscaling_timer.go
@@ -1,0 +1,108 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package autoscaling
+
+import (
+	"context"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/test/e2e/feature"
+	"k8s.io/kubernetes/test/e2e/framework"
+	e2eautoscaling "k8s.io/kubernetes/test/e2e/framework/autoscaling"
+	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
+	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
+	admissionapi "k8s.io/pod-security-admission/api"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega/gmeasure"
+)
+
+var _ = SIGDescribe(feature.ClusterSizeAutoscalingScaleUp, framework.WithSlow(), "Autoscaling", func() {
+	f := framework.NewDefaultFramework("autoscaling")
+	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
+	var experiment *gmeasure.Experiment
+
+	ginkgo.Describe("Autoscaling a service", func() {
+		ginkgo.BeforeEach(func(ctx context.Context) {
+			// Check if Cloud Autoscaler is enabled by trying to get its ConfigMap.
+			_, err := f.ClientSet.CoreV1().ConfigMaps("kube-system").Get(ctx, "cluster-autoscaler-status", metav1.GetOptions{})
+			if err != nil {
+				e2eskipper.Skipf("test expects Cluster Autoscaler to be enabled")
+			}
+			experiment = gmeasure.NewExperiment("Autoscaling a service")
+			ginkgo.AddReportEntry(experiment.Name, experiment)
+		})
+
+		ginkgo.Context("from 1 pod and 3 nodes to 8 pods and >=4 nodes", func() {
+			const nodesNum = 3 // Expect there to be 3 nodes before and after the test.
+
+			ginkgo.BeforeEach(func(ctx context.Context) {
+				nodes, err := e2enode.GetReadySchedulableNodes(ctx, f.ClientSet)
+				framework.ExpectNoError(err)
+				nodeCount := len(nodes.Items)
+				if nodeCount != nodesNum {
+					e2eskipper.Skipf("test expects %d schedulable nodes, found %d", nodesNum, nodeCount)
+				}
+				// As the last deferred cleanup ensure that the state is restored.
+				// AfterEach does not allow for this because it runs before other deferred
+				// cleanups happen, and they are blocking cluster restoring its initial size.
+				ginkgo.DeferCleanup(func(ctx context.Context) {
+					ginkgo.By("Waiting for scale down after test")
+					framework.ExpectNoError(e2enode.WaitForReadyNodes(ctx, f.ClientSet, nodeCount, 15*time.Minute))
+				})
+			})
+
+			ginkgo.It("takes less than 15 minutes", func(ctx context.Context) {
+				// Measured over multiple samples, scaling takes 10 +/- 2 minutes, so 15 minutes should be fully sufficient.
+				const timeToWait = 15 * time.Minute
+
+				// Calculate the CPU request of the service.
+				// This test expects that 8 pods will not fit in 'nodesNum' nodes, but will fit in >='nodesNum'+1 nodes.
+				// Make it so that 'nodesNum' pods fit perfectly per node.
+				nodes, err := e2enode.GetReadySchedulableNodes(ctx, f.ClientSet)
+				framework.ExpectNoError(err)
+				nodeCpus := nodes.Items[0].Status.Allocatable[v1.ResourceCPU]
+				nodeCPUMillis := (&nodeCpus).MilliValue()
+				cpuRequestMillis := int64(nodeCPUMillis / nodesNum)
+
+				// Start the service we want to scale and wait for it to be up and running.
+				nodeMemoryBytes := nodes.Items[0].Status.Allocatable[v1.ResourceMemory]
+				nodeMemoryMB := (&nodeMemoryBytes).Value() / 1024 / 1024
+				memRequestMB := nodeMemoryMB / 10 // Ensure each pod takes not more than 10% of node's allocatable memory.
+				replicas := 1
+				resourceConsumer := e2eautoscaling.NewDynamicResourceConsumer(ctx, "resource-consumer", f.Namespace.Name, e2eautoscaling.KindDeployment, replicas, 0, 0, 0, cpuRequestMillis, memRequestMB, f.ClientSet, f.ScalesGetter, e2eautoscaling.Disable, e2eautoscaling.Idle)
+				ginkgo.DeferCleanup(resourceConsumer.CleanUp)
+				resourceConsumer.WaitForReplicas(ctx, replicas, 1*time.Minute) // Should finish ~immediately, so 1 minute is more than enough.
+
+				// Enable Horizontal Pod Autoscaler with 50% target utilization and
+				// scale up the CPU usage to trigger autoscaling to 8 pods for target to be satisfied.
+				targetCPUUtilizationPercent := int32(50)
+				hpa := e2eautoscaling.CreateCPUResourceHorizontalPodAutoscaler(ctx, resourceConsumer, targetCPUUtilizationPercent, 1, 10)
+				ginkgo.DeferCleanup(e2eautoscaling.DeleteHorizontalPodAutoscaler, resourceConsumer, hpa.Name)
+				cpuLoad := 8 * cpuRequestMillis * int64(targetCPUUtilizationPercent) / 100 // 8 pods utilized to the target level
+				resourceConsumer.ConsumeCPU(int(cpuLoad))
+
+				// Measure the time it takes for the service to scale to 8 pods with 50% CPU utilization each.
+				experiment.SampleDuration("total scale-up time", func(idx int) {
+					resourceConsumer.WaitForReplicas(ctx, 8, timeToWait)
+				}, gmeasure.SamplingConfig{N: 1})
+			}) // Increase to run the test more than once.
+		})
+	})
+})

--- a/test/e2e/autoscaling/cluster_size_autoscaling.go
+++ b/test/e2e/autoscaling/cluster_size_autoscaling.go
@@ -1,0 +1,1048 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package autoscaling
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
+	schedulingv1 "k8s.io/api/scheduling/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/apimachinery/pkg/util/wait"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+	"k8s.io/kubernetes/test/e2e/feature"
+	"k8s.io/kubernetes/test/e2e/framework"
+	e2ekubectl "k8s.io/kubernetes/test/e2e/framework/kubectl"
+	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
+	e2erc "k8s.io/kubernetes/test/e2e/framework/rc"
+	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
+	"k8s.io/kubernetes/test/e2e/scheduling"
+	testutils "k8s.io/kubernetes/test/utils"
+	imageutils "k8s.io/kubernetes/test/utils/image"
+	admissionapi "k8s.io/pod-security-admission/api"
+	yaml "sigs.k8s.io/yaml/goyaml.v2"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+)
+
+const (
+	defaultTimeout         = 3 * time.Minute
+	scaleUpTimeout         = 5 * time.Minute
+	scaleUpTriggerTimeout  = 2 * time.Minute
+	scaleDownTimeout       = 20 * time.Minute
+	podTimeout             = 2 * time.Minute
+	rcCreationRetryTimeout = 4 * time.Minute
+	rcCreationRetryDelay   = 20 * time.Second
+	makeSchedulableTimeout = 10 * time.Minute
+	makeSchedulableDelay   = 20 * time.Second
+	freshStatusLimit       = 20 * time.Second
+
+	disabledTaint           = "DisabledForAutoscalingTest"
+	criticalAddonsOnlyTaint = "CriticalAddonsOnly"
+
+	caNoScaleUpStatus      = "NoActivity"
+	caOngoingScaleUpStatus = "InProgress"
+	timestampFormat        = "2006-01-02 15:04:05.999999999 -0700 MST"
+
+	expendablePriorityClassName = "expendable-priority"
+	highPriorityClassName       = "high-priority"
+
+	nonExistingBypassedSchedulerName = "non-existing-bypassed-scheduler"
+)
+
+// Test assumes that the cluster has a minimum number of nodes at the start of the test.
+// Example command to start the test cluster:
+// kubetest2 gce -v 2   --repo-root <k/k repo root>   --gcp-project <projct_name>   \
+//   --legacy-mode --build --up --env=ENABLE_CUSTOM_METRICS=true --env=KUBE_ENABLE_CLUSTER_AUTOSCALER=true \
+//   --env=KUBE_AUTOSCALER_MIN_NODES=3 --env=KUBE_AUTOSCALER_MAX_NODES=6 --env=KUBE_AUTOSCALER_ENABLE_SCALE_DOWN=true \
+//   --env=KUBE_ADMISSION_CONTROL=NamespaceLifecycle,LimitRanger,ServiceAccount,ResourceQuota,Priority --env=ENABLE_POD_PRIORITY=true
+
+// If you run the test in development consider changing values of the flags
+// to speed up the scale down so that the cluster restores its initial size faster.
+// Flags that can be adjusted:
+// * unremovable-node-recheck-timeout
+// * scale-down-unneeded-time
+// * scale-down-delay-after-add
+
+var _ = SIGDescribe("Cluster size autoscaling", framework.WithSlow(), func() {
+	f := framework.NewDefaultFramework("autoscaling")
+	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
+	var c clientset.Interface
+	var nodeCount int
+	var memAllocatableMb int
+
+	ginkgo.BeforeEach(func(ctx context.Context) {
+		c = f.ClientSet
+		_, err := c.CoreV1().ConfigMaps("kube-system").Get(ctx, "cluster-autoscaler-status", metav1.GetOptions{})
+		if err != nil {
+			e2eskipper.Skipf("test expects Cluster Autoscaler to be enabled")
+		}
+
+		framework.ExpectNoError(addKubeSystemPdbs(ctx, f))
+
+		nodes, err := e2enode.GetReadySchedulableNodes(ctx, c)
+		framework.ExpectNoError(err)
+		nodeCount = len(nodes.Items)
+		ginkgo.By(fmt.Sprintf("Initial number of schedulable nodes: %v", nodeCount))
+		gomega.Expect(nodes.Items).ToNot(gomega.BeEmpty())
+		mem := nodes.Items[0].Status.Allocatable[v1.ResourceMemory]
+		memAllocatableMb = int((&mem).Value() / 1024 / 1024)
+		// As the last deferred cleanup ensure that the state is restored.
+		// AfterEach does not allow for this because it runs before other deferred
+		// cleanups happen, and they are blocking cluster restoring its initial size.
+		ginkgo.DeferCleanup(func(ctx context.Context) {
+			ginkgo.By("Restoring the state after test")
+			framework.ExpectNoError(e2enode.WaitForReadyNodes(ctx, c, nodeCount, scaleDownTimeout))
+			nodes, err := c.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+			framework.ExpectNoError(err)
+
+			s := time.Now()
+		makeSchedulableLoop:
+			for start := time.Now(); time.Since(start) < makeSchedulableTimeout; time.Sleep(makeSchedulableDelay) {
+				var criticalAddonsOnlyErrorType *CriticalAddonsOnlyError
+				for _, n := range nodes.Items {
+					err = makeNodeSchedulable(ctx, c, &n, true)
+					if err != nil && errors.As(err, &criticalAddonsOnlyErrorType) {
+						continue makeSchedulableLoop
+					} else if err != nil {
+						klog.Infof("Error during cleanup: %v", err)
+					}
+				}
+				break
+			}
+			klog.Infof("Made nodes schedulable again in %v", time.Since(s).String())
+		})
+	})
+
+	f.It("shouldn't increase cluster size if pending pod is too large", feature.ClusterSizeAutoscalingScaleUp, func(ctx context.Context) {
+		ginkgo.By("Creating unschedulable pod")
+		ReserveMemory(ctx, f, "memory-reservation", 1, int(1.1*float64(memAllocatableMb)), false, defaultTimeout)
+		ginkgo.DeferCleanup(e2erc.DeleteRCAndWaitForGC, f.ClientSet, f.Namespace.Name, "memory-reservation")
+
+		ginkgo.By("Waiting for scale up hoping it won't happen")
+		// Verify that the appropriate event was generated
+		eventFound := false
+	EventsLoop:
+		for start := time.Now(); time.Since(start) < scaleUpTimeout; time.Sleep(20 * time.Second) {
+			ginkgo.By("Waiting for NotTriggerScaleUp event")
+			events, err := f.ClientSet.CoreV1().Events(f.Namespace.Name).List(ctx, metav1.ListOptions{})
+			framework.ExpectNoError(err)
+
+			for _, e := range events.Items {
+				if e.InvolvedObject.Kind == "Pod" && e.Reason == "NotTriggerScaleUp" {
+					ginkgo.By("NotTriggerScaleUp event found")
+					eventFound = true
+					break EventsLoop
+				}
+			}
+		}
+		if !eventFound {
+			framework.Failf("Expected event with kind 'Pod' and reason 'NotTriggerScaleUp' not found.")
+		}
+		// Verify that cluster size is not changed
+		framework.ExpectNoError(WaitForClusterSizeFunc(ctx, f.ClientSet,
+			func(size int) bool { return size <= nodeCount }, time.Second))
+	})
+
+	simpleScaleUpTest := func(ctx context.Context, unready int) {
+		ReserveMemory(ctx, f, "memory-reservation", 100, nodeCount*memAllocatableMb, false, 1*time.Second)
+		ginkgo.DeferCleanup(e2erc.DeleteRCAndWaitForGC, f.ClientSet, f.Namespace.Name, "memory-reservation")
+
+		// Verify that cluster size is increased
+		framework.ExpectNoError(WaitForClusterSizeFuncWithUnready(ctx, f.ClientSet,
+			func(size int) bool { return size >= nodeCount+1 }, scaleUpTimeout, unready))
+		framework.ExpectNoError(waitForAllCaPodsReadyInNamespace(ctx, f, c))
+	}
+
+	f.It("should increase cluster size if pending pods are small", feature.ClusterSizeAutoscalingScaleUp, func(ctx context.Context) {
+		simpleScaleUpTest(ctx, 0)
+	})
+
+	f.It("shouldn't trigger additional scale-ups during processing scale-up", feature.ClusterSizeAutoscalingScaleUp, func(ctx context.Context) {
+		// Wait for the situation to stabilize - CA should be running and have up-to-date node readiness info.
+		status, err := waitForScaleUpStatus(ctx, c, func(s *scaleUpStatus) bool {
+			return s.ready == s.target && s.ready <= nodeCount
+		}, scaleUpTriggerTimeout)
+		framework.ExpectNoError(err)
+
+		unmanagedNodes := nodeCount - status.ready
+
+		ginkgo.By("Schedule more pods than can fit and wait for cluster to scale-up")
+		ReserveMemory(ctx, f, "memory-reservation", 100, nodeCount*memAllocatableMb, false, 1*time.Second)
+		ginkgo.DeferCleanup(e2erc.DeleteRCAndWaitForGC, f.ClientSet, f.Namespace.Name, "memory-reservation")
+
+		status, err = waitForScaleUpStatus(ctx, c, func(s *scaleUpStatus) bool {
+			return s.status == caOngoingScaleUpStatus
+		}, scaleUpTriggerTimeout)
+		framework.ExpectNoError(err)
+		target := status.target
+		framework.ExpectNoError(waitForAllCaPodsReadyInNamespace(ctx, f, c))
+
+		ginkgo.By("Expect no more scale-up to be happening after all pods are scheduled")
+
+		// wait for a while until scale-up finishes; we cannot read CA status immediately
+		// after pods are scheduled as status config map is updated by CA once every loop iteration
+		status, err = waitForScaleUpStatus(ctx, c, func(s *scaleUpStatus) bool {
+			return s.status == caNoScaleUpStatus
+		}, 2*freshStatusLimit)
+		framework.ExpectNoError(err)
+
+		if status.target != target {
+			klog.Warningf("Final number of nodes (%v) does not match initial scale-up target (%v).", status.target, target)
+		}
+		gomega.Expect(status.timestamp.Add(freshStatusLimit)).To(gomega.BeTemporally(">=", time.Now()))
+		gomega.Expect(status.status).To(gomega.Equal(caNoScaleUpStatus))
+		gomega.Expect(status.ready).To(gomega.Equal(status.target))
+		nodes, err := e2enode.GetReadySchedulableNodes(ctx, f.ClientSet)
+		framework.ExpectNoError(err)
+		gomega.Expect(nodes.Items).To(gomega.HaveLen(status.target + unmanagedNodes))
+	})
+
+	f.It("should increase cluster size if pods are pending due to host port conflict", feature.ClusterSizeAutoscalingScaleUp, func(ctx context.Context) {
+		scheduling.CreateHostPortPods(ctx, f, "host-port", nodeCount+2, false)
+		ginkgo.DeferCleanup(e2erc.DeleteRCAndWaitForGC, f.ClientSet, f.Namespace.Name, "host-port")
+
+		framework.ExpectNoError(WaitForClusterSizeFunc(ctx, f.ClientSet,
+			func(size int) bool { return size >= nodeCount+2 }, scaleUpTimeout))
+		framework.ExpectNoError(waitForAllCaPodsReadyInNamespace(ctx, f, c))
+	})
+
+	f.It("should increase cluster size if pods are pending due to pod anti-affinity", feature.ClusterSizeAutoscalingScaleUp, func(ctx context.Context) {
+		pods := nodeCount
+		newPods := 2
+		labels := map[string]string{
+			"anti-affinity": "yes",
+		}
+		ginkgo.By("starting a pod with anti-affinity on each node")
+		framework.ExpectNoError(runAntiAffinityPods(ctx, f, f.Namespace.Name, pods, "anti-affinity-pod", labels, labels))
+		ginkgo.DeferCleanup(e2erc.DeleteRCAndWaitForGC, f.ClientSet, f.Namespace.Name, "anti-affinity-pod")
+		framework.ExpectNoError(waitForAllCaPodsReadyInNamespace(ctx, f, c))
+
+		ginkgo.By("scheduling extra pods with anti-affinity to existing ones")
+		framework.ExpectNoError(runAntiAffinityPods(ctx, f, f.Namespace.Name, newPods, "extra-pod", labels, labels))
+		ginkgo.DeferCleanup(e2erc.DeleteRCAndWaitForGC, f.ClientSet, f.Namespace.Name, "extra-pod")
+
+		framework.ExpectNoError(waitForAllCaPodsReadyInNamespace(ctx, f, c))
+		framework.ExpectNoError(e2enode.WaitForReadyNodes(ctx, c, nodeCount+newPods, scaleUpTimeout))
+	})
+
+	f.It("should increase cluster size if pod requesting EmptyDir volume is pending", feature.ClusterSizeAutoscalingScaleUp, func(ctx context.Context) {
+		ginkgo.By("creating pods")
+		pods := nodeCount
+		newPods := 1
+		labels := map[string]string{
+			"anti-affinity": "yes",
+		}
+		framework.ExpectNoError(runAntiAffinityPods(ctx, f, f.Namespace.Name, pods, "anti-affinity-pod", labels, labels))
+		ginkgo.DeferCleanup(e2erc.DeleteRCAndWaitForGC, f.ClientSet, f.Namespace.Name, "anti-affinity-pod")
+
+		ginkgo.By("waiting for all pods before triggering scale up")
+		framework.ExpectNoError(waitForAllCaPodsReadyInNamespace(ctx, f, c))
+
+		ginkgo.By("creating a pod requesting EmptyDir")
+		framework.ExpectNoError(runVolumeAntiAffinityPods(ctx, f, f.Namespace.Name, newPods, "extra-pod", labels, labels, emptyDirVolumes))
+		ginkgo.DeferCleanup(e2erc.DeleteRCAndWaitForGC, f.ClientSet, f.Namespace.Name, "extra-pod")
+
+		framework.ExpectNoError(waitForAllCaPodsReadyInNamespace(ctx, f, c))
+		framework.ExpectNoError(e2enode.WaitForReadyNodes(ctx, c, nodeCount+newPods, scaleUpTimeout))
+	})
+
+	f.It("should correctly scale down after a node is not needed", feature.ClusterSizeAutoscalingScaleDown, func(ctx context.Context) {
+		ginkgo.By("Increase cluster size")
+		cleanupFunc := increaseClusterSize(ctx, f, c, nodeCount+2)
+
+		ginkgo.By("Remove the RC to make nodes not needed any more")
+		framework.ExpectNoError(cleanupFunc())
+
+		ginkgo.By("Some uneeded nodes should be removed")
+		framework.ExpectNoError(WaitForClusterSizeFuncWithUnready(ctx, f.ClientSet,
+			func(size int) bool { return size < nodeCount+2 }, scaleDownTimeout, 0))
+	})
+
+	f.It("should be able to scale down when rescheduling a pod is required and pdb allows for it", feature.ClusterSizeAutoscalingScaleDown, func(ctx context.Context) {
+		runDrainTest(ctx, f, c, nodeCount, f.Namespace.Name, 1, 1, func(increasedSize int) {
+			ginkgo.By("Some node should be removed")
+			framework.ExpectNoError(WaitForClusterSizeFunc(ctx, f.ClientSet,
+				func(size int) bool { return size < increasedSize }, scaleDownTimeout))
+		})
+	})
+
+	f.It("shouldn't be able to scale down when rescheduling a pod is required, but pdb doesn't allow drain", feature.ClusterSizeAutoscalingScaleDown, func(ctx context.Context) {
+		runDrainTest(ctx, f, c, nodeCount, f.Namespace.Name, 1, 0, func(increasedSize int) {
+			ginkgo.By("No nodes should be removed")
+			time.Sleep(scaleDownTimeout)
+			nodes, err := e2enode.GetReadySchedulableNodes(ctx, f.ClientSet)
+			framework.ExpectNoError(err)
+			gomega.Expect(nodes.Items).To(gomega.HaveLen(increasedSize))
+		})
+	})
+
+	f.It("should be able to scale down by draining multiple pods one by one as dictated by pdb", feature.ClusterSizeAutoscalingScaleDown, func(ctx context.Context) {
+		runDrainTest(ctx, f, c, nodeCount, f.Namespace.Name, 2, 1, func(increasedSize int) {
+			ginkgo.By("Some node should be removed")
+			framework.ExpectNoError(WaitForClusterSizeFunc(ctx, f.ClientSet,
+				func(size int) bool { return size < increasedSize }, scaleDownTimeout))
+		})
+	})
+
+	f.It("should be able to scale down by draining system pods with pdb", feature.ClusterSizeAutoscalingScaleDown, func(ctx context.Context) {
+		runDrainTest(ctx, f, c, nodeCount, "kube-system", 2, 1, func(increasedSize int) {
+			ginkgo.By("Some node should be removed")
+			framework.ExpectNoError(WaitForClusterSizeFunc(ctx, f.ClientSet,
+				func(size int) bool { return size < increasedSize }, scaleDownTimeout))
+		})
+	})
+
+	f.It("shouldn't scale up when expendable pod is created", feature.ClusterSizeAutoscalingScaleUp, func(ctx context.Context) {
+		createPriorityClasses(ctx, f)
+		// Create nodesCountAfterResize+1 pods allocating 0.7 allocatable on present nodes. One more node will have to be created.
+		ginkgo.DeferCleanup(ReserveMemoryWithPriority, f, "memory-reservation", nodeCount+1, int(float64(nodeCount+1)*float64(0.7)*float64(memAllocatableMb)), false, time.Second, expendablePriorityClassName)
+		ginkgo.By(fmt.Sprintf("Waiting for scale up hoping it won't happen, sleep for %s", scaleUpTimeout.String()))
+		time.Sleep(scaleUpTimeout)
+		// Verify that cluster size is not changed
+		framework.ExpectNoError(WaitForClusterSizeFunc(ctx, f.ClientSet,
+			func(size int) bool { return size == nodeCount }, time.Second))
+	})
+
+	f.It("should scale up when non expendable pod is created", feature.ClusterSizeAutoscalingScaleUp, func(ctx context.Context) {
+		createPriorityClasses(ctx, f)
+		// Create nodesCountAfterResize+1 pods allocating 0.7 allocatable on present nodes. One more node will have to be created.
+		cleanupFunc := ReserveMemoryWithPriority(ctx, f, "memory-reservation", nodeCount+1, int(float64(nodeCount+1)*float64(0.7)*float64(memAllocatableMb)), true, scaleUpTimeout, highPriorityClassName)
+		defer func() {
+			framework.ExpectNoError(cleanupFunc())
+		}()
+		// Verify that cluster size is not changed
+		framework.ExpectNoError(WaitForClusterSizeFunc(ctx, f.ClientSet,
+			func(size int) bool { return size > nodeCount }, time.Second))
+	})
+
+	f.It("shouldn't scale up when expendable pod is preempted", feature.ClusterSizeAutoscalingScaleUp, func(ctx context.Context) {
+		createPriorityClasses(ctx, f)
+		// Create nodesCountAfterResize pods allocating 0.7 allocatable on present nodes - one pod per node.
+		cleanupFunc1 := ReserveMemoryWithPriority(ctx, f, "memory-reservation1", nodeCount, int(float64(nodeCount)*float64(0.7)*float64(memAllocatableMb)), true, defaultTimeout, expendablePriorityClassName)
+		defer func() {
+			framework.ExpectNoError(cleanupFunc1())
+		}()
+		// Create nodesCountAfterResize pods allocating 0.7 allocatable on present nodes - one pod per node. Pods created here should preempt pods created above.
+		cleanupFunc2 := ReserveMemoryWithPriority(ctx, f, "memory-reservation2", nodeCount, int(float64(nodeCount)*float64(0.7)*float64(memAllocatableMb)), true, defaultTimeout, highPriorityClassName)
+		defer func() {
+			framework.ExpectNoError(cleanupFunc2())
+		}()
+		framework.ExpectNoError(WaitForClusterSizeFunc(ctx, f.ClientSet,
+			func(size int) bool { return size == nodeCount }, time.Second))
+	})
+
+	f.It("should scale down when expendable pod is running", feature.ClusterSizeAutoscalingScaleDown, func(ctx context.Context) {
+		createPriorityClasses(ctx, f)
+		increasedSize := nodeCount + 2
+		cleanupIncreaseFunc := increaseClusterSize(ctx, f, c, increasedSize)
+		// Create increasedSize pods allocating 0.7 allocatable on present nodes - one pod per node.
+		cleanupFunc := ReserveMemoryWithPriority(ctx, f, "memory-reservation", increasedSize, int(float64(increasedSize)*float64(0.7)*float64(memAllocatableMb)), true, scaleUpTimeout, expendablePriorityClassName)
+		defer func() {
+			framework.ExpectNoError(cleanupFunc())
+		}()
+		ginkgo.By("Remove pods that increased the cluster size")
+		framework.ExpectNoError(cleanupIncreaseFunc())
+		ginkgo.By("Waiting for scale down")
+		framework.ExpectNoError(WaitForClusterSizeFunc(ctx, f.ClientSet,
+			func(size int) bool { return size == nodeCount }, scaleDownTimeout))
+	})
+
+	f.It("shouldn't scale down when non expendable pod is running", feature.ClusterSizeAutoscalingScaleDown, func(ctx context.Context) {
+		createPriorityClasses(ctx, f)
+		increasedSize := nodeCount + 2
+		cleanupIncreased := increaseClusterSize(ctx, f, c, increasedSize)
+		// Create increasedSize pods allocating 0.7 allocatable on present nodes - one pod per node.
+		cleanupFunc := ReserveMemoryWithPriority(ctx, f, "memory-reservation", increasedSize, int(float64(increasedSize)*float64(0.7)*float64(memAllocatableMb)), true, scaleUpTimeout, highPriorityClassName)
+		defer func() {
+			framework.ExpectNoError(cleanupFunc())
+		}()
+		framework.ExpectNoError(cleanupIncreased())
+		ginkgo.By(fmt.Sprintf("Waiting for scale down hoping it won't happen, sleep for %s", scaleDownTimeout.String()))
+		time.Sleep(scaleDownTimeout)
+		framework.ExpectNoError(WaitForClusterSizeFunc(ctx, f.ClientSet,
+			func(size int) bool { return size == increasedSize }, time.Second))
+	})
+
+	f.It("should scale up when unprocessed pod is created and is going to be unschedulable", feature.ClusterScaleUpBypassScheduler, func(ctx context.Context) {
+		// 70% of allocatable memory of a single node * replica count, forcing a scale up in case of normal pods
+		replicaCount := 2 * nodeCount
+		reservedMemory := int(float64(replicaCount) * float64(0.7) * float64(memAllocatableMb))
+		cleanupFunc := ReserveMemoryWithSchedulerName(ctx, f, "memory-reservation", replicaCount, reservedMemory, false, 1, nonExistingBypassedSchedulerName)
+		defer func() {
+			framework.ExpectNoError(cleanupFunc())
+		}()
+		// Verify that cluster size is increased
+		ginkgo.By("Waiting for cluster scale-up")
+		sizeFunc := func(size int) bool {
+			// Softly checks scale-up since other types of machines can be added which would affect #nodes
+			return size > nodeCount
+		}
+		framework.ExpectNoError(WaitForClusterSizeFuncWithUnready(ctx, f.ClientSet, sizeFunc, scaleUpTimeout, 0))
+	})
+
+	f.It("shouldn't scale up when unprocessed pod is created and is going to be schedulable", feature.ClusterScaleUpBypassScheduler, func(ctx context.Context) {
+		// 50% of allocatable memory of a single node, so that no scale up would trigger in normal cases
+		replicaCount := 1
+		reservedMemory := int(float64(0.5) * float64(memAllocatableMb))
+		cleanupFunc := ReserveMemoryWithSchedulerName(ctx, f, "memory-reservation", replicaCount, reservedMemory, false, 1, nonExistingBypassedSchedulerName)
+		defer func() {
+			framework.ExpectNoError(cleanupFunc())
+		}()
+		// Verify that cluster size is the same
+		ginkgo.By(fmt.Sprintf("Waiting for scale up hoping it won't happen, polling cluster size for %s", scaleUpTimeout.String()))
+		sizeFunc := func(size int) bool {
+			return size == nodeCount
+		}
+		gomega.Consistently(ctx, func() error {
+			return WaitForClusterSizeFunc(ctx, f.ClientSet, sizeFunc, time.Second)
+		}).WithTimeout(scaleUpTimeout).WithPolling(framework.Poll).ShouldNot(gomega.HaveOccurred())
+	})
+
+	f.It("shouldn't scale up when unprocessed pod is created and scheduler is not specified to be bypassed", feature.ClusterScaleUpBypassScheduler, func(ctx context.Context) {
+		// 70% of allocatable memory of a single node * replica count, forcing a scale up in case of normal pods
+		replicaCount := 2 * nodeCount
+		reservedMemory := int(float64(replicaCount) * float64(0.7) * float64(memAllocatableMb))
+		schedulerName := "non-existent-scheduler-" + f.UniqueName
+		cleanupFunc := ReserveMemoryWithSchedulerName(ctx, f, "memory-reservation", replicaCount, reservedMemory, false, 1, schedulerName)
+		defer func() {
+			framework.ExpectNoError(cleanupFunc())
+		}()
+		// Verify that cluster size is the same
+		ginkgo.By(fmt.Sprintf("Waiting for scale up hoping it won't happen, polling cluster size for %s", scaleUpTimeout.String()))
+		sizeFunc := func(size int) bool {
+			return size == nodeCount
+		}
+		gomega.Consistently(ctx, func() error {
+			return WaitForClusterSizeFunc(ctx, f.ClientSet, sizeFunc, time.Second)
+		}).WithTimeout(scaleUpTimeout).WithPolling(framework.Poll).ShouldNot(gomega.HaveOccurred())
+	})
+
+})
+
+func runDrainTest(ctx context.Context, f *framework.Framework, c clientset.Interface, nodeCount int, namespace string, podsPerNode, pdbSize int, verifyFunction func(int)) {
+	increasedCount := nodeCount + 2
+
+	cleanupIncreasedSizeFunc := increaseClusterSize(ctx, f, c, increasedCount)
+
+	nodes, err := f.ClientSet.CoreV1().Nodes().List(ctx, metav1.ListOptions{FieldSelector: fields.Set{
+		"spec.unschedulable": "false",
+	}.AsSelector().String()})
+	framework.ExpectNoError(err)
+	numPods := len(nodes.Items) * podsPerNode
+	testID := string(uuid.NewUUID()) // So that we can label and find pods
+	labelMap := map[string]string{"test_id": testID}
+	makeNodesSchedulable, err := runReplicatedPodOnEachNode(ctx, f, nodes.Items, namespace, podsPerNode, "reschedulable-pods", labelMap, 0)
+	framework.ExpectNoError(err)
+
+	ginkgo.DeferCleanup(e2erc.DeleteRCAndWaitForGC, f.ClientSet, namespace, "reschedulable-pods")
+
+	ginkgo.By("Create a PodDisruptionBudget")
+	minAvailable := intstr.FromInt32(int32(numPods - pdbSize))
+	pdb := &policyv1.PodDisruptionBudget{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test_pdb",
+			Namespace: namespace,
+		},
+		Spec: policyv1.PodDisruptionBudgetSpec{
+			Selector:     &metav1.LabelSelector{MatchLabels: labelMap},
+			MinAvailable: &minAvailable,
+		},
+	}
+	_, err = f.ClientSet.PolicyV1().PodDisruptionBudgets(namespace).Create(ctx, pdb, metav1.CreateOptions{})
+
+	ginkgo.DeferCleanup(framework.IgnoreNotFound(f.ClientSet.PolicyV1().PodDisruptionBudgets(namespace).Delete), pdb.Name, metav1.DeleteOptions{})
+
+	framework.ExpectNoError(err)
+	framework.ExpectNoError(cleanupIncreasedSizeFunc())
+	framework.ExpectNoError(makeNodesSchedulable())
+	verifyFunction(increasedCount)
+}
+
+func reserveMemory(ctx context.Context, f *framework.Framework, id string, replicas, megabytes int, expectRunning bool, timeout time.Duration, selector map[string]string, tolerations []v1.Toleration, priorityClassName, schedulerName string) func() error {
+	ginkgo.By(fmt.Sprintf("Running RC which reserves %v MB of memory", megabytes))
+	request := int64(1024 * 1024 * megabytes / replicas)
+	config := &testutils.RCConfig{
+		Client:            f.ClientSet,
+		Name:              id,
+		Namespace:         f.Namespace.Name,
+		Timeout:           timeout,
+		Image:             imageutils.GetPauseImageName(),
+		Replicas:          replicas,
+		MemRequest:        request,
+		NodeSelector:      selector,
+		Tolerations:       tolerations,
+		PriorityClassName: priorityClassName,
+		SchedulerName:     schedulerName,
+	}
+	for start := time.Now(); time.Since(start) < rcCreationRetryTimeout; time.Sleep(rcCreationRetryDelay) {
+		err := e2erc.RunRC(ctx, *config)
+		if err != nil && strings.Contains(err.Error(), "Error creating replication controller") {
+			klog.Warningf("Failed to create memory reservation: %v", err)
+			continue
+		}
+		if expectRunning {
+			framework.ExpectNoError(err)
+		}
+		return func() error {
+			return e2erc.DeleteRCAndWaitForGC(ctx, f.ClientSet, f.Namespace.Name, id)
+		}
+	}
+	framework.Failf("Failed to reserve memory within timeout")
+	return nil
+}
+
+// ReserveMemoryWithPriority creates a replication controller with pods with priority that, in summation,
+// request the specified amount of memory.
+func ReserveMemoryWithPriority(ctx context.Context, f *framework.Framework, id string, replicas, megabytes int, expectRunning bool, timeout time.Duration, priorityClassName string) func() error {
+	return reserveMemory(ctx, f, id, replicas, megabytes, expectRunning, timeout, nil, nil, priorityClassName, "")
+}
+
+// ReserveMemoryWithSchedulerName creates a replication controller with pods with scheduler name that, in summation,
+// request the specified amount of memory.
+func ReserveMemoryWithSchedulerName(ctx context.Context, f *framework.Framework, id string, replicas, megabytes int, expectRunning bool, timeout time.Duration, schedulerName string) func() error {
+	return reserveMemory(ctx, f, id, replicas, megabytes, expectRunning, timeout, nil, nil, "", schedulerName)
+}
+
+// ReserveMemory creates a replication controller with pods that, in summation,
+// request the specified amount of memory.
+func ReserveMemory(ctx context.Context, f *framework.Framework, id string, replicas, megabytes int, expectRunning bool, timeout time.Duration) func() error {
+	return reserveMemory(ctx, f, id, replicas, megabytes, expectRunning, timeout, nil, nil, "", "")
+}
+
+// WaitForClusterSizeFunc waits until the cluster size matches the given function.
+func WaitForClusterSizeFunc(ctx context.Context, c clientset.Interface, sizeFunc func(int) bool, timeout time.Duration) error {
+	return WaitForClusterSizeFuncWithUnready(ctx, c, sizeFunc, timeout, 0)
+}
+
+// WaitForClusterSizeFuncWithUnready waits until the cluster size matches the given function and assumes some unready nodes.
+func WaitForClusterSizeFuncWithUnready(ctx context.Context, c clientset.Interface, sizeFunc func(int) bool, timeout time.Duration, expectedUnready int) error {
+	for start := time.Now(); time.Since(start) < timeout && ctx.Err() == nil; time.Sleep(20 * time.Second) {
+		nodes, err := c.CoreV1().Nodes().List(ctx, metav1.ListOptions{FieldSelector: fields.Set{
+			"spec.unschedulable": "false",
+		}.AsSelector().String()})
+		if err != nil {
+			klog.Warningf("Failed to list nodes: %v", err)
+			continue
+		}
+		numNodes := len(nodes.Items)
+
+		// Filter out not-ready nodes.
+		e2enode.Filter(nodes, func(node v1.Node) bool {
+			return e2enode.IsConditionSetAsExpected(&node, v1.NodeReady, true)
+		})
+		numReady := len(nodes.Items)
+
+		if numNodes == numReady+expectedUnready && sizeFunc(numNodes) {
+			klog.Infof("Cluster has reached the desired size. Current size %d, not ready nodes %d", numNodes, numNodes-numReady)
+			return nil
+		}
+		klog.Infof("Waiting for cluster with func, current size %d, not ready nodes %d", numNodes, numNodes-numReady)
+	}
+	return fmt.Errorf("timeout waiting %v for appropriate cluster size", timeout)
+}
+
+func waitForCaPodsReadyInNamespace(ctx context.Context, f *framework.Framework, c clientset.Interface, tolerateUnreadyCount int) error {
+	var notready []string
+	for start := time.Now(); time.Now().Before(start.Add(scaleUpTimeout)) && ctx.Err() == nil; time.Sleep(20 * time.Second) {
+		pods, err := c.CoreV1().Pods(f.Namespace.Name).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return fmt.Errorf("failed to get pods: %w", err)
+		}
+		notready = make([]string, 0)
+		for _, pod := range pods.Items {
+			ready := false
+			for _, c := range pod.Status.Conditions {
+				if c.Type == v1.PodReady && c.Status == v1.ConditionTrue {
+					ready = true
+				}
+			}
+			// Failed pods in this context generally mean that they have been
+			// double scheduled onto a node, but then failed a constraint check.
+			if pod.Status.Phase == v1.PodFailed {
+				klog.Warningf("Pod has failed: %v", pod)
+			}
+			if !ready && pod.Status.Phase != v1.PodFailed {
+				notready = append(notready, pod.Name)
+			}
+		}
+		if len(notready) <= tolerateUnreadyCount {
+			klog.Infof("sufficient number of pods ready. Tolerating %d unready", tolerateUnreadyCount)
+			return nil
+		}
+		klog.Infof("Too many pods are not ready yet: %v", notready)
+	}
+	klog.Info("Timeout on waiting for pods being ready")
+	klog.Info(e2ekubectl.RunKubectlOrDie(f.Namespace.Name, "get", "pods", "-o", "json", "--all-namespaces"))
+	klog.Info(e2ekubectl.RunKubectlOrDie(f.Namespace.Name, "get", "nodes", "-o", "json"))
+
+	// Some pods are still not running.
+	return fmt.Errorf("too many pods are still not running: %v", notready)
+}
+
+func waitForAllCaPodsReadyInNamespace(ctx context.Context, f *framework.Framework, c clientset.Interface) error {
+	return waitForCaPodsReadyInNamespace(ctx, f, c, 0)
+}
+
+func makeNodeUnschedulable(ctx context.Context, c clientset.Interface, node *v1.Node) error {
+	ginkgo.By(fmt.Sprintf("Taint node %s", node.Name))
+	for j := 0; j < 3; j++ {
+		freshNode, err := c.CoreV1().Nodes().Get(ctx, node.Name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		for _, taint := range freshNode.Spec.Taints {
+			if taint.Key == disabledTaint {
+				return nil
+			}
+		}
+		freshNode.Spec.Taints = append(freshNode.Spec.Taints, v1.Taint{
+			Key:    disabledTaint,
+			Value:  "DisabledForTest",
+			Effect: v1.TaintEffectNoSchedule,
+		})
+		_, err = c.CoreV1().Nodes().Update(ctx, freshNode, metav1.UpdateOptions{})
+		if err == nil {
+			return nil
+		}
+		if !apierrors.IsConflict(err) {
+			return err
+		}
+		klog.Warningf("Got 409 conflict when trying to taint node, retries left: %v", 3-j)
+	}
+	return fmt.Errorf("failed to taint node in allowed number of retries")
+}
+
+// CriticalAddonsOnlyError implements the `error` interface, and signifies the
+// presence of the `CriticalAddonsOnly` taint on the node.
+type CriticalAddonsOnlyError struct{}
+
+func (CriticalAddonsOnlyError) Error() string {
+	return "CriticalAddonsOnly taint found on node"
+}
+
+func makeNodeSchedulable(ctx context.Context, c clientset.Interface, node *v1.Node, failOnCriticalAddonsOnly bool) error {
+	ginkgo.By(fmt.Sprintf("Remove taint from node %s", node.Name))
+	for j := 0; j < 3; j++ {
+		freshNode, err := c.CoreV1().Nodes().Get(ctx, node.Name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		var newTaints []v1.Taint
+		for _, taint := range freshNode.Spec.Taints {
+			if failOnCriticalAddonsOnly && taint.Key == criticalAddonsOnlyTaint {
+				return CriticalAddonsOnlyError{}
+			}
+			if taint.Key != disabledTaint {
+				newTaints = append(newTaints, taint)
+			}
+		}
+
+		if len(newTaints) == len(freshNode.Spec.Taints) {
+			return nil
+		}
+		freshNode.Spec.Taints = newTaints
+		_, err = c.CoreV1().Nodes().Update(ctx, freshNode, metav1.UpdateOptions{})
+		if err == nil {
+			return nil
+		}
+		if !apierrors.IsConflict(err) {
+			return err
+		}
+		klog.Warningf("Got 409 conflict when trying to taint node, retries left: %v", 3-j)
+	}
+	return fmt.Errorf("failed to remove taint from node in allowed number of retries")
+}
+
+// Create an RC running a given number of pods with anti-affinity
+func runAntiAffinityPods(ctx context.Context, f *framework.Framework, namespace string, pods int, id string, podLabels, antiAffinityLabels map[string]string) error {
+	config := &testutils.RCConfig{
+		Affinity:  buildAntiAffinity(antiAffinityLabels),
+		Client:    f.ClientSet,
+		Name:      id,
+		Namespace: namespace,
+		Timeout:   scaleUpTimeout,
+		Image:     imageutils.GetPauseImageName(),
+		Replicas:  pods,
+		Labels:    podLabels,
+	}
+	err := e2erc.RunRC(ctx, *config)
+	if err != nil {
+		return err
+	}
+	_, err = f.ClientSet.CoreV1().ReplicationControllers(namespace).Get(ctx, id, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func runVolumeAntiAffinityPods(ctx context.Context, f *framework.Framework, namespace string, pods int, id string, podLabels, antiAffinityLabels map[string]string, volumes []v1.Volume) error {
+	config := &testutils.RCConfig{
+		Affinity:  buildAntiAffinity(antiAffinityLabels),
+		Volumes:   volumes,
+		Client:    f.ClientSet,
+		Name:      id,
+		Namespace: namespace,
+		Timeout:   scaleUpTimeout,
+		Image:     imageutils.GetPauseImageName(),
+		Replicas:  pods,
+		Labels:    podLabels,
+	}
+	err := e2erc.RunRC(ctx, *config)
+	if err != nil {
+		return err
+	}
+	_, err = f.ClientSet.CoreV1().ReplicationControllers(namespace).Get(ctx, id, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+var emptyDirVolumes = []v1.Volume{
+	{
+		Name: "empty-volume",
+		VolumeSource: v1.VolumeSource{
+			EmptyDir: &v1.EmptyDirVolumeSource{},
+		},
+	},
+}
+
+func buildAntiAffinity(labels map[string]string) *v1.Affinity {
+	return &v1.Affinity{
+		PodAntiAffinity: &v1.PodAntiAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: []v1.PodAffinityTerm{
+				{
+					LabelSelector: &metav1.LabelSelector{
+						MatchLabels: labels,
+					},
+					TopologyKey: "kubernetes.io/hostname",
+				},
+			},
+		},
+	}
+}
+
+// Create an RC running a given number of pods on each node without adding any constraint forcing
+// such pod distribution. This is meant to create a bunch of underutilized (but not unused) nodes
+// with pods that can be rescheduled on different nodes.
+// This is achieved using the following method:
+// 1. disable scheduling on each node
+// 2. create an empty RC
+// 3. for each node:
+// 3a. enable scheduling on that node
+// 3b. increase number of replicas in RC by podsPerNode
+// Return the function to enable back scheduling on each node
+func runReplicatedPodOnEachNode(ctx context.Context, f *framework.Framework, nodes []v1.Node, namespace string, podsPerNode int, id string, labels map[string]string, memRequest int64) (func() error, error) {
+	ginkgo.By("Run a pod on each node")
+	for _, node := range nodes {
+		err := makeNodeUnschedulable(ctx, f.ClientSet, &node)
+		ginkgo.DeferCleanup(func(ctx context.Context) {
+			err := makeNodeSchedulable(ctx, f.ClientSet, &node, false)
+			klog.Infof("Error during cleanup: %v", err)
+		})
+
+		if err != nil {
+			return nil, err
+		}
+	}
+	config := &testutils.RCConfig{
+		Client:     f.ClientSet,
+		Name:       id,
+		Namespace:  namespace,
+		Timeout:    defaultTimeout,
+		Image:      imageutils.GetPauseImageName(),
+		Replicas:   0,
+		Labels:     labels,
+		MemRequest: memRequest,
+	}
+	err := e2erc.RunRC(ctx, *config)
+	if err != nil {
+		return nil, err
+	}
+	rc, err := f.ClientSet.CoreV1().ReplicationControllers(namespace).Get(ctx, id, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	for i, node := range nodes {
+		err = makeNodeSchedulable(ctx, f.ClientSet, &node, false)
+		if err != nil {
+			return nil, err
+		}
+
+		// Update replicas count, to create new pods that will be allocated on node
+		// (we retry 409 errors in case rc reference got out of sync)
+		for j := 0; j < 3; j++ {
+			*rc.Spec.Replicas = int32((i + 1) * podsPerNode)
+			rc, err = f.ClientSet.CoreV1().ReplicationControllers(namespace).Update(ctx, rc, metav1.UpdateOptions{})
+			if err == nil {
+				break
+			}
+			if !apierrors.IsConflict(err) {
+				return nil, err
+			}
+			klog.Warningf("Got 409 conflict when trying to scale RC, retries left: %v", 3-j)
+			rc, err = f.ClientSet.CoreV1().ReplicationControllers(namespace).Get(ctx, id, metav1.GetOptions{})
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		err = wait.PollUntilContextTimeout(ctx, 5*time.Second, podTimeout, true, func(ctx context.Context) (bool, error) {
+			rc, err = f.ClientSet.CoreV1().ReplicationControllers(namespace).Get(ctx, id, metav1.GetOptions{})
+			if err != nil || rc.Status.ReadyReplicas < int32((i+1)*podsPerNode) {
+				return false, nil
+			}
+			return true, nil
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to coerce RC into spawning a pod on node %s within timeout", node.Name)
+		}
+		err = makeNodeUnschedulable(ctx, f.ClientSet, &node)
+		if err != nil {
+			return nil, err
+		}
+	}
+	makeNodesSchedulable := func() error {
+		for _, node := range nodes {
+			err = makeNodeSchedulable(ctx, f.ClientSet, &node, false)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	return makeNodesSchedulable, nil
+}
+
+// Increase cluster size by creating pods with anti-affinity.
+// Returns a function that removes the pods.
+// Adds the same to deferred cleanup in case the function was not called.
+func increaseClusterSizeWithTimeout(ctx context.Context, f *framework.Framework, c clientset.Interface, targetNodeCount int, timeout time.Duration) func() error {
+	labels := map[string]string{
+		"anti-affinity": "yes",
+	}
+	framework.ExpectNoError(runAntiAffinityPods(ctx, f, f.Namespace.Name, targetNodeCount, "increase-size-pod", labels, labels))
+	cleanupFunc := func() error {
+		return e2erc.DeleteRCAndWaitForGC(ctx, f.ClientSet, f.Namespace.Name, "increase-size-pod")
+	}
+
+	ginkgo.DeferCleanup(func(ctx context.Context) {
+		klog.Infof("Cleaning up RC and pods if test did not clean them up")
+		err := cleanupFunc()
+		klog.Infof("Error during cleanup: %v", err)
+	})
+
+	// Verify that cluster size is increased
+	framework.ExpectNoError(WaitForClusterSizeFuncWithUnready(ctx, f.ClientSet,
+		func(size int) bool { return size >= targetNodeCount }, timeout, 0))
+	framework.ExpectNoError(waitForAllCaPodsReadyInNamespace(ctx, f, c))
+	return cleanupFunc
+}
+
+func increaseClusterSize(ctx context.Context, f *framework.Framework, c clientset.Interface, targetNodeCount int) func() error {
+	return increaseClusterSizeWithTimeout(ctx, f, c, targetNodeCount, scaleUpTimeout)
+}
+
+type scaleUpStatus struct {
+	status    string
+	ready     int
+	target    int
+	timestamp time.Time
+}
+
+// Try to get timestamp from status.
+func getStatusTimestamp(parsedStatus map[interface{}]interface{}) (time.Time, error) {
+	timestamp := parsedStatus["time"]
+	if timestamp == nil {
+		return time.Time{}, fmt.Errorf("failed to parse CA status timestamp, parsed status: %v", parsedStatus)
+	}
+
+	timestampParsed, err := time.Parse(timestampFormat, timestamp.(string))
+	if err != nil {
+		return time.Time{}, err
+	}
+	return timestampParsed, nil
+}
+
+// Try to get scaleup statuses of all groups
+func getScaleUpStatus(ctx context.Context, c clientset.Interface) (*scaleUpStatus, error) {
+	configMap, err := c.CoreV1().ConfigMaps("kube-system").Get(ctx, "cluster-autoscaler-status", metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	status, ok := configMap.Data["status"]
+	if !ok {
+		return nil, fmt.Errorf("status information not found in configmap")
+	}
+
+	parsedStatus := make(map[interface{}]interface{})
+	err = yaml.Unmarshal([]byte(status), &parsedStatus)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse the autoscaler status: %w", err)
+	}
+
+	timestamp, err := getStatusTimestamp(parsedStatus)
+	if err != nil {
+		return nil, err
+	}
+
+	result := scaleUpStatus{
+		status:    caNoScaleUpStatus,
+		ready:     0,
+		target:    0,
+		timestamp: timestamp,
+	}
+	for _, nodeGroup := range parsedStatus["nodeGroups"].([]interface{}) {
+		if nodeGroup.(map[interface{}]interface{})["scaleUp"].(map[interface{}]interface{})["status"].(string) == caOngoingScaleUpStatus {
+			result.status = caOngoingScaleUpStatus
+		}
+		newReady := nodeGroup.(map[interface{}]interface{})["health"].(map[interface{}]interface{})["nodeCounts"].(map[interface{}]interface{})["registered"].(map[interface{}]interface{})["ready"].(int)
+		if err != nil {
+			return nil, err
+		}
+		result.ready += newReady
+		newTarget := nodeGroup.(map[interface{}]interface{})["health"].(map[interface{}]interface{})["cloudProviderTarget"].(int)
+		if err != nil {
+			return nil, err
+		}
+		result.target += newTarget
+	}
+	klog.Infof("Cluster-Autoscaler scale-up status: %v (%v, %v)", result.status, result.ready, result.target)
+	return &result, nil
+}
+
+func waitForScaleUpStatus(ctx context.Context, c clientset.Interface, cond func(s *scaleUpStatus) bool, timeout time.Duration) (*scaleUpStatus, error) {
+	var finalErr error
+	var status *scaleUpStatus
+	err := wait.PollUntilContextTimeout(ctx, 5*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
+		status, finalErr = getScaleUpStatus(ctx, c)
+		if finalErr != nil {
+			klog.Infof("Error getting the autoscaler status: %v", finalErr)
+			return false, nil
+		}
+		if status.timestamp.Add(freshStatusLimit).Before(time.Now()) {
+			// stale status
+			finalErr = fmt.Errorf("status too old")
+			return false, nil
+		}
+		return cond(status), nil
+	})
+	if err != nil {
+		err = fmt.Errorf("failed to find expected scale up status: %v, last status: %v, final err: %v", err, status, finalErr)
+	}
+	return status, err
+}
+
+func addKubeSystemPdbs(ctx context.Context, f *framework.Framework) error {
+	ginkgo.By("Create PodDisruptionBudgets for kube-system components, so they can be migrated if required")
+
+	var newPdbs []string
+	cleanup := func(ctx context.Context) {
+		var finalErr error
+		for _, newPdbName := range newPdbs {
+			ginkgo.By(fmt.Sprintf("Delete PodDisruptionBudget %v", newPdbName))
+			err := f.ClientSet.PolicyV1().PodDisruptionBudgets("kube-system").Delete(ctx, newPdbName, metav1.DeleteOptions{})
+			if err != nil {
+				// log error, but attempt to remove other pdbs
+				klog.Errorf("Failed to delete PodDisruptionBudget %v, err: %v", newPdbName, err)
+				finalErr = err
+			}
+		}
+		if finalErr != nil {
+			framework.Failf("Error during PodDisruptionBudget cleanup: %v", finalErr)
+		}
+	}
+	ginkgo.DeferCleanup(cleanup)
+
+	type pdbInfo struct {
+		label        string
+		minAvailable int
+	}
+	pdbsToAdd := []pdbInfo{
+		{label: "kube-dns", minAvailable: 1},
+		{label: "kube-dns-autoscaler", minAvailable: 0},
+		{label: "metrics-server", minAvailable: 0},
+		{label: "kubernetes-dashboard", minAvailable: 0},
+		{label: "glbc", minAvailable: 0},
+		{label: "volume-snapshot-controller", minAvailable: 0},
+		{label: "fluentd-gcp", minAvailable: 0},
+		{label: "fluentd-gcp-scaler", minAvailable: 0},
+		{label: "event-exporter", minAvailable: 0},
+		{label: "cloud-controller-manager", minAvailable: 0},
+	}
+	for _, pdbData := range pdbsToAdd {
+		ginkgo.By(fmt.Sprintf("Create PodDisruptionBudget for %v", pdbData.label))
+		labelMap := map[string]string{"k8s-app": pdbData.label}
+		pdbName := fmt.Sprintf("test-pdb-for-%v", pdbData.label)
+		minAvailable := intstr.FromInt32(int32(pdbData.minAvailable))
+		pdb := &policyv1.PodDisruptionBudget{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      pdbName,
+				Namespace: "kube-system",
+			},
+			Spec: policyv1.PodDisruptionBudgetSpec{
+				Selector:     &metav1.LabelSelector{MatchLabels: labelMap},
+				MinAvailable: &minAvailable,
+			},
+		}
+		_, err := f.ClientSet.PolicyV1().PodDisruptionBudgets("kube-system").Create(ctx, pdb, metav1.CreateOptions{})
+		newPdbs = append(newPdbs, pdbName)
+
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func createPriorityClasses(ctx context.Context, f *framework.Framework) {
+	priorityClasses := map[string]int32{
+		expendablePriorityClassName: -15,
+		highPriorityClassName:       1000,
+	}
+	for className, priority := range priorityClasses {
+		_, err := f.ClientSet.SchedulingV1().PriorityClasses().Create(ctx, &schedulingv1.PriorityClass{ObjectMeta: metav1.ObjectMeta{Name: className}, Value: priority}, metav1.CreateOptions{})
+		if err != nil {
+			klog.Errorf("Error creating priority class: %v", err)
+		}
+		if err != nil && !apierrors.IsAlreadyExists(err) {
+			framework.Failf("unexpected error while creating priority class: %v", err)
+		}
+	}
+
+	ginkgo.DeferCleanup(func(ctx context.Context) {
+		for className := range priorityClasses {
+			err := f.ClientSet.SchedulingV1().PriorityClasses().Delete(ctx, className, metav1.DeleteOptions{})
+			if err != nil {
+				klog.Errorf("Error deleting priority class: %v", err)
+			}
+		}
+	})
+}

--- a/test/e2e/autoscaling/dns_autoscaling.go
+++ b/test/e2e/autoscaling/dns_autoscaling.go
@@ -1,0 +1,410 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package autoscaling
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/wait"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/e2e/feature"
+	"k8s.io/kubernetes/test/e2e/framework"
+	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
+	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
+	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
+	admissionapi "k8s.io/pod-security-admission/api"
+
+	"github.com/onsi/ginkgo/v2"
+)
+
+// This test requires coredns to be installed on the cluster with autoscaling enabled.
+// Compare your coredns manifest against the command below
+// helm template coredns -n kube-system coredns/coredns --set k8sAppLabelOverride=kube-dns --set fullnameOverride=coredns --set autoscaler.enabled=true
+
+// Constants used in dns-autoscaling test.
+const (
+	DNSdefaultTimeout    = 5 * time.Minute
+	ClusterAddonLabelKey = "k8s-app"
+	DNSLabelName         = "kube-dns"
+)
+
+var _ = SIGDescribe(feature.KubeDNSAutoscaler, "DNS horizontal autoscaling", func() {
+	f := framework.NewDefaultFramework("dns-autoscaling")
+	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
+	var c clientset.Interface
+	var previousParams map[string]string
+	var configMapNames map[string]string
+	var originDNSReplicasCount int
+	var DNSParams1 DNSParamsLinear
+	var DNSParams2 DNSParamsLinear
+	var DNSParams3 DNSParamsLinear
+
+	ginkgo.BeforeEach(func(ctx context.Context) {
+		c = f.ClientSet
+
+		nodes, err := e2enode.GetReadySchedulableNodes(ctx, c)
+		framework.ExpectNoError(err)
+		nodeCount := len(nodes.Items)
+
+		ginkgo.By("Collecting original replicas count and DNS scaling params")
+
+		// Check if we are running coredns or kube-dns, the only difference is the name of the autoscaling CM.
+		// The test should be have identically on both dns providers
+		provider, err := detectDNSProvider(ctx, c)
+		if err != nil {
+			e2eskipper.Skipf("Test expects DNS provider: %s", err)
+		}
+
+		originDNSReplicasCount, err = getDNSReplicas(ctx, c)
+		framework.ExpectNoError(err)
+		configMapNames = map[string]string{
+			"kube-dns": "kube-dns-autoscaler",
+			"coredns":  "coredns-autoscaler",
+		}
+
+		pcm, err := fetchDNSScalingConfigMap(ctx, c, configMapNames[provider])
+		framework.Logf("original DNS scaling params: %v", pcm)
+		framework.ExpectNoError(err)
+		previousParams = pcm.Data
+
+		if nodeCount <= 500 {
+			DNSParams1 = DNSParamsLinear{
+				nodesPerReplica: 1,
+			}
+			DNSParams2 = DNSParamsLinear{
+				nodesPerReplica: 2,
+			}
+			DNSParams3 = DNSParamsLinear{
+				nodesPerReplica: 3,
+				coresPerReplica: 3,
+			}
+		} else {
+			// In large clusters, avoid creating/deleting too many DNS pods,
+			// it is supposed to be correctness test, not performance one.
+			// The default setup is: 256 cores/replica, 16 nodes/replica.
+			// With nodeCount > 500, nodes/13, nodes/14, nodes/15 and nodes/16
+			// are different numbers.
+			DNSParams1 = DNSParamsLinear{
+				nodesPerReplica: 13,
+			}
+			DNSParams2 = DNSParamsLinear{
+				nodesPerReplica: 14,
+			}
+			DNSParams3 = DNSParamsLinear{
+				nodesPerReplica: 15,
+				coresPerReplica: 15,
+			}
+		}
+	})
+
+	// This test is separated because it is slow and need to run serially.
+	// Will take around 5 minutes to run on a 4 nodes cluster.
+	f.It(f.WithSerial(), f.WithSlow(), "kube-dns-autoscaler should scale kube-dns pods when cluster size changed", func(ctx context.Context) {
+		numNodes, err := e2enode.TotalRegistered(ctx, c)
+		framework.ExpectNoError(err)
+
+		configMapNames = map[string]string{
+			"kube-dns": "kube-dns-autoscaler",
+			"coredns":  "coredns-autoscaler",
+		}
+		provider, err := detectDNSProvider(ctx, c)
+		framework.ExpectNoError(err)
+
+		ginkgo.By("Replace the dns autoscaling parameters with testing parameters")
+		err = updateDNSScalingConfigMap(ctx, c, packDNSScalingConfigMap(configMapNames[provider], packLinearParams(&DNSParams1)))
+		framework.ExpectNoError(err)
+		defer func() {
+			ginkgo.By("Restoring initial dns autoscaling parameters")
+			err = updateDNSScalingConfigMap(ctx, c, packDNSScalingConfigMap(configMapNames[provider], previousParams))
+			framework.ExpectNoError(err)
+
+			ginkgo.By("Wait for number of running and ready kube-dns pods recover")
+			label := labels.SelectorFromSet(labels.Set(map[string]string{ClusterAddonLabelKey: DNSLabelName}))
+			_, err := e2epod.WaitForPodsWithLabelRunningReady(ctx, c, metav1.NamespaceSystem, label, originDNSReplicasCount, DNSdefaultTimeout)
+			framework.ExpectNoError(err)
+		}()
+		ginkgo.By("Wait for kube-dns scaled to expected number")
+		getExpectReplicasLinear := getExpectReplicasFuncLinear(ctx, c, &DNSParams1)
+		err = waitForDNSReplicasSatisfied(ctx, c, getExpectReplicasLinear, DNSdefaultTimeout)
+		framework.ExpectNoError(err)
+
+		ginkgo.By("Manually increase cluster size")
+		cleanupIncreasedSizeFunc := increaseClusterSize(ctx, f, c, numNodes+1)
+		err = WaitForClusterSizeFunc(ctx, c,
+			func(size int) bool { return size == numNodes+1 }, scaleUpTimeout)
+		framework.ExpectNoError(err)
+
+		ginkgo.By("Wait for kube-dns scaled to expected number")
+		getExpectReplicasLinear = getExpectReplicasFuncLinear(ctx, c, &DNSParams1)
+		err = waitForDNSReplicasSatisfied(ctx, c, getExpectReplicasLinear, DNSdefaultTimeout)
+		framework.ExpectNoError(err)
+
+		ginkgo.By("Replace the dns autoscaling parameters with another testing parameters")
+		err = updateDNSScalingConfigMap(ctx, c, packDNSScalingConfigMap(configMapNames[provider], packLinearParams(&DNSParams3)))
+		framework.ExpectNoError(err)
+
+		ginkgo.By("Wait for kube-dns scaled to expected number")
+		getExpectReplicasLinear = getExpectReplicasFuncLinear(ctx, c, &DNSParams3)
+		err = waitForDNSReplicasSatisfied(ctx, c, getExpectReplicasLinear, DNSdefaultTimeout)
+		framework.ExpectNoError(err)
+
+		ginkgo.By("Restoring cluster size")
+		framework.ExpectNoError(cleanupIncreasedSizeFunc())
+
+		ginkgo.By("Wait for kube-dns scaled to expected number")
+		err = waitForDNSReplicasSatisfied(ctx, c, getExpectReplicasLinear, DNSdefaultTimeout)
+		framework.ExpectNoError(err)
+	})
+
+	ginkgo.It("kube-dns-autoscaler should scale kube-dns pods in both nonfaulty and faulty scenarios", func(ctx context.Context) {
+
+		configMapNames = map[string]string{
+			"kube-dns": "kube-dns-autoscaler",
+			"coredns":  "coredns-autoscaler",
+		}
+		provider, err := detectDNSProvider(ctx, c)
+		framework.ExpectNoError(err)
+
+		ginkgo.By("Replace the dns autoscaling parameters with testing parameters")
+		cm := packDNSScalingConfigMap(configMapNames[provider], packLinearParams(&DNSParams1))
+		framework.Logf("Updating the following cm: %v", cm)
+		err = updateDNSScalingConfigMap(ctx, c, cm)
+		framework.ExpectNoError(err)
+		defer func() {
+			ginkgo.By("Restoring initial dns autoscaling parameters")
+			err = updateDNSScalingConfigMap(ctx, c, packDNSScalingConfigMap(configMapNames[provider], previousParams))
+			framework.ExpectNoError(err)
+		}()
+		ginkgo.By("Wait for kube-dns scaled to expected number")
+		getExpectReplicasLinear := getExpectReplicasFuncLinear(ctx, c, &DNSParams1)
+		err = waitForDNSReplicasSatisfied(ctx, c, getExpectReplicasLinear, DNSdefaultTimeout)
+		framework.ExpectNoError(err)
+
+		ginkgo.By("--- Scenario: should scale kube-dns based on changed parameters ---")
+		ginkgo.By("Replace the dns autoscaling parameters with another testing parameters")
+		err = updateDNSScalingConfigMap(ctx, c, packDNSScalingConfigMap(configMapNames[provider], packLinearParams(&DNSParams3)))
+		framework.ExpectNoError(err)
+		ginkgo.By("Wait for kube-dns scaled to expected number")
+		getExpectReplicasLinear = getExpectReplicasFuncLinear(ctx, c, &DNSParams3)
+		err = waitForDNSReplicasSatisfied(ctx, c, getExpectReplicasLinear, DNSdefaultTimeout)
+		framework.ExpectNoError(err)
+
+		ginkgo.By("--- Scenario: should re-create scaling parameters with default value when parameters got deleted ---")
+		ginkgo.By("Delete the ConfigMap for autoscaler")
+		err = deleteDNSScalingConfigMap(ctx, c, configMapNames[provider])
+		framework.ExpectNoError(err)
+
+		ginkgo.By("Wait for the ConfigMap got re-created")
+		_, err = waitForDNSConfigMapCreated(ctx, c, DNSdefaultTimeout, configMapNames[provider])
+		framework.ExpectNoError(err)
+
+		ginkgo.By("Replace the dns autoscaling parameters with another testing parameters")
+		err = updateDNSScalingConfigMap(ctx, c, packDNSScalingConfigMap(configMapNames[provider], packLinearParams(&DNSParams2)))
+		framework.ExpectNoError(err)
+		ginkgo.By("Wait for kube-dns/coredns scaled to expected number")
+		getExpectReplicasLinear = getExpectReplicasFuncLinear(ctx, c, &DNSParams2)
+		err = waitForDNSReplicasSatisfied(ctx, c, getExpectReplicasLinear, DNSdefaultTimeout)
+		framework.ExpectNoError(err)
+
+		ginkgo.By("--- Scenario: should recover after autoscaler pod got deleted ---")
+		ginkgo.By("Delete the autoscaler pod for kube-dns/coredns")
+		err = deleteDNSAutoscalerPod(ctx, c)
+		framework.ExpectNoError(err)
+
+		ginkgo.By("Replace the dns autoscaling parameters with another testing parameters")
+		err = updateDNSScalingConfigMap(ctx, c, packDNSScalingConfigMap(configMapNames[provider], packLinearParams(&DNSParams1)))
+		framework.ExpectNoError(err)
+		ginkgo.By("Wait for kube-dns/coredns scaled to expected number")
+		getExpectReplicasLinear = getExpectReplicasFuncLinear(ctx, c, &DNSParams1)
+		err = waitForDNSReplicasSatisfied(ctx, c, getExpectReplicasLinear, DNSdefaultTimeout)
+		framework.ExpectNoError(err)
+	})
+})
+
+// DNSParamsLinear is a struct for number of DNS pods.
+type DNSParamsLinear struct {
+	nodesPerReplica float64
+	coresPerReplica float64
+	min             int
+	max             int
+}
+
+type getExpectReplicasFunc func(c clientset.Interface) int
+
+func getExpectReplicasFuncLinear(ctx context.Context, c clientset.Interface, params *DNSParamsLinear) getExpectReplicasFunc {
+	return func(c clientset.Interface) int {
+		var replicasFromNodes float64
+		var replicasFromCores float64
+		nodes, err := e2enode.GetReadyNodesIncludingTainted(ctx, c)
+		framework.ExpectNoError(err)
+		if params.nodesPerReplica > 0 {
+			replicasFromNodes = math.Ceil(float64(len(nodes.Items)) / params.nodesPerReplica)
+		}
+		if params.coresPerReplica > 0 {
+			replicasFromCores = math.Ceil(float64(getSchedulableCores(nodes.Items)) / params.coresPerReplica)
+		}
+		return int(math.Max(1.0, math.Max(replicasFromNodes, replicasFromCores)))
+	}
+}
+
+func getSchedulableCores(nodes []v1.Node) int64 {
+	var sc resource.Quantity
+	for _, node := range nodes {
+		if !node.Spec.Unschedulable {
+			sc.Add(node.Status.Allocatable[v1.ResourceCPU])
+		}
+	}
+	return sc.Value()
+}
+
+func detectDNSProvider(ctx context.Context, c clientset.Interface) (string, error) {
+	cm, err := c.CoreV1().ConfigMaps(metav1.NamespaceSystem).Get(ctx, "coredns-autoscaler", metav1.GetOptions{})
+	if cm != nil && err == nil {
+		return "coredns", nil
+	}
+
+	cm, err = c.CoreV1().ConfigMaps(metav1.NamespaceSystem).Get(ctx, "kube-dns-autoscaler", metav1.GetOptions{})
+	if cm != nil && err == nil {
+		return "kube-dns", nil
+	}
+
+	return "", fmt.Errorf("the cluster doesn't have kube-dns or coredns autoscaling configured")
+}
+
+func fetchDNSScalingConfigMap(ctx context.Context, c clientset.Interface, configMapName string) (*v1.ConfigMap, error) {
+	cm, err := c.CoreV1().ConfigMaps(metav1.NamespaceSystem).Get(ctx, configMapName, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return cm, nil
+}
+
+func deleteDNSScalingConfigMap(ctx context.Context, c clientset.Interface, configMapName string) error {
+	if err := c.CoreV1().ConfigMaps(metav1.NamespaceSystem).Delete(ctx, configMapName, metav1.DeleteOptions{}); err != nil {
+		return err
+	}
+	framework.Logf("DNS autoscaling ConfigMap deleted.")
+	return nil
+}
+
+func packLinearParams(params *DNSParamsLinear) map[string]string {
+	paramsMap := make(map[string]string)
+	paramsMap["linear"] = fmt.Sprintf("{\"nodesPerReplica\": %v,\"coresPerReplica\": %v,\"min\": %v,\"max\": %v}",
+		params.nodesPerReplica,
+		params.coresPerReplica,
+		params.min,
+		params.max)
+	return paramsMap
+}
+
+func packDNSScalingConfigMap(configMapName string, params map[string]string) *v1.ConfigMap {
+	configMap := v1.ConfigMap{}
+	configMap.ObjectMeta.Name = configMapName
+	configMap.ObjectMeta.Namespace = metav1.NamespaceSystem
+	configMap.Data = params
+	return &configMap
+}
+
+func updateDNSScalingConfigMap(ctx context.Context, c clientset.Interface, configMap *v1.ConfigMap) error {
+	_, err := c.CoreV1().ConfigMaps(metav1.NamespaceSystem).Update(ctx, configMap, metav1.UpdateOptions{})
+	if err != nil {
+		return err
+	}
+	framework.Logf("DNS autoscaling ConfigMap updated.")
+	return nil
+}
+
+func getDNSReplicas(ctx context.Context, c clientset.Interface) (int, error) {
+	label := labels.SelectorFromSet(labels.Set(map[string]string{ClusterAddonLabelKey: DNSLabelName}))
+	listOpts := metav1.ListOptions{LabelSelector: label.String()}
+	deployments, err := c.AppsV1().Deployments(metav1.NamespaceSystem).List(ctx, listOpts)
+	if err != nil {
+		return 0, err
+	}
+	if len(deployments.Items) != 1 {
+		return 0, fmt.Errorf("expected 1 DNS deployment, got %v", len(deployments.Items))
+	}
+
+	deployment := deployments.Items[0]
+	return int(*(deployment.Spec.Replicas)), nil
+}
+
+func deleteDNSAutoscalerPod(ctx context.Context, c clientset.Interface) error {
+	selector, _ := labels.Parse(fmt.Sprintf("%s in (kube-dns-autoscaler, coredns-autoscaler)", ClusterAddonLabelKey))
+	listOpts := metav1.ListOptions{LabelSelector: selector.String()}
+	pods, err := c.CoreV1().Pods(metav1.NamespaceSystem).List(ctx, listOpts)
+	if err != nil {
+		return err
+	}
+	if len(pods.Items) != 1 {
+		return fmt.Errorf("expected 1 autoscaler pod, got %v", len(pods.Items))
+	}
+
+	podName := pods.Items[0].Name
+	if err := c.CoreV1().Pods(metav1.NamespaceSystem).Delete(ctx, podName, metav1.DeleteOptions{}); err != nil {
+		return err
+	}
+	framework.Logf("DNS autoscaling pod %v deleted.", podName)
+	return nil
+}
+
+func waitForDNSReplicasSatisfied(ctx context.Context, c clientset.Interface, getExpected getExpectReplicasFunc, timeout time.Duration) (err error) {
+	var current int
+	var expected int
+	framework.Logf("Waiting up to %v for kube-dns to reach expected replicas", timeout)
+	condition := func(ctx context.Context) (bool, error) {
+		current, err = getDNSReplicas(ctx, c)
+		if err != nil {
+			return false, err
+		}
+		expected = getExpected(c)
+		if current != expected {
+			framework.Logf("Replicas not as expected: got %v, expected %v", current, expected)
+			return false, nil
+		}
+		return true, nil
+	}
+
+	if err = wait.PollUntilContextTimeout(ctx, 2*time.Second, timeout, false, condition); err != nil {
+		return fmt.Errorf("err waiting for DNS replicas to satisfy %v, got %v: %w", expected, current, err)
+	}
+	framework.Logf("kube-dns reaches expected replicas: %v", expected)
+	return nil
+}
+
+func waitForDNSConfigMapCreated(ctx context.Context, c clientset.Interface, timeout time.Duration, configMapName string) (configMap *v1.ConfigMap, err error) {
+	framework.Logf("Waiting up to %v for DNS autoscaling ConfigMap to be re-created", timeout)
+	condition := func(ctx context.Context) (bool, error) {
+		configMap, err = fetchDNSScalingConfigMap(ctx, c, configMapName)
+		if err != nil {
+			return false, nil
+		}
+		return true, nil
+	}
+
+	if err = wait.PollUntilContextTimeout(ctx, time.Second, timeout, false, condition); err != nil {
+		return nil, fmt.Errorf("err waiting for DNS autoscaling ConfigMap got re-created: %w", err)
+	}
+	return configMap, nil
+}

--- a/test/e2e/feature/feature.go
+++ b/test/e2e/feature/feature.go
@@ -42,36 +42,15 @@ var (
 	CloudProvider = framework.WithFeature(framework.ValidFeatures.Add("CloudProvider"))
 
 	// TODO: document the feature (owning SIG, when to use this feature for a test)
-	ClusterAutoscalerScalability1 = framework.WithFeature(framework.ValidFeatures.Add("ClusterAutoscalerScalability1"))
-
-	// TODO: document the feature (owning SIG, when to use this feature for a test)
-	ClusterAutoscalerScalability2 = framework.WithFeature(framework.ValidFeatures.Add("ClusterAutoscalerScalability2"))
-
-	// TODO: document the feature (owning SIG, when to use this feature for a test)
-	ClusterAutoscalerScalability3 = framework.WithFeature(framework.ValidFeatures.Add("ClusterAutoscalerScalability3"))
-
-	// TODO: document the feature (owning SIG, when to use this feature for a test)
-	ClusterAutoscalerScalability4 = framework.WithFeature(framework.ValidFeatures.Add("ClusterAutoscalerScalability4"))
-
-	// TODO: document the feature (owning SIG, when to use this feature for a test)
-	ClusterAutoscalerScalability5 = framework.WithFeature(framework.ValidFeatures.Add("ClusterAutoscalerScalability5"))
-
-	// TODO: document the feature (owning SIG, when to use this feature for a test)
-	ClusterAutoscalerScalability6 = framework.WithFeature(framework.ValidFeatures.Add("ClusterAutoscalerScalability6"))
-
-	// TODO: document the feature (owning SIG, when to use this feature for a test)
 	ClusterDowngrade = framework.WithFeature(framework.ValidFeatures.Add("ClusterDowngrade"))
 
 	// TODO: document the feature (owning SIG, when to use this feature for a test)
 	ClusterScaleUpBypassScheduler = framework.WithFeature(framework.ValidFeatures.Add("ClusterScaleUpBypassScheduler"))
 
-	// TODO: document the feature (owning SIG, when to use this feature for a test)
-	ClusterSizeAutoscalingGpu = framework.WithFeature(framework.ValidFeatures.Add("ClusterSizeAutoscalingGpu"))
-
-	// TODO: document the feature (owning SIG, when to use this feature for a test)
+	// Owner: sig-autoscaling
 	ClusterSizeAutoscalingScaleDown = framework.WithFeature(framework.ValidFeatures.Add("ClusterSizeAutoscalingScaleDown"))
 
-	// TODO: document the feature (owning SIG, when to use this feature for a test)
+	// Owner: sig-autoscaling
 	ClusterSizeAutoscalingScaleUp = framework.WithFeature(framework.ValidFeatures.Add("ClusterSizeAutoscalingScaleUp"))
 
 	// TODO: document the feature (owning SIG, when to use this feature for a test)
@@ -192,6 +171,10 @@ var (
 
 	// TODO: document the feature (owning SIG, when to use this feature for a test)
 	Kind = framework.WithFeature(framework.ValidFeatures.Add("Kind"))
+
+	// Owner: sig-network
+	// Marks tests that require kube-dns-autoscaler
+	KubeDNSAutoscaler = framework.WithFeature(framework.ValidFeatures.Add("KubeDNSAutoscaler"))
 
 	// TODO: document the feature (owning SIG, when to use this feature for a test)
 	KubeletCredentialProviders = framework.WithFeature(framework.ValidFeatures.Add("KubeletCredentialProviders"))

--- a/vendor/github.com/onsi/gomega/gmeasure/cache.go
+++ b/vendor/github.com/onsi/gomega/gmeasure/cache.go
@@ -1,0 +1,202 @@
+package gmeasure
+
+import (
+	"crypto/md5"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/onsi/gomega/internal/gutil"
+)
+
+const CACHE_EXT = ".gmeasure-cache"
+
+/*
+ExperimentCache provides a director-and-file based cache of experiments
+*/
+type ExperimentCache struct {
+	Path string
+}
+
+/*
+NewExperimentCache creates and initializes a new cache.  Path must point to a directory (if path does not exist, NewExperimentCache will create a directory at path).
+
+Cached Experiments are stored as separate files in the cache directory - the filename is a hash of the Experiment name.  Each file contains two JSON-encoded objects - a CachedExperimentHeader that includes the experiment's name and cache version number, and then the Experiment itself.
+*/
+func NewExperimentCache(path string) (ExperimentCache, error) {
+	stat, err := os.Stat(path)
+	if os.IsNotExist(err) {
+		err := os.MkdirAll(path, 0777)
+		if err != nil {
+			return ExperimentCache{}, err
+		}
+	} else if !stat.IsDir() {
+		return ExperimentCache{}, fmt.Errorf("%s is not a directory", path)
+	}
+
+	return ExperimentCache{
+		Path: path,
+	}, nil
+}
+
+/*
+CachedExperimentHeader captures the name of the Cached Experiment and its Version
+*/
+type CachedExperimentHeader struct {
+	Name    string
+	Version int
+}
+
+func (cache ExperimentCache) hashOf(name string) string {
+	return fmt.Sprintf("%x", md5.Sum([]byte(name)))
+}
+
+func (cache ExperimentCache) readHeader(filename string) (CachedExperimentHeader, error) {
+	out := CachedExperimentHeader{}
+	f, err := os.Open(filepath.Join(cache.Path, filename))
+	if err != nil {
+		return out, err
+	}
+	defer f.Close()
+	err = json.NewDecoder(f).Decode(&out)
+	return out, err
+}
+
+/*
+List returns a list of all Cached Experiments found in the cache.
+*/
+func (cache ExperimentCache) List() ([]CachedExperimentHeader, error) {
+	var out []CachedExperimentHeader
+	names, err := gutil.ReadDir(cache.Path)
+	if err != nil {
+		return out, err
+	}
+	for _, name := range names {
+		if filepath.Ext(name) != CACHE_EXT {
+			continue
+		}
+		header, err := cache.readHeader(name)
+		if err != nil {
+			return out, err
+		}
+		out = append(out, header)
+	}
+	return out, nil
+}
+
+/*
+Clear empties out the cache - this will delete any and all detected cache files in the cache directory.  Use with caution!
+*/
+func (cache ExperimentCache) Clear() error {
+	names, err := gutil.ReadDir(cache.Path)
+	if err != nil {
+		return err
+	}
+	for _, name := range names {
+		if filepath.Ext(name) != CACHE_EXT {
+			continue
+		}
+		err := os.Remove(filepath.Join(cache.Path, name))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+/*
+Load fetches an experiment from the cache.  Lookup occurs by name.  Load requires that the version numer in the cache is equal to or greater than the passed-in version.
+
+If an experiment with corresponding name and version >= the passed-in version is found, it is unmarshaled and returned.
+
+If no experiment is found, or the cached version is smaller than the passed-in version, Load will return nil.
+
+When paired with Ginkgo you can cache experiments and prevent potentially expensive recomputation with this pattern:
+
+	const EXPERIMENT_VERSION = 1 //bump this to bust the cache and recompute _all_ experiments
+
+    Describe("some experiments", func() {
+    	var cache gmeasure.ExperimentCache
+    	var experiment *gmeasure.Experiment
+
+    	BeforeEach(func() {
+    		cache = gmeasure.NewExperimentCache("./gmeasure-cache")
+    		name := CurrentSpecReport().LeafNodeText
+    		experiment = cache.Load(name, EXPERIMENT_VERSION)
+    		if experiment != nil {
+    			AddReportEntry(experiment)
+    			Skip("cached")
+    		}
+    		experiment = gmeasure.NewExperiment(name)
+			AddReportEntry(experiment)
+    	})
+
+    	It("foo runtime", func() {
+    		experiment.SampleDuration("runtime", func() {
+    			//do stuff
+    		}, gmeasure.SamplingConfig{N:100})
+    	})
+
+    	It("bar runtime", func() {
+    		experiment.SampleDuration("runtime", func() {
+    			//do stuff
+    		}, gmeasure.SamplingConfig{N:100})
+    	})
+
+    	AfterEach(func() {
+    		if !CurrentSpecReport().State.Is(types.SpecStateSkipped) {
+	    		cache.Save(experiment.Name, EXPERIMENT_VERSION, experiment)
+	    	}
+    	})
+    })
+*/
+func (cache ExperimentCache) Load(name string, version int) *Experiment {
+	path := filepath.Join(cache.Path, cache.hashOf(name)+CACHE_EXT)
+	f, err := os.Open(path)
+	if err != nil {
+		return nil
+	}
+	defer f.Close()
+	dec := json.NewDecoder(f)
+	header := CachedExperimentHeader{}
+	dec.Decode(&header)
+	if header.Version < version {
+		return nil
+	}
+	out := NewExperiment("")
+	err = dec.Decode(out)
+	if err != nil {
+		return nil
+	}
+	return out
+}
+
+/*
+Save stores the passed-in experiment to the cache with the passed-in name and version.
+*/
+func (cache ExperimentCache) Save(name string, version int, experiment *Experiment) error {
+	path := filepath.Join(cache.Path, cache.hashOf(name)+CACHE_EXT)
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	enc := json.NewEncoder(f)
+	err = enc.Encode(CachedExperimentHeader{
+		Name:    name,
+		Version: version,
+	})
+	if err != nil {
+		return err
+	}
+	return enc.Encode(experiment)
+}
+
+/*
+Delete removes the experiment with the passed-in name from the cache
+*/
+func (cache ExperimentCache) Delete(name string) error {
+	path := filepath.Join(cache.Path, cache.hashOf(name)+CACHE_EXT)
+	return os.Remove(path)
+}

--- a/vendor/github.com/onsi/gomega/gmeasure/enum_support.go
+++ b/vendor/github.com/onsi/gomega/gmeasure/enum_support.go
@@ -1,0 +1,43 @@
+package gmeasure
+
+import "encoding/json"
+
+type enumSupport struct {
+	toString map[uint]string
+	toEnum   map[string]uint
+	maxEnum  uint
+}
+
+func newEnumSupport(toString map[uint]string) enumSupport {
+	toEnum, maxEnum := map[string]uint{}, uint(0)
+	for k, v := range toString {
+		toEnum[v] = k
+		if maxEnum < k {
+			maxEnum = k
+		}
+	}
+	return enumSupport{toString: toString, toEnum: toEnum, maxEnum: maxEnum}
+}
+
+func (es enumSupport) String(e uint) string {
+	if e > es.maxEnum {
+		return es.toString[0]
+	}
+	return es.toString[e]
+}
+
+func (es enumSupport) UnmarshJSON(b []byte) (uint, error) {
+	var dec string
+	if err := json.Unmarshal(b, &dec); err != nil {
+		return 0, err
+	}
+	out := es.toEnum[dec] // if we miss we get 0 which is what we want anyway
+	return out, nil
+}
+
+func (es enumSupport) MarshJSON(e uint) ([]byte, error) {
+	if e == 0 || e > es.maxEnum {
+		return json.Marshal(nil)
+	}
+	return json.Marshal(es.toString[e])
+}

--- a/vendor/github.com/onsi/gomega/gmeasure/experiment.go
+++ b/vendor/github.com/onsi/gomega/gmeasure/experiment.go
@@ -1,0 +1,527 @@
+/*
+Package gomega/gmeasure provides support for benchmarking and measuring code.  It is intended as a more robust replacement for Ginkgo V1's Measure nodes.
+
+gmeasure is organized around the metaphor of an Experiment that can record multiple Measurements.  A Measurement is a named collection of data points and gmeasure supports
+measuring Values (of type float64) and Durations (of type time.Duration).
+
+Experiments allows the user to record Measurements directly by passing in Values (i.e. float64) or Durations (i.e. time.Duration)
+or to measure measurements by passing in functions to measure.  When measuring functions Experiments take care of timing the duration of functions (for Duration measurements)
+and/or recording returned values (for Value measurements).  Experiments also support sampling functions - when told to sample Experiments will run functions repeatedly
+and measure and record results.  The sampling behavior is configured by passing in a SamplingConfig that can control the maximum number of samples, the maximum duration for sampling (or both)
+and the number of concurrent samples to take.
+
+Measurements can be decorated with additional information.  This is supported by passing in special typed decorators when recording measurements.  These include:
+
+- Units("any string") - to attach units to a Value Measurement (Duration Measurements always have units of "duration")
+- Style("any Ginkgo color style string") - to attach styling to a Measurement.  This styling is used when rendering console information about the measurement in reports.  Color style strings are documented at TODO.
+- Precision(integer or time.Duration) - to attach precision to a Measurement.  This controls how many decimal places to show for Value Measurements and how to round Duration Measurements when rendering them to screen.
+
+In addition, individual data points in a Measurement can be annotated with an Annotation("any string").  The annotation is associated with the individual data point and is intended to convey additional context about the data point.
+
+Once measurements are complete, an Experiment can generate a comprehensive report by calling its String() or ColorableString() method.
+
+Users can also access and analyze the resulting Measurements directly.  Use Experiment.Get(NAME) to fetch the Measurement named NAME.  This returned struct will have fields containing
+all the data points and annotations recorded by the experiment.  You can subsequently fetch the Measurement.Stats() to get a Stats struct that contains basic statistical information about the
+Measurement (min, max, median, mean, standard deviation).  You can order these Stats objects using RankStats() to identify best/worst performers across multpile experiments or measurements.
+
+gmeasure also supports caching Experiments via an ExperimentCache.  The cache supports storing and retreiving experiments by name and version.  This allows you to rerun code without
+repeating expensive experiments that may not have changed (which can be controlled by the cache version number).  It also enables you to compare new experiment runs with older runs to detect
+variations in performance/behavior.
+
+When used with Ginkgo, you can emit experiment reports and encode them in test reports easily using Ginkgo V2's support for Report Entries.
+Simply pass your experiment to AddReportEntry to get a report every time the tests run.  You can also use AddReportEntry with Measurements to emit all the captured data
+and Rankings to emit measurement summaries in rank order.
+
+Finally, Experiments provide an additional mechanism to measure durations called a Stopwatch.  The Stopwatch makes it easy to pepper code with statements that measure elapsed time across
+different sections of code and can be useful when debugging or evaluating bottlenecks in a given codepath.
+*/
+package gmeasure
+
+import (
+	"fmt"
+	"math"
+	"reflect"
+	"sync"
+	"time"
+
+	"github.com/onsi/gomega/gmeasure/table"
+)
+
+/*
+SamplingConfig configures the Sample family of experiment methods.
+These methods invoke passed-in functions repeatedly to sample and record a given measurement.
+SamplingConfig is used to control the maximum number of samples or time spent sampling (or both).  When both are specified sampling ends as soon as one of the conditions is met.
+SamplingConfig can also ensure a minimum interval between samples and can enable concurrent sampling.
+*/
+type SamplingConfig struct {
+	// N - the maximum number of samples to record
+	N int
+	// Duration - the maximum amount of time to spend recording samples
+	Duration time.Duration
+	// MinSamplingInterval - the minimum time that must elapse between samplings.  It is an error to specify both MinSamplingInterval and NumParallel.
+	MinSamplingInterval time.Duration
+	// NumParallel - the number of parallel workers to spin up to record samples.  It is an error to specify both MinSamplingInterval and NumParallel.
+	NumParallel int
+}
+
+// The Units decorator allows you to specify units (an arbitrary string) when recording values.  It is ignored when recording durations.
+//
+//     e := gmeasure.NewExperiment("My Experiment")
+//     e.RecordValue("length", 3.141, gmeasure.Units("inches"))
+//
+// Units are only set the first time a value of a given name is recorded.  In the example above any subsequent calls to e.RecordValue("length", X) will maintain the "inches" units even if a new set of Units("UNIT") are passed in later.
+type Units string
+
+// The Annotation decorator allows you to attach an annotation to a given recorded data-point:
+//
+// For example:
+//
+//     e := gmeasure.NewExperiment("My Experiment")
+//     e.RecordValue("length", 3.141, gmeasure.Annotation("bob"))
+//     e.RecordValue("length", 2.71, gmeasure.Annotation("jane"))
+//
+// ...will result in a Measurement named "length" that records two values )[3.141, 2.71]) annotation with (["bob", "jane"])
+type Annotation string
+
+// The Style decorator allows you to associate a style with a measurement.  This is used to generate colorful console reports using Ginkgo V2's
+// console formatter.  Styles are strings in curly brackets that correspond to a color or style.
+//
+// For example:
+//
+//     e := gmeasure.NewExperiment("My Experiment")
+//     e.RecordValue("length", 3.141, gmeasure.Style("{{blue}}{{bold}}"))
+//     e.RecordValue("length", 2.71)
+//     e.RecordDuration("cooking time", 3 * time.Second, gmeasure.Style("{{red}}{{underline}}"))
+//     e.RecordDuration("cooking time", 2 * time.Second)
+//
+// will emit a report with blue bold entries for the length measurement and red underlined entries for the cooking time measurement.
+//
+// Units are only set the first time a value or duration of a given name is recorded.  In the example above any subsequent calls to e.RecordValue("length", X) will maintain the "{{blue}}{{bold}}" style even if a new Style is passed in later.
+type Style string
+
+// The PrecisionBundle decorator controls the rounding of value and duration measurements.  See Precision().
+type PrecisionBundle struct {
+	Duration    time.Duration
+	ValueFormat string
+}
+
+// Precision() allows you to specify the precision of a value or duration measurement - this precision is used when rendering the measurement to screen.
+//
+// To control the precision of Value measurements, pass Precision an integer.  This will denote the number of decimal places to render (equivalen to the format string "%.Nf")
+// To control the precision of Duration measurements, pass Precision a time.Duration.  Duration measurements will be rounded oo the nearest time.Duration when rendered.
+//
+// For example:
+//
+//     e := gmeasure.NewExperiment("My Experiment")
+//     e.RecordValue("length", 3.141, gmeasure.Precision(2))
+//     e.RecordValue("length", 2.71)
+//     e.RecordDuration("cooking time", 3214 * time.Millisecond, gmeasure.Precision(100*time.Millisecond))
+//     e.RecordDuration("cooking time", 2623 * time.Millisecond)
+func Precision(p interface{}) PrecisionBundle {
+	out := DefaultPrecisionBundle
+	switch reflect.TypeOf(p) {
+	case reflect.TypeOf(time.Duration(0)):
+		out.Duration = p.(time.Duration)
+	case reflect.TypeOf(int(0)):
+		out.ValueFormat = fmt.Sprintf("%%.%df", p.(int))
+	default:
+		panic("invalid precision type, must be time.Duration or int")
+	}
+	return out
+}
+
+// DefaultPrecisionBundle captures the default precisions for Vale and Duration measurements.
+var DefaultPrecisionBundle = PrecisionBundle{
+	Duration:    100 * time.Microsecond,
+	ValueFormat: "%.3f",
+}
+
+type extractedDecorations struct {
+	annotation      Annotation
+	units           Units
+	precisionBundle PrecisionBundle
+	style           Style
+}
+
+func extractDecorations(args []interface{}) extractedDecorations {
+	var out extractedDecorations
+	out.precisionBundle = DefaultPrecisionBundle
+
+	for _, arg := range args {
+		switch reflect.TypeOf(arg) {
+		case reflect.TypeOf(out.annotation):
+			out.annotation = arg.(Annotation)
+		case reflect.TypeOf(out.units):
+			out.units = arg.(Units)
+		case reflect.TypeOf(out.precisionBundle):
+			out.precisionBundle = arg.(PrecisionBundle)
+		case reflect.TypeOf(out.style):
+			out.style = arg.(Style)
+		default:
+			panic(fmt.Sprintf("unrecognized argument %#v", arg))
+		}
+	}
+
+	return out
+}
+
+/*
+Experiment is gmeasure's core data type.  You use experiments to record Measurements and generate reports.
+Experiments are thread-safe and all methods can be called from multiple goroutines.
+*/
+type Experiment struct {
+	Name string
+
+	// Measurements includes all Measurements recorded by this experiment.  You should access them by name via Get() and GetStats()
+	Measurements Measurements
+	lock         *sync.Mutex
+}
+
+/*
+NexExperiment creates a new experiment with the passed-in name.
+
+When using Ginkgo we recommend immediately registering the experiment as a ReportEntry:
+
+	experiment = NewExperiment("My Experiment")
+	AddReportEntry(experiment.Name, experiment)
+
+this will ensure an experiment report is emitted as part of the test output and exported with any test reports.
+*/
+func NewExperiment(name string) *Experiment {
+	experiment := &Experiment{
+		Name: name,
+		lock: &sync.Mutex{},
+	}
+	return experiment
+}
+
+func (e *Experiment) report(enableStyling bool) string {
+	t := table.NewTable()
+	t.TableStyle.EnableTextStyling = enableStyling
+	t.AppendRow(table.R(
+		table.C("Name"), table.C("N"), table.C("Min"), table.C("Median"), table.C("Mean"), table.C("StdDev"), table.C("Max"),
+		table.Divider("="),
+		"{{bold}}",
+	))
+
+	for _, measurement := range e.Measurements {
+		r := table.R(measurement.Style)
+		t.AppendRow(r)
+		switch measurement.Type {
+		case MeasurementTypeNote:
+			r.AppendCell(table.C(measurement.Note))
+		case MeasurementTypeValue, MeasurementTypeDuration:
+			name := measurement.Name
+			if measurement.Units != "" {
+				name += " [" + measurement.Units + "]"
+			}
+			r.AppendCell(table.C(name))
+			r.AppendCell(measurement.Stats().cells()...)
+		}
+	}
+
+	out := e.Name + "\n"
+	if enableStyling {
+		out = "{{bold}}" + out + "{{/}}"
+	}
+	out += t.Render()
+	return out
+}
+
+/*
+ColorableString returns a Ginkgo formatted summary of the experiment and all its Measurements.
+It is called automatically by Ginkgo's reporting infrastructure when the Experiment is registered as a ReportEntry via AddReportEntry.
+*/
+func (e *Experiment) ColorableString() string {
+	return e.report(true)
+}
+
+/*
+ColorableString returns an unformatted summary of the experiment and all its Measurements.
+*/
+func (e *Experiment) String() string {
+	return e.report(false)
+}
+
+/*
+RecordNote records a Measurement of type MeasurementTypeNote - this is simply a textual note to annotate the experiment.  It will be emitted in any experiment reports.
+
+RecordNote supports the Style() decoration.
+*/
+func (e *Experiment) RecordNote(note string, args ...interface{}) {
+	decorations := extractDecorations(args)
+
+	e.lock.Lock()
+	defer e.lock.Unlock()
+	e.Measurements = append(e.Measurements, Measurement{
+		ExperimentName: e.Name,
+		Type:           MeasurementTypeNote,
+		Note:           note,
+		Style:          string(decorations.style),
+	})
+}
+
+/*
+RecordDuration records the passed-in duration on a Duration Measurement with the passed-in name.  If the Measurement does not exist it is created.
+
+RecordDuration supports the Style(), Precision(), and Annotation() decorations.
+*/
+func (e *Experiment) RecordDuration(name string, duration time.Duration, args ...interface{}) {
+	decorations := extractDecorations(args)
+	e.recordDuration(name, duration, decorations)
+}
+
+/*
+MeasureDuration runs the passed-in callback and times how long it takes to complete.  The resulting duration is recorded on a Duration Measurement with the passed-in name.  If the Measurement does not exist it is created.
+
+MeasureDuration supports the Style(), Precision(), and Annotation() decorations.
+*/
+func (e *Experiment) MeasureDuration(name string, callback func(), args ...interface{}) time.Duration {
+	t := time.Now()
+	callback()
+	duration := time.Since(t)
+	e.RecordDuration(name, duration, args...)
+	return duration
+}
+
+/*
+SampleDuration samples the passed-in callback and times how long it takes to complete each sample.
+The resulting durations are recorded on a Duration Measurement with the passed-in name.  If the Measurement does not exist it is created.
+
+The callback is given a zero-based index that increments by one between samples.  The Sampling is configured via the passed-in SamplingConfig
+
+SampleDuration supports the Style(), Precision(), and Annotation() decorations.  When passed an Annotation() the same annotation is applied to all sample measurements.
+*/
+func (e *Experiment) SampleDuration(name string, callback func(idx int), samplingConfig SamplingConfig, args ...interface{}) {
+	decorations := extractDecorations(args)
+	e.Sample(func(idx int) {
+		t := time.Now()
+		callback(idx)
+		duration := time.Since(t)
+		e.recordDuration(name, duration, decorations)
+	}, samplingConfig)
+}
+
+/*
+SampleDuration samples the passed-in callback and times how long it takes to complete each sample.
+The resulting durations are recorded on a Duration Measurement with the passed-in name.  If the Measurement does not exist it is created.
+
+The callback is given a zero-based index that increments by one between samples.  The callback must return an Annotation - this annotation is attached to the measured duration.
+
+The Sampling is configured via the passed-in SamplingConfig
+
+SampleAnnotatedDuration supports the Style() and Precision() decorations.
+*/
+func (e *Experiment) SampleAnnotatedDuration(name string, callback func(idx int) Annotation, samplingConfig SamplingConfig, args ...interface{}) {
+	decorations := extractDecorations(args)
+	e.Sample(func(idx int) {
+		t := time.Now()
+		decorations.annotation = callback(idx)
+		duration := time.Since(t)
+		e.recordDuration(name, duration, decorations)
+	}, samplingConfig)
+}
+
+func (e *Experiment) recordDuration(name string, duration time.Duration, decorations extractedDecorations) {
+	e.lock.Lock()
+	defer e.lock.Unlock()
+	idx := e.Measurements.IdxWithName(name)
+	if idx == -1 {
+		measurement := Measurement{
+			ExperimentName:  e.Name,
+			Type:            MeasurementTypeDuration,
+			Name:            name,
+			Units:           "duration",
+			Durations:       []time.Duration{duration},
+			PrecisionBundle: decorations.precisionBundle,
+			Style:           string(decorations.style),
+			Annotations:     []string{string(decorations.annotation)},
+		}
+		e.Measurements = append(e.Measurements, measurement)
+	} else {
+		if e.Measurements[idx].Type != MeasurementTypeDuration {
+			panic(fmt.Sprintf("attempting to record duration with name '%s'.  That name is already in-use for recording values.", name))
+		}
+		e.Measurements[idx].Durations = append(e.Measurements[idx].Durations, duration)
+		e.Measurements[idx].Annotations = append(e.Measurements[idx].Annotations, string(decorations.annotation))
+	}
+}
+
+/*
+NewStopwatch() returns a stopwatch configured to record duration measurements with this experiment.
+*/
+func (e *Experiment) NewStopwatch() *Stopwatch {
+	return newStopwatch(e)
+}
+
+/*
+RecordValue records the passed-in value on a Value Measurement with the passed-in name.  If the Measurement does not exist it is created.
+
+RecordValue supports the Style(), Units(), Precision(), and Annotation() decorations.
+*/
+func (e *Experiment) RecordValue(name string, value float64, args ...interface{}) {
+	decorations := extractDecorations(args)
+	e.recordValue(name, value, decorations)
+}
+
+/*
+MeasureValue runs the passed-in callback and records the return value on a Value Measurement with the passed-in name.  If the Measurement does not exist it is created.
+
+MeasureValue supports the Style(), Units(), Precision(), and Annotation() decorations.
+*/
+func (e *Experiment) MeasureValue(name string, callback func() float64, args ...interface{}) float64 {
+	value := callback()
+	e.RecordValue(name, value, args...)
+	return value
+}
+
+/*
+SampleValue samples the passed-in callback and records the return value on a Value Measurement with the passed-in name. If the Measurement does not exist it is created.
+
+The callback is given a zero-based index that increments by one between samples.  The callback must return a float64.  The Sampling is configured via the passed-in SamplingConfig
+
+SampleValue supports the Style(), Units(), Precision(), and Annotation() decorations.  When passed an Annotation() the same annotation is applied to all sample measurements.
+*/
+func (e *Experiment) SampleValue(name string, callback func(idx int) float64, samplingConfig SamplingConfig, args ...interface{}) {
+	decorations := extractDecorations(args)
+	e.Sample(func(idx int) {
+		value := callback(idx)
+		e.recordValue(name, value, decorations)
+	}, samplingConfig)
+}
+
+/*
+SampleAnnotatedValue samples the passed-in callback and records the return value on a Value Measurement with the passed-in name. If the Measurement does not exist it is created.
+
+The callback is given a zero-based index that increments by one between samples.  The callback must return a float64 and an Annotation - the annotation is attached to the recorded value.
+
+The Sampling is configured via the passed-in SamplingConfig
+
+SampleValue supports the Style(), Units(), and Precision() decorations.
+*/
+func (e *Experiment) SampleAnnotatedValue(name string, callback func(idx int) (float64, Annotation), samplingConfig SamplingConfig, args ...interface{}) {
+	decorations := extractDecorations(args)
+	e.Sample(func(idx int) {
+		var value float64
+		value, decorations.annotation = callback(idx)
+		e.recordValue(name, value, decorations)
+	}, samplingConfig)
+}
+
+func (e *Experiment) recordValue(name string, value float64, decorations extractedDecorations) {
+	e.lock.Lock()
+	defer e.lock.Unlock()
+	idx := e.Measurements.IdxWithName(name)
+	if idx == -1 {
+		measurement := Measurement{
+			ExperimentName:  e.Name,
+			Type:            MeasurementTypeValue,
+			Name:            name,
+			Style:           string(decorations.style),
+			Units:           string(decorations.units),
+			PrecisionBundle: decorations.precisionBundle,
+			Values:          []float64{value},
+			Annotations:     []string{string(decorations.annotation)},
+		}
+		e.Measurements = append(e.Measurements, measurement)
+	} else {
+		if e.Measurements[idx].Type != MeasurementTypeValue {
+			panic(fmt.Sprintf("attempting to record value with name '%s'.  That name is already in-use for recording durations.", name))
+		}
+		e.Measurements[idx].Values = append(e.Measurements[idx].Values, value)
+		e.Measurements[idx].Annotations = append(e.Measurements[idx].Annotations, string(decorations.annotation))
+	}
+}
+
+/*
+Sample samples the passed-in callback repeatedly.  The sampling is governed by the passed in SamplingConfig.
+
+The SamplingConfig can limit the total number of samples and/or the total time spent sampling the callback.
+The SamplingConfig can also instruct Sample to run with multiple concurrent workers.
+
+The callback is called with a zero-based index that incerements by one between samples.
+*/
+func (e *Experiment) Sample(callback func(idx int), samplingConfig SamplingConfig) {
+	if samplingConfig.N == 0 && samplingConfig.Duration == 0 {
+		panic("you must specify at least one of SamplingConfig.N and SamplingConfig.Duration")
+	}
+	if samplingConfig.MinSamplingInterval > 0 && samplingConfig.NumParallel > 1 {
+		panic("you cannot specify both SamplingConfig.MinSamplingInterval and SamplingConfig.NumParallel")
+	}
+	maxTime := time.Now().Add(100000 * time.Hour)
+	if samplingConfig.Duration > 0 {
+		maxTime = time.Now().Add(samplingConfig.Duration)
+	}
+	maxN := math.MaxInt32
+	if samplingConfig.N > 0 {
+		maxN = samplingConfig.N
+	}
+	numParallel := 1
+	if samplingConfig.NumParallel > numParallel {
+		numParallel = samplingConfig.NumParallel
+	}
+	minSamplingInterval := samplingConfig.MinSamplingInterval
+
+	work := make(chan int)
+	defer close(work)
+	if numParallel > 1 {
+		for worker := 0; worker < numParallel; worker++ {
+			go func() {
+				for idx := range work {
+					callback(idx)
+				}
+			}()
+		}
+	}
+
+	idx := 0
+	var avgDt time.Duration
+	for {
+		t := time.Now()
+		if numParallel > 1 {
+			work <- idx
+		} else {
+			callback(idx)
+		}
+		dt := time.Since(t)
+		if numParallel == 1 && dt < minSamplingInterval {
+			time.Sleep(minSamplingInterval - dt)
+			dt = time.Since(t)
+		}
+		if idx >= numParallel {
+			avgDt = (avgDt*time.Duration(idx-numParallel) + dt) / time.Duration(idx-numParallel+1)
+		}
+		idx += 1
+		if idx >= maxN {
+			return
+		}
+		if time.Now().Add(avgDt).After(maxTime) {
+			return
+		}
+	}
+}
+
+/*
+Get returns the Measurement with the associated name.  If no Measurement is found a zero Measurement{} is returned.
+*/
+func (e *Experiment) Get(name string) Measurement {
+	e.lock.Lock()
+	defer e.lock.Unlock()
+	idx := e.Measurements.IdxWithName(name)
+	if idx == -1 {
+		return Measurement{}
+	}
+	return e.Measurements[idx]
+}
+
+/*
+GetStats returns the Stats for the Measurement with the associated name.  If no Measurement is found a zero Stats{} is returned.
+
+experiment.GetStats(name) is equivalent to experiment.Get(name).Stats()
+*/
+func (e *Experiment) GetStats(name string) Stats {
+	measurement := e.Get(name)
+	e.lock.Lock()
+	defer e.lock.Unlock()
+	return measurement.Stats()
+}

--- a/vendor/github.com/onsi/gomega/gmeasure/measurement.go
+++ b/vendor/github.com/onsi/gomega/gmeasure/measurement.go
@@ -1,0 +1,235 @@
+package gmeasure
+
+import (
+	"fmt"
+	"math"
+	"sort"
+	"time"
+
+	"github.com/onsi/gomega/gmeasure/table"
+)
+
+type MeasurementType uint
+
+const (
+	MeasurementTypeInvalid MeasurementType = iota
+	MeasurementTypeNote
+	MeasurementTypeDuration
+	MeasurementTypeValue
+)
+
+var letEnumSupport = newEnumSupport(map[uint]string{uint(MeasurementTypeInvalid): "INVALID LOG ENTRY TYPE", uint(MeasurementTypeNote): "Note", uint(MeasurementTypeDuration): "Duration", uint(MeasurementTypeValue): "Value"})
+
+func (s MeasurementType) String() string { return letEnumSupport.String(uint(s)) }
+func (s *MeasurementType) UnmarshalJSON(b []byte) error {
+	out, err := letEnumSupport.UnmarshJSON(b)
+	*s = MeasurementType(out)
+	return err
+}
+func (s MeasurementType) MarshalJSON() ([]byte, error) { return letEnumSupport.MarshJSON(uint(s)) }
+
+/*
+Measurement records all captured data for a given measurement.  You generally don't make Measurements directly - but you can fetch them from Experiments using Get().
+
+When using Ginkgo, you can register Measurements as Report Entries via AddReportEntry.  This will emit all the captured data points when Ginkgo generates the report.
+*/
+type Measurement struct {
+	// Type is the MeasurementType - one of MeasurementTypeNote, MeasurementTypeDuration, or MeasurementTypeValue
+	Type MeasurementType
+
+	// ExperimentName is the name of the experiment that this Measurement is associated with
+	ExperimentName string
+
+	// If Type is MeasurementTypeNote, Note is populated with the note text.
+	Note string
+
+	// If Type is MeasurementTypeDuration or MeasurementTypeValue, Name is the name of the recorded measurement
+	Name string
+
+	// Style captures the styling information (if any) for this Measurement
+	Style string
+
+	// Units capture the units (if any) for this Measurement.  Units is set to "duration" if the Type is MeasurementTypeDuration
+	Units string
+
+	// PrecisionBundle captures the precision to use when rendering data for this Measurement.
+	// If Type is MeasurementTypeDuration then PrecisionBundle.Duration is used to round any durations before presentation.
+	// If Type is MeasurementTypeValue then PrecisionBundle.ValueFormat is used to format any values before presentation
+	PrecisionBundle PrecisionBundle
+
+	// If Type is MeasurementTypeDuration, Durations will contain all durations recorded for this measurement
+	Durations []time.Duration
+
+	// If Type is MeasurementTypeValue, Values will contain all float64s recorded for this measurement
+	Values []float64
+
+	// If Type is MeasurementTypeDuration or MeasurementTypeValue then Annotations will include string annotations for all recorded Durations or Values.
+	// If the user does not pass-in an Annotation() decoration for a particular value or duration, the corresponding entry in the Annotations slice will be the empty string ""
+	Annotations []string
+}
+
+type Measurements []Measurement
+
+func (m Measurements) IdxWithName(name string) int {
+	for idx, measurement := range m {
+		if measurement.Name == name {
+			return idx
+		}
+	}
+
+	return -1
+}
+
+func (m Measurement) report(enableStyling bool) string {
+	out := ""
+	style := m.Style
+	if !enableStyling {
+		style = ""
+	}
+	switch m.Type {
+	case MeasurementTypeNote:
+		out += fmt.Sprintf("%s - Note\n%s\n", m.ExperimentName, m.Note)
+		if style != "" {
+			out = style + out + "{{/}}"
+		}
+		return out
+	case MeasurementTypeValue, MeasurementTypeDuration:
+		out += fmt.Sprintf("%s - %s", m.ExperimentName, m.Name)
+		if m.Units != "" {
+			out += " [" + m.Units + "]"
+		}
+		if style != "" {
+			out = style + out + "{{/}}"
+		}
+		out += "\n"
+		out += m.Stats().String() + "\n"
+	}
+	t := table.NewTable()
+	t.TableStyle.EnableTextStyling = enableStyling
+	switch m.Type {
+	case MeasurementTypeValue:
+		t.AppendRow(table.R(table.C("Value", table.AlignTypeCenter), table.C("Annotation", table.AlignTypeCenter), table.Divider("="), style))
+		for idx := range m.Values {
+			t.AppendRow(table.R(
+				table.C(fmt.Sprintf(m.PrecisionBundle.ValueFormat, m.Values[idx]), table.AlignTypeRight),
+				table.C(m.Annotations[idx], "{{gray}}", table.AlignTypeLeft),
+			))
+		}
+	case MeasurementTypeDuration:
+		t.AppendRow(table.R(table.C("Duration", table.AlignTypeCenter), table.C("Annotation", table.AlignTypeCenter), table.Divider("="), style))
+		for idx := range m.Durations {
+			t.AppendRow(table.R(
+				table.C(m.Durations[idx].Round(m.PrecisionBundle.Duration).String(), style, table.AlignTypeRight),
+				table.C(m.Annotations[idx], "{{gray}}", table.AlignTypeLeft),
+			))
+		}
+	}
+	out += t.Render()
+	return out
+}
+
+/*
+ColorableString generates a styled report that includes all the data points for this Measurement.
+It is called automatically by Ginkgo's reporting infrastructure when the Measurement is registered as a ReportEntry via AddReportEntry.
+*/
+func (m Measurement) ColorableString() string {
+	return m.report(true)
+}
+
+/*
+String generates an unstyled report that includes all the data points for this Measurement.
+*/
+func (m Measurement) String() string {
+	return m.report(false)
+}
+
+/*
+Stats returns a Stats struct summarizing the statistic of this measurement
+*/
+func (m Measurement) Stats() Stats {
+	if m.Type == MeasurementTypeInvalid || m.Type == MeasurementTypeNote {
+		return Stats{}
+	}
+
+	out := Stats{
+		ExperimentName:  m.ExperimentName,
+		MeasurementName: m.Name,
+		Style:           m.Style,
+		Units:           m.Units,
+		PrecisionBundle: m.PrecisionBundle,
+	}
+
+	switch m.Type {
+	case MeasurementTypeValue:
+		out.Type = StatsTypeValue
+		out.N = len(m.Values)
+		if out.N == 0 {
+			return out
+		}
+		indices, sum := make([]int, len(m.Values)), 0.0
+		for idx, v := range m.Values {
+			indices[idx] = idx
+			sum += v
+		}
+		sort.Slice(indices, func(i, j int) bool {
+			return m.Values[indices[i]] < m.Values[indices[j]]
+		})
+		out.ValueBundle = map[Stat]float64{
+			StatMin:    m.Values[indices[0]],
+			StatMax:    m.Values[indices[out.N-1]],
+			StatMean:   sum / float64(out.N),
+			StatStdDev: 0.0,
+		}
+		out.AnnotationBundle = map[Stat]string{
+			StatMin: m.Annotations[indices[0]],
+			StatMax: m.Annotations[indices[out.N-1]],
+		}
+
+		if out.N%2 == 0 {
+			out.ValueBundle[StatMedian] = (m.Values[indices[out.N/2]] + m.Values[indices[out.N/2-1]]) / 2.0
+		} else {
+			out.ValueBundle[StatMedian] = m.Values[indices[(out.N-1)/2]]
+		}
+
+		for _, v := range m.Values {
+			out.ValueBundle[StatStdDev] += (v - out.ValueBundle[StatMean]) * (v - out.ValueBundle[StatMean])
+		}
+		out.ValueBundle[StatStdDev] = math.Sqrt(out.ValueBundle[StatStdDev] / float64(out.N))
+	case MeasurementTypeDuration:
+		out.Type = StatsTypeDuration
+		out.N = len(m.Durations)
+		if out.N == 0 {
+			return out
+		}
+		indices, sum := make([]int, len(m.Durations)), time.Duration(0)
+		for idx, v := range m.Durations {
+			indices[idx] = idx
+			sum += v
+		}
+		sort.Slice(indices, func(i, j int) bool {
+			return m.Durations[indices[i]] < m.Durations[indices[j]]
+		})
+		out.DurationBundle = map[Stat]time.Duration{
+			StatMin:  m.Durations[indices[0]],
+			StatMax:  m.Durations[indices[out.N-1]],
+			StatMean: sum / time.Duration(out.N),
+		}
+		out.AnnotationBundle = map[Stat]string{
+			StatMin: m.Annotations[indices[0]],
+			StatMax: m.Annotations[indices[out.N-1]],
+		}
+
+		if out.N%2 == 0 {
+			out.DurationBundle[StatMedian] = (m.Durations[indices[out.N/2]] + m.Durations[indices[out.N/2-1]]) / 2
+		} else {
+			out.DurationBundle[StatMedian] = m.Durations[indices[(out.N-1)/2]]
+		}
+		stdDev := 0.0
+		for _, v := range m.Durations {
+			stdDev += float64(v-out.DurationBundle[StatMean]) * float64(v-out.DurationBundle[StatMean])
+		}
+		out.DurationBundle[StatStdDev] = time.Duration(math.Sqrt(stdDev / float64(out.N)))
+	}
+
+	return out
+}

--- a/vendor/github.com/onsi/gomega/gmeasure/rank.go
+++ b/vendor/github.com/onsi/gomega/gmeasure/rank.go
@@ -1,0 +1,141 @@
+package gmeasure
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/onsi/gomega/gmeasure/table"
+)
+
+/*
+RankingCriteria is an enum representing the criteria by which Stats should be ranked.  The enum names should be self explanatory.  e.g. LowerMeanIsBetter means that Stats with lower mean values are considered more beneficial, with the lowest mean being declared the "winner" .
+*/
+type RankingCriteria uint
+
+const (
+	LowerMeanIsBetter RankingCriteria = iota
+	HigherMeanIsBetter
+	LowerMedianIsBetter
+	HigherMedianIsBetter
+	LowerMinIsBetter
+	HigherMinIsBetter
+	LowerMaxIsBetter
+	HigherMaxIsBetter
+)
+
+var rcEnumSupport = newEnumSupport(map[uint]string{uint(LowerMeanIsBetter): "Lower Mean is Better", uint(HigherMeanIsBetter): "Higher Mean is Better", uint(LowerMedianIsBetter): "Lower Median is Better", uint(HigherMedianIsBetter): "Higher Median is Better", uint(LowerMinIsBetter): "Lower Mins is Better", uint(HigherMinIsBetter): "Higher Min is Better", uint(LowerMaxIsBetter): "Lower Max is Better", uint(HigherMaxIsBetter): "Higher Max is Better"})
+
+func (s RankingCriteria) String() string { return rcEnumSupport.String(uint(s)) }
+func (s *RankingCriteria) UnmarshalJSON(b []byte) error {
+	out, err := rcEnumSupport.UnmarshJSON(b)
+	*s = RankingCriteria(out)
+	return err
+}
+func (s RankingCriteria) MarshalJSON() ([]byte, error) { return rcEnumSupport.MarshJSON(uint(s)) }
+
+/*
+Ranking ranks a set of Stats by a specified RankingCritera.  Use RankStats to create a Ranking.
+
+When using Ginkgo, you can register Rankings as Report Entries via AddReportEntry.  This will emit a formatted table representing the Stats in rank-order when Ginkgo generates the report.
+*/
+type Ranking struct {
+	Criteria RankingCriteria
+	Stats    []Stats
+}
+
+/*
+RankStats creates a new ranking of the passed-in stats according to the passed-in criteria.
+*/
+func RankStats(criteria RankingCriteria, stats ...Stats) Ranking {
+	sort.Slice(stats, func(i int, j int) bool {
+		switch criteria {
+		case LowerMeanIsBetter:
+			return stats[i].FloatFor(StatMean) < stats[j].FloatFor(StatMean)
+		case HigherMeanIsBetter:
+			return stats[i].FloatFor(StatMean) > stats[j].FloatFor(StatMean)
+		case LowerMedianIsBetter:
+			return stats[i].FloatFor(StatMedian) < stats[j].FloatFor(StatMedian)
+		case HigherMedianIsBetter:
+			return stats[i].FloatFor(StatMedian) > stats[j].FloatFor(StatMedian)
+		case LowerMinIsBetter:
+			return stats[i].FloatFor(StatMin) < stats[j].FloatFor(StatMin)
+		case HigherMinIsBetter:
+			return stats[i].FloatFor(StatMin) > stats[j].FloatFor(StatMin)
+		case LowerMaxIsBetter:
+			return stats[i].FloatFor(StatMax) < stats[j].FloatFor(StatMax)
+		case HigherMaxIsBetter:
+			return stats[i].FloatFor(StatMax) > stats[j].FloatFor(StatMax)
+		}
+		return false
+	})
+
+	out := Ranking{
+		Criteria: criteria,
+		Stats:    stats,
+	}
+
+	return out
+}
+
+/*
+Winner returns the Stats with the most optimal rank based on the specified ranking criteria.  For example, if the RankingCriteria is LowerMaxIsBetter then the Stats with the lowest value or duration for StatMax will be returned as the "winner"
+*/
+func (c Ranking) Winner() Stats {
+	if len(c.Stats) == 0 {
+		return Stats{}
+	}
+	return c.Stats[0]
+}
+
+func (c Ranking) report(enableStyling bool) string {
+	if len(c.Stats) == 0 {
+		return "Empty Ranking"
+	}
+	t := table.NewTable()
+	t.TableStyle.EnableTextStyling = enableStyling
+	t.AppendRow(table.R(
+		table.C("Experiment"), table.C("Name"), table.C("N"), table.C("Min"), table.C("Median"), table.C("Mean"), table.C("StdDev"), table.C("Max"),
+		table.Divider("="),
+		"{{bold}}",
+	))
+
+	for idx, stats := range c.Stats {
+		name := stats.MeasurementName
+		if stats.Units != "" {
+			name = name + " [" + stats.Units + "]"
+		}
+		experimentName := stats.ExperimentName
+		style := stats.Style
+		if idx == 0 {
+			style = "{{bold}}" + style
+			name += "\n*Winner*"
+			experimentName += "\n*Winner*"
+		}
+		r := table.R(style)
+		t.AppendRow(r)
+		r.AppendCell(table.C(experimentName), table.C(name))
+		r.AppendCell(stats.cells()...)
+
+	}
+	out := fmt.Sprintf("Ranking Criteria: %s\n", c.Criteria)
+	if enableStyling {
+		out = "{{bold}}" + out + "{{/}}"
+	}
+	out += t.Render()
+	return out
+}
+
+/*
+ColorableString generates a styled report that includes a table of the rank-ordered Stats
+It is called automatically by Ginkgo's reporting infrastructure when the Ranking is registered as a ReportEntry via AddReportEntry.
+*/
+func (c Ranking) ColorableString() string {
+	return c.report(true)
+}
+
+/*
+String generates an unstyled report that includes a table of the rank-ordered Stats
+*/
+func (c Ranking) String() string {
+	return c.report(false)
+}

--- a/vendor/github.com/onsi/gomega/gmeasure/stats.go
+++ b/vendor/github.com/onsi/gomega/gmeasure/stats.go
@@ -1,0 +1,153 @@
+package gmeasure
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/onsi/gomega/gmeasure/table"
+)
+
+/*
+Stat is an enum representing the statistics you can request of a Stats struct
+*/
+type Stat uint
+
+const (
+	StatInvalid Stat = iota
+	StatMin
+	StatMax
+	StatMean
+	StatMedian
+	StatStdDev
+)
+
+var statEnumSupport = newEnumSupport(map[uint]string{uint(StatInvalid): "INVALID STAT", uint(StatMin): "Min", uint(StatMax): "Max", uint(StatMean): "Mean", uint(StatMedian): "Median", uint(StatStdDev): "StdDev"})
+
+func (s Stat) String() string { return statEnumSupport.String(uint(s)) }
+func (s *Stat) UnmarshalJSON(b []byte) error {
+	out, err := statEnumSupport.UnmarshJSON(b)
+	*s = Stat(out)
+	return err
+}
+func (s Stat) MarshalJSON() ([]byte, error) { return statEnumSupport.MarshJSON(uint(s)) }
+
+type StatsType uint
+
+const (
+	StatsTypeInvalid StatsType = iota
+	StatsTypeValue
+	StatsTypeDuration
+)
+
+var statsTypeEnumSupport = newEnumSupport(map[uint]string{uint(StatsTypeInvalid): "INVALID STATS TYPE", uint(StatsTypeValue): "StatsTypeValue", uint(StatsTypeDuration): "StatsTypeDuration"})
+
+func (s StatsType) String() string { return statsTypeEnumSupport.String(uint(s)) }
+func (s *StatsType) UnmarshalJSON(b []byte) error {
+	out, err := statsTypeEnumSupport.UnmarshJSON(b)
+	*s = StatsType(out)
+	return err
+}
+func (s StatsType) MarshalJSON() ([]byte, error) { return statsTypeEnumSupport.MarshJSON(uint(s)) }
+
+/*
+Stats records the key statistics for a given measurement.  You generally don't make Stats directly - but you can fetch them from Experiments using GetStats() and from Measurements using Stats().
+
+When using Ginkgo, you can register Measurements as Report Entries via AddReportEntry.  This will emit all the captured data points when Ginkgo generates the report.
+*/
+type Stats struct {
+	// Type is the StatType - one of StatTypeDuration or StatTypeValue
+	Type StatsType
+
+	// ExperimentName is the name of the Experiment that recorded the Measurement from which this Stat is derived
+	ExperimentName string
+
+	// MeasurementName is the name of the Measurement from which this Stat is derived
+	MeasurementName string
+
+	// Units captures the Units of the Measurement from which this Stat is derived
+	Units string
+
+	// Style captures the Style of the Measurement from which this Stat is derived
+	Style string
+
+	// PrecisionBundle captures the precision to use when rendering data for this Measurement.
+	// If Type is StatTypeDuration then PrecisionBundle.Duration is used to round any durations before presentation.
+	// If Type is StatTypeValue then PrecisionBundle.ValueFormat is used to format any values before presentation
+	PrecisionBundle PrecisionBundle
+
+	// N represents the total number of data points in the Meassurement from which this Stat is derived
+	N int
+
+	// If Type is StatTypeValue, ValueBundle will be populated with float64s representing this Stat's statistics
+	ValueBundle map[Stat]float64
+
+	// If Type is StatTypeDuration, DurationBundle will be populated with float64s representing this Stat's statistics
+	DurationBundle map[Stat]time.Duration
+
+	// AnnotationBundle is populated with Annotations corresponding to the data points that can be associated with a Stat.
+	// For example AnnotationBundle[StatMin] will return the Annotation for the data point that has the minimum value/duration.
+	AnnotationBundle map[Stat]string
+}
+
+// String returns a minimal summary of the stats of the form "MIN < [MEDIAN] | <MEAN> ±STDDEV < MAX"
+func (s Stats) String() string {
+	return fmt.Sprintf("%s < [%s] | <%s> ±%s < %s", s.StringFor(StatMin), s.StringFor(StatMedian), s.StringFor(StatMean), s.StringFor(StatStdDev), s.StringFor(StatMax))
+}
+
+// ValueFor returns the float64 value for a particular Stat.  You should only use this if the Stats has Type StatsTypeValue
+// For example:
+//
+//    median := experiment.GetStats("length").ValueFor(gmeasure.StatMedian)
+//
+// will return the median data point for the "length" Measurement.
+func (s Stats) ValueFor(stat Stat) float64 {
+	return s.ValueBundle[stat]
+}
+
+// DurationFor returns the time.Duration for a particular Stat.  You should only use this if the Stats has Type StatsTypeDuration
+// For example:
+//
+//    mean := experiment.GetStats("runtime").ValueFor(gmeasure.StatMean)
+//
+// will return the mean duration for the "runtime" Measurement.
+func (s Stats) DurationFor(stat Stat) time.Duration {
+	return s.DurationBundle[stat]
+}
+
+// FloatFor returns a float64 representation of the passed-in Stat.
+// When Type is StatsTypeValue this is equivalent to s.ValueFor(stat).
+// When Type is StatsTypeDuration this is equivalent to float64(s.DurationFor(stat))
+func (s Stats) FloatFor(stat Stat) float64 {
+	switch s.Type {
+	case StatsTypeValue:
+		return s.ValueFor(stat)
+	case StatsTypeDuration:
+		return float64(s.DurationFor(stat))
+	}
+	return 0
+}
+
+// StringFor returns a formatted string representation of the passed-in Stat.
+// The formatting honors the precision directives provided in stats.PrecisionBundle
+func (s Stats) StringFor(stat Stat) string {
+	switch s.Type {
+	case StatsTypeValue:
+		return fmt.Sprintf(s.PrecisionBundle.ValueFormat, s.ValueFor(stat))
+	case StatsTypeDuration:
+		return s.DurationFor(stat).Round(s.PrecisionBundle.Duration).String()
+	}
+	return ""
+}
+
+func (s Stats) cells() []table.Cell {
+	out := []table.Cell{}
+	out = append(out, table.C(fmt.Sprintf("%d", s.N)))
+	for _, stat := range []Stat{StatMin, StatMedian, StatMean, StatStdDev, StatMax} {
+		content := s.StringFor(stat)
+		if s.AnnotationBundle[stat] != "" {
+			content += "\n" + s.AnnotationBundle[stat]
+		}
+		out = append(out, table.C(content))
+	}
+	return out
+}

--- a/vendor/github.com/onsi/gomega/gmeasure/stopwatch.go
+++ b/vendor/github.com/onsi/gomega/gmeasure/stopwatch.go
@@ -1,0 +1,117 @@
+package gmeasure
+
+import "time"
+
+/*
+Stopwatch provides a convenient abstraction for recording durations.  There are two ways to make a Stopwatch:
+
+You can make a Stopwatch from an Experiment via experiment.NewStopwatch().  This is how you first get a hold of a Stopwatch.
+
+You can subsequently call stopwatch.NewStopwatch() to get a fresh Stopwatch.
+This is only necessary if you need to record durations on a different goroutine as a single Stopwatch is not considered thread-safe.
+
+The Stopwatch starts as soon as it is created.  You can Pause() the stopwatch and Reset() it as needed.
+
+Stopwatches refer back to their parent Experiment.  They use this reference to record any measured durations back with the Experiment.
+*/
+type Stopwatch struct {
+	Experiment    *Experiment
+	t             time.Time
+	pauseT        time.Time
+	pauseDuration time.Duration
+	running       bool
+}
+
+func newStopwatch(experiment *Experiment) *Stopwatch {
+	return &Stopwatch{
+		Experiment: experiment,
+		t:          time.Now(),
+		running:    true,
+	}
+}
+
+/*
+NewStopwatch returns a new Stopwatch pointing to the same Experiment as this Stopwatch
+*/
+func (s *Stopwatch) NewStopwatch() *Stopwatch {
+	return newStopwatch(s.Experiment)
+}
+
+/*
+Record captures the amount of time that has passed since the Stopwatch was created or most recently Reset().  It records the duration on it's associated Experiment in a Measurement with the passed-in name.
+
+Record takes all the decorators that experiment.RecordDuration takes (e.g. Annotation("...") can be used to annotate this duration)
+
+Note that Record does not Reset the Stopwatch.  It does, however, return the Stopwatch so the following pattern is common:
+
+    stopwatch := experiment.NewStopwatch()
+    // first expensive operation
+    stopwatch.Record("first operation").Reset() //records the duration of the first operation and resets the stopwatch.
+    // second expensive operation
+    stopwatch.Record("second operation").Reset() //records the duration of the second operation and resets the stopwatch.
+
+omitting the Reset() after the first operation would cause the duration recorded for the second operation to include the time elapsed by both the first _and_ second operations.
+
+The Stopwatch must be running (i.e. not paused) when Record is called.
+*/
+func (s *Stopwatch) Record(name string, args ...interface{}) *Stopwatch {
+	if !s.running {
+		panic("stopwatch is not running - call Resume or Reset before calling Record")
+	}
+	duration := time.Since(s.t) - s.pauseDuration
+	s.Experiment.RecordDuration(name, duration, args...)
+	return s
+}
+
+/*
+Reset resets the Stopwatch.  Subsequent recorded durations will measure the time elapsed from the moment Reset was called.
+If the Stopwatch was Paused it is unpaused after calling Reset.
+*/
+func (s *Stopwatch) Reset() *Stopwatch {
+	s.running = true
+	s.t = time.Now()
+	s.pauseDuration = 0
+	return s
+}
+
+/*
+Pause pauses the Stopwatch.  While pasued the Stopwatch does not accumulate elapsed time.  This is useful for ignoring expensive operations that are incidental to the behavior you are attempting to characterize.
+Note: You must call Resume() before you can Record() subsequent measurements.
+
+For example:
+
+    stopwatch := experiment.NewStopwatch()
+    // first expensive operation
+    stopwatch.Record("first operation").Reset()
+    // second expensive operation - part 1
+    stopwatch.Pause()
+    // something expensive that we don't care about
+    stopwatch.Resume()
+    // second expensive operation - part 2
+    stopwatch.Record("second operation").Reset() // the recorded duration captures the time elapsed during parts 1 and 2 of the second expensive operation, but not the bit in between
+
+
+The Stopwatch must be running when Pause is called.
+*/
+func (s *Stopwatch) Pause() *Stopwatch {
+	if !s.running {
+		panic("stopwatch is not running - call Resume or Reset before calling Pause")
+	}
+	s.running = false
+	s.pauseT = time.Now()
+	return s
+}
+
+/*
+Resume resumes a paused Stopwatch.  Any time that elapses after Resume is called will be accumulated as elapsed time when a subsequent duration is Recorded.
+
+The Stopwatch must be Paused when Resume is called
+*/
+func (s *Stopwatch) Resume() *Stopwatch {
+	if s.running {
+		panic("stopwatch is running - call Pause before calling Resume")
+	}
+	s.running = true
+	s.pauseDuration = s.pauseDuration + time.Since(s.pauseT)
+	return s
+}

--- a/vendor/github.com/onsi/gomega/gmeasure/table/table.go
+++ b/vendor/github.com/onsi/gomega/gmeasure/table/table.go
@@ -1,0 +1,370 @@
+package table
+
+// This is a temporary package - Table will move to github.com/onsi/consolable once some more dust settles
+
+import (
+	"reflect"
+	"strings"
+	"unicode/utf8"
+)
+
+type AlignType uint
+
+const (
+	AlignTypeLeft AlignType = iota
+	AlignTypeCenter
+	AlignTypeRight
+)
+
+type Divider string
+
+type Row struct {
+	Cells   []Cell
+	Divider string
+	Style   string
+}
+
+func R(args ...interface{}) *Row {
+	r := &Row{
+		Divider: "-",
+	}
+	for _, arg := range args {
+		switch reflect.TypeOf(arg) {
+		case reflect.TypeOf(Divider("")):
+			r.Divider = string(arg.(Divider))
+		case reflect.TypeOf(r.Style):
+			r.Style = arg.(string)
+		case reflect.TypeOf(Cell{}):
+			r.Cells = append(r.Cells, arg.(Cell))
+		}
+	}
+	return r
+}
+
+func (r *Row) AppendCell(cells ...Cell) *Row {
+	r.Cells = append(r.Cells, cells...)
+	return r
+}
+
+func (r *Row) Render(widths []int, totalWidth int, tableStyle TableStyle, isLastRow bool) string {
+	out := ""
+	if len(r.Cells) == 1 {
+		out += strings.Join(r.Cells[0].render(totalWidth, r.Style, tableStyle), "\n") + "\n"
+	} else {
+		if len(r.Cells) != len(widths) {
+			panic("row vs width mismatch")
+		}
+		renderedCells := make([][]string, len(r.Cells))
+		maxHeight := 0
+		for colIdx, cell := range r.Cells {
+			renderedCells[colIdx] = cell.render(widths[colIdx], r.Style, tableStyle)
+			if len(renderedCells[colIdx]) > maxHeight {
+				maxHeight = len(renderedCells[colIdx])
+			}
+		}
+		for colIdx := range r.Cells {
+			for len(renderedCells[colIdx]) < maxHeight {
+				renderedCells[colIdx] = append(renderedCells[colIdx], strings.Repeat(" ", widths[colIdx]))
+			}
+		}
+		border := strings.Repeat(" ", tableStyle.Padding)
+		if tableStyle.VerticalBorders {
+			border += "|" + border
+		}
+		for lineIdx := 0; lineIdx < maxHeight; lineIdx++ {
+			for colIdx := range r.Cells {
+				out += renderedCells[colIdx][lineIdx]
+				if colIdx < len(r.Cells)-1 {
+					out += border
+				}
+			}
+			out += "\n"
+		}
+	}
+	if tableStyle.HorizontalBorders && !isLastRow && r.Divider != "" {
+		out += strings.Repeat(string(r.Divider), totalWidth) + "\n"
+	}
+
+	return out
+}
+
+type Cell struct {
+	Contents []string
+	Style    string
+	Align    AlignType
+}
+
+func C(contents string, args ...interface{}) Cell {
+	c := Cell{
+		Contents: strings.Split(contents, "\n"),
+	}
+	for _, arg := range args {
+		switch reflect.TypeOf(arg) {
+		case reflect.TypeOf(c.Style):
+			c.Style = arg.(string)
+		case reflect.TypeOf(c.Align):
+			c.Align = arg.(AlignType)
+		}
+	}
+	return c
+}
+
+func (c Cell) Width() (int, int) {
+	w, minW := 0, 0
+	for _, line := range c.Contents {
+		lineWidth := utf8.RuneCountInString(line)
+		if lineWidth > w {
+			w = lineWidth
+		}
+		for _, word := range strings.Split(line, " ") {
+			wordWidth := utf8.RuneCountInString(word)
+			if wordWidth > minW {
+				minW = wordWidth
+			}
+		}
+	}
+	return w, minW
+}
+
+func (c Cell) alignLine(line string, width int) string {
+	lineWidth := utf8.RuneCountInString(line)
+	if lineWidth == width {
+		return line
+	}
+	if lineWidth < width {
+		gap := width - lineWidth
+		switch c.Align {
+		case AlignTypeLeft:
+			return line + strings.Repeat(" ", gap)
+		case AlignTypeRight:
+			return strings.Repeat(" ", gap) + line
+		case AlignTypeCenter:
+			leftGap := gap / 2
+			rightGap := gap - leftGap
+			return strings.Repeat(" ", leftGap) + line + strings.Repeat(" ", rightGap)
+		}
+	}
+	return line
+}
+
+func (c Cell) splitWordToWidth(word string, width int) []string {
+	out := []string{}
+	n, subWord := 0, ""
+	for _, c := range word {
+		subWord += string(c)
+		n += 1
+		if n == width-1 {
+			out = append(out, subWord+"-")
+			n, subWord = 0, ""
+		}
+	}
+	return out
+}
+
+func (c Cell) splitToWidth(line string, width int) []string {
+	lineWidth := utf8.RuneCountInString(line)
+	if lineWidth <= width {
+		return []string{line}
+	}
+
+	outLines := []string{}
+	words := strings.Split(line, " ")
+	outWords := []string{words[0]}
+	length := utf8.RuneCountInString(words[0])
+	if length > width {
+		splitWord := c.splitWordToWidth(words[0], width)
+		lastIdx := len(splitWord) - 1
+		outLines = append(outLines, splitWord[:lastIdx]...)
+		outWords = []string{splitWord[lastIdx]}
+		length = utf8.RuneCountInString(splitWord[lastIdx])
+	}
+
+	for _, word := range words[1:] {
+		wordLength := utf8.RuneCountInString(word)
+		if length+wordLength+1 <= width {
+			length += wordLength + 1
+			outWords = append(outWords, word)
+			continue
+		}
+		outLines = append(outLines, strings.Join(outWords, " "))
+
+		outWords = []string{word}
+		length = wordLength
+		if length > width {
+			splitWord := c.splitWordToWidth(word, width)
+			lastIdx := len(splitWord) - 1
+			outLines = append(outLines, splitWord[:lastIdx]...)
+			outWords = []string{splitWord[lastIdx]}
+			length = utf8.RuneCountInString(splitWord[lastIdx])
+		}
+	}
+	if len(outWords) > 0 {
+		outLines = append(outLines, strings.Join(outWords, " "))
+	}
+
+	return outLines
+}
+
+func (c Cell) render(width int, style string, tableStyle TableStyle) []string {
+	out := []string{}
+	for _, line := range c.Contents {
+		out = append(out, c.splitToWidth(line, width)...)
+	}
+	for idx := range out {
+		out[idx] = c.alignLine(out[idx], width)
+	}
+
+	if tableStyle.EnableTextStyling {
+		style = style + c.Style
+		if style != "" {
+			for idx := range out {
+				out[idx] = style + out[idx] + "{{/}}"
+			}
+		}
+	}
+
+	return out
+}
+
+type TableStyle struct {
+	Padding           int
+	VerticalBorders   bool
+	HorizontalBorders bool
+	MaxTableWidth     int
+	MaxColWidth       int
+	EnableTextStyling bool
+}
+
+var DefaultTableStyle = TableStyle{
+	Padding:           1,
+	VerticalBorders:   true,
+	HorizontalBorders: true,
+	MaxTableWidth:     120,
+	MaxColWidth:       40,
+	EnableTextStyling: true,
+}
+
+type Table struct {
+	Rows []*Row
+
+	TableStyle TableStyle
+}
+
+func NewTable() *Table {
+	return &Table{
+		TableStyle: DefaultTableStyle,
+	}
+}
+
+func (t *Table) AppendRow(row *Row) *Table {
+	t.Rows = append(t.Rows, row)
+	return t
+}
+
+func (t *Table) Render() string {
+	out := ""
+	totalWidth, widths := t.computeWidths()
+	for rowIdx, row := range t.Rows {
+		out += row.Render(widths, totalWidth, t.TableStyle, rowIdx == len(t.Rows)-1)
+	}
+	return out
+}
+
+func (t *Table) computeWidths() (int, []int) {
+	nCol := 0
+	for _, row := range t.Rows {
+		if len(row.Cells) > nCol {
+			nCol = len(row.Cells)
+		}
+	}
+
+	// lets compute the contribution to width from the borders + padding
+	borderWidth := t.TableStyle.Padding
+	if t.TableStyle.VerticalBorders {
+		borderWidth += 1 + t.TableStyle.Padding
+	}
+	totalBorderWidth := borderWidth * (nCol - 1)
+
+	// lets compute the width of each column
+	widths := make([]int, nCol)
+	minWidths := make([]int, nCol)
+	for colIdx := range widths {
+		for _, row := range t.Rows {
+			if colIdx >= len(row.Cells) {
+				// ignore rows with fewer columns
+				continue
+			}
+			w, minWid := row.Cells[colIdx].Width()
+			if w > widths[colIdx] {
+				widths[colIdx] = w
+			}
+			if minWid > minWidths[colIdx] {
+				minWidths[colIdx] = minWid
+			}
+		}
+	}
+
+	// do we already fit?
+	if sum(widths)+totalBorderWidth <= t.TableStyle.MaxTableWidth {
+		// yes! we're done
+		return sum(widths) + totalBorderWidth, widths
+	}
+
+	// clamp the widths and minWidths to MaxColWidth
+	for colIdx := range widths {
+		widths[colIdx] = min(widths[colIdx], t.TableStyle.MaxColWidth)
+		minWidths[colIdx] = min(minWidths[colIdx], t.TableStyle.MaxColWidth)
+	}
+
+	// do we fit now?
+	if sum(widths)+totalBorderWidth <= t.TableStyle.MaxTableWidth {
+		// yes! we're done
+		return sum(widths) + totalBorderWidth, widths
+	}
+
+	// hmm... still no... can we possibly squeeze the table in without violating minWidths?
+	if sum(minWidths)+totalBorderWidth >= t.TableStyle.MaxTableWidth {
+		// nope - we're just going to have to exceed MaxTableWidth
+		return sum(minWidths) + totalBorderWidth, minWidths
+	}
+
+	// looks like we don't fit yet, but we should be able to fit without violating minWidths
+	// lets start scaling down
+	n := 0
+	for sum(widths)+totalBorderWidth > t.TableStyle.MaxTableWidth {
+		budget := t.TableStyle.MaxTableWidth - totalBorderWidth
+		baseline := sum(widths)
+
+		for colIdx := range widths {
+			widths[colIdx] = max((widths[colIdx]*budget)/baseline, minWidths[colIdx])
+		}
+		n += 1
+		if n > 100 {
+			break // in case we somehow fail to converge
+		}
+	}
+
+	return sum(widths) + totalBorderWidth, widths
+}
+
+func sum(s []int) int {
+	out := 0
+	for _, v := range s {
+		out += v
+	}
+	return out
+}
+
+func min(a int, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func max(a int, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -452,6 +452,8 @@ github.com/onsi/ginkgo/v2/types
 github.com/onsi/gomega
 github.com/onsi/gomega/format
 github.com/onsi/gomega/gcustom
+github.com/onsi/gomega/gmeasure
+github.com/onsi/gomega/gmeasure/table
 github.com/onsi/gomega/gstruct
 github.com/onsi/gomega/gstruct/errors
 github.com/onsi/gomega/internal


### PR DESCRIPTION
Note that these tests will take now more time to run as they are relying on the scale up and scale down to prepare the test case and restore the cluster state.

Remove all the gke and gce specific tests including:
- GPUs
- volumes (no way to provision volumes without provider specific infrastructure)
- scale up/down from/to 0
- tests checking what happens after breaking nodes (no way to simulate temporary network failure without provider assumptions)

Fix the pdb tests.

Due to lengthy process of scale down changing the scalability tests to start 100 nodes. With more nodes tests are hitting timeouts. In the future we might want to see whether we should just change the timeouts or there are some other problems with higher number of nodes. At the moment these tests are not run regularly anywhere.

/kind failing-test
/kind cleanup


#### What this PR does / why we need it:
Fix the failing tests of autoscaler after the GCP provider specific logic was removed.

```release-note
NONE

```