### PR TITLE
Reduce apiserver lease duration and GC interval to 20s

### DIFF
--- a/pkg/controlplane/apiserver/server.go
+++ b/pkg/controlplane/apiserver/server.go
@@ -52,10 +52,10 @@ import (
 var (
 	// IdentityLeaseGCPeriod is the interval which the lease GC controller checks for expired leases
 	// IdentityLeaseGCPeriod is exposed so integration tests can tune this value.
-	IdentityLeaseGCPeriod = 3600 * time.Second
+	IdentityLeaseGCPeriod = 20 * time.Second
 	// IdentityLeaseDurationSeconds is the duration of kube-apiserver lease in seconds
 	// IdentityLeaseDurationSeconds is exposed so integration tests can tune this value.
-	IdentityLeaseDurationSeconds = 3600
+	IdentityLeaseDurationSeconds = 20
 	// IdentityLeaseRenewIntervalPeriod is the interval of kube-apiserver renewing its lease in seconds
 	// IdentityLeaseRenewIntervalPeriod is exposed so integration tests can tune this value.
 	IdentityLeaseRenewIntervalPeriod = 10 * time.Second

--- a/test/integration/apiserver/peerproxy/peer_proxy_test.go
+++ b/test/integration/apiserver/peerproxy/peer_proxy_test.go
@@ -146,7 +146,7 @@ func TestPeerProxiedRequestToThirdServerAfterFirstDies(t *testing.T) {
 	setupStorageVersionGC(ctx, kubeClientSetA, informersA)
 	// reset lease duration to default value for serverB and serverC since we will not be
 	// shutting these down
-	controlplaneapiserver.IdentityLeaseDurationSeconds = 3600
+	controlplaneapiserver.IdentityLeaseDurationSeconds = 20
 
 	// start serverB with some api disabled
 	// override hostname to ensure unique ips


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
Reduces apiserver lease duration and garbage collection interval from 1 hour to 20 seconds (twice the lease renewal interval). This allows for faster detection of whether an apiserver is unhealthy, as its lease will expire much more quickly if it is not being actively renewed.

Allows other services to use apiserver leases as a reliable way of determining the number of available apiservers. Current specific use-case is for [konnectivity-network-proxy](https://github.com/carreter/apiserver-network-proxy/) agents to dynamically determine the number of k8s apiservers (and thus proxy servers assuming a 1:1 apiserver:proxy server mapping, which is usually the case). See this [issue](https://github.com/kubernetes-sigs/apiserver-network-proxy/issues/273) and this [design doc](https://docs.google.com/document/d/16G8U-QWR4tNfY2jiOk-ZUEMVwBkq9R9iXZqXrxPsGOE/edit#heading=h.ymlc40jj6ff0) for more information.


#### Which issue(s) this PR fixes:
N/A

#### Special notes for your reviewer:
N/A

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KNP dynamic proxy server count scaling design doc]: https://docs.google.com/document/d/16G8U-QWR4tNfY2jiOk-ZUEMVwBkq9R9iXZqXrxPsGOE/edit#heading=h.ymlc40jj6ff0
```
