### PR TITLE
Job: Fix a bug that the SuccessCriteriaMet could be added to the Job with successPolicy regardless of the featureGate enabling

### DIFF
--- a/pkg/controller/job/job_controller_test.go
+++ b/pkg/controller/job/job_controller_test.go
@@ -4531,6 +4531,37 @@ func TestSyncJobWithJobSuccessPolicy(t *testing.T) {
 				},
 			},
 		},
+		"when the JobSuccessPolicy is disabled, the Job never got SuccessCriteriaMet condition even if the Job has the successPolicy field": {
+			job: batch.Job{
+				TypeMeta:   validTypeMeta,
+				ObjectMeta: validObjectMeta,
+				Spec: batch.JobSpec{
+					Selector:       validSelector,
+					Template:       validTemplate,
+					CompletionMode: completionModePtr(batch.IndexedCompletion),
+					Parallelism:    ptr.To[int32](3),
+					Completions:    ptr.To[int32](3),
+					BackoffLimit:   ptr.To[int32](math.MaxInt32),
+					SuccessPolicy: &batch.SuccessPolicy{
+						Rules: []batch.SuccessPolicyRule{{
+							SucceededIndexes: ptr.To("0,1"),
+							SucceededCount:   ptr.To[int32](1),
+						}},
+					},
+				},
+			},
+			pods: []v1.Pod{
+				*buildPod().uid("a2").index("0").phase(v1.PodRunning).trackingFinalizer().Pod,
+				*buildPod().uid("b").index("1").phase(v1.PodSucceeded).trackingFinalizer().Pod,
+				*buildPod().uid("c").index("2").phase(v1.PodRunning).trackingFinalizer().Pod,
+			},
+			wantStatus: batch.JobStatus{
+				Active:                  2,
+				Succeeded:               1,
+				CompletedIndexes:        "1",
+				UncountedTerminatedPods: &batch.UncountedTerminatedPods{},
+			},
+		},
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {

--- a/pkg/controller/job/success_policy.go
+++ b/pkg/controller/job/success_policy.go
@@ -27,7 +27,7 @@ import (
 )
 
 func matchSuccessPolicy(logger klog.Logger, successPolicy *batch.SuccessPolicy, completions int32, succeededIndexes orderedIntervals) (string, bool) {
-	if successPolicy == nil || len(succeededIndexes) == 0 {
+	if !feature.DefaultFeatureGate.Enabled(features.JobSuccessPolicy) || successPolicy == nil || len(succeededIndexes) == 0 {
 		return "", false
 	}
 

--- a/pkg/controller/job/success_policy_test.go
+++ b/pkg/controller/job/success_policy_test.go
@@ -21,30 +21,41 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	batch "k8s.io/api/batch/v1"
+	"k8s.io/apiserver/pkg/util/feature"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/klog/v2/ktesting"
+	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/utils/ptr"
 )
 
 func TestMatchSuccessPolicy(t *testing.T) {
 	testCases := map[string]struct {
-		successPolicy        *batch.SuccessPolicy
-		completions          int32
-		succeededIndexes     orderedIntervals
-		wantMessage          string
-		wantMetSuccessPolicy bool
+		successPolicy          *batch.SuccessPolicy
+		completions            int32
+		succeededIndexes       orderedIntervals
+		wantMessage            string
+		wantMetSuccessPolicy   bool
+		enableJobSuccessPolicy bool
 	}{
-		"successPolicy is null": {
+		"JobSuccessPolicy is disabled": {
 			completions:      10,
 			succeededIndexes: orderedIntervals{{0, 0}},
+		},
+		"successPolicy is null": {
+			enableJobSuccessPolicy: true,
+			completions:            10,
+			succeededIndexes:       orderedIntervals{{0, 0}},
 		},
 		"any rules are nothing": {
-			completions:      10,
-			succeededIndexes: orderedIntervals{{0, 0}},
-			successPolicy:    &batch.SuccessPolicy{Rules: []batch.SuccessPolicyRule{}},
+			enableJobSuccessPolicy: true,
+			completions:            10,
+			succeededIndexes:       orderedIntervals{{0, 0}},
+			successPolicy:          &batch.SuccessPolicy{Rules: []batch.SuccessPolicyRule{}},
 		},
 		"rules.succeededIndexes is invalid format": {
-			completions:      10,
-			succeededIndexes: orderedIntervals{{0, 0}},
+			enableJobSuccessPolicy: true,
+			completions:            10,
+			succeededIndexes:       orderedIntervals{{0, 0}},
 			successPolicy: &batch.SuccessPolicy{
 				Rules: []batch.SuccessPolicyRule{{
 					SucceededIndexes: ptr.To("invalid-form"),
@@ -52,8 +63,9 @@ func TestMatchSuccessPolicy(t *testing.T) {
 			},
 		},
 		"rules.succeededIndexes is specified; succeededIndexes matched rules": {
-			completions:      10,
-			succeededIndexes: orderedIntervals{{0, 2}, {4, 7}},
+			enableJobSuccessPolicy: true,
+			completions:            10,
+			succeededIndexes:       orderedIntervals{{0, 2}, {4, 7}},
 			successPolicy: &batch.SuccessPolicy{
 				Rules: []batch.SuccessPolicyRule{{
 					SucceededIndexes: ptr.To("0-2"),
@@ -63,8 +75,9 @@ func TestMatchSuccessPolicy(t *testing.T) {
 			wantMetSuccessPolicy: true,
 		},
 		"rules.succeededIndexes is specified; succeededIndexes didn't match rules": {
-			completions:      10,
-			succeededIndexes: orderedIntervals{{0, 2}},
+			enableJobSuccessPolicy: true,
+			completions:            10,
+			succeededIndexes:       orderedIntervals{{0, 2}},
 			successPolicy: &batch.SuccessPolicy{
 				Rules: []batch.SuccessPolicyRule{{
 					SucceededIndexes: ptr.To("3"),
@@ -72,8 +85,9 @@ func TestMatchSuccessPolicy(t *testing.T) {
 			},
 		},
 		"rules.succeededCount is specified; succeededIndexes matched rules": {
-			completions:      10,
-			succeededIndexes: orderedIntervals{{0, 2}},
+			enableJobSuccessPolicy: true,
+			completions:            10,
+			succeededIndexes:       orderedIntervals{{0, 2}},
 			successPolicy: &batch.SuccessPolicy{
 				Rules: []batch.SuccessPolicyRule{{
 					SucceededCount: ptr.To[int32](2),
@@ -83,8 +97,9 @@ func TestMatchSuccessPolicy(t *testing.T) {
 			wantMetSuccessPolicy: true,
 		},
 		"rules.succeededCount is specified; succeededIndexes didn't match rules": {
-			completions:      10,
-			succeededIndexes: orderedIntervals{{0, 2}},
+			enableJobSuccessPolicy: true,
+			completions:            10,
+			succeededIndexes:       orderedIntervals{{0, 2}},
 			successPolicy: &batch.SuccessPolicy{
 				Rules: []batch.SuccessPolicyRule{{
 					SucceededCount: ptr.To[int32](4),
@@ -92,8 +107,9 @@ func TestMatchSuccessPolicy(t *testing.T) {
 			},
 		},
 		"multiple rules; rules.succeededIndexes is specified; succeededIndexes met one of rules": {
-			completions:      10,
-			succeededIndexes: orderedIntervals{{0, 2}, {4, 7}},
+			enableJobSuccessPolicy: true,
+			completions:            10,
+			succeededIndexes:       orderedIntervals{{0, 2}, {4, 7}},
 			successPolicy: &batch.SuccessPolicy{
 				Rules: []batch.SuccessPolicyRule{
 					{
@@ -108,8 +124,9 @@ func TestMatchSuccessPolicy(t *testing.T) {
 			wantMetSuccessPolicy: true,
 		},
 		"multiple rules; rules.succeededIndexes is specified; succeededIndexes met all rules": {
-			completions:      10,
-			succeededIndexes: orderedIntervals{{0, 2}, {4, 7}},
+			enableJobSuccessPolicy: true,
+			completions:            10,
+			succeededIndexes:       orderedIntervals{{0, 2}, {4, 7}},
 			successPolicy: &batch.SuccessPolicy{
 				Rules: []batch.SuccessPolicyRule{
 					{
@@ -124,8 +141,9 @@ func TestMatchSuccessPolicy(t *testing.T) {
 			wantMetSuccessPolicy: true,
 		},
 		"rules.succeededIndexes and rules.succeededCount are specified; succeededIndexes met all rules": {
-			completions:      10,
-			succeededIndexes: orderedIntervals{{0, 2}, {4, 7}},
+			enableJobSuccessPolicy: true,
+			completions:            10,
+			succeededIndexes:       orderedIntervals{{0, 2}, {4, 7}},
 			successPolicy: &batch.SuccessPolicy{
 				Rules: []batch.SuccessPolicyRule{{
 					SucceededIndexes: ptr.To("3-6"),
@@ -136,8 +154,9 @@ func TestMatchSuccessPolicy(t *testing.T) {
 			wantMessage:          "Matched rules at index 0",
 		},
 		"rules.succeededIndexes and rules.succeededCount are specified; succeededIndexes didn't match rules": {
-			completions:      10,
-			succeededIndexes: orderedIntervals{{0, 2}, {6, 7}},
+			enableJobSuccessPolicy: true,
+			completions:            10,
+			succeededIndexes:       orderedIntervals{{0, 2}, {6, 7}},
 			successPolicy: &batch.SuccessPolicy{
 				Rules: []batch.SuccessPolicyRule{{
 					SucceededIndexes: ptr.To("3-6"),
@@ -156,8 +175,9 @@ func TestMatchSuccessPolicy(t *testing.T) {
 		},
 
 		"rules.succeededIndexes is specified; succeededIndexes matched rules; rules is proper subset of succeededIndexes": {
-			completions:      10,
-			succeededIndexes: orderedIntervals{{1, 5}, {6, 9}},
+			enableJobSuccessPolicy: true,
+			completions:            10,
+			succeededIndexes:       orderedIntervals{{1, 5}, {6, 9}},
 			successPolicy: &batch.SuccessPolicy{
 				Rules: []batch.SuccessPolicyRule{{
 					SucceededIndexes: ptr.To("2-4,6-8"),
@@ -167,8 +187,9 @@ func TestMatchSuccessPolicy(t *testing.T) {
 			wantMessage:          "Matched rules at index 0",
 		},
 		"rules.succeededIndexes is specified; succeededIndexes matched rules; rules equals succeededIndexes": {
-			completions:      10,
-			succeededIndexes: orderedIntervals{{2, 4}, {6, 9}},
+			enableJobSuccessPolicy: true,
+			completions:            10,
+			succeededIndexes:       orderedIntervals{{2, 4}, {6, 9}},
 			successPolicy: &batch.SuccessPolicy{
 				Rules: []batch.SuccessPolicyRule{{
 					SucceededIndexes: ptr.To("2-4,6-9"),
@@ -178,8 +199,9 @@ func TestMatchSuccessPolicy(t *testing.T) {
 			wantMessage:          "Matched rules at index 0",
 		},
 		"rules.succeededIndexes is specified; succeededIndexes matched rules; rules is subset of succeededIndexes": {
-			completions:      10,
-			succeededIndexes: orderedIntervals{{2, 5}, {7, 15}},
+			enableJobSuccessPolicy: true,
+			completions:            10,
+			succeededIndexes:       orderedIntervals{{2, 5}, {7, 15}},
 			successPolicy: &batch.SuccessPolicy{
 				Rules: []batch.SuccessPolicyRule{{
 					SucceededIndexes: ptr.To("2-4,8-12"),
@@ -189,8 +211,9 @@ func TestMatchSuccessPolicy(t *testing.T) {
 			wantMessage:          "Matched rules at index 0",
 		},
 		"rules.succeededIndexes is specified; succeededIndexes didn't match rules; rules is an empty set": {
-			completions:      10,
-			succeededIndexes: orderedIntervals{{1, 3}},
+			enableJobSuccessPolicy: true,
+			completions:            10,
+			succeededIndexes:       orderedIntervals{{1, 3}},
 			successPolicy: &batch.SuccessPolicy{
 				Rules: []batch.SuccessPolicyRule{{
 					SucceededIndexes: ptr.To(""),
@@ -198,8 +221,9 @@ func TestMatchSuccessPolicy(t *testing.T) {
 			},
 		},
 		"rules.succeededIndexes is specified; succeededIndexes didn't match rules; succeededIndexes is an empty set": {
-			completions:      10,
-			succeededIndexes: orderedIntervals{},
+			enableJobSuccessPolicy: true,
+			completions:            10,
+			succeededIndexes:       orderedIntervals{},
 			successPolicy: &batch.SuccessPolicy{
 				Rules: []batch.SuccessPolicyRule{{
 					SucceededIndexes: ptr.To(""),
@@ -207,8 +231,9 @@ func TestMatchSuccessPolicy(t *testing.T) {
 			},
 		},
 		"rules.succeededIndexes is specified; succeededIndexes didn't match rules; rules and succeededIndexes are empty set": {
-			completions:      10,
-			succeededIndexes: orderedIntervals{},
+			enableJobSuccessPolicy: true,
+			completions:            10,
+			succeededIndexes:       orderedIntervals{},
 			successPolicy: &batch.SuccessPolicy{
 				Rules: []batch.SuccessPolicyRule{{
 					SucceededIndexes: ptr.To(""),
@@ -216,8 +241,9 @@ func TestMatchSuccessPolicy(t *testing.T) {
 			},
 		},
 		"rules.succeededIndexes is specified; succeededIndexes didn't match rules; all elements of rules.succeededIndexes aren't included in succeededIndexes": {
-			completions:      10,
-			succeededIndexes: orderedIntervals{{1, 3}, {5, 7}},
+			enableJobSuccessPolicy: true,
+			completions:            10,
+			succeededIndexes:       orderedIntervals{{1, 3}, {5, 7}},
 			successPolicy: &batch.SuccessPolicy{
 				Rules: []batch.SuccessPolicyRule{{
 					SucceededIndexes: ptr.To("10-12,14-16"),
@@ -225,8 +251,9 @@ func TestMatchSuccessPolicy(t *testing.T) {
 			},
 		},
 		"rules.succeededIndexes is specified; succeededIndexes didn't match rules; rules overlaps succeededIndexes at first": {
-			completions:      10,
-			succeededIndexes: orderedIntervals{{2, 4}, {6, 8}},
+			enableJobSuccessPolicy: true,
+			completions:            10,
+			succeededIndexes:       orderedIntervals{{2, 4}, {6, 8}},
 			successPolicy: &batch.SuccessPolicy{
 				Rules: []batch.SuccessPolicyRule{{
 					SucceededIndexes: ptr.To("1-3,5-7"),
@@ -234,8 +261,9 @@ func TestMatchSuccessPolicy(t *testing.T) {
 			},
 		},
 		"rules.succeededIndexes and rules.succeededCount are specified; succeededIndexes matched rules; rules overlaps succeededIndexes at first": {
-			completions:      10,
-			succeededIndexes: orderedIntervals{{2, 4}, {6, 8}},
+			enableJobSuccessPolicy: true,
+			completions:            10,
+			succeededIndexes:       orderedIntervals{{2, 4}, {6, 8}},
 			successPolicy: &batch.SuccessPolicy{
 				Rules: []batch.SuccessPolicyRule{{
 					SucceededIndexes: ptr.To("1-3,5-7"),
@@ -246,8 +274,9 @@ func TestMatchSuccessPolicy(t *testing.T) {
 			wantMessage:          "Matched rules at index 0",
 		},
 		"rules.succeededIndexes is specified; succeededIndexes didn't match rules; rules overlaps succeededIndexes at last": {
-			completions:      10,
-			succeededIndexes: orderedIntervals{{1, 3}, {5, 7}},
+			enableJobSuccessPolicy: true,
+			completions:            10,
+			succeededIndexes:       orderedIntervals{{1, 3}, {5, 7}},
 			successPolicy: &batch.SuccessPolicy{
 				Rules: []batch.SuccessPolicyRule{{
 					SucceededIndexes: ptr.To("2-4,6-9"),
@@ -255,8 +284,9 @@ func TestMatchSuccessPolicy(t *testing.T) {
 			},
 		},
 		"rules.succeededIndexes and rules.succeededCount are specified; succeededIndexes matched rules; rules overlaps succeededIndexes at last": {
-			completions:      10,
-			succeededIndexes: orderedIntervals{{1, 3}, {5, 7}},
+			enableJobSuccessPolicy: true,
+			completions:            10,
+			succeededIndexes:       orderedIntervals{{1, 3}, {5, 7}},
 			successPolicy: &batch.SuccessPolicy{
 				Rules: []batch.SuccessPolicyRule{{
 					SucceededIndexes: ptr.To("2-4,6-9"),
@@ -267,8 +297,9 @@ func TestMatchSuccessPolicy(t *testing.T) {
 			wantMessage:          "Matched rules at index 0",
 		},
 		"rules.succeededIndexes is specified; succeededIndexes didn't match rules; rules completely overlaps succeededIndexes": {
-			completions:      10,
-			succeededIndexes: orderedIntervals{{1, 3}, {7, 8}},
+			enableJobSuccessPolicy: true,
+			completions:            10,
+			succeededIndexes:       orderedIntervals{{1, 3}, {7, 8}},
 			successPolicy: &batch.SuccessPolicy{
 				Rules: []batch.SuccessPolicyRule{{
 					SucceededIndexes: ptr.To("0-4,6-9"),
@@ -276,8 +307,9 @@ func TestMatchSuccessPolicy(t *testing.T) {
 			},
 		},
 		"rules.succeededIndexes and rules.succeededCount are specified; succeededIndexes matched rules; rules completely overlaps succeededIndexes": {
-			completions:      10,
-			succeededIndexes: orderedIntervals{{1, 3}, {7, 8}},
+			enableJobSuccessPolicy: true,
+			completions:            10,
+			succeededIndexes:       orderedIntervals{{1, 3}, {7, 8}},
 			successPolicy: &batch.SuccessPolicy{
 				Rules: []batch.SuccessPolicyRule{{
 					SucceededIndexes: ptr.To("0-4,6-9"),
@@ -288,8 +320,9 @@ func TestMatchSuccessPolicy(t *testing.T) {
 			wantMessage:          "Matched rules at index 0",
 		},
 		"rules.succeededIndexes is specified; succeededIndexes didn't match rules; rules overlaps multiple succeededIndexes at last": {
-			completions:      10,
-			succeededIndexes: orderedIntervals{{1, 3}, {5, 9}},
+			enableJobSuccessPolicy: true,
+			completions:            10,
+			succeededIndexes:       orderedIntervals{{1, 3}, {5, 9}},
 			successPolicy: &batch.SuccessPolicy{
 				Rules: []batch.SuccessPolicyRule{{
 					SucceededIndexes: ptr.To("0-6,8-9"),
@@ -297,8 +330,9 @@ func TestMatchSuccessPolicy(t *testing.T) {
 			},
 		},
 		"rules.succeededIndexes and rules.succeededCount are specified; succeededIndexes matched rules; rules overlaps multiple succeededIndexes at last": {
-			completions:      10,
-			succeededIndexes: orderedIntervals{{1, 3}, {5, 9}},
+			enableJobSuccessPolicy: true,
+			completions:            10,
+			succeededIndexes:       orderedIntervals{{1, 3}, {5, 9}},
 			successPolicy: &batch.SuccessPolicy{
 				Rules: []batch.SuccessPolicyRule{{
 					SucceededIndexes: ptr.To("0-6,8-9"),
@@ -309,8 +343,9 @@ func TestMatchSuccessPolicy(t *testing.T) {
 			wantMessage:          "Matched rules at index 0",
 		},
 		"rules.succeededIndexes is specified; succeededIndexes didn't match rules; rules overlaps succeededIndexes at first, and rules equals succeededIndexes at last": {
-			completions:      10,
-			succeededIndexes: orderedIntervals{{1, 5}, {7, 10}},
+			enableJobSuccessPolicy: true,
+			completions:            10,
+			succeededIndexes:       orderedIntervals{{1, 5}, {7, 10}},
 			successPolicy: &batch.SuccessPolicy{
 				Rules: []batch.SuccessPolicyRule{{
 					SucceededIndexes: ptr.To("0-5,7-9"),
@@ -318,8 +353,9 @@ func TestMatchSuccessPolicy(t *testing.T) {
 			},
 		},
 		"rules.succeededIndexes and rules.succeededCount are specified; succeededIndexes matched rules; rules overlaps succeededIndexes at first, and rules equals succeededIndexes at last": {
-			completions:      10,
-			succeededIndexes: orderedIntervals{{1, 5}, {7, 10}},
+			enableJobSuccessPolicy: true,
+			completions:            10,
+			succeededIndexes:       orderedIntervals{{1, 5}, {7, 10}},
 			successPolicy: &batch.SuccessPolicy{
 				Rules: []batch.SuccessPolicyRule{{
 					SucceededIndexes: ptr.To("0-5,7-9"),
@@ -330,8 +366,9 @@ func TestMatchSuccessPolicy(t *testing.T) {
 			wantMessage:          "Matched rules at index 0",
 		},
 		"rules.succeededIndexes is specified; succeededIndexes didn't match rules; the first rules overlaps succeededIndexes at first": {
-			completions:      10,
-			succeededIndexes: orderedIntervals{{1, 10}},
+			enableJobSuccessPolicy: true,
+			completions:            10,
+			succeededIndexes:       orderedIntervals{{1, 10}},
 			successPolicy: &batch.SuccessPolicy{
 				Rules: []batch.SuccessPolicyRule{{
 					SucceededIndexes: ptr.To("0-3,6-9"),
@@ -339,8 +376,9 @@ func TestMatchSuccessPolicy(t *testing.T) {
 			},
 		},
 		"rules.succeededIndexes and rules.succeededCount are specified; succeededIndexes matched rules; the first rules overlaps succeededIndexes at first": {
-			completions:      10,
-			succeededIndexes: orderedIntervals{{1, 10}},
+			enableJobSuccessPolicy: true,
+			completions:            10,
+			succeededIndexes:       orderedIntervals{{1, 10}},
 			successPolicy: &batch.SuccessPolicy{
 				Rules: []batch.SuccessPolicyRule{{
 					SucceededIndexes: ptr.To("0-3,6-9"),
@@ -353,6 +391,7 @@ func TestMatchSuccessPolicy(t *testing.T) {
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
+			featuregatetesting.SetFeatureGateDuringTest(t, feature.DefaultFeatureGate, features.JobSuccessPolicy, tc.enableJobSuccessPolicy)
 			logger := ktesting.NewLogger(t,
 				ktesting.NewConfig(
 					ktesting.BufferLogs(true),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
The SuccessCriteriaMet condition could be added to the Job with successPolicy even if the JobSuccessPolicy featureGate is disabled the following logic:

https://github.com/kubernetes/kubernetes/blob/9d63e575f8482b857ef328325d2107df840b9deb/pkg/controller/job/job_controller.go#L883-L885

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part-of https://github.com/kubernetes/enhancements/issues/3998

#### Special notes for your reviewer:
Actually, if we don't apply this patch, the added unit test case, `when the JobSuccessPolicy is disabled, the Job never got SuccessCriteriaMet condition even if the Job has the successPolicy field`, failed in the following:

```shell
=== RUN   TestSyncJobWithJobSuccessPolicy/when_the_JobSuccessPolicy_is_disabled,_the_Job_never_got_SuccessCriteriaMet_condition_even_if_the_Job_has_the_successPolicy_field
    controller_utils.go:206: I0611 11:30:51.111538] Controller either never recorded expectations, or the ttl expired controller="default/foobar"
    controller_utils.go:954: I0611 11:30:51.111780] Ignoring inactive pod pod="default/mypod-1" phase="Succeeded" deletionTime=null
    tracking_utils.go:78: I0611 11:30:51.111851] Expecting tracking finalizers removed key="default/foobar" podUIDs=["a2","b","c"]
    job_controller.go:733: I0611 11:30:51.111934] Finished syncing job key="default/foobar" elapsed="0s"
    job_controller_test.go:4387: Unexpectd Job status (-want,+got):
          v1.JobStatus{
        - 	Conditions: nil,
        + 	Conditions: []v1.JobCondition{
        + 		{
        + 			Type:               "SuccessCriteriaMet",
        + 			Status:             "True",
        + 			LastProbeTime:      s"2024-06-11 11:30:51.109873 +0900 JST m=+0.027868334",
        + 			LastTransitionTime: s"2024-06-11 11:30:51.109873 +0900 JST m=+0.027868334",
        + 			Reason:             "SuccessPolicy",
        + 			Message:            "Matched rules at index 0",
        + 		},
        + 	},
          	... // 2 ignored fields
        - 	Active:           2,
        + 	Active:           0,
          	Succeeded:        1,
        - 	Failed:           0,
        + 	Failed:           2,
          	Terminating:      &0,
          	CompletedIndexes: "1",
          	... // 1 ignored and 2 identical fields
          }
--- FAIL: TestSyncJobWithJobSuccessPolicy (0.00s)
    --- FAIL: TestSyncJobWithJobSuccessPolicy/when_the_JobSuccessPolicy_is_disabled,_the_Job_never_got_SuccessCriteriaMet_condition_even_if_the_Job_has_the_successPolicy_field (0.00s)
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Job: Fix a 1.30 regression that the SuccessCriteriaMet could be added to the Job with successPolicy regardless of the featureGate enabling
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
https://github.com/kubernetes/enhancements/tree/master/keps/sig-apps/3998-job-success-completion-policy
```
