### PR TITLE
Allow spec.terminationGracePeriodSeconds to be used in downward API

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -6842,7 +6842,7 @@
         },
         "fieldRef": {
           "$ref": "#/definitions/io.k8s.api.core.v1.ObjectFieldSelector",
-          "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs."
+          "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs, spec.terminationGracePeriodSeconds."
         },
         "resourceFieldRef": {
           "$ref": "#/definitions/io.k8s.api.core.v1.ResourceFieldSelector",

--- a/api/openapi-spec/v3/api__v1_openapi.json
+++ b/api/openapi-spec/v3/api__v1_openapi.json
@@ -2017,7 +2017,7 @@
                 "$ref": "#/components/schemas/io.k8s.api.core.v1.ObjectFieldSelector"
               }
             ],
-            "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs."
+            "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs, spec.terminationGracePeriodSeconds."
           },
           "resourceFieldRef": {
             "allOf": [

--- a/api/openapi-spec/v3/apis__apps__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__apps__v1_openapi.json
@@ -2193,7 +2193,7 @@
                 "$ref": "#/components/schemas/io.k8s.api.core.v1.ObjectFieldSelector"
               }
             ],
-            "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs."
+            "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs, spec.terminationGracePeriodSeconds."
           },
           "resourceFieldRef": {
             "allOf": [

--- a/api/openapi-spec/v3/apis__batch__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__batch__v1_openapi.json
@@ -1542,7 +1542,7 @@
                 "$ref": "#/components/schemas/io.k8s.api.core.v1.ObjectFieldSelector"
               }
             ],
-            "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs."
+            "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs, spec.terminationGracePeriodSeconds."
           },
           "resourceFieldRef": {
             "allOf": [

--- a/pkg/apis/core/pods/helpers.go
+++ b/pkg/apis/core/pods/helpers.go
@@ -86,7 +86,8 @@ func ConvertDownwardAPIFieldLabel(version, label, value string) (string, string,
 		"status.hostIP",
 		"status.hostIPs",
 		"status.podIP",
-		"status.podIPs":
+		"status.podIPs",
+		"spec.terminationGracePeriodSeconds":
 		return label, value, nil
 	// This is for backwards compatibility with old v1 clients which send spec.host
 	case "spec.host":

--- a/pkg/apis/core/pods/helpers_test.go
+++ b/pkg/apis/core/pods/helpers_test.go
@@ -217,6 +217,13 @@ func TestConvertDownwardAPIFieldLabel(t *testing.T) {
 			expectedLabel: "status.hostIPs",
 			expectedValue: "10.244.0.6",
 		},
+		{
+			version:       "v1",
+			label:         "spec.terminationGracePeriodSeconds",
+			value:         "10",
+			expectedLabel: "spec.terminationGracePeriodSeconds",
+			expectedValue: "10",
+		},
 	}
 	for _, tc := range testCases {
 		label, value, err := ConvertDownwardAPIFieldLabel(tc.version, tc.label, tc.value)

--- a/pkg/apis/core/types.go
+++ b/pkg/apis/core/types.go
@@ -2128,7 +2128,7 @@ type EnvVar struct {
 // Only one of its fields may be set.
 type EnvVarSource struct {
 	// Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-	// metadata.uid, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+	// metadata.uid, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs, spec.terminationGracePeriodSeconds.
 	// +optional
 	FieldRef *ObjectFieldSelector
 	// Selects a resource of the container: only resources limits and requests

--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -2608,6 +2608,7 @@ var validEnvDownwardAPIFieldPathExpressions = sets.New(
 	"status.hostIPs",
 	"status.podIP",
 	"status.podIPs",
+	"spec.terminationGracePeriodSeconds",
 )
 
 var validContainerResourceFieldPathExpressions = sets.New(

--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -6180,7 +6180,7 @@ func TestRelaxedValidateEnv(t *testing.T) {
 				},
 			},
 		}},
-		expectedError: `[0].valueFrom.fieldRef.fieldPath: Unsupported value: "metadata.labels": supported values: "metadata.name", "metadata.namespace", "metadata.uid", "spec.nodeName", "spec.serviceAccountName", "status.hostIP", "status.hostIPs", "status.podIP", "status.podIPs"`,
+		expectedError: `[0].valueFrom.fieldRef.fieldPath: Unsupported value: "metadata.labels": supported values: "metadata.name", "metadata.namespace", "metadata.uid", "spec.nodeName", "spec.serviceAccountName", "spec.terminationGracePeriodSeconds", "status.hostIP", "status.hostIPs", "status.podIP", "status.podIPs"`,
 	}, {
 		name: "metadata.annotations without subscript",
 		envs: []core.EnvVar{{
@@ -6192,7 +6192,7 @@ func TestRelaxedValidateEnv(t *testing.T) {
 				},
 			},
 		}},
-		expectedError: `[0].valueFrom.fieldRef.fieldPath: Unsupported value: "metadata.annotations": supported values: "metadata.name", "metadata.namespace", "metadata.uid", "spec.nodeName", "spec.serviceAccountName", "status.hostIP", "status.hostIPs", "status.podIP", "status.podIPs"`,
+		expectedError: `[0].valueFrom.fieldRef.fieldPath: Unsupported value: "metadata.annotations": supported values: "metadata.name", "metadata.namespace", "metadata.uid", "spec.nodeName", "spec.serviceAccountName", "spec.terminationGracePeriodSeconds", "status.hostIP", "status.hostIPs", "status.podIP", "status.podIPs"`,
 	}, {
 		name: "metadata.annotations with invalid key",
 		envs: []core.EnvVar{{
@@ -6228,7 +6228,7 @@ func TestRelaxedValidateEnv(t *testing.T) {
 				},
 			},
 		}},
-		expectedError: `valueFrom.fieldRef.fieldPath: Unsupported value: "status.phase": supported values: "metadata.name", "metadata.namespace", "metadata.uid", "spec.nodeName", "spec.serviceAccountName", "status.hostIP", "status.hostIPs", "status.podIP", "status.podIPs"`,
+		expectedError: `valueFrom.fieldRef.fieldPath: Unsupported value: "status.phase": supported values: "metadata.name", "metadata.namespace", "metadata.uid", "spec.nodeName", "spec.serviceAccountName", "spec.terminationGracePeriodSeconds", "status.hostIP", "status.hostIPs", "status.podIP", "status.podIPs"`,
 	},
 	}
 	for _, tc := range errorCases {
@@ -6590,7 +6590,7 @@ func TestValidateEnv(t *testing.T) {
 				},
 			},
 		}},
-		expectedError: `[0].valueFrom.fieldRef.fieldPath: Unsupported value: "metadata.labels": supported values: "metadata.name", "metadata.namespace", "metadata.uid", "spec.nodeName", "spec.serviceAccountName", "status.hostIP", "status.hostIPs", "status.podIP", "status.podIPs"`,
+		expectedError: `[0].valueFrom.fieldRef.fieldPath: Unsupported value: "metadata.labels": supported values: "metadata.name", "metadata.namespace", "metadata.uid", "spec.nodeName", "spec.serviceAccountName", "spec.terminationGracePeriodSeconds", "status.hostIP", "status.hostIPs", "status.podIP", "status.podIPs"`,
 	}, {
 		name: "metadata.annotations without subscript",
 		envs: []core.EnvVar{{
@@ -6602,7 +6602,7 @@ func TestValidateEnv(t *testing.T) {
 				},
 			},
 		}},
-		expectedError: `[0].valueFrom.fieldRef.fieldPath: Unsupported value: "metadata.annotations": supported values: "metadata.name", "metadata.namespace", "metadata.uid", "spec.nodeName", "spec.serviceAccountName", "status.hostIP", "status.hostIPs", "status.podIP", "status.podIPs"`,
+		expectedError: `[0].valueFrom.fieldRef.fieldPath: Unsupported value: "metadata.annotations": supported values: "metadata.name", "metadata.namespace", "metadata.uid", "spec.nodeName", "spec.serviceAccountName", "spec.terminationGracePeriodSeconds", "status.hostIP", "status.hostIPs", "status.podIP", "status.podIPs"`,
 	}, {
 		name: "metadata.annotations with invalid key",
 		envs: []core.EnvVar{{
@@ -6638,7 +6638,7 @@ func TestValidateEnv(t *testing.T) {
 				},
 			},
 		}},
-		expectedError: `valueFrom.fieldRef.fieldPath: Unsupported value: "status.phase": supported values: "metadata.name", "metadata.namespace", "metadata.uid", "spec.nodeName", "spec.serviceAccountName", "status.hostIP", "status.hostIPs", "status.podIP", "status.podIPs"`,
+		expectedError: `valueFrom.fieldRef.fieldPath: Unsupported value: "status.phase": supported values: "metadata.name", "metadata.namespace", "metadata.uid", "spec.nodeName", "spec.serviceAccountName", "spec.terminationGracePeriodSeconds", "status.hostIP", "status.hostIPs", "status.podIP", "status.podIPs"`,
 	},
 	}
 	for _, tc := range errorCases {

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -21553,7 +21553,7 @@ func schema_k8sio_api_core_v1_EnvVarSource(ref common.ReferenceCallback) common.
 				Properties: map[string]spec.Schema{
 					"fieldRef": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
+							Description: "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs, spec.terminationGracePeriodSeconds.",
 							Ref:         ref("k8s.io/api/core/v1.ObjectFieldSelector"),
 						},
 					},

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -941,6 +941,12 @@ func (kl *Kubelet) podFieldSelectorRuntimeValue(fs *v1.ObjectFieldSelector, pod 
 		return podIP, nil
 	case "status.podIPs":
 		return strings.Join(podIPs, ","), nil
+	case "spec.terminationGracePeriodSeconds":
+		t := pod.Spec.TerminationGracePeriodSeconds
+		if t == nil {
+			return "30", nil
+		}
+		return strconv.Itoa(int(*t)), nil
 	}
 	return fieldpath.ExtractFieldPathAsString(pod, internalFieldPath)
 }

--- a/pkg/kubelet/kubelet_pods_test.go
+++ b/pkg/kubelet/kubelet_pods_test.go
@@ -703,6 +703,15 @@ func TestMakeEnvironmentVariables(t *testing.T) {
 						},
 					},
 					{
+						Name: "TERMINATION_GRACE_PERIOD",
+						ValueFrom: &v1.EnvVarSource{
+							FieldRef: &v1.ObjectFieldSelector{
+								APIVersion: "v1",
+								FieldPath:  "spec.terminationGracePeriodSeconds",
+							},
+						},
+					},
+					{
 						Name: "HOST_IP",
 						ValueFrom: &v1.EnvVarSource{
 							FieldRef: &v1.ObjectFieldSelector{
@@ -731,6 +740,7 @@ func TestMakeEnvironmentVariables(t *testing.T) {
 				{Name: "POD_SERVICE_ACCOUNT_NAME", Value: "special"},
 				{Name: "POD_IP", Value: "1.2.3.4"},
 				{Name: "POD_IPS", Value: "1.2.3.4,fd00::6"},
+				{Name: "TERMINATION_GRACE_PERIOD", Value: "31"},
 				{Name: "HOST_IP", Value: testKubeletHostIP},
 				{Name: "HOST_IPS", Value: testKubeletHostIP + "," + testKubeletHostIPv6},
 			},
@@ -2021,9 +2031,10 @@ func TestMakeEnvironmentVariables(t *testing.T) {
 					Annotations: map[string]string{},
 				},
 				Spec: v1.PodSpec{
-					ServiceAccountName: "special",
-					NodeName:           "node-name",
-					EnableServiceLinks: tc.enableServiceLinks,
+					ServiceAccountName:            "special",
+					NodeName:                      "node-name",
+					EnableServiceLinks:            tc.enableServiceLinks,
+					TerminationGracePeriodSeconds: ptr.To(int64(31)),
 				},
 			}
 			podIP := ""

--- a/staging/src/k8s.io/api/core/v1/generated.proto
+++ b/staging/src/k8s.io/api/core/v1/generated.proto
@@ -1378,7 +1378,7 @@ message EnvVar {
 // EnvVarSource represents a source for the value of an EnvVar.
 message EnvVarSource {
   // Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-  // spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+  // spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs, spec.terminationGracePeriodSeconds.
   // +optional
   optional ObjectFieldSelector fieldRef = 1;
 

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -2275,7 +2275,7 @@ type EnvVar struct {
 // EnvVarSource represents a source for the value of an EnvVar.
 type EnvVarSource struct {
 	// Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-	// spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+	// spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs, spec.terminationGracePeriodSeconds.
 	// +optional
 	FieldRef *ObjectFieldSelector `json:"fieldRef,omitempty" protobuf:"bytes,1,opt,name=fieldRef"`
 	// Selects a resource of the container: only resources limits and requests

--- a/staging/src/k8s.io/api/core/v1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/core/v1/types_swagger_doc_generated.go
@@ -627,7 +627,7 @@ func (EnvVar) SwaggerDoc() map[string]string {
 
 var map_EnvVarSource = map[string]string{
 	"":                 "EnvVarSource represents a source for the value of an EnvVar.",
-	"fieldRef":         "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
+	"fieldRef":         "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs, spec.terminationGracePeriodSeconds.",
 	"resourceFieldRef": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
 	"configMapKeyRef":  "Selects a key of a ConfigMap.",
 	"secretKeyRef":     "Selects a key of a secret in the pod's namespace",


### PR DESCRIPTION

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This adds `spec.terminationGracePeriodSeconds` as a valid downward API reference. This is useful to implement graceful shutdown in an application. Currently, a pod knows it will get two signals: SIGTERM, then SIGKILL (after terminationGracePeriodSeconds). However, if it has shutdown logic in between those, it does not know how long it has to complete. This prevents taking this context into account to make smarter decisions. Some examples:
* A server that slowly ramps up how forceful it is on terminating clients. Envoy has this functionality.
* A server that wants to serve existing clients as long as it can, but wants to gracefully close the protocol (sending RST_STREAM, TLS close alert, etc) rather than getting force-killed. This can be done in O(ms), so the server may have some logic such as "Wait until 5s before the max grace period, then shutdown".
* https://github.com/kubernetes/kubernetes/issues/50032#issuecomment-622564957

#### Which issue(s) this PR fixes:

Fixes #50032

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Allow `spec.terminationGracePeriodSeconds` to be used in downward API
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
