### PR TITLE
Automated cherry pick of #125767: Fix pv reclaim failed due to its phase is wrongly updated to

### DIFF
--- a/pkg/controller/volume/persistentvolume/pv_controller.go
+++ b/pkg/controller/volume/persistentvolume/pv_controller.go
@@ -1958,16 +1958,14 @@ func (ctrl *PersistentVolumeController) findDeletablePlugin(volume *v1.Persisten
 		}
 	}
 
-	if utilfeature.DefaultFeatureGate.Enabled(features.HonorPVReclaimPolicy) {
-		if metav1.HasAnnotation(volume.ObjectMeta, storagehelpers.AnnMigratedTo) {
-			// CSI migration scenario - do not depend on in-tree plugin
-			return nil, nil
-		}
+	if metav1.HasAnnotation(volume.ObjectMeta, storagehelpers.AnnMigratedTo) {
+		// CSI migration scenario - do not depend on in-tree plugin
+		return nil, nil
+	}
 
-		if volume.Spec.CSI != nil {
-			// CSI volume source scenario - external provisioner is requested
-			return nil, nil
-		}
+	if volume.Spec.CSI != nil {
+		// CSI volume source scenario - external provisioner is requested
+		return nil, nil
 	}
 
 	// The plugin that provisioned the volume was not found or the volume


### PR DESCRIPTION
Cherry pick of #125767 on release-1.30.

#125767: Fix pv reclaim failed due to its phase is wrongly updated to

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
For statically provisioned PVs, if its volume source is CSI type or it has migrated annotation, when it's deleted, the PersisentVolume controller won't changes its phase to the Failed state. 

With this patch, the external provisioner can remove the finalizer in next reconcile loop. Unfortunately if the provious existing pv has the Failed state, this patch won't take effort. It requires users to remove finalizer.
```