### PR TITLE
hack/local-up-cluster.sh: adapt to stricter --cors-allowed-origins

### DIFF
--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -242,7 +242,7 @@ EXTERNAL_HOSTNAME=${EXTERNAL_HOSTNAME:-localhost}
 KUBELET_HOST=${KUBELET_HOST:-"127.0.0.1"}
 KUBELET_RESOLV_CONF=${KUBELET_RESOLV_CONF:-"/etc/resolv.conf"}
 # By default only allow CORS for requests on localhost
-API_CORS_ALLOWED_ORIGINS=${API_CORS_ALLOWED_ORIGINS:-/127.0.0.1(:[0-9]+)?$,/localhost(:[0-9]+)?$}
+API_CORS_ALLOWED_ORIGINS=${API_CORS_ALLOWED_ORIGINS:-//127.0.0.1(:[0-9]+)?$,//localhost(:[0-9]+)?$}
 KUBELET_PORT=${KUBELET_PORT:-10250}
 # By default we use 0(close it) for it's insecure
 KUBELET_READ_ONLY_PORT=${KUBELET_READ_ONLY_PORT:-0}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

https://github.com/kubernetes/kubernetes/pull/112809 tightened what regular expressions are allowed and now requires that they start matching with a double dash. kube-apiserver failed to come up as a result when started by local-up-cluster.sh.

#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/kubernetes/pull/112809#issuecomment-2192199633

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/assign @tkashem 