### PR TITLE
drop deprecated PollImmediateWithContext and adopt PollUntilContextTimeout instead

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/discovery/aggregated/fake.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/discovery/aggregated/fake.go
@@ -97,10 +97,11 @@ func (f *fakeResourceManager) Validate() error {
 }
 
 func (f *fakeResourceManager) WaitForActions(ctx context.Context, timeout time.Duration) error {
-	err := wait.PollImmediateWithContext(
+	err := wait.PollUntilContextTimeout(
 		ctx,
 		100*time.Millisecond, // try every 100ms
 		timeout,              // timeout after timeout
+		false,
 		func(ctx context.Context) (done bool, err error) {
 			if f.HasExpectedNumberActions() {
 				return true, f.Validate()

--- a/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/controller/controller.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/controller/controller.go
@@ -270,7 +270,7 @@ func (d *DynamicEncryptionConfigContent) validateNewTransformersHealth(
 	ctx, cancel = context.WithTimeout(ctx, kmsPluginCloseGracePeriod)
 	defer cancel()
 
-	pollErr := wait.PollImmediateWithContext(ctx, 100*time.Millisecond, kmsPluginCloseGracePeriod, func(ctx context.Context) (bool, error) {
+	pollErr := wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, kmsPluginCloseGracePeriod, false, func(ctx context.Context) (bool, error) {
 		// create a fake http get request to health check endpoint
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("/healthz/%s", kmsPluginHealthzCheck.Name()), nil)
 		if err != nil {

--- a/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/controller/controller.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/controller/controller.go
@@ -270,7 +270,7 @@ func (d *DynamicEncryptionConfigContent) validateNewTransformersHealth(
 	ctx, cancel = context.WithTimeout(ctx, kmsPluginCloseGracePeriod)
 	defer cancel()
 
-	pollErr := wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, kmsPluginCloseGracePeriod, false, func(ctx context.Context) (bool, error) {
+	pollErr := wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, kmsPluginCloseGracePeriod, true, func(ctx context.Context) (bool, error) {
 		// create a fake http get request to health check endpoint
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("/healthz/%s", kmsPluginHealthzCheck.Name()), nil)
 		if err != nil {

--- a/test/e2e/framework/node/helper.go
+++ b/test/e2e/framework/node/helper.go
@@ -50,7 +50,7 @@ func WaitForAllNodesSchedulable(ctx context.Context, c clientset.Interface, time
 		ctx,
 		30*time.Second,
 		timeout,
-		false,
+		true,
 		CheckReadyForTests(ctx, c, framework.TestContext.NonblockingTaints, framework.TestContext.AllowedNotReadyNodes, largeClusterThreshold),
 	)
 }

--- a/test/e2e/framework/node/helper.go
+++ b/test/e2e/framework/node/helper.go
@@ -46,10 +46,11 @@ func WaitForAllNodesSchedulable(ctx context.Context, c clientset.Interface, time
 	}
 
 	framework.Logf("Waiting up to %v for all (but %d) nodes to be schedulable", timeout, framework.TestContext.AllowedNotReadyNodes)
-	return wait.PollImmediateWithContext(
+	return wait.PollUntilContextTimeout(
 		ctx,
 		30*time.Second,
 		timeout,
+		false,
 		CheckReadyForTests(ctx, c, framework.TestContext.NonblockingTaints, framework.TestContext.AllowedNotReadyNodes, largeClusterThreshold),
 	)
 }


### PR DESCRIPTION
What type of PR is this?
/kind cleanup
﻿
What this PR does / why we need it:
https://pkg.go.dev/k8s.io/apimachinery/pkg/util/wait#PollUntilContextTimeout
﻿
func PollUntilContextTimeout(ctx context.Context, interval, timeout time.Duration, immediate bool, condition ConditionWithContextFunc) error
﻿
Switch to PollUntilContextTimeout for improved control, efficiency, and compatibility, surpassing the deprecated PollImmediateWithContext.
﻿
Which issue(s) this PR fixes:
None
﻿
Special notes for your reviewer:
Does this PR introduce a user-facing change?
NONE
Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
NONE