### PR TITLE
bump knftables to v0.0.17

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -117,7 +117,7 @@ require (
 	k8s.io/sample-apiserver v0.0.0
 	k8s.io/system-validators v1.8.0
 	k8s.io/utils v0.0.0-20240711033017-18e509b52bc8
-	sigs.k8s.io/knftables v0.0.16
+	sigs.k8s.io/knftables v0.0.17
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1
 	sigs.k8s.io/yaml v1.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -970,8 +970,8 @@ sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.30.3 h1:2770sDpzrjjsA
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.30.3/go.mod h1:Ve9uj1L+deCXFrPOk1LpFXqTg7LCFzFso6PA48q/XZw=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd h1:EDPBXCAspyGV4jQlpZSudPeMmr1bNJefnuqLsRAsHZo=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd/go.mod h1:B8JuhiUyNFVKdsE8h686QcCxMaH6HrOAZj4vswFpcB0=
-sigs.k8s.io/knftables v0.0.16 h1:ZpTfNsjnidgoXdxxzcZLdSctqkpSO3QB3jo3zQ4PXqM=
-sigs.k8s.io/knftables v0.0.16/go.mod h1:f/5ZLKYEUPUhVjUCg6l80ACdL7CIIyeL0DxfgojGRTk=
+sigs.k8s.io/knftables v0.0.17 h1:wGchTyRF/iGTIjd+vRaR1m676HM7jB8soFtyr/148ic=
+sigs.k8s.io/knftables v0.0.17/go.mod h1:f/5ZLKYEUPUhVjUCg6l80ACdL7CIIyeL0DxfgojGRTk=
 sigs.k8s.io/kustomize/api v0.17.2 h1:E7/Fjk7V5fboiuijoZHgs4aHuexi5Y2loXlVOAVAG5g=
 sigs.k8s.io/kustomize/api v0.17.2/go.mod h1:UWTz9Ct+MvoeQsHcJ5e+vziRRkwimm3HytpZgIYqye0=
 sigs.k8s.io/kustomize/cmd/config v0.14.1/go.mod h1:Sw1cPsFqh4uYczCWKlidPgMrsffLPCAB+7ytYLlauY4=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1231,7 +1231,7 @@ sigs.k8s.io/apiserver-network-proxy/konnectivity-client/proto/client
 ## explicit; go 1.18
 sigs.k8s.io/json
 sigs.k8s.io/json/internal/golang/encoding/json
-# sigs.k8s.io/knftables v0.0.16
+# sigs.k8s.io/knftables v0.0.17
 ## explicit; go 1.20
 sigs.k8s.io/knftables
 # sigs.k8s.io/kustomize/api v0.17.2

--- a/vendor/sigs.k8s.io/knftables/CHANGELOG.md
+++ b/vendor/sigs.k8s.io/knftables/CHANGELOG.md
@@ -1,5 +1,28 @@
 # ChangeLog
 
+## v0.0.17
+
+- `ListRules()` now accepts `""` for the chain name, meaning to list
+  all rules in the table. (`@caseydavenport`)
+
+- `ListElements()` now handles elements with prefix/CIDR values (e.g.,
+  `"192.168.0.0/16"`; these are represented specially in the JSON
+  format and the old code didn't handle them). (`@caseydavenport`)
+
+- Added `NumOperations()` to `Transaction` (which lets you figure out
+  belatedly whether you added anything to the transaction or not, and
+  could also be used for metrics). (`@fasaxc`)
+
+- `knftables.Interface` now reuses the same `bytes.Buffer` for each
+  call to `nft` rather than constructing a new one each time, saving
+  time and memory. (`@aroradaman`)
+
+- Fixed map element deletion in `knftables.Fake` to not mistakenly
+  require that you fill in the `.Value` of the element. (`@npinaeva`)
+
+- Added `Fake.LastTransaction`, to retrieve the most-recently-executed
+  transaction. (`@npinaeva`)
+
 ## v0.0.16
 
 - Fixed a bug in `Fake.ParseDump()` when using IPv6. (`@npinaeva`)

--- a/vendor/sigs.k8s.io/knftables/README.md
+++ b/vendor/sigs.k8s.io/knftables/README.md
@@ -7,9 +7,11 @@ specifically focuses on supporting Kubernetes components which are
 using nftables in the way that nftables is supposed to be used (as
 opposed to using nftables in a naively-translated-from-iptables way,
 or using nftables to do totally valid things that aren't the sorts of
-things Kubernetes components are likely to need to do).
+things Kubernetes components are likely to need to do; see the
+"[iptables porting](./docs/iptables-porting.md)" doc for more thoughts
+on porting old iptables-based components to nftables.)
 
-It is still under development and is not yet API stable. (See the
+knftables is still under development and is not yet API stable. (See the
 section on "Possible future changes" below.)
 
 The library is implemented as a wrapper around the `nft` CLI, because

--- a/vendor/sigs.k8s.io/knftables/transaction.go
+++ b/vendor/sigs.k8s.io/knftables/transaction.go
@@ -19,7 +19,6 @@ package knftables
 import (
 	"bytes"
 	"fmt"
-	"io"
 )
 
 // Transaction represents an nftables transaction
@@ -48,17 +47,16 @@ const (
 	flushVerb   verb = "flush"
 )
 
-// asCommandBuf returns the transaction as an io.Reader that outputs a series of nft commands
-func (tx *Transaction) asCommandBuf() (io.Reader, error) {
+// populateCommandBuf populates the transaction as series of nft commands to the given bytes.Buffer.
+func (tx *Transaction) populateCommandBuf(buf *bytes.Buffer) error {
 	if tx.err != nil {
-		return nil, tx.err
+		return tx.err
 	}
 
-	buf := &bytes.Buffer{}
 	for _, op := range tx.operations {
 		op.obj.writeOperation(op.verb, tx.nftContext, buf)
 	}
-	return buf, nil
+	return nil
 }
 
 // String returns the transaction as a string containing the nft commands; if there is
@@ -74,6 +72,11 @@ func (tx *Transaction) String() string {
 	}
 
 	return buf.String()
+}
+
+// NumOperations returns the number of operations queued in the transaction.
+func (tx *Transaction) NumOperations() int {
+	return len(tx.operations)
 }
 
 func (tx *Transaction) operation(verb verb, obj Object) {


### PR DESCRIPTION
#### What this PR does / why we need it:
Revendors knftables. In particular, this contains @aroradaman's fix to use less memory (https://github.com/kubernetes-sigs/knftables/pull/9) and some `knftables.Fake` updates from @npinaeva to support the unit tests in #126013 (partial syncing for nftables).

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/kind feature
/priority important-soon
/sig network
/area kube-proxy

/assign @thockin 