### PR TITLE
scheduler: fix klog.KObjSlice when applied to []*NodeInfo

### DIFF
--- a/pkg/scheduler/framework/types.go
+++ b/pkg/scheduler/framework/types.go
@@ -591,6 +591,21 @@ type NodeInfo struct {
 	Generation int64
 }
 
+// NodeInfo implements KMetadata, so for example klog.KObjSlice(nodes) works
+// when nodes is a []*NodeInfo.
+var _ klog.KMetadata = &NodeInfo{}
+
+func (n *NodeInfo) GetName() string {
+	if n == nil {
+		return "<nil>"
+	}
+	if n.node == nil {
+		return "<no node>"
+	}
+	return n.node.Name
+}
+func (n *NodeInfo) GetNamespace() string { return "" }
+
 // nextGeneration: Let's make sure history never forgets the name...
 // Increments the generation number monotonically ensuring that generation numbers never collide.
 // Collision of the generation numbers would be particularly problematic if a node was deleted and

--- a/test/utils/ktesting/initoption/initoption.go
+++ b/test/utils/ktesting/initoption/initoption.go
@@ -28,3 +28,13 @@ func PerTestOutput(enabled bool) InitOption {
 		c.PerTestOutput = enabled
 	}
 }
+
+// BufferLogs controls whether log entries are captured in memory in addition
+// to being printed. Off by default. Unit tests that want to verify that
+// log entries are emitted as expected can turn this on and then retrieve
+// the captured log through the Underlier LogSink interface.
+func BufferLogs(enabled bool) InitOption {
+	return func(c *internal.InitConfig) {
+		c.BufferLogs = enabled
+	}
+}

--- a/test/utils/ktesting/internal/config.go
+++ b/test/utils/ktesting/internal/config.go
@@ -18,4 +18,5 @@ package internal
 
 type InitConfig struct {
 	PerTestOutput bool
+	BufferLogs    bool
 }

--- a/test/utils/ktesting/tcontext.go
+++ b/test/utils/ktesting/tcontext.go
@@ -36,7 +36,8 @@ import (
 )
 
 // Underlier is the additional interface implemented by the per-test LogSink
-// behind [TContext.Logger].
+// behind [TContext.Logger]. Together with [initoption.BufferLogs] it can be
+// used to capture log output in memory to check it in tests.
 type Underlier = ktesting.Underlier
 
 // CleanupGracePeriod is the time that a [TContext] gets canceled before the
@@ -245,6 +246,7 @@ func Init(tb TB, opts ...InitOption) TContext {
 			}),
 			ktesting.VerbosityFlagName("v"),
 			ktesting.VModuleFlagName("vmodule"),
+			ktesting.BufferLogs(c.BufferLogs),
 		)
 
 		// Copy klog settings instead of making the ktesting logger


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The DRA plugin uses klog.KObjSlice on a NodeInfo slice. It didn't actually work and only printed an error message about NodeInfo not implementing klog.KMetata. That's not a compile-time check due to limitations with Go generics and had been missed earlier.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/assign @sanposhiho 
