### PR TITLE
apiserver/storage: decrease running time of RunWatchSemantics

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/testing/watcher_tests.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/testing/watcher_tests.go
@@ -28,6 +28,7 @@ import (
 
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
@@ -1236,6 +1237,7 @@ func RunSendInitialEventsBackwardCompatibility(ctx context.Context, t *testing.T
 // - false indicates the value of the param was set to "false" by a test case
 // - true  indicates the value of the param was set to "true" by a test case
 func RunWatchSemantics(ctx context.Context, t *testing.T, store storage.Interface) {
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.WatchList, true)
 	trueVal, falseVal := true, false
 	addEventsFromCreatedPods := func(createdInitialPods []*example.Pod) []watch.Event {
 		var ret []watch.Event
@@ -1244,8 +1246,8 @@ func RunWatchSemantics(ctx context.Context, t *testing.T, store storage.Interfac
 		}
 		return ret
 	}
-	initialEventsEndFromLastCreatedPod := func(createdInitialPods []*example.Pod) []watch.Event {
-		return []watch.Event{{
+	initialEventsEndFromLastCreatedPod := func(createdInitialPods []*example.Pod) watch.Event {
+		return watch.Event{
 			Type: watch.Bookmark,
 			Object: &example.Pod{
 				ObjectMeta: metav1.ObjectMeta{
@@ -1253,7 +1255,7 @@ func RunWatchSemantics(ctx context.Context, t *testing.T, store storage.Interfac
 					Annotations:     map[string]string{metav1.InitialEventsAnnotationKey: "true"},
 				},
 			},
-		}}
+		}
 	}
 	scenarios := []struct {
 		name                string
@@ -1267,19 +1269,19 @@ func RunWatchSemantics(ctx context.Context, t *testing.T, store storage.Interfac
 		initialPods                []*example.Pod
 		podsAfterEstablishingWatch []*example.Pod
 
-		expectedInitialEvents                func(createdInitialPods []*example.Pod) []watch.Event
-		expectedInitialEventsBookmark        func(createdInitialPods []*example.Pod) []watch.Event
-		expectedEventsAfterEstablishingWatch func(createdPodsAfterWatch []*example.Pod) []watch.Event
+		expectedInitialEvents                      func(createdInitialPods []*example.Pod) []watch.Event
+		expectedInitialEventsBookmarkWithMinimalRV func(createdInitialPods []*example.Pod) watch.Event
+		expectedEventsAfterEstablishingWatch       func(createdPodsAfterWatch []*example.Pod) []watch.Event
 	}{
 		{
-			name:                                 "allowWatchBookmarks=true, sendInitialEvents=true, RV=unset",
-			allowWatchBookmarks:                  true,
-			sendInitialEvents:                    &trueVal,
-			initialPods:                          []*example.Pod{makePod("1"), makePod("2"), makePod("3")},
-			expectedInitialEvents:                addEventsFromCreatedPods,
-			expectedInitialEventsBookmark:        initialEventsEndFromLastCreatedPod,
-			podsAfterEstablishingWatch:           []*example.Pod{makePod("4"), makePod("5")},
-			expectedEventsAfterEstablishingWatch: addEventsFromCreatedPods,
+			name:                  "allowWatchBookmarks=true, sendInitialEvents=true, RV=unset",
+			allowWatchBookmarks:   true,
+			sendInitialEvents:     &trueVal,
+			initialPods:           []*example.Pod{makePod("1"), makePod("2"), makePod("3")},
+			expectedInitialEvents: addEventsFromCreatedPods,
+			expectedInitialEventsBookmarkWithMinimalRV: initialEventsEndFromLastCreatedPod,
+			podsAfterEstablishingWatch:                 []*example.Pod{makePod("4"), makePod("5")},
+			expectedEventsAfterEstablishingWatch:       addEventsFromCreatedPods,
 		},
 		{
 			name:                                 "allowWatchBookmarks=true, sendInitialEvents=false, RV=unset",
@@ -1306,15 +1308,15 @@ func RunWatchSemantics(ctx context.Context, t *testing.T, store storage.Interfac
 		},
 
 		{
-			name:                                 "allowWatchBookmarks=true, sendInitialEvents=true, RV=0",
-			allowWatchBookmarks:                  true,
-			sendInitialEvents:                    &trueVal,
-			resourceVersion:                      "0",
-			initialPods:                          []*example.Pod{makePod("1"), makePod("2"), makePod("3")},
-			expectedInitialEvents:                addEventsFromCreatedPods,
-			expectedInitialEventsBookmark:        initialEventsEndFromLastCreatedPod,
-			podsAfterEstablishingWatch:           []*example.Pod{makePod("4"), makePod("5")},
-			expectedEventsAfterEstablishingWatch: addEventsFromCreatedPods,
+			name:                  "allowWatchBookmarks=true, sendInitialEvents=true, RV=0",
+			allowWatchBookmarks:   true,
+			sendInitialEvents:     &trueVal,
+			resourceVersion:       "0",
+			initialPods:           []*example.Pod{makePod("1"), makePod("2"), makePod("3")},
+			expectedInitialEvents: addEventsFromCreatedPods,
+			expectedInitialEventsBookmarkWithMinimalRV: initialEventsEndFromLastCreatedPod,
+			podsAfterEstablishingWatch:                 []*example.Pod{makePod("4"), makePod("5")},
+			expectedEventsAfterEstablishingWatch:       addEventsFromCreatedPods,
 		},
 		{
 			name:                                 "allowWatchBookmarks=true, sendInitialEvents=false, RV=0",
@@ -1344,15 +1346,15 @@ func RunWatchSemantics(ctx context.Context, t *testing.T, store storage.Interfac
 		},
 
 		{
-			name:                                 "allowWatchBookmarks=true, sendInitialEvents=true, RV=1",
-			allowWatchBookmarks:                  true,
-			sendInitialEvents:                    &trueVal,
-			resourceVersion:                      "1",
-			initialPods:                          []*example.Pod{makePod("1"), makePod("2"), makePod("3")},
-			expectedInitialEvents:                addEventsFromCreatedPods,
-			expectedInitialEventsBookmark:        initialEventsEndFromLastCreatedPod,
-			podsAfterEstablishingWatch:           []*example.Pod{makePod("4"), makePod("5")},
-			expectedEventsAfterEstablishingWatch: addEventsFromCreatedPods,
+			name:                  "allowWatchBookmarks=true, sendInitialEvents=true, RV=1",
+			allowWatchBookmarks:   true,
+			sendInitialEvents:     &trueVal,
+			resourceVersion:       "1",
+			initialPods:           []*example.Pod{makePod("1"), makePod("2"), makePod("3")},
+			expectedInitialEvents: addEventsFromCreatedPods,
+			expectedInitialEventsBookmarkWithMinimalRV: initialEventsEndFromLastCreatedPod,
+			podsAfterEstablishingWatch:                 []*example.Pod{makePod("4"), makePod("5")},
+			expectedEventsAfterEstablishingWatch:       addEventsFromCreatedPods,
 		},
 		{
 			name:                                 "allowWatchBookmarks=true, sendInitialEvents=false, RV=1",
@@ -1384,15 +1386,15 @@ func RunWatchSemantics(ctx context.Context, t *testing.T, store storage.Interfac
 		},
 
 		{
-			name:                                 "allowWatchBookmarks=true, sendInitialEvents=true, RV=useCurrentRV",
-			allowWatchBookmarks:                  true,
-			sendInitialEvents:                    &trueVal,
-			useCurrentRV:                         true,
-			initialPods:                          []*example.Pod{makePod("1"), makePod("2"), makePod("3")},
-			expectedInitialEvents:                addEventsFromCreatedPods,
-			expectedInitialEventsBookmark:        initialEventsEndFromLastCreatedPod,
-			podsAfterEstablishingWatch:           []*example.Pod{makePod("4"), makePod("5")},
-			expectedEventsAfterEstablishingWatch: addEventsFromCreatedPods,
+			name:                  "allowWatchBookmarks=true, sendInitialEvents=true, RV=useCurrentRV",
+			allowWatchBookmarks:   true,
+			sendInitialEvents:     &trueVal,
+			useCurrentRV:          true,
+			initialPods:           []*example.Pod{makePod("1"), makePod("2"), makePod("3")},
+			expectedInitialEvents: addEventsFromCreatedPods,
+			expectedInitialEventsBookmarkWithMinimalRV: initialEventsEndFromLastCreatedPod,
+			podsAfterEstablishingWatch:                 []*example.Pod{makePod("4"), makePod("5")},
+			expectedEventsAfterEstablishingWatch:       addEventsFromCreatedPods,
 		},
 		{
 			name:                                 "allowWatchBookmarks=true, sendInitialEvents=false, RV=useCurrentRV",
@@ -1439,13 +1441,10 @@ func RunWatchSemantics(ctx context.Context, t *testing.T, store storage.Interfac
 	}
 	for idx, scenario := range scenarios {
 		t.Run(scenario.name, func(t *testing.T) {
+			t.Parallel()
 			// set up env
-			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.WatchList, true)
 			if scenario.expectedInitialEvents == nil {
 				scenario.expectedInitialEvents = func(_ []*example.Pod) []watch.Event { return nil }
-			}
-			if scenario.expectedInitialEventsBookmark == nil {
-				scenario.expectedInitialEventsBookmark = func(_ []*example.Pod) []watch.Event { return nil }
 			}
 			if scenario.expectedEventsAfterEstablishingWatch == nil {
 				scenario.expectedEventsAfterEstablishingWatch = func(_ []*example.Pod) []watch.Event { return nil }
@@ -1480,7 +1479,25 @@ func RunWatchSemantics(ctx context.Context, t *testing.T, store storage.Interfac
 
 			// make sure we only get initial events
 			testCheckResultsInStrictOrder(t, w, scenario.expectedInitialEvents(createdPods))
-			testCheckResultsInStrictOrder(t, w, scenario.expectedInitialEventsBookmark(createdPods))
+
+			// make sure that the actual bookmark has at least RV >= to the expected one
+			if scenario.expectedInitialEventsBookmarkWithMinimalRV != nil {
+				testCheckResultFunc(t, w, func(actualEvent watch.Event) {
+					expectedBookmarkEventWithMinRV := scenario.expectedInitialEventsBookmarkWithMinimalRV(createdPods)
+					expectedObj, err := meta.Accessor(expectedBookmarkEventWithMinRV.Object)
+					require.NoError(t, err)
+
+					actualObj, err := meta.Accessor(actualEvent.Object)
+					require.NoError(t, err)
+
+					require.GreaterOrEqual(t, actualObj.GetResourceVersion(), expectedObj.GetResourceVersion())
+
+					// once we know that the RV is at least >= the expected one
+					// rewrite it so that we can compare the objs
+					expectedObj.SetResourceVersion(actualObj.GetResourceVersion())
+					expectNoDiff(t, "incorrect event", expectedBookmarkEventWithMinRV, actualEvent)
+				})
+			}
 
 			createdPods = []*example.Pod{}
 			// add a pod that is greater than the storage's RV when the watch was started


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
xref: https://github.com/kubernetes/kubernetes/issues/125688

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
