### PR TITLE
kubeadm: use separate phase for changing the kubelet's kubeconfig on upgrade for ControlPlaneKubeletLocalMode

### DIFF
--- a/cmd/kubeadm/app/cmd/phases/upgrade/node/controlplane.go
+++ b/cmd/kubeadm/app/cmd/phases/upgrade/node/controlplane.go
@@ -24,7 +24,6 @@ import (
 
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/options"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/workflow"
-	"k8s.io/kubernetes/cmd/kubeadm/app/features"
 	"k8s.io/kubernetes/cmd/kubeadm/app/phases/upgrade"
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/apiclient"
 )
@@ -81,12 +80,6 @@ func runControlPlane() func(c workflow.RunData) error {
 
 		if err := upgrade.PerformAddonsUpgrade(client, cfg, data.PatchesDir(), data.OutputWriter()); err != nil {
 			return errors.Wrap(err, "failed to perform addons upgrade")
-		}
-
-		if features.Enabled(cfg.FeatureGates, features.ControlPlaneKubeletLocalMode) {
-			if err := upgrade.UpdateKubeletLocalMode(cfg, dryRun); err != nil {
-				return errors.Wrap(err, "failed to update kubelet local mode")
-			}
 		}
 
 		fmt.Println("[upgrade] The control plane instance for this node was successfully updated!")

--- a/cmd/kubeadm/app/cmd/phases/upgrade/node/kubeconfig.go
+++ b/cmd/kubeadm/app/cmd/phases/upgrade/node/kubeconfig.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package node holds phases of "kubeadm upgrade node".
+package node
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+
+	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/options"
+	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/workflow"
+	"k8s.io/kubernetes/cmd/kubeadm/app/features"
+	"k8s.io/kubernetes/cmd/kubeadm/app/phases/upgrade"
+)
+
+// NewKubeconfigPhase creates a kubeadm workflow phase that implements handling of kubeconfig upgrade.
+func NewKubeconfigPhase() workflow.Phase {
+	phase := workflow.Phase{
+		Name:   "kubeconfig",
+		Short:  "Upgrade kubeconfig files for this node",
+		Run:    runKubeconfig(),
+		Hidden: true,
+		InheritFlags: []string{
+			options.DryRun,
+			options.KubeconfigPath,
+		},
+	}
+	return phase
+}
+
+func runKubeconfig() func(c workflow.RunData) error {
+	return func(c workflow.RunData) error {
+		data, ok := c.(Data)
+		if !ok {
+			return errors.New("kubeconfig phase invoked with an invalid data struct")
+		}
+
+		// if this is not a control-plane node, this phase should not be executed
+		if !data.IsControlPlaneNode() {
+			fmt.Println("[upgrade] Skipping phase. Not a control plane node.")
+			return nil
+		}
+
+		// otherwise, retrieve all the info required for kubeconfig upgrade
+		cfg := data.InitCfg()
+		dryRun := data.DryRun()
+
+		if features.Enabled(cfg.FeatureGates, features.ControlPlaneKubeletLocalMode) {
+			if err := upgrade.UpdateKubeletLocalMode(cfg, dryRun); err != nil {
+				return errors.Wrap(err, "failed to update kubelet local mode")
+			}
+		}
+
+		fmt.Println("[upgrade] The kubeconfig for this node was successfully updated!")
+
+		return nil
+	}
+}

--- a/cmd/kubeadm/app/cmd/upgrade/node.go
+++ b/cmd/kubeadm/app/cmd/upgrade/node.go
@@ -97,6 +97,7 @@ func newCmdNode(out io.Writer) *cobra.Command {
 	// initialize the workflow runner with the list of phases
 	nodeRunner.AppendPhase(phases.NewPreflightPhase())
 	nodeRunner.AppendPhase(phases.NewControlPlane())
+	nodeRunner.AppendPhase(phases.NewKubeconfigPhase())
 	nodeRunner.AppendPhase(phases.NewKubeletConfigPhase())
 
 	// sets the data builder function, that will be used by the runner


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

xref discussions at: https://github.com/kubernetes/kubernetes/pull/125780/files#r1677004149

Follow up to:

* #125780

Moves changing the kubelet's kubeconfig to a separate hidden phase for `kubeadm upgrade`.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
[KEP]: https://github.com/kubernetes/enhancements/blob/master/keps/sig-cluster-lifecycle/kubeadm/4471-cp-join-kubelet-local-apiserver/README.md
```
