### PR TITLE
chore(servicecidr): use WaitForCacheSync after sharedInformerFactory Start in integration test

### DIFF
--- a/test/integration/servicecidr/migration_test.go
+++ b/test/integration/servicecidr/migration_test.go
@@ -82,6 +82,7 @@ func TestMigrateServiceCIDR(t *testing.T) {
 		client1,
 	).Run(tCtx, 5)
 	informers1.Start(tCtx.Done())
+	informers1.WaitForCacheSync(tCtx.Done())
 
 	// the default serviceCIDR should have a finalizer and ready condition set to true
 	if err := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, time.Minute, false, func(ctx context.Context) (bool, error) {
@@ -220,6 +221,7 @@ func TestMigrateServiceCIDR(t *testing.T) {
 		client2,
 	).Run(tCtx2, 5)
 	informers2.Start(tCtx2.Done())
+	informers2.WaitForCacheSync(tCtx.Done())
 
 	// delete the kubernetes.default service so the old DefaultServiceCIDR can be deleted
 	// and the new apiserver can take over

--- a/test/integration/servicecidr/servicecidr_test.go
+++ b/test/integration/servicecidr/servicecidr_test.go
@@ -68,6 +68,7 @@ func TestServiceAllocNewServiceCIDR(t *testing.T) {
 		client,
 	).Run(ctx, 5)
 	informerFactory.Start(ctx.Done())
+	informerFactory.WaitForCacheSync(ctx.Done())
 
 	// /29 = 6 services, kubernetes.default takes the first address
 	// make 5 more services to take up all IPs
@@ -169,6 +170,7 @@ func TestServiceCIDRDeletion(t *testing.T) {
 		client,
 	).Run(ctx, 5)
 	informerFactory.Start(ctx.Done())
+	informerFactory.WaitForCacheSync(ctx.Done())
 
 	// /29 = 6 services, kubernetes.default takes the first address
 	// make 5 more services to take up all IPs

--- a/test/integration/servicecidr/servicecidr_test.go
+++ b/test/integration/servicecidr/servicecidr_test.go
@@ -182,7 +182,7 @@ func TestServiceCIDRDeletion(t *testing.T) {
 	// create a new ServiceCIDRs that overlaps the default one
 	_, err = client.NetworkingV1beta1().ServiceCIDRs().Create(ctx, makeServiceCIDR("cidr1", cidr1, ""), metav1.CreateOptions{})
 	if err != nil {
-		t.Fatal((err))
+		t.Fatal(err)
 	}
 	// Wait until is ready.
 	if err := wait.PollUntilContextTimeout(context.Background(), 250*time.Millisecond, 30*time.Second, false, func(ctx context.Context) (bool, error) {
@@ -197,7 +197,7 @@ func TestServiceCIDRDeletion(t *testing.T) {
 	// we should be able to delete the ServiceCIDR despite it contains IP addresses as it overlaps with the default ServiceCIDR
 	err = client.NetworkingV1beta1().ServiceCIDRs().Delete(ctx, "cidr1", metav1.DeleteOptions{})
 	if err != nil {
-		t.Fatal((err))
+		t.Fatal(err)
 	}
 
 	if err := wait.PollUntilContextTimeout(context.Background(), 250*time.Millisecond, 30*time.Second, false, func(ctx context.Context) (bool, error) {
@@ -213,7 +213,7 @@ func TestServiceCIDRDeletion(t *testing.T) {
 	// add a new ServiceCIDR with a new range
 	_, err = client.NetworkingV1beta1().ServiceCIDRs().Create(ctx, makeServiceCIDR("cidr2", cidr2, ""), metav1.CreateOptions{})
 	if err != nil {
-		t.Fatal((err))
+		t.Fatal(err)
 	}
 	// wait the allocator process the new ServiceCIDR
 	// Wait until is ready.
@@ -239,7 +239,7 @@ func TestServiceCIDRDeletion(t *testing.T) {
 	// add a new ServiceCIDR that overlaps the existing one
 	_, err = client.NetworkingV1beta1().ServiceCIDRs().Create(ctx, makeServiceCIDR("cidr3", cidr3, ""), metav1.CreateOptions{})
 	if err != nil {
-		t.Fatal((err))
+		t.Fatal(err)
 	}
 	// Wait until is ready.
 	if err := wait.PollUntilContextTimeout(context.Background(), 250*time.Millisecond, 30*time.Second, false, func(ctx context.Context) (bool, error) {
@@ -254,7 +254,7 @@ func TestServiceCIDRDeletion(t *testing.T) {
 	// we should be able to delete the ServiceCIDR2 despite it contains IP addresses as it is contained on ServiceCIDR3
 	err = client.NetworkingV1beta1().ServiceCIDRs().Delete(ctx, "cidr2", metav1.DeleteOptions{})
 	if err != nil {
-		t.Fatal((err))
+		t.Fatal(err)
 	}
 
 	if err := wait.PollUntilContextTimeout(context.Background(), 250*time.Millisecond, 30*time.Second, false, func(ctx context.Context) (bool, error) {
@@ -270,7 +270,7 @@ func TestServiceCIDRDeletion(t *testing.T) {
 	// serviceCIDR3 will not be able to be deleted until the IPAddress is removed
 	err = client.NetworkingV1beta1().ServiceCIDRs().Delete(ctx, "cidr3", metav1.DeleteOptions{})
 	if err != nil {
-		t.Fatal((err))
+		t.Fatal(err)
 	}
 	// Wait until is not ready.
 	if err := wait.PollUntilContextTimeout(context.Background(), 250*time.Millisecond, 30*time.Second, false, func(ctx context.Context) (bool, error) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup
#### What this PR does / why we need it:
- use WaitForCacheSync method after sharedInformerFactory Start
- remove typo
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # https://github.com/kubernetes/kubernetes/issues/126256

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
