### PR TITLE
KEP-4222: Support either JSON or CBOR in FieldsV1.

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/helpers_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/helpers_test.go
@@ -249,3 +249,245 @@ func TestSetMetaDataLabel(t *testing.T) {
 		}
 	}
 }
+
+func TestFieldsV1MarshalJSON(t *testing.T) {
+	for _, tc := range []struct {
+		Name     string
+		FieldsV1 FieldsV1
+		Want     []byte
+		Error    string
+	}{
+		{
+			Name:     "nil encodes as json null",
+			FieldsV1: FieldsV1{},
+			Want:     []byte(`null`),
+		},
+		{
+			Name:     "empty invalid json is returned as-is",
+			FieldsV1: FieldsV1{Raw: []byte{}},
+			Want:     []byte{},
+		},
+		{
+			Name:     "cbor null is transcoded to json null",
+			FieldsV1: FieldsV1{Raw: []byte{0xf6}}, // null
+			Want:     []byte(`null`),
+		},
+		{
+			Name:     "valid non-map cbor and valid non-object json is returned as-is",
+			FieldsV1: FieldsV1{Raw: []byte{0x30}},
+			Want:     []byte{0x30}, // Valid CBOR encoding of -17 and JSON encoding of 0!
+		},
+		{
+			Name:     "self-described cbor map is transcoded to json map",
+			FieldsV1: FieldsV1{Raw: []byte{0xd9, 0xd9, 0xf7, 0xa1, 0x43, 'f', 'o', 'o', 0x43, 'b', 'a', 'r'}}, // 55799({"foo":"bar"})
+			Want:     []byte(`{"foo":"bar"}`),
+		},
+		{
+			Name:     "json object is returned as-is",
+			FieldsV1: FieldsV1{Raw: []byte(" \t\r\n{\"foo\":\"bar\"}")},
+			Want:     []byte(" \t\r\n{\"foo\":\"bar\"}"),
+		},
+		{
+			Name:     "invalid json is returned as-is",
+			FieldsV1: FieldsV1{Raw: []byte(`{{`)},
+			Want:     []byte(`{{`),
+		},
+		{
+			Name:     "invalid cbor fails to transcode to json",
+			FieldsV1: FieldsV1{Raw: []byte{0xa1}},
+			Error:    "metav1.FieldsV1 cbor invalid: unexpected EOF",
+		},
+	} {
+		t.Run(tc.Name, func(t *testing.T) {
+			got, err := tc.FieldsV1.MarshalJSON()
+			if err != nil {
+				if tc.Error == "" {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if msg := err.Error(); msg != tc.Error {
+					t.Fatalf("expected error %q, got %q", tc.Error, msg)
+				}
+			} else if tc.Error != "" {
+				t.Fatalf("expected error %q, got nil", tc.Error)
+			}
+			if diff := cmp.Diff(tc.Want, got); diff != "" {
+				t.Errorf("unexpected diff:\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestFieldsV1MarshalCBOR(t *testing.T) {
+	for _, tc := range []struct {
+		Name     string
+		FieldsV1 FieldsV1
+		Want     []byte
+		Error    string
+	}{
+		{
+			Name:     "nil encodes as cbor null",
+			FieldsV1: FieldsV1{},
+			Want:     []byte{0xf6}, // null
+		},
+		{
+			Name:     "empty invalid cbor is returned as-is",
+			FieldsV1: FieldsV1{Raw: []byte{}},
+			Want:     []byte{},
+		},
+		{
+			Name:     "json null is transcoded to cbor null",
+			FieldsV1: FieldsV1{Raw: []byte(`null`)},
+			Want:     []byte{0xf6}, // null
+		},
+		{
+			Name:     "valid non-map cbor and valid non-object json is returned as-is",
+			FieldsV1: FieldsV1{Raw: []byte{0x30}},
+			Want:     []byte{0x30}, // Valid CBOR encoding of -17 and JSON encoding of 0!
+		},
+		{
+			Name:     "json object is transcoded to cbor map",
+			FieldsV1: FieldsV1{Raw: []byte(" \t\r\n{\"foo\":\"bar\"}")},
+			Want:     []byte{0xa1, 0x43, 'f', 'o', 'o', 0x43, 'b', 'a', 'r'},
+		},
+		{
+			Name:     "self-described cbor map is returned as-is",
+			FieldsV1: FieldsV1{Raw: []byte{0xd9, 0xd9, 0xf7, 0xa1, 0x43, 'f', 'o', 'o', 0x43, 'b', 'a', 'r'}}, // 55799({"foo":"bar"})
+			Want:     []byte{0xd9, 0xd9, 0xf7, 0xa1, 0x43, 'f', 'o', 'o', 0x43, 'b', 'a', 'r'},                // 55799({"foo":"bar"})
+		},
+		{
+			Name:     "invalid json fails to transcode to cbor",
+			FieldsV1: FieldsV1{Raw: []byte(`{{`)},
+			Error:    "metav1.FieldsV1 json invalid: invalid character '{' looking for beginning of object key string",
+		},
+		{
+			Name:     "invalid cbor is returned as-is",
+			FieldsV1: FieldsV1{Raw: []byte{0xa1}},
+			Want:     []byte{0xa1},
+		},
+	} {
+		t.Run(tc.Name, func(t *testing.T) {
+			got, err := tc.FieldsV1.MarshalCBOR()
+			if err != nil {
+				if tc.Error == "" {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if msg := err.Error(); msg != tc.Error {
+					t.Fatalf("expected error %q, got %q", tc.Error, msg)
+				}
+			} else if tc.Error != "" {
+				t.Fatalf("expected error %q, got nil", tc.Error)
+			}
+
+			if diff := cmp.Diff(tc.Want, got); diff != "" {
+				t.Errorf("unexpected diff:\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestFieldsV1UnmarshalJSON(t *testing.T) {
+	for _, tc := range []struct {
+		Name  string
+		JSON  []byte
+		Into  *FieldsV1
+		Want  *FieldsV1
+		Error string
+	}{
+		{
+			Name:  "nil receiver returns error",
+			Into:  nil,
+			Error: "metav1.FieldsV1: UnmarshalJSON on nil pointer",
+		},
+		{
+			Name: "json null does not modify receiver", // conventional for json.Unmarshaler
+			JSON: []byte(`null`),
+			Into: &FieldsV1{Raw: []byte(`unmodified`)},
+			Want: &FieldsV1{Raw: []byte(`unmodified`)},
+		},
+		{
+			Name: "valid input is copied verbatim",
+			JSON: []byte("{\"foo\":\"bar\"} \t\r\n"),
+			Into: &FieldsV1{},
+			Want: &FieldsV1{Raw: []byte("{\"foo\":\"bar\"} \t\r\n")},
+		},
+		{
+			Name: "invalid input is copied verbatim",
+			JSON: []byte("{{"),
+			Into: &FieldsV1{},
+			Want: &FieldsV1{Raw: []byte("{{")},
+		},
+	} {
+		t.Run(tc.Name, func(t *testing.T) {
+			got := tc.Into.DeepCopy()
+			err := got.UnmarshalJSON(tc.JSON)
+			if err != nil {
+				if tc.Error == "" {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if msg := err.Error(); msg != tc.Error {
+					t.Fatalf("expected error %q, got %q", tc.Error, msg)
+				}
+			} else if tc.Error != "" {
+				t.Fatalf("expected error %q, got nil", tc.Error)
+			}
+
+			if diff := cmp.Diff(tc.Want, got); diff != "" {
+				t.Errorf("unexpected diff:\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestFieldsV1UnmarshalCBOR(t *testing.T) {
+	for _, tc := range []struct {
+		Name  string
+		CBOR  []byte
+		Into  *FieldsV1
+		Want  *FieldsV1
+		Error string
+	}{
+		{
+			Name:  "nil receiver returns error",
+			Into:  nil,
+			Want:  nil,
+			Error: "metav1.FieldsV1: UnmarshalCBOR on nil pointer",
+		},
+		{
+			Name: "cbor null does not modify receiver",
+			CBOR: []byte{0xf6},
+			Into: &FieldsV1{Raw: []byte(`unmodified`)},
+			Want: &FieldsV1{Raw: []byte(`unmodified`)},
+		},
+		{
+			Name: "valid input is copied verbatim",
+			CBOR: []byte{0xa1, 0x43, 'f', 'o', 'o', 0x43, 'b', 'a', 'r'},
+			Into: &FieldsV1{},
+			Want: &FieldsV1{Raw: []byte{0xa1, 0x43, 'f', 'o', 'o', 0x43, 'b', 'a', 'r'}},
+		},
+		{
+			Name: "invalid input is copied verbatim",
+			CBOR: []byte{0xff}, // UnmarshalCBOR should never be called with malformed input, testing anyway.
+			Into: &FieldsV1{},
+			Want: &FieldsV1{Raw: []byte{0xff}},
+		},
+	} {
+		t.Run(tc.Name, func(t *testing.T) {
+			got := tc.Into.DeepCopy()
+			err := got.UnmarshalCBOR(tc.CBOR)
+			if err != nil {
+				if tc.Error == "" {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if msg := err.Error(); msg != tc.Error {
+					t.Fatalf("expected error %q, got %q", tc.Error, msg)
+				}
+			} else if tc.Error != "" {
+				t.Fatalf("expected error %q, got nil", tc.Error)
+			}
+
+			if diff := cmp.Diff(tc.Want, got); diff != "" {
+				t.Errorf("unexpected diff:\n%s", diff)
+			}
+		})
+	}
+}

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/cbor/cbor_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/cbor/cbor_test.go
@@ -121,15 +121,27 @@ func (p *anyObject) UnmarshalCBOR(in []byte) error {
 	return modes.Decode.Unmarshal(in, &p.Value)
 }
 
-type structWithRawExtensionField struct {
-	Extension runtime.RawExtension `json:"extension"`
+type structWithRawFields struct {
+	FieldsV1            metav1.FieldsV1       `json:"f"`
+	FieldsV1Pointer     *metav1.FieldsV1      `json:"fp"`
+	RawExtension        runtime.RawExtension  `json:"r"`
+	RawExtensionPointer *runtime.RawExtension `json:"rp"`
 }
 
-func (p structWithRawExtensionField) GetObjectKind() schema.ObjectKind {
+func (structWithRawFields) GetObjectKind() schema.ObjectKind {
 	return schema.EmptyObjectKind
 }
 
-func (structWithRawExtensionField) DeepCopyObject() runtime.Object {
+func (structWithRawFields) DeepCopyObject() runtime.Object {
+	panic("unimplemented")
+}
+
+type structWithEmbeddedMetas struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+}
+
+func (structWithEmbeddedMetas) DeepCopyObject() runtime.Object {
 	panic("unimplemented")
 }
 
@@ -277,13 +289,35 @@ func TestDecode(t *testing.T) {
 			},
 		},
 		{
-			name:        "rawextension transcoded",
-			data:        []byte{0xa1, 0x49, 'e', 'x', 't', 'e', 'n', 's', 'i', 'o', 'n', 0xa1, 0x41, 'a', 0x01},
+			name:        "raw types transcoded",
+			data:        []byte{0xa4, 0x41, 'f', 0xa1, 0x41, 'a', 0x01, 0x42, 'f', 'p', 0xa1, 0x41, 'z', 0x02, 0x41, 'r', 0xa1, 0x41, 'b', 0x03, 0x42, 'r', 'p', 0xa1, 0x41, 'y', 0x04},
 			gvk:         &schema.GroupVersionKind{},
 			metaFactory: stubMetaFactory{gvk: &schema.GroupVersionKind{}},
 			typer:       stubTyper{gvks: []schema.GroupVersionKind{{Group: "x", Version: "y", Kind: "z"}}},
-			into:        &structWithRawExtensionField{},
-			expectedObj: &structWithRawExtensionField{Extension: runtime.RawExtension{Raw: []byte(`{"a":1}`)}},
+			into:        &structWithRawFields{},
+			expectedObj: &structWithRawFields{
+				FieldsV1:            metav1.FieldsV1{Raw: []byte(`{"a":1}`)},
+				FieldsV1Pointer:     &metav1.FieldsV1{Raw: []byte(`{"z":2}`)},
+				RawExtension:        runtime.RawExtension{Raw: []byte(`{"b":3}`)},
+				RawExtensionPointer: &runtime.RawExtension{Raw: []byte(`{"y":4}`)},
+			},
+			expectedGVK: &schema.GroupVersionKind{Group: "x", Version: "y", Kind: "z"},
+			assertOnError: func(t *testing.T, err error) {
+				if err != nil {
+					t.Errorf("expected nil error, got: %v", err)
+				}
+			},
+		},
+		{
+			name:        "object with embedded typemeta and objectmeta",
+			data:        []byte("\xa2\x48metadata\xa1\x44name\x43foo\x44spec\xa0"), // {"metadata": {"name": "foo"}}
+			gvk:         &schema.GroupVersionKind{},
+			metaFactory: stubMetaFactory{gvk: &schema.GroupVersionKind{}},
+			typer:       stubTyper{gvks: []schema.GroupVersionKind{{Group: "x", Version: "y", Kind: "z"}}},
+			into:        &structWithEmbeddedMetas{},
+			expectedObj: &structWithEmbeddedMetas{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
+			},
 			expectedGVK: &schema.GroupVersionKind{Group: "x", Version: "y", Kind: "z"},
 			assertOnError: func(t *testing.T, err error) {
 				if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup
/sig api-machinery

#### What this PR does / why we need it:

The value of FieldsV1 is dependent upon its serialization. All existent FieldsV1 usage can safely assume either JSON null or a JSON object. This is notably different from RawExtension, which might hold arbitrary bytes.

To retain backwards compatibility for existing programs, FieldsV1 values decoded from CBOR will be automatically transcoded to JSON. This will follow the same opt-out and migration plan as RawExtension.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

Separating this work from RawExtension again since the raw bytes of FieldsV1 are more constrained.

/cc @jpbetz @liggitt 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://kep.k8s.io/4222
```
