### PR TITLE
DO NOT MERGE: kubelet/prober: Continue probing terminal phase pods

### DIFF
--- a/pkg/kubelet/prober/worker.go
+++ b/pkg/kubelet/prober/worker.go
@@ -207,13 +207,6 @@ func (w *worker) doProbe(ctx context.Context) (keepGoing bool) {
 		return true
 	}
 
-	// Worker should terminate if pod is terminated.
-	if status.Phase == v1.PodFailed || status.Phase == v1.PodSucceeded {
-		klog.V(3).InfoS("Pod is terminated, exiting probe worker",
-			"pod", klog.KObj(w.pod), "phase", status.Phase)
-		return false
-	}
-
 	c, ok := podutil.GetContainerStatus(status.ContainerStatuses, w.container.Name)
 	if !ok || len(c.ContainerID) == 0 {
 		c, ok = podutil.GetContainerStatus(status.InitContainerStatuses, w.container.Name)


### PR DESCRIPTION
A terminal phase pod may still be running on the node (if the phase is set via the APIServer, by a node shutdown, or by an eviction) and is still a candidate for probes. It is the responsibility of the pod worker and the sync loop to stop probes at the appropriate time - the prober should continue to observe the state of the containers until instructed to stop by the worker.

TODO: Testing this out to see what breaks.

/kind bug

Fixes #124648

```release-note
The kubelet now correctly performs readiness checks on pods until the pod fully terminates during node graceful shutdown.
```

```docs

```
