### PR TITLE
kubectl wait: Introduce --wait-for-creation flag

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/wait/wait.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/wait/wait.go
@@ -328,15 +328,15 @@ func (o *WaitOptions) RunWait() error {
 	defer cancel()
 
 	isForDelete := strings.ToLower(o.ForCondition) == "delete"
-	if o.WaitForCreation && o.Timeout == 0 {
-		return fmt.Errorf("--wait-for-creation requires a timeout value greater than 0")
-	}
-
-	if o.WaitForCreation && isForDelete {
-		return fmt.Errorf("--wait-for-creation is mutually exclusive with --for=delete")
-	}
-
 	if o.WaitForCreation {
+		if o.Timeout == 0 {
+			return fmt.Errorf("--wait-for-creation requires a timeout value greater than 0")
+		}
+
+		if isForDelete {
+			return fmt.Errorf("--wait-for-creation is mutually exclusive with --for=delete")
+		}
+
 		err := func() error {
 			for {
 				select {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/wait/wait.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/wait/wait.go
@@ -156,7 +156,7 @@ func (flags *WaitFlags) AddFlags(cmd *cobra.Command) {
 
 	cmd.Flags().DurationVar(&flags.Timeout, "timeout", flags.Timeout, "The length of time to wait before giving up.  Zero means check once and don't wait, negative means wait for a week.")
 	cmd.Flags().StringVar(&flags.ForCondition, "for", flags.ForCondition, "The condition to wait on: [delete|condition=condition-name[=condition-value]|jsonpath='{JSONPath expression}'=[JSONPath value]]. The default condition-value is true.  Condition values are compared after Unicode simple case folding, which is a more general form of case-insensitivity.")
-	cmd.Flags().BoolVar(&flags.WaitForCreation, "wait-for-creation", flags.WaitForCreation, "If set to true, also wait for creation of objects if they do not already exist. This flag is ignored in --for=delete")
+	cmd.Flags().BoolVar(&flags.WaitForCreation, "wait-for-creation", flags.WaitForCreation, "If set to true, also wait for creation of objects if they do not already exist. This flag can not be used with --for=delete or --timeout=0")
 }
 
 // ToOptions converts from CLI inputs to runtime inputs
@@ -332,7 +332,11 @@ func (o *WaitOptions) RunWait() error {
 		return fmt.Errorf("--wait-for-creation requires a timeout value greater than 0")
 	}
 
-	if o.WaitForCreation && !isForDelete {
+	if o.WaitForCreation && isForDelete {
+		return fmt.Errorf("--wait-for-creation is mutually exclusive with --for=delete")
+	}
+
+	if o.WaitForCreation {
 		err := func() error {
 			for {
 				select {

--- a/test/cmd/legacy-script.sh
+++ b/test/cmd/legacy-script.sh
@@ -1036,6 +1036,7 @@ runTests() {
   ####################
 
   record_command run_wait_tests
+  record_command run_wait_with_non_existence_check_tests
 
   ####################
   # kubectl debug    #

--- a/test/cmd/wait.sh
+++ b/test/cmd/wait.sh
@@ -120,3 +120,107 @@ EOF
     set +o nounset
     set +o errexit
 }
+
+run_wait_with_non_existence_check_tests() {
+    set -o nounset
+    set -o errexit
+
+    kube::log::status "Testing kubectl wait"
+
+    create_and_use_new_namespace
+
+    ### Wait for deletion using --all flag
+
+    # create test data
+    kubectl create deployment test-1 --image=busybox
+    kubectl create deployment test-2 --image=busybox
+
+    # Post-Condition: deployments exists
+    kube::test::get_object_assert "deployments" "{{range .items}}{{.metadata.name}},{{end}}" 'test-1,test-2,'
+
+    # wait with jsonpath will timout for busybox deployment
+    set +o errexit
+    # Command: Wait with jsonpath support fields not exist in the first place
+    output_message=$(kubectl wait --wait-for-creation --for=jsonpath=.status.readyReplicas=1 deploy/test-1 2>&1)
+    set -o errexit
+
+    # Post-Condition: Wait failed
+    kube::test::if_has_string "${output_message}" 'timed out'
+
+    # Delete all deployments async to kubectl wait
+    ( sleep 2 && kubectl delete deployment --all ) &
+
+    # Command: Wait for all deployments to be deleted
+    output_message=$(kubectl wait deployment --for=delete --all)
+
+    # Post-Condition: Wait was successful
+    kube::test::if_has_string "${output_message}" 'test-1 condition met'
+    kube::test::if_has_string "${output_message}" 'test-2 condition met'
+
+    # create test data to test timeout error is occurred in correct time
+    kubectl apply -f - <<EOF
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: dtest
+  name: dtest
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: dtest
+  template:
+    metadata:
+      labels:
+        app: dtest
+    spec:
+      containers:
+      - name: bb
+        image: busybox
+        command: ["/bin/sh", "-c", "sleep infinity"]
+EOF
+
+    set +o errexit
+    # wait timeout error because condition is invalid
+    start_sec=$(date +"%s")
+    output_message=$(time kubectl wait pod --wait-for-creation --selector=app=dtest --for=condition=InvalidCondition --timeout=1s 2>&1)
+    end_sec=$(date +"%s")
+    len_sec=$((end_sec-start_sec))
+    set -o errexit
+    kube::test::if_has_string "${output_message}" 'timed out waiting for the condition '
+    test $len_sec -ge 1 && test $len_sec -le 2
+
+    # Clean deployment
+    kubectl delete deployment dtest
+
+    # create test data
+    kubectl create deployment test-3 --image=busybox
+
+    # wait with jsonpath without value to succeed
+    set +o errexit
+    # Command: Wait with jsonpath without value
+    output_message_0=$(kubectl wait --wait-for-creation --for=jsonpath='{.status.replicas}' deploy/test-3 2>&1)
+    # Command: Wait with relaxed jsonpath and filter expression
+    output_message_1=$(kubectl wait \
+        --for='jsonpath=spec.template.spec.containers[?(@.name=="busybox")].image=busybox' \
+        deploy/test-3)
+    set -o errexit
+
+    # Post-Condition: Wait succeed
+    kube::test::if_has_string "${output_message_0}" 'deployment.apps/test-3 condition met'
+    kube::test::if_has_string "${output_message_1}" 'deployment.apps/test-3 condition met'
+
+    # Clean deployment
+    kubectl delete deployment test-3
+
+    ( sleep 3 && kubectl create deployment test-4 --image=busybox ) &
+    output_message=$(kubectl wait --wait-for-creation --for=jsonpath=.status.replicas=1 deploy/test-4 2>&1)
+    kube::test::if_has_string "${output_message}" 'test-4 condition met'
+
+    kubectl delete deployment test-4
+
+    set +o nounset
+    set +o errexit
+}
+


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
https://github.com/kubernetes/kubernetes/pull/122994 was reverted by https://github.com/kubernetes/kubernetes/pull/125630/ due to a possible regression, when users specify `timeout=0`. This PR reintroduces this flag but with the default value is false. We'll continue discussions about setting it's default value to true separately. 

#### Does this PR introduce a user-facing change?

```release-note
Introducing --wait-for-creation flag in kubectl wait to also wait the creation of resource if they don't exist
```