### PR TITLE
Two adjustments of coding habits and two repeated testInput instances

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -320,7 +320,7 @@ function kube::build::docker_delete_old_containers() {
   done
 }
 
-# Takes $1 and computes a short has for it. Useful for unique tag generation
+# Takes $1 and computes a short hash for it. Useful for unique tag generation
 function kube::build::short_hash() {
   [[ $# -eq 1 ]] || {
     kube::log::error "Internal error.  No data based to short_hash."

--- a/build/common.sh
+++ b/build/common.sh
@@ -320,7 +320,7 @@ function kube::build::docker_delete_old_containers() {
   done
 }
 
-# Takes $1 and computes a short hash for it. Useful for unique tag generation
+# Takes $1 and computes a short has for it. Useful for unique tag generation
 function kube::build::short_hash() {
   [[ $# -eq 1 ]] || {
     kube::log::error "Internal error.  No data based to short_hash."

--- a/pkg/apis/core/v1/conversion_test.go
+++ b/pkg/apis/core/v1/conversion_test.go
@@ -373,7 +373,7 @@ func Test_core_PodStatus_to_v1_PodStatus(t *testing.T) {
 	}
 	for i, input := range testInputs {
 		v1PodStatus := v1.PodStatus{}
-		if err := corev1.Convert_core_PodStatus_To_v1_PodStatus(&input, &v1PodStatus, nil); nil != err {
+		if err := corev1.Convert_core_PodStatus_To_v1_PodStatus(&input, &v1PodStatus, nil); err != nil {
 			t.Errorf("%v: Convert core.PodStatus to v1.PodStatus failed with error %v", i, err.Error())
 		}
 
@@ -569,7 +569,7 @@ func Test_core_NodeSpec_to_v1_NodeSpec(t *testing.T) {
 	for i, testInput := range testInputs {
 		v1NodeSpec := v1.NodeSpec{}
 		// convert
-		if err := corev1.Convert_core_NodeSpec_To_v1_NodeSpec(&testInput, &v1NodeSpec, nil); nil != err {
+		if err := corev1.Convert_core_NodeSpec_To_v1_NodeSpec(&testInput, &v1NodeSpec, nil); err != nil {
 			t.Errorf("%v: Convert core.NodeSpec to v1.NodeSpec failed with error %v", i, err.Error())
 		}
 
@@ -637,15 +637,6 @@ func Test_v1_NodeSpec_to_core_NodeSpec(t *testing.T) {
 		// cidr only - 6
 		{
 			PodCIDR: "ace:cab:deca::/8",
-		},
-		// Both are provided
-		{
-			PodCIDR:  "10.0.1.0/24",
-			PodCIDRs: []string{"10.0.1.0/24", "ace:cab:deca::/8"},
-		},
-		// list only
-		{
-			PodCIDRs: []string{"10.0.1.0/24", "ace:cab:deca::/8"},
 		},
 		// Both are provided 4,6
 		{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Two adjustments of coding habits and two repeated testInput instances
As follows:	
// Both are provided   same as  // Both are provided 4,6
// list only same as // list only 4,6
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
