### PR TITLE
Generic Control Plane: Add Extra.DisableAvailableConditionController for kube-aggregator

### DIFF
--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/apiserver.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/apiserver.go
@@ -96,6 +96,13 @@ type ExtraConfig struct {
 	ServiceResolver ServiceResolver
 
 	RejectForwardingRedirects bool
+
+	// DisableAvailableConditionController disables the controller that updates the Available conditions for
+	// APIServices, Endpoints and Services. This controller runs in kube-aggregator and can interfere with
+	// Generic Control Plane components when certain apis are not available.
+	// TODO: We should find a better way to handle this. For now it will be for Generic Control Plane authors to
+	// disable this controller if they see issues.
+	DisableAvailableConditionController bool
 }
 
 // Config represents the configuration needed to create an APIAggregator.
@@ -310,24 +317,35 @@ func (c completedConfig) NewWithDelegate(delegationTarget genericapiserver.Deleg
 		})
 	}
 
-	availableController, err := statuscontrollers.NewAvailableConditionController(
-		informerFactory.Apiregistration().V1().APIServices(),
-		c.GenericConfig.SharedInformerFactory.Core().V1().Services(),
-		c.GenericConfig.SharedInformerFactory.Core().V1().Endpoints(),
-		apiregistrationClient.ApiregistrationV1(),
-		proxyTransportDial,
-		(func() ([]byte, []byte))(s.proxyCurrentCertKeyContent),
-		s.serviceResolver,
-	)
-	if err != nil {
-		return nil, err
+	// If the AvailableConditionController is disabled, we don't need to start the informers
+	// and the controller.
+	if !c.ExtraConfig.DisableAvailableConditionController {
+		availableController, err := statuscontrollers.NewAvailableConditionController(
+			informerFactory.Apiregistration().V1().APIServices(),
+			c.GenericConfig.SharedInformerFactory.Core().V1().Services(),
+			c.GenericConfig.SharedInformerFactory.Core().V1().Endpoints(),
+			apiregistrationClient.ApiregistrationV1(),
+			proxyTransportDial,
+			(func() ([]byte, []byte))(s.proxyCurrentCertKeyContent),
+			s.serviceResolver,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		s.GenericAPIServer.AddPostStartHookOrDie("start-kube-aggregator-informers", func(context genericapiserver.PostStartHookContext) error {
+			informerFactory.Start(context.StopCh)
+			c.GenericConfig.SharedInformerFactory.Start(context.StopCh)
+			return nil
+		})
+
+		s.GenericAPIServer.AddPostStartHookOrDie("apiservice-status-available-controller", func(context genericapiserver.PostStartHookContext) error {
+			// if we end up blocking for long periods of time, we may need to increase workers.
+			go availableController.Run(5, context.StopCh)
+			return nil
+		})
 	}
 
-	s.GenericAPIServer.AddPostStartHookOrDie("start-kube-aggregator-informers", func(context genericapiserver.PostStartHookContext) error {
-		informerFactory.Start(context.StopCh)
-		c.GenericConfig.SharedInformerFactory.Start(context.StopCh)
-		return nil
-	})
 	s.GenericAPIServer.AddPostStartHookOrDie("apiservice-registration-controller", func(context genericapiserver.PostStartHookContext) error {
 		go apiserviceRegistrationController.Run(context.StopCh, apiServiceRegistrationControllerInitiated)
 		select {
@@ -335,11 +353,6 @@ func (c completedConfig) NewWithDelegate(delegationTarget genericapiserver.Deleg
 		case <-apiServiceRegistrationControllerInitiated:
 		}
 
-		return nil
-	})
-	s.GenericAPIServer.AddPostStartHookOrDie("apiservice-status-available-controller", func(context genericapiserver.PostStartHookContext) error {
-		// if we end up blocking for long periods of time, we may need to increase workers.
-		go availableController.Run(5, context.StopCh)
 		return nil
 	})
 

--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/apiserver.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/apiserver.go
@@ -334,14 +334,14 @@ func (c completedConfig) NewWithDelegate(delegationTarget genericapiserver.Deleg
 		}
 
 		s.GenericAPIServer.AddPostStartHookOrDie("start-kube-aggregator-informers", func(context genericapiserver.PostStartHookContext) error {
-			informerFactory.Start(context.StopCh)
-			c.GenericConfig.SharedInformerFactory.Start(context.StopCh)
+			informerFactory.Start(context.Done())
+			c.GenericConfig.SharedInformerFactory.Start(context.Done())
 			return nil
 		})
 
 		s.GenericAPIServer.AddPostStartHookOrDie("apiservice-status-available-controller", func(context genericapiserver.PostStartHookContext) error {
 			// if we end up blocking for long periods of time, we may need to increase workers.
-			go availableController.Run(5, context.StopCh)
+			go availableController.Run(5, context.Done())
 			return nil
 		})
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

#### What this PR does / why we need it:

Towards https://github.com/kubernetes/enhancements/issues/4080, extending https://github.com/kubernetes/kubernetes/pull/120202.

When creating a Generic Control plane flavour without Services, Endpoints and Nodes this should not be running.
For now, there are no easy nice ways to disable this when/if API is not available. This enables Generic-ControlPlane authors to make the decision by disabling the controller via flag. 

Alternative is fork :/ 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

This is enabled by default and not change default behaviour. It is tool to disable the controller in particular usecase only.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Add Extra.DisableAvailableConditionController for Generic Control Plane setup in kube-aggregator
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
