### PR TITLE
Improve Variable Naming for Nominated Node in Scheduler

### DIFF
--- a/pkg/scheduler/schedule_one.go
+++ b/pkg/scheduler/schedule_one.go
@@ -536,8 +536,9 @@ func (sched *Scheduler) findNodesThatFitPod(ctx context.Context, fwk framework.F
 }
 
 func (sched *Scheduler) evaluateNominatedNode(ctx context.Context, pod *v1.Pod, fwk framework.Framework, state *framework.CycleState, diagnosis framework.Diagnosis) ([]*framework.NodeInfo, error) {
-	nnn := pod.Status.NominatedNodeName
-	nodeInfo, err := sched.nodeInfoSnapshot.Get(nnn)
+	// Retrieve the nominated node from the pod's status
+	nominatedNodeName := pod.Status.NominatedNodeName
+	nodeInfo, err := sched.nodeInfoSnapshot.Get(nominatedNodeName)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
This pull request improves the readability and maintainability of the code by changing the variable name nnn to nominatedNodeName in the evaluateNominatedNode function. The new name is more descriptive and makes it clear that the variable holds the name of the nominated node.

#### Changes:
Renamed the variable nnn to nominatedNodeName in the evaluateNominatedNode function.
Updated comments to reflect the new variable name.
