### PR TITLE
Make ServiceBackendPort an atomic struct

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -14052,7 +14052,8 @@
           "type": "integer"
         }
       },
-      "type": "object"
+      "type": "object",
+      "x-kubernetes-map-type": "atomic"
     },
     "io.k8s.api.networking.v1beta1.IPAddress": {
       "description": "IPAddress represents a single IP of a single IP Family. The object is designed to be used by APIs that operate on IP addresses. The object is used by the Service core API for allocation of IP addresses. An IP address can be represented in different formats, to guarantee the uniqueness of the IP, the name of the object is the IP address in canonical format, four decimal digits separated by dots suppressing leading zeros for IPv4 and the representation defined by RFC 5952 for IPv6. Valid: 192.168.1.5 or 2001:db8::1 or 2001:db8:aaaa:bbbb:cccc:dddd:eeee:1 Invalid: 10.01.2.3 or 2001:db8:0:0:0::1",

--- a/api/openapi-spec/v3/apis__networking.k8s.io__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__networking.k8s.io__v1_openapi.json
@@ -799,7 +799,8 @@
             "type": "integer"
           }
         },
-        "type": "object"
+        "type": "object",
+        "x-kubernetes-map-type": "atomic"
       },
       "io.k8s.apimachinery.pkg.apis.meta.v1.APIResource": {
         "description": "APIResource specifies the name of a resource and whether it is namespaced.",

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -40804,6 +40804,11 @@ func schema_k8sio_api_networking_v1_ServiceBackendPort(ref common.ReferenceCallb
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"x-kubernetes-map-type": "atomic",
+				},
+			},
 		},
 	}
 }

--- a/staging/src/k8s.io/api/networking/v1/generated.proto
+++ b/staging/src/k8s.io/api/networking/v1/generated.proto
@@ -541,6 +541,7 @@ message NetworkPolicySpec {
 }
 
 // ServiceBackendPort is the service port being referenced.
+// +structType=atomic
 message ServiceBackendPort {
   // name is the name of the port on the Service.
   // This is a mutually exclusive setting with "Number".

--- a/staging/src/k8s.io/api/networking/v1/types.go
+++ b/staging/src/k8s.io/api/networking/v1/types.go
@@ -531,6 +531,7 @@ type IngressServiceBackend struct {
 }
 
 // ServiceBackendPort is the service port being referenced.
+// +structType=atomic
 type ServiceBackendPort struct {
 	// name is the name of the port on the Service.
 	// This is a mutually exclusive setting with "Number".

--- a/staging/src/k8s.io/client-go/applyconfigurations/internal/internal.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/internal/internal.go
@@ -10977,6 +10977,7 @@ var schemaYAML = typed.YAMLObject(`types:
     - name: number
       type:
         scalar: numeric
+    elementRelationship: atomic
 - name: io.k8s.api.networking.v1alpha1.IPAddress
   map:
     fields:


### PR DESCRIPTION
This allows different actors to force ownership of one field without having to explicitly unset the other field.

See #125869

Before: `The Ingress "myingress" is invalid: spec.defaultBackend: Invalid value: "": cannot set both port name & port number`

After: success.

@jpbetz asserts this is safe:  https://github.com/kubernetes-sigs/structured-merge-diff/pull/170

/kind bug
/kind api-change

Fixes #125869

```release-note
Changed how the API server handles updates to `.spec.defaultBackend` of Ingress objects.
Server-side apply now considers `.spec.defaultBackend` to be an atomic struct.  This means that any field-owner who sets values in that struct (they are mutually exclusive) owns the whole struct. For almost all users this change has no impact; for controllers that want to change the default backend port from number to name (or vice-versa), this makes it easier.
```

