### PR TITLE
fix: enable and fixes rules from testifylint on test package

### DIFF
--- a/test/e2e/apimachinery/apply.go
+++ b/test/e2e/apimachinery/apply.go
@@ -39,9 +39,6 @@ import (
 	admissionapi "k8s.io/pod-security-admission/api"
 
 	"github.com/onsi/ginkgo/v2"
-
-	// ensure libs have a chance to initialize
-	_ "github.com/stretchr/testify/assert"
 )
 
 var _ = SIGDescribe("ServerSideApply", func() {

--- a/test/e2e/apimachinery/crd_conversion_webhook.go
+++ b/test/e2e/apimachinery/crd_conversion_webhook.go
@@ -44,9 +44,6 @@ import (
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apiextensions-apiserver/test/integration"
-
-	// ensure libs have a chance to initialize
-	_ "github.com/stretchr/testify/assert"
 )
 
 const (

--- a/test/e2e/apimachinery/field_validation.go
+++ b/test/e2e/apimachinery/field_validation.go
@@ -17,14 +17,12 @@ limitations under the License.
 package apimachinery
 
 import (
-	// ensure libs have a chance to initialize
 	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
 
 	"github.com/onsi/ginkgo/v2"
-	_ "github.com/stretchr/testify/assert"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/apiextensions-apiserver/test/integration/fixtures"

--- a/test/e2e/apimachinery/openapiv3.go
+++ b/test/e2e/apimachinery/openapiv3.go
@@ -42,9 +42,6 @@ import (
 	samplev1beta1 "k8s.io/sample-apiserver/pkg/apis/wardle/v1beta1"
 
 	"k8s.io/kubernetes/test/e2e/framework"
-
-	// ensure libs have a chance to initialize
-	_ "github.com/stretchr/testify/assert"
 )
 
 var _ = SIGDescribe("OpenAPIV3", func() {

--- a/test/e2e/apimachinery/webhook.go
+++ b/test/e2e/apimachinery/webhook.go
@@ -52,9 +52,6 @@ import (
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
-
-	// ensure libs have a chance to initialize
-	_ "github.com/stretchr/testify/assert"
 )
 
 const (

--- a/test/e2e/framework/expect_test.go
+++ b/test/e2e/framework/expect_test.go
@@ -44,7 +44,7 @@ func TestNewGomega(t *testing.T) {
 		t.Errorf("unexpected failure: %s", err.Error())
 	}
 	err := Gomega().Expect("hello").ToNot(gomega.Equal("hello"))
-	require.NotNil(t, err)
+	require.Error(t, err)
 	assert.Equal(t, `Expected
     <string>: hello
 not to equal

--- a/test/e2e/framework/internal/unittests/bugs/bugs_test.go
+++ b/test/e2e/framework/internal/unittests/bugs/bugs_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func TestBugs(t *testing.T) {
-	assert.NoError(t, framework.FormatBugs())
+	require.NoError(t, framework.FormatBugs())
 	RecordBugs()
 	Describe()
 

--- a/test/e2e/framework/pod/utils_test.go
+++ b/test/e2e/framework/pod/utils_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
@@ -65,7 +66,7 @@ func TestMixinRestrictedPodSecurity(t *testing.T) {
 	for _, pod := range restrictablePods {
 		t.Run(pod.Name, func(t *testing.T) {
 			p := pod // closure
-			assert.NoError(t, MixinRestrictedPodSecurity(&p))
+			require.NoError(t, MixinRestrictedPodSecurity(&p))
 			assert.Equal(t, GetRestrictedPodSecurityContext(), p.Spec.SecurityContext,
 				"Mixed in PodSecurityContext should equal the from-scratch PodSecurityContext")
 			assert.Equal(t, GetRestrictedContainerSecurityContext(), p.Spec.Containers[0].SecurityContext,

--- a/test/e2e/framework/testfiles/testfiles_test.go
+++ b/test/e2e/framework/testfiles/testfiles_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -49,13 +50,13 @@ func TestEmbeddedFileSource(t *testing.T) {
 	// read a file which exists and compare the contents
 	b, err := s.ReadTestFile(fooPath)
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, fooContents, string(b))
 
 	// read a non-existent file and ensure that the returned value is empty and error is nil
 	// Note: this is done so that the next file source can be tried by the caller
 	b, err = s.ReadTestFile(notExistsPath)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Empty(t, b)
 
 	// describing the test filesystem should list down all files

--- a/test/e2e/node/taints.go
+++ b/test/e2e/node/taints.go
@@ -35,8 +35,6 @@ import (
 	admissionapi "k8s.io/pod-security-admission/api"
 
 	"github.com/onsi/ginkgo/v2"
-	// ensure libs have a chance to initialize
-	_ "github.com/stretchr/testify/assert"
 )
 
 const (

--- a/test/e2e/scheduling/predicates.go
+++ b/test/e2e/scheduling/predicates.go
@@ -48,9 +48,6 @@ import (
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
-
-	// ensure libs have a chance to initialize
-	_ "github.com/stretchr/testify/assert"
 )
 
 const (

--- a/test/e2e/scheduling/preemption.go
+++ b/test/e2e/scheduling/preemption.go
@@ -48,9 +48,6 @@ import (
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
-
-	// ensure libs have a chance to initialize
-	_ "github.com/stretchr/testify/assert"
 )
 
 type priorityPair struct {

--- a/test/e2e/scheduling/priorities.go
+++ b/test/e2e/scheduling/priorities.go
@@ -26,9 +26,6 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 
-	// ensure libs have a chance to initialize
-	_ "github.com/stretchr/testify/assert"
-
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/test/e2e/storage/external/external_test.go
+++ b/test/e2e/storage/external/external_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"k8s.io/apimachinery/pkg/util/sets"
 	e2evolume "k8s.io/kubernetes/test/e2e/framework/volume"
@@ -68,7 +69,7 @@ func TestDriverParameter(t *testing.T) {
 	for _, testcase := range testcases {
 		actual, err := loadDriverDefinition(testcase.filename)
 		if testcase.err == "" {
-			assert.NoError(t, err, testcase.name)
+			require.NoError(t, err, testcase.name)
 		} else {
 			if assert.Error(t, err, testcase.name) {
 				assert.Equal(t, testcase.err, err.Error())

--- a/test/integration/apiserver/oidc/oidc_test.go
+++ b/test/integration/apiserver/oidc/oidc_test.go
@@ -260,7 +260,7 @@ jwt:
 			configureClient: configureClientFetchingOIDCCredentials,
 			assertErrFn: func(t *testing.T, errorToCheck error) {
 				expectedError := new(apierrors.StatusError)
-				assert.ErrorAs(t, errorToCheck, &expectedError)
+				require.ErrorAs(t, errorToCheck, &expectedError)
 				assert.Equal(
 					t,
 					`pods is forbidden: User "system:anonymous" cannot list resource "pods" in API group "" in the namespace "default"`,
@@ -552,7 +552,7 @@ func TestUpdatingRefreshTokenInCaseOfExpiredIDToken(t *testing.T) {
 
 			ctx := testContext(t)
 			_, err = expiredClient.CoreV1().Pods(defaultNamespace).List(ctx, metav1.ListOptions{})
-			assert.Error(t, err)
+			require.Error(t, err)
 
 			tt.configureUpdatingTokenBehaviour(t, oidcServer, signingPrivateKey)
 			idToken, stubRefreshToken := fetchOIDCCredentials(t, tokenURL, caCert)

--- a/test/integration/examples/apiserver_test.go
+++ b/test/integration/examples/apiserver_test.go
@@ -788,9 +788,9 @@ func testAPIGroupList(ctx context.Context, t *testing.T, client rest.Interface) 
 	if err != nil {
 		t.Fatalf("Error in unmarshalling response from server %s: %v", "/apis", err)
 	}
-	assert.Equal(t, 1, len(apiGroupList.Groups))
+	assert.Len(t, apiGroupList.Groups, 1)
 	assert.Equal(t, wardlev1alpha1.GroupName, apiGroupList.Groups[0].Name)
-	assert.Equal(t, 2, len(apiGroupList.Groups[0].Versions))
+	assert.Len(t, apiGroupList.Groups[0].Versions, 2)
 
 	v1alpha1 := metav1.GroupVersionForDiscovery{
 		GroupVersion: wardlev1alpha1.SchemeGroupVersion.String(),
@@ -818,7 +818,7 @@ func testAPIGroup(ctx context.Context, t *testing.T, client rest.Interface) {
 		t.Fatalf("Error in unmarshalling response from server %s: %v", "/apis/wardle.example.com", err)
 	}
 	assert.Equal(t, wardlev1alpha1.SchemeGroupVersion.Group, apiGroup.Name)
-	assert.Equal(t, 2, len(apiGroup.Versions))
+	assert.Len(t, apiGroup.Versions, 2)
 	assert.Equal(t, wardlev1alpha1.SchemeGroupVersion.String(), apiGroup.Versions[1].GroupVersion)
 	assert.Equal(t, wardlev1alpha1.SchemeGroupVersion.Version, apiGroup.Versions[1].Version)
 	assert.Equal(t, apiGroup.PreferredVersion, apiGroup.Versions[0])
@@ -836,7 +836,7 @@ func testAPIResourceList(ctx context.Context, t *testing.T, client rest.Interfac
 		t.Fatalf("Error in unmarshalling response from server %s: %v", "/apis/wardle.example.com/v1alpha1", err)
 	}
 	assert.Equal(t, wardlev1alpha1.SchemeGroupVersion.String(), apiResourceList.GroupVersion)
-	assert.Equal(t, 2, len(apiResourceList.APIResources))
+	assert.Len(t, apiResourceList.APIResources, 2)
 	assert.Equal(t, "fischers", apiResourceList.APIResources[0].Name)
 	assert.False(t, apiResourceList.APIResources[0].Namespaced)
 	assert.Equal(t, "flunders", apiResourceList.APIResources[1].Name)

--- a/test/utils/ktesting/errorcontext_test.go
+++ b/test/utils/ktesting/errorcontext_test.go
@@ -108,7 +108,7 @@ second error`,
 			assert.Equal(t, !tc.expectNoFail, tCtx.Failed(), "Failed()")
 			if tc.expectError == "" {
 				assert.NoError(t, err)
-			} else if assert.NotNil(t, err) {
+			} else if assert.Error(t, err) {
 				assert.Equal(t, tc.expectError, err.Error())
 			}
 		})

--- a/test/utils/ktesting/helper_test.go
+++ b/test/utils/ktesting/helper_test.go
@@ -56,11 +56,11 @@ func (tc testcase) run(t *testing.T) {
 	}
 
 	duration := time.Since(start)
-	assert.InDelta(t, tc.expectDuration.Seconds(), duration.Seconds(), 0.1, fmt.Sprintf("callback invocation duration %s", duration))
+	assert.InDelta(t, tc.expectDuration.Seconds(), duration.Seconds(), 0.1, "callback invocation duration %s", duration)
 	assert.Equal(t, !tc.expectNoFail, tCtx.Failed(), "Failed()")
 	if tc.expectError == "" {
 		assert.NoError(t, err)
-	} else if assert.NotNil(t, err) {
+	} else if assert.Error(t, err) {
 		t.Logf("Result:\n%s", err.Error())
 		assert.Equal(t, tc.expectError, normalize(err.Error()))
 	}

--- a/test/utils/ktesting/stepcontext_test.go
+++ b/test/utils/ktesting/stepcontext_test.go
@@ -74,7 +74,7 @@ step: Errorf a b 42`,
 				tCtx.Log(buffer.String())
 
 				noSuchValue := tCtx.Value("some other key")
-				assert.Equal(tCtx, nil, noSuchValue, "value for unknown context value key")
+				assert.Nil(tCtx, noSuchValue, "value for unknown context value key")
 			},
 			expectLog: `<klog header>: step: You requested a progress report.
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This fixes rules from testifylint on test package
They will be enabled on golangci once fixed for all other packages