### PR TITLE
[sample-apiserver] Fix: Use Correct Effective Version for kube

### DIFF
--- a/staging/src/k8s.io/sample-apiserver/pkg/cmd/server/start.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/cmd/server/start.go
@@ -60,7 +60,7 @@ type WardleServerOptions struct {
 	AlternateDNS []string
 }
 
-func wardleEmulationVersionToKubeEmulationVersion(ver *version.Version) *version.Version {
+func WardleVersionToKubeVersion(ver *version.Version) *version.Version {
 	if ver.Major() != 1 {
 		return nil
 	}
@@ -153,7 +153,7 @@ func NewCommandStartWardleServer(ctx context.Context, defaults *WardleServerOpti
 
 	// Set the emulation version mapping from the "Wardle" component to the kube component.
 	// This ensures that the emulation version of the latter is determined by the emulation version of the former.
-	utilruntime.Must(utilversion.DefaultComponentGlobalsRegistry.SetEmulationVersionMapping(apiserver.WardleComponentName, utilversion.DefaultKubeComponent, wardleEmulationVersionToKubeEmulationVersion))
+	utilruntime.Must(utilversion.DefaultComponentGlobalsRegistry.SetEmulationVersionMapping(apiserver.WardleComponentName, utilversion.DefaultKubeComponent, WardleVersionToKubeVersion))
 
 	utilversion.DefaultComponentGlobalsRegistry.AddFlags(flags)
 

--- a/staging/src/k8s.io/sample-apiserver/pkg/cmd/server/start.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/cmd/server/start.go
@@ -67,7 +67,11 @@ func wardleEmulationVersionToKubeEmulationVersion(ver *version.Version) *version
 	kubeVer := utilversion.DefaultKubeEffectiveVersion().BinaryVersion()
 	// "1.2" maps to kubeVer
 	offset := int(ver.Minor()) - 2
-	return kubeVer.OffsetMinor(offset)
+	mappedVer := kubeVer.OffsetMinor(offset)
+	if mappedVer.GreaterThan(kubeVer) {
+		return kubeVer
+	}
+	return mappedVer
 }
 
 // NewWardleServerOptions returns a new WardleServerOptions

--- a/staging/src/k8s.io/sample-apiserver/pkg/cmd/server/start.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/cmd/server/start.go
@@ -36,6 +36,7 @@ import (
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	utilversion "k8s.io/apiserver/pkg/util/version"
 	"k8s.io/component-base/featuregate"
+	baseversion "k8s.io/component-base/version"
 	"k8s.io/sample-apiserver/pkg/admission/plugin/banflunder"
 	"k8s.io/sample-apiserver/pkg/admission/wardleinitializer"
 	"k8s.io/sample-apiserver/pkg/apis/wardle/v1alpha1"
@@ -64,8 +65,8 @@ func wardleEmulationVersionToKubeEmulationVersion(ver *version.Version) *version
 		return nil
 	}
 	kubeVer := utilversion.DefaultKubeEffectiveVersion().BinaryVersion()
-	// "1.1" maps to kubeVer
-	offset := int(ver.Minor()) - 1
+	// "1.2" maps to kubeVer
+	offset := int(ver.Minor()) - 2
 	return kubeVer.OffsetMinor(offset)
 }
 
@@ -112,19 +113,44 @@ func NewCommandStartWardleServer(ctx context.Context, defaults *WardleServerOpti
 	flags := cmd.Flags()
 	o.RecommendedOptions.AddFlags(flags)
 
-	wardleEffectiveVersion := utilversion.NewEffectiveVersion("1.2")
-	wardleFeatureGate := utilfeature.DefaultFeatureGate.CopyKnownFeatures()
+	// The following lines demonstrate how to configure version compatibility and feature gates
+	// for the "Wardle" component, as an example of KEP-4330.
+
+	// Create an effective version object for the "Wardle" component.
+	// This initializes the binary version, the emulation version and the minimum compatibility version.
+	//
+	// Note:
+	// - The binary version represents the actual version of the running source code.
+	// - The emulation version is the version whose capabilities are being emulated by the binary.
+	// - The minimum compatibility version specifies the minimum version that the component remains compatible with.
+	//
+	// Refer to KEP-4330 for more details: https://github.com/kubernetes/enhancements/blob/master/keps/sig-architecture/4330-compatibility-versions
+	defaultWardleVersion := "1.2"
+	// Register the "Wardle" component with the global component registry,
+	// associating it with its effective version and feature gate configuration.
+	// Will skip if the component has been registered, like in the integration test.
+	_, wardleFeatureGate := utilversion.DefaultComponentGlobalsRegistry.ComponentGlobalsOrRegister(
+		apiserver.WardleComponentName, utilversion.NewEffectiveVersion(defaultWardleVersion),
+		featuregate.NewVersionedFeatureGate(version.MustParse(defaultWardleVersion)))
+
+	// Add versioned feature specifications for the "BanFlunder" feature.
+	// These specifications, together with the effective version, determine if the feature is enabled.
 	utilruntime.Must(wardleFeatureGate.AddVersioned(map[featuregate.Feature]featuregate.VersionedSpecs{
 		"BanFlunder": {
-			{Version: version.MustParse("1.2"), Default: true, PreRelease: featuregate.GA},
-			{Version: version.MustParse("1.1"), Default: false, PreRelease: featuregate.Beta},
+			{Version: version.MustParse("1.2"), Default: true, PreRelease: featuregate.GA, LockToDefault: true},
+			{Version: version.MustParse("1.1"), Default: true, PreRelease: featuregate.Beta},
 			{Version: version.MustParse("1.0"), Default: false, PreRelease: featuregate.Alpha},
 		},
 	}))
-	utilruntime.Must(utilversion.DefaultComponentGlobalsRegistry.Register(apiserver.WardleComponentName, wardleEffectiveVersion, wardleFeatureGate))
-	_, _ = utilversion.DefaultComponentGlobalsRegistry.ComponentGlobalsOrRegister(
-		utilversion.DefaultKubeComponent, utilversion.DefaultKubeEffectiveVersion(), utilfeature.DefaultMutableFeatureGate)
+
+	// Register the default kube component if not already present in the global registry.
+	_, _ = utilversion.DefaultComponentGlobalsRegistry.ComponentGlobalsOrRegister(utilversion.DefaultKubeComponent,
+		utilversion.NewEffectiveVersion(baseversion.DefaultKubeBinaryVersion), utilfeature.DefaultMutableFeatureGate)
+
+	// Set the emulation version mapping from the "Wardle" component to the kube component.
+	// This ensures that the emulation version of the latter is determined by the emulation version of the former.
 	utilruntime.Must(utilversion.DefaultComponentGlobalsRegistry.SetEmulationVersionMapping(apiserver.WardleComponentName, utilversion.DefaultKubeComponent, wardleEmulationVersionToKubeEmulationVersion))
+
 	utilversion.DefaultComponentGlobalsRegistry.AddFlags(flags)
 
 	return cmd
@@ -177,7 +203,7 @@ func (o *WardleServerOptions) Config() (*apiserver.Config, error) {
 	serverConfig.OpenAPIV3Config.Info.Title = "Wardle"
 	serverConfig.OpenAPIV3Config.Info.Version = "0.1"
 
-	serverConfig.FeatureGate = utilversion.DefaultComponentGlobalsRegistry.FeatureGateFor(apiserver.WardleComponentName)
+	serverConfig.FeatureGate = utilversion.DefaultComponentGlobalsRegistry.FeatureGateFor(utilversion.DefaultKubeComponent)
 	serverConfig.EffectiveVersion = utilversion.DefaultComponentGlobalsRegistry.EffectiveVersionFor(apiserver.WardleComponentName)
 
 	if err := o.RecommendedOptions.ApplyTo(serverConfig); err != nil {

--- a/staging/src/k8s.io/sample-apiserver/pkg/cmd/server/start_test.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/cmd/server/start_test.go
@@ -49,6 +49,11 @@ func TestWardleEmulationVersionToKubeEmulationVersion(t *testing.T) {
 			expectedKubeEmulationVer: defaultKubeEffectiveVersion.BinaryVersion().OffsetMinor(-2),
 		},
 		{
+			desc:                     "capped at kube binary",
+			wardleEmulationVer:       version.MajorMinor(1, 3),
+			expectedKubeEmulationVer: defaultKubeEffectiveVersion.BinaryVersion(),
+		},
+		{
 			desc:               "no mapping",
 			wardleEmulationVer: version.MajorMinor(2, 10),
 		},

--- a/staging/src/k8s.io/sample-apiserver/pkg/cmd/server/start_test.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/cmd/server/start_test.go
@@ -61,7 +61,7 @@ func TestWardleEmulationVersionToKubeEmulationVersion(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			mappedKubeEmulationVer := wardleEmulationVersionToKubeEmulationVersion(tc.wardleEmulationVer)
+			mappedKubeEmulationVer := WardleVersionToKubeVersion(tc.wardleEmulationVer)
 			assert.True(t, mappedKubeEmulationVer.EqualTo(tc.expectedKubeEmulationVer))
 		})
 	}

--- a/staging/src/k8s.io/sample-apiserver/pkg/cmd/server/start_test.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/cmd/server/start_test.go
@@ -35,13 +35,18 @@ func TestWardleEmulationVersionToKubeEmulationVersion(t *testing.T) {
 	}{
 		{
 			desc:                     "same version as than kube binary",
-			wardleEmulationVer:       version.MajorMinor(1, 1),
+			wardleEmulationVer:       version.MajorMinor(1, 2),
 			expectedKubeEmulationVer: defaultKubeEffectiveVersion.BinaryVersion(),
 		},
 		{
-			desc:                     "1 version higher than kube binary",
-			wardleEmulationVer:       version.MajorMinor(1, 2),
-			expectedKubeEmulationVer: defaultKubeEffectiveVersion.BinaryVersion().OffsetMinor(1),
+			desc:                     "1 version lower than kube binary",
+			wardleEmulationVer:       version.MajorMinor(1, 1),
+			expectedKubeEmulationVer: defaultKubeEffectiveVersion.BinaryVersion().OffsetMinor(-1),
+		},
+		{
+			desc:                     "2 versions lower than kube binary",
+			wardleEmulationVer:       version.MajorMinor(1, 0),
+			expectedKubeEmulationVer: defaultKubeEffectiveVersion.BinaryVersion().OffsetMinor(-2),
 		},
 		{
 			desc:               "no mapping",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Set effective kube version to default version + 1 minor version so the sample-apiserver could be deployed without the following error:
```
$ k logs wardle-server-65dbc6f5d-9pwv4 -n wardle
Defaulted container "wardle-server" out of: wardle-server, etcd
I0707 11:16:37.994750       1 registry.go:379] setting wardle:feature gate emulation version to 1.2
I0707 11:16:37.997302       1 registry.go:379] setting kube:feature gate emulation version to 1.32
I0707 11:16:37.997370       1 feature_gate.go:522] set feature gate emulationVersion to 1.32
I0707 11:16:37.998443       1 plugins.go:83] "Registered admission plugin" plugin="BanFlunder"
E0707 11:16:38.001481       1 run.go:72] "command failed" err="emulation version 1.32 is not between [1.30, 1.31.0]"
``` 

#### Which issue(s) this PR fixes:

Fixes #125938