### PR TITLE
kubectl prune v2: give more helpful message when using CRD

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply_test.go
@@ -2315,19 +2315,19 @@ func TestApplySetParentValidation(t *testing.T) {
 		"other namespaced builtin parents types are correctly parsed but invalid": {
 			applysetFlag:     "deployments.apps/thename",
 			expectParentKind: "Deployment",
-			expectErr:        "[namespace is required to use namespace-scoped ApplySet, resource \"apps/v1, Resource=deployments\" is not permitted as an ApplySet parent]",
+			expectErr:        "[namespace is required to use namespace-scoped ApplySet, resource \"apps/v1, Resource=deployments\" is not permitted as an ApplySet parent (CRD needs \"applyset.kubernetes.io/is-parent-type\" label)]",
 		},
 		"namespaced builtin parents with multi-segment groups are correctly parsed but invalid": {
 			applysetFlag:     "priorityclasses.scheduling.k8s.io/thename",
 			expectParentKind: "PriorityClass",
-			expectErr:        "resource \"scheduling.k8s.io/v1alpha1, Resource=priorityclasses\" is not permitted as an ApplySet parent",
+			expectErr:        "resource \"scheduling.k8s.io/v1alpha1, Resource=priorityclasses\" is not permitted as an ApplySet parent (CRD needs \"applyset.kubernetes.io/is-parent-type\" label)",
 		},
 		"non-namespaced builtin types are correctly parsed but invalid": {
 			applysetFlag:        "namespaces/thename",
 			expectParentKind:    "Namespace",
 			namespaceFlag:       "somenamespace",
 			expectBlankParentNs: true,
-			expectErr:           "resource \"/v1, Resource=namespaces\" is not permitted as an ApplySet parent",
+			expectErr:           "resource \"/v1, Resource=namespaces\" is not permitted as an ApplySet parent (CRD needs \"applyset.kubernetes.io/is-parent-type\" label)",
 		},
 		"parent namespace should use the value of the namespace flag": {
 			applysetFlag:     "mysecret",

--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/applyset.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/applyset.go
@@ -191,7 +191,7 @@ func (a ApplySet) Validate(ctx context.Context, client dynamic.Interface) error 
 		}
 		parentRefResourceIgnoreVersion := a.parentRef.Resource.GroupResource().WithVersion("")
 		if !permittedCRParents.Has(parentRefResourceIgnoreVersion) {
-			errors = append(errors, fmt.Errorf("resource %q is not permitted as an ApplySet parent", a.parentRef.Resource))
+			errors = append(errors, fmt.Errorf("resource %q is not permitted as an ApplySet parent (CRD needs %q label)", a.parentRef.Resource, ApplysetParentCRDLabel))
 		}
 	}
 	return utilerrors.NewAggregate(errors)


### PR DESCRIPTION
CRDs must be labelled with the applyset.kubernetes.io/is-parent-type
label to be used with ApplySet functionality.

If the CRD is not labelled, give the user a hint in the error message.

```release-note
Changed error message when (alpha) kubectl prune is used with a CRD without the required labels.
```