### PR TITLE
scheduler_perf: shut down apiserver clients before apiserver

### DIFF
--- a/test/integration/scheduler_perf/util.go
+++ b/test/integration/scheduler_perf/util.go
@@ -98,11 +98,10 @@ func mustSetupCluster(tCtx ktesting.TContext, config *config.KubeSchedulerConfig
 	if err != nil {
 		tCtx.Fatalf("start apiserver: %v", err)
 	}
+	// Cleanup will be in reverse order: first the clients by canceling the
+	// child context (happens automatically), then the server.
 	tCtx.Cleanup(server.TearDownFn)
-
-	// Cleanup will be in reverse order: first the clients get cancelled,
-	// then the apiserver is torn down via the automatic cancelation of
-	// tCtx.
+	tCtx = ktesting.WithCancel(tCtx)
 
 	// TODO: client connection configuration, such as QPS or Burst is configurable in theory, this could be derived from the `config`, need to
 	// support this when there is any testcase that depends on such configuration.


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The cancellation of the context happened after the cleanup of the apiserver, so clients using that context were kept running. That wasn't the intent and causes a slow shutdown because the apiserver delays its shutdown when it has active clients.

The fix is to create a new cancellation context and to use that for the clients. The automatic cancellation of it then happens before the apiserver cleanup.

#### Which issue(s) this PR fixes:

Related-to: https://github.com/kubernetes/kubernetes/issues/125223

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
