### PR TITLE
Make Job PodFailurePolicy e2e tests resilient to random failures to prepare them for conformance

### DIFF
--- a/test/e2e/framework/job/fixtures.go
+++ b/test/e2e/framework/job/fixtures.go
@@ -136,27 +136,6 @@ func NewTestJobOnNode(behavior, name string, rPol v1.RestartPolicy, parallelism,
 				exit 1
 			fi
 		`}
-	case "notTerminateOnce":
-		// Do not terminate the 0-indexed pod in the first run and
-		// succeed the second time. Fail the non-0-indexed pods until
-		// the marker file is created by the 0-indexed pod. The fact that
-		// the non-0-indexed pods are succeeded is used to determine that the
-		// 0th indexed pod already created the marker file.
-		setupHostPathDirectory(job)
-		job.Spec.Template.Spec.TerminationGracePeriodSeconds = ptr.To(int64(1))
-		job.Spec.Template.Spec.Containers[0].Command = []string{"/bin/sh", "-c"}
-		job.Spec.Template.Spec.Containers[0].Args = []string{`
-			if [[ -r /data/foo ]]
-			then
-				exit 0
-			elif [[ $JOB_COMPLETION_INDEX -eq 0 ]]
-			then
-				touch /data/foo
-				sleep 1000000
-			else
-				exit 1
-			fi
-		`}
 	case "notTerminateOncePerIndex":
 		// Use marker files per index. If the given marker file already exists
 		// then terminate successfully. Otherwise create the marker file and
@@ -173,8 +152,17 @@ func NewTestJobOnNode(behavior, name string, rPol v1.RestartPolicy, parallelism,
 				sleep 1000000
 			fi
 		`}
+		// Add readiness probe to allow the test client to check if the marker
+		// file is already created before evicting the Pod.
+		job.Spec.Template.Spec.Containers[0].ReadinessProbe = &v1.Probe{
+			PeriodSeconds: 1,
+			ProbeHandler: v1.ProbeHandler{
+				Exec: &v1.ExecAction{
+					Command: []string{"/bin/sh", "-c", "cat /data/foo-$JOB_COMPLETION_INDEX"},
+				},
+			},
+		}
 	}
-
 	return job
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Follow up to the https://github.com/kubernetes/kubernetes/pull/125482#issuecomment-2233408132.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

This is what is currently implemented:
* drop the test "Job should allow to use the pod failure policy to not count the failure towards the backoffLimit" because it is redundant with "Job should allow to use a pod failure policy to ignore failure for an evicted pod; matching on the exit code"
* make the other tests resilient to the random failures, by using backoffLimit = completions, and triggering "completion" failures, which are all ignored. If they were not, the Job would fail.

Initially I tried this: use backoffLimit: 6 in the init phase (until all pods are running or succeeded), and reduce (update) backoffLimit to 0 (or the current number of Failures), then evict the pod with index 0, this way we get a single controlled failure. However. I realized, the Job may fail if the replacement pod for 0-indexed pod fails to schedule after reducing backoffLimit to 0.

Another idea is to watch that the UID of the evicted pod is not in 'uncountedTerminatedPods.Failed'. but this requires switching to non indexed jobs, and overall seems quite low level.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
