### PR TITLE
Use PollUntilContextTimeout to replace PollImmediate in e2e

### DIFF
--- a/test/e2e/apimachinery/aggregator.go
+++ b/test/e2e/apimachinery/aggregator.go
@@ -733,7 +733,7 @@ func TestSampleAPIServer(ctx context.Context, f *framework.Framework, aggrclient
 	framework.ExpectNoError(err, "Unable to delete apiservice %s", apiServiceName)
 
 	ginkgo.By("Confirm that the generated APIService has been deleted")
-	err = wait.PollImmediate(apiServiceRetryPeriod, apiServiceRetryTimeout, checkApiServiceListQuantity(ctx, aggrclient, apiServiceLabelSelector, 0))
+	err = wait.PollUntilContextTimeout(ctx, apiServiceRetryPeriod, apiServiceRetryTimeout, true, checkApiServiceListQuantity(ctx, aggrclient, apiServiceLabelSelector, 0))
 	framework.ExpectNoError(err, "failed to count the required APIServices")
 	framework.Logf("APIService %s has been deleted.", apiServiceName)
 
@@ -779,8 +779,8 @@ func generateFlunderName(base string) string {
 	return fmt.Sprintf("%s-%d", base, id)
 }
 
-func checkApiServiceListQuantity(ctx context.Context, aggrclient *aggregatorclient.Clientset, label string, quantity int) func() (bool, error) {
-	return func() (bool, error) {
+func checkApiServiceListQuantity(ctx context.Context, aggrclient *aggregatorclient.Clientset, label string, quantity int) func(ctx context.Context) (bool, error) {
+	return func(context.Context) (bool, error) {
 		var err error
 
 		framework.Logf("Requesting list of APIServices to confirm quantity")

--- a/test/e2e/apimachinery/aggregator.go
+++ b/test/e2e/apimachinery/aggregator.go
@@ -733,7 +733,7 @@ func TestSampleAPIServer(ctx context.Context, f *framework.Framework, aggrclient
 	framework.ExpectNoError(err, "Unable to delete apiservice %s", apiServiceName)
 
 	ginkgo.By("Confirm that the generated APIService has been deleted")
-	err = wait.PollUntilContextTimeout(ctx, apiServiceRetryPeriod, apiServiceRetryTimeout, true, checkApiServiceListQuantity(ctx, aggrclient, apiServiceLabelSelector, 0))
+	err = wait.PollUntilContextTimeout(ctx, apiServiceRetryPeriod, apiServiceRetryTimeout, true, checkAPIServiceListQuantity(ctx, aggrclient, apiServiceLabelSelector, 0))
 	framework.ExpectNoError(err, "failed to count the required APIServices")
 	framework.Logf("APIService %s has been deleted.", apiServiceName)
 
@@ -779,7 +779,7 @@ func generateFlunderName(base string) string {
 	return fmt.Sprintf("%s-%d", base, id)
 }
 
-func checkApiServiceListQuantity(ctx context.Context, aggrclient *aggregatorclient.Clientset, label string, quantity int) func(ctx context.Context) (bool, error) {
+func checkAPIServiceListQuantity(ctx context.Context, aggrclient *aggregatorclient.Clientset, label string, quantity int) func(ctx context.Context) (bool, error) {
 	return func(context.Context) (bool, error) {
 		var err error
 

--- a/test/e2e/apimachinery/apiserver_identity.go
+++ b/test/e2e/apimachinery/apiserver_identity.go
@@ -147,9 +147,8 @@ var _ = SIGDescribe("kube-apiserver identity", feature.APIServerIdentity, func()
 
 			err = restartAPIServer(ctx, &node)
 			framework.ExpectNoError(err)
-
-			err = wait.PollImmediate(time.Second, wait.ForeverTestTimeout, func() (bool, error) {
-				lease, err = client.CoordinationV1().Leases(metav1.NamespaceSystem).Get(context.TODO(), leaseName, metav1.GetOptions{})
+			err = wait.PollUntilContextTimeout(ctx, time.Second, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
+				lease, err = client.CoordinationV1().Leases(metav1.NamespaceSystem).Get(ctx, leaseName, metav1.GetOptions{})
 				if err != nil {
 					return false, nil
 				}

--- a/test/e2e/apimachinery/custom_resource_definition.go
+++ b/test/e2e/apimachinery/custom_resource_definition.go
@@ -312,7 +312,7 @@ var _ = SIGDescribe("CustomResourceDefinition resources [Privileged:ClusterAdmin
 		]`), metav1.PatchOptions{})
 		framework.ExpectNoError(err, "setting default for a to \"A\" in schema")
 
-		err = wait.PollImmediate(time.Millisecond*100, wait.ForeverTestTimeout, func() (bool, error) {
+		err = wait.PollUntilContextTimeout(ctx, time.Millisecond*100, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
 			u1, err := crClient.Get(ctx, name1, metav1.GetOptions{})
 			if err != nil {
 				return false, err
@@ -354,7 +354,7 @@ var _ = SIGDescribe("CustomResourceDefinition resources [Privileged:ClusterAdmin
 		]`), metav1.PatchOptions{})
 		framework.ExpectNoError(err, "setting default for b to \"B\" and remove default for a")
 
-		err = wait.PollImmediate(time.Millisecond*100, wait.ForeverTestTimeout, func() (bool, error) {
+		err = wait.PollUntilContextTimeout(ctx, time.Millisecond*100, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
 			u2, err := crClient.Get(ctx, name2, metav1.GetOptions{})
 			if err != nil {
 				return false, err

--- a/test/e2e/apimachinery/storage_version.go
+++ b/test/e2e/apimachinery/storage_version.go
@@ -69,7 +69,7 @@ var _ = SIGDescribe("StorageVersion resources", feature.StorageVersionAPI, func(
 
 		// wait for sv to be GC'ed
 		framework.Logf("Waiting for storage version %v to be garbage collected", createdSV.Name)
-		err = wait.PollImmediate(100*time.Millisecond, wait.ForeverTestTimeout, func() (bool, error) {
+		err = wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
 			_, err := client.InternalV1alpha1().StorageVersions().Get(
 				ctx, createdSV.Name, metav1.GetOptions{})
 			if apierrors.IsNotFound(err) {

--- a/test/e2e/apimachinery/webhook.go
+++ b/test/e2e/apimachinery/webhook.go
@@ -425,7 +425,7 @@ var _ = SIGDescribe("AdmissionWebhook [Privileged:ClusterAdmin]", func() {
 		framework.ExpectNoError(err, "waiting for webhook configuration to be ready")
 
 		ginkgo.By("Creating a configMap that does not comply to the validation webhook rules")
-		err = wait.PollImmediate(100*time.Millisecond, 30*time.Second, func() (bool, error) {
+		err = wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, 30*time.Second, true, func(ctx context.Context) (bool, error) {
 			cm := namedNonCompliantConfigMap(string(uuid.NewUUID()), f)
 			_, err = client.CoreV1().ConfigMaps(f.Namespace.Name).Create(ctx, cm, metav1.CreateOptions{})
 			if err == nil {
@@ -450,7 +450,7 @@ var _ = SIGDescribe("AdmissionWebhook [Privileged:ClusterAdmin]", func() {
 		framework.ExpectNoError(err, "Updating validating webhook configuration")
 
 		ginkgo.By("Creating a configMap that does not comply to the validation webhook rules")
-		err = wait.PollImmediate(100*time.Millisecond, 30*time.Second, func() (bool, error) {
+		err = wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, 30*time.Second, true, func(ctx context.Context) (bool, error) {
 			cm := namedNonCompliantConfigMap(string(uuid.NewUUID()), f)
 			_, err = client.CoreV1().ConfigMaps(f.Namespace.Name).Create(ctx, cm, metav1.CreateOptions{})
 			if err != nil {
@@ -472,7 +472,7 @@ var _ = SIGDescribe("AdmissionWebhook [Privileged:ClusterAdmin]", func() {
 		framework.ExpectNoError(err, "Patching validating webhook configuration")
 
 		ginkgo.By("Creating a configMap that does not comply to the validation webhook rules")
-		err = wait.PollImmediate(100*time.Millisecond, 30*time.Second, func() (bool, error) {
+		err = wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, 30*time.Second, true, func(ctx context.Context) (bool, error) {
 			cm := namedNonCompliantConfigMap(string(uuid.NewUUID()), f)
 			_, err = client.CoreV1().ConfigMaps(f.Namespace.Name).Create(ctx, cm, metav1.CreateOptions{})
 			if err == nil {
@@ -527,7 +527,7 @@ var _ = SIGDescribe("AdmissionWebhook [Privileged:ClusterAdmin]", func() {
 		framework.ExpectNoError(err, "Updating mutating webhook configuration")
 
 		ginkgo.By("Creating a configMap that should not be mutated")
-		err = wait.PollImmediate(100*time.Millisecond, 30*time.Second, func() (bool, error) {
+		err = wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, 30*time.Second, true, func(ctx context.Context) (bool, error) {
 			cm := namedToBeMutatedConfigMap(string(uuid.NewUUID()), f)
 			created, err := client.CoreV1().ConfigMaps(f.Namespace.Name).Create(ctx, cm, metav1.CreateOptions{})
 			if err != nil {
@@ -547,7 +547,7 @@ var _ = SIGDescribe("AdmissionWebhook [Privileged:ClusterAdmin]", func() {
 		framework.ExpectNoError(err, "Patching mutating webhook configuration")
 
 		ginkgo.By("Creating a configMap that should be mutated")
-		err = wait.PollImmediate(100*time.Millisecond, 30*time.Second, func() (bool, error) {
+		err = wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, 30*time.Second, true, func(ctx context.Context) (bool, error) {
 			cm := namedToBeMutatedConfigMap(string(uuid.NewUUID()), f)
 			created, err := client.CoreV1().ConfigMaps(f.Namespace.Name).Create(ctx, cm, metav1.CreateOptions{})
 			if err != nil {
@@ -599,7 +599,7 @@ var _ = SIGDescribe("AdmissionWebhook [Privileged:ClusterAdmin]", func() {
 		framework.ExpectNoError(err, "waiting for webhook configuration to be ready")
 
 		ginkgo.By("Creating a configMap that does not comply to the validation webhook rules")
-		err = wait.PollImmediate(100*time.Millisecond, 30*time.Second, func() (bool, error) {
+		err = wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, 30*time.Second, true, func(ctx context.Context) (bool, error) {
 			cm := namedNonCompliantConfigMap(string(uuid.NewUUID()), f)
 			_, err = client.CoreV1().ConfigMaps(f.Namespace.Name).Create(ctx, cm, metav1.CreateOptions{})
 			if err == nil {
@@ -619,7 +619,7 @@ var _ = SIGDescribe("AdmissionWebhook [Privileged:ClusterAdmin]", func() {
 		framework.ExpectNoError(err, "Deleting collection of validating webhook configurations")
 
 		ginkgo.By("Creating a configMap that does not comply to the validation webhook rules")
-		err = wait.PollImmediate(100*time.Millisecond, 30*time.Second, func() (bool, error) {
+		err = wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, 30*time.Second, true, func(ctx context.Context) (bool, error) {
 			cm := namedNonCompliantConfigMap(string(uuid.NewUUID()), f)
 			_, err = client.CoreV1().ConfigMaps(f.Namespace.Name).Create(ctx, cm, metav1.CreateOptions{})
 			if err != nil {
@@ -673,7 +673,7 @@ var _ = SIGDescribe("AdmissionWebhook [Privileged:ClusterAdmin]", func() {
 		framework.ExpectNoError(err, "waiting for webhook configuration to be ready")
 
 		ginkgo.By("Creating a configMap that should be mutated")
-		err = wait.PollImmediate(100*time.Millisecond, 30*time.Second, func() (bool, error) {
+		err = wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, 30*time.Second, true, func(ctx context.Context) (bool, error) {
 			cm := namedToBeMutatedConfigMap(string(uuid.NewUUID()), f)
 			created, err := client.CoreV1().ConfigMaps(f.Namespace.Name).Create(ctx, cm, metav1.CreateOptions{})
 			if err != nil {
@@ -691,7 +691,7 @@ var _ = SIGDescribe("AdmissionWebhook [Privileged:ClusterAdmin]", func() {
 		framework.ExpectNoError(err, "Deleting collection of mutating webhook configurations")
 
 		ginkgo.By("Creating a configMap that should not be mutated")
-		err = wait.PollImmediate(100*time.Millisecond, 30*time.Second, func() (bool, error) {
+		err = wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, 30*time.Second, true, func(ctx context.Context) (bool, error) {
 			cm := namedToBeMutatedConfigMap(string(uuid.NewUUID()), f)
 			created, err := client.CoreV1().ConfigMaps(f.Namespace.Name).Create(ctx, cm, metav1.CreateOptions{})
 			if err != nil {
@@ -1899,7 +1899,7 @@ type updateConfigMapFn func(cm *v1.ConfigMap)
 
 func updateConfigMap(ctx context.Context, c clientset.Interface, ns, name string, update updateConfigMapFn) (*v1.ConfigMap, error) {
 	var cm *v1.ConfigMap
-	pollErr := wait.PollImmediate(2*time.Second, 1*time.Minute, func() (bool, error) {
+	pollErr := wait.PollUntilContextTimeout(ctx, 2*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 		var err error
 		if cm, err = c.CoreV1().ConfigMaps(ns).Get(ctx, name, metav1.GetOptions{}); err != nil {
 			return false, err
@@ -1921,7 +1921,7 @@ type updateCustomResourceFn func(cm *unstructured.Unstructured)
 
 func updateCustomResource(ctx context.Context, c dynamic.ResourceInterface, ns, name string, update updateCustomResourceFn) (*unstructured.Unstructured, error) {
 	var cr *unstructured.Unstructured
-	pollErr := wait.PollImmediate(2*time.Second, 1*time.Minute, func() (bool, error) {
+	pollErr := wait.PollUntilContextTimeout(ctx, 2*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 		var err error
 		if cr, err = c.Get(ctx, name, metav1.GetOptions{}); err != nil {
 			return false, err
@@ -2650,7 +2650,7 @@ func createWebhookConfigurationReadyNamespace(ctx context.Context, f *framework.
 // the webhook configuration.
 func waitWebhookConfigurationReady(ctx context.Context, f *framework.Framework, markersNamespaceName string) error {
 	cmClient := f.ClientSet.CoreV1().ConfigMaps(markersNamespaceName)
-	return wait.PollImmediate(100*time.Millisecond, 30*time.Second, func() (bool, error) {
+	return wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, 30*time.Second, true, func(ctx context.Context) (bool, error) {
 		marker := &v1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: string(uuid.NewUUID()),

--- a/test/e2e/apps/deployment.go
+++ b/test/e2e/apps/deployment.go
@@ -691,7 +691,7 @@ func stopDeployment(ctx context.Context, c clientset.Interface, ns, deploymentNa
 	gomega.Expect(rss.Items).Should(gomega.BeEmpty())
 	framework.Logf("Ensuring deployment %s's Pods were deleted", deploymentName)
 	var pods *v1.PodList
-	if err := wait.PollImmediate(time.Second, timeout, func() (bool, error) {
+	if err := wait.PollUntilContextTimeout(ctx, time.Second, timeout, true, func(ctx context.Context) (bool, error) {
 		pods, err = c.CoreV1().Pods(ns).List(ctx, options)
 		if err != nil {
 			return false, err
@@ -1558,7 +1558,7 @@ func waitForDeploymentOldRSsNum(ctx context.Context, c clientset.Interface, ns, 
 	var oldRSs []*appsv1.ReplicaSet
 	var d *appsv1.Deployment
 
-	pollErr := wait.PollImmediate(poll, 5*time.Minute, func() (bool, error) {
+	pollErr := wait.PollUntilContextTimeout(ctx, poll, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
 		deployment, err := c.AppsV1().Deployments(ns).Get(ctx, deploymentName, metav1.GetOptions{})
 		if err != nil {
 			return false, err

--- a/test/e2e/apps/job.go
+++ b/test/e2e/apps/job.go
@@ -131,7 +131,7 @@ var _ = SIGDescribe("Job", func() {
 		framework.ExpectNoError(err, "failed to create job in namespace: %s", f.Namespace.Name)
 
 		ginkgo.By("Ensuring job fails")
-		err = e2ejob.WaitForJobFailed(f.ClientSet, f.Namespace.Name, job.Name)
+		err = e2ejob.WaitForJobFailed(ctx, f.ClientSet, f.Namespace.Name, job.Name)
 		framework.ExpectNoError(err, "failed to ensure job failure in namespace: %s", f.Namespace.Name)
 	})
 
@@ -538,7 +538,7 @@ done`}
 		framework.ExpectNoError(err, "failed to create job in namespace: %s", f.Namespace.Name)
 
 		ginkgo.By("Awaiting for the job to fail as there are failed indexes")
-		err = e2ejob.WaitForJobFailed(f.ClientSet, f.Namespace.Name, job.Name)
+		err = e2ejob.WaitForJobFailed(ctx, f.ClientSet, f.Namespace.Name, job.Name)
 		framework.ExpectNoError(err, "failed to ensure job completion in namespace: %s", f.Namespace.Name)
 
 		ginkgo.By("Verifying the Job status fields to ensure all indexes were executed")
@@ -574,7 +574,7 @@ done`}
 		framework.ExpectNoError(err, "failed to create job in namespace: %s", f.Namespace.Name)
 
 		ginkgo.By("Awaiting for the job to fail as the number of max failed indexes is exceeded")
-		err = e2ejob.WaitForJobFailed(f.ClientSet, f.Namespace.Name, job.Name)
+		err = e2ejob.WaitForJobFailed(ctx, f.ClientSet, f.Namespace.Name, job.Name)
 		framework.ExpectNoError(err, "failed to ensure job completion in namespace: %s", f.Namespace.Name)
 
 		ginkgo.By("Verifying the Job status fields to ensure early termination of the job")
@@ -617,7 +617,7 @@ done`}
 		framework.ExpectNoError(err, "failed to create job in namespace: %s", f.Namespace.Name)
 
 		ginkgo.By("Awaiting for the job to fail as all indexes are failed")
-		err = e2ejob.WaitForJobFailed(f.ClientSet, f.Namespace.Name, job.Name)
+		err = e2ejob.WaitForJobFailed(ctx, f.ClientSet, f.Namespace.Name, job.Name)
 		framework.ExpectNoError(err, "failed to ensure job completion in namespace: %s", f.Namespace.Name)
 
 		ginkgo.By("Verifying the Job status fields to ensure the upper indexes didn't execute")

--- a/test/e2e/apps/rc.go
+++ b/test/e2e/apps/rc.go
@@ -546,7 +546,7 @@ func testReplicationControllerConditionCheck(ctx context.Context, f *framework.F
 	_, err := c.CoreV1().ResourceQuotas(namespace).Create(ctx, quota, metav1.CreateOptions{})
 	framework.ExpectNoError(err)
 
-	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 		quota, err = c.CoreV1().ResourceQuotas(namespace).Get(ctx, name, metav1.GetOptions{})
 		if err != nil {
 			return false, err
@@ -568,7 +568,7 @@ func testReplicationControllerConditionCheck(ctx context.Context, f *framework.F
 	ginkgo.By(fmt.Sprintf("Checking rc %q has the desired failure condition set", name))
 	generation := rc.Generation
 	conditions := rc.Status.Conditions
-	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 		rc, err = c.CoreV1().ReplicationControllers(namespace).Get(ctx, name, metav1.GetOptions{})
 		if err != nil {
 			return false, err
@@ -597,7 +597,7 @@ func testReplicationControllerConditionCheck(ctx context.Context, f *framework.F
 	ginkgo.By(fmt.Sprintf("Checking rc %q has no failure condition set", name))
 	generation = rc.Generation
 	conditions = rc.Status.Conditions
-	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 		rc, err = c.CoreV1().ReplicationControllers(namespace).Get(ctx, name, metav1.GetOptions{})
 		if err != nil {
 			return false, err
@@ -645,7 +645,7 @@ func testRCAdoptMatchingOrphans(ctx context.Context, f *framework.Framework) {
 	framework.ExpectNoError(err)
 
 	ginkgo.By("Then the orphan pod is adopted")
-	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 		p2, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(ctx, p.Name, metav1.GetOptions{})
 		// The Pod p should either be adopted or deleted by the RC
 		if apierrors.IsNotFound(err) {
@@ -678,7 +678,7 @@ func testRCReleaseControlledNotMatching(ctx context.Context, f *framework.Framew
 	framework.ExpectNoError(err)
 
 	p := pods.Items[0]
-	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 		pod, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(ctx, p.Name, metav1.GetOptions{})
 		framework.ExpectNoError(err)
 
@@ -695,7 +695,7 @@ func testRCReleaseControlledNotMatching(ctx context.Context, f *framework.Framew
 	framework.ExpectNoError(err)
 
 	ginkgo.By("Then the pod is released")
-	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 		p2, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(ctx, p.Name, metav1.GetOptions{})
 		framework.ExpectNoError(err)
 		for _, owner := range p2.OwnerReferences {
@@ -719,7 +719,7 @@ type updateRcFunc func(d *v1.ReplicationController)
 func updateReplicationControllerWithRetries(ctx context.Context, c clientset.Interface, namespace, name string, applyUpdate updateRcFunc) (*v1.ReplicationController, error) {
 	var rc *v1.ReplicationController
 	var updateErr error
-	pollErr := wait.PollImmediate(10*time.Millisecond, 1*time.Minute, func() (bool, error) {
+	pollErr := wait.PollUntilContextTimeout(ctx, 10*time.Millisecond, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 		var err error
 		if rc, err = c.CoreV1().ReplicationControllers(namespace).Get(ctx, name, metav1.GetOptions{}); err != nil {
 			return false, err

--- a/test/e2e/apps/replica_set.go
+++ b/test/e2e/apps/replica_set.go
@@ -243,7 +243,7 @@ func testReplicaSetConditionCheck(ctx context.Context, f *framework.Framework) {
 	_, err := c.CoreV1().ResourceQuotas(namespace).Create(ctx, quota, metav1.CreateOptions{})
 	framework.ExpectNoError(err)
 
-	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 		quota, err = c.CoreV1().ResourceQuotas(namespace).Get(ctx, name, metav1.GetOptions{})
 		if err != nil {
 			return false, err
@@ -265,7 +265,7 @@ func testReplicaSetConditionCheck(ctx context.Context, f *framework.Framework) {
 	ginkgo.By(fmt.Sprintf("Checking replica set %q has the desired failure condition set", name))
 	generation := rs.Generation
 	conditions := rs.Status.Conditions
-	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 		rs, err = c.AppsV1().ReplicaSets(namespace).Get(ctx, name, metav1.GetOptions{})
 		if err != nil {
 			return false, err
@@ -295,7 +295,7 @@ func testReplicaSetConditionCheck(ctx context.Context, f *framework.Framework) {
 	ginkgo.By(fmt.Sprintf("Checking replica set %q has no failure condition set", name))
 	generation = rs.Generation
 	conditions = rs.Status.Conditions
-	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 		rs, err = c.AppsV1().ReplicaSets(namespace).Get(ctx, name, metav1.GetOptions{})
 		if err != nil {
 			return false, err
@@ -343,7 +343,7 @@ func testRSAdoptMatchingAndReleaseNotMatching(ctx context.Context, f *framework.
 	framework.ExpectNoError(err)
 
 	ginkgo.By("Then the orphan pod is adopted")
-	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 		p2, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(ctx, p.Name, metav1.GetOptions{})
 		// The Pod p should either be adopted or deleted by the ReplicaSet
 		if apierrors.IsNotFound(err) {
@@ -366,7 +366,7 @@ func testRSAdoptMatchingAndReleaseNotMatching(ctx context.Context, f *framework.
 	framework.ExpectNoError(err)
 
 	p = &pods.Items[0]
-	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 		pod, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(ctx, p.Name, metav1.GetOptions{})
 		framework.ExpectNoError(err)
 
@@ -383,7 +383,7 @@ func testRSAdoptMatchingAndReleaseNotMatching(ctx context.Context, f *framework.
 	framework.ExpectNoError(err)
 
 	ginkgo.By("Then the pod is released")
-	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 		p2, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(ctx, p.Name, metav1.GetOptions{})
 		framework.ExpectNoError(err)
 		for _, owner := range p2.OwnerReferences {

--- a/test/e2e/apps/statefulset.go
+++ b/test/e2e/apps/statefulset.go
@@ -2554,7 +2554,7 @@ func verifyStatefulSetPVCsExist(ctx context.Context, c clientset.Interface, ss *
 	for _, id := range claimIds {
 		idSet[id] = struct{}{}
 	}
-	return wait.PollImmediate(e2estatefulset.StatefulSetPoll, e2estatefulset.StatefulSetTimeout, func() (bool, error) {
+	return wait.PollUntilContextTimeout(ctx, e2estatefulset.StatefulSetPoll, e2estatefulset.StatefulSetTimeout, true, func(ctx context.Context) (bool, error) {
 		pvcList, err := c.CoreV1().PersistentVolumeClaims(ss.Namespace).List(ctx, metav1.ListOptions{LabelSelector: klabels.Everything().String()})
 		if err != nil {
 			framework.Logf("WARNING: Failed to list pvcs for verification, retrying: %v", err)
@@ -2599,7 +2599,7 @@ func verifyStatefulSetPVCsExistWithOwnerRefs(ctx context.Context, c clientset.In
 	if setUID == "" {
 		framework.Failf("Statefulset %s missing UID", ss.Name)
 	}
-	return wait.PollImmediate(e2estatefulset.StatefulSetPoll, e2estatefulset.StatefulSetTimeout, func() (bool, error) {
+	return wait.PollUntilContextTimeout(ctx, e2estatefulset.StatefulSetPoll, e2estatefulset.StatefulSetTimeout, true, func(ctx context.Context) (bool, error) {
 		pvcList, err := c.CoreV1().PersistentVolumeClaims(ss.Namespace).List(ctx, metav1.ListOptions{LabelSelector: klabels.Everything().String()})
 		if err != nil {
 			framework.Logf("WARNING: Failed to list pvcs for verification, retrying: %v", err)

--- a/test/e2e/auth/service_accounts.go
+++ b/test/e2e/auth/service_accounts.go
@@ -740,7 +740,7 @@ var _ = SIGDescribe("ServiceAccounts", func() {
 			3. Reconciled if modified
 	*/
 	framework.ConformanceIt("should guarantee kube-root-ca.crt exist in any namespace", func(ctx context.Context) {
-		framework.ExpectNoError(wait.PollImmediate(500*time.Millisecond, wait.ForeverTestTimeout, func() (bool, error) {
+		framework.ExpectNoError(wait.PollUntilContextTimeout(ctx, 500*time.Millisecond, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
 			_, err := f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Get(ctx, rootCAConfigMapName, metav1.GetOptions{})
 			if err == nil {
 				return true, nil

--- a/test/e2e/autoscaling/cluster_size_autoscaling.go
+++ b/test/e2e/autoscaling/cluster_size_autoscaling.go
@@ -1767,7 +1767,7 @@ func runReplicatedPodOnEachNode(ctx context.Context, f *framework.Framework, nod
 			}
 		}
 
-		err = wait.PollImmediate(5*time.Second, podTimeout, func() (bool, error) {
+		err = wait.PollUntilContextTimeout(ctx, 5*time.Second, podTimeout, true, func(ctx context.Context) (bool, error) {
 			rc, err = f.ClientSet.CoreV1().ReplicationControllers(namespace).Get(ctx, id, metav1.GetOptions{})
 			if err != nil || rc.Status.ReadyReplicas < int32((i+1)*podsPerNode) {
 				return false, nil

--- a/test/e2e/common/node/podtemplates.go
+++ b/test/e2e/common/node/podtemplates.go
@@ -162,7 +162,7 @@ var _ = SIGDescribe("PodTemplates", func() {
 
 		ginkgo.By("check that the list of pod templates matches the requested quantity")
 
-		err = wait.PollImmediate(podTemplateRetryPeriod, podTemplateRetryTimeout, checkPodTemplateListQuantity(ctx, f, "podtemplate-set=true", 0))
+		err = wait.PollUntilContextTimeout(ctx, podTemplateRetryPeriod, podTemplateRetryTimeout, true, checkPodTemplateListQuantity(ctx, f, "podtemplate-set=true", 0))
 		framework.ExpectNoError(err, "failed to count required pod templates")
 
 	})
@@ -212,8 +212,8 @@ var _ = SIGDescribe("PodTemplates", func() {
 
 })
 
-func checkPodTemplateListQuantity(ctx context.Context, f *framework.Framework, label string, quantity int) func() (bool, error) {
-	return func() (bool, error) {
+func checkPodTemplateListQuantity(ctx context.Context, f *framework.Framework, label string, quantity int) func(ctx context.Context) (bool, error) {
+	return func(context.Context) (bool, error) {
 		var err error
 
 		framework.Logf("requesting list of pod templates to confirm quantity")

--- a/test/e2e/common/node/runtimeclass.go
+++ b/test/e2e/common/node/runtimeclass.go
@@ -164,7 +164,7 @@ var _ = SIGDescribe("RuntimeClass", func() {
 			framework.ExpectNoError(err, "failed to delete RuntimeClass %s", rcName)
 
 			ginkgo.By("Waiting for the RuntimeClass to disappear")
-			framework.ExpectNoError(wait.PollImmediate(framework.Poll, time.Minute, func() (bool, error) {
+			framework.ExpectNoError(wait.PollUntilContextTimeout(ctx, framework.Poll, time.Minute, true, func(ctx context.Context) (bool, error) {
 				_, err := rcClient.Get(ctx, rcName, metav1.GetOptions{})
 				if apierrors.IsNotFound(err) {
 					return true, nil // done

--- a/test/e2e/framework/job/wait.go
+++ b/test/e2e/framework/job/wait.go
@@ -101,8 +101,8 @@ func WaitForJobSuspend(ctx context.Context, c clientset.Interface, ns, jobName s
 }
 
 // WaitForJobFailed uses c to wait for the Job jobName in namespace ns to fail
-func WaitForJobFailed(c clientset.Interface, ns, jobName string) error {
-	return wait.PollImmediate(framework.Poll, JobTimeout, func() (bool, error) {
+func WaitForJobFailed(ctx context.Context, c clientset.Interface, ns, jobName string) error {
+	return wait.PollUntilContextTimeout(ctx, framework.Poll, JobTimeout, true, func(ctx context.Context) (bool, error) {
 		curr, err := c.BatchV1().Jobs(ns).Get(context.TODO(), jobName, metav1.GetOptions{})
 		if err != nil {
 			return false, err

--- a/test/e2e/framework/node/ssh.go
+++ b/test/e2e/framework/node/ssh.go
@@ -36,7 +36,7 @@ func WaitForSSHTunnels(ctx context.Context, namespace string) {
 	defer e2ekubectl.RunKubectl(namespace, "delete", "pod", "ssh-tunnel-test")
 
 	// allow up to a minute for new ssh tunnels to establish
-	wait.PollUntilContextTimeout(ctx, 5*time.Second, time.Minute, true, func(ctx context.Context) (bool, error) {
+	_ = wait.PollUntilContextTimeout(ctx, 5*time.Second, time.Minute, true, func(ctx context.Context) (bool, error) {
 		_, err := e2ekubectl.RunKubectl(namespace, "logs", "ssh-tunnel-test")
 		return err == nil, nil
 	})

--- a/test/e2e/kubectl/rollout.go
+++ b/test/e2e/kubectl/rollout.go
@@ -52,8 +52,8 @@ var _ = SIGDescribe("Kubectl rollout", func() {
 	})
 
 	ginkgo.Describe("undo", func() {
-		ginkgo.AfterEach(func() {
-			cleanupKubectlInputs(deploymentYaml, ns, "app=httpd")
+		ginkgo.AfterEach(func(ctx context.Context) {
+			cleanupKubectlInputs(ctx, deploymentYaml, ns, "app=httpd")
 		})
 		ginkgo.It("undo should rollback and update deployment env", func(ctx context.Context) {
 			var err error

--- a/test/e2e/network/dns.go
+++ b/test/e2e/network/dns.go
@@ -534,7 +534,7 @@ var _ = common.SIGDescribe("DNS", func() {
 		// - Custom search path is appended.
 		// - DNS query is sent to the specified server.
 		cmd = []string{"dig", "+short", "+search", testDNSNameShort}
-		digFunc := func() (bool, error) {
+		digFunc := func(context.Context) (bool, error) {
 			stdout, stderr, err := e2epod.ExecWithOptions(f, e2epod.ExecOptions{
 				Command:       cmd,
 				Namespace:     f.Namespace.Name,
@@ -554,7 +554,7 @@ var _ = common.SIGDescribe("DNS", func() {
 			}
 			return true, nil
 		}
-		err = wait.PollImmediate(5*time.Second, 3*time.Minute, digFunc)
+		err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 3*time.Minute, true, digFunc)
 		framework.ExpectNoError(err, "failed to verify customized name server and search path")
 
 		// TODO: Add more test cases for other DNSPolicies.

--- a/test/e2e/network/dns_common.go
+++ b/test/e2e/network/dns_common.go
@@ -89,13 +89,15 @@ func (t *dnsTestCommon) init(ctx context.Context) {
 	}
 }
 
-func (t *dnsTestCommon) checkDNSRecordFrom(name string, predicate func([]string) bool, target string, timeout time.Duration) {
+func (t *dnsTestCommon) checkDNSRecordFrom(ctx context.Context, name string, predicate func([]string) bool, target string, timeout time.Duration) {
 	var actual []string
 
-	err := wait.PollImmediate(
+	err := wait.PollUntilContextTimeout(
+		ctx,
 		time.Duration(1)*time.Second,
 		timeout,
-		func() (bool, error) {
+		true,
+		func(ctx context.Context) (bool, error) {
 			actual = t.runDig(name, target)
 			if predicate(actual) {
 				return true, nil

--- a/test/e2e/network/dns_configmap.go
+++ b/test/e2e/network/dns_configmap.go
@@ -91,32 +91,38 @@ func (t *dnsNameserverTest) run(ctx context.Context, isIPv6 bool) {
 
 	if isIPv6 {
 		t.checkDNSRecordFrom(
+			ctx,
 			"abc.acme.local",
 			func(actual []string) bool { return len(actual) == 1 && actual[0] == "2606:4700:4700::1111" },
 			"cluster-dns-ipv6",
 			moreForeverTestTimeout)
 		t.checkDNSRecordFrom(
+			ctx,
 			"def.acme.local",
 			func(actual []string) bool { return len(actual) == 1 && actual[0] == "2606:4700:4700::2222" },
 			"cluster-dns-ipv6",
 			moreForeverTestTimeout)
 		t.checkDNSRecordFrom(
+			ctx,
 			"widget.local",
 			func(actual []string) bool { return len(actual) == 1 && actual[0] == "2606:4700:4700::3333" },
 			"cluster-dns-ipv6",
 			moreForeverTestTimeout)
 	} else {
 		t.checkDNSRecordFrom(
+			ctx,
 			"abc.acme.local",
 			func(actual []string) bool { return len(actual) == 1 && actual[0] == "1.1.1.1" },
 			"cluster-dns",
 			moreForeverTestTimeout)
 		t.checkDNSRecordFrom(
+			ctx,
 			"def.acme.local",
 			func(actual []string) bool { return len(actual) == 1 && actual[0] == "2.2.2.2" },
 			"cluster-dns",
 			moreForeverTestTimeout)
 		t.checkDNSRecordFrom(
+			ctx,
 			"widget.local",
 			func(actual []string) bool { return len(actual) == 1 && actual[0] == "3.3.3.3" },
 			"cluster-dns",
@@ -127,6 +133,7 @@ func (t *dnsNameserverTest) run(ctx context.Context, isIPv6 bool) {
 	// Wait for the deleted ConfigMap to take effect, otherwise the
 	// configuration can bleed into other tests.
 	t.checkDNSRecordFrom(
+		ctx,
 		"abc.acme.local",
 		func(actual []string) bool { return len(actual) == 0 },
 		"cluster-dns",
@@ -151,12 +158,14 @@ func (t *dnsPtrFwdTest) run(ctx context.Context, isIPv6 bool) {
 	// Should still be able to lookup public nameserver without explicit upstream nameserver set.
 	if isIPv6 {
 		t.checkDNSRecordFrom(
+			ctx,
 			"2001:4860:4860::8888",
 			func(actual []string) bool { return len(actual) == 1 && actual[0] == googleDNSHostname+"." },
 			"ptr-record",
 			moreForeverTestTimeout)
 	} else {
 		t.checkDNSRecordFrom(
+			ctx,
 			"8.8.8.8",
 			func(actual []string) bool { return len(actual) == 1 && actual[0] == googleDNSHostname+"." },
 			"ptr-record",
@@ -186,6 +195,7 @@ func (t *dnsPtrFwdTest) run(ctx context.Context, isIPv6 bool) {
 
 	if isIPv6 {
 		t.checkDNSRecordFrom(
+			ctx,
 			"2001:db8::29",
 			func(actual []string) bool { return len(actual) == 1 && actual[0] == "my.test." },
 			"ptr-record",
@@ -193,6 +203,7 @@ func (t *dnsPtrFwdTest) run(ctx context.Context, isIPv6 bool) {
 
 		t.restoreDNSConfigMap(ctx, originalConfigMapData)
 		t.checkDNSRecordFrom(
+			ctx,
 			"2001:db8::29",
 			func(actual []string) bool { return len(actual) == 0 },
 			"ptr-record",
@@ -200,6 +211,7 @@ func (t *dnsPtrFwdTest) run(ctx context.Context, isIPv6 bool) {
 
 	} else {
 		t.checkDNSRecordFrom(
+			ctx,
 			"192.0.2.123",
 			func(actual []string) bool { return len(actual) == 1 && actual[0] == "my.test." },
 			"ptr-record",
@@ -207,6 +219,7 @@ func (t *dnsPtrFwdTest) run(ctx context.Context, isIPv6 bool) {
 
 		t.restoreDNSConfigMap(ctx, originalConfigMapData)
 		t.checkDNSRecordFrom(
+			ctx,
 			"192.0.2.123",
 			func(actual []string) bool { return len(actual) == 0 },
 			"ptr-record",
@@ -254,6 +267,7 @@ func (t *dnsExternalNameTest) run(ctx context.Context, isIPv6 bool) {
 
 	if isIPv6 {
 		t.checkDNSRecordFrom(
+			ctx,
 			fmt.Sprintf("%s.%s.svc.%s", serviceName, f.Namespace.Name, framework.TestContext.ClusterDNSDomain),
 			func(actual []string) bool {
 				return len(actual) >= 1 && actual[0] == googleDNSHostname+"."
@@ -262,6 +276,7 @@ func (t *dnsExternalNameTest) run(ctx context.Context, isIPv6 bool) {
 			moreForeverTestTimeout)
 	} else {
 		t.checkDNSRecordFrom(
+			ctx,
 			fmt.Sprintf("%s.%s.svc.%s", serviceName, f.Namespace.Name, framework.TestContext.ClusterDNSDomain),
 			func(actual []string) bool {
 				return len(actual) >= 1 && actual[0] == googleDNSHostname+"."
@@ -292,6 +307,7 @@ func (t *dnsExternalNameTest) run(ctx context.Context, isIPv6 bool) {
 	}
 	if isIPv6 {
 		t.checkDNSRecordFrom(
+			ctx,
 			fmt.Sprintf("%s.%s.svc.%s", serviceNameLocal, f.Namespace.Name, framework.TestContext.ClusterDNSDomain),
 			func(actual []string) bool {
 				return len(actual) >= 2 && actual[0] == fooHostname+"." && actual[1] == "2001:db8::29"
@@ -300,6 +316,7 @@ func (t *dnsExternalNameTest) run(ctx context.Context, isIPv6 bool) {
 			moreForeverTestTimeout)
 	} else {
 		t.checkDNSRecordFrom(
+			ctx,
 			fmt.Sprintf("%s.%s.svc.%s", serviceNameLocal, f.Namespace.Name, framework.TestContext.ClusterDNSDomain),
 			func(actual []string) bool {
 				return len(actual) == 2 && actual[0] == fooHostname+"." && actual[1] == "192.0.2.123"

--- a/test/e2e/network/dns_scale_records.go
+++ b/test/e2e/network/dns_scale_records.go
@@ -92,6 +92,7 @@ var _ = common.SIGDescribe(feature.PerformanceDNS, framework.WithSerial(), func(
 			qname := fmt.Sprintf("%v.%v.svc.%v", s.Name, s.Namespace, framework.TestContext.ClusterDNSDomain)
 			framework.Logf("Querying %v expecting %v", qname, svc.Spec.ClusterIP)
 			dnsTest.checkDNSRecordFrom(
+				ctx,
 				qname,
 				func(actual []string) bool {
 					return len(actual) == 1 && actual[0] == svc.Spec.ClusterIP

--- a/test/e2e/network/dual_stack.go
+++ b/test/e2e/network/dual_stack.go
@@ -272,7 +272,7 @@ var _ = common.SIGDescribe(feature.IPv6DualStack, func() {
 		validateServiceAndClusterIPFamily(svc, expectedFamilies, &expectedPolicy)
 
 		// ensure endpoint belong to same ipfamily as service
-		if err := wait.PollImmediate(500*time.Millisecond, 10*time.Second, func() (bool, error) {
+		if err := wait.PollUntilContextTimeout(ctx, 500*time.Millisecond, 10*time.Second, true, func(ctx context.Context) (bool, error) {
 			endpoint, err := cs.CoreV1().Endpoints(svc.Namespace).Get(ctx, svc.Name, metav1.GetOptions{})
 			if err != nil {
 				return false, nil
@@ -318,7 +318,7 @@ var _ = common.SIGDescribe(feature.IPv6DualStack, func() {
 		validateServiceAndClusterIPFamily(svc, expectedFamilies, &expectedPolicy)
 
 		// ensure endpoints belong to same ipfamily as service
-		if err := wait.PollImmediate(500*time.Millisecond, 10*time.Second, func() (bool, error) {
+		if err := wait.PollUntilContextTimeout(ctx, 500*time.Millisecond, 10*time.Second, true, func(ctx context.Context) (bool, error) {
 			endpoint, err := cs.CoreV1().Endpoints(svc.Namespace).Get(ctx, svc.Name, metav1.GetOptions{})
 			if err != nil {
 				return false, nil
@@ -363,7 +363,7 @@ var _ = common.SIGDescribe(feature.IPv6DualStack, func() {
 		validateServiceAndClusterIPFamily(svc, expectedFamilies, &expectedPolicy)
 
 		// ensure endpoints belong to same ipfamily as service
-		if err := wait.PollImmediate(500*time.Millisecond, 10*time.Second, func() (bool, error) {
+		if err := wait.PollUntilContextTimeout(ctx, 500*time.Millisecond, 10*time.Second, true, func(ctx context.Context) (bool, error) {
 			endpoint, err := cs.CoreV1().Endpoints(svc.Namespace).Get(ctx, svc.Name, metav1.GetOptions{})
 			if err != nil {
 				return false, nil
@@ -408,7 +408,7 @@ var _ = common.SIGDescribe(feature.IPv6DualStack, func() {
 		validateServiceAndClusterIPFamily(svc, expectedFamilies, &expectedPolicy)
 
 		// ensure endpoints belong to same ipfamily as service
-		if err := wait.PollImmediate(500*time.Millisecond, 10*time.Second, func() (bool, error) {
+		if err := wait.PollUntilContextTimeout(ctx, 500*time.Millisecond, 10*time.Second, true, func(ctx context.Context) (bool, error) {
 			endpoint, err := cs.CoreV1().Endpoints(svc.Namespace).Get(ctx, svc.Name, metav1.GetOptions{})
 			if err != nil {
 				return false, nil
@@ -453,7 +453,7 @@ var _ = common.SIGDescribe(feature.IPv6DualStack, func() {
 		validateServiceAndClusterIPFamily(svc, expectedFamilies, &expectedPolicy)
 
 		// ensure endpoints belong to same ipfamily as service
-		if err := wait.PollImmediate(500*time.Millisecond, 10*time.Second, func() (bool, error) {
+		if err := wait.PollUntilContextTimeout(ctx, 500*time.Millisecond, 10*time.Second, true, func(ctx context.Context) (bool, error) {
 			endpoint, err := cs.CoreV1().Endpoints(svc.Namespace).Get(ctx, svc.Name, metav1.GetOptions{})
 			if err != nil {
 				return false, nil

--- a/test/e2e/network/endpointslice.go
+++ b/test/e2e/network/endpointslice.go
@@ -120,7 +120,7 @@ var _ = common.SIGDescribe("EndpointSlice", func() {
 		})
 
 		// Expect Endpoints resource to be created.
-		if err := wait.PollImmediate(2*time.Second, wait.ForeverTestTimeout, func() (bool, error) {
+		if err := wait.PollUntilContextTimeout(ctx, 2*time.Second, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
 			_, err := cs.CoreV1().Endpoints(svc.Namespace).Get(ctx, svc.Name, metav1.GetOptions{})
 			if err != nil {
 				return false, nil
@@ -132,7 +132,7 @@ var _ = common.SIGDescribe("EndpointSlice", func() {
 
 		// Expect EndpointSlice resource to be created.
 		var endpointSlice discoveryv1.EndpointSlice
-		if err := wait.PollImmediate(2*time.Second, wait.ForeverTestTimeout, func() (bool, error) {
+		if err := wait.PollUntilContextTimeout(ctx, 2*time.Second, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
 			endpointSliceList, err := cs.DiscoveryV1().EndpointSlices(svc.Namespace).List(ctx, metav1.ListOptions{
 				LabelSelector: "kubernetes.io/service-name=" + svc.Name,
 			})
@@ -164,7 +164,7 @@ var _ = common.SIGDescribe("EndpointSlice", func() {
 		framework.ExpectNoError(err, "error deleting Service")
 
 		// Expect Endpoints resource to be deleted when Service is.
-		if err := wait.PollImmediate(2*time.Second, wait.ForeverTestTimeout, func() (bool, error) {
+		if err := wait.PollUntilContextTimeout(ctx, 2*time.Second, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
 			_, err := cs.CoreV1().Endpoints(svc.Namespace).Get(ctx, svc.Name, metav1.GetOptions{})
 			if err != nil {
 				if apierrors.IsNotFound(err) {
@@ -181,7 +181,7 @@ var _ = common.SIGDescribe("EndpointSlice", func() {
 		// up to 90 seconds since garbage collector only polls every 30 seconds
 		// and may need to retry informer resync at some point during an e2e
 		// run.
-		if err := wait.PollImmediate(2*time.Second, 90*time.Second, func() (bool, error) {
+		if err := wait.PollUntilContextTimeout(ctx, 2*time.Second, 90*time.Second, true, func(ctx context.Context) (bool, error) {
 			endpointSliceList, err := cs.DiscoveryV1().EndpointSlices(svc.Namespace).List(ctx, metav1.ListOptions{
 				LabelSelector: "kubernetes.io/service-name=" + svc.Name,
 			})

--- a/test/e2e/network/endpointslicemirroring.go
+++ b/test/e2e/network/endpointslicemirroring.go
@@ -84,7 +84,7 @@ var _ = common.SIGDescribe("EndpointSliceMirroring", func() {
 			_, err := cs.CoreV1().Endpoints(f.Namespace.Name).Create(ctx, endpoints, metav1.CreateOptions{})
 			framework.ExpectNoError(err, "Unexpected error creating Endpoints")
 
-			if err := wait.PollImmediate(2*time.Second, 12*time.Second, func() (bool, error) {
+			if err := wait.PollUntilContextTimeout(ctx, 2*time.Second, 12*time.Second, true, func(ctx context.Context) (bool, error) {
 				esList, err := cs.DiscoveryV1().EndpointSlices(f.Namespace.Name).List(ctx, metav1.ListOptions{
 					LabelSelector: discoveryv1.LabelServiceName + "=" + svc.Name,
 				})
@@ -136,7 +136,7 @@ var _ = common.SIGDescribe("EndpointSliceMirroring", func() {
 			framework.ExpectNoError(err, "Unexpected error updating Endpoints")
 
 			// Expect mirrored EndpointSlice resource to be updated.
-			if err := wait.PollImmediate(2*time.Second, 12*time.Second, func() (bool, error) {
+			if err := wait.PollUntilContextTimeout(ctx, 2*time.Second, 12*time.Second, true, func(ctx context.Context) (bool, error) {
 				esList, err := cs.DiscoveryV1().EndpointSlices(f.Namespace.Name).List(ctx, metav1.ListOptions{
 					LabelSelector: discoveryv1.LabelServiceName + "=" + svc.Name,
 				})
@@ -183,7 +183,7 @@ var _ = common.SIGDescribe("EndpointSliceMirroring", func() {
 			framework.ExpectNoError(err, "Unexpected error deleting Endpoints")
 
 			// Expect mirrored EndpointSlice resource to be updated.
-			if err := wait.PollImmediate(2*time.Second, 12*time.Second, func() (bool, error) {
+			if err := wait.PollUntilContextTimeout(ctx, 2*time.Second, 12*time.Second, true, func(ctx context.Context) (bool, error) {
 				esList, err := cs.DiscoveryV1().EndpointSlices(f.Namespace.Name).List(ctx, metav1.ListOptions{
 					LabelSelector: discoveryv1.LabelServiceName + "=" + svc.Name,
 				})
@@ -281,8 +281,8 @@ var _ = common.SIGDescribe("EndpointSliceMirroring", func() {
 			_, err := cs.CoreV1().Endpoints(f.Namespace.Name).Create(context.TODO(), endpoints, metav1.CreateOptions{})
 			framework.ExpectNoError(err, "Unexpected error creating Endpoints")
 
-			if err := wait.PollImmediate(2*time.Second, 12*time.Second, func() (bool, error) {
-				esList, err := cs.DiscoveryV1().EndpointSlices(f.Namespace.Name).List(context.TODO(), metav1.ListOptions{
+			if err := wait.PollUntilContextTimeout(ctx, 2*time.Second, 12*time.Second, true, func(ctx context.Context) (bool, error) {
+				esList, err := cs.DiscoveryV1().EndpointSlices(f.Namespace.Name).List(ctx, metav1.ListOptions{
 					LabelSelector: discoveryv1.LabelServiceName + "=" + svc.Name,
 				})
 				if err != nil {
@@ -314,8 +314,8 @@ var _ = common.SIGDescribe("EndpointSliceMirroring", func() {
 			framework.ExpectNoError(err, "Unexpected error deleting Endpoints")
 
 			// Expect mirrored EndpointSlice resource to be updated.
-			if err := wait.PollImmediate(2*time.Second, 12*time.Second, func() (bool, error) {
-				esList, err := cs.DiscoveryV1().EndpointSlices(f.Namespace.Name).List(context.TODO(), metav1.ListOptions{
+			if err := wait.PollUntilContextTimeout(ctx, 2*time.Second, 12*time.Second, true, func(ctx context.Context) (bool, error) {
+				esList, err := cs.DiscoveryV1().EndpointSlices(f.Namespace.Name).List(ctx, metav1.ListOptions{
 					LabelSelector: discoveryv1.LabelServiceName + "=" + svc.Name,
 				})
 				if err != nil {

--- a/test/e2e/network/funny_ips.go
+++ b/test/e2e/network/funny_ips.go
@@ -117,7 +117,7 @@ var _ = common.SIGDescribe("CVE-2021-29923", func() {
 		execPod := e2epod.CreateExecPodOrFail(ctx, cs, ns, "execpod", nil)
 		ip := netutils.ParseIPSloppy(clusterIPZero)
 		cmd := fmt.Sprintf("echo hostName | nc -v -t -w 2 %s %v", ip.String(), servicePort)
-		err = wait.PollImmediate(1*time.Second, e2eservice.ServiceReachabilityShortPollTimeout, func() (bool, error) {
+		err = wait.PollUntilContextTimeout(ctx, 1*time.Second, e2eservice.ServiceReachabilityShortPollTimeout, true, func(ctx context.Context) (bool, error) {
 			stdout, err := e2eoutput.RunHostCmd(execPod.Namespace, execPod.Name, cmd)
 			if err != nil {
 				framework.Logf("Service reachability failing with error: %v\nRetrying...", err)
@@ -136,7 +136,7 @@ var _ = common.SIGDescribe("CVE-2021-29923", func() {
 		// It may happen that the component implementing Services discard the IP.
 		// We have to check that the Service is not reachable in the address interpreted as decimal.
 		cmd = fmt.Sprintf("echo hostName | nc -v -t -w 2 %s %v", clusterIPOctal, servicePort)
-		err = wait.PollImmediate(1*time.Second, e2eservice.ServiceReachabilityShortPollTimeout, func() (bool, error) {
+		err = wait.PollUntilContextTimeout(ctx, 1*time.Second, e2eservice.ServiceReachabilityShortPollTimeout, true, func(ctx context.Context) (bool, error) {
 			stdout, err := e2eoutput.RunHostCmd(execPod.Namespace, execPod.Name, cmd)
 			if err != nil {
 				framework.Logf("Service reachability failing with error: %v\nRetrying...", err)

--- a/test/e2e/network/kube_proxy.go
+++ b/test/e2e/network/kube_proxy.go
@@ -222,7 +222,7 @@ var _ = common.SIGDescribe("KubeProxy", func() {
 		cmd := fmt.Sprintf("conntrack -L -f %s -d %v "+
 			"| grep -m 1 'CLOSE_WAIT.*dport=%v' ",
 			ipFamily, ip, testDaemonTCPPort)
-		if err := wait.PollImmediate(2*time.Second, epsilonSeconds*time.Second, func() (bool, error) {
+		if err := wait.PollUntilContextTimeout(ctx, 2*time.Second, epsilonSeconds*time.Second, true, func(ctx context.Context) (bool, error) {
 			result, err := e2epodoutput.RunHostCmd(fr.Namespace.Name, "e2e-net-exec", cmd)
 			// retry if we can't obtain the conntrack entry
 			if err != nil {

--- a/test/e2e/network/loadbalancer.go
+++ b/test/e2e/network/loadbalancer.go
@@ -1056,7 +1056,7 @@ var _ = common.SIGDescribe("LoadBalancers ExternalTrafficPolicy: Local", feature
 		ingressIP := e2eservice.GetIngressPoint(&svc.Status.LoadBalancer.Ingress[0])
 
 		ginkgo.By("reading clientIP using the TCP service's service port via its external VIP")
-		clientIPPort, err := GetHTTPContent(ingressIP, svcTCPPort, e2eservice.KubeProxyLagTimeout, "/clientip")
+		clientIPPort, err := GetHTTPContent(ctx, ingressIP, svcTCPPort, e2eservice.KubeProxyLagTimeout, "/clientip")
 		framework.ExpectNoError(err)
 		framework.Logf("ClientIP detected by target pod using VIP:SvcPort is %s", clientIPPort)
 
@@ -1321,7 +1321,7 @@ var _ = common.SIGDescribe("LoadBalancers ExternalTrafficPolicy: Local", feature
 		ginkgo.By(fmt.Sprintf("checking source ip is NOT preserved through loadbalancer %v", ingressIP))
 		var clientIP string
 		pollErr := wait.PollUntilContextTimeout(ctx, framework.Poll, 3*e2eservice.KubeProxyLagTimeout, true, func(ctx context.Context) (bool, error) {
-			clientIPPort, err := GetHTTPContent(ingressIP, svcTCPPort, e2eservice.KubeProxyLagTimeout, path)
+			clientIPPort, err := GetHTTPContent(ctx, ingressIP, svcTCPPort, e2eservice.KubeProxyLagTimeout, path)
 			if err != nil {
 				return false, nil
 			}
@@ -1360,7 +1360,7 @@ var _ = common.SIGDescribe("LoadBalancers ExternalTrafficPolicy: Local", feature
 		framework.ExpectNoError(err)
 		loadBalancerPropagationTimeout := e2eservice.GetServiceLoadBalancerPropagationTimeout(ctx, cs)
 		pollErr = wait.PollUntilContextTimeout(ctx, framework.PollShortTimeout, loadBalancerPropagationTimeout, true, func(ctx context.Context) (bool, error) {
-			clientIPPort, err := GetHTTPContent(ingressIP, svcTCPPort, e2eservice.KubeProxyLagTimeout, path)
+			clientIPPort, err := GetHTTPContent(ctx, ingressIP, svcTCPPort, e2eservice.KubeProxyLagTimeout, path)
 			if err != nil {
 				return false, nil
 			}

--- a/test/e2e/network/netpol/test_helper.go
+++ b/test/e2e/network/netpol/test_helper.go
@@ -169,7 +169,7 @@ func AddPodLabels(ctx context.Context, k8s *kubeManager, namespace string, name 
 	_, err = k8s.clientSet.CoreV1().Pods(namespace).Update(ctx, kubePod, metav1.UpdateOptions{})
 	framework.ExpectNoError(err, "Unable to add pod %s/%s labels", namespace, name)
 
-	err = wait.PollImmediate(waitInterval, waitTimeout, func() (done bool, err error) {
+	err = wait.PollUntilContextTimeout(ctx, waitInterval, waitTimeout, true, func(ctx context.Context) (done bool, err error) {
 		waitForPod, err := k8s.getPod(ctx, namespace, name)
 		if err != nil {
 			return false, err
@@ -195,7 +195,7 @@ func ResetPodLabels(ctx context.Context, k8s *kubeManager, namespace string, nam
 	_, err = k8s.clientSet.CoreV1().Pods(namespace).Update(ctx, kubePod, metav1.UpdateOptions{})
 	framework.ExpectNoError(err, "Unable to add pod %s/%s labels", namespace, name)
 
-	err = wait.PollImmediate(waitInterval, waitTimeout, func() (done bool, err error) {
+	err = wait.PollUntilContextTimeout(ctx, waitInterval, waitTimeout, true, func(ctx context.Context) (done bool, err error) {
 		waitForPod, err := k8s.getPod(ctx, namespace, name)
 		if err != nil {
 			return false, nil

--- a/test/e2e/network/networking.go
+++ b/test/e2e/network/networking.go
@@ -615,7 +615,7 @@ var _ = common.SIGDescribe("Networking", func() {
 		framework.ExpectNoError(verifyServeHostnameServiceUp(ctx, f.ClientSet, ns, podNames, svcIP, servicePort))
 
 		ginkgo.By("verifying that kubelet rules are eventually recreated")
-		err = utilwait.PollImmediate(framework.Poll, framework.RestartNodeReadyAgainTimeout, func() (bool, error) {
+		err = utilwait.PollUntilContextTimeout(ctx, framework.Poll, framework.RestartNodeReadyAgainTimeout, true, func(ctx context.Context) (bool, error) {
 			result, err = e2essh.SSH(ctx, "sudo iptables-save -t mangle", host, framework.TestContext.Provider)
 			if err != nil || result.Code != 0 {
 				e2essh.LogResult(result)

--- a/test/e2e/network/no_snat.go
+++ b/test/e2e/network/no_snat.go
@@ -85,7 +85,7 @@ var _ = common.SIGDescribe("NoSNAT", feature.NoSNAT, framework.WithSlow(), func(
 		}
 
 		ginkgo.By("waiting for all of the no-snat-test pods to be scheduled and running")
-		err = wait.PollImmediate(10*time.Second, 1*time.Minute, func() (bool, error) {
+		err = wait.PollUntilContextTimeout(ctx, 10*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 			pods, err := pc.List(ctx, metav1.ListOptions{LabelSelector: noSNATTestName})
 			if err != nil {
 				return false, err

--- a/test/e2e/network/proxy.go
+++ b/test/e2e/network/proxy.go
@@ -353,7 +353,7 @@ var _ = common.SIGDescribe("Proxy", func() {
 				urlString := strings.TrimRight(f.ClientConfig().Host, "/") + "/api/v1/namespaces/" + ns + "/pods/agnhost/proxy/some/path/with/" + httpVerb
 				framework.Logf("Starting http.Client for %s", urlString)
 
-				pollErr := wait.PollImmediate(requestRetryPeriod, requestRetryTimeout, validateProxyVerbRequest(client, urlString, httpVerb, msg))
+				pollErr := wait.PollUntilContextTimeout(ctx, requestRetryPeriod, requestRetryTimeout, true, validateProxyVerbRequest(client, urlString, httpVerb, msg))
 				framework.ExpectNoError(err, "Service didn't start within time out period. %v", pollErr)
 			}
 
@@ -364,7 +364,7 @@ var _ = common.SIGDescribe("Proxy", func() {
 				urlString := strings.TrimRight(f.ClientConfig().Host, "/") + "/api/v1/namespaces/" + ns + "/services/test-service/proxy/some/path/with/" + httpVerb
 				framework.Logf("Starting http.Client for %s", urlString)
 
-				pollErr := wait.PollImmediate(requestRetryPeriod, requestRetryTimeout, validateProxyVerbRequest(client, urlString, httpVerb, msg))
+				pollErr := wait.PollUntilContextTimeout(ctx, requestRetryPeriod, requestRetryTimeout, true, validateProxyVerbRequest(client, urlString, httpVerb, msg))
 				framework.ExpectNoError(err, "Service didn't start within time out period. %v", pollErr)
 			}
 		})
@@ -447,7 +447,7 @@ var _ = common.SIGDescribe("Proxy", func() {
 				urlString := strings.TrimRight(f.ClientConfig().Host, "/") + "/api/v1/namespaces/" + ns + "/pods/agnhost/proxy?method=" + httpVerb
 				framework.Logf("Starting http.Client for %s", urlString)
 
-				pollErr := wait.PollImmediate(requestRetryPeriod, requestRetryTimeout, validateProxyVerbRequest(client, urlString, httpVerb, msg))
+				pollErr := wait.PollUntilContextTimeout(ctx, requestRetryPeriod, requestRetryTimeout, true, validateProxyVerbRequest(client, urlString, httpVerb, msg))
 				framework.ExpectNoError(pollErr, "Pod didn't start within time out period. %v", pollErr)
 			}
 
@@ -458,7 +458,7 @@ var _ = common.SIGDescribe("Proxy", func() {
 				urlString := strings.TrimRight(f.ClientConfig().Host, "/") + "/api/v1/namespaces/" + ns + "/services/" + testSvcName + "/proxy?method=" + httpVerb
 				framework.Logf("Starting http.Client for %s", urlString)
 
-				pollErr := wait.PollImmediate(requestRetryPeriod, requestRetryTimeout, validateProxyVerbRequest(client, urlString, httpVerb, msg))
+				pollErr := wait.PollUntilContextTimeout(ctx, requestRetryPeriod, requestRetryTimeout, true, validateProxyVerbRequest(client, urlString, httpVerb, msg))
 				framework.ExpectNoError(pollErr, "Service didn't start within time out period. %v", pollErr)
 			}
 
@@ -491,8 +491,8 @@ func validateRedirectRequest(client *http.Client, redirectVerb string, urlString
 // validateProxyVerbRequest checks that a http request to a pod
 // or service was valid for any http verb. Requires agnhost image
 // with porter --json-response
-func validateProxyVerbRequest(client *http.Client, urlString string, httpVerb string, msg string) func() (bool, error) {
-	return func() (bool, error) {
+func validateProxyVerbRequest(client *http.Client, urlString string, httpVerb string, msg string) func(context.Context) (bool, error) {
+	return func(context.Context) (bool, error) {
 		var err error
 
 		request, err := http.NewRequest(httpVerb, urlString, nil)

--- a/test/e2e/network/util.go
+++ b/test/e2e/network/util.go
@@ -43,9 +43,9 @@ import (
 const secondNodePortSvcName = "second-node-port-service"
 
 // GetHTTPContent returns the content of the given url by HTTP.
-func GetHTTPContent(host string, port int, timeout time.Duration, url string) (string, error) {
+func GetHTTPContent(ctx context.Context, host string, port int, timeout time.Duration, url string) (string, error) {
 	var body bytes.Buffer
-	pollErr := wait.PollImmediate(framework.Poll, timeout, func() (bool, error) {
+	pollErr := wait.PollUntilContextTimeout(ctx, framework.Poll, timeout, true, func(ctx context.Context) (bool, error) {
 		result := e2enetwork.PokeHTTP(host, port, url, nil)
 		if result.Status == e2enetwork.HTTPSuccess {
 			body.Write(result.Body)
@@ -62,7 +62,7 @@ func GetHTTPContent(host string, port int, timeout time.Duration, url string) (s
 // GetHTTPContentFromTestContainer returns the content of the given url by HTTP via a test container.
 func GetHTTPContentFromTestContainer(ctx context.Context, config *e2enetwork.NetworkingTestConfig, host string, port int, timeout time.Duration, dialCmd string) (string, error) {
 	var body string
-	pollFn := func() (bool, error) {
+	pollFn := func(ctx context.Context) (bool, error) {
 		resp, err := config.GetResponseFromTestContainer(ctx, "http", dialCmd, host, port)
 		if err != nil || len(resp.Errors) > 0 || len(resp.Responses) == 0 {
 			return false, nil
@@ -70,7 +70,7 @@ func GetHTTPContentFromTestContainer(ctx context.Context, config *e2enetwork.Net
 		body = resp.Responses[0]
 		return true, nil
 	}
-	if pollErr := wait.PollImmediate(framework.Poll, timeout, pollFn); pollErr != nil {
+	if pollErr := wait.PollUntilContextTimeout(ctx, framework.Poll, timeout, true, pollFn); pollErr != nil {
 		return "", pollErr
 	}
 	return body, nil

--- a/test/e2e/storage/csimock/base.go
+++ b/test/e2e/storage/csimock/base.go
@@ -1109,9 +1109,9 @@ func anyOf(conditions ...wait.ConditionFunc) wait.ConditionFunc {
 	}
 }
 
-func waitForMaxVolumeCondition(pod *v1.Pod, cs clientset.Interface) error {
-	waitErr := wait.PollImmediate(10*time.Second, csiPodUnschedulableTimeout, func() (bool, error) {
-		pod, err := cs.CoreV1().Pods(pod.Namespace).Get(context.TODO(), pod.Name, metav1.GetOptions{})
+func waitForMaxVolumeCondition(ctx context.Context, pod *v1.Pod, cs clientset.Interface) error {
+	waitErr := wait.PollUntilContextTimeout(ctx, 10*time.Second, csiPodUnschedulableTimeout, true, func(ctx context.Context) (bool, error) {
+		pod, err := cs.CoreV1().Pods(pod.Namespace).Get(ctx, pod.Name, metav1.GetOptions{})
 		if err != nil {
 			return false, err
 		}

--- a/test/e2e/storage/csimock/csi_volume_expansion.go
+++ b/test/e2e/storage/csimock/csi_volume_expansion.go
@@ -473,11 +473,11 @@ var _ = utils.SIGDescribe("CSI Mock volume expansion", func() {
 func validateRecoveryBehaviour(ctx context.Context, pvc *v1.PersistentVolumeClaim, m *mockDriverSetup, test recoveryTest) {
 	var err error
 	ginkgo.By("Waiting for resizer to set allocated resource")
-	err = waitForAllocatedResource(pvc, m, test.allocatedResource)
+	err = waitForAllocatedResource(ctx, pvc, m, test.allocatedResource)
 	framework.ExpectNoError(err, "While waiting for allocated resource to be updated")
 
 	ginkgo.By("Waiting for resizer to set resize status")
-	err = waitForResizeStatus(pvc, m.cs, test.expectedResizeStatus)
+	err = waitForResizeStatus(ctx, pvc, m.cs, test.expectedResizeStatus)
 	framework.ExpectNoError(err, "While waiting for resize status to be set")
 
 	ginkgo.By("Recover pvc size")
@@ -500,7 +500,7 @@ func validateRecoveryBehaviour(ctx context.Context, pvc *v1.PersistentVolumeClai
 	// if expansion succeeded on controller but failed on the node
 	if test.simulatedCSIDriverError == expansionFailedOnNode {
 		ginkgo.By("Wait for expansion to fail on node again")
-		err = waitForResizeStatus(pvc, m.cs, v1.PersistentVolumeClaimNodeResizeFailed)
+		err = waitForResizeStatus(ctx, pvc, m.cs, v1.PersistentVolumeClaimNodeResizeFailed)
 		framework.ExpectNoError(err, "While waiting for resize status to be set to expansion-failed-on-node")
 
 		ginkgo.By("verify allocated resources after recovery")
@@ -541,12 +541,12 @@ func validateExpansionSuccess(ctx context.Context, pvc *v1.PersistentVolumeClaim
 	gomega.Expect(resizeStatus).To(gomega.BeZero(), "resize status should be empty")
 }
 
-func waitForResizeStatus(pvc *v1.PersistentVolumeClaim, c clientset.Interface, expectedState v1.ClaimResourceStatus) error {
+func waitForResizeStatus(ctx context.Context, pvc *v1.PersistentVolumeClaim, c clientset.Interface, expectedState v1.ClaimResourceStatus) error {
 	var actualResizeStatus *v1.ClaimResourceStatus
 
-	waitErr := wait.PollImmediate(resizePollInterval, csiResizeWaitPeriod, func() (bool, error) {
+	waitErr := wait.PollUntilContextTimeout(ctx, resizePollInterval, csiResizeWaitPeriod, true, func(ctx context.Context) (bool, error) {
 		var err error
-		updatedPVC, err := c.CoreV1().PersistentVolumeClaims(pvc.Namespace).Get(context.TODO(), pvc.Name, metav1.GetOptions{})
+		updatedPVC, err := c.CoreV1().PersistentVolumeClaims(pvc.Namespace).Get(ctx, pvc.Name, metav1.GetOptions{})
 
 		if err != nil {
 			return false, fmt.Errorf("error fetching pvc %q for checking for resize status: %w", pvc.Name, err)
@@ -561,9 +561,9 @@ func waitForResizeStatus(pvc *v1.PersistentVolumeClaim, c clientset.Interface, e
 	return nil
 }
 
-func waitForAllocatedResource(pvc *v1.PersistentVolumeClaim, m *mockDriverSetup, expectedSize string) error {
+func waitForAllocatedResource(ctx context.Context, pvc *v1.PersistentVolumeClaim, m *mockDriverSetup, expectedSize string) error {
 	expectedQuantity := resource.MustParse(expectedSize)
-	waitErr := wait.PollImmediate(resizePollInterval, csiResizeWaitPeriod, func() (bool, error) {
+	waitErr := wait.PollUntilContextTimeout(ctx, resizePollInterval, csiResizeWaitPeriod, true, func(ctx context.Context) (bool, error) {
 		var err error
 		updatedPVC, err := m.cs.CoreV1().PersistentVolumeClaims(pvc.Namespace).Get(context.TODO(), pvc.Name, metav1.GetOptions{})
 

--- a/test/e2e/storage/helpers.go
+++ b/test/e2e/storage/helpers.go
@@ -110,7 +110,7 @@ func getStorageClass(
 
 func waitForDeploymentToRecreatePod(ctx context.Context, client kubernetes.Interface, deployment *appsv1.Deployment) (v1.Pod, error) {
 	var runningPod v1.Pod
-	waitErr := wait.PollImmediate(10*time.Second, 5*time.Minute, func() (bool, error) {
+	waitErr := wait.PollUntilContextTimeout(ctx, 10*time.Second, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
 		podList, err := e2edeployment.GetPodsForDeployment(ctx, client, deployment)
 		if err != nil {
 			return false, fmt.Errorf("failed to get pods for deployment: %w", err)

--- a/test/e2e/storage/persistent_volumes-local.go
+++ b/test/e2e/storage/persistent_volumes-local.go
@@ -896,7 +896,7 @@ func createLocalPVCsPVs(ctx context.Context, config *localTestConfig, volumes []
 		// Verify PVCs are not bound by waiting for phase==bound with a timeout and asserting that we hit the timeout.
 		// There isn't really a great way to verify this without making the test be slow...
 		const bindTimeout = 10 * time.Second
-		waitErr := wait.PollImmediate(time.Second, bindTimeout, func() (done bool, err error) {
+		waitErr := wait.PollUntilContextTimeout(ctx, time.Second, bindTimeout, true, func(ctx context.Context) (done bool, err error) {
 			for _, volume := range volumes {
 				pvc, err := config.client.CoreV1().PersistentVolumeClaims(volume.pvc.Namespace).Get(ctx, volume.pvc.Name, metav1.GetOptions{})
 				if err != nil {

--- a/test/e2e/storage/persistent_volumes-local.go
+++ b/test/e2e/storage/persistent_volumes-local.go
@@ -895,7 +895,7 @@ func createLocalPVCsPVs(ctx context.Context, config *localTestConfig, volumes []
 	} else {
 		// Verify PVCs are not bound by waiting for phase==bound with a timeout and asserting that we hit the timeout.
 		// There isn't really a great way to verify this without making the test be slow...
-		const bindTimeout = 10 * time.Second
+		const bindTimeout = 5 * time.Minute
 		waitErr := wait.PollUntilContextTimeout(ctx, time.Second, bindTimeout, true, func(ctx context.Context) (done bool, err error) {
 			for _, volume := range volumes {
 				pvc, err := config.client.CoreV1().PersistentVolumeClaims(volume.pvc.Namespace).Get(ctx, volume.pvc.Name, metav1.GetOptions{})

--- a/test/e2e/storage/testsuites/subpath.go
+++ b/test/e2e/storage/testsuites/subpath.go
@@ -730,7 +730,7 @@ func waitForPodSubpathError(ctx context.Context, f *framework.Framework, pod *v1
 		return fmt.Errorf("failed to find container that uses subpath")
 	}
 
-	waitErr := wait.PollImmediate(framework.Poll, f.Timeouts.PodStart, func() (bool, error) {
+	waitErr := wait.PollUntilContextTimeout(ctx, framework.Poll, f.Timeouts.PodStart, true, func(ctx context.Context) (bool, error) {
 		pod, err := f.ClientSet.CoreV1().Pods(pod.Namespace).Get(ctx, pod.Name, metav1.GetOptions{})
 		if err != nil {
 			return false, err
@@ -817,7 +817,7 @@ func testPodContainerRestartWithHooks(ctx context.Context, f *framework.Framewor
 	// and "start pod".
 	ginkgo.By("Waiting for container to restart")
 	restarts := int32(0)
-	err = wait.PollImmediate(10*time.Second, f.Timeouts.PodDelete+f.Timeouts.PodStart, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 10*time.Second, f.Timeouts.PodDelete+f.Timeouts.PodStart, true, func(ctx context.Context) (bool, error) {
 		pod, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(ctx, pod.Name, metav1.GetOptions{})
 		if err != nil {
 			return false, err
@@ -848,7 +848,7 @@ func testPodContainerRestartWithHooks(ctx context.Context, f *framework.Framewor
 	ginkgo.By("Waiting for container to stop restarting")
 	stableCount := int(0)
 	stableThreshold := int(time.Minute / framework.Poll)
-	err = wait.PollImmediate(framework.Poll, f.Timeouts.PodStartSlow, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, framework.Poll, f.Timeouts.PodStartSlow, true, func(ctx context.Context) (bool, error) {
 		pod, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(ctx, pod.Name, metav1.GetOptions{})
 		if err != nil {
 			return false, err

--- a/test/e2e/storage/testsuites/volume_expand.go
+++ b/test/e2e/storage/testsuites/volume_expand.go
@@ -318,7 +318,7 @@ func ExpandPVCSize(ctx context.Context, origPVC *v1.PersistentVolumeClaim, size 
 	// Retry the update on error, until we hit a timeout.
 	// TODO: Determine whether "retry with timeout" is appropriate here. Maybe we should only retry on version conflict.
 	var lastUpdateError error
-	waitErr := wait.PollUntilContextTimeout(ctx, resizePollInterval, 30*time.Second, true, func(ctx context.Context) (bool, error) {
+	waitErr := wait.PollUntilContextTimeout(ctx, resizePollInterval, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
 		var err error
 		updatedPVC, err = c.CoreV1().PersistentVolumeClaims(origPVC.Namespace).Get(ctx, pvcName, metav1.GetOptions{})
 		if err != nil {

--- a/test/e2e/storage/testsuites/volume_expand.go
+++ b/test/e2e/storage/testsuites/volume_expand.go
@@ -318,7 +318,7 @@ func ExpandPVCSize(ctx context.Context, origPVC *v1.PersistentVolumeClaim, size 
 	// Retry the update on error, until we hit a timeout.
 	// TODO: Determine whether "retry with timeout" is appropriate here. Maybe we should only retry on version conflict.
 	var lastUpdateError error
-	waitErr := wait.PollImmediate(resizePollInterval, 30*time.Second, func() (bool, error) {
+	waitErr := wait.PollUntilContextTimeout(ctx, resizePollInterval, 30*time.Second, true, func(ctx context.Context) (bool, error) {
 		var err error
 		updatedPVC, err = c.CoreV1().PersistentVolumeClaims(origPVC.Namespace).Get(ctx, pvcName, metav1.GetOptions{})
 		if err != nil {

--- a/test/e2e/storage/testsuites/volumelimits.go
+++ b/test/e2e/storage/testsuites/volumelimits.go
@@ -384,7 +384,7 @@ func getInTreeNodeLimits(ctx context.Context, cs clientset.Interface, nodeName s
 func getCSINodeLimits(ctx context.Context, cs clientset.Interface, config *storageframework.PerTestConfig, nodeName string, driverInfo *storageframework.DriverInfo) (int, error) {
 	// Retry with a timeout, the driver might just have been installed and kubelet takes a while to publish everything.
 	var limit int
-	err := wait.PollImmediate(2*time.Second, csiNodeInfoTimeout, func() (bool, error) {
+	err := wait.PollUntilContextTimeout(ctx, 2*time.Second, csiNodeInfoTimeout, true, func(ctx context.Context) (bool, error) {
 		csiNode, err := cs.StorageV1().CSINodes().Get(ctx, nodeName, metav1.GetOptions{})
 		if err != nil {
 			framework.Logf("%s", err)

--- a/test/e2e/upgrades/apps/deployments.go
+++ b/test/e2e/upgrades/apps/deployments.go
@@ -177,7 +177,7 @@ func (t *DeploymentUpgradeTest) Teardown(ctx context.Context, f *framework.Frame
 
 // waitForDeploymentRevision waits for becoming the target revision of a delopyment.
 func waitForDeploymentRevision(ctx context.Context, c clientset.Interface, d *appsv1.Deployment, targetRevision string) error {
-	err := wait.PollImmediate(poll, pollLongTimeout, func() (bool, error) {
+	err := wait.PollUntilContextTimeout(ctx, poll, pollLongTimeout, true, func(ctx context.Context) (bool, error) {
 		deployment, err := c.AppsV1().Deployments(d.Namespace).Get(ctx, d.Name, metav1.GetOptions{})
 		if err != nil {
 			return false, err

--- a/test/e2e/upgrades/auth/serviceaccount_admission_controller_migration.go
+++ b/test/e2e/upgrades/auth/serviceaccount_admission_controller_migration.go
@@ -90,7 +90,7 @@ func (t *ServiceAccountAdmissionControllerMigrationTest) Teardown(ctx context.Co
 func inClusterClientMustWork(ctx context.Context, f *framework.Framework, pod *v1.Pod) {
 	var logs string
 	since := time.Now()
-	if err := wait.PollImmediate(15*time.Second, 5*time.Minute, func() (done bool, err error) {
+	if err := wait.PollUntilContextTimeout(ctx, 15*time.Second, 5*time.Minute, true, func(ctx context.Context) (done bool, err error) {
 		framework.Logf("Polling logs")
 		logs, err = e2epod.GetPodLogsSince(ctx, f.ClientSet, pod.Namespace, pod.Name, "inclusterclient", since)
 		if err != nil {

--- a/test/e2e/upgrades/network/kube_proxy_migration.go
+++ b/test/e2e/upgrades/network/kube_proxy_migration.go
@@ -115,7 +115,7 @@ func (t *KubeProxyDowngradeTest) Teardown(ctx context.Context, f *framework.Fram
 func waitForKubeProxyStaticPodsRunning(ctx context.Context, c clientset.Interface) error {
 	framework.Logf("Waiting up to %v for kube-proxy static pods running", defaultTestTimeout)
 
-	condition := func() (bool, error) {
+	condition := func(ctx context.Context) (bool, error) {
 		pods, err := getKubeProxyStaticPods(ctx, c)
 		if err != nil {
 			framework.Logf("Failed to get kube-proxy static pods: %v", err)
@@ -142,7 +142,7 @@ func waitForKubeProxyStaticPodsRunning(ctx context.Context, c clientset.Interfac
 		return true, nil
 	}
 
-	if err := wait.PollImmediate(5*time.Second, defaultTestTimeout, condition); err != nil {
+	if err := wait.PollUntilContextTimeout(ctx, 5*time.Second, defaultTestTimeout, true, condition); err != nil {
 		return fmt.Errorf("error waiting for kube-proxy static pods running: %w", err)
 	}
 	return nil
@@ -151,7 +151,7 @@ func waitForKubeProxyStaticPodsRunning(ctx context.Context, c clientset.Interfac
 func waitForKubeProxyStaticPodsDisappear(ctx context.Context, c clientset.Interface) error {
 	framework.Logf("Waiting up to %v for kube-proxy static pods disappear", defaultTestTimeout)
 
-	condition := func() (bool, error) {
+	condition := func(ctx context.Context) (bool, error) {
 		pods, err := getKubeProxyStaticPods(ctx, c)
 		if err != nil {
 			framework.Logf("Failed to get kube-proxy static pods: %v", err)
@@ -165,7 +165,7 @@ func waitForKubeProxyStaticPodsDisappear(ctx context.Context, c clientset.Interf
 		return true, nil
 	}
 
-	if err := wait.PollImmediate(5*time.Second, defaultTestTimeout, condition); err != nil {
+	if err := wait.PollUntilContextTimeout(ctx, 5*time.Second, defaultTestTimeout, true, condition); err != nil {
 		return fmt.Errorf("error waiting for kube-proxy static pods disappear: %w", err)
 	}
 	return nil
@@ -174,7 +174,7 @@ func waitForKubeProxyStaticPodsDisappear(ctx context.Context, c clientset.Interf
 func waitForKubeProxyDaemonSetRunning(ctx context.Context, f *framework.Framework, c clientset.Interface) error {
 	framework.Logf("Waiting up to %v for kube-proxy DaemonSet running", defaultTestTimeout)
 
-	condition := func() (bool, error) {
+	condition := func(ctx context.Context) (bool, error) {
 		daemonSets, err := getKubeProxyDaemonSet(ctx, c)
 		if err != nil {
 			framework.Logf("Failed to get kube-proxy DaemonSet: %v", err)
@@ -189,7 +189,7 @@ func waitForKubeProxyDaemonSetRunning(ctx context.Context, f *framework.Framewor
 		return e2edaemonset.CheckRunningOnAllNodes(ctx, f, &daemonSets.Items[0])
 	}
 
-	if err := wait.PollImmediate(5*time.Second, defaultTestTimeout, condition); err != nil {
+	if err := wait.PollUntilContextTimeout(ctx, 5*time.Second, defaultTestTimeout, true, condition); err != nil {
 		return fmt.Errorf("error waiting for kube-proxy DaemonSet running: %w", err)
 	}
 	return nil
@@ -198,7 +198,7 @@ func waitForKubeProxyDaemonSetRunning(ctx context.Context, f *framework.Framewor
 func waitForKubeProxyDaemonSetDisappear(ctx context.Context, c clientset.Interface) error {
 	framework.Logf("Waiting up to %v for kube-proxy DaemonSet disappear", defaultTestTimeout)
 
-	condition := func() (bool, error) {
+	condition := func(ctx context.Context) (bool, error) {
 		daemonSets, err := getKubeProxyDaemonSet(ctx, c)
 		if err != nil {
 			framework.Logf("Failed to get kube-proxy DaemonSet: %v", err)
@@ -212,7 +212,7 @@ func waitForKubeProxyDaemonSetDisappear(ctx context.Context, c clientset.Interfa
 		return true, nil
 	}
 
-	if err := wait.PollImmediate(5*time.Second, defaultTestTimeout, condition); err != nil {
+	if err := wait.PollUntilContextTimeout(ctx, 5*time.Second, defaultTestTimeout, true, condition); err != nil {
 		return fmt.Errorf("error waiting for kube-proxy DaemonSet disappear: %w", err)
 	}
 	return nil

--- a/test/e2e/windows/gmsa_full.go
+++ b/test/e2e/windows/gmsa_full.go
@@ -361,7 +361,7 @@ func deployGmsaWebhook(ctx context.Context, f *framework.Framework) error {
 	e2epod.NewPodClient(f).CreateSync(ctx, pod)
 
 	// Wait for the Webhook deployment to become ready. The deployer pod takes a few seconds to initialize and create resources
-	err := waitForDeployment(func() (*appsv1.Deployment, error) {
+	err := waitForDeployment(ctx, func() (*appsv1.Deployment, error) {
 		return f.ClientSet.AppsV1().Deployments(webHookNamespace).Get(ctx, webHookName, metav1.GetOptions{})
 	}, 10*time.Second, f.Timeouts.PodStart)
 	if err == nil {

--- a/test/e2e/windows/utils.go
+++ b/test/e2e/windows/utils.go
@@ -37,8 +37,8 @@ import (
 
 // waits for a deployment to be created and the desired replicas
 // are updated and available, and no old pods are running.
-func waitForDeployment(getDeploymentFunc func() (*appsv1.Deployment, error), interval, timeout time.Duration) error {
-	return wait.PollImmediate(interval, timeout, func() (bool, error) {
+func waitForDeployment(ctx context.Context, getDeploymentFunc func() (*appsv1.Deployment, error), interval, timeout time.Duration) error {
+	return wait.PollUntilContextTimeout(ctx, interval, timeout, true, func(ctx context.Context) (bool, error) {
 		deployment, err := getDeploymentFunc()
 		if err != nil {
 			if apierrors.IsNotFound(err) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
As shown in util/wait

```go
// Deprecated: This method does not return errors from context, use PollUntilContextTimeout.
// Note that the new method will no longer return ErrWaitTimeout and instead return errors
// defined by the context package. Will be removed in a future release.
func PollImmediate(interval, timeout time.Duration, condition ConditionFunc) error {
	return PollImmediateWithContext(context.Background(), interval, timeout, condition.WithContext())
}
```
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
none
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
none
```
