### PR TITLE
fix: enable testifylint on `staging/src/k8s.io/client-go`

### DIFF
--- a/staging/src/k8s.io/client-go/discovery/cached/disk/cached_discovery_test.go
+++ b/staging/src/k8s.io/client-go/discovery/cached/disk/cached_discovery_test.go
@@ -57,35 +57,35 @@ func TestCachedDiscoveryClient_Fresh(t *testing.T) {
 
 	cdc.ServerGroups()
 	assert.True(cdc.Fresh(), "should be fresh after groups call without cache")
-	assert.Equal(c.groupCalls, 1)
+	assert.Equal(1, c.groupCalls)
 
 	cdc.ServerGroups()
 	assert.True(cdc.Fresh(), "should be fresh after another groups call")
-	assert.Equal(c.groupCalls, 1)
+	assert.Equal(1, c.groupCalls)
 
 	cdc.ServerGroupsAndResources()
 	assert.True(cdc.Fresh(), "should be fresh after resources call")
-	assert.Equal(c.resourceCalls, 1)
+	assert.Equal(1, c.resourceCalls)
 
 	cdc.ServerGroupsAndResources()
 	assert.True(cdc.Fresh(), "should be fresh after another resources call")
-	assert.Equal(c.resourceCalls, 1)
+	assert.Equal(1, c.resourceCalls)
 
 	cdc = newCachedDiscoveryClient(&c, d, 60*time.Second)
 	cdc.ServerGroups()
 	assert.False(cdc.Fresh(), "should NOT be fresh after recreation with existing groups cache")
-	assert.Equal(c.groupCalls, 1)
+	assert.Equal(1, c.groupCalls)
 
 	cdc.ServerGroupsAndResources()
 	assert.False(cdc.Fresh(), "should NOT be fresh after recreation with existing resources cache")
-	assert.Equal(c.resourceCalls, 1)
+	assert.Equal(1, c.resourceCalls)
 
 	cdc.Invalidate()
 	assert.True(cdc.Fresh(), "should be fresh after cache invalidation")
 
 	cdc.ServerGroupsAndResources()
 	assert.True(cdc.Fresh(), "should ignore existing resources cache after invalidation")
-	assert.Equal(c.resourceCalls, 2)
+	assert.Equal(2, c.resourceCalls)
 }
 
 func TestNewCachedDiscoveryClient_TTL(t *testing.T) {
@@ -98,12 +98,12 @@ func TestNewCachedDiscoveryClient_TTL(t *testing.T) {
 	c := fakeDiscoveryClient{}
 	cdc := newCachedDiscoveryClient(&c, d, 1*time.Nanosecond)
 	cdc.ServerGroups()
-	assert.Equal(c.groupCalls, 1)
+	assert.Equal(1, c.groupCalls)
 
 	time.Sleep(1 * time.Second)
 
 	cdc.ServerGroups()
-	assert.Equal(c.groupCalls, 2)
+	assert.Equal(2, c.groupCalls)
 }
 
 func TestNewCachedDiscoveryClient_PathPerm(t *testing.T) {
@@ -193,14 +193,14 @@ func TestOpenAPIDiskCache(t *testing.T) {
 				i++
 
 				_, err = v.Schema(contentType)
-				assert.NoError(t, err)
+				require.NoError(t, err)
 
 				path := "/openapi/v3/" + strings.TrimPrefix(k, "/")
 				assert.Equal(t, 1, fakeServer.RequestCounters[path])
 
 				// Ensure schema call is served from memory
 				_, err = v.Schema(contentType)
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.Equal(t, 1, fakeServer.RequestCounters[path])
 
 				client.Invalidate()
@@ -208,13 +208,11 @@ func TestOpenAPIDiskCache(t *testing.T) {
 				// Refetch the schema from a new openapi client to try to force a new
 				// http request
 				newPaths, err := client.OpenAPIV3().Paths()
-				if !assert.NoError(t, err) {
-					continue
-				}
+				require.NoError(t, err)
 
 				// Ensure schema call is still served from disk
 				_, err = newPaths[k].Schema(contentType)
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.Equal(t, 1, fakeServer.RequestCounters[path])
 			}
 		})
@@ -368,7 +366,7 @@ func TestCachedDiscoveryClientUnaggregatedServerGroups(t *testing.T) {
 		require.NoError(t, err)
 		// Discovery groups cached in servergroups.json file.
 		numFound, err := numFilesFound(discoCache, "servergroups.json")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, 1, numFound,
 			"%s: expected 1 discovery cache file servergroups.json found, got %d", test.name, numFound)
 		// Test expected groups returned by server groups.
@@ -659,7 +657,7 @@ func TestCachedDiscoveryClientAggregatedServerGroups(t *testing.T) {
 		require.NoError(t, err)
 		// Discovery groups cached in servergroups.json file.
 		numFound, err := numFilesFound(discoCache, "servergroups.json")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, 1, numFound,
 			"%s: expected 1 discovery cache file servergroups.json found, got %d", test.name, numFound)
 		// Test expected groups returned by server groups.

--- a/staging/src/k8s.io/client-go/discovery/cached/memory/memcache_test.go
+++ b/staging/src/k8s.io/client-go/discovery/cached/memory/memcache_test.go
@@ -431,38 +431,28 @@ func TestOpenAPIMemCache(t *testing.T) {
 		t.Run(contentType, func(t *testing.T) {
 			for k, v := range paths {
 				original, err := v.Schema(contentType)
-				if !assert.NoError(t, err) {
-					continue
-				}
+				require.NoError(t, err)
 
 				pathsAgain, err := openapiClient.Paths()
-				if !assert.NoError(t, err) {
-					continue
-				}
+				require.NoError(t, err)
 
 				schemaAgain, err := pathsAgain[k].Schema(contentType)
-				if !assert.NoError(t, err) {
-					continue
-				}
+				require.NoError(t, err)
 
-				assert.True(t, reflect.ValueOf(paths).Pointer() == reflect.ValueOf(pathsAgain).Pointer())
-				assert.True(t, reflect.ValueOf(original).Pointer() == reflect.ValueOf(schemaAgain).Pointer())
+				assert.Equal(t, reflect.ValueOf(paths).Pointer(), reflect.ValueOf(pathsAgain).Pointer())
+				assert.Equal(t, reflect.ValueOf(original).Pointer(), reflect.ValueOf(schemaAgain).Pointer())
 
 				// Invalidate and try again. This time pointers should not be equal
 				client.Invalidate()
 
 				pathsAgain, err = client.OpenAPIV3().Paths()
-				if !assert.NoError(t, err) {
-					continue
-				}
+				require.NoError(t, err)
 
 				schemaAgain, err = pathsAgain[k].Schema(contentType)
-				if !assert.NoError(t, err) {
-					continue
-				}
+				require.NoError(t, err)
 
-				assert.True(t, reflect.ValueOf(paths).Pointer() != reflect.ValueOf(pathsAgain).Pointer())
-				assert.True(t, reflect.ValueOf(original).Pointer() != reflect.ValueOf(schemaAgain).Pointer())
+				assert.NotEqual(t, reflect.ValueOf(paths).Pointer(), reflect.ValueOf(pathsAgain).Pointer())
+				assert.NotEqual(t, reflect.ValueOf(original).Pointer(), reflect.ValueOf(schemaAgain).Pointer())
 				assert.Equal(t, original, schemaAgain)
 			}
 		})

--- a/staging/src/k8s.io/client-go/discovery/discovery_client_test.go
+++ b/staging/src/k8s.io/client-go/discovery/discovery_client_test.go
@@ -2425,9 +2425,9 @@ func TestAggregatedServerGroupsAndResources(t *testing.T) {
 				"%s: Expected GVKs (%s), got (%s)", test.name, expectedGroupNames.List(), actualGroupNames.List())
 			// If the core V1 group is returned from /api, it should be the first group.
 			if expectedGroupNames.Has("") {
-				assert.True(t, len(apiGroups) > 0)
+				assert.NotEmpty(t, apiGroups)
 				actualFirstGroup := apiGroups[0]
-				assert.True(t, len(actualFirstGroup.Versions) > 0)
+				assert.NotEmpty(t, actualFirstGroup.Versions)
 				actualFirstGroupVersion := actualFirstGroup.Versions[0].GroupVersion
 				assert.Equal(t, "v1", actualFirstGroupVersion)
 			}

--- a/staging/src/k8s.io/client-go/features/envvar_test.go
+++ b/staging/src/k8s.io/client-go/features/envvar_test.go
@@ -148,7 +148,7 @@ func TestEnvVarFeatureGates(t *testing.T) {
 			}
 			for expectedFeature, expectedValue := range scenario.expectedFeaturesState {
 				actualValue := target.Enabled(expectedFeature)
-				require.Equal(t, actualValue, expectedValue, "expected feature=%v, to be=%v, not=%v", expectedFeature, expectedValue, actualValue)
+				require.Equal(t, expectedValue, actualValue, "expected feature=%v, to be=%v, not=%v", expectedFeature, expectedValue, actualValue)
 			}
 
 			enabledViaEnvVarInternalMap := target.enabledViaEnvVar.Load().(map[Feature]bool)

--- a/staging/src/k8s.io/client-go/kubernetes/fake/clientset_generated_test.go
+++ b/staging/src/k8s.io/client-go/kubernetes/fake/clientset_generated_test.go
@@ -18,8 +18,10 @@ package fake
 
 import (
 	"context"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	v1 "k8s.io/api/core/v1"
 	policy "k8s.io/api/policy/v1"
@@ -88,9 +90,8 @@ func TestManagedFieldClientset(t *testing.T) {
 	_, err = client.CoreV1().ConfigMaps("default").Apply(context.Background(),
 		v1ac.ConfigMap(name, namespace).WithData(map[string]string{"k1": "xyz"}),
 		meta_v1.ApplyOptions{FieldManager: "test-manager-2"})
-	if assert.Error(t, err) {
-		assert.Equal(t, "Apply failed with 1 conflict: conflict with \"test-manager-1\": .data.k1", err.Error())
-	}
+	require.Error(t, err)
+	require.EqualError(t, err, "Apply failed with 1 conflict: conflict with \"test-manager-1\": .data.k1")
 
 	// Apply with test-manager-2
 	// Expect data to be shared with initial create and test-manager-1

--- a/staging/src/k8s.io/client-go/restmapper/discovery_test.go
+++ b/staging/src/k8s.io/client-go/restmapper/discovery_test.go
@@ -257,8 +257,8 @@ func TestDeferredDiscoveryRESTMapper_CacheMiss(t *testing.T) {
 	})
 	assert.NoError(err)
 	assert.True(cdc.fresh, "should be fresh after a cache-miss")
-	assert.Equal(cdc.invalidateCalls, 1, "should have called Invalidate() once")
-	assert.Equal(gvk.Kind, "Foo")
+	assert.Equal(1, cdc.invalidateCalls, "should have called Invalidate() once")
+	assert.Equal("Foo", gvk.Kind)
 
 	gvk, err = m.KindFor(schema.GroupVersionResource{
 		Group:    "a",
@@ -266,7 +266,7 @@ func TestDeferredDiscoveryRESTMapper_CacheMiss(t *testing.T) {
 		Resource: "foo",
 	})
 	assert.NoError(err)
-	assert.Equal(cdc.invalidateCalls, 1, "should NOT have called Invalidate() again")
+	assert.Equal(1, cdc.invalidateCalls, "should NOT have called Invalidate() again")
 
 	gvk, err = m.KindFor(schema.GroupVersionResource{
 		Group:    "a",
@@ -274,7 +274,7 @@ func TestDeferredDiscoveryRESTMapper_CacheMiss(t *testing.T) {
 		Resource: "bar",
 	})
 	assert.Error(err)
-	assert.Equal(cdc.invalidateCalls, 1, "should NOT have called Invalidate() again after another cache-miss, but with fresh==true")
+	assert.Equal(1, cdc.invalidateCalls, "should NOT have called Invalidate() again after another cache-miss, but with fresh==true")
 
 	cdc.fresh = false
 	gvk, err = m.KindFor(schema.GroupVersionResource{
@@ -283,7 +283,7 @@ func TestDeferredDiscoveryRESTMapper_CacheMiss(t *testing.T) {
 		Resource: "bar",
 	})
 	assert.Error(err)
-	assert.Equal(cdc.invalidateCalls, 2, "should HAVE called Invalidate() again after another cache-miss, but with fresh==false")
+	assert.Equal(2, cdc.invalidateCalls, "should HAVE called Invalidate() again after another cache-miss, but with fresh==false")
 }
 
 func TestGetAPIGroupResources(t *testing.T) {

--- a/staging/src/k8s.io/client-go/scale/client_test.go
+++ b/staging/src/k8s.io/client-go/scale/client_test.go
@@ -35,6 +35,7 @@ import (
 	fakerest "k8s.io/client-go/rest/fake"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	appsv1beta1 "k8s.io/api/apps/v1beta1"
 	appsv1beta2 "k8s.io/api/apps/v1beta2"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
@@ -274,9 +275,7 @@ func TestGetScale(t *testing.T) {
 
 	for _, groupResource := range groupResources {
 		scale, err := scaleClient.Scales("default").Get(context.TODO(), groupResource, "foo", metav1.GetOptions{})
-		if !assert.NoError(t, err, "should have been able to fetch a scale for %s", groupResource.String()) {
-			continue
-		}
+		require.NoError(t, err, "should have been able to fetch a scale for %s", groupResource.String())
 		assert.NotNil(t, scale, "should have returned a non-nil scale for %s", groupResource.String())
 
 		assert.Equal(t, expectedScale, scale, "should have returned the expected scale for %s", groupResource.String())
@@ -302,9 +301,7 @@ func TestUpdateScale(t *testing.T) {
 
 	for _, groupResource := range groupResources {
 		scale, err := scaleClient.Scales("default").Update(context.TODO(), groupResource, expectedScale, metav1.UpdateOptions{})
-		if !assert.NoError(t, err, "should have been able to fetch a scale for %s", groupResource.String()) {
-			continue
-		}
+		require.NoError(t, err, "should have been able to fetch a scale for %s", groupResource.String())
 		assert.NotNil(t, scale, "should have returned a non-nil scale for %s", groupResource.String())
 
 		assert.Equal(t, expectedScale, scale, "should have returned the expected scale for %s", groupResource.String())
@@ -345,9 +342,7 @@ func TestPatchScale(t *testing.T) {
 	patch := []byte(`{"spec":{"replicas":5}}`)
 	for _, gvr := range gvrs {
 		scale, err := scaleClient.Scales("default").Patch(context.TODO(), gvr, "foo", types.MergePatchType, patch, metav1.PatchOptions{})
-		if !assert.NoError(t, err, "should have been able to fetch a scale for %s", gvr.String()) {
-			continue
-		}
+		require.NoError(t, err, "should have been able to fetch a scale for %s", gvr.String())
 		assert.NotNil(t, scale, "should have returned a non-nil scale for %s", gvr.String())
 		assert.Equal(t, expectedScale, scale, "should have returned the expected scale for %s", gvr.String())
 	}
@@ -355,9 +350,7 @@ func TestPatchScale(t *testing.T) {
 	patch = []byte(`[{"op":"replace","path":"/spec/replicas","value":5}]`)
 	for _, gvr := range gvrs {
 		scale, err := scaleClient.Scales("default").Patch(context.TODO(), gvr, "foo", types.JSONPatchType, patch, metav1.PatchOptions{})
-		if !assert.NoError(t, err, "should have been able to fetch a scale for %s", gvr.String()) {
-			continue
-		}
+		require.NoError(t, err, "should have been able to fetch a scale for %s", gvr.String())
 		assert.NotNil(t, scale, "should have returned a non-nil scale for %s", gvr.String())
 		assert.Equal(t, expectedScale, scale, "should have returned the expected scale for %s", gvr.String())
 	}

--- a/staging/src/k8s.io/client-go/testing/fake_test.go
+++ b/staging/src/k8s.io/client-go/testing/fake_test.go
@@ -19,7 +19,7 @@ package testing
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -60,7 +60,7 @@ func TestOriginalObjectCaptured(t *testing.T) {
 
 	// execute the reaction chain
 	ret, err := f.Invokes(action, nil)
-	assert.NoError(t, err, "running Invokes failed")
+	require.NoError(t, err, "running Invokes failed")
 
 	// obtain a metadata accessor for the returned resource
 	accessor, err := meta.Accessor(ret)
@@ -137,7 +137,7 @@ func TestReactorChangesPersisted(t *testing.T) {
 
 	// execute the reaction chain
 	ret, err := f.Invokes(action, nil)
-	assert.NoError(t, err, "running Invokes failed")
+	require.NoError(t, err, "running Invokes failed")
 
 	// obtain a metadata accessor for the returned resource
 	accessor, err := meta.Accessor(ret)

--- a/staging/src/k8s.io/client-go/tools/cache/reflector_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/reflector_test.go
@@ -571,7 +571,7 @@ func TestReflectorListAndWatchWithErrors(t *testing.T) {
 			t.Errorf("unexpected ListAndWatch error: %v", err)
 		}
 		if item.listErr == nil && item.watchErr == nil {
-			assert.NoError(t, err)
+			require.NoError(t, err)
 		}
 	}
 }

--- a/staging/src/k8s.io/client-go/tools/cache/thread_safe_store_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/thread_safe_store_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestThreadSafeStoreDeleteRemovesEmptySetsFromIndex(t *testing.T) {
@@ -111,8 +111,6 @@ func TestThreadSafeStoreIndexingFunctionsWithMultipleValues(t *testing.T) {
 	store.Add("key1", "foo")
 	store.Add("key2", "bar")
 
-	assert := assert.New(t)
-
 	compare := func(key string, expected []string) error {
 		values := store.index.indices[testIndexer][key].List()
 		if cmp.Equal(values, expected) {
@@ -121,48 +119,48 @@ func TestThreadSafeStoreIndexingFunctionsWithMultipleValues(t *testing.T) {
 		return fmt.Errorf("unexpected index for key %s, diff=%s", key, cmp.Diff(values, expected))
 	}
 
-	assert.NoError(compare("foo", []string{"key1"}))
-	assert.NoError(compare("bar", []string{"key2"}))
+	require.NoError(t, compare("foo", []string{"key1"}))
+	require.NoError(t, compare("bar", []string{"key2"}))
 
 	store.Update("key2", "foo,bar")
 
-	assert.NoError(compare("foo", []string{"key1", "key2"}))
-	assert.NoError(compare("bar", []string{"key2"}))
+	require.NoError(t, compare("foo", []string{"key1", "key2"}))
+	require.NoError(t, compare("bar", []string{"key2"}))
 
 	store.Update("key1", "foo,bar")
 
-	assert.NoError(compare("foo", []string{"key1", "key2"}))
-	assert.NoError(compare("bar", []string{"key1", "key2"}))
+	require.NoError(t, compare("foo", []string{"key1", "key2"}))
+	require.NoError(t, compare("bar", []string{"key1", "key2"}))
 
 	store.Add("key3", "foo,bar,baz")
 
-	assert.NoError(compare("foo", []string{"key1", "key2", "key3"}))
-	assert.NoError(compare("bar", []string{"key1", "key2", "key3"}))
-	assert.NoError(compare("baz", []string{"key3"}))
+	require.NoError(t, compare("foo", []string{"key1", "key2", "key3"}))
+	require.NoError(t, compare("bar", []string{"key1", "key2", "key3"}))
+	require.NoError(t, compare("baz", []string{"key3"}))
 
 	store.Update("key1", "foo")
 
-	assert.NoError(compare("foo", []string{"key1", "key2", "key3"}))
-	assert.NoError(compare("bar", []string{"key2", "key3"}))
-	assert.NoError(compare("baz", []string{"key3"}))
+	require.NoError(t, compare("foo", []string{"key1", "key2", "key3"}))
+	require.NoError(t, compare("bar", []string{"key2", "key3"}))
+	require.NoError(t, compare("baz", []string{"key3"}))
 
 	store.Update("key2", "bar")
 
-	assert.NoError(compare("foo", []string{"key1", "key3"}))
-	assert.NoError(compare("bar", []string{"key2", "key3"}))
-	assert.NoError(compare("baz", []string{"key3"}))
+	require.NoError(t, compare("foo", []string{"key1", "key3"}))
+	require.NoError(t, compare("bar", []string{"key2", "key3"}))
+	require.NoError(t, compare("baz", []string{"key3"}))
 
 	store.Delete("key1")
 
-	assert.NoError(compare("foo", []string{"key3"}))
-	assert.NoError(compare("bar", []string{"key2", "key3"}))
-	assert.NoError(compare("baz", []string{"key3"}))
+	require.NoError(t, compare("foo", []string{"key3"}))
+	require.NoError(t, compare("bar", []string{"key2", "key3"}))
+	require.NoError(t, compare("baz", []string{"key3"}))
 
 	store.Delete("key3")
 
-	assert.NoError(compare("foo", []string{}))
-	assert.NoError(compare("bar", []string{"key2"}))
-	assert.NoError(compare("baz", []string{}))
+	require.NoError(t, compare("foo", []string{}))
+	require.NoError(t, compare("bar", []string{"key2"}))
+	require.NoError(t, compare("baz", []string{}))
 }
 
 func BenchmarkIndexer(b *testing.B) {

--- a/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection_test.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	coordinationv1 "k8s.io/api/coordination/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -930,14 +931,14 @@ func TestLeaderElectionConfigValidation(t *testing.T) {
 	}
 
 	_, err := NewLeaderElector(lec)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Invalid lock identity
 	resourceLockConfig.Identity = ""
 	lock.LockConfig = resourceLockConfig
 	lec.Lock = lock
 	_, err = NewLeaderElector(lec)
-	assert.Error(t, err, fmt.Errorf("Lock identity is empty"))
+	require.EqualError(t, err, "Lock identity is empty")
 }
 
 func assertEqualEvents(t *testing.T, expected []string, actual <-chan string) {

--- a/staging/src/k8s.io/client-go/tools/portforward/tunneling_connection_test.go
+++ b/staging/src/k8s.io/client-go/tools/portforward/tunneling_connection_test.go
@@ -53,7 +53,7 @@ func TestTunnelingConnection_ReadWriteClose(t *testing.T) {
 		conn, err := upgrader.Upgrade(w, req, nil)
 		require.NoError(t, err)
 		defer conn.Close() //nolint:errcheck
-		require.Equal(t, constants.WebsocketsSPDYTunnelingPortForwardV1, conn.Subprotocol())
+		assert.Equal(t, constants.WebsocketsSPDYTunnelingPortForwardV1, conn.Subprotocol())
 		tunnelingConn := NewTunnelingConnection("server", conn)
 		spdyConn, err := spdy.NewServerConnection(tunnelingConn, justQueueStream(streamChan))
 		require.NoError(t, err)
@@ -104,7 +104,7 @@ func TestTunnelingConnection_LocalRemoteAddress(t *testing.T) {
 		conn, err := upgrader.Upgrade(w, req, nil)
 		require.NoError(t, err)
 		defer conn.Close() //nolint:errcheck
-		require.Equal(t, constants.WebsocketsSPDYTunnelingPortForwardV1, conn.Subprotocol())
+		assert.Equal(t, constants.WebsocketsSPDYTunnelingPortForwardV1, conn.Subprotocol())
 		<-stopServerChan
 	}))
 	defer tunnelingServer.Close()
@@ -120,9 +120,9 @@ func TestTunnelingConnection_LocalRemoteAddress(t *testing.T) {
 	assert.Equal(t, "tcp", localAddr.Network(), "tunneling connection must be TCP")
 	assert.Equal(t, "tcp", remoteAddr.Network(), "tunneling connection must be TCP")
 	_, err = net.ResolveTCPAddr("tcp", localAddr.String())
-	assert.NoError(t, err, "tunneling connection local addr should parse")
+	require.NoError(t, err, "tunneling connection local addr should parse")
 	_, err = net.ResolveTCPAddr("tcp", remoteAddr.String())
-	assert.NoError(t, err, "tunneling connection remote addr should parse")
+	require.NoError(t, err, "tunneling connection remote addr should parse")
 }
 
 func TestTunnelingConnection_ReadWriteDeadlines(t *testing.T) {
@@ -136,7 +136,7 @@ func TestTunnelingConnection_ReadWriteDeadlines(t *testing.T) {
 		conn, err := upgrader.Upgrade(w, req, nil)
 		require.NoError(t, err)
 		defer conn.Close() //nolint:errcheck
-		require.Equal(t, constants.WebsocketsSPDYTunnelingPortForwardV1, conn.Subprotocol())
+		assert.Equal(t, constants.WebsocketsSPDYTunnelingPortForwardV1, conn.Subprotocol())
 		<-stopServerChan
 	}))
 	defer tunnelingServer.Close()
@@ -148,17 +148,17 @@ func TestTunnelingConnection_ReadWriteDeadlines(t *testing.T) {
 	defer tConn.Close() //nolint:errcheck
 	// Validate the read and write deadlines.
 	err = tConn.SetReadDeadline(time.Time{})
-	assert.NoError(t, err, "setting zero deadline should always succeed; turns off deadline")
+	require.NoError(t, err, "setting zero deadline should always succeed; turns off deadline")
 	err = tConn.SetWriteDeadline(time.Time{})
-	assert.NoError(t, err, "setting zero deadline should always succeed; turns off deadline")
+	require.NoError(t, err, "setting zero deadline should always succeed; turns off deadline")
 	err = tConn.SetDeadline(time.Time{})
-	assert.NoError(t, err, "setting zero deadline should always succeed; turns off deadline")
+	require.NoError(t, err, "setting zero deadline should always succeed; turns off deadline")
 	err = tConn.SetReadDeadline(time.Now().AddDate(10, 0, 0))
-	assert.NoError(t, err, "setting deadline 10 year from now succeeds")
+	require.NoError(t, err, "setting deadline 10 year from now succeeds")
 	err = tConn.SetWriteDeadline(time.Now().AddDate(10, 0, 0))
-	assert.NoError(t, err, "setting deadline 10 year from now succeeds")
+	require.NoError(t, err, "setting deadline 10 year from now succeeds")
 	err = tConn.SetDeadline(time.Now().AddDate(10, 0, 0))
-	assert.NoError(t, err, "setting deadline 10 year from now succeeds")
+	require.NoError(t, err, "setting deadline 10 year from now succeeds")
 }
 
 // dialForTunnelingConnection upgrades a request at the passed "url", creating

--- a/staging/src/k8s.io/client-go/transport/websocket/roundtripper_test.go
+++ b/staging/src/k8s.io/client-go/transport/websocket/roundtripper_test.go
@@ -22,7 +22,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"strings"
 	"testing"
 	"time"
 
@@ -70,7 +69,7 @@ func TestWebSocketRoundTripper_RoundTripperFails(t *testing.T) {
 		// Bad handshake means websocket server will not completely initialize.
 		_, err := webSocketServerStreams(req, w)
 		require.Error(t, err)
-		assert.True(t, strings.Contains(err.Error(), "websocket server finished before becoming ready"))
+		assert.ErrorContains(t, err, "websocket server finished before becoming ready")
 	}))
 	defer websocketServer.Close()
 
@@ -87,8 +86,8 @@ func TestWebSocketRoundTripper_RoundTripperFails(t *testing.T) {
 	_, err = rt.RoundTrip(req)
 	// Ensure a "bad handshake" error is returned, since requested protocol is not supported.
 	require.Error(t, err)
-	assert.True(t, strings.Contains(err.Error(), "websocket: bad handshake"))
-	assert.True(t, strings.Contains(err.Error(), "403 Forbidden"))
+	require.ErrorContains(t, err, "websocket: bad handshake")
+	require.ErrorContains(t, err, "403 Forbidden")
 	assert.True(t, httpstream.IsUpgradeFailure(err))
 }
 

--- a/staging/src/k8s.io/client-go/util/consistencydetector/data_consistency_detector_test.go
+++ b/staging/src/k8s.io/client-go/util/consistencydetector/data_consistency_detector_test.go
@@ -221,8 +221,8 @@ func TestDataConsistencyChecker(t *testing.T) {
 				CheckDataConsistency(ctx, "", scenario.lastSyncedResourceVersion, fakeLister.List, scenario.requestOptions, retrievedItemsFunc)
 			}
 
-			require.Equal(t, fakeLister.counter, scenario.expectedListRequests)
-			require.Equal(t, fakeLister.requestOptions, scenario.expectedRequestOptions)
+			require.Equal(t, scenario.expectedListRequests, fakeLister.counter)
+			require.Equal(t, scenario.expectedRequestOptions, fakeLister.requestOptions)
 		})
 	}
 }

--- a/staging/src/k8s.io/client-go/util/consistencydetector/list_data_consistency_detector_test.go
+++ b/staging/src/k8s.io/client-go/util/consistencydetector/list_data_consistency_detector_test.go
@@ -133,7 +133,7 @@ func TestCheckListFromCacheDataConsistencyIfRequestedInternalHappyPath(t *testin
 
 			require.Equal(t, 1, fakeLister.counter)
 			require.Len(t, fakeLister.requestOptions, 1)
-			require.Equal(t, fakeLister.requestOptions[0], scenario.expectedRequestOptions)
+			require.Equal(t, scenario.expectedRequestOptions, fakeLister.requestOptions[0])
 		})
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This fixes rules from testifylint on `staging/src/k8s.io/client-go` package