### PR TITLE
Add jpbetz to apimachinery OWNERS

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/OWNERS
+++ b/staging/src/k8s.io/apimachinery/pkg/OWNERS
@@ -5,5 +5,6 @@ approvers:
   - deads2k
   - smarterclayton
   - liggitt
+  - jpbetz
 emeritus_approvers:
   - lavalamp


### PR DESCRIPTION
Looks like I missed this one when adding myself to SIG TL OWNERS files.

/kind cleanup

/assign @deads2k

```release-note
NONE
```
