### PR TITLE
Support adding label based indexes to apiserver cache

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
+++ b/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
@@ -330,6 +330,12 @@ const (
 	// the 'nominalConcurrencyShares' field of the 'limited' section of a
 	// priority level.
 	ZeroLimitedNominalConcurrencyShares featuregate.Feature = "ZeroLimitedNominalConcurrencyShares"
+
+	// owner: @chenchun
+	// alpha: v1.32
+	//
+	// Add additional label indexes to cacher
+	CacherLabelIndex featuregate.Feature = "CacherLabelIndex"
 )
 
 func init() {
@@ -425,4 +431,6 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	ConsistentListFromCache: {Default: true, PreRelease: featuregate.Beta},
 
 	ZeroLimitedNominalConcurrencyShares: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.32
+
+	CacherLabelIndex: {Default: false, PreRelease: featuregate.Alpha},
 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
@@ -2224,12 +2224,12 @@ func TestForgetWatcher(t *testing.T) {
 		schema.GroupResource{Resource: "pods"},
 		"1",
 	)
-	forgetWatcherFn = forgetWatcher(cacher, w, 0, namespacedName{}, "", false)
+	forgetWatcherFn = forgetWatcher(cacher, w, 0, namespacedName{}, triggerIndex{}, false)
 	addWatcher := func(w *cacheWatcher) {
 		cacher.Lock()
 		defer cacher.Unlock()
 
-		cacher.watchers.addWatcher(w, 0, namespacedName{}, "", false)
+		cacher.watchers.addWatcher(w, 0, namespacedName{}, triggerIndex{}, false)
 	}
 
 	addWatcher(w)

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/metrics/metrics.go
@@ -176,6 +176,29 @@ var (
 			Help:           "Counter for consistent reads from cache.",
 			StabilityLevel: compbasemetrics.ALPHA,
 		}, []string{"resource", "success", "fallback"})
+
+	WatchDispatchEventNumWatchers = compbasemetrics.NewHistogramVec(
+		&compbasemetrics.HistogramOpts{
+			Namespace:      namespace,
+			Subsystem:      subsystem,
+			Name:           "watch_dispatch_event_num_watchers",
+			Help:           "Histogram of total number of watchers to dispatch event to.",
+			Buckets:        []float64{1, 2, 3, 4, 6, 8, 10, 15, 20, 30, 40, 50, 100, 200, 300, 500, 800, 1000, 2000, 3000},
+			StabilityLevel: compbasemetrics.ALPHA,
+		},
+		[]string{"resource"},
+	)
+
+	WatcherCountGauge = compbasemetrics.NewGaugeVec(
+		&compbasemetrics.GaugeOpts{
+			Namespace:      namespace,
+			Subsystem:      subsystem,
+			Name:           "watcher_counter",
+			Help:           "Counter of the inflight cacher watchers.",
+			StabilityLevel: compbasemetrics.ALPHA,
+		},
+		[]string{"resource", "index"},
+	)
 )
 
 var registerMetrics sync.Once
@@ -198,6 +221,8 @@ func Register() {
 		legacyregistry.MustRegister(WatchCacheInitializations)
 		legacyregistry.MustRegister(WatchCacheReadWait)
 		legacyregistry.MustRegister(ConsistentReadTotal)
+		legacyregistry.MustRegister(WatchDispatchEventNumWatchers)
+		legacyregistry.MustRegister(WatcherCountGauge)
 	})
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache.go
@@ -546,6 +546,8 @@ func (w *watchCache) waitUntilFreshAndListItems(ctx context.Context, resourceVer
 		for _, matchValue := range matchValues {
 			if result, err := w.store.ByIndex(matchValue.IndexName, matchValue.Value); err == nil {
 				return result, w.resourceVersion, matchValue.IndexName, nil
+			} else {
+				klog.Warningf("failed to list by index %s=%s: %v", matchValue.IndexName, matchValue.Value, err)
 			}
 		}
 		return w.store.List(), w.resourceVersion, "", nil

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher_test.go
@@ -57,6 +57,11 @@ func TestNamespaceScopedWatch(t *testing.T) {
 	storagetesting.RunTestNamespaceScopedWatch(ctx, t, store)
 }
 
+func TestLabelIndexWatch(t *testing.T) {
+	ctx, store, _ := testSetup(t)
+	storagetesting.RunTestWatchByLabels(ctx, t, store)
+}
+
 func TestDeleteTriggerWatch(t *testing.T) {
 	ctx, store, _ := testSetup(t)
 	storagetesting.RunTestDeleteTriggerWatch(ctx, t, store)

--- a/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/config.go
@@ -90,6 +90,11 @@ type Config struct {
 	// StorageObjectCountTracker is used to keep track of the total
 	// number of objects in the storage per resource.
 	StorageObjectCountTracker flowcontrolrequest.StorageObjectCountTracker
+
+	// IndexLabels are the keys of metadata.labels of an object. In addition to
+	// built-in indexes such as pod.spec.nodeName, the apiserver cacher will create
+	// additional indexes for these labels to speed up list and watch requests.
+	IndexLabels []string
 }
 
 // ConfigForResource is a Config specialized to a particular `schema.GroupResource`


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Ref: https://github.com/kubernetes/kubernetes/issues/126283

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #126283

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added alpha support for the API server to cache label based indexes. The new behavior is behind the `CacherLabelIndex` feature gate.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
