### PR TITLE
Revert "apiserver/storage/cacher: consistent read from cache supports limit"

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
@@ -201,6 +201,7 @@ func TestGetListCacheBypass(t *testing.T) {
 		{opts: storage.ListOptions{ResourceVersion: "0", Predicate: storage.SelectionPredicate{Continue: "a"}}, expectBypass: true},
 		{opts: storage.ListOptions{ResourceVersion: "1", Predicate: storage.SelectionPredicate{Continue: "a"}}, expectBypass: true},
 
+		{opts: storage.ListOptions{ResourceVersion: "", Predicate: storage.SelectionPredicate{Limit: 500}}, expectBypass: true},
 		{opts: storage.ListOptions{ResourceVersion: "0", Predicate: storage.SelectionPredicate{Limit: 500}}, expectBypass: false},
 		{opts: storage.ListOptions{ResourceVersion: "1", Predicate: storage.SelectionPredicate{Limit: 500}}, expectBypass: true},
 
@@ -213,7 +214,6 @@ func TestGetListCacheBypass(t *testing.T) {
 		featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ConsistentListFromCache, false)
 		testCases := append(commonTestCases,
 			testCase{opts: storage.ListOptions{ResourceVersion: ""}, expectBypass: true},
-			testCase{opts: storage.ListOptions{ResourceVersion: "", Predicate: storage.SelectionPredicate{Limit: 500}}, expectBypass: true},
 		)
 		for _, tc := range testCases {
 			testGetListCacheBypass(t, tc.opts, tc.expectBypass)
@@ -233,7 +233,6 @@ func TestGetListCacheBypass(t *testing.T) {
 
 		testCases := append(commonTestCases,
 			testCase{opts: storage.ListOptions{ResourceVersion: ""}, expectBypass: false},
-			testCase{opts: storage.ListOptions{ResourceVersion: "", Predicate: storage.SelectionPredicate{Limit: 500}}, expectBypass: false},
 		)
 		for _, tc := range testCases {
 			testGetListCacheBypass(t, tc.opts, tc.expectBypass)
@@ -2562,63 +2561,6 @@ func TestWatchStreamSeparation(t *testing.T) {
 			cacherGotBookmark := watchCacheResourceVersion == lastResourceVersion
 			if cacherGotBookmark != tc.expectBookmarkOnWatchCache {
 				t.Errorf("Unexpected watch cache bookmark check result, rv: %d, lastRV: %d, wantMatching: %v", watchCacheResourceVersion, lastResourceVersion, tc.expectBookmarkOnWatchCache)
-			}
-		})
-	}
-}
-
-func TestComputeListLimit(t *testing.T) {
-	scenarios := []struct {
-		name          string
-		opts          storage.ListOptions
-		expectedLimit int64
-	}{
-		{
-			name: "limit is zero",
-			opts: storage.ListOptions{
-				Predicate: storage.SelectionPredicate{
-					Limit: 0,
-				},
-			},
-			expectedLimit: 0,
-		},
-		{
-			name: "limit is positive, RV is unset",
-			opts: storage.ListOptions{
-				Predicate: storage.SelectionPredicate{
-					Limit: 1,
-				},
-				ResourceVersion: "",
-			},
-			expectedLimit: 1,
-		},
-		{
-			name: "limit is positive, RV = 100",
-			opts: storage.ListOptions{
-				Predicate: storage.SelectionPredicate{
-					Limit: 1,
-				},
-				ResourceVersion: "100",
-			},
-			expectedLimit: 1,
-		},
-		{
-			name: "legacy case: limit is positive, RV = 0",
-			opts: storage.ListOptions{
-				Predicate: storage.SelectionPredicate{
-					Limit: 1,
-				},
-				ResourceVersion: "0",
-			},
-			expectedLimit: 0,
-		},
-	}
-
-	for _, scenario := range scenarios {
-		t.Run(scenario.name, func(t *testing.T) {
-			actualLimit := computeListLimit(scenario.opts)
-			if actualLimit != scenario.expectedLimit {
-				t.Errorf("computeListLimit returned = %v, expected %v", actualLimit, scenario.expectedLimit)
 			}
 		})
 	}


### PR DESCRIPTION
Reverts kubernetes/kubernetes#125405

It flakes a lot. Can we revert https://github.com/kubernetes/kubernetes/pull/125405 as it blocked some PR merge today?

See https://testgrid.k8s.io/sig-release-master-blocking#ci-kubernetes-unit as well. Flake rate is ~30%+.

See https://github.com/kubernetes/kubernetes/issues/125688

/cc @p0lyn0mial @wojtek-t 
/assign @aojea @liggitt 

