### PR TITLE
Log kubelet pod resizing OOM error to event stream

### DIFF
--- a/pkg/kubelet/events/event.go
+++ b/pkg/kubelet/events/event.go
@@ -75,6 +75,7 @@ const (
 	FailedStatusPodSandBox               = "FailedPodSandBoxStatus"
 	FailedMountOnFilesystemMismatch      = "FailedMountOnFilesystemMismatch"
 	FailedPrepareDynamicResources        = "FailedPrepareDynamicResources"
+	FailedResizePodInPlace               = "FailedResizePodInPlace"
 	PossibleMemoryBackedVolumesOnDisk    = "PossibleMemoryBackedVolumesOnDisk"
 	CgroupV1                             = "CgroupV1"
 )

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -1319,6 +1319,13 @@ func (m *kubeGenericRuntimeManager) SyncPod(ctx context.Context, pod *v1.Pod, po
 	if isInPlacePodVerticalScalingAllowed(pod) {
 		if len(podContainerChanges.ContainersToUpdate) > 0 || podContainerChanges.UpdatePodResources {
 			m.doPodResizeAction(pod, podStatus, podContainerChanges, result)
+			if result.SyncError != nil {
+				ref, referr := ref.GetReference(legacyscheme.Scheme, pod)
+				if referr != nil {
+					klog.ErrorS(referr, "Couldn't make a ref to pod", "pod", klog.KObj(pod))
+				}
+				m.recorder.Eventf(ref, v1.EventTypeWarning, events.FailedResizePodInPlace, result.SyncError.Error())
+			}
 		}
 	}
 


### PR DESCRIPTION
/kind feature
/sig node

#### What this PR does / why we need it:
[InPlacePodVerticalScaling] Log event when kubelet fails to resize pod to memory limit less than currently allocated memory.

#### Which issue(s) this PR fixes:
Fixes #124786

#### Does this PR introduce a user-facing change?
```Warn user when attempting to inplace resize pod memory below allocated memory if `InPlacePodVerticalScaling` is enabled.```