### PR TITLE
e2e framework: don't add default skip when --label-filter is used

### DIFF
--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -399,7 +399,7 @@ func CreateGinkgoConfig() (types.SuiteConfig, types.ReporterConfig) {
 	// Randomize specs as well as suites
 	suiteConfig.RandomizeAllSpecs = true
 	// Disable skipped tests unless they are explicitly requested.
-	if len(suiteConfig.FocusStrings) == 0 && len(suiteConfig.SkipStrings) == 0 {
+	if len(suiteConfig.FocusStrings) == 0 && len(suiteConfig.SkipStrings) == 0 && suiteConfig.LabelFilter == "" {
 		suiteConfig.SkipStrings = []string{`\[Flaky\]|\[Feature:.+\]`}
 	}
 	return suiteConfig, reporterConfig


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The new pull-kubernetes-kind-dra uses

     -label-filter='Feature: containsAny DynamicResourceAllocation && !Flaky && !Serial'

to run DRA tests. That didn't work because the E2E framework behind its back added the default skip expression.

Same for some other node tests.

#### Which issue(s) this PR fixes:

Fixes:  https://github.com/kubernetes/kubernetes/issues/125950

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
