### PR TITLE
Revert "Move ConsistentListFromCache to Beta default"

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -1233,7 +1233,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 
 	genericfeatures.APIServingWithRoutine: {Default: true, PreRelease: featuregate.Beta},
 
-	genericfeatures.ConsistentListFromCache: {Default: true, PreRelease: featuregate.Beta},
+	genericfeatures.ConsistentListFromCache: {Default: false, PreRelease: featuregate.Alpha},
 
 	genericfeatures.CustomResourceValidationExpressions: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.31
 

--- a/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
+++ b/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
@@ -309,7 +309,6 @@ const (
 	// owner: @serathius
 	// kep: http://kep.k8s.io/2340
 	// alpha: v1.28
-	// beta: v1.31
 	//
 	// Allow the API server to serve consistent lists from cache
 	ConsistentListFromCache featuregate.Feature = "ConsistentListFromCache"
@@ -410,7 +409,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 
 	WatchList: {Default: true, PreRelease: featuregate.Beta},
 
-	ConsistentListFromCache: {Default: true, PreRelease: featuregate.Beta},
+	ConsistentListFromCache: {Default: false, PreRelease: featuregate.Alpha},
 
 	ZeroLimitedNominalConcurrencyShares: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.32
 }


### PR DESCRIPTION
This reverts commit 0c0e19b343d48d4bea0e7fa735e3781c70298a34.

During stress test for SVM controller, the controller is unable to make a `list` call due to following error:

```
resourceversion.go:155: I0716 21:49:26.973127] storage-version-migrator-controller: Error syncing SVM resource, retrying svm="crdsvm" err="error getting latest resourceVersion for stable.example.com/v1, Resource=testcrds: Timeout: Too large resource version: 28976, current: 20349"
```

With the feature disabled, the stress test passes.

xref: #126107

/assign deads2k jpbetz liggitt wojtek-t serathius 

/triage accepted
/kind bug
/kind api-change
/kind regression
/milestone v1.31
/priority important-soon

```release-note
Revert "Move ConsistentListFromCache feature flag to Beta and enable it by default"
```