### PR TITLE
Add ut coverage for capabilities.Setup

### DIFF
--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -8260,7 +8260,7 @@ func TestValidateLinuxPodSecurityContext(t *testing.T) {
 
 func TestValidateContainers(t *testing.T) {
 	volumeDevices := make(map[string]core.VolumeSource)
-	capabilities.SetForTests(capabilities.Capabilities{
+	capabilities.ResetForTest(&capabilities.Capabilities{
 		AllowPrivileged: true,
 	})
 
@@ -8463,7 +8463,7 @@ func TestValidateContainers(t *testing.T) {
 		t.Errorf("expected success: %v", errs)
 	}
 
-	capabilities.SetForTests(capabilities.Capabilities{
+	capabilities.ResetForTest(&capabilities.Capabilities{
 		AllowPrivileged: false,
 	})
 	errorCases := []struct {
@@ -9088,7 +9088,7 @@ func TestValidateContainers(t *testing.T) {
 
 func TestValidateInitContainers(t *testing.T) {
 	volumeDevices := make(map[string]core.VolumeSource)
-	capabilities.SetForTests(capabilities.Capabilities{
+	capabilities.ResetForTest(&capabilities.Capabilities{
 		AllowPrivileged: true,
 	})
 
@@ -9166,7 +9166,7 @@ func TestValidateInitContainers(t *testing.T) {
 		t.Errorf("expected success: %v", errs)
 	}
 
-	capabilities.SetForTests(capabilities.Capabilities{
+	capabilities.ResetForTest(&capabilities.Capabilities{
 		AllowPrivileged: false,
 	})
 	errorCases := []struct {
@@ -16465,7 +16465,7 @@ func TestValidatePodEphemeralContainersUpdate(t *testing.T) {
 
 	// Some tests use Windows host pods as an example of fields that might
 	// conflict between an ephemeral container and the rest of the pod.
-	capabilities.SetForTests(capabilities.Capabilities{
+	capabilities.ResetForTest(&capabilities.Capabilities{
 		AllowPrivileged: true,
 	})
 	makeWindowsHostPod := func(ephemeralContainers []core.EphemeralContainer) *core.Pod {
@@ -22995,7 +22995,7 @@ func TestValidateSecurityContext(t *testing.T) {
 		},
 	}
 	for k, v := range errorCases {
-		capabilities.SetForTests(capabilities.Capabilities{
+		capabilities.ResetForTest(&capabilities.Capabilities{
 			AllowPrivileged: v.capAllowPriv,
 		})
 		// note the unconditional `true` here for hostUsers. The failure case to test for ProcMount only includes it being true,
@@ -25680,7 +25680,7 @@ func TestValidateWindowsHostProcessPod(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 
-			capabilities.SetForTests(capabilities.Capabilities{
+			capabilities.ResetForTest(&capabilities.Capabilities{
 				AllowPrivileged: testCase.allowPrivileged,
 			})
 

--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -8260,7 +8260,8 @@ func TestValidateLinuxPodSecurityContext(t *testing.T) {
 
 func TestValidateContainers(t *testing.T) {
 	volumeDevices := make(map[string]core.VolumeSource)
-	capabilities.ResetForTest(&capabilities.Capabilities{
+	capabilities.ResetForTest()
+	capabilities.Initialize(capabilities.Capabilities{
 		AllowPrivileged: true,
 	})
 
@@ -8463,7 +8464,8 @@ func TestValidateContainers(t *testing.T) {
 		t.Errorf("expected success: %v", errs)
 	}
 
-	capabilities.ResetForTest(&capabilities.Capabilities{
+	capabilities.ResetForTest()
+	capabilities.Initialize(capabilities.Capabilities{
 		AllowPrivileged: false,
 	})
 	errorCases := []struct {
@@ -9088,7 +9090,8 @@ func TestValidateContainers(t *testing.T) {
 
 func TestValidateInitContainers(t *testing.T) {
 	volumeDevices := make(map[string]core.VolumeSource)
-	capabilities.ResetForTest(&capabilities.Capabilities{
+	capabilities.ResetForTest()
+	capabilities.Initialize(capabilities.Capabilities{
 		AllowPrivileged: true,
 	})
 
@@ -9166,7 +9169,8 @@ func TestValidateInitContainers(t *testing.T) {
 		t.Errorf("expected success: %v", errs)
 	}
 
-	capabilities.ResetForTest(&capabilities.Capabilities{
+	capabilities.ResetForTest()
+	capabilities.Initialize(capabilities.Capabilities{
 		AllowPrivileged: false,
 	})
 	errorCases := []struct {
@@ -16465,7 +16469,8 @@ func TestValidatePodEphemeralContainersUpdate(t *testing.T) {
 
 	// Some tests use Windows host pods as an example of fields that might
 	// conflict between an ephemeral container and the rest of the pod.
-	capabilities.ResetForTest(&capabilities.Capabilities{
+	capabilities.ResetForTest()
+	capabilities.Initialize(capabilities.Capabilities{
 		AllowPrivileged: true,
 	})
 	makeWindowsHostPod := func(ephemeralContainers []core.EphemeralContainer) *core.Pod {
@@ -22995,7 +23000,8 @@ func TestValidateSecurityContext(t *testing.T) {
 		},
 	}
 	for k, v := range errorCases {
-		capabilities.ResetForTest(&capabilities.Capabilities{
+		capabilities.ResetForTest()
+		capabilities.Initialize(capabilities.Capabilities{
 			AllowPrivileged: v.capAllowPriv,
 		})
 		// note the unconditional `true` here for hostUsers. The failure case to test for ProcMount only includes it being true,
@@ -25679,8 +25685,8 @@ func TestValidateWindowsHostProcessPod(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-
-			capabilities.ResetForTest(&capabilities.Capabilities{
+			capabilities.ResetForTest()
+			capabilities.Initialize(capabilities.Capabilities{
 				AllowPrivileged: testCase.allowPrivileged,
 			})
 

--- a/pkg/capabilities/capabilities.go
+++ b/pkg/capabilities/capabilities.go
@@ -68,11 +68,13 @@ func Setup(allowPrivileged bool, perConnectionBytesPerSec int64) {
 	})
 }
 
-// SetForTests sets capabilities for tests.  Convenience method for testing.  This should only be called from tests.
-func SetForTests(c Capabilities) {
+// ResetForTest resets the capabilities to a given state for testing purposes.
+// This function should only be called from tests.
+func ResetForTest(c *Capabilities) {
 	capInstance.lock.Lock()
 	defer capInstance.lock.Unlock()
-	capInstance.capabilities = &c
+	capInstance.capabilities = c
+	capInstance.once = sync.Once{}
 }
 
 // Get returns a read-only copy of the system capabilities.

--- a/pkg/capabilities/capabilities.go
+++ b/pkg/capabilities/capabilities.go
@@ -70,10 +70,10 @@ func Setup(allowPrivileged bool, perConnectionBytesPerSec int64) {
 
 // ResetForTest resets the capabilities to a given state for testing purposes.
 // This function should only be called from tests.
-func ResetForTest(c *Capabilities) {
+func ResetForTest() {
 	capInstance.lock.Lock()
 	defer capInstance.lock.Unlock()
-	capInstance.capabilities = c
+	capInstance.capabilities = nil
 	capInstance.once = sync.Once{}
 }
 

--- a/pkg/capabilities/capabilities_test.go
+++ b/pkg/capabilities/capabilities_test.go
@@ -78,7 +78,7 @@ func TestSetup(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			defer ResetForTest(nil)
+			ResetForTest(nil)
 
 			Setup(tc.allowPrivileged, tc.perConnectionBytesPerSec)
 			res := Get()

--- a/pkg/capabilities/capabilities_test.go
+++ b/pkg/capabilities/capabilities_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func TestGet(t *testing.T) {
-	defer ResetForTest(nil)
+	defer ResetForTest()
 	defaultCap := Capabilities{
 		AllowPrivileged: false,
 		PrivilegedSources: PrivilegedSources{
@@ -42,7 +42,8 @@ func TestGet(t *testing.T) {
 			HostNetworkSources: []string{"A", "B"},
 		},
 	}
-	ResetForTest(&cap)
+	ResetForTest()
+	Initialize(cap)
 
 	res = Get()
 	if !reflect.DeepEqual(cap, res) {
@@ -50,6 +51,7 @@ func TestGet(t *testing.T) {
 	}
 }
 func TestSetup(t *testing.T) {
+	defer ResetForTest()
 	testCases := []struct {
 		name                     string
 		allowPrivileged          bool
@@ -78,21 +80,13 @@ func TestSetup(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			ResetForTest(nil)
+			ResetForTest()
 
 			Setup(tc.allowPrivileged, tc.perConnectionBytesPerSec)
 			res := Get()
-			if !compareCapabilities(tc.expectedCapabilities, res) {
+			if !reflect.DeepEqual(tc.expectedCapabilities, res) {
 				t.Fatalf("expected Capabilities: %#v, got: %#v", tc.expectedCapabilities, res)
 			}
 		})
 	}
-}
-
-// compareCapabilities compares two Capabilities instances
-func compareCapabilities(a, b Capabilities) bool {
-	if a.AllowPrivileged != b.AllowPrivileged {
-		return false
-	}
-	return a.PerConnectionBandwidthLimitBytesPerSec == b.PerConnectionBandwidthLimitBytesPerSec
 }

--- a/test/integration/auth/podsecurity_test.go
+++ b/test/integration/auth/podsecurity_test.go
@@ -104,7 +104,7 @@ func TestPodSecurityWebhook(t *testing.T) {
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.AppArmor, true)
 
 	// Start test API server.
-	capabilities.SetForTests(capabilities.Capabilities{AllowPrivileged: true})
+	capabilities.ResetForTest(&capabilities.Capabilities{AllowPrivileged: true})
 	testServer := kubeapiservertesting.StartTestServerOrDie(t, kubeapiservertesting.NewDefaultTestServerOptions(), []string{
 		"--anonymous-auth=false",
 		"--allow-privileged=true",
@@ -138,7 +138,7 @@ func TestPodSecurityWebhook(t *testing.T) {
 
 func startPodSecurityServer(t *testing.T) *kubeapiservertesting.TestServer {
 	// ensure the global is set to allow privileged containers
-	capabilities.SetForTests(capabilities.Capabilities{AllowPrivileged: true})
+	capabilities.ResetForTest(&capabilities.Capabilities{AllowPrivileged: true})
 
 	server := kubeapiservertesting.StartTestServerOrDie(t, kubeapiservertesting.NewDefaultTestServerOptions(), []string{
 		"--anonymous-auth=false",

--- a/test/integration/auth/podsecurity_test.go
+++ b/test/integration/auth/podsecurity_test.go
@@ -104,7 +104,8 @@ func TestPodSecurityWebhook(t *testing.T) {
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.AppArmor, true)
 
 	// Start test API server.
-	capabilities.ResetForTest(&capabilities.Capabilities{AllowPrivileged: true})
+	capabilities.ResetForTest()
+	capabilities.Initialize(capabilities.Capabilities{AllowPrivileged: true})
 	testServer := kubeapiservertesting.StartTestServerOrDie(t, kubeapiservertesting.NewDefaultTestServerOptions(), []string{
 		"--anonymous-auth=false",
 		"--allow-privileged=true",
@@ -138,7 +139,8 @@ func TestPodSecurityWebhook(t *testing.T) {
 
 func startPodSecurityServer(t *testing.T) *kubeapiservertesting.TestServer {
 	// ensure the global is set to allow privileged containers
-	capabilities.ResetForTest(&capabilities.Capabilities{AllowPrivileged: true})
+	capabilities.ResetForTest()
+	capabilities.Initialize(capabilities.Capabilities{AllowPrivileged: true})
 
 	server := kubeapiservertesting.StartTestServerOrDie(t, kubeapiservertesting.NewDefaultTestServerOptions(), []string{
 		"--anonymous-auth=false",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup
#### What this PR does / why we need it:

Increases Unit Test coverage for `pkg/capabilities` to 100% by adding test cases for `capabilities.Setup`

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
N/A

#### Special notes for your reviewer:

This pull request introduces unit test coverage for the `Setup` function. Although there is an existing method, `SetForTests`, designed to facilitate testing, there has been no coverage for the actual `Setup` method until now.

If I've missed any guidelines or made any mistakes, I apologize and welcome your feedback.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
