### PR TITLE
Automated cherry pick of #125970: defaultMaskedPaths must be kept in sync with moby/moby.

### DIFF
--- a/pkg/securitycontext/util.go
+++ b/pkg/securitycontext/util.go
@@ -188,7 +188,7 @@ func AddNoNewPrivileges(sc *v1.SecurityContext) bool {
 
 var (
 	// These *must* be kept in sync with moby/moby.
-	// https://github.com/moby/moby/blob/master/oci/defaults.go#L105-L123
+	// https://github.com/moby/moby/blob/master/oci/defaults.go#L105-L124
 	// @jessfraz will watch changes to those files upstream.
 	defaultMaskedPaths = []string{
 		"/proc/asound",
@@ -201,6 +201,7 @@ var (
 		"/proc/sched_debug",
 		"/proc/scsi",
 		"/sys/firmware",
+		"/sys/devices/virtual/powercap",
 	}
 	defaultReadonlyPaths = []string{
 		"/proc/bus",


### PR DESCRIPTION
Cherry pick of #125970 on release-1.29.

#125970: defaultMaskedPaths must be kept in sync with moby/moby.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```