### PR TITLE
Add labels to PVCollector bound/unbound PVC metrics for VolumeAttributesClass Feature

### DIFF
--- a/pkg/controller/volume/persistentvolume/metrics/metrics.go
+++ b/pkg/controller/volume/persistentvolume/metrics/metrics.go
@@ -23,8 +23,10 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/component-base/metrics"
 	"k8s.io/component-base/metrics/legacyregistry"
+	storagehelpers "k8s.io/component-helpers/storage/volume"
 	"k8s.io/kubernetes/pkg/volume"
 	metricutil "k8s.io/kubernetes/pkg/volume/util"
+	"k8s.io/utils/ptr"
 )
 
 const (
@@ -93,21 +95,10 @@ type pvcBindingMetricDimensions struct {
 }
 
 func getPVCMetricDimensions(pvc *v1.PersistentVolumeClaim) pvcBindingMetricDimensions {
-	var storageClassName, volumeAttributesClassName string
-	namespace := pvc.Namespace
-
-	if pvc.Spec.StorageClassName != nil {
-		storageClassName = *pvc.Spec.StorageClassName
-	}
-
-	if pvc.Spec.VolumeAttributesClassName != nil {
-		volumeAttributesClassName = *pvc.Spec.VolumeAttributesClassName
-	}
-
 	return pvcBindingMetricDimensions{
-		namespace:                 namespace,
-		storageClassName:          storageClassName,
-		volumeAttributesClassName: volumeAttributesClassName,
+		namespace:                 pvc.Namespace,
+		storageClassName:          storagehelpers.GetPersistentVolumeClaimClass(pvc),
+		volumeAttributesClassName: ptr.Deref(pvc.Spec.VolumeAttributesClassName, ""),
 	}
 }
 

--- a/pkg/controller/volume/persistentvolume/metrics/metrics.go
+++ b/pkg/controller/volume/persistentvolume/metrics/metrics.go
@@ -39,10 +39,11 @@ const (
 	unboundPVCKey = "unbound_pvc_count"
 
 	// Label names.
-	namespaceLabel    = "namespace"
-	storageClassLabel = "storage_class"
-	pluginNameLabel   = "plugin_name"
-	volumeModeLabel   = "volume_mode"
+	namespaceLabel             = "namespace"
+	storageClassLabel          = "storage_class"
+	volumeAttributesClassLabel = "volume_attributes_class"
+	pluginNameLabel            = "plugin_name"
+	volumeModeLabel            = "volume_mode"
 
 	// String to use when plugin name cannot be determined
 	pluginNameNotAvailable = "N/A"
@@ -86,6 +87,30 @@ type pvAndPVCCountCollector struct {
 	pluginMgr *volume.VolumePluginMgr
 }
 
+// Holds all dimensions for bound/unbound PVC metrics
+type pvcBindingMetricDimensions struct {
+	namespace, storageClassName, volumeAttributesClassName string
+}
+
+func getPVCMetricDimensions(pvc *v1.PersistentVolumeClaim) pvcBindingMetricDimensions {
+	var storageClassName, volumeAttributesClassName string
+	namespace := pvc.Namespace
+
+	if pvc.Spec.StorageClassName != nil {
+		storageClassName = *pvc.Spec.StorageClassName
+	}
+
+	if pvc.Spec.VolumeAttributesClassName != nil {
+		volumeAttributesClassName = *pvc.Spec.VolumeAttributesClassName
+	}
+
+	return pvcBindingMetricDimensions{
+		namespace:                 namespace,
+		storageClassName:          storageClassName,
+		volumeAttributesClassName: volumeAttributesClassName,
+	}
+}
+
 // Check if our collector implements necessary collector interface
 var _ metrics.StableCollector = &pvAndPVCCountCollector{}
 
@@ -109,12 +134,12 @@ var (
 	boundPVCCountDesc = metrics.NewDesc(
 		metrics.BuildFQName("", pvControllerSubsystem, boundPVCKey),
 		"Gauge measuring number of persistent volume claim currently bound",
-		[]string{namespaceLabel}, nil,
+		[]string{namespaceLabel, storageClassLabel, volumeAttributesClassLabel}, nil,
 		metrics.ALPHA, "")
 	unboundPVCCountDesc = metrics.NewDesc(
 		metrics.BuildFQName("", pvControllerSubsystem, unboundPVCKey),
 		"Gauge measuring number of persistent volume claim currently unbound",
-		[]string{namespaceLabel}, nil,
+		[]string{namespaceLabel, storageClassLabel, volumeAttributesClassLabel}, nil,
 		metrics.ALPHA, "")
 
 	volumeOperationErrorsMetric = metrics.NewCounterVec(
@@ -218,32 +243,32 @@ func (collector *pvAndPVCCountCollector) pvCollect(ch chan<- metrics.Metric) {
 }
 
 func (collector *pvAndPVCCountCollector) pvcCollect(ch chan<- metrics.Metric) {
-	boundNumberByNamespace := make(map[string]int)
-	unboundNumberByNamespace := make(map[string]int)
+	boundNumber := make(map[pvcBindingMetricDimensions]int)
+	unboundNumber := make(map[pvcBindingMetricDimensions]int)
 	for _, pvcObj := range collector.pvcLister.List() {
 		pvc, ok := pvcObj.(*v1.PersistentVolumeClaim)
 		if !ok {
 			continue
 		}
 		if pvc.Status.Phase == v1.ClaimBound {
-			boundNumberByNamespace[pvc.Namespace]++
+			boundNumber[getPVCMetricDimensions(pvc)]++
 		} else {
-			unboundNumberByNamespace[pvc.Namespace]++
+			unboundNumber[getPVCMetricDimensions(pvc)]++
 		}
 	}
-	for namespace, number := range boundNumberByNamespace {
+	for pvcLabels, number := range boundNumber {
 		ch <- metrics.NewLazyConstMetric(
 			boundPVCCountDesc,
 			metrics.GaugeValue,
 			float64(number),
-			namespace)
+			pvcLabels.namespace, pvcLabels.storageClassName, pvcLabels.volumeAttributesClassName)
 	}
-	for namespace, number := range unboundNumberByNamespace {
+	for pvcLabels, number := range unboundNumber {
 		ch <- metrics.NewLazyConstMetric(
 			unboundPVCCountDesc,
 			metrics.GaugeValue,
 			float64(number),
-			namespace)
+			pvcLabels.namespace, pvcLabels.storageClassName, pvcLabels.volumeAttributesClassName)
 	}
 }
 

--- a/test/e2e/framework/pv/pv.go
+++ b/test/e2e/framework/pv/pv.go
@@ -621,12 +621,13 @@ func MakePersistentVolume(pvConfig PersistentVolumeConfig) *v1.PersistentVolume 
 			Capacity: v1.ResourceList{
 				v1.ResourceStorage: resource.MustParse(pvConfig.Capacity),
 			},
-			PersistentVolumeSource: pvConfig.PVSource,
-			AccessModes:            pvConfig.AccessModes,
-			ClaimRef:               claimRef,
-			StorageClassName:       pvConfig.StorageClassName,
-			NodeAffinity:           pvConfig.NodeAffinity,
-			VolumeMode:             pvConfig.VolumeMode,
+			PersistentVolumeSource:    pvConfig.PVSource,
+			AccessModes:               pvConfig.AccessModes,
+			ClaimRef:                  claimRef,
+			StorageClassName:          pvConfig.StorageClassName,
+			VolumeAttributesClassName: pvConfig.VolumeAttributesClassName,
+			NodeAffinity:              pvConfig.NodeAffinity,
+			VolumeMode:                pvConfig.VolumeMode,
 		},
 	}
 }

--- a/test/e2e/framework/pv/pv.go
+++ b/test/e2e/framework/pv/pv.go
@@ -104,6 +104,10 @@ type PersistentVolumeConfig struct {
 	// [Optiona] ReclaimPolicy defaults to "Reclaim" if unset
 	ReclaimPolicy    v1.PersistentVolumeReclaimPolicy
 	StorageClassName string
+	// [Optional] VolumeAttributesClassName specifies name of VolumeAttributesClass to which this PV belongs.
+	// When this field is not set, it indicates that this volume does not belong to any VAC.
+	// This is an alpha field and requires enabling VolumeAttributesClass feature.
+	VolumeAttributesClassName *string
 	// [Optional] NodeAffinity defines constraints that limit what nodes this
 	// volume can be accessed from.
 	NodeAffinity *v1.VolumeNodeAffinity

--- a/test/e2e/framework/pv/pv.go
+++ b/test/e2e/framework/pv/pv.go
@@ -104,10 +104,6 @@ type PersistentVolumeConfig struct {
 	// [Optiona] ReclaimPolicy defaults to "Reclaim" if unset
 	ReclaimPolicy    v1.PersistentVolumeReclaimPolicy
 	StorageClassName string
-	// [Optional] VolumeAttributesClassName specifies name of VolumeAttributesClass to which this PV belongs.
-	// When this field is not set, it indicates that this volume does not belong to any VAC.
-	// This is an alpha field and requires enabling VolumeAttributesClass feature.
-	VolumeAttributesClassName *string
 	// [Optional] NodeAffinity defines constraints that limit what nodes this
 	// volume can be accessed from.
 	NodeAffinity *v1.VolumeNodeAffinity
@@ -621,13 +617,12 @@ func MakePersistentVolume(pvConfig PersistentVolumeConfig) *v1.PersistentVolume 
 			Capacity: v1.ResourceList{
 				v1.ResourceStorage: resource.MustParse(pvConfig.Capacity),
 			},
-			PersistentVolumeSource:    pvConfig.PVSource,
-			AccessModes:               pvConfig.AccessModes,
-			ClaimRef:                  claimRef,
-			StorageClassName:          pvConfig.StorageClassName,
-			VolumeAttributesClassName: pvConfig.VolumeAttributesClassName,
-			NodeAffinity:              pvConfig.NodeAffinity,
-			VolumeMode:                pvConfig.VolumeMode,
+			PersistentVolumeSource: pvConfig.PVSource,
+			AccessModes:            pvConfig.AccessModes,
+			ClaimRef:               claimRef,
+			StorageClassName:       pvConfig.StorageClassName,
+			NodeAffinity:           pvConfig.NodeAffinity,
+			VolumeMode:             pvConfig.VolumeMode,
 		},
 	}
 }

--- a/test/e2e/storage/volume_metrics.go
+++ b/test/e2e/storage/volume_metrics.go
@@ -518,17 +518,17 @@ var _ = utils.SIGDescribe(framework.WithSerial(), "Volume metrics", func() {
 			pv  *v1.PersistentVolume
 			pvc *v1.PersistentVolumeClaim
 
-			storageClassName          = "bound-unbound-count-test-sc"
-			volumeAttributesClassName = "bound-unbound-count-test-vac"
-			// TODO: Insert volumeAttributesClassName into pvConfig/pvcConfig when "VolumeAttributesClass" is GA
-			pvConfig = e2epv.PersistentVolumeConfig{
+			storageClassName = "bound-unbound-count-test-sc"
+			pvConfig         = e2epv.PersistentVolumeConfig{
 				PVSource: v1.PersistentVolumeSource{
 					HostPath: &v1.HostPathVolumeSource{Path: "/data"},
 				},
 				NamePrefix:       "pv-test-",
 				StorageClassName: storageClassName,
 			}
-			pvcConfig = e2epv.PersistentVolumeClaimConfig{StorageClassName: &storageClassName}
+			// TODO: Insert volumeAttributesClassName into pvcConfig when "VolumeAttributesClass" is GA
+			volumeAttributesClassName = "bound-unbound-count-test-vac"
+			pvcConfig                 = e2epv.PersistentVolumeClaimConfig{StorageClassName: &storageClassName}
 
 			e2emetrics = []struct {
 				name      string
@@ -656,9 +656,7 @@ var _ = utils.SIGDescribe(framework.WithSerial(), "Volume metrics", func() {
 				dimensions := []string{namespaceKey, storageClassKey, volumeAttributeClassKey}
 				pvcConfigWithVAC := pvcConfig
 				pvcConfigWithVAC.VolumeAttributesClassName = &volumeAttributesClassName
-				pvConfigWithVAC := pvConfig
-				pvConfigWithVAC.VolumeAttributesClassName = &volumeAttributesClassName
-				pv, pvc, err = e2epv.CreatePVPVC(ctx, c, f.Timeouts, pvConfigWithVAC, pvcConfigWithVAC, ns, true)
+				pv, pvc, err = e2epv.CreatePVPVC(ctx, c, f.Timeouts, pvConfig, pvcConfigWithVAC, ns, true)
 				framework.ExpectNoError(err, "Error creating pv pvc: %v", err)
 				waitForPVControllerSync(ctx, metricsGrabber, boundPVKey, storageClassKey)
 				waitForPVControllerSync(ctx, metricsGrabber, boundPVCKey, volumeAttributeClassKey)

--- a/test/e2e/storage/volume_metrics.go
+++ b/test/e2e/storage/volume_metrics.go
@@ -19,6 +19,7 @@ package storage
 import (
 	"context"
 	"fmt"
+	"k8s.io/kubernetes/pkg/features"
 	"strings"
 	"time"
 
@@ -499,10 +500,11 @@ var _ = utils.SIGDescribe(framework.WithSerial(), "Volume metrics", func() {
 	// Test for pv controller metrics, concretely: bound/unbound pv/pvc count.
 	ginkgo.Describe("PVController", func() {
 		const (
-			classKey      = "storage_class"
-			namespaceKey  = "namespace"
-			pluginNameKey = "plugin_name"
-			volumeModeKey = "volume_mode"
+			namespaceKey            = "namespace"
+			pluginNameKey           = "plugin_name"
+			volumeModeKey           = "volume_mode"
+			storageClassKey         = "storage_class"
+			volumeAttributeClassKey = "volume_attributes_class"
 
 			totalPVKey    = "pv_collector_total_pv_count"
 			boundPVKey    = "pv_collector_bound_pv_count"
@@ -515,22 +517,24 @@ var _ = utils.SIGDescribe(framework.WithSerial(), "Volume metrics", func() {
 			pv  *v1.PersistentVolume
 			pvc *v1.PersistentVolumeClaim
 
-			className = "bound-unbound-count-test-sc"
-			pvConfig  = e2epv.PersistentVolumeConfig{
+			storageClassName          = "bound-unbound-count-test-sc"
+			volumeAttributesClassName = "bound-unbound-count-test-vac"
+			// TODO: Insert volumeAttributesClassName into pvConfig/pvcConfig when "VolumeAttributesClass" is GA
+			pvConfig = e2epv.PersistentVolumeConfig{
 				PVSource: v1.PersistentVolumeSource{
 					HostPath: &v1.HostPathVolumeSource{Path: "/data"},
 				},
 				NamePrefix:       "pv-test-",
-				StorageClassName: className,
+				StorageClassName: storageClassName,
 			}
-			pvcConfig = e2epv.PersistentVolumeClaimConfig{StorageClassName: &className}
+			pvcConfig = e2epv.PersistentVolumeClaimConfig{StorageClassName: &storageClassName}
 
 			e2emetrics = []struct {
 				name      string
 				dimension string
 			}{
-				{boundPVKey, classKey},
-				{unboundPVKey, classKey},
+				{boundPVKey, storageClassKey},
+				{unboundPVKey, storageClassKey},
 				{boundPVCKey, namespaceKey},
 				{unboundPVCKey, namespaceKey},
 			}
@@ -556,7 +560,7 @@ var _ = utils.SIGDescribe(framework.WithSerial(), "Volume metrics", func() {
 				if expectValues == nil {
 					expectValues = make(map[string]int64)
 				}
-				// We using relative increment value instead of absolute value to reduce unexpected flakes.
+				// We use relative increment value instead of absolute value to reduce unexpected flakes.
 				// Concretely, we expect the difference of the updated values and original values for each
 				// test suit are equal to expectValues.
 				actualValues := calculateRelativeValues(originMetricValues[i],
@@ -604,8 +608,8 @@ var _ = utils.SIGDescribe(framework.WithSerial(), "Volume metrics", func() {
 				var err error
 				pv, err = e2epv.CreatePV(ctx, c, f.Timeouts, pv)
 				framework.ExpectNoError(err, "Error creating pv: %v", err)
-				waitForPVControllerSync(ctx, metricsGrabber, unboundPVKey, classKey)
-				validator(ctx, []map[string]int64{nil, {className: 1}, nil, nil})
+				waitForPVControllerSync(ctx, metricsGrabber, unboundPVKey, storageClassKey)
+				validator(ctx, []map[string]int64{nil, {storageClassName: 1}, nil, nil})
 			})
 
 		ginkgo.It("should create unbound pvc count metrics for pvc controller after creating pvc only",
@@ -622,11 +626,49 @@ var _ = utils.SIGDescribe(framework.WithSerial(), "Volume metrics", func() {
 				var err error
 				pv, pvc, err = e2epv.CreatePVPVC(ctx, c, f.Timeouts, pvConfig, pvcConfig, ns, true)
 				framework.ExpectNoError(err, "Error creating pv pvc: %v", err)
-				waitForPVControllerSync(ctx, metricsGrabber, boundPVKey, classKey)
+				waitForPVControllerSync(ctx, metricsGrabber, boundPVKey, storageClassKey)
 				waitForPVControllerSync(ctx, metricsGrabber, boundPVCKey, namespaceKey)
-				validator(ctx, []map[string]int64{{className: 1}, nil, {ns: 1}, nil})
-
+				validator(ctx, []map[string]int64{{storageClassName: 1}, nil, {ns: 1}, nil})
 			})
+
+		// TODO: Merge with bound/unbound tests when "VolumeAttributesClass" feature is enabled by default
+		ginkgo.It("should create unbound pvc count metrics for pvc controller with volume attributes class dimension after creating pvc only",
+			func(ctx context.Context) {
+				framework.WithFeatureGate(features.VolumeAttributesClass)
+				var err error
+				dimensions := []string{namespaceKey, storageClassKey, volumeAttributeClassKey}
+				pvcConfigWithVAC := pvcConfig
+				pvcConfigWithVAC.VolumeAttributesClassName = &volumeAttributesClassName
+				pvcWithVAC := e2epv.MakePersistentVolumeClaim(pvcConfigWithVAC, ns)
+				pvc, err = e2epv.CreatePVC(ctx, c, ns, pvcWithVAC)
+				framework.ExpectNoError(err, "Error creating pvc: %v", err)
+				waitForPVControllerSync(ctx, metricsGrabber, unboundPVCKey, volumeAttributeClassKey)
+				controllerMetrics, err := metricsGrabber.GrabFromControllerManager(ctx)
+				framework.ExpectNoError(err, "Error getting c-m metricValues: %v", err)
+				err = testutil.ValidateMetrics(testutil.Metrics(controllerMetrics), unboundPVCKey, dimensions...)
+				framework.ExpectNoError(err, "Invalid metric in Controller Manager metrics: %q", unboundPVCKey)
+			})
+
+		// TODO: Merge with bound/unbound tests when "VolumeAttributesClass" feature is enabled by default
+		ginkgo.It("should create bound pv/pvc count metrics for pvc controller with volume attributes class dimension after creating both pv and pvc",
+			func(ctx context.Context) {
+				framework.WithFeatureGate(features.VolumeAttributesClass)
+				var err error
+				dimensions := []string{namespaceKey, storageClassKey, volumeAttributeClassKey}
+				pvcConfigWithVAC := pvcConfig
+				pvcConfigWithVAC.VolumeAttributesClassName = &volumeAttributesClassName
+				pvConfigWithVAC := pvConfig
+				pvConfigWithVAC.VolumeAttributesClassName = &volumeAttributesClassName
+				pv, pvc, err = e2epv.CreatePVPVC(ctx, c, f.Timeouts, pvConfigWithVAC, pvcConfigWithVAC, ns, true)
+				framework.ExpectNoError(err, "Error creating pv pvc: %v", err)
+				waitForPVControllerSync(ctx, metricsGrabber, boundPVKey, storageClassKey)
+				waitForPVControllerSync(ctx, metricsGrabber, boundPVCKey, volumeAttributeClassKey)
+				controllerMetrics, err := metricsGrabber.GrabFromControllerManager(ctx)
+				framework.ExpectNoError(err, "Error getting c-m metricValues: %v", err)
+				err = testutil.ValidateMetrics(testutil.Metrics(controllerMetrics), boundPVCKey, dimensions...)
+				framework.ExpectNoError(err, "Invalid metric in Controller Manager metrics: %q", boundPVCKey)
+			})
+
 		ginkgo.It("should create total pv count metrics for with plugin and volume mode labels after creating pv",
 			func(ctx context.Context) {
 				var err error

--- a/test/e2e/storage/volume_metrics.go
+++ b/test/e2e/storage/volume_metrics.go
@@ -633,7 +633,7 @@ var _ = utils.SIGDescribe(framework.WithSerial(), "Volume metrics", func() {
 			})
 
 		// TODO: Merge with bound/unbound tests when "VolumeAttributesClass" feature is enabled by default
-		ginkgo.It("should create unbound pvc count metrics for pvc controller with volume attributes class dimension after creating pvc only",
+		f.It("should create unbound pvc count metrics for pvc controller with volume attributes class dimension after creating pvc only",
 			feature.VolumeAttributesClass, framework.WithFeatureGate(features.VolumeAttributesClass), func(ctx context.Context) {
 				var err error
 				dimensions := []string{namespaceKey, storageClassKey, volumeAttributeClassKey}
@@ -650,7 +650,7 @@ var _ = utils.SIGDescribe(framework.WithSerial(), "Volume metrics", func() {
 			})
 
 		// TODO: Merge with bound/unbound tests when "VolumeAttributesClass" feature is enabled by default
-		ginkgo.It("should create bound pv/pvc count metrics for pvc controller with volume attributes class dimension after creating both pv and pvc",
+		f.It("should create bound pv/pvc count metrics for pvc controller with volume attributes class dimension after creating both pv and pvc",
 			feature.VolumeAttributesClass, framework.WithFeatureGate(features.VolumeAttributesClass), func(ctx context.Context) {
 				var err error
 				dimensions := []string{namespaceKey, storageClassKey, volumeAttributeClassKey}

--- a/test/e2e/storage/volume_metrics.go
+++ b/test/e2e/storage/volume_metrics.go
@@ -19,7 +19,6 @@ package storage
 import (
 	"context"
 	"fmt"
-	"k8s.io/kubernetes/pkg/features"
 	"strings"
 	"time"
 
@@ -33,7 +32,9 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/component-base/metrics/testutil"
 	"k8s.io/component-helpers/storage/ephemeral"
+	"k8s.io/kubernetes/pkg/features"
 	kubeletmetrics "k8s.io/kubernetes/pkg/kubelet/metrics"
+	"k8s.io/kubernetes/test/e2e/feature"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2emetrics "k8s.io/kubernetes/test/e2e/framework/metrics"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
@@ -633,8 +634,7 @@ var _ = utils.SIGDescribe(framework.WithSerial(), "Volume metrics", func() {
 
 		// TODO: Merge with bound/unbound tests when "VolumeAttributesClass" feature is enabled by default
 		ginkgo.It("should create unbound pvc count metrics for pvc controller with volume attributes class dimension after creating pvc only",
-			func(ctx context.Context) {
-				framework.WithFeatureGate(features.VolumeAttributesClass)
+			feature.VolumeAttributesClass, framework.WithFeatureGate(features.VolumeAttributesClass), func(ctx context.Context) {
 				var err error
 				dimensions := []string{namespaceKey, storageClassKey, volumeAttributeClassKey}
 				pvcConfigWithVAC := pvcConfig
@@ -651,8 +651,7 @@ var _ = utils.SIGDescribe(framework.WithSerial(), "Volume metrics", func() {
 
 		// TODO: Merge with bound/unbound tests when "VolumeAttributesClass" feature is enabled by default
 		ginkgo.It("should create bound pv/pvc count metrics for pvc controller with volume attributes class dimension after creating both pv and pvc",
-			func(ctx context.Context) {
-				framework.WithFeatureGate(features.VolumeAttributesClass)
+			feature.VolumeAttributesClass, framework.WithFeatureGate(features.VolumeAttributesClass), func(ctx context.Context) {
 				var err error
 				dimensions := []string{namespaceKey, storageClassKey, volumeAttributeClassKey}
 				pvcConfigWithVAC := pvcConfig


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Enhances observability of `VolumeAttributesClass` Feature by adding additional PVCollector metrics bound/unbound PVCs with labels for namespace, storage_class, volume_attributes_class.

With these additional labels, cluster operators can alarm on  `pv_collector_bound_pvc_count` to detect PVCs that are not able to bind. With the additional StorageClass and VolumeAttributesClass name labels, cluster operators can more easily check if a storage object misconfiguration is the cause of these binding issues. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #119302

#### Special notes for your reviewer:

Notes from July 22 SIG Implementation meeting:

@gnufied @jsafrane @AndrewSirenko @xing-yang @msau42 were all present and aligned on the following:

- We will add new labels to existing PV collector metric. All stakeholders agreed to this. @gnufied @jsafrane especially wanted some kind of metric on PV Collector. The downstream impact of changing metric by adding labels is better than additional metric with confusing name, especially because metric is `ALPHA`. 
- Metrics should also be added to kuberentes/kube-state-metrics in the near future. We are not bound by code freeze 24th deadline for that PR. @msau42 especially thinks metric should exist in kube-state-metrics.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added `storage_class` and `volume_attributes_class` labels to `pv_collector_bound_pvc_count` and `pv_collector_unbound_pvc_count` metrics.    
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/3751
```

