### PR TITLE
feat(kubelet/stats): match cadvisor error to lower not found stats log level

### DIFF
--- a/pkg/kubelet/server/stats/summary_sys_containers.go
+++ b/pkg/kubelet/server/stats/summary_sys_containers.go
@@ -83,7 +83,7 @@ func (sp *summaryProviderImpl) GetSystemContainersCPUAndMemoryStats(nodeConfig c
 		}
 		s, err := sp.provider.GetCgroupCPUAndMemoryStats(cont.name, cont.forceStatsUpdate)
 		if err != nil {
-			if errors.Is(errors.Unwrap(err), cadvisormemory.ErrDataNotFound) {
+			if errors.Is(err, cadvisormemory.ErrDataNotFound) {
 				klog.V(4).InfoS("cgroup stats not found in memory cache", "containerName", cont.name)
 			} else {
 				klog.ErrorS(err, "Failed to get system container stats", "containerName", cont.name)

--- a/pkg/kubelet/server/stats/summary_sys_containers.go
+++ b/pkg/kubelet/server/stats/summary_sys_containers.go
@@ -84,7 +84,7 @@ func (sp *summaryProviderImpl) GetSystemContainersCPUAndMemoryStats(nodeConfig c
 		s, err := sp.provider.GetCgroupCPUAndMemoryStats(cont.name, cont.forceStatsUpdate)
 		if err != nil {
 			if errors.Is(errors.Unwrap(err), cadvisormemory.ErrDataNotFound) {
-				klog.InfoS("cgroup stats not found in memory cache", "containerName", cont.name)
+				klog.V(4).InfoS("cgroup stats not found in memory cache", "containerName", cont.name)
 			} else {
 				klog.ErrorS(err, "Failed to get system container stats", "containerName", cont.name)
 			}

--- a/pkg/kubelet/stats/cadvisor_stats_provider.go
+++ b/pkg/kubelet/stats/cadvisor_stats_provider.go
@@ -499,7 +499,7 @@ func getCadvisorContainerInfo(ca cadvisor.Interface) (map[string]cadvisorapiv2.C
 			// response.
 			klog.ErrorS(err, "Partial failure issuing cadvisor.ContainerInfoV2")
 		} else {
-			return nil, fmt.Errorf("failed to get root cgroup stats: %v", err)
+			return nil, fmt.Errorf("failed to get root cgroup stats: %w", err)
 		}
 	}
 	return infos, nil

--- a/pkg/kubelet/stats/helper.go
+++ b/pkg/kubelet/stats/helper.go
@@ -318,7 +318,7 @@ func getCgroupInfo(cadvisor cadvisor.Interface, containerName string, updateStat
 		MaxAge:    maxAge,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to get container info for %q: %v", containerName, err)
+		return nil, fmt.Errorf("failed to get container info for %q: %w", containerName, err)
 	}
 	if len(infoMap) != 1 {
 		return nil, fmt.Errorf("unexpected number of containers: %v", len(infoMap))

--- a/pkg/kubelet/stats/provider.go
+++ b/pkg/kubelet/stats/provider.go
@@ -18,8 +18,10 @@ package stats
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
+	cadvisormemory "github.com/google/cadvisor/cache/memory"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	internalapi "k8s.io/cri-api/pkg/apis"
@@ -113,6 +115,9 @@ func (p *Provider) RlimitStats() (*statsapi.RlimitStats, error) {
 func (p *Provider) GetCgroupStats(cgroupName string, updateStats bool) (*statsapi.ContainerStats, *statsapi.NetworkStats, error) {
 	info, err := getCgroupInfo(p.cadvisor, cgroupName, updateStats)
 	if err != nil {
+		if errors.Is(errors.Unwrap(err), cadvisormemory.ErrDataNotFound) {
+			return nil, nil, fmt.Errorf("cgroup stats not found for %q: %w", cgroupName, cadvisormemory.ErrDataNotFound)
+		}
 		return nil, nil, fmt.Errorf("failed to get cgroup stats for %q: %v", cgroupName, err)
 	}
 	// Rootfs and imagefs doesn't make sense for raw cgroup.
@@ -126,6 +131,9 @@ func (p *Provider) GetCgroupStats(cgroupName string, updateStats bool) (*statsap
 func (p *Provider) GetCgroupCPUAndMemoryStats(cgroupName string, updateStats bool) (*statsapi.ContainerStats, error) {
 	info, err := getCgroupInfo(p.cadvisor, cgroupName, updateStats)
 	if err != nil {
+		if errors.Is(errors.Unwrap(err), cadvisormemory.ErrDataNotFound) {
+			return nil, fmt.Errorf("cgroup stats not found for %q: %w", cgroupName, cadvisormemory.ErrDataNotFound)
+		}
 		return nil, fmt.Errorf("failed to get cgroup stats for %q: %v", cgroupName, err)
 	}
 	// Rootfs and imagefs doesn't make sense for raw cgroup.

--- a/pkg/kubelet/stats/provider.go
+++ b/pkg/kubelet/stats/provider.go
@@ -115,7 +115,7 @@ func (p *Provider) RlimitStats() (*statsapi.RlimitStats, error) {
 func (p *Provider) GetCgroupStats(cgroupName string, updateStats bool) (*statsapi.ContainerStats, *statsapi.NetworkStats, error) {
 	info, err := getCgroupInfo(p.cadvisor, cgroupName, updateStats)
 	if err != nil {
-		if errors.Is(errors.Unwrap(err), cadvisormemory.ErrDataNotFound) {
+		if errors.Is(err, cadvisormemory.ErrDataNotFound) {
 			return nil, nil, fmt.Errorf("cgroup stats not found for %q: %w", cgroupName, cadvisormemory.ErrDataNotFound)
 		}
 		return nil, nil, fmt.Errorf("failed to get cgroup stats for %q: %v", cgroupName, err)
@@ -131,7 +131,7 @@ func (p *Provider) GetCgroupStats(cgroupName string, updateStats bool) (*statsap
 func (p *Provider) GetCgroupCPUAndMemoryStats(cgroupName string, updateStats bool) (*statsapi.ContainerStats, error) {
 	info, err := getCgroupInfo(p.cadvisor, cgroupName, updateStats)
 	if err != nil {
-		if errors.Is(errors.Unwrap(err), cadvisormemory.ErrDataNotFound) {
+		if errors.Is(err, cadvisormemory.ErrDataNotFound) {
 			return nil, fmt.Errorf("cgroup stats not found for %q: %w", cgroupName, cadvisormemory.ErrDataNotFound)
 		}
 		return nil, fmt.Errorf("failed to get cgroup stats for %q: %v", cgroupName, err)


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This "RecentStats: unable to find data in memory cache" error is not actionable, from the kubelet's point of view, if the entry is not found in the memory cache. We already have a similar code path in the same package:

https://github.com/kubernetes/kubernetes/blob/337f4e524aab8dedfeacfe8cc6b39dc0145a7214/pkg/kubelet/stats/cri_stats_provider.go#L444-L456

Thus, proposing it to lower the log level to info.

#### Which issue(s) this PR fixes:

N/A

#### Special notes for your reviewer:

I found this error logs quite noisy, without the actionable fix. Is there any reason for this to be in the error level? Isn't that possible, kubelet expectedly restarts, while containerd still runs the container, so the stats can be missing?

The main motivation here is to reduce the error logs in kubelet, unless it's actionable.

Open to other suggestions!

#### Does this PR introduce a user-facing change?

```release-note
kubelet/stats: set INFO log level for stats not found in cadvisor memory cache error
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
N/A
```
