### PR TITLE
Automated cherry pick of #126224: kubeadm: fix join bug where kubeletconfig was not patched in

### DIFF
--- a/cmd/kubeadm/app/cmd/phases/join/kubelet.go
+++ b/cmd/kubeadm/app/cmd/phases/join/kubelet.go
@@ -205,6 +205,14 @@ func runKubeletStartJoinPhase(c workflow.RunData) (returnErr error) {
 	fmt.Println("[kubelet-start] Starting the kubelet")
 	kubeletphase.TryStartKubelet()
 
+	// Apply patches to the in-memory kubelet configuration so that any configuration changes like kubelet healthz
+	// address and port options are respected during the wait below. WriteConfigToDisk already applied patches to
+	// the kubelet.yaml written to disk. This should be done after WriteConfigToDisk because both use the same config
+	// in memory and we don't want patches to be applied two times to the config that is written to disk.
+	if err := kubeletphase.ApplyPatchesToConfig(&initCfg.ClusterConfiguration, data.PatchesDir()); err != nil {
+		return errors.Wrap(err, "could not apply patches to the in-memory kubelet configuration")
+	}
+
 	// Now the kubelet will perform the TLS Bootstrap, transforming /etc/kubernetes/bootstrap-kubelet.conf to /etc/kubernetes/kubelet.conf
 	// Wait for the kubelet to create the /etc/kubernetes/kubelet.conf kubeconfig file. If this process
 	// times out, display a somewhat user-friendly message.

--- a/cmd/kubeadm/app/util/apiclient/wait.go
+++ b/cmd/kubeadm/app/util/apiclient/wait.go
@@ -250,7 +250,12 @@ func (w *KubeWaiter) WaitForKubelet(healthzAddress string, healthzPort int32) er
 		healthzEndpoint = fmt.Sprintf("http://%s:%d/healthz", healthzAddress, healthzPort)
 	)
 
-	fmt.Printf("[kubelet-check] Waiting for a healthy kubelet. This can take up to %v\n", w.timeout)
+	if healthzPort == 0 {
+		fmt.Println("[kubelet-check] Skipping the kubelet health check because the healthz port is set to 0")
+		return nil
+	}
+	fmt.Printf("[kubelet-check] Waiting for a healthy kubelet at %s. This can take up to %v\n",
+		healthzEndpoint, w.timeout)
 
 	formatError := func(cause string) error {
 		return errors.Errorf("The HTTP call equal to 'curl -sSL %s' returned %s\n",


### PR DESCRIPTION
Cherry pick of #126224 on release-1.30.

#126224: kubeadm: fix join bug where kubeletconfig was not patched in

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
kubeadm: fixed a bug on 'kubeadm join' where using patches with a kubeletconfiguration target was not respected when performing the local kubelet healthz check.
```