### PR TITLE
Deflake kubernetes-node-swap-fedora-serial jobs

### DIFF
--- a/test/e2e_node/pids_test.go
+++ b/test/e2e_node/pids_test.go
@@ -90,7 +90,7 @@ func makePodToVerifyPids(baseName string, pidsLimit resource.Quantity) *v1.Pod {
 func runPodPidsLimitTests(f *framework.Framework) {
 	ginkgo.It("should set pids.max for Pod", func(ctx context.Context) {
 		ginkgo.By("by creating a G pod")
-		pod := e2epod.NewPodClient(f).Create(ctx, &v1.Pod{
+		pod := e2epod.NewPodClient(f).CreateSync(ctx, &v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "pod" + string(uuid.NewUUID()),
 				Namespace: f.Namespace.Name,


### PR DESCRIPTION
#### What type of PR is this?

/kind flake

#### What this PR does / why we need it:

This PR is trying to deflake a flaky test. See #126007. 

PodPidsLimit e2e test became flaky after commit f6836df5207b1702c37e9dd6e6be295914ecd4fc, [#125981](https://github.com/kubernetes/kubernetes/pull/125981). See [testgrid](https://testgrid.k8s.io/sig-node-kubelet#kubelet-gce-e2e-swap-fedora-serial). The commit itself is harmless, it just cleans up pods at the end of the test. The test is flaky because it is unable to cleanup a pod within 2 mins. Based on [logs from a failed job](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-kubernetes-node-swap-fedora-serial/1811606748155351040), I noticed that the pod is not READY when it is being deleted. In this change, we just wait for pod to be READY before proceeding


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
 #126007

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
