### PR TITLE
Automated cherry pick of #125973: Mark a test case which sets up a sample-apiserver as serial

### DIFF
--- a/test/e2e/apimachinery/aggregator.go
+++ b/test/e2e/apimachinery/aggregator.go
@@ -131,6 +131,12 @@ func generateSampleAPIServerObjectNames(namespace string) sampleAPIServerObjectN
 	}
 }
 
+// SetUpSampleAPIServer sets up a sample-apiserver.
+//
+// Important:
+// Test cases that call this function should be marked as serial due to potential conflicts
+// with other test cases that also set up a sample-apiserver. For more information, see
+// https://github.com/kubernetes/kubernetes/issues/119582#issuecomment-2215054411.
 func SetUpSampleAPIServer(ctx context.Context, f *framework.Framework, aggrclient *aggregatorclient.Clientset, image string, n sampleAPIServerObjectNames, apiServiceGroupName, apiServiceVersion string) {
 	ginkgo.By("Registering the sample API server.")
 	client := f.ClientSet

--- a/test/e2e/apimachinery/openapiv3.go
+++ b/test/e2e/apimachinery/openapiv3.go
@@ -170,8 +170,11 @@ var _ = SIGDescribe("OpenAPIV3", func() {
 		Release : v1.27
 		Testname: OpenAPI V3 Aggregated APIServer
 		Description: Create an Aggregated APIServer. The OpenAPI V3 for the aggregated apiserver MUST be aggregated by the aggregator and published. The specification MUST be round trippable.
+
+		This test case is marked as serial due to potential conflicts with other test cases that set up a sample-apiserver.
+		For more information, see: https://github.com/kubernetes/kubernetes/issues/119582#issuecomment-2215054411.
 	*/
-	ginkgo.It("should contain OpenAPI V3 for Aggregated APIServer", func(ctx context.Context) {
+	f.It("should contain OpenAPI V3 for Aggregated APIServer", f.WithSerial(), func(ctx context.Context) {
 		config, err := framework.LoadConfig()
 		framework.ExpectNoError(err)
 		aggrclient, err := aggregatorclient.NewForConfig(config)


### PR DESCRIPTION
Cherry pick of #125973 on release-1.29.

#125973: Mark a test case which sets up a sample-apiserver as serial

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```