### PR TITLE
nodehostname address recommendation

### DIFF
--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -6145,9 +6145,10 @@ type NodeAddressType string
 
 // These are built-in addresses type of node. A cloud provider may set a type not listed here.
 const (
-	// NodeHostName identifies a name of the node. Although every node can be assumed
-	// to have a NodeAddress of this type, its exact syntax and semantics are not
-	// defined, and are not consistent between different clusters.
+	// NodeHostName identifies the node name of the system. Although every node can be
+	// assumed to have a NodeAddress of this type, its exact syntax and semantics are
+	// not defined, and are not consistent between different clusters. It is recommended
+	// to use the system node name reported by kernel for this field.
 	NodeHostName NodeAddressType = "Hostname"
 
 	// NodeInternalIP identifies an IP address which is assigned to one of the node's


### PR DESCRIPTION
node addresses are not well defined, in this case the hostname address type represent the node name, but seems to be common in some scenarios to override the hostname on the kubelet, causing a mismatch between the Node object name and the node name reported by the kernel. Setting the node.status.address of type hostname for the reported name of the kernel allow to expose these values in the API, specially useful for hostNetwork pods that will report the kernel value as hostname instead of the node name.

Ref: https://github.com/kubernetes/kubernetes/pull/126088

/kind cleanup
/kind documentation
```release-note
NONE
```
