### PR TITLE
Cleanup unused test functions - cont-ed

### DIFF
--- a/test/utils/audit.go
+++ b/test/utils/audit.go
@@ -128,55 +128,6 @@ func CheckAuditLinesFiltered(stream io.Reader, expected []AuditEvent, version sc
 	return missingReport, nil
 }
 
-// CheckAuditList searches an audit event list for the expected audit events.
-func CheckAuditList(el auditinternal.EventList, expected []AuditEvent) (missing []AuditEvent, err error) {
-	expectations := newAuditEventTracker(expected)
-
-	for _, e := range el.Items {
-		event, err := testEventFromInternal(&e)
-		if err != nil {
-			return expected, err
-		}
-
-		expectations.Mark(event)
-	}
-
-	return expectations.Missing(), nil
-}
-
-// CheckForDuplicates checks a list for duplicate events
-func CheckForDuplicates(el auditinternal.EventList) (auditinternal.EventList, error) {
-	// existingEvents holds a slice of audit events that have been seen
-	existingEvents := []AuditEvent{}
-	duplicates := auditinternal.EventList{}
-	for _, e := range el.Items {
-		event, err := testEventFromInternal(&e)
-		if err != nil {
-			return duplicates, err
-		}
-		event.ID = e.AuditID
-		for _, existing := range existingEvents {
-			if reflect.DeepEqual(existing, event) {
-				duplicates.Items = append(duplicates.Items, e)
-				continue
-			}
-		}
-		existingEvents = append(existingEvents, event)
-	}
-
-	var err error
-	if len(duplicates.Items) > 0 {
-		err = fmt.Errorf("failed duplicate check")
-	}
-
-	return duplicates, err
-}
-
-// testEventFromInternal takes an internal audit event and returns a test event
-func testEventFromInternal(e *auditinternal.Event) (AuditEvent, error) {
-	return testEventFromInternalFiltered(e, nil)
-}
-
 // testEventFromInternalFiltered takes an internal audit event and returns a test event, customAnnotationsFilter
 // controls which audit annotations are added to AuditEvent.CustomAuditAnnotations.
 // If the customAnnotationsFilter is nil, AuditEvent.CustomAuditAnnotations will be empty.

--- a/test/utils/conditions.go
+++ b/test/utils/conditions.go
@@ -103,13 +103,3 @@ func TerminatedContainers(pod *v1.Pod) map[string]string {
 	}
 	return states
 }
-
-// PodNotReady checks whether pod p's has a ready condition of status false.
-func PodNotReady(p *v1.Pod) (bool, error) {
-	// Check the ready condition is false.
-	if podutil.IsPodReady(p) {
-		return false, fmt.Errorf("pod '%s' on '%s' didn't have condition {%v %v}; conditions: %v",
-			p.ObjectMeta.Name, p.Spec.NodeName, v1.PodReady, v1.ConditionFalse, p.Status.Conditions)
-	}
-	return true, nil
-}

--- a/test/utils/create_resources.go
+++ b/test/utils/create_resources.go
@@ -24,9 +24,6 @@ import (
 	"time"
 
 	apps "k8s.io/api/apps/v1"
-	batch "k8s.io/api/batch/v1"
-	storage "k8s.io/api/storage/v1"
-
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -121,114 +118,12 @@ func CreateDeploymentWithRetries(c clientset.Interface, namespace string, obj *a
 	return RetryWithExponentialBackOff(createFunc)
 }
 
-func CreateDaemonSetWithRetries(c clientset.Interface, namespace string, obj *apps.DaemonSet) error {
-	if obj == nil {
-		return fmt.Errorf("object provided to create is empty")
-	}
-	createFunc := func() (bool, error) {
-		_, err := c.AppsV1().DaemonSets(namespace).Create(context.TODO(), obj, metav1.CreateOptions{})
-		if isGenerateNameConflict(obj.ObjectMeta, err) {
-			return false, nil
-		}
-		if err == nil || apierrors.IsAlreadyExists(err) {
-			return true, nil
-		}
-		return false, fmt.Errorf("failed to create object with non-retriable error: %v", err)
-	}
-	return RetryWithExponentialBackOff(createFunc)
-}
-
-func CreateJobWithRetries(c clientset.Interface, namespace string, obj *batch.Job) error {
-	if obj == nil {
-		return fmt.Errorf("object provided to create is empty")
-	}
-	createFunc := func() (bool, error) {
-		_, err := c.BatchV1().Jobs(namespace).Create(context.TODO(), obj, metav1.CreateOptions{})
-		if isGenerateNameConflict(obj.ObjectMeta, err) {
-			return false, nil
-		}
-		if err == nil || apierrors.IsAlreadyExists(err) {
-			return true, nil
-		}
-		return false, fmt.Errorf("failed to create object with non-retriable error: %v", err)
-	}
-	return RetryWithExponentialBackOff(createFunc)
-}
-
-func CreateSecretWithRetries(c clientset.Interface, namespace string, obj *v1.Secret) error {
-	if obj == nil {
-		return fmt.Errorf("object provided to create is empty")
-	}
-	createFunc := func() (bool, error) {
-		_, err := c.CoreV1().Secrets(namespace).Create(context.TODO(), obj, metav1.CreateOptions{})
-		if isGenerateNameConflict(obj.ObjectMeta, err) {
-			return false, nil
-		}
-		if err == nil || apierrors.IsAlreadyExists(err) {
-			return true, nil
-		}
-		return false, fmt.Errorf("failed to create object with non-retriable error: %v", err)
-	}
-	return RetryWithExponentialBackOff(createFunc)
-}
-
-func CreateConfigMapWithRetries(c clientset.Interface, namespace string, obj *v1.ConfigMap) error {
-	if obj == nil {
-		return fmt.Errorf("object provided to create is empty")
-	}
-	createFunc := func() (bool, error) {
-		_, err := c.CoreV1().ConfigMaps(namespace).Create(context.TODO(), obj, metav1.CreateOptions{})
-		if isGenerateNameConflict(obj.ObjectMeta, err) {
-			return false, nil
-		}
-		if err == nil || apierrors.IsAlreadyExists(err) {
-			return true, nil
-		}
-		return false, fmt.Errorf("failed to create object with non-retriable error: %v", err)
-	}
-	return RetryWithExponentialBackOff(createFunc)
-}
-
 func CreateServiceWithRetries(c clientset.Interface, namespace string, obj *v1.Service) error {
 	if obj == nil {
 		return fmt.Errorf("object provided to create is empty")
 	}
 	createFunc := func() (bool, error) {
 		_, err := c.CoreV1().Services(namespace).Create(context.TODO(), obj, metav1.CreateOptions{})
-		if isGenerateNameConflict(obj.ObjectMeta, err) {
-			return false, nil
-		}
-		if err == nil || apierrors.IsAlreadyExists(err) {
-			return true, nil
-		}
-		return false, fmt.Errorf("failed to create object with non-retriable error: %v", err)
-	}
-	return RetryWithExponentialBackOff(createFunc)
-}
-
-func CreateStorageClassWithRetries(c clientset.Interface, obj *storage.StorageClass) error {
-	if obj == nil {
-		return fmt.Errorf("object provided to create is empty")
-	}
-	createFunc := func() (bool, error) {
-		_, err := c.StorageV1().StorageClasses().Create(context.TODO(), obj, metav1.CreateOptions{})
-		if isGenerateNameConflict(obj.ObjectMeta, err) {
-			return false, nil
-		}
-		if err == nil || apierrors.IsAlreadyExists(err) {
-			return true, nil
-		}
-		return false, fmt.Errorf("failed to create object with non-retriable error: %v", err)
-	}
-	return RetryWithExponentialBackOff(createFunc)
-}
-
-func CreateResourceQuotaWithRetries(c clientset.Interface, namespace string, obj *v1.ResourceQuota) error {
-	if obj == nil {
-		return fmt.Errorf("object provided to create is empty")
-	}
-	createFunc := func() (bool, error) {
-		_, err := c.CoreV1().ResourceQuotas(namespace).Create(context.TODO(), obj, metav1.CreateOptions{})
 		if isGenerateNameConflict(obj.ObjectMeta, err) {
 			return false, nil
 		}

--- a/test/utils/delete_resources.go
+++ b/test/utils/delete_resources.go
@@ -22,7 +22,6 @@ import (
 	"context"
 	"fmt"
 
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	clientset "k8s.io/client-go/kubernetes"
@@ -55,15 +54,4 @@ func DeleteResource(c clientset.Interface, kind schema.GroupKind, namespace, nam
 	default:
 		return fmt.Errorf("unsupported kind when deleting: %v", kind)
 	}
-}
-
-func DeleteResourceWithRetries(c clientset.Interface, kind schema.GroupKind, namespace, name string, options metav1.DeleteOptions) error {
-	deleteFunc := func() (bool, error) {
-		err := DeleteResource(c, kind, namespace, name, options)
-		if err == nil || apierrors.IsNotFound(err) {
-			return true, nil
-		}
-		return false, fmt.Errorf("failed to delete object with non-retriable error: %v", err)
-	}
-	return RetryWithExponentialBackOff(deleteFunc)
 }

--- a/test/utils/deployment.go
+++ b/test/utils/deployment.go
@@ -328,25 +328,6 @@ func WaitForObservedDeployment(c clientset.Interface, ns, deploymentName string,
 	}, desiredGeneration, 2*time.Second, 1*time.Minute)
 }
 
-// WaitForDeploymentRollbackCleared waits for given deployment either started rolling back or doesn't need to rollback.
-func WaitForDeploymentRollbackCleared(c clientset.Interface, ns, deploymentName string, pollInterval, pollTimeout time.Duration) error {
-	err := wait.PollImmediate(pollInterval, pollTimeout, func() (bool, error) {
-		deployment, err := c.AppsV1().Deployments(ns).Get(context.TODO(), deploymentName, metav1.GetOptions{})
-		if err != nil {
-			return false, err
-		}
-		// Rollback not set or is kicked off
-		if deployment.Annotations[apps.DeprecatedRollbackTo] == "" {
-			return true, nil
-		}
-		return false, nil
-	})
-	if err != nil {
-		return fmt.Errorf("error waiting for deployment %s rollbackTo to be cleared: %v", deploymentName, err)
-	}
-	return nil
-}
-
 // WaitForDeploymentUpdatedReplicasGTE waits for given deployment to be observed by the controller and has at least a number of updatedReplicas
 func WaitForDeploymentUpdatedReplicasGTE(c clientset.Interface, ns, deploymentName string, minUpdatedReplicas int32, desiredGeneration int64, pollInterval, pollTimeout time.Duration) error {
 	var deployment *apps.Deployment


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/sig testing

#### What this PR does / why we need it:
Following up the work started in https://github.com/kubernetes/kubernetes/pull/124850 this is further cleaning up the `test/utils` directory getting rid of unused functions.

#### Special notes for your reviewer:
/assign @pohly 

I've used `deadcode` as you suggested in the previous PR, to clean the easy bits. The followups will cover cleaning and getting rid of some of the functions from `runner.go`. 

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
