### PR TITLE
Remove another 5 seconds from TestWatchStreamSeparation runtime

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
@@ -2543,7 +2543,7 @@ func TestWatchStreamSeparation(t *testing.T) {
 				defer cacher.watchCache.RUnlock()
 				return cacher.watchCache.resourceVersion
 			}
-			waitContext, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			waitContext, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 			defer cancel()
 			waitForEtcdBookmark := watchAndWaitForBookmark(t, waitContext, cacher.storage)
 
@@ -2568,13 +2568,13 @@ func TestWatchStreamSeparation(t *testing.T) {
 				contextMetadata = cacher.watchCache.waitingUntilFresh.contextMetadata
 			}
 			// For the first 100ms from watch creation, watch progress requests are ignored.
-			time.Sleep(200 * time.Millisecond)
+			time.Sleep(125 * time.Millisecond)
 			err = cacher.storage.RequestWatchProgress(metadata.NewOutgoingContext(context.Background(), contextMetadata))
 			if err != nil {
 				t.Fatal(err)
 			}
 			// Give time for bookmark to arrive
-			time.Sleep(time.Second)
+			time.Sleep(25 * time.Millisecond)
 
 			etcdWatchResourceVersion := waitForEtcdBookmark()
 			gotEtcdWatchBookmark := etcdWatchResourceVersion == lastResourceVersion


### PR DESCRIPTION

/kind flake

```release-note
NONE
```

Removes another 5s from runtime.

Ensured there are no flakes by cherry-picking to 4fa7ce6f3c0038ecec7c2ec3d6edb42315db3015 to avoid getting flakes from https://github.com/kubernetes/kubernetes/issues/125688#issuecomment-2190006751
/cc @wojtek-t 
```
kubernetes $ make test WHAT=staging/src/k8s.io/apiserver/pkg/storage/cacher GOFLAGS="-v" KUBE_TEST_ARGS='-c'
+++ [0626 13:30:28] Set GOMAXPROCS automatically to 24
+++ [0626 13:30:28] Running tests without code coverage and with -race
make: *** [Makefile:192: test] Error 1
kubernetes $ stress ./cacher.test --test.failfast --test.run TestWatchStreamSeparation 
5s: 40 runs so far, 0 failures
10s: 93 runs so far, 0 failures
15s: 145 runs so far, 0 failures
20s: 197 runs so far, 0 failures
25s: 247 runs so far, 0 failures
30s: 300 runs so far, 0 failures
35s: 352 runs so far, 0 failures
40s: 403 runs so far, 0 failures
45s: 455 runs so far, 0 failures
50s: 507 runs so far, 0 failures
55s: 561 runs so far, 0 failures
1m0s: 611 runs so far, 0 failures
1m5s: 663 runs so far, 0 failures
1m10s: 713 runs so far, 0 failures
```
