### PR TITLE
Fix flaking TestStoreListResourceVersion

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store_test.go
@@ -2446,6 +2446,14 @@ func newTestGenericStoreRegistry(t *testing.T, scheme *runtime.Scheme, hasCacheE
 		if err != nil {
 			t.Fatalf("Couldn't create cacher: %v", err)
 		}
+		if utilfeature.DefaultFeatureGate.Enabled(features.ResilientWatchCacheInitialization) {
+			// The tests assume that Get/GetList/Watch calls shouldn't fail.
+			// However, 429 error can now be returned if watchcache is under initialization.
+			// To avoid rewriting all tests, we wait for watchcache to initialize.
+			if err := cacher.Wait(context.Background()); err != nil {
+				t.Fatal(err)
+			}
+		}
 		d := destroyFunc
 		s = cacher
 		destroyFunc = func() {

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
@@ -1358,6 +1358,11 @@ func (c *Cacher) waitUntilWatchCacheFreshAndForceAllEvents(ctx context.Context, 
 	return nil
 }
 
+// Wait blocks until the cacher is Ready or Stopped, it returns an error if Stopped.
+func (c *Cacher) Wait(ctx context.Context) error {
+	return c.ready.wait(ctx)
+}
+
 // errWatcher implements watch.Interface to return a single error
 type errWatcher struct {
 	result chan watch.Event

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_test.go
@@ -472,8 +472,8 @@ func testSetupWithEtcdServer(t *testing.T, opts ...setupOption) (context.Context
 	if utilfeature.DefaultFeatureGate.Enabled(features.ResilientWatchCacheInitialization) {
 		// The tests assume that Get/GetList/Watch calls shouldn't fail.
 		// However, 429 error can now be returned if watchcache is under initialization.
-		// To avoid rewriting all tests, we wait for watcache to initialize.
-		if err := cacher.ready.wait(ctx); err != nil {
+		// To avoid rewriting all tests, we wait for watchcache to initialize.
+		if err := cacher.Wait(ctx); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
@@ -93,7 +93,7 @@ func newTestCacher(s storage.Interface) (*Cacher, storage.Versioner, error) {
 		// The tests assume that Get/GetList/Watch calls shouldn't fail.
 		// However, 429 error can now be returned if watchcache is under initialization.
 		// To avoid rewriting all tests, we wait for watcache to initialize.
-		if err := cacher.ready.wait(context.Background()); err != nil {
+		if err := cacher.Wait(context.Background()); err != nil {
 			return nil, storage.APIObjectVersioner{}, err
 		}
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind failing-test
/kind flake

#### What this PR does / why we need it:

```
$ go test -c ./staging/src/k8s.io/apiserver/pkg/registry/generic/registry
$ go run golang.org/x/tools/cmd/stress@latest -failure storage -p 1 ./registry.test -test.v -test.run ^TestStoreListResourceVersion$
5s: 9 runs so far, 0 failures
10s: 18 runs so far, 0 failures
15s: 28 runs so far, 0 failures
20s: 36 runs so far, 0 failures
```

After https://github.com/kubernetes/kubernetes/pull/124642 was merged it started flaking the test runs for TestStoreListResourceVersion. 

KEP https://kep.k8s.io/4568 says:

```
... an approach where we only delegate to etcd the (list) requests that (a) are not
setting any selectors AND (b) are setting a limit.
```

Since this test does not set a limit in ListOptions, it ends up trying to use the watchcache instead of calling etcd. The flakiness comes from the fact that the cache is not initialized, which returns a "too many requests" error and causes the test to fail.

Fixed by waiting until the cache is ready in order to run the tests.

#### Which issue(s) this PR fixes:

Fixes #125406

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
pkg k8s.io/apiserver/pkg/storage/cacher, method (*Cacher) Wait(context.Context) error
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
[Related KEP]: https://kep.k8s.io/4568
```
