### PR TITLE
Drop removed APIs from etcd data tests, remove special case logic for binaryVersion=0.0 and all usages

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/deleted_kinds.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/deleted_kinds.go
@@ -100,8 +100,7 @@ func (e *resourceExpirationEvaluator) shouldServe(gv schema.GroupVersion, versio
 	}
 
 	introduced, ok := versionedPtr.(introducedInterface)
-	// skip the introduced check for test when currentVersion is 0.0 to test all apis
-	if ok && (e.currentVersion.Major() > 0 || e.currentVersion.Minor() > 0) {
+	if ok {
 		majorIntroduced, minorIntroduced := introduced.APILifecycleIntroduced()
 		verIntroduced := apimachineryversion.MajorMinor(uint(majorIntroduced), uint(minorIntroduced))
 		if e.currentVersion.LessThan(verIntroduced) {

--- a/test/integration/controlplane/transformation/transformation_test.go
+++ b/test/integration/controlplane/transformation/transformation_test.go
@@ -30,6 +30,8 @@ import (
 
 	clientv3 "go.etcd.io/etcd/client/v3"
 
+	"sigs.k8s.io/yaml"
+
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -52,7 +54,6 @@ import (
 	"k8s.io/kubernetes/test/integration/framework"
 	"k8s.io/kubernetes/test/utils/ktesting"
 	"k8s.io/utils/pointer"
-	"sigs.k8s.io/yaml"
 )
 
 const (
@@ -116,7 +117,7 @@ func newTransformTest(tb testing.TB, transformerConfigYAML string, reload bool, 
 	}
 
 	if e.kubeAPIServer, err = kubeapiservertesting.StartTestServer(
-		tb, &kubeapiservertesting.TestServerInstanceOptions{BinaryVersion: "0.0"},
+		tb, nil,
 		e.getEncryptionOptions(reload), e.storageConfig); err != nil {
 		e.cleanUp()
 		return nil, fmt.Errorf("failed to start KubeAPI server: %w", err)

--- a/test/integration/etcd/data.go
+++ b/test/integration/etcd/data.go
@@ -230,38 +230,6 @@ func GetEtcdStorageDataForNamespace(namespace string) map[schema.GroupVersionRes
 		},
 		// --
 
-		// k8s.io/kubernetes/pkg/apis/flowcontrol/v1beta1
-		gvr("flowcontrol.apiserver.k8s.io", "v1beta1", "flowschemas"): {
-			Stub:             `{"metadata": {"name": "va2"}, "spec": {"priorityLevelConfiguration": {"name": "name1"}}}`,
-			ExpectedEtcdPath: "/registry/flowschemas/va2",
-			ExpectedGVK:      gvkP("flowcontrol.apiserver.k8s.io", "v1", "FlowSchema"),
-		},
-		// --
-
-		// k8s.io/kubernetes/pkg/apis/flowcontrol/v1beta1
-		gvr("flowcontrol.apiserver.k8s.io", "v1beta1", "prioritylevelconfigurations"): {
-			Stub:             `{"metadata": {"name": "conf2"}, "spec": {"type": "Limited", "limited": {"assuredConcurrencyShares":3, "limitResponse": {"type": "Reject"}}}}`,
-			ExpectedEtcdPath: "/registry/prioritylevelconfigurations/conf2",
-			ExpectedGVK:      gvkP("flowcontrol.apiserver.k8s.io", "v1", "PriorityLevelConfiguration"),
-		},
-		// --
-
-		// k8s.io/kubernetes/pkg/apis/flowcontrol/v1beta2
-		gvr("flowcontrol.apiserver.k8s.io", "v1beta2", "flowschemas"): {
-			Stub:             `{"metadata": {"name": "fs-1"}, "spec": {"priorityLevelConfiguration": {"name": "name1"}}}`,
-			ExpectedEtcdPath: "/registry/flowschemas/fs-1",
-			ExpectedGVK:      gvkP("flowcontrol.apiserver.k8s.io", "v1", "FlowSchema"),
-		},
-		// --
-
-		// k8s.io/kubernetes/pkg/apis/flowcontrol/v1beta2
-		gvr("flowcontrol.apiserver.k8s.io", "v1beta2", "prioritylevelconfigurations"): {
-			Stub:             `{"metadata": {"name": "conf3"}, "spec": {"type": "Limited", "limited": {"assuredConcurrencyShares":3, "limitResponse": {"type": "Reject"}}}}`,
-			ExpectedEtcdPath: "/registry/prioritylevelconfigurations/conf3",
-			ExpectedGVK:      gvkP("flowcontrol.apiserver.k8s.io", "v1", "PriorityLevelConfiguration"),
-		},
-		// --
-
 		// k8s.io/kubernetes/pkg/apis/flowcontrol/v1beta3
 		gvr("flowcontrol.apiserver.k8s.io", "v1beta3", "flowschemas"): {
 			Stub:             `{"metadata": {"name": "fs-2"}, "spec": {"priorityLevelConfiguration": {"name": "name1"}}}`,

--- a/test/integration/etcd/etcd_cross_group_test.go
+++ b/test/integration/etcd/etcd_cross_group_test.go
@@ -27,26 +27,15 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/apiserver/pkg/storage"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
-	utilversion "k8s.io/apiserver/pkg/util/version"
 	"k8s.io/client-go/dynamic"
-	"k8s.io/kubernetes/cmd/kube-apiserver/app/options"
 )
 
 // TestCrossGroupStorage tests to make sure that all objects stored in an expected location in etcd can be converted/read.
 func TestCrossGroupStorage(t *testing.T) {
-	testRegistry := utilversion.NewComponentGlobalsRegistry()
-	utilruntime.Must(testRegistry.Register("test", utilversion.NewEffectiveVersion("0.0"), utilfeature.DefaultFeatureGate.DeepCopy()))
-
-	apiServer := StartRealAPIServerOrDie(t, func(opts *options.ServerRunOptions) {
-		// force enable all resources so we can check storage.
-		opts.GenericServerRunOptions.ComponentName = "test"
-		opts.GenericServerRunOptions.ComponentGlobalsRegistry = testRegistry
-	})
+	apiServer := StartRealAPIServerOrDie(t)
 	defer apiServer.Cleanup()
 
 	etcdStorageData := GetEtcdStorageData()

--- a/test/integration/etcd/etcd_storage_path_test.go
+++ b/test/integration/etcd/etcd_storage_path_test.go
@@ -34,13 +34,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apiserver/pkg/util/feature"
-	utilversion "k8s.io/apiserver/pkg/util/version"
 	"k8s.io/client-go/dynamic"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
-	"k8s.io/kubernetes/cmd/kube-apiserver/app/options"
 )
 
 // Only add kinds to this list when this a virtual resource with get and create verbs that doesn't actually
@@ -76,13 +73,8 @@ var allowMissingTestdataFixtures = map[schema.GroupVersionKind]bool{
 func TestEtcdStoragePath(t *testing.T) {
 	featuregatetesting.SetFeatureGateDuringTest(t, feature.DefaultFeatureGate, "AllAlpha", true)
 	featuregatetesting.SetFeatureGateDuringTest(t, feature.DefaultFeatureGate, "AllBeta", true)
-	testRegistry := utilversion.NewComponentGlobalsRegistry()
-	utilruntime.Must(testRegistry.Register("test", utilversion.NewEffectiveVersion("0.0"), feature.DefaultFeatureGate.DeepCopy()))
 
-	apiServer := StartRealAPIServerOrDie(t, func(opts *options.ServerRunOptions) {
-		opts.GenericServerRunOptions.ComponentName = "test"
-		opts.GenericServerRunOptions.ComponentGlobalsRegistry = testRegistry
-	})
+	apiServer := StartRealAPIServerOrDie(t)
 	defer apiServer.Cleanup()
 	defer dumpEtcdKVOnFailure(t, apiServer.KV)
 


### PR DESCRIPTION
Addresses problems identified with tests using `BinaryVersion: 0.0` in this discussion: https://github.com/kubernetes/kubernetes/pull/125571#pullrequestreview-2154657070

/kind cleanup
/kind bug

```release-note
NONE
```