### PR TITLE
Remove noisy log in scheduler_perf

### DIFF
--- a/test/integration/scheduler_perf/util.go
+++ b/test/integration/scheduler_perf/util.go
@@ -328,7 +328,6 @@ func collectHistogramVec(metric string, labels map[string]string, lvMap map[stri
 	}
 
 	if vec.GetAggregatedSampleCount() == 0 {
-		klog.InfoS("It is expected that this metric wasn't recorded. The data for this metric won't be stored in a benchmark result file", "metric", metric, "labels", labels)
 		return nil
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
/sig scheduling
/assign @pohly 

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

The scheduler_perf is always failing, when debugging the log, lots of noisy logs which is useless, generally looks like:
```
measure-ns-0"}
I0612 01:42:44.899474   28230 util.go:331] "It is expected that this metric wasn't recorded. The data for this metric won't be stored in a benchmark result file" metric="scheduler_plugin_execution_duration_seconds" labels={"Name":"SchedulingPreferredAffinityWithNSSelector/5000Nodes/measure-ns-0"}
I0612 01:42:44.901253   28230 util.go:331] "It is expected that this metric wasn't recorded. The data for this metric won't be stored in a benchmark result file" metric="scheduler_plugin_execution_duration_seconds" labels={"Name":"SchedulingPreferredAffinityWithNSSelector/5000Nodes/measure-ns-0"}
I0612 01:42:44.904059   28230 util.go:331] "It is expected that this metric wasn't recorded. The data for this metric won't be stored in a benchmark result file" metric="scheduler_plugin_execution_duration_seconds" labels={"Name":"SchedulingPreferredAffinityWithNSSelector/5000Nodes/measure-ns-0"}
I0612 01:42:44.906210   28230 util.go:331] "It is expected that this metric wasn't recorded. The data for this metric won't be stored in a benchmark result file" metric="scheduler_plugin_execution_duration_seconds" labels={"Name":"SchedulingPreferredAffinityWithNSSelector/5000Nodes/measure-ns-0"}
I0612 01:42:44.908344   28230 util.go:331] "It is expected that this metric wasn't recorded. The data for this metric won't be stored in a benchmark result file" metric="scheduler_plugin_execution_duration_seconds" labels={"Name":"SchedulingPreferredAffinityWithNSSelector/5000Nodes/measure-ns-0"}
I0612 01:42:44.910242   28230 util.go:331] "It is expected that this metric wasn't recorded. The data for this metric won't be stored in a benchmark result file" metric="scheduler_plugin_execution_duration_seconds" labels={"Name":"SchedulingPreferredAffinityWithNSSelector/5000Nodes/measure-ns-0"}
I0612 01:42:44.912455   28230 util.go:331] "It is expected that this metric wasn't recorded. The data for this metric won't be stored in a benchmark result file" metric="scheduler_plugin_execution_duration_seconds" labels={"Name":"SchedulingPreferredAffinityWithNSSelector/5000Nodes/measure-ns-0"}
I0612 01:42:44.914824   28230 util.go:331] "It is expected that this metric wasn't recorded. The data for this metric won't be stored in a benchmark result file" metric="scheduler_plugin_execution_duration_seconds" labels={"Name":"SchedulingPreferredAffinityWithNSSelector/5000Nodes/measure-ns-0"}
I0612 01:42:44.919518   28230 util.go:331] "It is expected that this metric wasn't recorded. The data for this metric won't be stored in a benchmark result file" metric="scheduler_plugin_execution_duration_seconds" labels={"Name":"SchedulingPreferredAffinityWithNSSelector/5000Nodes/measure-ns-0"}
I0612 01:42:44.921737   28230 util.go:331] "It is expected that this metric wasn't recorded. The data for this metric won't be stored in a benchmark result file" metric="scheduler_plugin_execution_duration_seconds" labels={"Name":"SchedulingPreferredAffinityWithNSSelector/5000Nodes/measure-ns-0"}
I0612 01:42:44.925166   28230 util.go:331] "It is expected that this metric wasn't recorded. The data for this metric won't be stored in a benchmark result file" metric="scheduler_plugin_execution_duration_seconds" labels={"Name":"SchedulingPreferredAffinityWithNSSelector/5000Nodes/measure-ns-0"}
I0612 01:42:44.927315   28230 util.go:331] "It is expected that this metric wasn't recorded. The data for this metric won't be stored in a benchmark result file" metric="scheduler_plugin_execution_duration_seconds" labels={"Name":"SchedulingPreferredAffinityWithNSSelector/5000Nodes/measure-ns-0"}
I0612 01:42:44.929227   28230 util.go:331] "It is expected that this metric wasn't recorded. The data for this metric won't be stored in a benchmark result file" metric="scheduler_plugin_execution_duration_seconds" labels={"Name":"SchedulingPreferredAffinityWithNSSelector/5000Nodes/measure-ns-0"}
I0612 01:42:44.931173   28230 util.go:331] "It is expected that this metric wasn't recorded. The data for this metric won't be stored in a benchmark result file" metric="scheduler_plugin_execution_duration_seconds" labels={"Name":"SchedulingPreferredAffinityWithNSSelector/5000Nodes/measure-ns-0"}
I0612 01:42:44.933434   28230 util.go:331] "It is expected that this metric wasn't recorded. The data for this metric won't be stored in a benchmark result file" metric="scheduler_plugin_execution_duration_seconds" labels={"Name":"SchedulingPreferredAffinityWithNSSelector/5000Nodes/measure-ns-0"}
I0612 01:42:44.935677   28230 util.go:331] "It is expected that this metric wasn't recorded. The data for this metric won't be stored in a benchmark result file" metric="scheduler_plugin_execution_duration_seconds" labels={"Name":"SchedulingPreferredAffinityWithNSSelector/5000Nodes/measure-ns-0"}
I0612 01:42:44.938047   28230 util.go:331] "It is expected that this metric wasn't recorded. The data for this metric won't be stored in a benchmark result file" metric="scheduler_plugin_execution_duration_seconds" labels={"Name":"SchedulingPreferredAffinityWithNSSelector/5000Nodes/measure-ns-0"}
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
