### PR TITLE
Automated cherry pick of #122901: kubeadm: don't fail post upgrade in

### DIFF
--- a/cmd/kubeadm/app/phases/kubeconfig/kubeconfig.go
+++ b/cmd/kubeadm/app/phases/kubeconfig/kubeconfig.go
@@ -695,9 +695,8 @@ func EnsureAdminClusterRoleBindingImpl(ctx context.Context, adminClient, superAd
 			); err != nil {
 				lastError = err
 				if apierrors.IsAlreadyExists(err) {
-					// This should not happen, as the previous "create" call that uses
-					// the admin.conf should have passed. Return the error.
-					return true, err
+					klog.V(5).Infof("ClusterRoleBinding %s already exists.", kubeadmconstants.ClusterAdminsGroupAndClusterRoleBinding)
+					return true, nil
 				}
 				// Retry on any other type of error.
 				return false, nil

--- a/cmd/kubeadm/app/phases/kubeconfig/kubeconfig_test.go
+++ b/cmd/kubeadm/app/phases/kubeconfig/kubeconfig_test.go
@@ -850,7 +850,13 @@ func TestEnsureAdminClusterRoleBindingImpl(t *testing.T) {
 						schema.GroupResource{}, "name")
 				})
 			},
-			expectedError: true,
+			setupSuperAdminClient: func(client *clientsetfake.Clientset) {
+				client.PrependReactor("create", "clusterrolebindings", func(action clientgotesting.Action) (bool, runtime.Object, error) {
+					return true, nil, apierrors.NewAlreadyExists(
+						schema.GroupResource{}, "name")
+				})
+			},
+			expectedError: false,
 		},
 		{
 			name: "admin.conf: handle other errors, such as a server timeout",
@@ -916,7 +922,7 @@ func TestEnsureAdminClusterRoleBindingImpl(t *testing.T) {
 						schema.GroupResource{}, "name")
 				})
 			},
-			expectedError: true,
+			expectedError: false,
 		},
 	}
 


### PR DESCRIPTION
Cherry pick of #122901 on release-1.29.

#122901: kubeadm: don't fail post upgrade in

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

fixes kubernetes/kubeadm#3081

```release-note
kubeadm: do not exit with an error if the "super-admin.conf" cannot create a ClusterRoleBinding for the "cluster-admin" user, due to the ClusterRoleBInding already existing.
```


