### PR TITLE
Adds extra error information from response to bad handshake error when possible

### DIFF
--- a/staging/src/k8s.io/client-go/transport/websocket/roundtripper.go
+++ b/staging/src/k8s.io/client-go/transport/websocket/roundtripper.go
@@ -111,6 +111,10 @@ func (rt *RoundTripper) RoundTrip(request *http.Request) (retResp *http.Response
 	wsConn, resp, err := dialer.DialContext(request.Context(), request.URL.String(), request.Header)
 	if err != nil {
 		if errors.Is(err, gwebsocket.ErrBadHandshake) {
+			// Enhance the error message with the response status if possible.
+			if resp != nil && len(resp.Status) > 0 {
+				err = fmt.Errorf("%w (%s)", err, resp.Status)
+			}
 			return nil, &httpstream.UpgradeFailureError{Cause: err}
 		}
 		return nil, err

--- a/staging/src/k8s.io/client-go/transport/websocket/roundtripper_test.go
+++ b/staging/src/k8s.io/client-go/transport/websocket/roundtripper_test.go
@@ -87,7 +87,8 @@ func TestWebSocketRoundTripper_RoundTripperFails(t *testing.T) {
 	_, err = rt.RoundTrip(req)
 	// Ensure a "bad handshake" error is returned, since requested protocol is not supported.
 	require.Error(t, err)
-	assert.True(t, strings.Contains(err.Error(), "bad handshake"))
+	assert.True(t, strings.Contains(err.Error(), "websocket: bad handshake"))
+	assert.True(t, strings.Contains(err.Error(), "403 Forbidden"))
 	assert.True(t, httpstream.IsUpgradeFailure(err))
 }
 


### PR DESCRIPTION
* Adds the http response status to the `websocket: bad handshake` error for better visibility and debugging.
* This extra error information will print out on the command line giving more information on the reason for fallback from WebSocket to SPDY.
* The user must increase the verbosity level above `-v=4` in order to see these fallback error details (verbosity check is implemented in the `fallback_dialer.go`).

/kind cleanup

```release-note
NONE
```