### PR TITLE
Fix kubelet AppArmor rejection test

### DIFF
--- a/test/e2e_node/apparmor_test.go
+++ b/test/e2e_node/apparmor_test.go
@@ -92,7 +92,7 @@ var _ = SIGDescribe("AppArmor", feature.AppArmor, nodefeature.AppArmor, func() {
 
 			ginkgo.It("should reject a pod with an AppArmor profile", func(ctx context.Context) {
 				status := runAppArmorTest(ctx, f, false, v1.DeprecatedAppArmorBetaProfileRuntimeDefault)
-				expectSoftRejection(status)
+				expectRejection(status)
 			})
 		})
 	}
@@ -229,12 +229,11 @@ func createPodWithAppArmor(ctx context.Context, f *framework.Framework, profile 
 	return e2epod.NewPodClient(f).Create(ctx, pod)
 }
 
-func expectSoftRejection(status v1.PodStatus) {
+func expectRejection(status v1.PodStatus) {
 	args := []interface{}{"PodStatus: %+v", status}
-	gomega.Expect(status.Phase).To(gomega.Equal(v1.PodPending), args...)
+	gomega.Expect(status.Phase).To(gomega.Equal(v1.PodFailed), args...)
 	gomega.Expect(status.Reason).To(gomega.Equal("AppArmor"), args...)
 	gomega.Expect(status.Message).To(gomega.ContainSubstring("AppArmor"), args...)
-	gomega.Expect(status.ContainerStatuses[0].State.Waiting.Reason).To(gomega.Equal("Blocked"), args...)
 }
 
 func isAppArmorEnabled() bool {


### PR DESCRIPTION


#### What type of PR is this?


/kind failing-test


#### What this PR does / why we need it:
The corresponding e2e test needs to be adjusted side by side to the merged PR: https://github.com/kubernetes/kubernetes/pull/125776.
#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/kubernetes/issues/125829

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
