### PR TITLE
Update publishing-bot rules to Go 1.22.4 and 1.21.11

### DIFF
--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -7,31 +7,31 @@ rules:
       dirs:
       - staging/src/k8s.io/apimachinery
   - name: release-1.26
-    go: 1.21.10
+    go: 1.21.11
     source:
       branch: release-1.26
       dirs:
       - staging/src/k8s.io/apimachinery
   - name: release-1.27
-    go: 1.21.10
+    go: 1.21.11
     source:
       branch: release-1.27
       dirs:
       - staging/src/k8s.io/apimachinery
   - name: release-1.28
-    go: 1.21.10
+    go: 1.21.11
     source:
       branch: release-1.28
       dirs:
       - staging/src/k8s.io/apimachinery
   - name: release-1.29
-    go: 1.21.10
+    go: 1.21.11
     source:
       branch: release-1.29
       dirs:
       - staging/src/k8s.io/apimachinery
   - name: release-1.30
-    go: 1.22.3
+    go: 1.22.4
     source:
       branch: release-1.30
       dirs:
@@ -48,7 +48,7 @@ rules:
       dirs:
       - staging/src/k8s.io/api
   - name: release-1.26
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -57,7 +57,7 @@ rules:
       dirs:
       - staging/src/k8s.io/api
   - name: release-1.27
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -66,7 +66,7 @@ rules:
       dirs:
       - staging/src/k8s.io/api
   - name: release-1.28
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -75,7 +75,7 @@ rules:
       dirs:
       - staging/src/k8s.io/api
   - name: release-1.29
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -84,7 +84,7 @@ rules:
       dirs:
       - staging/src/k8s.io/api
   - name: release-1.30
-    go: 1.22.3
+    go: 1.22.4
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -110,7 +110,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.26
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -125,7 +125,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.27
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -140,7 +140,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.28
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -155,7 +155,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.29
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -170,7 +170,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.30
-    go: 1.22.3
+    go: 1.22.4
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -196,31 +196,31 @@ rules:
       dirs:
       - staging/src/k8s.io/code-generator
   - name: release-1.26
-    go: 1.21.10
+    go: 1.21.11
     source:
       branch: release-1.26
       dirs:
       - staging/src/k8s.io/code-generator
   - name: release-1.27
-    go: 1.21.10
+    go: 1.21.11
     source:
       branch: release-1.27
       dirs:
       - staging/src/k8s.io/code-generator
   - name: release-1.28
-    go: 1.21.10
+    go: 1.21.11
     source:
       branch: release-1.28
       dirs:
       - staging/src/k8s.io/code-generator
   - name: release-1.29
-    go: 1.21.10
+    go: 1.21.11
     source:
       branch: release-1.29
       dirs:
       - staging/src/k8s.io/code-generator
   - name: release-1.30
-    go: 1.22.3
+    go: 1.22.4
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -243,7 +243,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-base
   - name: release-1.26
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -256,7 +256,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-base
   - name: release-1.27
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -269,7 +269,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-base
   - name: release-1.28
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -282,7 +282,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-base
   - name: release-1.29
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -295,7 +295,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-base
   - name: release-1.30
-    go: 1.22.3
+    go: 1.22.4
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -323,7 +323,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-helpers
   - name: release-1.26
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -336,7 +336,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-helpers
   - name: release-1.27
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -349,7 +349,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-helpers
   - name: release-1.28
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -362,7 +362,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-helpers
   - name: release-1.29
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -375,7 +375,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-helpers
   - name: release-1.30
-    go: 1.22.3
+    go: 1.22.4
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -399,13 +399,13 @@ rules:
       dirs:
       - staging/src/k8s.io/kms
   - name: release-1.26
-    go: 1.21.10
+    go: 1.21.11
     source:
       branch: release-1.26
       dirs:
       - staging/src/k8s.io/kms
   - name: release-1.27
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -418,7 +418,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kms
   - name: release-1.28
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -431,7 +431,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kms
   - name: release-1.29
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -440,7 +440,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kms
   - name: release-1.30
-    go: 1.22.3
+    go: 1.22.4
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -468,7 +468,7 @@ rules:
       dirs:
       - staging/src/k8s.io/apiserver
   - name: release-1.26
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -485,7 +485,7 @@ rules:
       dirs:
       - staging/src/k8s.io/apiserver
   - name: release-1.27
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -502,7 +502,7 @@ rules:
       dirs:
       - staging/src/k8s.io/apiserver
   - name: release-1.28
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -519,7 +519,7 @@ rules:
       dirs:
       - staging/src/k8s.io/apiserver
   - name: release-1.29
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -536,7 +536,7 @@ rules:
       dirs:
       - staging/src/k8s.io/apiserver
   - name: release-1.30
-    go: 1.22.3
+    go: 1.22.4
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -576,7 +576,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-aggregator
   - name: release-1.26
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -597,7 +597,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-aggregator
   - name: release-1.27
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -618,7 +618,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-aggregator
   - name: release-1.28
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -639,7 +639,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-aggregator
   - name: release-1.29
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -660,7 +660,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-aggregator
   - name: release-1.30
-    go: 1.22.3
+    go: 1.22.4
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -708,7 +708,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.26
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -734,7 +734,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.27
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -760,7 +760,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.28
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -786,7 +786,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.29
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -812,7 +812,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.30
-    go: 1.22.3
+    go: 1.22.4
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -859,7 +859,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.26
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -879,7 +879,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.27
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -899,7 +899,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.28
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -919,7 +919,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.29
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -939,7 +939,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.30
-    go: 1.22.3
+    go: 1.22.4
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -983,7 +983,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.26
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -1006,7 +1006,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.27
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -1029,7 +1029,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.28
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -1052,7 +1052,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.29
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -1075,7 +1075,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.30
-    go: 1.22.3
+    go: 1.22.4
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -1114,7 +1114,7 @@ rules:
       dirs:
       - staging/src/k8s.io/metrics
   - name: release-1.26
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -1129,7 +1129,7 @@ rules:
       dirs:
       - staging/src/k8s.io/metrics
   - name: release-1.27
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -1144,7 +1144,7 @@ rules:
       dirs:
       - staging/src/k8s.io/metrics
   - name: release-1.28
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -1159,7 +1159,7 @@ rules:
       dirs:
       - staging/src/k8s.io/metrics
   - name: release-1.29
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -1174,7 +1174,7 @@ rules:
       dirs:
       - staging/src/k8s.io/metrics
   - name: release-1.30
-    go: 1.22.3
+    go: 1.22.4
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -1204,7 +1204,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cli-runtime
   - name: release-1.26
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: api
       branch: release-1.26
@@ -1217,7 +1217,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cli-runtime
   - name: release-1.27
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: api
       branch: release-1.27
@@ -1230,7 +1230,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cli-runtime
   - name: release-1.28
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: api
       branch: release-1.28
@@ -1243,7 +1243,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cli-runtime
   - name: release-1.29
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: api
       branch: release-1.29
@@ -1256,7 +1256,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cli-runtime
   - name: release-1.30
-    go: 1.22.3
+    go: 1.22.4
     dependencies:
     - repository: api
       branch: release-1.30
@@ -1286,7 +1286,7 @@ rules:
       dirs:
       - staging/src/k8s.io/sample-cli-plugin
   - name: release-1.26
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: api
       branch: release-1.26
@@ -1301,7 +1301,7 @@ rules:
       dirs:
       - staging/src/k8s.io/sample-cli-plugin
   - name: release-1.27
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: api
       branch: release-1.27
@@ -1316,7 +1316,7 @@ rules:
       dirs:
       - staging/src/k8s.io/sample-cli-plugin
   - name: release-1.28
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: api
       branch: release-1.28
@@ -1331,7 +1331,7 @@ rules:
       dirs:
       - staging/src/k8s.io/sample-cli-plugin
   - name: release-1.29
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: api
       branch: release-1.29
@@ -1346,7 +1346,7 @@ rules:
       dirs:
       - staging/src/k8s.io/sample-cli-plugin
   - name: release-1.30
-    go: 1.22.3
+    go: 1.22.4
     dependencies:
     - repository: api
       branch: release-1.30
@@ -1377,7 +1377,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-proxy
   - name: release-1.26
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -1392,7 +1392,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-proxy
   - name: release-1.27
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -1407,7 +1407,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-proxy
   - name: release-1.28
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -1422,7 +1422,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-proxy
   - name: release-1.29
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -1437,7 +1437,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-proxy
   - name: release-1.30
-    go: 1.22.3
+    go: 1.22.4
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -1460,31 +1460,31 @@ rules:
       dirs:
       - staging/src/k8s.io/cri-api
   - name: release-1.26
-    go: 1.21.10
+    go: 1.21.11
     source:
       branch: release-1.26
       dirs:
       - staging/src/k8s.io/cri-api
   - name: release-1.27
-    go: 1.21.10
+    go: 1.21.11
     source:
       branch: release-1.27
       dirs:
       - staging/src/k8s.io/cri-api
   - name: release-1.28
-    go: 1.21.10
+    go: 1.21.11
     source:
       branch: release-1.28
       dirs:
       - staging/src/k8s.io/cri-api
   - name: release-1.29
-    go: 1.21.10
+    go: 1.21.11
     source:
       branch: release-1.29
       dirs:
       - staging/src/k8s.io/cri-api
   - name: release-1.30
-    go: 1.22.3
+    go: 1.22.4
     source:
       branch: release-1.30
       dirs:
@@ -1532,7 +1532,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubelet
   - name: release-1.26
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -1547,7 +1547,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubelet
   - name: release-1.27
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -1562,7 +1562,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubelet
   - name: release-1.28
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -1583,7 +1583,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubelet
   - name: release-1.29
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -1604,7 +1604,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubelet
   - name: release-1.30
-    go: 1.22.3
+    go: 1.22.4
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -1642,7 +1642,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-scheduler
   - name: release-1.26
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -1657,7 +1657,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-scheduler
   - name: release-1.27
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -1672,7 +1672,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-scheduler
   - name: release-1.28
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -1687,7 +1687,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-scheduler
   - name: release-1.29
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -1702,7 +1702,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-scheduler
   - name: release-1.30
-    go: 1.22.3
+    go: 1.22.4
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -1738,7 +1738,7 @@ rules:
       dirs:
       - staging/src/k8s.io/controller-manager
   - name: release-1.26
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: api
       branch: release-1.26
@@ -1757,7 +1757,7 @@ rules:
       dirs:
       - staging/src/k8s.io/controller-manager
   - name: release-1.27
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: api
       branch: release-1.27
@@ -1776,7 +1776,7 @@ rules:
       dirs:
       - staging/src/k8s.io/controller-manager
   - name: release-1.28
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: api
       branch: release-1.28
@@ -1795,7 +1795,7 @@ rules:
       dirs:
       - staging/src/k8s.io/controller-manager
   - name: release-1.29
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: api
       branch: release-1.29
@@ -1814,7 +1814,7 @@ rules:
       dirs:
       - staging/src/k8s.io/controller-manager
   - name: release-1.30
-    go: 1.22.3
+    go: 1.22.4
     dependencies:
     - repository: api
       branch: release-1.30
@@ -1858,7 +1858,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cloud-provider
   - name: release-1.26
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: api
       branch: release-1.26
@@ -1881,7 +1881,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cloud-provider
   - name: release-1.27
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: api
       branch: release-1.27
@@ -1904,7 +1904,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cloud-provider
   - name: release-1.28
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: api
       branch: release-1.28
@@ -1927,7 +1927,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cloud-provider
   - name: release-1.29
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: api
       branch: release-1.29
@@ -1950,7 +1950,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cloud-provider
   - name: release-1.30
-    go: 1.22.3
+    go: 1.22.4
     dependencies:
     - repository: api
       branch: release-1.30
@@ -2000,7 +2000,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-controller-manager
   - name: release-1.26
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -2025,7 +2025,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-controller-manager
   - name: release-1.27
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -2050,7 +2050,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-controller-manager
   - name: release-1.28
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -2075,7 +2075,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-controller-manager
   - name: release-1.29
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -2100,7 +2100,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-controller-manager
   - name: release-1.30
-    go: 1.22.3
+    go: 1.22.4
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -2138,7 +2138,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cluster-bootstrap
   - name: release-1.26
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -2149,7 +2149,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cluster-bootstrap
   - name: release-1.27
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -2160,7 +2160,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cluster-bootstrap
   - name: release-1.28
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -2171,7 +2171,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cluster-bootstrap
   - name: release-1.29
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -2182,7 +2182,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cluster-bootstrap
   - name: release-1.30
-    go: 1.22.3
+    go: 1.22.4
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -2206,7 +2206,7 @@ rules:
       dirs:
       - staging/src/k8s.io/csi-translation-lib
   - name: release-1.26
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: api
       branch: release-1.26
@@ -2217,7 +2217,7 @@ rules:
       dirs:
       - staging/src/k8s.io/csi-translation-lib
   - name: release-1.27
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: api
       branch: release-1.27
@@ -2228,7 +2228,7 @@ rules:
       dirs:
       - staging/src/k8s.io/csi-translation-lib
   - name: release-1.28
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: api
       branch: release-1.28
@@ -2239,7 +2239,7 @@ rules:
       dirs:
       - staging/src/k8s.io/csi-translation-lib
   - name: release-1.29
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: api
       branch: release-1.29
@@ -2250,7 +2250,7 @@ rules:
       dirs:
       - staging/src/k8s.io/csi-translation-lib
   - name: release-1.30
-    go: 1.22.3
+    go: 1.22.4
     dependencies:
     - repository: api
       branch: release-1.30
@@ -2269,31 +2269,31 @@ rules:
       dirs:
       - staging/src/k8s.io/mount-utils
   - name: release-1.26
-    go: 1.21.10
+    go: 1.21.11
     source:
       branch: release-1.26
       dirs:
       - staging/src/k8s.io/mount-utils
   - name: release-1.27
-    go: 1.21.10
+    go: 1.21.11
     source:
       branch: release-1.27
       dirs:
       - staging/src/k8s.io/mount-utils
   - name: release-1.28
-    go: 1.21.10
+    go: 1.21.11
     source:
       branch: release-1.28
       dirs:
       - staging/src/k8s.io/mount-utils
   - name: release-1.29
-    go: 1.21.10
+    go: 1.21.11
     source:
       branch: release-1.29
       dirs:
       - staging/src/k8s.io/mount-utils
   - name: release-1.30
-    go: 1.22.3
+    go: 1.22.4
     source:
       branch: release-1.30
       dirs:
@@ -2302,7 +2302,7 @@ rules:
 - destination: legacy-cloud-providers
   branches:
   - name: release-1.26
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: api
       branch: release-1.26
@@ -2331,7 +2331,7 @@ rules:
       dirs:
       - staging/src/k8s.io/legacy-cloud-providers
   - name: release-1.27
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: api
       branch: release-1.27
@@ -2356,7 +2356,7 @@ rules:
       dirs:
       - staging/src/k8s.io/legacy-cloud-providers
   - name: release-1.28
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: api
       branch: release-1.28
@@ -2381,7 +2381,7 @@ rules:
       dirs:
       - staging/src/k8s.io/legacy-cloud-providers
   - name: release-1.29
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: api
       branch: release-1.29
@@ -2406,7 +2406,7 @@ rules:
       dirs:
       - staging/src/k8s.io/legacy-cloud-providers
   - name: release-1.30
-    go: 1.22.3
+    go: 1.22.4
     dependencies:
     - repository: api
       branch: release-1.30
@@ -2456,7 +2456,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubectl
   - name: release-1.26
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: api
       branch: release-1.26
@@ -2479,7 +2479,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubectl
   - name: release-1.27
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: api
       branch: release-1.27
@@ -2502,7 +2502,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubectl
   - name: release-1.28
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: api
       branch: release-1.28
@@ -2525,7 +2525,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubectl
   - name: release-1.29
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: api
       branch: release-1.29
@@ -2548,7 +2548,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubectl
   - name: release-1.30
-    go: 1.22.3
+    go: 1.22.4
     dependencies:
     - repository: api
       branch: release-1.30
@@ -2592,7 +2592,7 @@ rules:
       dirs:
       - staging/src/k8s.io/pod-security-admission
   - name: release-1.26
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: api
       branch: release-1.26
@@ -2611,7 +2611,7 @@ rules:
       dirs:
       - staging/src/k8s.io/pod-security-admission
   - name: release-1.27
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: api
       branch: release-1.27
@@ -2630,7 +2630,7 @@ rules:
       dirs:
       - staging/src/k8s.io/pod-security-admission
   - name: release-1.28
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: api
       branch: release-1.28
@@ -2649,7 +2649,7 @@ rules:
       dirs:
       - staging/src/k8s.io/pod-security-admission
   - name: release-1.29
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: api
       branch: release-1.29
@@ -2668,7 +2668,7 @@ rules:
       dirs:
       - staging/src/k8s.io/pod-security-admission
   - name: release-1.30
-    go: 1.22.3
+    go: 1.22.4
     dependencies:
     - repository: api
       branch: release-1.30
@@ -2712,7 +2712,7 @@ rules:
       dirs:
       - staging/src/k8s.io/dynamic-resource-allocation
   - name: release-1.26
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: apimachinery
       branch: release-1.26
@@ -2729,7 +2729,7 @@ rules:
       dirs:
       - staging/src/k8s.io/dynamic-resource-allocation
   - name: release-1.27
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -2746,7 +2746,7 @@ rules:
       dirs:
       - staging/src/k8s.io/dynamic-resource-allocation
   - name: release-1.28
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -2767,7 +2767,7 @@ rules:
       dirs:
       - staging/src/k8s.io/dynamic-resource-allocation
   - name: release-1.29
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -2788,7 +2788,7 @@ rules:
       dirs:
       - staging/src/k8s.io/dynamic-resource-allocation
   - name: release-1.30
-    go: 1.22.3
+    go: 1.22.4
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -2827,7 +2827,7 @@ rules:
       dirs:
       - staging/src/k8s.io/endpointslice
   - name: release-1.28
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: api
       branch: release-1.28
@@ -2842,7 +2842,7 @@ rules:
       dirs:
       - staging/src/k8s.io/endpointslice
   - name: release-1.29
-    go: 1.21.10
+    go: 1.21.11
     dependencies:
     - repository: api
       branch: release-1.29
@@ -2857,7 +2857,7 @@ rules:
       dirs:
       - staging/src/k8s.io/endpointslice
   - name: release-1.30
-    go: 1.22.3
+    go: 1.22.4
     dependencies:
     - repository: api
       branch: release-1.30


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Update publishing-bot rules to Go 1.22.4 and 1.21.11

#### Which issue(s) this PR fixes:

xref https://github.com/kubernetes/release/issues/3628

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```

/assign @saschagrunert @Verolop @dims 
cc @kubernetes/release-engineering 