### PR TITLE
scheduler: revert "Filter gated pods before calling isPodWorthRequeuing"

### DIFF
--- a/pkg/scheduler/internal/queue/scheduling_queue.go
+++ b/pkg/scheduler/internal/queue/scheduling_queue.go
@@ -1193,11 +1193,6 @@ func (p *PriorityQueue) movePodsToActiveOrBackoffQueue(logger klog.Logger, podIn
 
 	activated := false
 	for _, pInfo := range podInfoList {
-		// Since there may be many gated pods and they will not move from the
-		// unschedulable pool, we skip calling the expensive isPodWorthRequeueing.
-		if pInfo.Gated {
-			continue
-		}
 		schedulingHint := p.isPodWorthRequeuing(logger, pInfo, event, oldObj, newObj)
 		if schedulingHint == queueSkip {
 			// QueueingHintFn determined that this Pod isn't worth putting to activeQ or backoffQ by this event.

--- a/pkg/scheduler/internal/queue/scheduling_queue_test.go
+++ b/pkg/scheduler/internal/queue/scheduling_queue_test.go
@@ -95,11 +95,6 @@ var (
 	}
 )
 
-func setQueuedPodInfoGated(queuedPodInfo *framework.QueuedPodInfo) *framework.QueuedPodInfo {
-	queuedPodInfo.Gated = true
-	return queuedPodInfo
-}
-
 func getUnschedulablePod(p *PriorityQueue, pod *v1.Pod) *v1.Pod {
 	pInfo := p.unschedulablePods.get(pod)
 	if pInfo != nil {
@@ -1498,14 +1493,6 @@ func TestPriorityQueue_MoveAllToActiveOrBackoffQueueWithQueueingHint(t *testing.
 			hint:      queueHintReturnSkip,
 			expectedQ: unschedulablePods,
 		},
-		{
-			name:    "QueueHintFunction is not called when Pod is gated",
-			podInfo: setQueuedPodInfoGated(&framework.QueuedPodInfo{PodInfo: mustNewPodInfo(p), UnschedulablePlugins: sets.New("foo")}),
-			hint: func(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (framework.QueueingHint, error) {
-				return framework.Queue, fmt.Errorf("QueueingHintFn should not be called as pod is gated")
-			},
-			expectedQ: unschedulablePods,
-		},
 	}
 
 	for _, test := range tests {
@@ -2787,7 +2774,7 @@ func TestPendingPodsMetric(t *testing.T) {
 	gated := makeQueuedPodInfos(total-queueableNum, "y", failme, timestamp)
 	// Manually mark them as gated=true.
 	for _, pInfo := range gated {
-		setQueuedPodInfoGated(pInfo)
+		pInfo.Gated = true
 	}
 	pInfos = append(pInfos, gated...)
 	totalWithDelay := 20


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The main part of PR https://github.com/kubernetes/kubernetes/pull/124618 was adding this if check:

pkg/scheduler/internal/queue/scheduling_queue.go:

    movePodsToActiveOrBackoffQueue

         if pInfo.Gated {
              continue
         }

This was supposed to shortcut expensive work. But if a pod is gated because a plugin's PreEnqueue return false, then the event that caused movePodsToActiveOrBackoffQueue to be called must not be ignored for the pod. PreEnqueue has to be called for the pod again to check whether it is now scheduleable.

This affects DRA when using claim templates. This is independent from using classic DRA or structured parameters, in both cases a pod gets created, then the claim, and pod scheduling can only start once the claim exists.

Depending on timing, the scheduler sees the pod update (because the claim name is recorded in status) or the claim add first. If it first sees the pod update, the pod gets stuck because the claim is still unknown. Then when the claim add event is processed, the pod gets skipped because of the check above and remains stuck.

#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/kubernetes/issues/125223

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Fix https://github.com/kubernetes/kubernetes/issues/125223: a recent optimization in the scheduler caused pods to get stuck.
```

/cc @gabesaba