### PR TITLE
Fix test flakes for TestWatchSemantics

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/testing/watcher_tests.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/testing/watcher_tests.go
@@ -1486,11 +1486,15 @@ func RunWatchSemantics(ctx context.Context, t *testing.T, store storage.Interfac
 					expectedBookmarkEventWithMinRV := scenario.expectedInitialEventsBookmarkWithMinimalRV(createdPods)
 					expectedObj, err := meta.Accessor(expectedBookmarkEventWithMinRV.Object)
 					require.NoError(t, err)
+					expectedRV, err := storage.APIObjectVersioner{}.ObjectResourceVersion(expectedBookmarkEventWithMinRV.Object)
+					require.NoError(t, err)
 
 					actualObj, err := meta.Accessor(actualEvent.Object)
 					require.NoError(t, err)
+					actualRV, err := storage.APIObjectVersioner{}.ObjectResourceVersion(actualEvent.Object)
+					require.NoError(t, err)
 
-					require.GreaterOrEqual(t, actualObj.GetResourceVersion(), expectedObj.GetResourceVersion())
+					require.GreaterOrEqual(t, actualRV, expectedRV)
 
 					// once we know that the RV is at least >= the expected one
 					// rewrite it so that we can compare the objs


### PR DESCRIPTION
Ref https://github.com/kubernetes/kubernetes/pull/125731#issuecomment-2192016509

```release-note
NONE
```

/kind flake
/priority important-soon

/assign @p0lyn0mial
/cc @liggitt @dims 