### PR TITLE
kubeadm: implement ControlPlaneKubeletLocalMode

### DIFF
--- a/cmd/kubeadm/app/cmd/join.go
+++ b/cmd/kubeadm/app/cmd/join.go
@@ -219,6 +219,8 @@ func newCmdJoin(out io.Writer, joinOptions *joinOptions) *cobra.Command {
 	joinRunner.AppendPhase(phases.NewControlPlanePreparePhase())
 	joinRunner.AppendPhase(phases.NewCheckEtcdPhase())
 	joinRunner.AppendPhase(phases.NewKubeletStartPhase())
+	joinRunner.AppendPhase(phases.NewEtcdJoinPhase())
+	joinRunner.AppendPhase(phases.NewKubeletWaitBootstrapPhase())
 	joinRunner.AppendPhase(phases.NewControlPlaneJoinPhase())
 	joinRunner.AppendPhase(phases.NewWaitControlPlanePhase())
 

--- a/cmd/kubeadm/app/cmd/phases/join/controlplanejoin.go
+++ b/cmd/kubeadm/app/cmd/phases/join/controlplanejoin.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/options"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/workflow"
 	cmdutil "k8s.io/kubernetes/cmd/kubeadm/app/cmd/util"
+	"k8s.io/kubernetes/cmd/kubeadm/app/features"
 	etcdphase "k8s.io/kubernetes/cmd/kubeadm/app/phases/etcd"
 	markcontrolplanephase "k8s.io/kubernetes/cmd/kubeadm/app/phases/markcontrolplane"
 	etcdutil "k8s.io/kubernetes/cmd/kubeadm/app/util/etcd"
@@ -33,6 +34,11 @@ import (
 var controlPlaneJoinExample = cmdutil.Examples(`
 	# Joins a machine as a control plane instance
 	kubeadm join phase control-plane-join all
+`)
+
+var etcdJoinExample = cmdutil.Examples(`
+	# Joins etcd for a control plane instance
+	kubeadm join phase control-plane-join-etcd all
 `)
 
 func getControlPlaneJoinPhaseFlags(name string) []string {
@@ -73,6 +79,25 @@ func NewControlPlaneJoinPhase() workflow.Phase {
 	}
 }
 
+// NewEtcdJoinPhase creates a kubeadm workflow phase that implements joining etcd
+func NewEtcdJoinPhase() workflow.Phase {
+	return workflow.Phase{
+		Name:          "etcd-join",
+		Short:         fmt.Sprintf("[EXPERIMENTAL] Join etcd for control plane nodes (only used when feature gate %s is enabled)", features.ControlPlaneKubeletLocalMode),
+		Run:           runEtcdPhase,
+		Example:       etcdJoinExample,
+		InheritFlags:  getControlPlaneJoinPhaseFlags("etcd"),
+		ArgsValidator: cobra.NoArgs,
+		// TODO: unhide this phase once ControlPlaneKubeletLocalMode goes GA:
+		// https://github.com/kubernetes/enhancements/issues/4471
+		Hidden: true,
+		// Only run this phase as if `ControlPlaneKubeletLocalMode` is activated.
+		RunIf: func(c workflow.RunData) (bool, error) {
+			return checkFeatureState(c, features.ControlPlaneKubeletLocalMode, true)
+		},
+	}
+}
+
 func newEtcdLocalSubphase() workflow.Phase {
 	return workflow.Phase{
 		Name:          "etcd",
@@ -80,6 +105,11 @@ func newEtcdLocalSubphase() workflow.Phase {
 		Run:           runEtcdPhase,
 		InheritFlags:  getControlPlaneJoinPhaseFlags("etcd"),
 		ArgsValidator: cobra.NoArgs,
+		// Only run this phase as subphase of control-plane-join phase if
+		// `ControlPlaneKubeletLocalMode` is deactivated.
+		RunIf: func(c workflow.RunData) (bool, error) {
+			return checkFeatureState(c, features.ControlPlaneKubeletLocalMode, false)
+		},
 	}
 }
 

--- a/cmd/kubeadm/app/cmd/phases/join/data.go
+++ b/cmd/kubeadm/app/cmd/phases/join/data.go
@@ -20,11 +20,14 @@ package phases
 import (
 	"io"
 
+	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	clientset "k8s.io/client-go/kubernetes"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/workflow"
+	"k8s.io/kubernetes/cmd/kubeadm/app/features"
 )
 
 // JoinData is the interface to use for join phases.
@@ -43,4 +46,18 @@ type JoinData interface {
 	KubeletDir() string
 	ManifestDir() string
 	CertificateWriteDir() string
+}
+
+func checkFeatureState(c workflow.RunData, featureGate string, state bool) (bool, error) {
+	data, ok := c.(JoinData)
+	if !ok {
+		return false, errors.New("control-plane-join phase invoked with an invalid data struct")
+	}
+
+	cfg, err := data.InitCfg()
+	if err != nil {
+		return false, err
+	}
+
+	return state == features.Enabled(cfg.FeatureGates, featureGate), nil
 }

--- a/cmd/kubeadm/app/cmd/phases/join/kubelet.go
+++ b/cmd/kubeadm/app/cmd/phases/join/kubelet.go
@@ -40,8 +40,10 @@ import (
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/workflow"
 	"k8s.io/kubernetes/cmd/kubeadm/app/componentconfigs"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
+	"k8s.io/kubernetes/cmd/kubeadm/app/features"
 	kubeletphase "k8s.io/kubernetes/cmd/kubeadm/app/phases/kubelet"
 	patchnodephase "k8s.io/kubernetes/cmd/kubeadm/app/phases/patchnode"
+	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/apiclient"
 	dryrunutil "k8s.io/kubernetes/cmd/kubeadm/app/util/dryrun"
 	kubeconfigutil "k8s.io/kubernetes/cmd/kubeadm/app/util/kubeconfig"
@@ -85,6 +87,27 @@ func NewKubeletStartPhase() workflow.Phase {
 	}
 }
 
+// NewKubeletWaitBootstrapPhase creates a kubeadm workflow phase that start kubelet on a node.
+func NewKubeletWaitBootstrapPhase() workflow.Phase {
+	return workflow.Phase{
+		Name:  "kubelet-wait-bootstrap",
+		Short: "[EXPERIMENTAL] Wait for the kubelet to bootstrap itself (only used when feature gate ControlPlaneKubeletLocalMode is enabled)",
+		Run:   runKubeletWaitBootstrapPhase,
+		InheritFlags: []string{
+			options.CfgPath,
+			options.NodeCRISocket,
+			options.DryRun,
+		},
+		// TODO: unhide this phase once ControlPlaneKubeletLocalMode goes GA:
+		// https://github.com/kubernetes/enhancements/issues/4471
+		Hidden: true,
+		// Only run this phase as if `ControlPlaneKubeletLocalMode` is activated.
+		RunIf: func(c workflow.RunData) (bool, error) {
+			return checkFeatureState(c, features.ControlPlaneKubeletLocalMode, true)
+		},
+	}
+}
+
 func getKubeletStartJoinData(c workflow.RunData) (*kubeadmapi.JoinConfiguration, *kubeadmapi.InitConfiguration, *clientcmdapi.Config, error) {
 	data, ok := c.(JoinData)
 	if !ok {
@@ -117,8 +140,36 @@ func runKubeletStartJoinPhase(c workflow.RunData) (returnErr error) {
 	}
 	bootstrapKubeConfigFile := filepath.Join(data.KubeConfigDir(), kubeadmconstants.KubeletBootstrapKubeConfigFileName)
 
-	// Deletes the bootstrapKubeConfigFile, so the credential used for TLS bootstrap is removed from disk
-	defer os.Remove(bootstrapKubeConfigFile)
+	// Do not delete the bootstrapKubeConfigFile at the end of this function when
+	// using ControlPlaneKubeletLocalMode. The KubeletWaitBootstrapPhase will delete
+	// it when the feature is enabled.
+	if !features.Enabled(initCfg.FeatureGates, features.ControlPlaneKubeletLocalMode) {
+		// Deletes the bootstrapKubeConfigFile, so the credential used for TLS bootstrap is removed from disk
+		defer func() {
+			_ = os.Remove(bootstrapKubeConfigFile)
+		}()
+	}
+
+	// Create the bootstrap client before we possibly overwrite the server address
+	// for ControlPlaneKubeletLocalMode.
+	bootstrapClient, err := kubeconfigutil.ToClientSet(tlsBootstrapCfg)
+	if err != nil {
+		return errors.Errorf("could not create client from bootstrap kubeconfig")
+	}
+
+	if features.Enabled(initCfg.FeatureGates, features.ControlPlaneKubeletLocalMode) {
+		// Set the server url to LocalAPIEndpoint if the feature gate is enabled so the config
+		// which gets passed to the kubelet forces it to talk to the local kube-apiserver.
+		if cfg.ControlPlane != nil {
+			for c, conf := range tlsBootstrapCfg.Clusters {
+				conf.Server, err = kubeadmutil.GetLocalAPIEndpoint(&cfg.ControlPlane.LocalAPIEndpoint)
+				if err != nil {
+					return errors.Wrapf(err, "could not get LocalAPIEndpoint when %s is enabled", features.ControlPlaneKubeletLocalMode)
+				}
+				tlsBootstrapCfg.Clusters[c] = conf
+			}
+		}
+	}
 
 	// Write the bootstrap kubelet config file or the TLS-Bootstrapped kubelet config file down to disk
 	klog.V(1).Infof("[kubelet-start] writing bootstrap kubelet config file at %s", bootstrapKubeConfigFile)
@@ -140,11 +191,6 @@ func runKubeletStartJoinPhase(c workflow.RunData) (returnErr error) {
 		if err := certutil.WriteCert(caPath, tlsBootstrapCfg.Clusters[cluster].CertificateAuthorityData); err != nil {
 			return errors.Wrap(err, "couldn't save the CA certificate to disk")
 		}
-	}
-
-	bootstrapClient, err := kubeconfigutil.ClientSetFromFile(bootstrapKubeConfigFile)
-	if err != nil {
-		return errors.Errorf("couldn't create client from kubeconfig file %q", bootstrapKubeConfigFile)
 	}
 
 	// Obtain the name of this Node.
@@ -204,6 +250,36 @@ func runKubeletStartJoinPhase(c workflow.RunData) (returnErr error) {
 	// Try to start the kubelet service in case it's inactive
 	fmt.Println("[kubelet-start] Starting the kubelet")
 	kubeletphase.TryStartKubelet()
+
+	// Run the same code as KubeletWaitBootstrapPhase would do if the ControlPlaneKubeletLocalMode feature gate is disabled.
+	if !features.Enabled(initCfg.FeatureGates, features.ControlPlaneKubeletLocalMode) {
+		if err := runKubeletWaitBootstrapPhase(c); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// runKubeletWaitBootstrapPhase waits for the kubelet to finish its TLS bootstrap process.
+// This process is executed by the kubelet and completes with the node joining the cluster
+// with a dedicates set of credentials as required by the node authorizer.
+func runKubeletWaitBootstrapPhase(c workflow.RunData) (returnErr error) {
+	data, ok := c.(JoinData)
+	if !ok {
+		return errors.New("kubelet-start phase invoked with an invalid data struct")
+	}
+	cfg := data.Cfg()
+	initCfg, err := data.InitCfg()
+	if err != nil {
+		return err
+	}
+
+	bootstrapKubeConfigFile := filepath.Join(data.KubeConfigDir(), kubeadmconstants.KubeletBootstrapKubeConfigFileName)
+	// Deletes the bootstrapKubeConfigFile, so the credential used for TLS bootstrap is removed from disk
+	defer func() {
+		_ = os.Remove(bootstrapKubeConfigFile)
+	}()
 
 	// Now the kubelet will perform the TLS Bootstrap, transforming /etc/kubernetes/bootstrap-kubelet.conf to /etc/kubernetes/kubelet.conf
 	// Wait for the kubelet to create the /etc/kubernetes/kubelet.conf kubeconfig file. If this process

--- a/cmd/kubeadm/app/features/features.go
+++ b/cmd/kubeadm/app/features/features.go
@@ -38,6 +38,8 @@ const (
 	EtcdLearnerMode = "EtcdLearnerMode"
 	// WaitForAllControlPlaneComponents is expected to be alpha in v1.30
 	WaitForAllControlPlaneComponents = "WaitForAllControlPlaneComponents"
+	// ControlPlaneKubeletLocalMode is expected to be in alpha in v1.31, beta in v1.32
+	ControlPlaneKubeletLocalMode = "ControlPlaneKubeletLocalMode"
 )
 
 // InitFeatureGates are the default feature gates for the init command
@@ -53,6 +55,7 @@ var InitFeatureGates = FeatureList{
 	},
 	EtcdLearnerMode:                  {FeatureSpec: featuregate.FeatureSpec{Default: true, PreRelease: featuregate.Beta}},
 	WaitForAllControlPlaneComponents: {FeatureSpec: featuregate.FeatureSpec{Default: false, PreRelease: featuregate.Alpha}},
+	ControlPlaneKubeletLocalMode:     {FeatureSpec: featuregate.FeatureSpec{Default: false, PreRelease: featuregate.Alpha}},
 }
 
 // Feature represents a feature being gated


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

ControlPlaneKubeletLocalMode is a new feature gate that can be used to tell kubeadm to use the local kube-apiserver for the kubelet when joining control plane nodes.

* Adds a new phase `kubelet-wait-bootstrap` to join:
  * the new phase was previously embedded at the end of the `kubelet-start` phase.
  * if the feature gate is enabled: the phase runs after the `kubelet-start` and `control-plane-join-etcd` phase. 
  * if the feature gate is disabled: the phase does not run, but the same code runs at the end of the `kubelet-start` phase to preserve the old behaviour
* Adds a new phase `etcd-join` to join:
  * the new phase replaces the `etcd` subphase of `control-plane-join` when the feature gate is enabled.
  * if the feature gate is enabled: the phase runs after the `kubelet-start` phase.
  * if the feature gate is disabled: the original `etcd` subphase of `control-plane-join` runs to preserve the old behaviour.
* Changes the `kubelet-start` phase:
  * if the feature gate is enabled: set the url in the tls bootstrap configuration to the LocalAPIEndpoint.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Part of: https://github.com/kubernetes/enhancements/issues/4471

Part of: https://github.com/kubernetes/kubeadm/issues/2271

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubeadm: added the ControlPlaneKubeletLocalMode feature gate. It can be used to tell kubeadm to use the local kube-apiserver endpoint for the kubelet when creating a cluster with "kubeadm init" or when joining control plane nodes with "kubeadm join".  The "kubeadm join" workflow now includes two new experimental phases called "control-plane-join-etcd" and "kubelet-wait-bootstrap" which will be used when the feature gate is enabled. This phases will be marked as non-experimental when ControlPlaneKubeletLocalMode becomes GA. During "kubeadm upgrade" commands, if the feature gate is enabled, modify the "/etc/kubernetes/kubelet.conf " to use the local kube-apiserver endpoint. This upgrade mechanism will be removed once the feature gate goes GA and is hardcoded to true.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: https://github.com/kubernetes/enhancements/blob/bcd6c468b88903b49d1784a9364516142a8e83f9/keps/sig-cluster-lifecycle/kubeadm/4471-cp-join-kubelet-local-apiserver/README.md
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/blob/bcd6c468b88903b49d1784a9364516142a8e83f9/keps/sig-cluster-lifecycle/kubeadm/4471-cp-join-kubelet-local-apiserver/README.md
```
