### PR TITLE
KEP-4222: Remove temporary mechanism for skipping CBOR tests.

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/cbor/internal/modes/appendixa_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/cbor/internal/modes/appendixa_test.go
@@ -69,10 +69,6 @@ func TestAppendixA(t *testing.T) {
 		reject  string   // reason the decoder rejects the example
 		encoded []byte   // re-encoded object (only if different from example encoding)
 		reasons []string // reasons for re-encode difference
-
-		// TODO: The cases with nonempty fixme are known to be not working and fixing them
-		// is an alpha criteria. They're present and skipped for visibility.
-		fixme string
 	}{
 		{
 			example: hex("00"),
@@ -558,10 +554,6 @@ func TestAppendixA(t *testing.T) {
 		},
 	} {
 		t.Run(fmt.Sprintf("%x", tc.example), func(t *testing.T) {
-			if tc.fixme != "" {
-				t.Skip(tc.fixme) // TODO: Remove once all cases are fixed.
-			}
-
 			var decoded interface{}
 			err := modes.Decode.Unmarshal(tc.example, &decoded)
 			if err != nil {

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/cbor/internal/modes/decode_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/cbor/internal/modes/decode_test.go
@@ -45,11 +45,6 @@ func TestDecode(t *testing.T) {
 		into          interface{} // prototype for concrete destination type. if nil, decode into empty interface value.
 		want          interface{}
 		assertOnError func(t *testing.T, e error)
-
-		// TODO: Some failing test cases are included for completeness. The next library
-		// minor version should allow them all to be fixed. In the meantime, this field
-		// explains the behavior reason for a particular failure.
-		fixme string
 	}
 
 	// Test cases are grouped by the kind of the CBOR data item being decoded, as enumerated in
@@ -70,13 +65,6 @@ func TestDecode(t *testing.T) {
 						}
 
 						t.Run(fmt.Sprintf("%s/mode=%s", test.name, modeName), func(t *testing.T) {
-							if test.fixme != "" {
-								// TODO: Remove this along with the
-								// fixme field when the last skipped
-								// test case is passing.
-								t.Skip(test.fixme)
-							}
-
 							var dst reflect.Value
 							if test.into == nil {
 								var i interface{}


### PR DESCRIPTION
The CBOR decode and "appendix a" unit tests cover specific serialization behaviors that were known to be incomplete at the time. Now that all of those cases have been addressed, the mechanism for skipping those tests can be removed.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup
/sig api-machinery

#### What this PR does / why we need it:

The CBOR decode and "appendix a" unit tests cover specific serialization behaviors that were known
to be incomplete at the time. Now that all of those cases have been addressed, the mechanism for
skipping those tests can be removed.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://kep.k8s.io/4222
```
