### PR TITLE
clean up: scheduler remove expire assumed pod logic

### DIFF
--- a/pkg/scheduler/eventhandlers_test.go
+++ b/pkg/scheduler/eventhandlers_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"reflect"
 	"testing"
-	"time"
 
 	"github.com/google/go-cmp/cmp"
 	appsv1 "k8s.io/api/apps/v1"
@@ -200,7 +199,6 @@ func TestNodeConditionsChanged(t *testing.T) {
 }
 
 func TestUpdatePodInCache(t *testing.T) {
-	ttl := 10 * time.Second
 	nodeName := "node"
 
 	tests := []struct {
@@ -225,7 +223,7 @@ func TestUpdatePodInCache(t *testing.T) {
 			ctx, cancel := context.WithCancel(ctx)
 			defer cancel()
 			sched := &Scheduler{
-				Cache:           cache.New(ctx, ttl),
+				Cache:           cache.New(ctx),
 				SchedulingQueue: queue.NewTestQueue(ctx, nil),
 				logger:          logger,
 			}

--- a/pkg/scheduler/extender_test.go
+++ b/pkg/scheduler/extender_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"reflect"
 	"testing"
-	"time"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -328,7 +327,7 @@ func TestSchedulerWithExtenders(t *testing.T) {
 			ctx, cancel := context.WithCancel(ctx)
 			defer cancel()
 
-			cache := internalcache.New(ctx, time.Duration(0))
+			cache := internalcache.New(ctx)
 			for _, name := range test.nodes {
 				cache.AddNode(logger, createNode(name))
 			}

--- a/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption_test.go
+++ b/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption_test.go
@@ -1706,7 +1706,7 @@ func TestPreempt(t *testing.T) {
 
 			waitingPods := frameworkruntime.NewWaitingPodsMap()
 
-			cache := internalcache.New(ctx, time.Duration(0))
+			cache := internalcache.New(ctx)
 			for _, pod := range test.pods {
 				cache.AddPod(logger, pod)
 			}

--- a/pkg/scheduler/internal/cache/cache_test.go
+++ b/pkg/scheduler/internal/cache/cache_test.go
@@ -221,7 +221,7 @@ func TestAssumePodScheduled(t *testing.T) {
 			logger, ctx := ktesting.NewTestContext(t)
 			ctx, cancel := context.WithCancel(ctx)
 			defer cancel()
-			cache := newCache(ctx, time.Second, time.Second)
+			cache := newCache(ctx)
 			for _, pod := range tc.pods {
 				if err := cache.AssumePod(logger, pod); err != nil {
 					t.Fatalf("AssumePod failed: %v", err)
@@ -254,122 +254,10 @@ type testExpirePodStruct struct {
 	assumedTime time.Time
 }
 
-func assumeAndFinishBinding(logger klog.Logger, cache *cacheImpl, pod *v1.Pod, assumedTime time.Time) error {
-	if err := cache.AssumePod(logger, pod); err != nil {
-		return err
-	}
-	return cache.finishBinding(logger, pod, assumedTime)
-}
-
-// TestExpirePod tests that assumed pods will be removed if expired.
-// The removal will be reflected in node info.
-func TestExpirePod(t *testing.T) {
-	nodeName := "node"
-	testPods := []*v1.Pod{
-		makeBasePod(t, nodeName, "test-1", "100m", "500", "", []v1.ContainerPort{{HostIP: "127.0.0.1", HostPort: 80, Protocol: "TCP"}}),
-		makeBasePod(t, nodeName, "test-2", "200m", "1Ki", "", []v1.ContainerPort{{HostIP: "127.0.0.1", HostPort: 8080, Protocol: "TCP"}}),
-		makeBasePod(t, nodeName, "test-3", "200m", "1Ki", "", []v1.ContainerPort{{HostIP: "127.0.0.1", HostPort: 8080, Protocol: "TCP"}}),
-	}
-	now := time.Now()
-	defaultTTL := 10 * time.Second
-	tests := []struct {
-		name        string
-		pods        []*testExpirePodStruct
-		cleanupTime time.Time
-		ttl         time.Duration
-		wNodeInfo   *framework.NodeInfo
-	}{
-		{
-			name: "assumed pod would expire",
-			pods: []*testExpirePodStruct{
-				{pod: testPods[0], finishBind: true, assumedTime: now},
-			},
-			cleanupTime: now.Add(2 * defaultTTL),
-			wNodeInfo:   nil,
-			ttl:         defaultTTL,
-		},
-		{
-			name: "first one would expire, second and third would not",
-			pods: []*testExpirePodStruct{
-				{pod: testPods[0], finishBind: true, assumedTime: now},
-				{pod: testPods[1], finishBind: true, assumedTime: now.Add(3 * defaultTTL / 2)},
-				{pod: testPods[2]},
-			},
-			cleanupTime: now.Add(2 * defaultTTL),
-			wNodeInfo: newNodeInfo(
-				&framework.Resource{
-					MilliCPU: 400,
-					Memory:   2048,
-				},
-				&framework.Resource{
-					MilliCPU: 400,
-					Memory:   2048,
-				},
-				// Order gets altered when removing pods.
-				[]*v1.Pod{testPods[2], testPods[1]},
-				newHostPortInfoBuilder().add("TCP", "127.0.0.1", 8080).build(),
-				make(map[string]*framework.ImageStateSummary),
-			),
-			ttl: defaultTTL,
-		},
-		{
-			name: "assumed pod would never expire",
-			pods: []*testExpirePodStruct{
-				{pod: testPods[0], finishBind: true, assumedTime: now},
-			},
-			cleanupTime: now.Add(3 * defaultTTL),
-			wNodeInfo: newNodeInfo(
-				&framework.Resource{
-					MilliCPU: 100,
-					Memory:   500,
-				},
-				&framework.Resource{
-					MilliCPU: 100,
-					Memory:   500,
-				},
-				[]*v1.Pod{testPods[0]},
-				newHostPortInfoBuilder().add("TCP", "127.0.0.1", 80).build(),
-				make(map[string]*framework.ImageStateSummary),
-			),
-			ttl: time.Duration(0),
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			logger, ctx := ktesting.NewTestContext(t)
-			ctx, cancel := context.WithCancel(ctx)
-			defer cancel()
-			cache := newCache(ctx, tc.ttl, time.Second)
-
-			for _, pod := range tc.pods {
-				if err := cache.AssumePod(logger, pod.pod); err != nil {
-					t.Fatal(err)
-				}
-				if !pod.finishBind {
-					continue
-				}
-				if err := cache.finishBinding(logger, pod.pod, pod.assumedTime); err != nil {
-					t.Fatal(err)
-				}
-			}
-			// pods that got bound and have assumedTime + ttl < cleanupTime will get
-			// expired and removed
-			cache.cleanupAssumedPods(logger, tc.cleanupTime)
-			n := cache.nodes[nodeName]
-			if err := deepEqualWithoutGeneration(n, tc.wNodeInfo); err != nil {
-				t.Error(err)
-			}
-		})
-	}
-}
-
 // TestAddPodWillConfirm tests that a pod being Add()ed will be confirmed if assumed.
 // The pod info should still exist after manually expiring unconfirmed pods.
 func TestAddPodWillConfirm(t *testing.T) {
 	nodeName := "node"
-	now := time.Now()
-	ttl := 10 * time.Second
 
 	testPods := []*v1.Pod{
 		makeBasePod(t, nodeName, "test-1", "100m", "500", "", []v1.ContainerPort{{HostIP: "127.0.0.1", HostPort: 80, Protocol: "TCP"}}),
@@ -401,12 +289,7 @@ func TestAddPodWillConfirm(t *testing.T) {
 	logger, ctx := ktesting.NewTestContext(t)
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	cache := newCache(ctx, ttl, time.Second)
-	for _, podToAssume := range test.podsToAssume {
-		if err := assumeAndFinishBinding(logger, cache, podToAssume, now); err != nil {
-			t.Fatalf("assumePod failed: %v", err)
-		}
-	}
+	cache := newCache(ctx)
 	for _, podToAdd := range test.podsToAdd {
 		if err := cache.AddPod(logger, podToAdd); err != nil {
 			t.Fatalf("AddPod failed: %v", err)
@@ -416,7 +299,6 @@ func TestAddPodWillConfirm(t *testing.T) {
 			t.Error("expected error, no error found")
 		}
 	}
-	cache.cleanupAssumedPods(logger, now.Add(2*ttl))
 	// check after expiration. confirmed pods shouldn't be expired.
 	n := cache.nodes[nodeName]
 	if err := deepEqualWithoutGeneration(n, test.wNodeInfo); err != nil {
@@ -426,8 +308,6 @@ func TestAddPodWillConfirm(t *testing.T) {
 
 func TestDump(t *testing.T) {
 	nodeName := "node"
-	now := time.Now()
-	ttl := 10 * time.Second
 
 	testPods := []*v1.Pod{
 		makeBasePod(t, nodeName, "test-1", "100m", "500", "", []v1.ContainerPort{{HostIP: "127.0.0.1", HostPort: 80, Protocol: "TCP"}}),
@@ -444,12 +324,7 @@ func TestDump(t *testing.T) {
 	logger, ctx := ktesting.NewTestContext(t)
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	cache := newCache(ctx, ttl, time.Second)
-	for _, podToAssume := range test.podsToAssume {
-		if err := assumeAndFinishBinding(logger, cache, podToAssume, now); err != nil {
-			t.Errorf("assumePod failed: %v", err)
-		}
-	}
+	cache := newCache(ctx)
 	for _, podToAdd := range test.podsToAdd {
 		if err := cache.AddPod(logger, podToAdd); err != nil {
 			t.Errorf("AddPod failed: %v", err)
@@ -475,11 +350,9 @@ func TestDump(t *testing.T) {
 // TestAddPodAlwaysUpdatePodInfoInNodeInfo tests that AddPod method always updates PodInfo in NodeInfo,
 // even when the Pod is assumed one.
 func TestAddPodAlwaysUpdatesPodInfoInNodeInfo(t *testing.T) {
-	ttl := 10 * time.Second
 	logger, ctx := ktesting.NewTestContext(t)
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	now := time.Now()
 	p1 := makeBasePod(t, "node1", "test-1", "100m", "500", "", []v1.ContainerPort{{HostPort: 80}})
 
 	p2 := p1.DeepCopy()
@@ -512,12 +385,7 @@ func TestAddPodAlwaysUpdatesPodInfoInNodeInfo(t *testing.T) {
 		},
 	}
 
-	cache := newCache(ctx, ttl, time.Second)
-	for _, podToAssume := range test.podsToAssume {
-		if err := assumeAndFinishBinding(logger, cache, podToAssume, now); err != nil {
-			t.Fatalf("assumePod failed: %v", err)
-		}
-	}
+	cache := newCache(ctx)
 	for _, podToAdd := range test.podsToAddAfterAssume {
 		if err := cache.AddPod(logger, podToAdd); err != nil {
 			t.Fatalf("AddPod failed: %v", err)
@@ -533,9 +401,6 @@ func TestAddPodAlwaysUpdatesPodInfoInNodeInfo(t *testing.T) {
 
 // TestAddPodWillReplaceAssumed tests that a pod being Add()ed will replace any assumed pod.
 func TestAddPodWillReplaceAssumed(t *testing.T) {
-	now := time.Now()
-	ttl := 10 * time.Second
-
 	assumedPod := makeBasePod(t, "assumed-node-1", "test-1", "100m", "500", "", []v1.ContainerPort{{HostPort: 80}})
 	addedPod := makeBasePod(t, "actual-node", "test-1", "100m", "500", "", []v1.ContainerPort{{HostPort: 80}})
 	updatedPod := makeBasePod(t, "actual-node", "test-1", "200m", "500", "", []v1.ContainerPort{{HostPort: 90}})
@@ -571,12 +436,7 @@ func TestAddPodWillReplaceAssumed(t *testing.T) {
 	logger, ctx := ktesting.NewTestContext(t)
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	cache := newCache(ctx, ttl, time.Second)
-	for _, podToAssume := range test.podsToAssume {
-		if err := assumeAndFinishBinding(logger, cache, podToAssume, now); err != nil {
-			t.Fatalf("assumePod failed: %v", err)
-		}
-	}
+	cache := newCache(ctx)
 	for _, podToAdd := range test.podsToAdd {
 		if err := cache.AddPod(logger, podToAdd); err != nil {
 			t.Fatalf("AddPod failed: %v", err)
@@ -595,58 +455,9 @@ func TestAddPodWillReplaceAssumed(t *testing.T) {
 	}
 }
 
-// TestAddPodAfterExpiration tests that a pod being Add()ed will be added back if expired.
-func TestAddPodAfterExpiration(t *testing.T) {
-	nodeName := "node"
-	ttl := 10 * time.Second
-	basePod := makeBasePod(t, nodeName, "test", "100m", "500", "", []v1.ContainerPort{{HostIP: "127.0.0.1", HostPort: 80, Protocol: "TCP"}})
-	test := struct {
-		pod       *v1.Pod
-		wNodeInfo *framework.NodeInfo
-	}{
-		pod: basePod,
-		wNodeInfo: newNodeInfo(
-			&framework.Resource{
-				MilliCPU: 100,
-				Memory:   500,
-			},
-			&framework.Resource{
-				MilliCPU: 100,
-				Memory:   500,
-			},
-			[]*v1.Pod{basePod},
-			newHostPortInfoBuilder().add("TCP", "127.0.0.1", 80).build(),
-			make(map[string]*framework.ImageStateSummary),
-		),
-	}
-
-	logger, ctx := ktesting.NewTestContext(t)
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-	now := time.Now()
-	cache := newCache(ctx, ttl, time.Second)
-	if err := assumeAndFinishBinding(logger, cache, test.pod, now); err != nil {
-		t.Fatalf("assumePod failed: %v", err)
-	}
-	cache.cleanupAssumedPods(logger, now.Add(2*ttl))
-	// It should be expired and removed.
-	if err := isForgottenFromCache(test.pod, cache); err != nil {
-		t.Error(err)
-	}
-	if err := cache.AddPod(logger, test.pod); err != nil {
-		t.Fatalf("AddPod failed: %v", err)
-	}
-	// check after expiration. confirmed pods shouldn't be expired.
-	n := cache.nodes[nodeName]
-	if err := deepEqualWithoutGeneration(n, test.wNodeInfo); err != nil {
-		t.Error(err)
-	}
-}
-
 // TestUpdatePod tests that a pod will be updated if added before.
 func TestUpdatePod(t *testing.T) {
 	nodeName := "node"
-	ttl := 10 * time.Second
 	testPods := []*v1.Pod{
 		makeBasePod(t, nodeName, "test", "100m", "500", "", []v1.ContainerPort{{HostIP: "127.0.0.1", HostPort: 80, Protocol: "TCP"}}),
 		makeBasePod(t, nodeName, "test", "200m", "1Ki", "", []v1.ContainerPort{{HostIP: "127.0.0.1", HostPort: 8080, Protocol: "TCP"}}),
@@ -689,7 +500,7 @@ func TestUpdatePod(t *testing.T) {
 	logger, ctx := ktesting.NewTestContext(t)
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	cache := newCache(ctx, ttl, time.Second)
+	cache := newCache(ctx)
 	for _, podToAdd := range test.podsToAdd {
 		if err := cache.AddPod(logger, podToAdd); err != nil {
 			t.Fatalf("AddPod failed: %v", err)
@@ -714,7 +525,6 @@ func TestUpdatePod(t *testing.T) {
 // TestUpdatePodAndGet tests get always return latest pod state
 func TestUpdatePodAndGet(t *testing.T) {
 	nodeName := "node"
-	ttl := 10 * time.Second
 	testPods := []*v1.Pod{
 		makeBasePod(t, nodeName, "test", "100m", "500", "", []v1.ContainerPort{{HostIP: "127.0.0.1", HostPort: 80, Protocol: "TCP"}}),
 		makeBasePod(t, nodeName, "test", "200m", "1Ki", "", []v1.ContainerPort{{HostIP: "127.0.0.1", HostPort: 8080, Protocol: "TCP"}}),
@@ -751,7 +561,7 @@ func TestUpdatePodAndGet(t *testing.T) {
 			logger, ctx := ktesting.NewTestContext(t)
 			ctx, cancel := context.WithCancel(ctx)
 			defer cancel()
-			cache := newCache(ctx, ttl, time.Second)
+			cache := newCache(ctx)
 			// trying to get an unknown pod should return an error
 			// podToUpdate has not been added yet
 			if _, err := cache.GetPod(tc.podToUpdate); err == nil {
@@ -788,7 +598,6 @@ func TestUpdatePodAndGet(t *testing.T) {
 // TestExpireAddUpdatePod test the sequence that a pod is expired, added, then updated
 func TestExpireAddUpdatePod(t *testing.T) {
 	nodeName := "node"
-	ttl := 10 * time.Second
 	testPods := []*v1.Pod{
 		makeBasePod(t, nodeName, "test", "100m", "500", "", []v1.ContainerPort{{HostIP: "127.0.0.1", HostPort: 80, Protocol: "TCP"}}),
 		makeBasePod(t, nodeName, "test", "200m", "1Ki", "", []v1.ContainerPort{{HostIP: "127.0.0.1", HostPort: 8080, Protocol: "TCP"}}),
@@ -833,14 +642,7 @@ func TestExpireAddUpdatePod(t *testing.T) {
 	logger, ctx := ktesting.NewTestContext(t)
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	now := time.Now()
-	cache := newCache(ctx, ttl, time.Second)
-	for _, podToAssume := range test.podsToAssume {
-		if err := assumeAndFinishBinding(logger, cache, podToAssume, now); err != nil {
-			t.Fatalf("assumePod failed: %v", err)
-		}
-	}
-	cache.cleanupAssumedPods(logger, now.Add(2*ttl))
+	cache := newCache(ctx)
 
 	for _, podToAdd := range test.podsToAdd {
 		if err := cache.AddPod(logger, podToAdd); err != nil {
@@ -895,7 +697,7 @@ func TestEphemeralStorageResource(t *testing.T) {
 	logger, ctx := ktesting.NewTestContext(t)
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	cache := newCache(ctx, time.Second, time.Second)
+	cache := newCache(ctx)
 	if err := cache.AddPod(logger, test.pod); err != nil {
 		t.Fatalf("AddPod failed: %v", err)
 	}
@@ -949,7 +751,7 @@ func TestRemovePod(t *testing.T) {
 			ctx, cancel := context.WithCancel(ctx)
 			defer cancel()
 			nodeName := pod.Spec.NodeName
-			cache := newCache(ctx, time.Second, time.Second)
+			cache := newCache(ctx)
 			// Add/Assume pod succeeds even before adding the nodes.
 			if tt.assume {
 				if err := cache.AddPod(logger, pod); err != nil {
@@ -993,16 +795,14 @@ func TestForgetPod(t *testing.T) {
 	nodeName := "node"
 	basePod := makeBasePod(t, nodeName, "test", "100m", "500", "", []v1.ContainerPort{{HostIP: "127.0.0.1", HostPort: 80, Protocol: "TCP"}})
 	pods := []*v1.Pod{basePod}
-	now := time.Now()
-	ttl := 10 * time.Second
 	logger, ctx := ktesting.NewTestContext(t)
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	cache := newCache(ctx, ttl, time.Second)
+	cache := newCache(ctx)
 	for _, pod := range pods {
-		if err := assumeAndFinishBinding(logger, cache, pod, now); err != nil {
-			t.Fatalf("assumePod failed: %v", err)
+		if err := cache.AssumePod(logger, pod); err != nil {
+			t.Fatalf("AssumePod failed: %v", err)
 		}
 		isAssumed, err := cache.IsAssumedPod(pod)
 		if err != nil {
@@ -1212,7 +1012,7 @@ func TestNodeOperators(t *testing.T) {
 			imageStates := buildImageStates(tc.nodes)
 			expected := buildNodeInfo(node, tc.pods, imageStates)
 
-			cache := newCache(ctx, time.Second, time.Second)
+			cache := newCache(ctx)
 			for _, nodeItem := range tc.nodes {
 				cache.AddNode(logger, nodeItem)
 			}
@@ -1706,7 +1506,7 @@ func TestSchedulerCache_UpdateSnapshot(t *testing.T) {
 			_, ctx := ktesting.NewTestContext(t)
 			ctx, cancel := context.WithCancel(ctx)
 			defer cancel()
-			cache = newCache(ctx, time.Second, time.Second)
+			cache = newCache(ctx)
 			snapshot = NewEmptySnapshot()
 
 			for _, op := range test.operations {
@@ -1941,7 +1741,7 @@ func TestSchedulerCache_updateNodeInfoSnapshotList(t *testing.T) {
 			_, ctx := ktesting.NewTestContext(t)
 			ctx, cancel := context.WithCancel(ctx)
 			defer cancel()
-			cache = newCache(ctx, time.Second, time.Second)
+			cache = newCache(ctx)
 			snapshot = NewEmptySnapshot()
 
 			test.operations(t)
@@ -1969,31 +1769,6 @@ func BenchmarkUpdate1kNodes30kPods(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		cachedNodes := NewEmptySnapshot()
 		cache.UpdateSnapshot(logger, cachedNodes)
-	}
-}
-
-func BenchmarkExpirePods(b *testing.B) {
-	podNums := []int{
-		100,
-		1000,
-		10000,
-	}
-	for _, podNum := range podNums {
-		name := fmt.Sprintf("%dPods", podNum)
-		b.Run(name, func(b *testing.B) {
-			benchmarkExpire(b, podNum)
-		})
-	}
-}
-
-func benchmarkExpire(b *testing.B, podNum int) {
-	logger, _ := ktesting.NewTestContext(b)
-	now := time.Now()
-	for n := 0; n < b.N; n++ {
-		b.StopTimer()
-		cache := setupCacheWithAssumedPods(b, podNum, now)
-		b.StartTimer()
-		cache.cleanupAssumedPods(logger, now.Add(2*time.Second))
 	}
 }
 
@@ -2047,7 +1822,7 @@ func setupCacheOf1kNodes30kPods(b *testing.B) Cache {
 	logger, ctx := ktesting.NewTestContext(b)
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	cache := newCache(ctx, time.Second, time.Second)
+	cache := newCache(ctx)
 	for i := 0; i < 1000; i++ {
 		nodeName := fmt.Sprintf("node-%d", i)
 		for j := 0; j < 30; j++ {
@@ -2057,24 +1832,6 @@ func setupCacheOf1kNodes30kPods(b *testing.B) Cache {
 			if err := cache.AddPod(logger, pod); err != nil {
 				b.Fatalf("AddPod failed: %v", err)
 			}
-		}
-	}
-	return cache
-}
-
-func setupCacheWithAssumedPods(b *testing.B, podNum int, assumedTime time.Time) *cacheImpl {
-	logger, ctx := ktesting.NewTestContext(b)
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-	cache := newCache(ctx, time.Second, time.Second)
-	for i := 0; i < podNum; i++ {
-		nodeName := fmt.Sprintf("node-%d", i/10)
-		objName := fmt.Sprintf("%s-pod-%d", nodeName, i%10)
-		pod := makeBasePod(b, nodeName, objName, "0", "0", "", nil)
-
-		err := assumeAndFinishBinding(logger, cache, pod, assumedTime)
-		if err != nil {
-			b.Fatalf("assumePod failed: %v", err)
 		}
 	}
 	return cache

--- a/pkg/scheduler/internal/cache/fake/fake_cache.go
+++ b/pkg/scheduler/internal/cache/fake/fake_cache.go
@@ -37,9 +37,6 @@ func (c *Cache) AssumePod(logger klog.Logger, pod *v1.Pod) error {
 	return nil
 }
 
-// FinishBinding is a fake method for testing.
-func (c *Cache) FinishBinding(logger klog.Logger, pod *v1.Pod) error { return nil }
-
 // ForgetPod is a fake method for testing.
 func (c *Cache) ForgetPod(logger klog.Logger, pod *v1.Pod) error {
 	c.ForgetFunc(pod)

--- a/pkg/scheduler/internal/cache/interface.go
+++ b/pkg/scheduler/internal/cache/interface.go
@@ -71,9 +71,6 @@ type Cache interface {
 	// After expiration, its information would be subtracted.
 	AssumePod(logger klog.Logger, pod *v1.Pod) error
 
-	// FinishBinding signals that cache for assumed pod can be expired
-	FinishBinding(logger klog.Logger, pod *v1.Pod) error
-
 	// ForgetPod removes an assumed pod from cache.
 	ForgetPod(logger klog.Logger, pod *v1.Pod) error
 

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -50,12 +50,6 @@ import (
 	"k8s.io/kubernetes/pkg/scheduler/profile"
 )
 
-const (
-	// Duration the scheduler will wait before expiring an assumed pod.
-	// See issue #106361 for more details about this parameter and its value.
-	durationToExpireAssumedPod time.Duration = 0
-)
-
 // ErrNoNodesAvailable is used to describe the error that no nodes available to schedule pods.
 var ErrNoNodesAvailable = fmt.Errorf("no nodes available to schedule pods")
 
@@ -338,7 +332,7 @@ func New(ctx context.Context,
 		fwk.SetPodNominator(podQueue)
 	}
 
-	schedulerCache := internalcache.New(ctx, durationToExpireAssumedPod)
+	schedulerCache := internalcache.New(ctx)
 
 	// Setup cache debugger.
 	debugger := cachedebugger.New(nodeLister, podLister, schedulerCache, podQueue)

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -281,7 +281,7 @@ func TestFailureHandler(t *testing.T) {
 			podInformer.Informer().GetStore().Add(testPod)
 
 			queue := internalqueue.NewPriorityQueue(nil, informerFactory, internalqueue.WithClock(testingclock.NewFakeClock(time.Now())))
-			schedulerCache := internalcache.New(ctx, 30*time.Second)
+			schedulerCache := internalcache.New(ctx)
 
 			if err := queue.Add(logger, testPod); err != nil {
 				t.Fatalf("Add failed: %v", err)
@@ -341,7 +341,7 @@ func TestFailureHandler_PodAlreadyBound(t *testing.T) {
 	podInformer.Informer().GetStore().Add(testPod)
 
 	queue := internalqueue.NewPriorityQueue(nil, informerFactory, internalqueue.WithClock(testingclock.NewFakeClock(time.Now())))
-	schedulerCache := internalcache.New(ctx, 30*time.Second)
+	schedulerCache := internalcache.New(ctx)
 
 	// Add node to schedulerCache no matter it's deleted in API server or not.
 	schedulerCache.AddNode(logger, &nodeFoo)


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
since we set `durationToExpireAssumedPod` to 0, it no longer cleans up expired assumed pods, and has been running stably for many versions, so we can completely remove the cleanup expire assumed pod behavior.
#106361

#### Special notes for your reviewer:
@alculquicondor  @sanposhiho @Huang-Wei 

