### PR TITLE
Job: Add the CompletionsReached reason to the SuccessCriteriaMet condition

### DIFF
--- a/pkg/controller/job/job_controller_test.go
+++ b/pkg/controller/job/job_controller_test.go
@@ -5132,8 +5132,10 @@ func TestSyncJobWithJobBackoffLimitPerIndex(t *testing.T) {
 				UncountedTerminatedPods: &batch.UncountedTerminatedPods{},
 				Conditions: []batch.JobCondition{
 					{
-						Type:   batch.JobSuccessCriteriaMet,
-						Status: v1.ConditionTrue,
+						Type:    batch.JobSuccessCriteriaMet,
+						Status:  v1.ConditionTrue,
+						Reason:  batch.JobReasonCompletionsReached,
+						Message: "Reached to completions",
 					},
 					{
 						Type:   batch.JobComplete,
@@ -7092,8 +7094,10 @@ func TestJobBackoffForOnFailure(t *testing.T) {
 			expectedFailed:    0,
 			expectedConditions: []batch.JobCondition{
 				{
-					Type:   batch.JobSuccessCriteriaMet,
-					Status: v1.ConditionTrue,
+					Type:    batch.JobSuccessCriteriaMet,
+					Status:  v1.ConditionTrue,
+					Reason:  batch.JobReasonCompletionsReached,
+					Message: "Reached to completions",
 				},
 				{
 					Type:   batch.JobComplete,
@@ -7115,8 +7119,10 @@ func TestJobBackoffForOnFailure(t *testing.T) {
 			expectedFailed:    0,
 			expectedConditions: []batch.JobCondition{
 				{
-					Type:   batch.JobSuccessCriteriaMet,
-					Status: v1.ConditionTrue,
+					Type:    batch.JobSuccessCriteriaMet,
+					Status:  v1.ConditionTrue,
+					Reason:  batch.JobReasonCompletionsReached,
+					Message: "Reached to completions",
 				},
 				{
 					Type:   batch.JobComplete,

--- a/staging/src/k8s.io/api/batch/v1/types.go
+++ b/staging/src/k8s.io/api/batch/v1/types.go
@@ -651,6 +651,12 @@ const (
 	// https://kep.k8s.io/3998
 	// This is currently an alpha field.
 	JobReasonSuccessPolicy string = "SuccessPolicy"
+	// JobReasonCompletionsReached reason indicates a SuccessCriteriaMet condition is added due to
+	// a number of succeeded Job pods met completions.
+	// - https://kep.k8s.io/3998
+	// - https://kep.k8s.io/4368
+	// This is currently a beta field.
+	JobReasonCompletionsReached string = "CompletionsReached"
 )
 
 // JobCondition describes current state of a job.

--- a/test/e2e/apps/job.go
+++ b/test/e2e/apps/job.go
@@ -703,7 +703,7 @@ done`}
 		framework.ExpectNoError(err, "failed to create job in namespace: %s", f.Namespace.Name)
 
 		ginkgo.By("Awaiting for the job to have the interim success condition")
-		err = e2ejob.WaitForJobCondition(ctx, f.ClientSet, f.Namespace.Name, job.Name, batchv1.JobSuccessCriteriaMet, "")
+		err = e2ejob.WaitForJobCondition(ctx, f.ClientSet, f.Namespace.Name, job.Name, batchv1.JobSuccessCriteriaMet, batchv1.JobReasonCompletionsReached)
 		framework.ExpectNoError(err, "failed to ensure job has the interim success condition: %s", f.Namespace.Name)
 
 		ginkgo.By("Ensuring job reaches completions")

--- a/test/integration/job/job_test.go
+++ b/test/integration/job/job_test.go
@@ -1335,6 +1335,7 @@ func TestDelayTerminalPhaseCondition(t *testing.T) {
 					{
 						Type:   batchv1.JobSuccessCriteriaMet,
 						Status: v1.ConditionTrue,
+						Reason: batchv1.JobReasonCompletionsReached,
 					},
 				},
 			},
@@ -1347,6 +1348,7 @@ func TestDelayTerminalPhaseCondition(t *testing.T) {
 					{
 						Type:   batchv1.JobSuccessCriteriaMet,
 						Status: v1.ConditionTrue,
+						Reason: batchv1.JobReasonCompletionsReached,
 					},
 					{
 						Type:   batchv1.JobComplete,
@@ -1374,6 +1376,7 @@ func TestDelayTerminalPhaseCondition(t *testing.T) {
 					{
 						Type:   batchv1.JobSuccessCriteriaMet,
 						Status: v1.ConditionTrue,
+						Reason: batchv1.JobReasonCompletionsReached,
 					},
 				},
 			},
@@ -1385,6 +1388,7 @@ func TestDelayTerminalPhaseCondition(t *testing.T) {
 					{
 						Type:   batchv1.JobSuccessCriteriaMet,
 						Status: v1.ConditionTrue,
+						Reason: batchv1.JobReasonCompletionsReached,
 					},
 					{
 						Type:   batchv1.JobComplete,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
As we discussed [here](https://github.com/kubernetes/kubernetes/pull/125510#discussion_r1675670932), I added the new `CompletionsReached` reason for the `SuccessCriteriaMet` condition when the Job got the `SuccessCriteriaMet` condition as an interim condition due to reached to completions.

By this new reason, users can identify the place where the `SuccessCriteriaMet` came from.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part-of: https://github.com/kubernetes/enhancements/issues/3998

#### REVIEW STEPS

This PR is part of the JobSuccessPolicy Beta Graduation PR. 
So, please take a look in the following steps:

1. This PR.
2. https://github.com/kubernetes/kubernetes/pull/126075
3. https://github.com/kubernetes/kubernetes/pull/126064
4. https://github.com/kubernetes/kubernetes/pull/126067

#### Special notes for your reviewer:

The current `Complete` condition reason is an empty ("") when the number of succeeded Job pods (`.status.succeeded`) reached the completions (`.spec.completions`).
So, this new reason has never been propagated to the `Complete` condition reason to avoid breaking the existing condition specification.

Additionally, this new reason is used by a new [`job_succeeded_total`](https://github.com/kubernetes/kubernetes/pull/126075), which is a part of the `JobSuccessPolicy` beta graduation criteria:

https://github.com/kubernetes/kubernetes/blob/f5dbc1ac156635dc7c1ab16024a1ae139993f639/pkg/controller/job/job_controller.go#L1463-L1471

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
When the number of succeeded Job Pods (".status.succeeded") reached the completions (".spec.completions"), 
the Job got the interim condition "SuccessCriteriaMet" with the "CompletionsReached" reason.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
https://github.com/kubernetes/enhancements/tree/master/keps/sig-apps/3998-job-success-completion-policy
```
