### PR TITLE
Add additional leader regex check for addon manager

### DIFF
--- a/cluster/addons/addon-manager/CHANGELOG.md
+++ b/cluster/addons/addon-manager/CHANGELOG.md
@@ -1,3 +1,8 @@
+### Version 9.1.8 (Wed July 3 2024 Jeffrey Ying <jeffrey.ying86@live.com>)
+- Update kubectl to v1.30.2.
+- Update debian-base to v2.0.0.
+- Addon manager matches for "HOSTNAME---<hash>" in addition to "HOSTNAME_<hash>" when checking leader.
+
 ### Version 9.1.7 (Thu May 15 2023 Paco Xu <paco.xu@daocloud.io>)
 - Update kubectl to v1.27.1.
 - Use `--prune-allowlist` instead of deprecated `--prune-whitelist`.

--- a/cluster/addons/addon-manager/Makefile
+++ b/cluster/addons/addon-manager/Makefile
@@ -15,10 +15,10 @@
 IMAGE=gcr.io/k8s-staging-addon-manager/kube-addon-manager
 ARCH?=amd64
 TEMP_DIR:=$(shell mktemp -d)
-VERSION=v9.1.7
-KUBECTL_VERSION?=v1.27.1
+VERSION=v9.1.8
+KUBECTL_VERSION?=v1.30.2
 
-BASEIMAGE=registry.k8s.io/debian-base-$(ARCH):v1.0.1
+BASEIMAGE=registry.k8s.io/debian-base-$(ARCH):v2.0.0
 
 SUDO=$(if $(filter 0,$(shell id -u)),,sudo)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

For coordinated leader election, the name of the holder is placed in a Kubernetes object name. Per the [K8s docs](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/), names must follow this c onventions:

- contain no more than 253 characters
- contain only lowercase alphanumeric characters, '-' or '.'
- start with an alphanumeric character
- end with an alphanumeric character

The leader holder for all leases uses an underscore "_", concatenating a hostname and UUID. This proposal changes that concatenation to three dashes "---" such that the lease holder can still be a valid Kubernetes object name.

I don't think this should cause any issues as hostnames generally do not end with a ---. The main risk is if we have hostnames "foo.x.y.z" and "foo.x.y.z---".  Per [RFC952](https://www.rfc-editor.org/rfc/rfc952), the hostnames are required to start with an alpha character and cannot end with a hyphen.

A complete other alternative would be to not use a leasecandidate name to house the lease holder information and move it to a field in the leasecandidate instead. I dislike that approach as we'd have to have a random placeholder that doesn't convey any information as the name.

/cc @jpbetz @sttts 
/triage accepted

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
