### PR TITLE
KEP-4633: Add intgration tests for Anonymous Auth Configurable Endpoints

### DIFF
--- a/test/integration/apiserver/anonymous/anonymous_test.go
+++ b/test/integration/apiserver/anonymous/anonymous_test.go
@@ -1,0 +1,241 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package anonymous
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apiserver/pkg/features"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/client-go/kubernetes"
+	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	kubeapiserverapptesting "k8s.io/kubernetes/cmd/kube-apiserver/app/testing"
+	"k8s.io/kubernetes/pkg/apis/rbac"
+	"k8s.io/kubernetes/test/integration/authutil"
+	"k8s.io/kubernetes/test/integration/framework"
+)
+
+const (
+	defaultNamespace           = "default"
+	defaultRBACRoleName        = "developer-role"
+	defaultRBACRoleBindingName = "developer-role-binding"
+	anonymousUser              = "system:anonymous"
+)
+
+var (
+	defaultRole = &rbacv1.Role{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "Role"},
+		ObjectMeta: metav1.ObjectMeta{Name: defaultRBACRoleName, Namespace: defaultNamespace},
+		Rules: []rbacv1.PolicyRule{
+			{
+				Verbs:     []string{"list"},
+				Resources: []string{"pods"},
+				APIGroups: []string{""},
+			},
+		},
+	}
+	defaultRoleBinding = &rbacv1.RoleBinding{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "RoleBinding"},
+		ObjectMeta: metav1.ObjectMeta{Name: defaultRBACRoleBindingName, Namespace: defaultNamespace},
+		Subjects: []rbacv1.Subject{
+			{
+				APIGroup: rbac.GroupName,
+				Kind:     rbacv1.UserKind,
+				Name:     anonymousUser,
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: rbac.GroupName,
+			Kind:     "Role",
+			Name:     defaultRBACRoleName,
+		},
+	}
+)
+
+func TestStructuredAuthenticationConfig(t *testing.T) {
+	t.Log("Testing anonymous authenticator with authentication config")
+
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.StructuredAuthenticationConfiguration, true)
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.AnonymousAuthConfigurableEndpoints, true)
+
+	testCases := []struct {
+		desc            string
+		authConfig      string
+		additionalFlags []string
+		assertErrFn     func(t *testing.T, errorToCheck error)
+		assertFn        func(t *testing.T, server kubeapiserverapptesting.TestServer)
+	}{
+		{
+			desc: "valid config no conditions",
+			authConfig: `
+apiVersion: apiserver.config.k8s.io/v1beta1
+kind: AuthenticationConfiguration
+anonymous:
+  enabled: true
+`,
+			assertErrFn: func(t *testing.T, errorToCheck error) {
+				require.NoError(t, errorToCheck)
+			},
+			assertFn: func(t *testing.T, server kubeapiserverapptesting.TestServer) {
+				configureRBAC(t, server)
+
+				client := insecureHTTPClient(t)
+
+				resp, err := client.Get(server.ClientConfig.Host + "/api/v1/namespaces/default/pods")
+				require.NoError(t, err)
+				defer resp.Body.Close() //nolint:errcheck
+				require.Equal(t, 200, resp.StatusCode)
+
+				resp, err = client.Get(server.ClientConfig.Host + "/livez")
+				require.NoError(t, err)
+				defer resp.Body.Close() //nolint:errcheck
+				require.Equal(t, 200, resp.StatusCode)
+
+				resp, err = client.Get(server.ClientConfig.Host + "/healthz")
+				require.NoError(t, err)
+				defer resp.Body.Close() //nolint:errcheck
+				require.Equal(t, 200, resp.StatusCode)
+
+			},
+			additionalFlags: nil,
+		},
+		{
+			desc: "valid config with conditions",
+			authConfig: `
+apiVersion: apiserver.config.k8s.io/v1beta1
+kind: AuthenticationConfiguration
+anonymous:
+  enabled: true
+  conditions:
+  - path: "/livez"
+`,
+			assertErrFn: func(t *testing.T, errorToCheck error) {
+				require.NoError(t, errorToCheck)
+			},
+			assertFn: func(t *testing.T, server kubeapiserverapptesting.TestServer) {
+				client := insecureHTTPClient(t)
+
+				resp, err := client.Get(server.ClientConfig.Host + "/api/v1/namespaces/default/pods")
+				require.NoError(t, err)
+				defer resp.Body.Close() //nolint:errcheck
+				require.Equal(t, 401, resp.StatusCode)
+
+				resp, err = client.Get(server.ClientConfig.Host + "/livez")
+				require.NoError(t, err)
+				defer resp.Body.Close() //nolint:errcheck
+				require.Equal(t, 200, resp.StatusCode)
+
+				resp, err = client.Get(server.ClientConfig.Host + "/healthz")
+				require.NoError(t, err)
+				defer resp.Body.Close() //nolint:errcheck
+				require.Equal(t, 401, resp.StatusCode)
+
+			},
+			additionalFlags: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			flags := []string{"--authorization-mode=RBAC"}
+			flags = append(flags, fmt.Sprintf("--authentication-config=%s", writeTempFile(t, tc.authConfig)))
+			flags = append(flags, tc.additionalFlags...)
+
+			server, err := kubeapiserverapptesting.StartTestServer(
+				t,
+				kubeapiserverapptesting.NewDefaultTestServerOptions(),
+				flags,
+				framework.SharedEtcd(),
+			)
+
+			tc.assertErrFn(t, err)
+
+			if tc.assertFn == nil {
+				return
+			}
+
+			defer server.TearDownFn()
+
+			tc.assertFn(t, server)
+		})
+	}
+}
+
+func TestMain(m *testing.M) {
+	framework.EtcdMain(m.Run)
+}
+
+func writeTempFile(t *testing.T, content string) string {
+	t.Helper()
+	file, err := os.CreateTemp("", "anonymous-auth-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := os.Remove(file.Name()); err != nil {
+			t.Fatal(err)
+		}
+	})
+	if err := os.WriteFile(file.Name(), []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+	return file.Name()
+}
+
+func configureRBAC(t *testing.T, server kubeapiserverapptesting.TestServer) {
+	t.Helper()
+
+	kc := kubernetes.NewForConfigOrDie(server.ClientConfig)
+
+	_, err := kc.RbacV1().Roles(defaultNamespace).Create(context.Background(), defaultRole, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	_, err = kc.RbacV1().RoleBindings(defaultNamespace).Create(context.Background(), defaultRoleBinding, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	authutil.WaitForNamedAuthorizationUpdate(
+		t,
+		context.Background(),
+		kc.AuthorizationV1(),
+		anonymousUser,
+		defaultNamespace, // namespace
+		"list",
+		"", // resource name
+		schema.GroupResource{Group: "", Resource: "pods"},
+		true,
+	)
+}
+
+func insecureHTTPClient(t *testing.T) *http.Client {
+	t.Helper()
+
+	return &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+	}
+}


### PR DESCRIPTION
…nts.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it: 

Adds integration tests for the KEP-4633.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
N/A
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: 
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/4633
```
