### PR TITLE
Expose emptyResponseError publicly to allow usage by other applications

### DIFF
--- a/staging/src/k8s.io/client-go/discovery/cached/memory/memcache.go
+++ b/staging/src/k8s.io/client-go/discovery/cached/memory/memcache.go
@@ -63,11 +63,11 @@ var (
 )
 
 // Server returning empty ResourceList for Group/Version.
-type emptyResponseError struct {
+type EmptyResponseError struct {
 	gv string
 }
 
-func (e *emptyResponseError) Error() string {
+func (e *EmptyResponseError) Error() string {
 	return fmt.Sprintf("received empty response for: %s", e.gv)
 }
 
@@ -114,7 +114,8 @@ func (d *memCacheClient) ServerResourcesForGroupVersion(groupVersion string) (*m
 		r, err := d.serverResourcesForGroupVersion(groupVersion)
 		if err != nil {
 			// Don't log "empty response" as an error; it is a common response for metrics.
-			if _, emptyErr := err.(*emptyResponseError); emptyErr {
+			var emptyErr *EmptyResponseError
+			if errors.As(err, &emptyErr) {
 				// Log at same verbosity as disk cache.
 				klog.V(3).Infof("%v", err)
 			} else {
@@ -280,7 +281,8 @@ func (d *memCacheClient) refreshLocked() error {
 				r, err := d.serverResourcesForGroupVersion(gv)
 				if err != nil {
 					// Don't log "empty response" as an error; it is a common response for metrics.
-					if _, emptyErr := err.(*emptyResponseError); emptyErr {
+					var emptyErr *EmptyResponseError
+					if errors.As(err, &emptyErr) {
 						// Log at same verbosity as disk cache.
 						klog.V(3).Infof("%v", err)
 					} else {
@@ -307,7 +309,7 @@ func (d *memCacheClient) serverResourcesForGroupVersion(groupVersion string) (*m
 		return r, err
 	}
 	if len(r.APIResources) == 0 {
-		return r, &emptyResponseError{gv: groupVersion}
+		return r, &EmptyResponseError{gv: groupVersion}
 	}
 	return r, nil
 }


### PR DESCRIPTION
Downstream apps (e.g., kpt-config-sync) require error-type matching to replicate the empty response workaround

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR makes emptyResponseError publicly accessible, allowing downstream applications like [kpt-config-sync](https://github.com/GoogleContainerTools/kpt-config-sync) to use type matching to handle empty server responses for metrics.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```
NONE
```
