### PR TITLE
Node Request Certificates require to have IPs

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -45,6 +45,13 @@ const (
 	// Enable usage of Provision of PVCs from snapshots in other namespaces
 	CrossNamespaceVolumeDataSource featuregate.Feature = "CrossNamespaceVolumeDataSource"
 
+	// owner: @aojea
+	// Deprecated: v1.31
+	//
+	// Allow kubelet to request a certificate without any Node IP available, only
+	// with DNS names.
+	AllowDNSOnlyNodeCSR featuregate.Feature = "AllowDNSOnlyNodeCSR"
+
 	// owner: @thockin
 	// deprecated: v1.29
 	//
@@ -982,6 +989,8 @@ func init() {
 // when adding or removing one entry.
 var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	CrossNamespaceVolumeDataSource: {Default: false, PreRelease: featuregate.Alpha},
+
+	AllowDNSOnlyNodeCSR: {Default: false, PreRelease: featuregate.Deprecated}, // remove after 1.33
 
 	AllowServiceLBStatusOnNonLB: {Default: false, PreRelease: featuregate.Deprecated}, // remove after 1.29
 


### PR DESCRIPTION
/kind bug


#### What this PR does / why we need it:

Before #121028 the hostname was always added to the Node object by the kubelet as address type `v1.NodeHostName`.

Post #121028 the kubelet waits for the external cloud provider to set all the Node addresses, `v1.NodeHostName` included.

#121028  caused an issue with some scenarios where the users want to override the hostname, and was fixed by #124516.

Post #124516 the kubelet initialize the Node object with the obtained hostname during the bootstrap, it can be overridden later by the cloud provider (unit test asserting this behavior in https://github.com/kubernetes/kubernetes/pull/125809)

Since now the Node object already contains at least one IP or DNSName, depending of the value of the hostname, the kubelet, when using the certificate manager, always requests a certificate at bootstrap with incomplete information, as it still may have to wait for the external cloud provider to populate the node addresses.

Make the condition to request the kubelet certificate to have at least one IP addresses, instead of having one IP or DNSName, solve the problem of kubelet requesting certificates too early.

An alternative is to wait for the external cloud provider taint to be removed

```release-note
kubelet now requests serving certificates only once it has at least one IP address in the `.status.addresses` of its associated Node object. This avoids requesting DNS-only serving certificates before externally set addresses are in place. Until 1.33, the previous behavior can be opted back into by setting the deprecated AllowDNSOnlyNodeCSR feature gate to true in the kubelet.
```

/sig node
/sig auth

/assign @danwinship @liggitt