### PR TITLE
Add jpbetz to /test OWNERS

### DIFF
--- a/test/OWNERS
+++ b/test/OWNERS
@@ -25,6 +25,7 @@ approvers:
   - dims
   - enj
   - janetkuo
+  - jpbetz
   - liggitt
   - mikedanese
   - MrHohn


### PR DESCRIPTION
There are various api machinery related change I need to be able to approve under this directory.  I'll also work on getting the sub-directory OWNERS cleaned up (https://github.com/kubernetes/kubernetes/pull/125709 is a start), but in the meantime, I'd like to be added here.

/kind cleanup

```release-note
NONE
```

