### PR TITLE
KEP-4222: Reject math/big.Int on encode and bignum tags on decode for CBOR.

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/cbor/internal/modes/appendixa_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/cbor/internal/modes/appendixa_test.go
@@ -121,7 +121,6 @@ func TestAppendixA(t *testing.T) {
 		{
 			example: hex("c249010000000000000000"),
 			reject:  "decoding tagged positive bigint value to interface{} can't reproduce this value without losing distinction between float and integer",
-			fixme:   "decoding bigint to interface{} must not produce math/big.Int",
 		},
 		{
 			example: hex("3bffffffffffffffff"),
@@ -130,7 +129,6 @@ func TestAppendixA(t *testing.T) {
 		{
 			example: hex("c349010000000000000000"),
 			reject:  "-18446744073709551617 overflows int64 and falling back to float64 (as with JSON) loses distinction between float and integer",
-			fixme:   "decoding negative bigint to interface{} must not produce math/big.Int",
 		},
 		{
 			example: hex("20"),

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/cbor/internal/modes/decode.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/cbor/internal/modes/decode.go
@@ -96,6 +96,10 @@ var Decode cbor.DecMode = func() cbor.DecMode {
 		// representation (RFC 8259 Section 6).
 		NaN: cbor.NaNDecodeForbidden,
 		Inf: cbor.InfDecodeForbidden,
+
+		// Reject the arbitrary-precision integer tags because they can't be faithfully
+		// roundtripped through the allowable Unstructured types.
+		BignumTag: cbor.BignumTagForbidden,
 	}.DecMode()
 	if err != nil {
 		panic(err)

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/cbor/internal/modes/decode_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/cbor/internal/modes/decode_test.go
@@ -739,29 +739,25 @@ func TestDecode(t *testing.T) {
 
 		group(t, "unsigned bignum", []test{
 			{
-				name:  "rejected",
-				in:    hex("c249010000000000000000"), // 2(18446744073709551616)
-				fixme: "decoding cbor data tagged with 2 produces big.Int instead of rejecting",
-				assertOnError: func(t *testing.T, e error) {
-					// TODO: Once this can pass, make the assertion stronger.
-					if e == nil {
-						t.Error("expected non-nil error")
+				name: "rejected",
+				in:   hex("c249010000000000000000"), // 2(18446744073709551616)
+				assertOnError: assertOnConcreteError(func(t *testing.T, e *cbor.UnacceptableDataItemError) {
+					if diff := cmp.Diff(&cbor.UnacceptableDataItemError{CBORType: "tag", Message: "bignum"}, e); diff != "" {
+						t.Errorf("unexpected error diff:\n%s", diff)
 					}
-				},
+				}),
 			},
 		})
 
 		group(t, "negative bignum", []test{
 			{
-				name:  "rejected",
-				in:    hex("c349010000000000000000"), // 3(-18446744073709551617)
-				fixme: "decoding cbor data tagged with 3 produces big.Int instead of rejecting",
-				assertOnError: func(t *testing.T, e error) {
-					// TODO: Once this can pass, make the assertion stronger.
-					if e == nil {
-						t.Error("expected non-nil error")
+				name: "rejected",
+				in:   hex("c349010000000000000000"), // 3(-18446744073709551617)
+				assertOnError: assertOnConcreteError(func(t *testing.T, e *cbor.UnacceptableDataItemError) {
+					if diff := cmp.Diff(&cbor.UnacceptableDataItemError{CBORType: "tag", Message: "bignum"}, e); diff != "" {
+						t.Errorf("unexpected error diff:\n%s", diff)
 					}
-				},
+				}),
 			},
 		})
 

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/cbor/internal/modes/encode.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/cbor/internal/modes/encode.go
@@ -37,11 +37,10 @@ var Encode cbor.EncMode = func() cbor.EncMode {
 		NaNConvert: cbor.NaNConvertReject,
 		InfConvert: cbor.InfConvertReject,
 
-		// Prefer encoding math/big.Int to one of the 64-bit integer types if it fits. When
-		// later decoded into Unstructured, the set of allowable concrete numeric types is
-		// limited to int64 and float64, so the distinction between big integer and integer
-		// can't be preserved.
-		BigIntConvert: cbor.BigIntConvertShortest,
+		// Error on attempt to encode math/big.Int values, which can't be faithfully
+		// roundtripped through Unstructured in general (the dynamic numeric types allowed
+		// in Unstructured are limited to float64 and int64).
+		BigIntConvert: cbor.BigIntConvertReject,
 
 		// MarshalJSON for time.Time writes RFC3339 with nanos.
 		Time: cbor.TimeRFC3339Nano,

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/cbor/internal/modes/encode_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/cbor/internal/modes/encode_test.go
@@ -18,6 +18,8 @@ package modes_test
 
 import (
 	"fmt"
+	"math/big"
+	"reflect"
 	"testing"
 
 	"github.com/fxamacker/cbor/v2"
@@ -53,6 +55,15 @@ func TestEncode(t *testing.T) {
 			want:          []byte{0xa1, 0x41, 0x41, 0x02}, // {"A": 2}
 			assertOnError: assertNilError,
 		},
+		{
+			name: "math/big.Int values are rejected",
+			in:   big.NewInt(1),
+			assertOnError: assertOnConcreteError(func(t *testing.T, got *cbor.UnsupportedTypeError) {
+				if want := (&cbor.UnsupportedTypeError{Type: reflect.TypeFor[big.Int]()}); *want != *got {
+					t.Errorf("unexpected error, got %#v (%q), want %#v (%q)", got, got.Error(), want, want.Error())
+				}
+			}),
+		},
 	} {
 		encModes := tc.modes
 		if len(encModes) == 0 {
@@ -68,7 +79,7 @@ func TestEncode(t *testing.T) {
 			t.Run(fmt.Sprintf("mode=%s/%s", modeName, tc.name), func(t *testing.T) {
 				out, err := encMode.Marshal(tc.in)
 				tc.assertOnError(t, err)
-				if diff := cmp.Diff(tc.want, out); diff != "" {
+				if diff := cmp.Diff(tc.want, out, cmp.Comparer(func(a, b reflect.Type) bool { return a == b })); diff != "" {
 					t.Errorf("unexpected output:\n%s", diff)
 				}
 			})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup
/sig api-machinery

#### What this PR does / why we need it:

Although CBOR can roundtrip arbitrary precision integers, they don't roundtrip properly through Unstructured because Unstructured is limited to the dynamic numeric types int64 and float64. Rather than serializing them (and potentially losing information), reject them explicitly with an error.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://kep.k8s.io/4222
```
