### PR TITLE
fix: enable testifylint on `staging/src/k8s.io/cloud-provider`

### DIFF
--- a/staging/src/k8s.io/cloud-provider/controllers/route/route_controller_test.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/route/route_controller_test.go
@@ -35,6 +35,7 @@ import (
 	netutils "k8s.io/utils/net"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func alwaysReady() bool { return true }
@@ -439,7 +440,7 @@ func TestReconcile(t *testing.T) {
 			informerFactory := informers.NewSharedInformerFactory(testCase.clientset, 0)
 			rc := New(routes, testCase.clientset, informerFactory.Core().V1().Nodes(), cluster, cidrs)
 			rc.nodeListerSynced = alwaysReady
-			assert.NoError(t, rc.reconcile(ctx, testCase.nodes, testCase.initialRoutes), "failed to reconcile")
+			require.NoError(t, rc.reconcile(ctx, testCase.nodes, testCase.initialRoutes), "failed to reconcile")
 			for _, action := range testCase.clientset.Actions() {
 				if action.GetVerb() == "update" && action.GetResource().Resource == "nodes" {
 					node := action.(core.UpdateAction).GetObject().(*v1.Node)

--- a/staging/src/k8s.io/cloud-provider/options/options_test.go
+++ b/staging/src/k8s.io/cloud-provider/options/options_test.go
@@ -40,6 +40,7 @@ import (
 	netutils "k8s.io/utils/net"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDefaultFlags(t *testing.T) {
@@ -370,14 +371,14 @@ func TestCreateConfig(t *testing.T) {
 		"--webhook-secure-port=10300",
 	}
 	err = fs.Parse(args)
-	assert.Nil(t, err, "unexpected error: %s", err)
+	require.NoError(t, err, "unexpected error: %s", err)
 
 	fs.VisitAll(func(f *pflag.Flag) {
 		fmt.Printf("%s: %s\n", f.Name, f.Value)
 	})
 
 	c, err := s.Config([]string{"foo", "bar"}, []string{}, nil, []string{"foo", "bar", "baz"}, []string{})
-	assert.Nil(t, err, "unexpected error: %s", err)
+	require.NoError(t, err, "unexpected error: %s", err)
 
 	expected := &appconfig.Config{
 		ComponentConfig: cpconfig.CloudControllerManagerConfiguration{


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This fixes rules from testifylint on `staging/src/k8s.io/cloud-provider` package