### PR TITLE
Fix a bug where QHint doesn't requeue Pods correctly if a deleted pod uses the same PVC with the ReadWriteOncePod access mode

### DIFF
--- a/pkg/scheduler/framework/plugins/volumerestrictions/volume_restrictions_test.go
+++ b/pkg/scheduler/framework/plugins/volumerestrictions/volume_restrictions_test.go
@@ -640,6 +640,22 @@ func Test_isSchedulableAfterPodDeleted(t *testing.T) {
 			expectedHint: framework.QueueSkip,
 			expectedErr:  false,
 		},
+		"queue-has-same-claim": {
+			pod:          st.MakePod().Name("pod1").PVC("claim-rwop").Obj(),
+			oldObj:       st.MakePod().Name("pod2").PVC("claim-rwop").Obj(),
+			existingPods: []*v1.Pod{},
+			existingPVC:  &v1.PersistentVolumeClaim{},
+			expectedHint: framework.Queue,
+			expectedErr:  false,
+		},
+		"skip-no-same-claim": {
+			pod:          st.MakePod().Name("pod1").PVC("claim-1-rwop").Obj(),
+			oldObj:       st.MakePod().Name("pod2").PVC("claim-2-rwop").Obj(),
+			existingPods: []*v1.Pod{},
+			existingPVC:  &v1.PersistentVolumeClaim{},
+			expectedHint: framework.QueueSkip,
+			expectedErr:  false,
+		},
 	}
 
 	for name, tc := range testcases {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Since https://github.com/kubernetes/kubernetes/pull/125280 is merged, the e2e test `/test/e2e/storage/testsuites/readwriteoncepod.go#L133` is broken. 

The root cause is that https://github.com/kubernetes/kubernetes/pull/125279 returns framework.QueueSkip when a deleted pod uses the same PVC with the ReadWriteOncePod access mode.

Logs:
```
2024-07-21T21:30:13.641636804Z stderr F I0721 21:30:13.641489       1 preemption.go:383] "Preemptor Pod preempted victim Pod" logger="PostFilter.DefaultPreemption" pod="read-write-once-pod-5158/pod-cbeaeb78-e96c-444f-ae6e-12b26ba59960" preemptor="read-write-once-pod-5158/pod-cbeaeb78-e96c-444f-ae6e-12b26ba59960" victim="read-write-once-pod-5158/pod-28243e7a-9680-409a-9cb3-3c37a8d52b3e" node="kind-worker"
2024-07-21T21:30:13.641996424Z stderr F I0721 21:30:13.641890       1 schedule_one.go:1056] "Unable to schedule pod; no fit; waiting" pod="read-write-once-pod-5158/pod-cbeaeb78-e96c-444f-ae6e-12b26ba59960" err="0/3 nodes are available: 1 node(s) had untolerated taint {node-role.kubernetes.io/control-plane: }, 2 node has pod using PersistentVolumeClaim with the same name and ReadWriteOncePod access mode."
2024-07-21T21:30:13.642322385Z stderr F I0721 21:30:13.642186       1 scheduling_queue.go:860] "Pod moved to an internal scheduling queue" pod="read-write-once-pod-5158/pod-cbeaeb78-e96c-444f-ae6e-12b26ba59960" event="ScheduleAttemptFailure" queue="Unschedulable" schedulingCycle=1918 hint=0 unschedulable plugins={"TaintToleration":{},"VolumeRestrictions":{}}
2024-07-21T21:30:13.642578987Z stderr F I0721 21:30:13.642470       1 schedule_one.go:1123] "Updating pod condition" pod="read-write-once-pod-5158/pod-cbeaeb78-e96c-444f-ae6e-12b26ba59960" conditionType="PodScheduled" conditionStatus="False" conditionReason="Unschedulable"
2024-07-21T21:30:13.643145814Z stderr F I0721 21:30:13.642533       1 eventhandlers.go:268] "Update event for scheduled pod" pod="read-write-once-pod-5158/pod-28243e7a-9680-409a-9cb3-3c37a8d52b3e"
2024-07-21T21:30:13.656732155Z stderr F I0721 21:30:13.654591       1 eventhandlers.go:174] "Update event for unscheduled pod" pod="read-write-once-pod-5158/pod-cbeaeb78-e96c-444f-ae6e-12b26ba59960"
2024-07-21T21:30:15.363103648Z stderr F I0721 21:30:15.362934       1 eventhandlers.go:268] "Update event for scheduled pod" pod="read-write-once-pod-5158/pod-28243e7a-9680-409a-9cb3-3c37a8d52b3e"
2024-07-21T21:30:15.958698642Z stderr F I0721 21:30:15.958572       1 eventhandlers.go:310] "Delete event for scheduled pod" pod="read-write-once-pod-5158/pod-28243e7a-9680-409a-9cb3-3c37a8d52b3e"
2024-07-21T21:35:17.638824377Z stderr F I0721 21:35:17.638626       1 eventhandlers.go:174] "Update event for unscheduled pod" pod="read-write-once-pod-5158/pod-cbeaeb78-e96c-444f-ae6e-12b26ba59960"
2024-07-21T21:35:17.641748258Z stderr F I0721 21:35:17.641624       1 eventhandlers.go:201] "Delete event for unscheduled pod" pod="read-write-once-pod-5158/pod-cbeaeb78-e96c-444f-ae6e-12b26ba59960"
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Ref #126142 https://github.com/kubernetes/kubernetes/issues/118893

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
