### PR TITLE
Updating kubelet on Windows to query uuid from registry

### DIFF
--- a/pkg/kubelet/winstats/perfcounter_nodestats.go
+++ b/pkg/kubelet/winstats/perfcounter_nodestats.go
@@ -20,10 +20,7 @@ limitations under the License.
 package winstats
 
 import (
-	"errors"
-	"fmt"
 	"os"
-	"os/exec"
 	"runtime"
 	"strconv"
 	"strings"
@@ -33,6 +30,7 @@ import (
 	"unsafe"
 
 	cadvisorapi "github.com/google/cadvisor/info/v1"
+	"github.com/pkg/errors"
 	"golang.org/x/sys/windows"
 	"golang.org/x/sys/windows/registry"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -256,15 +254,21 @@ func (p *perfCounterNodeStatsClient) getCPUUsageNanoCores() uint64 {
 }
 
 func getSystemUUID() (string, error) {
-	result, err := exec.Command("wmic", "csproduct", "get", "UUID").Output()
+	k, err := registry.OpenKey(registry.LOCAL_MACHINE, `SYSTEM\HardwareConfig`, registry.QUERY_VALUE)
 	if err != nil {
-		return "", err
+		return "", errors.Wrap(err, "failed to open registry key HKLM\\SYSTEM\\HardwareConfig")
 	}
-	fields := strings.Fields(string(result))
-	if len(fields) != 2 {
-		return "", fmt.Errorf("received unexpected value retrieving vm uuid: %q", string(result))
+	defer k.Close()
+
+	uuid, _, err := k.GetStringValue("LastConfig")
+	if err != nil {
+		return "", errors.Wrap(err, "failed to read registry value LastConfig from key HKLM\\SYSTEM\\HardwareConfig")
 	}
-	return fields[1], nil
+
+	uuid = strings.Trim(uuid, "{")
+	uuid = strings.Trim(uuid, "}")
+	uuid = strings.ToUpper(uuid)
+	return uuid, nil
 }
 
 func getPhysicallyInstalledSystemMemoryBytes() (uint64, error) {

--- a/pkg/kubelet/winstats/perfcounter_nodestats_test.go
+++ b/pkg/kubelet/winstats/perfcounter_nodestats_test.go
@@ -21,7 +21,9 @@ package winstats
 
 import (
 	"os"
+	"os/exec"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -187,4 +189,14 @@ func testGetPhysicallyInstalledSystemMemoryBytes(t *testing.T) {
 	totalMemory, err := getPhysicallyInstalledSystemMemoryBytes()
 	assert.NoError(t, err)
 	assert.NotZero(t, totalMemory)
+}
+
+func TestGetSystemUUID(t *testing.T) {
+	uuidFromRegistry, err := getSystemUUID()
+	assert.NoError(t, err)
+
+	uuidFromWmi, err := exec.Command("powershell.exe", "Get-WmiObject", "Win32_ComputerSystemProduct", "|", "Select-Object", "-ExpandProperty UUID").Output()
+	assert.NoError(t, err)
+	uuidFromWmiString := strings.Trim(string(uuidFromWmi), "\r\n")
+	assert.Equal(t, uuidFromWmiString, uuidFromRegistry)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:

/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Currently the kubelet uses the wmi cli tool `wmic` to query for the UUID.
`wmic` has been deprecated for a number of Windows Serer releases and is removed in Windows Server 2025 so we need to update how this value is queried.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
A different approach was tried https://github.com/kubernetes/kubernetes/pull/106093 but this approach doesn't bring in any additional go depencies.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Stop using wmic on Windows to get uuid in the kubelet
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/sig windows
/area kubelet
