### PR TITLE
[Vendor] Bumpup hcsshim version from v0.8.25 to v0.8.26.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/GoogleCloudPlatform/k8s-cloud-provider v1.18.1-0.20220218231025-f11817397a1b
 	github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab
 	github.com/Microsoft/go-winio v0.6.0
-	github.com/Microsoft/hcsshim v0.8.25
+	github.com/Microsoft/hcsshim v0.8.26
 	github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e
 	github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5
 	github.com/blang/semver/v4 v4.0.0

--- a/go.sum
+++ b/go.sum
@@ -201,8 +201,8 @@ github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6
 github.com/Microsoft/go-winio v0.4.17/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
 github.com/Microsoft/go-winio v0.6.0 h1:slsWYD/zyx7lCXoZVlvQrj0hPTM1HI4+v1sIda2yDvg=
 github.com/Microsoft/go-winio v0.6.0/go.mod h1:cTAf44im0RAYeL23bpB+fzCyDH2MJiz2BO69KH/soAE=
-github.com/Microsoft/hcsshim v0.8.25 h1:fRMwXiwk3qDwc0P05eHnh+y2v07JdtsfQ1fuAc69m9g=
-github.com/Microsoft/hcsshim v0.8.25/go.mod h1:4zegtUJth7lAvFyc6cH2gGQ5B3OFQim01nnU2M8jKDg=
+github.com/Microsoft/hcsshim v0.8.26 h1:770C4dtDITZUaMQ9d6lVPdM8Lq4S0E0Tthy6T91mDMo=
+github.com/Microsoft/hcsshim v0.8.26/go.mod h1:4zegtUJth7lAvFyc6cH2gGQ5B3OFQim01nnU2M8jKDg=
 github.com/NYTimes/gziphandler v1.1.1 h1:ZUDjpQae29j0ryrS0u/B8HZfJBtBQHjqw2rQ2cqUQ3I=
 github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMomdKFjzJNB0c=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=

--- a/vendor/github.com/Microsoft/hcsshim/hcn/hcn.go
+++ b/vendor/github.com/Microsoft/hcsshim/hcn/hcn.go
@@ -264,6 +264,18 @@ func SetPolicySupported() error {
 	return platformDoesNotSupportError("SetPolicy")
 }
 
+// ModifyLoadbalancerSupported returns an error if the HCN version does not support ModifyLoadbalancer.
+func ModifyLoadbalancerSupported() error {
+	supported, err := GetCachedSupportedFeatures()
+	if err != nil {
+		return err
+	}
+	if supported.ModifyLoadbalancer {
+		return nil
+	}
+	return platformDoesNotSupportError("ModifyLoadbalancer")
+}
+
 // VxlanPortSupported returns an error if the HCN version does not support configuring the VXLAN TCP port.
 func VxlanPortSupported() error {
 	supported, err := GetCachedSupportedFeatures()

--- a/vendor/github.com/Microsoft/hcsshim/hcn/hcnerrors.go
+++ b/vendor/github.com/Microsoft/hcsshim/hcn/hcnerrors.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Microsoft/hcsshim/internal/hcserror"
 	"github.com/Microsoft/hcsshim/internal/interop"
 	"github.com/sirupsen/logrus"
+	"golang.org/x/sys/windows"
 )
 
 var (
@@ -50,6 +51,7 @@ type ErrorCode uint32
 const (
 	ERROR_NOT_FOUND                     = 0x490
 	HCN_E_PORT_ALREADY_EXISTS ErrorCode = 0x803b0013
+	HCN_E_NOTIMPL             ErrorCode = ErrorCode(windows.E_NOTIMPL)
 )
 
 type HcnError struct {
@@ -75,6 +77,10 @@ func IsElementNotFoundError(err error) bool {
 
 func IsPortAlreadyExistsError(err error) bool {
 	return CheckErrorWithCode(err, HCN_E_PORT_ALREADY_EXISTS)
+}
+
+func IsNotImplemented(err error) bool {
+	return CheckErrorWithCode(err, HCN_E_NOTIMPL)
 }
 
 func new(hr error, title string, rest string) error {

--- a/vendor/github.com/Microsoft/hcsshim/hcn/hcnglobals.go
+++ b/vendor/github.com/Microsoft/hcsshim/hcn/hcnglobals.go
@@ -76,6 +76,17 @@ var (
 
 	//HNS 14.0 allows for TierAcl Policy support
 	TierAclPolicyVersion = VersionRanges{VersionRange{MinVersion: Version{Major: 14, Minor: 0}, MaxVersion: Version{Major: math.MaxInt32, Minor: math.MaxInt32}}}
+
+	//HNS 15.0 allows for NetworkACL Policy support
+	NetworkACLPolicyVersion = VersionRanges{VersionRange{MinVersion: Version{Major: 15, Minor: 0}, MaxVersion: Version{Major: math.MaxInt32, Minor: math.MaxInt32}}}
+
+	//HNS 15.0 allows for NestedIpSet support
+	NestedIpSetVersion = VersionRanges{VersionRange{MinVersion: Version{Major: 15, Minor: 0}, MaxVersion: Version{Major: math.MaxInt32, Minor: math.MaxInt32}}}
+
+	//HNS 15.1 allows support for DisableHostPort flag.
+	DisableHostPortVersion = VersionRanges{VersionRange{MinVersion: Version{Major: 15, Minor: 1}, MaxVersion: Version{Major: math.MaxInt32, Minor: math.MaxInt32}}}
+	// HNS 15.4 allows for Modify Loadbalancer support
+	ModifyLoadbalancerVersion = VersionRanges{VersionRange{MinVersion: Version{Major: 15, Minor: 4}, MaxVersion: Version{Major: math.MaxInt32, Minor: math.MaxInt32}}}
 )
 
 // GetGlobals returns the global properties of the HCN Service.

--- a/vendor/github.com/Microsoft/hcsshim/hcn/hcnpolicy.go
+++ b/vendor/github.com/Microsoft/hcsshim/hcn/hcnpolicy.go
@@ -141,10 +141,11 @@ type QosPolicySetting struct {
 
 // OutboundNatPolicySetting sets outbound Network Address Translation on an Endpoint.
 type OutboundNatPolicySetting struct {
-	VirtualIP    string   `json:",omitempty"`
-	Exceptions   []string `json:",omitempty"`
-	Destinations []string `json:",omitempty"`
-	Flags        NatFlags `json:",omitempty"`
+	VirtualIP        string   `json:",omitempty"`
+	Exceptions       []string `json:",omitempty"`
+	Destinations     []string `json:",omitempty"`
+	Flags            NatFlags `json:",omitempty"`
+	MaxPortPoolUsage uint16   `json:",omitempty"`
 }
 
 // SDNRoutePolicySetting sets SDN Route on an Endpoint.

--- a/vendor/github.com/Microsoft/hcsshim/hcn/hcnsupport.go
+++ b/vendor/github.com/Microsoft/hcsshim/hcn/hcnsupport.go
@@ -32,6 +32,10 @@ type SupportedFeatures struct {
 	L4Proxy                  bool        `json:"L4Proxy"`    // network policy that applies VFP rules to all endpoints on the network to redirect traffic
 	L4WfpProxy               bool        `json:"L4WfpProxy"` // endpoint policy that applies WFP filters to redirect traffic to/from that endpoint
 	TierAcl                  bool        `json:"TierAcl"`
+	NetworkACL               bool        `json:"NetworkACL"`
+	NestedIpSet              bool        `json:"NestedIpSet"`
+	DisableHostPort          bool        `json:"DisableHostPort"`
+	ModifyLoadbalancer       bool        `json:"ModifyLoadbalancer"`
 }
 
 // AclFeatures are the supported ACL possibilities.
@@ -107,6 +111,10 @@ func getSupportedFeatures() (SupportedFeatures, error) {
 	features.L4Proxy = isFeatureSupported(globals.Version, L4ProxyPolicyVersion)
 	features.L4WfpProxy = isFeatureSupported(globals.Version, L4WfpProxyPolicyVersion)
 	features.TierAcl = isFeatureSupported(globals.Version, TierAclPolicyVersion)
+	features.NetworkACL = isFeatureSupported(globals.Version, NetworkACLPolicyVersion)
+	features.NestedIpSet = isFeatureSupported(globals.Version, NestedIpSetVersion)
+	features.DisableHostPort = isFeatureSupported(globals.Version, DisableHostPortVersion)
+	features.ModifyLoadbalancer = isFeatureSupported(globals.Version, ModifyLoadbalancerVersion)
 
 	logrus.WithFields(logrus.Fields{
 		"version":           fmt.Sprintf("%+v", globals.Version),

--- a/vendor/github.com/Microsoft/hcsshim/internal/hns/hnspolicy.go
+++ b/vendor/github.com/Microsoft/hcsshim/internal/hns/hnspolicy.go
@@ -56,9 +56,10 @@ type PaPolicy struct {
 
 type OutboundNatPolicy struct {
 	Policy
-	VIP          string   `json:"VIP,omitempty"`
-	Exceptions   []string `json:"ExceptionList,omitempty"`
-	Destinations []string `json:",omitempty"`
+	VIP              string   `json:"VIP,omitempty"`
+	Exceptions       []string `json:"ExceptionList,omitempty"`
+	Destinations     []string `json:",omitempty"`
+	MaxPortPoolUsage uint16   `json:",omitempty"`
 }
 
 type ProxyPolicy struct {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -68,7 +68,7 @@ github.com/Microsoft/go-winio/internal/socket
 github.com/Microsoft/go-winio/pkg/guid
 github.com/Microsoft/go-winio/pkg/security
 github.com/Microsoft/go-winio/vhd
-# github.com/Microsoft/hcsshim v0.8.25
+# github.com/Microsoft/hcsshim v0.8.26
 ## explicit; go 1.13
 github.com/Microsoft/hcsshim
 github.com/Microsoft/hcsshim/computestorage


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

The changes are backported from : https://github.com/kubernetes/kubernetes/pull/125598

This tag of hcsshim brings in a couple welcome features/improvements. One being exposing a way to update loadbaalncer in hns. This tag also contains some optimizations for querying whether a ModifyLoadbalancer HCN feature
is supported, which is a common workflow in kube-proxy on Windows. The first result from querying HCN is now cached so further calls can skip the hcn query as well as the version range parsing that was performed.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
