### PR TITLE
Allow calling Stop multiple times on RetryWatcher

### DIFF
--- a/staging/src/k8s.io/client-go/tools/watch/retrywatcher_test.go
+++ b/staging/src/k8s.io/client-go/tools/watch/retrywatcher_test.go
@@ -586,6 +586,8 @@ func TestRetryWatcherToFinishWithUnreadEvents(t *testing.T) {
 	time.Sleep(10 * time.Millisecond)
 
 	watcher.Stop()
+	// Verify a second stop does not cause a panic
+	watcher.Stop()
 
 	maxTime := time.Second
 	select {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This makes the `RetryWatcher.Stop` method idempotent so that if `Stop` is called multiple times, it does not cause a panic due to closing a closed channel.

#### Which issue(s) this PR fixes:

N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Allow calling Stop multiple times on RetryWatcher without panicking
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

N/A
