### PR TITLE
Automated cherry pick of #122030: fix issue with using feature HonorPVReclaimPolicy in
#125767: Fix pv reclaim failed due to its phase is wrongly updated to

### DIFF
--- a/pkg/controller/volume/persistentvolume/delete_test.go
+++ b/pkg/controller/volume/persistentvolume/delete_test.go
@@ -148,9 +148,9 @@ func TestDeleteSync(t *testing.T) {
 		},
 		{
 			// PV requires external deleter
-			name:            "8-10 - external deleter",
-			initialVolumes:  []*v1.PersistentVolume{newExternalProvisionedVolume("volume8-10", "1Gi", "uid10-1", "claim10-1", v1.VolumeBound, v1.PersistentVolumeReclaimDelete, classEmpty, gceDriver, nil, volume.AnnBoundByController)},
-			expectedVolumes: []*v1.PersistentVolume{newExternalProvisionedVolume("volume8-10", "1Gi", "uid10-1", "claim10-1", v1.VolumeReleased, v1.PersistentVolumeReclaimDelete, classEmpty, gceDriver, nil, volume.AnnBoundByController)},
+			name:            "8-10-1 - external deleter when volume is dynamic provisioning",
+			initialVolumes:  []*v1.PersistentVolume{newExternalProvisionedVolume("volume8-10-1", "1Gi", "uid10-1-1", "claim10-1-1", v1.VolumeBound, v1.PersistentVolumeReclaimDelete, classEmpty, gceDriver, nil, volume.AnnBoundByController)},
+			expectedVolumes: []*v1.PersistentVolume{newExternalProvisionedVolume("volume8-10-1", "1Gi", "uid10-1-1", "claim10-1-1", v1.VolumeReleased, v1.PersistentVolumeReclaimDelete, classEmpty, gceDriver, nil, volume.AnnBoundByController)},
 			initialClaims:   noclaims,
 			expectedClaims:  noclaims,
 			expectedEvents:  noevents,
@@ -161,6 +161,28 @@ func TestDeleteSync(t *testing.T) {
 				test.expectedVolumes[0].Annotations[volume.AnnDynamicallyProvisioned] = "external.io/test"
 				return testSyncVolume(ctrl, reactor, test)
 			},
+		},
+		{
+			// PV requires external deleter
+			name:            "8-10-2 - external deleter when volume is static provisioning",
+			initialVolumes:  []*v1.PersistentVolume{newExternalProvisionedVolume("volume8-10-2", "1Gi", "uid10-1-2", "claim10-1-2", v1.VolumeBound, v1.PersistentVolumeReclaimDelete, classEmpty, gceDriver, nil, volume.AnnBoundByController)},
+			expectedVolumes: []*v1.PersistentVolume{newExternalProvisionedVolume("volume8-10-2", "1Gi", "uid10-1-2", "claim10-1-2", v1.VolumeReleased, v1.PersistentVolumeReclaimDelete, classEmpty, gceDriver, nil, volume.AnnBoundByController)},
+			initialClaims:   noclaims,
+			expectedClaims:  noclaims,
+			expectedEvents:  noevents,
+			errors:          noerrors,
+			test:            testSyncVolume,
+		},
+		{
+			// PV requires external deleter
+			name:            "8-10-3 - external deleter when volume is migrated",
+			initialVolumes:  []*v1.PersistentVolume{volumeWithAnnotation(volume.AnnMigratedTo, "pd.csi.storage.gke.io", volumeWithAnnotation(volume.AnnDynamicallyProvisioned, "kubernetes.io/gce-pd", newVolume("volume8-10-3", "1Gi", "uid10-1-3", "claim10-1-3", v1.VolumeBound, v1.PersistentVolumeReclaimDelete, classEmpty, volume.AnnDynamicallyProvisioned)))},
+			expectedVolumes: []*v1.PersistentVolume{volumeWithAnnotation(volume.AnnMigratedTo, "pd.csi.storage.gke.io", volumeWithAnnotation(volume.AnnDynamicallyProvisioned, "kubernetes.io/gce-pd", newVolume("volume8-10-3", "1Gi", "uid10-1-3", "claim10-1-3", v1.VolumeReleased, v1.PersistentVolumeReclaimDelete, classEmpty, volume.AnnDynamicallyProvisioned)))},
+			initialClaims:   noclaims,
+			expectedClaims:  noclaims,
+			expectedEvents:  noevents,
+			errors:          noerrors,
+			test:            testSyncVolume,
 		},
 		{
 			// delete success - two PVs are provisioned for a single claim.

--- a/pkg/controller/volume/persistentvolume/pv_controller.go
+++ b/pkg/controller/volume/persistentvolume/pv_controller.go
@@ -1953,6 +1953,18 @@ func (ctrl *PersistentVolumeController) findDeletablePlugin(volume *v1.Persisten
 		}
 	}
 
+	if utilfeature.DefaultFeatureGate.Enabled(features.HonorPVReclaimPolicy) {
+		if metav1.HasAnnotation(volume.ObjectMeta, storagehelpers.AnnMigratedTo) {
+			// CSI migration scenario - do not depend on in-tree plugin
+			return nil, nil
+		}
+
+		if volume.Spec.CSI != nil {
+			// CSI volume source scenario - external provisioner is requested
+			return nil, nil
+		}
+	}
+
 	// The plugin that provisioned the volume was not found or the volume
 	// was not dynamically provisioned. Try to find a plugin by spec.
 	spec := vol.NewSpecFromPersistentVolume(volume, false)

--- a/pkg/controller/volume/persistentvolume/pv_controller.go
+++ b/pkg/controller/volume/persistentvolume/pv_controller.go
@@ -1953,16 +1953,14 @@ func (ctrl *PersistentVolumeController) findDeletablePlugin(volume *v1.Persisten
 		}
 	}
 
-	if utilfeature.DefaultFeatureGate.Enabled(features.HonorPVReclaimPolicy) {
-		if metav1.HasAnnotation(volume.ObjectMeta, storagehelpers.AnnMigratedTo) {
-			// CSI migration scenario - do not depend on in-tree plugin
-			return nil, nil
-		}
+	if metav1.HasAnnotation(volume.ObjectMeta, storagehelpers.AnnMigratedTo) {
+		// CSI migration scenario - do not depend on in-tree plugin
+		return nil, nil
+	}
 
-		if volume.Spec.CSI != nil {
-			// CSI volume source scenario - external provisioner is requested
-			return nil, nil
-		}
+	if volume.Spec.CSI != nil {
+		// CSI volume source scenario - external provisioner is requested
+		return nil, nil
 	}
 
 	// The plugin that provisioned the volume was not found or the volume


### PR DESCRIPTION
Cherry pick of #122030 #125767 on release-1.28.

#122030: fix issue with using feature HonorPVReclaimPolicy in
#125767: Fix pv reclaim failed due to its phase is wrongly updated to

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
For statically provisioned PVs, if its volume source is CSI type or it has migrated annotation, when it's deleted, the PersisentVolume controller won't changes its phase to the Failed state. 

With this patch, the external provisioner can remove the finalizer in next reconcile loop. Unfortunately if the provious existing pv has the Failed state, this patch won't take effort. It requires users to remove finalizer.
```