### PR TITLE
fix panic when watching ReplicationController with Bookmark enabled

### DIFF
--- a/pkg/printers/internalversion/printers.go
+++ b/pkg/printers/internalversion/printers.go
@@ -1126,7 +1126,11 @@ func printReplicationController(obj *api.ReplicationController, options printers
 
 	row.Cells = append(row.Cells, obj.Name, int64(desiredReplicas), int64(currentReplicas), int64(readyReplicas), translateTimestampSince(obj.CreationTimestamp))
 	if options.Wide {
-		names, images := layoutContainerCells(obj.Spec.Template.Spec.Containers)
+		var containers []api.Container
+		if obj.Spec.Template != nil {
+			containers = obj.Spec.Template.Spec.Containers
+		}
+		names, images := layoutContainerCells(containers)
 		row.Cells = append(row.Cells, names, images, labels.FormatLabels(obj.Spec.Selector))
 	}
 	return []metav1.TableRow{row}, nil

--- a/pkg/printers/internalversion/printers_test.go
+++ b/pkg/printers/internalversion/printers_test.go
@@ -4666,6 +4666,19 @@ func TestPrintReplicationController(t *testing.T) {
 			// Columns: Name, Desired, Current, Ready, Age, Containers, Images, Selector
 			expected: []metav1.TableRow{{Cells: []interface{}{"rc1", int64(5), int64(3), int64(1), "<unknown>", "test", "test_image", "a=b"}}},
 		},
+		{
+			// make sure Bookmark event will not lead a panic
+			rc: api.ReplicationController{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						metav1.InitialEventsAnnotationKey: "true",
+					},
+				},
+			},
+			options: printers.GenerateOptions{Wide: true},
+			// Columns: Name, Desired, Current, Ready, Age, Containers, Images, Selector
+			expected: []metav1.TableRow{{Cells: []interface{}{"", int64(0), int64(0), int64(0), "<unknown>", "", "", "<none>"}}},
+		},
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug 

#### What this PR does / why we need it:
when performing a `Table` Watching request with `allowWatchBookmarks` enabled, `kube-apiserver` could panic and close the watch stream.

we can reproduce this issue by:
```
# open a local http port without auth
kubectl proxy &

# perform request via cURL
curl 'http://localhost:8001/api/v1/replicationcontrollers?watch=true&allowWatchBookmarks=true' -H 'Accept: application/json;as=Table;v=v1;g=meta.k8s.io,application/json;as=Table;v=v1beta1;g=meta.k8s.io,application/json'

# wait a few seconds, below information should be returned.
2024/07/10 12:17:01 httputil: ReverseProxy read error during body copy: stream error: stream ID 1; INTERNAL_ERROR; received from peer
curl: (18) transfer closed with outstanding read data remaining
```

Panic log could be found in kube-apiserver:
<details>

<summary>Panic Log</summary>

```
E0709 09:47:34.549967       1 runtime.go:79] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
goroutine 12074030 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic({0x277c340, 0x4dd78a0})
	k8s.io/apimachinery/pkg/util/runtime/runtime.go:75 +0x7c
k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x4006b3c000, 0x1, 0x40057fe700?})
	k8s.io/apimachinery/pkg/util/runtime/runtime.go:49 +0x78
panic({0x277c340?, 0x4dd78a0?})
	runtime/panic.go:770 +0x124
k8s.io/kubernetes/pkg/printers/internalversion.printReplicationController(0x4007b82840, {0x5?, 0x0?})
	k8s.io/kubernetes/pkg/printers/internalversion/printers.go:1127 +0x1e4
reflect.Value.call({0x2768f20?, 0x2e46cf0?, 0x13?}, {0x2c20ae1, 0x4}, {0x4006b3cb18, 0x2, 0x2?})
	reflect/value.go:596 +0x970
reflect.Value.Call({0x2768f20?, 0x2e46cf0?, 0x4009a04b58?}, {0x4009a04b18?, 0x40012fc620?, 0x32e1418?})
	reflect/value.go:380 +0x94
k8s.io/kubernetes/pkg/printers.(*HumanReadableGenerator).GenerateTable(0x0?, {0x32c2bb8, 0x4007b82840}, {0x0, 0x1})
	k8s.io/kubernetes/pkg/printers/tablegenerator.go:86 +0x1b8
k8s.io/kubernetes/pkg/printers/storage.TableConvertor.ConvertToTable({{0x32b7ea0?, 0x400066ce30?}}, {0x1b?, 0x20?}, {0x32c2bb8?, 0x4007b82840?}, {0x32bc360?, 0x400a190c40?})
	k8s.io/kubernetes/pkg/printers/storage/storage.go:46 +0xd8
k8s.io/apiserver/pkg/registry/generic/registry.(*Store).ConvertToTable(0x0?, {0x32e1798?, 0x4007c84f00?}, {0x32c2bb8?, 0x4007b82840?}, {0x32bc360?, 0x400a190c40?})
	k8s.io/apiserver/pkg/registry/generic/registry/store.go:1644 +0x44
k8s.io/apiserver/pkg/endpoints/handlers.asTable({0x32e1798, 0x4007c84f00}, {0x32c2bb8, 0x4007b82840}, 0x400a190c40, 0x400199e1a0, {{0x400976d591, 0xb}, {0x400976d58c, 0x2}})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:375 +0x17c
k8s.io/apiserver/pkg/endpoints/handlers.doTransformObject({0x32e1798, 0x4007c84f00}, {0x32c2bb8, 0x4007b82840}, {0x2b43c00, 0x400a190c40}, 0x4007c852c0, 0x400199e1a0)
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:270 +0x188
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEmbeddedEncoder).doEncode(0x400a9f3a90, {0x32c2bb8, 0x4007b82840}, {0xffff66499918, 0x400843d520})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:82 +0x68
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEmbeddedEncoder).Encode(0x400a9f3a90, {0x32c2bb8?, 0x4007b82840}, {0xffff66499918, 0x400843d520})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:78 +0x114
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).doEncode(0x4006676f20, {0x32c2bb8, 0x4007b82840}, {{0x2c27806?, 0x4009a05278?}, {0x32c2bb8?, 0x4007b82840?}}, {0xffff664f8b18, 0x40081deba0})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:186 +0xd4
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).Encode.func1(...)
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:175
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).Encode(0x4006676f20, {{0x2c27806?, 0x32c2bb8?}, {0x32c2bb8?, 0x4007b82840?}})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:180 +0x140
k8s.io/apiserver/pkg/endpoints/handlers.(*WatchServer).HandleHTTP(0x4008210a00, {0x32d0800, 0x40081deba0}, 0x40088d1440)
	k8s.io/apiserver/pkg/endpoints/handlers/watch.go:249 +0x944
net/http.HandlerFunc.ServeHTTP(0x4009a05678?, {0x32d0800?, 0x40081deba0?}, 0x400a59ccb0?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/endpoints/handlers.ListResource.func1.4.1()
	k8s.io/apiserver/pkg/endpoints/handlers/get.go:283 +0x74
k8s.io/apiserver/pkg/endpoints/metrics.RecordLongRunning(0x40088d1440, 0x25d7aa0?, {0x2c282c0, 0x9}, 0x4009a05870)
	k8s.io/apiserver/pkg/endpoints/metrics/metrics.go:528 +0x494
k8s.io/apiserver/pkg/endpoints/handlers.ListResource.func1.4()
	k8s.io/apiserver/pkg/endpoints/handlers/get.go:281 +0x10c
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRoutine.func17({0x32d0590, 0x400052bd88}, 0x40088d0b40)
	k8s.io/apiserver/pkg/server/filters/routine.go:73 +0x190
net/http.HandlerFunc.ServeHTTP(0x40088d0a20?, {0x32d0590?, 0x400052bd88?}, 0x4000582008?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRequestInfo.func18({0x32d0590, 0x400052bd88}, 0x40088d0a20)
	k8s.io/apiserver/pkg/endpoints/filters/requestinfo.go:39 +0x104
net/http.HandlerFunc.ServeHTTP(0x40088d0900?, {0x32d0590?, 0x400052bd88?}, 0x583f2895be0d?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRequestReceivedTimestamp.withRequestReceivedTimestampWithClock.func32({0x32d0590, 0x400052bd88}, 0x40088d0900)
	k8s.io/apiserver/pkg/endpoints/filters/request_received_time.go:38 +0xac
net/http.HandlerFunc.ServeHTTP(0x4007626af8?, {0x32d0590?, 0x400052bd88?}, 0xffff66237dc8?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithMuxAndDiscoveryComplete.func19({0x32d0590?, 0x400052bd88?}, 0x40088d0900?)
	k8s.io/apiserver/pkg/endpoints/filters/mux_discovery_complete.go:52 +0xd0
net/http.HandlerFunc.ServeHTTP(0x4008b67401?, {0x32d0590?, 0x400052bd88?}, 0xe3634c89f3dc954a?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithPanicRecovery.withPanicRecovery.func33({0x32d0590?, 0x400052bd88?}, 0x4008b67410?)
	k8s.io/apiserver/pkg/server/filters/wrap.go:74 +0x9c
net/http.HandlerFunc.ServeHTTP(0x4007c84a50?, {0x32d0590?, 0x400052bd88?}, 0x4008228ae0?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithAuditInit.withAuditInit.func34({0x32d0590, 0x400052bd88}, 0x40088d07e0)
	k8s.io/apiserver/pkg/endpoints/filters/audit_init.go:63 +0x110
net/http.HandlerFunc.ServeHTTP(0x0?, {0x32d0590?, 0x400052bd88?}, 0x400377d560?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.(*APIServerHandler).ServeHTTP(0x0?, {0x32d0590?, 0x400052bd88?}, 0x103b860?)
	k8s.io/apiserver/pkg/server/handler.go:189 +0x30
net/http.serverHandler.ServeHTTP({0x4007626e18?}, {0x32d0590?, 0x400052bd88?}, 0x32fa1c0?)
	net/http/server.go:3137 +0xbc
net/http.initALPNRequest.ServeHTTP({{0x32e1798?, 0x4007b5cd20?}, 0x40068e6008?, {0x40036e1860?}}, {0x32d0590, 0x400052bd88}, 0x40088d07e0)
	net/http/server.go:3745 +0x1b4
golang.org/x/net/http2.(*serverConn).runHandler(0x0?, 0x89634?, 0x0?, 0x4007626fa8?)
	golang.org/x/net@v0.23.0/http2/server.go:2369 +0xc0
created by golang.org/x/net/http2.(*serverConn).scheduleHandler in goroutine 12074002
	golang.org/x/net@v0.23.0/http2/server.go:2304 +0x208
E0709 09:47:34.551466       1 wrap.go:58] "apiserver panic'd" method="GET" URI="/api/v1/replicationcontrollers?allowWatchBookmarks=true&limit=500&resourceVersionMatch=NotOlderThan&sendInitialEvents=true&watch=true" auditID="80d700c3-39a5-4ad4-95fa-759d5090a4a7"
http2: panic serving 192.168.228.1:50926: runtime error: invalid memory address or nil pointer dereference
goroutine 12074030 [running]:
golang.org/x/net/http2.(*serverConn).runHandler.func1()
	golang.org/x/net@v0.23.0/http2/server.go:2362 +0x13c
panic({0x277c340?, 0x4dd78a0?})
	runtime/panic.go:770 +0x124
k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x4006b3c000, 0x1, 0x40057fe700?})
	k8s.io/apimachinery/pkg/util/runtime/runtime.go:56 +0xe0
panic({0x277c340?, 0x4dd78a0?})
	runtime/panic.go:770 +0x124
k8s.io/kubernetes/pkg/printers/internalversion.printReplicationController(0x4007b82840, {0x5?, 0x0?})
	k8s.io/kubernetes/pkg/printers/internalversion/printers.go:1127 +0x1e4
reflect.Value.call({0x2768f20?, 0x2e46cf0?, 0x13?}, {0x2c20ae1, 0x4}, {0x4006b3cb18, 0x2, 0x2?})
	reflect/value.go:596 +0x970
reflect.Value.Call({0x2768f20?, 0x2e46cf0?, 0x4009a04b58?}, {0x4009a04b18?, 0x40012fc620?, 0x32e1418?})
	reflect/value.go:380 +0x94
k8s.io/kubernetes/pkg/printers.(*HumanReadableGenerator).GenerateTable(0x0?, {0x32c2bb8, 0x4007b82840}, {0x0, 0x1})
	k8s.io/kubernetes/pkg/printers/tablegenerator.go:86 +0x1b8
k8s.io/kubernetes/pkg/printers/storage.TableConvertor.ConvertToTable({{0x32b7ea0?, 0x400066ce30?}}, {0x1b?, 0x20?}, {0x32c2bb8?, 0x4007b82840?}, {0x32bc360?, 0x400a190c40?})
	k8s.io/kubernetes/pkg/printers/storage/storage.go:46 +0xd8
k8s.io/apiserver/pkg/registry/generic/registry.(*Store).ConvertToTable(0x0?, {0x32e1798?, 0x4007c84f00?}, {0x32c2bb8?, 0x4007b82840?}, {0x32bc360?, 0x400a190c40?})
	k8s.io/apiserver/pkg/registry/generic/registry/store.go:1644 +0x44
k8s.io/apiserver/pkg/endpoints/handlers.asTable({0x32e1798, 0x4007c84f00}, {0x32c2bb8, 0x4007b82840}, 0x400a190c40, 0x400199e1a0, {{0x400976d591, 0xb}, {0x400976d58c, 0x2}})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:375 +0x17c
k8s.io/apiserver/pkg/endpoints/handlers.doTransformObject({0x32e1798, 0x4007c84f00}, {0x32c2bb8, 0x4007b82840}, {0x2b43c00, 0x400a190c40}, 0x4007c852c0, 0x400199e1a0)
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:270 +0x188
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEmbeddedEncoder).doEncode(0x400a9f3a90, {0x32c2bb8, 0x4007b82840}, {0xffff66499918, 0x400843d520})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:82 +0x68
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEmbeddedEncoder).Encode(0x400a9f3a90, {0x32c2bb8?, 0x4007b82840}, {0xffff66499918, 0x400843d520})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:78 +0x114
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).doEncode(0x4006676f20, {0x32c2bb8, 0x4007b82840}, {{0x2c27806?, 0x4009a05278?}, {0x32c2bb8?, 0x4007b82840?}}, {0xffff664f8b18, 0x40081deba0})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:186 +0xd4
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).Encode.func1(...)
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:175
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).Encode(0x4006676f20, {{0x2c27806?, 0x32c2bb8?}, {0x32c2bb8?, 0x4007b82840?}})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:180 +0x140
k8s.io/apiserver/pkg/endpoints/handlers.(*WatchServer).HandleHTTP(0x4008210a00, {0x32d0800, 0x40081deba0}, 0x40088d1440)
	k8s.io/apiserver/pkg/endpoints/handlers/watch.go:249 +0x944
net/http.HandlerFunc.ServeHTTP(0x4009a05678?, {0x32d0800?, 0x40081deba0?}, 0x400a59ccb0?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/endpoints/handlers.ListResource.func1.4.1()
	k8s.io/apiserver/pkg/endpoints/handlers/get.go:283 +0x74
k8s.io/apiserver/pkg/endpoints/metrics.RecordLongRunning(0x40088d1440, 0x25d7aa0?, {0x2c282c0, 0x9}, 0x4009a05870)
	k8s.io/apiserver/pkg/endpoints/metrics/metrics.go:528 +0x494
k8s.io/apiserver/pkg/endpoints/handlers.ListResource.func1.4()
	k8s.io/apiserver/pkg/endpoints/handlers/get.go:281 +0x10c
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRoutine.func17({0x32d0590, 0x400052bd88}, 0x40088d0b40)
	k8s.io/apiserver/pkg/server/filters/routine.go:73 +0x190
net/http.HandlerFunc.ServeHTTP(0x40088d0a20?, {0x32d0590?, 0x400052bd88?}, 0x4000582008?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRequestInfo.func18({0x32d0590, 0x400052bd88}, 0x40088d0a20)
	k8s.io/apiserver/pkg/endpoints/filters/requestinfo.go:39 +0x104
net/http.HandlerFunc.ServeHTTP(0x40088d0900?, {0x32d0590?, 0x400052bd88?}, 0x583f2895be0d?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRequestReceivedTimestamp.withRequestReceivedTimestampWithClock.func32({0x32d0590, 0x400052bd88}, 0x40088d0900)
	k8s.io/apiserver/pkg/endpoints/filters/request_received_time.go:38 +0xac
net/http.HandlerFunc.ServeHTTP(0x4007626af8?, {0x32d0590?, 0x400052bd88?}, 0xffff66237dc8?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithMuxAndDiscoveryComplete.func19({0x32d0590?, 0x400052bd88?}, 0x40088d0900?)
	k8s.io/apiserver/pkg/endpoints/filters/mux_discovery_complete.go:52 +0xd0
net/http.HandlerFunc.ServeHTTP(0x4008b67401?, {0x32d0590?, 0x400052bd88?}, 0xe3634c89f3dc954a?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithPanicRecovery.withPanicRecovery.func33({0x32d0590?, 0x400052bd88?}, 0x4008b67410?)
	k8s.io/apiserver/pkg/server/filters/wrap.go:74 +0x9c
net/http.HandlerFunc.ServeHTTP(0x4007c84a50?, {0x32d0590?, 0x400052bd88?}, 0x4008228ae0?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithAuditInit.withAuditInit.func34({0x32d0590, 0x400052bd88}, 0x40088d07e0)
	k8s.io/apiserver/pkg/endpoints/filters/audit_init.go:63 +0x110
net/http.HandlerFunc.ServeHTTP(0x0?, {0x32d0590?, 0x400052bd88?}, 0x400377d560?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.(*APIServerHandler).ServeHTTP(0x0?, {0x32d0590?, 0x400052bd88?}, 0x103b860?)
	k8s.io/apiserver/pkg/server/handler.go:189 +0x30
net/http.serverHandler.ServeHTTP({0x4007626e18?}, {0x32d0590?, 0x400052bd88?}, 0x32fa1c0?)
	net/http/server.go:3137 +0xbc
net/http.initALPNRequest.ServeHTTP({{0x32e1798?, 0x4007b5cd20?}, 0x40068e6008?, {0x40036e1860?}}, {0x32d0590, 0x400052bd88}, 0x40088d07e0)
	net/http/server.go:3745 +0x1b4
golang.org/x/net/http2.(*serverConn).runHandler(0x0?, 0x89634?, 0x0?, 0x4007626fa8?)
	golang.org/x/net@v0.23.0/http2/server.go:2369 +0xc0
created by golang.org/x/net/http2.(*serverConn).scheduleHandler in goroutine 12074002
	golang.org/x/net@v0.23.0/http2/server.go:2304 +0x208
E0709 09:48:07.234825       1 runtime.go:79] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
goroutine 12078321 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic({0x277c340, 0x4dd78a0})
	k8s.io/apimachinery/pkg/util/runtime/runtime.go:75 +0x7c
k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x4009e12000, 0x1, 0x4006e008c0?})
	k8s.io/apimachinery/pkg/util/runtime/runtime.go:49 +0x78
panic({0x277c340?, 0x4dd78a0?})
	runtime/panic.go:770 +0x124
k8s.io/kubernetes/pkg/printers/internalversion.printReplicationController(0x4009b5ec60, {0x5?, 0x0?})
	k8s.io/kubernetes/pkg/printers/internalversion/printers.go:1127 +0x1e4
reflect.Value.call({0x2768f20?, 0x2e46cf0?, 0x13?}, {0x2c20ae1, 0x4}, {0x4009e12b18, 0x2, 0x2?})
	reflect/value.go:596 +0x970
reflect.Value.Call({0x2768f20?, 0x2e46cf0?, 0x4006ee0b58?}, {0x4006ee0b18?, 0x4006ee0a58?, 0x629b4?})
	reflect/value.go:380 +0x94
k8s.io/kubernetes/pkg/printers.(*HumanReadableGenerator).GenerateTable(0x4006ee0bb8?, {0x32c2bb8, 0x4009b5ec60}, {0x0, 0x1})
	k8s.io/kubernetes/pkg/printers/tablegenerator.go:86 +0x1b8
k8s.io/kubernetes/pkg/printers/storage.TableConvertor.ConvertToTable({{0x32b7ea0?, 0x400066ce30?}}, {0x80?, 0x10?}, {0x32c2bb8?, 0x4009b5ec60?}, {0x32bc360?, 0x4009b5b2c0?})
	k8s.io/kubernetes/pkg/printers/storage/storage.go:46 +0xd8
k8s.io/apiserver/pkg/registry/generic/registry.(*Store).ConvertToTable(0x0?, {0x32e1798?, 0x4009b69b60?}, {0x32c2bb8?, 0x4009b5ec60?}, {0x32bc360?, 0x4009b5b2c0?})
	k8s.io/apiserver/pkg/registry/generic/registry/store.go:1644 +0x44
k8s.io/apiserver/pkg/endpoints/handlers.asTable({0x32e1798, 0x4009b69b60}, {0x32c2bb8, 0x4009b5ec60}, 0x4009b5b2c0, 0x400182d1e0, {{0x400723dd71, 0xb}, {0x400723dd6c, 0x2}})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:375 +0x17c
k8s.io/apiserver/pkg/endpoints/handlers.doTransformObject({0x32e1798, 0x4009b69b60}, {0x32c2bb8, 0x4009b5ec60}, {0x2b43c00, 0x4009b5b2c0}, 0x4009b69e60, 0x400182d1e0)
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:270 +0x188
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEmbeddedEncoder).doEncode(0x4009b6aaf0, {0x32c2bb8, 0x4009b5ec60}, {0xffff66499918, 0x4009b7b1c0})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:82 +0x68
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEmbeddedEncoder).Encode(0x4009b6aaf0, {0x32c2bb8?, 0x4009b5ec60}, {0xffff66499918, 0x4009b7b1c0})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:78 +0x114
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).doEncode(0x40095ff340, {0x32c2bb8, 0x4009b5ec60}, {{0x2c27806?, 0x4006ee1278?}, {0x32c2bb8?, 0x4009b5ec60?}}, {0xffff664f8b18, 0x4009b7ae00})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:186 +0xd4
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).Encode.func1(...)
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:175
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).Encode(0x40095ff340, {{0x2c27806?, 0x32c2bb8?}, {0x32c2bb8?, 0x4009b5ec60?}})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:180 +0x140
k8s.io/apiserver/pkg/endpoints/handlers.(*WatchServer).HandleHTTP(0x400962fa40, {0x32d0800, 0x4009b7ae00}, 0x4009d9afc0)
	k8s.io/apiserver/pkg/endpoints/handlers/watch.go:249 +0x944
net/http.HandlerFunc.ServeHTTP(0x4006ee1678?, {0x32d0800?, 0x4009b7ae00?}, 0x4009e08460?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/endpoints/handlers.ListResource.func1.4.1()
	k8s.io/apiserver/pkg/endpoints/handlers/get.go:283 +0x74
k8s.io/apiserver/pkg/endpoints/metrics.RecordLongRunning(0x4009d9afc0, 0x25d7aa0?, {0x2c282c0, 0x9}, 0x4006ee1870)
	k8s.io/apiserver/pkg/endpoints/metrics/metrics.go:528 +0x494
k8s.io/apiserver/pkg/endpoints/handlers.ListResource.func1.4()
	k8s.io/apiserver/pkg/endpoints/handlers/get.go:281 +0x10c
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRoutine.func17({0x32d0590, 0x400a707cc0}, 0x4009d9a7e0)
	k8s.io/apiserver/pkg/server/filters/routine.go:73 +0x190
net/http.HandlerFunc.ServeHTTP(0x4009d9a6c0?, {0x32d0590?, 0x400a707cc0?}, 0x40000aa808?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRequestInfo.func18({0x32d0590, 0x400a707cc0}, 0x4009d9a6c0)
	k8s.io/apiserver/pkg/endpoints/filters/requestinfo.go:39 +0x104
net/http.HandlerFunc.ServeHTTP(0x4009d9a5a0?, {0x32d0590?, 0x400a707cc0?}, 0x5846d5dcec7c?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRequestReceivedTimestamp.withRequestReceivedTimestampWithClock.func32({0x32d0590, 0x400a707cc0}, 0x4009d9a5a0)
	k8s.io/apiserver/pkg/endpoints/filters/request_received_time.go:38 +0xac
net/http.HandlerFunc.ServeHTTP(0x40076f1af8?, {0x32d0590?, 0x400a707cc0?}, 0xffff66509880?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithMuxAndDiscoveryComplete.func19({0x32d0590?, 0x400a707cc0?}, 0x4009d9a5a0?)
	k8s.io/apiserver/pkg/endpoints/filters/mux_discovery_complete.go:52 +0xd0
net/http.HandlerFunc.ServeHTTP(0x4009b35501?, {0x32d0590?, 0x400a707cc0?}, 0x1ab4b6e321f841d3?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithPanicRecovery.withPanicRecovery.func33({0x32d0590?, 0x400a707cc0?}, 0x4009b355f0?)
	k8s.io/apiserver/pkg/server/filters/wrap.go:74 +0x9c
net/http.HandlerFunc.ServeHTTP(0x4009b69710?, {0x32d0590?, 0x400a707cc0?}, 0x40096aa840?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithAuditInit.withAuditInit.func34({0x32d0590, 0x400a707cc0}, 0x4009d9a480)
	k8s.io/apiserver/pkg/endpoints/filters/audit_init.go:63 +0x110
net/http.HandlerFunc.ServeHTTP(0x40041244c0?, {0x32d0590?, 0x400a707cc0?}, 0x1e81c?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.(*APIServerHandler).ServeHTTP(0x40076f1d08?, {0x32d0590?, 0x400a707cc0?}, 0x10401?)
	k8s.io/apiserver/pkg/server/handler.go:189 +0x30
net/http.serverHandler.ServeHTTP({0x40076f1d38?}, {0x32d0590?, 0x400a707cc0?}, 0xc1f80?)
	net/http/server.go:3137 +0xbc
net/http.initALPNRequest.ServeHTTP({{0x32e1798?, 0x40081eeb10?}, 0x40081e0e08?, {0x40036e1860?}}, {0x32d0590, 0x400a707cc0}, 0x4009d9a480)
	net/http/server.go:3745 +0x1b4
golang.org/x/net/http2.(*serverConn).runHandler(0x0?, 0x89634?, 0x4008caa9c0?, 0x0?)
	golang.org/x/net@v0.23.0/http2/server.go:2369 +0xc0
created by golang.org/x/net/http2.(*serverConn).scheduleHandler in goroutine 12076879
	golang.org/x/net@v0.23.0/http2/server.go:2304 +0x208
E0709 09:48:07.234976       1 wrap.go:58] "apiserver panic'd" method="GET" URI="/api/v1/namespaces/default/replicationcontrollers?allowWatchBookmarks=true&limit=500&resourceVersionMatch=NotOlderThan&sendInitialEvents=true&watch=true" auditID="fb50e831-624c-48ef-a52d-ea978944812f"
http2: panic serving 192.168.228.1:48282: runtime error: invalid memory address or nil pointer dereference
goroutine 12078321 [running]:
golang.org/x/net/http2.(*serverConn).runHandler.func1()
	golang.org/x/net@v0.23.0/http2/server.go:2362 +0x13c
panic({0x277c340?, 0x4dd78a0?})
	runtime/panic.go:770 +0x124
k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x4009e12000, 0x1, 0x4006e008c0?})
	k8s.io/apimachinery/pkg/util/runtime/runtime.go:56 +0xe0
panic({0x277c340?, 0x4dd78a0?})
	runtime/panic.go:770 +0x124
k8s.io/kubernetes/pkg/printers/internalversion.printReplicationController(0x4009b5ec60, {0x5?, 0x0?})
	k8s.io/kubernetes/pkg/printers/internalversion/printers.go:1127 +0x1e4
reflect.Value.call({0x2768f20?, 0x2e46cf0?, 0x13?}, {0x2c20ae1, 0x4}, {0x4009e12b18, 0x2, 0x2?})
	reflect/value.go:596 +0x970
reflect.Value.Call({0x2768f20?, 0x2e46cf0?, 0x4006ee0b58?}, {0x4006ee0b18?, 0x4006ee0a58?, 0x629b4?})
	reflect/value.go:380 +0x94
k8s.io/kubernetes/pkg/printers.(*HumanReadableGenerator).GenerateTable(0x4006ee0bb8?, {0x32c2bb8, 0x4009b5ec60}, {0x0, 0x1})
	k8s.io/kubernetes/pkg/printers/tablegenerator.go:86 +0x1b8
k8s.io/kubernetes/pkg/printers/storage.TableConvertor.ConvertToTable({{0x32b7ea0?, 0x400066ce30?}}, {0x80?, 0x10?}, {0x32c2bb8?, 0x4009b5ec60?}, {0x32bc360?, 0x4009b5b2c0?})
	k8s.io/kubernetes/pkg/printers/storage/storage.go:46 +0xd8
k8s.io/apiserver/pkg/registry/generic/registry.(*Store).ConvertToTable(0x0?, {0x32e1798?, 0x4009b69b60?}, {0x32c2bb8?, 0x4009b5ec60?}, {0x32bc360?, 0x4009b5b2c0?})
	k8s.io/apiserver/pkg/registry/generic/registry/store.go:1644 +0x44
k8s.io/apiserver/pkg/endpoints/handlers.asTable({0x32e1798, 0x4009b69b60}, {0x32c2bb8, 0x4009b5ec60}, 0x4009b5b2c0, 0x400182d1e0, {{0x400723dd71, 0xb}, {0x400723dd6c, 0x2}})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:375 +0x17c
k8s.io/apiserver/pkg/endpoints/handlers.doTransformObject({0x32e1798, 0x4009b69b60}, {0x32c2bb8, 0x4009b5ec60}, {0x2b43c00, 0x4009b5b2c0}, 0x4009b69e60, 0x400182d1e0)
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:270 +0x188
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEmbeddedEncoder).doEncode(0x4009b6aaf0, {0x32c2bb8, 0x4009b5ec60}, {0xffff66499918, 0x4009b7b1c0})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:82 +0x68
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEmbeddedEncoder).Encode(0x4009b6aaf0, {0x32c2bb8?, 0x4009b5ec60}, {0xffff66499918, 0x4009b7b1c0})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:78 +0x114
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).doEncode(0x40095ff340, {0x32c2bb8, 0x4009b5ec60}, {{0x2c27806?, 0x4006ee1278?}, {0x32c2bb8?, 0x4009b5ec60?}}, {0xffff664f8b18, 0x4009b7ae00})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:186 +0xd4
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).Encode.func1(...)
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:175
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).Encode(0x40095ff340, {{0x2c27806?, 0x32c2bb8?}, {0x32c2bb8?, 0x4009b5ec60?}})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:180 +0x140
k8s.io/apiserver/pkg/endpoints/handlers.(*WatchServer).HandleHTTP(0x400962fa40, {0x32d0800, 0x4009b7ae00}, 0x4009d9afc0)
	k8s.io/apiserver/pkg/endpoints/handlers/watch.go:249 +0x944
net/http.HandlerFunc.ServeHTTP(0x4006ee1678?, {0x32d0800?, 0x4009b7ae00?}, 0x4009e08460?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/endpoints/handlers.ListResource.func1.4.1()
	k8s.io/apiserver/pkg/endpoints/handlers/get.go:283 +0x74
k8s.io/apiserver/pkg/endpoints/metrics.RecordLongRunning(0x4009d9afc0, 0x25d7aa0?, {0x2c282c0, 0x9}, 0x4006ee1870)
	k8s.io/apiserver/pkg/endpoints/metrics/metrics.go:528 +0x494
k8s.io/apiserver/pkg/endpoints/handlers.ListResource.func1.4()
	k8s.io/apiserver/pkg/endpoints/handlers/get.go:281 +0x10c
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRoutine.func17({0x32d0590, 0x400a707cc0}, 0x4009d9a7e0)
	k8s.io/apiserver/pkg/server/filters/routine.go:73 +0x190
net/http.HandlerFunc.ServeHTTP(0x4009d9a6c0?, {0x32d0590?, 0x400a707cc0?}, 0x40000aa808?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRequestInfo.func18({0x32d0590, 0x400a707cc0}, 0x4009d9a6c0)
	k8s.io/apiserver/pkg/endpoints/filters/requestinfo.go:39 +0x104
net/http.HandlerFunc.ServeHTTP(0x4009d9a5a0?, {0x32d0590?, 0x400a707cc0?}, 0x5846d5dcec7c?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRequestReceivedTimestamp.withRequestReceivedTimestampWithClock.func32({0x32d0590, 0x400a707cc0}, 0x4009d9a5a0)
	k8s.io/apiserver/pkg/endpoints/filters/request_received_time.go:38 +0xac
net/http.HandlerFunc.ServeHTTP(0x40076f1af8?, {0x32d0590?, 0x400a707cc0?}, 0xffff66509880?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithMuxAndDiscoveryComplete.func19({0x32d0590?, 0x400a707cc0?}, 0x4009d9a5a0?)
	k8s.io/apiserver/pkg/endpoints/filters/mux_discovery_complete.go:52 +0xd0
net/http.HandlerFunc.ServeHTTP(0x4009b35501?, {0x32d0590?, 0x400a707cc0?}, 0x1ab4b6e321f841d3?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithPanicRecovery.withPanicRecovery.func33({0x32d0590?, 0x400a707cc0?}, 0x4009b355f0?)
	k8s.io/apiserver/pkg/server/filters/wrap.go:74 +0x9c
net/http.HandlerFunc.ServeHTTP(0x4009b69710?, {0x32d0590?, 0x400a707cc0?}, 0x40096aa840?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithAuditInit.withAuditInit.func34({0x32d0590, 0x400a707cc0}, 0x4009d9a480)
	k8s.io/apiserver/pkg/endpoints/filters/audit_init.go:63 +0x110
net/http.HandlerFunc.ServeHTTP(0x40041244c0?, {0x32d0590?, 0x400a707cc0?}, 0x1e81c?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.(*APIServerHandler).ServeHTTP(0x40076f1d08?, {0x32d0590?, 0x400a707cc0?}, 0x10401?)
	k8s.io/apiserver/pkg/server/handler.go:189 +0x30
net/http.serverHandler.ServeHTTP({0x40076f1d38?}, {0x32d0590?, 0x400a707cc0?}, 0xc1f80?)
	net/http/server.go:3137 +0xbc
net/http.initALPNRequest.ServeHTTP({{0x32e1798?, 0x40081eeb10?}, 0x40081e0e08?, {0x40036e1860?}}, {0x32d0590, 0x400a707cc0}, 0x4009d9a480)
	net/http/server.go:3745 +0x1b4
golang.org/x/net/http2.(*serverConn).runHandler(0x0?, 0x89634?, 0x4008caa9c0?, 0x0?)
	golang.org/x/net@v0.23.0/http2/server.go:2369 +0xc0
created by golang.org/x/net/http2.(*serverConn).scheduleHandler in goroutine 12076879
	golang.org/x/net@v0.23.0/http2/server.go:2304 +0x208
E0709 09:48:17.305082       1 runtime.go:79] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
goroutine 12079255 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic({0x277c340, 0x4dd78a0})
	k8s.io/apimachinery/pkg/util/runtime/runtime.go:75 +0x7c
k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x4009ede000, 0x1, 0x400785ce00?})
	k8s.io/apimachinery/pkg/util/runtime/runtime.go:49 +0x78
panic({0x277c340?, 0x4dd78a0?})
	runtime/panic.go:770 +0x124
k8s.io/kubernetes/pkg/printers/internalversion.printReplicationController(0x40045b3600, {0x5?, 0x0?})
	k8s.io/kubernetes/pkg/printers/internalversion/printers.go:1127 +0x1e4
reflect.Value.call({0x2768f20?, 0x2e46cf0?, 0x13?}, {0x2c20ae1, 0x4}, {0x4009edeb18, 0x2, 0x2?})
	reflect/value.go:596 +0x970
reflect.Value.Call({0x2768f20?, 0x2e46cf0?, 0x4009744b58?}, {0x4009744b18?, 0x4000e24800?, 0x1?})
	reflect/value.go:380 +0x94
k8s.io/kubernetes/pkg/printers.(*HumanReadableGenerator).GenerateTable(0x27a4460?, {0x32c2bb8, 0x40045b3600}, {0x0, 0x1})
	k8s.io/kubernetes/pkg/printers/tablegenerator.go:86 +0x1b8
k8s.io/kubernetes/pkg/printers/storage.TableConvertor.ConvertToTable({{0x32b7ea0?, 0x400066ce30?}}, {0x4007f9c770?, 0x4001091200?}, {0x32c2bb8?, 0x40045b3600?}, {0x32bc360?, 0x4002c7f380?})
	k8s.io/kubernetes/pkg/printers/storage/storage.go:46 +0xd8
k8s.io/apiserver/pkg/registry/generic/registry.(*Store).ConvertToTable(0x10?, {0x32e1798?, 0x40045069c0?}, {0x32c2bb8?, 0x40045b3600?}, {0x32bc360?, 0x4002c7f380?})
	k8s.io/apiserver/pkg/registry/generic/registry/store.go:1644 +0x44
k8s.io/apiserver/pkg/endpoints/handlers.asTable({0x32e1798, 0x40045069c0}, {0x32c2bb8, 0x40045b3600}, 0x4002c7f380, 0x400182d1e0, {{0x400723c561, 0xb}, {0x400723c55c, 0x2}})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:375 +0x17c
k8s.io/apiserver/pkg/endpoints/handlers.doTransformObject({0x32e1798, 0x40045069c0}, {0x32c2bb8, 0x40045b3600}, {0x2b43c00, 0x4002c7f380}, 0x4004507ad0, 0x400182d1e0)
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:270 +0x188
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEmbeddedEncoder).doEncode(0x4006fd0c30, {0x32c2bb8, 0x40045b3600}, {0xffff66499918, 0x400aa5b080})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:82 +0x68
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEmbeddedEncoder).Encode(0x4006fd0c30, {0x32c2bb8?, 0x40045b3600}, {0xffff66499918, 0x400aa5b080})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:78 +0x114
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).doEncode(0x40092a2790, {0x32c2bb8, 0x40045b3600}, {{0x2c27806?, 0x4009745278?}, {0x32c2bb8?, 0x40045b3600?}}, {0xffff664f8b18, 0x400a06cac0})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:186 +0xd4
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).Encode.func1(...)
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:175
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).Encode(0x40092a2790, {{0x2c27806?, 0x32c2bb8?}, {0x32c2bb8?, 0x40045b3600?}})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:180 +0x140
k8s.io/apiserver/pkg/endpoints/handlers.(*WatchServer).HandleHTTP(0x4001c115e0, {0x32d0800, 0x400a06cac0}, 0x4004f8b0e0)
	k8s.io/apiserver/pkg/endpoints/handlers/watch.go:249 +0x944
net/http.HandlerFunc.ServeHTTP(0x4009745678?, {0x32d0800?, 0x400a06cac0?}, 0x4007368700?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/endpoints/handlers.ListResource.func1.4.1()
	k8s.io/apiserver/pkg/endpoints/handlers/get.go:283 +0x74
k8s.io/apiserver/pkg/endpoints/metrics.RecordLongRunning(0x4004f8b0e0, 0x25d7aa0?, {0x2c282c0, 0x9}, 0x4009745870)
	k8s.io/apiserver/pkg/endpoints/metrics/metrics.go:528 +0x494
k8s.io/apiserver/pkg/endpoints/handlers.ListResource.func1.4()
	k8s.io/apiserver/pkg/endpoints/handlers/get.go:281 +0x10c
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRoutine.func17({0x32d0590, 0x400a6f44f0}, 0x4003bf5c20)
	k8s.io/apiserver/pkg/server/filters/routine.go:73 +0x190
net/http.HandlerFunc.ServeHTTP(0x4003bf5b00?, {0x32d0590?, 0x400a6f44f0?}, 0x40026a8008?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRequestInfo.func18({0x32d0590, 0x400a6f44f0}, 0x4003bf5b00)
	k8s.io/apiserver/pkg/endpoints/filters/requestinfo.go:39 +0x104
net/http.HandlerFunc.ServeHTTP(0x4003bf59e0?, {0x32d0590?, 0x400a6f44f0?}, 0x5849259429bd?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRequestReceivedTimestamp.withRequestReceivedTimestampWithClock.func32({0x32d0590, 0x400a6f44f0}, 0x4003bf59e0)
	k8s.io/apiserver/pkg/endpoints/filters/request_received_time.go:38 +0xac
net/http.HandlerFunc.ServeHTTP(0x4003a49af8?, {0x32d0590?, 0x400a6f44f0?}, 0xffff6672f958?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithMuxAndDiscoveryComplete.func19({0x32d0590?, 0x400a6f44f0?}, 0x4003bf59e0?)
	k8s.io/apiserver/pkg/endpoints/filters/mux_discovery_complete.go:52 +0xd0
net/http.HandlerFunc.ServeHTTP(0x4007f9d501?, {0x32d0590?, 0x400a6f44f0?}, 0xf26798f13fd3ca2a?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithPanicRecovery.withPanicRecovery.func33({0x32d0590?, 0x400a6f44f0?}, 0x4007f9d510?)
	k8s.io/apiserver/pkg/server/filters/wrap.go:74 +0x9c
net/http.HandlerFunc.ServeHTTP(0x4004506210?, {0x32d0590?, 0x400a6f44f0?}, 0x4006673d10?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithAuditInit.withAuditInit.func34({0x32d0590, 0x400a6f44f0}, 0x4003bf58c0)
	k8s.io/apiserver/pkg/endpoints/filters/audit_init.go:63 +0x110
net/http.HandlerFunc.ServeHTTP(0x0?, {0x32d0590?, 0x400a6f44f0?}, 0x40038f09c0?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.(*APIServerHandler).ServeHTTP(0x0?, {0x32d0590?, 0x400a6f44f0?}, 0x103b860?)
	k8s.io/apiserver/pkg/server/handler.go:189 +0x30
net/http.serverHandler.ServeHTTP({0x4003a49e18?}, {0x32d0590?, 0x400a6f44f0?}, 0x32fa1c0?)
	net/http/server.go:3137 +0xbc
net/http.initALPNRequest.ServeHTTP({{0x32e1798?, 0x400394b140?}, 0x4007418008?, {0x40036e1860?}}, {0x32d0590, 0x400a6f44f0}, 0x4003bf58c0)
	net/http/server.go:3745 +0x1b4
golang.org/x/net/http2.(*serverConn).runHandler(0x100000000000000?, 0x1a142b0?, 0x40096c2360?, 0x4003a49fb0?)
	golang.org/x/net@v0.23.0/http2/server.go:2369 +0xc0
created by golang.org/x/net/http2.(*serverConn).scheduleHandler in goroutine 12079637
	golang.org/x/net@v0.23.0/http2/server.go:2304 +0x208
E0709 09:48:17.305273       1 wrap.go:58] "apiserver panic'd" method="GET" URI="/api/v1/namespaces/default/replicationcontrollers?allowWatchBookmarks=true&limit=500&resourceVersionMatch=NotOlderThan&sendInitialEvents=true&watch=true" auditID="e2905e2b-d482-453d-8e08-c5064d11c884"
http2: panic serving 192.168.228.1:54354: runtime error: invalid memory address or nil pointer dereference
goroutine 12079255 [running]:
golang.org/x/net/http2.(*serverConn).runHandler.func1()
	golang.org/x/net@v0.23.0/http2/server.go:2362 +0x13c
panic({0x277c340?, 0x4dd78a0?})
	runtime/panic.go:770 +0x124
k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x4009ede000, 0x1, 0x400785ce00?})
	k8s.io/apimachinery/pkg/util/runtime/runtime.go:56 +0xe0
panic({0x277c340?, 0x4dd78a0?})
	runtime/panic.go:770 +0x124
k8s.io/kubernetes/pkg/printers/internalversion.printReplicationController(0x40045b3600, {0x5?, 0x0?})
	k8s.io/kubernetes/pkg/printers/internalversion/printers.go:1127 +0x1e4
reflect.Value.call({0x2768f20?, 0x2e46cf0?, 0x13?}, {0x2c20ae1, 0x4}, {0x4009edeb18, 0x2, 0x2?})
	reflect/value.go:596 +0x970
reflect.Value.Call({0x2768f20?, 0x2e46cf0?, 0x4009744b58?}, {0x4009744b18?, 0x4000e24800?, 0x1?})
	reflect/value.go:380 +0x94
k8s.io/kubernetes/pkg/printers.(*HumanReadableGenerator).GenerateTable(0x27a4460?, {0x32c2bb8, 0x40045b3600}, {0x0, 0x1})
	k8s.io/kubernetes/pkg/printers/tablegenerator.go:86 +0x1b8
k8s.io/kubernetes/pkg/printers/storage.TableConvertor.ConvertToTable({{0x32b7ea0?, 0x400066ce30?}}, {0x4007f9c770?, 0x4001091200?}, {0x32c2bb8?, 0x40045b3600?}, {0x32bc360?, 0x4002c7f380?})
	k8s.io/kubernetes/pkg/printers/storage/storage.go:46 +0xd8
k8s.io/apiserver/pkg/registry/generic/registry.(*Store).ConvertToTable(0x10?, {0x32e1798?, 0x40045069c0?}, {0x32c2bb8?, 0x40045b3600?}, {0x32bc360?, 0x4002c7f380?})
	k8s.io/apiserver/pkg/registry/generic/registry/store.go:1644 +0x44
k8s.io/apiserver/pkg/endpoints/handlers.asTable({0x32e1798, 0x40045069c0}, {0x32c2bb8, 0x40045b3600}, 0x4002c7f380, 0x400182d1e0, {{0x400723c561, 0xb}, {0x400723c55c, 0x2}})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:375 +0x17c
k8s.io/apiserver/pkg/endpoints/handlers.doTransformObject({0x32e1798, 0x40045069c0}, {0x32c2bb8, 0x40045b3600}, {0x2b43c00, 0x4002c7f380}, 0x4004507ad0, 0x400182d1e0)
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:270 +0x188
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEmbeddedEncoder).doEncode(0x4006fd0c30, {0x32c2bb8, 0x40045b3600}, {0xffff66499918, 0x400aa5b080})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:82 +0x68
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEmbeddedEncoder).Encode(0x4006fd0c30, {0x32c2bb8?, 0x40045b3600}, {0xffff66499918, 0x400aa5b080})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:78 +0x114
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).doEncode(0x40092a2790, {0x32c2bb8, 0x40045b3600}, {{0x2c27806?, 0x4009745278?}, {0x32c2bb8?, 0x40045b3600?}}, {0xffff664f8b18, 0x400a06cac0})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:186 +0xd4
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).Encode.func1(...)
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:175
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).Encode(0x40092a2790, {{0x2c27806?, 0x32c2bb8?}, {0x32c2bb8?, 0x40045b3600?}})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:180 +0x140
k8s.io/apiserver/pkg/endpoints/handlers.(*WatchServer).HandleHTTP(0x4001c115e0, {0x32d0800, 0x400a06cac0}, 0x4004f8b0e0)
	k8s.io/apiserver/pkg/endpoints/handlers/watch.go:249 +0x944
net/http.HandlerFunc.ServeHTTP(0x4009745678?, {0x32d0800?, 0x400a06cac0?}, 0x4007368700?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/endpoints/handlers.ListResource.func1.4.1()
	k8s.io/apiserver/pkg/endpoints/handlers/get.go:283 +0x74
k8s.io/apiserver/pkg/endpoints/metrics.RecordLongRunning(0x4004f8b0e0, 0x25d7aa0?, {0x2c282c0, 0x9}, 0x4009745870)
	k8s.io/apiserver/pkg/endpoints/metrics/metrics.go:528 +0x494
k8s.io/apiserver/pkg/endpoints/handlers.ListResource.func1.4()
	k8s.io/apiserver/pkg/endpoints/handlers/get.go:281 +0x10c
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRoutine.func17({0x32d0590, 0x400a6f44f0}, 0x4003bf5c20)
	k8s.io/apiserver/pkg/server/filters/routine.go:73 +0x190
net/http.HandlerFunc.ServeHTTP(0x4003bf5b00?, {0x32d0590?, 0x400a6f44f0?}, 0x40026a8008?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRequestInfo.func18({0x32d0590, 0x400a6f44f0}, 0x4003bf5b00)
	k8s.io/apiserver/pkg/endpoints/filters/requestinfo.go:39 +0x104
net/http.HandlerFunc.ServeHTTP(0x4003bf59e0?, {0x32d0590?, 0x400a6f44f0?}, 0x5849259429bd?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRequestReceivedTimestamp.withRequestReceivedTimestampWithClock.func32({0x32d0590, 0x400a6f44f0}, 0x4003bf59e0)
	k8s.io/apiserver/pkg/endpoints/filters/request_received_time.go:38 +0xac
net/http.HandlerFunc.ServeHTTP(0x4003a49af8?, {0x32d0590?, 0x400a6f44f0?}, 0xffff6672f958?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithMuxAndDiscoveryComplete.func19({0x32d0590?, 0x400a6f44f0?}, 0x4003bf59e0?)
	k8s.io/apiserver/pkg/endpoints/filters/mux_discovery_complete.go:52 +0xd0
net/http.HandlerFunc.ServeHTTP(0x4007f9d501?, {0x32d0590?, 0x400a6f44f0?}, 0xf26798f13fd3ca2a?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithPanicRecovery.withPanicRecovery.func33({0x32d0590?, 0x400a6f44f0?}, 0x4007f9d510?)
	k8s.io/apiserver/pkg/server/filters/wrap.go:74 +0x9c
net/http.HandlerFunc.ServeHTTP(0x4004506210?, {0x32d0590?, 0x400a6f44f0?}, 0x4006673d10?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithAuditInit.withAuditInit.func34({0x32d0590, 0x400a6f44f0}, 0x4003bf58c0)
	k8s.io/apiserver/pkg/endpoints/filters/audit_init.go:63 +0x110
net/http.HandlerFunc.ServeHTTP(0x0?, {0x32d0590?, 0x400a6f44f0?}, 0x40038f09c0?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.(*APIServerHandler).ServeHTTP(0x0?, {0x32d0590?, 0x400a6f44f0?}, 0x103b860?)
	k8s.io/apiserver/pkg/server/handler.go:189 +0x30
net/http.serverHandler.ServeHTTP({0x4003a49e18?}, {0x32d0590?, 0x400a6f44f0?}, 0x32fa1c0?)
	net/http/server.go:3137 +0xbc
net/http.initALPNRequest.ServeHTTP({{0x32e1798?, 0x400394b140?}, 0x4007418008?, {0x40036e1860?}}, {0x32d0590, 0x400a6f44f0}, 0x4003bf58c0)
	net/http/server.go:3745 +0x1b4
golang.org/x/net/http2.(*serverConn).runHandler(0x100000000000000?, 0x1a142b0?, 0x40096c2360?, 0x4003a49fb0?)
	golang.org/x/net@v0.23.0/http2/server.go:2369 +0xc0
created by golang.org/x/net/http2.(*serverConn).scheduleHandler in goroutine 12079637
	golang.org/x/net@v0.23.0/http2/server.go:2304 +0x208
I0709 09:55:31.218497       1 trace.go:236] Trace[1177612687]: "GuaranteedUpdate etcd3" audit-id:,key:/masterleases/192.168.228.2,type:*v1.Endpoints,resource:apiServerIPInfo (09-Jul-2024 09:55:30.507) (total time: 709ms):
Trace[1177612687]: ---"Transaction prepared" 430ms (09:55:30.942)
Trace[1177612687]: ---"Txn call completed" 274ms (09:55:31.216)
Trace[1177612687]: [709.200849ms] [709.200849ms] END
E0709 09:56:47.586880       1 runtime.go:79] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
goroutine 12143105 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic({0x277c340, 0x4dd78a0})
	k8s.io/apimachinery/pkg/util/runtime/runtime.go:75 +0x7c
k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x4006792000, 0x1, 0x40073d9880?})
	k8s.io/apimachinery/pkg/util/runtime/runtime.go:49 +0x78
panic({0x277c340?, 0x4dd78a0?})
	runtime/panic.go:770 +0x124
k8s.io/kubernetes/pkg/printers/internalversion.printReplicationController(0x400498ac60, {0x5?, 0x0?})
	k8s.io/kubernetes/pkg/printers/internalversion/printers.go:1127 +0x1e4
reflect.Value.call({0x2768f20?, 0x2e46cf0?, 0x13?}, {0x2c20ae1, 0x4}, {0x4006792b18, 0x2, 0x2?})
	reflect/value.go:596 +0x970
reflect.Value.Call({0x2768f20?, 0x2e46cf0?, 0x400972ab58?}, {0x400972ab18?, 0xa1c9014d05411b2a?, 0x15?})
	reflect/value.go:380 +0x94
k8s.io/kubernetes/pkg/printers.(*HumanReadableGenerator).GenerateTable(0x400972abb8?, {0x32c2bb8, 0x400498ac60}, {0x0, 0x1})
	k8s.io/kubernetes/pkg/printers/tablegenerator.go:86 +0x1b8
k8s.io/kubernetes/pkg/printers/storage.TableConvertor.ConvertToTable({{0x32b7ea0?, 0x400066ce30?}}, {0x80?, 0x10?}, {0x32c2bb8?, 0x400498ac60?}, {0x32bc360?, 0x4008a8dd40?})
	k8s.io/kubernetes/pkg/printers/storage/storage.go:46 +0xd8
k8s.io/apiserver/pkg/registry/generic/registry.(*Store).ConvertToTable(0x0?, {0x32e1798?, 0x4004e019b0?}, {0x32c2bb8?, 0x400498ac60?}, {0x32bc360?, 0x4008a8dd40?})
	k8s.io/apiserver/pkg/registry/generic/registry/store.go:1644 +0x44
k8s.io/apiserver/pkg/endpoints/handlers.asTable({0x32e1798, 0x4004e019b0}, {0x32c2bb8, 0x400498ac60}, 0x4008a8dd40, 0x400199e1a0, {{0x400723cd41, 0xb}, {0x400723cd3c, 0x2}})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:375 +0x17c
k8s.io/apiserver/pkg/endpoints/handlers.doTransformObject({0x32e1798, 0x4004e019b0}, {0x32c2bb8, 0x400498ac60}, {0x2b43c00, 0x4008a8dd40}, 0x4004e01e60, 0x400199e1a0)
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:270 +0x188
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEmbeddedEncoder).doEncode(0x400a0ca690, {0x32c2bb8, 0x400498ac60}, {0xffff66499918, 0x4002d7e2c0})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:82 +0x68
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEmbeddedEncoder).Encode(0x400a0ca690, {0x32c2bb8?, 0x400498ac60}, {0xffff66499918, 0x4002d7e2c0})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:78 +0x114
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).doEncode(0x4009ca0e70, {0x32c2bb8, 0x400498ac60}, {{0x2c27806?, 0x400972b278?}, {0x32c2bb8?, 0x400498ac60?}}, {0xffff664f8b18, 0x4007e89e40})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:186 +0xd4
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).Encode.func1(...)
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:175
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).Encode(0x4009ca0e70, {{0x2c27806?, 0x32c2bb8?}, {0x32c2bb8?, 0x400498ac60?}})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:180 +0x140
k8s.io/apiserver/pkg/endpoints/handlers.(*WatchServer).HandleHTTP(0x4008405860, {0x32d0800, 0x4007e89e40}, 0x4002b70ea0)
	k8s.io/apiserver/pkg/endpoints/handlers/watch.go:249 +0x944
net/http.HandlerFunc.ServeHTTP(0x400972b678?, {0x32d0800?, 0x4007e89e40?}, 0x4002ad6620?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/endpoints/handlers.ListResource.func1.4.1()
	k8s.io/apiserver/pkg/endpoints/handlers/get.go:283 +0x74
k8s.io/apiserver/pkg/endpoints/metrics.RecordLongRunning(0x4002b70ea0, 0x25d7aa0?, {0x2c282c0, 0x9}, 0x400972b870)
	k8s.io/apiserver/pkg/endpoints/metrics/metrics.go:528 +0x494
k8s.io/apiserver/pkg/endpoints/handlers.ListResource.func1.4()
	k8s.io/apiserver/pkg/endpoints/handlers/get.go:281 +0x10c
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRoutine.func17({0x32d0590, 0x400a707540}, 0x4002b70240)
	k8s.io/apiserver/pkg/server/filters/routine.go:73 +0x190
net/http.HandlerFunc.ServeHTTP(0x4002b70120?, {0x32d0590?, 0x400a707540?}, 0x400050c808?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRequestInfo.func18({0x32d0590, 0x400a707540}, 0x4002b70120)
	k8s.io/apiserver/pkg/endpoints/filters/requestinfo.go:39 +0x104
net/http.HandlerFunc.ServeHTTP(0x4002b70000?, {0x32d0590?, 0x400a707540?}, 0x58bfd0125f3c?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRequestReceivedTimestamp.withRequestReceivedTimestampWithClock.func32({0x32d0590, 0x400a707540}, 0x4002b70000)
	k8s.io/apiserver/pkg/endpoints/filters/request_received_time.go:38 +0xac
net/http.HandlerFunc.ServeHTTP(0x4007c1daf8?, {0x32d0590?, 0x400a707540?}, 0xffff666348a8?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithMuxAndDiscoveryComplete.func19({0x32d0590?, 0x400a707540?}, 0x4002b70000?)
	k8s.io/apiserver/pkg/endpoints/filters/mux_discovery_complete.go:52 +0xd0
net/http.HandlerFunc.ServeHTTP(0x40046f6201?, {0x32d0590?, 0x400a707540?}, 0x5271c32b9e80fdb9?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithPanicRecovery.withPanicRecovery.func33({0x32d0590?, 0x400a707540?}, 0x40046f6240?)
	k8s.io/apiserver/pkg/server/filters/wrap.go:74 +0x9c
net/http.HandlerFunc.ServeHTTP(0x4004e01470?, {0x32d0590?, 0x400a707540?}, 0x400a734b10?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithAuditInit.withAuditInit.func34({0x32d0590, 0x400a707540}, 0x4004cbfe60)
	k8s.io/apiserver/pkg/endpoints/filters/audit_init.go:63 +0x110
net/http.HandlerFunc.ServeHTTP(0x0?, {0x32d0590?, 0x400a707540?}, 0x400377d440?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.(*APIServerHandler).ServeHTTP(0x0?, {0x32d0590?, 0x400a707540?}, 0x103b860?)
	k8s.io/apiserver/pkg/server/handler.go:189 +0x30
net/http.serverHandler.ServeHTTP({0x4007c1de18?}, {0x32d0590?, 0x400a707540?}, 0x32fa1c0?)
	net/http/server.go:3137 +0xbc
net/http.initALPNRequest.ServeHTTP({{0x32e1798?, 0x400aa159e0?}, 0x400722d508?, {0x40036e1860?}}, {0x32d0590, 0x400a707540}, 0x4004cbfe60)
	net/http/server.go:3745 +0x1b4
golang.org/x/net/http2.(*serverConn).runHandler(0x0?, 0x89634?, 0x0?, 0x4007c1dfb0?)
	golang.org/x/net@v0.23.0/http2/server.go:2369 +0xc0
created by golang.org/x/net/http2.(*serverConn).scheduleHandler in goroutine 12143078
	golang.org/x/net@v0.23.0/http2/server.go:2304 +0x208
E0709 09:56:47.587146       1 wrap.go:58] "apiserver panic'd" method="GET" URI="/api/v1/replicationcontrollers?allowWatchBookmarks=true&limit=500&resourceVersionMatch=NotOlderThan&sendInitialEvents=true&watch=true" auditID="3e26616d-625e-42bb-96fd-4649614be073"
http2: panic serving 192.168.228.1:58402: runtime error: invalid memory address or nil pointer dereference
goroutine 12143105 [running]:
golang.org/x/net/http2.(*serverConn).runHandler.func1()
	golang.org/x/net@v0.23.0/http2/server.go:2362 +0x13c
panic({0x277c340?, 0x4dd78a0?})
	runtime/panic.go:770 +0x124
k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x4006792000, 0x1, 0x40073d9880?})
	k8s.io/apimachinery/pkg/util/runtime/runtime.go:56 +0xe0
panic({0x277c340?, 0x4dd78a0?})
	runtime/panic.go:770 +0x124
k8s.io/kubernetes/pkg/printers/internalversion.printReplicationController(0x400498ac60, {0x5?, 0x0?})
	k8s.io/kubernetes/pkg/printers/internalversion/printers.go:1127 +0x1e4
reflect.Value.call({0x2768f20?, 0x2e46cf0?, 0x13?}, {0x2c20ae1, 0x4}, {0x4006792b18, 0x2, 0x2?})
	reflect/value.go:596 +0x970
reflect.Value.Call({0x2768f20?, 0x2e46cf0?, 0x400972ab58?}, {0x400972ab18?, 0xa1c9014d05411b2a?, 0x15?})
	reflect/value.go:380 +0x94
k8s.io/kubernetes/pkg/printers.(*HumanReadableGenerator).GenerateTable(0x400972abb8?, {0x32c2bb8, 0x400498ac60}, {0x0, 0x1})
	k8s.io/kubernetes/pkg/printers/tablegenerator.go:86 +0x1b8
k8s.io/kubernetes/pkg/printers/storage.TableConvertor.ConvertToTable({{0x32b7ea0?, 0x400066ce30?}}, {0x80?, 0x10?}, {0x32c2bb8?, 0x400498ac60?}, {0x32bc360?, 0x4008a8dd40?})
	k8s.io/kubernetes/pkg/printers/storage/storage.go:46 +0xd8
k8s.io/apiserver/pkg/registry/generic/registry.(*Store).ConvertToTable(0x0?, {0x32e1798?, 0x4004e019b0?}, {0x32c2bb8?, 0x400498ac60?}, {0x32bc360?, 0x4008a8dd40?})
	k8s.io/apiserver/pkg/registry/generic/registry/store.go:1644 +0x44
k8s.io/apiserver/pkg/endpoints/handlers.asTable({0x32e1798, 0x4004e019b0}, {0x32c2bb8, 0x400498ac60}, 0x4008a8dd40, 0x400199e1a0, {{0x400723cd41, 0xb}, {0x400723cd3c, 0x2}})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:375 +0x17c
k8s.io/apiserver/pkg/endpoints/handlers.doTransformObject({0x32e1798, 0x4004e019b0}, {0x32c2bb8, 0x400498ac60}, {0x2b43c00, 0x4008a8dd40}, 0x4004e01e60, 0x400199e1a0)
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:270 +0x188
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEmbeddedEncoder).doEncode(0x400a0ca690, {0x32c2bb8, 0x400498ac60}, {0xffff66499918, 0x4002d7e2c0})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:82 +0x68
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEmbeddedEncoder).Encode(0x400a0ca690, {0x32c2bb8?, 0x400498ac60}, {0xffff66499918, 0x4002d7e2c0})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:78 +0x114
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).doEncode(0x4009ca0e70, {0x32c2bb8, 0x400498ac60}, {{0x2c27806?, 0x400972b278?}, {0x32c2bb8?, 0x400498ac60?}}, {0xffff664f8b18, 0x4007e89e40})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:186 +0xd4
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).Encode.func1(...)
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:175
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).Encode(0x4009ca0e70, {{0x2c27806?, 0x32c2bb8?}, {0x32c2bb8?, 0x400498ac60?}})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:180 +0x140
k8s.io/apiserver/pkg/endpoints/handlers.(*WatchServer).HandleHTTP(0x4008405860, {0x32d0800, 0x4007e89e40}, 0x4002b70ea0)
	k8s.io/apiserver/pkg/endpoints/handlers/watch.go:249 +0x944
net/http.HandlerFunc.ServeHTTP(0x400972b678?, {0x32d0800?, 0x4007e89e40?}, 0x4002ad6620?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/endpoints/handlers.ListResource.func1.4.1()
	k8s.io/apiserver/pkg/endpoints/handlers/get.go:283 +0x74
k8s.io/apiserver/pkg/endpoints/metrics.RecordLongRunning(0x4002b70ea0, 0x25d7aa0?, {0x2c282c0, 0x9}, 0x400972b870)
	k8s.io/apiserver/pkg/endpoints/metrics/metrics.go:528 +0x494
k8s.io/apiserver/pkg/endpoints/handlers.ListResource.func1.4()
	k8s.io/apiserver/pkg/endpoints/handlers/get.go:281 +0x10c
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRoutine.func17({0x32d0590, 0x400a707540}, 0x4002b70240)
	k8s.io/apiserver/pkg/server/filters/routine.go:73 +0x190
net/http.HandlerFunc.ServeHTTP(0x4002b70120?, {0x32d0590?, 0x400a707540?}, 0x400050c808?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRequestInfo.func18({0x32d0590, 0x400a707540}, 0x4002b70120)
	k8s.io/apiserver/pkg/endpoints/filters/requestinfo.go:39 +0x104
net/http.HandlerFunc.ServeHTTP(0x4002b70000?, {0x32d0590?, 0x400a707540?}, 0x58bfd0125f3c?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRequestReceivedTimestamp.withRequestReceivedTimestampWithClock.func32({0x32d0590, 0x400a707540}, 0x4002b70000)
	k8s.io/apiserver/pkg/endpoints/filters/request_received_time.go:38 +0xac
net/http.HandlerFunc.ServeHTTP(0x4007c1daf8?, {0x32d0590?, 0x400a707540?}, 0xffff666348a8?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithMuxAndDiscoveryComplete.func19({0x32d0590?, 0x400a707540?}, 0x4002b70000?)
	k8s.io/apiserver/pkg/endpoints/filters/mux_discovery_complete.go:52 +0xd0
net/http.HandlerFunc.ServeHTTP(0x40046f6201?, {0x32d0590?, 0x400a707540?}, 0x5271c32b9e80fdb9?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithPanicRecovery.withPanicRecovery.func33({0x32d0590?, 0x400a707540?}, 0x40046f6240?)
	k8s.io/apiserver/pkg/server/filters/wrap.go:74 +0x9c
net/http.HandlerFunc.ServeHTTP(0x4004e01470?, {0x32d0590?, 0x400a707540?}, 0x400a734b10?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithAuditInit.withAuditInit.func34({0x32d0590, 0x400a707540}, 0x4004cbfe60)
	k8s.io/apiserver/pkg/endpoints/filters/audit_init.go:63 +0x110
net/http.HandlerFunc.ServeHTTP(0x0?, {0x32d0590?, 0x400a707540?}, 0x400377d440?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.(*APIServerHandler).ServeHTTP(0x0?, {0x32d0590?, 0x400a707540?}, 0x103b860?)
	k8s.io/apiserver/pkg/server/handler.go:189 +0x30
net/http.serverHandler.ServeHTTP({0x4007c1de18?}, {0x32d0590?, 0x400a707540?}, 0x32fa1c0?)
	net/http/server.go:3137 +0xbc
net/http.initALPNRequest.ServeHTTP({{0x32e1798?, 0x400aa159e0?}, 0x400722d508?, {0x40036e1860?}}, {0x32d0590, 0x400a707540}, 0x4004cbfe60)
	net/http/server.go:3745 +0x1b4
golang.org/x/net/http2.(*serverConn).runHandler(0x0?, 0x89634?, 0x0?, 0x4007c1dfb0?)
	golang.org/x/net@v0.23.0/http2/server.go:2369 +0xc0
created by golang.org/x/net/http2.(*serverConn).scheduleHandler in goroutine 12143078
	golang.org/x/net@v0.23.0/http2/server.go:2304 +0x208
E0709 09:56:48.809016       1 runtime.go:79] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
goroutine 12143084 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic({0x277c340, 0x4dd78a0})
	k8s.io/apimachinery/pkg/util/runtime/runtime.go:75 +0x7c
k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x4003ea6000, 0x1, 0x4008ddca80?})
	k8s.io/apimachinery/pkg/util/runtime/runtime.go:49 +0x78
panic({0x277c340?, 0x4dd78a0?})
	runtime/panic.go:770 +0x124
k8s.io/kubernetes/pkg/printers/internalversion.printReplicationController(0x400769c000, {0x5?, 0x0?})
	k8s.io/kubernetes/pkg/printers/internalversion/printers.go:1127 +0x1e4
reflect.Value.call({0x2768f20?, 0x2e46cf0?, 0x13?}, {0x2c20ae1, 0x4}, {0x4003ea6b18, 0x2, 0x2?})
	reflect/value.go:596 +0x970
reflect.Value.Call({0x2768f20?, 0x2e46cf0?, 0x400972cb58?}, {0x400972cb18?, 0xffff66336aa0?, 0x40097e8720?})
	reflect/value.go:380 +0x94
k8s.io/kubernetes/pkg/printers.(*HumanReadableGenerator).GenerateTable(0x2bb9aa0?, {0x32c2bb8, 0x400769c000}, {0x0, 0x1})
	k8s.io/kubernetes/pkg/printers/tablegenerator.go:86 +0x1b8
k8s.io/kubernetes/pkg/printers/storage.TableConvertor.ConvertToTable({{0x32b7ea0?, 0x400066ce30?}}, {0x40011cc990?, 0x32c8380?}, {0x32c2bb8?, 0x400769c000?}, {0x32bc360?, 0x4008f7a700?})
	k8s.io/kubernetes/pkg/printers/storage/storage.go:46 +0xd8
k8s.io/apiserver/pkg/registry/generic/registry.(*Store).ConvertToTable(0x4e37d40?, {0x32e1798?, 0x4004c4d920?}, {0x32c2bb8?, 0x400769c000?}, {0x32bc360?, 0x4008f7a700?})
	k8s.io/apiserver/pkg/registry/generic/registry/store.go:1644 +0x44
k8s.io/apiserver/pkg/endpoints/handlers.asTable({0x32e1798, 0x4004c4d920}, {0x32c2bb8, 0x400769c000}, 0x4008f7a700, 0x400199e1a0, {{0x400723cd41, 0xb}, {0x400723cd3c, 0x2}})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:375 +0x17c
k8s.io/apiserver/pkg/endpoints/handlers.doTransformObject({0x32e1798, 0x4004c4d920}, {0x32c2bb8, 0x400769c000}, {0x2b43c00, 0x4008f7a700}, 0x4004c4dce0, 0x400199e1a0)
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:270 +0x188
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEmbeddedEncoder).doEncode(0x4009fe7db0, {0x32c2bb8, 0x400769c000}, {0xffff66499918, 0x40088e1240})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:82 +0x68
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEmbeddedEncoder).Encode(0x4009fe7db0, {0x32c2bb8?, 0x400769c000}, {0xffff66499918, 0x40088e1240})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:78 +0x114
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).doEncode(0x4009e3f550, {0x32c2bb8, 0x400769c000}, {{0x2c27806?, 0x400972d278?}, {0x32c2bb8?, 0x400769c000?}}, {0xffff664f8b18, 0x40050449a0})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:186 +0xd4
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).Encode.func1(...)
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:175
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).Encode(0x4009e3f550, {{0x2c27806?, 0x32c2bb8?}, {0x32c2bb8?, 0x400769c000?}})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:180 +0x140
k8s.io/apiserver/pkg/endpoints/handlers.(*WatchServer).HandleHTTP(0x4003b2e3c0, {0x32d0800, 0x40050449a0}, 0x4002915560)
	k8s.io/apiserver/pkg/endpoints/handlers/watch.go:249 +0x944
net/http.HandlerFunc.ServeHTTP(0x400972d678?, {0x32d0800?, 0x40050449a0?}, 0x4001a3ebd0?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/endpoints/handlers.ListResource.func1.4.1()
	k8s.io/apiserver/pkg/endpoints/handlers/get.go:283 +0x74
k8s.io/apiserver/pkg/endpoints/metrics.RecordLongRunning(0x4002915560, 0x25d7aa0?, {0x2c282c0, 0x9}, 0x400972d870)
	k8s.io/apiserver/pkg/endpoints/metrics/metrics.go:528 +0x494
k8s.io/apiserver/pkg/endpoints/handlers.ListResource.func1.4()
	k8s.io/apiserver/pkg/endpoints/handlers/get.go:281 +0x10c
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRoutine.func17({0x32d0590, 0x400052bea0}, 0x4002914b40)
	k8s.io/apiserver/pkg/server/filters/routine.go:73 +0x190
net/http.HandlerFunc.ServeHTTP(0x4002914a20?, {0x32d0590?, 0x400052bea0?}, 0x4000d00008?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRequestInfo.func18({0x32d0590, 0x400052bea0}, 0x4002914a20)
	k8s.io/apiserver/pkg/endpoints/filters/requestinfo.go:39 +0x104
net/http.HandlerFunc.ServeHTTP(0x4002914900?, {0x32d0590?, 0x400052bea0?}, 0x58bffdf0a40d?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRequestReceivedTimestamp.withRequestReceivedTimestampWithClock.func32({0x32d0590, 0x400052bea0}, 0x4002914900)
	k8s.io/apiserver/pkg/endpoints/filters/request_received_time.go:38 +0xac
net/http.HandlerFunc.ServeHTTP(0x40023b2af8?, {0x32d0590?, 0x400052bea0?}, 0xffff660f3f08?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithMuxAndDiscoveryComplete.func19({0x32d0590?, 0x400052bea0?}, 0x4002914900?)
	k8s.io/apiserver/pkg/endpoints/filters/mux_discovery_complete.go:52 +0xd0
net/http.HandlerFunc.ServeHTTP(0x4004911e01?, {0x32d0590?, 0x400052bea0?}, 0x385111ff443d4314?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithPanicRecovery.withPanicRecovery.func33({0x32d0590?, 0x400052bea0?}, 0x4004911e00?)
	k8s.io/apiserver/pkg/server/filters/wrap.go:74 +0x9c
net/http.HandlerFunc.ServeHTTP(0x4004c4d350?, {0x32d0590?, 0x400052bea0?}, 0x4000eb8900?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithAuditInit.withAuditInit.func34({0x32d0590, 0x400052bea0}, 0x40029147e0)
	k8s.io/apiserver/pkg/endpoints/filters/audit_init.go:63 +0x110
net/http.HandlerFunc.ServeHTTP(0x72?, {0x32d0590?, 0x400052bea0?}, 0x72?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.(*APIServerHandler).ServeHTTP(0x0?, {0x32d0590?, 0x400052bea0?}, 0x5000?)
	k8s.io/apiserver/pkg/server/handler.go:189 +0x30
net/http.serverHandler.ServeHTTP({0x40023b2e18?}, {0x32d0590?, 0x400052bea0?}, 0x40092bc0f0?)
	net/http/server.go:3137 +0xbc
net/http.initALPNRequest.ServeHTTP({{0x32e1798?, 0x400aa159e0?}, 0x400722d508?, {0x40036e1860?}}, {0x32d0590, 0x400052bea0}, 0x40029147e0)
	net/http/server.go:3745 +0x1b4
golang.org/x/net/http2.(*serverConn).runHandler(0x4ea0de0?, 0x0?, 0x0?, 0x400492ccb0?)
	golang.org/x/net@v0.23.0/http2/server.go:2369 +0xc0
created by golang.org/x/net/http2.(*serverConn).scheduleHandler in goroutine 12143078
	golang.org/x/net@v0.23.0/http2/server.go:2304 +0x208
E0709 09:56:48.809048       1 wrap.go:58] "apiserver panic'd" method="GET" URI="/api/v1/replicationcontrollers?allowWatchBookmarks=true&limit=500&resourceVersionMatch=NotOlderThan&sendInitialEvents=true&watch=true" auditID="1756f838-86e6-4788-a1a8-9e064d3f845b"
http2: panic serving 192.168.228.1:58402: runtime error: invalid memory address or nil pointer dereference
goroutine 12143084 [running]:
golang.org/x/net/http2.(*serverConn).runHandler.func1()
	golang.org/x/net@v0.23.0/http2/server.go:2362 +0x13c
panic({0x277c340?, 0x4dd78a0?})
	runtime/panic.go:770 +0x124
k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x4003ea6000, 0x1, 0x4008ddca80?})
	k8s.io/apimachinery/pkg/util/runtime/runtime.go:56 +0xe0
panic({0x277c340?, 0x4dd78a0?})
	runtime/panic.go:770 +0x124
k8s.io/kubernetes/pkg/printers/internalversion.printReplicationController(0x400769c000, {0x5?, 0x0?})
	k8s.io/kubernetes/pkg/printers/internalversion/printers.go:1127 +0x1e4
reflect.Value.call({0x2768f20?, 0x2e46cf0?, 0x13?}, {0x2c20ae1, 0x4}, {0x4003ea6b18, 0x2, 0x2?})
	reflect/value.go:596 +0x970
reflect.Value.Call({0x2768f20?, 0x2e46cf0?, 0x400972cb58?}, {0x400972cb18?, 0xffff66336aa0?, 0x40097e8720?})
	reflect/value.go:380 +0x94
k8s.io/kubernetes/pkg/printers.(*HumanReadableGenerator).GenerateTable(0x2bb9aa0?, {0x32c2bb8, 0x400769c000}, {0x0, 0x1})
	k8s.io/kubernetes/pkg/printers/tablegenerator.go:86 +0x1b8
k8s.io/kubernetes/pkg/printers/storage.TableConvertor.ConvertToTable({{0x32b7ea0?, 0x400066ce30?}}, {0x40011cc990?, 0x32c8380?}, {0x32c2bb8?, 0x400769c000?}, {0x32bc360?, 0x4008f7a700?})
	k8s.io/kubernetes/pkg/printers/storage/storage.go:46 +0xd8
k8s.io/apiserver/pkg/registry/generic/registry.(*Store).ConvertToTable(0x4e37d40?, {0x32e1798?, 0x4004c4d920?}, {0x32c2bb8?, 0x400769c000?}, {0x32bc360?, 0x4008f7a700?})
	k8s.io/apiserver/pkg/registry/generic/registry/store.go:1644 +0x44
k8s.io/apiserver/pkg/endpoints/handlers.asTable({0x32e1798, 0x4004c4d920}, {0x32c2bb8, 0x400769c000}, 0x4008f7a700, 0x400199e1a0, {{0x400723cd41, 0xb}, {0x400723cd3c, 0x2}})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:375 +0x17c
k8s.io/apiserver/pkg/endpoints/handlers.doTransformObject({0x32e1798, 0x4004c4d920}, {0x32c2bb8, 0x400769c000}, {0x2b43c00, 0x4008f7a700}, 0x4004c4dce0, 0x400199e1a0)
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:270 +0x188
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEmbeddedEncoder).doEncode(0x4009fe7db0, {0x32c2bb8, 0x400769c000}, {0xffff66499918, 0x40088e1240})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:82 +0x68
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEmbeddedEncoder).Encode(0x4009fe7db0, {0x32c2bb8?, 0x400769c000}, {0xffff66499918, 0x40088e1240})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:78 +0x114
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).doEncode(0x4009e3f550, {0x32c2bb8, 0x400769c000}, {{0x2c27806?, 0x400972d278?}, {0x32c2bb8?, 0x400769c000?}}, {0xffff664f8b18, 0x40050449a0})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:186 +0xd4
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).Encode.func1(...)
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:175
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).Encode(0x4009e3f550, {{0x2c27806?, 0x32c2bb8?}, {0x32c2bb8?, 0x400769c000?}})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:180 +0x140
k8s.io/apiserver/pkg/endpoints/handlers.(*WatchServer).HandleHTTP(0x4003b2e3c0, {0x32d0800, 0x40050449a0}, 0x4002915560)
	k8s.io/apiserver/pkg/endpoints/handlers/watch.go:249 +0x944
net/http.HandlerFunc.ServeHTTP(0x400972d678?, {0x32d0800?, 0x40050449a0?}, 0x4001a3ebd0?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/endpoints/handlers.ListResource.func1.4.1()
	k8s.io/apiserver/pkg/endpoints/handlers/get.go:283 +0x74
k8s.io/apiserver/pkg/endpoints/metrics.RecordLongRunning(0x4002915560, 0x25d7aa0?, {0x2c282c0, 0x9}, 0x400972d870)
	k8s.io/apiserver/pkg/endpoints/metrics/metrics.go:528 +0x494
k8s.io/apiserver/pkg/endpoints/handlers.ListResource.func1.4()
	k8s.io/apiserver/pkg/endpoints/handlers/get.go:281 +0x10c
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRoutine.func17({0x32d0590, 0x400052bea0}, 0x4002914b40)
	k8s.io/apiserver/pkg/server/filters/routine.go:73 +0x190
net/http.HandlerFunc.ServeHTTP(0x4002914a20?, {0x32d0590?, 0x400052bea0?}, 0x4000d00008?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRequestInfo.func18({0x32d0590, 0x400052bea0}, 0x4002914a20)
	k8s.io/apiserver/pkg/endpoints/filters/requestinfo.go:39 +0x104
net/http.HandlerFunc.ServeHTTP(0x4002914900?, {0x32d0590?, 0x400052bea0?}, 0x58bffdf0a40d?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRequestReceivedTimestamp.withRequestReceivedTimestampWithClock.func32({0x32d0590, 0x400052bea0}, 0x4002914900)
	k8s.io/apiserver/pkg/endpoints/filters/request_received_time.go:38 +0xac
net/http.HandlerFunc.ServeHTTP(0x40023b2af8?, {0x32d0590?, 0x400052bea0?}, 0xffff660f3f08?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithMuxAndDiscoveryComplete.func19({0x32d0590?, 0x400052bea0?}, 0x4002914900?)
	k8s.io/apiserver/pkg/endpoints/filters/mux_discovery_complete.go:52 +0xd0
net/http.HandlerFunc.ServeHTTP(0x4004911e01?, {0x32d0590?, 0x400052bea0?}, 0x385111ff443d4314?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithPanicRecovery.withPanicRecovery.func33({0x32d0590?, 0x400052bea0?}, 0x4004911e00?)
	k8s.io/apiserver/pkg/server/filters/wrap.go:74 +0x9c
net/http.HandlerFunc.ServeHTTP(0x4004c4d350?, {0x32d0590?, 0x400052bea0?}, 0x4000eb8900?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithAuditInit.withAuditInit.func34({0x32d0590, 0x400052bea0}, 0x40029147e0)
	k8s.io/apiserver/pkg/endpoints/filters/audit_init.go:63 +0x110
net/http.HandlerFunc.ServeHTTP(0x72?, {0x32d0590?, 0x400052bea0?}, 0x72?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.(*APIServerHandler).ServeHTTP(0x0?, {0x32d0590?, 0x400052bea0?}, 0x5000?)
	k8s.io/apiserver/pkg/server/handler.go:189 +0x30
net/http.serverHandler.ServeHTTP({0x40023b2e18?}, {0x32d0590?, 0x400052bea0?}, 0x40092bc0f0?)
	net/http/server.go:3137 +0xbc
net/http.initALPNRequest.ServeHTTP({{0x32e1798?, 0x400aa159e0?}, 0x400722d508?, {0x40036e1860?}}, {0x32d0590, 0x400052bea0}, 0x40029147e0)
	net/http/server.go:3745 +0x1b4
golang.org/x/net/http2.(*serverConn).runHandler(0x4ea0de0?, 0x0?, 0x0?, 0x400492ccb0?)
	golang.org/x/net@v0.23.0/http2/server.go:2369 +0xc0
created by golang.org/x/net/http2.(*serverConn).scheduleHandler in goroutine 12143078
	golang.org/x/net@v0.23.0/http2/server.go:2304 +0x208
I0709 09:57:25.916523       1 trace.go:236] Trace[1714632612]: "Update" accept:application/vnd.kubernetes.protobuf, */*,audit-id:d5a88dd2-dca3-4f42-a41f-de25e44678c3,client:192.168.228.2,api-group:coordination.k8s.io,api-version:v1,name:kube-controller-manager,subresource:,namespace:kube-system,protocol:HTTP/2.0,resource:leases,scope:resource,url:/apis/coordination.k8s.io/v1/namespaces/kube-system/leases/kube-controller-manager,user-agent:kube-controller-manager/v1.30.0 (linux/arm64) kubernetes/7c48c2b/leader-election,verb:PUT (09-Jul-2024 09:57:25.227) (total time: 688ms):
Trace[1714632612]: ["GuaranteedUpdate etcd3" audit-id:d5a88dd2-dca3-4f42-a41f-de25e44678c3,key:/leases/kube-system/kube-controller-manager,type:*coordination.Lease,resource:leases.coordination.k8s.io 688ms (09:57:25.227)
Trace[1714632612]:  ---"Txn call completed" 686ms (09:57:25.916)]
Trace[1714632612]: [688.985007ms] [688.985007ms] END
E0709 09:57:39.884941       1 runtime.go:79] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
goroutine 12149587 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic({0x277c340, 0x4dd78a0})
	k8s.io/apimachinery/pkg/util/runtime/runtime.go:75 +0x7c
k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x4007070000, 0x1, 0x4007fc56c0?})
	k8s.io/apimachinery/pkg/util/runtime/runtime.go:49 +0x78
panic({0x277c340?, 0x4dd78a0?})
	runtime/panic.go:770 +0x124
k8s.io/kubernetes/pkg/printers/internalversion.printReplicationController(0x4009dbc2c0, {0x5?, 0x0?})
	k8s.io/kubernetes/pkg/printers/internalversion/printers.go:1127 +0x1e4
reflect.Value.call({0x2768f20?, 0x2e46cf0?, 0x13?}, {0x2c20ae1, 0x4}, {0x4007070b18, 0x2, 0x2?})
	reflect/value.go:596 +0x970
reflect.Value.Call({0x2768f20?, 0x2e46cf0?, 0x400984cb58?}, {0x400984cb18?, 0x4004068360?, 0x4003709000?})
	reflect/value.go:380 +0x94
k8s.io/kubernetes/pkg/printers.(*HumanReadableGenerator).GenerateTable(0x400984cb01?, {0x32c2bb8, 0x4009dbc2c0}, {0x0, 0x1})
	k8s.io/kubernetes/pkg/printers/tablegenerator.go:86 +0x1b8
k8s.io/kubernetes/pkg/printers/storage.TableConvertor.ConvertToTable({{0x32b7ea0?, 0x400066ce30?}}, {0x400493e290?, 0x400a479b90?}, {0x32c2bb8?, 0x4009dbc2c0?}, {0x32bc360?, 0x4008663700?})
	k8s.io/kubernetes/pkg/printers/storage/storage.go:46 +0xd8
k8s.io/apiserver/pkg/registry/generic/registry.(*Store).ConvertToTable(0x400984cc05?, {0x32e1798?, 0x4008b7ee10?}, {0x32c2bb8?, 0x4009dbc2c0?}, {0x32bc360?, 0x4008663700?})
	k8s.io/apiserver/pkg/registry/generic/registry/store.go:1644 +0x44
k8s.io/apiserver/pkg/endpoints/handlers.asTable({0x32e1798, 0x4008b7ee10}, {0x32c2bb8, 0x4009dbc2c0}, 0x4008663700, 0x400182d1e0, {{0x40004d1fa1, 0xb}, {0x40004d1f9c, 0x2}})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:375 +0x17c
k8s.io/apiserver/pkg/endpoints/handlers.doTransformObject({0x32e1798, 0x4008b7ee10}, {0x32c2bb8, 0x4009dbc2c0}, {0x2b43c00, 0x4008663700}, 0x4008b7f140, 0x400182d1e0)
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:270 +0x188
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEmbeddedEncoder).doEncode(0x40073b7310, {0x32c2bb8, 0x4009dbc2c0}, {0xffff66499918, 0x4008fbddc0})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:82 +0x68
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEmbeddedEncoder).Encode(0x40073b7310, {0x32c2bb8?, 0x4009dbc2c0}, {0xffff66499918, 0x4008fbddc0})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:78 +0x114
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).doEncode(0x4006cd33f0, {0x32c2bb8, 0x4009dbc2c0}, {{0x2c27806?, 0x400984d278?}, {0x32c2bb8?, 0x4009dbc2c0?}}, {0xffff664f8b18, 0x4008fbdb80})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:186 +0xd4
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).Encode.func1(...)
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:175
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).Encode(0x4006cd33f0, {{0x2c27806?, 0x32c2bb8?}, {0x32c2bb8?, 0x4009dbc2c0?}})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:180 +0x140
k8s.io/apiserver/pkg/endpoints/handlers.(*WatchServer).HandleHTTP(0x4007e6b9a0, {0x32d0800, 0x4008fbdb80}, 0x40039da000)
	k8s.io/apiserver/pkg/endpoints/handlers/watch.go:249 +0x944
net/http.HandlerFunc.ServeHTTP(0x400984d678?, {0x32d0800?, 0x4008fbdb80?}, 0x400185e5b0?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/endpoints/handlers.ListResource.func1.4.1()
	k8s.io/apiserver/pkg/endpoints/handlers/get.go:283 +0x74
k8s.io/apiserver/pkg/endpoints/metrics.RecordLongRunning(0x40039da000, 0x25d7aa0?, {0x2c282c0, 0x9}, 0x400984d870)
	k8s.io/apiserver/pkg/endpoints/metrics/metrics.go:528 +0x494
k8s.io/apiserver/pkg/endpoints/handlers.ListResource.func1.4()
	k8s.io/apiserver/pkg/endpoints/handlers/get.go:281 +0x10c
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRoutine.func17({0x32d0590, 0x4004e97c98}, 0x40040697a0)
	k8s.io/apiserver/pkg/server/filters/routine.go:73 +0x190
net/http.HandlerFunc.ServeHTTP(0x4004069680?, {0x32d0590?, 0x4004e97c98?}, 0x4000100008?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRequestInfo.func18({0x32d0590, 0x4004e97c98}, 0x4004069680)
	k8s.io/apiserver/pkg/endpoints/filters/requestinfo.go:39 +0x104
net/http.HandlerFunc.ServeHTTP(0x4004069560?, {0x32d0590?, 0x4004e97c98?}, 0x58cbec8c0790?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRequestReceivedTimestamp.withRequestReceivedTimestampWithClock.func32({0x32d0590, 0x4004e97c98}, 0x4004069560)
	k8s.io/apiserver/pkg/endpoints/filters/request_received_time.go:38 +0xac
net/http.HandlerFunc.ServeHTTP(0x40067a4af8?, {0x32d0590?, 0x4004e97c98?}, 0xffff664f95d0?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithMuxAndDiscoveryComplete.func19({0x32d0590?, 0x4004e97c98?}, 0x4004069560?)
	k8s.io/apiserver/pkg/endpoints/filters/mux_discovery_complete.go:52 +0xd0
net/http.HandlerFunc.ServeHTTP(0x400493e901?, {0x32d0590?, 0x4004e97c98?}, 0x1baf72e5ee7b0f6f?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithPanicRecovery.withPanicRecovery.func33({0x32d0590?, 0x4004e97c98?}, 0x400493e950?)
	k8s.io/apiserver/pkg/server/filters/wrap.go:74 +0x9c
net/http.HandlerFunc.ServeHTTP(0x4008b7e930?, {0x32d0590?, 0x4004e97c98?}, 0x40096d9830?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithAuditInit.withAuditInit.func34({0x32d0590, 0x4004e97c98}, 0x4004069440)
	k8s.io/apiserver/pkg/endpoints/filters/audit_init.go:63 +0x110
net/http.HandlerFunc.ServeHTTP(0x0?, {0x32d0590?, 0x4004e97c98?}, 0x4003b0cc60?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.(*APIServerHandler).ServeHTTP(0x0?, {0x32d0590?, 0x4004e97c98?}, 0x103b860?)
	k8s.io/apiserver/pkg/server/handler.go:189 +0x30
net/http.serverHandler.ServeHTTP({0x40067a4e18?}, {0x32d0590?, 0x4004e97c98?}, 0x32fa1c0?)
	net/http/server.go:3137 +0xbc
net/http.initALPNRequest.ServeHTTP({{0x32e1798?, 0x40080ce450?}, 0x4006730a88?, {0x40036e1860?}}, {0x32d0590, 0x4004e97c98}, 0x4004069440)
	net/http/server.go:3745 +0x1b4
golang.org/x/net/http2.(*serverConn).runHandler(0x0?, 0x89634?, 0x0?, 0x40067a4fb0?)
	golang.org/x/net@v0.23.0/http2/server.go:2369 +0xc0
created by golang.org/x/net/http2.(*serverConn).scheduleHandler in goroutine 12149578
	golang.org/x/net@v0.23.0/http2/server.go:2304 +0x208
E0709 09:57:39.885376       1 wrap.go:58] "apiserver panic'd" method="GET" URI="/api/v1/namespaces/default/replicationcontrollers?allowWatchBookmarks=true&limit=500&resourceVersionMatch=NotOlderThan&sendInitialEvents=true&watch=true" auditID="5c0782a3-1497-40f2-b5d7-5a4965a42d42"
http2: panic serving 192.168.228.1:33392: runtime error: invalid memory address or nil pointer dereference
goroutine 12149587 [running]:
golang.org/x/net/http2.(*serverConn).runHandler.func1()
	golang.org/x/net@v0.23.0/http2/server.go:2362 +0x13c
panic({0x277c340?, 0x4dd78a0?})
	runtime/panic.go:770 +0x124
k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x4007070000, 0x1, 0x4007fc56c0?})
	k8s.io/apimachinery/pkg/util/runtime/runtime.go:56 +0xe0
panic({0x277c340?, 0x4dd78a0?})
	runtime/panic.go:770 +0x124
k8s.io/kubernetes/pkg/printers/internalversion.printReplicationController(0x4009dbc2c0, {0x5?, 0x0?})
	k8s.io/kubernetes/pkg/printers/internalversion/printers.go:1127 +0x1e4
reflect.Value.call({0x2768f20?, 0x2e46cf0?, 0x13?}, {0x2c20ae1, 0x4}, {0x4007070b18, 0x2, 0x2?})
	reflect/value.go:596 +0x970
reflect.Value.Call({0x2768f20?, 0x2e46cf0?, 0x400984cb58?}, {0x400984cb18?, 0x4004068360?, 0x4003709000?})
	reflect/value.go:380 +0x94
k8s.io/kubernetes/pkg/printers.(*HumanReadableGenerator).GenerateTable(0x400984cb01?, {0x32c2bb8, 0x4009dbc2c0}, {0x0, 0x1})
	k8s.io/kubernetes/pkg/printers/tablegenerator.go:86 +0x1b8
k8s.io/kubernetes/pkg/printers/storage.TableConvertor.ConvertToTable({{0x32b7ea0?, 0x400066ce30?}}, {0x400493e290?, 0x400a479b90?}, {0x32c2bb8?, 0x4009dbc2c0?}, {0x32bc360?, 0x4008663700?})
	k8s.io/kubernetes/pkg/printers/storage/storage.go:46 +0xd8
k8s.io/apiserver/pkg/registry/generic/registry.(*Store).ConvertToTable(0x400984cc05?, {0x32e1798?, 0x4008b7ee10?}, {0x32c2bb8?, 0x4009dbc2c0?}, {0x32bc360?, 0x4008663700?})
	k8s.io/apiserver/pkg/registry/generic/registry/store.go:1644 +0x44
k8s.io/apiserver/pkg/endpoints/handlers.asTable({0x32e1798, 0x4008b7ee10}, {0x32c2bb8, 0x4009dbc2c0}, 0x4008663700, 0x400182d1e0, {{0x40004d1fa1, 0xb}, {0x40004d1f9c, 0x2}})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:375 +0x17c
k8s.io/apiserver/pkg/endpoints/handlers.doTransformObject({0x32e1798, 0x4008b7ee10}, {0x32c2bb8, 0x4009dbc2c0}, {0x2b43c00, 0x4008663700}, 0x4008b7f140, 0x400182d1e0)
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:270 +0x188
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEmbeddedEncoder).doEncode(0x40073b7310, {0x32c2bb8, 0x4009dbc2c0}, {0xffff66499918, 0x4008fbddc0})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:82 +0x68
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEmbeddedEncoder).Encode(0x40073b7310, {0x32c2bb8?, 0x4009dbc2c0}, {0xffff66499918, 0x4008fbddc0})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:78 +0x114
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).doEncode(0x4006cd33f0, {0x32c2bb8, 0x4009dbc2c0}, {{0x2c27806?, 0x400984d278?}, {0x32c2bb8?, 0x4009dbc2c0?}}, {0xffff664f8b18, 0x4008fbdb80})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:186 +0xd4
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).Encode.func1(...)
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:175
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).Encode(0x4006cd33f0, {{0x2c27806?, 0x32c2bb8?}, {0x32c2bb8?, 0x4009dbc2c0?}})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:180 +0x140
k8s.io/apiserver/pkg/endpoints/handlers.(*WatchServer).HandleHTTP(0x4007e6b9a0, {0x32d0800, 0x4008fbdb80}, 0x40039da000)
	k8s.io/apiserver/pkg/endpoints/handlers/watch.go:249 +0x944
net/http.HandlerFunc.ServeHTTP(0x400984d678?, {0x32d0800?, 0x4008fbdb80?}, 0x400185e5b0?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/endpoints/handlers.ListResource.func1.4.1()
	k8s.io/apiserver/pkg/endpoints/handlers/get.go:283 +0x74
k8s.io/apiserver/pkg/endpoints/metrics.RecordLongRunning(0x40039da000, 0x25d7aa0?, {0x2c282c0, 0x9}, 0x400984d870)
	k8s.io/apiserver/pkg/endpoints/metrics/metrics.go:528 +0x494
k8s.io/apiserver/pkg/endpoints/handlers.ListResource.func1.4()
	k8s.io/apiserver/pkg/endpoints/handlers/get.go:281 +0x10c
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRoutine.func17({0x32d0590, 0x4004e97c98}, 0x40040697a0)
	k8s.io/apiserver/pkg/server/filters/routine.go:73 +0x190
net/http.HandlerFunc.ServeHTTP(0x4004069680?, {0x32d0590?, 0x4004e97c98?}, 0x4000100008?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRequestInfo.func18({0x32d0590, 0x4004e97c98}, 0x4004069680)
	k8s.io/apiserver/pkg/endpoints/filters/requestinfo.go:39 +0x104
net/http.HandlerFunc.ServeHTTP(0x4004069560?, {0x32d0590?, 0x4004e97c98?}, 0x58cbec8c0790?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRequestReceivedTimestamp.withRequestReceivedTimestampWithClock.func32({0x32d0590, 0x4004e97c98}, 0x4004069560)
	k8s.io/apiserver/pkg/endpoints/filters/request_received_time.go:38 +0xac
net/http.HandlerFunc.ServeHTTP(0x40067a4af8?, {0x32d0590?, 0x4004e97c98?}, 0xffff664f95d0?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithMuxAndDiscoveryComplete.func19({0x32d0590?, 0x4004e97c98?}, 0x4004069560?)
	k8s.io/apiserver/pkg/endpoints/filters/mux_discovery_complete.go:52 +0xd0
net/http.HandlerFunc.ServeHTTP(0x400493e901?, {0x32d0590?, 0x4004e97c98?}, 0x1baf72e5ee7b0f6f?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithPanicRecovery.withPanicRecovery.func33({0x32d0590?, 0x4004e97c98?}, 0x400493e950?)
	k8s.io/apiserver/pkg/server/filters/wrap.go:74 +0x9c
net/http.HandlerFunc.ServeHTTP(0x4008b7e930?, {0x32d0590?, 0x4004e97c98?}, 0x40096d9830?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithAuditInit.withAuditInit.func34({0x32d0590, 0x4004e97c98}, 0x4004069440)
	k8s.io/apiserver/pkg/endpoints/filters/audit_init.go:63 +0x110
net/http.HandlerFunc.ServeHTTP(0x0?, {0x32d0590?, 0x4004e97c98?}, 0x4003b0cc60?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.(*APIServerHandler).ServeHTTP(0x0?, {0x32d0590?, 0x4004e97c98?}, 0x103b860?)
	k8s.io/apiserver/pkg/server/handler.go:189 +0x30
net/http.serverHandler.ServeHTTP({0x40067a4e18?}, {0x32d0590?, 0x4004e97c98?}, 0x32fa1c0?)
	net/http/server.go:3137 +0xbc
net/http.initALPNRequest.ServeHTTP({{0x32e1798?, 0x40080ce450?}, 0x4006730a88?, {0x40036e1860?}}, {0x32d0590, 0x4004e97c98}, 0x4004069440)
	net/http/server.go:3745 +0x1b4
golang.org/x/net/http2.(*serverConn).runHandler(0x0?, 0x89634?, 0x0?, 0x40067a4fb0?)
	golang.org/x/net@v0.23.0/http2/server.go:2369 +0xc0
created by golang.org/x/net/http2.(*serverConn).scheduleHandler in goroutine 12149578
	golang.org/x/net@v0.23.0/http2/server.go:2304 +0x208
E0709 09:59:28.858654       1 runtime.go:79] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
goroutine 12163272 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic({0x277c340, 0x4dd78a0})
	k8s.io/apimachinery/pkg/util/runtime/runtime.go:75 +0x7c
k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x4006d3a000, 0x1, 0x4009e87c00?})
	k8s.io/apimachinery/pkg/util/runtime/runtime.go:49 +0x78
panic({0x277c340?, 0x4dd78a0?})
	runtime/panic.go:770 +0x124
k8s.io/kubernetes/pkg/printers/internalversion.printReplicationController(0x40070d11e0, {0x5?, 0x0?})
	k8s.io/kubernetes/pkg/printers/internalversion/printers.go:1127 +0x1e4
reflect.Value.call({0x2768f20?, 0x2e46cf0?, 0x13?}, {0x2c20ae1, 0x4}, {0x4006d3ab18, 0x2, 0x2?})
	reflect/value.go:596 +0x970
reflect.Value.Call({0x2768f20?, 0x2e46cf0?, 0x4009862b58?}, {0x4009862b18?, 0x4009862a58?, 0x629b4?})
	reflect/value.go:380 +0x94
k8s.io/kubernetes/pkg/printers.(*HumanReadableGenerator).GenerateTable(0x4009862bb8?, {0x32c2bb8, 0x40070d11e0}, {0x0, 0x1})
	k8s.io/kubernetes/pkg/printers/tablegenerator.go:86 +0x1b8
k8s.io/kubernetes/pkg/printers/storage.TableConvertor.ConvertToTable({{0x32b7ea0?, 0x400066ce30?}}, {0x80?, 0x10?}, {0x32c2bb8?, 0x40070d11e0?}, {0x32bc360?, 0x400964d080?})
	k8s.io/kubernetes/pkg/printers/storage/storage.go:46 +0xd8
k8s.io/apiserver/pkg/registry/generic/registry.(*Store).ConvertToTable(0x0?, {0x32e1798?, 0x4004f2ec30?}, {0x32c2bb8?, 0x40070d11e0?}, {0x32bc360?, 0x400964d080?})
	k8s.io/apiserver/pkg/registry/generic/registry/store.go:1644 +0x44
k8s.io/apiserver/pkg/endpoints/handlers.asTable({0x32e1798, 0x4004f2ec30}, {0x32c2bb8, 0x40070d11e0}, 0x400964d080, 0x400199e1a0, {{0x4007ef2f01, 0xb}, {0x4007ef2efc, 0x2}})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:375 +0x17c
k8s.io/apiserver/pkg/endpoints/handlers.doTransformObject({0x32e1798, 0x4004f2ec30}, {0x32c2bb8, 0x40070d11e0}, {0x2b43c00, 0x400964d080}, 0x4004f2f0b0, 0x400199e1a0)
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:270 +0x188
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEmbeddedEncoder).doEncode(0x40070e7ae0, {0x32c2bb8, 0x40070d11e0}, {0xffff66499918, 0x4008eeacc0})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:82 +0x68
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEmbeddedEncoder).Encode(0x40070e7ae0, {0x32c2bb8?, 0x40070d11e0}, {0xffff66499918, 0x4008eeacc0})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:78 +0x114
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).doEncode(0x40092a2790, {0x32c2bb8, 0x40070d11e0}, {{0x2c27806?, 0x4009863278?}, {0x32c2bb8?, 0x40070d11e0?}}, {0xffff664f8b18, 0x4008eea8c0})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:186 +0xd4
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).Encode.func1(...)
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:175
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).Encode(0x40092a2790, {{0x2c27806?, 0x32c2bb8?}, {0x32c2bb8?, 0x40070d11e0?}})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:180 +0x140
k8s.io/apiserver/pkg/endpoints/handlers.(*WatchServer).HandleHTTP(0x4007f5d680, {0x32d0800, 0x4008eea8c0}, 0x40040ae900)
	k8s.io/apiserver/pkg/endpoints/handlers/watch.go:249 +0x944
net/http.HandlerFunc.ServeHTTP(0x4009863678?, {0x32d0800?, 0x4008eea8c0?}, 0x4002bdb110?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/endpoints/handlers.ListResource.func1.4.1()
	k8s.io/apiserver/pkg/endpoints/handlers/get.go:283 +0x74
k8s.io/apiserver/pkg/endpoints/metrics.RecordLongRunning(0x40040ae900, 0x25d7aa0?, {0x2c282c0, 0x9}, 0x4009863870)
	k8s.io/apiserver/pkg/endpoints/metrics/metrics.go:528 +0x494
k8s.io/apiserver/pkg/endpoints/handlers.ListResource.func1.4()
	k8s.io/apiserver/pkg/endpoints/handlers/get.go:281 +0x10c
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRoutine.func17({0x32d0590, 0x4004e96710}, 0x40040ae120)
	k8s.io/apiserver/pkg/server/filters/routine.go:73 +0x190
net/http.HandlerFunc.ServeHTTP(0x40040ae000?, {0x32d0590?, 0x4004e96710?}, 0x4000600008?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRequestInfo.func18({0x32d0590, 0x4004e96710}, 0x40040ae000)
	k8s.io/apiserver/pkg/endpoints/filters/requestinfo.go:39 +0x104
net/http.HandlerFunc.ServeHTTP(0x400384fe60?, {0x32d0590?, 0x4004e96710?}, 0x58e551e7f5a9?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRequestReceivedTimestamp.withRequestReceivedTimestampWithClock.func32({0x32d0590, 0x4004e96710}, 0x400384fe60)
	k8s.io/apiserver/pkg/endpoints/filters/request_received_time.go:38 +0xac
net/http.HandlerFunc.ServeHTTP(0x40071e3af8?, {0x32d0590?, 0x4004e96710?}, 0xffff66621908?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithMuxAndDiscoveryComplete.func19({0x32d0590?, 0x4004e96710?}, 0x400384fe60?)
	k8s.io/apiserver/pkg/endpoints/filters/mux_discovery_complete.go:52 +0xd0
net/http.HandlerFunc.ServeHTTP(0x40041ace01?, {0x32d0590?, 0x4004e96710?}, 0x70b08e84ca6f8d4f?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithPanicRecovery.withPanicRecovery.func33({0x32d0590?, 0x4004e96710?}, 0x40041acea0?)
	k8s.io/apiserver/pkg/server/filters/wrap.go:74 +0x9c
net/http.HandlerFunc.ServeHTTP(0x4004f2e660?, {0x32d0590?, 0x4004e96710?}, 0x400a14a360?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithAuditInit.withAuditInit.func34({0x32d0590, 0x4004e96710}, 0x400384fd40)
	k8s.io/apiserver/pkg/endpoints/filters/audit_init.go:63 +0x110
net/http.HandlerFunc.ServeHTTP(0xd?, {0x32d0590?, 0x4004e96710?}, 0xd?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.(*APIServerHandler).ServeHTTP(0x0?, {0x32d0590?, 0x4004e96710?}, 0x4800?)
	k8s.io/apiserver/pkg/server/handler.go:189 +0x30
net/http.serverHandler.ServeHTTP({0x40071e3d38?}, {0x32d0590?, 0x4004e96710?}, 0x40081faa98?)
	net/http/server.go:3137 +0xbc
net/http.initALPNRequest.ServeHTTP({{0x32e1798?, 0x4007857c50?}, 0x400575e708?, {0x40036e1860?}}, {0x32d0590, 0x4004e96710}, 0x400384fd40)
	net/http/server.go:3745 +0x1b4
golang.org/x/net/http2.(*serverConn).runHandler(0x4ea0de0?, 0x0?, 0x0?, 0x0?)
	golang.org/x/net@v0.23.0/http2/server.go:2369 +0xc0
created by golang.org/x/net/http2.(*serverConn).scheduleHandler in goroutine 12163255
	golang.org/x/net@v0.23.0/http2/server.go:2304 +0x208
E0709 09:59:28.858885       1 wrap.go:58] "apiserver panic'd" method="GET" URI="/api/v1/replicationcontrollers?allowWatchBookmarks=true&limit=500&resourceVersionMatch=NotOlderThan&sendInitialEvents=true&watch=true" auditID="136a4efb-7775-42b3-b0ef-ef1960ebdc85"
http2: panic serving 192.168.228.1:39898: runtime error: invalid memory address or nil pointer dereference
goroutine 12163272 [running]:
golang.org/x/net/http2.(*serverConn).runHandler.func1()
	golang.org/x/net@v0.23.0/http2/server.go:2362 +0x13c
panic({0x277c340?, 0x4dd78a0?})
	runtime/panic.go:770 +0x124
k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x4006d3a000, 0x1, 0x4009e87c00?})
	k8s.io/apimachinery/pkg/util/runtime/runtime.go:56 +0xe0
panic({0x277c340?, 0x4dd78a0?})
	runtime/panic.go:770 +0x124
k8s.io/kubernetes/pkg/printers/internalversion.printReplicationController(0x40070d11e0, {0x5?, 0x0?})
	k8s.io/kubernetes/pkg/printers/internalversion/printers.go:1127 +0x1e4
reflect.Value.call({0x2768f20?, 0x2e46cf0?, 0x13?}, {0x2c20ae1, 0x4}, {0x4006d3ab18, 0x2, 0x2?})
	reflect/value.go:596 +0x970
reflect.Value.Call({0x2768f20?, 0x2e46cf0?, 0x4009862b58?}, {0x4009862b18?, 0x4009862a58?, 0x629b4?})
	reflect/value.go:380 +0x94
k8s.io/kubernetes/pkg/printers.(*HumanReadableGenerator).GenerateTable(0x4009862bb8?, {0x32c2bb8, 0x40070d11e0}, {0x0, 0x1})
	k8s.io/kubernetes/pkg/printers/tablegenerator.go:86 +0x1b8
k8s.io/kubernetes/pkg/printers/storage.TableConvertor.ConvertToTable({{0x32b7ea0?, 0x400066ce30?}}, {0x80?, 0x10?}, {0x32c2bb8?, 0x40070d11e0?}, {0x32bc360?, 0x400964d080?})
	k8s.io/kubernetes/pkg/printers/storage/storage.go:46 +0xd8
k8s.io/apiserver/pkg/registry/generic/registry.(*Store).ConvertToTable(0x0?, {0x32e1798?, 0x4004f2ec30?}, {0x32c2bb8?, 0x40070d11e0?}, {0x32bc360?, 0x400964d080?})
	k8s.io/apiserver/pkg/registry/generic/registry/store.go:1644 +0x44
k8s.io/apiserver/pkg/endpoints/handlers.asTable({0x32e1798, 0x4004f2ec30}, {0x32c2bb8, 0x40070d11e0}, 0x400964d080, 0x400199e1a0, {{0x4007ef2f01, 0xb}, {0x4007ef2efc, 0x2}})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:375 +0x17c
k8s.io/apiserver/pkg/endpoints/handlers.doTransformObject({0x32e1798, 0x4004f2ec30}, {0x32c2bb8, 0x40070d11e0}, {0x2b43c00, 0x400964d080}, 0x4004f2f0b0, 0x400199e1a0)
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:270 +0x188
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEmbeddedEncoder).doEncode(0x40070e7ae0, {0x32c2bb8, 0x40070d11e0}, {0xffff66499918, 0x4008eeacc0})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:82 +0x68
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEmbeddedEncoder).Encode(0x40070e7ae0, {0x32c2bb8?, 0x40070d11e0}, {0xffff66499918, 0x4008eeacc0})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:78 +0x114
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).doEncode(0x40092a2790, {0x32c2bb8, 0x40070d11e0}, {{0x2c27806?, 0x4009863278?}, {0x32c2bb8?, 0x40070d11e0?}}, {0xffff664f8b18, 0x4008eea8c0})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:186 +0xd4
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).Encode.func1(...)
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:175
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).Encode(0x40092a2790, {{0x2c27806?, 0x32c2bb8?}, {0x32c2bb8?, 0x40070d11e0?}})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:180 +0x140
k8s.io/apiserver/pkg/endpoints/handlers.(*WatchServer).HandleHTTP(0x4007f5d680, {0x32d0800, 0x4008eea8c0}, 0x40040ae900)
	k8s.io/apiserver/pkg/endpoints/handlers/watch.go:249 +0x944
net/http.HandlerFunc.ServeHTTP(0x4009863678?, {0x32d0800?, 0x4008eea8c0?}, 0x4002bdb110?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/endpoints/handlers.ListResource.func1.4.1()
	k8s.io/apiserver/pkg/endpoints/handlers/get.go:283 +0x74
k8s.io/apiserver/pkg/endpoints/metrics.RecordLongRunning(0x40040ae900, 0x25d7aa0?, {0x2c282c0, 0x9}, 0x4009863870)
	k8s.io/apiserver/pkg/endpoints/metrics/metrics.go:528 +0x494
k8s.io/apiserver/pkg/endpoints/handlers.ListResource.func1.4()
	k8s.io/apiserver/pkg/endpoints/handlers/get.go:281 +0x10c
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRoutine.func17({0x32d0590, 0x4004e96710}, 0x40040ae120)
	k8s.io/apiserver/pkg/server/filters/routine.go:73 +0x190
net/http.HandlerFunc.ServeHTTP(0x40040ae000?, {0x32d0590?, 0x4004e96710?}, 0x4000600008?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRequestInfo.func18({0x32d0590, 0x4004e96710}, 0x40040ae000)
	k8s.io/apiserver/pkg/endpoints/filters/requestinfo.go:39 +0x104
net/http.HandlerFunc.ServeHTTP(0x400384fe60?, {0x32d0590?, 0x4004e96710?}, 0x58e551e7f5a9?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRequestReceivedTimestamp.withRequestReceivedTimestampWithClock.func32({0x32d0590, 0x4004e96710}, 0x400384fe60)
	k8s.io/apiserver/pkg/endpoints/filters/request_received_time.go:38 +0xac
net/http.HandlerFunc.ServeHTTP(0x40071e3af8?, {0x32d0590?, 0x4004e96710?}, 0xffff66621908?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithMuxAndDiscoveryComplete.func19({0x32d0590?, 0x4004e96710?}, 0x400384fe60?)
	k8s.io/apiserver/pkg/endpoints/filters/mux_discovery_complete.go:52 +0xd0
net/http.HandlerFunc.ServeHTTP(0x40041ace01?, {0x32d0590?, 0x4004e96710?}, 0x70b08e84ca6f8d4f?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithPanicRecovery.withPanicRecovery.func33({0x32d0590?, 0x4004e96710?}, 0x40041acea0?)
	k8s.io/apiserver/pkg/server/filters/wrap.go:74 +0x9c
net/http.HandlerFunc.ServeHTTP(0x4004f2e660?, {0x32d0590?, 0x4004e96710?}, 0x400a14a360?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithAuditInit.withAuditInit.func34({0x32d0590, 0x4004e96710}, 0x400384fd40)
	k8s.io/apiserver/pkg/endpoints/filters/audit_init.go:63 +0x110
net/http.HandlerFunc.ServeHTTP(0xd?, {0x32d0590?, 0x4004e96710?}, 0xd?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.(*APIServerHandler).ServeHTTP(0x0?, {0x32d0590?, 0x4004e96710?}, 0x4800?)
	k8s.io/apiserver/pkg/server/handler.go:189 +0x30
net/http.serverHandler.ServeHTTP({0x40071e3d38?}, {0x32d0590?, 0x4004e96710?}, 0x40081faa98?)
	net/http/server.go:3137 +0xbc
net/http.initALPNRequest.ServeHTTP({{0x32e1798?, 0x4007857c50?}, 0x400575e708?, {0x40036e1860?}}, {0x32d0590, 0x4004e96710}, 0x400384fd40)
	net/http/server.go:3745 +0x1b4
golang.org/x/net/http2.(*serverConn).runHandler(0x4ea0de0?, 0x0?, 0x0?, 0x0?)
	golang.org/x/net@v0.23.0/http2/server.go:2369 +0xc0
created by golang.org/x/net/http2.(*serverConn).scheduleHandler in goroutine 12163255
	golang.org/x/net@v0.23.0/http2/server.go:2304 +0x208
E0709 09:59:30.009914       1 runtime.go:79] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
goroutine 12163402 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic({0x277c340, 0x4dd78a0})
	k8s.io/apimachinery/pkg/util/runtime/runtime.go:75 +0x7c
k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x4006f18000, 0x1, 0x400ac0cfc0?})
	k8s.io/apimachinery/pkg/util/runtime/runtime.go:49 +0x78
panic({0x277c340?, 0x4dd78a0?})
	runtime/panic.go:770 +0x124
k8s.io/kubernetes/pkg/printers/internalversion.printReplicationController(0x400841cb00, {0x5?, 0x0?})
	k8s.io/kubernetes/pkg/printers/internalversion/printers.go:1127 +0x1e4
reflect.Value.call({0x2768f20?, 0x2e46cf0?, 0x13?}, {0x2c20ae1, 0x4}, {0x4006f18b18, 0x2, 0x2?})
	reflect/value.go:596 +0x970
reflect.Value.Call({0x2768f20?, 0x2e46cf0?, 0x4009ce8b58?}, {0x4009ce8b18?, 0x30?, 0x29fe1c0?})
	reflect/value.go:380 +0x94
k8s.io/kubernetes/pkg/printers.(*HumanReadableGenerator).GenerateTable(0x4009ce8bd8?, {0x32c2bb8, 0x400841cb00}, {0x0, 0x1})
	k8s.io/kubernetes/pkg/printers/tablegenerator.go:86 +0x1b8
k8s.io/kubernetes/pkg/printers/storage.TableConvertor.ConvertToTable({{0x32b7ea0?, 0x400066ce30?}}, {0x30?, 0x40000aa808?}, {0x32c2bb8?, 0x400841cb00?}, {0x32bc360?, 0x40088b3300?})
	k8s.io/kubernetes/pkg/printers/storage/storage.go:46 +0xd8
k8s.io/apiserver/pkg/registry/generic/registry.(*Store).ConvertToTable(0x32e2598?, {0x32e1798?, 0x4008e18990?}, {0x32c2bb8?, 0x400841cb00?}, {0x32bc360?, 0x40088b3300?})
	k8s.io/apiserver/pkg/registry/generic/registry/store.go:1644 +0x44
k8s.io/apiserver/pkg/endpoints/handlers.asTable({0x32e1798, 0x4008e18990}, {0x32c2bb8, 0x400841cb00}, 0x40088b3300, 0x400199e1a0, {{0x4007ef2f01, 0xb}, {0x4007ef2efc, 0x2}})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:375 +0x17c
k8s.io/apiserver/pkg/endpoints/handlers.doTransformObject({0x32e1798, 0x4008e18990}, {0x32c2bb8, 0x400841cb00}, {0x2b43c00, 0x40088b3300}, 0x4008e18cf0, 0x400199e1a0)
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:270 +0x188
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEmbeddedEncoder).doEncode(0x4009503e50, {0x32c2bb8, 0x400841cb00}, {0xffff66499918, 0x4003e127e0})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:82 +0x68
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEmbeddedEncoder).Encode(0x4009503e50, {0x32c2bb8?, 0x400841cb00}, {0xffff66499918, 0x4003e127e0})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:78 +0x114
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).doEncode(0x4009e3f3f0, {0x32c2bb8, 0x400841cb00}, {{0x2c27806?, 0x4009ce9278?}, {0x32c2bb8?, 0x400841cb00?}}, {0xffff664f8b18, 0x400a6c07c0})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:186 +0xd4
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).Encode.func1(...)
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:175
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).Encode(0x4009e3f3f0, {{0x2c27806?, 0x32c2bb8?}, {0x32c2bb8?, 0x400841cb00?}})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:180 +0x140
k8s.io/apiserver/pkg/endpoints/handlers.(*WatchServer).HandleHTTP(0x4007e36e60, {0x32d0800, 0x400a6c07c0}, 0x400487c480)
	k8s.io/apiserver/pkg/endpoints/handlers/watch.go:249 +0x944
net/http.HandlerFunc.ServeHTTP(0x4009ce9678?, {0x32d0800?, 0x400a6c07c0?}, 0x4007671b20?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/endpoints/handlers.ListResource.func1.4.1()
	k8s.io/apiserver/pkg/endpoints/handlers/get.go:283 +0x74
k8s.io/apiserver/pkg/endpoints/metrics.RecordLongRunning(0x400487c480, 0x25d7aa0?, {0x2c282c0, 0x9}, 0x4009ce9870)
	k8s.io/apiserver/pkg/endpoints/metrics/metrics.go:528 +0x494
k8s.io/apiserver/pkg/endpoints/handlers.ListResource.func1.4()
	k8s.io/apiserver/pkg/endpoints/handlers/get.go:281 +0x10c
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRoutine.func17({0x32d0590, 0x4004e96850}, 0x40048cbc20)
	k8s.io/apiserver/pkg/server/filters/routine.go:73 +0x190
net/http.HandlerFunc.ServeHTTP(0x40048cbb00?, {0x32d0590?, 0x4004e96850?}, 0x4000600008?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRequestInfo.func18({0x32d0590, 0x4004e96850}, 0x40048cbb00)
	k8s.io/apiserver/pkg/endpoints/filters/requestinfo.go:39 +0x104
net/http.HandlerFunc.ServeHTTP(0x40048cb9e0?, {0x32d0590?, 0x4004e96850?}, 0x58e58a75ce78?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRequestReceivedTimestamp.withRequestReceivedTimestampWithClock.func32({0x32d0590, 0x4004e96850}, 0x40048cb9e0)
	k8s.io/apiserver/pkg/endpoints/filters/request_received_time.go:38 +0xac
net/http.HandlerFunc.ServeHTTP(0x4006e19af8?, {0x32d0590?, 0x4004e96850?}, 0xffff663bde08?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithMuxAndDiscoveryComplete.func19({0x32d0590?, 0x4004e96850?}, 0x40048cb9e0?)
	k8s.io/apiserver/pkg/endpoints/filters/mux_discovery_complete.go:52 +0xd0
net/http.HandlerFunc.ServeHTTP(0x40080bb101?, {0x32d0590?, 0x4004e96850?}, 0x3c4b635a0ce550bd?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithPanicRecovery.withPanicRecovery.func33({0x32d0590?, 0x4004e96850?}, 0x40080bb150?)
	k8s.io/apiserver/pkg/server/filters/wrap.go:74 +0x9c
net/http.HandlerFunc.ServeHTTP(0x4008e184e0?, {0x32d0590?, 0x4004e96850?}, 0x400a14a8a0?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithAuditInit.withAuditInit.func34({0x32d0590, 0x4004e96850}, 0x40048cb8c0)
	k8s.io/apiserver/pkg/endpoints/filters/audit_init.go:63 +0x110
net/http.HandlerFunc.ServeHTTP(0xb?, {0x32d0590?, 0x4004e96850?}, 0xb?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.(*APIServerHandler).ServeHTTP(0x0?, {0x32d0590?, 0x4004e96850?}, 0x4800?)
	k8s.io/apiserver/pkg/server/handler.go:189 +0x30
net/http.serverHandler.ServeHTTP({0x4004b5ec40?}, {0x32d0590?, 0x4004e96850?}, 0x40081faa98?)
	net/http/server.go:3137 +0xbc
net/http.initALPNRequest.ServeHTTP({{0x32e1798?, 0x4007857c50?}, 0x400575e708?, {0x40036e1860?}}, {0x32d0590, 0x4004e96850}, 0x40048cb8c0)
	net/http/server.go:3745 +0x1b4
golang.org/x/net/http2.(*serverConn).runHandler(0x4ea0de0?, 0x0?, 0x0?, 0x4006e19fb0?)
	golang.org/x/net@v0.23.0/http2/server.go:2369 +0xc0
created by golang.org/x/net/http2.(*serverConn).scheduleHandler in goroutine 12163255
	golang.org/x/net@v0.23.0/http2/server.go:2304 +0x208
E0709 09:59:30.010285       1 wrap.go:58] "apiserver panic'd" method="GET" URI="/api/v1/replicationcontrollers?allowWatchBookmarks=true&limit=500&resourceVersionMatch=NotOlderThan&sendInitialEvents=true&watch=true" auditID="707336b3-f1df-408a-b69c-0d3c79267a80"
http2: panic serving 192.168.228.1:39898: runtime error: invalid memory address or nil pointer dereference
goroutine 12163402 [running]:
golang.org/x/net/http2.(*serverConn).runHandler.func1()
	golang.org/x/net@v0.23.0/http2/server.go:2362 +0x13c
panic({0x277c340?, 0x4dd78a0?})
	runtime/panic.go:770 +0x124
k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x4006f18000, 0x1, 0x400ac0cfc0?})
	k8s.io/apimachinery/pkg/util/runtime/runtime.go:56 +0xe0
panic({0x277c340?, 0x4dd78a0?})
	runtime/panic.go:770 +0x124
k8s.io/kubernetes/pkg/printers/internalversion.printReplicationController(0x400841cb00, {0x5?, 0x0?})
	k8s.io/kubernetes/pkg/printers/internalversion/printers.go:1127 +0x1e4
reflect.Value.call({0x2768f20?, 0x2e46cf0?, 0x13?}, {0x2c20ae1, 0x4}, {0x4006f18b18, 0x2, 0x2?})
	reflect/value.go:596 +0x970
reflect.Value.Call({0x2768f20?, 0x2e46cf0?, 0x4009ce8b58?}, {0x4009ce8b18?, 0x30?, 0x29fe1c0?})
	reflect/value.go:380 +0x94
k8s.io/kubernetes/pkg/printers.(*HumanReadableGenerator).GenerateTable(0x4009ce8bd8?, {0x32c2bb8, 0x400841cb00}, {0x0, 0x1})
	k8s.io/kubernetes/pkg/printers/tablegenerator.go:86 +0x1b8
k8s.io/kubernetes/pkg/printers/storage.TableConvertor.ConvertToTable({{0x32b7ea0?, 0x400066ce30?}}, {0x30?, 0x40000aa808?}, {0x32c2bb8?, 0x400841cb00?}, {0x32bc360?, 0x40088b3300?})
	k8s.io/kubernetes/pkg/printers/storage/storage.go:46 +0xd8
k8s.io/apiserver/pkg/registry/generic/registry.(*Store).ConvertToTable(0x32e2598?, {0x32e1798?, 0x4008e18990?}, {0x32c2bb8?, 0x400841cb00?}, {0x32bc360?, 0x40088b3300?})
	k8s.io/apiserver/pkg/registry/generic/registry/store.go:1644 +0x44
k8s.io/apiserver/pkg/endpoints/handlers.asTable({0x32e1798, 0x4008e18990}, {0x32c2bb8, 0x400841cb00}, 0x40088b3300, 0x400199e1a0, {{0x4007ef2f01, 0xb}, {0x4007ef2efc, 0x2}})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:375 +0x17c
k8s.io/apiserver/pkg/endpoints/handlers.doTransformObject({0x32e1798, 0x4008e18990}, {0x32c2bb8, 0x400841cb00}, {0x2b43c00, 0x40088b3300}, 0x4008e18cf0, 0x400199e1a0)
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:270 +0x188
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEmbeddedEncoder).doEncode(0x4009503e50, {0x32c2bb8, 0x400841cb00}, {0xffff66499918, 0x4003e127e0})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:82 +0x68
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEmbeddedEncoder).Encode(0x4009503e50, {0x32c2bb8?, 0x400841cb00}, {0xffff66499918, 0x4003e127e0})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:78 +0x114
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).doEncode(0x4009e3f3f0, {0x32c2bb8, 0x400841cb00}, {{0x2c27806?, 0x4009ce9278?}, {0x32c2bb8?, 0x400841cb00?}}, {0xffff664f8b18, 0x400a6c07c0})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:186 +0xd4
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).Encode.func1(...)
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:175
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).Encode(0x4009e3f3f0, {{0x2c27806?, 0x32c2bb8?}, {0x32c2bb8?, 0x400841cb00?}})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:180 +0x140
k8s.io/apiserver/pkg/endpoints/handlers.(*WatchServer).HandleHTTP(0x4007e36e60, {0x32d0800, 0x400a6c07c0}, 0x400487c480)
	k8s.io/apiserver/pkg/endpoints/handlers/watch.go:249 +0x944
net/http.HandlerFunc.ServeHTTP(0x4009ce9678?, {0x32d0800?, 0x400a6c07c0?}, 0x4007671b20?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/endpoints/handlers.ListResource.func1.4.1()
	k8s.io/apiserver/pkg/endpoints/handlers/get.go:283 +0x74
k8s.io/apiserver/pkg/endpoints/metrics.RecordLongRunning(0x400487c480, 0x25d7aa0?, {0x2c282c0, 0x9}, 0x4009ce9870)
	k8s.io/apiserver/pkg/endpoints/metrics/metrics.go:528 +0x494
k8s.io/apiserver/pkg/endpoints/handlers.ListResource.func1.4()
	k8s.io/apiserver/pkg/endpoints/handlers/get.go:281 +0x10c
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRoutine.func17({0x32d0590, 0x4004e96850}, 0x40048cbc20)
	k8s.io/apiserver/pkg/server/filters/routine.go:73 +0x190
net/http.HandlerFunc.ServeHTTP(0x40048cbb00?, {0x32d0590?, 0x4004e96850?}, 0x4000600008?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRequestInfo.func18({0x32d0590, 0x4004e96850}, 0x40048cbb00)
	k8s.io/apiserver/pkg/endpoints/filters/requestinfo.go:39 +0x104
net/http.HandlerFunc.ServeHTTP(0x40048cb9e0?, {0x32d0590?, 0x4004e96850?}, 0x58e58a75ce78?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRequestReceivedTimestamp.withRequestReceivedTimestampWithClock.func32({0x32d0590, 0x4004e96850}, 0x40048cb9e0)
	k8s.io/apiserver/pkg/endpoints/filters/request_received_time.go:38 +0xac
net/http.HandlerFunc.ServeHTTP(0x4006e19af8?, {0x32d0590?, 0x4004e96850?}, 0xffff663bde08?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithMuxAndDiscoveryComplete.func19({0x32d0590?, 0x4004e96850?}, 0x40048cb9e0?)
	k8s.io/apiserver/pkg/endpoints/filters/mux_discovery_complete.go:52 +0xd0
net/http.HandlerFunc.ServeHTTP(0x40080bb101?, {0x32d0590?, 0x4004e96850?}, 0x3c4b635a0ce550bd?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithPanicRecovery.withPanicRecovery.func33({0x32d0590?, 0x4004e96850?}, 0x40080bb150?)
	k8s.io/apiserver/pkg/server/filters/wrap.go:74 +0x9c
net/http.HandlerFunc.ServeHTTP(0x4008e184e0?, {0x32d0590?, 0x4004e96850?}, 0x400a14a8a0?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithAuditInit.withAuditInit.func34({0x32d0590, 0x4004e96850}, 0x40048cb8c0)
	k8s.io/apiserver/pkg/endpoints/filters/audit_init.go:63 +0x110
net/http.HandlerFunc.ServeHTTP(0xb?, {0x32d0590?, 0x4004e96850?}, 0xb?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.(*APIServerHandler).ServeHTTP(0x0?, {0x32d0590?, 0x4004e96850?}, 0x4800?)
	k8s.io/apiserver/pkg/server/handler.go:189 +0x30
net/http.serverHandler.ServeHTTP({0x4004b5ec40?}, {0x32d0590?, 0x4004e96850?}, 0x40081faa98?)
	net/http/server.go:3137 +0xbc
net/http.initALPNRequest.ServeHTTP({{0x32e1798?, 0x4007857c50?}, 0x400575e708?, {0x40036e1860?}}, {0x32d0590, 0x4004e96850}, 0x40048cb8c0)
	net/http/server.go:3745 +0x1b4
golang.org/x/net/http2.(*serverConn).runHandler(0x4ea0de0?, 0x0?, 0x0?, 0x4006e19fb0?)
	golang.org/x/net@v0.23.0/http2/server.go:2369 +0xc0
created by golang.org/x/net/http2.(*serverConn).scheduleHandler in goroutine 12163255
	golang.org/x/net@v0.23.0/http2/server.go:2304 +0x208
E0709 10:02:46.386718       1 runtime.go:79] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
goroutine 12187862 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic({0x277c340, 0x4dd78a0})
	k8s.io/apimachinery/pkg/util/runtime/runtime.go:75 +0x7c
k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x4007360000, 0x1, 0x40094a1340?})
	k8s.io/apimachinery/pkg/util/runtime/runtime.go:49 +0x78
panic({0x277c340?, 0x4dd78a0?})
	runtime/panic.go:770 +0x124
k8s.io/kubernetes/pkg/printers/internalversion.printReplicationController(0x4009bd6160, {0x5?, 0x0?})
	k8s.io/kubernetes/pkg/printers/internalversion/printers.go:1127 +0x1e4
reflect.Value.call({0x2768f20?, 0x2e46cf0?, 0x13?}, {0x2c20ae1, 0x4}, {0x4007360b18, 0x2, 0x2?})
	reflect/value.go:596 +0x970
reflect.Value.Call({0x2768f20?, 0x2e46cf0?, 0x4009822b58?}, {0x4009822b18?, 0x400a367200?, 0x4009eabca0?})
	reflect/value.go:380 +0x94
k8s.io/kubernetes/pkg/printers.(*HumanReadableGenerator).GenerateTable(0x4009822b01?, {0x32c2bb8, 0x4009bd6160}, {0x0, 0x1})
	k8s.io/kubernetes/pkg/printers/tablegenerator.go:86 +0x1b8
k8s.io/kubernetes/pkg/printers/storage.TableConvertor.ConvertToTable({{0x32b7ea0?, 0x400066ce30?}}, {0x4004885a00?, 0x4002ad68c0?}, {0x32c2bb8?, 0x4009bd6160?}, {0x32bc360?, 0x4007523880?})
	k8s.io/kubernetes/pkg/printers/storage/storage.go:46 +0xd8
k8s.io/apiserver/pkg/registry/generic/registry.(*Store).ConvertToTable(0x4009822c05?, {0x32e1798?, 0x4009ac4480?}, {0x32c2bb8?, 0x4009bd6160?}, {0x32bc360?, 0x4007523880?})
	k8s.io/apiserver/pkg/registry/generic/registry/store.go:1644 +0x44
k8s.io/apiserver/pkg/endpoints/handlers.asTable({0x32e1798, 0x4009ac4480}, {0x32c2bb8, 0x4009bd6160}, 0x4007523880, 0x400199e1a0, {{0x400150b831, 0xb}, {0x400150b82c, 0x2}})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:375 +0x17c
k8s.io/apiserver/pkg/endpoints/handlers.doTransformObject({0x32e1798, 0x4009ac4480}, {0x32c2bb8, 0x4009bd6160}, {0x2b43c00, 0x4007523880}, 0x4009ac47e0, 0x400199e1a0)
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:270 +0x188
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEmbeddedEncoder).doEncode(0x4009fe7db0, {0x32c2bb8, 0x4009bd6160}, {0xffff66499918, 0x4008b4ee40})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:82 +0x68
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEmbeddedEncoder).Encode(0x4009fe7db0, {0x32c2bb8?, 0x4009bd6160}, {0xffff66499918, 0x4008b4ee40})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:78 +0x114
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).doEncode(0x4009f408f0, {0x32c2bb8, 0x4009bd6160}, {{0x2c27806?, 0x4009823278?}, {0x32c2bb8?, 0x4009bd6160?}}, {0xffff664f8b18, 0x4008b4eac0})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:186 +0xd4
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).Encode.func1(...)
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:175
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).Encode(0x4009f408f0, {{0x2c27806?, 0x32c2bb8?}, {0x32c2bb8?, 0x4009bd6160?}})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:180 +0x140
k8s.io/apiserver/pkg/endpoints/handlers.(*WatchServer).HandleHTTP(0x4007126d20, {0x32d0800, 0x4008b4eac0}, 0x4005c978c0)
	k8s.io/apiserver/pkg/endpoints/handlers/watch.go:249 +0x944
net/http.HandlerFunc.ServeHTTP(0x4009823678?, {0x32d0800?, 0x4008b4eac0?}, 0x4002ad7570?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/endpoints/handlers.ListResource.func1.4.1()
	k8s.io/apiserver/pkg/endpoints/handlers/get.go:283 +0x74
k8s.io/apiserver/pkg/endpoints/metrics.RecordLongRunning(0x4005c978c0, 0x25d7aa0?, {0x2c282c0, 0x9}, 0x4009823870)
	k8s.io/apiserver/pkg/endpoints/metrics/metrics.go:528 +0x494
k8s.io/apiserver/pkg/endpoints/handlers.ListResource.func1.4()
	k8s.io/apiserver/pkg/endpoints/handlers/get.go:281 +0x10c
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRoutine.func17({0x32d0590, 0x400a7074b0}, 0x4005c96d80)
	k8s.io/apiserver/pkg/server/filters/routine.go:73 +0x190
net/http.HandlerFunc.ServeHTTP(0x4005c96c60?, {0x32d0590?, 0x400a7074b0?}, 0x40000aa808?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRequestInfo.func18({0x32d0590, 0x400a7074b0}, 0x4005c96c60)
	k8s.io/apiserver/pkg/endpoints/filters/requestinfo.go:39 +0x104
net/http.HandlerFunc.ServeHTTP(0x4005c96a20?, {0x32d0590?, 0x400a7074b0?}, 0x59135369828d?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRequestReceivedTimestamp.withRequestReceivedTimestampWithClock.func32({0x32d0590, 0x400a7074b0}, 0x4005c96a20)
	k8s.io/apiserver/pkg/endpoints/filters/request_received_time.go:38 +0xac
net/http.HandlerFunc.ServeHTTP(0x400419aaf8?, {0x32d0590?, 0x400a7074b0?}, 0xffff66163e18?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithMuxAndDiscoveryComplete.func19({0x32d0590?, 0x400a7074b0?}, 0x4005c96a20?)
	k8s.io/apiserver/pkg/endpoints/filters/mux_discovery_complete.go:52 +0xd0
net/http.HandlerFunc.ServeHTTP(0x4004751201?, {0x32d0590?, 0x400a7074b0?}, 0x455c586054996940?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithPanicRecovery.withPanicRecovery.func33({0x32d0590?, 0x400a7074b0?}, 0x4004751200?)
	k8s.io/apiserver/pkg/server/filters/wrap.go:74 +0x9c
net/http.HandlerFunc.ServeHTTP(0x4009ac4000?, {0x32d0590?, 0x400a7074b0?}, 0x400a655dd0?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithAuditInit.withAuditInit.func34({0x32d0590, 0x400a7074b0}, 0x4005c96900)
	k8s.io/apiserver/pkg/endpoints/filters/audit_init.go:63 +0x110
net/http.HandlerFunc.ServeHTTP(0x0?, {0x32d0590?, 0x400a7074b0?}, 0x40036edec0?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.(*APIServerHandler).ServeHTTP(0x0?, {0x32d0590?, 0x400a7074b0?}, 0x103b860?)
	k8s.io/apiserver/pkg/server/handler.go:189 +0x30
net/http.serverHandler.ServeHTTP({0x400419ae18?}, {0x32d0590?, 0x400a7074b0?}, 0x32fa1c0?)
	net/http/server.go:3137 +0xbc
net/http.initALPNRequest.ServeHTTP({{0x32e1798?, 0x400a371ce0?}, 0x40095a1c08?, {0x40036e1860?}}, {0x32d0590, 0x400a7074b0}, 0x4005c96900)
	net/http/server.go:3745 +0x1b4
golang.org/x/net/http2.(*serverConn).runHandler(0x0?, 0x89634?, 0x20?, 0x400419afb0?)
	golang.org/x/net@v0.23.0/http2/server.go:2369 +0xc0
created by golang.org/x/net/http2.(*serverConn).scheduleHandler in goroutine 12187884
	golang.org/x/net@v0.23.0/http2/server.go:2304 +0x208
E0709 10:02:46.386889       1 wrap.go:58] "apiserver panic'd" method="GET" URI="/api/v1/replicationcontrollers?allowWatchBookmarks=true&limit=500&resourceVersionMatch=NotOlderThan&sendInitialEvents=true&watch=true" auditID="4563c21c-6781-4eee-9098-54f5eadcb3b7"
http2: panic serving 192.168.228.1:59448: runtime error: invalid memory address or nil pointer dereference
goroutine 12187862 [running]:
golang.org/x/net/http2.(*serverConn).runHandler.func1()
	golang.org/x/net@v0.23.0/http2/server.go:2362 +0x13c
panic({0x277c340?, 0x4dd78a0?})
	runtime/panic.go:770 +0x124
k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x4007360000, 0x1, 0x40094a1340?})
	k8s.io/apimachinery/pkg/util/runtime/runtime.go:56 +0xe0
panic({0x277c340?, 0x4dd78a0?})
	runtime/panic.go:770 +0x124
k8s.io/kubernetes/pkg/printers/internalversion.printReplicationController(0x4009bd6160, {0x5?, 0x0?})
	k8s.io/kubernetes/pkg/printers/internalversion/printers.go:1127 +0x1e4
reflect.Value.call({0x2768f20?, 0x2e46cf0?, 0x13?}, {0x2c20ae1, 0x4}, {0x4007360b18, 0x2, 0x2?})
	reflect/value.go:596 +0x970
reflect.Value.Call({0x2768f20?, 0x2e46cf0?, 0x4009822b58?}, {0x4009822b18?, 0x400a367200?, 0x4009eabca0?})
	reflect/value.go:380 +0x94
k8s.io/kubernetes/pkg/printers.(*HumanReadableGenerator).GenerateTable(0x4009822b01?, {0x32c2bb8, 0x4009bd6160}, {0x0, 0x1})
	k8s.io/kubernetes/pkg/printers/tablegenerator.go:86 +0x1b8
k8s.io/kubernetes/pkg/printers/storage.TableConvertor.ConvertToTable({{0x32b7ea0?, 0x400066ce30?}}, {0x4004885a00?, 0x4002ad68c0?}, {0x32c2bb8?, 0x4009bd6160?}, {0x32bc360?, 0x4007523880?})
	k8s.io/kubernetes/pkg/printers/storage/storage.go:46 +0xd8
k8s.io/apiserver/pkg/registry/generic/registry.(*Store).ConvertToTable(0x4009822c05?, {0x32e1798?, 0x4009ac4480?}, {0x32c2bb8?, 0x4009bd6160?}, {0x32bc360?, 0x4007523880?})
	k8s.io/apiserver/pkg/registry/generic/registry/store.go:1644 +0x44
k8s.io/apiserver/pkg/endpoints/handlers.asTable({0x32e1798, 0x4009ac4480}, {0x32c2bb8, 0x4009bd6160}, 0x4007523880, 0x400199e1a0, {{0x400150b831, 0xb}, {0x400150b82c, 0x2}})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:375 +0x17c
k8s.io/apiserver/pkg/endpoints/handlers.doTransformObject({0x32e1798, 0x4009ac4480}, {0x32c2bb8, 0x4009bd6160}, {0x2b43c00, 0x4007523880}, 0x4009ac47e0, 0x400199e1a0)
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:270 +0x188
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEmbeddedEncoder).doEncode(0x4009fe7db0, {0x32c2bb8, 0x4009bd6160}, {0xffff66499918, 0x4008b4ee40})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:82 +0x68
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEmbeddedEncoder).Encode(0x4009fe7db0, {0x32c2bb8?, 0x4009bd6160}, {0xffff66499918, 0x4008b4ee40})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:78 +0x114
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).doEncode(0x4009f408f0, {0x32c2bb8, 0x4009bd6160}, {{0x2c27806?, 0x4009823278?}, {0x32c2bb8?, 0x4009bd6160?}}, {0xffff664f8b18, 0x4008b4eac0})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:186 +0xd4
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).Encode.func1(...)
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:175
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).Encode(0x4009f408f0, {{0x2c27806?, 0x32c2bb8?}, {0x32c2bb8?, 0x4009bd6160?}})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:180 +0x140
k8s.io/apiserver/pkg/endpoints/handlers.(*WatchServer).HandleHTTP(0x4007126d20, {0x32d0800, 0x4008b4eac0}, 0x4005c978c0)
	k8s.io/apiserver/pkg/endpoints/handlers/watch.go:249 +0x944
net/http.HandlerFunc.ServeHTTP(0x4009823678?, {0x32d0800?, 0x4008b4eac0?}, 0x4002ad7570?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/endpoints/handlers.ListResource.func1.4.1()
	k8s.io/apiserver/pkg/endpoints/handlers/get.go:283 +0x74
k8s.io/apiserver/pkg/endpoints/metrics.RecordLongRunning(0x4005c978c0, 0x25d7aa0?, {0x2c282c0, 0x9}, 0x4009823870)
	k8s.io/apiserver/pkg/endpoints/metrics/metrics.go:528 +0x494
k8s.io/apiserver/pkg/endpoints/handlers.ListResource.func1.4()
	k8s.io/apiserver/pkg/endpoints/handlers/get.go:281 +0x10c
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRoutine.func17({0x32d0590, 0x400a7074b0}, 0x4005c96d80)
	k8s.io/apiserver/pkg/server/filters/routine.go:73 +0x190
net/http.HandlerFunc.ServeHTTP(0x4005c96c60?, {0x32d0590?, 0x400a7074b0?}, 0x40000aa808?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRequestInfo.func18({0x32d0590, 0x400a7074b0}, 0x4005c96c60)
	k8s.io/apiserver/pkg/endpoints/filters/requestinfo.go:39 +0x104
net/http.HandlerFunc.ServeHTTP(0x4005c96a20?, {0x32d0590?, 0x400a7074b0?}, 0x59135369828d?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRequestReceivedTimestamp.withRequestReceivedTimestampWithClock.func32({0x32d0590, 0x400a7074b0}, 0x4005c96a20)
	k8s.io/apiserver/pkg/endpoints/filters/request_received_time.go:38 +0xac
net/http.HandlerFunc.ServeHTTP(0x400419aaf8?, {0x32d0590?, 0x400a7074b0?}, 0xffff66163e18?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithMuxAndDiscoveryComplete.func19({0x32d0590?, 0x400a7074b0?}, 0x4005c96a20?)
	k8s.io/apiserver/pkg/endpoints/filters/mux_discovery_complete.go:52 +0xd0
net/http.HandlerFunc.ServeHTTP(0x4004751201?, {0x32d0590?, 0x400a7074b0?}, 0x455c586054996940?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithPanicRecovery.withPanicRecovery.func33({0x32d0590?, 0x400a7074b0?}, 0x4004751200?)
	k8s.io/apiserver/pkg/server/filters/wrap.go:74 +0x9c
net/http.HandlerFunc.ServeHTTP(0x4009ac4000?, {0x32d0590?, 0x400a7074b0?}, 0x400a655dd0?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithAuditInit.withAuditInit.func34({0x32d0590, 0x400a7074b0}, 0x4005c96900)
	k8s.io/apiserver/pkg/endpoints/filters/audit_init.go:63 +0x110
net/http.HandlerFunc.ServeHTTP(0x0?, {0x32d0590?, 0x400a7074b0?}, 0x40036edec0?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.(*APIServerHandler).ServeHTTP(0x0?, {0x32d0590?, 0x400a7074b0?}, 0x103b860?)
	k8s.io/apiserver/pkg/server/handler.go:189 +0x30
net/http.serverHandler.ServeHTTP({0x400419ae18?}, {0x32d0590?, 0x400a7074b0?}, 0x32fa1c0?)
	net/http/server.go:3137 +0xbc
net/http.initALPNRequest.ServeHTTP({{0x32e1798?, 0x400a371ce0?}, 0x40095a1c08?, {0x40036e1860?}}, {0x32d0590, 0x400a7074b0}, 0x4005c96900)
	net/http/server.go:3745 +0x1b4
golang.org/x/net/http2.(*serverConn).runHandler(0x0?, 0x89634?, 0x20?, 0x400419afb0?)
	golang.org/x/net@v0.23.0/http2/server.go:2369 +0xc0
created by golang.org/x/net/http2.(*serverConn).scheduleHandler in goroutine 12187884
	golang.org/x/net@v0.23.0/http2/server.go:2304 +0x208
E0709 10:02:47.544727       1 runtime.go:79] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
goroutine 12187924 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic({0x277c340, 0x4dd78a0})
	k8s.io/apimachinery/pkg/util/runtime/runtime.go:75 +0x7c
k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x40065aa000, 0x1, 0x4007fc4380?})
	k8s.io/apimachinery/pkg/util/runtime/runtime.go:49 +0x78
panic({0x277c340?, 0x4dd78a0?})
	runtime/panic.go:770 +0x124
k8s.io/kubernetes/pkg/printers/internalversion.printReplicationController(0x4006239a20, {0x5?, 0x0?})
	k8s.io/kubernetes/pkg/printers/internalversion/printers.go:1127 +0x1e4
reflect.Value.call({0x2768f20?, 0x2e46cf0?, 0x13?}, {0x2c20ae1, 0x4}, {0x40065aab18, 0x2, 0x2?})
	reflect/value.go:596 +0x970
reflect.Value.Call({0x2768f20?, 0x2e46cf0?, 0x40097f4b58?}, {0x40097f4b18?, 0x30?, 0x29fe1c0?})
	reflect/value.go:380 +0x94
k8s.io/kubernetes/pkg/printers.(*HumanReadableGenerator).GenerateTable(0x40097f4bd8?, {0x32c2bb8, 0x4006239a20}, {0x0, 0x1})
	k8s.io/kubernetes/pkg/printers/tablegenerator.go:86 +0x1b8
k8s.io/kubernetes/pkg/printers/storage.TableConvertor.ConvertToTable({{0x32b7ea0?, 0x400066ce30?}}, {0x30?, 0x40000aa808?}, {0x32c2bb8?, 0x4006239a20?}, {0x32bc360?, 0x400a550040?})
	k8s.io/kubernetes/pkg/printers/storage/storage.go:46 +0xd8
k8s.io/apiserver/pkg/registry/generic/registry.(*Store).ConvertToTable(0x32e2598?, {0x32e1798?, 0x4007ae3920?}, {0x32c2bb8?, 0x4006239a20?}, {0x32bc360?, 0x400a550040?})
	k8s.io/apiserver/pkg/registry/generic/registry/store.go:1644 +0x44
k8s.io/apiserver/pkg/endpoints/handlers.asTable({0x32e1798, 0x4007ae3920}, {0x32c2bb8, 0x4006239a20}, 0x400a550040, 0x400199e1a0, {{0x400150b831, 0xb}, {0x400150b82c, 0x2}})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:375 +0x17c
k8s.io/apiserver/pkg/endpoints/handlers.doTransformObject({0x32e1798, 0x4007ae3920}, {0x32c2bb8, 0x4006239a20}, {0x2b43c00, 0x400a550040}, 0x4007ae3ce0, 0x400199e1a0)
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:270 +0x188
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEmbeddedEncoder).doEncode(0x400a354870, {0x32c2bb8, 0x4006239a20}, {0xffff66499918, 0x4002d7e260})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:82 +0x68
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEmbeddedEncoder).Encode(0x400a354870, {0x32c2bb8?, 0x4006239a20}, {0xffff66499918, 0x4002d7e260})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:78 +0x114
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).doEncode(0x4006cd34a0, {0x32c2bb8, 0x4006239a20}, {{0x2c27806?, 0x40097f5278?}, {0x32c2bb8?, 0x4006239a20?}}, {0xffff664f8b18, 0x40088e1e00})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:186 +0xd4
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).Encode.func1(...)
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:175
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).Encode(0x4006cd34a0, {{0x2c27806?, 0x32c2bb8?}, {0x32c2bb8?, 0x4006239a20?}})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:180 +0x140
k8s.io/apiserver/pkg/endpoints/handlers.(*WatchServer).HandleHTTP(0x4009bfb040, {0x32d0800, 0x40088e1e00}, 0x4003b670e0)
	k8s.io/apiserver/pkg/endpoints/handlers/watch.go:249 +0x944
net/http.HandlerFunc.ServeHTTP(0x40097f5678?, {0x32d0800?, 0x40088e1e00?}, 0x4008534cb0?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/endpoints/handlers.ListResource.func1.4.1()
	k8s.io/apiserver/pkg/endpoints/handlers/get.go:283 +0x74
k8s.io/apiserver/pkg/endpoints/metrics.RecordLongRunning(0x4003b670e0, 0x25d7aa0?, {0x2c282c0, 0x9}, 0x40097f5870)
	k8s.io/apiserver/pkg/endpoints/metrics/metrics.go:528 +0x494
k8s.io/apiserver/pkg/endpoints/handlers.ListResource.func1.4()
	k8s.io/apiserver/pkg/endpoints/handlers/get.go:281 +0x10c
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRoutine.func17({0x32d0590, 0x4004f68b60}, 0x4003b66900)
	k8s.io/apiserver/pkg/server/filters/routine.go:73 +0x190
net/http.HandlerFunc.ServeHTTP(0x4003b667e0?, {0x32d0590?, 0x4004f68b60?}, 0x40026a8008?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRequestInfo.func18({0x32d0590, 0x4004f68b60}, 0x4003b667e0)
	k8s.io/apiserver/pkg/endpoints/filters/requestinfo.go:39 +0x104
net/http.HandlerFunc.ServeHTTP(0x4003b666c0?, {0x32d0590?, 0x4004f68b60?}, 0x59138815f5d2?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRequestReceivedTimestamp.withRequestReceivedTimestampWithClock.func32({0x32d0590, 0x4004f68b60}, 0x4003b666c0)
	k8s.io/apiserver/pkg/endpoints/filters/request_received_time.go:38 +0xac
net/http.HandlerFunc.ServeHTTP(0x40047d9af8?, {0x32d0590?, 0x4004f68b60?}, 0xffff66102480?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithMuxAndDiscoveryComplete.func19({0x32d0590?, 0x4004f68b60?}, 0x4003b666c0?)
	k8s.io/apiserver/pkg/endpoints/filters/mux_discovery_complete.go:52 +0xd0
net/http.HandlerFunc.ServeHTTP(0x40072d5b01?, {0x32d0590?, 0x4004f68b60?}, 0xaaab6aa36983e599?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithPanicRecovery.withPanicRecovery.func33({0x32d0590?, 0x4004f68b60?}, 0x40072d5b40?)
	k8s.io/apiserver/pkg/server/filters/wrap.go:74 +0x9c
net/http.HandlerFunc.ServeHTTP(0x4007ae34a0?, {0x32d0590?, 0x4004f68b60?}, 0x40094b6000?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithAuditInit.withAuditInit.func34({0x32d0590, 0x4004f68b60}, 0x4003b66480)
	k8s.io/apiserver/pkg/endpoints/filters/audit_init.go:63 +0x110
net/http.HandlerFunc.ServeHTTP(0x43?, {0x32d0590?, 0x4004f68b60?}, 0x43?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.(*APIServerHandler).ServeHTTP(0x0?, {0x32d0590?, 0x4004f68b60?}, 0x5000?)
	k8s.io/apiserver/pkg/server/handler.go:189 +0x30
net/http.serverHandler.ServeHTTP({0x4004582380?}, {0x32d0590?, 0x4004f68b60?}, 0x40092bc0f0?)
	net/http/server.go:3137 +0xbc
net/http.initALPNRequest.ServeHTTP({{0x32e1798?, 0x400a371ce0?}, 0x40095a1c08?, {0x40036e1860?}}, {0x32d0590, 0x4004f68b60}, 0x4003b66480)
	net/http/server.go:3745 +0x1b4
golang.org/x/net/http2.(*serverConn).runHandler(0x4ea0de0?, 0x0?, 0x0?, 0x40047d9fb0?)
	golang.org/x/net@v0.23.0/http2/server.go:2369 +0xc0
created by golang.org/x/net/http2.(*serverConn).scheduleHandler in goroutine 12187884
	golang.org/x/net@v0.23.0/http2/server.go:2304 +0x208
E0709 10:02:47.545375       1 wrap.go:58] "apiserver panic'd" method="GET" URI="/api/v1/replicationcontrollers?allowWatchBookmarks=true&limit=500&resourceVersionMatch=NotOlderThan&sendInitialEvents=true&watch=true" auditID="56e24364-09ca-43d9-8cd6-99fb64212aea"
http2: panic serving 192.168.228.1:59448: runtime error: invalid memory address or nil pointer dereference
goroutine 12187924 [running]:
golang.org/x/net/http2.(*serverConn).runHandler.func1()
	golang.org/x/net@v0.23.0/http2/server.go:2362 +0x13c
panic({0x277c340?, 0x4dd78a0?})
	runtime/panic.go:770 +0x124
k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x40065aa000, 0x1, 0x4007fc4380?})
	k8s.io/apimachinery/pkg/util/runtime/runtime.go:56 +0xe0
panic({0x277c340?, 0x4dd78a0?})
	runtime/panic.go:770 +0x124
k8s.io/kubernetes/pkg/printers/internalversion.printReplicationController(0x4006239a20, {0x5?, 0x0?})
	k8s.io/kubernetes/pkg/printers/internalversion/printers.go:1127 +0x1e4
reflect.Value.call({0x2768f20?, 0x2e46cf0?, 0x13?}, {0x2c20ae1, 0x4}, {0x40065aab18, 0x2, 0x2?})
	reflect/value.go:596 +0x970
reflect.Value.Call({0x2768f20?, 0x2e46cf0?, 0x40097f4b58?}, {0x40097f4b18?, 0x30?, 0x29fe1c0?})
	reflect/value.go:380 +0x94
k8s.io/kubernetes/pkg/printers.(*HumanReadableGenerator).GenerateTable(0x40097f4bd8?, {0x32c2bb8, 0x4006239a20}, {0x0, 0x1})
	k8s.io/kubernetes/pkg/printers/tablegenerator.go:86 +0x1b8
k8s.io/kubernetes/pkg/printers/storage.TableConvertor.ConvertToTable({{0x32b7ea0?, 0x400066ce30?}}, {0x30?, 0x40000aa808?}, {0x32c2bb8?, 0x4006239a20?}, {0x32bc360?, 0x400a550040?})
	k8s.io/kubernetes/pkg/printers/storage/storage.go:46 +0xd8
k8s.io/apiserver/pkg/registry/generic/registry.(*Store).ConvertToTable(0x32e2598?, {0x32e1798?, 0x4007ae3920?}, {0x32c2bb8?, 0x4006239a20?}, {0x32bc360?, 0x400a550040?})
	k8s.io/apiserver/pkg/registry/generic/registry/store.go:1644 +0x44
k8s.io/apiserver/pkg/endpoints/handlers.asTable({0x32e1798, 0x4007ae3920}, {0x32c2bb8, 0x4006239a20}, 0x400a550040, 0x400199e1a0, {{0x400150b831, 0xb}, {0x400150b82c, 0x2}})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:375 +0x17c
k8s.io/apiserver/pkg/endpoints/handlers.doTransformObject({0x32e1798, 0x4007ae3920}, {0x32c2bb8, 0x4006239a20}, {0x2b43c00, 0x400a550040}, 0x4007ae3ce0, 0x400199e1a0)
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:270 +0x188
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEmbeddedEncoder).doEncode(0x400a354870, {0x32c2bb8, 0x4006239a20}, {0xffff66499918, 0x4002d7e260})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:82 +0x68
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEmbeddedEncoder).Encode(0x400a354870, {0x32c2bb8?, 0x4006239a20}, {0xffff66499918, 0x4002d7e260})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:78 +0x114
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).doEncode(0x4006cd34a0, {0x32c2bb8, 0x4006239a20}, {{0x2c27806?, 0x40097f5278?}, {0x32c2bb8?, 0x4006239a20?}}, {0xffff664f8b18, 0x40088e1e00})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:186 +0xd4
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).Encode.func1(...)
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:175
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).Encode(0x4006cd34a0, {{0x2c27806?, 0x32c2bb8?}, {0x32c2bb8?, 0x4006239a20?}})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:180 +0x140
k8s.io/apiserver/pkg/endpoints/handlers.(*WatchServer).HandleHTTP(0x4009bfb040, {0x32d0800, 0x40088e1e00}, 0x4003b670e0)
	k8s.io/apiserver/pkg/endpoints/handlers/watch.go:249 +0x944
net/http.HandlerFunc.ServeHTTP(0x40097f5678?, {0x32d0800?, 0x40088e1e00?}, 0x4008534cb0?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/endpoints/handlers.ListResource.func1.4.1()
	k8s.io/apiserver/pkg/endpoints/handlers/get.go:283 +0x74
k8s.io/apiserver/pkg/endpoints/metrics.RecordLongRunning(0x4003b670e0, 0x25d7aa0?, {0x2c282c0, 0x9}, 0x40097f5870)
	k8s.io/apiserver/pkg/endpoints/metrics/metrics.go:528 +0x494
k8s.io/apiserver/pkg/endpoints/handlers.ListResource.func1.4()
	k8s.io/apiserver/pkg/endpoints/handlers/get.go:281 +0x10c
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRoutine.func17({0x32d0590, 0x4004f68b60}, 0x4003b66900)
	k8s.io/apiserver/pkg/server/filters/routine.go:73 +0x190
net/http.HandlerFunc.ServeHTTP(0x4003b667e0?, {0x32d0590?, 0x4004f68b60?}, 0x40026a8008?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRequestInfo.func18({0x32d0590, 0x4004f68b60}, 0x4003b667e0)
	k8s.io/apiserver/pkg/endpoints/filters/requestinfo.go:39 +0x104
net/http.HandlerFunc.ServeHTTP(0x4003b666c0?, {0x32d0590?, 0x4004f68b60?}, 0x59138815f5d2?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRequestReceivedTimestamp.withRequestReceivedTimestampWithClock.func32({0x32d0590, 0x4004f68b60}, 0x4003b666c0)
	k8s.io/apiserver/pkg/endpoints/filters/request_received_time.go:38 +0xac
net/http.HandlerFunc.ServeHTTP(0x40047d9af8?, {0x32d0590?, 0x4004f68b60?}, 0xffff66102480?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithMuxAndDiscoveryComplete.func19({0x32d0590?, 0x4004f68b60?}, 0x4003b666c0?)
	k8s.io/apiserver/pkg/endpoints/filters/mux_discovery_complete.go:52 +0xd0
net/http.HandlerFunc.ServeHTTP(0x40072d5b01?, {0x32d0590?, 0x4004f68b60?}, 0xaaab6aa36983e599?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithPanicRecovery.withPanicRecovery.func33({0x32d0590?, 0x4004f68b60?}, 0x40072d5b40?)
	k8s.io/apiserver/pkg/server/filters/wrap.go:74 +0x9c
net/http.HandlerFunc.ServeHTTP(0x4007ae34a0?, {0x32d0590?, 0x4004f68b60?}, 0x40094b6000?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithAuditInit.withAuditInit.func34({0x32d0590, 0x4004f68b60}, 0x4003b66480)
	k8s.io/apiserver/pkg/endpoints/filters/audit_init.go:63 +0x110
net/http.HandlerFunc.ServeHTTP(0x43?, {0x32d0590?, 0x4004f68b60?}, 0x43?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.(*APIServerHandler).ServeHTTP(0x0?, {0x32d0590?, 0x4004f68b60?}, 0x5000?)
	k8s.io/apiserver/pkg/server/handler.go:189 +0x30
net/http.serverHandler.ServeHTTP({0x4004582380?}, {0x32d0590?, 0x4004f68b60?}, 0x40092bc0f0?)
	net/http/server.go:3137 +0xbc
net/http.initALPNRequest.ServeHTTP({{0x32e1798?, 0x400a371ce0?}, 0x40095a1c08?, {0x40036e1860?}}, {0x32d0590, 0x4004f68b60}, 0x4003b66480)
	net/http/server.go:3745 +0x1b4
golang.org/x/net/http2.(*serverConn).runHandler(0x4ea0de0?, 0x0?, 0x0?, 0x40047d9fb0?)
	golang.org/x/net@v0.23.0/http2/server.go:2369 +0xc0
created by golang.org/x/net/http2.(*serverConn).scheduleHandler in goroutine 12187884
	golang.org/x/net@v0.23.0/http2/server.go:2304 +0x208
E0709 10:04:02.406261       1 runtime.go:79] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
goroutine 12197409 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic({0x277c340, 0x4dd78a0})
	k8s.io/apimachinery/pkg/util/runtime/runtime.go:75 +0x7c
k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x4007070000, 0x1, 0x4007fc5500?})
	k8s.io/apimachinery/pkg/util/runtime/runtime.go:49 +0x78
panic({0x277c340?, 0x4dd78a0?})
	runtime/panic.go:770 +0x124
k8s.io/kubernetes/pkg/printers/internalversion.printReplicationController(0x4007c61600, {0x5?, 0x0?})
	k8s.io/kubernetes/pkg/printers/internalversion/printers.go:1127 +0x1e4
reflect.Value.call({0x2768f20?, 0x2e46cf0?, 0x13?}, {0x2c20ae1, 0x4}, {0x4007070b18, 0x2, 0x2?})
	reflect/value.go:596 +0x970
reflect.Value.Call({0x2768f20?, 0x2e46cf0?, 0x40043b6b58?}, {0x40043b6b18?, 0x4007e2eea0?, 0x4002b901f0?})
	reflect/value.go:380 +0x94
k8s.io/kubernetes/pkg/printers.(*HumanReadableGenerator).GenerateTable(0x40043b6bb8?, {0x32c2bb8, 0x4007c61600}, {0x0, 0x1})
	k8s.io/kubernetes/pkg/printers/tablegenerator.go:86 +0x1b8
k8s.io/kubernetes/pkg/printers/storage.TableConvertor.ConvertToTable({{0x32b7ea0?, 0x400066ce30?}}, {0x80?, 0x10?}, {0x32c2bb8?, 0x4007c61600?}, {0x32bc360?, 0x4008f3c400?})
	k8s.io/kubernetes/pkg/printers/storage/storage.go:46 +0xd8
k8s.io/apiserver/pkg/registry/generic/registry.(*Store).ConvertToTable(0x0?, {0x32e1798?, 0x4007e4b7a0?}, {0x32c2bb8?, 0x4007c61600?}, {0x32bc360?, 0x4008f3c400?})
	k8s.io/apiserver/pkg/registry/generic/registry/store.go:1644 +0x44
k8s.io/apiserver/pkg/endpoints/handlers.asTable({0x32e1798, 0x4007e4b7a0}, {0x32c2bb8, 0x4007c61600}, 0x4008f3c400, 0x400182d1e0, {{0x400723d591, 0xb}, {0x400723d58c, 0x2}})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:375 +0x17c
k8s.io/apiserver/pkg/endpoints/handlers.doTransformObject({0x32e1798, 0x4007e4b7a0}, {0x32c2bb8, 0x4007c61600}, {0x2b43c00, 0x4008f3c400}, 0x4007e4baa0, 0x400182d1e0)
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:270 +0x188
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEmbeddedEncoder).doEncode(0x40096dbb80, {0x32c2bb8, 0x4007c61600}, {0xffff66499918, 0x4007c62240})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:82 +0x68
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEmbeddedEncoder).Encode(0x40096dbb80, {0x32c2bb8?, 0x4007c61600}, {0xffff66499918, 0x4007c62240})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:78 +0x114
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).doEncode(0x40052886e0, {0x32c2bb8, 0x4007c61600}, {{0x2c27806?, 0x40043b7278?}, {0x32c2bb8?, 0x4007c61600?}}, {0xffff664f8b18, 0x40085858e0})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:186 +0xd4
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).Encode.func1(...)
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:175
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).Encode(0x40052886e0, {{0x2c27806?, 0x32c2bb8?}, {0x32c2bb8?, 0x4007c61600?}})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:180 +0x140
k8s.io/apiserver/pkg/endpoints/handlers.(*WatchServer).HandleHTTP(0x4008452280, {0x32d0800, 0x40085858e0}, 0x4007e70360)
	k8s.io/apiserver/pkg/endpoints/handlers/watch.go:249 +0x944
net/http.HandlerFunc.ServeHTTP(0x40043b7678?, {0x32d0800?, 0x40085858e0?}, 0x40086c4e70?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/endpoints/handlers.ListResource.func1.4.1()
	k8s.io/apiserver/pkg/endpoints/handlers/get.go:283 +0x74
k8s.io/apiserver/pkg/endpoints/metrics.RecordLongRunning(0x4007e70360, 0x25d7aa0?, {0x2c282c0, 0x9}, 0x40043b7870)
	k8s.io/apiserver/pkg/endpoints/metrics/metrics.go:528 +0x494
k8s.io/apiserver/pkg/endpoints/handlers.ListResource.func1.4()
	k8s.io/apiserver/pkg/endpoints/handlers/get.go:281 +0x10c
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRoutine.func17({0x32d0590, 0x400a6f5840}, 0x4007e2fb00)
	k8s.io/apiserver/pkg/server/filters/routine.go:73 +0x190
net/http.HandlerFunc.ServeHTTP(0x4007e2f9e0?, {0x32d0590?, 0x400a6f5840?}, 0x40000aa808?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRequestInfo.func18({0x32d0590, 0x400a6f5840}, 0x4007e2f9e0)
	k8s.io/apiserver/pkg/endpoints/filters/requestinfo.go:39 +0x104
net/http.HandlerFunc.ServeHTTP(0x4007e2f8c0?, {0x32d0590?, 0x400a6f5840?}, 0x59252bb1712b?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRequestReceivedTimestamp.withRequestReceivedTimestampWithClock.func32({0x32d0590, 0x400a6f5840}, 0x4007e2f8c0)
	k8s.io/apiserver/pkg/endpoints/filters/request_received_time.go:38 +0xac
net/http.HandlerFunc.ServeHTTP(0x4007c1faf8?, {0x32d0590?, 0x400a6f5840?}, 0xffff663af428?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithMuxAndDiscoveryComplete.func19({0x32d0590?, 0x400a6f5840?}, 0x4007e2f8c0?)
	k8s.io/apiserver/pkg/endpoints/filters/mux_discovery_complete.go:52 +0xd0
net/http.HandlerFunc.ServeHTTP(0x40046a4901?, {0x32d0590?, 0x400a6f5840?}, 0x784a6c68f1a9e8bf?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithPanicRecovery.withPanicRecovery.func33({0x32d0590?, 0x400a6f5840?}, 0x40046a49a0?)
	k8s.io/apiserver/pkg/server/filters/wrap.go:74 +0x9c
net/http.HandlerFunc.ServeHTTP(0x4007e4b350?, {0x32d0590?, 0x400a6f5840?}, 0x4009fcbf80?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithAuditInit.withAuditInit.func34({0x32d0590, 0x400a6f5840}, 0x4007e2f7a0)
	k8s.io/apiserver/pkg/endpoints/filters/audit_init.go:63 +0x110
net/http.HandlerFunc.ServeHTTP(0x0?, {0x32d0590?, 0x400a6f5840?}, 0x40035adaa0?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.(*APIServerHandler).ServeHTTP(0x0?, {0x32d0590?, 0x400a6f5840?}, 0x103b860?)
	k8s.io/apiserver/pkg/server/handler.go:189 +0x30
net/http.serverHandler.ServeHTTP({0x4007c1fe18?}, {0x32d0590?, 0x400a6f5840?}, 0x32fa1c0?)
	net/http/server.go:3137 +0xbc
net/http.initALPNRequest.ServeHTTP({{0x32e1798?, 0x4007e4ab10?}, 0x40077df508?, {0x40036e1860?}}, {0x32d0590, 0x400a6f5840}, 0x4007e2f7a0)
	net/http/server.go:3745 +0x1b4
golang.org/x/net/http2.(*serverConn).runHandler(0x0?, 0x89634?, 0x0?, 0x4007c1ffb0?)
	golang.org/x/net@v0.23.0/http2/server.go:2369 +0xc0
created by golang.org/x/net/http2.(*serverConn).scheduleHandler in goroutine 12197293
	golang.org/x/net@v0.23.0/http2/server.go:2304 +0x208
E0709 10:04:02.406552       1 wrap.go:58] "apiserver panic'd" method="GET" URI="/api/v1/namespaces/default/replicationcontrollers?allowWatchBookmarks=true&limit=500&resourceVersionMatch=NotOlderThan&sendInitialEvents=true&watch=true" auditID="399d35d7-ce1e-4c0d-8d95-4556b08189f8"
http2: panic serving 192.168.228.1:51766: runtime error: invalid memory address or nil pointer dereference
goroutine 12197409 [running]:
golang.org/x/net/http2.(*serverConn).runHandler.func1()
	golang.org/x/net@v0.23.0/http2/server.go:2362 +0x13c
panic({0x277c340?, 0x4dd78a0?})
	runtime/panic.go:770 +0x124
k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x4007070000, 0x1, 0x4007fc5500?})
	k8s.io/apimachinery/pkg/util/runtime/runtime.go:56 +0xe0
panic({0x277c340?, 0x4dd78a0?})
	runtime/panic.go:770 +0x124
k8s.io/kubernetes/pkg/printers/internalversion.printReplicationController(0x4007c61600, {0x5?, 0x0?})
	k8s.io/kubernetes/pkg/printers/internalversion/printers.go:1127 +0x1e4
reflect.Value.call({0x2768f20?, 0x2e46cf0?, 0x13?}, {0x2c20ae1, 0x4}, {0x4007070b18, 0x2, 0x2?})
	reflect/value.go:596 +0x970
reflect.Value.Call({0x2768f20?, 0x2e46cf0?, 0x40043b6b58?}, {0x40043b6b18?, 0x4007e2eea0?, 0x4002b901f0?})
	reflect/value.go:380 +0x94
k8s.io/kubernetes/pkg/printers.(*HumanReadableGenerator).GenerateTable(0x40043b6bb8?, {0x32c2bb8, 0x4007c61600}, {0x0, 0x1})
	k8s.io/kubernetes/pkg/printers/tablegenerator.go:86 +0x1b8
k8s.io/kubernetes/pkg/printers/storage.TableConvertor.ConvertToTable({{0x32b7ea0?, 0x400066ce30?}}, {0x80?, 0x10?}, {0x32c2bb8?, 0x4007c61600?}, {0x32bc360?, 0x4008f3c400?})
	k8s.io/kubernetes/pkg/printers/storage/storage.go:46 +0xd8
k8s.io/apiserver/pkg/registry/generic/registry.(*Store).ConvertToTable(0x0?, {0x32e1798?, 0x4007e4b7a0?}, {0x32c2bb8?, 0x4007c61600?}, {0x32bc360?, 0x4008f3c400?})
	k8s.io/apiserver/pkg/registry/generic/registry/store.go:1644 +0x44
k8s.io/apiserver/pkg/endpoints/handlers.asTable({0x32e1798, 0x4007e4b7a0}, {0x32c2bb8, 0x4007c61600}, 0x4008f3c400, 0x400182d1e0, {{0x400723d591, 0xb}, {0x400723d58c, 0x2}})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:375 +0x17c
k8s.io/apiserver/pkg/endpoints/handlers.doTransformObject({0x32e1798, 0x4007e4b7a0}, {0x32c2bb8, 0x4007c61600}, {0x2b43c00, 0x4008f3c400}, 0x4007e4baa0, 0x400182d1e0)
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:270 +0x188
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEmbeddedEncoder).doEncode(0x40096dbb80, {0x32c2bb8, 0x4007c61600}, {0xffff66499918, 0x4007c62240})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:82 +0x68
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEmbeddedEncoder).Encode(0x40096dbb80, {0x32c2bb8?, 0x4007c61600}, {0xffff66499918, 0x4007c62240})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:78 +0x114
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).doEncode(0x40052886e0, {0x32c2bb8, 0x4007c61600}, {{0x2c27806?, 0x40043b7278?}, {0x32c2bb8?, 0x4007c61600?}}, {0xffff664f8b18, 0x40085858e0})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:186 +0xd4
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).Encode.func1(...)
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:175
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).Encode(0x40052886e0, {{0x2c27806?, 0x32c2bb8?}, {0x32c2bb8?, 0x4007c61600?}})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:180 +0x140
k8s.io/apiserver/pkg/endpoints/handlers.(*WatchServer).HandleHTTP(0x4008452280, {0x32d0800, 0x40085858e0}, 0x4007e70360)
	k8s.io/apiserver/pkg/endpoints/handlers/watch.go:249 +0x944
net/http.HandlerFunc.ServeHTTP(0x40043b7678?, {0x32d0800?, 0x40085858e0?}, 0x40086c4e70?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/endpoints/handlers.ListResource.func1.4.1()
	k8s.io/apiserver/pkg/endpoints/handlers/get.go:283 +0x74
k8s.io/apiserver/pkg/endpoints/metrics.RecordLongRunning(0x4007e70360, 0x25d7aa0?, {0x2c282c0, 0x9}, 0x40043b7870)
	k8s.io/apiserver/pkg/endpoints/metrics/metrics.go:528 +0x494
k8s.io/apiserver/pkg/endpoints/handlers.ListResource.func1.4()
	k8s.io/apiserver/pkg/endpoints/handlers/get.go:281 +0x10c
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRoutine.func17({0x32d0590, 0x400a6f5840}, 0x4007e2fb00)
	k8s.io/apiserver/pkg/server/filters/routine.go:73 +0x190
net/http.HandlerFunc.ServeHTTP(0x4007e2f9e0?, {0x32d0590?, 0x400a6f5840?}, 0x40000aa808?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRequestInfo.func18({0x32d0590, 0x400a6f5840}, 0x4007e2f9e0)
	k8s.io/apiserver/pkg/endpoints/filters/requestinfo.go:39 +0x104
net/http.HandlerFunc.ServeHTTP(0x4007e2f8c0?, {0x32d0590?, 0x400a6f5840?}, 0x59252bb1712b?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRequestReceivedTimestamp.withRequestReceivedTimestampWithClock.func32({0x32d0590, 0x400a6f5840}, 0x4007e2f8c0)
	k8s.io/apiserver/pkg/endpoints/filters/request_received_time.go:38 +0xac
net/http.HandlerFunc.ServeHTTP(0x4007c1faf8?, {0x32d0590?, 0x400a6f5840?}, 0xffff663af428?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithMuxAndDiscoveryComplete.func19({0x32d0590?, 0x400a6f5840?}, 0x4007e2f8c0?)
	k8s.io/apiserver/pkg/endpoints/filters/mux_discovery_complete.go:52 +0xd0
net/http.HandlerFunc.ServeHTTP(0x40046a4901?, {0x32d0590?, 0x400a6f5840?}, 0x784a6c68f1a9e8bf?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithPanicRecovery.withPanicRecovery.func33({0x32d0590?, 0x400a6f5840?}, 0x40046a49a0?)
	k8s.io/apiserver/pkg/server/filters/wrap.go:74 +0x9c
net/http.HandlerFunc.ServeHTTP(0x4007e4b350?, {0x32d0590?, 0x400a6f5840?}, 0x4009fcbf80?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithAuditInit.withAuditInit.func34({0x32d0590, 0x400a6f5840}, 0x4007e2f7a0)
	k8s.io/apiserver/pkg/endpoints/filters/audit_init.go:63 +0x110
net/http.HandlerFunc.ServeHTTP(0x0?, {0x32d0590?, 0x400a6f5840?}, 0x40035adaa0?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.(*APIServerHandler).ServeHTTP(0x0?, {0x32d0590?, 0x400a6f5840?}, 0x103b860?)
	k8s.io/apiserver/pkg/server/handler.go:189 +0x30
net/http.serverHandler.ServeHTTP({0x4007c1fe18?}, {0x32d0590?, 0x400a6f5840?}, 0x32fa1c0?)
	net/http/server.go:3137 +0xbc
net/http.initALPNRequest.ServeHTTP({{0x32e1798?, 0x4007e4ab10?}, 0x40077df508?, {0x40036e1860?}}, {0x32d0590, 0x400a6f5840}, 0x4007e2f7a0)
	net/http/server.go:3745 +0x1b4
golang.org/x/net/http2.(*serverConn).runHandler(0x0?, 0x89634?, 0x0?, 0x4007c1ffb0?)
	golang.org/x/net@v0.23.0/http2/server.go:2369 +0xc0
created by golang.org/x/net/http2.(*serverConn).scheduleHandler in goroutine 12197293
	golang.org/x/net@v0.23.0/http2/server.go:2304 +0x208
E0709 10:04:03.483840       1 runtime.go:79] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
goroutine 12197507 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic({0x277c340, 0x4dd78a0})
	k8s.io/apimachinery/pkg/util/runtime/runtime.go:75 +0x7c
k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x4008f06000, 0x1, 0x40078fe380?})
	k8s.io/apimachinery/pkg/util/runtime/runtime.go:49 +0x78
panic({0x277c340?, 0x4dd78a0?})
	runtime/panic.go:770 +0x124
k8s.io/kubernetes/pkg/printers/internalversion.printReplicationController(0x4007e7b760, {0x5?, 0x0?})
	k8s.io/kubernetes/pkg/printers/internalversion/printers.go:1127 +0x1e4
reflect.Value.call({0x2768f20?, 0x2e46cf0?, 0x13?}, {0x2c20ae1, 0x4}, {0x4008f06b18, 0x2, 0x2?})
	reflect/value.go:596 +0x970
reflect.Value.Call({0x2768f20?, 0x2e46cf0?, 0x40046e6b58?}, {0x40046e6b18?, 0x40046e6a58?, 0x629b4?})
	reflect/value.go:380 +0x94
k8s.io/kubernetes/pkg/printers.(*HumanReadableGenerator).GenerateTable(0x40046e6bc8?, {0x32c2bb8, 0x4007e7b760}, {0x0, 0x1})
	k8s.io/kubernetes/pkg/printers/tablegenerator.go:86 +0x1b8
k8s.io/kubernetes/pkg/printers/storage.TableConvertor.ConvertToTable({{0x32b7ea0?, 0x400066ce30?}}, {0x40046e6c08?, 0x148e48?}, {0x32c2bb8?, 0x4007e7b760?}, {0x32bc360?, 0x400720a940?})
	k8s.io/kubernetes/pkg/printers/storage/storage.go:46 +0xd8
k8s.io/apiserver/pkg/registry/generic/registry.(*Store).ConvertToTable(0x40046e6cc8?, {0x32e1798?, 0x400764fe30?}, {0x32c2bb8?, 0x4007e7b760?}, {0x32bc360?, 0x400720a940?})
	k8s.io/apiserver/pkg/registry/generic/registry/store.go:1644 +0x44
k8s.io/apiserver/pkg/endpoints/handlers.asTable({0x32e1798, 0x400764fe30}, {0x32c2bb8, 0x4007e7b760}, 0x400720a940, 0x400182d1e0, {{0x400723d591, 0xb}, {0x400723d58c, 0x2}})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:375 +0x17c
k8s.io/apiserver/pkg/endpoints/handlers.doTransformObject({0x32e1798, 0x400764fe30}, {0x32c2bb8, 0x4007e7b760}, {0x2b43c00, 0x400720a940}, 0x4007f0e1b0, 0x400182d1e0)
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:270 +0x188
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEmbeddedEncoder).doEncode(0x400958f090, {0x32c2bb8, 0x4007e7b760}, {0xffff66499918, 0x4008a82b60})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:82 +0x68
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEmbeddedEncoder).Encode(0x400958f090, {0x32c2bb8?, 0x4007e7b760}, {0xffff66499918, 0x4008a82b60})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:78 +0x114
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).doEncode(0x4009302370, {0x32c2bb8, 0x4007e7b760}, {{0x2c27806?, 0x40046e7278?}, {0x32c2bb8?, 0x4007e7b760?}}, {0xffff664f8b18, 0x4007678640})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:186 +0xd4
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).Encode.func1(...)
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:175
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).Encode(0x4009302370, {{0x2c27806?, 0x32c2bb8?}, {0x32c2bb8?, 0x4007e7b760?}})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:180 +0x140
k8s.io/apiserver/pkg/endpoints/handlers.(*WatchServer).HandleHTTP(0x4007ea74a0, {0x32d0800, 0x4007678640}, 0x4007674120)
	k8s.io/apiserver/pkg/endpoints/handlers/watch.go:249 +0x944
net/http.HandlerFunc.ServeHTTP(0x40046e7678?, {0x32d0800?, 0x4007678640?}, 0x4007c6d1f0?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/endpoints/handlers.ListResource.func1.4.1()
	k8s.io/apiserver/pkg/endpoints/handlers/get.go:283 +0x74
k8s.io/apiserver/pkg/endpoints/metrics.RecordLongRunning(0x4007674120, 0x25d7aa0?, {0x2c282c0, 0x9}, 0x40046e7870)
	k8s.io/apiserver/pkg/endpoints/metrics/metrics.go:528 +0x494
k8s.io/apiserver/pkg/endpoints/handlers.ListResource.func1.4()
	k8s.io/apiserver/pkg/endpoints/handlers/get.go:281 +0x10c
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRoutine.func17({0x32d0590, 0x400593b3e8}, 0x400807f8c0)
	k8s.io/apiserver/pkg/server/filters/routine.go:73 +0x190
net/http.HandlerFunc.ServeHTTP(0x400807f7a0?, {0x32d0590?, 0x400593b3e8?}, 0x4000100008?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRequestInfo.func18({0x32d0590, 0x400593b3e8}, 0x400807f7a0)
	k8s.io/apiserver/pkg/endpoints/filters/requestinfo.go:39 +0x104
net/http.HandlerFunc.ServeHTTP(0x400807f680?, {0x32d0590?, 0x400593b3e8?}, 0x59253b29763b?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRequestReceivedTimestamp.withRequestReceivedTimestampWithClock.func32({0x32d0590, 0x400593b3e8}, 0x400807f680)
	k8s.io/apiserver/pkg/endpoints/filters/request_received_time.go:38 +0xac
net/http.HandlerFunc.ServeHTTP(0x4006a36af8?, {0x32d0590?, 0x400593b3e8?}, 0xffff66255d08?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithMuxAndDiscoveryComplete.func19({0x32d0590?, 0x400593b3e8?}, 0x400807f680?)
	k8s.io/apiserver/pkg/endpoints/filters/mux_discovery_complete.go:52 +0xd0
net/http.HandlerFunc.ServeHTTP(0x40097bea01?, {0x32d0590?, 0x400593b3e8?}, 0xfb27b1c2a8e65bbd?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithPanicRecovery.withPanicRecovery.func33({0x32d0590?, 0x400593b3e8?}, 0x40097bea50?)
	k8s.io/apiserver/pkg/server/filters/wrap.go:74 +0x9c
net/http.HandlerFunc.ServeHTTP(0x400764f9e0?, {0x32d0590?, 0x400593b3e8?}, 0x4009c93920?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithAuditInit.withAuditInit.func34({0x32d0590, 0x400593b3e8}, 0x400807f560)
	k8s.io/apiserver/pkg/endpoints/filters/audit_init.go:63 +0x110
net/http.HandlerFunc.ServeHTTP(0x0?, {0x32d0590?, 0x400593b3e8?}, 0x4003a778f0?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.(*APIServerHandler).ServeHTTP(0x0?, {0x32d0590?, 0x400593b3e8?}, 0x103b860?)
	k8s.io/apiserver/pkg/server/handler.go:189 +0x30
net/http.serverHandler.ServeHTTP({0x4006a36e18?}, {0x32d0590?, 0x400593b3e8?}, 0x32fa1c0?)
	net/http/server.go:3137 +0xbc
net/http.initALPNRequest.ServeHTTP({{0x32e1798?, 0x4007e4ab10?}, 0x40077df508?, {0x40036e1860?}}, {0x32d0590, 0x400593b3e8}, 0x400807f560)
	net/http/server.go:3745 +0x1b4
golang.org/x/net/http2.(*serverConn).runHandler(0x0?, 0x89634?, 0x29?, 0x0?)
	golang.org/x/net@v0.23.0/http2/server.go:2369 +0xc0
created by golang.org/x/net/http2.(*serverConn).scheduleHandler in goroutine 12197293
	golang.org/x/net@v0.23.0/http2/server.go:2304 +0x208
E0709 10:04:03.483976       1 wrap.go:58] "apiserver panic'd" method="GET" URI="/api/v1/namespaces/default/replicationcontrollers?allowWatchBookmarks=true&limit=500&resourceVersionMatch=NotOlderThan&sendInitialEvents=true&watch=true" auditID="3aedce62-17b0-4665-88aa-3c97307c76df"
http2: panic serving 192.168.228.1:51766: runtime error: invalid memory address or nil pointer dereference
goroutine 12197507 [running]:
golang.org/x/net/http2.(*serverConn).runHandler.func1()
	golang.org/x/net@v0.23.0/http2/server.go:2362 +0x13c
panic({0x277c340?, 0x4dd78a0?})
	runtime/panic.go:770 +0x124
k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x4008f06000, 0x1, 0x40078fe380?})
	k8s.io/apimachinery/pkg/util/runtime/runtime.go:56 +0xe0
panic({0x277c340?, 0x4dd78a0?})
	runtime/panic.go:770 +0x124
k8s.io/kubernetes/pkg/printers/internalversion.printReplicationController(0x4007e7b760, {0x5?, 0x0?})
	k8s.io/kubernetes/pkg/printers/internalversion/printers.go:1127 +0x1e4
reflect.Value.call({0x2768f20?, 0x2e46cf0?, 0x13?}, {0x2c20ae1, 0x4}, {0x4008f06b18, 0x2, 0x2?})
	reflect/value.go:596 +0x970
reflect.Value.Call({0x2768f20?, 0x2e46cf0?, 0x40046e6b58?}, {0x40046e6b18?, 0x40046e6a58?, 0x629b4?})
	reflect/value.go:380 +0x94
k8s.io/kubernetes/pkg/printers.(*HumanReadableGenerator).GenerateTable(0x40046e6bc8?, {0x32c2bb8, 0x4007e7b760}, {0x0, 0x1})
	k8s.io/kubernetes/pkg/printers/tablegenerator.go:86 +0x1b8
k8s.io/kubernetes/pkg/printers/storage.TableConvertor.ConvertToTable({{0x32b7ea0?, 0x400066ce30?}}, {0x40046e6c08?, 0x148e48?}, {0x32c2bb8?, 0x4007e7b760?}, {0x32bc360?, 0x400720a940?})
	k8s.io/kubernetes/pkg/printers/storage/storage.go:46 +0xd8
k8s.io/apiserver/pkg/registry/generic/registry.(*Store).ConvertToTable(0x40046e6cc8?, {0x32e1798?, 0x400764fe30?}, {0x32c2bb8?, 0x4007e7b760?}, {0x32bc360?, 0x400720a940?})
	k8s.io/apiserver/pkg/registry/generic/registry/store.go:1644 +0x44
k8s.io/apiserver/pkg/endpoints/handlers.asTable({0x32e1798, 0x400764fe30}, {0x32c2bb8, 0x4007e7b760}, 0x400720a940, 0x400182d1e0, {{0x400723d591, 0xb}, {0x400723d58c, 0x2}})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:375 +0x17c
k8s.io/apiserver/pkg/endpoints/handlers.doTransformObject({0x32e1798, 0x400764fe30}, {0x32c2bb8, 0x4007e7b760}, {0x2b43c00, 0x400720a940}, 0x4007f0e1b0, 0x400182d1e0)
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:270 +0x188
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEmbeddedEncoder).doEncode(0x400958f090, {0x32c2bb8, 0x4007e7b760}, {0xffff66499918, 0x4008a82b60})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:82 +0x68
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEmbeddedEncoder).Encode(0x400958f090, {0x32c2bb8?, 0x4007e7b760}, {0xffff66499918, 0x4008a82b60})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:78 +0x114
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).doEncode(0x4009302370, {0x32c2bb8, 0x4007e7b760}, {{0x2c27806?, 0x40046e7278?}, {0x32c2bb8?, 0x4007e7b760?}}, {0xffff664f8b18, 0x4007678640})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:186 +0xd4
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).Encode.func1(...)
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:175
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).Encode(0x4009302370, {{0x2c27806?, 0x32c2bb8?}, {0x32c2bb8?, 0x4007e7b760?}})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:180 +0x140
k8s.io/apiserver/pkg/endpoints/handlers.(*WatchServer).HandleHTTP(0x4007ea74a0, {0x32d0800, 0x4007678640}, 0x4007674120)
	k8s.io/apiserver/pkg/endpoints/handlers/watch.go:249 +0x944
net/http.HandlerFunc.ServeHTTP(0x40046e7678?, {0x32d0800?, 0x4007678640?}, 0x4007c6d1f0?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/endpoints/handlers.ListResource.func1.4.1()
	k8s.io/apiserver/pkg/endpoints/handlers/get.go:283 +0x74
k8s.io/apiserver/pkg/endpoints/metrics.RecordLongRunning(0x4007674120, 0x25d7aa0?, {0x2c282c0, 0x9}, 0x40046e7870)
	k8s.io/apiserver/pkg/endpoints/metrics/metrics.go:528 +0x494
k8s.io/apiserver/pkg/endpoints/handlers.ListResource.func1.4()
	k8s.io/apiserver/pkg/endpoints/handlers/get.go:281 +0x10c
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRoutine.func17({0x32d0590, 0x400593b3e8}, 0x400807f8c0)
	k8s.io/apiserver/pkg/server/filters/routine.go:73 +0x190
net/http.HandlerFunc.ServeHTTP(0x400807f7a0?, {0x32d0590?, 0x400593b3e8?}, 0x4000100008?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRequestInfo.func18({0x32d0590, 0x400593b3e8}, 0x400807f7a0)
	k8s.io/apiserver/pkg/endpoints/filters/requestinfo.go:39 +0x104
net/http.HandlerFunc.ServeHTTP(0x400807f680?, {0x32d0590?, 0x400593b3e8?}, 0x59253b29763b?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRequestReceivedTimestamp.withRequestReceivedTimestampWithClock.func32({0x32d0590, 0x400593b3e8}, 0x400807f680)
	k8s.io/apiserver/pkg/endpoints/filters/request_received_time.go:38 +0xac
net/http.HandlerFunc.ServeHTTP(0x4006a36af8?, {0x32d0590?, 0x400593b3e8?}, 0xffff66255d08?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithMuxAndDiscoveryComplete.func19({0x32d0590?, 0x400593b3e8?}, 0x400807f680?)
	k8s.io/apiserver/pkg/endpoints/filters/mux_discovery_complete.go:52 +0xd0
net/http.HandlerFunc.ServeHTTP(0x40097bea01?, {0x32d0590?, 0x400593b3e8?}, 0xfb27b1c2a8e65bbd?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithPanicRecovery.withPanicRecovery.func33({0x32d0590?, 0x400593b3e8?}, 0x40097bea50?)
	k8s.io/apiserver/pkg/server/filters/wrap.go:74 +0x9c
net/http.HandlerFunc.ServeHTTP(0x400764f9e0?, {0x32d0590?, 0x400593b3e8?}, 0x4009c93920?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithAuditInit.withAuditInit.func34({0x32d0590, 0x400593b3e8}, 0x400807f560)
	k8s.io/apiserver/pkg/endpoints/filters/audit_init.go:63 +0x110
net/http.HandlerFunc.ServeHTTP(0x0?, {0x32d0590?, 0x400593b3e8?}, 0x4003a778f0?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.(*APIServerHandler).ServeHTTP(0x0?, {0x32d0590?, 0x400593b3e8?}, 0x103b860?)
	k8s.io/apiserver/pkg/server/handler.go:189 +0x30
net/http.serverHandler.ServeHTTP({0x4006a36e18?}, {0x32d0590?, 0x400593b3e8?}, 0x32fa1c0?)
	net/http/server.go:3137 +0xbc
net/http.initALPNRequest.ServeHTTP({{0x32e1798?, 0x4007e4ab10?}, 0x40077df508?, {0x40036e1860?}}, {0x32d0590, 0x400593b3e8}, 0x400807f560)
	net/http/server.go:3745 +0x1b4
golang.org/x/net/http2.(*serverConn).runHandler(0x0?, 0x89634?, 0x29?, 0x0?)
	golang.org/x/net@v0.23.0/http2/server.go:2369 +0xc0
created by golang.org/x/net/http2.(*serverConn).scheduleHandler in goroutine 12197293
	golang.org/x/net@v0.23.0/http2/server.go:2304 +0x208
E0709 10:14:02.157507       1 runtime.go:79] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
goroutine 12271912 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic({0x277c340, 0x4dd78a0})
	k8s.io/apimachinery/pkg/util/runtime/runtime.go:75 +0x7c
k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x4006e5e000, 0x1, 0x4006918000?})
	k8s.io/apimachinery/pkg/util/runtime/runtime.go:49 +0x78
panic({0x277c340?, 0x4dd78a0?})
	runtime/panic.go:770 +0x124
k8s.io/kubernetes/pkg/printers/internalversion.printReplicationController(0x400788d8c0, {0x5?, 0x0?})
	k8s.io/kubernetes/pkg/printers/internalversion/printers.go:1127 +0x1e4
reflect.Value.call({0x2768f20?, 0x2e46cf0?, 0x13?}, {0x2c20ae1, 0x4}, {0x4006e5eb18, 0x2, 0x2?})
	reflect/value.go:596 +0x970
reflect.Value.Call({0x2768f20?, 0x2e46cf0?, 0x4001f0ab58?}, {0x4001f0ab18?, 0x4001f0aa58?, 0x629b4?})
	reflect/value.go:380 +0x94
k8s.io/kubernetes/pkg/printers.(*HumanReadableGenerator).GenerateTable(0x4001f0abb8?, {0x32c2bb8, 0x400788d8c0}, {0x0, 0x1})
	k8s.io/kubernetes/pkg/printers/tablegenerator.go:86 +0x1b8
k8s.io/kubernetes/pkg/printers/storage.TableConvertor.ConvertToTable({{0x32b7ea0?, 0x400066ce30?}}, {0x80?, 0x10?}, {0x32c2bb8?, 0x400788d8c0?}, {0x32bc360?, 0x4008ddb280?})
	k8s.io/kubernetes/pkg/printers/storage/storage.go:46 +0xd8
k8s.io/apiserver/pkg/registry/generic/registry.(*Store).ConvertToTable(0x0?, {0x32e1798?, 0x4007951d70?}, {0x32c2bb8?, 0x400788d8c0?}, {0x32bc360?, 0x4008ddb280?})
	k8s.io/apiserver/pkg/registry/generic/registry/store.go:1644 +0x44
k8s.io/apiserver/pkg/endpoints/handlers.asTable({0x32e1798, 0x4007951d70}, {0x32c2bb8, 0x400788d8c0}, 0x4008ddb280, 0x400199e1a0, {{0x4006fff051, 0xb}, {0x4006fff04c, 0x2}})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:375 +0x17c
k8s.io/apiserver/pkg/endpoints/handlers.doTransformObject({0x32e1798, 0x4007951d70}, {0x32c2bb8, 0x400788d8c0}, {0x2b43c00, 0x4008ddb280}, 0x4007c18150, 0x400199e1a0)
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:270 +0x188
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEmbeddedEncoder).doEncode(0x40096dbb30, {0x32c2bb8, 0x400788d8c0}, {0xffff66499918, 0x4008e433e0})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:82 +0x68
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEmbeddedEncoder).Encode(0x40096dbb30, {0x32c2bb8?, 0x400788d8c0}, {0xffff66499918, 0x4008e433e0})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:78 +0x114
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).doEncode(0x400992dce0, {0x32c2bb8, 0x400788d8c0}, {{0x2c27806?, 0x4001f0b278?}, {0x32c2bb8?, 0x400788d8c0?}}, {0xffff664f8b18, 0x4008397e60})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:186 +0xd4
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).Encode.func1(...)
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:175
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).Encode(0x400992dce0, {{0x2c27806?, 0x32c2bb8?}, {0x32c2bb8?, 0x400788d8c0?}})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:180 +0x140
k8s.io/apiserver/pkg/endpoints/handlers.(*WatchServer).HandleHTTP(0x4007bc00a0, {0x32d0800, 0x4008397e60}, 0x4008631b00)
	k8s.io/apiserver/pkg/endpoints/handlers/watch.go:249 +0x944
net/http.HandlerFunc.ServeHTTP(0x4001f0b678?, {0x32d0800?, 0x4008397e60?}, 0x4009340ee0?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/endpoints/handlers.ListResource.func1.4.1()
	k8s.io/apiserver/pkg/endpoints/handlers/get.go:283 +0x74
k8s.io/apiserver/pkg/endpoints/metrics.RecordLongRunning(0x4008631b00, 0x25d7aa0?, {0x2c282c0, 0x9}, 0x4001f0b870)
	k8s.io/apiserver/pkg/endpoints/metrics/metrics.go:528 +0x494
k8s.io/apiserver/pkg/endpoints/handlers.ListResource.func1.4()
	k8s.io/apiserver/pkg/endpoints/handlers/get.go:281 +0x10c
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRoutine.func17({0x32d0590, 0x4008a92d38}, 0x4008631320)
	k8s.io/apiserver/pkg/server/filters/routine.go:73 +0x190
net/http.HandlerFunc.ServeHTTP(0x40086310e0?, {0x32d0590?, 0x4008a92d38?}, 0x40000aa808?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRequestInfo.func18({0x32d0590, 0x4008a92d38}, 0x40086310e0)
	k8s.io/apiserver/pkg/endpoints/filters/requestinfo.go:39 +0x104
net/http.HandlerFunc.ServeHTTP(0x4008630fc0?, {0x32d0590?, 0x4008a92d38?}, 0x59b0a8287ff2?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRequestReceivedTimestamp.withRequestReceivedTimestampWithClock.func32({0x32d0590, 0x4008a92d38}, 0x4008630fc0)
	k8s.io/apiserver/pkg/endpoints/filters/request_received_time.go:38 +0xac
net/http.HandlerFunc.ServeHTTP(0x4006400af8?, {0x32d0590?, 0x4008a92d38?}, 0xffff660fa308?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithMuxAndDiscoveryComplete.func19({0x32d0590?, 0x4008a92d38?}, 0x4008630fc0?)
	k8s.io/apiserver/pkg/endpoints/filters/mux_discovery_complete.go:52 +0xd0
net/http.HandlerFunc.ServeHTTP(0x4004b81801?, {0x32d0590?, 0x4008a92d38?}, 0x1c215005c3edd2f0?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithPanicRecovery.withPanicRecovery.func33({0x32d0590?, 0x4008a92d38?}, 0x4004b81830?)
	k8s.io/apiserver/pkg/server/filters/wrap.go:74 +0x9c
net/http.HandlerFunc.ServeHTTP(0x40079518f0?, {0x32d0590?, 0x4008a92d38?}, 0x40071b1c80?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithAuditInit.withAuditInit.func34({0x32d0590, 0x4008a92d38}, 0x4008630ea0)
	k8s.io/apiserver/pkg/endpoints/filters/audit_init.go:63 +0x110
net/http.HandlerFunc.ServeHTTP(0x27?, {0x32d0590?, 0x4008a92d38?}, 0x27?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.(*APIServerHandler).ServeHTTP(0x0?, {0x32d0590?, 0x4008a92d38?}, 0x4800?)
	k8s.io/apiserver/pkg/server/handler.go:189 +0x30
net/http.serverHandler.ServeHTTP({0x4006400e18?}, {0x32d0590?, 0x4008a92d38?}, 0x4009b1a138?)
	net/http/server.go:3137 +0xbc
net/http.initALPNRequest.ServeHTTP({{0x32e1798?, 0x40079510b0?}, 0x400773f188?, {0x40036e1860?}}, {0x32d0590, 0x4008a92d38}, 0x4008630ea0)
	net/http/server.go:3745 +0x1b4
golang.org/x/net/http2.(*serverConn).runHandler(0x4ea0de0?, 0x0?, 0x0?, 0x4006400fa8?)
	golang.org/x/net@v0.23.0/http2/server.go:2369 +0xc0
created by golang.org/x/net/http2.(*serverConn).scheduleHandler in goroutine 12271909
	golang.org/x/net@v0.23.0/http2/server.go:2304 +0x208
E0709 10:14:02.157933       1 wrap.go:58] "apiserver panic'd" method="GET" URI="/api/v1/replicationcontrollers?allowWatchBookmarks=true&limit=500&resourceVersionMatch=NotOlderThan&sendInitialEvents=true&watch=true" auditID="61fd272e-5de7-4b73-9907-9e78d8b283d7"
http2: panic serving 192.168.228.1:37842: runtime error: invalid memory address or nil pointer dereference
goroutine 12271912 [running]:
golang.org/x/net/http2.(*serverConn).runHandler.func1()
	golang.org/x/net@v0.23.0/http2/server.go:2362 +0x13c
panic({0x277c340?, 0x4dd78a0?})
	runtime/panic.go:770 +0x124
k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x4006e5e000, 0x1, 0x4006918000?})
	k8s.io/apimachinery/pkg/util/runtime/runtime.go:56 +0xe0
panic({0x277c340?, 0x4dd78a0?})
	runtime/panic.go:770 +0x124
k8s.io/kubernetes/pkg/printers/internalversion.printReplicationController(0x400788d8c0, {0x5?, 0x0?})
	k8s.io/kubernetes/pkg/printers/internalversion/printers.go:1127 +0x1e4
reflect.Value.call({0x2768f20?, 0x2e46cf0?, 0x13?}, {0x2c20ae1, 0x4}, {0x4006e5eb18, 0x2, 0x2?})
	reflect/value.go:596 +0x970
reflect.Value.Call({0x2768f20?, 0x2e46cf0?, 0x4001f0ab58?}, {0x4001f0ab18?, 0x4001f0aa58?, 0x629b4?})
	reflect/value.go:380 +0x94
k8s.io/kubernetes/pkg/printers.(*HumanReadableGenerator).GenerateTable(0x4001f0abb8?, {0x32c2bb8, 0x400788d8c0}, {0x0, 0x1})
	k8s.io/kubernetes/pkg/printers/tablegenerator.go:86 +0x1b8
k8s.io/kubernetes/pkg/printers/storage.TableConvertor.ConvertToTable({{0x32b7ea0?, 0x400066ce30?}}, {0x80?, 0x10?}, {0x32c2bb8?, 0x400788d8c0?}, {0x32bc360?, 0x4008ddb280?})
	k8s.io/kubernetes/pkg/printers/storage/storage.go:46 +0xd8
k8s.io/apiserver/pkg/registry/generic/registry.(*Store).ConvertToTable(0x0?, {0x32e1798?, 0x4007951d70?}, {0x32c2bb8?, 0x400788d8c0?}, {0x32bc360?, 0x4008ddb280?})
	k8s.io/apiserver/pkg/registry/generic/registry/store.go:1644 +0x44
k8s.io/apiserver/pkg/endpoints/handlers.asTable({0x32e1798, 0x4007951d70}, {0x32c2bb8, 0x400788d8c0}, 0x4008ddb280, 0x400199e1a0, {{0x4006fff051, 0xb}, {0x4006fff04c, 0x2}})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:375 +0x17c
k8s.io/apiserver/pkg/endpoints/handlers.doTransformObject({0x32e1798, 0x4007951d70}, {0x32c2bb8, 0x400788d8c0}, {0x2b43c00, 0x4008ddb280}, 0x4007c18150, 0x400199e1a0)
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:270 +0x188
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEmbeddedEncoder).doEncode(0x40096dbb30, {0x32c2bb8, 0x400788d8c0}, {0xffff66499918, 0x4008e433e0})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:82 +0x68
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEmbeddedEncoder).Encode(0x40096dbb30, {0x32c2bb8?, 0x400788d8c0}, {0xffff66499918, 0x4008e433e0})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:78 +0x114
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).doEncode(0x400992dce0, {0x32c2bb8, 0x400788d8c0}, {{0x2c27806?, 0x4001f0b278?}, {0x32c2bb8?, 0x400788d8c0?}}, {0xffff664f8b18, 0x4008397e60})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:186 +0xd4
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).Encode.func1(...)
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:175
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).Encode(0x400992dce0, {{0x2c27806?, 0x32c2bb8?}, {0x32c2bb8?, 0x400788d8c0?}})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:180 +0x140
k8s.io/apiserver/pkg/endpoints/handlers.(*WatchServer).HandleHTTP(0x4007bc00a0, {0x32d0800, 0x4008397e60}, 0x4008631b00)
	k8s.io/apiserver/pkg/endpoints/handlers/watch.go:249 +0x944
net/http.HandlerFunc.ServeHTTP(0x4001f0b678?, {0x32d0800?, 0x4008397e60?}, 0x4009340ee0?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/endpoints/handlers.ListResource.func1.4.1()
	k8s.io/apiserver/pkg/endpoints/handlers/get.go:283 +0x74
k8s.io/apiserver/pkg/endpoints/metrics.RecordLongRunning(0x4008631b00, 0x25d7aa0?, {0x2c282c0, 0x9}, 0x4001f0b870)
	k8s.io/apiserver/pkg/endpoints/metrics/metrics.go:528 +0x494
k8s.io/apiserver/pkg/endpoints/handlers.ListResource.func1.4()
	k8s.io/apiserver/pkg/endpoints/handlers/get.go:281 +0x10c
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRoutine.func17({0x32d0590, 0x4008a92d38}, 0x4008631320)
	k8s.io/apiserver/pkg/server/filters/routine.go:73 +0x190
net/http.HandlerFunc.ServeHTTP(0x40086310e0?, {0x32d0590?, 0x4008a92d38?}, 0x40000aa808?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRequestInfo.func18({0x32d0590, 0x4008a92d38}, 0x40086310e0)
	k8s.io/apiserver/pkg/endpoints/filters/requestinfo.go:39 +0x104
net/http.HandlerFunc.ServeHTTP(0x4008630fc0?, {0x32d0590?, 0x4008a92d38?}, 0x59b0a8287ff2?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRequestReceivedTimestamp.withRequestReceivedTimestampWithClock.func32({0x32d0590, 0x4008a92d38}, 0x4008630fc0)
	k8s.io/apiserver/pkg/endpoints/filters/request_received_time.go:38 +0xac
net/http.HandlerFunc.ServeHTTP(0x4006400af8?, {0x32d0590?, 0x4008a92d38?}, 0xffff660fa308?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithMuxAndDiscoveryComplete.func19({0x32d0590?, 0x4008a92d38?}, 0x4008630fc0?)
	k8s.io/apiserver/pkg/endpoints/filters/mux_discovery_complete.go:52 +0xd0
net/http.HandlerFunc.ServeHTTP(0x4004b81801?, {0x32d0590?, 0x4008a92d38?}, 0x1c215005c3edd2f0?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithPanicRecovery.withPanicRecovery.func33({0x32d0590?, 0x4008a92d38?}, 0x4004b81830?)
	k8s.io/apiserver/pkg/server/filters/wrap.go:74 +0x9c
net/http.HandlerFunc.ServeHTTP(0x40079518f0?, {0x32d0590?, 0x4008a92d38?}, 0x40071b1c80?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithAuditInit.withAuditInit.func34({0x32d0590, 0x4008a92d38}, 0x4008630ea0)
	k8s.io/apiserver/pkg/endpoints/filters/audit_init.go:63 +0x110
net/http.HandlerFunc.ServeHTTP(0x27?, {0x32d0590?, 0x4008a92d38?}, 0x27?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.(*APIServerHandler).ServeHTTP(0x0?, {0x32d0590?, 0x4008a92d38?}, 0x4800?)
	k8s.io/apiserver/pkg/server/handler.go:189 +0x30
net/http.serverHandler.ServeHTTP({0x4006400e18?}, {0x32d0590?, 0x4008a92d38?}, 0x4009b1a138?)
	net/http/server.go:3137 +0xbc
net/http.initALPNRequest.ServeHTTP({{0x32e1798?, 0x40079510b0?}, 0x400773f188?, {0x40036e1860?}}, {0x32d0590, 0x4008a92d38}, 0x4008630ea0)
	net/http/server.go:3745 +0x1b4
golang.org/x/net/http2.(*serverConn).runHandler(0x4ea0de0?, 0x0?, 0x0?, 0x4006400fa8?)
	golang.org/x/net@v0.23.0/http2/server.go:2369 +0xc0
created by golang.org/x/net/http2.(*serverConn).scheduleHandler in goroutine 12271909
	golang.org/x/net@v0.23.0/http2/server.go:2304 +0x208
E0709 10:14:03.240061       1 runtime.go:79] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
goroutine 12267321 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic({0x277c340, 0x4dd78a0})
	k8s.io/apimachinery/pkg/util/runtime/runtime.go:75 +0x7c
k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x4006e4a000, 0x1, 0x40074eec40?})
	k8s.io/apimachinery/pkg/util/runtime/runtime.go:49 +0x78
panic({0x277c340?, 0x4dd78a0?})
	runtime/panic.go:770 +0x124
k8s.io/kubernetes/pkg/printers/internalversion.printReplicationController(0x4007e7e000, {0x5?, 0x0?})
	k8s.io/kubernetes/pkg/printers/internalversion/printers.go:1127 +0x1e4
reflect.Value.call({0x2768f20?, 0x2e46cf0?, 0x13?}, {0x2c20ae1, 0x4}, {0x4006e4ab18, 0x2, 0x2?})
	reflect/value.go:596 +0x970
reflect.Value.Call({0x2768f20?, 0x2e46cf0?, 0x40012f6b58?}, {0x40012f6b18?, 0xffff663a9e20?, 0x40094713b0?})
	reflect/value.go:380 +0x94
k8s.io/kubernetes/pkg/printers.(*HumanReadableGenerator).GenerateTable(0x2bb9aa0?, {0x32c2bb8, 0x4007e7e000}, {0x0, 0x1})
	k8s.io/kubernetes/pkg/printers/tablegenerator.go:86 +0x1b8
k8s.io/kubernetes/pkg/printers/storage.TableConvertor.ConvertToTable({{0x32b7ea0?, 0x400066ce30?}}, {0x40011cc990?, 0x32c8380?}, {0x32c2bb8?, 0x4007e7e000?}, {0x32bc360?, 0x4008f3df00?})
	k8s.io/kubernetes/pkg/printers/storage/storage.go:46 +0xd8
k8s.io/apiserver/pkg/registry/generic/registry.(*Store).ConvertToTable(0x4e37d40?, {0x32e1798?, 0x4008ac4c60?}, {0x32c2bb8?, 0x4007e7e000?}, {0x32bc360?, 0x4008f3df00?})
	k8s.io/apiserver/pkg/registry/generic/registry/store.go:1644 +0x44
k8s.io/apiserver/pkg/endpoints/handlers.asTable({0x32e1798, 0x4008ac4c60}, {0x32c2bb8, 0x4007e7e000}, 0x4008f3df00, 0x400199e1a0, {{0x4006fff051, 0xb}, {0x4006fff04c, 0x2}})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:375 +0x17c
k8s.io/apiserver/pkg/endpoints/handlers.doTransformObject({0x32e1798, 0x4008ac4c60}, {0x32c2bb8, 0x4007e7e000}, {0x2b43c00, 0x4008f3df00}, 0x4008ac4fc0, 0x400199e1a0)
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:270 +0x188
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEmbeddedEncoder).doEncode(0x4008e26eb0, {0x32c2bb8, 0x4007e7e000}, {0xffff66499918, 0x40078e0020})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:82 +0x68
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEmbeddedEncoder).Encode(0x4008e26eb0, {0x32c2bb8?, 0x4007e7e000}, {0xffff66499918, 0x40078e0020})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:78 +0x114
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).doEncode(0x4008487550, {0x32c2bb8, 0x4007e7e000}, {{0x2c27806?, 0x40012f7278?}, {0x32c2bb8?, 0x4007e7e000?}}, {0xffff664f8b18, 0x40054f27c0})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:186 +0xd4
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).Encode.func1(...)
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:175
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).Encode(0x4008487550, {{0x2c27806?, 0x32c2bb8?}, {0x32c2bb8?, 0x4007e7e000?}})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:180 +0x140
k8s.io/apiserver/pkg/endpoints/handlers.(*WatchServer).HandleHTTP(0x40078be280, {0x32d0800, 0x40054f27c0}, 0x4008b585a0)
	k8s.io/apiserver/pkg/endpoints/handlers/watch.go:249 +0x944
net/http.HandlerFunc.ServeHTTP(0x40012f7678?, {0x32d0800?, 0x40054f27c0?}, 0x40088d8770?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/endpoints/handlers.ListResource.func1.4.1()
	k8s.io/apiserver/pkg/endpoints/handlers/get.go:283 +0x74
k8s.io/apiserver/pkg/endpoints/metrics.RecordLongRunning(0x4008b585a0, 0x25d7aa0?, {0x2c282c0, 0x9}, 0x40012f7870)
	k8s.io/apiserver/pkg/endpoints/metrics/metrics.go:528 +0x494
k8s.io/apiserver/pkg/endpoints/handlers.ListResource.func1.4()
	k8s.io/apiserver/pkg/endpoints/handlers/get.go:281 +0x10c
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRoutine.func17({0x32d0590, 0x4005f90f10}, 0x400434fb00)
	k8s.io/apiserver/pkg/server/filters/routine.go:73 +0x190
net/http.HandlerFunc.ServeHTTP(0x400434f9e0?, {0x32d0590?, 0x4005f90f10?}, 0x4000c80008?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRequestInfo.func18({0x32d0590, 0x4005f90f10}, 0x400434f9e0)
	k8s.io/apiserver/pkg/endpoints/filters/requestinfo.go:39 +0x104
net/http.HandlerFunc.ServeHTTP(0x400434f8c0?, {0x32d0590?, 0x4005f90f10?}, 0x59b0df46241c?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRequestReceivedTimestamp.withRequestReceivedTimestampWithClock.func32({0x32d0590, 0x4005f90f10}, 0x400434f8c0)
	k8s.io/apiserver/pkg/endpoints/filters/request_received_time.go:38 +0xac
net/http.HandlerFunc.ServeHTTP(0x40075d9af8?, {0x32d0590?, 0x4005f90f10?}, 0xffff660aa738?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithMuxAndDiscoveryComplete.func19({0x32d0590?, 0x4005f90f10?}, 0x400434f8c0?)
	k8s.io/apiserver/pkg/endpoints/filters/mux_discovery_complete.go:52 +0xd0
net/http.HandlerFunc.ServeHTTP(0x4008058201?, {0x32d0590?, 0x4005f90f10?}, 0x793e908fe2a28e28?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithPanicRecovery.withPanicRecovery.func33({0x32d0590?, 0x4005f90f10?}, 0x4008058260?)
	k8s.io/apiserver/pkg/server/filters/wrap.go:74 +0x9c
net/http.HandlerFunc.ServeHTTP(0x4008ac47e0?, {0x32d0590?, 0x4005f90f10?}, 0x4006a38de0?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithAuditInit.withAuditInit.func34({0x32d0590, 0x4005f90f10}, 0x400434f7a0)
	k8s.io/apiserver/pkg/endpoints/filters/audit_init.go:63 +0x110
net/http.HandlerFunc.ServeHTTP(0x0?, {0x32d0590?, 0x4005f90f10?}, 0x63670?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.(*APIServerHandler).ServeHTTP(0x1?, {0x32d0590?, 0x4005f90f10?}, 0x215b4?)
	k8s.io/apiserver/pkg/server/handler.go:189 +0x30
net/http.serverHandler.ServeHTTP({0x40075d9d58?}, {0x32d0590?, 0x4005f90f10?}, 0x1aa3a40?)
	net/http/server.go:3137 +0xbc
net/http.initALPNRequest.ServeHTTP({{0x32e1798?, 0x40079510b0?}, 0x400773f188?, {0x40036e1860?}}, {0x32d0590, 0x4005f90f10}, 0x400434f7a0)
	net/http/server.go:3745 +0x1b4
golang.org/x/net/http2.(*serverConn).runHandler(0x4002e6b110?, 0x4008ddb240?, 0x2bd4d?, 0x40018a8840?)
	golang.org/x/net@v0.23.0/http2/server.go:2369 +0xc0
created by golang.org/x/net/http2.(*serverConn).scheduleHandler in goroutine 12271909
	golang.org/x/net@v0.23.0/http2/server.go:2304 +0x208
E0709 10:14:03.240367       1 wrap.go:58] "apiserver panic'd" method="GET" URI="/api/v1/replicationcontrollers?allowWatchBookmarks=true&limit=500&resourceVersionMatch=NotOlderThan&sendInitialEvents=true&watch=true" auditID="1bf4aed7-93b4-49a9-8223-952955486471"
http2: panic serving 192.168.228.1:37842: runtime error: invalid memory address or nil pointer dereference
goroutine 12267321 [running]:
golang.org/x/net/http2.(*serverConn).runHandler.func1()
	golang.org/x/net@v0.23.0/http2/server.go:2362 +0x13c
panic({0x277c340?, 0x4dd78a0?})
	runtime/panic.go:770 +0x124
k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x4006e4a000, 0x1, 0x40074eec40?})
	k8s.io/apimachinery/pkg/util/runtime/runtime.go:56 +0xe0
panic({0x277c340?, 0x4dd78a0?})
	runtime/panic.go:770 +0x124
k8s.io/kubernetes/pkg/printers/internalversion.printReplicationController(0x4007e7e000, {0x5?, 0x0?})
	k8s.io/kubernetes/pkg/printers/internalversion/printers.go:1127 +0x1e4
reflect.Value.call({0x2768f20?, 0x2e46cf0?, 0x13?}, {0x2c20ae1, 0x4}, {0x4006e4ab18, 0x2, 0x2?})
	reflect/value.go:596 +0x970
reflect.Value.Call({0x2768f20?, 0x2e46cf0?, 0x40012f6b58?}, {0x40012f6b18?, 0xffff663a9e20?, 0x40094713b0?})
	reflect/value.go:380 +0x94
k8s.io/kubernetes/pkg/printers.(*HumanReadableGenerator).GenerateTable(0x2bb9aa0?, {0x32c2bb8, 0x4007e7e000}, {0x0, 0x1})
	k8s.io/kubernetes/pkg/printers/tablegenerator.go:86 +0x1b8
k8s.io/kubernetes/pkg/printers/storage.TableConvertor.ConvertToTable({{0x32b7ea0?, 0x400066ce30?}}, {0x40011cc990?, 0x32c8380?}, {0x32c2bb8?, 0x4007e7e000?}, {0x32bc360?, 0x4008f3df00?})
	k8s.io/kubernetes/pkg/printers/storage/storage.go:46 +0xd8
k8s.io/apiserver/pkg/registry/generic/registry.(*Store).ConvertToTable(0x4e37d40?, {0x32e1798?, 0x4008ac4c60?}, {0x32c2bb8?, 0x4007e7e000?}, {0x32bc360?, 0x4008f3df00?})
	k8s.io/apiserver/pkg/registry/generic/registry/store.go:1644 +0x44
k8s.io/apiserver/pkg/endpoints/handlers.asTable({0x32e1798, 0x4008ac4c60}, {0x32c2bb8, 0x4007e7e000}, 0x4008f3df00, 0x400199e1a0, {{0x4006fff051, 0xb}, {0x4006fff04c, 0x2}})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:375 +0x17c
k8s.io/apiserver/pkg/endpoints/handlers.doTransformObject({0x32e1798, 0x4008ac4c60}, {0x32c2bb8, 0x4007e7e000}, {0x2b43c00, 0x4008f3df00}, 0x4008ac4fc0, 0x400199e1a0)
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:270 +0x188
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEmbeddedEncoder).doEncode(0x4008e26eb0, {0x32c2bb8, 0x4007e7e000}, {0xffff66499918, 0x40078e0020})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:82 +0x68
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEmbeddedEncoder).Encode(0x4008e26eb0, {0x32c2bb8?, 0x4007e7e000}, {0xffff66499918, 0x40078e0020})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:78 +0x114
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).doEncode(0x4008487550, {0x32c2bb8, 0x4007e7e000}, {{0x2c27806?, 0x40012f7278?}, {0x32c2bb8?, 0x4007e7e000?}}, {0xffff664f8b18, 0x40054f27c0})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:186 +0xd4
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).Encode.func1(...)
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:175
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).Encode(0x4008487550, {{0x2c27806?, 0x32c2bb8?}, {0x32c2bb8?, 0x4007e7e000?}})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:180 +0x140
k8s.io/apiserver/pkg/endpoints/handlers.(*WatchServer).HandleHTTP(0x40078be280, {0x32d0800, 0x40054f27c0}, 0x4008b585a0)
	k8s.io/apiserver/pkg/endpoints/handlers/watch.go:249 +0x944
net/http.HandlerFunc.ServeHTTP(0x40012f7678?, {0x32d0800?, 0x40054f27c0?}, 0x40088d8770?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/endpoints/handlers.ListResource.func1.4.1()
	k8s.io/apiserver/pkg/endpoints/handlers/get.go:283 +0x74
k8s.io/apiserver/pkg/endpoints/metrics.RecordLongRunning(0x4008b585a0, 0x25d7aa0?, {0x2c282c0, 0x9}, 0x40012f7870)
	k8s.io/apiserver/pkg/endpoints/metrics/metrics.go:528 +0x494
k8s.io/apiserver/pkg/endpoints/handlers.ListResource.func1.4()
	k8s.io/apiserver/pkg/endpoints/handlers/get.go:281 +0x10c
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRoutine.func17({0x32d0590, 0x4005f90f10}, 0x400434fb00)
	k8s.io/apiserver/pkg/server/filters/routine.go:73 +0x190
net/http.HandlerFunc.ServeHTTP(0x400434f9e0?, {0x32d0590?, 0x4005f90f10?}, 0x4000c80008?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRequestInfo.func18({0x32d0590, 0x4005f90f10}, 0x400434f9e0)
	k8s.io/apiserver/pkg/endpoints/filters/requestinfo.go:39 +0x104
net/http.HandlerFunc.ServeHTTP(0x400434f8c0?, {0x32d0590?, 0x4005f90f10?}, 0x59b0df46241c?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRequestReceivedTimestamp.withRequestReceivedTimestampWithClock.func32({0x32d0590, 0x4005f90f10}, 0x400434f8c0)
	k8s.io/apiserver/pkg/endpoints/filters/request_received_time.go:38 +0xac
net/http.HandlerFunc.ServeHTTP(0x40075d9af8?, {0x32d0590?, 0x4005f90f10?}, 0xffff660aa738?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithMuxAndDiscoveryComplete.func19({0x32d0590?, 0x4005f90f10?}, 0x400434f8c0?)
	k8s.io/apiserver/pkg/endpoints/filters/mux_discovery_complete.go:52 +0xd0
net/http.HandlerFunc.ServeHTTP(0x4008058201?, {0x32d0590?, 0x4005f90f10?}, 0x793e908fe2a28e28?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithPanicRecovery.withPanicRecovery.func33({0x32d0590?, 0x4005f90f10?}, 0x4008058260?)
	k8s.io/apiserver/pkg/server/filters/wrap.go:74 +0x9c
net/http.HandlerFunc.ServeHTTP(0x4008ac47e0?, {0x32d0590?, 0x4005f90f10?}, 0x4006a38de0?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithAuditInit.withAuditInit.func34({0x32d0590, 0x4005f90f10}, 0x400434f7a0)
	k8s.io/apiserver/pkg/endpoints/filters/audit_init.go:63 +0x110
net/http.HandlerFunc.ServeHTTP(0x0?, {0x32d0590?, 0x4005f90f10?}, 0x63670?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.(*APIServerHandler).ServeHTTP(0x1?, {0x32d0590?, 0x4005f90f10?}, 0x215b4?)
	k8s.io/apiserver/pkg/server/handler.go:189 +0x30
net/http.serverHandler.ServeHTTP({0x40075d9d58?}, {0x32d0590?, 0x4005f90f10?}, 0x1aa3a40?)
	net/http/server.go:3137 +0xbc
net/http.initALPNRequest.ServeHTTP({{0x32e1798?, 0x40079510b0?}, 0x400773f188?, {0x40036e1860?}}, {0x32d0590, 0x4005f90f10}, 0x400434f7a0)
	net/http/server.go:3745 +0x1b4
golang.org/x/net/http2.(*serverConn).runHandler(0x4002e6b110?, 0x4008ddb240?, 0x2bd4d?, 0x40018a8840?)
	golang.org/x/net@v0.23.0/http2/server.go:2369 +0xc0
created by golang.org/x/net/http2.(*serverConn).scheduleHandler in goroutine 12271909
	golang.org/x/net@v0.23.0/http2/server.go:2304 +0x208
I0709 10:25:34.583300       1 trace.go:236] Trace[1801593762]: "Update" accept:application/vnd.kubernetes.protobuf, */*,audit-id:591d5e3c-dc89-4c39-a343-89832199a725,client:192.168.228.2,api-group:coordination.k8s.io,api-version:v1,name:kube-controller-manager,subresource:,namespace:kube-system,protocol:HTTP/2.0,resource:leases,scope:resource,url:/apis/coordination.k8s.io/v1/namespaces/kube-system/leases/kube-controller-manager,user-agent:kube-controller-manager/v1.30.0 (linux/arm64) kubernetes/7c48c2b/leader-election,verb:PUT (09-Jul-2024 10:25:34.023) (total time: 557ms):
Trace[1801593762]: ["GuaranteedUpdate etcd3" audit-id:591d5e3c-dc89-4c39-a343-89832199a725,key:/leases/kube-system/kube-controller-manager,type:*coordination.Lease,resource:leases.coordination.k8s.io 556ms (10:25:34.024)
Trace[1801593762]:  ---"Txn call completed" 553ms (10:25:34.580)]
Trace[1801593762]: [557.156998ms] [557.156998ms] END
I0709 10:25:34.618251       1 trace.go:236] Trace[1881374510]: "Update" accept:application/vnd.kubernetes.protobuf, */*,audit-id:5b27b922-d063-4f5b-9f51-7656e283316a,client:192.168.228.2,api-group:coordination.k8s.io,api-version:v1,name:kube-scheduler,subresource:,namespace:kube-system,protocol:HTTP/2.0,resource:leases,scope:resource,url:/apis/coordination.k8s.io/v1/namespaces/kube-system/leases/kube-scheduler,user-agent:kube-scheduler/v1.30.0 (linux/arm64) kubernetes/7c48c2b/leader-election,verb:PUT (09-Jul-2024 10:25:34.090) (total time: 527ms):
Trace[1881374510]: ["GuaranteedUpdate etcd3" audit-id:5b27b922-d063-4f5b-9f51-7656e283316a,key:/leases/kube-system/kube-scheduler,type:*coordination.Lease,resource:leases.coordination.k8s.io 527ms (10:25:34.090)
Trace[1881374510]:  ---"Txn call completed" 525ms (10:25:34.617)]
Trace[1881374510]: [527.620713ms] [527.620713ms] END
I0709 10:26:13.497294       1 trace.go:236] Trace[1707761820]: "Update" accept:application/vnd.kubernetes.protobuf, */*,audit-id:4f754802-06da-4532-8276-149aa3ce7c41,client:192.168.228.2,api-group:coordination.k8s.io,api-version:v1,name:kube-controller-manager,subresource:,namespace:kube-system,protocol:HTTP/2.0,resource:leases,scope:resource,url:/apis/coordination.k8s.io/v1/namespaces/kube-system/leases/kube-controller-manager,user-agent:kube-controller-manager/v1.30.0 (linux/arm64) kubernetes/7c48c2b/leader-election,verb:PUT (09-Jul-2024 10:26:12.156) (total time: 1340ms):
Trace[1707761820]: ["GuaranteedUpdate etcd3" audit-id:4f754802-06da-4532-8276-149aa3ce7c41,key:/leases/kube-system/kube-controller-manager,type:*coordination.Lease,resource:leases.coordination.k8s.io 1340ms (10:26:12.156)
Trace[1707761820]:  ---"Txn call completed" 1339ms (10:26:13.496)]
Trace[1707761820]: [1.340662907s] [1.340662907s] END
I0709 10:26:13.537508       1 trace.go:236] Trace[2145220561]: "Update" accept:application/vnd.kubernetes.protobuf, */*,audit-id:c3104fa0-f741-4f3e-a927-f6bad18117ff,client:::1,api-group:coordination.k8s.io,api-version:v1,name:apiserver-c7uylvfxlbqccnk6myfkwetzze,subresource:,namespace:kube-system,protocol:HTTP/2.0,resource:leases,scope:resource,url:/apis/coordination.k8s.io/v1/namespaces/kube-system/leases/apiserver-c7uylvfxlbqccnk6myfkwetzze,user-agent:kube-apiserver/v1.30.0 (linux/arm64) kubernetes/7c48c2b,verb:PUT (09-Jul-2024 10:26:12.573) (total time: 963ms):
Trace[2145220561]: ["GuaranteedUpdate etcd3" audit-id:c3104fa0-f741-4f3e-a927-f6bad18117ff,key:/leases/kube-system/apiserver-c7uylvfxlbqccnk6myfkwetzze,type:*coordination.Lease,resource:leases.coordination.k8s.io 963ms (10:26:12.573)
Trace[2145220561]:  ---"Txn call completed" 962ms (10:26:13.537)]
Trace[2145220561]: [963.738677ms] [963.738677ms] END
I0709 10:26:13.538437       1 trace.go:236] Trace[1493675174]: "Update" accept:application/vnd.kubernetes.protobuf, */*,audit-id:36f48e3c-8bba-4c96-b06d-ded36acfe667,client:192.168.228.2,api-group:coordination.k8s.io,api-version:v1,name:kube-scheduler,subresource:,namespace:kube-system,protocol:HTTP/2.0,resource:leases,scope:resource,url:/apis/coordination.k8s.io/v1/namespaces/kube-system/leases/kube-scheduler,user-agent:kube-scheduler/v1.30.0 (linux/arm64) kubernetes/7c48c2b/leader-election,verb:PUT (09-Jul-2024 10:26:12.237) (total time: 1301ms):
Trace[1493675174]: ["GuaranteedUpdate etcd3" audit-id:36f48e3c-8bba-4c96-b06d-ded36acfe667,key:/leases/kube-system/kube-scheduler,type:*coordination.Lease,resource:leases.coordination.k8s.io 1300ms (10:26:12.237)
Trace[1493675174]:  ---"Txn call completed" 1299ms (10:26:13.538)]
Trace[1493675174]: [1.301081083s] [1.301081083s] END
I0709 10:38:16.993943       1 trace.go:236] Trace[467848259]: "Update" accept:application/vnd.kubernetes.protobuf, */*,audit-id:8b384f9d-9a83-46b7-a999-d146187bde60,client:192.168.228.2,api-group:coordination.k8s.io,api-version:v1,name:kube-scheduler,subresource:,namespace:kube-system,protocol:HTTP/2.0,resource:leases,scope:resource,url:/apis/coordination.k8s.io/v1/namespaces/kube-system/leases/kube-scheduler,user-agent:kube-scheduler/v1.30.0 (linux/arm64) kubernetes/7c48c2b/leader-election,verb:PUT (09-Jul-2024 10:38:16.445) (total time: 548ms):
Trace[467848259]: ["GuaranteedUpdate etcd3" audit-id:8b384f9d-9a83-46b7-a999-d146187bde60,key:/leases/kube-system/kube-scheduler,type:*coordination.Lease,resource:leases.coordination.k8s.io 548ms (10:38:16.445)
Trace[467848259]:  ---"Txn call completed" 545ms (10:38:16.993)]
Trace[467848259]: [548.624886ms] [548.624886ms] END
I0709 10:38:16.993943       1 trace.go:236] Trace[1061761966]: "Update" accept:application/vnd.kubernetes.protobuf, */*,audit-id:fcbad7f8-d97d-4d57-ad03-6a9c41cb3adf,client:192.168.228.2,api-group:coordination.k8s.io,api-version:v1,name:kube-controller-manager,subresource:,namespace:kube-system,protocol:HTTP/2.0,resource:leases,scope:resource,url:/apis/coordination.k8s.io/v1/namespaces/kube-system/leases/kube-controller-manager,user-agent:kube-controller-manager/v1.30.0 (linux/arm64) kubernetes/7c48c2b/leader-election,verb:PUT (09-Jul-2024 10:38:16.364) (total time: 629ms):
Trace[1061761966]: ["GuaranteedUpdate etcd3" audit-id:fcbad7f8-d97d-4d57-ad03-6a9c41cb3adf,key:/leases/kube-system/kube-controller-manager,type:*coordination.Lease,resource:leases.coordination.k8s.io 628ms (10:38:16.365)
Trace[1061761966]:  ---"Txn call completed" 627ms (10:38:16.993)]
Trace[1061761966]: [629.001458ms] [629.001458ms] END
I0709 10:38:24.098528       1 trace.go:236] Trace[1174728620]: "Update" accept:application/vnd.kubernetes.protobuf, */*,audit-id:636205ea-b192-458f-936e-0c471d7f5100,client:192.168.228.2,api-group:coordination.k8s.io,api-version:v1,name:kube-scheduler,subresource:,namespace:kube-system,protocol:HTTP/2.0,resource:leases,scope:resource,url:/apis/coordination.k8s.io/v1/namespaces/kube-system/leases/kube-scheduler,user-agent:kube-scheduler/v1.30.0 (linux/arm64) kubernetes/7c48c2b/leader-election,verb:PUT (09-Jul-2024 10:38:23.555) (total time: 543ms):
Trace[1174728620]: ["GuaranteedUpdate etcd3" audit-id:636205ea-b192-458f-936e-0c471d7f5100,key:/leases/kube-system/kube-scheduler,type:*coordination.Lease,resource:leases.coordination.k8s.io 542ms (10:38:23.555)
Trace[1174728620]:  ---"Txn call completed" 541ms (10:38:24.097)]
Trace[1174728620]: [543.021739ms] [543.021739ms] END
I0709 10:38:26.196127       1 trace.go:236] Trace[921371446]: "Update" accept:application/vnd.kubernetes.protobuf, */*,audit-id:2ac8431a-9223-4f7c-ae6d-d17ae3e76371,client:192.168.228.2,api-group:coordination.k8s.io,api-version:v1,name:kube-controller-manager,subresource:,namespace:kube-system,protocol:HTTP/2.0,resource:leases,scope:resource,url:/apis/coordination.k8s.io/v1/namespaces/kube-system/leases/kube-controller-manager,user-agent:kube-controller-manager/v1.30.0 (linux/arm64) kubernetes/7c48c2b/leader-election,verb:PUT (09-Jul-2024 10:38:25.350) (total time: 845ms):
Trace[921371446]: ["GuaranteedUpdate etcd3" audit-id:2ac8431a-9223-4f7c-ae6d-d17ae3e76371,key:/leases/kube-system/kube-controller-manager,type:*coordination.Lease,resource:leases.coordination.k8s.io 845ms (10:38:25.350)
Trace[921371446]:  ---"Txn call completed" 843ms (10:38:26.195)]
Trace[921371446]: [845.749952ms] [845.749952ms] END
I0709 10:38:28.248366       1 trace.go:236] Trace[281322190]: "Update" accept:application/vnd.kubernetes.protobuf, */*,audit-id:9c0c03ff-e619-422f-89ad-18a72ec1baa4,client:192.168.228.2,api-group:coordination.k8s.io,api-version:v1,name:kube-scheduler,subresource:,namespace:kube-system,protocol:HTTP/2.0,resource:leases,scope:resource,url:/apis/coordination.k8s.io/v1/namespaces/kube-system/leases/kube-scheduler,user-agent:kube-scheduler/v1.30.0 (linux/arm64) kubernetes/7c48c2b/leader-election,verb:PUT (09-Jul-2024 10:38:26.102) (total time: 2145ms):
Trace[281322190]: ["GuaranteedUpdate etcd3" audit-id:9c0c03ff-e619-422f-89ad-18a72ec1baa4,key:/leases/kube-system/kube-scheduler,type:*coordination.Lease,resource:leases.coordination.k8s.io 2145ms (10:38:26.103)
Trace[281322190]:  ---"Txn call completed" 2143ms (10:38:28.248)]
Trace[281322190]: [2.145277032s] [2.145277032s] END
I0709 10:39:11.388441       1 trace.go:236] Trace[1345596324]: "GuaranteedUpdate etcd3" audit-id:,key:/masterleases/192.168.228.2,type:*v1.Endpoints,resource:apiServerIPInfo (09-Jul-2024 10:39:10.803) (total time: 585ms):
Trace[1345596324]: ---"initial value restored" 359ms (10:39:11.163)
Trace[1345596324]: ---"Transaction prepared" 70ms (10:39:11.233)
Trace[1345596324]: ---"Txn call completed" 154ms (10:39:11.388)
Trace[1345596324]: [585.030522ms] [585.030522ms] END
I0709 10:39:12.790221       1 trace.go:236] Trace[40688711]: "Update" accept:application/vnd.kubernetes.protobuf, */*,audit-id:b2f4be4e-54fb-4754-ac36-2b5ac3f1b3ce,client:192.168.228.2,api-group:coordination.k8s.io,api-version:v1,name:kube-scheduler,subresource:,namespace:kube-system,protocol:HTTP/2.0,resource:leases,scope:resource,url:/apis/coordination.k8s.io/v1/namespaces/kube-system/leases/kube-scheduler,user-agent:kube-scheduler/v1.30.0 (linux/arm64) kubernetes/7c48c2b/leader-election,verb:PUT (09-Jul-2024 10:39:11.927) (total time: 862ms):
Trace[40688711]: ["GuaranteedUpdate etcd3" audit-id:b2f4be4e-54fb-4754-ac36-2b5ac3f1b3ce,key:/leases/kube-system/kube-scheduler,type:*coordination.Lease,resource:leases.coordination.k8s.io 862ms (10:39:11.927)
Trace[40688711]:  ---"Txn call completed" 860ms (10:39:12.789)]
Trace[40688711]: [862.505835ms] [862.505835ms] END
I0709 10:41:16.667805       1 trace.go:236] Trace[890289547]: "Update" accept:application/vnd.kubernetes.protobuf, */*,audit-id:440f10c3-07ce-4dc3-ab29-cb6af0bb4072,client:192.168.228.2,api-group:coordination.k8s.io,api-version:v1,name:kube-scheduler,subresource:,namespace:kube-system,protocol:HTTP/2.0,resource:leases,scope:resource,url:/apis/coordination.k8s.io/v1/namespaces/kube-system/leases/kube-scheduler,user-agent:kube-scheduler/v1.30.0 (linux/arm64) kubernetes/7c48c2b/leader-election,verb:PUT (09-Jul-2024 10:41:16.031) (total time: 636ms):
Trace[890289547]: ["GuaranteedUpdate etcd3" audit-id:440f10c3-07ce-4dc3-ab29-cb6af0bb4072,key:/leases/kube-system/kube-scheduler,type:*coordination.Lease,resource:leases.coordination.k8s.io 636ms (10:41:16.031)
Trace[890289547]:  ---"Txn call completed" 634ms (10:41:16.667)]
Trace[890289547]: [636.526854ms] [636.526854ms] END
I0709 10:41:24.501037       1 trace.go:236] Trace[2066088758]: "Update" accept:application/vnd.kubernetes.protobuf, */*,audit-id:97fbf94b-701a-4852-a70d-8108c999db3b,client:::1,api-group:coordination.k8s.io,api-version:v1,name:apiserver-c7uylvfxlbqccnk6myfkwetzze,subresource:,namespace:kube-system,protocol:HTTP/2.0,resource:leases,scope:resource,url:/apis/coordination.k8s.io/v1/namespaces/kube-system/leases/apiserver-c7uylvfxlbqccnk6myfkwetzze,user-agent:kube-apiserver/v1.30.0 (linux/arm64) kubernetes/7c48c2b,verb:PUT (09-Jul-2024 10:41:23.823) (total time: 677ms):
Trace[2066088758]: ["GuaranteedUpdate etcd3" audit-id:97fbf94b-701a-4852-a70d-8108c999db3b,key:/leases/kube-system/apiserver-c7uylvfxlbqccnk6myfkwetzze,type:*coordination.Lease,resource:leases.coordination.k8s.io 676ms (10:41:23.824)
Trace[2066088758]:  ---"Txn call completed" 675ms (10:41:24.500)]
Trace[2066088758]: [677.127363ms] [677.127363ms] END
I0709 10:43:40.487965       1 trace.go:236] Trace[1887870986]: "Update" accept:application/vnd.kubernetes.protobuf, */*,audit-id:7d81b002-7c83-488b-9739-095ad05c24c1,client:192.168.228.2,api-group:coordination.k8s.io,api-version:v1,name:kube-scheduler,subresource:,namespace:kube-system,protocol:HTTP/2.0,resource:leases,scope:resource,url:/apis/coordination.k8s.io/v1/namespaces/kube-system/leases/kube-scheduler,user-agent:kube-scheduler/v1.30.0 (linux/arm64) kubernetes/7c48c2b/leader-election,verb:PUT (09-Jul-2024 10:43:37.802) (total time: 2677ms):
Trace[1887870986]: ["GuaranteedUpdate etcd3" audit-id:7d81b002-7c83-488b-9739-095ad05c24c1,key:/leases/kube-system/kube-scheduler,type:*coordination.Lease,resource:leases.coordination.k8s.io 2675ms (10:43:37.804)
Trace[1887870986]:  ---"Txn call completed" 2674ms (10:43:40.479)]
Trace[1887870986]: [2.677626797s] [2.677626797s] END
I0709 10:43:40.606678       1 trace.go:236] Trace[578317912]: "Update" accept:application/vnd.kubernetes.protobuf, */*,audit-id:08053c24-2774-4499-b5eb-8a48a79cceb1,client:192.168.228.2,api-group:coordination.k8s.io,api-version:v1,name:kube-controller-manager,subresource:,namespace:kube-system,protocol:HTTP/2.0,resource:leases,scope:resource,url:/apis/coordination.k8s.io/v1/namespaces/kube-system/leases/kube-controller-manager,user-agent:kube-controller-manager/v1.30.0 (linux/arm64) kubernetes/7c48c2b/leader-election,verb:PUT (09-Jul-2024 10:43:38.091) (total time: 2514ms):
Trace[578317912]: ["GuaranteedUpdate etcd3" audit-id:08053c24-2774-4499-b5eb-8a48a79cceb1,key:/leases/kube-system/kube-controller-manager,type:*coordination.Lease,resource:leases.coordination.k8s.io 2513ms (10:43:38.093)
Trace[578317912]:  ---"Txn call completed" 2491ms (10:43:40.606)]
Trace[578317912]: [2.514792013s] [2.514792013s] END
E0709 14:56:20.097456       1 authentication.go:73] "Unable to authenticate the request" err="[invalid bearer token, service account token has expired]"
E0709 14:56:20.097458       1 authentication.go:73] "Unable to authenticate the request" err="[invalid bearer token, service account token has expired]"
E0710 00:40:20.123585       1 authentication.go:73] "Unable to authenticate the request" err="[invalid bearer token, service account token has expired]"
E0710 00:40:20.123882       1 authentication.go:73] "Unable to authenticate the request" err="[invalid bearer token, service account token has expired]"
I0710 01:58:53.505182       1 trace.go:236] Trace[256705025]: "Update" accept:application/vnd.kubernetes.protobuf, */*,audit-id:1b704221-5940-4958-8f8b-f998326c17ee,client:192.168.228.2,api-group:coordination.k8s.io,api-version:v1,name:kube-scheduler,subresource:,namespace:kube-system,protocol:HTTP/2.0,resource:leases,scope:resource,url:/apis/coordination.k8s.io/v1/namespaces/kube-system/leases/kube-scheduler,user-agent:kube-scheduler/v1.30.0 (linux/arm64) kubernetes/7c48c2b/leader-election,verb:PUT (10-Jul-2024 01:57:33.782) (total time: 675ms):
Trace[256705025]: ["GuaranteedUpdate etcd3" audit-id:1b704221-5940-4958-8f8b-f998326c17ee,key:/leases/kube-system/kube-scheduler,type:*coordination.Lease,resource:leases.coordination.k8s.io 675ms (01:57:33.782)
Trace[256705025]:  ---"Txn call completed" 672ms (01:58:53.501)]
Trace[256705025]: [675.627742ms] [675.627742ms] END
I0710 01:58:53.505223       1 trace.go:236] Trace[881564424]: "Update" accept:application/vnd.kubernetes.protobuf, */*,audit-id:51ac23da-2736-4817-a5eb-19f85a67c759,client:192.168.228.2,api-group:coordination.k8s.io,api-version:v1,name:kube-controller-manager,subresource:,namespace:kube-system,protocol:HTTP/2.0,resource:leases,scope:resource,url:/apis/coordination.k8s.io/v1/namespaces/kube-system/leases/kube-controller-manager,user-agent:kube-controller-manager/v1.30.0 (linux/arm64) kubernetes/7c48c2b/leader-election,verb:PUT (10-Jul-2024 01:57:33.782) (total time: 676ms):
Trace[881564424]: ["GuaranteedUpdate etcd3" audit-id:51ac23da-2736-4817-a5eb-19f85a67c759,key:/leases/kube-system/kube-controller-manager,type:*coordination.Lease,resource:leases.coordination.k8s.io 676ms (01:57:33.782)
Trace[881564424]:  ---"Txn call completed" 673ms (01:58:53.501)]
Trace[881564424]: [676.428824ms] [676.428824ms] END
E0710 01:58:54.800606       1 authentication.go:73] "Unable to authenticate the request" err="[invalid bearer token, service account token has expired]"
E0710 01:58:54.800604       1 authentication.go:73] "Unable to authenticate the request" err="[invalid bearer token, service account token has expired]"
I0710 02:27:23.156102       1 trace.go:236] Trace[1578310872]: "Update" accept:application/vnd.kubernetes.protobuf,application/json,audit-id:b0b92e55-b49a-4139-b8c8-15a6bb71deb1,client:192.168.228.2,api-group:coordination.k8s.io,api-version:v1,name:kind-control-plane,subresource:,namespace:kube-node-lease,protocol:HTTP/2.0,resource:leases,scope:resource,url:/apis/coordination.k8s.io/v1/namespaces/kube-node-lease/leases/kind-control-plane,user-agent:kubelet/v1.30.0 (linux/arm64) kubernetes/7c48c2b,verb:PUT (10-Jul-2024 02:27:21.874) (total time: 1279ms):
Trace[1578310872]: ["GuaranteedUpdate etcd3" audit-id:b0b92e55-b49a-4139-b8c8-15a6bb71deb1,key:/leases/kube-node-lease/kind-control-plane,type:*coordination.Lease,resource:leases.coordination.k8s.io 1278ms (02:27:21.874)
Trace[1578310872]:  ---"Txn call completed" 1275ms (02:27:23.153)]
Trace[1578310872]: [1.279402638s] [1.279402638s] END
E0710 03:59:27.708308       1 authentication.go:73] "Unable to authenticate the request" err="[invalid bearer token, service account token has expired]"
E0710 03:59:27.708772       1 authentication.go:73] "Unable to authenticate the request" err="[invalid bearer token, service account token has expired]"
E0710 04:07:38.085250       1 runtime.go:79] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
goroutine 14341794 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic({0x277c340, 0x4dd78a0})
	k8s.io/apimachinery/pkg/util/runtime/runtime.go:75 +0x7c
k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x4007ab2000, 0x1, 0x4004439880?})
	k8s.io/apimachinery/pkg/util/runtime/runtime.go:49 +0x78
panic({0x277c340?, 0x4dd78a0?})
	runtime/panic.go:770 +0x124
k8s.io/kubernetes/pkg/printers/internalversion.printReplicationController(0x4008dd2580, {0x5?, 0x0?})
	k8s.io/kubernetes/pkg/printers/internalversion/printers.go:1127 +0x1e4
reflect.Value.call({0x2768f20?, 0x2e46cf0?, 0x2b14de0?}, {0x2c20ae1, 0x4}, {0x4007ab2b18, 0x2, 0x2056cc0?})
	reflect/value.go:596 +0x970
reflect.Value.Call({0x2768f20?, 0x2e46cf0?, 0x4007ab2b58?}, {0x4007ab2b18?, 0x0?, 0x4004439880?})
	reflect/value.go:380 +0x94
k8s.io/kubernetes/pkg/printers.(*HumanReadableGenerator).GenerateTable(0x0?, {0x32c2bb8, 0x4008dd2580}, {0x1, 0x1})
	k8s.io/kubernetes/pkg/printers/tablegenerator.go:86 +0x1b8
k8s.io/kubernetes/pkg/printers/storage.TableConvertor.ConvertToTable({{0x32b7ea0?, 0x400066ce30?}}, {0x2?, 0x2?}, {0x32c2bb8?, 0x4008dd2580?}, {0x32bc360?, 0x400bb23540?})
	k8s.io/kubernetes/pkg/printers/storage/storage.go:46 +0xd8
k8s.io/apiserver/pkg/registry/generic/registry.(*Store).ConvertToTable(0x4007ab2cf0?, {0x32e1798?, 0x4004df05d0?}, {0x32c2bb8?, 0x4008dd2580?}, {0x32bc360?, 0x400bb23540?})
	k8s.io/apiserver/pkg/registry/generic/registry/store.go:1644 +0x44
k8s.io/apiserver/pkg/endpoints/handlers.asTable({0x32e1798, 0x4004df05d0}, {0x32c2bb8, 0x4008dd2580}, 0x400bb23540, 0x400199e1a0, {{0x4006ffe331, 0xb}, {0x4006ffe32c, 0x2}})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:375 +0x17c
k8s.io/apiserver/pkg/endpoints/handlers.doTransformObject({0x32e1798, 0x4004df05d0}, {0x32c2bb8, 0x4008dd2580}, {0x2b43c00, 0x400bb23540}, 0x4004df0ab0, 0x400199e1a0)
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:270 +0x188
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEmbeddedEncoder).doEncode(0x400918da90, {0x32c2bb8, 0x4008dd2580}, {0xffff66499918, 0x4003cbc500})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:82 +0x68
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEmbeddedEncoder).Encode(0x400918da90, {0x32c2bb8?, 0x4008dd2580}, {0xffff66499918, 0x4003cbc500})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:78 +0x114
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).doEncode(0x4006ddfc30, {0x32c2bb8, 0x4008dd2580}, {{0x2c27806?, 0x4007ab3278?}, {0x32c2bb8?, 0x4008dd2580?}}, {0xffff664f8b18, 0x400ab53a80})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:186 +0xd4
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).Encode.func1(...)
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:175
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).Encode(0x4006ddfc30, {{0x2c27806?, 0x32c2bb8?}, {0x32c2bb8?, 0x4008dd2580?}})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:180 +0x140
k8s.io/apiserver/pkg/endpoints/handlers.(*WatchServer).HandleHTTP(0x4007f5d360, {0x32d0800, 0x400ab53a80}, 0x4004f70b40)
	k8s.io/apiserver/pkg/endpoints/handlers/watch.go:249 +0x944
net/http.HandlerFunc.ServeHTTP(0x4009fef678?, {0x32d0800?, 0x400ab53a80?}, 0x40000fc0e0?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/endpoints/handlers.ListResource.func1.4.1()
	k8s.io/apiserver/pkg/endpoints/handlers/get.go:283 +0x74
k8s.io/apiserver/pkg/endpoints/metrics.RecordLongRunning(0x4004f70b40, 0x25d7aa0?, {0x2c282c0, 0x9}, 0x4009fef870)
	k8s.io/apiserver/pkg/endpoints/metrics/metrics.go:528 +0x494
k8s.io/apiserver/pkg/endpoints/handlers.ListResource.func1.4()
	k8s.io/apiserver/pkg/endpoints/handlers/get.go:281 +0x10c
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRoutine.func17({0x32d0590, 0x4005d74138}, 0x4004f70120)
	k8s.io/apiserver/pkg/server/filters/routine.go:73 +0x190
net/http.HandlerFunc.ServeHTTP(0x4008433e60?, {0x32d0590?, 0x4005d74138?}, 0x4000c80008?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRequestInfo.func18({0x32d0590, 0x4005d74138}, 0x4008433e60)
	k8s.io/apiserver/pkg/endpoints/filters/requestinfo.go:39 +0x104
net/http.HandlerFunc.ServeHTTP(0x4008433d40?, {0x32d0590?, 0x4005d74138?}, 0x68c515c5b4d4?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRequestReceivedTimestamp.withRequestReceivedTimestampWithClock.func32({0x32d0590, 0x4005d74138}, 0x4008433d40)
	k8s.io/apiserver/pkg/endpoints/filters/request_received_time.go:38 +0xac
net/http.HandlerFunc.ServeHTTP(0x4006e5baf8?, {0x32d0590?, 0x4005d74138?}, 0xffff663a8200?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithMuxAndDiscoveryComplete.func19({0x32d0590?, 0x4005d74138?}, 0x4008433d40?)
	k8s.io/apiserver/pkg/endpoints/filters/mux_discovery_complete.go:52 +0xd0
net/http.HandlerFunc.ServeHTTP(0x4008d5f301?, {0x32d0590?, 0x4005d74138?}, 0x4ba920ca61d06de0?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithPanicRecovery.withPanicRecovery.func33({0x32d0590?, 0x4005d74138?}, 0x4008d5f3d0?)
	k8s.io/apiserver/pkg/server/filters/wrap.go:74 +0x9c
net/http.HandlerFunc.ServeHTTP(0x4004df0090?, {0x32d0590?, 0x4005d74138?}, 0x400e388240?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithAuditInit.withAuditInit.func34({0x32d0590, 0x4005d74138}, 0x4008433c20)
	k8s.io/apiserver/pkg/endpoints/filters/audit_init.go:63 +0x110
net/http.HandlerFunc.ServeHTTP(0x0?, {0x32d0590?, 0x4005d74138?}, 0x40038f0a80?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.(*APIServerHandler).ServeHTTP(0x0?, {0x32d0590?, 0x4005d74138?}, 0x103b860?)
	k8s.io/apiserver/pkg/server/handler.go:189 +0x30
net/http.serverHandler.ServeHTTP({0x4006e5be18?}, {0x32d0590?, 0x4005d74138?}, 0x32fa1c0?)
	net/http/server.go:3137 +0xbc
net/http.initALPNRequest.ServeHTTP({{0x32e1798?, 0x4007801530?}, 0x4004964388?, {0x40036e1860?}}, {0x32d0590, 0x4005d74138}, 0x4008433c20)
	net/http/server.go:3745 +0x1b4
golang.org/x/net/http2.(*serverConn).runHandler(0x0?, 0x89634?, 0x0?, 0x0?)
	golang.org/x/net@v0.23.0/http2/server.go:2369 +0xc0
created by golang.org/x/net/http2.(*serverConn).scheduleHandler in goroutine 14341774
	golang.org/x/net@v0.23.0/http2/server.go:2304 +0x208
E0710 04:07:38.085849       1 wrap.go:58] "apiserver panic'd" method="GET" URI="/api/v1/replicationcontrollers?watch=true&allowWatchBookmarks=true" auditID="0c4eb963-a24b-4c50-bd3b-689006a6d238"
http2: panic serving 192.168.228.1:50928: runtime error: invalid memory address or nil pointer dereference
goroutine 14341794 [running]:
golang.org/x/net/http2.(*serverConn).runHandler.func1()
	golang.org/x/net@v0.23.0/http2/server.go:2362 +0x13c
panic({0x277c340?, 0x4dd78a0?})
	runtime/panic.go:770 +0x124
k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x4007ab2000, 0x1, 0x4004439880?})
	k8s.io/apimachinery/pkg/util/runtime/runtime.go:56 +0xe0
panic({0x277c340?, 0x4dd78a0?})
	runtime/panic.go:770 +0x124
k8s.io/kubernetes/pkg/printers/internalversion.printReplicationController(0x4008dd2580, {0x5?, 0x0?})
	k8s.io/kubernetes/pkg/printers/internalversion/printers.go:1127 +0x1e4
reflect.Value.call({0x2768f20?, 0x2e46cf0?, 0x2b14de0?}, {0x2c20ae1, 0x4}, {0x4007ab2b18, 0x2, 0x2056cc0?})
	reflect/value.go:596 +0x970
reflect.Value.Call({0x2768f20?, 0x2e46cf0?, 0x4007ab2b58?}, {0x4007ab2b18?, 0x0?, 0x4004439880?})
	reflect/value.go:380 +0x94
k8s.io/kubernetes/pkg/printers.(*HumanReadableGenerator).GenerateTable(0x0?, {0x32c2bb8, 0x4008dd2580}, {0x1, 0x1})
	k8s.io/kubernetes/pkg/printers/tablegenerator.go:86 +0x1b8
k8s.io/kubernetes/pkg/printers/storage.TableConvertor.ConvertToTable({{0x32b7ea0?, 0x400066ce30?}}, {0x2?, 0x2?}, {0x32c2bb8?, 0x4008dd2580?}, {0x32bc360?, 0x400bb23540?})
	k8s.io/kubernetes/pkg/printers/storage/storage.go:46 +0xd8
k8s.io/apiserver/pkg/registry/generic/registry.(*Store).ConvertToTable(0x4007ab2cf0?, {0x32e1798?, 0x4004df05d0?}, {0x32c2bb8?, 0x4008dd2580?}, {0x32bc360?, 0x400bb23540?})
	k8s.io/apiserver/pkg/registry/generic/registry/store.go:1644 +0x44
k8s.io/apiserver/pkg/endpoints/handlers.asTable({0x32e1798, 0x4004df05d0}, {0x32c2bb8, 0x4008dd2580}, 0x400bb23540, 0x400199e1a0, {{0x4006ffe331, 0xb}, {0x4006ffe32c, 0x2}})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:375 +0x17c
k8s.io/apiserver/pkg/endpoints/handlers.doTransformObject({0x32e1798, 0x4004df05d0}, {0x32c2bb8, 0x4008dd2580}, {0x2b43c00, 0x400bb23540}, 0x4004df0ab0, 0x400199e1a0)
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:270 +0x188
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEmbeddedEncoder).doEncode(0x400918da90, {0x32c2bb8, 0x4008dd2580}, {0xffff66499918, 0x4003cbc500})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:82 +0x68
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEmbeddedEncoder).Encode(0x400918da90, {0x32c2bb8?, 0x4008dd2580}, {0xffff66499918, 0x4003cbc500})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:78 +0x114
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).doEncode(0x4006ddfc30, {0x32c2bb8, 0x4008dd2580}, {{0x2c27806?, 0x4007ab3278?}, {0x32c2bb8?, 0x4008dd2580?}}, {0xffff664f8b18, 0x400ab53a80})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:186 +0xd4
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).Encode.func1(...)
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:175
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).Encode(0x4006ddfc30, {{0x2c27806?, 0x32c2bb8?}, {0x32c2bb8?, 0x4008dd2580?}})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:180 +0x140
k8s.io/apiserver/pkg/endpoints/handlers.(*WatchServer).HandleHTTP(0x4007f5d360, {0x32d0800, 0x400ab53a80}, 0x4004f70b40)
	k8s.io/apiserver/pkg/endpoints/handlers/watch.go:249 +0x944
net/http.HandlerFunc.ServeHTTP(0x4009fef678?, {0x32d0800?, 0x400ab53a80?}, 0x40000fc0e0?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/endpoints/handlers.ListResource.func1.4.1()
	k8s.io/apiserver/pkg/endpoints/handlers/get.go:283 +0x74
k8s.io/apiserver/pkg/endpoints/metrics.RecordLongRunning(0x4004f70b40, 0x25d7aa0?, {0x2c282c0, 0x9}, 0x4009fef870)
	k8s.io/apiserver/pkg/endpoints/metrics/metrics.go:528 +0x494
k8s.io/apiserver/pkg/endpoints/handlers.ListResource.func1.4()
	k8s.io/apiserver/pkg/endpoints/handlers/get.go:281 +0x10c
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRoutine.func17({0x32d0590, 0x4005d74138}, 0x4004f70120)
	k8s.io/apiserver/pkg/server/filters/routine.go:73 +0x190
net/http.HandlerFunc.ServeHTTP(0x4008433e60?, {0x32d0590?, 0x4005d74138?}, 0x4000c80008?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRequestInfo.func18({0x32d0590, 0x4005d74138}, 0x4008433e60)
	k8s.io/apiserver/pkg/endpoints/filters/requestinfo.go:39 +0x104
net/http.HandlerFunc.ServeHTTP(0x4008433d40?, {0x32d0590?, 0x4005d74138?}, 0x68c515c5b4d4?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRequestReceivedTimestamp.withRequestReceivedTimestampWithClock.func32({0x32d0590, 0x4005d74138}, 0x4008433d40)
	k8s.io/apiserver/pkg/endpoints/filters/request_received_time.go:38 +0xac
net/http.HandlerFunc.ServeHTTP(0x4006e5baf8?, {0x32d0590?, 0x4005d74138?}, 0xffff663a8200?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithMuxAndDiscoveryComplete.func19({0x32d0590?, 0x4005d74138?}, 0x4008433d40?)
	k8s.io/apiserver/pkg/endpoints/filters/mux_discovery_complete.go:52 +0xd0
net/http.HandlerFunc.ServeHTTP(0x4008d5f301?, {0x32d0590?, 0x4005d74138?}, 0x4ba920ca61d06de0?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithPanicRecovery.withPanicRecovery.func33({0x32d0590?, 0x4005d74138?}, 0x4008d5f3d0?)
	k8s.io/apiserver/pkg/server/filters/wrap.go:74 +0x9c
net/http.HandlerFunc.ServeHTTP(0x4004df0090?, {0x32d0590?, 0x4005d74138?}, 0x400e388240?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithAuditInit.withAuditInit.func34({0x32d0590, 0x4005d74138}, 0x4008433c20)
	k8s.io/apiserver/pkg/endpoints/filters/audit_init.go:63 +0x110
net/http.HandlerFunc.ServeHTTP(0x0?, {0x32d0590?, 0x4005d74138?}, 0x40038f0a80?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.(*APIServerHandler).ServeHTTP(0x0?, {0x32d0590?, 0x4005d74138?}, 0x103b860?)
	k8s.io/apiserver/pkg/server/handler.go:189 +0x30
net/http.serverHandler.ServeHTTP({0x4006e5be18?}, {0x32d0590?, 0x4005d74138?}, 0x32fa1c0?)
	net/http/server.go:3137 +0xbc
net/http.initALPNRequest.ServeHTTP({{0x32e1798?, 0x4007801530?}, 0x4004964388?, {0x40036e1860?}}, {0x32d0590, 0x4005d74138}, 0x4008433c20)
	net/http/server.go:3745 +0x1b4
golang.org/x/net/http2.(*serverConn).runHandler(0x0?, 0x89634?, 0x0?, 0x0?)
	golang.org/x/net@v0.23.0/http2/server.go:2369 +0xc0
created by golang.org/x/net/http2.(*serverConn).scheduleHandler in goroutine 14341774
	golang.org/x/net@v0.23.0/http2/server.go:2304 +0x208
E0710 04:08:09.437893       1 runtime.go:79] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
goroutine 14345530 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic({0x277c340, 0x4dd78a0})
	k8s.io/apimachinery/pkg/util/runtime/runtime.go:75 +0x7c
k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x400e26a000, 0x1, 0x40093e48c0?})
	k8s.io/apimachinery/pkg/util/runtime/runtime.go:49 +0x78
panic({0x277c340?, 0x4dd78a0?})
	runtime/panic.go:770 +0x124
k8s.io/kubernetes/pkg/printers/internalversion.printReplicationController(0x4008f249a0, {0x5?, 0x0?})
	k8s.io/kubernetes/pkg/printers/internalversion/printers.go:1127 +0x1e4
reflect.Value.call({0x2768f20?, 0x2e46cf0?, 0x2b14de0?}, {0x2c20ae1, 0x4}, {0x400e26ab18, 0x2, 0x2056cc0?})
	reflect/value.go:596 +0x970
reflect.Value.Call({0x2768f20?, 0x2e46cf0?, 0x400e26ab58?}, {0x400e26ab18?, 0x0?, 0x40093e48c0?})
	reflect/value.go:380 +0x94
k8s.io/kubernetes/pkg/printers.(*HumanReadableGenerator).GenerateTable(0x0?, {0x32c2bb8, 0x4008f249a0}, {0x1, 0x1})
	k8s.io/kubernetes/pkg/printers/tablegenerator.go:86 +0x1b8
k8s.io/kubernetes/pkg/printers/storage.TableConvertor.ConvertToTable({{0x32b7ea0?, 0x400066ce30?}}, {0x2?, 0x2?}, {0x32c2bb8?, 0x4008f249a0?}, {0x32bc360?, 0x400498dd80?})
	k8s.io/kubernetes/pkg/printers/storage/storage.go:46 +0xd8
k8s.io/apiserver/pkg/registry/generic/registry.(*Store).ConvertToTable(0x400e26acf0?, {0x32e1798?, 0x40088e6a50?}, {0x32c2bb8?, 0x4008f249a0?}, {0x32bc360?, 0x400498dd80?})
	k8s.io/apiserver/pkg/registry/generic/registry/store.go:1644 +0x44
k8s.io/apiserver/pkg/endpoints/handlers.asTable({0x32e1798, 0x40088e6a50}, {0x32c2bb8, 0x4008f249a0}, 0x400498dd80, 0x400199e1a0, {{0x4006ffe331, 0xb}, {0x4006ffe32c, 0x2}})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:375 +0x17c
k8s.io/apiserver/pkg/endpoints/handlers.doTransformObject({0x32e1798, 0x40088e6a50}, {0x32c2bb8, 0x4008f249a0}, {0x2b43c00, 0x400498dd80}, 0x40088e6de0, 0x400199e1a0)
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:270 +0x188
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEmbeddedEncoder).doEncode(0x40073b6870, {0x32c2bb8, 0x4008f249a0}, {0xffff66499918, 0x4008778be0})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:82 +0x68
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEmbeddedEncoder).Encode(0x40073b6870, {0x32c2bb8?, 0x4008f249a0}, {0xffff66499918, 0x4008778be0})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:78 +0x114
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).doEncode(0x40094e3d90, {0x32c2bb8, 0x4008f249a0}, {{0x2c27806?, 0x400e26b278?}, {0x32c2bb8?, 0x4008f249a0?}}, {0xffff664f8b18, 0x4008778840})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:186 +0xd4
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).Encode.func1(...)
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:175
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).Encode(0x40094e3d90, {{0x2c27806?, 0x32c2bb8?}, {0x32c2bb8?, 0x4008f249a0?}})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:180 +0x140
k8s.io/apiserver/pkg/endpoints/handlers.(*WatchServer).HandleHTTP(0x4007342be0, {0x32d0800, 0x4008778840}, 0x40048ea000)
	k8s.io/apiserver/pkg/endpoints/handlers/watch.go:249 +0x944
net/http.HandlerFunc.ServeHTTP(0x40097ff678?, {0x32d0800?, 0x4008778840?}, 0x40016c4e00?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/endpoints/handlers.ListResource.func1.4.1()
	k8s.io/apiserver/pkg/endpoints/handlers/get.go:283 +0x74
k8s.io/apiserver/pkg/endpoints/metrics.RecordLongRunning(0x40048ea000, 0x25d7aa0?, {0x2c282c0, 0x9}, 0x40097ff870)
	k8s.io/apiserver/pkg/endpoints/metrics/metrics.go:528 +0x494
k8s.io/apiserver/pkg/endpoints/handlers.ListResource.func1.4()
	k8s.io/apiserver/pkg/endpoints/handlers/get.go:281 +0x10c
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRoutine.func17({0x32d0590, 0x4007cd6d00}, 0x40043c7560)
	k8s.io/apiserver/pkg/server/filters/routine.go:73 +0x190
net/http.HandlerFunc.ServeHTTP(0x40043c7200?, {0x32d0590?, 0x4007cd6d00?}, 0x4000c80008?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRequestInfo.func18({0x32d0590, 0x4007cd6d00}, 0x40043c7200)
	k8s.io/apiserver/pkg/endpoints/filters/requestinfo.go:39 +0x104
net/http.HandlerFunc.ServeHTTP(0x40043c70e0?, {0x32d0590?, 0x4007cd6d00?}, 0x68cc5c0898e4?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRequestReceivedTimestamp.withRequestReceivedTimestampWithClock.func32({0x32d0590, 0x4007cd6d00}, 0x40043c70e0)
	k8s.io/apiserver/pkg/endpoints/filters/request_received_time.go:38 +0xac
net/http.HandlerFunc.ServeHTTP(0x40072a8af8?, {0x32d0590?, 0x4007cd6d00?}, 0xffff65ee6b28?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithMuxAndDiscoveryComplete.func19({0x32d0590?, 0x4007cd6d00?}, 0x40043c70e0?)
	k8s.io/apiserver/pkg/endpoints/filters/mux_discovery_complete.go:52 +0xd0
net/http.HandlerFunc.ServeHTTP(0x4003692601?, {0x32d0590?, 0x4007cd6d00?}, 0xe7cb5aa35c516d96?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithPanicRecovery.withPanicRecovery.func33({0x32d0590?, 0x4007cd6d00?}, 0x4003692640?)
	k8s.io/apiserver/pkg/server/filters/wrap.go:74 +0x9c
net/http.HandlerFunc.ServeHTTP(0x40088e65d0?, {0x32d0590?, 0x4007cd6d00?}, 0x4006673620?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithAuditInit.withAuditInit.func34({0x32d0590, 0x4007cd6d00}, 0x40043c6fc0)
	k8s.io/apiserver/pkg/endpoints/filters/audit_init.go:63 +0x110
net/http.HandlerFunc.ServeHTTP(0x66?, {0x32d0590?, 0x4007cd6d00?}, 0x66?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.(*APIServerHandler).ServeHTTP(0x0?, {0x32d0590?, 0x4007cd6d00?}, 0x4800?)
	k8s.io/apiserver/pkg/server/handler.go:189 +0x30
net/http.serverHandler.ServeHTTP({0x4008ea0ee0?}, {0x32d0590?, 0x4007cd6d00?}, 0x400e319c20?)
	net/http/server.go:3137 +0xbc
net/http.initALPNRequest.ServeHTTP({{0x32e1798?, 0x4007801530?}, 0x4004964388?, {0x40036e1860?}}, {0x32d0590, 0x4007cd6d00}, 0x40043c6fc0)
	net/http/server.go:3745 +0x1b4
golang.org/x/net/http2.(*serverConn).runHandler(0x4ea0de0?, 0x0?, 0x0?, 0x40072a8fa8?)
	golang.org/x/net@v0.23.0/http2/server.go:2369 +0xc0
created by golang.org/x/net/http2.(*serverConn).scheduleHandler in goroutine 14341774
	golang.org/x/net@v0.23.0/http2/server.go:2304 +0x208
E0710 04:08:09.438087       1 wrap.go:58] "apiserver panic'd" method="GET" URI="/api/v1/replicationcontrollers?watch=true&allowWatchBookmarks=true" auditID="430b1980-432c-44dd-8fa6-f103a851ae3b"
http2: panic serving 192.168.228.1:50928: runtime error: invalid memory address or nil pointer dereference
goroutine 14345530 [running]:
golang.org/x/net/http2.(*serverConn).runHandler.func1()
	golang.org/x/net@v0.23.0/http2/server.go:2362 +0x13c
panic({0x277c340?, 0x4dd78a0?})
	runtime/panic.go:770 +0x124
k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x400e26a000, 0x1, 0x40093e48c0?})
	k8s.io/apimachinery/pkg/util/runtime/runtime.go:56 +0xe0
panic({0x277c340?, 0x4dd78a0?})
	runtime/panic.go:770 +0x124
k8s.io/kubernetes/pkg/printers/internalversion.printReplicationController(0x4008f249a0, {0x5?, 0x0?})
	k8s.io/kubernetes/pkg/printers/internalversion/printers.go:1127 +0x1e4
reflect.Value.call({0x2768f20?, 0x2e46cf0?, 0x2b14de0?}, {0x2c20ae1, 0x4}, {0x400e26ab18, 0x2, 0x2056cc0?})
	reflect/value.go:596 +0x970
reflect.Value.Call({0x2768f20?, 0x2e46cf0?, 0x400e26ab58?}, {0x400e26ab18?, 0x0?, 0x40093e48c0?})
	reflect/value.go:380 +0x94
k8s.io/kubernetes/pkg/printers.(*HumanReadableGenerator).GenerateTable(0x0?, {0x32c2bb8, 0x4008f249a0}, {0x1, 0x1})
	k8s.io/kubernetes/pkg/printers/tablegenerator.go:86 +0x1b8
k8s.io/kubernetes/pkg/printers/storage.TableConvertor.ConvertToTable({{0x32b7ea0?, 0x400066ce30?}}, {0x2?, 0x2?}, {0x32c2bb8?, 0x4008f249a0?}, {0x32bc360?, 0x400498dd80?})
	k8s.io/kubernetes/pkg/printers/storage/storage.go:46 +0xd8
k8s.io/apiserver/pkg/registry/generic/registry.(*Store).ConvertToTable(0x400e26acf0?, {0x32e1798?, 0x40088e6a50?}, {0x32c2bb8?, 0x4008f249a0?}, {0x32bc360?, 0x400498dd80?})
	k8s.io/apiserver/pkg/registry/generic/registry/store.go:1644 +0x44
k8s.io/apiserver/pkg/endpoints/handlers.asTable({0x32e1798, 0x40088e6a50}, {0x32c2bb8, 0x4008f249a0}, 0x400498dd80, 0x400199e1a0, {{0x4006ffe331, 0xb}, {0x4006ffe32c, 0x2}})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:375 +0x17c
k8s.io/apiserver/pkg/endpoints/handlers.doTransformObject({0x32e1798, 0x40088e6a50}, {0x32c2bb8, 0x4008f249a0}, {0x2b43c00, 0x400498dd80}, 0x40088e6de0, 0x400199e1a0)
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:270 +0x188
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEmbeddedEncoder).doEncode(0x40073b6870, {0x32c2bb8, 0x4008f249a0}, {0xffff66499918, 0x4008778be0})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:82 +0x68
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEmbeddedEncoder).Encode(0x40073b6870, {0x32c2bb8?, 0x4008f249a0}, {0xffff66499918, 0x4008778be0})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:78 +0x114
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).doEncode(0x40094e3d90, {0x32c2bb8, 0x4008f249a0}, {{0x2c27806?, 0x400e26b278?}, {0x32c2bb8?, 0x4008f249a0?}}, {0xffff664f8b18, 0x4008778840})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:186 +0xd4
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).Encode.func1(...)
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:175
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).Encode(0x40094e3d90, {{0x2c27806?, 0x32c2bb8?}, {0x32c2bb8?, 0x4008f249a0?}})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:180 +0x140
k8s.io/apiserver/pkg/endpoints/handlers.(*WatchServer).HandleHTTP(0x4007342be0, {0x32d0800, 0x4008778840}, 0x40048ea000)
	k8s.io/apiserver/pkg/endpoints/handlers/watch.go:249 +0x944
net/http.HandlerFunc.ServeHTTP(0x40097ff678?, {0x32d0800?, 0x4008778840?}, 0x40016c4e00?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/endpoints/handlers.ListResource.func1.4.1()
	k8s.io/apiserver/pkg/endpoints/handlers/get.go:283 +0x74
k8s.io/apiserver/pkg/endpoints/metrics.RecordLongRunning(0x40048ea000, 0x25d7aa0?, {0x2c282c0, 0x9}, 0x40097ff870)
	k8s.io/apiserver/pkg/endpoints/metrics/metrics.go:528 +0x494
k8s.io/apiserver/pkg/endpoints/handlers.ListResource.func1.4()
	k8s.io/apiserver/pkg/endpoints/handlers/get.go:281 +0x10c
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRoutine.func17({0x32d0590, 0x4007cd6d00}, 0x40043c7560)
	k8s.io/apiserver/pkg/server/filters/routine.go:73 +0x190
net/http.HandlerFunc.ServeHTTP(0x40043c7200?, {0x32d0590?, 0x4007cd6d00?}, 0x4000c80008?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRequestInfo.func18({0x32d0590, 0x4007cd6d00}, 0x40043c7200)
	k8s.io/apiserver/pkg/endpoints/filters/requestinfo.go:39 +0x104
net/http.HandlerFunc.ServeHTTP(0x40043c70e0?, {0x32d0590?, 0x4007cd6d00?}, 0x68cc5c0898e4?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRequestReceivedTimestamp.withRequestReceivedTimestampWithClock.func32({0x32d0590, 0x4007cd6d00}, 0x40043c70e0)
	k8s.io/apiserver/pkg/endpoints/filters/request_received_time.go:38 +0xac
net/http.HandlerFunc.ServeHTTP(0x40072a8af8?, {0x32d0590?, 0x4007cd6d00?}, 0xffff65ee6b28?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithMuxAndDiscoveryComplete.func19({0x32d0590?, 0x4007cd6d00?}, 0x40043c70e0?)
	k8s.io/apiserver/pkg/endpoints/filters/mux_discovery_complete.go:52 +0xd0
net/http.HandlerFunc.ServeHTTP(0x4003692601?, {0x32d0590?, 0x4007cd6d00?}, 0xe7cb5aa35c516d96?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithPanicRecovery.withPanicRecovery.func33({0x32d0590?, 0x4007cd6d00?}, 0x4003692640?)
	k8s.io/apiserver/pkg/server/filters/wrap.go:74 +0x9c
net/http.HandlerFunc.ServeHTTP(0x40088e65d0?, {0x32d0590?, 0x4007cd6d00?}, 0x4006673620?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithAuditInit.withAuditInit.func34({0x32d0590, 0x4007cd6d00}, 0x40043c6fc0)
	k8s.io/apiserver/pkg/endpoints/filters/audit_init.go:63 +0x110
net/http.HandlerFunc.ServeHTTP(0x66?, {0x32d0590?, 0x4007cd6d00?}, 0x66?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.(*APIServerHandler).ServeHTTP(0x0?, {0x32d0590?, 0x4007cd6d00?}, 0x4800?)
	k8s.io/apiserver/pkg/server/handler.go:189 +0x30
net/http.serverHandler.ServeHTTP({0x4008ea0ee0?}, {0x32d0590?, 0x4007cd6d00?}, 0x400e319c20?)
	net/http/server.go:3137 +0xbc
net/http.initALPNRequest.ServeHTTP({{0x32e1798?, 0x4007801530?}, 0x4004964388?, {0x40036e1860?}}, {0x32d0590, 0x4007cd6d00}, 0x40043c6fc0)
	net/http/server.go:3745 +0x1b4
golang.org/x/net/http2.(*serverConn).runHandler(0x4ea0de0?, 0x0?, 0x0?, 0x40072a8fa8?)
	golang.org/x/net@v0.23.0/http2/server.go:2369 +0xc0
created by golang.org/x/net/http2.(*serverConn).scheduleHandler in goroutine 14341774
	golang.org/x/net@v0.23.0/http2/server.go:2304 +0x208
E0710 04:17:01.471122       1 runtime.go:79] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
goroutine 14411956 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic({0x277c340, 0x4dd78a0})
	k8s.io/apimachinery/pkg/util/runtime/runtime.go:75 +0x7c
k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x4003ea6000, 0x1, 0x40092a8700?})
	k8s.io/apimachinery/pkg/util/runtime/runtime.go:49 +0x78
panic({0x277c340?, 0x4dd78a0?})
	runtime/panic.go:770 +0x124
k8s.io/kubernetes/pkg/printers/internalversion.printReplicationController(0x4008e46580, {0x5?, 0x0?})
	k8s.io/kubernetes/pkg/printers/internalversion/printers.go:1127 +0x1e4
reflect.Value.call({0x2768f20?, 0x2e46cf0?, 0x2b14de0?}, {0x2c20ae1, 0x4}, {0x4003ea6b18, 0x2, 0x2056cc0?})
	reflect/value.go:596 +0x970
reflect.Value.Call({0x2768f20?, 0x2e46cf0?, 0x4003ea6b58?}, {0x4003ea6b18?, 0x0?, 0x40092a8700?})
	reflect/value.go:380 +0x94
k8s.io/kubernetes/pkg/printers.(*HumanReadableGenerator).GenerateTable(0x0?, {0x32c2bb8, 0x4008e46580}, {0x1, 0x1})
	k8s.io/kubernetes/pkg/printers/tablegenerator.go:86 +0x1b8
k8s.io/kubernetes/pkg/printers/storage.TableConvertor.ConvertToTable({{0x32b7ea0?, 0x400066ce30?}}, {0x2?, 0x2?}, {0x32c2bb8?, 0x4008e46580?}, {0x32bc360?, 0x400ddf0940?})
	k8s.io/kubernetes/pkg/printers/storage/storage.go:46 +0xd8
k8s.io/apiserver/pkg/registry/generic/registry.(*Store).ConvertToTable(0x4003ea6cf0?, {0x32e1798?, 0x400a52ee10?}, {0x32c2bb8?, 0x4008e46580?}, {0x32bc360?, 0x400ddf0940?})
	k8s.io/apiserver/pkg/registry/generic/registry/store.go:1644 +0x44
k8s.io/apiserver/pkg/endpoints/handlers.asTable({0x32e1798, 0x400a52ee10}, {0x32c2bb8, 0x4008e46580}, 0x400ddf0940, 0x400199e1a0, {{0x400e813b81, 0xb}, {0x400e813b7c, 0x2}})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:375 +0x17c
k8s.io/apiserver/pkg/endpoints/handlers.doTransformObject({0x32e1798, 0x400a52ee10}, {0x32c2bb8, 0x4008e46580}, {0x2b43c00, 0x400ddf0940}, 0x400a52f1a0, 0x400199e1a0)
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:270 +0x188
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEmbeddedEncoder).doEncode(0x4003622d20, {0x32c2bb8, 0x4008e46580}, {0xffff66499918, 0x4009a514a0})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:82 +0x68
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEmbeddedEncoder).Encode(0x4003622d20, {0x32c2bb8?, 0x4008e46580}, {0xffff66499918, 0x4009a514a0})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:78 +0x114
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).doEncode(0x400701f290, {0x32c2bb8, 0x4008e46580}, {{0x2c27806?, 0x4003ea7278?}, {0x32c2bb8?, 0x4008e46580?}}, {0xffff664f8b18, 0x400e138bc0})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:186 +0xd4
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).Encode.func1(...)
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:175
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).Encode(0x400701f290, {{0x2c27806?, 0x32c2bb8?}, {0x32c2bb8?, 0x4008e46580?}})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:180 +0x140
k8s.io/apiserver/pkg/endpoints/handlers.(*WatchServer).HandleHTTP(0x400164c3c0, {0x32d0800, 0x400e138bc0}, 0x4004a9b9e0)
	k8s.io/apiserver/pkg/endpoints/handlers/watch.go:249 +0x944
net/http.HandlerFunc.ServeHTTP(0x4002a3b678?, {0x32d0800?, 0x400e138bc0?}, 0x4001cd0e70?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/endpoints/handlers.ListResource.func1.4.1()
	k8s.io/apiserver/pkg/endpoints/handlers/get.go:283 +0x74
k8s.io/apiserver/pkg/endpoints/metrics.RecordLongRunning(0x4004a9b9e0, 0x25d7aa0?, {0x2c282c0, 0x9}, 0x4002a3b870)
	k8s.io/apiserver/pkg/endpoints/metrics/metrics.go:528 +0x494
k8s.io/apiserver/pkg/endpoints/handlers.ListResource.func1.4()
	k8s.io/apiserver/pkg/endpoints/handlers/get.go:281 +0x10c
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRoutine.func17({0x32d0590, 0x400114ea48}, 0x4004a9aea0)
	k8s.io/apiserver/pkg/server/filters/routine.go:73 +0x190
net/http.HandlerFunc.ServeHTTP(0x4004a9ad80?, {0x32d0590?, 0x400114ea48?}, 0x4000d00008?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRequestInfo.func18({0x32d0590, 0x400114ea48}, 0x4004a9ad80)
	k8s.io/apiserver/pkg/endpoints/filters/requestinfo.go:39 +0x104
net/http.HandlerFunc.ServeHTTP(0x4004a9aa20?, {0x32d0590?, 0x400114ea48?}, 0x694829051930?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRequestReceivedTimestamp.withRequestReceivedTimestampWithClock.func32({0x32d0590, 0x400114ea48}, 0x4004a9aa20)
	k8s.io/apiserver/pkg/endpoints/filters/request_received_time.go:38 +0xac
net/http.HandlerFunc.ServeHTTP(0x4006fbcaf8?, {0x32d0590?, 0x400114ea48?}, 0xffff66409028?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithMuxAndDiscoveryComplete.func19({0x32d0590?, 0x400114ea48?}, 0x4004a9aa20?)
	k8s.io/apiserver/pkg/endpoints/filters/mux_discovery_complete.go:52 +0xd0
net/http.HandlerFunc.ServeHTTP(0x4004db7401?, {0x32d0590?, 0x400114ea48?}, 0x9b2e24c568c59725?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithPanicRecovery.withPanicRecovery.func33({0x32d0590?, 0x400114ea48?}, 0x4004db7490?)
	k8s.io/apiserver/pkg/server/filters/wrap.go:74 +0x9c
net/http.HandlerFunc.ServeHTTP(0x400a52e960?, {0x32d0590?, 0x400114ea48?}, 0x400e813b90?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithAuditInit.withAuditInit.func34({0x32d0590, 0x400114ea48}, 0x4004a9a900)
	k8s.io/apiserver/pkg/endpoints/filters/audit_init.go:63 +0x110
net/http.HandlerFunc.ServeHTTP(0x54?, {0x32d0590?, 0x400114ea48?}, 0x54?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.(*APIServerHandler).ServeHTTP(0x0?, {0x32d0590?, 0x400114ea48?}, 0x4006fbcb70?)
	k8s.io/apiserver/pkg/server/handler.go:189 +0x30
net/http.serverHandler.ServeHTTP({0x0?}, {0x32d0590?, 0x400114ea48?}, 0x4008c9a120?)
	net/http/server.go:3137 +0xbc
net/http.initALPNRequest.ServeHTTP({{0x32e1798?, 0x400a52e0f0?}, 0x4004874008?, {0x40036e1860?}}, {0x32d0590, 0x400114ea48}, 0x4004a9a900)
	net/http/server.go:3745 +0x1b4
golang.org/x/net/http2.(*serverConn).runHandler(0x4008aeddd0?, 0x32e1798?, 0x4004c81c20?, 0x4006fbcfb0?)
	golang.org/x/net@v0.23.0/http2/server.go:2369 +0xc0
created by golang.org/x/net/http2.(*serverConn).scheduleHandler in goroutine 14411823
	golang.org/x/net@v0.23.0/http2/server.go:2304 +0x208
E0710 04:17:01.471458       1 wrap.go:58] "apiserver panic'd" method="GET" URI="/api/v1/replicationcontrollers?watch=true&allowWatchBookmarks=true" auditID="a7e5a1a3-837f-42ca-9b70-d0ccd6f4eaf2"
http2: panic serving 192.168.228.1:55854: runtime error: invalid memory address or nil pointer dereference
goroutine 14411956 [running]:
golang.org/x/net/http2.(*serverConn).runHandler.func1()
	golang.org/x/net@v0.23.0/http2/server.go:2362 +0x13c
panic({0x277c340?, 0x4dd78a0?})
	runtime/panic.go:770 +0x124
k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x4003ea6000, 0x1, 0x40092a8700?})
	k8s.io/apimachinery/pkg/util/runtime/runtime.go:56 +0xe0
panic({0x277c340?, 0x4dd78a0?})
	runtime/panic.go:770 +0x124
k8s.io/kubernetes/pkg/printers/internalversion.printReplicationController(0x4008e46580, {0x5?, 0x0?})
	k8s.io/kubernetes/pkg/printers/internalversion/printers.go:1127 +0x1e4
reflect.Value.call({0x2768f20?, 0x2e46cf0?, 0x2b14de0?}, {0x2c20ae1, 0x4}, {0x4003ea6b18, 0x2, 0x2056cc0?})
	reflect/value.go:596 +0x970
reflect.Value.Call({0x2768f20?, 0x2e46cf0?, 0x4003ea6b58?}, {0x4003ea6b18?, 0x0?, 0x40092a8700?})
	reflect/value.go:380 +0x94
k8s.io/kubernetes/pkg/printers.(*HumanReadableGenerator).GenerateTable(0x0?, {0x32c2bb8, 0x4008e46580}, {0x1, 0x1})
	k8s.io/kubernetes/pkg/printers/tablegenerator.go:86 +0x1b8
k8s.io/kubernetes/pkg/printers/storage.TableConvertor.ConvertToTable({{0x32b7ea0?, 0x400066ce30?}}, {0x2?, 0x2?}, {0x32c2bb8?, 0x4008e46580?}, {0x32bc360?, 0x400ddf0940?})
	k8s.io/kubernetes/pkg/printers/storage/storage.go:46 +0xd8
k8s.io/apiserver/pkg/registry/generic/registry.(*Store).ConvertToTable(0x4003ea6cf0?, {0x32e1798?, 0x400a52ee10?}, {0x32c2bb8?, 0x4008e46580?}, {0x32bc360?, 0x400ddf0940?})
	k8s.io/apiserver/pkg/registry/generic/registry/store.go:1644 +0x44
k8s.io/apiserver/pkg/endpoints/handlers.asTable({0x32e1798, 0x400a52ee10}, {0x32c2bb8, 0x4008e46580}, 0x400ddf0940, 0x400199e1a0, {{0x400e813b81, 0xb}, {0x400e813b7c, 0x2}})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:375 +0x17c
k8s.io/apiserver/pkg/endpoints/handlers.doTransformObject({0x32e1798, 0x400a52ee10}, {0x32c2bb8, 0x4008e46580}, {0x2b43c00, 0x400ddf0940}, 0x400a52f1a0, 0x400199e1a0)
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:270 +0x188
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEmbeddedEncoder).doEncode(0x4003622d20, {0x32c2bb8, 0x4008e46580}, {0xffff66499918, 0x4009a514a0})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:82 +0x68
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEmbeddedEncoder).Encode(0x4003622d20, {0x32c2bb8?, 0x4008e46580}, {0xffff66499918, 0x4009a514a0})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:78 +0x114
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).doEncode(0x400701f290, {0x32c2bb8, 0x4008e46580}, {{0x2c27806?, 0x4003ea7278?}, {0x32c2bb8?, 0x4008e46580?}}, {0xffff664f8b18, 0x400e138bc0})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:186 +0xd4
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).Encode.func1(...)
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:175
k8s.io/apiserver/pkg/endpoints/handlers.(*watchEncoder).Encode(0x400701f290, {{0x2c27806?, 0x32c2bb8?}, {0x32c2bb8?, 0x4008e46580?}})
	k8s.io/apiserver/pkg/endpoints/handlers/response.go:180 +0x140
k8s.io/apiserver/pkg/endpoints/handlers.(*WatchServer).HandleHTTP(0x400164c3c0, {0x32d0800, 0x400e138bc0}, 0x4004a9b9e0)
	k8s.io/apiserver/pkg/endpoints/handlers/watch.go:249 +0x944
net/http.HandlerFunc.ServeHTTP(0x4002a3b678?, {0x32d0800?, 0x400e138bc0?}, 0x4001cd0e70?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/endpoints/handlers.ListResource.func1.4.1()
	k8s.io/apiserver/pkg/endpoints/handlers/get.go:283 +0x74
k8s.io/apiserver/pkg/endpoints/metrics.RecordLongRunning(0x4004a9b9e0, 0x25d7aa0?, {0x2c282c0, 0x9}, 0x4002a3b870)
	k8s.io/apiserver/pkg/endpoints/metrics/metrics.go:528 +0x494
k8s.io/apiserver/pkg/endpoints/handlers.ListResource.func1.4()
	k8s.io/apiserver/pkg/endpoints/handlers/get.go:281 +0x10c
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRoutine.func17({0x32d0590, 0x400114ea48}, 0x4004a9aea0)
	k8s.io/apiserver/pkg/server/filters/routine.go:73 +0x190
net/http.HandlerFunc.ServeHTTP(0x4004a9ad80?, {0x32d0590?, 0x400114ea48?}, 0x4000d00008?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRequestInfo.func18({0x32d0590, 0x400114ea48}, 0x4004a9ad80)
	k8s.io/apiserver/pkg/endpoints/filters/requestinfo.go:39 +0x104
net/http.HandlerFunc.ServeHTTP(0x4004a9aa20?, {0x32d0590?, 0x400114ea48?}, 0x694829051930?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRequestReceivedTimestamp.withRequestReceivedTimestampWithClock.func32({0x32d0590, 0x400114ea48}, 0x4004a9aa20)
	k8s.io/apiserver/pkg/endpoints/filters/request_received_time.go:38 +0xac
net/http.HandlerFunc.ServeHTTP(0x4006fbcaf8?, {0x32d0590?, 0x400114ea48?}, 0xffff66409028?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithMuxAndDiscoveryComplete.func19({0x32d0590?, 0x400114ea48?}, 0x4004a9aa20?)
	k8s.io/apiserver/pkg/endpoints/filters/mux_discovery_complete.go:52 +0xd0
net/http.HandlerFunc.ServeHTTP(0x4004db7401?, {0x32d0590?, 0x400114ea48?}, 0x9b2e24c568c59725?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithPanicRecovery.withPanicRecovery.func33({0x32d0590?, 0x400114ea48?}, 0x4004db7490?)
	k8s.io/apiserver/pkg/server/filters/wrap.go:74 +0x9c
net/http.HandlerFunc.ServeHTTP(0x400a52e960?, {0x32d0590?, 0x400114ea48?}, 0x400e813b90?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithAuditInit.withAuditInit.func34({0x32d0590, 0x400114ea48}, 0x4004a9a900)
	k8s.io/apiserver/pkg/endpoints/filters/audit_init.go:63 +0x110
net/http.HandlerFunc.ServeHTTP(0x54?, {0x32d0590?, 0x400114ea48?}, 0x54?)
	net/http/server.go:2166 +0x38
k8s.io/apiserver/pkg/server.(*APIServerHandler).ServeHTTP(0x0?, {0x32d0590?, 0x400114ea48?}, 0x4006fbcb70?)
	k8s.io/apiserver/pkg/server/handler.go:189 +0x30
net/http.serverHandler.ServeHTTP({0x0?}, {0x32d0590?, 0x400114ea48?}, 0x4008c9a120?)
	net/http/server.go:3137 +0xbc
net/http.initALPNRequest.ServeHTTP({{0x32e1798?, 0x400a52e0f0?}, 0x4004874008?, {0x40036e1860?}}, {0x32d0590, 0x400114ea48}, 0x4004a9a900)
	net/http/server.go:3745 +0x1b4
golang.org/x/net/http2.(*serverConn).runHandler(0x4008aeddd0?, 0x32e1798?, 0x4004c81c20?, 0x4006fbcfb0?)
	golang.org/x/net@v0.23.0/http2/server.go:2369 +0xc0
created by golang.org/x/net/http2.(*serverConn).scheduleHandler in goroutine 14411823
	golang.org/x/net@v0.23.0/http2/server.go:2304 +0x208
```
</details>

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
