### PR TITLE
update kube-network-policies to v0.4.0

### DIFF
--- a/cluster/addons/kube-network-policies/kube-network-policies.yaml
+++ b/cluster/addons/kube-network-policies/kube-network-policies.yaml
@@ -27,7 +27,7 @@ spec:
       serviceAccountName: kube-network-policies
       containers:
       - name: kube-network-policies
-        image: registry.k8s.io/networking/kube-network-policies:v0.3.0
+        image: registry.k8s.io/networking/kube-network-policies:v0.4.0
         command:
         - /bin/sh
         - -c
@@ -45,11 +45,6 @@ spec:
         - mountPath: /lib/modules
           name: lib-modules
           readOnly: true
-        env:
-        - name: MY_NODE_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: spec.nodeName
       volumes:
       - name: varlog
         hostPath:


### PR DESCRIPTION

/kind flake
```release-note
NONE
```
Followup on Dan's comment fixing the use of env variables and instead use the same mechanism that kube-proxy has, using the hostname and allowing users to override the name using a flag

Needs https://github.com/kubernetes/k8s.io/pull/6919/files