### PR TITLE
Copy input to UnmarshalJSON on the apiextensions JSON types.

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1/marshal.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1/marshal.go
@@ -130,7 +130,7 @@ func (s JSON) MarshalJSON() ([]byte, error) {
 
 func (s *JSON) UnmarshalJSON(data []byte) error {
 	if len(data) > 0 && !bytes.Equal(data, nullLiteral) {
-		s.Raw = data
+		s.Raw = append(s.Raw[0:0], data...)
 	}
 	return nil
 }

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1/marshal_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1/marshal_test.go
@@ -148,3 +148,24 @@ func TestJSONSchemaPropsOrArrayMarshalJSON(t *testing.T) {
 		}
 	}
 }
+
+func TestJSONUnderlyingArrayReuse(t *testing.T) {
+	const want = `{"foo":"bar"}`
+
+	b := []byte(want)
+
+	var s JSON
+	if err := s.UnmarshalJSON(b); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Underlying array is modified.
+	copy(b[2:5], "bar")
+	copy(b[8:11], "foo")
+
+	// If UnmarshalJSON copied the bytes of its argument, then it should not have been affected
+	// by the mutation.
+	if got := string(s.Raw); got != want {
+		t.Errorf("unexpected mutation, got %s want %s", got, want)
+	}
+}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1/marshal.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1/marshal.go
@@ -130,7 +130,7 @@ func (s JSON) MarshalJSON() ([]byte, error) {
 
 func (s *JSON) UnmarshalJSON(data []byte) error {
 	if len(data) > 0 && !bytes.Equal(data, nullLiteral) {
-		s.Raw = data
+		s.Raw = append(s.Raw[0:0], data...)
 	}
 	return nil
 }

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1/marshal_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1/marshal_test.go
@@ -148,3 +148,24 @@ func TestJSONSchemaPropsOrArrayMarshalJSON(t *testing.T) {
 		}
 	}
 }
+
+func TestJSONUnderlyingArrayReuse(t *testing.T) {
+	const want = `{"foo":"bar"}`
+
+	b := []byte(want)
+
+	var s JSON
+	if err := s.UnmarshalJSON(b); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Underlying array is modified.
+	copy(b[2:5], "bar")
+	copy(b[8:11], "foo")
+
+	// If UnmarshalJSON copied the bytes of its argument, then it should not have been affected
+	// by the mutation.
+	if got := string(s.Raw); got != want {
+		t.Errorf("unexpected mutation, got %s want %s", got, want)
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug
/sig api-machinery

#### What this PR does / why we need it:

According to the contract of json.Unmarshaler: "UnmarshalJSON must copy the JSON data if it wishes to retain the data after returning." If the input is not copied, the underlying array of Raw could be reused by the caller of UnmarshalJSON, and any modifications would be visible in Raw (and vice versa).

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
