### PR TITLE
Remove metav1.{Label|Field}SelectorQueryParam

### DIFF
--- a/pkg/client/tests/listwatch_test.go
+++ b/pkg/client/tests/listwatch_test.go
@@ -55,7 +55,7 @@ func buildLocation(resourcePath string, query url.Values) string {
 }
 
 func TestListWatchesCanList(t *testing.T) {
-	fieldSelectorQueryParamName := metav1.FieldSelectorQueryParam("v1")
+	fieldSelectorQueryParamName := "fieldSelector"
 	table := []struct {
 		desc          string
 		location      string
@@ -109,7 +109,7 @@ func TestListWatchesCanList(t *testing.T) {
 }
 
 func TestListWatchesCanWatch(t *testing.T) {
-	fieldSelectorQueryParamName := metav1.FieldSelectorQueryParam("v1")
+	fieldSelectorQueryParamName := "fieldSelector"
 	table := []struct {
 		desc          string
 		rv            string

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
@@ -1207,16 +1207,6 @@ type RootPaths struct {
 	Paths []string `json:"paths" protobuf:"bytes,1,rep,name=paths"`
 }
 
-// TODO: remove me when watch is refactored
-func LabelSelectorQueryParam(version string) string {
-	return "labelSelector"
-}
-
-// TODO: remove me when watch is refactored
-func FieldSelectorQueryParam(version string) string {
-	return "fieldSelector"
-}
-
 // String returns available api versions as a human-friendly version string.
 func (apiVersions APIVersions) String() string {
 	return strings.Join(apiVersions.Versions, ",")

--- a/staging/src/k8s.io/cli-runtime/pkg/resource/builder_test.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/builder_test.go
@@ -1264,7 +1264,7 @@ func TestResourceByNameAndEmptySelector(t *testing.T) {
 
 func TestLabelSelector(t *testing.T) {
 	pods, svc := testData()
-	labelKey := metav1.LabelSelectorQueryParam(corev1GV.String())
+	labelKey := "labelSelector"
 	b := newDefaultBuilderWith(fakeClientWith("", t, map[string]string{
 		"/namespaces/test/pods?" + labelKey + "=a%3Db":     runtime.EncodeOrDie(corev1Codec, pods),
 		"/namespaces/test/services?" + labelKey + "=a%3Db": runtime.EncodeOrDie(corev1Codec, svc),
@@ -1308,7 +1308,7 @@ func TestLabelSelectorRequiresKnownTypes(t *testing.T) {
 
 func TestFieldSelector(t *testing.T) {
 	pods, svc := testData()
-	fieldKey := metav1.FieldSelectorQueryParam(corev1GV.String())
+	fieldKey := "fieldSelector"
 	b := newDefaultBuilderWith(fakeClientWith("", t, map[string]string{
 		"/namespaces/test/pods?" + fieldKey + "=a%3Db":     runtime.EncodeOrDie(corev1Codec, pods),
 		"/namespaces/test/services?" + fieldKey + "=a%3Db": runtime.EncodeOrDie(corev1Codec, svc),
@@ -1630,7 +1630,7 @@ func TestSingleItemImpliedRootScopedObject(t *testing.T) {
 
 func TestListObject(t *testing.T) {
 	pods, _ := testData()
-	labelKey := metav1.LabelSelectorQueryParam(corev1GV.String())
+	labelKey := "labelSelector"
 	b := newDefaultBuilderWith(fakeClientWith("", t, map[string]string{
 		"/namespaces/test/pods?" + labelKey + "=a%3Db": runtime.EncodeOrDie(corev1Codec, pods),
 	})).
@@ -1663,7 +1663,7 @@ func TestListObject(t *testing.T) {
 
 func TestListObjectWithDifferentVersions(t *testing.T) {
 	pods, svc := testData()
-	labelKey := metav1.LabelSelectorQueryParam(corev1GV.String())
+	labelKey := "labelSelector"
 	obj, err := newDefaultBuilderWith(fakeClientWith("", t, map[string]string{
 		"/namespaces/test/pods?" + labelKey + "=a%3Db":     runtime.EncodeOrDie(corev1Codec, pods),
 		"/namespaces/test/services?" + labelKey + "=a%3Db": runtime.EncodeOrDie(corev1Codec, svc),
@@ -1690,7 +1690,7 @@ func TestListObjectWithDifferentVersions(t *testing.T) {
 
 func TestListObjectSubresource(t *testing.T) {
 	pods, _ := testData()
-	labelKey := metav1.LabelSelectorQueryParam(corev1GV.String())
+	labelKey := "labelSelector"
 	b := newDefaultBuilderWith(fakeClientWith("", t, map[string]string{
 		"/namespaces/test/pods?" + labelKey: runtime.EncodeOrDie(corev1Codec, pods),
 	})).

--- a/staging/src/k8s.io/cli-runtime/pkg/resource/helper_test.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/helper_test.go
@@ -374,6 +374,7 @@ func TestHelperGet(t *testing.T) {
 }
 
 func TestHelperList(t *testing.T) {
+	labelKey := "labelSelector"
 	tests := []struct {
 		name    string
 		Err     bool
@@ -416,7 +417,7 @@ func TestHelperList(t *testing.T) {
 					t.Errorf("url doesn't contain name: %#v", req.URL)
 					return false
 				}
-				if req.URL.Query().Get(metav1.LabelSelectorQueryParam(corev1GV.String())) != labels.SelectorFromSet(labels.Set{"foo": "baz"}).String() {
+				if req.URL.Query().Get(labelKey) != labels.SelectorFromSet(labels.Set{"foo": "baz"}).String() {
 					t.Errorf("url doesn't contain query parameters: %#v", req.URL)
 					return false
 				}
@@ -444,7 +445,7 @@ func TestHelperList(t *testing.T) {
 					t.Errorf("url doesn't contain name: %#v", req.URL)
 					return false
 				}
-				if req.URL.Query().Get(metav1.LabelSelectorQueryParam(corev1GV.String())) != labels.SelectorFromSet(labels.Set{"foo": "baz"}).String() {
+				if req.URL.Query().Get(labelKey) != labels.SelectorFromSet(labels.Set{"foo": "baz"}).String() {
 					t.Errorf("url doesn't contain query parameters: %#v", req.URL)
 					return false
 				}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete_test.go
@@ -882,6 +882,7 @@ func TestDeleteMultipleSelector(t *testing.T) {
 	tf := cmdtesting.NewTestFactory().WithNamespace("test")
 	defer tf.Cleanup()
 
+	labelKey := "labelSelector"
 	codec := scheme.Codecs.LegacyCodec(scheme.Scheme.PrioritizedVersionsAllGroups()...)
 
 	tf.UnstructuredClient = &fake.RESTClient{
@@ -889,12 +890,12 @@ func TestDeleteMultipleSelector(t *testing.T) {
 		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
 			switch p, m := req.URL.Path, req.Method; {
 			case p == "/namespaces/test/pods" && m == "GET":
-				if req.URL.Query().Get(metav1.LabelSelectorQueryParam("v1")) != "a=b" {
+				if req.URL.Query().Get(labelKey) != "a=b" {
 					t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
 				}
 				return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, pods)}, nil
 			case p == "/namespaces/test/services" && m == "GET":
-				if req.URL.Query().Get(metav1.LabelSelectorQueryParam("v1")) != "a=b" {
+				if req.URL.Query().Get(labelKey) != "a=b" {
 					t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
 				}
 				return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, svc)}, nil

--- a/staging/src/k8s.io/kubectl/pkg/cmd/get/get_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/get/get_test.go
@@ -1511,7 +1511,7 @@ func TestGetMultipleTypeObjectsWithLabelSelector(t *testing.T) {
 	tf.UnstructuredClient = &fake.RESTClient{
 		NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
 		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
-			if req.URL.Query().Get(metav1.LabelSelectorQueryParam("v1")) != "a=b" {
+			if req.URL.Query().Get("labelSelector") != "a=b" {
 				t.Fatalf("request url: %#v,and request: %#v", req.URL, req)
 			}
 			switch req.URL.Path {
@@ -1556,7 +1556,7 @@ func TestGetMultipleTypeTableObjectsWithLabelSelector(t *testing.T) {
 	tf.UnstructuredClient = &fake.RESTClient{
 		NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
 		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
-			if req.URL.Query().Get(metav1.LabelSelectorQueryParam("v1")) != "a=b" {
+			if req.URL.Query().Get("labelSelector") != "a=b" {
 				t.Fatalf("request url: %#v,and request: %#v", req.URL, req)
 			}
 			switch req.URL.Path {
@@ -1601,7 +1601,7 @@ func TestGetMultipleTypeObjectsWithFieldSelector(t *testing.T) {
 	tf.UnstructuredClient = &fake.RESTClient{
 		NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
 		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
-			if req.URL.Query().Get(metav1.FieldSelectorQueryParam("v1")) != "a=b" {
+			if req.URL.Query().Get("fieldSelector") != "a=b" {
 				t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
 			}
 			switch req.URL.Path {
@@ -1646,7 +1646,7 @@ func TestGetMultipleTypeTableObjectsWithFieldSelector(t *testing.T) {
 	tf.UnstructuredClient = &fake.RESTClient{
 		NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
 		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
-			if req.URL.Query().Get(metav1.FieldSelectorQueryParam("v1")) != "a=b" {
+			if req.URL.Query().Get("fieldSelector") != "a=b" {
 				t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
 			}
 			switch req.URL.Path {
@@ -1893,7 +1893,7 @@ func TestWatchLabelSelector(t *testing.T) {
 	tf.UnstructuredClient = &fake.RESTClient{
 		NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
 		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
-			if req.URL.Query().Get(metav1.LabelSelectorQueryParam("v1")) != "a=b" {
+			if req.URL.Query().Get("labelSelector") != "a=b" {
 				t.Fatalf("request url: %#v,and request: %#v", req.URL, req)
 			}
 			switch req.URL.Path {
@@ -1945,7 +1945,7 @@ func TestWatchTableLabelSelector(t *testing.T) {
 	tf.UnstructuredClient = &fake.RESTClient{
 		NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
 		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
-			if req.URL.Query().Get(metav1.LabelSelectorQueryParam("v1")) != "a=b" {
+			if req.URL.Query().Get("labelSelector") != "a=b" {
 				t.Fatalf("request url: %#v,and request: %#v", req.URL, req)
 			}
 			switch req.URL.Path {
@@ -1997,7 +1997,7 @@ func TestWatchFieldSelector(t *testing.T) {
 	tf.UnstructuredClient = &fake.RESTClient{
 		NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
 		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
-			if req.URL.Query().Get(metav1.FieldSelectorQueryParam("v1")) != "a=b" {
+			if req.URL.Query().Get("fieldSelector") != "a=b" {
 				t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
 			}
 			switch req.URL.Path {
@@ -2049,7 +2049,7 @@ func TestWatchTableFieldSelector(t *testing.T) {
 	tf.UnstructuredClient = &fake.RESTClient{
 		NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
 		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
-			if req.URL.Query().Get(metav1.FieldSelectorQueryParam("v1")) != "a=b" {
+			if req.URL.Query().Get("fieldSelector") != "a=b" {
 				t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
 			}
 			switch req.URL.Path {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
After #48991, `metav1.{Label|Field}SelectorQueryParam` has not been used at all. 
The `client-go` no longer exposes `LabelSelectorParam` or `FieldSelectorParam` methods, users should use `VersionedParams` with `metav1.ListOptions` instead.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
The `metav1` package (`k8s.io/apimachinery/pkg/apis/meta/v1`) no longer exposes `LabelSelectorQueryParam` or `FieldSelectorQueryParam` methods, please use `metav1.ListOptions` instead.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
