### PR TITLE
feat(pkg/kubelet/images): do not error log gc if still held

### DIFF
--- a/pkg/kubelet/images/image_gc_manager.go
+++ b/pkg/kubelet/images/image_gc_manager.go
@@ -308,6 +308,8 @@ func (im *realImageGCManager) detectImages(ctx context.Context, detectTime time.
 	return imagesInUse, nil
 }
 
+var ErrImageGCFailedLowerFreedBytes = goerrors.New("Failed to garbage collect required amount of images")
+
 func (im *realImageGCManager) GarbageCollect(ctx context.Context, beganGC time.Time) error {
 	ctx, otelSpan := im.tracer.Start(ctx, "Images/GarbageCollect")
 	defer otelSpan.End()
@@ -360,7 +362,7 @@ func (im *realImageGCManager) GarbageCollect(ctx context.Context, beganGC time.T
 		}
 
 		if freed < amountToFree {
-			err := fmt.Errorf("Failed to garbage collect required amount of images. Attempted to free %d bytes, but only found %d bytes eligible to free.", amountToFree, freed)
+			err := fmt.Errorf("%w. Attempted to free %d bytes, but only found %d bytes eligible to free.", ErrImageGCFailedLowerFreedBytes, amountToFree, freed)
 			im.recorder.Eventf(im.nodeRef, v1.EventTypeWarning, events.FreeDiskSpaceFailed, err.Error())
 			return err
 		}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Images may be still held by containers. In such case, the image gc failure is not actionable and expected, thus should be logged as non-error.

#### Which issue(s) this PR fixes:

N/A

#### Special notes for your reviewer:

We find this error logs quite non-actionable, while we can still get these data points. via events. Maybe I am missing some cases, where the gc failure can happen for other reasons than the images are still being used by containers. Please let me know if there's a better way to handle this.

#### Does this PR introduce a user-facing change?

```release-note
kubelet/images: switch to INFO logs for gc failures with lowered freed bytes errors
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
N/A
```
