### PR TITLE
Fix that PodIP field is temporarily removed for a terminal pod

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -2024,11 +2024,12 @@ func (kl *Kubelet) SyncTerminatingPod(_ context.Context, pod *v1.Pod, podStatus 
 	// catch race conditions introduced by callers updating pod status out of order.
 	// TODO: have KillPod return the terminal status of stopped containers and write that into the
 	//  cache immediately
-	podStatus, err := kl.containerRuntime.GetPodStatus(ctx, pod.UID, pod.Name, pod.Namespace)
+	stoppedPodStatus, err := kl.containerRuntime.GetPodStatus(ctx, pod.UID, pod.Name, pod.Namespace)
 	if err != nil {
 		klog.ErrorS(err, "Unable to read pod status prior to final pod termination", "pod", klog.KObj(pod), "podUID", pod.UID)
 		return err
 	}
+	preserveDataFromBeforeStopping(stoppedPodStatus, podStatus)
 	var runningContainers []string
 	type container struct {
 		Name       string
@@ -2039,7 +2040,7 @@ func (kl *Kubelet) SyncTerminatingPod(_ context.Context, pod *v1.Pod, podStatus 
 	var containers []container
 	klogV := klog.V(4)
 	klogVEnabled := klogV.Enabled()
-	for _, s := range podStatus.ContainerStatuses {
+	for _, s := range stoppedPodStatus.ContainerStatuses {
 		if s.State == kubecontainer.ContainerStateRunning {
 			runningContainers = append(runningContainers, s.ID.String())
 		}
@@ -2068,13 +2069,22 @@ func (kl *Kubelet) SyncTerminatingPod(_ context.Context, pod *v1.Pod, podStatus 
 	// The computation is done here to ensure the pod status used for it contains
 	// information about the container end states (including exit codes) - when
 	// SyncTerminatedPod is called the containers may already be removed.
-	apiPodStatus = kl.generateAPIPodStatus(pod, podStatus, true)
+	apiPodStatus = kl.generateAPIPodStatus(pod, stoppedPodStatus, true)
 	kl.statusManager.SetPodStatus(pod, apiPodStatus)
 
 	// we have successfully stopped all containers, the pod is terminating, our status is "done"
 	klog.V(4).InfoS("Pod termination stopped all running containers", "pod", klog.KObj(pod), "podUID", pod.UID)
 
 	return nil
+}
+
+// preserveDataFromBeforeStopping preserves data, like IPs, which are expected
+// to be sent to the API server after termination, but are no longer returned by
+// containerRuntime.GetPodStatus for a stopped pod.
+// Note that Kubelet restart, after the pod is stopped, may still cause losing
+// track of the data.
+func preserveDataFromBeforeStopping(stoppedPodStatus, podStatus *kubecontainer.PodStatus) {
+	stoppedPodStatus.IPs = podStatus.IPs
 }
 
 // SyncTerminatingRuntimePod is expected to terminate running containers in a pod that we have no

--- a/test/e2e_node/pod_ips.go
+++ b/test/e2e_node/pod_ips.go
@@ -1,0 +1,235 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2enode
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/tools/cache"
+	watchtools "k8s.io/client-go/tools/watch"
+	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
+	"k8s.io/kubernetes/test/e2e/framework"
+	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
+	"k8s.io/kubernetes/test/e2e/network/common"
+	imageutils "k8s.io/kubernetes/test/utils/image"
+	admissionapi "k8s.io/pod-security-admission/api"
+)
+
+var _ = common.SIGDescribe("Pod IPs", func() {
+	f := framework.NewDefaultFramework("pod-ips")
+	f.NamespacePodSecurityLevel = admissionapi.LevelRestricted
+	testFinalizer := "example.com/test-finalizer"
+
+	watchPodIPWhileTerminating := func(ctx context.Context, pod *v1.Pod) {
+		ctxUntil, cancel := context.WithTimeout(ctx, f.Timeouts.PodStart)
+		defer cancel()
+
+		fieldSelector := fields.OneTermEqualSelector("metadata.name", pod.Name).String()
+		w := &cache.ListWatch{
+			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+				options.FieldSelector = fieldSelector
+				return f.ClientSet.CoreV1().Pods(f.Namespace.Name).Watch(ctx, options)
+			},
+		}
+
+		ginkgo.By(fmt.Sprintf("Started watch for pod (%v/%v) to enter terminal phase", pod.Namespace, pod.Name))
+		_, err := watchtools.Until(ctxUntil, pod.ResourceVersion, w, func(event watch.Event) (bool, error) {
+			if pod, ok := event.Object.(*v1.Pod); ok {
+				found := pod.ObjectMeta.Name == pod.Name &&
+					pod.ObjectMeta.Namespace == f.Namespace.Name
+				if !found {
+					ginkgo.By(fmt.Sprintf("Found unexpected Pod (%s/%s) in phase %v", pod.ObjectMeta.Namespace, pod.ObjectMeta.Name, pod.Status.Phase))
+					return false, nil
+				}
+				ginkgo.By(fmt.Sprintf("Found Pod (%s/%s) in phase %v, podIP=%v, podIPs=%v", pod.ObjectMeta.Namespace, pod.ObjectMeta.Name, pod.Status.Phase, pod.Status.PodIP, pod.Status.PodIPs))
+				if pod.Status.Phase != v1.PodPending {
+					gomega.Expect(pod.Status.PodIP).NotTo(gomega.BeEmpty(), fmt.Sprintf("PodIP not set for pod (%s/%s) in phase %v", pod.ObjectMeta.Namespace, pod.ObjectMeta.Name, pod.Status.Phase))
+					gomega.Expect(pod.Status.PodIPs).NotTo(gomega.BeEmpty(), fmt.Sprintf("PodIPs not set for pod (%s/%s) in phase %v", pod.ObjectMeta.Namespace, pod.ObjectMeta.Name, pod.Status.Phase))
+				}
+				// end the watch if the pod reached terminal phase
+				return podutil.IsPodPhaseTerminal(pod.Status.Phase), nil
+			}
+			ginkgo.By(fmt.Sprintf("Observed event: %+v", event.Object))
+			return false, nil
+		})
+		framework.ExpectNoError(err, "failed to see event that pod (%s/%s) enter terminal phase: %v", pod.Namespace, pod.Name, err)
+		ginkgo.By(fmt.Sprintf("Ended watch for pod (%v/%v) entering terminal phase", pod.Namespace, pod.Name))
+	}
+
+	ginkgo.Context("when pod gets terminated", func() {
+		ginkgo.It("should contain podIPs in status for succeeded pod", func(ctx context.Context) {
+			podName := "pod-ips-success-" + string(uuid.NewUUID())
+
+			podSpec := e2epod.MustMixinRestrictedPodSecurity(&v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: podName,
+				},
+				Spec: v1.PodSpec{
+					RestartPolicy: v1.RestartPolicyNever,
+					Containers: []v1.Container{
+						{
+							Name:    podName,
+							Image:   imageutils.GetE2EImage(imageutils.BusyBox),
+							Command: []string{"sh", "-c"},
+							Args: []string{`
+								sleep 1
+								exit 0
+							`,
+							},
+						},
+					},
+				},
+			})
+
+			ginkgo.By(fmt.Sprintf("creating the pod (%v/%v)", podSpec.Namespace, podSpec.Name))
+			podClient := e2epod.NewPodClient(f)
+			pod := podClient.Create(ctx, podSpec)
+
+			watchPodIPWhileTerminating(ctx, pod)
+
+			ginkgo.By(fmt.Sprintf("getting the terminal state for pod (%v/%v)", podSpec.Namespace, podSpec.Name))
+			pod, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(ctx, podName, metav1.GetOptions{})
+			framework.ExpectNoError(err, "failed to get the final state for pod (%s/%s)", pod.Namespace, pod.Name)
+			gomega.Expect(pod.Status.Phase).To(gomega.Equal(v1.PodSucceeded), fmt.Sprintf("Non-terminal phase for pod (%s/%s): %v", pod.ObjectMeta.Namespace, pod.ObjectMeta.Name, pod.Status.Phase))
+			gomega.Expect(pod.Status.ContainerStatuses[0].State.Terminated).ShouldNot(gomega.BeNil())
+			gomega.Expect(pod.Status.ContainerStatuses[0].State.Terminated.ExitCode).Should(gomega.Equal(int32(0)))
+		})
+
+		ginkgo.It("should contain podIPs in status for failed pod", func(ctx context.Context) {
+			podName := "pod-ips-crash-" + string(uuid.NewUUID())
+
+			podSpec := e2epod.MustMixinRestrictedPodSecurity(&v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: podName,
+				},
+				Spec: v1.PodSpec{
+					RestartPolicy: v1.RestartPolicyNever,
+					Containers: []v1.Container{
+						{
+							Name:    podName,
+							Image:   imageutils.GetE2EImage(imageutils.BusyBox),
+							Command: []string{"sh", "-c"},
+							Args: []string{`
+								exit 42
+							`,
+							},
+						},
+					},
+				},
+			})
+
+			ginkgo.By(fmt.Sprintf("creating the pod (%v/%v)", podSpec.Namespace, podSpec.Name))
+			podClient := e2epod.NewPodClient(f)
+			pod := podClient.Create(ctx, podSpec)
+
+			watchPodIPWhileTerminating(ctx, pod)
+
+			ginkgo.By(fmt.Sprintf("getting the terminal state for pod (%v/%v)", podSpec.Namespace, podSpec.Name))
+			pod, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(ctx, podName, metav1.GetOptions{})
+			framework.ExpectNoError(err, "failed to get the final state for pod (%s/%s)", pod.Namespace, pod.Name)
+			gomega.Expect(pod.Status.Phase).To(gomega.Equal(v1.PodFailed), fmt.Sprintf("Non-terminal phase for pod (%s/%s): %v", pod.ObjectMeta.Namespace, pod.ObjectMeta.Name, pod.Status.Phase))
+			gomega.Expect(pod.Status.ContainerStatuses[0].State.Terminated).ShouldNot(gomega.BeNil())
+			gomega.Expect(pod.Status.ContainerStatuses[0].State.Terminated.ExitCode).Should(gomega.Equal(int32(42)))
+		})
+
+		ginkgo.It("should contain podIPs in status for during termination", func(ctx context.Context) {
+			podName := "pod-ips-terminating-" + string(uuid.NewUUID())
+
+			podSpec := e2epod.MustMixinRestrictedPodSecurity(&v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       podName,
+					Finalizers: []string{testFinalizer},
+				},
+				Spec: v1.PodSpec{
+					RestartPolicy: v1.RestartPolicyNever,
+					Containers: []v1.Container{
+						{
+							Name:    podName,
+							Image:   imageutils.GetE2EImage(imageutils.BusyBox),
+							Command: []string{"sh", "-c"},
+							Args: []string{`
+							sleep 9999999 &
+							PID=$!
+							_term() {
+								kill $PID
+								echo "Caught SIGTERM signal!"
+							}
+
+							trap _term SIGTERM
+							touch /tmp/trap-marker
+							wait $PID
+
+							exit 42
+							`,
+							},
+							ReadinessProbe: &v1.Probe{
+								PeriodSeconds: 1,
+								ProbeHandler: v1.ProbeHandler{
+									Exec: &v1.ExecAction{
+										Command: []string{"/bin/sh", "-c", "cat /tmp/trap-marker"},
+									},
+								},
+							},
+							Lifecycle: &v1.Lifecycle{
+								PreStop: &v1.LifecycleHandler{
+									Exec: &v1.ExecAction{
+										Command: ExecCommand(podName, execCommand{
+											Delay: 1,
+										}),
+									},
+								},
+							},
+						},
+					},
+				},
+			})
+
+			ginkgo.By(fmt.Sprintf("creating the pod (%v/%v)", podSpec.Namespace, podSpec.Name))
+			podClient := e2epod.NewPodClient(f)
+			pod := podClient.Create(ctx, podSpec)
+
+			ginkgo.By(fmt.Sprintf("set up cleanup of the finalizer for the pod (%v/%v)", f.Namespace.Name, pod.Name))
+			ginkgo.DeferCleanup(e2epod.NewPodClient(f).RemoveFinalizer, pod.Name, testFinalizer)
+
+			ginkgo.By(fmt.Sprintf("Waiting for the pod (%v/%v) to be running and the SIGTERM trap is registered", pod.Namespace, pod.Name))
+			err := e2epod.WaitTimeoutForPodReadyInNamespace(ctx, f.ClientSet, pod.Name, f.Namespace.Name, f.Timeouts.PodStart)
+			framework.ExpectNoError(err, "Failed to await for the pod to be running: %q", pod.Name)
+
+			ginkgo.By(fmt.Sprintf("Deleting the pod (%v/%v) to trigger termination", pod.Namespace, pod.Name))
+			err = e2epod.NewPodClient(f).Delete(ctx, pod.Name, metav1.DeleteOptions{})
+			framework.ExpectNoError(err, "Failed to delete the pod: %q", pod.Name)
+
+			watchPodIPWhileTerminating(ctx, pod)
+
+			ginkgo.By(fmt.Sprintf("getting the terminal state for pod (%v/%v)", podSpec.Namespace, podSpec.Name))
+			pod, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(ctx, podName, metav1.GetOptions{})
+			framework.ExpectNoError(err, "failed to get the final state for pod (%s/%s)", pod.Namespace, pod.Name)
+			gomega.Expect(pod.Status.Phase).To(gomega.Equal(v1.PodFailed), fmt.Sprintf("Non-terminal phase for pod (%s/%s): %v", pod.ObjectMeta.Namespace, pod.ObjectMeta.Name, pod.Status.Phase))
+			gomega.Expect(pod.Status.ContainerStatuses[0].State.Terminated).ShouldNot(gomega.BeNil())
+			gomega.Expect(pod.Status.ContainerStatuses[0].State.Terminated.ExitCode).Should(gomega.Equal(int32(42)))
+		})
+	})
+})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
/kind regression
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Additionally, due to the bug there is one more unnecessary API call sent by Kubelet.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #125370

#### Special notes for your reviewer:

```yaml
apiVersion: batch/v1
kind: Job
metadata:
  name: pi
spec:
  template:
    spec:
      containers:
      - name: pi
        image: howardjohn/shell
        command:
        - bash
        - -c
        - |
          sleep 3
          exit 0
      restartPolicy: Never
  backoffLimit: 1
```

Output to `> kubectl get pod -w -ocustom-columns=NAME:.metadata.name,PHASE:.status.phase,IP:.status.podIP | ts "%Y-%m-%d %H:%M:%.S"`:
before:
```
2024-06-10 09:43:05.083475 NAME       PHASE     IP
2024-06-10 09:43:05.083657 pi-bslsx   Pending   <none>
2024-06-10 09:43:05.087107 pi-bslsx   Pending   <none>
2024-06-10 09:43:05.095358 pi-bslsx   Pending   <none>
2024-06-10 09:43:07.197929 pi-bslsx   Running   10.244.1.21
2024-06-10 09:43:10.203104 pi-bslsx   Running   10.244.1.21
2024-06-10 09:43:11.324259 pi-bslsx   Succeeded   <none>
2024-06-10 09:43:12.208545 pi-bslsx   Succeeded   10.244.1.21
2024-06-10 09:43:12.219699 pi-bslsx   Succeeded   10.244.1.21
```
after fix (note there is no extra API status update):
```
2024-06-10 09:38:16.270212 NAME       PHASE     IP
2024-06-10 09:38:16.270374 pi-xgtw6   Pending   <none>
2024-06-10 09:38:16.275953 pi-xgtw6   Pending   <none>
2024-06-10 09:38:16.283406 pi-xgtw6   Pending   <none>
2024-06-10 09:38:17.954194 pi-xgtw6   Running   10.244.1.20
2024-06-10 09:38:20.960806 pi-xgtw6   Running   10.244.1.20
2024-06-10 09:38:22.130329 pi-xgtw6   Succeeded   10.244.1.20
2024-06-10 09:38:22.974978 pi-xgtw6   Succeeded   10.244.1.20
```
Note that the last status update in both cases is the removal of the Job finalizer.

Some questions potential questions based on my priv chats:
1. why in the broken version the last status update contains the IP?
This is because the last status update is triggered by [`syncTerminatedPod`](https://github.com/kubernetes/kubernetes/blob/291378cd33cb89342fa876e201030172bb33d3b9/pkg/kubelet/kubelet.go#L2161C20-L2161C37) which generates the `apiPodStatus` based on the `podStatus` which is passed from the cache in [pod_workers](https://github.com/kubernetes/kubernetes/blob/291378cd33cb89342fa876e201030172bb33d3b9/pkg/kubelet/pod_workers.go#L1256). In contrary, the status update triggered by `syncTerminating` pods was just based on the container runtime `containerRuntime.GetPodStatus`.
2. Why does the container runtime not populate the IP information for stopped pods? 
Because of the explicit check for SANDBOX_READY [here](https://github.com/kubernetes/kubernetes/blob/291378cd33cb89342fa876e201030172bb33d3b9/pkg/kubelet/kuberuntime/kuberuntime_manager.go#L1460-L1462)
3. Why does the `podStatus` cache contains the IP information when `syncTerminatedPod` is called. Because it gets updated inside [updateCache](https://github.com/kubernetes/kubernetes/blob/dae1859c896d742de1ee60a349475f8e28b61995/pkg/kubelet/pleg/generic.go#L432). Note that, in that case we also fallback to `oldPodStatus.IP` for stopped containers, see [here](https://github.com/kubernetes/kubernetes/blob/dae1859c896d742de1ee60a349475f8e28b61995/pkg/kubelet/pleg/generic.go#L424-L426).  
4. Are there more fields that need to be copied? 
It seems not. When calling `containerRuntime.GetPodStatus` on a stopped pod all fields except for [podStatus](https://github.com/kubernetes/kubernetes/blob/dae1859c896d742de1ee60a349475f8e28b61995/pkg/kubelet/container/runtime.go#L307C3-L323) except for `IP` and `Timestamp` are returned. The `Timestamp` field seems only be used when storing in cache, see [here](https://github.com/kubernetes/kubernetes/blob/dae1859c896d742de1ee60a349475f8e28b61995/pkg/kubelet/pleg/generic.go#L478-L482), and [here](https://github.com/kubernetes/kubernetes/blob/dae1859c896d742de1ee60a349475f8e28b61995/pkg/kubelet/container/cache.go#L102-L117) . However, we don't store this status in cache.
5. Why copy the information at the `podStatus` (*kubecontainer.PodStatus) level, not at the `apiPodStatus` (v1.PodStatus) level?
Both would work, but adjusting the underlying structure is less code (single field vs two), and keeps them consistent as commented [here](https://github.com/kubernetes/kubernetes/pull/125404#discussion_r1634560821)
6. Is a more generic approach possible, rather than fixing a specific field? 
Possibly, we could fallback the IPs inside `generateAPIPodStatus` or `convertStatusToAPIStatus`, which also have access to `oldPodStatus`, containing the IPs, but this would affect many more code paths. The proposed fix is minimal to only fix the new status update introduced in https://github.com/kubernetes/kubernetes/pull/115331/: https://github.com/kubernetes/kubernetes/pull/115331/files#diff-67dd9e8f3ee257072765326cb4f242852554a2c0753563fa51e292c0a63a7b94R2022
7. Why after the fix there is one less status update? Because kubelet skips sending status update if there is no difference (skips sending patch if empty inside [PatchPodStatus](https://github.com/kubernetes/kubernetes/blob/a4b8edd0f7131f0979d1f7168de1bfa5cb838d01/pkg/kubelet/status/status_manager.go#L873)). The only difference between the 2 status updates triggered by `syncTerminatingPod` and `syncTerminatedPod` was the presence of the `IP` fields, so `syncTerminatedPod` is skipped.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix the bug where PodIP field is temporarily removed for a terminal pod
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
