### PR TITLE
KEP-4222: Disable recognition of Binary(Unm|M)arshaler in CBOR serializer.

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/cbor/internal/modes/decode.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/cbor/internal/modes/decode.go
@@ -135,6 +135,10 @@ var Decode cbor.DecMode = func() cbor.DecMode {
 
 		// Reject anything other than the simple values true, false, and null.
 		SimpleValues: simpleValues,
+
+		// Disable default recognition of types implementing encoding.BinaryUnmarshaler,
+		// which is not recognized for JSON decoding.
+		BinaryUnmarshaler: cbor.BinaryUnmarshalerNone,
 	}.DecMode()
 	if err != nil {
 		panic(err)

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/cbor/internal/modes/encode.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/cbor/internal/modes/encode.go
@@ -87,6 +87,10 @@ var Encode cbor.EncMode = func() cbor.EncMode {
 		// base64 encoding of the original bytes. No base64 encoding or decoding needs to be
 		// performed for []byte-to-CBOR-to-[]byte roundtrips.
 		ByteSliceLaterFormat: cbor.ByteSliceLaterFormatBase64,
+
+		// Disable default recognition of types implementing encoding.BinaryMarshaler, which
+		// is not recognized for JSON encoding.
+		BinaryMarshaler: cbor.BinaryMarshalerNone,
 	}.EncMode()
 	if err != nil {
 		panic(err)

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/cbor/internal/modes/encode_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/cbor/internal/modes/encode_test.go
@@ -26,6 +26,12 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
+type int64BinaryMarshaler int64
+
+func (i int64BinaryMarshaler) MarshalBinary() ([]byte, error) {
+	return []byte{}, nil
+}
+
 func TestEncode(t *testing.T) {
 	for _, tc := range []struct {
 		name          string
@@ -34,6 +40,12 @@ func TestEncode(t *testing.T) {
 		want          []byte
 		assertOnError func(t *testing.T, e error)
 	}{
+		{
+			name:          "implementations of BinaryMarshaler are ignored",
+			in:            int64BinaryMarshaler(7),
+			want:          []byte{0x07},
+			assertOnError: assertNilError,
+		},
 		{
 			name: "all duplicate fields are ignored", // Matches behavior of JSON serializer.
 			in: struct {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup
/sig api-machinery

#### What this PR does / why we need it:

The underlying CBOR library will by default encode a value to and from byte string if its type implements encoding.BinaryMarshaler or encoding.BinaryUnmarshaler, respectively. This is now disabled via an option to avoid diverging from JSON in those cases.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://kep.k8s.io/4222
```
