### PR TITLE
kubeadm: Add '--yes' flag to the list of allowed flags

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/validation/validation.go
+++ b/cmd/kubeadm/app/apis/kubeadm/validation/validation.go
@@ -609,7 +609,7 @@ func isAllowedFlag(flagName string) bool {
 		kubeadmcmdoptions.NodeName,
 		kubeadmcmdoptions.KubeconfigDir,
 		kubeadmcmdoptions.UploadCerts,
-		"print-join-command", "rootfs", "v", "log-file")
+		"print-join-command", "rootfs", "v", "log-file", "yes")
 	if allowedFlags.Has(flagName) {
 		return true
 	}

--- a/cmd/kubeadm/app/apis/kubeadm/validation/validation_test.go
+++ b/cmd/kubeadm/app/apis/kubeadm/validation/validation_test.go
@@ -749,9 +749,11 @@ func TestValidateMixedArguments(t *testing.T) {
 		// Expected to succeed, --config is mixed with skip-* flags only or no other flags
 		{[]string{"--config=hello", "--skip-token-print=true"}, true},
 		{[]string{"--config=hello", "--ignore-preflight-errors=baz", "--skip-token-print"}, true},
+		{[]string{"--config=hello", "--yes=true"}, true},
 		// Expected to fail, --config is mixed with the --foo flag
 		{[]string{"--config=hello", "--ignore-preflight-errors=baz", "--foo=bar"}, false},
 		{[]string{"--config=hello", "--foo=bar"}, false},
+		{[]string{"--config=hello", "--yes=true", "--foo=bar"}, false},
 		// Expected to fail, --config is mixed with the upgrade related flag
 		{[]string{"--config=hello", "--allow-experimental-upgrades"}, false},
 	}
@@ -767,6 +769,7 @@ func TestValidateMixedArguments(t *testing.T) {
 		f.StringSliceVar(&ignorePreflightErrors, "ignore-preflight-errors", ignorePreflightErrors, "flag not bound to config object")
 		f.Bool("allow-experimental-upgrades", true, "upgrade flags for plan and apply command")
 		f.Bool("skip-token-print", false, "flag not bound to config object")
+		f.Bool("yes", false, "flag not bound to config object")
 		f.StringVar(&cfgPath, "config", cfgPath, "Path to kubeadm config file")
 		if err := f.Parse(rt.args); err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
#### What type of PR is this?

/kind regression

#### What this PR does / why we need it:

This PR makes it possible to use the `--yes` flag along with the `--config` flag in `kubeadm`. Right now, trying to do so results in the following error:

```
can not mix '--config' with arguments [yes]
To see the stack trace of this error execute with --v=5 or higher
```

For more details and motivation, see the kubeadm issue: https://github.com/kubernetes/kubeadm/issues/3076

#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes/kubeadm/issues/3076

#### Does this PR introduce a user-facing change?
```release-note
Fixes a 1.30 regression in kubeadm: Added `--yes` flag to the list of allowed flags so that it can be mixed with `kubeadm upgrade apply --config`
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```

cc @neolit123 