### PR TITLE
kubelet/cm/devicemanager: log grpc Serve error

### DIFF
--- a/pkg/kubelet/cm/devicemanager/plugin/v1beta1/server.go
+++ b/pkg/kubelet/cm/devicemanager/plugin/v1beta1/server.go
@@ -109,7 +109,9 @@ func (s *server) Start() error {
 	api.RegisterRegistrationServer(s.grpc, s)
 	go func() {
 		defer s.wg.Done()
-		s.grpc.Serve(ln)
+		if err = s.grpc.Serve(ln); err != nil {
+			klog.ErrorS(err, "Error while serving device plugin registration grpc server")
+		}
 	}()
 
 	return nil

--- a/pkg/kubelet/cm/devicemanager/plugin/v1beta1/stub.go
+++ b/pkg/kubelet/cm/devicemanager/plugin/v1beta1/stub.go
@@ -156,7 +156,9 @@ func (m *Stub) Start() error {
 
 	go func() {
 		defer m.wg.Done()
-		m.server.Serve(sock)
+		if err = m.server.Serve(sock); err != nil {
+			klog.ErrorS(err, "Error while serving device plugin registration grpc server")
+		}
 	}()
 
 	var lastDialErr error


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind cleanup

#### What this PR does / why we need it:

The Serve method from a grpc server can return an at any time if net.Listener,Accept returns a fatal error. Since the grpc server is started in a goroutine and runs alongside other code it is hard to bubble up the error to kubelet. Most places that instantiate a grpc server in the project log the error that is returned by Serve.

#### Which issue(s) this PR fixes:

For #125506 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
