### PR TITLE
[FG:InPlacePodVerticalScaling] Use latest status from runtime at resizing

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1949,7 +1949,7 @@ func (kl *Kubelet) SyncPod(ctx context.Context, updateType kubetypes.SyncPodType
 		// TODO(vinaykul,InPlacePodVerticalScaling): Investigate doing this in HandlePodUpdates + periodic SyncLoop scan
 		//     See: https://github.com/kubernetes/kubernetes/pull/102884#discussion_r663160060
 		if kl.podWorkers.CouldHaveRunningContainers(pod.UID) && !kubetypes.IsStaticPod(pod) {
-			pod = kl.handlePodResourcesResize(pod)
+			pod = kl.handlePodResourcesResize(pod, &apiPodStatus)
 		}
 	}
 
@@ -2768,7 +2768,7 @@ func isPodResizeInProgress(pod *v1.Pod, podStatus *v1.PodStatus) bool {
 	return false
 }
 
-func (kl *Kubelet) canResizePod(pod *v1.Pod) (bool, *v1.Pod, v1.PodResizeStatus) {
+func (kl *Kubelet) canResizePod(pod *v1.Pod, podStatus *v1.PodStatus) (bool, *v1.Pod, v1.PodResizeStatus) {
 	var otherActivePods []*v1.Pod
 
 	node, err := kl.getNodeAnyWay()
@@ -2777,6 +2777,7 @@ func (kl *Kubelet) canResizePod(pod *v1.Pod) (bool, *v1.Pod, v1.PodResizeStatus)
 		return false, nil, ""
 	}
 	podCopy := pod.DeepCopy()
+	podCopy.Status = *podStatus.DeepCopy()
 	cpuAvailable := node.Status.Allocatable.Cpu().MilliValue()
 	memAvailable := node.Status.Allocatable.Memory().Value()
 	cpuRequests := resource.GetResourceRequest(podCopy, v1.ResourceCPU)
@@ -2812,16 +2813,17 @@ func (kl *Kubelet) canResizePod(pod *v1.Pod) (bool, *v1.Pod, v1.PodResizeStatus)
 	return true, podCopy, v1.PodResizeStatusInProgress
 }
 
-func (kl *Kubelet) handlePodResourcesResize(pod *v1.Pod) *v1.Pod {
-	if pod.Status.Phase != v1.PodRunning {
+func (kl *Kubelet) handlePodResourcesResize(pod *v1.Pod, podStatus *v1.PodStatus) *v1.Pod {
+	if podStatus.Phase != v1.PodRunning {
 		return pod
 	}
-	podResized := false
+	requestsResized := false
+	limitsResized := false
 	for _, container := range pod.Spec.Containers {
 		if len(container.Resources.Requests) == 0 {
 			continue
 		}
-		containerStatus, found := podutil.GetContainerStatus(pod.Status.ContainerStatuses, container.Name)
+		containerStatus, found := podutil.GetContainerStatus(podStatus.ContainerStatuses, container.Name)
 		if !found {
 			klog.V(5).InfoS("ContainerStatus not found", "pod", pod.Name, "container", container.Name)
 			break
@@ -2831,17 +2833,25 @@ func (kl *Kubelet) handlePodResourcesResize(pod *v1.Pod) *v1.Pod {
 			break
 		}
 		if !cmp.Equal(container.Resources.Requests, containerStatus.AllocatedResources) {
-			podResized = true
+			requestsResized = true
 			break
 		}
+		if !cmp.Equal(container.Resources.Limits, containerStatus.Resources.Limits) {
+			limitsResized = true
+		}
 	}
-	if !podResized {
+	if !requestsResized {
+		if limitsResized {
+			updatePod := pod.DeepCopy()
+			updatePod.Status = *podStatus.DeepCopy()
+			return updatePod
+		}
 		return pod
 	}
 
 	kl.podResizeMutex.Lock()
 	defer kl.podResizeMutex.Unlock()
-	fit, updatedPod, resizeStatus := kl.canResizePod(pod)
+	fit, updatedPod, resizeStatus := kl.canResizePod(pod, podStatus)
 	if updatedPod == nil {
 		return pod
 	}

--- a/test/e2e/common/node/pod_resize.go
+++ b/test/e2e/common/node/pod_resize.go
@@ -33,6 +33,7 @@ import (
 	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
+	testutils "k8s.io/kubernetes/test/utils"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
@@ -1012,6 +1013,565 @@ func doPodResizeErrorTests(f *framework.Framework) {
 	}
 }
 
+func doConsecutivePodResizeTests(f *framework.Framework) {
+	var podClient *e2epod.PodClient
+	ginkgo.BeforeEach(func() {
+		podClient = e2epod.NewPodClient(f)
+	})
+
+	type testCase struct {
+		isSynchronous    bool
+		name             string
+		containers       []e2epod.ResizableContainerInfo
+		containerPatches [][]v1.Container
+		intervals        []time.Duration
+		expected         [][]e2epod.ResizableContainerInfo
+	}
+
+	noRestart := v1.NotRequired
+	doRestart := v1.RestartContainer
+
+	tests := []testCase{
+		{
+			isSynchronous: false,
+			name:          "Resize with restarting twice asynchronously",
+			containers: []e2epod.ResizableContainerInfo{
+				{
+					Name:      "c1",
+					Resources: &e2epod.ContainerResources{CPUReq: "100m", CPULim: "100m", MemReq: "200Mi", MemLim: "200Mi"},
+					CPUPolicy: &doRestart,
+					MemPolicy: &noRestart,
+				},
+			},
+			containerPatches: [][]v1.Container{
+				{
+					{
+						Name: "c1",
+						Resources: v1.ResourceRequirements{
+							Requests: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("150m"),
+								v1.ResourceMemory: resource.MustParse("300Mi"),
+							},
+							Limits: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("150m"),
+								v1.ResourceMemory: resource.MustParse("300Mi"),
+							},
+						},
+					},
+				},
+				{
+					{
+						Name: "c1",
+						Resources: v1.ResourceRequirements{
+							Requests: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("200m"),
+								v1.ResourceMemory: resource.MustParse("400Mi"),
+							},
+							Limits: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("200m"),
+								v1.ResourceMemory: resource.MustParse("400Mi"),
+							},
+						},
+					},
+				},
+			},
+			intervals: []time.Duration{1 * time.Second},
+			expected: [][]e2epod.ResizableContainerInfo{
+				{},
+				{{
+					Name:         "c1",
+					Resources:    &e2epod.ContainerResources{CPUReq: "200m", CPULim: "200m", MemReq: "400Mi", MemLim: "400Mi"},
+					CPUPolicy:    &doRestart,
+					MemPolicy:    &noRestart,
+					RestartCount: 2,
+				}},
+			},
+		},
+		{
+			isSynchronous: true,
+			name:          "Resize with restarting twice synchronously",
+			containers: []e2epod.ResizableContainerInfo{
+				{
+					Name:      "c1",
+					Resources: &e2epod.ContainerResources{CPUReq: "100m", CPULim: "100m", MemReq: "200Mi", MemLim: "200Mi"},
+					CPUPolicy: &doRestart,
+					MemPolicy: &noRestart,
+				},
+			},
+			containerPatches: [][]v1.Container{
+				{
+					{
+						Name: "c1",
+						Resources: v1.ResourceRequirements{
+							Requests: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("150m"),
+								v1.ResourceMemory: resource.MustParse("300Mi"),
+							},
+							Limits: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("150m"),
+								v1.ResourceMemory: resource.MustParse("300Mi"),
+							},
+						},
+					},
+				},
+				{
+					{
+						Name: "c1",
+						Resources: v1.ResourceRequirements{
+							Requests: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("200m"),
+								v1.ResourceMemory: resource.MustParse("400Mi"),
+							},
+							Limits: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("200m"),
+								v1.ResourceMemory: resource.MustParse("400Mi"),
+							},
+						},
+					},
+				},
+			},
+			intervals: []time.Duration{0},
+			expected: [][]e2epod.ResizableContainerInfo{
+				{{
+					Name:         "c1",
+					Resources:    &e2epod.ContainerResources{CPUReq: "150m", CPULim: "150m", MemReq: "300Mi", MemLim: "300Mi"},
+					CPUPolicy:    &doRestart,
+					MemPolicy:    &noRestart,
+					RestartCount: 1,
+				}},
+				{{
+					Name:         "c1",
+					Resources:    &e2epod.ContainerResources{CPUReq: "200m", CPULim: "200m", MemReq: "400Mi", MemLim: "400Mi"},
+					CPUPolicy:    &doRestart,
+					MemPolicy:    &noRestart,
+					RestartCount: 2,
+				}},
+			},
+		},
+		{
+			isSynchronous: false,
+			name:          "Resize without restarting twice asynchronously",
+			containers: []e2epod.ResizableContainerInfo{
+				{
+					Name:      "c1",
+					Resources: &e2epod.ContainerResources{CPUReq: "100m", CPULim: "100m", MemReq: "200Mi", MemLim: "200Mi"},
+					CPUPolicy: &noRestart,
+					MemPolicy: &noRestart,
+				},
+			},
+			containerPatches: [][]v1.Container{
+				{
+					{
+						Name: "c1",
+						Resources: v1.ResourceRequirements{
+							Requests: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("150m"),
+								v1.ResourceMemory: resource.MustParse("300Mi"),
+							},
+							Limits: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("150m"),
+								v1.ResourceMemory: resource.MustParse("300Mi"),
+							},
+						},
+					},
+				},
+				{
+					{
+						Name: "c1",
+						Resources: v1.ResourceRequirements{
+							Requests: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("200m"),
+								v1.ResourceMemory: resource.MustParse("400Mi"),
+							},
+							Limits: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("200m"),
+								v1.ResourceMemory: resource.MustParse("400Mi"),
+							},
+						},
+					},
+				},
+			},
+			intervals: []time.Duration{1 * time.Second},
+			expected: [][]e2epod.ResizableContainerInfo{
+				{},
+				{{
+					Name:         "c1",
+					Resources:    &e2epod.ContainerResources{CPUReq: "200m", CPULim: "200m", MemReq: "400Mi", MemLim: "400Mi"},
+					CPUPolicy:    &noRestart,
+					MemPolicy:    &noRestart,
+					RestartCount: 0,
+				}},
+			},
+		},
+		{
+			isSynchronous: false,
+			name:          "Resize with restarting, then resize without restarting asynchronously",
+			containers: []e2epod.ResizableContainerInfo{
+				{
+					Name:      "c1",
+					Resources: &e2epod.ContainerResources{CPUReq: "100m", CPULim: "100m", MemReq: "200Mi", MemLim: "200Mi"},
+					CPUPolicy: &doRestart,
+					MemPolicy: &noRestart,
+				},
+			},
+			containerPatches: [][]v1.Container{
+				{
+					{
+						Name: "c1",
+						Resources: v1.ResourceRequirements{
+							Requests: v1.ResourceList{
+								v1.ResourceCPU: resource.MustParse("150m"),
+							},
+							Limits: v1.ResourceList{
+								v1.ResourceCPU: resource.MustParse("150m"),
+							},
+						},
+					},
+				},
+				{
+					{
+						Name: "c1",
+						Resources: v1.ResourceRequirements{
+							Requests: v1.ResourceList{
+								v1.ResourceMemory: resource.MustParse("400Mi"),
+							},
+							Limits: v1.ResourceList{
+								v1.ResourceMemory: resource.MustParse("400Mi"),
+							},
+						},
+					},
+				},
+			},
+			intervals: []time.Duration{1 * time.Second},
+			expected: [][]e2epod.ResizableContainerInfo{
+				{},
+				{{
+					Name:         "c1",
+					Resources:    &e2epod.ContainerResources{CPUReq: "150m", CPULim: "150m", MemReq: "400Mi", MemLim: "400Mi"},
+					CPUPolicy:    &doRestart,
+					MemPolicy:    &noRestart,
+					RestartCount: 1,
+				}},
+			},
+		},
+		{
+			isSynchronous: false,
+			name:          "Resize without restarting, then resize with restarting asynchronously",
+			containers: []e2epod.ResizableContainerInfo{
+				{
+					Name:      "c1",
+					Resources: &e2epod.ContainerResources{CPUReq: "100m", CPULim: "100m", MemReq: "200Mi", MemLim: "200Mi"},
+					CPUPolicy: &noRestart,
+					MemPolicy: &doRestart,
+				},
+			},
+			containerPatches: [][]v1.Container{
+				{
+					{
+						Name: "c1",
+						Resources: v1.ResourceRequirements{
+							Requests: v1.ResourceList{
+								v1.ResourceCPU: resource.MustParse("150m"),
+							},
+							Limits: v1.ResourceList{
+								v1.ResourceCPU: resource.MustParse("150m"),
+							},
+						},
+					},
+				},
+				{
+					{
+						Name: "c1",
+						Resources: v1.ResourceRequirements{
+							Requests: v1.ResourceList{
+								v1.ResourceMemory: resource.MustParse("400Mi"),
+							},
+							Limits: v1.ResourceList{
+								v1.ResourceMemory: resource.MustParse("400Mi"),
+							},
+						},
+					},
+				},
+			},
+			intervals: []time.Duration{1 * time.Second},
+			expected: [][]e2epod.ResizableContainerInfo{
+				{},
+				{{
+					Name:         "c1",
+					Resources:    &e2epod.ContainerResources{CPUReq: "150m", CPULim: "150m", MemReq: "400Mi", MemLim: "400Mi"},
+					CPUPolicy:    &noRestart,
+					MemPolicy:    &doRestart,
+					RestartCount: 1,
+				}},
+			},
+		},
+		{
+			isSynchronous: false,
+			name:          "Resize only limits with restarting twice asynchronously",
+			containers: []e2epod.ResizableContainerInfo{
+				{
+					Name:      "c1",
+					Resources: &e2epod.ContainerResources{CPUReq: "100m", CPULim: "200m", MemReq: "200Mi", MemLim: "300Mi"},
+					CPUPolicy: &doRestart,
+					MemPolicy: &noRestart,
+				},
+			},
+			containerPatches: [][]v1.Container{
+				{
+					{
+						Name: "c1",
+						Resources: v1.ResourceRequirements{
+							Limits: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("250m"),
+								v1.ResourceMemory: resource.MustParse("350Mi"),
+							},
+						},
+					},
+				},
+				{
+					{
+						Name: "c1",
+						Resources: v1.ResourceRequirements{
+							Limits: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("300m"),
+								v1.ResourceMemory: resource.MustParse("400Mi"),
+							},
+						},
+					},
+				},
+			},
+			intervals: []time.Duration{1 * time.Second},
+			expected: [][]e2epod.ResizableContainerInfo{
+				{},
+				{{
+					Name:         "c1",
+					Resources:    &e2epod.ContainerResources{CPUReq: "100m", CPULim: "300m", MemReq: "200Mi", MemLim: "400Mi"},
+					CPUPolicy:    &doRestart,
+					MemPolicy:    &noRestart,
+					RestartCount: 2,
+				}},
+			},
+		},
+		{
+			isSynchronous: false,
+			name:          "Resize only requests with restarting twice asynchronously",
+			containers: []e2epod.ResizableContainerInfo{
+				{
+					Name:      "c1",
+					Resources: &e2epod.ContainerResources{CPUReq: "100m", CPULim: "300m", MemReq: "200Mi", MemLim: "400Mi"},
+					CPUPolicy: &doRestart,
+					MemPolicy: &noRestart,
+				},
+			},
+			containerPatches: [][]v1.Container{
+				{
+					{
+						Name: "c1",
+						Resources: v1.ResourceRequirements{
+							Requests: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("150m"),
+								v1.ResourceMemory: resource.MustParse("250Mi"),
+							},
+						},
+					},
+				},
+				{
+					{
+						Name: "c1",
+						Resources: v1.ResourceRequirements{
+							Requests: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("200m"),
+								v1.ResourceMemory: resource.MustParse("300Mi"),
+							},
+						},
+					},
+				},
+			},
+			intervals: []time.Duration{1 * time.Second},
+			expected: [][]e2epod.ResizableContainerInfo{
+				{},
+				{{
+					Name:         "c1",
+					Resources:    &e2epod.ContainerResources{CPUReq: "200m", CPULim: "300m", MemReq: "300Mi", MemLim: "400Mi"},
+					CPUPolicy:    &doRestart,
+					MemPolicy:    &noRestart,
+					RestartCount: 2,
+				}},
+			},
+		},
+		{
+			isSynchronous: false,
+			name:          "Resize only limits without restarting twice asynchronously",
+			containers: []e2epod.ResizableContainerInfo{
+				{
+					Name:      "c1",
+					Resources: &e2epod.ContainerResources{CPUReq: "100m", CPULim: "200m", MemReq: "200Mi", MemLim: "300Mi"},
+					CPUPolicy: &noRestart,
+					MemPolicy: &noRestart,
+				},
+			},
+			containerPatches: [][]v1.Container{
+				{
+					{
+						Name: "c1",
+						Resources: v1.ResourceRequirements{
+							Limits: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("250m"),
+								v1.ResourceMemory: resource.MustParse("350Mi"),
+							},
+						},
+					},
+				},
+				{
+					{
+						Name: "c1",
+						Resources: v1.ResourceRequirements{
+							Limits: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("300m"),
+								v1.ResourceMemory: resource.MustParse("400Mi"),
+							},
+						},
+					},
+				},
+			},
+			intervals: []time.Duration{1 * time.Second},
+			expected: [][]e2epod.ResizableContainerInfo{
+				{},
+				{{
+					Name:         "c1",
+					Resources:    &e2epod.ContainerResources{CPUReq: "100m", CPULim: "300m", MemReq: "200Mi", MemLim: "400Mi"},
+					CPUPolicy:    &noRestart,
+					MemPolicy:    &noRestart,
+					RestartCount: 0,
+				}},
+			},
+		},
+		{
+			isSynchronous: false,
+			name:          "Resize only requests without restarting twice asynchronously",
+			containers: []e2epod.ResizableContainerInfo{
+				{
+					Name:      "c1",
+					Resources: &e2epod.ContainerResources{CPUReq: "100m", CPULim: "300m", MemReq: "200Mi", MemLim: "400Mi"},
+					CPUPolicy: &noRestart,
+					MemPolicy: &noRestart,
+				},
+			},
+			containerPatches: [][]v1.Container{
+				{
+					{
+						Name: "c1",
+						Resources: v1.ResourceRequirements{
+							Requests: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("150m"),
+								v1.ResourceMemory: resource.MustParse("250Mi"),
+							},
+						},
+					},
+				},
+				{
+					{
+						Name: "c1",
+						Resources: v1.ResourceRequirements{
+							Requests: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("200m"),
+								v1.ResourceMemory: resource.MustParse("300Mi"),
+							},
+						},
+					},
+				},
+			},
+			intervals: []time.Duration{1 * time.Second},
+			expected: [][]e2epod.ResizableContainerInfo{
+				{},
+				{{
+					Name:         "c1",
+					Resources:    &e2epod.ContainerResources{CPUReq: "200m", CPULim: "300m", MemReq: "300Mi", MemLim: "400Mi"},
+					CPUPolicy:    &noRestart,
+					MemPolicy:    &noRestart,
+					RestartCount: 0,
+				}},
+			},
+		},
+	}
+
+	timeouts := framework.NewTimeoutContext()
+
+	for idx := range tests {
+		tc := tests[idx]
+		ginkgo.It(tc.name, func(ctx context.Context) {
+			var testPod, patchedPod *v1.Pod
+			var pErr error
+
+			tStamp := strconv.Itoa(time.Now().Nanosecond())
+			e2epod.InitDefaultResizePolicy(tc.containers)
+			for _, e := range tc.expected {
+				if len(e) > 0 {
+					e2epod.InitDefaultResizePolicy(e)
+				}
+			}
+			testPod = e2epod.MakePodWithResizableContainers(f.Namespace.Name, "testpod", tStamp, tc.containers)
+			testPod = e2epod.MustMixinRestrictedPodSecurity(testPod)
+
+			ginkgo.By("creating pod")
+			newPod := podClient.CreateSync(ctx, testPod)
+
+			ginkgo.By("verifying initial pod resources, allocations are as expected")
+			e2epod.VerifyPodResources(newPod, tc.containers)
+			ginkgo.By("verifying initial pod resize policy is as expected")
+			e2epod.VerifyPodResizePolicy(newPod, tc.containers)
+
+			err := e2epod.WaitForPodCondition(ctx, f.ClientSet, newPod.Namespace, newPod.Name, "Ready", timeouts.PodStartShort, testutils.PodRunningReady)
+			framework.ExpectNoError(err, "pod %s/%s did not go running", newPod.Namespace, newPod.Name)
+			framework.Logf("pod %s/%s running", newPod.Namespace, newPod.Name)
+
+			ginkgo.By("verifying initial pod status resources")
+			e2epod.VerifyPodStatusResources(newPod, tc.containers)
+
+			for i, p := range tc.containerPatches {
+				ginkgo.By("patching pod for resize")
+				patch, err := json.Marshal(v1.Pod{Spec: v1.PodSpec{Containers: p}})
+				framework.ExpectNoError(err, "failed to marshal patch")
+				patchedPod, pErr = f.ClientSet.CoreV1().Pods(newPod.Namespace).Patch(ctx, newPod.Name,
+					types.StrategicMergePatchType, patch, metav1.PatchOptions{})
+				framework.ExpectNoError(pErr, "failed to patch pod for resize")
+
+				last := i == len(tc.containerPatches)-1
+				if !tc.isSynchronous && !last {
+					time.Sleep(tc.intervals[i])
+					continue
+				}
+
+				ginkgo.By("verifying pod patched for resize")
+				e2epod.VerifyPodResources(patchedPod, tc.expected[i])
+				if i == 0 {
+					err = e2epod.VerifyPodAllocations(patchedPod, tc.containers)
+				} else if tc.isSynchronous {
+					err = e2epod.VerifyPodAllocations(patchedPod, tc.expected[i-1])
+				}
+				framework.ExpectNoError(err, "failed to verify Pod allocations for patchedPod")
+
+				ginkgo.By("waiting for resize to be actuated")
+				resizedPod := e2epod.WaitForPodResizeActuation(ctx, f, podClient, newPod, patchedPod, tc.expected[i], nil, false)
+
+				ginkgo.By("verifying pod resources after resize")
+				e2epod.VerifyPodResources(resizedPod, tc.expected[i])
+
+				ginkgo.By("verifying pod allocations after resize")
+				err = e2epod.VerifyPodAllocations(resizedPod, tc.expected[i])
+				framework.ExpectNoError(err, "failed to verify Pod allocations for resizedPod")
+
+				if !last {
+					time.Sleep(tc.intervals[i])
+				}
+			}
+
+			ginkgo.By("deleting pod")
+			podClient.DeleteSync(ctx, newPod.Name, metav1.DeleteOptions{}, timeouts.PodDelete)
+		})
+	}
+}
+
 // NOTE: Pod resize scheduler resource quota tests are out of scope in e2e_node tests,
 //       because in e2e_node tests
 //          a) scheduler and controller manager is not running by the Node e2e
@@ -1033,4 +1593,5 @@ var _ = SIGDescribe("Pod InPlace Resize Container", framework.WithSerial(), feat
 
 	doPodResizeTests(f)
 	doPodResizeErrorTests(f)
+	doConsecutivePodResizeTests(f)
 })

--- a/test/e2e/framework/pod/resize.go
+++ b/test/e2e/framework/pod/resize.go
@@ -370,7 +370,11 @@ func VerifyPodContainersCgroupValues(ctx context.Context, f *framework.Framework
 
 func waitForContainerRestart(ctx context.Context, podClient *PodClient, pod *v1.Pod, expectedContainers []ResizableContainerInfo, initialContainers []ResizableContainerInfo, isRollback bool) error {
 	ginkgo.GinkgoHelper()
-	var restartContainersExpected []string
+	type restartExpectation struct {
+		cName        string
+		restartCount int32
+	}
+	var restartContainersExpected []restartExpectation
 
 	restartContainers := expectedContainers
 	// if we're rolling back, extract restart counts from test case "expected" containers
@@ -380,7 +384,7 @@ func waitForContainerRestart(ctx context.Context, podClient *PodClient, pod *v1.
 
 	for _, ci := range restartContainers {
 		if ci.RestartCount > 0 {
-			restartContainersExpected = append(restartContainersExpected, ci.Name)
+			restartContainersExpected = append(restartContainersExpected, restartExpectation{cName: ci.Name, restartCount: ci.RestartCount})
 		}
 	}
 	if len(restartContainersExpected) == 0 {
@@ -392,9 +396,9 @@ func waitForContainerRestart(ctx context.Context, podClient *PodClient, pod *v1.
 		return err
 	}
 	restartedContainersCount := 0
-	for _, cName := range restartContainersExpected {
-		cs, _ := podutil.GetContainerStatus(pod.Status.ContainerStatuses, cName)
-		if cs.RestartCount < 1 {
+	for _, expect := range restartContainersExpected {
+		cs, _ := podutil.GetContainerStatus(pod.Status.ContainerStatuses, expect.cName)
+		if cs.RestartCount < expect.restartCount {
 			break
 		}
 		restartedContainersCount++

--- a/test/e2e/framework/pod/resize.go
+++ b/test/e2e/framework/pod/resize.go
@@ -175,7 +175,7 @@ func InitDefaultResizePolicy(containers []ResizableContainerInfo) {
 }
 
 func makeResizableContainer(tcInfo ResizableContainerInfo) (v1.Container, v1.ContainerStatus) {
-	cmd := "grep Cpus_allowed_list /proc/self/status | cut -f2 && sleep 1d"
+	cmd := "trap exit TERM; grep Cpus_allowed_list /proc/self/status | cut -f2 && sleep 1d"
 	res, alloc, resizePol := getTestResourceInfo(tcInfo)
 
 	tc := v1.Container{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:
In order to solve a couple of problems caused by requesting pod resizing consecutively, this PR uses the latest pod status at the following work in resizing:
- Update pod status
  If resource requests are requested to be updated, `allocatedResources` and `resize` in the pod status is updated. This update should base on the latest status. Otherwise, the pod status will be overwritten with an outdated status in `pod`.
- Compute pod resize actions
  `computePodResizeAction()` refers to the status in `pod` which is replaced in `handlePodResourcesResize()`. In order to determine actions based on the latest status, the pod status should be updated with the latest status.

`apiPodStatus`, which is copied to `pod.Status`, is generated from the latest pod status that a pod worker gets from the PLEG cache.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #125205

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed a bug that it takes one more minute when a pod with the RestartContainer resize policy is requested to be resized a couple of times quickly. Also fixed a bug that a pod status is sometimes regressed to outdated information in the same case.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
