### PR TITLE
Ensure controller revision data is valid json

### DIFF
--- a/pkg/apis/apps/fuzzer/fuzzer.go
+++ b/pkg/apis/apps/fuzzer/fuzzer.go
@@ -22,6 +22,7 @@ import (
 	fuzz "github.com/google/gofuzz"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	runtimeserializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/kubernetes/pkg/apis/apps"
@@ -30,6 +31,11 @@ import (
 // Funcs returns the fuzzer functions for the apps api group.
 var Funcs = func(codecs runtimeserializer.CodecFactory) []interface{} {
 	return []interface{}{
+		func(r *apps.ControllerRevision, c fuzz.Continue) {
+			c.FuzzNoCustom(r)
+			// match the fuzzer default content for runtime.Object
+			r.Data = runtime.RawExtension{Raw: []byte(`{"apiVersion":"unknown.group/unknown","kind":"Something","someKey":"someValue"}`)}
+		},
 		func(s *apps.StatefulSet, c fuzz.Continue) {
 			c.FuzzNoCustom(s) // fuzz self without calling this function again
 

--- a/pkg/apis/apps/types.go
+++ b/pkg/apis/apps/types.go
@@ -331,7 +331,7 @@ type ControllerRevision struct {
 	metav1.ObjectMeta
 
 	// Data is the Object representing the state.
-	Data runtime.Object
+	Data runtime.RawExtension
 
 	// Revision indicates the revision of the state represented by Data.
 	Revision int64

--- a/pkg/apis/apps/v1/zz_generated.conversion.go
+++ b/pkg/apis/apps/v1/zz_generated.conversion.go
@@ -347,9 +347,7 @@ func RegisterConversions(s *runtime.Scheme) error {
 
 func autoConvert_v1_ControllerRevision_To_apps_ControllerRevision(in *v1.ControllerRevision, out *apps.ControllerRevision, s conversion.Scope) error {
 	out.ObjectMeta = in.ObjectMeta
-	if err := runtime.Convert_runtime_RawExtension_To_runtime_Object(&in.Data, &out.Data, s); err != nil {
-		return err
-	}
+	out.Data = in.Data
 	out.Revision = in.Revision
 	return nil
 }
@@ -361,9 +359,7 @@ func Convert_v1_ControllerRevision_To_apps_ControllerRevision(in *v1.ControllerR
 
 func autoConvert_apps_ControllerRevision_To_v1_ControllerRevision(in *apps.ControllerRevision, out *v1.ControllerRevision, s conversion.Scope) error {
 	out.ObjectMeta = in.ObjectMeta
-	if err := runtime.Convert_runtime_Object_To_runtime_RawExtension(&in.Data, &out.Data, s); err != nil {
-		return err
-	}
+	out.Data = in.Data
 	out.Revision = in.Revision
 	return nil
 }
@@ -375,17 +371,7 @@ func Convert_apps_ControllerRevision_To_v1_ControllerRevision(in *apps.Controlle
 
 func autoConvert_v1_ControllerRevisionList_To_apps_ControllerRevisionList(in *v1.ControllerRevisionList, out *apps.ControllerRevisionList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	if in.Items != nil {
-		in, out := &in.Items, &out.Items
-		*out = make([]apps.ControllerRevision, len(*in))
-		for i := range *in {
-			if err := Convert_v1_ControllerRevision_To_apps_ControllerRevision(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
-	}
+	out.Items = *(*[]apps.ControllerRevision)(unsafe.Pointer(&in.Items))
 	return nil
 }
 
@@ -396,17 +382,7 @@ func Convert_v1_ControllerRevisionList_To_apps_ControllerRevisionList(in *v1.Con
 
 func autoConvert_apps_ControllerRevisionList_To_v1_ControllerRevisionList(in *apps.ControllerRevisionList, out *v1.ControllerRevisionList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	if in.Items != nil {
-		in, out := &in.Items, &out.Items
-		*out = make([]v1.ControllerRevision, len(*in))
-		for i := range *in {
-			if err := Convert_apps_ControllerRevision_To_v1_ControllerRevision(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
-	}
+	out.Items = *(*[]v1.ControllerRevision)(unsafe.Pointer(&in.Items))
 	return nil
 }
 

--- a/pkg/apis/apps/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/apps/v1beta1/zz_generated.conversion.go
@@ -278,9 +278,7 @@ func RegisterConversions(s *runtime.Scheme) error {
 
 func autoConvert_v1beta1_ControllerRevision_To_apps_ControllerRevision(in *v1beta1.ControllerRevision, out *apps.ControllerRevision, s conversion.Scope) error {
 	out.ObjectMeta = in.ObjectMeta
-	if err := runtime.Convert_runtime_RawExtension_To_runtime_Object(&in.Data, &out.Data, s); err != nil {
-		return err
-	}
+	out.Data = in.Data
 	out.Revision = in.Revision
 	return nil
 }
@@ -292,9 +290,7 @@ func Convert_v1beta1_ControllerRevision_To_apps_ControllerRevision(in *v1beta1.C
 
 func autoConvert_apps_ControllerRevision_To_v1beta1_ControllerRevision(in *apps.ControllerRevision, out *v1beta1.ControllerRevision, s conversion.Scope) error {
 	out.ObjectMeta = in.ObjectMeta
-	if err := runtime.Convert_runtime_Object_To_runtime_RawExtension(&in.Data, &out.Data, s); err != nil {
-		return err
-	}
+	out.Data = in.Data
 	out.Revision = in.Revision
 	return nil
 }
@@ -306,17 +302,7 @@ func Convert_apps_ControllerRevision_To_v1beta1_ControllerRevision(in *apps.Cont
 
 func autoConvert_v1beta1_ControllerRevisionList_To_apps_ControllerRevisionList(in *v1beta1.ControllerRevisionList, out *apps.ControllerRevisionList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	if in.Items != nil {
-		in, out := &in.Items, &out.Items
-		*out = make([]apps.ControllerRevision, len(*in))
-		for i := range *in {
-			if err := Convert_v1beta1_ControllerRevision_To_apps_ControllerRevision(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
-	}
+	out.Items = *(*[]apps.ControllerRevision)(unsafe.Pointer(&in.Items))
 	return nil
 }
 
@@ -327,17 +313,7 @@ func Convert_v1beta1_ControllerRevisionList_To_apps_ControllerRevisionList(in *v
 
 func autoConvert_apps_ControllerRevisionList_To_v1beta1_ControllerRevisionList(in *apps.ControllerRevisionList, out *v1beta1.ControllerRevisionList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	if in.Items != nil {
-		in, out := &in.Items, &out.Items
-		*out = make([]v1beta1.ControllerRevision, len(*in))
-		for i := range *in {
-			if err := Convert_apps_ControllerRevision_To_v1beta1_ControllerRevision(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
-	}
+	out.Items = *(*[]v1beta1.ControllerRevision)(unsafe.Pointer(&in.Items))
 	return nil
 }
 

--- a/pkg/apis/apps/v1beta2/zz_generated.conversion.go
+++ b/pkg/apis/apps/v1beta2/zz_generated.conversion.go
@@ -378,9 +378,7 @@ func RegisterConversions(s *runtime.Scheme) error {
 
 func autoConvert_v1beta2_ControllerRevision_To_apps_ControllerRevision(in *v1beta2.ControllerRevision, out *apps.ControllerRevision, s conversion.Scope) error {
 	out.ObjectMeta = in.ObjectMeta
-	if err := runtime.Convert_runtime_RawExtension_To_runtime_Object(&in.Data, &out.Data, s); err != nil {
-		return err
-	}
+	out.Data = in.Data
 	out.Revision = in.Revision
 	return nil
 }
@@ -392,9 +390,7 @@ func Convert_v1beta2_ControllerRevision_To_apps_ControllerRevision(in *v1beta2.C
 
 func autoConvert_apps_ControllerRevision_To_v1beta2_ControllerRevision(in *apps.ControllerRevision, out *v1beta2.ControllerRevision, s conversion.Scope) error {
 	out.ObjectMeta = in.ObjectMeta
-	if err := runtime.Convert_runtime_Object_To_runtime_RawExtension(&in.Data, &out.Data, s); err != nil {
-		return err
-	}
+	out.Data = in.Data
 	out.Revision = in.Revision
 	return nil
 }
@@ -406,17 +402,7 @@ func Convert_apps_ControllerRevision_To_v1beta2_ControllerRevision(in *apps.Cont
 
 func autoConvert_v1beta2_ControllerRevisionList_To_apps_ControllerRevisionList(in *v1beta2.ControllerRevisionList, out *apps.ControllerRevisionList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	if in.Items != nil {
-		in, out := &in.Items, &out.Items
-		*out = make([]apps.ControllerRevision, len(*in))
-		for i := range *in {
-			if err := Convert_v1beta2_ControllerRevision_To_apps_ControllerRevision(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
-	}
+	out.Items = *(*[]apps.ControllerRevision)(unsafe.Pointer(&in.Items))
 	return nil
 }
 
@@ -427,17 +413,7 @@ func Convert_v1beta2_ControllerRevisionList_To_apps_ControllerRevisionList(in *v
 
 func autoConvert_apps_ControllerRevisionList_To_v1beta2_ControllerRevisionList(in *apps.ControllerRevisionList, out *v1beta2.ControllerRevisionList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	if in.Items != nil {
-		in, out := &in.Items, &out.Items
-		*out = make([]v1beta2.ControllerRevision, len(*in))
-		for i := range *in {
-			if err := Convert_apps_ControllerRevision_To_v1beta2_ControllerRevision(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
-	}
+	out.Items = *(*[]v1beta2.ControllerRevision)(unsafe.Pointer(&in.Items))
 	return nil
 }
 

--- a/pkg/apis/apps/zz_generated.deepcopy.go
+++ b/pkg/apis/apps/zz_generated.deepcopy.go
@@ -33,9 +33,7 @@ func (in *ControllerRevision) DeepCopyInto(out *ControllerRevision) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
 	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
-	if in.Data != nil {
-		out.Data = in.Data.DeepCopyObject()
-	}
+	in.Data.DeepCopyInto(&out.Data)
 	return
 }
 

--- a/pkg/controlplane/import_known_versions_test.go
+++ b/pkg/controlplane/import_known_versions_test.go
@@ -23,6 +23,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	apinamingtest "k8s.io/apimachinery/pkg/api/apitesting/naming"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
@@ -70,6 +71,7 @@ var typesAllowedTags = map[reflect.Type]bool{
 	reflect.TypeOf(metav1.GroupVersionResource{}): true,
 	reflect.TypeOf(metav1.Status{}):               true,
 	reflect.TypeOf(metav1.Condition{}):            true,
+	reflect.TypeOf(runtime.RawExtension{}):        true,
 }
 
 // These fields are limited exceptions to the standard JSON naming structure.

--- a/pkg/registry/apps/controllerrevision/strategy.go
+++ b/pkg/registry/apps/controllerrevision/strategy.go
@@ -62,7 +62,7 @@ func (strategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
 func (strategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	revision := obj.(*apps.ControllerRevision)
 
-	return validation.ValidateControllerRevision(revision)
+	return validation.ValidateControllerRevisionCreate(revision)
 }
 
 // WarningsOnCreate returns warnings for the creation of the given object.


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Validates content of controller revision is actually valid json on create.

#### Special notes for your reviewer:

This was assumed before and the controller revision libraries only use json, but this was not enforced server-side. Non-json content in this field would cause problems for some API clients.

#### Does this PR introduce a user-facing change?
```release-note
kube-apiserver: ControllerRevision objects are now verified to contain valid JSON data in the `data` field.
```

/sig api-machinery
/cc @jpbetz @deads2k @pohly @benluddy 