### PR TITLE
Remove deprecated kubectl run and drain flags

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/drain/drain.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/drain/drain.go
@@ -224,8 +224,6 @@ func NewCmdDrain(f cmdutil.Factory, ioStreams genericiooptions.IOStreams) *cobra
 	}
 	cmd.Flags().BoolVar(&o.drainer.Force, "force", o.drainer.Force, "Continue even if there are pods that do not declare a controller.")
 	cmd.Flags().BoolVar(&o.drainer.IgnoreAllDaemonSets, "ignore-daemonsets", o.drainer.IgnoreAllDaemonSets, "Ignore DaemonSet-managed pods.")
-	cmd.Flags().BoolVar(&o.drainer.DeleteEmptyDirData, "delete-local-data", o.drainer.DeleteEmptyDirData, "Continue even if there are pods using emptyDir (local data that will be deleted when the node is drained).")
-	cmd.Flags().MarkDeprecated("delete-local-data", "This option is deprecated and will be deleted. Use --delete-emptydir-data.")
 	cmd.Flags().BoolVar(&o.drainer.DeleteEmptyDirData, "delete-emptydir-data", o.drainer.DeleteEmptyDirData, "Continue even if there are pods using emptyDir (local data that will be deleted when the node is drained).")
 	cmd.Flags().IntVar(&o.drainer.GracePeriodSeconds, "grace-period", o.drainer.GracePeriodSeconds, "Period of time in seconds given to each pod to terminate gracefully. If negative, the default value specified in the pod will be used.")
 	cmd.Flags().DurationVar(&o.drainer.Timeout, "timeout", o.drainer.Timeout, "The length of time to wait before giving up, zero means infinite")

--- a/staging/src/k8s.io/kubectl/pkg/cmd/drain/drain_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/drain/drain_test.go
@@ -636,17 +636,6 @@ func TestDrain(t *testing.T) {
 			expectOutputToContain: "node/node drained",
 		},
 		{
-			description:           "Ensure compatibility for --delete-local-data until fully deprecated",
-			node:                  node,
-			expected:              cordonedNode,
-			pods:                  []corev1.Pod{jobPod},
-			rcs:                   []corev1.ReplicationController{rc},
-			args:                  []string{"node", "--force", "--delete-local-data=true"},
-			expectFatal:           false,
-			expectDelete:          true,
-			expectOutputToContain: "node/node drained",
-		},
-		{
 			description:           "Job-managed terminated pod",
 			node:                  node,
 			expected:              cordonedNode,

--- a/staging/src/k8s.io/kubectl/pkg/cmd/run/run.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/run/run.go
@@ -167,22 +167,6 @@ func NewCmdRun(f cmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Com
 	cmdutil.AddApplyAnnotationFlags(cmd)
 	cmdutil.AddPodRunningTimeoutFlag(cmd, defaultPodAttachTimeout)
 
-	// Deprecate the cascade flag. If set, it has no practical effect since the created pod has no dependents.
-	// TODO: Remove the cascade flag from the run command in kubectl 1.29
-	cmd.Flags().MarkDeprecated("cascade", "because it is not relevant for this command. It will be removed in version 1.29.")
-
-	// Deprecate and hide unused flags.
-	// These flags are being added to the run command by DeleteFlags to support pod deletion after attach,
-	// but they are not used if set, so they effectively do nothing.
-	// TODO: Remove these flags from the run command in kubectl 1.29
-	cmd.Flags().MarkDeprecated("filename", "because it is not used by this command. It will be removed in version 1.29.")
-	cmd.Flags().MarkDeprecated("force", "because it is not used by this command. It will be removed in version 1.29.")
-	cmd.Flags().MarkDeprecated("grace-period", "because it is not used by this command. It will be removed in version 1.29.")
-	cmd.Flags().MarkDeprecated("kustomize", "because it is not used by this command. It will be removed in version 1.29.")
-	cmd.Flags().MarkDeprecated("recursive", "because it is not used by this command. It will be removed in version 1.29.")
-	cmd.Flags().MarkDeprecated("timeout", "because it is not used by this command. It will be removed in version 1.29.")
-	cmd.Flags().MarkDeprecated("wait", "because it is not used by this command. It will be removed in version 1.29.")
-
 	return cmd
 }
 


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/sig cli

#### What this PR does / why we need it:
Drop support for several flags which were deprecated for significant portion of time, and they were not doing anything useful either way, since they were not wired properly after `kubectl run` refactorings back from https://github.com/kubernetes/kubernetes/pull/87077

#### Which issue(s) this PR fixes:
NONE

#### Special notes for your reviewer:
/assign @ardaguclu 

#### Does this PR introduce a user-facing change?
```release-note
Drop support for the deprecated and unsupported kubectl run flags:
- filename
- force
- grace-period
- kustomize
- recursive
- timeout
- wait

Drop support for the deprecated --delete-local-data from kubectl drain, users should use --delete-emptydir-data, instead.
```
