### PR TITLE
e2e/framework/metrics: handle index out of bounds panic

### DIFF
--- a/test/e2e/framework/metrics/kube_proxy_metrics.go
+++ b/test/e2e/framework/metrics/kube_proxy_metrics.go
@@ -17,6 +17,8 @@ limitations under the License.
 package metrics
 
 import (
+	"fmt"
+
 	"k8s.io/component-base/metrics/testutil"
 )
 
@@ -24,8 +26,11 @@ import (
 type KubeProxyMetrics testutil.Metrics
 
 // GetCounterMetricValue returns value for metric type counter.
-func (m *KubeProxyMetrics) GetCounterMetricValue(metricName string) float64 {
-	return float64(testutil.Metrics(*m)[metricName][0].Value)
+func (m *KubeProxyMetrics) GetCounterMetricValue(metricName string) (float64, error) {
+	if len(testutil.Metrics(*m)[metricName]) == 0 {
+		return 0, fmt.Errorf("metric '%s' not found", metricName)
+	}
+	return float64(testutil.Metrics(*m)[metricName][0].Value), nil
 }
 
 func newKubeProxyMetricsMetrics() KubeProxyMetrics {

--- a/test/e2e/network/kube_proxy.go
+++ b/test/e2e/network/kube_proxy.go
@@ -299,7 +299,8 @@ var _ = common.SIGDescribe("KubeProxy", func() {
 		// get value of target metric before accessing localhost nodeports
 		metrics, err := metricsGrabber.GrabFromKubeProxy(ctx, nodeName)
 		framework.ExpectNoError(err)
-		targetMetricBefore := metrics.GetCounterMetricValue(metricName)
+		targetMetricBefore, err := metrics.GetCounterMetricValue(metricName)
+		framework.ExpectNoError(err)
 
 		// create pod
 		ginkgo.By("creating test pod")
@@ -359,7 +360,8 @@ var _ = common.SIGDescribe("KubeProxy", func() {
 		if err := wait.PollUntilContextTimeout(ctx, 10*time.Second, 2*time.Minute, true, func(_ context.Context) (bool, error) {
 			metrics, err := metricsGrabber.GrabFromKubeProxy(ctx, nodeName)
 			framework.ExpectNoError(err)
-			targetMetricAfter := metrics.GetCounterMetricValue(metricName)
+			targetMetricAfter, err := metrics.GetCounterMetricValue(metricName)
+			framework.ExpectNoError(err)
 			return targetMetricAfter > targetMetricBefore, nil
 		}); err != nil {
 			framework.Failf("expected %s metric to be updated after accessing endpoints via localhost nodeports", metricName)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
This handles a potential panic in e2e kube proxy metrics collector.
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/sig network
