### PR TITLE
cli-runtime resource strict verify YAML content from url, path, kustomize, stdin

### DIFF
--- a/staging/src/k8s.io/cli-runtime/pkg/resource/builder.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/builder.go
@@ -373,7 +373,7 @@ func (b *Builder) URL(httpAttemptCount int, urls ...*url.URL) *Builder {
 	for _, u := range urls {
 		b.paths = append(b.paths, &URLVisitor{
 			URL:              u,
-			StreamVisitor:    NewStreamVisitor(nil, b.mapper, u.String(), b.schema),
+			StreamVisitor:    NewStreamVisitor(nil, b.mapper, u.String(), b.schema, WithStrictStreamVisitor()),
 			HttpAttemptCount: httpAttemptCount,
 		})
 	}

--- a/staging/src/k8s.io/cli-runtime/pkg/resource/kustomizevisitor.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/kustomizevisitor.go
@@ -49,6 +49,6 @@ func (v *KustomizeVisitor) Visit(fn VisitorFunc) error {
 		return err
 	}
 	sv := NewStreamVisitor(
-		bytes.NewReader(v.yml), v.mapper, v.dirPath, v.schema)
+		bytes.NewReader(v.yml), v.mapper, v.dirPath, v.schema, WithStrictStreamVisitor())
 	return sv.Visit(fn)
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
cli-runtime resource strict verify YAML content from url, path, kustomize, stdin

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #125885

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubectl will strictly check the yaml content from url, path, kustomize, stdin
```
