### PR TITLE
Remove deprecated kubectl exec command execution without dash

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/exec/exec.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/exec/exec.go
@@ -200,17 +200,8 @@ func (p *ExecOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, argsIn []s
 	}
 	if argsLenAtDash > -1 {
 		p.Command = argsIn[argsLenAtDash:]
-	} else if len(argsIn) > 1 {
-		if !p.Quiet {
-			fmt.Fprint(p.ErrOut, "kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future version. Use kubectl exec [POD] -- [COMMAND] instead.\n")
-		}
-		p.Command = argsIn[1:]
-	} else if len(argsIn) > 0 && len(p.FilenameOptions.Filenames) != 0 {
-		if !p.Quiet {
-			fmt.Fprint(p.ErrOut, "kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future version. Use kubectl exec [POD] -- [COMMAND] instead.\n")
-		}
-		p.Command = argsIn[0:]
-		p.ResourceName = ""
+	} else if len(argsIn) > 1 || (len(argsIn) > 0 && len(p.FilenameOptions.Filenames) != 0) {
+		return cmdutil.UsageErrorf(cmd, "exec [POD] [COMMAND] is not supported anymore. Use exec [POD] -- [COMMAND] instead")
 	}
 
 	var err error

--- a/staging/src/k8s.io/kubectl/pkg/cmd/exec/exec_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/exec/exec_test.go
@@ -110,20 +110,17 @@ func TestPodAndContainer(t *testing.T) {
 			p:             &ExecOptions{},
 			args:          []string{"foo", "cmd"},
 			argsLenAtDash: -1,
-			expectedPod:   "foo",
-			expectedArgs:  []string{"cmd"},
+			expectError:   true,
 			name:          "cmd, cmd is behind dash",
 			obj:           execPod(),
 		},
 		{
-			p:                 &ExecOptions{StreamOptions: StreamOptions{ContainerName: "bar"}},
-			args:              []string{"foo", "cmd"},
-			argsLenAtDash:     -1,
-			expectedPod:       "foo",
-			expectedContainer: "bar",
-			expectedArgs:      []string{"cmd"},
-			name:              "cmd, container in flag",
-			obj:               execPod(),
+			p:             &ExecOptions{StreamOptions: StreamOptions{ContainerName: "bar"}},
+			args:          []string{"foo", "cmd"},
+			argsLenAtDash: -1,
+			expectError:   true,
+			name:          "cmd, container in flag",
+			obj:           execPod(),
 		},
 	}
 	for _, test := range tests {
@@ -238,8 +235,8 @@ func TestExec(t *testing.T) {
 				Executor: ex,
 			}
 			cmd := NewCmdExec(tf, genericiooptions.NewTestIOStreamsDiscard())
-			args := []string{"pod/foo", "command"}
-			if err := params.Complete(tf, cmd, args, -1); err != nil {
+			args := []string{"pod/foo", "--", "command"}
+			if err := params.Complete(tf, cmd, args, 1); err != nil {
 				t.Fatal(err)
 			}
 			err := params.Run()

--- a/test/cmd/exec.sh
+++ b/test/cmd/exec.sh
@@ -26,7 +26,7 @@ run_kubectl_exec_pod_tests() {
   kube::log::status "Testing kubectl exec POD COMMAND"
 
   ### Test execute non-existing POD
-  output_message=$(! kubectl exec abc date 2>&1)
+  output_message=$(! kubectl exec abc 2>&1 -- date)
   # POD abc should error since it doesn't exist
   kube::test::if_has_string "${output_message}" 'pods "abc" not found'
 


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
`kubectl exec [POD] [COMMAND]` execution functionality was deprecated nearly 5 years ago by https://github.com/kubernetes/kubernetes/pull/88460 and it is suggested to use `kubectl exec [POD] -- [COMMAND]` instead.

This PR removes this functionality by returning an error.

#### Does this PR introduce a user-facing change?
```release-note
Removing deprecated kubectl exec [POD] [COMMAND]
```
