### PR TITLE
Improve PVC protection controller's scalability by batch-processing PVCs by namespace & caching live pod list results

### DIFF
--- a/pkg/controller/volume/pvcprotection/pvc_protection_controller_test.go
+++ b/pkg/controller/volume/pvcprotection/pvc_protection_controller_test.go
@@ -47,6 +47,7 @@ type reaction struct {
 
 const (
 	defaultNS       = "default"
+	namespace2      = "namespace-2"
 	defaultPVCName  = "pvc1"
 	defaultPodName  = "pod1"
 	defaultNodeName = "node1"
@@ -58,6 +59,22 @@ func pod() *v1.Pod {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      defaultPodName,
 			Namespace: defaultNS,
+			UID:       defaultUID,
+		},
+		Spec: v1.PodSpec{
+			NodeName: defaultNodeName,
+		},
+		Status: v1.PodStatus{
+			Phase: v1.PodPending,
+		},
+	}
+}
+
+func podWithConfig(name string, namespace string) *v1.Pod {
+	return &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
 			UID:       defaultUID,
 		},
 		Spec: v1.PodSpec{
@@ -117,6 +134,15 @@ func pvc() *v1.PersistentVolumeClaim {
 	}
 }
 
+func pvcWithConfig(name string, namespace string) *v1.PersistentVolumeClaim {
+	return &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+}
+
 func withProtectionFinalizer(pvc *v1.PersistentVolumeClaim) *v1.PersistentVolumeClaim {
 	pvc.Finalizers = append(pvc.Finalizers, volumeutil.PVCProtectionFinalizer)
 	return pvc
@@ -142,6 +168,23 @@ func generateUpdateErrorFunc(t *testing.T, failures int) clienttesting.ReactionF
 			return true, nil, apierrors.NewForbidden(update.GetResource().GroupResource(), acc.GetName(), errors.New("Mock error"))
 		}
 		// Update succeeds
+		return false, nil, nil
+	}
+}
+
+func generatePodListErrorFunc(t *testing.T, failures int) clienttesting.ReactionFunc {
+	i := 0
+	return func(action clienttesting.Action) (bool, runtime.Object, error) {
+		i++
+		if i <= failures {
+			// Pod List fails
+			list, ok := action.(clienttesting.ListAction)
+			if !ok {
+				t.Fatalf("Reactor got non-list action: %+v", action)
+			}
+			return true, nil, apierrors.NewForbidden(list.GetResource().GroupResource(), "mock pod", errors.New("Mock error"))
+		}
+		// List succeeds
 		return false, nil, nil
 	}
 }
@@ -175,7 +218,7 @@ func TestPVCProtectionController(t *testing.T) {
 		reactors []reaction
 		// PVC event to simulate. This PVC will be automatically added to
 		// initialObjects.
-		updatedPVC *v1.PersistentVolumeClaim
+		updatedPVCs []*v1.PersistentVolumeClaim
 		// Pod event to simulate. This Pod will be automatically added to
 		// initialObjects.
 		updatedPod *v1.Pod
@@ -190,20 +233,21 @@ func TestPVCProtectionController(t *testing.T) {
 		// PVC events
 		//
 		{
-			name:       "PVC without finalizer -> finalizer is added",
-			updatedPVC: pvc(),
+			name:        "PVC without finalizer -> finalizer is added",
+			updatedPVCs: []*v1.PersistentVolumeClaim{pvc(), pvcWithConfig("pvc2", "namespace-2")},
 			expectedActions: []clienttesting.Action{
 				clienttesting.NewUpdateAction(pvcGVR, defaultNS, withProtectionFinalizer(pvc())),
+				clienttesting.NewUpdateAction(pvcGVR, "namespace-2", withProtectionFinalizer(pvcWithConfig("pvc2", "namespace-2"))),
 			},
 		},
 		{
 			name:            "PVC with finalizer -> no action",
-			updatedPVC:      withProtectionFinalizer(pvc()),
+			updatedPVCs:     []*v1.PersistentVolumeClaim{withProtectionFinalizer(pvc()), withProtectionFinalizer(pvcWithConfig("pvc2", "namespace-2"))},
 			expectedActions: []clienttesting.Action{},
 		},
 		{
-			name:       "saving PVC finalizer fails -> controller retries",
-			updatedPVC: pvc(),
+			name:        "saving PVC finalizer fails -> controller retries",
+			updatedPVCs: []*v1.PersistentVolumeClaim{pvc()},
 			reactors: []reaction{
 				{
 					verb:      "update",
@@ -221,16 +265,29 @@ func TestPVCProtectionController(t *testing.T) {
 			},
 		},
 		{
-			name:       "deleted PVC with finalizer -> finalizer is removed",
-			updatedPVC: deleted(withProtectionFinalizer(pvc())),
+			name: "deleted PVC with finalizers across different namespaces -> finalizer is removed",
+			updatedPVCs: []*v1.PersistentVolumeClaim{deleted(withProtectionFinalizer(pvc())),
+				deleted(withProtectionFinalizer(pvcWithConfig("pvc2", "namespace-2")))},
 			expectedActions: []clienttesting.Action{
 				clienttesting.NewListAction(podGVR, podGVK, defaultNS, metav1.ListOptions{}),
 				clienttesting.NewUpdateAction(pvcGVR, defaultNS, deleted(pvc())),
+				clienttesting.NewListAction(podGVR, podGVK, "namespace-2", metav1.ListOptions{}),
+				clienttesting.NewUpdateAction(pvcGVR, "namespace-2", deleted(pvcWithConfig("pvc2", "namespace-2"))),
 			},
 		},
 		{
-			name:       "finalizer removal fails -> controller retries",
-			updatedPVC: deleted(withProtectionFinalizer(pvc())),
+			name: "multiple PVCs with finalizer for the same namespace; no alive pods -> finalizer is removed and only one API pod list is made",
+			updatedPVCs: []*v1.PersistentVolumeClaim{deleted(withProtectionFinalizer(pvc())),
+				deleted(withProtectionFinalizer(pvcWithConfig("pvc2", defaultNS)))},
+			expectedActions: []clienttesting.Action{
+				clienttesting.NewListAction(podGVR, podGVK, defaultNS, metav1.ListOptions{}),
+				clienttesting.NewUpdateAction(pvcGVR, defaultNS, deleted(pvc())),
+				clienttesting.NewUpdateAction(pvcGVR, defaultNS, deleted(pvcWithConfig("pvc2", defaultNS))),
+			},
+		},
+		{
+			name:        "finalizer removal fails -> controller retries",
+			updatedPVCs: []*v1.PersistentVolumeClaim{deleted(withProtectionFinalizer(pvc()))},
 			reactors: []reaction{
 				{
 					verb:      "update",
@@ -251,11 +308,32 @@ func TestPVCProtectionController(t *testing.T) {
 			},
 		},
 		{
+			name:        "delete multiple PVCs of the same namespace; pod list fails for one PVC -> add failing PVC back to queue and continue to the next PVC",
+			updatedPVCs: []*v1.PersistentVolumeClaim{deleted(withProtectionFinalizer(pvc())), deleted(withProtectionFinalizer(pvcWithConfig("pvc2", defaultNS)))},
+			reactors: []reaction{
+				{
+					verb:      "list",
+					resource:  "pods",
+					reactorfn: generatePodListErrorFunc(t, 1 /* update fails twice*/),
+				},
+			},
+			expectedActions: []clienttesting.Action{
+				// Fails
+				clienttesting.NewListAction(podGVR, podGVK, defaultNS, metav1.ListOptions{}),
+				// Succeed with next pvc in queue
+				clienttesting.NewListAction(podGVR, podGVK, defaultNS, metav1.ListOptions{}),
+				clienttesting.NewUpdateAction(pvcGVR, defaultNS, deleted(pvcWithConfig("pvc2", defaultNS))),
+
+				clienttesting.NewListAction(podGVR, podGVK, defaultNS, metav1.ListOptions{}),
+				clienttesting.NewUpdateAction(pvcGVR, defaultNS, deleted(pvc())),
+			},
+		},
+		{
 			name: "deleted PVC with finalizer + pod with the PVC exists -> finalizer is not removed",
 			initialObjects: []runtime.Object{
 				withPVC(defaultPVCName, pod()),
 			},
-			updatedPVC:      deleted(withProtectionFinalizer(pvc())),
+			updatedPVCs:     []*v1.PersistentVolumeClaim{deleted(withProtectionFinalizer(pvc()))},
 			expectedActions: []clienttesting.Action{},
 		},
 		{
@@ -263,10 +341,26 @@ func TestPVCProtectionController(t *testing.T) {
 			initialObjects: []runtime.Object{
 				withEmptyDir(withPVC("unrelatedPVC", pod())),
 			},
-			updatedPVC: deleted(withProtectionFinalizer(pvc())),
+			updatedPVCs: []*v1.PersistentVolumeClaim{deleted(withProtectionFinalizer(pvc()))},
 			expectedActions: []clienttesting.Action{
 				clienttesting.NewListAction(podGVR, podGVK, defaultNS, metav1.ListOptions{}),
 				clienttesting.NewUpdateAction(pvcGVR, defaultNS, deleted(pvc())),
+			},
+		},
+		{
+			name: "deleted multiple PVCs with finalizer (same namespace) + pod with unrelated PVC and EmptyDir exists -> only one live pod list & finalizers are removed",
+			initialObjects: []runtime.Object{
+				withEmptyDir(withPVC("unrelatedPVC", pod())),
+			},
+			updatedPVCs: []*v1.PersistentVolumeClaim{deleted(withProtectionFinalizer(pvc())),
+				deleted(withProtectionFinalizer(pvcWithConfig("pvc2", defaultNS))),
+				deleted(withProtectionFinalizer(pvcWithConfig("pvc3", defaultNS))),
+			},
+			expectedActions: []clienttesting.Action{
+				clienttesting.NewListAction(podGVR, podGVK, defaultNS, metav1.ListOptions{}),
+				clienttesting.NewUpdateAction(pvcGVR, defaultNS, deleted(pvc())),
+				clienttesting.NewUpdateAction(pvcGVR, defaultNS, deleted(pvcWithConfig("pvc2", defaultNS))),
+				clienttesting.NewUpdateAction(pvcGVR, defaultNS, deleted(pvcWithConfig("pvc3", defaultNS))),
 			},
 		},
 		{
@@ -274,7 +368,7 @@ func TestPVCProtectionController(t *testing.T) {
 			initialObjects: []runtime.Object{
 				withStatus(v1.PodFailed, withPVC(defaultPVCName, pod())),
 			},
-			updatedPVC:      deleted(withProtectionFinalizer(pvc())),
+			updatedPVCs:     []*v1.PersistentVolumeClaim{deleted(withProtectionFinalizer(pvc()))},
 			expectedActions: []clienttesting.Action{},
 		},
 		{
@@ -283,9 +377,24 @@ func TestPVCProtectionController(t *testing.T) {
 				withPVC(defaultPVCName, pod()),
 			},
 			informersAreLate: true,
-			updatedPVC:       deleted(withProtectionFinalizer(pvc())),
+			updatedPVCs:      []*v1.PersistentVolumeClaim{deleted(withProtectionFinalizer(pvc()))},
 			expectedActions: []clienttesting.Action{
 				clienttesting.NewListAction(podGVR, podGVK, defaultNS, metav1.ListOptions{}),
+			},
+		},
+
+		{
+			name: "mix of deleted PVCs with some used by a pod and some unused -> finalizer is removed only for unused PVCs",
+			initialObjects: []runtime.Object{
+				withPVC(defaultPVCName, pod()),
+				withPVC("pvc3", podWithConfig("pod2", "namespace-3")),
+			},
+			informersAreLate: true,
+			updatedPVCs:      []*v1.PersistentVolumeClaim{deleted(withProtectionFinalizer(pvc())), deleted(withProtectionFinalizer(pvcWithConfig("pvc2", defaultNS))), deleted(withProtectionFinalizer(pvcWithConfig("pvc3", "namespace-3")))},
+			expectedActions: []clienttesting.Action{
+				clienttesting.NewListAction(podGVR, podGVK, defaultNS, metav1.ListOptions{}),
+				clienttesting.NewUpdateAction(pvcGVR, defaultNS, deleted(pvcWithConfig("pvc2", defaultNS))),
+				clienttesting.NewListAction(podGVR, podGVK, "namespace-3", metav1.ListOptions{}),
 			},
 		},
 		//
@@ -376,9 +485,11 @@ func TestPVCProtectionController(t *testing.T) {
 			clientObjs    []runtime.Object
 			informersObjs []runtime.Object
 		)
-		if test.updatedPVC != nil {
-			clientObjs = append(clientObjs, test.updatedPVC)
-			informersObjs = append(informersObjs, test.updatedPVC)
+		if test.updatedPVCs != nil {
+			for i := 0; i < len(test.updatedPVCs); i++ {
+				clientObjs = append(clientObjs, test.updatedPVCs[i])
+				informersObjs = append(informersObjs, test.updatedPVCs[i])
+			}
 		}
 		if test.updatedPod != nil {
 			clientObjs = append(clientObjs, test.updatedPod)
@@ -388,7 +499,6 @@ func TestPVCProtectionController(t *testing.T) {
 		if !test.informersAreLate {
 			informersObjs = append(informersObjs, test.initialObjects...)
 		}
-
 		// Create client with initial data
 		client := fake.NewSimpleClientset(clientObjs...)
 
@@ -423,8 +533,10 @@ func TestPVCProtectionController(t *testing.T) {
 		}
 
 		// Start the test by simulating an event
-		if test.updatedPVC != nil {
-			ctrl.pvcAddedUpdated(logger, test.updatedPVC)
+		if test.updatedPVCs != nil {
+			for i := 0; i < len(test.updatedPVCs); i++ {
+				ctrl.pvcAddedUpdated(logger, test.updatedPVCs[i])
+			}
 		}
 		switch {
 		case test.deletedPod != nil && test.updatedPod != nil && test.deletedPod.Namespace == test.updatedPod.Namespace && test.deletedPod.Name == test.updatedPod.Name:
@@ -445,12 +557,18 @@ func TestPVCProtectionController(t *testing.T) {
 			}
 			if ctrl.queue.Len() > 0 {
 				logger.V(5).Info("Non-empty queue, processing one", "test", test.name, "queueLength", ctrl.queue.Len())
-				ctrl.processNextWorkItem(context.TODO())
+				ctx := context.TODO()
+				ctrl.processNextWorkItem()
+				for ctrl.pvcProcessingStore.namespaceQueue.Len() != 0 {
+					ctrl.processPVCsByNamespace(ctx)
+				}
 			}
+
 			if ctrl.queue.Len() > 0 {
 				// There is still some work in the queue, process it now
 				continue
 			}
+
 			currentActionCount := len(client.Actions())
 			if currentActionCount < len(test.expectedActions) {
 				// Do not log every wait, only when the action count changes.

--- a/test/e2e/storage/testsuites/base.go
+++ b/test/e2e/storage/testsuites/base.go
@@ -81,6 +81,7 @@ var CSISuites = append(BaseSuites,
 	InitSnapshottableTestSuite,
 	InitSnapshottableStressTestSuite,
 	InitVolumePerformanceTestSuite,
+	InitPvcDeletionPerformanceTestSuite,
 	InitReadWriteOncePodTestSuite,
 	InitVolumeModifyTestSuite,
 )

--- a/test/e2e/storage/testsuites/pvcdeletionperf.go
+++ b/test/e2e/storage/testsuites/pvcdeletionperf.go
@@ -1,0 +1,248 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testsuites
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+
+	v1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/e2e/framework"
+	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
+	e2epv "k8s.io/kubernetes/test/e2e/framework/pv"
+	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
+	storageframework "k8s.io/kubernetes/test/e2e/storage/framework"
+	admissionapi "k8s.io/pod-security-admission/api"
+)
+
+type pvcDeletionPerformanceTestSuite struct {
+	tsInfo storageframework.TestSuiteInfo
+}
+
+var _ storageframework.TestSuite = &pvcDeletionPerformanceTestSuite{}
+
+const pvcDeletionTestTimeout = 30 * time.Minute
+
+// InitPvcDeletionPerformanceTestSuite returns pvcDeletionPerformanceTestSuite that implements TestSuite interface
+// This test suite brings up a number of pods and PVCS (configured upstream), deletes the pods, and then deletes the PVCs.
+// The main goal is to record the duration for the PVC/PV deletion process for each run, and so the test doesn't set explicit expectations to match against.
+func InitPvcDeletionPerformanceTestSuite() storageframework.TestSuite {
+	return &pvcDeletionPerformanceTestSuite{
+		tsInfo: storageframework.TestSuiteInfo{
+			Name: "pvc-deletion-performance",
+			TestPatterns: []storageframework.TestPattern{
+				storageframework.BlockVolModeDynamicPV,
+			},
+		},
+	}
+}
+
+func (t *pvcDeletionPerformanceTestSuite) GetTestSuiteInfo() storageframework.TestSuiteInfo {
+	return t.tsInfo
+}
+
+func (t *pvcDeletionPerformanceTestSuite) SkipUnsupportedTests(driver storageframework.TestDriver, pattern storageframework.TestPattern) {
+}
+
+func (t *pvcDeletionPerformanceTestSuite) DefineTests(driver storageframework.TestDriver, pattern storageframework.TestPattern) {
+	type local struct {
+		config  *storageframework.PerTestConfig
+		cs      clientset.Interface
+		ns      *v1.Namespace
+		scName  string
+		pvcs    []*v1.PersistentVolumeClaim
+		options *storageframework.PerformanceTestOptions
+		stopCh  chan struct{}
+		pods    []*v1.Pod
+	}
+	var (
+		dInfo *storageframework.DriverInfo
+		l     *local
+	)
+	ginkgo.BeforeEach(func() {
+		// Check preconditions
+		dDriver := driver.(storageframework.DynamicPVTestDriver)
+		if dDriver == nil {
+			e2eskipper.Skipf("Test driver does not support dynamically created volumes")
+		}
+		dInfo = dDriver.GetDriverInfo()
+		if dInfo == nil {
+			e2eskipper.Skipf("Failed to get Driver info -- skipping")
+		}
+		if dInfo.PerformanceTestOptions == nil || dInfo.PerformanceTestOptions.ProvisioningOptions == nil {
+			e2eskipper.Skipf("Driver %s doesn't specify performance test options -- skipping", dInfo.Name)
+		}
+	})
+
+	// Set high QPS for the framework to avoid client-side throttling from the test itself,
+	// which can interfere with measuring deletion time
+	frameworkOptions := framework.Options{
+		ClientQPS:   500,
+		ClientBurst: 1000,
+	}
+	f := framework.NewFramework("pvc-deletion-performance", frameworkOptions, nil)
+	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
+
+	ginkgo.AfterEach(func(ctx context.Context) {
+		if l != nil {
+			if l.stopCh != nil {
+				ginkgo.By("Closing informer channel")
+				close(l.stopCh)
+			}
+			deletingStats := &performanceStats{
+				mutex:             &sync.Mutex{},
+				perObjectInterval: make(map[string]*interval),
+				operationMetrics:  &storageframework.Metrics{},
+			}
+			var (
+				errs []error
+				mu   sync.Mutex
+				wg   sync.WaitGroup
+			)
+
+			wg.Add(len(l.pods))
+			for _, pod := range l.pods {
+				go func(pod *v1.Pod) {
+					defer ginkgo.GinkgoRecover()
+					defer wg.Done()
+
+					framework.Logf("Deleting pod %v", pod.Name)
+					err := e2epod.DeletePodWithWait(ctx, l.cs, pod)
+					mu.Lock()
+					defer mu.Unlock()
+					errs = append(errs, err)
+				}(pod)
+			}
+			wg.Wait()
+
+			ginkgo.By("Deleting all PVCs")
+
+			startTime := time.Now()
+			wg.Add(len(l.pvcs))
+			for _, pvc := range l.pvcs {
+				go func(pvc *v1.PersistentVolumeClaim) { // Start a goroutine for each PVC
+					defer wg.Done() // Decrement the counter when the goroutine finishes
+					startDeletingPvcTime := time.Now()
+					framework.Logf("Start deleting PVC %v", pvc.GetName())
+					deletingStats.mutex.Lock()
+					deletingStats.perObjectInterval[pvc.Name] = &interval{
+						create: startDeletingPvcTime,
+					}
+					deletingStats.mutex.Unlock()
+					err := e2epv.DeletePersistentVolumeClaim(ctx, l.cs, pvc.Name, pvc.Namespace)
+					framework.ExpectNoError(err)
+					startDeletingPVTime := time.Now()
+					err = e2epv.WaitForPersistentVolumeDeleted(ctx, l.cs, pvc.Spec.VolumeName, 1*time.Second, 100*time.Minute)
+					framework.Logf("Deleted PV %v, PVC %v in %v", pvc.Spec.VolumeName, pvc.GetName(), time.Since(startDeletingPVTime))
+					framework.ExpectNoError(err)
+				}(pvc)
+			}
+			wg.Wait()
+
+			endTime := time.Now() // Capture overall end time
+			totalDuration := endTime.Sub(startTime)
+			framework.Logf("Deleted all PVC/PVs in %v", totalDuration) // Log total deletion time
+
+			ginkgo.By(fmt.Sprintf("Deleting Storage Class %s", l.scName))
+			err := l.cs.StorageV1().StorageClasses().Delete(ctx, l.scName, metav1.DeleteOptions{})
+			framework.ExpectNoError(err)
+
+		} else {
+			ginkgo.By("Local l setup is nil")
+		}
+	})
+
+	f.It("should delete volumes at scale within performance constraints", f.WithSlow(), f.WithSerial(), func(ctx context.Context) {
+		l = &local{
+			cs:      f.ClientSet,
+			ns:      f.Namespace,
+			options: dInfo.PerformanceTestOptions,
+		}
+		l.config = driver.PrepareTest(ctx, f)
+
+		sc := driver.(storageframework.DynamicPVTestDriver).GetDynamicProvisionStorageClass(ctx, l.config, pattern.FsType)
+		ginkgo.By(fmt.Sprintf("Creating Storage Class %v", sc))
+		if sc.VolumeBindingMode != nil && *sc.VolumeBindingMode == storagev1.VolumeBindingWaitForFirstConsumer {
+			e2eskipper.Skipf("WaitForFirstConsumer binding mode currently not supported for this test")
+		}
+		ginkgo.By(fmt.Sprintf("Creating Storage Class %s", sc.Name))
+		sc, err := l.cs.StorageV1().StorageClasses().Create(ctx, sc, metav1.CreateOptions{})
+		framework.ExpectNoError(err)
+		l.scName = sc.Name
+
+		// Stats for volume provisioning operation; we only need this because imported function newPVCWatch from volumeperf.go requires this as an argument
+		// (this test itself doesn't use these stats)
+		provisioningStats := &performanceStats{
+			mutex:             &sync.Mutex{},
+			perObjectInterval: make(map[string]*interval),
+			operationMetrics:  &storageframework.Metrics{},
+		}
+		// Create a controller to watch on PVCs
+		// When all PVCs provisioned by this test are in the Bound state, the controller
+		// sends a signal to the channel
+		controller := newPVCWatch(ctx, f, l.options.ProvisioningOptions.Count, provisioningStats)
+		l.stopCh = make(chan struct{})
+		go controller.Run(l.stopCh)
+		waitForProvisionCh = make(chan []*v1.PersistentVolumeClaim)
+
+		ginkgo.By(fmt.Sprintf("Creating %d PVCs of size %s", l.options.ProvisioningOptions.Count, l.options.ProvisioningOptions.VolumeSize))
+		for i := 0; i < l.options.ProvisioningOptions.Count; i++ {
+			pvc := e2epv.MakePersistentVolumeClaim(e2epv.PersistentVolumeClaimConfig{
+				ClaimSize:        l.options.ProvisioningOptions.VolumeSize,
+				StorageClassName: &sc.Name,
+			}, l.ns.Name)
+			pvc, err = l.cs.CoreV1().PersistentVolumeClaims(l.ns.Name).Create(ctx, pvc, metav1.CreateOptions{})
+			framework.ExpectNoError(err)
+			// Store create time for each PVC
+			provisioningStats.mutex.Lock()
+			provisioningStats.perObjectInterval[pvc.Name] = &interval{
+				create: pvc.CreationTimestamp.Time,
+			}
+			provisioningStats.mutex.Unlock()
+			// Create pods
+			podConfig := e2epod.Config{
+				NS:           l.ns.Name,
+				SeLinuxLabel: e2epv.SELinuxLabel,
+			}
+			pod, _ := e2epod.MakeSecPod(&podConfig)
+			_, err = l.cs.CoreV1().Pods(pod.Namespace).Create(ctx, pod, metav1.CreateOptions{})
+			if err != nil {
+				framework.Failf("Failed to create pod [%+v]. Error: %v", pod, err)
+			}
+			framework.ExpectNoError(err)
+
+			l.pods = append(l.pods, pod)
+		}
+
+		ginkgo.By("Waiting for all PVCs to be Bound...")
+
+		select {
+		case l.pvcs = <-waitForProvisionCh:
+			framework.Logf("All PVCs in Bound state")
+		case <-time.After(pvcDeletionTestTimeout):
+			ginkgo.Fail(fmt.Sprintf("expected all PVCs to be in Bound state within %v", pvcDeletionTestTimeout.Round(time.Second)))
+		}
+	})
+
+}


### PR DESCRIPTION
#### What type of PR is this?
Add one of the following kinds:
/kind bug

#### What this PR does / why we need it:
Currently, PVC protection controller does a live list of all pods in the namespace every time a PVC is deleted (if pod informer says no pods are using the PVC) as a final check, as informer's cached data can be stale. This can be a scalability issue when we have a large number of pods/PVCs being created and deleted.
We want to improve the scalability of PVC Protection Controller by reducing the number of API calls made to list live pods. Based on previous discussions, we can achieve this by batch-processing PVCs and caching live pod list API call results by namespace.

After implementing this change, we conducted some e2e testing and saw a significant reduction in the number of API calls and latency gain. The tests bring up an X number of independent pods and PVCs (using CSI hostpath driver with immediate binding mode), wait for PVCs to become bound, and then delete all the pods for PVCs. The QPS/burst setting used for kube-controller-manager cross all the tests is 100/100 (GKE's value for "big" clusters with larger workloads ). Here's a summary of our most significant test results:

<meta charset="utf-8"><b style="font-weight:normal;" id="docs-internal-guid-ed3e5c60-7fff-94ac-6d22-ce2fa96c87a0"><div dir="ltr" style="margin-left:-7.5pt;" align="left">
Number of Pods/PVCs | PVC Protection Controller Change | External Provisioner QPS/burst | Latency
-- | -- | -- | --
10k | no | 30/60 | >120m (~expected based on 4k deletions after 75m)
10k | yes | 30/60 | 22m
1k | no | 5/10 (default) | 18m46s
1k | no | 30/60 | 18m
1k | yes | 5/10 (default) | 13m34s
1k | yes | 30/60 | 2m30s-3m40s
1k | yes | 30/60 | 5m42s

</div><br /></b>
Note: During testing, we found that the external-provisioner's QPS/burst rate (default=5/10) is another source of latency in the PVC/PV deletion workflow (the external-provisioner is in charge of making API DELETE requests for "Released" PVs). For most of the test results referenced here, we set 30/60 as the qps/burst for external-provisioner and kept it consistent to single out the effect of the PVC Protection Controller change.

As observed from the table above, we get a significant latency gain with this change for PVC Protection Controller. The number of API calls observed were also consistently < 10 for either 1k or 10ks PVCs, which is a significant reduction from the current "1 API call per PVC" mechanism.

#### Which issue(s) this PR fixes:
Fixes #109282

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Improve PVC Protection Controller's scalability by batch-processing PVCs by namespace with lazy live pod listing.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
Steps to run the referenced tests for reference:
1. [Set up kubetest](https://github.com/kubernetes/test-infra/blob/master/kubetest/README.md)
2. (Recommended) Set a custom [QPS/burst for kube-controller-manager](https://github.com/kubernetes/kubernetes/blob/fc3abdaf2dbb11c84033635b1d26f12fe12ef001/cmd/kube-controller-manager/app/options/options.go#L456) to be 100/100 (referenced from GKE's value for "big" clusters/larger workloads)
3. (Recommended) Set a custom [QPS/burst value for external-provisioner](https://github.com/kubernetes/kubernetes/blob/fa15f12fb509875a8466242d8f5fe643217ec502/test/e2e/storage/drivers/csi.go#L274). Example:	
```
patches = append(patches, utils.PatchCSIOptions{
		DriverContainerName:      "csi-provisioner",
		DriverContainerArguments: []string{"--kube-api-qps=100", "--kube-api-burst=100"},
})
```
4. Set the [number of PVCs to be provisioned for the test](https://github.com/kubernetes/kubernetes/blob/fa15f12fb509875a8466242d8f5fe643217ec502/test/e2e/storage/drivers/csi.go#L126)
5. Build a kubetest cluster: kubetest --build && NUM_NODES=X kubetest --up (X=10 for 1k PVC test, X=100 for 10k PVC test) (we have a max limit of 128 disks per nodes)
6. Run the test with ginkgo.focus and ginkgo.v for full logging (recommended to store the output in a separate file)
Example: ./hack/ginkgo-e2e.sh --ginkgo.focus="pvc-deletion-performance" --ginkgo.v > output_logs.txt
7. Find the deleting time: grep "Deleted all" output_logs.txt
