### PR TITLE
patch: define the environment variable once in the deployment after fixing the deployment resource descriptor

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/patch.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/patch.go
@@ -1557,7 +1557,7 @@ func mergeSliceWithSpecialElements(original, patch []interface{}, mergeKey strin
 				mergeValue, ok := typedV[mergeKey]
 				if ok {
 					var err error
-					original, err = deleteMatchingEntry(original, mergeKey, mergeValue)
+					original, err = deleteMatchingEntries(original, mergeKey, mergeValue)
 					if err != nil {
 						return nil, nil, err
 					}
@@ -1581,30 +1581,13 @@ func mergeSliceWithSpecialElements(original, patch []interface{}, mergeKey strin
 }
 
 // delete matching entry (based on merge key) from a merging list
-func deleteMatchingEntry(original []interface{}, mergeKey string, mergeValue interface{}) ([]interface{}, error) {
+func deleteMatchingEntries(original []interface{}, mergeKey string, mergeValue interface{}) ([]interface{}, error) {
 	_, originalKey, found, err := findLastMapInSliceBasedOnKeyValue(original, mergeKey, mergeValue)
 	if err != nil {
 		return nil, err
 	}
 
 	if found {
-		// Delete the element at originalKey.
-		original = append(original[:originalKey], original[originalKey+1:]...)
-	}
-	return original, nil
-}
-
-// delete all matching entries (based on merge key) from a merging list
-func deleteMatchingEntries(original []interface{}, mergeKey string, mergeValue interface{}) ([]interface{}, error) {
-	for {
-		_, originalKey, found, err := findMapInSliceBasedOnKeyValue(original, mergeKey, mergeValue)
-		if err != nil {
-			return nil, err
-		}
-
-		if !found {
-			break
-		}
 		// Delete the element at originalKey.
 		original = append(original[:originalKey], original[originalKey+1:]...)
 	}

--- a/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/patch.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/patch.go
@@ -1557,7 +1557,7 @@ func mergeSliceWithSpecialElements(original, patch []interface{}, mergeKey strin
 				mergeValue, ok := typedV[mergeKey]
 				if ok {
 					var err error
-					original, err = deleteMatchingEntries(original, mergeKey, mergeValue)
+					original, err = deleteMatchingEntry(original, mergeKey, mergeValue)
 					if err != nil {
 						return nil, nil, err
 					}
@@ -1578,6 +1578,20 @@ func mergeSliceWithSpecialElements(original, patch []interface{}, mergeKey strin
 		return patchWithoutSpecialElements, nil, nil
 	}
 	return original, patchWithoutSpecialElements, nil
+}
+
+// delete matching entry (based on merge key) from a merging list
+func deleteMatchingEntry(original []interface{}, mergeKey string, mergeValue interface{}) ([]interface{}, error) {
+	_, originalKey, found, err := findLastMapInSliceBasedOnKeyValue(original, mergeKey, mergeValue)
+	if err != nil {
+		return nil, err
+	}
+
+	if found {
+		// Delete the element at originalKey.
+		original = append(original[:originalKey], original[originalKey+1:]...)
+	}
+	return original, nil
 }
 
 // delete all matching entries (based on merge key) from a merging list
@@ -1644,6 +1658,34 @@ func deleteFromSlice(current, toDelete []interface{}) []interface{} {
 		}
 	}
 	return processed
+}
+
+// This method no longer panics if any element of the slice is not a map.
+func findLastMapInSliceBasedOnKeyValue(m []interface{}, key string, value interface{}) (map[string]interface{}, int, bool, error) {
+	found := false
+	returnTypedV := map[string]interface{}{}
+	returnKeyIndex := 0
+
+	for keyIndex, v := range m {
+		typedV, ok := v.(map[string]interface{})
+		if !ok {
+			return nil, 0, false, fmt.Errorf("value for key %v is not a map", keyIndex)
+		}
+
+		valueToMatch, ok := typedV[key]
+		if ok && valueToMatch == value {
+			returnTypedV = typedV
+			returnKeyIndex = keyIndex
+			found = true
+			continue
+		}
+	}
+
+	if found {
+		return returnTypedV, returnKeyIndex, true, nil
+	}
+
+	return nil, 0, false, nil
 }
 
 // This method no longer panics if any element of the slice is not a map.

--- a/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/patch_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/patch_test.go
@@ -400,8 +400,10 @@ testCases:
           $patch: delete
     modified:
       mergingList:
+        - name: 1
         - name: 2
           value: a
+        - name: 3
   - description: retainKeys map can add a field when no retainKeys directive present
     original:
       retainKeysMap:


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
The problem is:
A container has defined environment variable with name key11 that is duplicated (there are two env vars with the same name, the value is also the same).
When you fix the deployment resource descriptor so that environment variable with name x appears only once and push it with kubectl apply, deployment with no environment variable named x is created and therefore no environment variable named x is passed to replica set and pods.
This can have a serious impact on the production environment, such as the specified IP address disappearing.
We expect to define environment variable with name x once after fixing the deployment.

#### Which issue(s) this PR fixes:
Fixes #58477

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Defined the environment variable once in the deployment after fixing the deployment resource descriptor.
```
#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
Before fix:
A container has defined environment variable with name key11 that is duplicated (there are two env vars with the same name, the value is also the same). 
![deploy same key](https://github.com/kubernetes/kubernetes/assets/173667072/68dd1968-28a6-4905-b923-b412ebc39f89)
![deploy same key success](https://github.com/kubernetes/kubernetes/assets/173667072/5abba21c-828b-4067-959c-9d891a35afcf)

When you fix the deployment resource descriptor so that environment variable with name key11 appears only once and push it with kubectl apply, deployment with no environment variable named key11 is created and therefore no environment variable named key11 is passed to replica set and pods.
![deploy fix configuration](https://github.com/kubernetes/kubernetes/assets/173667072/feb4c6d0-5b80-4cba-8fbf-97b52be0e152)
![deploy fix configuration success](https://github.com/kubernetes/kubernetes/assets/173667072/4260b573-8535-441f-9e44-ff0cfdc37db1)

After fix:
After fixing the deployment, environment variable with name key11is defined in the deployment once .
![after fix](https://github.com/kubernetes/kubernetes/assets/173667072/09d30530-eea6-4e22-920c-6328a03b92f8)
![success](https://github.com/kubernetes/kubernetes/assets/173667072/6d6d8f5b-62bf-44a4-b999-b1935cecbb07)

