### PR TITLE
kubeadm: Remove unused function in phases/certs

### DIFF
--- a/cmd/kubeadm/app/phases/certs/certs.go
+++ b/cmd/kubeadm/app/phases/certs/certs.go
@@ -129,16 +129,6 @@ func CreateCACertAndKeyFiles(certSpec *KubeadmCert, cfg *kubeadmapi.InitConfigur
 	)
 }
 
-// NewCSR will generate a new CSR and accompanying key
-func NewCSR(certSpec *KubeadmCert, cfg *kubeadmapi.InitConfiguration) (*x509.CertificateRequest, crypto.Signer, error) {
-	certConfig, err := certSpec.GetConfig(cfg)
-	if err != nil {
-		return nil, nil, errors.Wrap(err, "failed to retrieve cert configuration")
-	}
-
-	return pkiutil.NewCSRAndKey(certConfig)
-}
-
 // CreateCertAndKeyFilesWithCA loads the given certificate authority from disk, then generates and writes out the given certificate and key.
 // The certSpec and caCertSpec should both be one of the variables from this package.
 func CreateCertAndKeyFilesWithCA(certSpec *KubeadmCert, caCertSpec *KubeadmCert, cfg *kubeadmapi.InitConfiguration) error {

--- a/cmd/kubeadm/app/phases/certs/certs_test.go
+++ b/cmd/kubeadm/app/phases/certs/certs_test.go
@@ -25,7 +25,6 @@ import (
 	"testing"
 
 	"github.com/pkg/errors"
-	"github.com/stretchr/testify/assert"
 
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	certutil "k8s.io/client-go/util/cert"
@@ -634,38 +633,6 @@ func TestValidateMethods(t *testing.T) {
 			t.Errorf("expected success, error executing validateFunc: %v, %v", test.name, err)
 		} else if !test.expectedSuccess && err == nil {
 			t.Errorf("expected failure, no error executing validateFunc: %v", test.name)
-		}
-	}
-}
-
-func TestNewCSR(t *testing.T) {
-	kubeadmCert := KubeadmCertAPIServer()
-	cfg := testutil.GetDefaultInternalConfig(t)
-
-	certConfig, err := kubeadmCert.GetConfig(cfg)
-	if err != nil {
-		t.Fatalf("couldn't get cert config: %v", err)
-	}
-
-	csr, _, err := NewCSR(kubeadmCert, cfg)
-
-	if err != nil {
-		t.Errorf("invalid signature on CSR: %v", err)
-	}
-
-	assert.ElementsMatch(t, certConfig.Organization, csr.Subject.Organization, "organizations not equal")
-
-	if csr.Subject.CommonName != certConfig.CommonName {
-		t.Errorf("expected common name %q, got %q", certConfig.CommonName, csr.Subject.CommonName)
-	}
-
-	assert.ElementsMatch(t, certConfig.AltNames.DNSNames, csr.DNSNames, "dns names not equal")
-
-	assert.Len(t, csr.IPAddresses, len(certConfig.AltNames.IPs))
-
-	for i, ip := range csr.IPAddresses {
-		if !ip.Equal(certConfig.AltNames.IPs[i]) {
-			t.Errorf("[%d]: %v != %v", i, ip, certConfig.AltNames.IPs[i])
 		}
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

kubeadm: Remove unused function in phases/certs

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
