### PR TITLE
[client-go] Enable FakeDiscovery client to simulate errors by fixing error handling

### DIFF
--- a/staging/src/k8s.io/client-go/discovery/fake/discovery.go
+++ b/staging/src/k8s.io/client-go/discovery/fake/discovery.go
@@ -47,7 +47,9 @@ func (c *FakeDiscovery) ServerResourcesForGroupVersion(groupVersion string) (*me
 		Verb:     "get",
 		Resource: schema.GroupVersionResource{Resource: "resource"},
 	}
-	c.Invokes(action, nil)
+	if _, err := c.Invokes(action, nil); err != nil {
+		return nil, err
+	}
 	for _, resourceList := range c.Resources {
 		if resourceList.GroupVersion == groupVersion {
 			return resourceList, nil
@@ -77,7 +79,9 @@ func (c *FakeDiscovery) ServerGroupsAndResources() ([]*metav1.APIGroup, []*metav
 		Verb:     "get",
 		Resource: schema.GroupVersionResource{Resource: "resource"},
 	}
-	c.Invokes(action, nil)
+	if _, err = c.Invokes(action, nil); err != nil {
+		return resultGroups, c.Resources, err
+	}
 	return resultGroups, c.Resources, nil
 }
 
@@ -100,7 +104,9 @@ func (c *FakeDiscovery) ServerGroups() (*metav1.APIGroupList, error) {
 		Verb:     "get",
 		Resource: schema.GroupVersionResource{Resource: "group"},
 	}
-	c.Invokes(action, nil)
+	if _, err := c.Invokes(action, nil); err != nil {
+		return nil, err
+	}
 
 	groups := map[string]*metav1.APIGroup{}
 

--- a/staging/src/k8s.io/client-go/discovery/fake/discovery_test.go
+++ b/staging/src/k8s.io/client-go/discovery/fake/discovery_test.go
@@ -63,3 +63,48 @@ func TestFakingServerVersionWithError(t *testing.T) {
 		t.Fatal("ServerVersion should return expected error, returned different error instead")
 	}
 }
+
+func TestFakingServerResourcesForGroupVersionWithError(t *testing.T) {
+	expectedError := errors.New("an error occurred")
+	fakeClient := fakeclientset.NewClientset()
+	fakeClient.Discovery().(*fakediscovery.FakeDiscovery).PrependReactor("*", "*", func(action kubetesting.Action) (handled bool, ret runtime.Object, err error) {
+		return true, nil, expectedError
+	})
+
+	result, err := fakeClient.Discovery().ServerResourcesForGroupVersion("dummy.group.io/v1beta2")
+	if result != nil {
+		t.Errorf(`expect result to be nil but got "%v" instead`, result)
+	}
+	if !errors.Is(err, expectedError) {
+		t.Errorf(`expect error to be "%v" but got "%v" instead`, expectedError, err)
+	}
+}
+
+func TestFakingServerGroupsWithError(t *testing.T) {
+	expectedError := errors.New("an error occurred")
+	fakeClient := fakeclientset.NewClientset()
+	fakeClient.Discovery().(*fakediscovery.FakeDiscovery).PrependReactor("*", "*", func(action kubetesting.Action) (handled bool, ret runtime.Object, err error) {
+		return true, nil, expectedError
+	})
+
+	result, err := fakeClient.Discovery().ServerGroups()
+	if result != nil {
+		t.Errorf(`expect result to be nil but got "%v" instead`, result)
+	}
+	if !errors.Is(err, expectedError) {
+		t.Errorf(`expect error to be "%v" but got "%v" instead`, expectedError, err)
+	}
+}
+
+func TestFakingServerGroupsAndResourcesWithError(t *testing.T) {
+	expectedError := errors.New("an error occurred")
+	fakeClient := fakeclientset.NewClientset()
+	fakeClient.Discovery().(*fakediscovery.FakeDiscovery).PrependReactor("get", "resource", func(action kubetesting.Action) (handled bool, ret runtime.Object, err error) {
+		return true, nil, expectedError
+	})
+
+	_, _, err := fakeClient.Discovery().ServerGroupsAndResources()
+	if !errors.Is(err, expectedError) {
+		t.Errorf(`expect error to be "%v" but got "%v" instead`, expectedError, err)
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Return the error returned by `Invokes` so the `FakeDiscovery` client is able to simulate any error with reactors. 

#### Which issue(s) this PR fixes:

Fixes #125879

#### Special notes for your reviewer:

A related [PR](https://github.com/kubernetes/kubernetes/pull/114291) that partially addressed this issue has already been merged. 

#### Does this PR introduce a user-facing change?

No. 

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

N/A
