### PR TITLE
kubeadm: improve the error/warning messages of `validateSupportedVersion` to include the checked resource kind

### DIFF
--- a/cmd/kubeadm/app/util/config/common_test.go
+++ b/cmd/kubeadm/app/util/config/common_test.go
@@ -43,69 +43,77 @@ const KubeadmGroupName = "kubeadm.k8s.io"
 
 func TestValidateSupportedVersion(t *testing.T) {
 	tests := []struct {
-		gv                schema.GroupVersion
+		gvk               schema.GroupVersionKind
 		allowDeprecated   bool
 		allowExperimental bool
 		expectedErr       bool
 	}{
 		{
-			gv: schema.GroupVersion{
+			gvk: schema.GroupVersionKind{
 				Group:   KubeadmGroupName,
 				Version: "v1alpha1",
+				Kind:    "InitConfiguration",
 			},
 			expectedErr: true,
 		},
 		{
-			gv: schema.GroupVersion{
+			gvk: schema.GroupVersionKind{
 				Group:   KubeadmGroupName,
 				Version: "v1alpha2",
+				Kind:    "InitConfiguration",
 			},
 			expectedErr: true,
 		},
 		{
-			gv: schema.GroupVersion{
+			gvk: schema.GroupVersionKind{
 				Group:   KubeadmGroupName,
 				Version: "v1alpha3",
+				Kind:    "InitConfiguration",
 			},
 			expectedErr: true,
 		},
 		{
-			gv: schema.GroupVersion{
+			gvk: schema.GroupVersionKind{
 				Group:   KubeadmGroupName,
 				Version: "v1beta1",
+				Kind:    "InitConfiguration",
 			},
 			expectedErr: true,
 		},
 		{
-			gv: schema.GroupVersion{
+			gvk: schema.GroupVersionKind{
 				Group:   KubeadmGroupName,
 				Version: "v1beta2",
+				Kind:    "InitConfiguration",
 			},
 			expectedErr: true,
 		},
 		{
-			gv: schema.GroupVersion{
+			gvk: schema.GroupVersionKind{
 				Group:   KubeadmGroupName,
 				Version: "v1beta3",
+				Kind:    "ClusterConfiguration",
 			},
 		},
 		{
-			gv: schema.GroupVersion{
+			gvk: schema.GroupVersionKind{
 				Group:   "foo.k8s.io",
 				Version: "v1",
+				Kind:    "InitConfiguration",
 			},
 		},
 		{
-			gv: schema.GroupVersion{
+			gvk: schema.GroupVersionKind{
 				Group:   KubeadmGroupName,
 				Version: "v1beta4",
+				Kind:    "ResetConfiguration",
 			},
 		},
 	}
 
 	for _, rt := range tests {
-		t.Run(fmt.Sprintf("%s/allowDeprecated:%t", rt.gv, rt.allowDeprecated), func(t *testing.T) {
-			err := validateSupportedVersion(rt.gv, rt.allowDeprecated, rt.allowExperimental)
+		t.Run(fmt.Sprintf("%s/allowDeprecated:%t", rt.gvk.GroupVersion(), rt.allowDeprecated), func(t *testing.T) {
+			err := validateSupportedVersion(rt.gvk, rt.allowDeprecated, rt.allowExperimental)
 			if rt.expectedErr && err == nil {
 				t.Error("unexpected success")
 			} else if !rt.expectedErr && err != nil {

--- a/cmd/kubeadm/app/util/config/initconfiguration.go
+++ b/cmd/kubeadm/app/util/config/initconfiguration.go
@@ -322,7 +322,7 @@ func documentMapToInitConfiguration(gvkmap kubeadmapi.DocumentMap, allowDeprecat
 		fileContent := gvkmap[gvk]
 
 		// first, check if this GVK is supported and possibly not deprecated
-		if err := validateSupportedVersion(gvk.GroupVersion(), allowDeprecated, allowExperimental); err != nil {
+		if err := validateSupportedVersion(gvk, allowDeprecated, allowExperimental); err != nil {
 			return nil, err
 		}
 

--- a/cmd/kubeadm/app/util/config/joinconfiguration.go
+++ b/cmd/kubeadm/app/util/config/joinconfiguration.go
@@ -106,7 +106,7 @@ func documentMapToJoinConfiguration(gvkmap kubeadmapi.DocumentMap, allowDeprecat
 		}
 
 		// check if this version is supported and possibly not deprecated
-		if err := validateSupportedVersion(gvk.GroupVersion(), allowDeprecated, allowExperimental); err != nil {
+		if err := validateSupportedVersion(gvk, allowDeprecated, allowExperimental); err != nil {
 			return nil, err
 		}
 

--- a/cmd/kubeadm/app/util/config/resetconfiguration.go
+++ b/cmd/kubeadm/app/util/config/resetconfiguration.go
@@ -110,7 +110,7 @@ func documentMapToResetConfiguration(gvkmap kubeadmapi.DocumentMap, allowDepreca
 		}
 
 		// check if this version is supported and possibly not deprecated
-		if err := validateSupportedVersion(gvk.GroupVersion(), allowDeprecated, allowExperimental); err != nil {
+		if err := validateSupportedVersion(gvk, allowDeprecated, allowExperimental); err != nil {
 			return nil, err
 		}
 

--- a/cmd/kubeadm/app/util/config/upgradeconfiguration.go
+++ b/cmd/kubeadm/app/util/config/upgradeconfiguration.go
@@ -45,7 +45,7 @@ func documentMapToUpgradeConfiguration(gvkmap kubeadmapi.DocumentMap, allowDepre
 
 	for gvk, bytes := range gvkmap {
 		// check if this version is supported and possibly not deprecated
-		if err := validateSupportedVersion(gvk.GroupVersion(), allowDeprecated, true); err != nil {
+		if err := validateSupportedVersion(gvk, allowDeprecated, true); err != nil {
 			return nil, err
 		}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Usually, the configuration file used for `kubeadm init` contains two resource kinds (`InitConfiguration` and `ClusterConfiguration`), which results in the same warning/error output twice, confusing the users.
```sh
# kubeadm init --config old.yaml 
W0627 10:03:49.846990    4540 common.go:101] your configuration file uses a deprecated API spec: "kubeadm.k8s.io/v1beta3". Please use 'kubeadm config migrate --old-config old.yaml --new-config new.yaml', which will write the new, similar spec using a newer API version.
W0627 10:03:49.847521    4540 common.go:101] your configuration file uses a deprecated API spec: "kubeadm.k8s.io/v1beta3". Please use 'kubeadm config migrate --old-config old.yaml --new-config new.yaml', which will write the new, similar spec using a newer API version.
[init] Using Kubernetes version: v1.31.0-alpha.2.268+bffc02b955c8bd
...
```

If we also print the resource kind, it is more helpful to understand the cause of the warning/error.
```sh
# kubeadm init --config old.yaml 
W0627 10:37:15.863516    6153 common.go:101] your configuration file uses a deprecated API spec: "kubeadm.k8s.io/v1beta3" (kind: "ClusterConfiguration"). Please use 'kubeadm config migrate --old-config old.yaml --new-config new.yaml', which will write the new, similar spec using a newer API version.
W0627 10:37:15.863936    6153 common.go:101] your configuration file uses a deprecated API spec: "kubeadm.k8s.io/v1beta3" (kind: "InitConfiguration"). Please use 'kubeadm config migrate --old-config old.yaml --new-config new.yaml', which will write the new, similar spec using a newer API version.
[init] Using Kubernetes version: v1.31.0-alpha.2.268+bffc02b955c8bd
```


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubeadm: improve the warning/error messages of `validateSupportedVersion` to include the checked resource kind name.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
