### PR TITLE
Adds metrics to PortForward Websockets

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/util/proxy/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/proxy/metrics/metrics.go
@@ -33,7 +33,7 @@ var registerMetricsOnce sync.Once
 
 var (
 	// streamTranslatorRequestsTotal counts the number of requests that were handled by
-	// the StreamTranslatorProxy.
+	// the StreamTranslatorProxy (RemoteCommand subprotocol).
 	streamTranslatorRequestsTotal = metrics.NewCounterVec(
 		&metrics.CounterOpts{
 			Subsystem:      subsystem,
@@ -43,19 +43,37 @@ var (
 		},
 		[]string{statuscode},
 	)
+	// streamTunnelRequestsTotal counts the number of requests that were handled by
+	// the StreamTunnelProxy (PortForward subprotocol).
+	streamTunnelRequestsTotal = metrics.NewCounterVec(
+		&metrics.CounterOpts{
+			Subsystem:      subsystem,
+			Name:           "stream_tunnel_requests_total",
+			Help:           "Total number of requests that were handled by the StreamTunnelProxy, which processes streaming PortForward/V2",
+			StabilityLevel: metrics.ALPHA,
+		},
+		[]string{statuscode},
+	)
 )
 
 func Register() {
 	registerMetricsOnce.Do(func() {
 		legacyregistry.MustRegister(streamTranslatorRequestsTotal)
+		legacyregistry.MustRegister(streamTunnelRequestsTotal)
 	})
 }
 
 func ResetForTest() {
 	streamTranslatorRequestsTotal.Reset()
+	streamTunnelRequestsTotal.Reset()
 }
 
 // IncStreamTranslatorRequest increments the # of requests handled by the StreamTranslatorProxy.
 func IncStreamTranslatorRequest(ctx context.Context, status string) {
 	streamTranslatorRequestsTotal.WithContext(ctx).WithLabelValues(status).Add(1)
+}
+
+// IncStreamTunnelRequest increments the # of requests handled by the StreamTunnelProxy.
+func IncStreamTunnelRequest(ctx context.Context, status string) {
+	streamTunnelRequestsTotal.WithContext(ctx).WithLabelValues(status).Add(1)
 }


### PR DESCRIPTION
* Adds metric to `PortForward` tunneling through WebSockets: `stream_tunnel_requests_total`.
* Includes unit tests for the new metric.
  * Current unit test coverage for this `proxy` package: `84.0%`
  * `ok  	k8s.io/apiserver/pkg/util/proxy	2.921s	coverage: 84.0% of statements`

/kind cleanup

```release-note
NONE
```
- [Transition from SPDY to WebSockets #4006](https://github.com/kubernetes/enhancements/issues/4006)

