### PR TITLE
client-go: enable proxy reactor for fake client's GetLogs handler

### DIFF
--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_pod_expansion.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_pod_expansion.go
@@ -56,14 +56,10 @@ func (c *FakePods) GetBinding(name string) (result *v1.Binding, err error) {
 }
 
 func (c *FakePods) GetLogs(name string, opts *v1.PodLogOptions) *restclient.Request {
-	action := core.GenericActionImpl{}
-	action.Verb = "get"
-	action.Namespace = c.ns
-	action.Resource = podsResource
-	action.Subresource = "log"
-	action.Value = opts
-
-	_, _ = c.Fake.Invokes(action, &v1.Pod{})
+	if resp := c.Fake.InvokesProxy(core.NewGetLogAction(podsResource, c.ns, name, opts.Container, opts.SinceSeconds, opts.SinceTime)); resp != nil {
+		return resp.(*restclient.Request)
+	}
+	// Fallback to current behavior in case if there is no  Proxy Reactors found for the sub resource action
 	fakeClient := &fakerest.RESTClient{
 		Client: fakerest.CreateHTTPClient(func(request *http.Request) (*http.Response, error) {
 			resp := &http.Response{

--- a/staging/src/k8s.io/client-go/testing/actions.go
+++ b/staging/src/k8s.io/client-go/testing/actions.go
@@ -302,6 +302,19 @@ func NewRootWatchAction(resource schema.GroupVersionResource, opts interface{}) 
 	return action
 }
 
+func NewGetLogAction(resource schema.GroupVersionResource, namespace string, name string, containerName string, sinceSeconds *int64, sinceTime *metav1.Time) GetLogActionImpl {
+	action := GetLogActionImpl{}
+	action.Verb = "get"
+	action.Subresource = "log"
+	action.Resource = resource
+	action.Namespace = namespace
+	action.PodName = name
+	action.SinceTime = sinceTime
+	action.SinceSeconds = sinceSeconds
+	action.ContainerName = containerName
+	return action
+}
+
 func ExtractFromListOptions(opts interface{}) (labelSelector labels.Selector, fieldSelector fields.Selector, resourceVersion string) {
 	var err error
 	switch t := opts.(type) {
@@ -428,6 +441,14 @@ type ProxyGetAction interface {
 	GetPort() string
 	GetPath() string
 	GetParams() map[string]string
+}
+
+type LogGetAction interface {
+	Action
+	GetPodName() string
+	GetContainerName() string
+	GetSinceSeconds() *int64
+	GetSinceTime() *metav1.Time
 }
 
 type ActionImpl struct {
@@ -694,5 +715,43 @@ func (a ProxyGetActionImpl) DeepCopy() Action {
 		Port:       a.Port,
 		Path:       a.Path,
 		Params:     params,
+	}
+}
+
+type GetLogActionImpl struct {
+	ActionImpl
+	PodName       string
+	ContainerName string
+	SinceSeconds  *int64
+	SinceTime     *metav1.Time
+}
+
+func (g GetLogActionImpl) GetName() string {
+	return g.PodName
+}
+
+func (g GetLogActionImpl) GetPodName() string {
+	return g.PodName
+}
+
+func (g GetLogActionImpl) GetContainerName() string {
+	return g.ContainerName
+}
+
+func (g GetLogActionImpl) GetSinceSeconds() *int64 {
+	return g.SinceSeconds
+}
+
+func (g GetLogActionImpl) GetSinceTime() *metav1.Time {
+	return g.SinceTime
+}
+
+func (g GetLogActionImpl) DeepCopy() Action {
+	return GetLogActionImpl{
+		ActionImpl:    g.ActionImpl.DeepCopy().(ActionImpl),
+		PodName:       g.PodName,
+		ContainerName: g.ContainerName,
+		SinceSeconds:  g.SinceSeconds,
+		SinceTime:     g.SinceTime,
 	}
 }

--- a/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/logsforobject_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/logsforobject_test.go
@@ -57,7 +57,7 @@ func TestLogsForObject(t *testing.T) {
 			name: "pod logs",
 			obj:  testPodWithOneContainers(),
 			actions: []testclient.Action{
-				getLogsAction("test", &corev1.PodLogOptions{Container: "c1"}),
+				getLogsAction("test", "foo", &corev1.PodLogOptions{Container: "c1"}),
 			},
 			expectedSources: []corev1.ObjectReference{
 				{
@@ -76,11 +76,11 @@ func TestLogsForObject(t *testing.T) {
 			allContainers: true,
 			allPods:       false,
 			actions: []testclient.Action{
-				getLogsAction("test", &corev1.PodLogOptions{Container: "foo-2-and-2-and-1-initc1"}),
-				getLogsAction("test", &corev1.PodLogOptions{Container: "foo-2-and-2-and-1-initc2"}),
-				getLogsAction("test", &corev1.PodLogOptions{Container: "foo-2-and-2-and-1-c1"}),
-				getLogsAction("test", &corev1.PodLogOptions{Container: "foo-2-and-2-and-1-c2"}),
-				getLogsAction("test", &corev1.PodLogOptions{Container: "foo-2-and-2-and-1-e1"}),
+				getLogsAction("test", "foo-two-containers-and-two-init-containers", &corev1.PodLogOptions{Container: "foo-2-and-2-and-1-initc1"}),
+				getLogsAction("test", "foo-two-containers-and-two-init-containers", &corev1.PodLogOptions{Container: "foo-2-and-2-and-1-initc2"}),
+				getLogsAction("test", "foo-two-containers-and-two-init-containers", &corev1.PodLogOptions{Container: "foo-2-and-2-and-1-c1"}),
+				getLogsAction("test", "foo-two-containers-and-two-init-containers", &corev1.PodLogOptions{Container: "foo-2-and-2-and-1-c2"}),
+				getLogsAction("test", "foo-two-containers-and-two-init-containers", &corev1.PodLogOptions{Container: "foo-2-and-2-and-1-e1"}),
 			},
 			expectedSources: []corev1.ObjectReference{
 				{
@@ -124,7 +124,7 @@ func TestLogsForObject(t *testing.T) {
 			name: "pod logs: default to first container",
 			obj:  testPodWithTwoContainers(),
 			actions: []testclient.Action{
-				getLogsAction("test", &corev1.PodLogOptions{Container: "foo-2-c1"}),
+				getLogsAction("test", "foo-two-containers", &corev1.PodLogOptions{Container: "foo-2-c1"}),
 			},
 			expectedSources: []corev1.ObjectReference{
 				{
@@ -142,7 +142,7 @@ func TestLogsForObject(t *testing.T) {
 				Items: []corev1.Pod{*testPodWithOneContainers()},
 			},
 			actions: []testclient.Action{
-				getLogsAction("test", &corev1.PodLogOptions{Container: "c1"}),
+				getLogsAction("test", "foo", &corev1.PodLogOptions{Container: "c1"}),
 			},
 			expectedSources: []corev1.ObjectReference{{
 				Kind:       testPodWithOneContainers().Kind,
@@ -199,8 +199,8 @@ func TestLogsForObject(t *testing.T) {
 				},
 			},
 			actions: []testclient.Action{
-				getLogsAction("test", &corev1.PodLogOptions{Container: "c1"}),
-				getLogsAction("test", &corev1.PodLogOptions{Container: "c2"}),
+				getLogsAction("test", "foo", &corev1.PodLogOptions{Container: "c1"}),
+				getLogsAction("test", "bar", &corev1.PodLogOptions{Container: "c2"}),
 			},
 			expectedSources: []corev1.ObjectReference{{
 				Kind:       "pod",
@@ -225,10 +225,10 @@ func TestLogsForObject(t *testing.T) {
 			allContainers: true,
 			allPods:       false,
 			actions: []testclient.Action{
-				getLogsAction("test", &corev1.PodLogOptions{Container: "foo-2-and-2-initc1"}),
-				getLogsAction("test", &corev1.PodLogOptions{Container: "foo-2-and-2-initc2"}),
-				getLogsAction("test", &corev1.PodLogOptions{Container: "foo-2-and-2-c1"}),
-				getLogsAction("test", &corev1.PodLogOptions{Container: "foo-2-and-2-c2"}),
+				getLogsAction("test", "foo-two-containers-and-two-init-containers", &corev1.PodLogOptions{Container: "foo-2-and-2-initc1"}),
+				getLogsAction("test", "foo-two-containers-and-two-init-containers", &corev1.PodLogOptions{Container: "foo-2-and-2-initc2"}),
+				getLogsAction("test", "foo-two-containers-and-two-init-containers", &corev1.PodLogOptions{Container: "foo-2-and-2-c1"}),
+				getLogsAction("test", "foo-two-containers-and-two-init-containers", &corev1.PodLogOptions{Container: "foo-2-and-2-c2"}),
 			},
 			expectedSources: []corev1.ObjectReference{
 				{
@@ -267,7 +267,7 @@ func TestLogsForObject(t *testing.T) {
 				Items: []corev1.Pod{*testPodWithTwoContainersAndTwoInitAndOneEphemeralContainers()},
 			},
 			actions: []testclient.Action{
-				getLogsAction("test", &corev1.PodLogOptions{Container: "foo-2-and-2-and-1-c1"}),
+				getLogsAction("test", "foo-two-containers-and-two-init-containers", &corev1.PodLogOptions{Container: "foo-2-and-2-and-1-c1"}),
 			},
 			expectedSources: []corev1.ObjectReference{
 				{
@@ -290,7 +290,7 @@ func TestLogsForObject(t *testing.T) {
 			clientsetPods: []runtime.Object{testPodWithOneContainers()},
 			actions: []testclient.Action{
 				testclient.NewListAction(podsResource, podsKind, "test", metav1.ListOptions{LabelSelector: "foo=bar"}),
-				getLogsAction("test", &corev1.PodLogOptions{Container: "c1"}),
+				getLogsAction("test", "foo", &corev1.PodLogOptions{Container: "c1"}),
 			},
 			expectedSources: []corev1.ObjectReference{{
 				Kind:       testPodWithOneContainers().Kind,
@@ -311,7 +311,7 @@ func TestLogsForObject(t *testing.T) {
 			clientsetPods: []runtime.Object{testPodWithOneContainers()},
 			actions: []testclient.Action{
 				testclient.NewListAction(podsResource, podsKind, "test", metav1.ListOptions{LabelSelector: "foo=bar"}),
-				getLogsAction("test", &corev1.PodLogOptions{Container: "c1"}),
+				getLogsAction("test", "foo", &corev1.PodLogOptions{Container: "c1"}),
 			},
 			expectedSources: []corev1.ObjectReference{{
 				Kind:       testPodWithOneContainers().Kind,
@@ -332,7 +332,7 @@ func TestLogsForObject(t *testing.T) {
 			clientsetPods: []runtime.Object{testPodWithOneContainers()},
 			actions: []testclient.Action{
 				testclient.NewListAction(podsResource, podsKind, "test", metav1.ListOptions{LabelSelector: "foo=bar"}),
-				getLogsAction("test", &corev1.PodLogOptions{Container: "c1"}),
+				getLogsAction("test", "foo", &corev1.PodLogOptions{Container: "c1"}),
 			},
 			expectedSources: []corev1.ObjectReference{{
 				Kind:       testPodWithOneContainers().Kind,
@@ -353,7 +353,7 @@ func TestLogsForObject(t *testing.T) {
 			clientsetPods: []runtime.Object{testPodWithOneContainers()},
 			actions: []testclient.Action{
 				testclient.NewListAction(podsResource, podsKind, "test", metav1.ListOptions{LabelSelector: "foo=bar"}),
-				getLogsAction("test", &corev1.PodLogOptions{Container: "c1"}),
+				getLogsAction("test", "foo", &corev1.PodLogOptions{Container: "c1"}),
 			},
 			expectedSources: []corev1.ObjectReference{{
 				Kind:       testPodWithOneContainers().Kind,
@@ -374,7 +374,7 @@ func TestLogsForObject(t *testing.T) {
 			clientsetPods: []runtime.Object{testPodWithOneContainers()},
 			actions: []testclient.Action{
 				testclient.NewListAction(podsResource, podsKind, "test", metav1.ListOptions{LabelSelector: "foo=bar"}),
-				getLogsAction("test", &corev1.PodLogOptions{Container: "c1"}),
+				getLogsAction("test", "foo", &corev1.PodLogOptions{Container: "c1"}),
 			},
 			expectedSources: []corev1.ObjectReference{{
 				Kind:       testPodWithOneContainers().Kind,
@@ -631,12 +631,15 @@ func testPodWithTwoContainersAndTwoInitAndOneEphemeralContainers() *corev1.Pod {
 	}
 }
 
-func getLogsAction(namespace string, opts *corev1.PodLogOptions) testclient.Action {
-	action := testclient.GenericActionImpl{}
+func getLogsAction(namespace string, name string, opts *corev1.PodLogOptions) testclient.Action {
+	action := testclient.GetLogActionImpl{}
 	action.Verb = "get"
 	action.Namespace = namespace
 	action.Resource = podsResource
 	action.Subresource = "log"
-	action.Value = opts
+	action.SinceTime = opts.SinceTime
+	action.SinceSeconds = opts.SinceSeconds
+	action.ContainerName = opts.Container
+	action.PodName = name
 	return action
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:

This change introduces a new Action named `LogGetAction` that can be used with `ProxyReactionChain` in order to retrieve custom logs from `GetLogs` pod expansion handlers as part of the fake client-go test helpers.

Enabling this aids in better testing of infra where the components are performing certain analysis of the logs obtained from the container. This also enables in simulating different behavior with the `GetLogs` handlers.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #125590

#### Special notes for your reviewer:
NA

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
enabled fake tests clients to leverage `ProxyReactionChain` to yield custom logs from `GetLogs` handlers under pod expansion
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NA
```
