### PR TITLE
Automated cherry pick of #126167: Hot fix for panic on schema conversion.

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/compilation.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/compilation.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cel
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -124,6 +125,9 @@ func Compile(s *schema.Structural, declType *apiservercel.DeclType, perCallLimit
 
 	if len(s.Extensions.XValidations) == 0 {
 		return nil, nil
+	}
+	if declType == nil {
+		return nil, errors.New("failed to convert to declType for CEL validation rules")
 	}
 	celRules := s.Extensions.XValidations
 

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/model/adaptor.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/model/adaptor.go
@@ -62,6 +62,9 @@ func (s *Structural) Pattern() string {
 }
 
 func (s *Structural) Items() common.Schema {
+	if s.Structural.Items == nil {
+		return nil
+	}
 	return &Structural{Structural: s.Structural.Items}
 }
 

--- a/test/integration/apiserver/crd_validation_expressions_test.go
+++ b/test/integration/apiserver/crd_validation_expressions_test.go
@@ -658,6 +658,103 @@ func TestCustomResourceValidatorsWithBlockingErrors(t *testing.T) {
 	})
 }
 
+// TestCustomResourceValidatorsWithSchemaConversion tests CRD replacement with schema conversion issue should not panic.
+func TestCustomResourceValidatorsWithSchemaConversion(t *testing.T) {
+	server, err := apiservertesting.StartTestServer(t, apiservertesting.NewDefaultTestServerOptions(), nil, framework.SharedEtcd())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer server.TearDownFn()
+	config := server.ClientConfig
+
+	apiExtensionClient, err := clientset.NewForConfig(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dynamicClient, err := dynamic.NewForConfig(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create CRD with normal items+array schema
+	structuralWithValidators := crdWithSchema(t, "Structural", structuralSchemaWithItemsUnderArray)
+	crd, err := fixtures.CreateNewV1CustomResourceDefinition(structuralWithValidators, apiExtensionClient, dynamicClient)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gvr := schema.GroupVersionResource{
+		Group:    crd.Spec.Group,
+		Version:  crd.Spec.Versions[0].Name,
+		Resource: crd.Spec.Names.Plural,
+	}
+	crClient := dynamicClient.Resource(gvr)
+
+	// Create a valid CR instance
+	name1 := names.SimpleNameGenerator.GenerateName("cr-1")
+	_, err = crClient.Create(context.TODO(), &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": gvr.Group + "/" + gvr.Version,
+		"kind":       crd.Spec.Names.Kind,
+		"metadata": map[string]interface{}{
+			"name": name1,
+		},
+		"spec": map[string]interface{}{
+			"backend": []interface{}{
+				map[string]interface{}{
+					"replicas": 8,
+				},
+			},
+		},
+	}}, metav1.CreateOptions{})
+	if err != nil {
+		t.Errorf("Failed to create custom resource: %v", err)
+	}
+	crd, err = apiExtensionClient.ApiextensionsV1().CustomResourceDefinitions().Get(context.TODO(), crd.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	structuralSchemaWithItemsUnderObject := crdWithSchema(t, "Structural", structuralSchemaWithItemsUnderObject)
+	structuralSchemaWithItemsUnderObject.SetResourceVersion(crd.GetResourceVersion())
+	// Update CRD with invalid schema items under object
+	crd, err = apiExtensionClient.ApiextensionsV1().CustomResourceDefinitions().Update(context.TODO(), structuralSchemaWithItemsUnderObject, metav1.UpdateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Make an unrelated update to the previous persisted CR instance to make sure CRD handler doesn't panic
+	oldCR, err := crClient.Get(context.TODO(), name1, metav1.GetOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldCR.Object["metadata"].(map[string]interface{})["labels"] = map[string]interface{}{"key": "value"}
+	_, err = crClient.Update(context.TODO(), oldCR, metav1.UpdateOptions{})
+	if err == nil || !strings.Contains(err.Error(), "rule compiler initialization error: failed to convert to declType for CEL validation rules") {
+		t.Fatalf("expect error to contain \rule compiler initialization error: failed to convert to declType for CEL validation rules\" but get: %v", err)
+	}
+	// Create another CR instance with an array and be rejected
+	name2 := names.SimpleNameGenerator.GenerateName("cr-2")
+	_, err = crClient.Create(context.TODO(), &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": gvr.Group + "/" + gvr.Version,
+		"kind":       crd.Spec.Names.Kind,
+		"metadata": map[string]interface{}{
+			"name": name2,
+		},
+		"spec": map[string]interface{}{
+			"backend": []interface{}{
+				map[string]interface{}{
+					"replicas": 7,
+				},
+			},
+		},
+	}}, metav1.CreateOptions{})
+	if err == nil || !strings.Contains(err.Error(), "Invalid value: \"array\": spec.backend in body must be of type object: \"array\"") {
+		t.Fatalf("expect error to contain \"Invalid value: \"array\": spec.backend in body must be of type object: \"array\"\" but get: %v", err)
+	}
+	// Delete the CRD
+	err = fixtures.DeleteV1CustomResourceDefinition(structuralWithValidators, apiExtensionClient)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 func nonStructuralCrdWithValidations() *apiextensionsv1beta1.CustomResourceDefinition {
 	return &apiextensionsv1beta1.CustomResourceDefinition{
 		ObjectMeta: metav1.ObjectMeta{
@@ -881,6 +978,76 @@ var structuralSchemaWithBlockingErr = []byte(`
           "z": {
             "type": "integer",
 			"default": 0
+          }
+        }
+      }
+    }
+  }
+}`)
+
+var structuralSchemaWithItemsUnderArray = []byte(`
+{
+  "openAPIV3Schema": {
+    "description": "CRD with CEL validators",
+    "type": "object",
+    "properties": {
+      "spec": {
+        "type": "object",
+        "properties": {
+          "backend": {
+            "type": "array",
+            "maxItems": 100,
+            "items": {
+              "type": "object",
+              "properties": {
+                "replicas": {
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "replicas"
+              ],
+              "x-kubernetes-validations": [
+                {
+                  "rule": "0 <= self.replicas && self.replicas <= 10"
+                }
+              ]
+            }
+          }
+        }
+      }
+    }
+  }
+}`)
+
+var structuralSchemaWithItemsUnderObject = []byte(`
+{
+  "openAPIV3Schema": {
+    "description": "CRD with CEL validators",
+    "type": "object",
+    "properties": {
+      "spec": {
+        "type": "object",
+        "properties": {
+          "backend": {
+            "type": "object",
+            "maxItems": 100,
+            "items": {
+              "type": "object",
+              "properties": {
+                "replicas": {
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "replicas"
+              ],
+              "x-kubernetes-validations": [
+                {
+                  "rule": "0 <= self.replicas && self.replicas <= 10"
+                }
+              ]
+            }
           }
         }
       }


### PR DESCRIPTION
Cherry pick of #126167 on release-1.30.

#126167: Hot fix for panic on schema conversion.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```