### PR TITLE
KEP-4222: Enable JSON-compatible base64 encoding of []byte for CBOR.

### DIFF
--- a/pkg/api/testing/unstructured_test.go
+++ b/pkg/api/testing/unstructured_test.go
@@ -150,30 +150,6 @@ func TestRoundtripToUnstructured(t *testing.T) {
 	// These are GVKs that whose CBOR roundtrippability is blocked by a known issue that must be
 	// resolved as a prerequisite for alpha.
 	knownFailureReasons := map[string][]schema.GroupVersionKind{
-		// Since JSON cannot directly represent arbitrary byte sequences, a byte slice
-		// encodes to a JSON string containing the base64 encoding of the slice
-		// contents. Decoding a JSON string into a byte slice assumes (and requires) that
-		// the JSON string contain base64-encoded data. The CBOR serializer must be
-		// compatible with this behavior.
-		"byte slices should be represented in unstructured as base64-encoded strings": {
-			{Version: "v1", Kind: "Secret"},
-			{Version: "v1", Kind: "SecretList"},
-			{Version: "v1", Kind: "RangeAllocation"},
-			{Version: "v1", Kind: "ConfigMap"},
-			{Version: "v1", Kind: "ConfigMapList"},
-			{Group: "admissionregistration.k8s.io", Version: "v1beta1", Kind: "MutatingWebhookConfiguration"},
-			{Group: "admissionregistration.k8s.io", Version: "v1beta1", Kind: "MutatingWebhookConfigurationList"},
-			{Group: "admissionregistration.k8s.io", Version: "v1beta1", Kind: "ValidatingWebhookConfiguration"},
-			{Group: "admissionregistration.k8s.io", Version: "v1beta1", Kind: "ValidatingWebhookConfigurationList"},
-			{Group: "admissionregistration.k8s.io", Version: "v1", Kind: "MutatingWebhookConfiguration"},
-			{Group: "admissionregistration.k8s.io", Version: "v1", Kind: "MutatingWebhookConfigurationList"},
-			{Group: "admissionregistration.k8s.io", Version: "v1", Kind: "ValidatingWebhookConfiguration"},
-			{Group: "admissionregistration.k8s.io", Version: "v1", Kind: "ValidatingWebhookConfigurationList"},
-			{Group: "certificates.k8s.io", Version: "v1beta1", Kind: "CertificateSigningRequest"},
-			{Group: "certificates.k8s.io", Version: "v1beta1", Kind: "CertificateSigningRequestList"},
-			{Group: "certificates.k8s.io", Version: "v1", Kind: "CertificateSigningRequest"},
-			{Group: "certificates.k8s.io", Version: "v1", Kind: "CertificateSigningRequestList"},
-		},
 		// If a RawExtension's bytes are invalid JSON, its containing object can't be encoded to JSON.
 		"rawextension needs to work in programs that assume json": {
 			{Version: "v1", Kind: "List"},

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/cbor/internal/modes/appendixa_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/cbor/internal/modes/appendixa_test.go
@@ -286,11 +286,11 @@ func TestAppendixA(t *testing.T) {
 			},
 		},
 		{
-			example: hex("d74401020304"),
-			decoded: "\x01\x02\x03\x04",
-			encoded: hex("4401020304"),
+			example: hex("d74401020304"), // 23(h'01020304')
+			decoded: "01020304",
+			encoded: hex("483031303230333034"), // '01020304'
 			reasons: []string{
-				reasonTagIgnored,
+				"decoding a byte string enclosed in an expected later encoding tag into an interface{} value automatically converts to the specified encoding for JSON interoperability",
 			},
 		},
 		{

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/cbor/internal/modes/decode.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/cbor/internal/modes/decode.go
@@ -97,8 +97,12 @@ var Decode cbor.DecMode = func() cbor.DecMode {
 		// Produce string concrete values when decoding a CBOR byte string into interface{}.
 		DefaultByteStringType: reflect.TypeOf(""),
 
-		// Allow CBOR byte strings to be decoded into string destination values.
-		ByteStringToString: cbor.ByteStringToStringAllowed,
+		// Allow CBOR byte strings to be decoded into string destination values. If a byte
+		// string is enclosed in an "expected later encoding" tag
+		// (https://www.rfc-editor.org/rfc/rfc8949.html#section-3.4.5.2), then the text
+		// encoding indicated by that tag (e.g. base64) will be applied to the contents of
+		// the byte string.
+		ByteStringToString: cbor.ByteStringToStringAllowedWithExpectedLaterEncoding,
 
 		// Allow CBOR byte strings to match struct fields when appearing as a map key.
 		FieldNameByteString: cbor.FieldNameByteStringAllowed,
@@ -118,6 +122,12 @@ var Decode cbor.DecMode = func() cbor.DecMode {
 		// representation (RFC 8259 Section 6).
 		NaN: cbor.NaNDecodeForbidden,
 		Inf: cbor.InfDecodeForbidden,
+
+		// When unmarshaling a byte string into a []byte, assume that the byte string
+		// contains base64-encoded bytes, unless explicitly counterindicated by an "expected
+		// later encoding" tag. This is consistent with the because of unmarshaling a JSON
+		// text into a []byte.
+		ByteStringExpectedFormat: cbor.ByteStringExpectedBase64,
 
 		// Reject the arbitrary-precision integer tags because they can't be faithfully
 		// roundtripped through the allowable Unstructured types.

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/cbor/internal/modes/decode_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/cbor/internal/modes/decode_test.go
@@ -163,6 +163,46 @@ func TestDecode(t *testing.T) {
 			want:          "",
 			assertOnError: assertNilError,
 		},
+		{
+			name:          "byte string into []byte assumes base64",
+			in:            []byte("\x48AQIDBA=="), // 'AQIDBA=='
+			into:          []byte{},
+			want:          []byte{0x01, 0x02, 0x03, 0x04},
+			assertOnError: assertNilError,
+		},
+		{
+			name:          "byte string into []byte errors on invalid base64",
+			in:            hex("41ff"), // h'ff'
+			into:          []byte{},
+			assertOnError: assertErrorMessage("cbor: failed to decode base64 from byte string: illegal base64 data at input byte 0"),
+		},
+		{
+			name:          "empty byte string into []byte assumes base64",
+			in:            hex("40"), // ''
+			into:          []byte{},
+			want:          []byte{},
+			assertOnError: assertNilError,
+		},
+		{
+			name:          "byte string with expected encoding tag into []byte does not convert",
+			in:            hex("d64401020304"), // 22(h'01020304')
+			into:          []byte{},
+			want:          []byte{0x01, 0x02, 0x03, 0x04},
+			assertOnError: assertNilError,
+		},
+		{
+			name:          "byte string with expected encoding tag into string converts",
+			in:            hex("d64401020304"), // 22(h'01020304')
+			into:          "",
+			want:          "AQIDBA==",
+			assertOnError: assertNilError,
+		},
+		{
+			name:          "byte string with expected encoding tag into interface{} converts",
+			in:            hex("d64401020304"), // 22(h'01020304')
+			want:          "AQIDBA==",
+			assertOnError: assertNilError,
+		},
 	})
 
 	group(t, "text string", []test{

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/cbor/internal/modes/encode.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/cbor/internal/modes/encode.go
@@ -79,6 +79,14 @@ var Encode cbor.EncMode = func() cbor.EncMode {
 		// Marshal Go byte arrays to CBOR arrays of integers (as in JSON) instead of byte
 		// strings.
 		ByteArray: cbor.ByteArrayToArray,
+
+		// Marshal []byte to CBOR byte string enclosed in tag 22 (expected later base64
+		// encoding, https://www.rfc-editor.org/rfc/rfc8949.html#section-3.4.5.2), to
+		// interoperate with the existing JSON behavior. This indicates to the decoder that,
+		// when decoding into a string (or unstructured), the resulting value should be the
+		// base64 encoding of the original bytes. No base64 encoding or decoding needs to be
+		// performed for []byte-to-CBOR-to-[]byte roundtrips.
+		ByteSliceLaterFormat: cbor.ByteSliceLaterFormatBase64,
 	}.EncMode()
 	if err != nil {
 		panic(err)

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/cbor/internal/modes/encode_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/cbor/internal/modes/encode_test.go
@@ -70,6 +70,18 @@ func TestEncode(t *testing.T) {
 			want:          []byte{0x83, 0x01, 0x02, 0x03}, // [1, 2, 3]
 			assertOnError: assertNilError,
 		},
+		{
+			name:          "string marshalled to byte string",
+			in:            "hello",
+			want:          []byte{0x45, 'h', 'e', 'l', 'l', 'o'},
+			assertOnError: assertNilError,
+		},
+		{
+			name:          "[]byte marshalled to byte string in expected base64 encoding tag",
+			in:            []byte("hello"),
+			want:          []byte{0xd6, 0x45, 'h', 'e', 'l', 'l', 'o'},
+			assertOnError: assertNilError,
+		},
 	} {
 		encModes := tc.modes
 		if len(encModes) == 0 {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup
/sig api-machinery

#### What this PR does / why we need it:

The encoding/json package marshals []byte to a JSON string containing the base64 encoding of the input slice's bytes, and unmarshals JSON strings to []byte by assuming the JSON string contains a valid base64 text.

As a binary format, CBOR is capable of representing arbitrary byte sequences without converting them to a text encoding, but it also needs to interoperate with the existing JSON serializer. It does this using the "expected later encoding" tags defined in RFC 8949, which indicate a specific text encoding to be used when interoperating with text-based protocols. The actual conversion to or from a text encoding is deferred until necessary, so no conversion is performed during roundtrips of []byte to CBOR.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://kep.k8s.io/4222
```
