### PR TITLE
Fix for typecheck doesn't notice compile errors in test files

### DIFF
--- a/hack/verify-typecheck.sh
+++ b/hack/verify-typecheck.sh
@@ -26,6 +26,17 @@ source "${KUBE_ROOT}/hack/lib/init.sh"
 cd "${KUBE_ROOT}"
 
 kube::golang::setup_env
+kube::util::require-jq
+
+if [[ $# == 0 ]]; then
+  # Doing it this way is MUCH faster than simply saying "all", and there doesn't
+  # seem to be a simpler way to express "this whole workspace".
+  packages=()
+  kube::util::read-array packages < <(
+      go work edit -json | jq -r '.Use[].DiskPath + "/..."'
+  )
+  set -- "${packages[@]}"
+fi
 
 ret=0
 TYPECHECK_SERIAL="${TYPECHECK_SERIAL:-false}"

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/celcoststability_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/celcoststability_test.go
@@ -37,17 +37,19 @@ func TestCelCostStability(t *testing.T) {
 	}{
 		{name: "integers",
 			// 1st obj and schema args are for "self.val1" field, 2nd for "self.val2" and so on.
-			obj:    objs(math.MaxInt64, math.MaxInt64, math.MaxInt32, math.MaxInt32, math.MaxInt64, math.MaxInt64),
+			obj: objs(int64(math.MaxInt64), int64(math.MaxInt64), int32(math.MaxInt32), int32(math.MaxInt32),
+				int64(math.MaxInt64), int64(math.MaxInt64)),
 			schema: schemas(integerType, integerType, int32Type, int32Type, int64Type, int64Type),
 			expectCost: map[string]int64{
-				ValsEqualThemselvesAndDataLiteral("self.val1", "self.val2", fmt.Sprintf("%d", math.MaxInt64)): 11,
+				ValsEqualThemselvesAndDataLiteral("self.val1", "self.val2", fmt.Sprintf("%d", int64(math.MaxInt64))): 11,
 				"self.val1 == self.val6":                              5, // integer with no format is the same as int64
 				"type(self.val1) == int":                              4,
 				fmt.Sprintf("self.val3 + 1 == %d + 1", math.MaxInt32): 5, // CEL integers are 64 bit
 			},
 		},
 		{name: "numbers",
-			obj:    objs(math.MaxFloat64, math.MaxFloat64, math.MaxFloat32, math.MaxFloat32, math.MaxFloat64, math.MaxFloat64, int64(1)),
+			obj: objs(float64(math.MaxFloat64), float64(math.MaxFloat64), float32(math.MaxFloat32), float32(math.MaxFloat32),
+				float64(math.MaxFloat64), float64(math.MaxFloat64), int64(1)),
 			schema: schemas(numberType, numberType, floatType, floatType, doubleType, doubleType, doubleType),
 			expectCost: map[string]int64{
 				ValsEqualThemselvesAndDataLiteral("self.val1", "self.val2", fmt.Sprintf("%f", math.MaxFloat64)): 11,
@@ -1218,7 +1220,7 @@ func TestCelEstimatedCostStability(t *testing.T) {
 			// 1st obj and schema args are for "self.val1" field, 2nd for "self.val2" and so on.
 			schema: schemas(integerType, integerType, int32Type, int32Type, int64Type, int64Type),
 			expectCost: map[string]uint64{
-				ValsEqualThemselvesAndDataLiteral("self.val1", "self.val2", fmt.Sprintf("%d", math.MaxInt64)): 8,
+				ValsEqualThemselvesAndDataLiteral("self.val1", "self.val2", fmt.Sprintf("%d", int64(math.MaxInt64))): 8,
 				"self.val1 == self.val6":                              4, // integer with no format is the same as int64
 				"type(self.val1) == int":                              4,
 				fmt.Sprintf("self.val3 + 1 == %d + 1", math.MaxInt32): 5, // CEL integers are 64 bit

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/validation_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/validation_test.go
@@ -67,12 +67,13 @@ func TestValidationExpressions(t *testing.T) {
 		// equality, comparisons and type specific functions
 		{name: "integers",
 			// 1st obj and schema args are for "self.val1" field, 2nd for "self.val2" and so on.
-			obj:    objs(math.MaxInt64, math.MaxInt64, math.MaxInt32, math.MaxInt32, math.MaxInt64, math.MaxInt64),
+			obj: objs(int64(math.MaxInt64), int64(math.MaxInt64), int32(math.MaxInt32), int32(math.MaxInt32),
+				int64(math.MaxInt64), int64(math.MaxInt64)),
 			schema: schemas(integerType, integerType, int32Type, int32Type, int64Type, int64Type),
 			valid: []string{
-				ValsEqualThemselvesAndDataLiteral("self.val1", "self.val2", fmt.Sprintf("%d", math.MaxInt64)),
+				ValsEqualThemselvesAndDataLiteral("self.val1", "self.val2", fmt.Sprintf("%d", int64(math.MaxInt64))),
 				ValsEqualThemselvesAndDataLiteral("self.val3", "self.val4", fmt.Sprintf("%d", math.MaxInt32)),
-				ValsEqualThemselvesAndDataLiteral("self.val5", "self.val6", fmt.Sprintf("%d", math.MaxInt64)),
+				ValsEqualThemselvesAndDataLiteral("self.val5", "self.val6", fmt.Sprintf("%d", int64(math.MaxInt64))),
 				"self.val1 == self.val6", // integer with no format is the same as int64
 				"type(self.val1) == int",
 				fmt.Sprintf("self.val3 + 1 == %d + 1", math.MaxInt32), // CEL integers are 64 bit
@@ -86,7 +87,8 @@ func TestValidationExpressions(t *testing.T) {
 			},
 		},
 		{name: "numbers",
-			obj:    objs(math.MaxFloat64, math.MaxFloat64, math.MaxFloat32, math.MaxFloat32, math.MaxFloat64, math.MaxFloat64, int64(1)),
+			obj: objs(float64(math.MaxFloat64), float64(math.MaxFloat64), float32(math.MaxFloat32), float32(math.MaxFloat32),
+				float64(math.MaxFloat64), float64(math.MaxFloat64), int64(1)),
 			schema: schemas(numberType, numberType, floatType, floatType, doubleType, doubleType, doubleType),
 			valid: []string{
 				ValsEqualThemselvesAndDataLiteral("self.val1", "self.val2", fmt.Sprintf("%f", math.MaxFloat64)),
@@ -2842,7 +2844,7 @@ func TestCELValidationLimit(t *testing.T) {
 	}{
 		{
 			name:   "test limit",
-			obj:    objs(math.MaxInt64),
+			obj:    objs(int64(math.MaxInt64)),
 			schema: schemas(integerType),
 			valid: []string{
 				"self.val1 > 0",

--- a/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/kmsv2/envelope_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/kmsv2/envelope_test.go
@@ -1,3 +1,6 @@
+//go:build !windows
+// +build !windows
+
 /*
 Copyright 2022 The Kubernetes Authors.
 

--- a/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/kmsv2/grpc_service_unix_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/kmsv2/grpc_service_unix_test.go
@@ -1,3 +1,6 @@
+//go:build !windows
+// +build !windows
+
 /*
 Copyright 2022 The Kubernetes Authors.
 

--- a/staging/src/k8s.io/component-base/logs/api/v1/types_test.go
+++ b/staging/src/k8s.io/component-base/logs/api/v1/types_test.go
@@ -96,7 +96,7 @@ func TestVModule(t *testing.T) {
 			},
 		},
 		{
-			arg:         fmt.Sprintf("invalidint32=%d", math.MaxInt32+1),
+			arg:         fmt.Sprintf("invalidint32=%d", uint(math.MaxInt32+1)),
 			expectError: `parsing verbosity in "invalidint32=2147483648": strconv.ParseUint: parsing "2147483648": value out of range`,
 		},
 	}


### PR DESCRIPTION
List out explicitly all the staging repos as well so all the files under staging/ are "loaded" and we'll see problems if any. (This includes _test.go files).

With this patch, for example a bad edit in a test file will show up like this:
```
ERROR(darwin/arm64): /Users/davanum/go/src/k8s.io/kubernetes/staging/src/k8s.io/dynamic-resource-allocation/structured/namedresources/cel/compile_test.go:126:10: Compiler (variable of type *compiler) is not a type
ERROR(darwin/arm64): /Users/davanum/go/src/k8s.io/kubernetes/staging/src/k8s.io/dynamic-resource-allocation/structured/namedresources/cel/compile_test.go:126:8: c declared and not used
```

if say the edit was this:
```
diff --git a/staging/src/k8s.io/dynamic-resource-allocation/structured/namedresources/cel/compile_test.go b/staging/src/k8s.io/dynamic-resource-allocation/structured/namedresources/cel/compile_test.go
index bea913c81fc5..836a998e9dfa 100644
--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/namedresources/cel/compile_test.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/namedresources/cel/compile_test.go
@@ -123,6 +123,7 @@ attributes.stringslice["stringslice"].isSorted()`,
                },
        } {
                t.Run(name, func(t *testing.T) {
+                       var c Compiler
                        _, ctx := ktesting.NewTestContext(t)
                        result := Compiler.CompileCELExpression(scenario.expression, environment.StoredExpressions)
                        if scenario.expectCompileError != "" && result.Error == nil {
```


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #125807

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

```
Co-authored-by: Tim Hockin <thockin@google.com>
```