### PR TITLE
remove unneeded e2e features

### DIFF
--- a/test/e2e/apimachinery/resource_quota.go
+++ b/test/e2e/apimachinery/resource_quota.go
@@ -1274,7 +1274,7 @@ var _ = SIGDescribe("ResourceQuota", func() {
 	})
 })
 
-var _ = SIGDescribe("ResourceQuota", feature.VolumeAttributesClass, framework.WithFeatureGate(features.VolumeAttributesClass), func() {
+var _ = SIGDescribe("ResourceQuota", framework.WithFeatureGate(features.VolumeAttributesClass), func() {
 	f := framework.NewDefaultFramework("resourcequota-volumeattributesclass")
 	f.NamespacePodSecurityLevel = admissionapi.LevelBaseline
 

--- a/test/e2e/feature/feature.go
+++ b/test/e2e/feature/feature.go
@@ -528,13 +528,6 @@ var (
 	// TODO: document the feature (owning SIG, when to use this feature for a test)
 	ValidatingAdmissionPolicy = framework.WithFeature(framework.ValidFeatures.Add("ValidatingAdmissionPolicy"))
 
-	// Owner: sig-storage
-	// Tests related to VolumeAttributesClass (https://kep.k8s.io/3751)
-	//
-	// TODO: This label only requires the API storage.k8s.io/v1alpha1 and the VolumeAttributesClass feature-gate enabled.
-	// It should be removed after k/k #124350 is merged.
-	VolumeAttributesClass = framework.WithFeature(framework.ValidFeatures.Add("VolumeAttributesClass"))
-
 	// TODO: document the feature (owning SIG, when to use this feature for a test)
 	Volumes = framework.WithFeature(framework.ValidFeatures.Add("Volumes"))
 

--- a/test/e2e/storage/testsuites/volume_modify.go
+++ b/test/e2e/storage/testsuites/volume_modify.go
@@ -30,7 +30,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/errors"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/pkg/features"
-	e2efeature "k8s.io/kubernetes/test/e2e/feature"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	e2epv "k8s.io/kubernetes/test/e2e/framework/pv"
@@ -61,7 +60,7 @@ func InitCustomVolumeModifyTestSuite(patterns []storageframework.TestPattern) st
 			SupportedSizeRange: e2evolume.SizeRange{
 				Min: "1Gi",
 			},
-			TestTags: []interface{}{e2efeature.VolumeAttributesClass, framework.WithFeatureGate(features.VolumeAttributesClass)},
+			TestTags: []interface{}{framework.WithFeatureGate(features.VolumeAttributesClass)},
 		},
 	}
 }

--- a/test/e2e/storage/volume_metrics.go
+++ b/test/e2e/storage/volume_metrics.go
@@ -34,7 +34,6 @@ import (
 	"k8s.io/component-helpers/storage/ephemeral"
 	"k8s.io/kubernetes/pkg/features"
 	kubeletmetrics "k8s.io/kubernetes/pkg/kubelet/metrics"
-	"k8s.io/kubernetes/test/e2e/feature"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2emetrics "k8s.io/kubernetes/test/e2e/framework/metrics"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
@@ -626,38 +625,36 @@ var _ = utils.SIGDescribe(framework.WithSerial(), "Volume metrics", func() {
 			})
 
 		// TODO: Merge with bound/unbound tests when "VolumeAttributesClass" feature is enabled by default
-		f.It("should create unbound pvc count metrics for pvc controller with volume attributes class dimension after creating pvc only",
-			feature.VolumeAttributesClass, framework.WithFeatureGate(features.VolumeAttributesClass), func(ctx context.Context) {
-				var err error
-				dimensions := []string{namespaceKey, storageClassKey, volumeAttributeClassKey}
-				pvcConfigWithVAC := pvcConfig
-				pvcConfigWithVAC.VolumeAttributesClassName = &volumeAttributesClassName
-				pvcWithVAC := e2epv.MakePersistentVolumeClaim(pvcConfigWithVAC, ns)
-				pvc, err = e2epv.CreatePVC(ctx, c, ns, pvcWithVAC)
-				framework.ExpectNoError(err, "Error creating pvc: %v", err)
-				waitForPVControllerSync(ctx, metricsGrabber, unboundPVCKey, volumeAttributeClassKey)
-				controllerMetrics, err := metricsGrabber.GrabFromControllerManager(ctx)
-				framework.ExpectNoError(err, "Error getting c-m metricValues: %v", err)
-				err = testutil.ValidateMetrics(testutil.Metrics(controllerMetrics), unboundPVCKey, dimensions...)
-				framework.ExpectNoError(err, "Invalid metric in Controller Manager metrics: %q", unboundPVCKey)
-			})
+		f.It("should create unbound pvc count metrics for pvc controller with volume attributes class dimension after creating pvc only", framework.WithFeatureGate(features.VolumeAttributesClass), func(ctx context.Context) {
+			var err error
+			dimensions := []string{namespaceKey, storageClassKey, volumeAttributeClassKey}
+			pvcConfigWithVAC := pvcConfig
+			pvcConfigWithVAC.VolumeAttributesClassName = &volumeAttributesClassName
+			pvcWithVAC := e2epv.MakePersistentVolumeClaim(pvcConfigWithVAC, ns)
+			pvc, err = e2epv.CreatePVC(ctx, c, ns, pvcWithVAC)
+			framework.ExpectNoError(err, "Error creating pvc: %v", err)
+			waitForPVControllerSync(ctx, metricsGrabber, unboundPVCKey, volumeAttributeClassKey)
+			controllerMetrics, err := metricsGrabber.GrabFromControllerManager(ctx)
+			framework.ExpectNoError(err, "Error getting c-m metricValues: %v", err)
+			err = testutil.ValidateMetrics(testutil.Metrics(controllerMetrics), unboundPVCKey, dimensions...)
+			framework.ExpectNoError(err, "Invalid metric in Controller Manager metrics: %q", unboundPVCKey)
+		})
 
 		// TODO: Merge with bound/unbound tests when "VolumeAttributesClass" feature is enabled by default
-		f.It("should create bound pv/pvc count metrics for pvc controller with volume attributes class dimension after creating both pv and pvc",
-			feature.VolumeAttributesClass, framework.WithFeatureGate(features.VolumeAttributesClass), func(ctx context.Context) {
-				var err error
-				dimensions := []string{namespaceKey, storageClassKey, volumeAttributeClassKey}
-				pvcConfigWithVAC := pvcConfig
-				pvcConfigWithVAC.VolumeAttributesClassName = &volumeAttributesClassName
-				pv, pvc, err = e2epv.CreatePVPVC(ctx, c, f.Timeouts, pvConfig, pvcConfigWithVAC, ns, true)
-				framework.ExpectNoError(err, "Error creating pv pvc: %v", err)
-				waitForPVControllerSync(ctx, metricsGrabber, boundPVKey, storageClassKey)
-				waitForPVControllerSync(ctx, metricsGrabber, boundPVCKey, volumeAttributeClassKey)
-				controllerMetrics, err := metricsGrabber.GrabFromControllerManager(ctx)
-				framework.ExpectNoError(err, "Error getting c-m metricValues: %v", err)
-				err = testutil.ValidateMetrics(testutil.Metrics(controllerMetrics), boundPVCKey, dimensions...)
-				framework.ExpectNoError(err, "Invalid metric in Controller Manager metrics: %q", boundPVCKey)
-			})
+		f.It("should create bound pv/pvc count metrics for pvc controller with volume attributes class dimension after creating both pv and pvc", framework.WithFeatureGate(features.VolumeAttributesClass), func(ctx context.Context) {
+			var err error
+			dimensions := []string{namespaceKey, storageClassKey, volumeAttributeClassKey}
+			pvcConfigWithVAC := pvcConfig
+			pvcConfigWithVAC.VolumeAttributesClassName = &volumeAttributesClassName
+			pv, pvc, err = e2epv.CreatePVPVC(ctx, c, f.Timeouts, pvConfig, pvcConfigWithVAC, ns, true)
+			framework.ExpectNoError(err, "Error creating pv pvc: %v", err)
+			waitForPVControllerSync(ctx, metricsGrabber, boundPVKey, storageClassKey)
+			waitForPVControllerSync(ctx, metricsGrabber, boundPVCKey, volumeAttributeClassKey)
+			controllerMetrics, err := metricsGrabber.GrabFromControllerManager(ctx)
+			framework.ExpectNoError(err, "Error getting c-m metricValues: %v", err)
+			err = testutil.ValidateMetrics(testutil.Metrics(controllerMetrics), boundPVCKey, dimensions...)
+			framework.ExpectNoError(err, "Invalid metric in Controller Manager metrics: %q", boundPVCKey)
+		})
 
 		ginkgo.It("should create total pv count metrics for with plugin and volume mode labels after creating pv",
 			func(ctx context.Context) {

--- a/test/e2e/storage/volumeattributesclass.go
+++ b/test/e2e/storage/volumeattributesclass.go
@@ -27,7 +27,6 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/kubernetes/pkg/features"
-	"k8s.io/kubernetes/test/e2e/feature"
 	"k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/e2e/storage/utils"
 	admissionapi "k8s.io/pod-security-admission/api"
@@ -36,7 +35,7 @@ import (
 	"github.com/onsi/gomega"
 )
 
-var _ = utils.SIGDescribe("VolumeAttributesClass", feature.VolumeAttributesClass, framework.WithFeatureGate(features.VolumeAttributesClass), func() {
+var _ = utils.SIGDescribe("VolumeAttributesClass", framework.WithFeatureGate(features.VolumeAttributesClass), func() {
 
 	f := framework.NewDefaultFramework("csi-volumeattributesclass")
 	f.NamespacePodSecurityLevel = admissionapi.LevelBaseline


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

After https://github.com/kubernetes/kubernetes/pull/124350 is merged, the following e2e feature labels become useless. 

- VolumeAttributesClass
- HonorPVReclaimPolicy

the above features only require the feature gate to be on and alpha/beta is available. 

/hold
util https://github.com/kubernetes/test-infra/pull/32648 is merged.

By the way, the job `pull-kubernetes-e2e-storage-kind-alpha-features` and `ci-kubernetes-e2e-storage-kind-alpha-features` can be removed once https://github.com/kubernetes/test-infra/pull/32648 is merged. The existing jobs `pull/ci-kubernetes-e2e-alpha-features` and `pull/ci-kubernetes-e2e-kind-beta-features` will cover these tests.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
