### PR TITLE
[WIP] reuse etcd client to monitor storage metric

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/metrics/metrics.go
@@ -286,12 +286,6 @@ func (m *monitorCollector) setGetter(monitorGetter func() ([]Monitor, error)) {
 	m.monitorGetter = monitorGetter
 }
 
-func (m *monitorCollector) getGetter() func() ([]Monitor, error) {
-	m.mutex.Lock()
-	defer m.mutex.Unlock()
-	return m.monitorGetter
-}
-
 // DescribeWithStability implements compbasemetrics.StableColletor
 func (c *monitorCollector) DescribeWithStability(ch chan<- *compbasemetrics.Desc) {
 	ch <- storageSizeDescription


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:



##### motivation

We have recently noticed an increase in gRPC errors (specifically, use of closed network connection) in apiserver logs.

`
I0619 00:22:[31.927056 11](tel:3192705611) http2_client.go:959] "[transport] [client-transport 0xc004144900] Closing: connection error: desc = \"error reading from server: read tcp 10.0.33.210:43716→10.0.32.16:2379: use of closed network connection\"\n"
`
would like to rca for the recurring error message.

##### suspect
The following is `tcpdump` screenshot,

noticed there is `etcdserverpb.Maintenance/Status`  call around the grpc error occurrence timeline.

<img width="1221" alt="image" src="https://github.com/kubernetes/kubernetes/assets/128085442/68466df8-efdd-4682-8ae4-87df9f6ba4a5">


We suspect the status call was introduced by PR: https://github.com/kubernetes/kubernetes/pull/118812/commits
where etcd client is frequently initialized and shutDown.

##### validation

the error message seems clear with this PR change (reuse the existing etcd cilent)

<img width="1019" alt="image" src="https://github.com/kubernetes/kubernetes/assets/128085442/59898f60-3d00-4b97-8467-9645158f0211">




#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #125770

#### Special notes for your reviewer:

We are looking for more evidence to build the causality between the grpc erros and the suspected PR https://github.com/kubernetes/kubernetes/pull/118812/commits. 

Any insight is appreciated.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
NONE

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
NONE
