### PR TITLE
[WIP] Use one lease per object

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/lease_manager.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/lease_manager.go
@@ -27,7 +27,7 @@ import (
 
 const (
 	defaultLeaseReuseDurationSeconds = 60
-	defaultLeaseMaxObjectCount       = 1000
+	defaultLeaseMaxObjectCount       = 1
 )
 
 // LeaseManagerConfig is configuration for creating a lease manager.


### PR DESCRIPTION
PoC to validate if https://github.com/etcd-io/etcd/issues/15993 allows K8s to start using one lease per object allowing us to fix https://github.com/kubernetes/kubernetes/issues/110210. Creating PR to build k8s binaries needed to run scalability tests.
```release-note
NONE
```
