### PR TITLE
scheduler: impose a backoff penalty on gated Pods

### DIFF
--- a/pkg/scheduler/framework/types.go
+++ b/pkg/scheduler/framework/types.go
@@ -232,7 +232,7 @@ type QueuedPodInfo struct {
 	// The time pod added to the scheduling queue.
 	Timestamp time.Time
 	// Number of schedule attempts before successfully scheduled.
-	// It's used to record the # attempts metric.
+	// It's used to record the # attempts metric and calculate the backoff time this Pod is obliged to get before retrying.
 	Attempts int
 	// The time when the pod is added to the queue for the first time. The pod may be added
 	// back to the queue multiple times before it's successfully scheduled.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

#### What this PR does / why we need it:

Starting the story from the concept of backoff in the scheduler; a backoff time in the scheduler is a [penalty](https://github.com/kubernetes/kubernetes/blob/09472b673d9e34b866fbd41c544887ba60d7ca7b/pkg/scheduler/framework/interface.go#L93-L95) that we impose on Pods when they consume a scheduling cycle, but they didn't get scheduled and came back to the queue.

But, currently all gated Pods are always regarded as not backing off.
That is **only** correct for a vanilla scheduler because all Pods gated by SchedulingGates haven't experienced any scheduling and thus are not backing off for sure.
A custom PreEnqueue plugin might gate Pods after they experience some scheduling cycles; those mean -
1. Pods have experienced some scheduling cycles.
2. They get gated by a custom PreEnqueue plugin.
3. They get un-gated for some reasons.
4. 💥 Whoa! They're moved to activeQ without a backoff penalty.

Regardless of whether a Pod is gated or not, they are supposed to get a penalty if they wasted some scheduling cycles before. 
It's the law in the scheduler; it's their obligation that they must meet before retrying a schedule again.

This PR changes `isPodBackingoff()` not to skip gated Pods so that we can prevent such Pods from exploiting loopholes, ignoring the law, and escaping a penalty.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #125538

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
The scheduler retries gated Pods more appropriately, giving them a backoff penalty too.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
