### PR TITLE
Sample cli plugin help

### DIFF
--- a/staging/src/k8s.io/sample-cli-plugin/pkg/cmd/ns.go
+++ b/staging/src/k8s.io/sample-cli-plugin/pkg/cmd/ns.go
@@ -82,6 +82,9 @@ func NewCmdNamespace(streams genericiooptions.IOStreams) *cobra.Command {
 		Short:        "View or set the current namespace",
 		Example:      fmt.Sprintf(namespaceExample, "kubectl"),
 		SilenceUsage: true,
+		Annotations: map[string]string{
+			cobra.CommandDisplayNameAnnotation: "kubectl ns",
+		},
 		RunE: func(c *cobra.Command, args []string) error {
 			if err := o.Complete(c, args); err != nil {
 				return err


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fixes usage of cobra in the sample-cli-plugin so help text reflects the usage of
the plugin.

With current code the plugin help text is inconsistent, sometimes `ns` and sometimes `kubectl ns`. With this change we always have `kubectl ns`.

Example help with this change:

```
$ kubectl ns -h
View or set the current namespace

Usage:
  kubectl ns [new-namespace] [flags]

Examples:

	# view the current namespace in your KUBECONFIG
	kubectl ns

	# view all of the namespaces in use by contexts in your KUBECONFIG
	kubectl ns --list

	# switch your current-context to one that contains the desired namespace
	kubectl ns foo

Flags:
  ...
  -h, --help                           help for kubectl ns

```

#### Which issue(s) this PR fixes:

Issue not reported.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

This affects developers using the sample-cli-plugin as example for creating new kubectl plugins or updating existing plugins. Not sure if release notes are required.

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
