### PR TITLE
Add me to kube-proxy config api approvers

### DIFF
--- a/staging/src/k8s.io/kube-proxy/config/OWNERS
+++ b/staging/src/k8s.io/kube-proxy/config/OWNERS
@@ -5,6 +5,7 @@ options:
   no_parent_owners: true
 approvers:
   - api-approvers
+  - danwinship
 reviewers:
   - api-reviewers
   - sig-network-reviewers


### PR DESCRIPTION
#### What this PR does / why we need it:
adds me to staging/src/k8s.io/kube-proxy/config/OWNERS, per https://github.com/kubernetes/kubernetes/pull/126072#issuecomment-2231853473

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/kind cleanup
/sig network

/assign @thockin
```
