### PR TITLE
Migrate cpumanager to contextual logging

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -35,6 +35,7 @@ import (
 	"time"
 
 	"github.com/coreos/go-systemd/v22/daemon"
+	"github.com/go-logr/logr"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"go.opentelemetry.io/otel"
@@ -583,14 +584,14 @@ func makeEventRecorder(ctx context.Context, kubeDeps *kubelet.Dependencies, node
 	}
 }
 
-func getReservedCPUs(machineInfo *cadvisorapi.MachineInfo, cpus string) (cpuset.CPUSet, error) {
+func getReservedCPUs(logger logr.Logger, machineInfo *cadvisorapi.MachineInfo, cpus string) (cpuset.CPUSet, error) {
 	emptyCPUSet := cpuset.New()
 
 	if cpus == "" {
 		return emptyCPUSet, nil
 	}
 
-	topo, err := topology.Discover(machineInfo)
+	topo, err := topology.Discover(logger, machineInfo)
 	if err != nil {
 		return emptyCPUSet, fmt.Errorf("unable to discover CPU topology info: %s", err)
 	}
@@ -786,7 +787,7 @@ func run(ctx context.Context, s *options.KubeletServer, kubeDeps *kubelet.Depend
 		if err != nil {
 			return err
 		}
-		reservedSystemCPUs, err := getReservedCPUs(machineInfo, s.ReservedSystemCPUs)
+		reservedSystemCPUs, err := getReservedCPUs(logger, machineInfo, s.ReservedSystemCPUs)
 		if err != nil {
 			return err
 		}

--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -251,6 +251,7 @@ linters:
             contextual k8s.io/kubernetes/pkg/kubelet/certificate/.*
             contextual k8s.io/kubernetes/pkg/kubelet/cm/devicemanager/.*
             contextual k8s.io/kubernetes/pkg/kubelet/cm/dra/.*
+            contextual k8s.io/kubernetes/pkg/kubelet/cm/cpumanager/.*
             contextual k8s.io/kubernetes/pkg/kubelet/cm/memorymanager/.*
             contextual k8s.io/kubernetes/pkg/kubelet/cm/topologymanager/.*
             contextual k8s.io/kubernetes/pkg/kubelet/lifecycle/.*

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -260,6 +260,7 @@ linters:
             contextual k8s.io/kubernetes/pkg/kubelet/certificate/.*
             contextual k8s.io/kubernetes/pkg/kubelet/cm/devicemanager/.*
             contextual k8s.io/kubernetes/pkg/kubelet/cm/dra/.*
+            contextual k8s.io/kubernetes/pkg/kubelet/cm/cpumanager/.*
             contextual k8s.io/kubernetes/pkg/kubelet/cm/memorymanager/.*
             contextual k8s.io/kubernetes/pkg/kubelet/cm/topologymanager/.*
             contextual k8s.io/kubernetes/pkg/kubelet/lifecycle/.*

--- a/hack/logcheck.conf
+++ b/hack/logcheck.conf
@@ -65,6 +65,7 @@ contextual k8s.io/kubernetes/test/e2e/dra/.*
 contextual k8s.io/kubernetes/pkg/kubelet/certificate/.*
 contextual k8s.io/kubernetes/pkg/kubelet/cm/devicemanager/.*
 contextual k8s.io/kubernetes/pkg/kubelet/cm/dra/.*
+contextual k8s.io/kubernetes/pkg/kubelet/cm/cpumanager/.*
 contextual k8s.io/kubernetes/pkg/kubelet/cm/memorymanager/.*
 contextual k8s.io/kubernetes/pkg/kubelet/cm/topologymanager/.*
 contextual k8s.io/kubernetes/pkg/kubelet/lifecycle/.*

--- a/pkg/kubelet/cm/container_manager_linux.go
+++ b/pkg/kubelet/cm/container_manager_linux.go
@@ -327,6 +327,7 @@ func NewContainerManager(mountUtil mount.Interface, cadvisorInterface cadvisor.I
 
 	// Initialize CPU manager
 	cm.cpuManager, err = cpumanager.NewManager(
+		logger,
 		nodeConfig.CPUManagerPolicy,
 		nodeConfig.CPUManagerPolicyOptions,
 		nodeConfig.CPUManagerReconcilePeriod,
@@ -625,7 +626,7 @@ func (cm *containerManagerImpl) Start(ctx context.Context, node *v1.Node,
 	}
 
 	// Initialize CPU manager
-	err := cm.cpuManager.Start(cpumanager.ActivePodsFunc(activePods), sourcesReady, podStatusProvider, runtimeService, containerMap.Clone())
+	err := cm.cpuManager.Start(ctx, cpumanager.ActivePodsFunc(activePods), sourcesReady, podStatusProvider, runtimeService, containerMap.Clone())
 	if err != nil {
 		return fmt.Errorf("start cpu manager error: %w", err)
 	}

--- a/pkg/kubelet/cm/container_manager_stub.go
+++ b/pkg/kubelet/cm/container_manager_stub.go
@@ -44,6 +44,7 @@ type containerManagerStub struct {
 	shouldResetExtendedResourceCapacity bool
 	extendedPluginResources             v1.ResourceList
 	memoryManager                       memorymanager.Manager
+	cpuManager                          cpumanager.Manager
 }
 
 var _ ContainerManager = &containerManagerStub{}
@@ -51,6 +52,7 @@ var _ ContainerManager = &containerManagerStub{}
 func (cm *containerManagerStub) Start(ctx context.Context, _ *v1.Node, _ ActivePodsFunc, _ GetNodeFunc, _ config.SourcesReady, _ status.PodStatusProvider, _ internalapi.RuntimeService, _ bool) error {
 	klog.V(2).InfoS("Starting stub container manager")
 	cm.memoryManager = memorymanager.NewFakeManager(ctx)
+	cm.cpuManager = cpumanager.NewFakeManager(klog.FromContext(ctx))
 	return nil
 }
 
@@ -127,7 +129,7 @@ func (cm *containerManagerStub) UpdatePluginResources(*schedulerframework.NodeIn
 }
 
 func (cm *containerManagerStub) InternalContainerLifecycle() InternalContainerLifecycle {
-	return &internalContainerLifecycleImpl{cpumanager.NewFakeManager(), cm.memoryManager, topologymanager.NewFakeManager()}
+	return &internalContainerLifecycleImpl{cm.cpuManager, cm.memoryManager, topologymanager.NewFakeManager()}
 }
 
 func (cm *containerManagerStub) GetPodCgroupRoot() string {

--- a/pkg/kubelet/cm/container_manager_windows.go
+++ b/pkg/kubelet/cm/container_manager_windows.go
@@ -98,7 +98,7 @@ func (cm *containerManagerImpl) Start(ctx context.Context, node *v1.Node,
 	containerMap, containerRunningSet := buildContainerMapAndRunningSetFromRuntime(ctx, runtimeService)
 
 	if utilfeature.DefaultFeatureGate.Enabled(kubefeatures.WindowsCPUAndMemoryAffinity) {
-		err := cm.cpuManager.Start(cpumanager.ActivePodsFunc(activePods), sourcesReady, podStatusProvider, runtimeService, containerMap.Clone())
+		err := cm.cpuManager.Start(ctx, cpumanager.ActivePodsFunc(activePods), sourcesReady, podStatusProvider, runtimeService, containerMap.Clone())
 		if err != nil {
 			return fmt.Errorf("start cpu manager error: %v", err)
 		}
@@ -140,7 +140,7 @@ func NewContainerManager(mountUtil mount.Interface, cadvisorInterface cadvisor.I
 	logger := klog.TODO()
 
 	cm.topologyManager = topologymanager.NewFakeManager()
-	cm.cpuManager = cpumanager.NewFakeManager()
+	cm.cpuManager = cpumanager.NewFakeManager(klog.TODO())
 	cm.memoryManager = memorymanager.NewFakeManager(context.TODO())
 
 	if utilfeature.DefaultFeatureGate.Enabled(kubefeatures.WindowsCPUAndMemoryAffinity) {
@@ -156,6 +156,7 @@ func NewContainerManager(mountUtil mount.Interface, cadvisorInterface cadvisor.I
 
 		klog.InfoS("Creating cpu manager")
 		cm.cpuManager, err = cpumanager.NewManager(
+			klog.TODO(),
 			nodeConfig.CPUManagerPolicy,
 			nodeConfig.CPUManagerPolicyOptions,
 			nodeConfig.CPUManagerReconcilePeriod,

--- a/pkg/kubelet/cm/cpumanager/cpu_assignment_test.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_assignment_test.go
@@ -22,10 +22,12 @@ import (
 	"testing"
 
 	"k8s.io/kubernetes/pkg/kubelet/cm/cpumanager/topology"
+	"k8s.io/kubernetes/test/utils/ktesting"
 	"k8s.io/utils/cpuset"
 )
 
 func TestCPUAccumulatorFreeSockets(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
 	testCases := []struct {
 		description   string
 		topo          *topology.CPUTopology
@@ -114,7 +116,7 @@ func TestCPUAccumulatorFreeSockets(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			acc := newCPUAccumulator(tc.topo, tc.availableCPUs, 0, CPUSortingStrategyPacked)
+			acc := newCPUAccumulator(logger, tc.topo, tc.availableCPUs, 0, CPUSortingStrategyPacked)
 			result := acc.freeSockets()
 			sort.Ints(result)
 			if !reflect.DeepEqual(result, tc.expect) {
@@ -126,6 +128,7 @@ func TestCPUAccumulatorFreeSockets(t *testing.T) {
 }
 
 func TestCPUAccumulatorFreeNUMANodes(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
 	testCases := []struct {
 		description   string
 		topo          *topology.CPUTopology
@@ -214,7 +217,7 @@ func TestCPUAccumulatorFreeNUMANodes(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			acc := newCPUAccumulator(tc.topo, tc.availableCPUs, 0, CPUSortingStrategyPacked)
+			acc := newCPUAccumulator(logger, tc.topo, tc.availableCPUs, 0, CPUSortingStrategyPacked)
 			result := acc.freeNUMANodes()
 			if !reflect.DeepEqual(result, tc.expect) {
 				t.Errorf("expected %v to equal %v", result, tc.expect)
@@ -224,6 +227,7 @@ func TestCPUAccumulatorFreeNUMANodes(t *testing.T) {
 }
 
 func TestCPUAccumulatorFreeSocketsAndNUMANodes(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
 	testCases := []struct {
 		description     string
 		topo            *topology.CPUTopology
@@ -263,7 +267,7 @@ func TestCPUAccumulatorFreeSocketsAndNUMANodes(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			acc := newCPUAccumulator(tc.topo, tc.availableCPUs, 0, CPUSortingStrategyPacked)
+			acc := newCPUAccumulator(logger, tc.topo, tc.availableCPUs, 0, CPUSortingStrategyPacked)
 			resultNUMANodes := acc.freeNUMANodes()
 			if !reflect.DeepEqual(resultNUMANodes, tc.expectNUMANodes) {
 				t.Errorf("expected NUMA Nodes %v to equal %v", resultNUMANodes, tc.expectNUMANodes)
@@ -277,6 +281,7 @@ func TestCPUAccumulatorFreeSocketsAndNUMANodes(t *testing.T) {
 }
 
 func TestCPUAccumulatorFreeCores(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
 	testCases := []struct {
 		description   string
 		topo          *topology.CPUTopology
@@ -335,7 +340,7 @@ func TestCPUAccumulatorFreeCores(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			acc := newCPUAccumulator(tc.topo, tc.availableCPUs, 0, CPUSortingStrategyPacked)
+			acc := newCPUAccumulator(logger, tc.topo, tc.availableCPUs, 0, CPUSortingStrategyPacked)
 			result := acc.freeCores()
 			if !reflect.DeepEqual(result, tc.expect) {
 				t.Errorf("expected %v to equal %v", result, tc.expect)
@@ -345,6 +350,7 @@ func TestCPUAccumulatorFreeCores(t *testing.T) {
 }
 
 func TestCPUAccumulatorFreeCPUs(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
 	testCases := []struct {
 		description   string
 		topo          *topology.CPUTopology
@@ -391,7 +397,7 @@ func TestCPUAccumulatorFreeCPUs(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			acc := newCPUAccumulator(tc.topo, tc.availableCPUs, 0, CPUSortingStrategyPacked)
+			acc := newCPUAccumulator(logger, tc.topo, tc.availableCPUs, 0, CPUSortingStrategyPacked)
 			result := acc.freeCPUs()
 			if !reflect.DeepEqual(result, tc.expect) {
 				t.Errorf("expected %v to equal %v", result, tc.expect)
@@ -401,6 +407,7 @@ func TestCPUAccumulatorFreeCPUs(t *testing.T) {
 }
 
 func TestCPUAccumulatorTake(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
 	testCases := []struct {
 		description     string
 		topo            *topology.CPUTopology
@@ -477,7 +484,7 @@ func TestCPUAccumulatorTake(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			acc := newCPUAccumulator(tc.topo, tc.availableCPUs, tc.numCPUs, CPUSortingStrategyPacked)
+			acc := newCPUAccumulator(logger, tc.topo, tc.availableCPUs, tc.numCPUs, CPUSortingStrategyPacked)
 			totalTaken := 0
 			for _, cpus := range tc.takeCPUs {
 				acc.take(cpus)
@@ -639,6 +646,7 @@ func commonTakeByTopologyTestCases(t *testing.T) []takeByTopologyTestCase {
 }
 
 func TestTakeByTopologyNUMAPacked(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
 	testCases := commonTakeByTopologyTestCases(t)
 	testCases = append(testCases, []takeByTopologyTestCase{
 		{
@@ -750,7 +758,7 @@ func TestTakeByTopologyNUMAPacked(t *testing.T) {
 				strategy = CPUSortingStrategySpread
 			}
 
-			result, err := takeByTopologyNUMAPacked(tc.topo, tc.availableCPUs, tc.numCPUs, strategy, tc.opts.PreferAlignByUncoreCacheOption)
+			result, err := takeByTopologyNUMAPacked(logger, tc.topo, tc.availableCPUs, tc.numCPUs, strategy, tc.opts.PreferAlignByUncoreCacheOption)
 			if tc.expErr != "" && err != nil && err.Error() != tc.expErr {
 				t.Errorf("expected error to be [%v] but it was [%v]", tc.expErr, err)
 			}
@@ -762,6 +770,7 @@ func TestTakeByTopologyNUMAPacked(t *testing.T) {
 }
 
 func TestTakeByTopologyWithSpreadPhysicalCPUsPreferredOption(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
 	testCases := []struct {
 		description   string
 		topo          *topology.CPUTopology
@@ -851,7 +860,7 @@ func TestTakeByTopologyWithSpreadPhysicalCPUsPreferredOption(t *testing.T) {
 		if tc.opts.DistributeCPUsAcrossCores {
 			strategy = CPUSortingStrategySpread
 		}
-		result, err := takeByTopologyNUMAPacked(tc.topo, tc.availableCPUs, tc.numCPUs, strategy, tc.opts.PreferAlignByUncoreCacheOption)
+		result, err := takeByTopologyNUMAPacked(logger, tc.topo, tc.availableCPUs, tc.numCPUs, strategy, tc.opts.PreferAlignByUncoreCacheOption)
 		if tc.expErr != "" && err.Error() != tc.expErr {
 			t.Errorf("testCase %q failed, expected error to be [%v] but it was [%v]", tc.description, tc.expErr, err)
 		}
@@ -957,6 +966,7 @@ func commonTakeByTopologyExtendedTestCases(t *testing.T) []takeByTopologyExtende
 }
 
 func TestTakeByTopologyNUMADistributed(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
 	testCases := commonTakeByTopologyExtendedTestCases(t)
 	testCases = append(testCases, []takeByTopologyExtendedTestCase{
 		{
@@ -1053,7 +1063,7 @@ func TestTakeByTopologyNUMADistributed(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			result, err := takeByTopologyNUMADistributed(tc.topo, tc.availableCPUs, tc.numCPUs, tc.cpuGroupSize, CPUSortingStrategyPacked)
+			result, err := takeByTopologyNUMADistributed(logger, tc.topo, tc.availableCPUs, tc.numCPUs, tc.cpuGroupSize, CPUSortingStrategyPacked)
 			if err != nil {
 				if tc.expErr == "" {
 					t.Errorf("unexpected error [%v]", err)

--- a/pkg/kubelet/cm/cpumanager/cpu_manager_test.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_manager_test.go
@@ -31,12 +31,14 @@ import (
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/kubernetes/pkg/features"
 
+	"github.com/go-logr/logr"
 	cadvisorapi "github.com/google/cadvisor/info/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+	"k8s.io/kubernetes/test/utils/ktesting"
 
 	"k8s.io/kubernetes/pkg/kubelet/cm/containermap"
 	"k8s.io/kubernetes/pkg/kubelet/cm/cpumanager/state"
@@ -105,23 +107,23 @@ func (p *mockPolicy) Name() string {
 	return "mock"
 }
 
-func (p *mockPolicy) Start(s state.State) error {
+func (p *mockPolicy) Start(_ logr.Logger, s state.State) error {
 	return p.err
 }
 
-func (p *mockPolicy) Allocate(s state.State, pod *v1.Pod, container *v1.Container) error {
+func (p *mockPolicy) Allocate(_ logr.Logger, s state.State, pod *v1.Pod, container *v1.Container) error {
 	return p.err
 }
 
-func (p *mockPolicy) RemoveContainer(s state.State, podUID string, containerName string) error {
+func (p *mockPolicy) RemoveContainer(_ logr.Logger, s state.State, podUID string, containerName string) error {
 	return p.err
 }
 
-func (p *mockPolicy) GetTopologyHints(s state.State, pod *v1.Pod, container *v1.Container) map[string][]topologymanager.TopologyHint {
+func (p *mockPolicy) GetTopologyHints(_ logr.Logger, s state.State, pod *v1.Pod, container *v1.Container) map[string][]topologymanager.TopologyHint {
 	return nil
 }
 
-func (p *mockPolicy) GetPodTopologyHints(s state.State, pod *v1.Pod) map[string][]topologymanager.TopologyHint {
+func (p *mockPolicy) GetPodTopologyHints(_ logr.Logger, s state.State, pod *v1.Pod) map[string][]topologymanager.TopologyHint {
 	return nil
 }
 
@@ -288,7 +290,10 @@ func TestCPUManagerAdd(t *testing.T) {
 		featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.WindowsCPUAndMemoryAffinity, true)
 	}
 
+	logger, _ := ktesting.NewTestContext(t)
+
 	testPolicy, _ := NewStaticPolicy(
+		logger,
 		&topology.CPUTopology{
 			NumCPUs:    4,
 			NumSockets: 1,
@@ -339,7 +344,7 @@ func TestCPUManagerAdd(t *testing.T) {
 				assignments:   state.ContainerCPUAssignments{},
 				defaultCPUSet: cpuset.New(1, 2, 3, 4),
 			},
-			lastUpdateState: state.NewMemoryState(),
+			lastUpdateState: state.NewMemoryState(logger),
 			containerRuntime: mockRuntimeService{
 				err: testCase.updateErr,
 			},
@@ -358,7 +363,7 @@ func TestCPUManagerAdd(t *testing.T) {
 				testCase.description, testCase.expAllocateErr, err)
 		}
 
-		mgr.AddContainer(pod, container, "fakeID")
+		mgr.AddContainer(logger, pod, container, "fakeID")
 		_, _, err = mgr.containerMap.GetContainerRef("fakeID")
 		if !reflect.DeepEqual(err, testCase.expAddContainerErr) {
 			t.Errorf("CPU Manager AddContainer() error (%v). expected error: %v but got: %v",
@@ -557,7 +562,8 @@ func TestCPUManagerAddWithInitContainers(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		policy, _ := NewStaticPolicy(testCase.topo, testCase.numReservedCPUs, cpuset.New(), topologymanager.NewFakeManager(), nil)
+		logger, _ := ktesting.NewTestContext(t)
+		policy, _ := NewStaticPolicy(logger, testCase.topo, testCase.numReservedCPUs, cpuset.New(), topologymanager.NewFakeManager(), nil)
 
 		mockState := &mockState{
 			assignments:   testCase.stAssignments,
@@ -567,7 +573,7 @@ func TestCPUManagerAddWithInitContainers(t *testing.T) {
 		mgr := &manager{
 			policy:            policy,
 			state:             mockState,
-			lastUpdateState:   state.NewMemoryState(),
+			lastUpdateState:   state.NewMemoryState(logger),
 			containerRuntime:  mockRuntimeService{},
 			containerMap:      containermap.NewContainerMap(),
 			podStatusProvider: mockPodStatusProvider{},
@@ -598,7 +604,7 @@ func TestCPUManagerAddWithInitContainers(t *testing.T) {
 					testCase.description, containerIDs[i], err)
 			}
 
-			mgr.AddContainer(testCase.pod, &containers[i], containerIDs[i])
+			mgr.AddContainer(logger, testCase.pod, &containers[i], containerIDs[i])
 			_, _, err = mgr.containerMap.GetContainerRef(containerIDs[i])
 			if err != nil {
 				t.Errorf("StaticPolicy AddContainer() error (%v). unexpected error for container id: %v: %v",
@@ -720,7 +726,8 @@ func TestCPUManagerGenerate(t *testing.T) {
 			}
 			defer os.RemoveAll(sDir)
 
-			mgr, err := NewManager(testCase.cpuPolicyName, nil, 5*time.Second, machineInfo, cpuset.New(), testCase.nodeAllocatableReservation, sDir, topologymanager.NewFakeManager())
+			logger, _ := ktesting.NewTestContext(t)
+			mgr, err := NewManager(logger, testCase.cpuPolicyName, nil, 5*time.Second, machineInfo, cpuset.New(), testCase.nodeAllocatableReservation, sDir, topologymanager.NewFakeManager())
 			if testCase.expectedError != nil {
 				if !strings.Contains(err.Error(), testCase.expectedError.Error()) {
 					t.Errorf("Unexpected error message. Have: %s wants %s", err.Error(), testCase.expectedError.Error())
@@ -747,6 +754,7 @@ func TestCPUManagerRemove(t *testing.T) {
 	containerID := "fakeID"
 	containerMap := containermap.NewContainerMap()
 
+	logger, _ := ktesting.NewTestContext(t)
 	mgr := &manager{
 		policy: &mockPolicy{
 			err: nil,
@@ -755,7 +763,7 @@ func TestCPUManagerRemove(t *testing.T) {
 			assignments:   state.ContainerCPUAssignments{},
 			defaultCPUSet: cpuset.New(),
 		},
-		lastUpdateState:   state.NewMemoryState(),
+		lastUpdateState:   state.NewMemoryState(logger),
 		containerRuntime:  mockRuntimeService{},
 		containerMap:      containerMap,
 		activePods:        func() []*v1.Pod { return nil },
@@ -763,7 +771,7 @@ func TestCPUManagerRemove(t *testing.T) {
 	}
 
 	containerMap.Add("", "", containerID)
-	err := mgr.RemoveContainer(containerID)
+	err := mgr.RemoveContainer(logger, containerID)
 	if err != nil {
 		t.Errorf("CPU Manager RemoveContainer() error. expected error to be nil but got: %v", err)
 	}
@@ -772,7 +780,7 @@ func TestCPUManagerRemove(t *testing.T) {
 		policy: &mockPolicy{
 			err: fmt.Errorf("fake error"),
 		},
-		state:             state.NewMemoryState(),
+		state:             state.NewMemoryState(logger),
 		containerRuntime:  mockRuntimeService{},
 		containerMap:      containerMap,
 		activePods:        func() []*v1.Pod { return nil },
@@ -780,7 +788,7 @@ func TestCPUManagerRemove(t *testing.T) {
 	}
 
 	containerMap.Add("", "", containerID)
-	err = mgr.RemoveContainer(containerID)
+	err = mgr.RemoveContainer(logger, containerID)
 	if !reflect.DeepEqual(err, fmt.Errorf("fake error")) {
 		t.Errorf("CPU Manager RemoveContainer() error. expected error: fake error but got: %v", err)
 	}
@@ -791,7 +799,10 @@ func TestReconcileState(t *testing.T) {
 		featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.WindowsCPUAndMemoryAffinity, true)
 	}
 
+	logger, _ := ktesting.NewTestContext(t)
+
 	testPolicy, _ := NewStaticPolicy(
+		logger,
 		&topology.CPUTopology{
 			NumCPUs:    8,
 			NumSockets: 2,
@@ -1245,13 +1256,14 @@ func TestReconcileState(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
+		logger, _ := ktesting.NewTestContext(t)
 		mgr := &manager{
 			policy: testCase.policy,
 			state: &mockState{
 				assignments:   testCase.stAssignments,
 				defaultCPUSet: testCase.stDefaultCPUSet,
 			},
-			lastUpdateState: state.NewMemoryState(),
+			lastUpdateState: state.NewMemoryState(logger),
 			containerRuntime: mockRuntimeService{
 				err: testCase.updateErr,
 			},
@@ -1265,7 +1277,7 @@ func TestReconcileState(t *testing.T) {
 			},
 		}
 		mgr.sourcesReady = &sourcesReadyStub{}
-		success, failure := mgr.reconcileState()
+		success, failure := mgr.reconcileState(context.Background())
 
 		if !reflect.DeepEqual(testCase.expectStAssignments, mgr.state.GetCPUAssignments()) {
 			t.Errorf("%v", testCase.description)
@@ -1318,7 +1330,9 @@ func TestCPUManagerAddWithResvList(t *testing.T) {
 		featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.WindowsCPUAndMemoryAffinity, true)
 	}
 
+	logger, _ := ktesting.NewTestContext(t)
 	testPolicy, _ := NewStaticPolicy(
+		logger,
 		&topology.CPUTopology{
 			NumCPUs:    4,
 			NumSockets: 1,
@@ -1359,7 +1373,7 @@ func TestCPUManagerAddWithResvList(t *testing.T) {
 				assignments:   state.ContainerCPUAssignments{},
 				defaultCPUSet: cpuset.New(0, 1, 2, 3),
 			},
-			lastUpdateState: state.NewMemoryState(),
+			lastUpdateState: state.NewMemoryState(logger),
 			containerRuntime: mockRuntimeService{
 				err: testCase.updateErr,
 			},
@@ -1378,7 +1392,7 @@ func TestCPUManagerAddWithResvList(t *testing.T) {
 				testCase.description, testCase.expAllocateErr, err)
 		}
 
-		mgr.AddContainer(pod, container, "fakeID")
+		mgr.AddContainer(logger, pod, container, "fakeID")
 		_, _, err = mgr.containerMap.GetContainerRef("fakeID")
 		if !reflect.DeepEqual(err, testCase.expAddContainerErr) {
 			t.Errorf("CPU Manager AddContainer() error (%v). expected error: %v but got: %v",
@@ -1449,7 +1463,8 @@ func TestCPUManagerHandlePolicyOptions(t *testing.T) {
 			}
 			defer os.RemoveAll(sDir)
 
-			_, err = NewManager(testCase.cpuPolicyName, testCase.cpuPolicyOptions, 5*time.Second, machineInfo, cpuset.New(), nodeAllocatableReservation, sDir, topologymanager.NewFakeManager())
+			logger, _ := ktesting.NewTestContext(t)
+			_, err = NewManager(logger, testCase.cpuPolicyName, testCase.cpuPolicyOptions, 5*time.Second, machineInfo, cpuset.New(), nodeAllocatableReservation, sDir, topologymanager.NewFakeManager())
 			if err == nil {
 				t.Errorf("Expected error, but NewManager succeeded")
 			}
@@ -1462,12 +1477,14 @@ func TestCPUManagerHandlePolicyOptions(t *testing.T) {
 }
 
 func TestCPUManagerGetAllocatableCPUs(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
 	if runtime.GOOS == "windows" {
 		featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.WindowsCPUAndMemoryAffinity, true)
 	}
 
 	nonePolicy, _ := NewNonePolicy(nil)
 	staticPolicy, _ := NewStaticPolicy(
+		logger,
 		&topology.CPUTopology{
 			NumCPUs:    4,
 			NumSockets: 1,
@@ -1508,7 +1525,7 @@ func TestCPUManagerGetAllocatableCPUs(t *testing.T) {
 				assignments:   state.ContainerCPUAssignments{},
 				defaultCPUSet: cpuset.New(0, 1, 2, 3),
 			},
-			lastUpdateState:   state.NewMemoryState(),
+			lastUpdateState:   state.NewMemoryState(logger),
 			containerMap:      containermap.NewContainerMap(),
 			podStatusProvider: mockPodStatusProvider{},
 			sourcesReady:      &sourcesReadyStub{},

--- a/pkg/kubelet/cm/cpumanager/fake_cpu_manager.go
+++ b/pkg/kubelet/cm/cpumanager/fake_cpu_manager.go
@@ -17,7 +17,10 @@ limitations under the License.
 package cpumanager
 
 import (
-	"k8s.io/api/core/v1"
+	"context"
+
+	"github.com/go-logr/logr"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/kubelet/cm/containermap"
 	"k8s.io/kubernetes/pkg/kubelet/cm/cpumanager/state"
@@ -28,41 +31,46 @@ import (
 )
 
 type fakeManager struct {
-	state state.State
+	logger logr.Logger
+	state  state.State
 }
 
-func (m *fakeManager) Start(activePods ActivePodsFunc, sourcesReady config.SourcesReady, podStatusProvider status.PodStatusProvider, containerRuntime runtimeService, initialContainers containermap.ContainerMap) error {
-	klog.InfoS("Start()")
+func (m *fakeManager) Start(ctx context.Context, activePods ActivePodsFunc, sourcesReady config.SourcesReady, podStatusProvider status.PodStatusProvider, containerRuntime runtimeService, initialContainers containermap.ContainerMap) error {
+	logger := klog.FromContext(ctx)
+	logger.Info("Start()")
 	return nil
 }
 
 func (m *fakeManager) Policy() Policy {
-	klog.InfoS("Policy()")
+	m.logger.Info("Policy()")
 	pol, _ := NewNonePolicy(nil)
 	return pol
 }
 
 func (m *fakeManager) Allocate(pod *v1.Pod, container *v1.Container) error {
-	klog.InfoS("Allocate", "pod", klog.KObj(pod), "containerName", container.Name)
+	logger := klog.TODO()
+	logger.Info("Allocate", "pod", klog.KObj(pod), "containerName", container.Name)
 	return nil
 }
 
-func (m *fakeManager) AddContainer(pod *v1.Pod, container *v1.Container, containerID string) {
-	klog.InfoS("AddContainer", "pod", klog.KObj(pod), "containerName", container.Name, "containerID", containerID)
+func (m *fakeManager) AddContainer(logger logr.Logger, pod *v1.Pod, container *v1.Container, containerID string) {
+	logger.Info("AddContainer", "pod", klog.KObj(pod), "containerName", container.Name, "containerID", containerID)
 }
 
-func (m *fakeManager) RemoveContainer(containerID string) error {
-	klog.InfoS("RemoveContainer", "containerID", containerID)
+func (m *fakeManager) RemoveContainer(logger logr.Logger, containerID string) error {
+	logger.Info("RemoveContainer", "containerID", containerID)
 	return nil
 }
 
 func (m *fakeManager) GetTopologyHints(pod *v1.Pod, container *v1.Container) map[string][]topologymanager.TopologyHint {
-	klog.InfoS("Get container topology hints")
+	logger := klog.TODO()
+	logger.Info("Get container topology hints")
 	return map[string][]topologymanager.TopologyHint{}
 }
 
 func (m *fakeManager) GetPodTopologyHints(pod *v1.Pod) map[string][]topologymanager.TopologyHint {
-	klog.InfoS("Get pod topology hints")
+	logger := klog.TODO()
+	logger.Info("Get pod topology hints")
 	return map[string][]topologymanager.TopologyHint{}
 }
 
@@ -71,28 +79,30 @@ func (m *fakeManager) State() state.Reader {
 }
 
 func (m *fakeManager) GetExclusiveCPUs(podUID, containerName string) cpuset.CPUSet {
-	klog.InfoS("GetExclusiveCPUs", "podUID", podUID, "containerName", containerName)
+	m.logger.Info("GetExclusiveCPUs", "podUID", podUID, "containerName", containerName)
 	return cpuset.CPUSet{}
 }
 
 func (m *fakeManager) GetAllocatableCPUs() cpuset.CPUSet {
-	klog.InfoS("Get Allocatable CPUs")
+	m.logger.Info("Get Allocatable CPUs")
 	return cpuset.CPUSet{}
 }
 
 func (m *fakeManager) GetCPUAffinity(podUID, containerName string) cpuset.CPUSet {
-	klog.InfoS("GetCPUAffinity", "podUID", podUID, "containerName", containerName)
+	m.logger.Info("GetCPUAffinity", "podUID", podUID, "containerName", containerName)
 	return cpuset.CPUSet{}
 }
 
 func (m *fakeManager) GetAllCPUs() cpuset.CPUSet {
-	klog.InfoS("GetAllCPUs")
+	m.logger.Info("GetAllCPUs")
 	return cpuset.CPUSet{}
 }
 
 // NewFakeManager creates empty/fake cpu manager
-func NewFakeManager() Manager {
+func NewFakeManager(logger logr.Logger) Manager {
+	logger = klog.LoggerWithName(logger, "cpu.fake")
 	return &fakeManager{
-		state: state.NewMemoryState(),
+		logger: logger,
+		state:  state.NewMemoryState(logger),
 	}
 }

--- a/pkg/kubelet/cm/cpumanager/policy.go
+++ b/pkg/kubelet/cm/cpumanager/policy.go
@@ -17,8 +17,9 @@ limitations under the License.
 package cpumanager
 
 import (
-	"k8s.io/api/core/v1"
+	"github.com/go-logr/logr"
 
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/kubernetes/pkg/kubelet/cm/cpumanager/state"
 	"k8s.io/kubernetes/pkg/kubelet/cm/topologymanager"
 	"k8s.io/utils/cpuset"
@@ -27,19 +28,19 @@ import (
 // Policy implements logic for pod container to CPU assignment.
 type Policy interface {
 	Name() string
-	Start(s state.State) error
+	Start(logger logr.Logger, s state.State) error
 	// Allocate call is idempotent
-	Allocate(s state.State, pod *v1.Pod, container *v1.Container) error
+	Allocate(logger logr.Logger, s state.State, pod *v1.Pod, container *v1.Container) error
 	// RemoveContainer call is idempotent
-	RemoveContainer(s state.State, podUID string, containerName string) error
+	RemoveContainer(logger logr.Logger, s state.State, podUID string, containerName string) error
 	// GetTopologyHints implements the topologymanager.HintProvider Interface
 	// and is consulted to achieve NUMA aware resource alignment among this
 	// and other resource controllers.
-	GetTopologyHints(s state.State, pod *v1.Pod, container *v1.Container) map[string][]topologymanager.TopologyHint
+	GetTopologyHints(logger logr.Logger, s state.State, pod *v1.Pod, container *v1.Container) map[string][]topologymanager.TopologyHint
 	// GetPodTopologyHints implements the topologymanager.HintProvider Interface
 	// and is consulted to achieve NUMA aware resource alignment per Pod
 	// among this and other resource controllers.
-	GetPodTopologyHints(s state.State, pod *v1.Pod) map[string][]topologymanager.TopologyHint
+	GetPodTopologyHints(logger logr.Logger, s state.State, pod *v1.Pod) map[string][]topologymanager.TopologyHint
 	// GetAllocatableCPUs returns the total set of CPUs available for allocation.
 	GetAllocatableCPUs(m state.State) cpuset.CPUSet
 }

--- a/pkg/kubelet/cm/cpumanager/policy_none.go
+++ b/pkg/kubelet/cm/cpumanager/policy_none.go
@@ -19,14 +19,15 @@ package cpumanager
 import (
 	"fmt"
 
-	"k8s.io/api/core/v1"
-	"k8s.io/klog/v2"
+	"github.com/go-logr/logr"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/kubernetes/pkg/kubelet/cm/cpumanager/state"
 	"k8s.io/kubernetes/pkg/kubelet/cm/topologymanager"
 	"k8s.io/utils/cpuset"
 )
 
-type nonePolicy struct{}
+type nonePolicy struct {
+}
 
 var _ Policy = &nonePolicy{}
 
@@ -45,24 +46,24 @@ func (p *nonePolicy) Name() string {
 	return string(PolicyNone)
 }
 
-func (p *nonePolicy) Start(s state.State) error {
-	klog.InfoS("None policy: Start")
+func (p *nonePolicy) Start(logger logr.Logger, s state.State) error {
+	logger.Info("Start")
 	return nil
 }
 
-func (p *nonePolicy) Allocate(s state.State, pod *v1.Pod, container *v1.Container) error {
+func (p *nonePolicy) Allocate(_ logr.Logger, s state.State, pod *v1.Pod, container *v1.Container) error {
 	return nil
 }
 
-func (p *nonePolicy) RemoveContainer(s state.State, podUID string, containerName string) error {
+func (p *nonePolicy) RemoveContainer(_ logr.Logger, s state.State, podUID string, containerName string) error {
 	return nil
 }
 
-func (p *nonePolicy) GetTopologyHints(s state.State, pod *v1.Pod, container *v1.Container) map[string][]topologymanager.TopologyHint {
+func (p *nonePolicy) GetTopologyHints(_ logr.Logger, s state.State, pod *v1.Pod, container *v1.Container) map[string][]topologymanager.TopologyHint {
 	return nil
 }
 
-func (p *nonePolicy) GetPodTopologyHints(s state.State, pod *v1.Pod) map[string][]topologymanager.TopologyHint {
+func (p *nonePolicy) GetPodTopologyHints(_ logr.Logger, s state.State, pod *v1.Pod) map[string][]topologymanager.TopologyHint {
 	return nil
 }
 

--- a/pkg/kubelet/cm/cpumanager/policy_none_test.go
+++ b/pkg/kubelet/cm/cpumanager/policy_none_test.go
@@ -19,6 +19,8 @@ package cpumanager
 import (
 	"testing"
 
+	"k8s.io/kubernetes/test/utils/ktesting"
+
 	"k8s.io/kubernetes/pkg/kubelet/cm/cpumanager/state"
 	"k8s.io/utils/cpuset"
 )
@@ -33,6 +35,7 @@ func TestNonePolicyName(t *testing.T) {
 }
 
 func TestNonePolicyAllocate(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
 	policy := &nonePolicy{}
 
 	st := &mockState{
@@ -43,13 +46,14 @@ func TestNonePolicyAllocate(t *testing.T) {
 	testPod := makePod("fakePod", "fakeContainer", "1000m", "1000m")
 
 	container := &testPod.Spec.Containers[0]
-	err := policy.Allocate(st, testPod, container)
+	err := policy.Allocate(logger, st, testPod, container)
 	if err != nil {
 		t.Errorf("NonePolicy Allocate() error. expected no error but got: %v", err)
 	}
 }
 
 func TestNonePolicyRemove(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
 	policy := &nonePolicy{}
 
 	st := &mockState{
@@ -60,7 +64,7 @@ func TestNonePolicyRemove(t *testing.T) {
 	testPod := makePod("fakePod", "fakeContainer", "1000m", "1000m")
 
 	container := &testPod.Spec.Containers[0]
-	err := policy.RemoveContainer(st, string(testPod.UID), container.Name)
+	err := policy.RemoveContainer(logger, st, string(testPod.UID), container.Name)
 	if err != nil {
 		t.Errorf("NonePolicy RemoveContainer() error. expected no error but got %v", err)
 	}

--- a/pkg/kubelet/cm/cpumanager/policy_static.go
+++ b/pkg/kubelet/cm/cpumanager/policy_static.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/go-logr/logr"
+
 	v1 "k8s.io/api/core/v1"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	resourcehelper "k8s.io/component-helpers/resource"
@@ -131,7 +133,7 @@ var _ Policy = &staticPolicy{}
 // NewStaticPolicy returns a CPU manager policy that does not change CPU
 // assignments for exclusively pinned guaranteed containers after the main
 // container process starts.
-func NewStaticPolicy(topology *topology.CPUTopology, numReservedCPUs int, reservedCPUs cpuset.CPUSet, affinity topologymanager.Store, cpuPolicyOptions map[string]string) (Policy, error) {
+func NewStaticPolicy(logger logr.Logger, topology *topology.CPUTopology, numReservedCPUs int, reservedCPUs cpuset.CPUSet, affinity topologymanager.Store, cpuPolicyOptions map[string]string) (Policy, error) {
 	opts, err := NewStaticPolicyOptions(cpuPolicyOptions)
 	if err != nil {
 		return nil, err
@@ -142,7 +144,7 @@ func NewStaticPolicy(topology *topology.CPUTopology, numReservedCPUs int, reserv
 	}
 
 	cpuGroupSize := topology.CPUsPerCore()
-	klog.InfoS("Static policy created with configuration", "options", opts, "cpuGroupSize", cpuGroupSize)
+	logger.Info("created with configuration", "options", opts, "cpuGroupSize", cpuGroupSize)
 
 	policy := &staticPolicy{
 		topology:     topology,
@@ -162,7 +164,7 @@ func NewStaticPolicy(topology *topology.CPUTopology, numReservedCPUs int, reserv
 		//
 		// For example: Given a system with 8 CPUs available and HT enabled,
 		// if numReservedCPUs=2, then reserved={0,4}
-		reserved, _ = policy.takeByTopology(allCPUs, numReservedCPUs)
+		reserved, _ = policy.takeByTopology(logger, allCPUs, numReservedCPUs)
 	}
 
 	if reserved.Size() != numReservedCPUs {
@@ -179,7 +181,7 @@ func NewStaticPolicy(topology *topology.CPUTopology, numReservedCPUs int, reserv
 		reservedPhysicalCPUs = reservedPhysicalCPUs.Union(topology.CPUDetails.CPUsInCores(core))
 	}
 
-	klog.InfoS("Reserved CPUs not available for exclusive assignment", "reservedSize", reserved.Size(), "reserved", reserved, "reservedPhysicalCPUs", reservedPhysicalCPUs)
+	logger.Info("Reserved CPUs not available for exclusive assignment", "reservedSize", reserved.Size(), "reserved", reserved, "reservedPhysicalCPUs", reservedPhysicalCPUs)
 	policy.reservedCPUs = reserved
 	policy.reservedPhysicalCPUs = reservedPhysicalCPUs
 
@@ -190,16 +192,16 @@ func (p *staticPolicy) Name() string {
 	return string(PolicyStatic)
 }
 
-func (p *staticPolicy) Start(s state.State) error {
-	if err := p.validateState(s); err != nil {
-		klog.ErrorS(err, "Static policy invalid state, please drain node and remove policy state file")
+func (p *staticPolicy) Start(logger logr.Logger, s state.State) error {
+	if err := p.validateState(logger, s); err != nil {
+		logger.Error(err, "invalid state, please drain node and remove policy state file")
 		return err
 	}
-	p.initializeMetrics(s)
+	p.initializeMetrics(logger, s)
 	return nil
 }
 
-func (p *staticPolicy) validateState(s state.State) error {
+func (p *staticPolicy) validateState(logger logr.Logger, s state.State) error {
 	tmpAssignments := s.GetCPUAssignments()
 	tmpDefaultCPUset := s.GetDefaultCPUSet()
 
@@ -215,7 +217,7 @@ func (p *staticPolicy) validateState(s state.State) error {
 		}
 		// state is empty initialize
 		s.SetDefaultCPUSet(allCPUs)
-		klog.InfoS("Static policy initialized", "defaultCPUSet", allCPUs)
+		logger.Info("Static policy initialized", "defaultCPUSet", allCPUs)
 		return nil
 	}
 
@@ -225,12 +227,12 @@ func (p *staticPolicy) validateState(s state.State) error {
 	// - user tampered with file
 	if p.options.StrictCPUReservation {
 		if !p.reservedCPUs.Intersection(tmpDefaultCPUset).IsEmpty() {
-			return fmt.Errorf("some of strictly reserved cpus: \"%s\" are present in defaultCpuSet: \"%s\"",
+			return fmt.Errorf("some of strictly reserved cpus: %q are present in defaultCpuSet: %q",
 				p.reservedCPUs.Intersection(tmpDefaultCPUset).String(), tmpDefaultCPUset.String())
 		}
 	} else {
 		if !p.reservedCPUs.Intersection(tmpDefaultCPUset).Equals(p.reservedCPUs) {
-			return fmt.Errorf("not all reserved cpus: \"%s\" are present in defaultCpuSet: \"%s\"",
+			return fmt.Errorf("not all reserved cpus: %q are present in defaultCpuSet: %q",
 				p.reservedCPUs.String(), tmpDefaultCPUset.String())
 		}
 	}
@@ -240,7 +242,7 @@ func (p *staticPolicy) validateState(s state.State) error {
 		for container, cset := range tmpAssignments[pod] {
 			// None of the cpu in DEFAULT cset should be in s.assignments
 			if !tmpDefaultCPUset.Intersection(cset).IsEmpty() {
-				return fmt.Errorf("pod: %s, container: %s cpuset: \"%s\" overlaps with default cpuset \"%s\"",
+				return fmt.Errorf("pod: %s, container: %s cpuset: %q overlaps with default cpuset %q",
 					pod, container, cset.String(), tmpDefaultCPUset.String())
 			}
 		}
@@ -262,7 +264,7 @@ func (p *staticPolicy) validateState(s state.State) error {
 	}
 	totalKnownCPUs = totalKnownCPUs.Union(tmpCPUSets...)
 	if !totalKnownCPUs.Equals(allCPUs) {
-		return fmt.Errorf("current set of available CPUs \"%s\" doesn't match with CPUs in state \"%s\"",
+		return fmt.Errorf("current set of available CPUs %q doesn't match with CPUs in state %q",
 			allCPUs.String(), totalKnownCPUs.String())
 
 	}
@@ -314,19 +316,24 @@ func (p *staticPolicy) updateCPUsToReuse(pod *v1.Pod, container *v1.Container, c
 	p.cpusToReuse[string(pod.UID)] = p.cpusToReuse[string(pod.UID)].Difference(cset)
 }
 
-func (p *staticPolicy) Allocate(s state.State, pod *v1.Pod, container *v1.Container) (rerr error) {
-	numCPUs := p.guaranteedCPUs(pod, container)
+func (p *staticPolicy) Allocate(logger logr.Logger, s state.State, pod *v1.Pod, container *v1.Container) (rerr error) {
+	logger = klog.LoggerWithValues(logger, "pod", klog.KObj(pod), "podUID", pod.UID, "containerName", container.Name)
+	logger.Info("Allocate start") // V=0 for backward compatibility
+	defer logger.V(2).Info("Allocate end")
+
+	numCPUs := p.guaranteedCPUs(logger, pod, container)
 	if numCPUs == 0 {
 		// container belongs in the shared pool (nothing to do; use default cpuset)
 		return nil
 	}
 
 	if utilfeature.DefaultFeatureGate.Enabled(features.PodLevelResources) && resourcehelper.IsPodLevelResourcesSet(pod) {
-		klog.V(2).InfoS("CPU Manager allocation skipped, pod is using pod-level resources which are not supported by the static CPU manager policy", "pod", klog.KObj(pod), "podUID", pod.UID)
+		logger.Info("CPU Manager allocation skipped, pod is using pod-level resources which are not supported by the static CPU manager policy")
 		return nil
 	}
 
-	klog.InfoS("Static policy: Allocate", "pod", klog.KObj(pod), "containerName", container.Name)
+	logger.Info("Static policy: Allocate")
+
 	// container belongs in an exclusively allocated pool
 	metrics.CPUManagerPinningRequestsTotal.Inc()
 	defer func() {
@@ -379,26 +386,26 @@ func (p *staticPolicy) Allocate(s state.State, pod *v1.Pod, container *v1.Contai
 	}
 	if cset, ok := s.GetCPUSet(string(pod.UID), container.Name); ok {
 		p.updateCPUsToReuse(pod, container, cset)
-		klog.InfoS("Static policy: container already present in state, skipping", "pod", klog.KObj(pod), "containerName", container.Name)
+		logger.Info("Static policy: container already present in state, skipping")
 		return nil
 	}
 
 	// Call Topology Manager to get the aligned socket affinity across all hint providers.
 	hint := p.affinity.GetAffinity(string(pod.UID), container.Name)
-	klog.InfoS("Topology Affinity", "pod", klog.KObj(pod), "containerName", container.Name, "affinity", hint)
+	logger.Info("Topology Affinity", "affinity", hint)
 
 	// Allocate CPUs according to the NUMA affinity contained in the hint.
-	cpuAllocation, err := p.allocateCPUs(s, numCPUs, hint.NUMANodeAffinity, p.cpusToReuse[string(pod.UID)])
+	cpuAllocation, err := p.allocateCPUs(logger, s, numCPUs, hint.NUMANodeAffinity, p.cpusToReuse[string(pod.UID)])
 	if err != nil {
-		klog.ErrorS(err, "Unable to allocate CPUs", "pod", klog.KObj(pod), "containerName", container.Name, "numCPUs", numCPUs)
+		logger.Error(err, "Unable to allocate CPUs", "numCPUs", numCPUs)
 		return err
 	}
 
 	s.SetCPUSet(string(pod.UID), container.Name, cpuAllocation.CPUs)
 	p.updateCPUsToReuse(pod, container, cpuAllocation.CPUs)
-	p.updateMetricsOnAllocate(s, cpuAllocation)
+	p.updateMetricsOnAllocate(logger, s, cpuAllocation)
 
-	klog.V(4).InfoS("Allocated exclusive CPUs", "pod", klog.KObj(pod), "containerName", container.Name, "cpuset", cpuAllocation.CPUs.String())
+	logger.V(4).Info("Allocated exclusive CPUs", "cpuset", cpuAllocation.CPUs.String())
 	return nil
 }
 
@@ -415,22 +422,27 @@ func getAssignedCPUsOfSiblings(s state.State, podUID string, containerName strin
 	return cset
 }
 
-func (p *staticPolicy) RemoveContainer(s state.State, podUID string, containerName string) error {
-	klog.InfoS("Static policy: RemoveContainer", "podUID", podUID, "containerName", containerName)
+func (p *staticPolicy) RemoveContainer(logger logr.Logger, s state.State, podUID string, containerName string) error {
+	logger = klog.LoggerWithValues(logger, "podUID", podUID, "containerName", containerName)
+	logger.Info("RemoveContainer start") // backward compatibility
+	defer logger.V(4).Info("RemoveContainer start")
 	cpusInUse := getAssignedCPUsOfSiblings(s, podUID, containerName)
-	if toRelease, ok := s.GetCPUSet(podUID, containerName); ok {
-		s.Delete(podUID, containerName)
-		// Mutate the shared pool, adding released cpus.
-		toRelease = toRelease.Difference(cpusInUse)
-		s.SetDefaultCPUSet(s.GetDefaultCPUSet().Union(toRelease))
-		p.updateMetricsOnRelease(s, toRelease)
-
+	toRelease, ok := s.GetCPUSet(podUID, containerName)
+	if !ok {
+		return nil
 	}
+	s.Delete(podUID, containerName)
+	// Mutate the shared pool, adding released cpus.
+	toRelease = toRelease.Difference(cpusInUse)
+	updatedCPUs := s.GetDefaultCPUSet().Union(toRelease)
+	s.SetDefaultCPUSet(updatedCPUs)
+	p.updateMetricsOnRelease(logger, s, toRelease)
+	logger.Info(" RemoveContainer end", "defaultCPUSet", updatedCPUs)
 	return nil
 }
 
-func (p *staticPolicy) allocateCPUs(s state.State, numCPUs int, numaAffinity bitmask.BitMask, reusableCPUs cpuset.CPUSet) (topology.Allocation, error) {
-	klog.InfoS("AllocateCPUs", "numCPUs", numCPUs, "socket", numaAffinity)
+func (p *staticPolicy) allocateCPUs(logger logr.Logger, s state.State, numCPUs int, numaAffinity bitmask.BitMask, reusableCPUs cpuset.CPUSet) (topology.Allocation, error) {
+	logger.Info("AllocateCPUs", "numCPUs", numCPUs, "socket", numaAffinity)
 
 	allocatableCPUs := p.GetAvailableCPUs(s).Union(reusableCPUs)
 
@@ -444,7 +456,7 @@ func (p *staticPolicy) allocateCPUs(s state.State, numCPUs int, numaAffinity bit
 			numAlignedToAlloc = numCPUs
 		}
 
-		allocatedCPUs, err := p.takeByTopology(alignedCPUs, numAlignedToAlloc)
+		allocatedCPUs, err := p.takeByTopology(logger, alignedCPUs, numAlignedToAlloc)
 		if err != nil {
 			return topology.EmptyAllocation(), err
 		}
@@ -453,7 +465,7 @@ func (p *staticPolicy) allocateCPUs(s state.State, numCPUs int, numaAffinity bit
 	}
 
 	// Get any remaining CPUs from what's leftover after attempting to grab aligned ones.
-	remainingCPUs, err := p.takeByTopology(allocatableCPUs.Difference(result.CPUs), numCPUs-result.CPUs.Size())
+	remainingCPUs, err := p.takeByTopology(logger, allocatableCPUs.Difference(result.CPUs), numCPUs-result.CPUs.Size())
 	if err != nil {
 		return topology.EmptyAllocation(), err
 	}
@@ -463,20 +475,20 @@ func (p *staticPolicy) allocateCPUs(s state.State, numCPUs int, numaAffinity bit
 	// Remove allocated CPUs from the shared CPUSet.
 	s.SetDefaultCPUSet(s.GetDefaultCPUSet().Difference(result.CPUs))
 
-	klog.InfoS("AllocateCPUs", "result", result.String())
+	logger.Info("AllocateCPUs", "result", result.String())
 	return result, nil
 }
 
-func (p *staticPolicy) guaranteedCPUs(pod *v1.Pod, container *v1.Container) int {
+func (p *staticPolicy) guaranteedCPUs(logger logr.Logger, pod *v1.Pod, container *v1.Container) int {
 	qos := v1qos.GetPodQOS(pod)
 	if qos != v1.PodQOSGuaranteed {
-		klog.V(5).InfoS("Exclusive CPU allocation skipped, pod QoS is not guaranteed", "pod", klog.KObj(pod), "containerName", container.Name, "qos", qos)
+		logger.V(5).Info("Exclusive CPU allocation skipped, pod QoS is not guaranteed", "qos", qos)
 		return 0
 	}
 	cpuQuantity := container.Resources.Requests[v1.ResourceCPU]
 	cpuValue := cpuQuantity.Value()
 	if cpuValue*1000 != cpuQuantity.MilliValue() {
-		klog.V(5).InfoS("Exclusive CPU allocation skipped, pod requested non-integral CPUs", "pod", klog.KObj(pod), "containerName", container.Name, "cpu", cpuValue)
+		logger.V(5).Info("Exclusive CPU allocation skipped, pod requested non-integral CPUs", "cpu", cpuValue)
 		return 0
 	}
 	// Safe downcast to do for all systems with < 2.1 billion CPUs.
@@ -485,7 +497,7 @@ func (p *staticPolicy) guaranteedCPUs(pod *v1.Pod, container *v1.Container) int 
 	return int(cpuQuantity.Value())
 }
 
-func (p *staticPolicy) podGuaranteedCPUs(pod *v1.Pod) int {
+func (p *staticPolicy) podGuaranteedCPUs(logger logr.Logger, pod *v1.Pod) int {
 	// The maximum of requested CPUs by init containers.
 	requestedByInitContainers := 0
 	requestedByRestartableInitContainers := 0
@@ -493,7 +505,7 @@ func (p *staticPolicy) podGuaranteedCPUs(pod *v1.Pod) int {
 		if _, ok := container.Resources.Requests[v1.ResourceCPU]; !ok {
 			continue
 		}
-		requestedCPU := p.guaranteedCPUs(pod, &container)
+		requestedCPU := p.guaranteedCPUs(logger, pod, &container)
 		// See https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/753-sidecar-containers#resources-calculation-for-scheduling-and-pod-admission
 		// for the detail.
 		if podutil.IsRestartableInitContainer(&container) {
@@ -509,7 +521,7 @@ func (p *staticPolicy) podGuaranteedCPUs(pod *v1.Pod) int {
 		if _, ok := container.Resources.Requests[v1.ResourceCPU]; !ok {
 			continue
 		}
-		requestedByAppContainers += p.guaranteedCPUs(pod, &container)
+		requestedByAppContainers += p.guaranteedCPUs(logger, pod, &container)
 	}
 
 	requestedByLongRunningContainers := requestedByAppContainers + requestedByRestartableInitContainers
@@ -519,7 +531,7 @@ func (p *staticPolicy) podGuaranteedCPUs(pod *v1.Pod) int {
 	return requestedByLongRunningContainers
 }
 
-func (p *staticPolicy) takeByTopology(availableCPUs cpuset.CPUSet, numCPUs int) (cpuset.CPUSet, error) {
+func (p *staticPolicy) takeByTopology(logger logr.Logger, availableCPUs cpuset.CPUSet, numCPUs int) (cpuset.CPUSet, error) {
 	cpuSortingStrategy := CPUSortingStrategyPacked
 	if p.options.DistributeCPUsAcrossCores {
 		cpuSortingStrategy = CPUSortingStrategySpread
@@ -530,15 +542,17 @@ func (p *staticPolicy) takeByTopology(availableCPUs cpuset.CPUSet, numCPUs int) 
 		if p.options.FullPhysicalCPUsOnly {
 			cpuGroupSize = p.cpuGroupSize
 		}
-		return takeByTopologyNUMADistributed(p.topology, availableCPUs, numCPUs, cpuGroupSize, cpuSortingStrategy)
+		return takeByTopologyNUMADistributed(logger, p.topology, availableCPUs, numCPUs, cpuGroupSize, cpuSortingStrategy)
 	}
 
-	return takeByTopologyNUMAPacked(p.topology, availableCPUs, numCPUs, cpuSortingStrategy, p.options.PreferAlignByUncoreCacheOption)
+	return takeByTopologyNUMAPacked(logger, p.topology, availableCPUs, numCPUs, cpuSortingStrategy, p.options.PreferAlignByUncoreCacheOption)
 }
 
-func (p *staticPolicy) GetTopologyHints(s state.State, pod *v1.Pod, container *v1.Container) map[string][]topologymanager.TopologyHint {
+func (p *staticPolicy) GetTopologyHints(logger logr.Logger, s state.State, pod *v1.Pod, container *v1.Container) map[string][]topologymanager.TopologyHint {
+	logger = klog.LoggerWithValues(logger, "pod", klog.KObj(pod), "podUID", pod.UID, "containerName", container.Name)
+
 	// Get a count of how many guaranteed CPUs have been requested.
-	requested := p.guaranteedCPUs(pod, container)
+	requested := p.guaranteedCPUs(logger, pod, container)
 
 	// Number of required CPUs is not an integer or a container is not part of the Guaranteed QoS class.
 	// It will be treated by the TopologyManager as having no preference and cause it to ignore this
@@ -549,7 +563,7 @@ func (p *staticPolicy) GetTopologyHints(s state.State, pod *v1.Pod, container *v
 	}
 
 	if utilfeature.DefaultFeatureGate.Enabled(features.PodLevelResources) && resourcehelper.IsPodLevelResourcesSet(pod) {
-		klog.V(3).InfoS("CPU Manager hint generation skipped, pod is using pod-level resources which are not supported by the static CPU manager policy", "pod", klog.KObj(pod), "podUID", pod.UID)
+		logger.V(3).Info("CPU Manager hint generation skipped, pod is using pod-level resources which are not supported by the static CPU manager policy", "pod", klog.KObj(pod), "podUID", pod.UID)
 		return nil
 	}
 
@@ -558,7 +572,7 @@ func (p *staticPolicy) GetTopologyHints(s state.State, pod *v1.Pod, container *v
 	// kubelet restart, for example.
 	if allocated, exists := s.GetCPUSet(string(pod.UID), container.Name); exists {
 		if allocated.Size() != requested {
-			klog.InfoS("CPUs already allocated to container with different number than request", "pod", klog.KObj(pod), "containerName", container.Name, "requestedSize", requested, "allocatedSize", allocated.Size())
+			logger.Info("CPUs already allocated to container with different number than request", "requestedSize", requested, "allocatedSize", allocated.Size())
 			// An empty list of hints will be treated as a preference that cannot be satisfied.
 			// In definition of hints this is equal to: TopologyHint[NUMANodeAffinity: nil, Preferred: false].
 			// For all but the best-effort policy, the Topology Manager will throw a pod-admission error.
@@ -566,7 +580,7 @@ func (p *staticPolicy) GetTopologyHints(s state.State, pod *v1.Pod, container *v
 				string(v1.ResourceCPU): {},
 			}
 		}
-		klog.InfoS("Regenerating TopologyHints for CPUs already allocated", "pod", klog.KObj(pod), "containerName", container.Name)
+		logger.Info("Regenerating TopologyHints for CPUs already allocated")
 		return map[string][]topologymanager.TopologyHint{
 			string(v1.ResourceCPU): p.generateCPUTopologyHints(allocated, cpuset.CPUSet{}, requested),
 		}
@@ -581,16 +595,18 @@ func (p *staticPolicy) GetTopologyHints(s state.State, pod *v1.Pod, container *v
 
 	// Generate hints.
 	cpuHints := p.generateCPUTopologyHints(available, reusable, requested)
-	klog.InfoS("TopologyHints generated", "pod", klog.KObj(pod), "containerName", container.Name, "cpuHints", cpuHints)
+	logger.Info("TopologyHints generated", "cpuHints", cpuHints)
 
 	return map[string][]topologymanager.TopologyHint{
 		string(v1.ResourceCPU): cpuHints,
 	}
 }
 
-func (p *staticPolicy) GetPodTopologyHints(s state.State, pod *v1.Pod) map[string][]topologymanager.TopologyHint {
+func (p *staticPolicy) GetPodTopologyHints(logger logr.Logger, s state.State, pod *v1.Pod) map[string][]topologymanager.TopologyHint {
+	logger = klog.LoggerWithValues(logger, "pod", klog.KObj(pod), "podUID", pod.UID)
+
 	// Get a count of how many guaranteed CPUs have been requested by Pod.
-	requested := p.podGuaranteedCPUs(pod)
+	requested := p.podGuaranteedCPUs(logger, pod)
 
 	// Number of required CPUs is not an integer or a pod is not part of the Guaranteed QoS class.
 	// It will be treated by the TopologyManager as having no preference and cause it to ignore this
@@ -601,19 +617,21 @@ func (p *staticPolicy) GetPodTopologyHints(s state.State, pod *v1.Pod) map[strin
 	}
 
 	if utilfeature.DefaultFeatureGate.Enabled(features.PodLevelResources) && resourcehelper.IsPodLevelResourcesSet(pod) {
-		klog.V(3).InfoS("CPU Manager pod hint generation skipped, pod is using pod-level resources which are not supported by the static CPU manager policy", "pod", klog.KObj(pod), "podUID", pod.UID)
+		logger.V(3).Info("CPU Manager pod hint generation skipped, pod is using pod-level resources which are not supported by the static CPU manager policy")
 		return nil
 	}
 
 	assignedCPUs := cpuset.New()
 	for _, container := range append(pod.Spec.InitContainers, pod.Spec.Containers...) {
-		requestedByContainer := p.guaranteedCPUs(pod, &container)
+		logger_ := klog.LoggerWithValues(logger, "containerName", container.Name)
+
+		requestedByContainer := p.guaranteedCPUs(logger, pod, &container)
 		// Short circuit to regenerate the same hints if there are already
 		// guaranteed CPUs allocated to the Container. This might happen after a
 		// kubelet restart, for example.
 		if allocated, exists := s.GetCPUSet(string(pod.UID), container.Name); exists {
 			if allocated.Size() != requestedByContainer {
-				klog.InfoS("CPUs already allocated to container with different number than request", "pod", klog.KObj(pod), "containerName", container.Name, "allocatedSize", requested, "requestedByContainer", requestedByContainer, "allocatedSize", allocated.Size())
+				logger_.Info("CPUs already allocated to container with different number than request", "allocatedSize", requested, "requestedByContainer", requestedByContainer, "allocatedSize", allocated.Size())
 				// An empty list of hints will be treated as a preference that cannot be satisfied.
 				// In definition of hints this is equal to: TopologyHint[NUMANodeAffinity: nil, Preferred: false].
 				// For all but the best-effort policy, the Topology Manager will throw a pod-admission error.
@@ -626,7 +644,7 @@ func (p *staticPolicy) GetPodTopologyHints(s state.State, pod *v1.Pod) map[strin
 		}
 	}
 	if assignedCPUs.Size() == requested {
-		klog.InfoS("Regenerating TopologyHints for CPUs already allocated", "pod", klog.KObj(pod))
+		logger.Info("Regenerating TopologyHints for CPUs already allocated")
 		return map[string][]topologymanager.TopologyHint{
 			string(v1.ResourceCPU): p.generateCPUTopologyHints(assignedCPUs, cpuset.CPUSet{}, requested),
 		}
@@ -644,7 +662,7 @@ func (p *staticPolicy) GetPodTopologyHints(s state.State, pod *v1.Pod) map[strin
 
 	// Generate hints.
 	cpuHints := p.generateCPUTopologyHints(available, reusable, requested)
-	klog.InfoS("TopologyHints generated", "pod", klog.KObj(pod), "cpuHints", cpuHints)
+	logger.Info("TopologyHints generated", "cpuHints", cpuHints)
 
 	return map[string][]topologymanager.TopologyHint{
 		string(v1.ResourceCPU): cpuHints,
@@ -756,17 +774,17 @@ func (p *staticPolicy) getAlignedCPUs(numaAffinity bitmask.BitMask, allocatableC
 	return alignedCPUs
 }
 
-func (p *staticPolicy) initializeMetrics(s state.State) {
+func (p *staticPolicy) initializeMetrics(logger logr.Logger, s state.State) {
 	metrics.CPUManagerSharedPoolSizeMilliCores.Set(float64(p.GetAvailableCPUs(s).Size() * 1000))
 	metrics.ContainerAlignedComputeResourcesFailure.WithLabelValues(metrics.AlignScopeContainer, metrics.AlignedPhysicalCPU).Add(0) // ensure the value exists
 	metrics.ContainerAlignedComputeResources.WithLabelValues(metrics.AlignScopeContainer, metrics.AlignedPhysicalCPU).Add(0)        // ensure the value exists
 	metrics.ContainerAlignedComputeResources.WithLabelValues(metrics.AlignScopeContainer, metrics.AlignedUncoreCache).Add(0)        // ensure the value exists
 	totalAssignedCPUs := getTotalAssignedExclusiveCPUs(s)
 	metrics.CPUManagerExclusiveCPUsAllocationCount.Set(float64(totalAssignedCPUs.Size()))
-	updateAllocationPerNUMAMetric(p.topology, totalAssignedCPUs)
+	updateAllocationPerNUMAMetric(logger, p.topology, totalAssignedCPUs)
 }
 
-func (p *staticPolicy) updateMetricsOnAllocate(s state.State, cpuAlloc topology.Allocation) {
+func (p *staticPolicy) updateMetricsOnAllocate(logger logr.Logger, s state.State, cpuAlloc topology.Allocation) {
 	ncpus := cpuAlloc.CPUs.Size()
 	metrics.CPUManagerExclusiveCPUsAllocationCount.Add(float64(ncpus))
 	metrics.CPUManagerSharedPoolSizeMilliCores.Add(float64(-ncpus * 1000))
@@ -774,15 +792,15 @@ func (p *staticPolicy) updateMetricsOnAllocate(s state.State, cpuAlloc topology.
 		metrics.ContainerAlignedComputeResources.WithLabelValues(metrics.AlignScopeContainer, metrics.AlignedUncoreCache).Inc()
 	}
 	totalAssignedCPUs := getTotalAssignedExclusiveCPUs(s)
-	updateAllocationPerNUMAMetric(p.topology, totalAssignedCPUs)
+	updateAllocationPerNUMAMetric(logger, p.topology, totalAssignedCPUs)
 }
 
-func (p *staticPolicy) updateMetricsOnRelease(s state.State, cset cpuset.CPUSet) {
+func (p *staticPolicy) updateMetricsOnRelease(logger logr.Logger, s state.State, cset cpuset.CPUSet) {
 	ncpus := cset.Size()
 	metrics.CPUManagerExclusiveCPUsAllocationCount.Add(float64(-ncpus))
 	metrics.CPUManagerSharedPoolSizeMilliCores.Add(float64(ncpus * 1000))
 	totalAssignedCPUs := getTotalAssignedExclusiveCPUs(s)
-	updateAllocationPerNUMAMetric(p.topology, totalAssignedCPUs.Difference(cset))
+	updateAllocationPerNUMAMetric(logger, p.topology, totalAssignedCPUs.Difference(cset))
 }
 
 func getTotalAssignedExclusiveCPUs(s state.State) cpuset.CPUSet {
@@ -791,12 +809,11 @@ func getTotalAssignedExclusiveCPUs(s state.State) cpuset.CPUSet {
 		for _, cset := range assignment {
 			totalAssignedCPUs = totalAssignedCPUs.Union(cset)
 		}
-
 	}
 	return totalAssignedCPUs
 }
 
-func updateAllocationPerNUMAMetric(topo *topology.CPUTopology, allocatedCPUs cpuset.CPUSet) {
+func updateAllocationPerNUMAMetric(logger logr.Logger, topo *topology.CPUTopology, allocatedCPUs cpuset.CPUSet) {
 	numaCount := make(map[int]int)
 
 	// Count CPUs allocated per NUMA node
@@ -805,7 +822,7 @@ func updateAllocationPerNUMAMetric(topo *topology.CPUTopology, allocatedCPUs cpu
 		if err != nil {
 			//NOTE: We are logging the error but it is highly unlikely to happen as the CPUset
 			//      is already computed, evaluated and there is no room for user tampering.
-			klog.ErrorS(err, "Unable to determine NUMA node", "cpuID", cpuID)
+			logger.Error(err, "Unable to determine NUMA node", "cpuID", cpuID)
 		}
 		numaCount[numaNode]++
 	}

--- a/pkg/kubelet/cm/cpumanager/state/state_checkpoint_test.go
+++ b/pkg/kubelet/cm/cpumanager/state/state_checkpoint_test.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager"
 	"k8s.io/kubernetes/pkg/kubelet/cm/containermap"
 	testutil "k8s.io/kubernetes/pkg/kubelet/cm/cpumanager/state/testing"
+	"k8s.io/kubernetes/test/utils/ktesting"
 	"k8s.io/utils/cpuset"
 )
 
@@ -219,7 +220,8 @@ func TestCheckpointStateRestore(t *testing.T) {
 				require.NoErrorf(t, err, "could not create testing checkpoint: %v", err)
 			}
 
-			restoredState, err := NewCheckpointState(testingDir, testingCheckpoint, tc.policyName, tc.initialContainers)
+			logger, _ := ktesting.NewTestContext(t)
+			restoredState, err := NewCheckpointState(logger, testingDir, testingCheckpoint, tc.policyName, tc.initialContainers)
 			if strings.TrimSpace(tc.expectedError) == "" {
 				require.NoError(t, err)
 			} else {
@@ -273,7 +275,8 @@ func TestCheckpointStateStore(t *testing.T) {
 			// ensure there is no previous checkpoint
 			cpm.RemoveCheckpoint(testingCheckpoint)
 
-			cs1, err := NewCheckpointState(testingDir, testingCheckpoint, "none", nil)
+			logger, _ := ktesting.NewTestContext(t)
+			cs1, err := NewCheckpointState(logger, testingDir, testingCheckpoint, "none", nil)
 			if err != nil {
 				t.Fatalf("could not create testing checkpointState instance: %v", err)
 			}
@@ -283,7 +286,7 @@ func TestCheckpointStateStore(t *testing.T) {
 			cs1.SetCPUAssignments(tc.expectedState.assignments)
 
 			// restore checkpoint with previously stored values
-			cs2, err := NewCheckpointState(testingDir, testingCheckpoint, "none", nil)
+			cs2, err := NewCheckpointState(logger, testingDir, testingCheckpoint, "none", nil)
 			if err != nil {
 				t.Fatalf("could not create testing checkpointState instance: %v", err)
 			}
@@ -346,7 +349,8 @@ func TestCheckpointStateHelpers(t *testing.T) {
 			// ensure there is no previous checkpoint
 			cpm.RemoveCheckpoint(testingCheckpoint)
 
-			state, err := NewCheckpointState(testingDir, testingCheckpoint, "none", nil)
+			logger, _ := ktesting.NewTestContext(t)
+			state, err := NewCheckpointState(logger, testingDir, testingCheckpoint, "none", nil)
 			if err != nil {
 				t.Fatalf("could not create testing checkpointState instance: %v", err)
 			}
@@ -395,7 +399,8 @@ func TestCheckpointStateClear(t *testing.T) {
 			}
 			defer os.RemoveAll(testingDir)
 
-			state, err := NewCheckpointState(testingDir, testingCheckpoint, "none", nil)
+			logger, _ := ktesting.NewTestContext(t)
+			state, err := NewCheckpointState(logger, testingDir, testingCheckpoint, "none", nil)
 			if err != nil {
 				t.Fatalf("could not create testing checkpointState instance: %v", err)
 			}

--- a/pkg/kubelet/cm/cpumanager/topology/topology.go
+++ b/pkg/kubelet/cm/cpumanager/topology/topology.go
@@ -19,8 +19,8 @@ package topology
 import (
 	"fmt"
 
+	"github.com/go-logr/logr"
 	cadvisorapi "github.com/google/cadvisor/info/v1"
-	"k8s.io/klog/v2"
 	"k8s.io/utils/cpuset"
 )
 
@@ -338,7 +338,7 @@ func getUncoreCacheID(core cadvisorapi.Core) int {
 }
 
 // Discover returns CPUTopology based on cadvisor node info
-func Discover(machineInfo *cadvisorapi.MachineInfo) (*CPUTopology, error) {
+func Discover(logger logr.Logger, machineInfo *cadvisorapi.MachineInfo) (*CPUTopology, error) {
 	if machineInfo.NumCores == 0 {
 		return nil, fmt.Errorf("could not detect number of cpus")
 	}
@@ -359,7 +359,7 @@ func Discover(machineInfo *cadvisorapi.MachineInfo) (*CPUTopology, error) {
 					}
 				}
 			} else {
-				klog.ErrorS(nil, "Could not get unique coreID for socket", "socket", core.SocketID, "core", core.Id, "threads", core.Threads)
+				logger.Info("Could not get unique coreID for socket", "socket", core.SocketID, "core", core.Id, "threads", core.Threads)
 				return nil, err
 			}
 		}

--- a/pkg/kubelet/cm/cpumanager/topology/topology_test.go
+++ b/pkg/kubelet/cm/cpumanager/topology/topology_test.go
@@ -20,8 +20,10 @@ import (
 	"reflect"
 	"testing"
 
-	cadvisorapi "github.com/google/cadvisor/info/v1"
 	"github.com/google/go-cmp/cmp"
+
+	cadvisorapi "github.com/google/cadvisor/info/v1"
+	"k8s.io/kubernetes/test/utils/ktesting"
 	"k8s.io/utils/cpuset"
 )
 
@@ -818,9 +820,11 @@ func Test_Discover(t *testing.T) {
 			wantErr: false,
 		},
 	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := Discover(&tt.machineInfo)
+			logger, _ := ktesting.NewTestContext(t)
+			got, err := Discover(logger, &tt.machineInfo)
 			if err != nil {
 				if tt.wantErr {
 					t.Logf("Discover() expected error = %v", err)

--- a/pkg/kubelet/cm/cpumanager/topology_hints_test.go
+++ b/pkg/kubelet/cm/cpumanager/topology_hints_test.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/cm/cpumanager/topology"
 	"k8s.io/kubernetes/pkg/kubelet/cm/topologymanager"
 	"k8s.io/kubernetes/pkg/kubelet/cm/topologymanager/bitmask"
+	"k8s.io/kubernetes/test/utils/ktesting"
 	"k8s.io/utils/cpuset"
 )
 
@@ -73,6 +74,7 @@ type containerOptions struct {
 }
 
 func TestPodGuaranteedCPUs(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
 	options := [][]*containerOptions{
 		{
 			{request: "0", limit: "0"},
@@ -200,7 +202,7 @@ func TestPodGuaranteedCPUs(t *testing.T) {
 	}
 	for _, tc := range tcases {
 		t.Run(tc.name, func(t *testing.T) {
-			requestedCPU := p.podGuaranteedCPUs(tc.pod)
+			requestedCPU := p.podGuaranteedCPUs(logger, tc.pod)
 
 			if requestedCPU != tc.expectedCPU {
 				t.Errorf("Expected in result to be %v , got %v", tc.expectedCPU, requestedCPU)
@@ -210,12 +212,13 @@ func TestPodGuaranteedCPUs(t *testing.T) {
 }
 
 func TestGetTopologyHints(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
 	machineInfo := returnMachineInfo()
 
 	for _, tc := range returnTestCases() {
 		featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.PodLevelResources, tc.podLevelResourcesEnabled)
 
-		topology, _ := topology.Discover(&machineInfo)
+		topology, _ := topology.Discover(logger, &machineInfo)
 
 		var activePods []*v1.Pod
 		for p := range tc.assignments {
@@ -260,12 +263,13 @@ func TestGetTopologyHints(t *testing.T) {
 }
 
 func TestGetPodTopologyHints(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
 	machineInfo := returnMachineInfo()
 
 	for _, tc := range returnTestCases() {
 		featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.PodLevelResources, tc.podLevelResourcesEnabled)
 
-		topology, _ := topology.Discover(&machineInfo)
+		topology, _ := topology.Discover(logger, &machineInfo)
 
 		var activePods []*v1.Pod
 		for p := range tc.assignments {

--- a/pkg/kubelet/cm/fake_container_manager.go
+++ b/pkg/kubelet/cm/fake_container_manager.go
@@ -21,6 +21,7 @@ import (
 	"sync"
 
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
 
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/types"
@@ -45,6 +46,7 @@ type FakeContainerManager struct {
 	PodContainerManager                 *FakePodContainerManager
 	shouldResetExtendedResourceCapacity bool
 	nodeConfig                          NodeConfig
+	cpuManager                          cpumanager.Manager
 	memoryManager                       memorymanager.Manager
 }
 
@@ -53,6 +55,7 @@ var _ ContainerManager = &FakeContainerManager{}
 func NewFakeContainerManager() *FakeContainerManager {
 	return &FakeContainerManager{
 		PodContainerManager: NewFakePodContainerManager(),
+		cpuManager:          cpumanager.NewFakeManager(klog.TODO()),
 		memoryManager:       memorymanager.NewFakeManager(context.TODO()),
 	}
 }
@@ -181,7 +184,7 @@ func (cm *FakeContainerManager) InternalContainerLifecycle() InternalContainerLi
 	cm.Lock()
 	defer cm.Unlock()
 	cm.CalledFunctions = append(cm.CalledFunctions, "InternalContainerLifecycle")
-	return &internalContainerLifecycleImpl{cpumanager.NewFakeManager(), cm.memoryManager, topologymanager.NewFakeManager()}
+	return &internalContainerLifecycleImpl{cm.cpuManager, cm.memoryManager, topologymanager.NewFakeManager()}
 }
 
 func (cm *FakeContainerManager) GetPodCgroupRoot() string {

--- a/pkg/kubelet/cm/internal_container_lifecycle.go
+++ b/pkg/kubelet/cm/internal_container_lifecycle.go
@@ -21,6 +21,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/kubelet/cm/cpumanager"
 	"k8s.io/kubernetes/pkg/kubelet/cm/memorymanager"
 	"k8s.io/kubernetes/pkg/kubelet/cm/topologymanager"
@@ -41,7 +42,7 @@ type internalContainerLifecycleImpl struct {
 
 func (i *internalContainerLifecycleImpl) PreStartContainer(pod *v1.Pod, container *v1.Container, containerID string) error {
 	if i.cpuManager != nil {
-		i.cpuManager.AddContainer(pod, container, containerID)
+		i.cpuManager.AddContainer(klog.TODO(), pod, container, containerID)
 	}
 
 	if i.memoryManager != nil {

--- a/pkg/kubelet/cm/internal_container_lifecycle_test.go
+++ b/pkg/kubelet/cm/internal_container_lifecycle_test.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"testing"
 
+	"github.com/go-logr/logr"
+
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/kubernetes/pkg/kubelet/cm/cpumanager"
 	"k8s.io/kubernetes/pkg/kubelet/cm/memorymanager"
@@ -31,7 +33,7 @@ type mockCPUManager struct {
 	cpumanager.Manager
 }
 
-func (cpuManager *mockCPUManager) AddContainer(*v1.Pod, *v1.Container, string) {
+func (cpuManager *mockCPUManager) AddContainer(logr.Logger, *v1.Pod, *v1.Container, string) {
 	cpuManager.called = true
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Move to contextual logging,  which is an enabler to make the cpumanager logs easier to follow in the reconciliation and the cleanup flows.
This is part of an ongoing effort to make it easier to understand and troubleshoot the behavior of the resource managers.


#### Which issue(s) this PR fixes:
Fixes 123037 (partially, see issue)
Fixes 130069 (partially, see issue)

#### Special notes for your reviewer:
I'm contemplating alternative options about splitting this PR. I'm not sure targeting only parts of cpumanager (e.g. the flow mentioned in the description) is a better approach but I'm open to alternatives.

#### Does this PR introduce a user-facing change?
```release-note
Migrate the cpumanager to contextual logging
```
