### PR TITLE
component-base/logs: inherit defaults from klog

### DIFF
--- a/staging/src/k8s.io/component-base/logs/api/v1/options.go
+++ b/staging/src/k8s.io/component-base/logs/api/v1/options.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"math"
 	"os"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -55,9 +56,20 @@ const (
 )
 
 // NewLoggingConfiguration returns a struct holding the default logging configuration.
+// The initial verbosity is the same as currently configured in klog.
 func NewLoggingConfiguration() *LoggingConfiguration {
 	c := LoggingConfiguration{}
 	SetRecommendedLoggingConfiguration(&c)
+
+	if f := loggingFlags.Lookup("v"); f != nil {
+		value, _ := strconv.Atoi(f.Value.String())
+		c.Verbosity = VerbosityLevel(value)
+	}
+	if f := loggingFlags.Lookup("vmodule"); f != nil {
+		value := f.Value.String()
+		_ = VModuleConfigurationPflag(&c.VModule).Set(value)
+	}
+
 	return &c
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

A test might use ktesting.SetDefaultVerbosity to configure different defaults. Those only have an effect when component-base/logs then honors those defaults instead of applying its own/

#### Special notes for your reviewer:

Found while trying to bump up the default verbosity in test/integration/scheduler_perf in a PR without having to change the -v parameter in the Prow job.

As the default verbosity in klog is the as it was in component-base/logs (-v=0, -vmodule empty), this is not a change of behavior unless a binary actively changes klog before using component-base/logs.

#### Does this PR introduce a user-facing change?
```release-note
component-base/logs: changing klog verbosity now affects the defaults returned by NewLoggingConfiguration. Embedded configurations which use SetRecommendedLoggingConfiguration are unchanged.
```
