### PR TITLE
fix: enable testifylint on `pkg/controller`

### DIFF
--- a/pkg/controller/controller_utils_test.go
+++ b/pkg/controller/controller_utils_test.go
@@ -58,6 +58,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // NewFakeControllerExpectationsLookup creates a fake store for PodExpectations.
@@ -183,7 +184,7 @@ func TestControllerExpectations(t *testing.T) {
 
 	// RC fires off adds and deletes at apiserver, then sets expectations
 	rcKey, err := KeyFunc(rc)
-	assert.NoError(t, err, "Couldn't get key for object %#v: %v", rc, err)
+	require.NoError(t, err, "Couldn't get key for object %#v: %v", rc, err)
 
 	e.SetExpectations(logger, rcKey, adds, dels)
 	var wg sync.WaitGroup
@@ -238,7 +239,7 @@ func TestControllerExpectations(t *testing.T) {
 				e.SetExpectations(logger, rcKey, test.expectationsToSet[0], test.expectationsToSet[1])
 			}
 			podExp, exists, err := e.GetExpectations(rcKey)
-			assert.NoError(t, err, "Could not get expectations for rc, exists %v and err %v", exists, err)
+			require.NoError(t, err, "Could not get expectations for rc, exists %v and err %v", exists, err)
 			assert.True(t, exists, "Could not get expectations for rc, exists %v and err %v", exists, err)
 
 			add, del := podExp.GetExpectations()
@@ -382,12 +383,12 @@ func TestCreatePodsWithGenerateName(t *testing.T) {
 			}
 
 			err := test.podCreationFunc(podControl)
-			assert.NoError(t, err, "unexpected error: %v", err)
+			require.NoError(t, err, "unexpected error: %v", err)
 
 			fakeHandler.ValidateRequest(t, "/api/v1/namespaces/default/pods", "POST", nil)
 			var actualPod = &v1.Pod{}
 			err = json.Unmarshal([]byte(fakeHandler.RequestBody), actualPod)
-			assert.NoError(t, err, "unexpected error: %v", err)
+			require.NoError(t, err, "unexpected error: %v", err)
 			assert.True(t, apiequality.Semantic.DeepDerivative(test.wantPod, actualPod),
 				"Body: %s", fakeHandler.RequestBody)
 		})
@@ -426,10 +427,10 @@ func TestCountTerminatingPods(t *testing.T) {
 
 	terminatingPods := CountTerminatingPods(podPointers)
 
-	assert.Equal(t, terminatingPods, int32(2))
+	assert.Equal(t, int32(2), terminatingPods)
 
 	terminatingList := FilterTerminatingPods(podPointers)
-	assert.Equal(t, len(terminatingList), int(2))
+	assert.Len(t, terminatingList, int(2))
 }
 
 func TestActivePodFiltering(t *testing.T) {
@@ -957,7 +958,7 @@ func TestRemoveTaintOffNode(t *testing.T) {
 	for _, test := range tests {
 		node, _ := test.nodeHandler.Get(context.TODO(), test.nodeName, metav1.GetOptions{})
 		err := RemoveTaintOffNode(context.TODO(), test.nodeHandler, test.nodeName, node, test.taintsToRemove...)
-		assert.NoError(t, err, "%s: RemoveTaintOffNode() error = %v", test.name, err)
+		require.NoError(t, err, "%s: RemoveTaintOffNode() error = %v", test.name, err)
 
 		node, _ = test.nodeHandler.Get(context.TODO(), test.nodeName, metav1.GetOptions{})
 		assert.EqualValues(t, test.expectedTaints, node.Spec.Taints,
@@ -1196,7 +1197,7 @@ func TestAddOrUpdateTaintOnNode(t *testing.T) {
 			assert.Equal(t, test.expectedErr, err, "AddOrUpdateTaintOnNode get unexpected error")
 			continue
 		}
-		assert.NoError(t, err, "%s: AddOrUpdateTaintOnNode() error = %v", test.name, err)
+		require.NoError(t, err, "%s: AddOrUpdateTaintOnNode() error = %v", test.name, err)
 
 		node, _ := test.nodeHandler.Get(context.TODO(), test.nodeName, metav1.GetOptions{})
 		assert.EqualValues(t, test.expectedTaints, node.Spec.Taints,

--- a/pkg/controller/podautoscaler/horizontal_test.go
+++ b/pkg/controller/podautoscaler/horizontal_test.go
@@ -757,7 +757,7 @@ func (tc *testCase) setupController(t *testing.T) (*HorizontalController, inform
 					tc.expectedDesiredReplicas,
 					(int64(tc.reportedLevels[0])*100)/tc.reportedCPURequests[0].MilliValue(), tc.specReplicas), obj.Message)
 			default:
-				assert.False(t, true, fmt.Sprintf("Unexpected event: %s / %s", obj.Reason, obj.Message))
+				assert.False(t, true, "Unexpected event: %s / %s", obj.Reason, obj.Message)
 			}
 		}
 		tc.eventCreated = true
@@ -3863,7 +3863,7 @@ func TestCalculateScaleUpLimitWithScalingRules(t *testing.T) {
 			},
 		},
 	})
-	assert.Equal(t, calculated, int32(2))
+	assert.Equal(t, int32(2), calculated)
 }
 
 func TestCalculateScaleDownLimitWithBehaviors(t *testing.T) {
@@ -3885,7 +3885,7 @@ func TestCalculateScaleDownLimitWithBehaviors(t *testing.T) {
 			},
 		},
 	})
-	assert.Equal(t, calculated, int32(3))
+	assert.Equal(t, int32(3), calculated)
 }
 
 func generateScalingRules(pods, podsPeriod, percent, percentPeriod, stabilizationWindow int32) *autoscalingv2.HPAScalingRules {

--- a/pkg/controller/podautoscaler/metrics/client_test.go
+++ b/pkg/controller/podautoscaler/metrics/client_test.go
@@ -41,6 +41,7 @@ import (
 	emfake "k8s.io/metrics/pkg/client/external_metrics/fake"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var fixedTimestamp = time.Date(2015, time.November, 10, 12, 30, 0, 0, time.UTC)
@@ -209,11 +210,11 @@ func (tc *restClientTestCase) prepareTestClient(t *testing.T) (*metricsfake.Clie
 
 func (tc *restClientTestCase) verifyResults(t *testing.T, metrics PodMetricsInfo, timestamp time.Time, err error) {
 	if tc.desiredError != nil {
-		assert.Error(t, err, "there should be an error retrieving the metrics")
+		require.Error(t, err, "there should be an error retrieving the metrics")
 		assert.Contains(t, fmt.Sprintf("%v", err), fmt.Sprintf("%v", tc.desiredError), "the error message should be as expected")
 		return
 	}
-	assert.NoError(t, err, "there should be no error retrieving the metrics")
+	require.NoError(t, err, "there should be no error retrieving the metrics")
 	assert.NotNil(t, metrics, "there should be metrics returned")
 
 	if len(metrics) != len(tc.desiredMetricValues) {
@@ -230,7 +231,7 @@ func (tc *restClientTestCase) verifyResults(t *testing.T, metrics PodMetricsInfo
 	}
 
 	targetTimestamp := offsetTimestampBy(tc.targetTimestamp)
-	assert.True(t, targetTimestamp.Equal(timestamp), fmt.Sprintf("the timestamp should be as expected (%s) but was %s", targetTimestamp, timestamp))
+	assert.True(t, targetTimestamp.Equal(timestamp), "the timestamp should be as expected (%s) but was %s", targetTimestamp, timestamp)
 }
 
 func (tc *restClientTestCase) runTest(t *testing.T) {

--- a/pkg/controller/podautoscaler/metrics/utilization_test.go
+++ b/pkg/controller/podautoscaler/metrics/utilization_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type resourceUtilizationRatioTestCase struct {
@@ -38,12 +39,12 @@ func (tc *resourceUtilizationRatioTestCase) runTest(t *testing.T) {
 	actualUtilizationRatio, actualCurrentUtilization, actualRawAverageValue, actualErr := GetResourceUtilizationRatio(tc.metrics, tc.requests, tc.targetUtilization)
 
 	if tc.expectedErr != nil {
-		assert.Error(t, actualErr, "there should be an error getting the utilization ratio")
+		require.Error(t, actualErr, "there should be an error getting the utilization ratio")
 		assert.Contains(t, fmt.Sprintf("%v", actualErr), fmt.Sprintf("%v", tc.expectedErr), "the error message should be as expected")
 		return
 	}
 
-	assert.NoError(t, actualErr, "there should be no error retrieving the utilization ratio")
+	require.NoError(t, actualErr, "there should be no error retrieving the utilization ratio")
 	assert.Equal(t, tc.expectedUtilizationRatio, actualUtilizationRatio, "the utilization ratios should be as expected")
 	assert.Equal(t, tc.expectedCurrentUtilization, actualCurrentUtilization, "the current utilization should be as expected")
 	assert.Equal(t, tc.expectedRawAverageValue, actualRawAverageValue, "the raw average value should be as expected")

--- a/pkg/controller/podautoscaler/replica_calculator_test.go
+++ b/pkg/controller/podautoscaler/replica_calculator_test.go
@@ -355,9 +355,7 @@ func (tc *replicaCalcTestCase) runTest(t *testing.T) {
 	selector, err := metav1.LabelSelectorAsSelector(&metav1.LabelSelector{
 		MatchLabels: map[string]string{"name": podNamePrefix},
 	})
-	if err != nil {
-		require.Nil(t, err, "something went horribly wrong...")
-	}
+	require.NoError(t, err, "something went horribly wrong...")
 
 	if tc.resource != nil {
 		outReplicas, outUtilization, outRawValue, outTimestamp, err := replicaCalc.GetResourceReplicas(context.TODO(), tc.currentReplicas, tc.resource.targetUtilization, tc.resource.name, testNamespace, selector, tc.container)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This fixes rules from testifylint on `pkg/controller` package