### PR TITLE
KEP-4191: Split Image Filesystem promotion to Beta

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -391,10 +391,14 @@ const (
 	// Enable POD resources API with Get method
 	KubeletPodResourcesGet featuregate.Feature = "KubeletPodResourcesGet"
 
-	// KubeletSeparateDiskGC enables Kubelet to garbage collection images/containers on different filesystems
 	// owner: @kannon92
 	// kep: https://kep.k8s.io/4191
 	// alpha: v1.29
+	// beta: v1.31
+	//
+	// The split image filesystem feature enables kubelet to perform garbage collection
+	// of images (read-only layers) and/or containers (writeable layers) deployed on
+	// separate filesystems.
 	KubeletSeparateDiskGC featuregate.Feature = "KubeletSeparateDiskGC"
 
 	// owner: @sallyom
@@ -1078,7 +1082,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 
 	KubeletPodResourcesGet: {Default: false, PreRelease: featuregate.Alpha},
 
-	KubeletSeparateDiskGC: {Default: false, PreRelease: featuregate.Alpha},
+	KubeletSeparateDiskGC: {Default: true, PreRelease: featuregate.Beta},
 
 	KubeletTracing: {Default: true, PreRelease: featuregate.Beta},
 


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Promote [KEP-4191](https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/4191-split-image-filesystem/README.md) "Split Image Filesystem" to Beta. Starting from the upcoming Kubernetes release v1.31, the feature will be enabled by default, allowing users to deploy split image and container filesystems without enabling the feature gate to benefit from the new functionality.

Related:

- https://github.com/kubernetes/enhancements/pull/4684

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

```release-note
Promote KEP-4191 "Split Image Filesystem" to Beta.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
[KEP]: https://kep.k8s.io/4191
```
