### PR TITLE
fix(kubectl): Unify exit code of kubectl config delete

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/delete_user.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/delete_user.go
@@ -85,7 +85,8 @@ func (o *DeleteUserOptions) Complete(cmd *cobra.Command, args []string) error {
 	o.config = config
 
 	if len(args) != 1 {
-		return cmdutil.UsageErrorf(cmd, "user to delete is required")
+		cmd.Help()
+		return nil
 	}
 	o.user = args[0]
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/delete_user_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/delete_user_test.go
@@ -34,11 +34,6 @@ func TestDeleteUserComplete(t *testing.T) {
 		err  string
 	}{
 		{
-			name: "no args",
-			args: []string{},
-			err:  "user to delete is required",
-		},
-		{
 			name: "user provided",
 			args: []string{"minikube"},
 			err:  "",
@@ -75,6 +70,54 @@ func TestDeleteUserComplete(t *testing.T) {
 
 			if options.configFile != pathOptions.GlobalFile {
 				t.Fatalf("expected configFile to be %v, got %v", pathOptions.GlobalFile, options.configFile)
+			}
+		})
+	}
+}
+
+func TestDeleteUserCompleteWithoutArgs(t *testing.T) {
+	var tests = []struct {
+		name string
+		args []string
+		err  string
+	}{
+		{
+			name: "no args",
+			args: []string{},
+			err:  "",
+		},
+	}
+
+	for i := range tests {
+		test := tests[i]
+		t.Run(test.name, func(t *testing.T) {
+			tf := cmdtesting.NewTestFactory()
+			defer tf.Cleanup()
+
+			ioStreams, _, out, _ := genericiooptions.NewTestIOStreams()
+			pathOptions, err := tf.PathOptionsWithConfig(clientcmdapi.Config{})
+			if err != nil {
+				t.Fatalf("unexpected error executing command: %v", err)
+			}
+
+			cmd := NewCmdConfigDeleteUser(ioStreams, pathOptions)
+			cmd.SetOut(out)
+			options := NewDeleteUserOptions(ioStreams, pathOptions)
+
+			if err := options.Complete(cmd, test.args); err != nil {
+				if test.err == "" {
+					t.Fatalf("unexpected error executing command: %v", err)
+				}
+
+				if !strings.Contains(err.Error(), test.err) {
+					t.Fatalf("expected error to contain %v, got %v", test.err, err.Error())
+				}
+
+				return
+			}
+
+			if options.configFile != "" {
+				t.Fatalf("expected configFile not to be set, got %v", options.configFile)
 			}
 		})
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes kubernetes/kubectl#1641

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Exit code of `kubectl config delete-user` changed from 1 to 0
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
