### PR TITLE
kubelet: add option to configure housekeeping period

### DIFF
--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -71649,6 +71649,12 @@ func schema_k8sio_kubelet_config_v1beta1_KubeletConfiguration(ref common.Referen
 							Ref:         ref("k8s.io/kubelet/config/v1beta1.UserNamespaces"),
 						},
 					},
+					"podHousekeepingPeriod": {
+						SchemaProps: spec.SchemaProps{
+							Description: "PodHousekeepingPeriod is the interval to specify the frequency for performing global pod cleanup tasks. Specifying a high value for this will result in low frequency for lower performance overhead but may result in high latency to remove orphaned resources and remove unwanted pods. Default: 2s",
+							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Duration"),
+						},
+					},
 				},
 				Required: []string{"containerRuntimeEndpoint"},
 			},

--- a/pkg/kubelet/apis/config/fuzzer/fuzzer.go
+++ b/pkg/kubelet/apis/config/fuzzer/fuzzer.go
@@ -126,6 +126,7 @@ func Funcs(codecs runtimeserializer.CodecFactory) []interface{} {
 				"AllAlpha": false,
 				"AllBeta":  true,
 			}
+			obj.PodHousekeepingPeriod = metav1.Duration{Duration: 2 * time.Second}
 		},
 
 		// tokenAttributes field is only supported in v1 CredentialProvider

--- a/pkg/kubelet/apis/config/helpers_test.go
+++ b/pkg/kubelet/apis/config/helpers_test.go
@@ -307,5 +307,6 @@ var (
 		"FailCgroupV1",
 		"CrashLoopBackOff.MaxContainerRestartPeriod",
 		"UserNamespaces.IDsPerPod",
+		"PodHousekeepingPeriod",
 	)
 )

--- a/pkg/kubelet/apis/config/scheme/testdata/KubeletConfiguration/after/v1beta1.yaml
+++ b/pkg/kubelet/apis/config/scheme/testdata/KubeletConfiguration/after/v1beta1.yaml
@@ -76,6 +76,7 @@ nodeStatusMaxImages: 50
 nodeStatusReportFrequency: 5m0s
 nodeStatusUpdateFrequency: 10s
 oomScoreAdj: -999
+podHousekeepingPeriod: 2s
 podLogsDir: /var/log/pods
 podPidsLimit: -1
 port: 10250

--- a/pkg/kubelet/apis/config/scheme/testdata/KubeletConfiguration/roundtrip/default/v1beta1.yaml
+++ b/pkg/kubelet/apis/config/scheme/testdata/KubeletConfiguration/roundtrip/default/v1beta1.yaml
@@ -76,6 +76,7 @@ nodeStatusMaxImages: 50
 nodeStatusReportFrequency: 5m0s
 nodeStatusUpdateFrequency: 10s
 oomScoreAdj: -999
+podHousekeepingPeriod: 2s
 podLogsDir: /var/log/pods
 podPidsLimit: -1
 port: 10250

--- a/pkg/kubelet/apis/config/types.go
+++ b/pkg/kubelet/apis/config/types.go
@@ -543,6 +543,13 @@ type KubeletConfiguration struct {
 	// +featureGate=UserNamespacesSupport
 	// +optional
 	UserNamespaces *UserNamespaces
+
+	// PodHousekeepingPeriod is the interval to specify the frequency for
+	// performing global pod cleanup tasks. Specifying a high value for this
+	// will result in low frequency for lower performance overhead but may
+	// result in high latency to remove orphaned resources and remove
+	// unwanted pods.
+	PodHousekeepingPeriod metav1.Duration
 }
 
 // KubeletAuthorizationMode denotes the authorization mode for the kubelet

--- a/pkg/kubelet/apis/config/v1beta1/defaults.go
+++ b/pkg/kubelet/apis/config/v1beta1/defaults.go
@@ -319,4 +319,8 @@ func SetDefaults_KubeletConfiguration(obj *kubeletconfigv1beta1.KubeletConfigura
 			obj.ImagePullCredentialsVerificationPolicy = kubeletconfigv1beta1.NeverVerifyPreloadedImages
 		}
 	}
+
+	if obj.PodHousekeepingPeriod == nil {
+		obj.PodHousekeepingPeriod = &metav1.Duration{Duration: 2 * time.Second}
+	}
 }

--- a/pkg/kubelet/apis/config/v1beta1/defaults_test.go
+++ b/pkg/kubelet/apis/config/v1beta1/defaults_test.go
@@ -133,6 +133,7 @@ func TestSetDefaultsKubeletConfiguration(t *testing.T) {
 				PodLogsDir:                    DefaultPodLogsDir,
 				SingleProcessOOMKill:          nil,
 				CrashLoopBackOff:              v1beta1.CrashLoopBackOffConfig{},
+				PodHousekeepingPeriod:         &metav1.Duration{Duration: 2 * time.Second},
 			},
 		},
 		{
@@ -267,6 +268,7 @@ func TestSetDefaultsKubeletConfiguration(t *testing.T) {
 				LocalStorageCapacityIsolation:   ptr.To(false),
 				PodLogsDir:                      "",
 				SingleProcessOOMKill:            ptr.To(false),
+				PodHousekeepingPeriod:           &metav1.Duration{Duration: 2 * time.Second},
 			},
 			&v1beta1.KubeletConfiguration{
 				EnableServer:       ptr.To(false),
@@ -373,6 +375,7 @@ func TestSetDefaultsKubeletConfiguration(t *testing.T) {
 				PodLogsDir:                    DefaultPodLogsDir,
 				SingleProcessOOMKill:          ptr.To(false),
 				CrashLoopBackOff:              v1beta1.CrashLoopBackOffConfig{},
+				PodHousekeepingPeriod:         &metav1.Duration{Duration: 2 * time.Second},
 			},
 		},
 		{
@@ -533,6 +536,7 @@ func TestSetDefaultsKubeletConfiguration(t *testing.T) {
 				CrashLoopBackOff: v1beta1.CrashLoopBackOffConfig{
 					MaxContainerRestartPeriod: &metav1.Duration{Duration: 55 * time.Second},
 				},
+				PodHousekeepingPeriod: &metav1.Duration{Duration: 2 * time.Second},
 			},
 			&v1beta1.KubeletConfiguration{
 				FeatureGates:       map[string]bool{"KubeletCrashLoopBackOffMax": true},
@@ -690,6 +694,7 @@ func TestSetDefaultsKubeletConfiguration(t *testing.T) {
 				CrashLoopBackOff: v1beta1.CrashLoopBackOffConfig{
 					MaxContainerRestartPeriod: &metav1.Duration{Duration: 55 * time.Second},
 				},
+				PodHousekeepingPeriod: &metav1.Duration{Duration: 2 * time.Second},
 			},
 		},
 		{
@@ -786,6 +791,7 @@ func TestSetDefaultsKubeletConfiguration(t *testing.T) {
 				PodLogsDir:                    DefaultPodLogsDir,
 				SingleProcessOOMKill:          nil,
 				CrashLoopBackOff:              v1beta1.CrashLoopBackOffConfig{},
+				PodHousekeepingPeriod:         &metav1.Duration{Duration: 2 * time.Second},
 			},
 		},
 		{
@@ -882,6 +888,7 @@ func TestSetDefaultsKubeletConfiguration(t *testing.T) {
 				PodLogsDir:                    DefaultPodLogsDir,
 				SingleProcessOOMKill:          nil,
 				CrashLoopBackOff:              v1beta1.CrashLoopBackOffConfig{},
+				PodHousekeepingPeriod:         &metav1.Duration{Duration: 2 * time.Second},
 			},
 		},
 		{
@@ -977,6 +984,7 @@ func TestSetDefaultsKubeletConfiguration(t *testing.T) {
 				LocalStorageCapacityIsolation: ptr.To(true),
 				PodLogsDir:                    DefaultPodLogsDir,
 				CrashLoopBackOff:              v1beta1.CrashLoopBackOffConfig{},
+				PodHousekeepingPeriod:         &metav1.Duration{Duration: 2 * time.Second},
 			},
 		},
 		{
@@ -1076,6 +1084,7 @@ func TestSetDefaultsKubeletConfiguration(t *testing.T) {
 				CrashLoopBackOff: v1beta1.CrashLoopBackOffConfig{
 					MaxContainerRestartPeriod: &metav1.Duration{Duration: MaxContainerBackOff},
 				},
+				PodHousekeepingPeriod: &metav1.Duration{Duration: 2 * time.Second},
 			},
 		},
 	}

--- a/pkg/kubelet/apis/config/v1beta1/zz_generated.conversion.go
+++ b/pkg/kubelet/apis/config/v1beta1/zz_generated.conversion.go
@@ -595,6 +595,9 @@ func autoConvert_v1beta1_KubeletConfiguration_To_config_KubeletConfiguration(in 
 		return err
 	}
 	out.UserNamespaces = (*config.UserNamespaces)(unsafe.Pointer(in.UserNamespaces))
+	if err := v1.Convert_Pointer_v1_Duration_To_v1_Duration(&in.PodHousekeepingPeriod, &out.PodHousekeepingPeriod, s); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -801,6 +804,9 @@ func autoConvert_config_KubeletConfiguration_To_v1beta1_KubeletConfiguration(in 
 		return err
 	}
 	out.UserNamespaces = (*configv1beta1.UserNamespaces)(unsafe.Pointer(in.UserNamespaces))
+	if err := v1.Convert_v1_Duration_To_Pointer_v1_Duration(&in.PodHousekeepingPeriod, &out.PodHousekeepingPeriod, s); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/pkg/kubelet/apis/config/zz_generated.deepcopy.go
+++ b/pkg/kubelet/apis/config/zz_generated.deepcopy.go
@@ -485,6 +485,7 @@ func (in *KubeletConfiguration) DeepCopyInto(out *KubeletConfiguration) {
 		*out = new(UserNamespaces)
 		(*in).DeepCopyInto(*out)
 	}
+	out.PodHousekeepingPeriod = in.PodHousekeepingPeriod
 	return
 }
 

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -170,18 +170,10 @@ const (
 	// MaxImageBackOff is the max backoff period for image pulls, exported for the e2e test
 	MaxImageBackOff = 300 * time.Second
 
-	// Period for performing global cleanup tasks.
-	housekeepingPeriod = time.Second * 2
-
 	// Duration at which housekeeping failed to satisfy the invariant that
 	// housekeeping should be fast to avoid blocking pod config (while
 	// housekeeping is running no new pods are started or deleted).
 	housekeepingWarningDuration = time.Second * 1
-
-	// Period after which the runtime cache expires - set to slightly longer than
-	// the expected length between housekeeping periods, which explicitly refreshes
-	// the cache.
-	runtimeCacheRefreshPeriod = housekeepingPeriod + housekeepingWarningDuration
 
 	// Period for performing eviction monitoring.
 	// ensure this is kept in sync with internal cadvisor housekeeping.
@@ -641,6 +633,7 @@ func NewMainKubelet(ctx context.Context,
 		nodeStartupLatencyTracker:    kubeDeps.NodeStartupLatencyTracker,
 		healthChecker:                kubeDeps.HealthChecker,
 		flagz:                        kubeDeps.Flagz,
+		podHousekeepingPeriod:        kubeCfg.PodHousekeepingPeriod.Duration,
 	}
 
 	var secretManager secret.Manager
@@ -808,6 +801,10 @@ func NewMainKubelet(ctx context.Context,
 	klet.runner = runtime
 	klet.allocationManager.SetContainerRuntime(runtime)
 
+	// Period after which the runtime cache expires - set to slightly longer than
+	// the expected length between housekeeping periods, which explicitly refreshes
+	// the cache.
+	runtimeCacheRefreshPeriod := kubeCfg.PodHousekeepingPeriod.Duration + housekeepingWarningDuration
 	runtimeCache, err := kubecontainer.NewRuntimeCache(klet.containerRuntime, runtimeCacheRefreshPeriod)
 	if err != nil {
 		return nil, err
@@ -1476,6 +1473,9 @@ type Kubelet struct {
 
 	// flagz is the Reader interface to get flags for flagz page.
 	flagz flagz.Reader
+
+	// podHousekeepingPeriod is the period for performing global pod cleanup tasks
+	podHousekeepingPeriod time.Duration
 }
 
 // ListPodStats is delegated to StatsProvider, which implements stats.Provider interface
@@ -2431,7 +2431,7 @@ func (kl *Kubelet) syncLoop(ctx context.Context, updates <-chan kubetypes.PodUpd
 	// sync interval is defaulted to 10s.
 	syncTicker := time.NewTicker(time.Second)
 	defer syncTicker.Stop()
-	housekeepingTicker := time.NewTicker(housekeepingPeriod)
+	housekeepingTicker := time.NewTicker(kl.podHousekeepingPeriod)
 	defer housekeepingTicker.Stop()
 	plegCh := kl.pleg.Watch()
 	const (

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -484,6 +484,7 @@ func TestSyncLoopAbort(t *testing.T) {
 	// The syncLoop waits on time.After(resyncInterval), set it really big so that we don't race for
 	// the channel close
 	kubelet.resyncInterval = time.Second * 30
+	kubelet.podHousekeepingPeriod = time.Second * 2
 
 	ch := make(chan kubetypes.PodUpdate)
 	close(ch)

--- a/staging/src/k8s.io/kubelet/config/v1beta1/types.go
+++ b/staging/src/k8s.io/kubelet/config/v1beta1/types.go
@@ -926,6 +926,15 @@ type KubeletConfiguration struct {
 	// +featureGate=UserNamespacesSupport
 	// +optional
 	UserNamespaces *UserNamespaces `json:"userNamespaces,omitempty"`
+
+	// PodHousekeepingPeriod is the interval to specify the frequency for
+	// performing global pod cleanup tasks. Specifying a high value for this
+	// will result in low frequency for lower performance overhead but may
+	// result in high latency to remove orphaned resources and remove
+	// unwanted pods.
+	// Default: 2s
+	// +optional
+	PodHousekeepingPeriod *metav1.Duration `json:"podHousekeepingPeriod,omitempty"`
 }
 
 type KubeletAuthorizationMode string

--- a/staging/src/k8s.io/kubelet/config/v1beta1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/kubelet/config/v1beta1/zz_generated.deepcopy.go
@@ -532,6 +532,11 @@ func (in *KubeletConfiguration) DeepCopyInto(out *KubeletConfiguration) {
 		*out = new(UserNamespaces)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.PodHousekeepingPeriod != nil {
+		in, out := &in.PodHousekeepingPeriod, &out.PodHousekeepingPeriod
+		*out = new(v1.Duration)
+		**out = **in
+	}
 	return
 }
 


### PR DESCRIPTION

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Add a configurable option in kubelet configuration to allow changing kubelet's internal housekeeping period. Quoted from #89936 


> Kubelet has a "housekeeping"/cleanup routine that it performs every 2s to remove orphaned resources and remove unwanted pods. This is primarily a performance improvement for lowering CPU usage on low-churn nodes or environments where this trade-off can happen, such as a local development Kubernetes (minikube/kind)


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #89936

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added `podHousekeepingPeriod` in kubelet configuration to adjust the period for performing global pod cleanup tasks.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
