### PR TITLE
[WIP] kube-proxy: reuse node informer to improve efficiency

### DIFF
--- a/cmd/kube-proxy/app/server.go
+++ b/cmd/kube-proxy/app/server.go
@@ -44,8 +44,11 @@ import (
 	"k8s.io/apiserver/pkg/server/routes"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/informers"
+	v1informers "k8s.io/client-go/informers/core/v1"
 	clientset "k8s.io/client-go/kubernetes"
+	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/client-go/tools/events"
@@ -163,7 +166,8 @@ type ProxyServer struct {
 	PrimaryIPFamily v1.IPFamily
 	NodeIPs         map[v1.IPFamily]net.IP
 
-	podCIDRs []string // only used for LocalModeNodeCIDR
+	podCIDRs     []string // only used for LocalModeNodeCIDR
+	nodeInformer v1informers.NodeInformer
 
 	Proxier proxy.Provider
 }
@@ -196,7 +200,24 @@ func newProxyServer(ctx context.Context, cfg *kubeproxyconfig.KubeProxyConfigura
 		return nil, err
 	}
 
-	rawNodeIPs := getNodeIPs(ctx, s.Client, s.Hostname)
+	// Make an informer that selects for our nodename.
+	currentNodeInformerFactory := informers.NewSharedInformerFactoryWithOptions(s.Client, s.Config.ConfigSyncPeriod.Duration,
+		informers.WithTweakListOptions(func(options *metav1.ListOptions) {
+			options.FieldSelector = fields.OneTermEqualSelector("metadata.name", s.Hostname).String()
+		}))
+	s.nodeInformer = currentNodeInformerFactory.Core().V1().Nodes()
+	nodeLister := s.nodeInformer.Lister()
+	nodeInformerHasSynced := s.nodeInformer.Informer().HasSynced
+
+	// This has to start after the calls to NewNodeConfig because that must
+	// configure the shared informer event handler first.
+	currentNodeInformerFactory.Start(wait.NeverStop)
+
+	if !cache.WaitForNamedCacheSync("node informer cache", ctx.Done(), nodeInformerHasSynced) {
+		return nil, fmt.Errorf("can not sync node informer")
+	}
+
+	rawNodeIPs := getNodeIPs(ctx, nodeLister, s.Hostname)
 	s.PrimaryIPFamily, s.NodeIPs = detectNodeIPs(ctx, rawNodeIPs, cfg.BindAddress)
 
 	if len(cfg.NodePortAddresses) == 1 && cfg.NodePortAddresses[0] == kubeproxyconfig.NodePortAddressesPrimary {
@@ -561,12 +582,7 @@ func (s *ProxyServer) Run(ctx context.Context) error {
 	informerFactory.Start(wait.NeverStop)
 	serviceInformerFactory.Start(wait.NeverStop)
 
-	// Make an informer that selects for our nodename.
-	currentNodeInformerFactory := informers.NewSharedInformerFactoryWithOptions(s.Client, s.Config.ConfigSyncPeriod.Duration,
-		informers.WithTweakListOptions(func(options *metav1.ListOptions) {
-			options.FieldSelector = fields.OneTermEqualSelector("metadata.name", s.NodeRef.Name).String()
-		}))
-	nodeConfig := config.NewNodeConfig(ctx, currentNodeInformerFactory.Core().V1().Nodes(), s.Config.ConfigSyncPeriod.Duration)
+	nodeConfig := config.NewNodeConfig(ctx, s.nodeInformer, s.Config.ConfigSyncPeriod.Duration)
 	// https://issues.k8s.io/111321
 	if s.Config.DetectLocalMode == kubeproxyconfig.LocalModeNodeCIDR {
 		nodeConfig.RegisterEventHandler(proxy.NewNodePodCIDRHandler(ctx, s.podCIDRs))
@@ -579,10 +595,6 @@ func (s *ProxyServer) Run(ctx context.Context) error {
 	nodeConfig.RegisterEventHandler(s.Proxier)
 
 	go nodeConfig.Run(wait.NeverStop)
-
-	// This has to start after the calls to NewNodeConfig because that must
-	// configure the shared informer event handler first.
-	currentNodeInformerFactory.Start(wait.NeverStop)
 
 	// Birth Cry after the birth is successful
 	s.birthCry()
@@ -657,20 +669,19 @@ func detectNodeIPs(ctx context.Context, rawNodeIPs []net.IP, bindAddress string)
 
 // getNodeIP returns IPs for the node with the provided name.  If
 // required, it will wait for the node to be created.
-func getNodeIPs(ctx context.Context, client clientset.Interface, name string) []net.IP {
+func getNodeIPs(ctx context.Context, nodeLister corelisters.NodeLister, name string) []net.IP {
 	logger := klog.FromContext(ctx)
 	var nodeIPs []net.IP
-	backoff := wait.Backoff{
-		Steps:    6,
-		Duration: 1 * time.Second,
-		Factor:   2.0,
-		Jitter:   0.2,
-	}
 
-	err := wait.ExponentialBackoff(backoff, func() (bool, error) {
-		node, err := client.CoreV1().Nodes().Get(ctx, name, metav1.GetOptions{})
+	err := wait.PollUntilContextCancel(ctx, 1*time.Second, true, func(context.Context) (bool, error) {
+		node, err := nodeLister.Get(name)
 		if err != nil {
 			logger.Error(err, "Failed to retrieve node info")
+			return false, nil
+		}
+		// don't consider the node if is going to be deleted and keep waiting
+		if !node.DeletionTimestamp.IsZero() {
+			logger.Info("Node is being deleted", "node", node.Name)
 			return false, nil
 		}
 		nodeIPs, err = utilnode.GetNodeHostIPs(node)
@@ -682,6 +693,8 @@ func getNodeIPs(ctx context.Context, client clientset.Interface, name string) []
 	})
 	if err == nil {
 		logger.Info("Successfully retrieved node IP(s)", "IPs", nodeIPs)
+	} else {
+		logger.Info("Error to retrieve node IP(s)", "error", err)
 	}
 	return nodeIPs
 }

--- a/cmd/kube-proxy/app/server.go
+++ b/cmd/kube-proxy/app/server.go
@@ -209,8 +209,6 @@ func newProxyServer(ctx context.Context, cfg *kubeproxyconfig.KubeProxyConfigura
 	nodeLister := s.nodeInformer.Lister()
 	nodeInformerHasSynced := s.nodeInformer.Informer().HasSynced
 
-	// This has to start after the calls to NewNodeConfig because that must
-	// configure the shared informer event handler first.
 	currentNodeInformerFactory.Start(wait.NeverStop)
 
 	if !cache.WaitForNamedCacheSync("node informer cache", ctx.Done(), nodeInformerHasSynced) {
@@ -577,8 +575,7 @@ func (s *ProxyServer) Run(ctx context.Context) error {
 		serviceCIDRConfig.RegisterEventHandler(s.Proxier)
 		go serviceCIDRConfig.Run(wait.NeverStop)
 	}
-	// This has to start after the calls to NewServiceConfig because that
-	// function must configure its shared informer event handlers first.
+
 	informerFactory.Start(wait.NeverStop)
 	serviceInformerFactory.Start(wait.NeverStop)
 

--- a/cmd/kube-proxy/app/server_linux.go
+++ b/cmd/kube-proxy/app/server_linux.go
@@ -80,7 +80,7 @@ func (s *ProxyServer) platformSetup(ctx context.Context) error {
 	logger := klog.FromContext(ctx)
 	if s.Config.DetectLocalMode == proxyconfigapi.LocalModeNodeCIDR {
 		logger.Info("Watching for node, awaiting podCIDR allocation", "hostname", s.Hostname)
-		node, err := waitForPodCIDR(ctx, s.nodeInformer.Lister(), s.Hostname)
+		node, err := waitForPodCIDR(ctx, s.NodeInformer.Lister(), s.Hostname)
 		if err != nil {
 			return err
 		}

--- a/cmd/kube-proxy/app/server_linux.go
+++ b/cmd/kube-proxy/app/server_linux.go
@@ -32,14 +32,9 @@ import (
 	"github.com/google/cadvisor/utils/sysfs"
 
 	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/fields"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/apimachinery/pkg/util/wait"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
-	clientset "k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/cache"
-	toolswatch "k8s.io/client-go/tools/watch"
+	corelisters "k8s.io/client-go/listers/core/v1"
 	utilsysctl "k8s.io/component-helpers/node/util/sysctl"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/features"
@@ -85,7 +80,7 @@ func (s *ProxyServer) platformSetup(ctx context.Context) error {
 	logger := klog.FromContext(ctx)
 	if s.Config.DetectLocalMode == proxyconfigapi.LocalModeNodeCIDR {
 		logger.Info("Watching for node, awaiting podCIDR allocation", "hostname", s.Hostname)
-		node, err := waitForPodCIDR(ctx, s.Client, s.Hostname)
+		node, err := waitForPodCIDR(ctx, s.nodeInformer.Lister(), s.Hostname)
 		if err != nil {
 			return err
 		}
@@ -415,48 +410,33 @@ func getConntrackMax(ctx context.Context, config proxyconfigapi.KubeProxyConntra
 	return 0, nil
 }
 
-func waitForPodCIDR(ctx context.Context, client clientset.Interface, nodeName string) (*v1.Node, error) {
+func waitForPodCIDR(ctx context.Context, nodeLister corelisters.NodeLister, nodeName string) (*v1.Node, error) {
+	logger := klog.FromContext(ctx)
 	// since allocators can assign the podCIDR after the node registers, we do a watch here to wait
 	// for podCIDR to be assigned, instead of assuming that the Get() on startup will have it.
 	ctx, cancelFunc := context.WithTimeout(ctx, timeoutForNodePodCIDR)
 	defer cancelFunc()
 
-	fieldSelector := fields.OneTermEqualSelector("metadata.name", nodeName).String()
-	lw := &cache.ListWatch{
-		ListFunc: func(options metav1.ListOptions) (object runtime.Object, e error) {
-			options.FieldSelector = fieldSelector
-			return client.CoreV1().Nodes().List(ctx, options)
-		},
-		WatchFunc: func(options metav1.ListOptions) (i watch.Interface, e error) {
-			options.FieldSelector = fieldSelector
-			return client.CoreV1().Nodes().Watch(ctx, options)
-		},
-	}
-	condition := func(event watch.Event) (bool, error) {
-		// don't process delete events
-		if event.Type != watch.Modified && event.Type != watch.Added {
+	var node *v1.Node
+	err := wait.PollUntilContextCancel(ctx, 1*time.Second, true, func(context.Context) (bool, error) {
+		var listerErr error
+		node, listerErr = nodeLister.Get(nodeName)
+		if listerErr != nil {
+			logger.Error(listerErr, "Failed to retrieve node info")
 			return false, nil
 		}
 
-		n, ok := event.Object.(*v1.Node)
-		if !ok {
-			return false, fmt.Errorf("event object not of type Node")
-		}
 		// don't consider the node if is going to be deleted and keep waiting
-		if !n.DeletionTimestamp.IsZero() {
+		if !node.DeletionTimestamp.IsZero() {
+			logger.Info("Node is being deleted", "node", node.Name)
 			return false, nil
 		}
-		return n.Spec.PodCIDR != "" && len(n.Spec.PodCIDRs) > 0, nil
-	}
-
-	evt, err := toolswatch.UntilWithSync(ctx, lw, &v1.Node{}, nil, condition)
+		return node.Spec.PodCIDR != "" && len(node.Spec.PodCIDRs) > 0, nil
+	})
 	if err != nil {
 		return nil, fmt.Errorf("timeout waiting for PodCIDR allocation to configure detect-local-mode %v: %v", proxyconfigapi.LocalModeNodeCIDR, err)
 	}
-	if n, ok := evt.Object.(*v1.Node); ok {
-		return n, nil
-	}
-	return nil, fmt.Errorf("event object not of type node")
+	return node, nil
 }
 
 func detectNumCPU() int {

--- a/cmd/kube-proxy/app/server_linux_test.go
+++ b/cmd/kube-proxy/app/server_linux_test.go
@@ -558,7 +558,10 @@ detectLocalMode: "BridgeInterface"`)
 			}()
 
 			if tc.append {
-				file.WriteString("append fake content")
+				_, err = file.WriteString("append fake content")
+				if err != nil {
+					t.Fatal(err)
+				}
 			}
 
 			select {

--- a/cmd/kube-proxy/app/server_linux_test.go
+++ b/cmd/kube-proxy/app/server_linux_test.go
@@ -728,7 +728,7 @@ func TestProxyServer_platformSetup(t *testing.T) {
 					v1.IPv4Protocol: netutils.ParseIPSloppy("127.0.0.1"),
 					v1.IPv6Protocol: net.IPv6zero,
 				},
-				nodeInformer: nodeInformer,
+				NodeInformer: nodeInformer,
 			}
 
 			err = s.platformSetup(ctx)

--- a/cmd/kube-proxy/app/server_linux_test.go
+++ b/cmd/kube-proxy/app/server_linux_test.go
@@ -34,10 +34,8 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/informers"
 	clientsetfake "k8s.io/client-go/kubernetes/fake"
-	clientgotesting "k8s.io/client-go/testing"
 	proxyconfigapi "k8s.io/kubernetes/pkg/proxy/apis/config"
 	proxyutil "k8s.io/kubernetes/pkg/proxy/util"
 	"k8s.io/kubernetes/test/utils/ktesting"
@@ -444,15 +442,19 @@ func Test_getLocalDetectors(t *testing.T) {
 }
 
 func makeNodeWithPodCIDRs(cidrs ...string) *v1.Node {
-	if len(cidrs) == 0 {
-		return &v1.Node{}
-	}
-	return &v1.Node{
-		Spec: v1.NodeSpec{
-			PodCIDR:  cidrs[0],
-			PodCIDRs: cidrs,
+	node := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "nodeName",
+			ResourceVersion: "1000",
 		},
 	}
+	if len(cidrs) > 0 {
+		node.Spec = v1.NodeSpec{
+			PodCIDR:  cidrs[0],
+			PodCIDRs: cidrs,
+		}
+	}
+	return node
 }
 
 func TestConfigChange(t *testing.T) {
@@ -535,40 +537,42 @@ detectLocalMode: "BridgeInterface"`)
 	}
 
 	for _, tc := range testCases {
-		_, ctx := ktesting.NewTestContext(t)
-		file, tempDir, err := setUp()
-		if err != nil {
-			t.Fatalf("unexpected error when setting up environment: %v", err)
-		}
-
-		opt := NewOptions()
-		opt.ConfigFile = file.Name()
-		err = opt.Complete(new(pflag.FlagSet))
-		if err != nil {
-			t.Fatal(err)
-		}
-		opt.proxyServer = tc.proxyServer
-
-		errCh := make(chan error, 1)
-		go func() {
-			errCh <- opt.runLoop(ctx)
-		}()
-
-		if tc.append {
-			file.WriteString("append fake content")
-		}
-
-		select {
-		case err := <-errCh:
+		t.Run(tc.name, func(t *testing.T) {
+			_, ctx := ktesting.NewTestContext(t)
+			file, tempDir, err := setUp()
 			if err != nil {
-				if !strings.Contains(err.Error(), tc.expectedErr) {
-					t.Errorf("[%s] Expected error containing %v, got %v", tc.name, tc.expectedErr, err)
-				}
+				t.Fatalf("unexpected error when setting up environment: %v", err)
 			}
-		case <-time.After(10 * time.Second):
-			t.Errorf("[%s] Timeout: unable to get any events or internal timeout.", tc.name)
-		}
-		tearDown(file, tempDir)
+
+			opt := NewOptions()
+			opt.ConfigFile = file.Name()
+			err = opt.Complete(new(pflag.FlagSet))
+			if err != nil {
+				t.Fatal(err)
+			}
+			opt.proxyServer = tc.proxyServer
+
+			errCh := make(chan error, 1)
+			go func() {
+				errCh <- opt.runLoop(ctx)
+			}()
+
+			if tc.append {
+				file.WriteString("append fake content")
+			}
+
+			select {
+			case err := <-errCh:
+				if err != nil {
+					if !strings.Contains(err.Error(), tc.expectedErr) {
+						t.Errorf("[%s] Expected error containing %v, got %v", tc.name, tc.expectedErr, err)
+					}
+				}
+			case <-time.After(10 * time.Second):
+				t.Errorf("[%s] Timeout: unable to get any events or internal timeout.", tc.name)
+			}
+			tearDown(file, tempDir)
+		})
 	}
 }
 
@@ -576,10 +580,13 @@ func Test_waitForPodCIDR(t *testing.T) {
 	_, ctx := ktesting.NewTestContext(t)
 	expected := []string{"192.168.0.0/24", "fd00:1:2::/64"}
 	nodeName := "test-node"
+	now := metav1.Now()
+	// oldNode is being deleted and should be skipped
 	oldNode := &v1.Node{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            nodeName,
-			ResourceVersion: "1000",
+			Name:              nodeName,
+			ResourceVersion:   "1000",
+			DeletionTimestamp: &now,
 		},
 		Spec: v1.NodeSpec{
 			PodCIDR:  "10.0.0.0/24",
@@ -591,28 +598,31 @@ func Test_waitForPodCIDR(t *testing.T) {
 			Name:            nodeName,
 			ResourceVersion: "1",
 		},
+		Spec: v1.NodeSpec{
+			PodCIDR:  "192.168.0.0/24",
+			PodCIDRs: []string{"192.168.0.0/24", "fd00:1:2::/64"},
+		},
 	}
-	updatedNode := node.DeepCopy()
-	updatedNode.Spec.PodCIDRs = expected
-	updatedNode.Spec.PodCIDR = expected[0]
 
-	// start with the new node
+	// start with a node that is being deleted
 	client := clientsetfake.NewSimpleClientset()
-	client.AddReactor("list", "nodes", func(action clientgotesting.Action) (handled bool, ret runtime.Object, err error) {
-		obj := &v1.NodeList{}
-		return true, obj, nil
-	})
-	fakeWatch := watch.NewFake()
-	client.PrependWatchReactor("nodes", clientgotesting.DefaultWatchReactor(fakeWatch, nil))
+	informer := informers.NewSharedInformerFactoryWithOptions(client, 0)
+	nodeStore := informer.Core().V1().Nodes().Informer().GetStore()
+	err := nodeStore.Add(oldNode)
+	if err != nil {
+		t.Fatal(err)
+	}
+	nodeLister := informer.Core().V1().Nodes().Lister()
 
 	go func() {
-		fakeWatch.Add(node)
-		// receive a delete event for the old node
-		fakeWatch.Delete(oldNode)
-		// set the PodCIDRs on the new node
-		fakeWatch.Modify(updatedNode)
+		// simulate a new Node is created
+		time.Sleep(1 * time.Second)
+		err := nodeStore.Add(node)
+		if err != nil {
+			t.Error(err)
+		}
 	}()
-	got, err := waitForPodCIDR(ctx, client, node.Name)
+	got, err := waitForPodCIDR(ctx, nodeLister, node.Name)
 	if err != nil {
 		t.Errorf("waitForPodCIDR() unexpected error %v", err)
 		return
@@ -651,21 +661,23 @@ func TestGetConntrackMax(t *testing.T) {
 	}
 
 	for i, tc := range testCases {
-		cfg := proxyconfigapi.KubeProxyConntrackConfiguration{
-			Min:        ptr.To(tc.min),
-			MaxPerCore: ptr.To(tc.maxPerCore),
-		}
-		_, ctx := ktesting.NewTestContext(t)
-		x, e := getConntrackMax(ctx, cfg)
-		if e != nil {
-			if tc.err == "" {
-				t.Errorf("[%d] unexpected error: %v", i, e)
-			} else if !strings.Contains(e.Error(), tc.err) {
-				t.Errorf("[%d] expected an error containing %q: %v", i, tc.err, e)
+		t.Run(fmt.Sprintf("test-case-%d", i), func(t *testing.T) {
+			_, ctx := ktesting.NewTestContext(t)
+			cfg := proxyconfigapi.KubeProxyConntrackConfiguration{
+				Min:        ptr.To(tc.min),
+				MaxPerCore: ptr.To(tc.maxPerCore),
 			}
-		} else if x != tc.expected {
-			t.Errorf("[%d] expected %d, got %d", i, tc.expected, x)
-		}
+			x, e := getConntrackMax(ctx, cfg)
+			if e != nil {
+				if tc.err == "" {
+					t.Errorf("[%d] unexpected error: %v", i, e)
+				} else if !strings.Contains(e.Error(), tc.err) {
+					t.Errorf("[%d] expected an error containing %q: %v", i, tc.err, e)
+				}
+			} else if x != tc.expected {
+				t.Errorf("[%d] expected %d, got %d", i, tc.expected, x)
+			}
+		})
 	}
 }
 
@@ -697,17 +709,26 @@ func TestProxyServer_platformSetup(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			_, ctx := ktesting.NewTestContext(t)
-			client := clientsetfake.NewSimpleClientset(tt.node)
+			client := clientsetfake.NewSimpleClientset()
+			informer := informers.NewSharedInformerFactoryWithOptions(client, 0)
+			nodeInformer := informer.Core().V1().Nodes()
+			nodeStore := nodeInformer.Informer().GetStore()
+			err := nodeStore.Add(tt.node)
+			if err != nil {
+				t.Fatal(err)
+			}
 			s := &ProxyServer{
 				Config:   tt.config,
 				Client:   client,
-				Hostname: "nodename",
+				Hostname: tt.node.Name,
 				NodeIPs: map[v1.IPFamily]net.IP{
 					v1.IPv4Protocol: netutils.ParseIPSloppy("127.0.0.1"),
 					v1.IPv6Protocol: net.IPv6zero,
 				},
+				nodeInformer: nodeInformer,
 			}
-			err := s.platformSetup(ctx)
+
+			err = s.platformSetup(ctx)
 			if err != nil {
 				t.Errorf("ProxyServer.createProxier() error = %v", err)
 				return


### PR DESCRIPTION
/kind bug

Kube-proxy needs to obtain the node IPs and, in some modes, the PodCIDR value of the node object.

For the former it performs several Get requests to the apiserver, and if is not able to get in time, it keeps going using the localhost address. This PR changes to wait until the node object is present, this is a safe assumption as the kube-proxy needs to work connected to the apiserver.

For the later, it started a watch to get the Node object again, after getting the Node IPs

```release-note
kube-proxy improves the startup process by only performing at List and Watch at startup to obtain the Node information. It will block the startup process until the Node object is obtained.
```

/sig network
ping @linxiulei 

Alternative to https://github.com/kubernetes/kubernetes/pull/124670