### PR TITLE
Promote JobPodFailurePolicy and PodDisruptionConditions e2e tests to Conformance

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -1055,6 +1055,14 @@
     pod. Modify the labels of one of the Job's Pods. The Job MUST release the Pod.
   release: v1.16
   file: test/e2e/apps/job.go
+- testname: Verify Pod Failure policy allows to fail job early on exit code.
+  codename: '[sig-apps] Job should allow to use the pod failure policy on exit code
+    to fail the job early [Conformance]'
+  description: Create a job with pod failure policy, and exactly one pod failing.
+    The exit code of the failed pod matches the pod failure policy triggering the
+    Job failure.
+  release: v1.31
+  file: test/e2e/apps/job.go
 - testname: Jobs, apply changes to status
   codename: '[sig-apps] Job should apply changes to a job status [Conformance]'
   description: Attempt to create a running Job which MUST succeed. Attempt to patch
@@ -2749,6 +2757,15 @@
     found, the scheduler MUST preempt a lower priority pod to schedule the critical
     pod.
   release: v1.19
+  file: test/e2e/scheduling/preemption.go
+- testname: Verify the DisruptionTarget condition is added to the preempted pod
+  codename: '[sig-scheduling] SchedulerPreemption [Serial] validates pod disruption
+    condition is added to the preempted pod [Conformance]'
+  description: ' 1. Run a low priority pod with finalizer which consumes 1/1 of node
+    resources 2. Schedule a higher priority pod which also consumes 1/1 of node resources
+    3. See if the pod with lower priority is preempted and has the pod disruption
+    condition 4. Remove the finalizer so that the pod can be deleted by GC'
+  release: v1.31
   file: test/e2e/scheduling/preemption.go
 - testname: CSIDriver, lifecycle
   codename: '[sig-storage] CSIInlineVolumes should run through the lifecycle of a

--- a/test/e2e/apps/job.go
+++ b/test/e2e/apps/job.go
@@ -96,7 +96,14 @@ var _ = SIGDescribe("Job", func() {
 		gomega.Expect(successes).To(gomega.Equal(completions), "expected %d successful job pods, but got  %d", completions, successes)
 	})
 
-	ginkgo.It("should allow to use the pod failure policy on exit code to fail the job early", func(ctx context.Context) {
+	/*
+		Release: v1.31
+		Testname: Verify Pod Failure policy allows to fail job early on exit code.
+		Description: Create a job with pod failure policy, and exactly one
+		pod failing. The exit code of the failed pod matches the pod failure
+		policy triggering the Job failure.
+	*/
+	framework.ConformanceIt("should allow to use the pod failure policy on exit code to fail the job early", func(ctx context.Context) {
 
 		// We fail the Job's pod only once to ensure the backoffLimit is not
 		// reached and thus the job is failed due to the pod failure policy

--- a/test/e2e/scheduling/preemption.go
+++ b/test/e2e/scheduling/preemption.go
@@ -317,11 +317,16 @@ var _ = SIGDescribe("SchedulerPreemption", framework.WithSerial(), func() {
 		}
 	})
 
-	// 1. Run a low priority pod with finalizer which consumes 1/1 of node resources
-	// 2. Schedule a higher priority pod which also consumes 1/1 of node resources
-	// 3. See if the pod with lower priority is preempted and has the pod disruption condition
-	// 4. Remove the finalizer so that the pod can be deleted by GC
-	ginkgo.It("validates pod disruption condition is added to the preempted pod", func(ctx context.Context) {
+	/*
+		Release: v1.31
+		Testname: Verify the DisruptionTarget condition is added to the preempted pod
+		Description:
+		1. Run a low priority pod with finalizer which consumes 1/1 of node resources
+		2. Schedule a higher priority pod which also consumes 1/1 of node resources
+		3. See if the pod with lower priority is preempted and has the pod disruption condition
+		4. Remove the finalizer so that the pod can be deleted by GC
+	*/
+	framework.ConformanceIt("validates pod disruption condition is added to the preempted pod", func(ctx context.Context) {
 		podRes := v1.ResourceList{testExtendedResource: resource.MustParse("1")}
 
 		ginkgo.By("Select a node to run the lower and higher priority pods")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind documentation

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Tracking issue: https://github.com/kubernetes/enhancements/issues/3329

#### Special notes for your reviewer:

Actual commit for the conformance tests is the second. The first commit marks the feature gates as GA, so the conformance suite only runs GA tests. The first commit does not lock the feature gates, so that the diff is minimal. 
When the two PRs are merged, then this commit can be removed entirely:
- https://github.com/kubernetes/kubernetes/pull/125461
- https://github.com/kubernetes/kubernetes/pull/125442

Promoting tests to conformance instructions: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/conformance-tests.md#promoting-tests-to-conformance 

There are no failures according to the testgrids:
Testgrid https://testgrid.k8s.io/sig-apps#gce (103 builds)
- "Job should allow to use the pod failure policy on exit code to fail the job early"
- "Job should allow to use the pod failure policy to not count the failure towards the backoffLimit"
- "Job should allow to use a pod failure policy to ignore failure for an evicted pod; matching on the exit code"
- "should allow to use a pod failure policy to ignore failure for an evicted pod; matching on the DisruptionTarget condition"

Testgrid https://testgrid.k8s.io/sig-scheduling#gce-serial (76 builds)
- "validates pod disruption condition is added to the preempted pod"

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
https://github.com/kubernetes/enhancements/tree/master/keps/sig-apps/3329-retriable-and-non-retriable-failures
```
