### PR TITLE
fix: kubectl secret creation from env file (solves #1610)

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/env_file_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/env_file_test.go
@@ -32,20 +32,41 @@ func Test_processEnvFileLine(t *testing.T) {
 		expectedValue string
 		expectedErr   string
 	}{
-		{"the utf8bom is trimmed on the first line",
-			append(utf8bom, 'a', '=', 'c'), 0, "a", "c", ""},
+		{
+			"the utf8bom is trimmed on the first line",
+			append(utf8bom, 'a', '=', 'c'), 0, "a", "c", "",
+		},
 
-		{"the utf8bom is NOT trimmed on the second line",
-			append(utf8bom, 'a', '=', 'c'), 1, "", "", "not a valid key name"},
+		{
+			"the utf8bom is NOT trimmed on the second line",
+			append(utf8bom, 'a', '=', 'c'), 1, "", "", "not a valid key name",
+		},
 
-		{"no key is returned on a comment line",
-			[]byte{' ', '#', 'c'}, 0, "", "", ""},
+		{
+			"no key is returned on a comment line",
+			[]byte{' ', '#', 'c'},
+			0, "", "", "",
+		},
 
-		{"no key is returned on a blank line",
-			[]byte{' ', ' ', '\t'}, 0, "", "", ""},
+		{
+			"no key is returned on a blank line",
+			[]byte{' ', ' ', '\t'},
+			0, "", "", "",
+		},
 
-		{"key is returned even with no value",
-			[]byte{' ', 'x', '='}, 0, "x", "", ""},
+		{
+			"key is returned even with no value",
+			[]byte{' ', 'x', '='},
+			0, "x", "", "",
+		},
+		{
+			"one line value is surrounded to quotes",
+			[]byte("prefixed_key=\"prefixed value\""), 0, "prefixed_key", "\"prefixed value\"", "",
+		},
+		{
+			"multiline value surrounded to quotes",
+			[]byte("multiline_key=\"line1\n... (rest of the value) ...\nlast line\""), 0, "multiline_key", "\"line1\n... (rest of the value) ...\nlast line\"", "",
+		},
 	}
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Currently Kubectl does not supports the creation of secrets with multiline values from an env file. That's because the code reads line by line the files.

This PR checks the quotes surrounding to detect the begin and the end of a value in the env file. This will allow the support for multiline values without neither breaking changes nor adding external dependencies.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes kubernetes/kubectl#1610

#### Special notes for your reviewer:
I added corresponding test cases.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
