### PR TITLE
[kubelet] Cleanup incorrect log about static pod status change

### DIFF
--- a/pkg/kubelet/kubelet_getters.go
+++ b/pkg/kubelet/kubelet_getters.go
@@ -210,12 +210,12 @@ func (kl *Kubelet) getPodResourcesDir() string {
 // pods.
 func (kl *Kubelet) GetPods() []*v1.Pod {
 	pods := kl.podManager.GetPods()
-	// a kubelet running without apiserver requires an additional
-	// update of the static pod status. See #57106
 	for i, p := range pods {
+		// Pod cache does not get updated status for static pods.
+		// TODO(tallclair): Most callers of GetPods() do not need pod status. We should either parameterize this,
+		// or move the status injection to only the callers that do need it (maybe just the /pods http handler?).
 		if kubelettypes.IsStaticPod(p) {
 			if status, ok := kl.statusManager.GetPodStatus(p.UID); ok {
-				klog.V(2).InfoS("Pod status updated", "pod", klog.KObj(p), "status", status.Phase)
 				// do not mutate the cache
 				p = p.DeepCopy()
 				p.Status = status


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Every call to the Kubelet `GetPods()` method logs a message (`v(2)`) about the pod status changing for every static pod. This log message is both spammy and incorrect, as there is no logic around a status change where it is logged. The worst offender is the FS resource analyzer, which periodically calls this method (default `1m` period).

#### Which issue(s) this PR fixes:
Fixes #98422

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/sig node
/priority important-longterm

/cc @jvanz 