### PR TITLE
WIP: Add RestartContainerDuringTermination feature

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -650,6 +650,14 @@ const (
 	// No effect for other cases such as using serverTLSbootstap.
 	ReloadKubeletServerCertificateFile featuregate.Feature = "ReloadKubeletServerCertificateFile"
 
+	// owner: @gjkim42 @SergeyKanzhelev @matthyx
+	// kep: http://kep.k8s.io/753
+	// kep: http://kep.k8s.io/4438
+	// alpha: v1.33
+	//
+	// Allows containers to restart during pod termination.
+	RestartContainerDuringTermination featuregate.Feature = "RestartContainerDuringTermination"
+
 	// owner: @SergeyKanzhelev
 	// kep: https://kep.k8s.io/4680
 	//
@@ -1664,6 +1672,10 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 
 	ReloadKubeletServerCertificateFile: {
 		{Version: version.MustParse("1.31"), Default: true, PreRelease: featuregate.Beta},
+	},
+
+	RestartContainerDuringTermination: {
+		{Version: version.MustParse("1.33"), Default: false, PreRelease: featuregate.Alpha},
 	},
 
 	ResourceHealthStatus: {

--- a/pkg/kubelet/container/helpers.go
+++ b/pkg/kubelet/container/helpers.go
@@ -23,7 +23,9 @@ import (
 	"hash/fnv"
 	"strings"
 
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/klog/v2"
+	"k8s.io/kubernetes/pkg/features"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -110,11 +112,18 @@ func ShouldContainerBeRestarted(container *v1.Container, pod *v1.Pod, podStatus 
 	}
 	if pod.Spec.RestartPolicy == v1.RestartPolicyOnFailure {
 		// Check the exit code.
-		if status.ExitCode == 0 &&
-			status.Reason != string(ReasonLivenessProbe) &&
-			status.Reason != string(ReasonStartupProbe) {
-			klog.V(4).InfoS("Already successfully ran container, do nothing", "pod", klog.KObj(pod), "containerName", container.Name)
-			return false
+		if !utilfeature.DefaultFeatureGate.Enabled(features.RestartContainerDuringTermination) {
+			if status.ExitCode == 0 {
+				klog.V(4).InfoS("Already successfully ran container, do nothing", "pod", klog.KObj(pod), "containerName", container.Name)
+				return false
+			}
+		} else {
+			if status.ExitCode == 0 &&
+				status.Reason != string(ReasonLivenessProbe) &&
+				status.Reason != string(ReasonStartupProbe) {
+				klog.V(4).InfoS("Already successfully ran container, do nothing", "pod", klog.KObj(pod), "containerName", container.Name)
+				return false
+			}
 		}
 	}
 	return true

--- a/pkg/kubelet/container/runtime.go
+++ b/pkg/kubelet/container/runtime.go
@@ -107,6 +107,9 @@ type Runtime interface {
 	// only hard kill paths are allowed to specify a gracePeriodOverride in the kubelet in order to not corrupt user data.
 	// it is useful when doing SIGKILL for hard eviction scenarios, or max grace period during soft eviction scenarios.
 	KillPod(ctx context.Context, pod *v1.Pod, runningPod Pod, gracePeriodOverride *int64) error
+	// SyncTerminatingPod syncs the terminating pod into the desired pod.
+	// It returns true if the pod is fully terminated.
+	SyncTerminatingPod(ctx context.Context, pod *v1.Pod, podStatus *PodStatus, gracePeriodOverride *int64, pullSecrets []v1.Secret, backOff *flowcontrol.Backoff, stopPod bool) (bool, error)
 	// GetPodStatus retrieves the status of the pod, including the
 	// information of all containers in the pod that are visible in Runtime.
 	GetPodStatus(ctx context.Context, uid types.UID, name, namespace string) (*PodStatus, error)

--- a/pkg/kubelet/container/testing/fake_runtime.go
+++ b/pkg/kubelet/container/testing/fake_runtime.go
@@ -263,6 +263,21 @@ func (f *FakeRuntime) KillPod(_ context.Context, pod *v1.Pod, runningPod kubecon
 	return f.Err
 }
 
+func (f *FakeRuntime) SyncTerminatingPod(ctx context.Context, pod *v1.Pod, podStatus *kubecontainer.PodStatus, gracePeriodOverride *int64, pullSecrets []v1.Secret, backOff *flowcontrol.Backoff, stopPod bool) (bool, error) {
+	f.Lock()
+	defer f.Unlock()
+
+	f.CalledFunctions = append(f.CalledFunctions, "SyncTerminatingPod")
+	f.KilledPods = append(f.KilledPods, string(pod.UID))
+	for _, c := range podStatus.ContainerStatuses {
+		f.KilledContainers = append(f.KilledContainers, c.Name)
+	}
+	if f.Err != nil {
+		return false, f.Err
+	}
+	return true, nil
+}
+
 func (f *FakeRuntime) RunContainerInPod(container v1.Container, pod *v1.Pod, volumeMap map[string]volume.VolumePlugin) error {
 	f.Lock()
 	defer f.Unlock()

--- a/pkg/kubelet/container/testing/runtime_mock.go
+++ b/pkg/kubelet/container/testing/runtime_mock.go
@@ -1264,6 +1264,68 @@ func (_c *MockRuntime_SyncPod_Call) RunAndReturn(run func(context.Context, *core
 	return _c
 }
 
+// SyncTerminatingPod provides a mock function with given fields: ctx, pod, podStatus, gracePeriodOverride, pullSecrets, backOff, stopPod
+func (_m *MockRuntime) SyncTerminatingPod(ctx context.Context, pod *corev1.Pod, podStatus *container.PodStatus, gracePeriodOverride *int64, pullSecrets []corev1.Secret, backOff *flowcontrol.Backoff, stopPod bool) (bool, error) {
+	ret := _m.Called(ctx, pod, podStatus, gracePeriodOverride, pullSecrets, backOff, stopPod)
+
+	if len(ret) == 0 {
+		panic("no return value specified for SyncTerminatingPod")
+	}
+
+	var r0 bool
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, *corev1.Pod, *container.PodStatus, *int64, []corev1.Secret, *flowcontrol.Backoff, bool) (bool, error)); ok {
+		return rf(ctx, pod, podStatus, gracePeriodOverride, pullSecrets, backOff, stopPod)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *corev1.Pod, *container.PodStatus, *int64, []corev1.Secret, *flowcontrol.Backoff, bool) bool); ok {
+		r0 = rf(ctx, pod, podStatus, gracePeriodOverride, pullSecrets, backOff, stopPod)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *corev1.Pod, *container.PodStatus, *int64, []corev1.Secret, *flowcontrol.Backoff, bool) error); ok {
+		r1 = rf(ctx, pod, podStatus, gracePeriodOverride, pullSecrets, backOff, stopPod)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockRuntime_SyncTerminatingPod_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SyncTerminatingPod'
+type MockRuntime_SyncTerminatingPod_Call struct {
+	*mock.Call
+}
+
+// SyncTerminatingPod is a helper method to define mock.On call
+//   - ctx context.Context
+//   - pod *corev1.Pod
+//   - podStatus *container.PodStatus
+//   - gracePeriodOverride *int64
+//   - pullSecrets []corev1.Secret
+//   - backOff *flowcontrol.Backoff
+//   - stopPod bool
+func (_e *MockRuntime_Expecter) SyncTerminatingPod(ctx interface{}, pod interface{}, podStatus interface{}, gracePeriodOverride interface{}, pullSecrets interface{}, backOff interface{}, stopPod interface{}) *MockRuntime_SyncTerminatingPod_Call {
+	return &MockRuntime_SyncTerminatingPod_Call{Call: _e.mock.On("SyncTerminatingPod", ctx, pod, podStatus, gracePeriodOverride, pullSecrets, backOff, stopPod)}
+}
+
+func (_c *MockRuntime_SyncTerminatingPod_Call) Run(run func(ctx context.Context, pod *corev1.Pod, podStatus *container.PodStatus, gracePeriodOverride *int64, pullSecrets []corev1.Secret, backOff *flowcontrol.Backoff, stopPod bool)) *MockRuntime_SyncTerminatingPod_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*corev1.Pod), args[2].(*container.PodStatus), args[3].(*int64), args[4].([]corev1.Secret), args[5].(*flowcontrol.Backoff), args[6].(bool))
+	})
+	return _c
+}
+
+func (_c *MockRuntime_SyncTerminatingPod_Call) Return(_a0 bool, _a1 error) *MockRuntime_SyncTerminatingPod_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockRuntime_SyncTerminatingPod_Call) RunAndReturn(run func(context.Context, *corev1.Pod, *container.PodStatus, *int64, []corev1.Secret, *flowcontrol.Backoff, bool) (bool, error)) *MockRuntime_SyncTerminatingPod_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Type provides a mock function with no fields
 func (_m *MockRuntime) Type() string {
 	ret := _m.Called()

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -2122,28 +2122,27 @@ func (kl *Kubelet) SyncTerminatingPod(_ context.Context, pod *v1.Pod, podStatus 
 
 	kl.probeManager.StopLivenessAndStartup(pod)
 
-	var podStopped bool
-	var err error
 	if !utilfeature.DefaultFeatureGate.Enabled(features.RestartContainerDuringTermination) {
 		p := kubecontainer.ConvertPodStatusToRunningPod(kl.getRuntime().Type(), podStatus)
-		err = kl.killPod(ctx, pod, p, gracePeriod)
-		if err == nil {
-			podStopped = true
+		if err := kl.killPod(ctx, pod, p, gracePeriod); err != nil {
+			kl.recorder.Eventf(pod, v1.EventTypeWarning, events.FailedToKillPod, "error killing pod: %v", err)
+			// there was an error killing the pod, so we return that error directly
+			utilruntime.HandleError(err)
+			return err
 		}
 	} else {
-		podStopped, err = kl.syncTerminatingPod(ctx, pod, podStatus, gracePeriod, kl.getPullSecretsForPod(pod), kl.backOff)
-	}
-	if err != nil {
-		kl.recorder.Eventf(pod, v1.EventTypeWarning, events.FailedToKillPod, "error killing pod: %v", err)
-		// there was an error killing the pod, so we return that error directly
-		utilruntime.HandleError(err)
-		return err
-	}
-
-	if !podStopped {
-		// If the pod is not yet stopped, we should return an error to signal
-		// that the sync loop should back off.
-		return fmt.Errorf("pod is not yet stopped")
+		podStopped, err := kl.syncTerminatingPod(ctx, pod, podStatus, gracePeriod, kl.getPullSecretsForPod(pod), kl.backOff)
+		if err != nil {
+			kl.recorder.Eventf(pod, v1.EventTypeWarning, events.FailedToKillPod, "error killing pod: %v", err)
+			// there was an error killing the pod, so we return that error directly
+			utilruntime.HandleError(err)
+			return err
+		}
+		if !podStopped {
+			// If the pod is not yet stopped, we should return an error to signal
+			// that the sync loop should back off.
+			return fmt.Errorf("pod is not yet stopped")
+		}
 	}
 
 	// Once the containers are stopped, we can stop probing for liveness and readiness.

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -2131,7 +2131,7 @@ func (kl *Kubelet) SyncTerminatingPod(_ context.Context, pod *v1.Pod, podStatus 
 			return err
 		}
 	} else {
-		podStopped, err := kl.syncTerminatingPod(ctx, pod, podStatus, gracePeriod, kl.getPullSecretsForPod(pod), kl.backOff)
+		podStopped, err := kl.syncTerminatingPod(ctx, pod, podStatus, gracePeriod, kl.getPullSecretsForPod(pod), kl.crashLoopBackOff)
 		if err != nil {
 			kl.recorder.Eventf(pod, v1.EventTypeWarning, events.FailedToKillPod, "error killing pod: %v", err)
 			// there was an error killing the pod, so we return that error directly

--- a/pkg/kubelet/kuberuntime/fake_kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/fake_kuberuntime_manager.go
@@ -157,5 +157,7 @@ func newFakeKubeRuntimeManager(runtimeService internalapi.RuntimeService, imageS
 		}
 	}
 
+	kubeRuntimeManager.containerLifecycle = newContainerLifecycle(kubeRuntimeManager)
+
 	return kubeRuntimeManager, nil
 }

--- a/pkg/kubelet/kuberuntime/kuberuntime_container.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container.go
@@ -263,7 +263,7 @@ func (m *kubeGenericRuntimeManager) startContainer(ctx context.Context, podSandb
 	// When creating a container, mark the resources as actuated.
 	if err := m.allocationManager.SetActuatedResources(pod, container); err != nil {
 		m.recordContainerEvent(pod, container, "", v1.EventTypeWarning, events.FailedToCreateContainer, "Error: %v", err)
-		return err.Error(), ErrCreateContainerConfig
+		return kubeContainerID, err.Error(), ErrCreateContainerConfig
 	}
 
 	err = m.internalLifecycle.PreCreateContainer(pod, container, containerConfig)

--- a/pkg/kubelet/kuberuntime/kuberuntime_container_lifecycle.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_lifecycle.go
@@ -333,7 +333,7 @@ func (c *containerWorker) prepareForTermination(ctx context.Context, pod *v1.Pod
 	if len(message) == 0 {
 		message = fmt.Sprintf("Stopping container %s", containerSpec.Name)
 	}
-	c.m.recordContainerEvent(pod, containerSpec, containerID.ID, v1.EventTypeNormal, events.KillingContainer, message)
+	c.m.recordContainerEvent(pod, containerSpec, containerID.ID, v1.EventTypeNormal, events.KillingContainer, "%v", message)
 
 	if gracePeriodOverride != nil {
 		gracePeriod = *gracePeriodOverride

--- a/pkg/kubelet/kuberuntime/kuberuntime_container_lifecycle.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_lifecycle.go
@@ -1,0 +1,381 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kuberuntime
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	kubetypes "k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+	crierror "k8s.io/cri-api/pkg/errors"
+	"k8s.io/klog/v2"
+	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
+	"k8s.io/kubernetes/pkg/kubelet/events"
+	"k8s.io/kubernetes/pkg/kubelet/util/format"
+)
+
+// containerLifecycle manages the lifecycle of containers. It is responsible
+// for starting and terminating containers in a thread-safe manner.
+// containerLifecycle needs to serialize the start and termination operations
+// for each container as starting a container is a blocking operation, while
+// terminating a container is a non-blocking operation.
+type containerLifecycle struct {
+	// TODO: Remove dependency on kubeGenericRuntimeManager
+	m *kubeGenericRuntimeManager
+
+	lock         sync.Mutex
+	containerMap map[kubetypes.UID]map[string]*containerWorker
+}
+
+func newContainerLifecycle(m *kubeGenericRuntimeManager) *containerLifecycle {
+	return &containerLifecycle{
+		m:            m,
+		containerMap: make(map[kubetypes.UID]map[string]*containerWorker),
+	}
+}
+
+// startContainer starts a container in a blocking manner with a container
+// lock. It returns an error if the container is terminating or it failed to
+// start the container.
+func (cl *containerLifecycle) startContainer(ctx context.Context, podSandboxID string, podSandboxConfig *runtimeapi.PodSandboxConfig, spec *startSpec, pod *v1.Pod, podStatus *kubecontainer.PodStatus, pullSecrets []v1.Secret, podIP string, podIPs []string, imageVolumes kubecontainer.ImageVolumes) (string, error) {
+	c := cl.ensureContainer(pod.UID, spec.container.Name)
+
+	return c.startContainer(ctx, podSandboxID, podSandboxConfig, spec, pod, podStatus, pullSecrets, podIP, podIPs, imageVolumes)
+}
+
+// startContainerDuringPodTermination starts a container in a blocking manner
+// with a container lock even if the container is termination requested. It
+// returns an error if the container has stopped or it failed to start the
+// container.
+func (cl *containerLifecycle) startContainerDuringPodTermination(ctx context.Context, podSandboxID string, podSandboxConfig *runtimeapi.PodSandboxConfig, spec *startSpec, pod *v1.Pod, podStatus *kubecontainer.PodStatus, pullSecrets []v1.Secret, podIP string, podIPs []string, imageVolumes kubecontainer.ImageVolumes) (string, error) {
+	c := cl.ensureContainer(pod.UID, spec.container.Name)
+
+	return c.startContainerDuringPodTermination(ctx, podSandboxID, podSandboxConfig, spec, pod, podStatus, pullSecrets, podIP, podIPs, imageVolumes)
+}
+
+// requestTermination requests the termination of a container so that it can
+// terminate the container in a non-blocking manner.
+func (cl *containerLifecycle) requestTermination(pod *v1.Pod, containerID kubecontainer.ContainerID, containerName, message string, reason containerKillReason, gracePeriodOverride *int64, ordering *terminationOrdering) {
+	c := cl.ensureContainer(pod.UID, containerName)
+
+	c.requestTermination(pod, containerID, containerName, message, reason, gracePeriodOverride, ordering)
+}
+
+func (cl *containerLifecycle) isPodStopped(podUID kubetypes.UID) bool {
+	cl.lock.Lock()
+	defer cl.lock.Unlock()
+
+	containers, exists := cl.containerMap[podUID]
+	if !exists {
+		return true
+	}
+
+	for _, worker := range containers {
+		if !worker.isTerminated() {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (cl *containerLifecycle) removePodIfStopped(podUID kubetypes.UID) bool {
+	cl.lock.Lock()
+	defer cl.lock.Unlock()
+
+	containers, exists := cl.containerMap[podUID]
+	if !exists {
+		return true
+	}
+
+	for _, worker := range containers {
+		if !worker.isTerminated() {
+			return false
+		}
+	}
+
+	delete(cl.containerMap, podUID)
+	return true
+}
+
+// ensureContainer ensures the container worker for the given podUID and
+// containerName.
+// Note that this method is for internal use only.
+func (cl *containerLifecycle) ensureContainer(podUID kubetypes.UID, containerName string) *containerWorker {
+	cl.lock.Lock()
+	defer cl.lock.Unlock()
+
+	containers, exists := cl.containerMap[podUID]
+	if !exists {
+		cl.containerMap[podUID] = make(map[string]*containerWorker)
+		containers = cl.containerMap[podUID]
+	}
+
+	c, exists := containers[containerName]
+	if !exists {
+		containers[containerName] = &containerWorker{
+			m: cl.m,
+		}
+		c = containers[containerName]
+	}
+
+	return c
+}
+
+type containerPhase int
+
+const (
+	containerPhaseRunning containerPhase = iota
+	// containerPhaseTerminationRequested is a state that indicates the container
+	// is requested to terminate.
+	containerPhaseTerminationRequested
+	// containerPhaseStopping is a state that indicates the container is trying
+	// to terminate gracefully.
+	// The container worker must not restart the container from this state.
+	containerPhaseStopping
+	// containerPhaseTerminated is a state that indicates the container has
+	// terminated. The container worker should be removed from the container
+	// map before restarting the container.
+	containerPhaseTerminated
+)
+
+// containerWorker serializes the start and termination operations for a
+// container.
+type containerWorker struct {
+	// TODO: Remove dependency on kubeGenericRuntimeManager
+	m *kubeGenericRuntimeManager
+
+	// containerCh is a channel to pass the container termination request to the
+	// container worker.
+	containerCh chan containerTermination
+
+	// lock locks the container during the start operation and protects the
+	// fields below.
+	lock sync.Mutex
+
+	// phase of the container
+	phase containerPhase
+	// restartCh is a channel to notify the container worker to restart the
+	// terminating container.
+	restartCh chan struct{}
+	// should restart the container even if it is your turn to exit.
+	shouldRestart bool
+}
+
+type containerTermination struct {
+	containerID kubecontainer.ContainerID
+	restartCh   chan struct{}
+}
+
+func (c *containerWorker) startContainer(ctx context.Context, podSandboxID string, podSandboxConfig *runtimeapi.PodSandboxConfig, spec *startSpec, pod *v1.Pod, podStatus *kubecontainer.PodStatus, pullSecrets []v1.Secret, podIP string, podIPs []string, imageVolumes kubecontainer.ImageVolumes) (string, error) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	if c.phase >= containerPhaseTerminationRequested && c.phase < containerPhaseTerminated {
+		klog.V(3).InfoS("Container is terminating, should not start the container", "pod", klog.KObj(pod), "podUID", pod.UID, "containerName", spec.container.Name)
+		return "", fmt.Errorf("container %q is terminating", spec.container.Name)
+	}
+
+	c.phase = containerPhaseRunning
+
+	_, msg, err := c.m.startContainer(ctx, podSandboxID, podSandboxConfig, spec, pod, podStatus, pullSecrets, podIP, podIPs, imageVolumes)
+	return msg, err
+}
+
+func (c *containerWorker) startContainerDuringPodTermination(ctx context.Context, podSandboxID string, podSandboxConfig *runtimeapi.PodSandboxConfig, spec *startSpec, pod *v1.Pod, podStatus *kubecontainer.PodStatus, pullSecrets []v1.Secret, podIP string, podIPs []string, imageVolumes kubecontainer.ImageVolumes) (string, error) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	if c.phase >= containerPhaseStopping {
+		klog.V(3).InfoS("Container has stopped, should not restart the container", "pod", klog.KObj(pod), "podUID", pod.UID, "containerName", spec.container.Name)
+		return "", fmt.Errorf("container %q already has stopped", spec.container.Name)
+	}
+
+	containerID, msg, err := c.m.startContainer(ctx, podSandboxID, podSandboxConfig, spec, pod, podStatus, pullSecrets, podIP, podIPs, imageVolumes)
+	if err != nil {
+		return msg, err
+	}
+
+	if c.phase == containerPhaseTerminationRequested && c.restartCh != nil {
+		close(c.restartCh)
+		restartCh := make(chan struct{})
+		c.containerCh <- containerTermination{
+			containerID: containerID,
+			restartCh:   restartCh,
+		}
+		c.restartCh = restartCh
+		c.shouldRestart = true
+	}
+
+	return msg, nil
+}
+
+func (c *containerWorker) requestTermination(pod *v1.Pod, containerID kubecontainer.ContainerID, containerName, message string, reason containerKillReason, gracePeriodOverride *int64, ordering *terminationOrdering) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	if c.phase >= containerPhaseTerminationRequested {
+		klog.V(3).InfoS("Container termination worker already scheduled", "pod", klog.KObj(pod), "podUID", pod.UID, "containerName", containerName)
+		return
+	}
+	c.phase = containerPhaseTerminationRequested
+
+	// Note that exactly one containerTermination can be buffered in the
+	// channel to avoid deadlock.
+	c.containerCh = make(chan containerTermination, 1)
+	go func(ctx context.Context) {
+		defer utilruntime.HandleCrash()
+		klog.V(3).InfoS("Container termination worker has started", "pod", klog.KObj(pod), "podUID", pod.UID, "containerName", containerName)
+		defer klog.V(3).InfoS("Container termination worker has stopped", "pod", klog.KObj(pod), "podUID", pod.UID, "containerName", containerName)
+		defer close(c.containerCh)
+
+		c.terminationWorkerLoop(ctx, c.containerCh, pod, containerName, message, reason, gracePeriodOverride, ordering)
+	}(context.TODO())
+
+	restartCh := make(chan struct{})
+	c.containerCh <- containerTermination{
+		containerID: containerID,
+		restartCh:   restartCh,
+	}
+	c.restartCh = restartCh
+}
+
+func (c *containerWorker) terminationWorkerLoop(ctx context.Context, ch <-chan containerTermination, pod *v1.Pod, containerName, message string, reason containerKillReason, gracePeriodOverride *int64, ordering *terminationOrdering) {
+	defer func() {
+		c.lock.Lock()
+		defer c.lock.Unlock()
+		c.phase = containerPhaseTerminated
+	}()
+
+	start := time.Now()
+
+	for container := range c.containerCh {
+		// prepare for termination
+		containerID := container.containerID
+		gracePeriod, err := c.prepareForTermination(ctx, pod, containerID, containerName, message, reason, gracePeriodOverride)
+		if err != nil {
+			klog.ErrorS(err, "Failed to prepare to kill container", "pod", klog.KObj(pod), "podUID", pod.UID, "containerName", containerName, "containerID", containerID)
+			return
+		}
+		remainingGracePeriod := gracePeriod - int64(time.Since(start).Seconds())
+
+		if ordering != nil {
+			select {
+			case <-container.restartCh:
+				c.lock.Lock()
+				c.shouldRestart = false
+				c.lock.Unlock()
+				klog.V(3).InfoS("Container is restarting during the termination", "pod", klog.KObj(pod), "podUID", pod.UID, "containerName", containerName, "containerID", containerID)
+				continue
+			case <-ordering.waitForTurnCh(containerName, remainingGracePeriod):
+				c.lock.Lock()
+				// This is needed because the container may have been restarted
+				// before acquiring the lock.
+				if c.shouldRestart {
+					c.shouldRestart = false
+					c.lock.Unlock()
+					continue
+				}
+				c.phase = containerPhaseStopping
+				c.lock.Unlock()
+			}
+		}
+		// We cannot restart the container from here.
+		err = c.stopContainer(ctx, pod, containerID, containerName, remainingGracePeriod, ordering)
+		if err != nil {
+			klog.ErrorS(err, "Failed to kill container", "pod", klog.KObj(pod), "podUID", pod.UID, "containerName", containerName, "containerID", containerID)
+			return
+		}
+		return
+	}
+}
+
+// prepareForTermination prepares for the termination of a container and returns
+// the grace period to terminate the container.
+func (c *containerWorker) prepareForTermination(ctx context.Context, pod *v1.Pod, containerID kubecontainer.ContainerID, containerName string, message string, reason containerKillReason, gracePeriodOverride *int64) (int64, error) {
+	var containerSpec *v1.Container
+	if pod != nil {
+		if containerSpec = kubecontainer.GetContainerSpec(pod, containerName); containerSpec == nil {
+			return -1, fmt.Errorf("failed to get containerSpec %q (id=%q) in pod %q when killing container for reason %q",
+				containerName, containerID.String(), format.Pod(pod), message)
+		}
+	} else {
+		// Restore necessary information if one of the specs is nil.
+		restoredPod, restoredContainer, err := c.m.restoreSpecsFromContainerLabels(ctx, containerID)
+		if err != nil {
+			return -1, err
+		}
+		pod, containerSpec = restoredPod, restoredContainer
+	}
+
+	// From this point, pod and container must be non-nil.
+	gracePeriod := setTerminationGracePeriod(pod, containerSpec, containerName, containerID, reason)
+
+	if len(message) == 0 {
+		message = fmt.Sprintf("Stopping container %s", containerSpec.Name)
+	}
+	c.m.recordContainerEvent(pod, containerSpec, containerID.ID, v1.EventTypeNormal, events.KillingContainer, message)
+
+	if gracePeriodOverride != nil {
+		gracePeriod = *gracePeriodOverride
+		klog.V(3).InfoS("Terminating container with a grace period override", "pod", klog.KObj(pod), "podUID", pod.UID,
+			"containerName", containerName, "containerID", containerID.String(), "gracePeriod", gracePeriod)
+	}
+
+	// Run the pre-stop lifecycle hooks if applicable and if there is enough time to run it
+	if containerSpec.Lifecycle != nil && containerSpec.Lifecycle.PreStop != nil && gracePeriod > 0 {
+		c.m.executePreStopHook(ctx, pod, containerID, containerSpec, gracePeriod)
+	}
+
+	return gracePeriod, nil
+}
+
+func (c *containerWorker) stopContainer(ctx context.Context, pod *v1.Pod, containerID kubecontainer.ContainerID, containerName string, gracePeriod int64, ordering *terminationOrdering) error {
+	// always give containers a minimal shutdown window to avoid unnecessary SIGKILLs
+	if gracePeriod < minimumGracePeriodInSeconds {
+		gracePeriod = minimumGracePeriodInSeconds
+	}
+
+	klog.V(2).InfoS("Stopping container with a grace period", "pod", klog.KObj(pod), "podUID", pod.UID,
+		"containerName", containerName, "containerID", containerID.String(), "gracePeriod", gracePeriod)
+
+	err := c.m.runtimeService.StopContainer(ctx, containerID.ID, gracePeriod)
+	if err != nil && !crierror.IsNotFound(err) {
+		klog.ErrorS(err, "Container termination failed with gracePeriod", "pod", klog.KObj(pod), "podUID", pod.UID,
+			"containerName", containerName, "containerID", containerID.String(), "gracePeriod", gracePeriod)
+		return err
+	}
+	klog.V(3).InfoS("Container exited normally", "pod", klog.KObj(pod), "podUID", pod.UID,
+		"containerName", containerName, "containerID", containerID.String())
+
+	if ordering != nil {
+		ordering.containerTerminated(containerName)
+	}
+
+	return nil
+}
+
+func (c *containerWorker) isTerminated() bool {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	return c.phase == containerPhaseTerminated
+}

--- a/pkg/kubelet/kuberuntime/kuberuntime_container_lifecycle.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_lifecycle.go
@@ -74,7 +74,7 @@ func (cl *containerLifecycle) startContainerDuringPodTermination(ctx context.Con
 
 // requestTermination requests the termination of a container so that it can
 // terminate the container in a non-blocking manner.
-func (cl *containerLifecycle) requestTermination(pod *v1.Pod, containerID kubecontainer.ContainerID, containerName, message string, reason containerKillReason, gracePeriodOverride *int64, ordering *terminationOrdering) {
+func (cl *containerLifecycle) requestTermination(pod *v1.Pod, containerID kubecontainer.ContainerID, containerName, message string, reason kubecontainer.ContainerKillReason, gracePeriodOverride *int64, ordering *terminationOrdering) {
 	c := cl.ensureContainer(pod.UID, containerName)
 
 	c.requestTermination(pod, containerID, containerName, message, reason, gracePeriodOverride, ordering)
@@ -229,7 +229,7 @@ func (c *containerWorker) startContainerDuringPodTermination(ctx context.Context
 	return msg, nil
 }
 
-func (c *containerWorker) requestTermination(pod *v1.Pod, containerID kubecontainer.ContainerID, containerName, message string, reason containerKillReason, gracePeriodOverride *int64, ordering *terminationOrdering) {
+func (c *containerWorker) requestTermination(pod *v1.Pod, containerID kubecontainer.ContainerID, containerName, message string, reason kubecontainer.ContainerKillReason, gracePeriodOverride *int64, ordering *terminationOrdering) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
@@ -259,7 +259,7 @@ func (c *containerWorker) requestTermination(pod *v1.Pod, containerID kubecontai
 	c.restartCh = restartCh
 }
 
-func (c *containerWorker) terminationWorkerLoop(ctx context.Context, ch <-chan containerTermination, pod *v1.Pod, containerName, message string, reason containerKillReason, gracePeriodOverride *int64, ordering *terminationOrdering) {
+func (c *containerWorker) terminationWorkerLoop(ctx context.Context, ch <-chan containerTermination, pod *v1.Pod, containerName, message string, reason kubecontainer.ContainerKillReason, gracePeriodOverride *int64, ordering *terminationOrdering) {
 	defer func() {
 		c.lock.Lock()
 		defer c.lock.Unlock()
@@ -311,7 +311,7 @@ func (c *containerWorker) terminationWorkerLoop(ctx context.Context, ch <-chan c
 
 // prepareForTermination prepares for the termination of a container and returns
 // the grace period to terminate the container.
-func (c *containerWorker) prepareForTermination(ctx context.Context, pod *v1.Pod, containerID kubecontainer.ContainerID, containerName string, message string, reason containerKillReason, gracePeriodOverride *int64) (int64, error) {
+func (c *containerWorker) prepareForTermination(ctx context.Context, pod *v1.Pod, containerID kubecontainer.ContainerID, containerName string, message string, reason kubecontainer.ContainerKillReason, gracePeriodOverride *int64) (int64, error) {
 	var containerSpec *v1.Container
 	if pod != nil {
 		if containerSpec = kubecontainer.GetContainerSpec(pod, containerName); containerSpec == nil {

--- a/pkg/kubelet/kuberuntime/kuberuntime_container_lifecycle_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_lifecycle_test.go
@@ -1,0 +1,287 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kuberuntime
+
+import (
+	"context"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/flowcontrol"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+	apitest "k8s.io/cri-api/pkg/apis/testing"
+	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
+	"k8s.io/utils/ptr"
+)
+
+func stringSliceContains(slice []string, s string) bool {
+	for _, v := range slice {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}
+
+func TestSyncTerminatingPod(t *testing.T) {
+	testCases := []struct {
+		desc  string
+		pod   *v1.Pod
+		setup func(*testing.T, *apitest.FakeRuntimeService)
+
+		extraTest func(*testing.T, *apitest.FakeRuntimeService)
+
+		expectedNumStoppedContainers int
+		expectedTerminationOrder     []string
+	}{
+		{
+			desc: "pod with 2 containers and 1 ephemeral container",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					UID:       "12345678",
+					Name:      "foo",
+					Namespace: "new",
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name:  "foo1",
+							Image: "busybox",
+						},
+						{
+							Name:  "foo2",
+							Image: "busybox",
+						},
+					},
+					EphemeralContainers: []v1.EphemeralContainer{
+						{
+							EphemeralContainerCommon: v1.EphemeralContainerCommon{
+								Name:  "debug",
+								Image: "busybox",
+							},
+						},
+					},
+					TerminationGracePeriodSeconds: ptr.To(int64(30)),
+				},
+			},
+			expectedNumStoppedContainers: 3,
+		},
+		{
+			desc: "pod with 1 containers and 3 restartable init containers",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					UID:       "12345678",
+					Name:      "foo",
+					Namespace: "new",
+				},
+				Spec: v1.PodSpec{
+					InitContainers: []v1.Container{
+						{
+							Name:          "restartable-init1",
+							Image:         "busybox",
+							RestartPolicy: ptr.To(v1.ContainerRestartPolicyAlways),
+						},
+						{
+							Name:          "restartable-init2",
+							Image:         "busybox",
+							RestartPolicy: ptr.To(v1.ContainerRestartPolicyAlways),
+						},
+						{
+							Name:          "restartable-init3",
+							Image:         "busybox",
+							RestartPolicy: ptr.To(v1.ContainerRestartPolicyAlways),
+						},
+					},
+					Containers: []v1.Container{
+						{
+							Name:  "foo1",
+							Image: "busybox",
+						},
+					},
+					TerminationGracePeriodSeconds: ptr.To(int64(30)),
+				},
+			},
+			expectedNumStoppedContainers: 4,
+			expectedTerminationOrder: []string{
+				"foo1",
+				"restartable-init3",
+				"restartable-init2",
+				"restartable-init1",
+			},
+		},
+		{
+			desc: "pod with a slowly terminating container and 2 restartable init containers",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					UID:       "12345678",
+					Name:      "foo",
+					Namespace: "new",
+				},
+				Spec: v1.PodSpec{
+					InitContainers: []v1.Container{
+						{
+							Name:            "restartable-init1",
+							Image:           "busybox",
+							RestartPolicy:   ptr.To(v1.ContainerRestartPolicyAlways),
+							ImagePullPolicy: v1.PullIfNotPresent,
+						},
+						{
+							Name:          "restartable-init2",
+							Image:         "busybox",
+							RestartPolicy: ptr.To(v1.ContainerRestartPolicyAlways),
+						},
+					},
+					Containers: []v1.Container{
+						{
+							Name:  "foo1",
+							Image: "busybox",
+						},
+					},
+					TerminationGracePeriodSeconds: ptr.To(int64(30)),
+				},
+			},
+			setup: func(t *testing.T, fakeRuntime *apitest.FakeRuntimeService) {
+				// assume that the regular container takes 5 seconds to stop
+				for _, c := range fakeRuntime.Containers {
+					if c.Metadata.Name == "foo1" {
+						c.TerminationDuration = 3 * time.Second
+					}
+				}
+				t.Logf("A restartable init container %q is crashed for some reason", "restartable-init1")
+				for _, c := range fakeRuntime.Containers {
+					if c.Metadata.Name == "restartable-init1" {
+						c.State = runtimeapi.ContainerState_CONTAINER_EXITED
+					}
+				}
+			},
+			extraTest: func(t *testing.T, fakeRuntime *apitest.FakeRuntimeService) {
+				t.Logf("Check the restartable init containers restart during the pod termination due to the slow termination of the main container")
+				assert.True(t, stringSliceContains(fakeRuntime.Called, "CreateContainer"))
+				assert.True(t, stringSliceContains(fakeRuntime.Called, "StartContainer"))
+			},
+			expectedNumStoppedContainers: 4,
+			expectedTerminationOrder: []string{
+				"restartable-init1",
+				"foo1",
+				"restartable-init2",
+				"restartable-init1",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			ctx := context.Background()
+			fakeRuntime, _, m, err := createTestRuntimeManager()
+			require.NoError(t, err)
+
+			// Set fake sandbox and fake containers to fakeRuntime.
+			fakeSandbox, _ := makeAndSetFakePod(t, m, fakeRuntime, tc.pod)
+
+			if tc.setup != nil {
+				fakeRuntime.Lock()
+				tc.setup(t, fakeRuntime)
+				fakeRuntime.Unlock()
+			}
+
+			backoff := flowcontrol.NewBackOff(time.Second, time.Minute)
+
+			t.Log("Waiting for the pod to be stopped")
+			for {
+				// Convert the fakeContainers to kubecontainer.Container
+				fakeRuntime.Lock()
+				containers := make([]*kubecontainer.Status, 0, len(fakeRuntime.Containers))
+				for id, c := range fakeRuntime.Containers {
+					containers = append(containers, &kubecontainer.Status{
+						ID: kubecontainer.ContainerID{
+							ID: id,
+						},
+						Name:  c.Metadata.Name,
+						State: toKubeContainerState(c.State),
+						// convert int64 to time.Time
+						CreatedAt:  time.Unix(0, c.CreatedAt),
+						FinishedAt: time.Unix(0, c.FinishedAt),
+						Image:      c.Image.Image,
+						ImageRef:   c.ImageRef,
+					})
+				}
+				fakeRuntime.Unlock()
+
+				sort.Slice(containers, func(i, j int) bool {
+					// Sort containers by creation time in descending order
+					return containers[i].CreatedAt.After(containers[j].CreatedAt)
+				})
+
+				podStatus := &kubecontainer.PodStatus{
+					ID:                tc.pod.UID,
+					Name:              tc.pod.Name,
+					Namespace:         tc.pod.Namespace,
+					ContainerStatuses: containers,
+					SandboxStatuses: []*runtimeapi.PodSandboxStatus{
+						&fakeSandbox.PodSandboxStatus,
+					},
+				}
+
+				stopped, err := m.SyncTerminatingPod(ctx, tc.pod, podStatus, nil, []v1.Secret{}, backoff, true)
+				require.NoError(t, err)
+				if stopped {
+					break
+				}
+				time.Sleep(100 * time.Millisecond)
+			}
+
+			t.Log("Check all containers and sandboxes are stopped")
+			assert.Len(t, fakeRuntime.Containers, tc.expectedNumStoppedContainers)
+			assert.Len(t, fakeRuntime.Sandboxes, 1)
+			for _, sandbox := range fakeRuntime.Sandboxes {
+				assert.Equal(t, runtimeapi.PodSandboxState_SANDBOX_NOTREADY, sandbox.State)
+			}
+			for _, c := range fakeRuntime.Containers {
+				assert.Equal(t, runtimeapi.ContainerState_CONTAINER_EXITED, c.State, "unexpected container state, container: %v", c.Metadata.Name)
+			}
+
+			t.Log("Sort containers by finishedAt to check termination order")
+			sortedContainers := make([]*apitest.FakeContainer, 0, len(fakeRuntime.Containers))
+			for _, c := range fakeRuntime.Containers {
+				sortedContainers = append(sortedContainers, c)
+			}
+			sort.Slice(sortedContainers, func(i, j int) bool {
+				return sortedContainers[i].FinishedAt < sortedContainers[j].FinishedAt
+			})
+			for i, c := range sortedContainers {
+				t.Logf("container %d: %s, finishedAt: %v", i, c.Metadata.Name, c.FinishedAt)
+			}
+
+			t.Log("Check all containers terminated in the right order")
+			if len(tc.expectedTerminationOrder) != 0 {
+				assert.Equal(t, len(tc.expectedTerminationOrder), len(sortedContainers))
+				for i, c := range sortedContainers {
+					assert.Equal(t, tc.expectedTerminationOrder[i], c.Metadata.Name, "unexpected container termination order: index: %d", i)
+				}
+			}
+
+			if tc.extraTest != nil {
+				tc.extraTest(t, fakeRuntime)
+			}
+		})
+	}
+}

--- a/pkg/kubelet/kuberuntime/kuberuntime_container_lifecycle_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_lifecycle_test.go
@@ -285,3 +285,56 @@ func TestSyncTerminatingPod(t *testing.T) {
 		})
 	}
 }
+
+func TestSyncTerminatingPod_PendingPod(t *testing.T) {
+	ctx := context.Background()
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:       "12345678",
+			Name:      "foo",
+			Namespace: "new",
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name:  "foo1",
+					Image: "non-existing",
+				},
+				{
+					Name:  "foo2",
+					Image: "non-existing",
+				},
+			},
+			TerminationGracePeriodSeconds: ptr.To(int64(30)),
+		},
+	}
+
+	fakeRuntime, _, m, err := createTestRuntimeManager()
+	require.NoError(t, err)
+
+	sandbox := makeFakePodSandbox(t, m, sandboxTemplate{
+		pod:       pod,
+		createdAt: fakeCreatedAt,
+		state:     runtimeapi.PodSandboxState_SANDBOX_READY,
+	})
+	fakeRuntime.SetFakeSandboxes([]*apitest.FakePodSandbox{sandbox})
+
+	stopped, err := m.SyncTerminatingPod(ctx, pod, &kubecontainer.PodStatus{
+		ID:        pod.UID,
+		Name:      pod.Name,
+		Namespace: pod.Namespace,
+		// Assume the containers could not be created
+		ContainerStatuses: []*kubecontainer.Status{},
+		SandboxStatuses: []*runtimeapi.PodSandboxStatus{
+			&sandbox.PodSandboxStatus,
+		},
+	}, nil, []v1.Secret{}, flowcontrol.NewBackOff(time.Second, time.Minute), true)
+	require.NoError(t, err)
+	assert.True(t, stopped)
+
+	t.Log("Check all sandboxes are stopped")
+	assert.Len(t, fakeRuntime.Sandboxes, 1)
+	for _, sandbox := range fakeRuntime.Sandboxes {
+		assert.Equal(t, runtimeapi.PodSandboxState_SANDBOX_NOTREADY, sandbox.State)
+	}
+}

--- a/pkg/kubelet/kuberuntime/kuberuntime_container_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_test.go
@@ -570,7 +570,7 @@ func testLifeCycleHook(t *testing.T, testPod *v1.Pod, testContainer *v1.Containe
 		}
 
 		// Now try to create a container, which should in turn invoke PostStart Hook
-		_, err := m.startContainer(ctx, fakeSandBox.Id, fakeSandBoxConfig, containerStartSpec(testContainer), testPod, fakePodStatus, nil, "", []string{}, nil)
+		_, _, err := m.startContainer(ctx, fakeSandBox.Id, fakeSandBoxConfig, containerStartSpec(testContainer), testPod, fakePodStatus, nil, "", []string{}, nil)
 		if err != nil {
 			t.Errorf("startContainer error =%v", err)
 		}

--- a/pkg/kubelet/kuberuntime/kuberuntime_container_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_test.go
@@ -778,7 +778,7 @@ func TestKillContainerGracePeriod(t *testing.T) {
 	tests := []struct {
 		name                string
 		pod                 *v1.Pod
-		reason              containerKillReason
+		reason              kubecontainer.ContainerKillReason
 		expectedGracePeriod int64
 	}{
 		{
@@ -786,7 +786,7 @@ func TestKillContainerGracePeriod(t *testing.T) {
 			pod: &v1.Pod{
 				Spec: v1.PodSpec{Containers: []v1.Container{{Name: "foo"}}},
 			},
-			reason:              reasonUnknown,
+			reason:              kubecontainer.ReasonUnknown,
 			expectedGracePeriod: int64(2),
 		},
 		{
@@ -797,7 +797,7 @@ func TestKillContainerGracePeriod(t *testing.T) {
 					TerminationGracePeriodSeconds: &longGracePeriod,
 				},
 			},
-			reason:              reasonUnknown,
+			reason:              kubecontainer.ReasonUnknown,
 			expectedGracePeriod: longGracePeriod,
 		},
 		{
@@ -810,7 +810,7 @@ func TestKillContainerGracePeriod(t *testing.T) {
 					TerminationGracePeriodSeconds: &longGracePeriod,
 				},
 			},
-			reason:              reasonLivenessProbe,
+			reason:              kubecontainer.ReasonLivenessProbe,
 			expectedGracePeriod: shortGracePeriod,
 		},
 		{
@@ -823,7 +823,7 @@ func TestKillContainerGracePeriod(t *testing.T) {
 					TerminationGracePeriodSeconds: &longGracePeriod,
 				},
 			},
-			reason:              reasonStartupProbe,
+			reason:              kubecontainer.ReasonStartupProbe,
 			expectedGracePeriod: shortGracePeriod,
 		},
 		{
@@ -836,7 +836,7 @@ func TestKillContainerGracePeriod(t *testing.T) {
 					TerminationGracePeriodSeconds: &shortGracePeriod,
 				},
 			},
-			reason:              reasonStartupProbe,
+			reason:              kubecontainer.ReasonStartupProbe,
 			expectedGracePeriod: longGracePeriod,
 		},
 		{
@@ -849,7 +849,7 @@ func TestKillContainerGracePeriod(t *testing.T) {
 					TerminationGracePeriodSeconds: &shortGracePeriod,
 				},
 			},
-			reason:              reasonLivenessProbe,
+			reason:              kubecontainer.ReasonLivenessProbe,
 			expectedGracePeriod: longGracePeriod,
 		},
 		{
@@ -862,7 +862,7 @@ func TestKillContainerGracePeriod(t *testing.T) {
 					TerminationGracePeriodSeconds: &longGracePeriod,
 				},
 			},
-			reason:              reasonUnknown,
+			reason:              kubecontainer.ReasonUnknown,
 			expectedGracePeriod: longGracePeriod,
 		},
 		{
@@ -875,7 +875,7 @@ func TestKillContainerGracePeriod(t *testing.T) {
 					TerminationGracePeriodSeconds: &longGracePeriod,
 				},
 			},
-			reason:              reasonUnknown,
+			reason:              kubecontainer.ReasonUnknown,
 			expectedGracePeriod: longGracePeriod,
 		},
 		{
@@ -890,7 +890,7 @@ func TestKillContainerGracePeriod(t *testing.T) {
 					TerminationGracePeriodSeconds: &longGracePeriod,
 				},
 			},
-			reason:              reasonUnknown,
+			reason:              kubecontainer.ReasonUnknown,
 			expectedGracePeriod: longGracePeriod,
 		},
 		{
@@ -905,7 +905,7 @@ func TestKillContainerGracePeriod(t *testing.T) {
 					TerminationGracePeriodSeconds: &longGracePeriod,
 				},
 			},
-			reason:              reasonStartupProbe,
+			reason:              kubecontainer.ReasonStartupProbe,
 			expectedGracePeriod: shortGracePeriod,
 		},
 		{
@@ -920,7 +920,7 @@ func TestKillContainerGracePeriod(t *testing.T) {
 					TerminationGracePeriodSeconds: &longGracePeriod,
 				},
 			},
-			reason:              reasonLivenessProbe,
+			reason:              kubecontainer.ReasonLivenessProbe,
 			expectedGracePeriod: mediumGracePeriod,
 		},
 	}

--- a/pkg/kubelet/kuberuntime/kuberuntime_gc.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_gc.go
@@ -141,7 +141,7 @@ func (cgc *containerGC) removeOldestN(ctx context.Context, containers []containe
 				ID:   containers[i].id,
 			}
 			message := "Container is in unknown state, try killing it before removal"
-			if err := cgc.manager.killContainer(ctx, nil, id, containers[i].name, message, reasonUnknown, nil, nil); err != nil {
+			if err := cgc.manager.killContainer(ctx, nil, id, containers[i].name, message, kubecontainer.ReasonUnknown, nil, nil); err != nil {
 				klog.ErrorS(err, "Failed to stop container", "containerID", containers[i].id)
 				continue
 			}

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -1701,6 +1701,11 @@ func (m *kubeGenericRuntimeManager) syncTerminatingContainers(ctx context.Contex
 		return true, nil
 	}
 
+	if len(actions.containerIDsToKill) == 0 {
+		klog.V(3).InfoS("No containers to kill for pod", "pod", klog.KObj(pod))
+		return true, nil
+	}
+
 	var termOrdering *terminationOrdering
 	// we only care about container termination ordering if the sidecars feature is enabled
 	if utilfeature.DefaultFeatureGate.Enabled(features.SidecarContainers) {

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -481,16 +481,6 @@ func (m *kubeGenericRuntimeManager) GetPods(ctx context.Context, all bool) ([]*k
 	return result, nil
 }
 
-// containerKillReason explains what killed a given container
-type containerKillReason string
-
-const (
-	reasonStartupProbe        containerKillReason = "StartupProbe"
-	reasonLivenessProbe       containerKillReason = "LivenessProbe"
-	reasonFailedPostStartHook containerKillReason = "FailedPostStartHook"
-	reasonUnknown             containerKillReason = "Unknown"
-)
-
 // containerToKillInfo contains necessary information to kill a container.
 type containerToKillInfo struct {
 	// The spec of the container.
@@ -501,7 +491,7 @@ type containerToKillInfo struct {
 	message string
 	// The reason is a clearer source of info on why a container will be killed
 	// TODO: replace message with reason?
-	reason containerKillReason
+	reason kubecontainer.ContainerKillReason
 }
 
 // containerResources holds the set of resources applicable to the running container
@@ -1032,7 +1022,7 @@ func (m *kubeGenericRuntimeManager) computePodActions(ctx context.Context, pod *
 							container: next,
 							message: fmt.Sprintf("Init container is in %q state, try killing it before restart",
 								initLastStatus.State),
-							reason: reasonUnknown,
+							reason: kubecontainer.ReasonUnknown,
 						}
 					}
 					changes.NextInitContainerToStart = next
@@ -1082,7 +1072,7 @@ func (m *kubeGenericRuntimeManager) computePodActions(ctx context.Context, pod *
 						container: &pod.Spec.Containers[idx],
 						message: fmt.Sprintf("Container is in %q state, try killing it before restart",
 							containerStatus.State),
-						reason: reasonUnknown,
+						reason: kubecontainer.ReasonUnknown,
 					}
 				}
 			}
@@ -1090,7 +1080,7 @@ func (m *kubeGenericRuntimeManager) computePodActions(ctx context.Context, pod *
 		}
 		// The container is running, but kill the container if any of the following condition is met.
 		var message string
-		var reason containerKillReason
+		var reason kubecontainer.ContainerKillReason
 		restart := shouldRestartOnFailure(pod)
 		if _, _, changed := containerChanged(&container, containerStatus); changed {
 			message = fmt.Sprintf("Container %s definition changed", container.Name)
@@ -1100,11 +1090,11 @@ func (m *kubeGenericRuntimeManager) computePodActions(ctx context.Context, pod *
 		} else if liveness, found := m.livenessManager.Get(containerStatus.ID); found && liveness == proberesults.Failure {
 			// If the container failed the liveness probe, we should kill it.
 			message = fmt.Sprintf("Container %s failed liveness probe", container.Name)
-			reason = reasonLivenessProbe
+			reason = kubecontainer.ReasonLivenessProbe
 		} else if startup, found := m.startupManager.Get(containerStatus.ID); found && startup == proberesults.Failure {
 			// If the container failed the startup probe, we should kill it.
 			message = fmt.Sprintf("Container %s failed startup probe", container.Name)
-			reason = reasonStartupProbe
+			reason = kubecontainer.ReasonStartupProbe
 		} else if !m.computePodResizeAction(pod, idx, false, containerStatus, &changes) {
 			// computePodResizeAction updates 'changes' if resize policy requires restarting this container
 			continue
@@ -1717,7 +1707,7 @@ func (m *kubeGenericRuntimeManager) syncTerminatingContainers(ctx context.Contex
 	}
 
 	for cName, containerID := range actions.containerIDsToKill {
-		m.containerLifecycle.requestTermination(pod, containerID, cName, "", reasonUnknown, gracePeriodOverride, termOrdering)
+		m.containerLifecycle.requestTermination(pod, containerID, cName, "", kubecontainer.ReasonUnknown, gracePeriodOverride, termOrdering)
 	}
 
 	var stopped bool

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -1205,6 +1205,12 @@
     lockToDefault: false
     preRelease: Alpha
     version: "1.31"
+- name: RestartContainerDuringTermination
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.33"
 - name: RetryGenerateName
   versionedSpecs:
   - default: false

--- a/test/e2e/feature/feature.go
+++ b/test/e2e/feature/feature.go
@@ -429,6 +429,11 @@ var (
 	ResourceHealthStatus = framework.WithFeature(framework.ValidFeatures.Add("ResourceHealthStatus"))
 
 	// Owner: sig-node
+	// KEP 4438
+	// KEP 753 (SidecarContainers)
+	RestartContainerDuringTermination = framework.WithFeature(framework.ValidFeatures.Add("RestartContaineDuringTermination"))
+
+	// Owner: sig-node
 	// Runtime Handler
 	RuntimeHandler = framework.WithFeature(framework.ValidFeatures.Add("RuntimeHandler"))
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #121398 

TODOs
- [ ] fix e2e tests of https://github.com/kubernetes/kubernetes/pull/124086/files
- [x] fix `Should transition to Failed phase a pod which is deleted while pending`
- [ ] Liveness, readiness, and startup probing
- [x] container lifecycle hooks running
- [ ] secret and configmap volume updates

This manages container termination in a non-blocking way.
xref:
- https://github.com/kubernetes/kubernetes/pull/121412
- https://github.com/kubernetes/enhancements/issues/4438
- https://github.com/kubernetes/enhancements/issues/753
- https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/4438-container-restart-termination- 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
The new feature gate "RestartContainerDuringTermination" is now available. The feature allows containers to restart during another container's termination or pod termination.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/4438-container-restart-termination
```

/uncc all