### PR TITLE
fix race on integration test for portforward

### DIFF
--- a/test/integration/apiserver/portforward/portforward_test.go
+++ b/test/integration/apiserver/portforward/portforward_test.go
@@ -113,7 +113,15 @@ func TestPortforward(t *testing.T) {
 	// local port missing asks os to find random open port.
 	// Example: ":8000" (local = random, remote = 8000)
 	localRemotePort := fmt.Sprintf(":%s", remotePort)
-	streams, _, out, errOut := genericiooptions.NewTestIOStreams()
+	out := &mBuffer{
+		buffer: bytes.Buffer{},
+	}
+	errOut := &bytes.Buffer{}
+	streams := genericiooptions.IOStreams{
+		In:     &bytes.Buffer{},
+		Out:    out,
+		ErrOut: errOut,
+	}
 	portForwardOptions := portforward.NewDefaultPortForwardOptions(streams)
 	portForwardOptions.Namespace = "default"
 	portForwardOptions.PodName = "mypod"
@@ -225,4 +233,21 @@ func (d *dummyPortForwarder) PortForward(ctx context.Context, name string, uid t
 	}
 	resp.Write(stream) //nolint:errcheck
 	return stream.Close()
+}
+
+type mBuffer struct {
+	mu     sync.Mutex
+	buffer bytes.Buffer
+}
+
+func (s *mBuffer) Write(p []byte) (n int, err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buffer.Write(p)
+}
+
+func (s *mBuffer) String() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buffer.String()
 }


### PR DESCRIPTION
Fixes: #125904 

```release-note
NONE
```

The race happens because the test reads the buffer used to store the `stdout` that is also used by the streams .

Making the buffer thread safe removes the race

```
o test -timeout 30s -run ^TestPortforward$ k8s.io/kubernetes/test/integration/apiserver/portforward  -count 1 -race
ok      k8s.io/kubernetes/test/integration/apiserver/portforward        8.784s
```
