### PR TITLE
Use atomic writer for cpu policy

### DIFF
--- a/pkg/kubelet/cm/cpumanager/cpu_manager.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_manager.go
@@ -268,7 +268,7 @@ func (m *manager) AddContainer(pod *v1.Pod, container *v1.Container, containerID
 	m.Lock()
 	defer m.Unlock()
 	if cset, exists := m.state.GetCPUSet(string(pod.UID), container.Name); exists {
-		m.lastUpdateState.SetCPUSet(string(pod.UID), container.Name, cset)
+		m.lastUpdateState.SetCPUSet(string(pod.UID), container.Name, cset, m.state.GetDefaultCPUSet())
 	}
 	m.containerMap.Add(string(pod.UID), container.Name, containerID)
 }
@@ -294,7 +294,7 @@ func (m *manager) policyRemoveContainerByID(containerID string) error {
 
 	err = m.policy.RemoveContainer(m.state, podUID, containerName)
 	if err == nil {
-		m.lastUpdateState.Delete(podUID, containerName)
+		m.lastUpdateState.Delete(podUID, containerName, m.state.GetDefaultCPUSet())
 		m.containerMap.RemoveByContainerID(containerID)
 	}
 
@@ -304,7 +304,7 @@ func (m *manager) policyRemoveContainerByID(containerID string) error {
 func (m *manager) policyRemoveContainerByRef(podUID string, containerName string) error {
 	err := m.policy.RemoveContainer(m.state, podUID, containerName)
 	if err == nil {
-		m.lastUpdateState.Delete(podUID, containerName)
+		m.lastUpdateState.Delete(podUID, containerName, m.state.GetDefaultCPUSet())
 		m.containerMap.RemoveByContainerRef(podUID, containerName)
 	}
 
@@ -477,7 +477,7 @@ func (m *manager) reconcileState() (success []reconciledContainer, failure []rec
 					failure = append(failure, reconciledContainer{pod.Name, container.Name, containerID})
 					continue
 				}
-				m.lastUpdateState.SetCPUSet(string(pod.UID), container.Name, cset)
+				m.lastUpdateState.SetCPUSet(string(pod.UID), container.Name, cset, m.state.GetDefaultCPUSet())
 			}
 			success = append(success, reconciledContainer{pod.Name, container.Name, containerID})
 		}

--- a/pkg/kubelet/cm/cpumanager/cpu_manager_test.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_manager_test.go
@@ -69,11 +69,6 @@ func (s *mockState) SetCPUSet(podUID string, containerName string, cset cpuset.C
 	s.defaultCPUSet = defaultCPUSet
 }
 
-func (s *mockState) SetDefaultCPUSet(cset cpuset.CPUSet) error {
-	s.defaultCPUSet = cset
-	return nil
-}
-
 func (s *mockState) Delete(podUID string, containerName string, defaultCPUSet cpuset.CPUSet) {
 	delete(s.assignments[podUID], containerName)
 	if len(s.assignments[podUID]) == 0 {

--- a/pkg/kubelet/cm/cpumanager/cpu_manager_test.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_manager_test.go
@@ -61,22 +61,25 @@ func (s *mockState) GetCPUSetOrDefault(podUID string, containerName string) cpus
 	return s.GetDefaultCPUSet()
 }
 
-func (s *mockState) SetCPUSet(podUID string, containerName string, cset cpuset.CPUSet) {
+func (s *mockState) SetCPUSet(podUID string, containerName string, cset cpuset.CPUSet, defaultCPUSet cpuset.CPUSet) {
 	if _, exists := s.assignments[podUID]; !exists {
 		s.assignments[podUID] = make(map[string]cpuset.CPUSet)
 	}
 	s.assignments[podUID][containerName] = cset
+	s.defaultCPUSet = defaultCPUSet
 }
 
-func (s *mockState) SetDefaultCPUSet(cset cpuset.CPUSet) {
+func (s *mockState) SetDefaultCPUSet(cset cpuset.CPUSet) error {
 	s.defaultCPUSet = cset
+	return nil
 }
 
-func (s *mockState) Delete(podUID string, containerName string) {
+func (s *mockState) Delete(podUID string, containerName string, defaultCPUSet cpuset.CPUSet) {
 	delete(s.assignments[podUID], containerName)
 	if len(s.assignments[podUID]) == 0 {
 		delete(s.assignments, podUID)
 	}
+	s.defaultCPUSet = defaultCPUSet
 }
 
 func (s *mockState) ClearState() {
@@ -84,8 +87,9 @@ func (s *mockState) ClearState() {
 	s.assignments = make(state.ContainerCPUAssignments)
 }
 
-func (s *mockState) SetCPUAssignments(a state.ContainerCPUAssignments) {
+func (s *mockState) SetCPUAssignments(a state.ContainerCPUAssignments, defaultCPUSet cpuset.CPUSet) {
 	s.assignments = a.Clone()
+	s.defaultCPUSet = defaultCPUSet
 }
 
 func (s *mockState) GetCPUAssignments() state.ContainerCPUAssignments {

--- a/pkg/kubelet/cm/cpumanager/policy_static.go
+++ b/pkg/kubelet/cm/cpumanager/policy_static.go
@@ -202,7 +202,7 @@ func (p *staticPolicy) validateState(s state.State) error {
 		}
 		// state is empty initialize
 		allCPUs := p.topology.CPUDetails.CPUs()
-		s.SetDefaultCPUSet(allCPUs)
+		s.SetCPUAssignments(state.ContainerCPUAssignments{}, allCPUs)
 		return nil
 	}
 

--- a/pkg/kubelet/cm/cpumanager/state/state.go
+++ b/pkg/kubelet/cm/cpumanager/state/state.go
@@ -44,10 +44,14 @@ type Reader interface {
 }
 
 type writer interface {
-	SetCPUSet(podUID string, containerName string, cpuset cpuset.CPUSet)
-	SetDefaultCPUSet(cpuset cpuset.CPUSet)
-	SetCPUAssignments(ContainerCPUAssignments)
-	Delete(podUID string, containerName string)
+	// SetCPUSet save the container assignment. And save to checkpoint
+	SetCPUSet(podUID string, containerName string, cpuset cpuset.CPUSet, defaultCPUSet cpuset.CPUSet)
+	// SetDefaultCPUSet save the entire cpuset, it should be called during initialization
+	SetDefaultCPUSet(cpuset cpuset.CPUSet) error
+	// SetCPUAssignments save the entire assignments. And save to checkpoint
+	SetCPUAssignments(assignments ContainerCPUAssignments, defaultCPUSet cpuset.CPUSet)
+	// Delete the container assignment. And save to checkpoint
+	Delete(podUID string, containerName string, defaultCPUSet cpuset.CPUSet)
 	ClearState()
 }
 

--- a/pkg/kubelet/cm/cpumanager/state/state.go
+++ b/pkg/kubelet/cm/cpumanager/state/state.go
@@ -46,8 +46,6 @@ type Reader interface {
 type writer interface {
 	// SetCPUSet save the container assignment. And save to checkpoint
 	SetCPUSet(podUID string, containerName string, cpuset cpuset.CPUSet, defaultCPUSet cpuset.CPUSet)
-	// SetDefaultCPUSet save the entire cpuset, it should be called during initialization
-	SetDefaultCPUSet(cpuset cpuset.CPUSet) error
 	// SetCPUAssignments save the entire assignments. And save to checkpoint
 	SetCPUAssignments(assignments ContainerCPUAssignments, defaultCPUSet cpuset.CPUSet)
 	// Delete the container assignment. And save to checkpoint

--- a/pkg/kubelet/cm/cpumanager/state/state_checkpoint.go
+++ b/pkg/kubelet/cm/cpumanager/state/state_checkpoint.go
@@ -204,20 +204,6 @@ func (sc *stateCheckpoint) SetCPUSet(podUID string, containerName string, cset c
 	}
 }
 
-// SetDefaultCPUSet sets default CPU set
-func (sc *stateCheckpoint) SetDefaultCPUSet(cset cpuset.CPUSet) error {
-	sc.mux.Lock()
-	defer sc.mux.Unlock()
-	if err := sc.cache.SetDefaultCPUSet(cset); err != nil {
-		return err
-	}
-	err := sc.storeState()
-	if err != nil {
-		klog.InfoS("Store state to checkpoint error", "err", err)
-	}
-	return nil
-}
-
 // SetCPUAssignments sets CPU to pod assignments
 func (sc *stateCheckpoint) SetCPUAssignments(a ContainerCPUAssignments, defaultCPUSet cpuset.CPUSet) {
 	sc.mux.Lock()

--- a/pkg/kubelet/cm/cpumanager/state/state_mem.go
+++ b/pkg/kubelet/cm/cpumanager/state/state_mem.go
@@ -99,7 +99,7 @@ func (s *stateMemory) Delete(podUID string, containerName string, defaultCPUSet 
 		delete(s.assignments, podUID)
 	}
 	s.defaultCPUSet = defaultCPUSet
-	klog.V(2).InfoS("Deleted CPUSet assignment", "podUID", podUID, "containerName", containerName, "defaultCPUSet", defaultCPUSet)
+	klog.V(2).InfoS("Deleted CPUSet assignment", "podUID", podUID, "containerName", containerName, "currentDefaultCPUSet", defaultCPUSet)
 }
 
 func (s *stateMemory) ClearState() {

--- a/pkg/kubelet/cm/cpumanager/state/state_mem.go
+++ b/pkg/kubelet/cm/cpumanager/state/state_mem.go
@@ -17,7 +17,6 @@ limitations under the License.
 package state
 
 import (
-	"fmt"
 	"sync"
 
 	"k8s.io/klog/v2"
@@ -79,20 +78,7 @@ func (s *stateMemory) SetCPUSet(podUID string, containerName string, cset cpuset
 
 	s.assignments[podUID][containerName] = cset
 	s.defaultCPUSet = defaultCPUSet
-	klog.InfoS("Updated desired CPUSet", "podUID", podUID, "containerName", containerName, "cpuSet", cset)
-}
-
-func (s *stateMemory) SetDefaultCPUSet(cset cpuset.CPUSet) error {
-	s.Lock()
-	defer s.Unlock()
-
-	if !s.defaultCPUSet.IsEmpty() {
-		return fmt.Errorf("Couldn't reset defaultCPUSet to: %v", cset)
-	}
-
-	s.defaultCPUSet = cset
-	klog.InfoS("Updated default CPUSet", "cpuSet", cset)
-	return nil
+	klog.InfoS("Updated desired CPUSet", "podUID", podUID, "containerName", containerName, "cpuSet", cset, "defaultCPUSet", defaultCPUSet)
 }
 
 func (s *stateMemory) SetCPUAssignments(a ContainerCPUAssignments, defaultCPUSet cpuset.CPUSet) {
@@ -101,7 +87,7 @@ func (s *stateMemory) SetCPUAssignments(a ContainerCPUAssignments, defaultCPUSet
 
 	s.assignments = a.Clone()
 	s.defaultCPUSet = defaultCPUSet
-	klog.InfoS("Updated CPUSet assignments", "assignments", a)
+	klog.InfoS("Updated CPUSet assignments", "assignments", a, "defaultCPUSet", defaultCPUSet)
 }
 
 func (s *stateMemory) Delete(podUID string, containerName string, defaultCPUSet cpuset.CPUSet) {
@@ -113,7 +99,7 @@ func (s *stateMemory) Delete(podUID string, containerName string, defaultCPUSet 
 		delete(s.assignments, podUID)
 	}
 	s.defaultCPUSet = defaultCPUSet
-	klog.V(2).InfoS("Deleted CPUSet assignment", "podUID", podUID, "containerName", containerName)
+	klog.V(2).InfoS("Deleted CPUSet assignment", "podUID", podUID, "containerName", containerName, "defaultCPUSet", defaultCPUSet)
 }
 
 func (s *stateMemory) ClearState() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

When the cpu policy_static  `Allocate` for a container, it will write this checkpoint twice:
1. write the `DefaultCPUSet` after assigned cpu
2. write the container `assignment`

If the node crashed (e.g.  lost power )after the kubelet finished the first write,  the checkpoint data is inconsistent. And kubelet will fail to start:
```
kubelet.go:1435] "Failed to start ContainerManager" err="start cpu manager error: current set of ava
ilable CPUs \"0-127\" doesn't match with CPUs in state \"0-1,30-31,64-65,94-95\""
```

This change write the `DefaultCPUSet` and `assignment` atomically.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/110478#issuecomment-1151814368

#### Special notes for your reviewer:

It is a little hard to reproduce it. We can inject some error on writing the container `assignment` https://gist.github.com/chenk008/c3e12598d974a25b7afff495e44246f1

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
