### PR TITLE
Automated cherry pick of #124883: kubectl create cronjobs: Manually set OwnerReferences

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_job_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_job_test.go
@@ -24,6 +24,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 )
 
 func TestCreateJobValidation(t *testing.T) {
@@ -161,9 +162,17 @@ func TestCreateJobFromCronJob(t *testing.T) {
 			expected: &batchv1.Job{
 				TypeMeta: metav1.TypeMeta{APIVersion: batchv1.SchemeGroupVersion.String(), Kind: "Job"},
 				ObjectMeta: metav1.ObjectMeta{
-					Name:            jobName,
-					Annotations:     map[string]string{"cronjob.kubernetes.io/instantiate": "manual"},
-					OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(cronJob, batchv1.SchemeGroupVersion.WithKind("CronJob"))},
+					Name:        jobName,
+					Annotations: map[string]string{"cronjob.kubernetes.io/instantiate": "manual"},
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: batchv1.SchemeGroupVersion.String(),
+							Kind:       "CronJob",
+							Name:       cronJob.GetName(),
+							UID:        cronJob.GetUID(),
+							Controller: ptr.To(true),
+						},
+					},
 				},
 				Spec: batchv1.JobSpec{
 					Template: corev1.PodTemplateSpec{


### PR DESCRIPTION
Cherry pick of #124883 on release-1.29.

#124883: kubectl create cronjobs: Manually set OwnerReferences

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fixes a 1.28 regression in `kubectl create cronjobs` that unintentionally required additional permissions (cronjobs/finalizers)
```