### PR TITLE
WIP: kube-apiserver: clean up testserver from fixture code

### DIFF
--- a/cmd/kube-apiserver/app/testing/testserver.go
+++ b/cmd/kube-apiserver/app/testing/testserver.go
@@ -104,8 +104,6 @@ type TestServerInstanceOptions struct {
 	// Set the BinaryVersion of server effective version.
 	// Default to 1.31
 	BinaryVersion string
-	// Set non-default request timeout in the server.
-	RequestTimeout time.Duration
 }
 
 // TestServer return values supplied by kube-test-ApiServer
@@ -196,9 +194,6 @@ func StartTestServer(t ktesting.TB, instanceOptions *TestServerInstanceOptions, 
 	utilruntime.Must(utilversion.DefaultComponentGlobalsRegistry.Register(utilversion.DefaultKubeComponent, effectiveVersion, featureGate))
 
 	s := options.NewServerRunOptions()
-	if instanceOptions.RequestTimeout > 0 {
-		s.GenericServerRunOptions.RequestTimeout = instanceOptions.RequestTimeout
-	}
 
 	for _, f := range s.Flags().FlagSets {
 		fs.AddFlagSet(f)

--- a/cmd/kube-apiserver/app/testing/testserver.go
+++ b/cmd/kube-apiserver/app/testing/testserver.go
@@ -51,12 +51,11 @@ import (
 	logsapi "k8s.io/component-base/logs/api/v1"
 	"k8s.io/klog/v2"
 	"k8s.io/kube-aggregator/pkg/apiserver"
+	"k8s.io/kubernetes/cmd/kube-apiserver/app"
+	"k8s.io/kubernetes/cmd/kube-apiserver/app/options"
 	"k8s.io/kubernetes/pkg/features"
 	testutil "k8s.io/kubernetes/test/utils"
 	"k8s.io/kubernetes/test/utils/ktesting"
-
-	"k8s.io/kubernetes/cmd/kube-apiserver/app"
-	"k8s.io/kubernetes/cmd/kube-apiserver/app/options"
 )
 
 func init() {
@@ -170,8 +169,6 @@ func StartTestServer(t ktesting.TB, instanceOptions *TestServerInstanceOptions, 
 		}
 	}()
 
-	fs := pflag.NewFlagSet("test", pflag.PanicOnError)
-
 	featureGate := utilfeature.DefaultMutableFeatureGate
 	effectiveVersion := utilversion.DefaultKubeEffectiveVersion()
 	if instanceOptions.BinaryVersion != "" {
@@ -183,7 +180,7 @@ func StartTestServer(t ktesting.TB, instanceOptions *TestServerInstanceOptions, 
 	utilruntime.Must(utilversion.DefaultComponentGlobalsRegistry.Register(utilversion.DefaultKubeComponent, effectiveVersion, featureGate))
 
 	s := options.NewServerRunOptions()
-
+	fs := pflag.NewFlagSet("test", pflag.PanicOnError)
 	for _, f := range s.Flags().FlagSets {
 		fs.AddFlagSet(f)
 	}

--- a/cmd/kube-apiserver/app/testing/testserver.go
+++ b/cmd/kube-apiserver/app/testing/testserver.go
@@ -18,16 +18,9 @@ package testing
 
 import (
 	"context"
-	"crypto/ecdsa"
-	"crypto/elliptic"
-	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
-	"crypto/x509/pkix"
-	"encoding/pem"
 	"fmt"
-	"math"
-	"math/big"
 	"net"
 	"os"
 	"path/filepath"
@@ -54,7 +47,6 @@ import (
 	restclient "k8s.io/client-go/rest"
 	clientgotransport "k8s.io/client-go/transport"
 	"k8s.io/client-go/util/cert"
-	"k8s.io/client-go/util/keyutil"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	logsapi "k8s.io/component-base/logs/api/v1"
 	"k8s.io/klog/v2"
@@ -98,9 +90,6 @@ type TestServerInstanceOptions struct {
 	// to version skew
 	// 2. kube-apiserver and aggregated apiserver
 
-	// We specify this as on option to pass a common proxyCA to multiple apiservers to simulate
-	// an apiserver version skew scenario where all apiservers use the same proxyCA to verify client connections.
-	ProxyCA *ProxyCA
 	// Set the BinaryVersion of server effective version.
 	// Default to 1.31
 	BinaryVersion string
@@ -209,94 +198,6 @@ func StartTestServer(t ktesting.TB, instanceOptions *TestServerInstanceOptions, 
 		// set up default headers for request header auth
 		reqHeaders := serveroptions.NewDelegatingAuthenticationOptions()
 		s.Authentication.RequestHeader = &reqHeaders.RequestHeader
-
-		var proxySigningKey *rsa.PrivateKey
-		var proxySigningCert *x509.Certificate
-
-		if instanceOptions.ProxyCA != nil {
-			// use provided proxyCA
-			proxySigningKey = instanceOptions.ProxyCA.ProxySigningKey
-			proxySigningCert = instanceOptions.ProxyCA.ProxySigningCert
-
-		} else {
-			// create certificates for aggregation and client-cert auth
-			proxySigningKey, err = testutil.NewPrivateKey()
-			if err != nil {
-				return result, err
-			}
-			proxySigningCert, err = cert.NewSelfSignedCACert(cert.Config{CommonName: "front-proxy-ca"}, proxySigningKey)
-			if err != nil {
-				return result, err
-			}
-		}
-		proxyCACertFile := filepath.Join(s.SecureServing.ServerCert.CertDirectory, "proxy-ca.crt")
-		if err := os.WriteFile(proxyCACertFile, testutil.EncodeCertPEM(proxySigningCert), 0644); err != nil {
-			return result, err
-		}
-		s.Authentication.RequestHeader.ClientCAFile = proxyCACertFile
-
-		// give the kube api server an "identity" it can use to for request header auth
-		// so that aggregated api servers can understand who the calling user is
-		s.Authentication.RequestHeader.AllowedNames = []string{"ash", "misty", "brock"}
-
-		// create private key
-		signer, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-		if err != nil {
-			return result, err
-		}
-
-		// make a client certificate for the api server - common name has to match one of our defined names above
-		serial, err := rand.Int(rand.Reader, new(big.Int).SetInt64(math.MaxInt64-1))
-		if err != nil {
-			return result, err
-		}
-		serial = new(big.Int).Add(serial, big.NewInt(1))
-		tenThousandHoursLater := time.Now().Add(10_000 * time.Hour)
-		certTmpl := x509.Certificate{
-			Subject: pkix.Name{
-				CommonName: "misty",
-			},
-			SerialNumber: serial,
-			NotBefore:    proxySigningCert.NotBefore,
-			NotAfter:     tenThousandHoursLater,
-			KeyUsage:     x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
-			ExtKeyUsage: []x509.ExtKeyUsage{
-				x509.ExtKeyUsageClientAuth,
-			},
-			BasicConstraintsValid: true,
-		}
-		certDERBytes, err := x509.CreateCertificate(rand.Reader, &certTmpl, proxySigningCert, signer.Public(), proxySigningKey)
-		if err != nil {
-			return result, err
-		}
-		clientCrtOfAPIServer, err := x509.ParseCertificate(certDERBytes)
-		if err != nil {
-			return result, err
-		}
-
-		// write the cert to disk
-		certificatePath := filepath.Join(s.SecureServing.ServerCert.CertDirectory, "misty-crt.crt")
-		certBlock := pem.Block{
-			Type:  "CERTIFICATE",
-			Bytes: clientCrtOfAPIServer.Raw,
-		}
-		certBytes := pem.EncodeToMemory(&certBlock)
-		if err := cert.WriteCert(certificatePath, certBytes); err != nil {
-			return result, err
-		}
-
-		// write the key to disk
-		privateKeyPath := filepath.Join(s.SecureServing.ServerCert.CertDirectory, "misty-crt.key")
-		encodedPrivateKey, err := keyutil.MarshalPrivateKeyToPEM(signer)
-		if err != nil {
-			return result, err
-		}
-		if err := keyutil.WriteKey(privateKeyPath, encodedPrivateKey); err != nil {
-			return result, err
-		}
-
-		s.ProxyClientKeyFile = filepath.Join(s.SecureServing.ServerCert.CertDirectory, "misty-crt.key")
-		s.ProxyClientCertFile = filepath.Join(s.SecureServing.ServerCert.CertDirectory, "misty-crt.crt")
 
 		clientSigningKey, err := testutil.NewPrivateKey()
 		if err != nil {

--- a/cmd/kube-apiserver/app/testing/testserver.go
+++ b/cmd/kube-apiserver/app/testing/testserver.go
@@ -36,7 +36,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	serveroptions "k8s.io/apiserver/pkg/server/options"
 	"k8s.io/apiserver/pkg/storage/storagebackend"
@@ -47,7 +46,6 @@ import (
 	restclient "k8s.io/client-go/rest"
 	clientgotransport "k8s.io/client-go/transport"
 	"k8s.io/client-go/util/cert"
-	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	logsapi "k8s.io/component-base/logs/api/v1"
 	"k8s.io/klog/v2"
 	"k8s.io/kube-aggregator/pkg/apiserver"
@@ -88,10 +86,6 @@ type TestServerInstanceOptions struct {
 	// 1. kube-apiserver and peer when the local apiserver is not able to serve the request due
 	// to version skew
 	// 2. kube-apiserver and aggregated apiserver
-
-	// Set the BinaryVersion of server effective version.
-	// Default to 1.31
-	BinaryVersion string
 
 	///////////////////////////////////////////////////
 	// DO NOT ADD TEST FIXTURE CODE HERE. USE FLAGS. //
@@ -176,16 +170,6 @@ func StartTestServer(t ktesting.TB, instanceOptions *TestServerInstanceOptions, 
 			tearDown()
 		}
 	}()
-
-	featureGate := utilfeature.DefaultMutableFeatureGate
-	effectiveVersion := utilversion.DefaultKubeEffectiveVersion()
-	if instanceOptions.BinaryVersion != "" {
-		effectiveVersion = utilversion.NewEffectiveVersion(instanceOptions.BinaryVersion)
-	}
-	// need to call SetFeatureGateEmulationVersionDuringTest to reset the feature gate emulation version at the end of the test.
-	featuregatetesting.SetFeatureGateEmulationVersionDuringTest(t, featureGate, effectiveVersion.EmulationVersion())
-	utilversion.DefaultComponentGlobalsRegistry.Reset()
-	utilruntime.Must(utilversion.DefaultComponentGlobalsRegistry.Register(utilversion.DefaultKubeComponent, effectiveVersion, featureGate))
 
 	s := options.NewServerRunOptions()
 	fs := pflag.NewFlagSet("test", pflag.PanicOnError)

--- a/cmd/kube-apiserver/app/testing/testserver.go
+++ b/cmd/kube-apiserver/app/testing/testserver.go
@@ -92,6 +92,14 @@ type TestServerInstanceOptions struct {
 	// Set the BinaryVersion of server effective version.
 	// Default to 1.31
 	BinaryVersion string
+
+	///////////////////////////////////////////////////
+	// DO NOT ADD TEST FIXTURE CODE HERE. USE FLAGS. //
+	//                                               //
+	// Adding new fields here is nearly always the   //
+	// wrong approach. This is an integration test   //
+	// helper that must be considered a black box.   //
+	///////////////////////////////////////////////////
 }
 
 // TestServer return values supplied by kube-test-ApiServer

--- a/test/integration/apiserver/peerproxy/peer_proxy_test.go
+++ b/test/integration/apiserver/peerproxy/peer_proxy_test.go
@@ -18,7 +18,17 @@ package peerproxy
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
 	"fmt"
+	"math"
+	"math/big"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -35,6 +45,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/transport"
 	"k8s.io/client-go/util/cert"
+	"k8s.io/client-go/util/keyutil"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/klog/v2"
 	kastesting "k8s.io/kubernetes/cmd/kube-apiserver/app/testing"
@@ -48,7 +59,6 @@ import (
 )
 
 func TestPeerProxiedRequest(t *testing.T) {
-
 	ktesting.SetDefaultVerbosity(1)
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	t.Cleanup(cancel)
@@ -67,23 +77,33 @@ func TestPeerProxiedRequest(t *testing.T) {
 	// create certificates for aggregation and client-cert auth
 	proxyCA, err := createProxyCertContent()
 	require.NoError(t, err)
+	proxyCACertFile, proxyClientKeyFile, proxyClientCrtFile := createProxyCAFiles(t, proxyCA)
 
 	// start test server with all APIs enabled
 	// override hostname to ensure unique ips
 	server.SetHostnameFuncForTests("test-server-a")
-	serverA := kastesting.StartTestServerOrDie(t, &kastesting.TestServerInstanceOptions{
-		EnableCertAuth: true,
-		ProxyCA:        &proxyCA},
-		[]string{}, etcd)
+	serverA := kastesting.StartTestServerOrDie(t, &kastesting.TestServerInstanceOptions{EnableCertAuth: true}, []string{
+		"--requestheader-client-ca-file=" + proxyCACertFile,
+		// give the kube api server an "identity" it can use to for request header auth
+		// so that aggregated api servers can understand who the calling user is
+		"--requestheader-allowed-names=ash,misty,brock",
+		"--proxy-client-key-file=" + proxyClientKeyFile,
+		"--proxy-client-cert-file=" + proxyClientCrtFile,
+	}, etcd)
 	defer serverA.TearDownFn()
 
 	// start another test server with some api disabled
 	// override hostname to ensure unique ips
 	server.SetHostnameFuncForTests("test-server-b")
-	serverB := kastesting.StartTestServerOrDie(t, &kastesting.TestServerInstanceOptions{
-		EnableCertAuth: true,
-		ProxyCA:        &proxyCA},
-		[]string{fmt.Sprintf("--runtime-config=%s", "batch/v1=false")}, etcd)
+	serverB := kastesting.StartTestServerOrDie(t, &kastesting.TestServerInstanceOptions{EnableCertAuth: true}, []string{
+		"--requestheader-client-ca-file=" + proxyCACertFile,
+		// give the kube api server an "identity" it can use to for request header auth
+		// so that aggregated api servers can understand who the calling user is
+		"--requestheader-allowed-names=ash,misty,brock",
+		"--proxy-client-key-file=" + proxyClientKeyFile,
+		"--proxy-client-cert-file=" + proxyClientCrtFile,
+		fmt.Sprintf("--runtime-config=%s", "batch/v1=false"),
+	}, etcd)
 	defer serverB.TearDownFn()
 
 	kubeClientSetA, err := kubernetes.NewForConfig(serverA.ClientConfig)
@@ -109,7 +129,6 @@ func TestPeerProxiedRequest(t *testing.T) {
 }
 
 func TestPeerProxiedRequestToThirdServerAfterFirstDies(t *testing.T) {
-
 	ktesting.SetDefaultVerbosity(1)
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	t.Cleanup(cancel)
@@ -128,6 +147,7 @@ func TestPeerProxiedRequestToThirdServerAfterFirstDies(t *testing.T) {
 	// create certificates for aggregation and client-cert auth
 	proxyCA, err := createProxyCertContent()
 	require.NoError(t, err)
+	proxyCACertFile, proxyClientKeyFile, proxyClientCrtFile := createProxyCAFiles(t, proxyCA)
 
 	// set lease duration to 1s for serverA to ensure that storageversions for serverA are updated
 	// once it is shutdown
@@ -138,7 +158,14 @@ func TestPeerProxiedRequestToThirdServerAfterFirstDies(t *testing.T) {
 	// start serverA with all APIs enabled
 	// override hostname to ensure unique ips
 	server.SetHostnameFuncForTests("test-server-a")
-	serverA := kastesting.StartTestServerOrDie(t, &kastesting.TestServerInstanceOptions{EnableCertAuth: true, ProxyCA: &proxyCA}, []string{}, etcd)
+	serverA := kastesting.StartTestServerOrDie(t, &kastesting.TestServerInstanceOptions{EnableCertAuth: true}, []string{
+		"--requestheader-client-ca-file=" + proxyCACertFile,
+		// give the kube api server an "identity" it can use to for request header auth
+		// so that aggregated api servers can understand who the calling user is
+		"--requestheader-allowed-names=ash,misty,brock",
+		"--proxy-client-key-file=" + proxyClientKeyFile,
+		"--proxy-client-cert-file=" + proxyClientCrtFile,
+	}, etcd)
 	kubeClientSetA, err := kubernetes.NewForConfig(serverA.ClientConfig)
 	require.NoError(t, err)
 	// ensure storageversion garbage collector ctlr is set up
@@ -151,7 +178,13 @@ func TestPeerProxiedRequestToThirdServerAfterFirstDies(t *testing.T) {
 	// start serverB with some api disabled
 	// override hostname to ensure unique ips
 	server.SetHostnameFuncForTests("test-server-b")
-	serverB := kastesting.StartTestServerOrDie(t, &kastesting.TestServerInstanceOptions{EnableCertAuth: true, ProxyCA: &proxyCA}, []string{
+	serverB := kastesting.StartTestServerOrDie(t, &kastesting.TestServerInstanceOptions{EnableCertAuth: true}, []string{
+		"--requestheader-client-ca-file=" + proxyCACertFile,
+		// give the kube api server an "identity" it can use to for request header auth
+		// so that aggregated api servers can understand who the calling user is
+		"--requestheader-allowed-names=ash,misty,brock",
+		"--proxy-client-key-file=" + proxyClientKeyFile,
+		"--proxy-client-cert-file=" + proxyClientCrtFile,
 		fmt.Sprintf("--runtime-config=%v", "batch/v1=false")}, etcd)
 	defer serverB.TearDownFn()
 	kubeClientSetB, err := kubernetes.NewForConfig(serverB.ClientConfig)
@@ -163,7 +196,14 @@ func TestPeerProxiedRequestToThirdServerAfterFirstDies(t *testing.T) {
 	// start serverC with all APIs enabled
 	// override hostname to ensure unique ips
 	server.SetHostnameFuncForTests("test-server-c")
-	serverC := kastesting.StartTestServerOrDie(t, &kastesting.TestServerInstanceOptions{EnableCertAuth: true, ProxyCA: &proxyCA}, []string{}, etcd)
+	serverC := kastesting.StartTestServerOrDie(t, &kastesting.TestServerInstanceOptions{EnableCertAuth: true}, []string{
+		"--requestheader-client-ca-file=" + proxyCACertFile,
+		// give the kube api server an "identity" it can use to for request header auth
+		// so that aggregated api servers can understand who the calling user is
+		"--requestheader-allowed-names=ash,misty,brock",
+		"--proxy-client-key-file=" + proxyClientKeyFile,
+		"--proxy-client-cert-file=" + proxyClientCrtFile,
+	}, etcd)
 	defer serverC.TearDownFn()
 
 	// create jobs resource using serverA
@@ -191,6 +231,65 @@ func TestPeerProxiedRequestToThirdServerAfterFirstDies(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotEmpty(t, jobsB)
 	assert.Equal(t, job.Name, jobsB.Items[0].Name)
+}
+
+func createProxyCAFiles(t *testing.T, proxyCA kastesting.ProxyCA) (string, string, string) {
+	certDir, err := os.MkdirTemp("", "test-peer-proxy-*")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(certDir) })
+
+	// use provided proxyCA
+	proxyCACertFile := filepath.Join(certDir, "proxy-ca.crt")
+	err = os.WriteFile(proxyCACertFile, testutil.EncodeCertPEM(proxyCA.ProxySigningCert), 0644)
+	require.NoError(t, err)
+
+	// create private key
+	signer, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	// make a client certificate for the api server - common name has to match one of our defined names above
+	serial, err := rand.Int(rand.Reader, new(big.Int).SetInt64(math.MaxInt64-1))
+	require.NoError(t, err)
+	serial = new(big.Int).Add(serial, big.NewInt(1))
+	tenThousandHoursLater := time.Now().Add(10_000 * time.Hour)
+	certTmpl := x509.Certificate{
+		Subject: pkix.Name{
+			CommonName: "misty",
+		},
+		SerialNumber: serial,
+		NotBefore:    proxyCA.ProxySigningCert.NotBefore,
+		NotAfter:     tenThousandHoursLater,
+		KeyUsage:     x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage: []x509.ExtKeyUsage{
+			x509.ExtKeyUsageClientAuth,
+		},
+		BasicConstraintsValid: true,
+	}
+	certDERBytes, err := x509.CreateCertificate(rand.Reader, &certTmpl, proxyCA.ProxySigningCert, signer.Public(), proxyCA.ProxySigningKey)
+	require.NoError(t, err)
+	clientCrtOfAPIServer, err := x509.ParseCertificate(certDERBytes)
+	require.NoError(t, err)
+
+	// write the cert to disk
+	certificatePath := filepath.Join(certDir, "misty-crt.crt")
+	certBlock := pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: clientCrtOfAPIServer.Raw,
+	}
+	certBytes := pem.EncodeToMemory(&certBlock)
+	err = cert.WriteCert(certificatePath, certBytes)
+	require.NoError(t, err)
+
+	// write the key to disk
+	privateKeyPath := filepath.Join(certDir, "misty-crt.key")
+	encodedPrivateKey, err := keyutil.MarshalPrivateKeyToPEM(signer)
+	require.NoError(t, err)
+	err = keyutil.WriteKey(privateKeyPath, encodedPrivateKey)
+	require.NoError(t, err)
+
+	proxyClientKeyFile := "--proxy-client-key-file=" + filepath.Join(certDir, "misty-crt.key")
+	proxyClientCrtFile := "--proxy-client-cert-file=" + filepath.Join(certDir, "misty-crt.crt")
+	return proxyCACertFile, proxyClientKeyFile, proxyClientCrtFile
 }
 
 func setupStorageVersionGC(ctx context.Context, kubeClientSet *kubernetes.Clientset, informers informers.SharedInformerFactory) {

--- a/test/integration/scheduler_perf/util.go
+++ b/test/integration/scheduler_perf/util.go
@@ -93,10 +93,10 @@ func mustSetupCluster(tCtx ktesting.TContext, config *config.KubeSchedulerConfig
 		// Disable ServiceAccount admission plugin as we don't have serviceaccount controller running.
 		"--disable-admission-plugins=ServiceAccount,TaintNodesByCondition,Priority",
 		"--runtime-config=" + strings.Join(runtimeConfig, ","),
+		// Timeout sufficiently long to handle deleting pods of the largest test cases.
+		"--request-timeout=10m",
 	}
 	serverOpts := apiservertesting.NewDefaultTestServerOptions()
-	// Timeout sufficiently long to handle deleting pods of the largest test cases.
-	serverOpts.RequestTimeout = 10 * time.Minute
 	server, err := apiservertesting.StartTestServer(tCtx, serverOpts, customFlags, framework.SharedEtcd())
 	if err != nil {
 		tCtx.Fatalf("start apiserver: %v", err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

The kube-apiserver intergraton test testserver is meant as a block box to start kube-apiserver in-process as (via flags) configurable test fixture that 99% matches the real kube-apiserver.

<img width="386" alt="Bildschirmfoto 2024-07-22 um 20 19 50" src="https://github.com/user-attachments/assets/cbe00339-9fdb-4640-b1d2-ba1c62ecf1a5">

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```