### PR TITLE
scheduler_perf: Measure performance of scheduling when many gated pods

### DIFF
--- a/test/integration/scheduler_perf/config/performance-config.yaml
+++ b/test/integration/scheduler_perf/config/performance-config.yaml
@@ -1044,3 +1044,34 @@
       measurePods: 2500
       measureClaims: 500 # must be measurePods / 5
       maxClaimsPerNode: 2
+
+# This test case simulates the scheduling when many pods are gated and others are gradually deleted.
+# https://github.com/kubernetes/kubernetes/issues/124384
+- name: SchedulingWhileGated
+  defaultPodTemplatePath: config/templates/light-pod.yaml
+  workloadTemplate:
+  - opcode: createNodes
+    count: 1
+    nodeTemplatePath: config/templates/node-with-name.yaml
+    # Create pods that will stay gated to the end of the test.
+  - opcode: createPods
+    countParam: $gatedPods
+    podTemplatePath: config/templates/gated-pod.yaml
+    skipWaitToCompletion: true
+    # Wait to make sure gated pods are enqueued in scheduler.
+  - opcode: sleep
+    duration: 5s
+    # Create pods that will be gradually deleted after being scheduled.
+  - opcode: createPods
+    countParam: $deletingPods
+    deletePodsPerSecond: 50
+  - opcode: createPods
+    countParam: $measurePods
+    collectMetrics: true
+  workloads:
+  - name: 1Node
+    labels: [performance, fast]
+    params:
+      gatedPods: 10000
+      deletingPods: 20000
+      measurePods: 20000

--- a/test/integration/scheduler_perf/config/templates/gated-pod.yaml
+++ b/test/integration/scheduler_perf/config/templates/gated-pod.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  generateName: gated-pod-
+spec:
+  schedulingGates:
+  - name: test.k8s.io/hold
+  containers:
+  - image: registry.k8s.io/pause:3.10
+    name: pause

--- a/test/integration/scheduler_perf/config/templates/light-pod.yaml
+++ b/test/integration/scheduler_perf/config/templates/light-pod.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  generateName: light-pod-
+spec:
+  containers:
+  - image: registry.k8s.io/pause:3.10
+    name: pause
+  terminationGracePeriodSeconds: 0


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Add a test case to measure performance of scheduling pods when many other are gated and also the other ones are gradually deleted.
It also adds required scheduler_perf options to wait for pods to be gated and to delete scheduled pods gradually at specified frequency.

Before #124618

```json
{
  "data": {
    "Average": 62.02774316107592,
    "Perc50": 62.05425620810171,
    "Perc90": 67.01505580348199,
    "Perc95": 68.94981921792085,
    "Perc99": 70.03097175750753
  },
  "unit": "pods/s",
  "labels": {
    "Metric": "SchedulingThroughput",
    "Name": "SchedulingWhileGated/1Node/namespace-3",
    "extension_point": "not applicable",
    "plugin": "not applicable",
    "result": "not applicable"
  }
}
```

On master (similar results also right after the #124618)

```json
{
  "data": {
    "Average": 273.68160876917875,
    "Perc50": 267.03833014783277,
    "Perc90": 337.98113220329475,
    "Perc95": 359.00267241589347,
    "Perc99": 403.9227905625068
  },
  "unit": "pods/s",
  "labels": {
    "Metric": "SchedulingThroughput",
    "Name": "SchedulingWhileGated/1Node/namespace-3",
    "extension_point": "not applicable",
    "plugin": "not applicable",
    "result": "not applicable"
  }
}
```

#### Which issue(s) this PR fixes:

Related to #124384 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
