### PR TITLE
Fix metrics cache in EndpointSlice Reconciler

### DIFF
--- a/pkg/controller/endpointslicemirroring/metrics/cache_test.go
+++ b/pkg/controller/endpointslicemirroring/metrics/cache_test.go
@@ -30,8 +30,8 @@ func TestNumEndpointsAndSlices(t *testing.T) {
 	p80 := int32(80)
 	p443 := int32(443)
 
-	pmKey80443 := endpointsliceutil.NewPortMapKey([]discovery.EndpointPort{{Port: &p80}, {Port: &p443}})
-	pmKey80 := endpointsliceutil.NewPortMapKey([]discovery.EndpointPort{{Port: &p80}})
+	pmKey80443 := endpointsliceutil.NewPortMapKey([]discovery.EndpointPort{{Port: &p80}, {Port: &p443}}, discovery.AddressTypeIPv4)
+	pmKey80 := endpointsliceutil.NewPortMapKey([]discovery.EndpointPort{{Port: &p80}}, discovery.AddressTypeIPv4)
 
 	spCacheEfficient := NewEndpointPortCache()
 	spCacheEfficient.Set(pmKey80, EfficiencyInfo{Endpoints: 45, Slices: 1})

--- a/pkg/controller/endpointslicemirroring/reconciler.go
+++ b/pkg/controller/endpointslicemirroring/reconciler.go
@@ -306,7 +306,7 @@ func (r *reconciler) deleteEndpoints(ctx context.Context, namespace, name string
 func endpointSlicesByKey(existingSlices []*discovery.EndpointSlice) map[addrTypePortMapKey][]*discovery.EndpointSlice {
 	slicesByKey := map[addrTypePortMapKey][]*discovery.EndpointSlice{}
 	for _, existingSlice := range existingSlices {
-		epKey := addrTypePortMapKey(endpointsliceutil.NewAddrTypePortMapKey(endpointsliceutil.NewPortMapKey(existingSlice.Ports), existingSlice.AddressType))
+		epKey := addrTypePortMapKey(endpointsliceutil.NewPortMapKey(existingSlice.Ports, existingSlice.AddressType))
 		slicesByKey[epKey] = append(slicesByKey[epKey], existingSlice)
 	}
 	return slicesByKey

--- a/pkg/controller/endpointslicemirroring/reconciler.go
+++ b/pkg/controller/endpointslicemirroring/reconciler.go
@@ -306,7 +306,7 @@ func (r *reconciler) deleteEndpoints(ctx context.Context, namespace, name string
 func endpointSlicesByKey(existingSlices []*discovery.EndpointSlice) map[addrTypePortMapKey][]*discovery.EndpointSlice {
 	slicesByKey := map[addrTypePortMapKey][]*discovery.EndpointSlice{}
 	for _, existingSlice := range existingSlices {
-		epKey := newAddrTypePortMapKey(existingSlice.Ports, existingSlice.AddressType)
+		epKey := addrTypePortMapKey(endpointsliceutil.NewAddrTypePortMapKey(endpointsliceutil.NewPortMapKey(existingSlice.Ports), existingSlice.AddressType))
 		slicesByKey[epKey] = append(slicesByKey[epKey], existingSlice)
 	}
 	return slicesByKey

--- a/pkg/controller/endpointslicemirroring/reconciler.go
+++ b/pkg/controller/endpointslicemirroring/reconciler.go
@@ -140,7 +140,7 @@ func (r *reconciler) reconcile(ctx context.Context, endpoints *corev1.Endpoints,
 	for portKey, desiredEndpoints := range d.endpointsByKey {
 		numEndpoints := len(desiredEndpoints)
 		pmSlices, pmTotals := r.reconcileByPortMapping(
-			endpoints, existingSlicesByKey[portKey], desiredEndpoints, d.portsByKey[portKey], portKey.addressType())
+			endpoints, existingSlicesByKey[portKey], desiredEndpoints, d.portsByKey[portKey], portKey.AddressType())
 
 		slices.append(pmSlices)
 		totals.add(pmTotals)
@@ -303,10 +303,10 @@ func (r *reconciler) deleteEndpoints(ctx context.Context, namespace, name string
 
 // endpointSlicesByKey returns a map that groups EndpointSlices by unique
 // addrTypePortMapKey values.
-func endpointSlicesByKey(existingSlices []*discovery.EndpointSlice) map[addrTypePortMapKey][]*discovery.EndpointSlice {
-	slicesByKey := map[addrTypePortMapKey][]*discovery.EndpointSlice{}
+func endpointSlicesByKey(existingSlices []*discovery.EndpointSlice) map[endpointsliceutil.PortMapKey][]*discovery.EndpointSlice {
+	slicesByKey := map[endpointsliceutil.PortMapKey][]*discovery.EndpointSlice{}
 	for _, existingSlice := range existingSlices {
-		epKey := addrTypePortMapKey(endpointsliceutil.NewPortMapKey(existingSlice.Ports, existingSlice.AddressType))
+		epKey := endpointsliceutil.NewPortMapKey(existingSlice.Ports, existingSlice.AddressType)
 		slicesByKey[epKey] = append(slicesByKey[epKey], existingSlice)
 	}
 	return slicesByKey

--- a/pkg/controller/endpointslicemirroring/reconciler_helpers.go
+++ b/pkg/controller/endpointslicemirroring/reconciler_helpers.go
@@ -49,22 +49,22 @@ func (t *totalsByAction) add(totals totalsByAction) {
 // newDesiredCalc initializes and returns a new desiredCalc.
 func newDesiredCalc() *desiredCalc {
 	return &desiredCalc{
-		portsByKey:          map[addrTypePortMapKey][]discovery.EndpointPort{},
-		endpointsByKey:      map[addrTypePortMapKey]endpointsliceutil.EndpointSet{},
+		portsByKey:          map[endpointsliceutil.PortMapKey][]discovery.EndpointPort{},
+		endpointsByKey:      map[endpointsliceutil.PortMapKey]endpointsliceutil.EndpointSet{},
 		numDesiredEndpoints: 0,
 	}
 }
 
 // desiredCalc helps calculate desired endpoints and ports.
 type desiredCalc struct {
-	portsByKey          map[addrTypePortMapKey][]discovery.EndpointPort
-	endpointsByKey      map[addrTypePortMapKey]endpointsliceutil.EndpointSet
+	portsByKey          map[endpointsliceutil.PortMapKey][]discovery.EndpointPort
+	endpointsByKey      map[endpointsliceutil.PortMapKey]endpointsliceutil.EndpointSet
 	numDesiredEndpoints int
 }
 
 // multiAddrTypePortMapKey stores addrTypePortMapKey for different address
 // types.
-type multiAddrTypePortMapKey map[discovery.AddressType]addrTypePortMapKey
+type multiAddrTypePortMapKey map[discovery.AddressType]endpointsliceutil.PortMapKey
 
 // initPorts initializes ports for a subset and address type and returns the
 // corresponding addrTypePortMapKey.
@@ -74,7 +74,7 @@ func (d *desiredCalc) initPorts(subsetPorts []v1.EndpointPort) multiAddrTypePort
 	multiKey := multiAddrTypePortMapKey{}
 
 	for _, addrType := range addrTypes {
-		multiKey[addrType] = addrTypePortMapKey(endpointsliceutil.NewPortMapKey(endpointPorts, addrType))
+		multiKey[addrType] = endpointsliceutil.NewPortMapKey(endpointPorts, addrType)
 		if _, ok := d.endpointsByKey[multiKey[addrType]]; !ok {
 			d.endpointsByKey[multiKey[addrType]] = endpointsliceutil.EndpointSet{}
 		}

--- a/pkg/controller/endpointslicemirroring/reconciler_helpers.go
+++ b/pkg/controller/endpointslicemirroring/reconciler_helpers.go
@@ -74,7 +74,7 @@ func (d *desiredCalc) initPorts(subsetPorts []v1.EndpointPort) multiAddrTypePort
 	multiKey := multiAddrTypePortMapKey{}
 
 	for _, addrType := range addrTypes {
-		multiKey[addrType] = newAddrTypePortMapKey(endpointPorts, addrType)
+		multiKey[addrType] = addrTypePortMapKey(endpointsliceutil.NewAddrTypePortMapKey(endpointsliceutil.NewPortMapKey(endpointPorts), addrType))
 		if _, ok := d.endpointsByKey[multiKey[addrType]]; !ok {
 			d.endpointsByKey[multiKey[addrType]] = endpointsliceutil.EndpointSet{}
 		}

--- a/pkg/controller/endpointslicemirroring/reconciler_helpers.go
+++ b/pkg/controller/endpointslicemirroring/reconciler_helpers.go
@@ -74,7 +74,7 @@ func (d *desiredCalc) initPorts(subsetPorts []v1.EndpointPort) multiAddrTypePort
 	multiKey := multiAddrTypePortMapKey{}
 
 	for _, addrType := range addrTypes {
-		multiKey[addrType] = addrTypePortMapKey(endpointsliceutil.NewAddrTypePortMapKey(endpointsliceutil.NewPortMapKey(endpointPorts), addrType))
+		multiKey[addrType] = addrTypePortMapKey(endpointsliceutil.NewPortMapKey(endpointPorts, addrType))
 		if _, ok := d.endpointsByKey[multiKey[addrType]]; !ok {
 			d.endpointsByKey[multiKey[addrType]] = endpointsliceutil.EndpointSet{}
 		}

--- a/pkg/controller/endpointslicemirroring/utils.go
+++ b/pkg/controller/endpointslicemirroring/utils.go
@@ -18,7 +18,6 @@ package endpointslicemirroring
 
 import (
 	"fmt"
-	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	discovery "k8s.io/api/discovery/v1"
@@ -30,17 +29,6 @@ import (
 	"k8s.io/kubernetes/pkg/apis/discovery/validation"
 	netutils "k8s.io/utils/net"
 )
-
-// addrTypePortMapKey is used to uniquely identify groups of endpoint ports and
-// address types.
-type addrTypePortMapKey string
-
-func (pk addrTypePortMapKey) addressType() discovery.AddressType {
-	if strings.HasPrefix(string(pk), string(discovery.AddressTypeIPv6)) {
-		return discovery.AddressTypeIPv6
-	}
-	return discovery.AddressTypeIPv4
-}
 
 // newEndpointSlice returns an EndpointSlice generated from an Endpoints
 // resource, ports, and address type.

--- a/pkg/controller/endpointslicemirroring/utils.go
+++ b/pkg/controller/endpointslicemirroring/utils.go
@@ -27,7 +27,6 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
-	endpointsliceutil "k8s.io/endpointslice/util"
 	"k8s.io/kubernetes/pkg/apis/discovery/validation"
 	netutils "k8s.io/utils/net"
 )
@@ -35,12 +34,6 @@ import (
 // addrTypePortMapKey is used to uniquely identify groups of endpoint ports and
 // address types.
 type addrTypePortMapKey string
-
-// newAddrTypePortMapKey generates a PortMapKey from endpoint ports.
-func newAddrTypePortMapKey(endpointPorts []discovery.EndpointPort, addrType discovery.AddressType) addrTypePortMapKey {
-	pmk := fmt.Sprintf("%s-%s", addrType, endpointsliceutil.NewPortMapKey(endpointPorts))
-	return addrTypePortMapKey(pmk)
-}
 
 func (pk addrTypePortMapKey) addressType() discovery.AddressType {
 	if strings.HasPrefix(string(pk), string(discovery.AddressTypeIPv6)) {

--- a/staging/src/k8s.io/endpointslice/metrics/cache_test.go
+++ b/staging/src/k8s.io/endpointslice/metrics/cache_test.go
@@ -31,8 +31,8 @@ import (
 func TestNumEndpointsAndSlices(t *testing.T) {
 	c := NewCache(int32(100))
 
-	pmKey80443 := endpointsliceutil.NewPortMapKey([]discovery.EndpointPort{{Port: ptr.To[int32](80)}, {Port: ptr.To[int32](443)}})
-	pmKey80 := endpointsliceutil.NewPortMapKey([]discovery.EndpointPort{{Port: ptr.To[int32](80)}})
+	pmKey80443 := endpointsliceutil.NewPortMapKey([]discovery.EndpointPort{{Port: ptr.To[int32](80)}, {Port: ptr.To[int32](443)}}, discovery.AddressTypeIPv4)
+	pmKey80 := endpointsliceutil.NewPortMapKey([]discovery.EndpointPort{{Port: ptr.To[int32](80)}}, discovery.AddressTypeIPv4)
 
 	spCacheEfficient := NewServicePortCache()
 	spCacheEfficient.Set(pmKey80, EfficiencyInfo{Endpoints: 45, Slices: 1})
@@ -61,8 +61,8 @@ func TestNumEndpointsAndSlices(t *testing.T) {
 func TestPlaceHolderSlice(t *testing.T) {
 	c := NewCache(int32(100))
 
-	pmKey80443 := endpointsliceutil.NewPortMapKey([]discovery.EndpointPort{{Port: ptr.To[int32](80)}, {Port: ptr.To[int32](443)}})
-	pmKey80 := endpointsliceutil.NewPortMapKey([]discovery.EndpointPort{{Port: ptr.To[int32](80)}})
+	pmKey80443 := endpointsliceutil.NewPortMapKey([]discovery.EndpointPort{{Port: ptr.To[int32](80)}, {Port: ptr.To[int32](443)}}, discovery.AddressTypeIPv4)
+	pmKey80 := endpointsliceutil.NewPortMapKey([]discovery.EndpointPort{{Port: ptr.To[int32](80)}}, discovery.AddressTypeIPv4)
 
 	sp := NewServicePortCache()
 	sp.Set(pmKey80, EfficiencyInfo{Endpoints: 0, Slices: 1})
@@ -175,8 +175,8 @@ func TestCache_ServicesByTrafficDistribution(t *testing.T) {
 func benchmarkUpdateServicePortCache(b *testing.B, num int) {
 	c := NewCache(int32(100))
 	ns := "benchmark"
-	httpKey := endpointsliceutil.NewPortMapKey([]discovery.EndpointPort{{Port: ptr.To[int32](80)}})
-	httpsKey := endpointsliceutil.NewPortMapKey([]discovery.EndpointPort{{Port: ptr.To[int32](443)}})
+	httpKey := endpointsliceutil.NewPortMapKey([]discovery.EndpointPort{{Port: ptr.To[int32](80)}}, discovery.AddressTypeIPv4)
+	httpsKey := endpointsliceutil.NewPortMapKey([]discovery.EndpointPort{{Port: ptr.To[int32](443)}}, discovery.AddressTypeIPv4)
 	spCache := &ServicePortCache{items: map[endpointsliceutil.PortMapKey]EfficiencyInfo{
 		httpKey: {
 			Endpoints: 182,

--- a/staging/src/k8s.io/endpointslice/reconciler.go
+++ b/staging/src/k8s.io/endpointslice/reconciler.go
@@ -136,14 +136,19 @@ func (r *Reconciler) Reconcile(logger klog.Logger, service *corev1.Service, pods
 		slicesByAddressType[existingSlice.AddressType] = append(slicesByAddressType[existingSlice.AddressType], existingSlice)
 	}
 
+	spMetrics := metrics.NewServicePortCache()
+
 	// reconcile for existing.
 	for addressType := range serviceSupportedAddressesTypes {
 		existingSlices := slicesByAddressType[addressType]
-		err := r.reconcileByAddressType(logger, service, pods, existingSlices, triggerTime, addressType)
+		err := r.reconcileByAddressType(logger, service, pods, existingSlices, triggerTime, addressType, spMetrics)
 		if err != nil {
 			errs = append(errs, err)
 		}
 	}
+
+	serviceNN := types.NamespacedName{Name: service.Name, Namespace: service.Namespace}
+	r.metricsCache.UpdateServicePortCache(serviceNN, spMetrics)
 
 	// delete those which are of addressType that is no longer supported
 	// by the service
@@ -164,7 +169,7 @@ func (r *Reconciler) Reconcile(logger klog.Logger, service *corev1.Service, pods
 // compares them with the endpoints already present in any existing endpoint
 // slices (by address type) for the given service. It creates, updates, or deletes endpoint slices
 // to ensure the desired set of pods are represented by endpoint slices.
-func (r *Reconciler) reconcileByAddressType(logger klog.Logger, service *corev1.Service, pods []*corev1.Pod, existingSlices []*discovery.EndpointSlice, triggerTime time.Time, addressType discovery.AddressType) error {
+func (r *Reconciler) reconcileByAddressType(logger klog.Logger, service *corev1.Service, pods []*corev1.Pod, existingSlices []*discovery.EndpointSlice, triggerTime time.Time, addressType discovery.AddressType, spMetrics *metrics.ServicePortCache) error {
 	errs := []error{}
 
 	slicesToCreate := []*discovery.EndpointSlice{}
@@ -231,7 +236,6 @@ func (r *Reconciler) reconcileByAddressType(logger klog.Logger, service *corev1.
 		}
 	}
 
-	spMetrics := metrics.NewServicePortCache()
 	totalAdded := 0
 	totalRemoved := 0
 
@@ -244,10 +248,12 @@ func (r *Reconciler) reconcileByAddressType(logger klog.Logger, service *corev1.
 		totalAdded += added
 		totalRemoved += removed
 
-		spMetrics.Set(portMap, metrics.EfficiencyInfo{
-			Endpoints: numEndpoints,
-			Slices:    len(existingSlicesByPortMap[portMap]) + len(pmSlicesToCreate) - len(pmSlicesToDelete),
-		})
+		spMetrics.Set(
+			newAddrTypePortMapKey(portMap, addressType),
+			metrics.EfficiencyInfo{
+				Endpoints: numEndpoints,
+				Slices:    len(existingSlicesByPortMap[portMap]) + len(pmSlicesToCreate) - len(pmSlicesToDelete),
+			})
 
 		slicesToCreate = append(slicesToCreate, pmSlicesToCreate...)
 		slicesToUpdate = append(slicesToUpdate, pmSlicesToUpdate...)
@@ -272,17 +278,18 @@ func (r *Reconciler) reconcileByAddressType(logger klog.Logger, service *corev1.
 		} else {
 			slicesToCreate = append(slicesToCreate, placeholderSlice)
 		}
-		spMetrics.Set(endpointsliceutil.NewPortMapKey(placeholderSlice.Ports), metrics.EfficiencyInfo{
-			Endpoints: 0,
-			Slices:    1,
-		})
+		spMetrics.Set(
+			newAddrTypePortMapKey(endpointsliceutil.NewPortMapKey(placeholderSlice.Ports), addressType),
+			metrics.EfficiencyInfo{
+				Endpoints: 0,
+				Slices:    1,
+			})
 	}
 
 	metrics.EndpointsAddedPerSync.WithLabelValues().Observe(float64(totalAdded))
 	metrics.EndpointsRemovedPerSync.WithLabelValues().Observe(float64(totalRemoved))
 
 	serviceNN := types.NamespacedName{Name: service.Name, Namespace: service.Namespace}
-	r.metricsCache.UpdateServicePortCache(serviceNN, spMetrics)
 
 	// Topology hints are assigned per address type. This means it is
 	// theoretically possible for endpoints of one address type to be assigned

--- a/staging/src/k8s.io/endpointslice/reconciler.go
+++ b/staging/src/k8s.io/endpointslice/reconciler.go
@@ -249,7 +249,7 @@ func (r *Reconciler) reconcileByAddressType(logger klog.Logger, service *corev1.
 		totalRemoved += removed
 
 		spMetrics.Set(
-			newAddrTypePortMapKey(portMap, addressType),
+			endpointsliceutil.NewAddrTypePortMapKey(portMap, addressType),
 			metrics.EfficiencyInfo{
 				Endpoints: numEndpoints,
 				Slices:    len(existingSlicesByPortMap[portMap]) + len(pmSlicesToCreate) - len(pmSlicesToDelete),
@@ -279,7 +279,7 @@ func (r *Reconciler) reconcileByAddressType(logger klog.Logger, service *corev1.
 			slicesToCreate = append(slicesToCreate, placeholderSlice)
 		}
 		spMetrics.Set(
-			newAddrTypePortMapKey(endpointsliceutil.NewPortMapKey(placeholderSlice.Ports), addressType),
+			endpointsliceutil.NewAddrTypePortMapKey(endpointsliceutil.NewPortMapKey(placeholderSlice.Ports), addressType),
 			metrics.EfficiencyInfo{
 				Endpoints: 0,
 				Slices:    1,

--- a/staging/src/k8s.io/endpointslice/reconciler.go
+++ b/staging/src/k8s.io/endpointslice/reconciler.go
@@ -181,7 +181,7 @@ func (r *Reconciler) reconcileByAddressType(logger klog.Logger, service *corev1.
 	existingSlicesByPortMap := map[endpointsliceutil.PortMapKey][]*discovery.EndpointSlice{}
 	for _, existingSlice := range existingSlices {
 		if ownedBy(existingSlice, service) {
-			epHash := endpointsliceutil.NewPortMapKey(existingSlice.Ports)
+			epHash := endpointsliceutil.NewPortMapKey(existingSlice.Ports, addressType)
 			existingSlicesByPortMap[epHash] = append(existingSlicesByPortMap[epHash], existingSlice)
 		} else {
 			slicesToDelete = append(slicesToDelete, existingSlice)
@@ -198,7 +198,7 @@ func (r *Reconciler) reconcileByAddressType(logger klog.Logger, service *corev1.
 		}
 
 		endpointPorts := getEndpointPorts(logger, service, pod)
-		epHash := endpointsliceutil.NewPortMapKey(endpointPorts)
+		epHash := endpointsliceutil.NewPortMapKey(endpointPorts, addressType)
 		if _, ok := desiredEndpointsByPortMap[epHash]; !ok {
 			desiredEndpointsByPortMap[epHash] = endpointsliceutil.EndpointSet{}
 		}
@@ -249,7 +249,7 @@ func (r *Reconciler) reconcileByAddressType(logger klog.Logger, service *corev1.
 		totalRemoved += removed
 
 		spMetrics.Set(
-			endpointsliceutil.NewAddrTypePortMapKey(portMap, addressType),
+			endpointsliceutil.NewPortMapKey(desiredMetaByPortMap[portMap].ports, addressType),
 			metrics.EfficiencyInfo{
 				Endpoints: numEndpoints,
 				Slices:    len(existingSlicesByPortMap[portMap]) + len(pmSlicesToCreate) - len(pmSlicesToDelete),
@@ -279,7 +279,7 @@ func (r *Reconciler) reconcileByAddressType(logger klog.Logger, service *corev1.
 			slicesToCreate = append(slicesToCreate, placeholderSlice)
 		}
 		spMetrics.Set(
-			endpointsliceutil.NewAddrTypePortMapKey(endpointsliceutil.NewPortMapKey(placeholderSlice.Ports), addressType),
+			endpointsliceutil.NewPortMapKey(placeholderSlice.Ports, addressType),
 			metrics.EfficiencyInfo{
 				Endpoints: 0,
 				Slices:    1,

--- a/staging/src/k8s.io/endpointslice/reconciler_test.go
+++ b/staging/src/k8s.io/endpointslice/reconciler_test.go
@@ -521,24 +521,24 @@ func TestReconcile1Pod(t *testing.T) {
 				}
 
 				expectTrackedGeneration(t, r.endpointSliceTracker, &slice, 1)
-
-				expectSlicesChangedPerSync := 1
-				if testCase.service.Spec.IPFamilies != nil && len(testCase.service.Spec.IPFamilies) > 0 {
-					expectSlicesChangedPerSync = len(testCase.service.Spec.IPFamilies)
-				}
-				expectMetrics(t,
-					expectedMetrics{
-						desiredSlices:        1,
-						actualSlices:         1,
-						desiredEndpoints:     1,
-						addedPerSync:         len(testCase.expectedEndpointPerSlice),
-						removedPerSync:       0,
-						numCreated:           len(testCase.expectedEndpointPerSlice),
-						numUpdated:           0,
-						numDeleted:           0,
-						slicesChangedPerSync: expectSlicesChangedPerSync,
-					})
 			}
+
+			expectSlicesChangedPerSync := 1
+			if len(testCase.service.Spec.IPFamilies) > 0 {
+				expectSlicesChangedPerSync = len(testCase.service.Spec.IPFamilies)
+			}
+			expectMetrics(t,
+				expectedMetrics{
+					desiredSlices:        len(testCase.expectedEndpointPerSlice),
+					actualSlices:         len(testCase.expectedEndpointPerSlice),
+					desiredEndpoints:     len(testCase.expectedEndpointPerSlice),
+					addedPerSync:         len(testCase.expectedEndpointPerSlice),
+					removedPerSync:       0,
+					numCreated:           len(testCase.expectedEndpointPerSlice),
+					numUpdated:           0,
+					numDeleted:           0,
+					slicesChangedPerSync: expectSlicesChangedPerSync,
+				})
 		})
 	}
 }
@@ -2606,7 +2606,7 @@ func expectMetrics(t *testing.T, em expectedMetrics) {
 	}
 
 	actualDeleted, err := testutil.GetCounterMetricValue(metrics.EndpointSliceChanges.WithLabelValues("delete"))
-	handleErr(t, err, "desiredEndpointSlices")
+	handleErr(t, err, "endpointSliceChangesDeleted")
 	if actualDeleted != float64(em.numDeleted) {
 		t.Errorf("Expected endpointSliceChangesDeleted to be %d, got %v", em.numDeleted, actualDeleted)
 	}

--- a/staging/src/k8s.io/endpointslice/util/controller_utils.go
+++ b/staging/src/k8s.io/endpointslice/util/controller_utils.go
@@ -158,18 +158,13 @@ func getServicesForPod(serviceLister v1listers.ServiceLister, namespace string, 
 type PortMapKey string
 
 // NewPortMapKey generates a PortMapKey from endpoint ports.
-func NewPortMapKey(endpointPorts []discovery.EndpointPort) PortMapKey {
+func NewPortMapKey(endpointPorts []discovery.EndpointPort, addrType discovery.AddressType) PortMapKey {
 	// Normalize nil to empty slice so they hash the same.
 	if endpointPorts == nil {
 		endpointPorts = []discovery.EndpointPort{}
 	}
 	sort.Sort(portsInOrder(endpointPorts))
-	return PortMapKey(deepHashObjectToString(endpointPorts))
-}
-
-// NewAddrTypePortMapKey generates a PortMapKey from endpoint ports and address type.
-func NewAddrTypePortMapKey(portMapKey PortMapKey, addrType discovery.AddressType) PortMapKey {
-	pmk := fmt.Sprintf("%s-%s", addrType, portMapKey)
+	pmk := fmt.Sprintf("%s-%s", addrType, PortMapKey(deepHashObjectToString(endpointPorts)))
 	return PortMapKey(pmk)
 }
 

--- a/staging/src/k8s.io/endpointslice/util/controller_utils.go
+++ b/staging/src/k8s.io/endpointslice/util/controller_utils.go
@@ -167,6 +167,12 @@ func NewPortMapKey(endpointPorts []discovery.EndpointPort) PortMapKey {
 	return PortMapKey(deepHashObjectToString(endpointPorts))
 }
 
+// NewAddrTypePortMapKey generates a PortMapKey from endpoint ports and address type.
+func NewAddrTypePortMapKey(portMapKey PortMapKey, addrType discovery.AddressType) PortMapKey {
+	pmk := fmt.Sprintf("%s-%s", addrType, portMapKey)
+	return PortMapKey(pmk)
+}
+
 // deepHashObjectToString creates a unique hash string from a go object.
 func deepHashObjectToString(objectToWrite interface{}) string {
 	hasher := fnv.New128a()

--- a/staging/src/k8s.io/endpointslice/util/controller_utils.go
+++ b/staging/src/k8s.io/endpointslice/util/controller_utils.go
@@ -23,6 +23,7 @@ import (
 	"hash/fnv"
 	"reflect"
 	"sort"
+	"strings"
 
 	v1 "k8s.io/api/core/v1"
 	discovery "k8s.io/api/discovery/v1"
@@ -164,8 +165,19 @@ func NewPortMapKey(endpointPorts []discovery.EndpointPort, addrType discovery.Ad
 		endpointPorts = []discovery.EndpointPort{}
 	}
 	sort.Sort(portsInOrder(endpointPorts))
-	pmk := fmt.Sprintf("%s-%s", addrType, PortMapKey(deepHashObjectToString(endpointPorts)))
+	pmk := fmt.Sprintf("%s-%s", addrType, deepHashObjectToString(endpointPorts))
 	return PortMapKey(pmk)
+}
+
+// AddressType returns the discovery.AddressType associated with this PortMapKey.
+func (pk PortMapKey) AddressType() discovery.AddressType {
+	if strings.HasPrefix(string(pk), string(discovery.AddressTypeIPv6)) {
+		return discovery.AddressTypeIPv6
+	}
+	if strings.HasPrefix(string(pk), string(discovery.AddressTypeFQDN)) {
+		return discovery.AddressTypeFQDN
+	}
+	return discovery.AddressTypeIPv4
 }
 
 // deepHashObjectToString creates a unique hash string from a go object.

--- a/staging/src/k8s.io/endpointslice/util/controller_utils_test.go
+++ b/staging/src/k8s.io/endpointslice/util/controller_utils_test.go
@@ -953,10 +953,28 @@ func TestNewPortMapKey_NilVsEmptySlice(t *testing.T) {
 	var nilPorts []discovery.EndpointPort
 	emptyPorts := []discovery.EndpointPort{}
 
-	nilKey := NewPortMapKey(nilPorts)
-	emptyKey := NewPortMapKey(emptyPorts)
+	nilKey := NewPortMapKey(nilPorts, discovery.AddressTypeIPv4)
+	emptyKey := NewPortMapKey(emptyPorts, discovery.AddressTypeIPv4)
 
 	if nilKey != emptyKey {
 		t.Errorf("NewPortMapKey should return the same key for nil and empty slice, got nil=%q empty=%q", nilKey, emptyKey)
+	}
+}
+
+func TestNewPortMapKey_AddressType(t *testing.T) {
+	emptyPorts := []discovery.EndpointPort{}
+
+	kepv4 := NewPortMapKey(emptyPorts, discovery.AddressTypeIPv4)
+	kepv6 := NewPortMapKey(emptyPorts, discovery.AddressTypeIPv6)
+	kepFQDN := NewPortMapKey(emptyPorts, discovery.AddressTypeFQDN)
+
+	if kepv4 == kepv6 {
+		t.Errorf("NewPortMapKey should return different keys for different address types, got kepv4=%q kepv6=%q", kepv4, kepv6)
+	}
+	if kepv4 == kepFQDN {
+		t.Errorf("NewPortMapKey should return different keys for different address types, got kepv4=%q kepFQDN=%q", kepv4, kepFQDN)
+	}
+	if kepv6 == kepFQDN {
+		t.Errorf("NewPortMapKey should return different keys for different address types, got kepv6=%q kepFQDN=%q", kepv6, kepFQDN)
 	}
 }

--- a/staging/src/k8s.io/endpointslice/util/controller_utils_test.go
+++ b/staging/src/k8s.io/endpointslice/util/controller_utils_test.go
@@ -964,17 +964,55 @@ func TestNewPortMapKey_NilVsEmptySlice(t *testing.T) {
 func TestNewPortMapKey_AddressType(t *testing.T) {
 	emptyPorts := []discovery.EndpointPort{}
 
-	kepv4 := NewPortMapKey(emptyPorts, discovery.AddressTypeIPv4)
-	kepv6 := NewPortMapKey(emptyPorts, discovery.AddressTypeIPv6)
-	kepFQDN := NewPortMapKey(emptyPorts, discovery.AddressTypeFQDN)
+	keyv4 := NewPortMapKey(emptyPorts, discovery.AddressTypeIPv4)
+	keyv6 := NewPortMapKey(emptyPorts, discovery.AddressTypeIPv6)
+	keyFQDN := NewPortMapKey(emptyPorts, discovery.AddressTypeFQDN)
 
-	if kepv4 == kepv6 {
-		t.Errorf("NewPortMapKey should return different keys for different address types, got kepv4=%q kepv6=%q", kepv4, kepv6)
+	if keyv4 == keyv6 {
+		t.Errorf("NewPortMapKey should return different keys for different address types, got keyv4=%q keyv6=%q", keyv4, keyv6)
 	}
-	if kepv4 == kepFQDN {
-		t.Errorf("NewPortMapKey should return different keys for different address types, got kepv4=%q kepFQDN=%q", kepv4, kepFQDN)
+	if keyv4 == keyFQDN {
+		t.Errorf("NewPortMapKey should return different keys for different address types, got keyv4=%q keyFQDN=%q", keyv4, keyFQDN)
 	}
-	if kepv6 == kepFQDN {
-		t.Errorf("NewPortMapKey should return different keys for different address types, got kepv6=%q kepFQDN=%q", kepv6, kepFQDN)
+	if keyv6 == keyFQDN {
+		t.Errorf("NewPortMapKey should return different keys for different address types, got keyv6=%q keyFQDN=%q", keyv6, keyFQDN)
+	}
+}
+
+func TestPortMapKey_AddressType(t *testing.T) {
+	tests := []struct {
+		name string // description of this test case
+		// Named input parameters for receiver constructor.
+		endpointPorts []discovery.EndpointPort
+		addrType      discovery.AddressType
+		want          discovery.AddressType
+	}{
+		{
+			name:          "IPv4 address type",
+			endpointPorts: []discovery.EndpointPort{},
+			addrType:      discovery.AddressTypeIPv4,
+			want:          discovery.AddressTypeIPv4,
+		},
+		{
+			name:          "IPv6 address type",
+			endpointPorts: []discovery.EndpointPort{},
+			addrType:      discovery.AddressTypeIPv6,
+			want:          discovery.AddressTypeIPv6,
+		},
+		{
+			name:          "FQDN address type",
+			endpointPorts: []discovery.EndpointPort{},
+			addrType:      discovery.AddressTypeFQDN,
+			want:          discovery.AddressTypeFQDN,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pk := NewPortMapKey(tt.endpointPorts, tt.addrType)
+			got := pk.AddressType()
+			if got != tt.want {
+				t.Errorf("AddressType() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }

--- a/staging/src/k8s.io/endpointslice/utils.go
+++ b/staging/src/k8s.io/endpointslice/utils.go
@@ -407,3 +407,9 @@ func FindPort(pod *v1.Pod, svcPort *v1.ServicePort) (int, error) {
 
 	return 0, fmt.Errorf("no suitable port for manifest: %s", pod.UID)
 }
+
+// newAddrTypePortMapKey generates a PortMapKey from endpoint ports and address type.
+func newAddrTypePortMapKey(portMapKey endpointutil.PortMapKey, addrType discovery.AddressType) endpointutil.PortMapKey {
+	pmk := fmt.Sprintf("%s-%s", addrType, portMapKey)
+	return endpointutil.PortMapKey(pmk)
+}

--- a/staging/src/k8s.io/endpointslice/utils.go
+++ b/staging/src/k8s.io/endpointslice/utils.go
@@ -407,9 +407,3 @@ func FindPort(pod *v1.Pod, svcPort *v1.ServicePort) (int, error) {
 
 	return 0, fmt.Errorf("no suitable port for manifest: %s", pod.UID)
 }
-
-// newAddrTypePortMapKey generates a PortMapKey from endpoint ports and address type.
-func newAddrTypePortMapKey(portMapKey endpointutil.PortMapKey, addrType discovery.AddressType) endpointutil.PortMapKey {
-	pmk := fmt.Sprintf("%s-%s", addrType, portMapKey)
-	return endpointutil.PortMapKey(pmk)
-}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Metrics below were reported for only 1 IP Family in dualstack as the metrics cache of the second iteration in reconcileByAddressType was overwritten with the same map key.
* endpoint_slice_controller_desired_endpoint_slices
* endpoint_slice_controller_num_endpoint_slices
* endpoint_slice_controller_endpoints_desired

#### Which issue(s) this PR fixes:

Fixes #126004

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
fixes endpoint_slice_controller_desired_endpoint_slices, endpoint_slice_controller_num_endpoint_slices and endpoint_slice_controller_endpoints_desired metrics for dualstack services
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
