### PR TITLE
cmd: add missing short descriptions to kube commands

### DIFF
--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -69,7 +69,8 @@ func NewAPIServerCommand() *cobra.Command {
 	s := options.NewServerRunOptions()
 
 	cmd := &cobra.Command{
-		Use: "kube-apiserver",
+		Use:   "kube-apiserver",
+		Short: "Services REST operations and provides the frontend to the cluster",
 		Long: `The Kubernetes API server validates and configures data
 for the api objects which include pods, services, replicationcontrollers, and
 others. The API Server services REST operations and provides the frontend to the

--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -117,7 +117,8 @@ func NewControllerManagerCommand() *cobra.Command {
 	}
 
 	cmd := &cobra.Command{
-		Use: "kube-controller-manager",
+		Use:   "kube-controller-manager",
+		Short: "A daemon that embeds the core control loops shipped with Kubernetes",
 		Long: `The Kubernetes controller manager is a daemon that embeds
 the core control loops shipped with Kubernetes. In applications of robotics and
 automation, a control loop is a non-terminating loop that regulates the state of

--- a/cmd/kube-proxy/app/server.go
+++ b/cmd/kube-proxy/app/server.go
@@ -92,7 +92,8 @@ func NewProxyCommand() *cobra.Command {
 	opts := NewOptions()
 
 	cmd := &cobra.Command{
-		Use: "kube-proxy",
+		Use:   "kube-proxy",
+		Short: "A daemon that runs on each node reflecting services from the Kubernetes API",
 		Long: `The Kubernetes network proxy runs on each node. This
 reflects services as defined in the Kubernetes API on each node and can do simple
 TCP, UDP, and SCTP stream forwarding or round robin TCP, UDP, and SCTP forwarding across a set of backends.

--- a/cmd/kube-scheduler/app/server.go
+++ b/cmd/kube-scheduler/app/server.go
@@ -86,7 +86,8 @@ func NewSchedulerCommand(registryOptions ...Option) *cobra.Command {
 	opts := options.NewOptions()
 
 	cmd := &cobra.Command{
-		Use: "kube-scheduler",
+		Use:   "kube-scheduler",
+		Short: "Controls performance, capacity and availability through policies and topology awareness",
 		Long: `The Kubernetes scheduler is a control plane process which assigns
 Pods to Nodes. The scheduler determines which Nodes are valid placements for
 each Pod in the scheduling queue according to constraints and available

--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -142,7 +142,8 @@ func NewKubeletCommand() *cobra.Command {
 	}
 
 	cmd := &cobra.Command{
-		Use: componentKubelet,
+		Use:   componentKubelet,
+		Short: `The primary "node agent" that runs on each node`,
 		Long: `The kubelet is the primary "node agent" that runs on each
 node. It can register the node with the apiserver using one of: the hostname; a flag to
 override the hostname; or specific logic for a cloud provider.


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind feature

#### What this PR does / why we need it:

This PR adds short descriptions for the kubernetes command line tools.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
