### PR TITLE
Update publishing-bot rules to Go 1.22.5

### DIFF
--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -7,25 +7,25 @@ rules:
       dirs:
       - staging/src/k8s.io/apimachinery
   - name: release-1.27
-    go: 1.22.4
+    go: 1.22.5
     source:
       branch: release-1.27
       dirs:
       - staging/src/k8s.io/apimachinery
   - name: release-1.28
-    go: 1.22.4
+    go: 1.22.5
     source:
       branch: release-1.28
       dirs:
       - staging/src/k8s.io/apimachinery
   - name: release-1.29
-    go: 1.22.4
+    go: 1.22.5
     source:
       branch: release-1.29
       dirs:
       - staging/src/k8s.io/apimachinery
   - name: release-1.30
-    go: 1.22.4
+    go: 1.22.5
     source:
       branch: release-1.30
       dirs:
@@ -42,7 +42,7 @@ rules:
       dirs:
       - staging/src/k8s.io/api
   - name: release-1.27
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -51,7 +51,7 @@ rules:
       dirs:
       - staging/src/k8s.io/api
   - name: release-1.28
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -60,7 +60,7 @@ rules:
       dirs:
       - staging/src/k8s.io/api
   - name: release-1.29
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -69,7 +69,7 @@ rules:
       dirs:
       - staging/src/k8s.io/api
   - name: release-1.30
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -95,7 +95,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.27
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -110,7 +110,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.28
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -125,7 +125,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.29
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -140,7 +140,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.30
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -166,25 +166,25 @@ rules:
       dirs:
       - staging/src/k8s.io/code-generator
   - name: release-1.27
-    go: 1.22.4
+    go: 1.22.5
     source:
       branch: release-1.27
       dirs:
       - staging/src/k8s.io/code-generator
   - name: release-1.28
-    go: 1.22.4
+    go: 1.22.5
     source:
       branch: release-1.28
       dirs:
       - staging/src/k8s.io/code-generator
   - name: release-1.29
-    go: 1.22.4
+    go: 1.22.5
     source:
       branch: release-1.29
       dirs:
       - staging/src/k8s.io/code-generator
   - name: release-1.30
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -207,7 +207,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-base
   - name: release-1.27
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -220,7 +220,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-base
   - name: release-1.28
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -233,7 +233,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-base
   - name: release-1.29
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -246,7 +246,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-base
   - name: release-1.30
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -274,7 +274,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-helpers
   - name: release-1.27
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -287,7 +287,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-helpers
   - name: release-1.28
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -300,7 +300,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-helpers
   - name: release-1.29
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -313,7 +313,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-helpers
   - name: release-1.30
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -337,7 +337,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kms
   - name: release-1.27
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -350,7 +350,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kms
   - name: release-1.28
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -363,7 +363,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kms
   - name: release-1.29
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -372,7 +372,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kms
   - name: release-1.30
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -400,7 +400,7 @@ rules:
       dirs:
       - staging/src/k8s.io/apiserver
   - name: release-1.27
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -417,7 +417,7 @@ rules:
       dirs:
       - staging/src/k8s.io/apiserver
   - name: release-1.28
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -434,7 +434,7 @@ rules:
       dirs:
       - staging/src/k8s.io/apiserver
   - name: release-1.29
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -451,7 +451,7 @@ rules:
       dirs:
       - staging/src/k8s.io/apiserver
   - name: release-1.30
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -491,7 +491,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-aggregator
   - name: release-1.27
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -512,7 +512,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-aggregator
   - name: release-1.28
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -533,7 +533,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-aggregator
   - name: release-1.29
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -554,7 +554,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-aggregator
   - name: release-1.30
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -602,7 +602,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.27
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -628,7 +628,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.28
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -654,7 +654,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.29
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -680,7 +680,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.30
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -727,7 +727,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.27
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -747,7 +747,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.28
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -767,7 +767,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.29
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -787,7 +787,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.30
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -831,7 +831,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.27
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -854,7 +854,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.28
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -877,7 +877,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.29
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -900,7 +900,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.30
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -939,7 +939,7 @@ rules:
       dirs:
       - staging/src/k8s.io/metrics
   - name: release-1.27
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -954,7 +954,7 @@ rules:
       dirs:
       - staging/src/k8s.io/metrics
   - name: release-1.28
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -969,7 +969,7 @@ rules:
       dirs:
       - staging/src/k8s.io/metrics
   - name: release-1.29
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -984,7 +984,7 @@ rules:
       dirs:
       - staging/src/k8s.io/metrics
   - name: release-1.30
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -1014,7 +1014,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cli-runtime
   - name: release-1.27
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: api
       branch: release-1.27
@@ -1027,7 +1027,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cli-runtime
   - name: release-1.28
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: api
       branch: release-1.28
@@ -1040,7 +1040,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cli-runtime
   - name: release-1.29
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: api
       branch: release-1.29
@@ -1053,7 +1053,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cli-runtime
   - name: release-1.30
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: api
       branch: release-1.30
@@ -1083,7 +1083,7 @@ rules:
       dirs:
       - staging/src/k8s.io/sample-cli-plugin
   - name: release-1.27
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: api
       branch: release-1.27
@@ -1098,7 +1098,7 @@ rules:
       dirs:
       - staging/src/k8s.io/sample-cli-plugin
   - name: release-1.28
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: api
       branch: release-1.28
@@ -1113,7 +1113,7 @@ rules:
       dirs:
       - staging/src/k8s.io/sample-cli-plugin
   - name: release-1.29
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: api
       branch: release-1.29
@@ -1128,7 +1128,7 @@ rules:
       dirs:
       - staging/src/k8s.io/sample-cli-plugin
   - name: release-1.30
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: api
       branch: release-1.30
@@ -1159,7 +1159,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-proxy
   - name: release-1.27
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -1174,7 +1174,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-proxy
   - name: release-1.28
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -1189,7 +1189,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-proxy
   - name: release-1.29
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -1204,7 +1204,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-proxy
   - name: release-1.30
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -1227,25 +1227,25 @@ rules:
       dirs:
       - staging/src/k8s.io/cri-api
   - name: release-1.27
-    go: 1.22.4
+    go: 1.22.5
     source:
       branch: release-1.27
       dirs:
       - staging/src/k8s.io/cri-api
   - name: release-1.28
-    go: 1.22.4
+    go: 1.22.5
     source:
       branch: release-1.28
       dirs:
       - staging/src/k8s.io/cri-api
   - name: release-1.29
-    go: 1.22.4
+    go: 1.22.5
     source:
       branch: release-1.29
       dirs:
       - staging/src/k8s.io/cri-api
   - name: release-1.30
-    go: 1.22.4
+    go: 1.22.5
     source:
       branch: release-1.30
       dirs:
@@ -1293,7 +1293,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubelet
   - name: release-1.27
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -1308,7 +1308,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubelet
   - name: release-1.28
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -1329,7 +1329,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubelet
   - name: release-1.29
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -1350,7 +1350,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubelet
   - name: release-1.30
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -1388,7 +1388,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-scheduler
   - name: release-1.27
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -1403,7 +1403,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-scheduler
   - name: release-1.28
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -1418,7 +1418,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-scheduler
   - name: release-1.29
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -1433,7 +1433,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-scheduler
   - name: release-1.30
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -1469,7 +1469,7 @@ rules:
       dirs:
       - staging/src/k8s.io/controller-manager
   - name: release-1.27
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: api
       branch: release-1.27
@@ -1488,7 +1488,7 @@ rules:
       dirs:
       - staging/src/k8s.io/controller-manager
   - name: release-1.28
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: api
       branch: release-1.28
@@ -1507,7 +1507,7 @@ rules:
       dirs:
       - staging/src/k8s.io/controller-manager
   - name: release-1.29
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: api
       branch: release-1.29
@@ -1526,7 +1526,7 @@ rules:
       dirs:
       - staging/src/k8s.io/controller-manager
   - name: release-1.30
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: api
       branch: release-1.30
@@ -1570,7 +1570,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cloud-provider
   - name: release-1.27
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: api
       branch: release-1.27
@@ -1593,7 +1593,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cloud-provider
   - name: release-1.28
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: api
       branch: release-1.28
@@ -1616,7 +1616,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cloud-provider
   - name: release-1.29
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: api
       branch: release-1.29
@@ -1639,7 +1639,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cloud-provider
   - name: release-1.30
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: api
       branch: release-1.30
@@ -1689,7 +1689,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-controller-manager
   - name: release-1.27
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -1714,7 +1714,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-controller-manager
   - name: release-1.28
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -1739,7 +1739,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-controller-manager
   - name: release-1.29
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -1764,7 +1764,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-controller-manager
   - name: release-1.30
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -1802,7 +1802,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cluster-bootstrap
   - name: release-1.27
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -1813,7 +1813,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cluster-bootstrap
   - name: release-1.28
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -1824,7 +1824,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cluster-bootstrap
   - name: release-1.29
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -1835,7 +1835,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cluster-bootstrap
   - name: release-1.30
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -1859,7 +1859,7 @@ rules:
       dirs:
       - staging/src/k8s.io/csi-translation-lib
   - name: release-1.27
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: api
       branch: release-1.27
@@ -1870,7 +1870,7 @@ rules:
       dirs:
       - staging/src/k8s.io/csi-translation-lib
   - name: release-1.28
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: api
       branch: release-1.28
@@ -1881,7 +1881,7 @@ rules:
       dirs:
       - staging/src/k8s.io/csi-translation-lib
   - name: release-1.29
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: api
       branch: release-1.29
@@ -1892,7 +1892,7 @@ rules:
       dirs:
       - staging/src/k8s.io/csi-translation-lib
   - name: release-1.30
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: api
       branch: release-1.30
@@ -1911,25 +1911,25 @@ rules:
       dirs:
       - staging/src/k8s.io/mount-utils
   - name: release-1.27
-    go: 1.22.4
+    go: 1.22.5
     source:
       branch: release-1.27
       dirs:
       - staging/src/k8s.io/mount-utils
   - name: release-1.28
-    go: 1.22.4
+    go: 1.22.5
     source:
       branch: release-1.28
       dirs:
       - staging/src/k8s.io/mount-utils
   - name: release-1.29
-    go: 1.22.4
+    go: 1.22.5
     source:
       branch: release-1.29
       dirs:
       - staging/src/k8s.io/mount-utils
   - name: release-1.30
-    go: 1.22.4
+    go: 1.22.5
     source:
       branch: release-1.30
       dirs:
@@ -1938,7 +1938,7 @@ rules:
 - destination: legacy-cloud-providers
   branches:
   - name: release-1.27
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: api
       branch: release-1.27
@@ -1963,7 +1963,7 @@ rules:
       dirs:
       - staging/src/k8s.io/legacy-cloud-providers
   - name: release-1.28
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: api
       branch: release-1.28
@@ -1988,7 +1988,7 @@ rules:
       dirs:
       - staging/src/k8s.io/legacy-cloud-providers
   - name: release-1.29
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: api
       branch: release-1.29
@@ -2013,7 +2013,7 @@ rules:
       dirs:
       - staging/src/k8s.io/legacy-cloud-providers
   - name: release-1.30
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: api
       branch: release-1.30
@@ -2063,7 +2063,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubectl
   - name: release-1.27
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: api
       branch: release-1.27
@@ -2086,7 +2086,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubectl
   - name: release-1.28
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: api
       branch: release-1.28
@@ -2109,7 +2109,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubectl
   - name: release-1.29
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: api
       branch: release-1.29
@@ -2132,7 +2132,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubectl
   - name: release-1.30
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: api
       branch: release-1.30
@@ -2176,7 +2176,7 @@ rules:
       dirs:
       - staging/src/k8s.io/pod-security-admission
   - name: release-1.27
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: api
       branch: release-1.27
@@ -2195,7 +2195,7 @@ rules:
       dirs:
       - staging/src/k8s.io/pod-security-admission
   - name: release-1.28
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: api
       branch: release-1.28
@@ -2214,7 +2214,7 @@ rules:
       dirs:
       - staging/src/k8s.io/pod-security-admission
   - name: release-1.29
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: api
       branch: release-1.29
@@ -2233,7 +2233,7 @@ rules:
       dirs:
       - staging/src/k8s.io/pod-security-admission
   - name: release-1.30
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: api
       branch: release-1.30
@@ -2277,7 +2277,7 @@ rules:
       dirs:
       - staging/src/k8s.io/dynamic-resource-allocation
   - name: release-1.27
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -2294,7 +2294,7 @@ rules:
       dirs:
       - staging/src/k8s.io/dynamic-resource-allocation
   - name: release-1.28
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -2315,7 +2315,7 @@ rules:
       dirs:
       - staging/src/k8s.io/dynamic-resource-allocation
   - name: release-1.29
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -2336,7 +2336,7 @@ rules:
       dirs:
       - staging/src/k8s.io/dynamic-resource-allocation
   - name: release-1.30
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -2375,7 +2375,7 @@ rules:
       dirs:
       - staging/src/k8s.io/endpointslice
   - name: release-1.28
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: api
       branch: release-1.28
@@ -2390,7 +2390,7 @@ rules:
       dirs:
       - staging/src/k8s.io/endpointslice
   - name: release-1.29
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: api
       branch: release-1.29
@@ -2405,7 +2405,7 @@ rules:
       dirs:
       - staging/src/k8s.io/endpointslice
   - name: release-1.30
-    go: 1.22.4
+    go: 1.22.5
     dependencies:
     - repository: api
       branch: release-1.30


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Update publishing-bot rules to Go 1.22.5

#### Which issue(s) this PR fixes:

xref https://github.com/kubernetes/release/issues/3657

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```

/assign @saschagrunert @Verolop @dims 
cc @kubernetes/release-engineering 