### PR TITLE
PSA: allow procMount type Unmasked in baseline

### DIFF
--- a/staging/src/k8s.io/pod-security-admission/policy/check_procMount.go
+++ b/staging/src/k8s.io/pod-security-admission/policy/check_procMount.go
@@ -35,6 +35,9 @@ spec.initContainers[*].securityContext.procMount
 
 **Allowed Values:** undefined/null, "Default"
 
+However, if the pod is in a user namespace (`hostUsers: false`), and the
+UserNamespacesPodSecurityStandards feature is enabled, all values are allowed.
+
 */
 
 func init() {
@@ -58,6 +61,14 @@ func CheckProcMount() Check {
 }
 
 func procMount_1_0(podMetadata *metav1.ObjectMeta, podSpec *corev1.PodSpec) CheckResult {
+	// TODO: When we remove the UserNamespacesPodSecurityStandards feature gate (and GA this relaxation),
+	// create a new policy version.
+	// Note: pod validation will check for well formed procMount type, so avoid double validation and allow everything
+	// here.
+	if relaxPolicyForUserNamespacePod(podSpec) {
+		return CheckResult{Allowed: true}
+	}
+
 	var badContainers []string
 	forbiddenProcMountTypes := sets.NewString()
 	visitContainers(podSpec, func(container *corev1.Container) {

--- a/staging/src/k8s.io/pod-security-admission/policy/check_runAsNonRoot_test.go
+++ b/staging/src/k8s.io/pod-security-admission/policy/check_runAsNonRoot_test.go
@@ -25,12 +25,12 @@ import (
 
 func TestRunAsNonRoot(t *testing.T) {
 	tests := []struct {
-		name                                     string
-		pod                                      *corev1.Pod
-		expectReason                             string
-		expectDetail                             string
-		allowed                                  bool
-		enableUserNamespacesPodSecurityStandards bool
+		name           string
+		pod            *corev1.Pod
+		expectReason   string
+		expectDetail   string
+		expectAllowed  bool
+		relaxForUserNS bool
 	}{
 		{
 			name: "no explicit runAsNonRoot",
@@ -87,8 +87,8 @@ func TestRunAsNonRoot(t *testing.T) {
 			pod: &corev1.Pod{Spec: corev1.PodSpec{
 				HostUsers: utilpointer.Bool(false),
 			}},
-			allowed:                                  true,
-			enableUserNamespacesPodSecurityStandards: true,
+			expectAllowed:  true,
+			relaxForUserNS: true,
 		},
 		{
 			name: "UserNamespacesPodSecurityStandards enabled with HostUsers",
@@ -98,21 +98,24 @@ func TestRunAsNonRoot(t *testing.T) {
 				},
 				HostUsers: utilpointer.Bool(true),
 			}},
-			expectReason:                             `runAsNonRoot != true`,
-			expectDetail:                             `pod or container "a" must set securityContext.runAsNonRoot=true`,
-			allowed:                                  false,
-			enableUserNamespacesPodSecurityStandards: true,
+			expectReason:   `runAsNonRoot != true`,
+			expectDetail:   `pod or container "a" must set securityContext.runAsNonRoot=true`,
+			expectAllowed:  false,
+			relaxForUserNS: true,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			if tc.enableUserNamespacesPodSecurityStandards {
+			if tc.relaxForUserNS {
 				RelaxPolicyForUserNamespacePods(true)
+				t.Cleanup(func() {
+					RelaxPolicyForUserNamespacePods(false)
+				})
 			}
 			result := runAsNonRoot_1_0(&tc.pod.ObjectMeta, &tc.pod.Spec)
-			if result.Allowed && !tc.allowed {
-				t.Fatal("expected disallowed")
+			if result.Allowed != tc.expectAllowed {
+				t.Fatalf("expected Allowed to be %v was %v", tc.expectAllowed, result.Allowed)
 			}
 			if e, a := tc.expectReason, result.ForbiddenReason; e != a {
 				t.Errorf("expected\n%s\ngot\n%s", e, a)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

#### What this PR does / why we need it:
a masked proc mount has traditionally been used to prevent untrusted containers from accessing leaky kernel APIs. However, within a user namespace, typical ID checks protect better than masked proc. Further, allowing unmasked proc with a user namespace gives access to a container mounting sub procs, which opens avenues for container-in-container use cases.

Update PSS for baseline to allow a container to access an unmasked /proc, if it's in a user namespace. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kube-apiserver: when the alpha `UserNamespacesPodSecurityStandards` feature gate is enabled, Pod Security Admission enforcement of the baseline policy now allows `procMount=Unmasked` for user namespace pods that set `hostUsers=false`.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/4265
```
