### PR TITLE
kube-proxy: internal config: refactor BindAddress

### DIFF
--- a/cmd/kube-proxy/app/options_test.go
+++ b/cmd/kube-proxy/app/options_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/require"
 
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	componentbaseconfig "k8s.io/component-base/config"
@@ -188,7 +189,8 @@ nodePortAddresses:
 				expBindAddr = expBindAddr[1 : len(tc.bindAddress)-1]
 			}
 			expected := &kubeproxyconfig.KubeProxyConfiguration{
-				BindAddress: expBindAddr,
+				NodeIPOverride: []string{expBindAddr},
+				IPFamilyPolicy: v1.IPFamilyPolicyPreferDualStack,
 				ClientConnection: componentbaseconfig.ClientConnectionConfiguration{
 					AcceptContentTypes: "abc",
 					Burst:              100,
@@ -452,6 +454,15 @@ func TestProcessV1Alpha1Flags(t *testing.T) {
 			},
 			validate: func(config *kubeproxyconfig.KubeProxyConfiguration) bool {
 				return reflect.DeepEqual(config.DetectLocal.ClusterCIDRs, []string{"2002:0:0:1234::/64", "10.0.0.0/14"})
+			},
+		},
+		{
+			name: "bind address",
+			flags: []string{
+				"--bind-address=0.0.0.0",
+			},
+			validate: func(config *kubeproxyconfig.KubeProxyConfiguration) bool {
+				return reflect.DeepEqual(config.NodeIPOverride, []string{"0.0.0.0"})
 			},
 		},
 	}

--- a/cmd/kube-proxy/app/server.go
+++ b/cmd/kube-proxy/app/server.go
@@ -626,9 +626,9 @@ func (s *ProxyServer) birthCry() {
 // dual-stack if the backend is capable of supporting both IP families, regardless of
 // whether the node is *actually* configured as dual-stack or not.)
 
-// (Note that on Linux, the node IPs are used only to determine whether a given
-// LoadBalancerSourceRanges value matches the node or not. In particular, they are *not*
-// used for NodePort handling.)
+// (Note that on Linux, the node IPs are used only (a) to determine whether a given
+// LoadBalancerSourceRanges value matches the node or not, and (b) as the IP(s) to
+// accept NodePort connections on when NodePortAddresses is set to 'primary'.)
 //
 // The order of precedence is:
 //  1. if bindAddress is not 0.0.0.0 or ::, then it is used as the primary IP.

--- a/pkg/proxy/apis/config/fuzzer/fuzzer.go
+++ b/pkg/proxy/apis/config/fuzzer/fuzzer.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/google/gofuzz"
 
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtimeserializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	kubeproxyconfig "k8s.io/kubernetes/pkg/proxy/apis/config"
@@ -83,7 +84,6 @@ func Funcs(codecs runtimeserializer.CodecFactory) []interface{} {
 	return []interface{}{
 		func(obj *kubeproxyconfig.KubeProxyConfiguration, c fuzz.Continue) {
 			c.FuzzNoCustom(obj)
-			obj.BindAddress = fmt.Sprintf("%d.%d.%d.%d", c.Intn(256), c.Intn(256), c.Intn(256), c.Intn(256))
 			obj.ClientConnection.ContentType = c.RandString()
 			obj.DetectLocal.ClusterCIDRs = getRandomDualStackCIDR(c)
 			obj.Linux.Conntrack.MaxPerCore = ptr.To(c.Int31())
@@ -95,6 +95,7 @@ func Funcs(codecs runtimeserializer.CodecFactory) []interface{} {
 			obj.IPTables.MasqueradeBit = ptr.To(c.Int31())
 			obj.IPTables.LocalhostNodePorts = ptr.To(c.RandBool())
 			obj.NFTables.MasqueradeBit = ptr.To(c.Int31())
+			obj.NodeIPOverride = []string{fmt.Sprintf("%d.%d.%d.%d", c.Intn(256), c.Intn(256), c.Intn(256), c.Intn(256))}
 			obj.MetricsBindAddress = fmt.Sprintf("%d.%d.%d.%d:%d", c.Intn(256), c.Intn(256), c.Intn(256), c.Intn(256), c.Intn(65536))
 			obj.Linux.OOMScoreAdj = ptr.To(c.Int31())
 			obj.ClientConnection.ContentType = "bar"
@@ -102,6 +103,7 @@ func Funcs(codecs runtimeserializer.CodecFactory) []interface{} {
 			if obj.Logging.Format == "" {
 				obj.Logging.Format = "text"
 			}
+			obj.IPFamilyPolicy = v1.IPFamilyPolicyPreferDualStack
 		},
 	}
 }

--- a/pkg/proxy/apis/config/types.go
+++ b/pkg/proxy/apis/config/types.go
@@ -17,6 +17,7 @@ limitations under the License.
 package config
 
 import (
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	componentbaseconfig "k8s.io/component-base/config"
 	logsapi "k8s.io/component-base/logs/api/v1"
@@ -179,10 +180,14 @@ type KubeProxyConfiguration struct {
 	// kube-proxy is running on. If unset, the node name is assumed to be the same as
 	// the node's hostname.
 	HostnameOverride string
-	// bindAddress can be used to override kube-proxy's idea of what its node's
-	// primary IP is. Note that the name is a historical artifact, and kube-proxy does
-	// not actually bind any sockets to this IP.
-	BindAddress string
+	// nodeIPOverride lets you override the node IP(s) if kube-proxy is auto-detecting
+	// the wrong IP(s).
+	NodeIPOverride []string
+	// ipFamilyPolicy controls whether kube-proxy runs in single-stack or dual-stack mode.
+	// The default is 'PreferDualStack' if nodeIPOverride is not specified, 'SingleStack'
+	// if nodeIPOverride contains a single IP, or 'RequireDualStack' if nodeIPOverride
+	// contains dual-stack IPs.
+	IPFamilyPolicy v1.IPFamilyPolicy
 	// healthzBindAddress is the IP address and port for the health check server to
 	// serve on, defaulting to "0.0.0.0:10256" (if bindAddress is unset or IPv4), or
 	// "[::]:10256" (if bindAddress is IPv6).

--- a/pkg/proxy/apis/config/v1alpha1/conversion.go
+++ b/pkg/proxy/apis/config/v1alpha1/conversion.go
@@ -19,6 +19,7 @@ package v1alpha1
 import (
 	"strings"
 
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/conversion"
 	"k8s.io/kube-proxy/config/v1alpha1"
 	"k8s.io/kubernetes/pkg/proxy/apis/config"
@@ -54,6 +55,10 @@ func Convert_config_KubeProxyConfiguration_To_v1alpha1_KubeProxyConfiguration(in
 	if len(in.DetectLocal.ClusterCIDRs) > 0 {
 		out.ClusterCIDR = strings.Join(in.DetectLocal.ClusterCIDRs, ",")
 	}
+
+	if len(in.NodeIPOverride) > 0 {
+		out.BindAddress = in.NodeIPOverride[0]
+	}
 	return nil
 }
 
@@ -87,6 +92,12 @@ func Convert_v1alpha1_KubeProxyConfiguration_To_config_KubeProxyConfiguration(in
 	if len(in.ClusterCIDR) > 0 {
 		out.DetectLocal.ClusterCIDRs = strings.Split(in.ClusterCIDR, ",")
 	}
+
+	if len(in.BindAddress) > 0 {
+		out.NodeIPOverride = []string{in.BindAddress}
+	}
+
+	out.IPFamilyPolicy = v1.IPFamilyPolicyPreferDualStack
 	return nil
 }
 

--- a/pkg/proxy/apis/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/proxy/apis/config/v1alpha1/zz_generated.conversion.go
@@ -137,7 +137,7 @@ func autoConvert_v1alpha1_KubeProxyConfiguration_To_config_KubeProxyConfiguratio
 	}
 	out.Logging = in.Logging
 	out.HostnameOverride = in.HostnameOverride
-	out.BindAddress = in.BindAddress
+	// WARNING: in.BindAddress requires manual conversion: does not exist in peer-type
 	out.HealthzBindAddress = in.HealthzBindAddress
 	out.MetricsBindAddress = in.MetricsBindAddress
 	out.BindAddressHardFail = in.BindAddressHardFail
@@ -179,7 +179,8 @@ func autoConvert_config_KubeProxyConfiguration_To_v1alpha1_KubeProxyConfiguratio
 	}
 	out.Logging = in.Logging
 	out.HostnameOverride = in.HostnameOverride
-	out.BindAddress = in.BindAddress
+	// WARNING: in.NodeIPOverride requires manual conversion: does not exist in peer-type
+	// WARNING: in.IPFamilyPolicy requires manual conversion: does not exist in peer-type
 	out.HealthzBindAddress = in.HealthzBindAddress
 	out.MetricsBindAddress = in.MetricsBindAddress
 	out.BindAddressHardFail = in.BindAddressHardFail

--- a/pkg/proxy/apis/config/validation/validation.go
+++ b/pkg/proxy/apis/config/validation/validation.go
@@ -70,8 +70,8 @@ func Validate(config *kubeproxyconfig.KubeProxyConfiguration) field.ErrorList {
 		allErrs = append(allErrs, field.Invalid(newPath.Child("SyncPeriod"), config.MinSyncPeriod, fmt.Sprintf("must be greater than or equal to %s", newPath.Child("MinSyncPeriod").String())))
 	}
 
-	if netutils.ParseIPSloppy(config.BindAddress) == nil {
-		allErrs = append(allErrs, field.Invalid(newPath.Child("BindAddress"), config.BindAddress, "not a valid textual representation of an IP address"))
+	if len(config.NodeIPOverride) > 0 {
+		allErrs = append(allErrs, validateDualStackIPStrings(config.NodeIPOverride, newPath.Child("NodeIPOverride"))...)
 	}
 
 	if config.HealthzBindAddress != "" {
@@ -343,6 +343,29 @@ func validateDetectLocalConfiguration(mode kubeproxyconfig.LocalMode, config kub
 	case kubeproxyconfig.LocalModeClusterCIDR:
 		if len(config.ClusterCIDRs) > 0 {
 			allErrs = append(allErrs, validateDualStackCIDRStrings(config.ClusterCIDRs, fldPath.Child("ClusterCIDRs"))...)
+		}
+	}
+	return allErrs
+}
+
+func validateDualStackIPStrings(ipStrings []string, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	switch {
+	case len(ipStrings) == 0:
+		allErrs = append(allErrs, field.Invalid(fldPath, ipStrings, "must contain at least one IP"))
+	case len(ipStrings) > 2:
+		allErrs = append(allErrs, field.Invalid(fldPath, ipStrings, "must be a either a single IP or dual-stack pair of IPs (e.g. [10.100.0.0, fde4:8dba:82e1::])"))
+	default:
+		for i, ipString := range ipStrings {
+			if netutils.ParseIPSloppy(ipString) == nil {
+				allErrs = append(allErrs, field.Invalid(fldPath.Index(i), ipString, "must be a valid IP (e.g. 10.100.0.0 or fde4:8dba:82e1::)"))
+			}
+		}
+		if len(ipStrings) == 2 {
+			ifDualStack, err := netutils.IsDualStackIPStrings(ipStrings)
+			if err == nil && !ifDualStack {
+				allErrs = append(allErrs, field.Invalid(fldPath, ipStrings, "must be a either a single IP or dual-stack pair of IPs (e.g. [10.100.0.0, fde4:8dba:82e1::])"))
+			}
 		}
 	}
 	return allErrs

--- a/pkg/proxy/apis/config/validation/validation_test.go
+++ b/pkg/proxy/apis/config/validation/validation_test.go
@@ -33,7 +33,7 @@ import (
 
 func TestValidateKubeProxyConfiguration(t *testing.T) {
 	baseConfig := &kubeproxyconfig.KubeProxyConfiguration{
-		BindAddress:        "192.168.59.103",
+		NodeIPOverride:     []string{"192.168.59.103"},
 		HealthzBindAddress: "0.0.0.0:10256",
 		MetricsBindAddress: "127.0.0.1:10249",
 		DetectLocalMode:    kubeproxyconfig.LocalModeClusterCIDR,
@@ -80,9 +80,14 @@ func TestValidateKubeProxyConfiguration(t *testing.T) {
 				config.HealthzBindAddress = ""
 			},
 		},
+		"empty NodeIPOverride": {
+			mutateConfigFunc: func(config *kubeproxyconfig.KubeProxyConfiguration) {
+				config.NodeIPOverride = []string{}
+			},
+		},
 		"IPv6": {
 			mutateConfigFunc: func(config *kubeproxyconfig.KubeProxyConfiguration) {
-				config.BindAddress = "fd00:192:168:59::103"
+				config.NodeIPOverride = []string{"fd00:192:168:59::103"}
 				config.HealthzBindAddress = ""
 				config.MetricsBindAddress = "[::1]:10249"
 				config.DetectLocal.ClusterCIDRs = []string{"fd00:192:168:59::/64"}
@@ -119,11 +124,11 @@ func TestValidateKubeProxyConfiguration(t *testing.T) {
 				}
 			},
 		},
-		"invalid BindAddress": {
+		"invalid NodeIPOverride": {
 			mutateConfigFunc: func(config *kubeproxyconfig.KubeProxyConfiguration) {
-				config.BindAddress = "10.10.12.11:2000"
+				config.NodeIPOverride = []string{"10.10.12.11:2000"}
 			},
-			expectedErrs: field.ErrorList{field.Invalid(newPath.Child("BindAddress"), "10.10.12.11:2000", "not a valid textual representation of an IP address")},
+			expectedErrs: field.ErrorList{field.Invalid(newPath.Child("NodeIPOverride").Index(0), "10.10.12.11:2000", "must be a valid IP (e.g. 10.100.0.0 or fde4:8dba:82e1::)")},
 		},
 		"invalid HealthzBindAddress": {
 			mutateConfigFunc: func(config *kubeproxyconfig.KubeProxyConfiguration) {
@@ -879,6 +884,69 @@ func TestValidateDualStackCIDRStrings(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			errs := validateDualStackCIDRStrings(tc.cidrStrings, newPath.Child("DualStackCIDRList"))
+			assert.Equalf(t, len(tc.expectedErrs), len(errs),
+				"expected %d errors, got %d errors: %v", len(tc.expectedErrs), len(errs), errs,
+			)
+			for i, err := range errs {
+				assert.Equal(t, tc.expectedErrs[i].Error(), err.Error())
+			}
+		})
+	}
+}
+
+func TestValidateDualStackIPStrings(t *testing.T) {
+	newPath := field.NewPath("KubeProxyConfiguration")
+
+	testCases := []struct {
+		name         string
+		ipStrings    []string
+		expectedErrs field.ErrorList
+	}{
+		{
+			name:         "empty cidr string",
+			ipStrings:    []string{},
+			expectedErrs: field.ErrorList{field.Invalid(newPath.Child("DualStackIPList"), []string{}, "must contain at least one IP")},
+		},
+		{
+			name:         "single ipv4",
+			ipStrings:    []string{"192.168.0.0"},
+			expectedErrs: field.ErrorList{},
+		},
+		{
+			name:         "single ipv6",
+			ipStrings:    []string{"fd00:10:96::"},
+			expectedErrs: field.ErrorList{},
+		},
+		{
+			name:         "dual stack ip pair",
+			ipStrings:    []string{"172.16.200.0", "fde4:8dba:82e1::"},
+			expectedErrs: field.ErrorList{},
+		},
+		{
+			name:         "multiple ipv4",
+			ipStrings:    []string{"10.100.0.0", "192.168.0.0", "fde4:8dba:82e1::"},
+			expectedErrs: field.ErrorList{field.Invalid(newPath.Child("DualStackIPList"), []string{"10.100.0.0", "192.168.0.0", "fde4:8dba:82e1::"}, "must be a either a single IP or dual-stack pair of IPs (e.g. [10.100.0.0, fde4:8dba:82e1::])")},
+		},
+		{
+			name:         "multiple ipv6",
+			ipStrings:    []string{"fd00:10:96::", "fde4:8dba:82e1::"},
+			expectedErrs: field.ErrorList{field.Invalid(newPath.Child("DualStackIPList"), []string{"fd00:10:96::", "fde4:8dba:82e1::"}, "must be a either a single IP or dual-stack pair of IPs (e.g. [10.100.0.0, fde4:8dba:82e1::])")},
+		},
+		{
+			name:         "ipv6 host-port",
+			ipStrings:    []string{"[fd00:10:96::]:54321", "192.168.0.0"},
+			expectedErrs: field.ErrorList{field.Invalid(newPath.Child("DualStackIPList").Index(0), "[fd00:10:96::]:54321", "must be a valid IP (e.g. 10.100.0.0 or fde4:8dba:82e1::)")},
+		},
+		{
+			name:         "ipv4 host-port",
+			ipStrings:    []string{"fde4:8dba:82e1::", "172.16.200.0:3306"},
+			expectedErrs: field.ErrorList{field.Invalid(newPath.Child("DualStackIPList").Index(1), "172.16.200.0:3306", "must be a valid IP (e.g. 10.100.0.0 or fde4:8dba:82e1::)")},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			errs := validateDualStackIPStrings(tc.ipStrings, newPath.Child("DualStackIPList"))
 			assert.Equalf(t, len(tc.expectedErrs), len(errs),
 				"expected %d errors, got %d errors: %v", len(tc.expectedErrs), len(errs), errs,
 			)

--- a/pkg/proxy/apis/config/zz_generated.deepcopy.go
+++ b/pkg/proxy/apis/config/zz_generated.deepcopy.go
@@ -62,6 +62,11 @@ func (in *KubeProxyConfiguration) DeepCopyInto(out *KubeProxyConfiguration) {
 	}
 	out.ClientConnection = in.ClientConnection
 	in.Logging.DeepCopyInto(&out.Logging)
+	if in.NodeIPOverride != nil {
+		in, out := &in.NodeIPOverride, &out.NodeIPOverride
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	in.IPTables.DeepCopyInto(&out.IPTables)
 	in.IPVS.DeepCopyInto(&out.IPVS)
 	out.Winkernel = in.Winkernel


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
This PR replace BindAddress with NodeIPOverride for internal configuration of kube-proxy adhering to the v1alpha2 version specifications as detailed in https://kep.k8s.io/784.


split out from https://github.com/kubernetes/kubernetes/pull/121830/commits
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
