### PR TITLE
Automated cherry pick of #124531: gitRepo volume: directory must be max 1 level deep

### DIFF
--- a/pkg/volume/git_repo/git_repo.go
+++ b/pkg/volume/git_repo/git_repo.go
@@ -261,6 +261,12 @@ func validateVolume(src *v1.GitRepoVolumeSource) error {
 	if err := validateNonFlagArgument(src.Directory, "directory"); err != nil {
 		return err
 	}
+	if (src.Revision != "") && (src.Directory != "") {
+		cleanedDir := filepath.Clean(src.Directory)
+		if strings.Contains(cleanedDir, "/") || (strings.Contains(cleanedDir, "\\")) {
+			return fmt.Errorf("%q is not a valid directory, it must not contain a directory separator", src.Directory)
+		}
+	}
 	return nil
 }
 

--- a/pkg/volume/git_repo/git_repo_test.go
+++ b/pkg/volume/git_repo/git_repo_test.go
@@ -267,6 +267,20 @@ func TestPlugin(t *testing.T) {
 			},
 			isExpectedFailure: true,
 		},
+		{
+			name: "invalid-revision-directory-combo",
+			vol: &v1.Volume{
+				Name: "vol1",
+				VolumeSource: v1.VolumeSource{
+					GitRepo: &v1.GitRepoVolumeSource{
+						Repository: gitURL,
+						Revision:   "main",
+						Directory:  "foo/bar",
+					},
+				},
+			},
+			isExpectedFailure: true,
+		},
 	}
 
 	for _, scenario := range scenarios {


### PR DESCRIPTION
Cherry pick of #124531 on release-1.30.

#124531: gitRepo volume: directory must be max 1 level deep

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```