### PR TITLE
Hot fix for schema conversion panic

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/compilation.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/compilation.go
@@ -24,6 +24,7 @@ import (
 	"github.com/google/cel-go/cel"
 	"github.com/google/cel-go/checker"
 	"github.com/google/cel-go/common/types"
+	"github.com/pkg/errors"
 
 	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apiextensions-apiserver/pkg/apiserver/schema"
@@ -124,6 +125,9 @@ func Compile(s *schema.Structural, declType *apiservercel.DeclType, perCallLimit
 
 	if len(s.XValidations) == 0 {
 		return nil, nil
+	}
+	if declType == nil {
+		return nil, errors.New("Failed to convert to declType for CEL validation rules")
 	}
 	celRules := s.XValidations
 

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/model/adaptor.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/model/adaptor.go
@@ -62,6 +62,9 @@ func (s *Structural) Pattern() string {
 }
 
 func (s *Structural) Items() common.Schema {
+	if s.Structural.Items == nil {
+		return nil
+	}
 	return &Structural{Structural: s.Structural.Items}
 }
 

--- a/test/integration/apiserver/crd_validation_expressions_test.go
+++ b/test/integration/apiserver/crd_validation_expressions_test.go
@@ -658,6 +658,103 @@ func TestCustomResourceValidatorsWithBlockingErrors(t *testing.T) {
 	})
 }
 
+// TestCustomResourceValidatorsWithSchemaConversion tests CRD replacement with schema conversion issue should not panic.
+func TestCustomResourceValidatorsWithSchemaConversion(t *testing.T) {
+	server, err := apiservertesting.StartTestServer(t, apiservertesting.NewDefaultTestServerOptions(), nil, framework.SharedEtcd())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer server.TearDownFn()
+	config := server.ClientConfig
+
+	apiExtensionClient, err := clientset.NewForConfig(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dynamicClient, err := dynamic.NewForConfig(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create CRD with normal items+array schema
+	structuralWithValidators := crdWithSchema(t, "Structural", structuralSchemaWithItemsUnderArray)
+	crd, err := fixtures.CreateNewV1CustomResourceDefinition(structuralWithValidators, apiExtensionClient, dynamicClient)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gvr := schema.GroupVersionResource{
+		Group:    crd.Spec.Group,
+		Version:  crd.Spec.Versions[0].Name,
+		Resource: crd.Spec.Names.Plural,
+	}
+	crClient := dynamicClient.Resource(gvr)
+
+	// Create a valid CR instance
+	name1 := names.SimpleNameGenerator.GenerateName("cr-1")
+	_, err = crClient.Create(context.TODO(), &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": gvr.Group + "/" + gvr.Version,
+		"kind":       crd.Spec.Names.Kind,
+		"metadata": map[string]interface{}{
+			"name": name1,
+		},
+		"spec": map[string]interface{}{
+			"backend": []interface{}{
+				map[string]interface{}{
+					"replicas": 8,
+				},
+			},
+		},
+	}}, metav1.CreateOptions{})
+	if err != nil {
+		t.Errorf("Failed to create custom resource: %v", err)
+	}
+	crd, err = apiExtensionClient.ApiextensionsV1().CustomResourceDefinitions().Get(context.TODO(), crd.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	structuralSchemaWithItemsUnderObject := crdWithSchema(t, "Structural", structuralSchemaWithItemsUnderObject)
+	structuralSchemaWithItemsUnderObject.SetResourceVersion(crd.GetResourceVersion())
+	// Update CRD with invalid schema items under object
+	crd, err = apiExtensionClient.ApiextensionsV1().CustomResourceDefinitions().Update(context.TODO(), structuralSchemaWithItemsUnderObject, metav1.UpdateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Make an unrelated update to the previous persisted CR instance to make sure CRD handler doesn't panic
+	oldCR, err := crClient.Get(context.TODO(), name1, metav1.GetOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldCR.Object["metadata"].(map[string]interface{})["labels"] = map[string]interface{}{"key": "value"}
+	_, err = crClient.Update(context.TODO(), oldCR, metav1.UpdateOptions{})
+	if err == nil || !strings.Contains(err.Error(), "rule compiler initialization error: Failed to convert to declType for CEL validation rules") {
+		t.Fatalf("expect error to contain \rule compiler initialization error: Failed to convert to declType for CEL validation rules\" but get: %v", err)
+	}
+	// Create another CR instance with an array and be rejected
+	name2 := names.SimpleNameGenerator.GenerateName("cr-2")
+	_, err = crClient.Create(context.TODO(), &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": gvr.Group + "/" + gvr.Version,
+		"kind":       crd.Spec.Names.Kind,
+		"metadata": map[string]interface{}{
+			"name": name2,
+		},
+		"spec": map[string]interface{}{
+			"backend": []interface{}{
+				map[string]interface{}{
+					"replicas": 7,
+				},
+			},
+		},
+	}}, metav1.CreateOptions{})
+	if err == nil || !strings.Contains(err.Error(), "Invalid value: \"array\": spec.backend in body must be of type object: \"array\"") {
+		t.Fatalf("expect error to contain \"Invalid value: \"array\": spec.backend in body must be of type object: \"array\"\" but get: %v", err)
+	}
+	// Delete the CRD
+	err = fixtures.DeleteV1CustomResourceDefinition(structuralWithValidators, apiExtensionClient)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 func nonStructuralCrdWithValidations() *apiextensionsv1beta1.CustomResourceDefinition {
 	return &apiextensionsv1beta1.CustomResourceDefinition{
 		ObjectMeta: metav1.ObjectMeta{
@@ -881,6 +978,76 @@ var structuralSchemaWithBlockingErr = []byte(`
           "z": {
             "type": "integer",
 			"default": 0
+          }
+        }
+      }
+    }
+  }
+}`)
+
+var structuralSchemaWithItemsUnderArray = []byte(`
+{
+  "openAPIV3Schema": {
+    "description": "CRD with CEL validators",
+    "type": "object",
+    "properties": {
+      "spec": {
+        "type": "object",
+        "properties": {
+          "backend": {
+            "type": "array",
+            "maxItems": 100,
+            "items": {
+              "type": "object",
+              "properties": {
+                "replicas": {
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "replicas"
+              ],
+              "x-kubernetes-validations": [
+                {
+                  "rule": "0 <= self.replicas && self.replicas <= 10"
+                }
+              ]
+            }
+          }
+        }
+      }
+    }
+  }
+}`)
+
+var structuralSchemaWithItemsUnderObject = []byte(`
+{
+  "openAPIV3Schema": {
+    "description": "CRD with CEL validators",
+    "type": "object",
+    "properties": {
+      "spec": {
+        "type": "object",
+        "properties": {
+          "backend": {
+            "type": "object",
+            "maxItems": 100,
+            "items": {
+              "type": "object",
+              "properties": {
+                "replicas": {
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "replicas"
+              ],
+              "x-kubernetes-validations": [
+                {
+                  "rule": "0 <= self.replicas && self.replicas <= 10"
+                }
+              ]
+            }
           }
         }
       }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This is to partially fix https://github.com/kubernetes/kubernetes/issues/126133 by not panic.
After this fix is merged, we will be backporting the fix to earlier releases. And having a separate pr for adding additional guards.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kube-apiserver: fixes a potential crash serving CustomResourceDefinitions that combine an invalid schema and CEL validation rules.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
