### PR TITLE
Prune explicit nulls from client-side apply create

### DIFF
--- a/hack/testdata/null-propagation/deployment-null.yml
+++ b/hack/testdata/null-propagation/deployment-null.yml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-dep-null
+spec:
+  selector:
+    matchLabels:
+      l1: l1
+  template:
+    metadata:
+      labels:
+        l1: l1
+    spec:
+      containers:
+        - name: nginx
+          image: registry.k8s.io/nginx:1.7.9
+          resources:
+            requests:
+              memory: "64Mi"
+              cpu: null
+          terminationMessagePolicy: null

--- a/hack/testdata/null-propagation/resourcesquota-null.yml
+++ b/hack/testdata/null-propagation/resourcesquota-null.yml
@@ -1,0 +1,8 @@
+kind: ResourceQuota
+apiVersion: v1
+metadata:
+  name: my-rq
+spec:
+  hard:
+    limits.cpu: null
+    limits.memory: null

--- a/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/patch.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/patch.go
@@ -1361,6 +1361,10 @@ func mergeMap(original, patch map[string]interface{}, schema LookupPatchMeta, me
 		// original. Otherwise, check if we want to preserve it or skip it.
 		// Preserving the null value is useful when we want to send an explicit
 		// delete to the API server.
+		// In some cases, this may lead to inconsistent behavior with create.
+		// ref: https://github.com/kubernetes/kubernetes/issues/123304
+		// To avoid breaking compatibility,
+		// we made corresponding changes on the client side to ensure that the create and patch behaviors are idempotent.
 		if patchV == nil {
 			delete(original, k)
 			if mergeOptions.IgnoreUnmatchedNulls {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
In #40630, we introduced the ability for patches to remove keys by explicitly setting the null value.

This can lead to inconsistent behavior between create and patch in some scenarios, so to avoid making destructive changes to the Api, we'll do the same on the client side so that kubectl apply on create and kubectl apply on update behave the same way.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/123304

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
In the client-side apply on create, defining the null value as "delete the key associated with this value".
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
