### PR TITLE
Fix fmt verbs for strings in roundtrip test errors

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/apitesting/roundtrip/roundtrip.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/apitesting/roundtrip/roundtrip.go
@@ -350,14 +350,14 @@ func roundTrip(t *testing.T, scheme *runtime.Scheme, codec runtime.Codec, object
 	// decode (deserialize) the encoded data back into an object
 	obj2, err := runtime.Decode(codec, data)
 	if err != nil {
-		t.Errorf("%v: %v\nCodec: %#v\nData: %s\nSource: %#v", name, err, codec, dataAsString(data), dump.Pretty(object))
+		t.Errorf("%v: %v\nCodec: %#v\nData: %s\nSource: %s", name, err, codec, dataAsString(data), dump.Pretty(object))
 		panic("failed")
 	}
 
 	// ensure that the object produced from decoding the encoded data is equal
 	// to the original object
 	if !apiequality.Semantic.DeepEqual(original, obj2) {
-		t.Errorf("%v: diff: %v\nCodec: %#v\nSource:\n\n%#v\n\nEncoded:\n\n%s\n\nFinal:\n\n%#v", name, cmp.Diff(original, obj2), codec, dump.Pretty(original), dataAsString(data), dump.Pretty(obj2))
+		t.Errorf("%v: diff: %v\nCodec: %#v\nSource:\n\n%s\n\nEncoded:\n\n%s\n\nFinal:\n\n%s", name, cmp.Diff(original, obj2), codec, dump.Pretty(original), dataAsString(data), dump.Pretty(obj2))
 		return
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup
/sig api-machinery

#### What this PR does / why we need it:

Some of the calls to t.Errorf from apitesting/roundtrip use the %#v verb (Go-syntax representation) for string arguments that are have already been formatted for legibility by something like like cmp.Diff. Quoting and escaping newlines in these strings makes them harder to read, like this:

```
        "(*storage.CSIDriver)({\n  TypeMeta: (v1.TypeMeta) {\n    Kind: (string) \"\",\n    APIVersion: (string) \"\"\n  },\n  ObjectMeta: (v1.ObjectMeta) {\n    Name: (string) (len=15) \"犱âM邽[ǎ*ʄ\",\n    GenerateName: (string) (len=42) \"潘Ⱥéȹī詊胺侺燡Ʊ缦¯#懃aʫ壻ƫ\",\n    Namespace: (string) (len=9) \"'Oų熐ƀ\",\n    SelfLink: (string) (len=3) \"zsr\",\n    UID: (types.UID) (len=3) \"蔒\",\n    ResourceVersion: (string) (len=20) \"10197290819010680393\",\n    Generation: (int64) 4069182792319625215,\n    CreationTimestamp: (v1.Time) {\n      Time: (time.Time) {\n        wall: (uint64) 0,\n        ext: (int64) 63833624996,\n        loc: (*time.Location)({\n          name: (string) (len=5) \"Local\",\n          zone: ([]time.zone) (len=6) {\n            (time.zone) {\n              name: (string) (len=3) \"LMT\",\n              offset: (int) -17762,\n              isDST: (bool) false\n            },\n            (time.zone) {\n              name: (string) (len=3) \"EDT\",\n              offset: (int) -14400,\n              isDST: (bool) true\n            },\n            (time.zone) {\n              name: (string) (len=3) \"EST\",\n              offset: (int) -18000,\n              isDST: (bool) false\n            },\n            (time.zone) {\n              name: (string) (len=3) \"EST\",\n              offset: (int) -18000,\n              isDST: (bool) false\n            },\n            (time.zone) {\n              name: (string) (len=3) \"EWT\",\n              offset: (int) -14400,\n              isDST: (bool) true\n            },\n            (time.zone) {\n              name: (string) (len=3) \"EPT\",\n              offset: (int) -144
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
