### PR TITLE
feat(kubelet/cm/cpumanager): lower stale container remove log level to INFO

### DIFF
--- a/pkg/kubelet/cm/cpumanager/cpu_manager.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_manager.go
@@ -381,7 +381,7 @@ func (m *manager) removeStaleState() {
 	for podUID, containers := range assignments {
 		for containerName := range containers {
 			if _, ok := activeContainers[podUID][containerName]; !ok {
-				klog.InfoS("RemoveStaleState: removing container (based on the latest CPU assignments)", "podUID", podUID, "containerName", containerName)
+				klog.InfoS("RemoveStaleState: removing container based on the latest CPU assignments", "podUID", podUID, "containerName", containerName)
 				err := m.policyRemoveContainerByRef(podUID, containerName)
 				if err != nil {
 					klog.ErrorS(err, "RemoveStaleState: failed to remove container", "podUID", podUID, "containerName", containerName)
@@ -392,7 +392,7 @@ func (m *manager) removeStaleState() {
 
 	m.containerMap.Visit(func(podUID, containerName, containerID string) {
 		if _, ok := activeContainers[podUID][containerName]; !ok {
-			klog.InfoS("RemoveStaleState: removing container (from container map cache)", "podUID", podUID, "containerName", containerName)
+			klog.InfoS("RemoveStaleState: removing container from container map cache", "podUID", podUID, "containerName", containerName)
 			err := m.policyRemoveContainerByRef(podUID, containerName)
 			if err != nil {
 				klog.ErrorS(err, "RemoveStaleState: failed to remove container", "podUID", podUID, "containerName", containerName)

--- a/pkg/kubelet/cm/cpumanager/cpu_manager.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_manager.go
@@ -378,10 +378,10 @@ func (m *manager) removeStaleState() {
 	// Loop through the CPUManager state. Remove any state for containers not
 	// in the `activeContainers` list built above.
 	assignments := m.state.GetCPUAssignments()
-	for podUID := range assignments {
-		for containerName := range assignments[podUID] {
+	for podUID, containers := range assignments {
+		for containerName := range containers {
 			if _, ok := activeContainers[podUID][containerName]; !ok {
-				klog.ErrorS(nil, "RemoveStaleState: removing container", "podUID", podUID, "containerName", containerName)
+				klog.InfoS("RemoveStaleState: removing container (based on the latest CPU assignments)", "podUID", podUID, "containerName", containerName)
 				err := m.policyRemoveContainerByRef(podUID, containerName)
 				if err != nil {
 					klog.ErrorS(err, "RemoveStaleState: failed to remove container", "podUID", podUID, "containerName", containerName)
@@ -392,7 +392,7 @@ func (m *manager) removeStaleState() {
 
 	m.containerMap.Visit(func(podUID, containerName, containerID string) {
 		if _, ok := activeContainers[podUID][containerName]; !ok {
-			klog.ErrorS(nil, "RemoveStaleState: removing container", "podUID", podUID, "containerName", containerName)
+			klog.InfoS("RemoveStaleState: removing container (from container map cache)", "podUID", podUID, "containerName", containerName)
 			err := m.policyRemoveContainerByRef(podUID, containerName)
 			if err != nil {
 				klog.ErrorS(err, "RemoveStaleState: failed to remove container", "podUID", podUID, "containerName", containerName)

--- a/pkg/kubelet/cm/cpumanager/state/state.go
+++ b/pkg/kubelet/cm/cpumanager/state/state.go
@@ -20,7 +20,8 @@ import (
 	"k8s.io/utils/cpuset"
 )
 
-// ContainerCPUAssignments type used in cpu manager state
+// ContainerCPUAssignments type used in cpu manager state.
+// Maps pod UID to container name, and container name to cpuset.CPUSet.
 type ContainerCPUAssignments map[string]map[string]cpuset.CPUSet
 
 // Clone returns a copy of ContainerCPUAssignments


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The "RemoveStaleState" is the part of the normal reconcile process, thus it should not be error log unless it fails to do so. This will help reduce the noise in kubelet error log alerts.

Also, document the CPU assignments map.

#### Which issue(s) this PR fixes:

N/A

#### Special notes for your reviewer:

Please let me know if I misunderstood anything.

Thanks!

#### Does this PR introduce a user-facing change?

```release-note
kubelet: lower RemoveStaleState operation log level to INFO (failure still in ERROR level)
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
