### PR TITLE
kube_features: DevicePluginCDIDevices: LockToDefault

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -1006,7 +1006,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 
 	DisableNodeKubeProxyVersion: {Default: true, PreRelease: featuregate.Beta},
 
-	DevicePluginCDIDevices: {Default: true, PreRelease: featuregate.GA},
+	DevicePluginCDIDevices: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.33
 
 	DynamicResourceAllocation: {Default: false, PreRelease: featuregate.Alpha},
 

--- a/pkg/kubelet/cm/devicemanager/pod_devices_test.go
+++ b/pkg/kubelet/cm/devicemanager/pod_devices_test.go
@@ -24,10 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"k8s.io/apimachinery/pkg/util/sets"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
-	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	pluginapi "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
-	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/kubelet/cm/devicemanager/checkpoint"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 )
@@ -168,44 +165,18 @@ func TestDeviceRunContainerOptions(t *testing.T) {
 	)
 	testCases := []struct {
 		description          string
-		gate                 bool
 		responsesPerResource map[string]*pluginapi.ContainerAllocateResponse
 		expected             *DeviceRunContainerOptions
 	}{
 		{
 			description: "empty response",
-			gate:        false,
 			responsesPerResource: map[string]*pluginapi.ContainerAllocateResponse{
 				resource1: newContainerAllocateResponse(),
 			},
 			expected: &DeviceRunContainerOptions{},
 		},
 		{
-			description: "cdi devices are ingored when feature gate is disabled",
-			gate:        false,
-			responsesPerResource: map[string]*pluginapi.ContainerAllocateResponse{
-				resource1: newContainerAllocateResponse(
-					withDevices(map[string]string{"/dev/r1": "/dev/r1"}),
-					withMounts(map[string]string{"/home/lib1": "/home/lib1"}),
-					withEnvs(map[string]string{"ENV1": "VALUE1"}),
-					withCDIDevices("vendor1.com/class1=device1", "vendor2.com/class2=device2"),
-				),
-			},
-			expected: &DeviceRunContainerOptions{
-				Devices: []kubecontainer.DeviceInfo{
-					{PathOnHost: "/dev/r1", PathInContainer: "/dev/r1", Permissions: "mrw"},
-				},
-				Mounts: []kubecontainer.Mount{
-					{Name: "/home/lib1", HostPath: "/home/lib1", ContainerPath: "/home/lib1", ReadOnly: true},
-				},
-				Envs: []kubecontainer.EnvVar{
-					{Name: "ENV1", Value: "VALUE1"},
-				},
-			},
-		},
-		{
-			description: "cdi devices are handled when feature gate is enabled",
-			gate:        true,
+			description: "cdi devices are handled",
 			responsesPerResource: map[string]*pluginapi.ContainerAllocateResponse{
 				resource1: newContainerAllocateResponse(
 					withCDIDevices("vendor1.com/class1=device1", "vendor2.com/class2=device2"),
@@ -222,8 +193,7 @@ func TestDeviceRunContainerOptions(t *testing.T) {
 			},
 		},
 		{
-			description: "cdi devices from multiple resources are handled when feature gate is enabled",
-			gate:        true,
+			description: "cdi devices from multiple resources are handled",
 			responsesPerResource: map[string]*pluginapi.ContainerAllocateResponse{
 				resource1: newContainerAllocateResponse(
 					withCDIDevices("vendor1.com/class1=device1", "vendor2.com/class2=device2"),
@@ -246,7 +216,6 @@ func TestDeviceRunContainerOptions(t *testing.T) {
 		},
 		{
 			description: "duplicate cdi devices are skipped",
-			gate:        true,
 			responsesPerResource: map[string]*pluginapi.ContainerAllocateResponse{
 				resource1: newContainerAllocateResponse(
 					withCDIDevices("vendor1.com/class1=device1", "vendor2.com/class2=device2"),
@@ -272,7 +241,6 @@ func TestDeviceRunContainerOptions(t *testing.T) {
 		t.Run(tc.description, func(t *testing.T) {
 			as := assert.New(t)
 
-			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.DevicePluginCDIDevices, tc.gate)
 			podDevices := newPodDevices()
 			for resourceName, response := range tc.responsesPerResource {
 				podDevices.insert("pod", "container", resourceName,


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

It locks DevicePluginCDIDevices feature gate to default as suggested in [this review comment](https://github.com/kubernetes/kubernetes/pull/123315#discussion_r1627765691)

#### Does this PR introduce a user-facing change?

```release-note
NONE
```