### PR TITLE
Adds logging during remote command executor fallback

### DIFF
--- a/staging/src/k8s.io/client-go/tools/remotecommand/fallback.go
+++ b/staging/src/k8s.io/client-go/tools/remotecommand/fallback.go
@@ -18,6 +18,8 @@ package remotecommand
 
 import (
 	"context"
+
+	"k8s.io/klog/v2"
 )
 
 var _ Executor = &FallbackExecutor{}
@@ -51,6 +53,7 @@ func (f *FallbackExecutor) Stream(options StreamOptions) error {
 func (f *FallbackExecutor) StreamWithContext(ctx context.Context, options StreamOptions) error {
 	err := f.primary.StreamWithContext(ctx, options)
 	if f.shouldFallback(err) {
+		klog.V(4).Infof("RemoteCommand fallback: %v", err)
 		return f.secondary.StreamWithContext(ctx, options)
 	}
 	return err


### PR DESCRIPTION
* Adds logging for visibility when `RemoteCommand` executor falls back to legacy SPDY.
 
/kind cleanup

```release-note
NONE
```

- [Transition from SPDY to WebSockets #4006](https://github.com/kubernetes/enhancements/issues/4006)
