### PR TITLE
e2e test for No SNAT

### DIFF
--- a/test/e2e/feature/feature.go
+++ b/test/e2e/feature/feature.go
@@ -255,10 +255,6 @@ var (
 	NodeOutOfServiceVolumeDetach = framework.WithFeature(framework.ValidFeatures.Add("NodeOutOfServiceVolumeDetach"))
 
 	// Owner: sig-network
-	// Marks a single test that tests pod-to-pod connectivity between every pair of nodes.
-	NoSNAT = framework.WithFeature(framework.ValidFeatures.Add("NoSNAT"))
-
-	// Owner: sig-network
 	// Marks a single test that tests cluster DNS performance with many services.
 	PerformanceDNS = framework.WithFeature(framework.ValidFeatures.Add("PerformanceDNS"))
 

--- a/test/e2e/network/no_snat.go
+++ b/test/e2e/network/no_snat.go
@@ -29,7 +29,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	admissionapi "k8s.io/pod-security-admission/api"
 
-	"k8s.io/kubernetes/test/e2e/feature"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
@@ -64,7 +63,7 @@ var (
 
 // This test verifies that a Pod on each node in a cluster can talk to Pods on every other node without SNAT.
 // We use the [Feature:NoSNAT] tag so that most jobs will skip this test by default.
-var _ = common.SIGDescribe("NoSNAT", feature.NoSNAT, framework.WithSlow(), func() {
+var _ = common.SIGDescribe("NoSNAT", func() {
 	f := framework.NewDefaultFramework("no-snat-test")
 	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
 	ginkgo.It("Should be able to send traffic between Pods without SNAT", func(ctx context.Context) {
@@ -72,7 +71,7 @@ var _ = common.SIGDescribe("NoSNAT", feature.NoSNAT, framework.WithSlow(), func(
 		pc := cs.CoreV1().Pods(f.Namespace.Name)
 
 		ginkgo.By("creating a test pod on each Node")
-		nodes, err := e2enode.GetReadySchedulableNodes(ctx, cs)
+		nodes, err := e2enode.GetBoundedReadySchedulableNodes(ctx, cs, 3)
 		framework.ExpectNoError(err)
 		gomega.Expect(nodes.Items).ToNot(gomega.BeEmpty(), "no Nodes in the cluster")
 


### PR DESCRIPTION

/kind cleanup
```release-note
NONE
```

The kubernetes network model defines that each Pod should be able to reach any other Pod without NAT, the only test that was exercising this feature was tagged as Slow because it tried to schedule one Pod each Node of the cluster, but if we limit the number of nodes at a maximum of 3 we'll never be slow.


Remove also the feature NoSNAT tag as it should run in any cluster, as a next step, after evaluation the feedback on more CIs, we may promote it to conformance in the next release.