### PR TITLE
KEP-4222: Decode CBOR time tags to interface{} as RFC 3339 timestamps.

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/cbor/internal/modes/appendixa_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/cbor/internal/modes/appendixa_test.go
@@ -300,17 +300,15 @@ func TestAppendixA(t *testing.T) {
 				reasonByteString,
 				reasonTimeToInterface,
 			},
-			fixme: "decoding of tagged time into interface{} must produce RFC3339 timestamp compatible with JSON, not time.Time",
 		},
 		{
 			example: hex("c11a514b67b0"),
-			decoded: "2013-03-21T16:04:00Z",
-			encoded: hex("54323031332d30332d32315431363a30343a30305a"),
+			decoded: "2013-03-21T20:04:00Z",
+			encoded: hex("54323031332d30332d32315432303a30343a30305a"),
 			reasons: []string{
 				reasonByteString,
 				reasonTimeToInterface,
 			},
-			fixme: "decoding of tagged time into interface{} must produce RFC3339 timestamp compatible with JSON, not time.Time",
 		},
 		{
 			example: hex("c1fb41d452d9ec200000"),
@@ -320,7 +318,6 @@ func TestAppendixA(t *testing.T) {
 				reasonByteString,
 				reasonTimeToInterface,
 			},
-			fixme: "decoding of tagged time into interface{} must produce RFC3339 timestamp compatible with JSON, not time.Time",
 		},
 		{
 			example: hex("d74401020304"),

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/cbor/internal/modes/decode.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/cbor/internal/modes/decode.go
@@ -85,6 +85,9 @@ var Decode cbor.DecMode = func() cbor.DecMode {
 		// instead of the default, a cbor.Tag representing a (number, content) pair.
 		UnrecognizedTagToAny: cbor.UnrecognizedTagContentToAny,
 
+		// Decode time tags to interface{} as strings containing RFC 3339 timestamps.
+		TimeTagToAny: cbor.TimeTagToRFC3339Nano,
+
 		// For parity with JSON, strings can be decoded into time.Time if they are RFC 3339
 		// timestamps.
 		ByteStringToTime: cbor.ByteStringToTimeAllowed,

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/cbor/internal/modes/decode_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/cbor/internal/modes/decode_test.go
@@ -647,7 +647,6 @@ func TestDecode(t *testing.T) {
 				name:          "tag 0 RFC3339 text string",
 				in:            hex("c074323030362d30312d30325431353a30343a30355a"), // 0("2006-01-02T15:04:05Z")
 				want:          "2006-01-02T15:04:05Z",
-				fixme:         "decoding RFC3339 text string tagged with 0 produces time.Time instead of RFC3339 timestamp string",
 				assertOnError: assertNilError,
 			},
 			{
@@ -668,63 +667,54 @@ func TestDecode(t *testing.T) {
 				name:          "tag 1 timestamp unsigned integer",
 				in:            hex("c11a43b940e5"), // 1(1136214245)
 				want:          "2006-01-02T15:04:05Z",
-				fixme:         "decoding cbor data tagged with 1 produces time.Time instead of RFC3339 timestamp string",
 				assertOnError: assertNilError,
 			},
 			{
 				name:          "tag 1 with float16 value",
 				in:            hex("c1f93c00"), // 1(1.0_1)
 				want:          "1970-01-01T00:00:01Z",
-				fixme:         "decoding cbor data tagged with 1 produces time.Time instead of RFC3339 timestamp string",
 				assertOnError: assertNilError,
 			},
 			{
 				name:          "tag 1 with float32 value",
 				in:            hex("c1fa3f800000"), // 1(1.0_2)
 				want:          "1970-01-01T00:00:01Z",
-				fixme:         "decoding cbor data tagged with 1 produces time.Time instead of RFC3339 timestamp string",
 				assertOnError: assertNilError,
 			},
 			{
 				name:          "tag 1 with float64 value",
 				in:            hex("c1fb3ff0000000000000"), // 1(1.0_3)
 				want:          "1970-01-01T00:00:01Z",
-				fixme:         "decoding cbor data tagged with 1 produces time.Time instead of RFC3339 timestamp string",
 				assertOnError: assertNilError,
 			},
 			{
 				name:          "tag 1 with a five digit year",
 				in:            hex("c11b0000003afff44181"), // 1(253402300801)
 				want:          "10000-01-01T00:00:01Z",
-				fixme:         "decoding cbor data tagged with 1 produces time.Time instead of RFC3339 timestamp string",
-				assertOnError: assertNilError,
+				assertOnError: assertErrorMessage("cbor: decoded time cannot be represented in RFC3339 format with sub-second precision: Time.MarshalText: year outside of range [0,9999]"),
 			},
 			{
 				name:          "tag 1 with a negative integer value",
 				in:            hex("c120"), // 1(-1)
 				want:          "1969-12-31T23:59:59Z",
-				fixme:         "decoding cbor data tagged with 1 produces time.Time instead of RFC3339 timestamp string",
 				assertOnError: assertNilError,
 			},
 			{
 				name:          "tag 1 with a negative float16 value",
 				in:            hex("c1f9bc00"), // 1(-1.0_1)
 				want:          "1969-12-31T23:59:59Z",
-				fixme:         "decoding cbor data tagged with 1 produces time.Time instead of RFC3339 timestamp string",
 				assertOnError: assertNilError,
 			},
 			{
 				name:          "tag 1 with a negative float32 value",
 				in:            hex("c1fabf800000"), // 1(-1.0_2)
 				want:          "1969-12-31T23:59:59Z",
-				fixme:         "decoding cbor data tagged with 1 produces time.Time instead of RFC3339 timestamp string",
 				assertOnError: assertNilError,
 			},
 			{
 				name:          "tag 1 with a negative float64 value",
 				in:            hex("c1fbbff0000000000000"), // 1(-1.0_3)
 				want:          "1969-12-31T23:59:59Z",
-				fixme:         "decoding cbor data tagged with 1 produces time.Time instead of RFC3339 timestamp string",
 				assertOnError: assertNilError,
 			},
 			{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup
/sig api-machinery

#### What this PR does / why we need it:

The default CBOR library configuration unmarshals time values (tags 0 and 1) to `interface{}` as `time.Time`, which is inconsistent with the JSON-based Unstructured behavior. This configures times to decode to `interface{}` as `string` values containing RFC3339 timestamps. The effect is that `time.Time` to `Unstructured` gives the same result via both JSON and CBOR.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://kep.k8s.io/4222
```
