### PR TITLE
chore: add DefaultSelector method ut

### DIFF
--- a/pkg/scheduler/framework/plugins/helper/spread_test.go
+++ b/pkg/scheduler/framework/plugins/helper/spread_test.go
@@ -22,8 +22,10 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
 	st "k8s.io/kubernetes/pkg/scheduler/testing"
@@ -96,6 +98,172 @@ func TestGetPodServices(t *testing.T) {
 			} else if diff := cmp.Diff(test.expect, get); diff != "" {
 				t.Errorf("Unexpected services (-want, +got):\n%s", diff)
 			}
+		})
+	}
+}
+
+func TestDefaultSelector(t *testing.T) {
+	const (
+		namespace                 = "test"
+		podName                   = "test-pod"
+		serviceName               = "test-service"
+		replicaSetName            = "test-replicaset"
+		replicationControllerName = "test-replicationcontroller"
+		statefulSetName           = "test-statefulset"
+
+		podLabelKey = "podLabelKey"
+		podLabelVal = "podLabelVal"
+
+		replicaSetLabelKey = "replicaSetLabelKey"
+		replicaSetLabelVal = "replicaSetLabelVal"
+
+		replicationLabelKey = "replicationLabelKey"
+		replicationLabelVal = "replicationLabelVal"
+
+		statefulSetLabelKey = "statefulSetLabelKey"
+		statefulSetLabelVal = "statefulSetLabelVal"
+	)
+
+	fakeInformerFactory := informers.NewSharedInformerFactory(&fake.Clientset{}, 0*time.Second)
+
+	// Create fake service
+	addFakeService := func() error {
+		// Create fake service
+		service := &v1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      serviceName,
+				Namespace: namespace,
+			},
+			Spec: v1.ServiceSpec{
+				Selector: map[string]string{
+					podLabelKey: podLabelVal,
+				},
+			},
+		}
+		return fakeInformerFactory.Core().V1().Services().Informer().GetStore().Add(service)
+	}
+
+	// Create fake ReplicaSet
+	addFakeReplicaSet := func() error {
+		replicaSet := &appsv1.ReplicaSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      replicaSetName,
+				Namespace: namespace,
+			},
+			Spec: appsv1.ReplicaSetSpec{
+				Selector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						replicaSetLabelKey: replicaSetLabelVal,
+					},
+				},
+			},
+		}
+		return fakeInformerFactory.Apps().V1().ReplicaSets().Informer().GetStore().Add(replicaSet)
+	}
+
+	// Create fake ReplicationController
+	addFakeReplicationController := func() error {
+		replicationController := &v1.ReplicationController{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      replicationControllerName,
+				Namespace: namespace,
+			},
+			Spec: v1.ReplicationControllerSpec{
+				Selector: map[string]string{
+					replicationLabelKey: replicationLabelVal,
+				},
+			},
+		}
+		return fakeInformerFactory.Core().V1().ReplicationControllers().Informer().GetStore().Add(replicationController)
+	}
+
+	// Create fake StatefulSet
+	addFakeStatefulSet := func() error {
+		statefulSet := &appsv1.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      statefulSetName,
+				Namespace: namespace,
+			},
+			Spec: appsv1.StatefulSetSpec{
+				Selector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						statefulSetLabelKey: statefulSetLabelVal,
+					},
+				},
+			},
+		}
+		return fakeInformerFactory.Apps().V1().StatefulSets().Informer().GetStore().Add(statefulSet)
+	}
+
+	tests := []struct {
+		name                string
+		pod                 *v1.Pod
+		expect              labels.Set
+		addFakeResourceList []func() error
+	}{
+		{
+			name: "DefaultSelector for default case",
+			pod: st.MakePod().Name(podName).
+				Namespace(namespace).Label(podLabelKey, podLabelVal).
+				Obj(),
+			expect:              labels.Set{},
+			addFakeResourceList: nil,
+		},
+		{
+			name: "DefaultSelector for no OwnerReference pod case",
+			pod: st.MakePod().Name(podName).
+				Namespace(namespace).Label(podLabelKey, podLabelVal).
+				Obj(),
+			expect:              labels.Set{podLabelKey: podLabelVal},
+			addFakeResourceList: []func() error{addFakeService},
+		},
+		{
+			name: "DefaultSelector for ReplicaSet OwnerReference pod case",
+			pod: st.MakePod().Name(podName).
+				Namespace(namespace).Label(podLabelKey, podLabelVal).
+				OwnerReference(replicaSetName, appsv1.SchemeGroupVersion.WithKind("ReplicaSet")).Obj(),
+			expect:              labels.Set{podLabelKey: podLabelVal, replicaSetLabelKey: replicaSetLabelVal},
+			addFakeResourceList: []func() error{addFakeService, addFakeReplicaSet},
+		},
+		{
+			name: "DefaultSelector for ReplicationController OwnerReference pod case",
+			pod: st.MakePod().Name(podName).
+				Namespace(namespace).Label(podLabelKey, podLabelVal).
+				OwnerReference(replicationControllerName, v1.SchemeGroupVersion.WithKind("ReplicationController")).Obj(),
+			expect:              labels.Set{podLabelKey: podLabelVal, replicationLabelKey: replicationLabelVal},
+			addFakeResourceList: []func() error{addFakeService, addFakeReplicationController},
+		},
+		{
+			name: "DefaultSelector for StatefulSet OwnerReference pod case",
+			pod: st.MakePod().Name(podName).
+				Namespace(namespace).Label(podLabelKey, podLabelVal).
+				OwnerReference(statefulSetName, appsv1.SchemeGroupVersion.WithKind("StatefulSet")).Obj(),
+			expect:              labels.Set{podLabelKey: podLabelVal, statefulSetLabelKey: statefulSetLabelVal},
+			addFakeResourceList: []func() error{addFakeService, addFakeStatefulSet},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// Add fake resources if needed.
+			if test.addFakeResourceList != nil {
+				for _, addFakeResource := range test.addFakeResourceList {
+					err := addFakeResource()
+					if err != nil {
+						t.Fatalf("failed to add fake resource: %v", err)
+					}
+				}
+			}
+
+			get := DefaultSelector(test.pod,
+				fakeInformerFactory.Core().V1().Services().Lister(),
+				fakeInformerFactory.Core().V1().ReplicationControllers().Lister(),
+				fakeInformerFactory.Apps().V1().ReplicaSets().Lister(),
+				fakeInformerFactory.Apps().V1().StatefulSets().Lister())
+			diff := cmp.Diff(test.expect.String(), get.String())
+			if diff != "" {
+				t.Errorf("Unexpected services (-want, +got):\n%s", diff)
+			}
+
 		})
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
- increase DefaultSelector method ut coverage
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
