### PR TITLE
[Backport] Fix verify target to not update env var if already set

### DIFF
--- a/build/root/Makefile
+++ b/build/root/Makefile
@@ -123,9 +123,12 @@ endef
 ifeq ($(PRINT_HELP),y)
 verify:
 	echo "$$VERIFY_HELP_INFO"
-else
+else ifeq ($(origin KUBE_VERIFY_GIT_BRANCH), undefined)
 verify:
 	KUBE_VERIFY_GIT_BRANCH=$(BRANCH) hack/make-rules/verify.sh
+else
+verify:
+	hack/make-rules/verify.sh
 endif
 
 define QUICK_VERIFY_HELP_INFO


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind failing-test


#### What this PR does / why we need it:
Cherrypicks fix from https://github.com/kubernetes/kubernetes/pull/122020

> KUBE_VERIFY_GIT_BRANCH env var is set in job config for verify-govulncheck.sh and verify-readonly-packages.sh. It was being overridden when the make target was invoked, making it unusable. Now the env var is only set when it is undefined, maintaining compatibility with already existing jobs.


#### Which issue(s) this PR fixes:

Fixes failing test: https://testgrid.k8s.io/sig-release-1.28-blocking#verify-1.28

#### Special notes for your reviewer:
Relevant PR: https://github.com/kubernetes/kubernetes/pull/124751

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
Related to https://github.com/kubernetes/sig-security/issues/100

**Note**: Initially when the original PR was merged, the govulncheck script was not backported to release-1.28 so this fix did not need a backport

/sig release security architecture
/release-note-none