### PR TITLE
De-flake VAC tests by returning new PVC from WaitForVolumeModification

### DIFF
--- a/test/e2e/storage/testsuites/volume_modify.go
+++ b/test/e2e/storage/testsuites/volume_modify.go
@@ -188,12 +188,11 @@ func (v *volumeModifyTestSuite) DefineTests(driver storageframework.TestDriver, 
 		framework.ExpectNoError(err, "While creating pod for modifying")
 
 		ginkgo.By("Modifying PVC via VAC")
-		newPVC := SetPVCVACName(ctx, l.resource.Pvc, l.vac.Name, f.ClientSet, setVACWaitPeriod)
-		l.resource.Pvc = newPVC
+		l.resource.Pvc = SetPVCVACName(ctx, l.resource.Pvc, l.vac.Name, f.ClientSet, setVACWaitPeriod)
 		gomega.Expect(l.resource.Pvc).NotTo(gomega.BeNil())
 
 		ginkgo.By("Waiting for modification to finish")
-		WaitForVolumeModification(ctx, l.resource.Pvc, f.ClientSet, modifyVolumeWaitPeriod)
+		l.resource.Pvc = WaitForVolumeModification(ctx, l.resource.Pvc, f.ClientSet, modifyVolumeWaitPeriod)
 
 		pvcConditions := l.resource.Pvc.Status.Conditions
 		gomega.Expect(pvcConditions).To(gomega.BeEmpty(), "PVC should not have conditions")
@@ -223,12 +222,11 @@ func (v *volumeModifyTestSuite) DefineTests(driver storageframework.TestDriver, 
 		framework.ExpectNoError(err, "While creating pod for modifying")
 
 		ginkgo.By("Modifying PVC via VAC")
-		newPVC := SetPVCVACName(ctx, l.resource.Pvc, newVAC.Name, f.ClientSet, setVACWaitPeriod)
-		l.resource.Pvc = newPVC
+		l.resource.Pvc = SetPVCVACName(ctx, l.resource.Pvc, newVAC.Name, f.ClientSet, setVACWaitPeriod)
 		gomega.Expect(l.resource.Pvc).NotTo(gomega.BeNil())
 
 		ginkgo.By("Waiting for modification to finish")
-		WaitForVolumeModification(ctx, l.resource.Pvc, f.ClientSet, modifyVolumeWaitPeriod)
+		l.resource.Pvc = WaitForVolumeModification(ctx, l.resource.Pvc, f.ClientSet, modifyVolumeWaitPeriod)
 
 		pvcConditions := l.resource.Pvc.Status.Conditions
 		gomega.Expect(pvcConditions).To(gomega.BeEmpty(), "PVC should not have conditions")
@@ -254,16 +252,18 @@ func SetPVCVACName(ctx context.Context, origPVC *v1.PersistentVolumeClaim, name 
 
 // WaitForVolumeModification waits for the volume to be modified
 // The input PVC is assumed to have a VolumeAttributesClassName set
-func WaitForVolumeModification(ctx context.Context, pvc *v1.PersistentVolumeClaim, c clientset.Interface, timeout time.Duration) {
+func WaitForVolumeModification(ctx context.Context, pvc *v1.PersistentVolumeClaim, c clientset.Interface, timeout time.Duration) *v1.PersistentVolumeClaim {
+	var newPVC *v1.PersistentVolumeClaim
 	pvName := pvc.Spec.VolumeName
 	gomega.Eventually(ctx, func(g gomega.Gomega) {
 		pv, err := c.CoreV1().PersistentVolumes().Get(ctx, pvName, metav1.GetOptions{})
 		framework.ExpectNoError(err, "While getting existing PV")
 		g.Expect(pv.Spec.VolumeAttributesClassName).NotTo(gomega.BeNil())
-		newPVC, err := c.CoreV1().PersistentVolumeClaims(pvc.Namespace).Get(ctx, pvc.Name, metav1.GetOptions{})
+		newPVC, err = c.CoreV1().PersistentVolumeClaims(pvc.Namespace).Get(ctx, pvc.Name, metav1.GetOptions{})
 		framework.ExpectNoError(err, "While getting new PVC")
 		g.Expect(vacMatches(newPVC, *pv.Spec.VolumeAttributesClassName, true)).To(gomega.BeTrueBecause("Modified PVC should match expected VAC"))
 	}, timeout, modifyPollInterval).Should(gomega.Succeed())
+	return newPVC
 }
 
 func CleanupVAC(ctx context.Context, vac *storagev1alpha1.VolumeAttributesClass, c clientset.Interface, timeout time.Duration) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
/kind failing-test
/kind flake

#### What this PR does / why we need it:

The VAC e2e tests use a stale object for checking if it has any conditions. This PR returns the latest PVC from `WaitForVolumeModification` and uses that up to date PVC for checking conditions in the tests.

#### Which issue(s) this PR fixes:
Partially addresses  #126154

#### Special notes for your reviewer:

Note that this only fixes half the reason this test flakes, see https://github.com/kubernetes/kubernetes/issues/126154#issuecomment-2245404911 - the other half is fixed by https://github.com/kubernetes-csi/external-resizer/pull/419

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
