### PR TITLE
Use omitempty for optional fields in Job Pod Failure Policy

### DIFF
--- a/staging/src/k8s.io/api/batch/v1/types.go
+++ b/staging/src/k8s.io/api/batch/v1/types.go
@@ -176,7 +176,7 @@ type PodFailurePolicyOnExitCodesRequirement struct {
 	// When specified, it should match one the container or initContainer
 	// names in the pod template.
 	// +optional
-	ContainerName *string `json:"containerName" protobuf:"bytes,1,opt,name=containerName"`
+	ContainerName *string `json:"containerName,omitempty" protobuf:"bytes,1,opt,name=containerName"`
 
 	// Represents the relationship between the container exit code(s) and the
 	// specified values. Containers completed with success (exit code 0) are
@@ -236,14 +236,14 @@ type PodFailurePolicyRule struct {
 
 	// Represents the requirement on the container exit codes.
 	// +optional
-	OnExitCodes *PodFailurePolicyOnExitCodesRequirement `json:"onExitCodes" protobuf:"bytes,2,opt,name=onExitCodes"`
+	OnExitCodes *PodFailurePolicyOnExitCodesRequirement `json:"onExitCodes,omitempty" protobuf:"bytes,2,opt,name=onExitCodes"`
 
 	// Represents the requirement on the pod conditions. The requirement is represented
 	// as a list of pod condition patterns. The requirement is satisfied if at
 	// least one pattern matches an actual pod condition. At most 20 elements are allowed.
 	// +listType=atomic
 	// +optional
-	OnPodConditions []PodFailurePolicyOnPodConditionsPattern `json:"onPodConditions" protobuf:"bytes,3,opt,name=onPodConditions"`
+	OnPodConditions []PodFailurePolicyOnPodConditionsPattern `json:"onPodConditions,omitempty" protobuf:"bytes,3,opt,name=onPodConditions"`
 }
 
 // PodFailurePolicy describes how failed pods influence the backoffLimit.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
/kind api-change

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #126040

#### Special notes for your reviewer:

My procedure for testing (repro):
0. repro by creating Jobset with Job template embedding the snippet:
```yaml
        podFailurePolicy:
          rules:
          - action: FailJob
            onPodConditions:
            - type: DisruptionTarget
          - action: Ignore
            onExitCodes:
              operator: In
              values: [ 42 ]
```
In results in the following errors:
```sh
> k create -f jobset.yaml
The JobSet "failurepolicy-abcdef" is invalid: 
* spec.replicatedJobs[0].template.spec.podFailurePolicy.rules[0].onExitCodes: Invalid value: "null": spec.replicatedJobs[0].template.spec.podFailurePolicy.rules[0].onExitCodes in body must be of type object: "null"
* spec.replicatedJobs[0].template.spec.podFailurePolicy.rules[1].onExitCodes.containerName: Invalid value: "null": spec.replicatedJobs[0].template.spec.podFailurePolicy.rules[1].onExitCodes.containerName in body must be of type string: "null"
* spec.replicatedJobs[0].template.spec.podFailurePolicy.rules[1].onPodConditions: Invalid value: "null": spec.replicatedJobs[0].template.spec.podFailurePolicy.rules[1].onPodConditions in body must be of type array: "null"
* <nil>: Invalid value: "null": some validation rules were not checked because the object was invalid; correct the existing errors to complete validation
```
1. Build JobSet using the updated `k8s.io/api`: 
- clone `https://github.com/kubernetes/api` into JobSet repo  under `bin/k8s_api/api`, and checkout the `release-1.29` branch
- make code adjustments as in this repro (adding "omitempty")
- adjust JobSet's `go.mod` with `replace k8s.io/api => ./bin/k8s_api/api` to use the code, and adjust its Dockerfile with new line `replace k8s.io/api => ./bin/k8s_api/api`, then `go mod tidy`
- build JobSet image with `make kind-image-build`
- load the image to kind: `kind load docker-image gcr.io/k8s-staging-jobset/jobset:0b8c19c-dirty --name kind`
- adjust the JobSet image for the running deployment with `kubectl edit deploy/jobset-controller-manager -njobset-system`
2. The JobSet creation succeeds, the `kubectl get job -oyaml` returns the correct snippet:
```yaml
    podFailurePolicy:
      rules:
      - action: FailJob
        onPodConditions:
        - status: "True"
          type: DisruptionTarget
      - action: Ignore
        onExitCodes:
          containerName: null
          operator: In
          values:
          - 42
```
(same snippet is created when creating the Job directly, without JobSet)

I have also confirmed that it only matters which version of k8s API is used to build the JobSet. In particular, when used fixed version to build JobSet, then I was able to create JobSets on 1.26 and 1.27 k8s clusters.

I see we did similar fixes in the past like here: https://github.com/kubernetes/kubernetes/pull/121000/

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Use omitempty for optional Job Pod Failure Policy fields
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
https://github.com/kubernetes/enhancements/tree/master/keps/sig-apps/3329-retriable-and-non-retriable-failures
```
