### PR TITLE
Use generics in scheduling queue's heap

### DIFF
--- a/pkg/scheduler/eventhandlers.go
+++ b/pkg/scheduler/eventhandlers.go
@@ -147,9 +147,7 @@ func (sched *Scheduler) addPodToSchedulingQueue(obj interface{}) {
 	logger := sched.logger
 	pod := obj.(*v1.Pod)
 	logger.V(3).Info("Add event for unscheduled pod", "pod", klog.KObj(pod))
-	if err := sched.SchedulingQueue.Add(logger, pod); err != nil {
-		utilruntime.HandleError(fmt.Errorf("unable to queue %T: %v", obj, err))
-	}
+	sched.SchedulingQueue.Add(logger, pod)
 }
 
 func (sched *Scheduler) updatePodInSchedulingQueue(oldObj, newObj interface{}) {
@@ -172,9 +170,7 @@ func (sched *Scheduler) updatePodInSchedulingQueue(oldObj, newObj interface{}) {
 	}
 
 	logger.V(4).Info("Update event for unscheduled pod", "pod", klog.KObj(newPod))
-	if err := sched.SchedulingQueue.Update(logger, oldPod, newPod); err != nil {
-		utilruntime.HandleError(fmt.Errorf("unable to update %T: %v", newObj, err))
-	}
+	sched.SchedulingQueue.Update(logger, oldPod, newPod)
 }
 
 func (sched *Scheduler) deletePodFromSchedulingQueue(obj interface{}) {
@@ -199,9 +195,7 @@ func (sched *Scheduler) deletePodFromSchedulingQueue(obj interface{}) {
 	}
 
 	logger.V(3).Info("Delete event for unscheduled pod", "pod", klog.KObj(pod))
-	if err := sched.SchedulingQueue.Delete(pod); err != nil {
-		utilruntime.HandleError(fmt.Errorf("unable to dequeue %T: %v", obj, err))
-	}
+	sched.SchedulingQueue.Delete(pod)
 	fwk, err := sched.frameworkForPod(pod)
 	if err != nil {
 		// This shouldn't happen, because we only accept for scheduling the pods

--- a/pkg/scheduler/internal/heap/heap.go
+++ b/pkg/scheduler/internal/heap/heap.go
@@ -24,29 +24,28 @@ import (
 	"container/heap"
 	"fmt"
 
-	"k8s.io/client-go/tools/cache"
 	"k8s.io/kubernetes/pkg/scheduler/metrics"
 )
 
 // KeyFunc is a function type to get the key from an object.
-type KeyFunc func(obj interface{}) (string, error)
+type KeyFunc[T any] func(obj T) string
 
-type heapItem struct {
-	obj   interface{} // The object which is stored in the heap.
-	index int         // The index of the object's key in the Heap.queue.
+type heapItem[T any] struct {
+	obj   T   // The object which is stored in the heap.
+	index int // The index of the object's key in the Heap.queue.
 }
 
-type itemKeyValue struct {
+type itemKeyValue[T any] struct {
 	key string
-	obj interface{}
+	obj T
 }
 
 // data is an internal struct that implements the standard heap interface
 // and keeps the data stored in the heap.
-type data struct {
+type data[T any] struct {
 	// items is a map from key of the objects to the objects and their index.
 	// We depend on the property that items in the map are in the queue and vice versa.
-	items map[string]*heapItem
+	items map[string]*heapItem[T]
 	// queue implements a heap data structure and keeps the order of elements
 	// according to the heap invariant. The queue keeps the keys of objects stored
 	// in "items".
@@ -54,18 +53,18 @@ type data struct {
 
 	// keyFunc is used to make the key used for queued item insertion and retrieval, and
 	// should be deterministic.
-	keyFunc KeyFunc
+	keyFunc KeyFunc[T]
 	// lessFunc is used to compare two objects in the heap.
-	lessFunc lessFunc
+	lessFunc LessFunc[T]
 }
 
 var (
-	_ = heap.Interface(&data{}) // heapData is a standard heap
+	_ = heap.Interface(&data[any]{}) // heapData is a standard heap
 )
 
 // Less compares two objects and returns true if the first one should go
 // in front of the second one in the heap.
-func (h *data) Less(i, j int) bool {
+func (h *data[T]) Less(i, j int) bool {
 	if i > len(h.queue) || j > len(h.queue) {
 		return false
 	}
@@ -81,11 +80,11 @@ func (h *data) Less(i, j int) bool {
 }
 
 // Len returns the number of items in the Heap.
-func (h *data) Len() int { return len(h.queue) }
+func (h *data[T]) Len() int { return len(h.queue) }
 
 // Swap implements swapping of two elements in the heap. This is a part of standard
 // heap interface and should never be called directly.
-func (h *data) Swap(i, j int) {
+func (h *data[T]) Swap(i, j int) {
 	h.queue[i], h.queue[j] = h.queue[j], h.queue[i]
 	item := h.items[h.queue[i]]
 	item.index = i
@@ -93,16 +92,16 @@ func (h *data) Swap(i, j int) {
 	item.index = j
 }
 
-// Push is supposed to be called by heap.Push only.
-func (h *data) Push(kv interface{}) {
-	keyValue := kv.(*itemKeyValue)
+// Push is supposed to be called by container/heap.Push only.
+func (h *data[T]) Push(kv interface{}) {
+	keyValue := kv.(*itemKeyValue[T])
 	n := len(h.queue)
-	h.items[keyValue.key] = &heapItem{keyValue.obj, n}
+	h.items[keyValue.key] = &heapItem[T]{keyValue.obj, n}
 	h.queue = append(h.queue, keyValue.key)
 }
 
-// Pop is supposed to be called by heap.Pop only.
-func (h *data) Pop() interface{} {
+// Pop is supposed to be called by container/heap.Pop only.
+func (h *data[T]) Pop() interface{} {
 	key := h.queue[len(h.queue)-1]
 	h.queue = h.queue[0 : len(h.queue)-1]
 	item, ok := h.items[key]
@@ -114,56 +113,44 @@ func (h *data) Pop() interface{} {
 	return item.obj
 }
 
-// Peek is supposed to be called by heap.Peek only.
-func (h *data) Peek() interface{} {
+// Peek returns the head of the heap without removing it.
+func (h *data[T]) Peek() (T, bool) {
 	if len(h.queue) > 0 {
-		return h.items[h.queue[0]].obj
+		return h.items[h.queue[0]].obj, true
 	}
-	return nil
+	var zero T
+	return zero, false
 }
 
 // Heap is a producer/consumer queue that implements a heap data structure.
 // It can be used to implement priority queues and similar data structures.
-type Heap struct {
+type Heap[T any] struct {
 	// data stores objects and has a queue that keeps their ordering according
 	// to the heap invariant.
-	data *data
+	data *data[T]
 	// metricRecorder updates the counter when elements of a heap get added or
 	// removed, and it does nothing if it's nil
 	metricRecorder metrics.MetricRecorder
 }
 
-// Add inserts an item, and puts it in the queue. The item is updated if it
+// AddOrUpdate inserts an item, and puts it in the queue. The item is updated if it
 // already exists.
-func (h *Heap) Add(obj interface{}) error {
-	key, err := h.data.keyFunc(obj)
-	if err != nil {
-		return cache.KeyError{Obj: obj, Err: err}
-	}
+func (h *Heap[T]) AddOrUpdate(obj T) {
+	key := h.data.keyFunc(obj)
 	if _, exists := h.data.items[key]; exists {
 		h.data.items[key].obj = obj
 		heap.Fix(h.data, h.data.items[key].index)
 	} else {
-		heap.Push(h.data, &itemKeyValue{key, obj})
+		heap.Push(h.data, &itemKeyValue[T]{key, obj})
 		if h.metricRecorder != nil {
 			h.metricRecorder.Inc()
 		}
 	}
-	return nil
-}
-
-// Update is the same as Add in this implementation. When the item does not
-// exist, it is added.
-func (h *Heap) Update(obj interface{}) error {
-	return h.Add(obj)
 }
 
 // Delete removes an item.
-func (h *Heap) Delete(obj interface{}) error {
-	key, err := h.data.keyFunc(obj)
-	if err != nil {
-		return cache.KeyError{Obj: obj, Err: err}
-	}
+func (h *Heap[T]) Delete(obj T) error {
+	key := h.data.keyFunc(obj)
 	if item, ok := h.data.items[key]; ok {
 		heap.Remove(h.data, item.index)
 		if h.metricRecorder != nil {
@@ -175,43 +162,48 @@ func (h *Heap) Delete(obj interface{}) error {
 }
 
 // Peek returns the head of the heap without removing it.
-func (h *Heap) Peek() interface{} {
+func (h *Heap[T]) Peek() (T, bool) {
 	return h.data.Peek()
 }
 
 // Pop returns the head of the heap and removes it.
-func (h *Heap) Pop() (interface{}, error) {
+func (h *Heap[T]) Pop() (T, error) {
 	obj := heap.Pop(h.data)
 	if obj != nil {
 		if h.metricRecorder != nil {
 			h.metricRecorder.Dec()
 		}
-		return obj, nil
+		return obj.(T), nil
 	}
-	return nil, fmt.Errorf("object was removed from heap data")
+	var zero T
+	return zero, fmt.Errorf("heap is empty")
 }
 
 // Get returns the requested item, or sets exists=false.
-func (h *Heap) Get(obj interface{}) (interface{}, bool, error) {
-	key, err := h.data.keyFunc(obj)
-	if err != nil {
-		return nil, false, cache.KeyError{Obj: obj, Err: err}
-	}
+func (h *Heap[T]) Get(obj T) (T, bool) {
+	key := h.data.keyFunc(obj)
 	return h.GetByKey(key)
 }
 
 // GetByKey returns the requested item, or sets exists=false.
-func (h *Heap) GetByKey(key string) (interface{}, bool, error) {
+func (h *Heap[T]) GetByKey(key string) (T, bool) {
 	item, exists := h.data.items[key]
 	if !exists {
-		return nil, false, nil
+		var zero T
+		return zero, false
 	}
-	return item.obj, true, nil
+	return item.obj, true
+}
+
+func (h *Heap[T]) Has(obj T) bool {
+	key := h.data.keyFunc(obj)
+	_, ok := h.GetByKey(key)
+	return ok
 }
 
 // List returns a list of all the items.
-func (h *Heap) List() []interface{} {
-	list := make([]interface{}, 0, len(h.data.items))
+func (h *Heap[T]) List() []T {
+	list := make([]T, 0, len(h.data.items))
 	for _, item := range h.data.items {
 		list = append(list, item.obj)
 	}
@@ -219,20 +211,20 @@ func (h *Heap) List() []interface{} {
 }
 
 // Len returns the number of items in the heap.
-func (h *Heap) Len() int {
+func (h *Heap[T]) Len() int {
 	return len(h.data.queue)
 }
 
 // New returns a Heap which can be used to queue up items to process.
-func New(keyFn KeyFunc, lessFn lessFunc) *Heap {
+func New[T any](keyFn KeyFunc[T], lessFn LessFunc[T]) *Heap[T] {
 	return NewWithRecorder(keyFn, lessFn, nil)
 }
 
 // NewWithRecorder wraps an optional metricRecorder to compose a Heap object.
-func NewWithRecorder(keyFn KeyFunc, lessFn lessFunc, metricRecorder metrics.MetricRecorder) *Heap {
-	return &Heap{
-		data: &data{
-			items:    map[string]*heapItem{},
+func NewWithRecorder[T any](keyFn KeyFunc[T], lessFn LessFunc[T], metricRecorder metrics.MetricRecorder) *Heap[T] {
+	return &Heap[T]{
+		data: &data[T]{
+			items:    map[string]*heapItem[T]{},
 			queue:    []string{},
 			keyFunc:  keyFn,
 			lessFunc: lessFn,
@@ -241,6 +233,6 @@ func NewWithRecorder(keyFn KeyFunc, lessFn lessFunc, metricRecorder metrics.Metr
 	}
 }
 
-// lessFunc is a function that receives two items and returns true if the first
+// LessFunc is a function that receives two items and returns true if the first
 // item should be placed before the second one when the list is sorted.
-type lessFunc = func(item1, item2 interface{}) bool
+type LessFunc[T any] func(item1, item2 T) bool

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -287,9 +287,7 @@ func TestFailureHandler(t *testing.T) {
 			queue := internalqueue.NewPriorityQueue(nil, informerFactory, internalqueue.WithClock(testingclock.NewFakeClock(time.Now())))
 			schedulerCache := internalcache.New(ctx, 30*time.Second)
 
-			if err := queue.Add(logger, testPod); err != nil {
-				t.Fatalf("Add failed: %v", err)
-			}
+			queue.Add(logger, testPod)
 
 			if _, err := queue.Pop(logger); err != nil {
 				t.Fatalf("Pop failed: %v", err)

--- a/test/integration/scheduler/queue_test.go
+++ b/test/integration/scheduler/queue_test.go
@@ -314,13 +314,7 @@ func TestCoreResourceEnqueue(t *testing.T) {
 				newPod = oldPod.DeepCopy()
 				newPod.Status.Conditions[0].Message = "injected message"
 
-				if err := testCtx.Scheduler.SchedulingQueue.Update(
-					klog.FromContext(testCtx.Ctx),
-					oldPod,
-					newPod,
-				); err != nil {
-					return fmt.Errorf("failed to update the pod: %w", err)
-				}
+				testCtx.Scheduler.SchedulingQueue.Update(klog.FromContext(testCtx.Ctx), oldPod, newPod)
 				return nil
 			},
 			wantRequeuedPods: sets.Set[string]{},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

#### What this PR does / why we need it:

By introducing generics to Heap, scheduling queue can be simplified by removing type assertions. `podInfoKeyFunc` is also improved, by creating the `ObjectName` directly.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
