### PR TITLE
[strategicpatch] support duplicated mergeKey values

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/patch.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/patch.go
@@ -57,6 +57,37 @@ const (
 // json marshaling and/or unmarshaling operations.
 type JSONMap map[string]interface{}
 
+type PatchOptions struct {
+	preconditions []mergepatch.PreconditionFunc
+	// AllowDuplicates indicates if we allow duplicate values for merge key in a list.
+	AllowDuplicates bool
+}
+
+type PatchOption func(*PatchOptions)
+
+func WithPreconditions(fns ...mergepatch.PreconditionFunc) PatchOption {
+	return func(o *PatchOptions) {
+		o.preconditions = append(o.preconditions, fns...)
+	}
+}
+
+// WithDuplicateMergeKeySupport sets whether we allow duplicate values for merge key in a list (default: false).
+func WithDuplicateMergeKeySupport(allow bool) PatchOption {
+	return func(o *PatchOptions) {
+		o.AllowDuplicates = allow
+	}
+}
+
+func applyPatchOptions(opts ...PatchOption) PatchOptions {
+	options := PatchOptions{
+		AllowDuplicates: false,
+	}
+	for _, o := range opts {
+		o(&options)
+	}
+	return options
+}
+
 type DiffOptions struct {
 	// SetElementOrder determines whether we generate the $setElementOrder parallel list.
 	SetElementOrder bool
@@ -70,6 +101,8 @@ type DiffOptions struct {
 	// And the fields that are present will be merged with live object.
 	// All the missing fields will be cleared when patching.
 	BuildRetainKeysDirective bool
+	// AllowDuplicates indicates if we allow duplicate values for merge key in a list.
+	AllowDuplicates bool
 }
 
 type MergeOptions struct {
@@ -91,17 +124,17 @@ type MergeOptions struct {
 // document and a modified document, which are passed to the method as json encoded content. It will
 // return a patch that yields the modified document when applied to the original document, or an error
 // if either of the two documents is invalid.
-func CreateTwoWayMergePatch(original, modified []byte, dataStruct interface{}, fns ...mergepatch.PreconditionFunc) ([]byte, error) {
+func CreateTwoWayMergePatch(original, modified []byte, dataStruct interface{}, opts ...PatchOption) ([]byte, error) {
 	schema, err := NewPatchMetaFromStruct(dataStruct)
 	if err != nil {
 		return nil, err
 	}
 
-	return CreateTwoWayMergePatchUsingLookupPatchMeta(original, modified, schema, fns...)
+	return CreateTwoWayMergePatchUsingLookupPatchMeta(original, modified, schema, opts...)
 }
 
 func CreateTwoWayMergePatchUsingLookupPatchMeta(
-	original, modified []byte, schema LookupPatchMeta, fns ...mergepatch.PreconditionFunc) ([]byte, error) {
+	original, modified []byte, schema LookupPatchMeta, opts ...PatchOption) ([]byte, error) {
 	originalMap := map[string]interface{}{}
 	if len(original) > 0 {
 		if err := json.Unmarshal(original, &originalMap); err != nil {
@@ -116,7 +149,7 @@ func CreateTwoWayMergePatchUsingLookupPatchMeta(
 		}
 	}
 
-	patchMap, err := CreateTwoWayMergeMapPatchUsingLookupPatchMeta(originalMap, modifiedMap, schema, fns...)
+	patchMap, err := CreateTwoWayMergeMapPatchUsingLookupPatchMeta(originalMap, modifiedMap, schema, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -127,18 +160,21 @@ func CreateTwoWayMergePatchUsingLookupPatchMeta(
 // CreateTwoWayMergeMapPatch creates a patch from an original and modified JSON objects,
 // encoded JSONMap.
 // The serialized version of the map can then be passed to StrategicMergeMapPatch.
-func CreateTwoWayMergeMapPatch(original, modified JSONMap, dataStruct interface{}, fns ...mergepatch.PreconditionFunc) (JSONMap, error) {
+func CreateTwoWayMergeMapPatch(original, modified JSONMap, dataStruct interface{}, opts ...PatchOption) (JSONMap, error) {
 	schema, err := NewPatchMetaFromStruct(dataStruct)
 	if err != nil {
 		return nil, err
 	}
 
-	return CreateTwoWayMergeMapPatchUsingLookupPatchMeta(original, modified, schema, fns...)
+	return CreateTwoWayMergeMapPatchUsingLookupPatchMeta(original, modified, schema, opts...)
 }
 
-func CreateTwoWayMergeMapPatchUsingLookupPatchMeta(original, modified JSONMap, schema LookupPatchMeta, fns ...mergepatch.PreconditionFunc) (JSONMap, error) {
+func CreateTwoWayMergeMapPatchUsingLookupPatchMeta(original, modified JSONMap, schema LookupPatchMeta, opts ...PatchOption) (JSONMap, error) {
+	patchOpts := applyPatchOptions(opts...)
+
 	diffOptions := DiffOptions{
 		SetElementOrder: true,
+		AllowDuplicates: patchOpts.AllowDuplicates,
 	}
 	patchMap, err := diffMaps(original, modified, schema, diffOptions)
 	if err != nil {
@@ -146,7 +182,7 @@ func CreateTwoWayMergeMapPatchUsingLookupPatchMeta(original, modified JSONMap, s
 	}
 
 	// Apply the preconditions to the patch, and return an error if any of them fail.
-	for _, fn := range fns {
+	for _, fn := range patchOpts.preconditions {
 		if !fn(patchMap) {
 			return nil, mergepatch.NewErrPreconditionFailed(patchMap)
 		}
@@ -222,7 +258,7 @@ func diffMaps(original, modified map[string]interface{}, schema LookupPatchMeta,
 	}
 
 	updatePatchIfMissing(original, modified, patch, diffOptions)
-	// Insert the retainKeysList iff there are values present in the retainKeysList and
+	// Insert the retainKeysList if there are values present in the retainKeysList and
 	// either of the following is true:
 	// - the patch is not empty
 	// - there are additional field in original that need to be cleared
@@ -727,6 +763,9 @@ func diffListsOfMaps(original, modified []interface{}, schema LookupPatchMeta, m
 		return nil, nil, err
 	}
 
+	var previousOriginalElementMergeKeyValueString, previousModifiedElementMergeKeyValueString string
+	bothPreviousInBounds := false
+
 	originalIndex, modifiedIndex := 0, 0
 	for {
 		originalInBounds := originalIndex < len(originalSorted)
@@ -776,6 +815,33 @@ func diffListsOfMaps(original, modified []interface{}, schema LookupPatchMeta, m
 				patch = append(patch, modifiedElement)
 			}
 			modifiedIndex++
+		// modified missing one of duplicated by MergeKey value elements
+		case diffOptions.AllowDuplicates && bothPreviousInBounds &&
+			originalElementMergeKeyValueString == previousOriginalElementMergeKeyValueString &&
+			previousOriginalElementMergeKeyValueString == previousModifiedElementMergeKeyValueString:
+			// if deleted one of duplicates by mergeKey, will send "delete" and "insert" commands
+			if !diffOptions.IgnoreDeletions {
+				var modifiedToAdd []interface{}
+				for i := modifiedIndex - 1; i >= 0; i-- {
+					element, mergeKeyValue, err := getMapAndMergeKeyValueByIndex(i, mergeKey, modifiedSorted)
+					if err != nil {
+						return nil, nil, err
+					}
+					if fmt.Sprintf("%v", mergeKeyValue) != originalElementMergeKeyValueString {
+						break
+					}
+					// reverse to keep ordering
+					modifiedToAdd = append([]interface{}{element}, modifiedToAdd...)
+				}
+				deletionList = append(deletionList, CreateDeleteDirective(mergeKey, originalElementMergeKeyValue))
+				// remove existing occurencies added if previous elements pair has diffs
+				patch, err = removePatchElementsByMergeKeyValue(patch, mergeKey, originalElementMergeKeyValueString)
+				if err != nil {
+					return nil, nil, err
+				}
+				patch = append(patch, modifiedToAdd...)
+			}
+			originalIndex++
 		// only original is in bound
 		case !modifiedInBounds:
 			fallthrough
@@ -787,9 +853,28 @@ func diffListsOfMaps(original, modified []interface{}, schema LookupPatchMeta, m
 			}
 			originalIndex++
 		}
+
+		previousOriginalElementMergeKeyValueString = originalElementMergeKeyValueString
+		previousModifiedElementMergeKeyValueString = modifiedElementMergeKeyValueString
+		bothPreviousInBounds = bothInBounds
 	}
 
 	return patch, deletionList, nil
+}
+
+// removePatchElementsByMergeKeyValue removes all elements from patch list with matching MergeKey value
+func removePatchElementsByMergeKeyValue(patch []interface{}, mergeKey, mergeKeyValue string) ([]interface{}, error) {
+	result := make([]interface{}, 0, len(patch))
+	for i, val := range patch {
+		_, key, err := getMapAndMergeKeyValueByIndex(i, mergeKey, patch)
+		if err != nil {
+			return nil, err
+		}
+		if fmt.Sprintf("%v", key) != mergeKeyValue {
+			result = append(result, val)
+		}
+	}
+	return result, nil
 }
 
 // getMapAndMergeKeyValueByIndex return a map in the list and its merge key value given the index of the map.
@@ -1561,6 +1646,13 @@ func mergeSliceWithSpecialElements(original, patch []interface{}, mergeKey strin
 				mergeValue, ok := typedV[mergeKey]
 				if ok {
 					var err error
+					// WARNING: side effect here. using 'original' in deleteMatchingEntries() if we have deletions
+					// breaks content of underlying array like '1, 2, 3, 4' -> delete 3 -> '1, 2, 4, 4',
+					// which causes incorrect ordering in 'mergeSlice(...)', because it uses its copy of
+					// 'original' slice (on the same array, but with original length 4)
+					// as source of truth about elements order.
+					// This is the reason of broken ordering in test case
+					// "behavior of set element order for a merging int list with duplicate"
 					original, err = deleteMatchingEntries(original, mergeKey, mergeValue)
 					if err != nil {
 						return nil, nil, err
@@ -2102,7 +2194,9 @@ func mapsOfMapsHaveConflicts(typedLeft, typedRight map[string]interface{}, schem
 // in a way that is different from how it is changed in current (e.g., deleting it, changing its
 // value). We also propagate values fields that do not exist in original but are explicitly
 // defined in modified.
-func CreateThreeWayMergePatch(original, modified, current []byte, schema LookupPatchMeta, overwrite bool, fns ...mergepatch.PreconditionFunc) ([]byte, error) {
+func CreateThreeWayMergePatch(original, modified, current []byte, schema LookupPatchMeta, overwrite bool, opts ...PatchOption) ([]byte, error) {
+	patchOpts := applyPatchOptions(opts...)
+
 	originalMap := map[string]interface{}{}
 	if len(original) > 0 {
 		if err := json.Unmarshal(original, &originalMap); err != nil {
@@ -2131,6 +2225,7 @@ func CreateThreeWayMergePatch(original, modified, current []byte, schema LookupP
 	deltaMapDiffOptions := DiffOptions{
 		IgnoreDeletions: true,
 		SetElementOrder: true,
+		AllowDuplicates: patchOpts.AllowDuplicates,
 	}
 	deltaMap, err := diffMaps(currentMap, modifiedMap, schema, deltaMapDiffOptions)
 	if err != nil {
@@ -2139,6 +2234,7 @@ func CreateThreeWayMergePatch(original, modified, current []byte, schema LookupP
 	deletionsMapDiffOptions := DiffOptions{
 		SetElementOrder:           true,
 		IgnoreChangesAndAdditions: true,
+		AllowDuplicates:           patchOpts.AllowDuplicates,
 	}
 	deletionsMap, err := diffMaps(originalMap, modifiedMap, schema, deletionsMapDiffOptions)
 	if err != nil {
@@ -2152,7 +2248,7 @@ func CreateThreeWayMergePatch(original, modified, current []byte, schema LookupP
 	}
 
 	// Apply the preconditions to the patch, and return an error if any of them fail.
-	for _, fn := range fns {
+	for _, fn := range patchOpts.preconditions {
 		if !fn(patchMap) {
 			return nil, mergepatch.NewErrPreconditionFailed(patchMap)
 		}
@@ -2161,7 +2257,9 @@ func CreateThreeWayMergePatch(original, modified, current []byte, schema LookupP
 	// If overwrite is false, and the patch contains any keys that were changed differently,
 	// then return a conflict error.
 	if !overwrite {
-		changeMapDiffOptions := DiffOptions{}
+		changeMapDiffOptions := DiffOptions{
+			AllowDuplicates: patchOpts.AllowDuplicates,
+		}
 		changedMap, err := diffMaps(originalMap, currentMap, schema, changeMapDiffOptions)
 		if err != nil {
 			return nil, err

--- a/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/patch_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/patch_test.go
@@ -65,6 +65,15 @@ type StrategicMergePatchRawTestCase struct {
 	StrategicMergePatchRawTestCaseData
 }
 
+type StrategicMergePatchBackwardCompatibilityTestCase struct {
+	Description string
+	Original    []byte
+	Modified    []byte
+	Current     []byte
+	Generation  []StrategicMergePatchGenerationRawTestCaseData
+	Application []StrategicMergePatchApplicationRawTestCaseData
+}
+
 type StrategicMergePatchTestCaseData struct {
 	// Original is the original object (last-applied config in annotation)
 	Original map[string]interface{}
@@ -94,6 +103,22 @@ type StrategicMergePatchRawTestCaseData struct {
 	Result        []byte
 	TwoWayResult  []byte
 	ExpectedError string
+}
+
+type StrategicMergePatchGenerationRawTestCaseData struct {
+	Description                    string
+	DuplicateMergeKeyValuesEnabled bool
+	TwoWay                         []byte
+	ThreeWay                       []byte
+}
+
+type StrategicMergePatchApplicationRawTestCaseData struct {
+	Description                    string
+	DuplicateMergeKeyValuesEnabled bool
+	TwoWay                         []byte
+	TwoWayResult                   []byte
+	ThreeWay                       []byte
+	ThreeWayResult                 []byte
 }
 
 type MergeItem struct {
@@ -804,6 +829,558 @@ func TestCustomStrategicMergePatch(t *testing.T) {
 					testPatchApplication(t, original, expectedTwoWayPatch, expectedResult, c.Description, c.ExpectedError, schema)
 				}
 			}
+		})
+	}
+}
+
+var featureGateTestCases = []StrategicMergePatchBackwardCompatibilityTestCase{
+	{
+		Description: "removing element from a merging list with duplicate",
+		Original: []byte(`
+mergingList:
+- name: 1
+- name: 2
+  value: dup1
+- name: 3
+- name: 2
+  value: dup2
+`),
+		Current: []byte(`
+mergingList:
+- name: 1
+- name: 2
+  value: dup1
+- name: 3
+- name: 2
+  value: dup2
+`),
+		Modified: []byte(`
+mergingList:
+- name: 1
+- name: 2
+  value: dup2
+- name: 3
+`),
+		Generation: []StrategicMergePatchGenerationRawTestCaseData{
+			{
+				Description:                    "new client",
+				DuplicateMergeKeyValuesEnabled: true,
+				TwoWay: []byte(`
+$setElementOrder/mergingList:
+- name: 1
+- name: 2
+- name: 3
+mergingList:
+- name: 2
+  value: dup2
+- $patch: delete
+  name: 2
+`),
+				ThreeWay: []byte(`
+$setElementOrder/mergingList:
+- name: 1
+- name: 2
+- name: 3
+mergingList:
+- name: 2
+  value: dup2
+- $patch: delete
+  name: 2
+`),
+			},
+			{
+				Description:                    "old client",
+				DuplicateMergeKeyValuesEnabled: false,
+				TwoWay: []byte(`
+$setElementOrder/mergingList:
+- name: 1
+- name: 2
+- name: 3
+mergingList:
+- $patch: delete
+  name: 2
+`),
+				ThreeWay: []byte(`
+$setElementOrder/mergingList:
+- name: 1
+- name: 2
+- name: 3
+mergingList:
+- $patch: delete
+  name: 2
+`),
+			},
+		},
+		Application: []StrategicMergePatchApplicationRawTestCaseData{
+			{
+				Description:                    "new client new server",
+				DuplicateMergeKeyValuesEnabled: true,
+				TwoWay: []byte(`
+$setElementOrder/mergingList:
+- name: 1
+- name: 2
+- name: 3
+mergingList:
+- name: 2
+  value: dup2
+- $patch: delete
+  name: 2
+`),
+				ThreeWay: []byte(`
+$setElementOrder/mergingList:
+- name: 1
+- name: 2
+- name: 3
+mergingList:
+- name: 2
+  value: dup2
+- $patch: delete
+  name: 2
+`),
+				TwoWayResult: []byte(`
+mergingList:
+- name: 1
+- name: 2
+  value: dup2
+- name: 3
+`),
+				ThreeWayResult: []byte(`
+mergingList:
+- name: 1
+- name: 2
+  value: dup2
+- name: 3
+`),
+			},
+			{
+				Description:                    "old client new server",
+				DuplicateMergeKeyValuesEnabled: true,
+				TwoWay: []byte(`
+$setElementOrder/mergingList:
+- name: 1
+- name: 2
+- name: 3
+mergingList:
+- $patch: delete
+  name: 2
+`),
+				ThreeWay: []byte(`
+$setElementOrder/mergingList:
+- name: 1
+- name: 2
+- name: 3
+mergingList:
+- $patch: delete
+  name: 2
+`),
+				TwoWayResult: []byte(`
+mergingList:
+- name: 1
+- name: 3
+`),
+				ThreeWayResult: []byte(`
+mergingList:
+- name: 1
+- name: 3
+`),
+			},
+			{
+				Description:                    "new client old server",
+				DuplicateMergeKeyValuesEnabled: false,
+				TwoWay: []byte(`
+$setElementOrder/mergingList:
+- name: 1
+- name: 2
+- name: 3
+mergingList:
+- name: 2
+  value: dup2
+- $patch: delete
+  name: 2
+`),
+				ThreeWay: []byte(`
+$setElementOrder/mergingList:
+- name: 1
+- name: 2
+- name: 3
+mergingList:
+- name: 2
+  value: dup2
+- $patch: delete
+  name: 2
+`),
+				TwoWayResult: []byte(`
+mergingList:
+- name: 1
+- name: 2
+  value: dup2
+- name: 3
+`),
+				ThreeWayResult: []byte(`
+mergingList:
+- name: 1
+- name: 2
+  value: dup2
+- name: 3
+`),
+			},
+			{
+				Description:                    "old client old server",
+				DuplicateMergeKeyValuesEnabled: false,
+				TwoWay: []byte(`
+$setElementOrder/mergingList:
+- name: 1
+- name: 2
+- name: 3
+mergingList:
+- $patch: delete
+  name: 2
+`),
+				ThreeWay: []byte(`
+$setElementOrder/mergingList:
+- name: 1
+- name: 2
+- name: 3
+mergingList:
+- $patch: delete
+  name: 2
+`),
+				TwoWayResult: []byte(`
+mergingList:
+- name: 1
+- name: 3
+`),
+				ThreeWayResult: []byte(`
+mergingList:
+- name: 1
+- name: 3
+`),
+			},
+		},
+	},
+	{
+		Description: "removing one duplicate element and updating another in merging list",
+		Original: []byte(`
+mergingList:
+- name: 1
+- name: 2
+  value: dup1
+- name: 3
+- name: 2
+  value: dup2
+`),
+		Current: []byte(`
+mergingList:
+- name: 1
+- name: 2
+  value: dup1
+- name: 3
+- name: 2
+  value: dup2
+- name: 4
+`),
+		Modified: []byte(`
+mergingList:
+- name: 1
+- name: 2
+  value: newValue
+- name: 3
+`),
+		Generation: []StrategicMergePatchGenerationRawTestCaseData{
+			{
+				Description:                    "new client",
+				DuplicateMergeKeyValuesEnabled: true,
+				TwoWay: []byte(`
+$setElementOrder/mergingList:
+- name: 1
+- name: 2
+- name: 3
+mergingList:
+- name: 2
+  value: newValue
+- $patch: delete
+  name: 2
+`),
+				ThreeWay: []byte(`
+$setElementOrder/mergingList:
+- name: 1
+- name: 2
+- name: 3
+mergingList:
+- name: 2
+  value: newValue
+- $patch: delete
+  name: 2
+`),
+			},
+			{
+				Description:                    "old client",
+				DuplicateMergeKeyValuesEnabled: false,
+				TwoWay: []byte(`
+$setElementOrder/mergingList:
+- name: 1
+- name: 2
+- name: 3
+mergingList:
+- name: 2
+  value: newValue
+- $patch: delete
+  name: 2
+`),
+				ThreeWay: []byte(`
+$setElementOrder/mergingList:
+- name: 1
+- name: 2
+- name: 3
+mergingList:
+- $patch: delete
+  name: 2
+  value: newValue
+`),
+			},
+		},
+		Application: []StrategicMergePatchApplicationRawTestCaseData{
+			{
+				// This test case has wrong ordering in ThreeWayMerge result because of side effect in mergeSliceWithSpecialElements
+				// function, same as in case 'behavior of set element order for a merging int list with duplicate'
+				Description:                    "new client new server",
+				DuplicateMergeKeyValuesEnabled: true,
+				TwoWay: []byte(`
+$setElementOrder/mergingList:
+- name: 1
+- name: 2
+- name: 3
+mergingList:
+- name: 2
+  value: newValue
+- $patch: delete
+  name: 2
+`),
+				ThreeWay: []byte(`
+$setElementOrder/mergingList:
+- name: 1
+- name: 2
+- name: 3
+mergingList:
+- name: 2
+  value: newValue
+- $patch: delete
+  name: 2
+`),
+				TwoWayResult: []byte(`
+mergingList:
+- name: 1
+- name: 2
+  value: newValue
+- name: 3
+`),
+				ThreeWayResult: []byte(`
+mergingList:
+- name: 1
+- name: 4
+- name: 2
+  value: newValue
+- name: 3
+`),
+			},
+			{
+				Description:                    "old client new server",
+				DuplicateMergeKeyValuesEnabled: true,
+				TwoWay: []byte(`
+$setElementOrder/mergingList:
+- name: 1
+- name: 2
+- name: 3
+mergingList:
+- name: 2
+  value: newValue
+- $patch: delete
+  name: 2
+`),
+				ThreeWay: []byte(`
+$setElementOrder/mergingList:
+- name: 1
+- name: 2
+- name: 3
+mergingList:
+- $patch: delete
+  name: 2
+  value: newValue
+`),
+				TwoWayResult: []byte(`
+mergingList:
+- name: 1
+- name: 2
+  value: newValue
+- name: 3
+`),
+				ThreeWayResult: []byte(`
+mergingList:
+- name: 1
+- name: 3
+- name: 4
+`),
+			},
+			{
+				// This test case has wrong ordering in ThreeWayMerge result because of side effect in mergeSliceWithSpecialElements
+				// function, same as in case 'behavior of set element order for a merging int list with duplicate'
+				Description:                    "new client old server",
+				DuplicateMergeKeyValuesEnabled: false,
+				TwoWay: []byte(`
+$setElementOrder/mergingList:
+- name: 1
+- name: 2
+- name: 3
+mergingList:
+- name: 2
+  value: newValue
+- $patch: delete
+  name: 2
+`),
+				ThreeWay: []byte(`
+$setElementOrder/mergingList:
+- name: 1
+- name: 2
+- name: 3
+mergingList:
+- name: 2
+  value: newValue
+- $patch: delete
+  name: 2
+`),
+				TwoWayResult: []byte(`
+mergingList:
+- name: 1
+- name: 2
+  value: newValue
+- name: 3
+`),
+				ThreeWayResult: []byte(`
+mergingList:
+- name: 1
+- name: 4
+- name: 2
+  value: newValue
+- name: 3
+`),
+			},
+			{
+				Description:                    "old client old server",
+				DuplicateMergeKeyValuesEnabled: false,
+				TwoWay: []byte(`
+$setElementOrder/mergingList:
+- name: 1
+- name: 2
+- name: 3
+mergingList:
+- name: 2
+  value: newValue
+- $patch: delete
+  name: 2
+`),
+				ThreeWay: []byte(`
+$setElementOrder/mergingList:
+- name: 1
+- name: 2
+- name: 3
+mergingList:
+- $patch: delete
+  name: 2
+  value: newValue
+`),
+				TwoWayResult: []byte(`
+mergingList:
+- name: 1
+- name: 2
+  value: newValue
+- name: 3
+`),
+				ThreeWayResult: []byte(`
+mergingList:
+- name: 1
+- name: 3
+- name: 4
+`),
+			},
+		},
+	},
+}
+
+func TestFeatureGates(t *testing.T) {
+	mergeItemOpenapiSchema := PatchMetaFromOpenAPI{
+		Schema: sptest.GetSchemaOrDie(&fakeMergeItemSchema, "mergeItem"),
+	}
+	mergeItemOpenapiV3Schema := PatchMetaFromOpenAPIV3{
+		SchemaList: fakeMergeItemV3Schema.SchemaOrDie().Components.Schemas,
+		Schema:     fakeMergeItemV3Schema.SchemaOrDie().Components.Schemas["mergeItem"],
+	}
+	schemas := []LookupPatchMeta{
+		mergeItemStructSchema,
+		mergeItemOpenapiSchema,
+		mergeItemOpenapiV3Schema,
+	}
+
+	for _, schema := range schemas {
+		// run multiple times to exercise different map traversal orders
+		for i := 0; i < 10; i++ {
+			for _, c := range featureGateTestCases {
+				testFeatureGatePatchCreation(t, schema, c)
+				testFeatureGatePatchApplication(t, schema, c)
+			}
+		}
+	}
+}
+
+func testFeatureGatePatchCreation(t *testing.T, schema LookupPatchMeta, c StrategicMergePatchBackwardCompatibilityTestCase) {
+	original, modified := yamlToJSONOrError(t, c.Original), yamlToJSONOrError(t, c.Modified)
+
+	for _, current := range c.Generation {
+		expectedTwoWay := yamlToJSONOrError(t, current.TwoWay)
+		desc := fmt.Sprintf("%s/PatchCreation/TwoWay/%s", c.Description, current.Description)
+		t.Run(desc, func(t *testing.T) {
+			actualPatch, err := CreateTwoWayMergePatchUsingLookupPatchMeta(original, modified, schema,
+				WithDuplicateMergeKeySupport(current.DuplicateMergeKeyValuesEnabled))
+			if err != nil {
+				t.Errorf("error: %s\nin test case: %s\ncannot create two way patch:\noriginal:%s\nmodified:%s\nduplicate MergeKey values enabled:%t\n",
+					err, c.Description, c.Original, c.Modified, current.DuplicateMergeKeyValuesEnabled)
+				return
+			}
+			testPatchCreation(t, expectedTwoWay, actualPatch, c.Description)
+		})
+
+		currentManifest := yamlToJSONOrError(t, c.Current)
+		expectedThreeWay := yamlToJSONOrError(t, current.ThreeWay)
+		desc = fmt.Sprintf("%s/PatchCreation/ThreeWay/%s", c.Description, current.Description)
+		t.Run(desc, func(t *testing.T) {
+			actual, err := CreateThreeWayMergePatch(original, modified, currentManifest, schema, false,
+				WithDuplicateMergeKeySupport(current.DuplicateMergeKeyValuesEnabled))
+			if err != nil {
+				t.Errorf("error: %s\nin test case: %s\ncannot create three way patch:\noriginal:%s\nmodified:%s\ncurrent:%s\nduplicate MergeKey values enabled:%t\n",
+					err, c.Description, c.Original, c.Modified, c.Current, current.DuplicateMergeKeyValuesEnabled)
+				return
+			}
+			testPatchCreation(t, expectedThreeWay, actual, c.Description)
+		})
+	}
+}
+
+func testFeatureGatePatchApplication(t *testing.T, schema LookupPatchMeta, c StrategicMergePatchBackwardCompatibilityTestCase) {
+	original := yamlToJSONOrError(t, c.Original)
+
+	for _, current := range c.Application {
+		patch, expectedResult := yamlToJSONOrError(t, current.TwoWay), yamlToJSONOrError(t, current.TwoWayResult)
+		desc := fmt.Sprintf("%s/PatchApplication/TwoWay/%s", c.Description, current.Description)
+		t.Run(desc, func(t *testing.T) {
+			testPatchApplication(t, original, patch, expectedResult, c.Description,
+				"", schema)
+		})
+
+		threeWayPatch, expectedThreeWayResult := yamlToJSONOrError(t, current.ThreeWay), yamlToJSONOrError(t, current.ThreeWayResult)
+		currentManifest := yamlToJSONOrError(t, c.Current)
+		desc = fmt.Sprintf("%s/PatchApplication/ThreeWay/%s", c.Description, current.Description)
+		t.Run(desc, func(t *testing.T) {
+			testPatchApplication(t, currentManifest, threeWayPatch, expectedThreeWayResult, c.Description,
+				"", schema)
 		})
 	}
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/patcher.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/patcher.go
@@ -296,7 +296,9 @@ func (p *Patcher) buildStrategicMergePatchFromOpenAPIV3(original, modified, curr
 			continue
 		}
 		lookupPatchMeta := strategicpatch.PatchMetaFromOpenAPIV3{Schema: c, SchemaList: gvSpec.Components.Schemas}
-		if openapiv3Patch, err := strategicpatch.CreateThreeWayMergePatch(original, modified, current, lookupPatchMeta, p.Overwrite); err != nil {
+		if openapiv3Patch, err := strategicpatch.CreateThreeWayMergePatch(
+			original, modified, current, lookupPatchMeta, p.Overwrite,
+			strategicpatch.WithDuplicateMergeKeySupport(true)); err != nil {
 			return nil, err
 		} else {
 			return openapiv3Patch, nil
@@ -315,7 +317,9 @@ func (p *Patcher) buildStrategicMergeFromOpenAPI(openAPISchema openapi.Resources
 		return nil, nil
 	}
 	lookupPatchMeta := strategicpatch.PatchMetaFromOpenAPI{Schema: schema}
-	if openapiPatch, err := strategicpatch.CreateThreeWayMergePatch(original, modified, current, lookupPatchMeta, p.Overwrite); err != nil {
+	if openapiPatch, err := strategicpatch.CreateThreeWayMergePatch(
+		original, modified, current, lookupPatchMeta, p.Overwrite,
+		strategicpatch.WithDuplicateMergeKeySupport(true)); err != nil {
 		return nil, err
 	} else {
 		return openapiPatch, nil
@@ -345,7 +349,9 @@ func (p *Patcher) buildStrategicMergeFromBuiltins(versionedObj runtime.Object, o
 	if err != nil {
 		return nil, err
 	}
-	patch, err := strategicpatch.CreateThreeWayMergePatch(original, modified, current, lookupPatchMeta, p.Overwrite)
+	patch, err := strategicpatch.CreateThreeWayMergePatch(
+		original, modified, current, lookupPatchMeta, p.Overwrite,
+		strategicpatch.WithDuplicateMergeKeySupport(true))
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go
@@ -505,7 +505,7 @@ func (o *DebugOptions) debugByEphemeralContainer(ctx context.Context, pod *corev
 		return nil, "", fmt.Errorf("error creating JSON for debug container: %v", err)
 	}
 
-	patch, err := strategicpatch.CreateTwoWayMergePatch(podJS, debugJS, pod)
+	patch, err := strategicpatch.CreateTwoWayMergePatch(podJS, debugJS, pod, strategicpatch.WithDuplicateMergeKeySupport(true))
 	if err != nil {
 		return nil, "", fmt.Errorf("error creating patch to add debug container: %v", err)
 	}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/set/helper.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/set/helper.go
@@ -105,7 +105,7 @@ func CalculatePatch(patch *Patch, encoder runtime.Encoder, mutateFn PatchFn) boo
 		return false
 	}
 
-	patch.Patch, patch.Err = strategicpatch.CreateTwoWayMergePatch(patch.Before, patch.After, patch.Info.Object)
+	patch.Patch, patch.Err = strategicpatch.CreateTwoWayMergePatch(patch.Before, patch.After, patch.Info.Object, strategicpatch.WithDuplicateMergeKeySupport(true))
 	return true
 }
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/taint/taint.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/taint/taint.go
@@ -285,7 +285,7 @@ func (o TaintOptions) RunTaint() error {
 		if err != nil {
 			return err
 		}
-		patchBytes, err := strategicpatch.CreateTwoWayMergePatch(oldData, newData, obj)
+		patchBytes, err := strategicpatch.CreateTwoWayMergePatch(oldData, newData, obj, strategicpatch.WithDuplicateMergeKeySupport(true))
 		createdPatch := err == nil
 		if err != nil {
 			klog.V(2).Infof("couldn't compute patch: %v", err)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/editor/editoptions.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/editor/editoptions.go
@@ -695,7 +695,8 @@ func (o *EditOptions) visitToPatch(originalInfos []*resource.Info, patchVisitor 
 			return err
 		default:
 			patchType = types.StrategicMergePatchType
-			patch, err = strategicpatch.CreateTwoWayMergePatch(originalJS, editedJS, versionedObject, preconditions...)
+			patch, err = strategicpatch.CreateTwoWayMergePatch(originalJS, editedJS, versionedObject,
+				strategicpatch.WithPreconditions(preconditions...))
 			if err != nil {
 				klog.V(4).Infof("Unable to calculate diff, no merge is possible: %v", err)
 				if mergepatch.IsPreconditionFailed(err) {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/editor/editoptions.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/editor/editoptions.go
@@ -695,8 +695,10 @@ func (o *EditOptions) visitToPatch(originalInfos []*resource.Info, patchVisitor 
 			return err
 		default:
 			patchType = types.StrategicMergePatchType
-			patch, err = strategicpatch.CreateTwoWayMergePatch(originalJS, editedJS, versionedObject,
-				strategicpatch.WithPreconditions(preconditions...))
+			patch, err = strategicpatch.CreateTwoWayMergePatch(
+				originalJS, editedJS, versionedObject,
+				strategicpatch.WithPreconditions(preconditions...),
+				strategicpatch.WithDuplicateMergeKeySupport(true))
 			if err != nil {
 				klog.V(4).Infof("Unable to calculate diff, no merge is possible: %v", err)
 				if mergepatch.IsPreconditionFailed(err) {

--- a/staging/src/k8s.io/kubectl/pkg/drain/cordon.go
+++ b/staging/src/k8s.io/kubectl/pkg/drain/cordon.go
@@ -93,7 +93,7 @@ func (c *CordonHelper) PatchOrReplaceWithContext(clientCtx context.Context, clie
 		return err, nil
 	}
 
-	patchBytes, patchErr := strategicpatch.CreateTwoWayMergePatch(oldData, newData, c.node)
+	patchBytes, patchErr := strategicpatch.CreateTwoWayMergePatch(oldData, newData, c.node, strategicpatch.WithDuplicateMergeKeySupport(true))
 	if patchErr == nil {
 		patchOptions := metav1.PatchOptions{}
 		if serverDryRun {


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/sig api-machinery

#### What this PR does / why we need it:
Fix bug in strategicpatch which was unable to properly handle list values with duplicated MergeKey values.

Original manifest contains duplicated value with mergeKey `2`:
```yaml
mergingList:
- name: 1
- name: 2
  value: dup1
- name: 3
- name: 2
  value: dup2
```
Trying to remove one of duplicates (for example, with `kubectl apply` of following):
```yaml
mergingList:
- name: 1
- name: 2
  value: dup2
- name: 3
```
Actual result of patching: removed both of duplicates:
```yaml
mergingList:
- name: 1
- name: 3
```

Since we allow user to have duplicated values in manifests, it seems to be reasonable to provide at least minimal support of those in strategicmerge. Currently, the user cannot even delete one of the duplicates added by mistake, as this would result in a manifest missing the necessary value.

Adding stricter validation might be a more strategic solution, but it requires significant time for migration. Therefore, I suggest supporting duplicate values at least until the validation is implemented and prevents the creation of such manifests.

#### Which issue(s) this PR fixes:
Fixes #58477
Fixes #93266

#### Special notes for your reviewer:
Discovered reason of incorrect element ordering described in test case `add map and delete map from merging list`.
This behavior is caused by a side effect of `mergeSliceWithSpecialElements` function, which was changing contents of `original` slice upper in call stack, where it was used to determine elements order and assumed to be still unmodified. 
Left comment, didnt fix.

#### Does this PR introduce a user-facing change?
```release-note
Fixed strategicpatch bug when attempt to remove one of duplicated by mergeKey value elements from list 
with `kubectl appy` could lead to removal of all elements with this mergeKey.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```