### PR TITLE
fix secret/configmap/downwardAPI subPath mounted disappeared after update

### DIFF
--- a/pkg/volume/util/atomic_writer_test.go
+++ b/pkg/volume/util/atomic_writer_test.go
@@ -245,7 +245,7 @@ func TestPathsToRemove(t *testing.T) {
 			continue
 		}
 
-		actual, err := writer.pathsToRemove(tc.payload2, filepath.Join(targetDir, oldTsDir))
+		actual, _, err := writer.pathsToRemove(tc.payload2, filepath.Join(targetDir, oldTsDir))
 		if err != nil {
 			t.Errorf("%v: unexpected error determining paths to remove: %v", tc.name, err)
 			continue

--- a/pkg/volume/util/subpath/subpat_cache_test.go
+++ b/pkg/volume/util/subpath/subpat_cache_test.go
@@ -1,0 +1,30 @@
+package subpath
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/util/uuid"
+)
+
+func TestHasSubpath(t *testing.T) {
+	podUid1 := uuid.NewUUID()
+	podUid2 := uuid.NewUUID()
+	podUid3 := uuid.NewUUID()
+	volume1 := fmt.Sprintf("/var/lib/kubelet/pods/%s/volumes/kubernetes.io~projected/..2024_07_20_08_33_38.4283786363/secret/cert", podUid1)
+	volume2 := fmt.Sprintf("/var/lib/kubelet/pods/%s/volumes/kubernetes.io~projected/..2024_07_20_08_33_38.4283786363/secret/data", podUid2)
+	volume3 := fmt.Sprintf("/var/lib/kubelet/pods/%s/volumes/kubernetes.io~projected/..2024_07_20_08_33_38.4283786363/secret/other", podUid3)
+
+	addSubpathToCache(volume1)
+	addSubpathToCache(volume2)
+
+	assert.Equal(t, true, HasSubpath(volume1))
+	assert.Equal(t, true, HasSubpath(volume2))
+	assert.Equal(t, false, HasSubpath(volume3))
+
+	removeSubpathByPodDir(fmt.Sprintf("/var/lib/kubelet/pods/%s/volumes", podUid1))
+
+	assert.Equal(t, false, HasSubpath(volume1))
+	assert.Equal(t, true, HasSubpath(volume2))
+}

--- a/pkg/volume/util/subpath/subpath_cache.go
+++ b/pkg/volume/util/subpath/subpath_cache.go
@@ -1,0 +1,50 @@
+package subpath
+
+import (
+	"strings"
+	"sync"
+
+	"k8s.io/klog/v2"
+)
+
+var (
+	cache *subpathCache
+)
+
+func init() {
+	cache = &subpathCache{
+		cache: make(map[string]struct{}),
+	}
+}
+
+type subpathCache struct {
+	mutex sync.Mutex
+	cache map[string]struct{}
+}
+
+func addSubpathToCache(key string) {
+	cache.mutex.Lock()
+	defer cache.mutex.Unlock()
+	cache.cache[key] = struct{}{}
+}
+
+func removeSubpathByPodDir(podVolumeDir string) {
+	cache.mutex.Lock()
+	defer cache.mutex.Unlock()
+	for k := range cache.cache {
+		if strings.HasPrefix(k, podVolumeDir) {
+			klog.Infof("Removing subpath %q from cache", k)
+			delete(cache.cache, k)
+		}
+	}
+}
+
+// HasSubpath checks if the given subpath oldTSDir
+// (like /var/lib/kubelet/pods/${PODUID}/volumes/kubernetes.io~projected/${volumeName}/..2024_07_20_08_33_38.4283786363/data)
+// is in the cache
+func HasSubpath(key string) bool {
+	cache.mutex.Lock()
+	defer cache.mutex.Unlock()
+	_, ok := cache.cache[key]
+	return ok
+}

--- a/pkg/volume/util/subpath/subpath_linux.go
+++ b/pkg/volume/util/subpath/subpath_linux.go
@@ -206,6 +206,10 @@ func doBindSubPath(mounter mount.Interface, subpath Subpath) (hostPath string, e
 	if err != nil {
 		return "", err
 	}
+
+	// add pod subpath to cache
+	addSubpathToCache(subpath.Path)
+
 	if alreadyMounted {
 		return bindPathTarget, nil
 	}
@@ -242,6 +246,7 @@ func doCleanSubPaths(mounter mount.Interface, podDir string, volumeName string) 
 	// scan /var/lib/kubelet/pods/<uid>/volume-subpaths/<volume>/*
 	subPathDir := filepath.Join(podDir, containerSubPathDirectoryName, volumeName)
 	klog.V(4).Infof("Cleaning up subpath mounts for %s", subPathDir)
+	defer removeSubpathByPodDir(podDir)
 
 	containerDirs, err := ioutil.ReadDir(subPathDir)
 	if err != nil {


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
fix secret/configmap/downwardAPI subPath mounted disappeared after update
subPath mounted will not receive update, so we should retain there subpaths when update

this pr add subpath caches let `AtomicWriter` know which subpath should keep in oldTsDir

#### Which issue(s) this PR fixes:
Fixes #126112

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```
