### PR TITLE
Fix runtime panic in imagevolume `CanSupport` method

### DIFF
--- a/pkg/volume/image/image.go
+++ b/pkg/volume/image/image.go
@@ -49,7 +49,7 @@ func (o *imagePlugin) GetPluginName() string                           { return 
 func (o *imagePlugin) GetVolumeName(spec *volume.Spec) (string, error) { return o.spec.Name(), nil }
 
 func (o *imagePlugin) CanSupport(spec *volume.Spec) bool {
-	return spec.Volume.Image != nil
+	return spec != nil && spec.Volume != nil && spec.Volume.Image != nil
 }
 
 func (o *imagePlugin) NewMounter(spec *volume.Spec, podRef *v1.Pod, opts volume.VolumeOptions) (volume.Mounter, error) {


### PR DESCRIPTION

#### What type of PR is this?


/kind failing-test

#### What this PR does / why we need it:
The following tests are failing right now:

- ci-kubernetes-e2e-ec2-alpha-enabled-default
- ci-kubernetes-e2e-gci-gce-alpha-enabled-default

Because of:

```
goroutine 347 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic({0x33092b0, 0x4d6ed00}, {0x296a7e0, 0x4c20c10})
        k8s.io/apimachinery/pkg/util/runtime/runtime.go:107 +0xbc
k8s.io/apimachinery/pkg/util/runtime.handleCrash({0x33092b0, 0x4d6ed00}, {0x296a7e0, 0x4c20c10}, {0x4d6ed00, 0x0, 0x1000000004400a5?})
        k8s.io/apimachinery/pkg/util/runtime/runtime.go:82 +0x5e
k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x0, 0x0, 0xc000517be8?})
        k8s.io/apimachinery/pkg/util/runtime/runtime.go:59 +0x108
panic({0x296a7e0?, 0x4c20c10?})
        runtime/panic.go:770 +0x132
k8s.io/kubernetes/pkg/volume/image.(*imagePlugin).CanSupport(0xc00183d140?, 0xc0006a2600?)
        k8s.io/kubernetes/pkg/volume/image/image.go:52 +0x3
k8s.io/kubernetes/pkg/volume.(*VolumePluginMgr).FindPluginBySpec(0xc0008a1388, 0xc000f7ddb8)
        k8s.io/kubernetes/pkg/volume/plugins.go:637 +0x208
k8s.io/kubernetes/pkg/kubelet/volumemanager/cache.(*desiredStateOfWorld).AddPodToVolume(0xc000517bc0, {0xc000e94a50, 0x24}, 0xc00172b208, 0xc000f7ddb8, {0xc0017892a0, 0xe}, {0xc000a4d6ec, 0x3}, {0xc000978af0, ...})
        k8s.io/kubernetes/pkg/kubelet/volumemanager/cache/desired_state_of_world.go:270 +0xf2
k8s.io/kubernetes/pkg/kubelet/volumemanager/populator.(*desiredStateOfWorldPopulator).processPodVolumes(0xc0003e6700, 0xc00172b208, 0xc00183ddd8)
        k8s.io/kubernetes/pkg/kubelet/volumemanager/populator/desired_state_of_world_populator.go:319 +0x685
k8s.io/kubernetes/pkg/kubelet/volumemanager/populator.(*desiredStateOfWorldPopulator).findAndAddNewPods(0xc0003e6700)
        k8s.io/kubernetes/pkg/kubelet/volumemanager/populator/desired_state_of_world_populator.go:204 +0x2dc
k8s.io/kubernetes/pkg/kubelet/volumemanager/populator.(*desiredStateOfWorldPopulator).populatorLoop(0xc0003e6700)
        k8s.io/kubernetes/pkg/kubelet/volumemanager/populator/desired_state_of_world_populator.go:173 +0x18
k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0xc000905eb0?)
        k8s.io/apimachinery/pkg/util/wait/backoff.go:226 +0x33
k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0xc00183df70, {0x32d7340, 0xc000a7be60}, 0x1, 0xc0000b2660)
        k8s.io/apimachinery/pkg/util/wait/backoff.go:227 +0xaf
k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc000f8bf70, 0x5f5e100, 0x0, 0x1, 0xc0000b2660)
        k8s.io/apimachinery/pkg/util/wait/backoff.go:204 +0x7f
k8s.io/apimachinery/pkg/util/wait.Until(...)
        k8s.io/apimachinery/pkg/util/wait/backoff.go:161
k8s.io/kubernetes/pkg/kubelet/volumemanager/populator.(*desiredStateOfWorldPopulator).Run(0xc0003e6700, {0x32e3228, 0xc000b3faa0}, 0xc0000b2660)
        k8s.io/kubernetes/pkg/kubelet/volumemanager/populator/desired_state_of_world_populator.go:158 +0x1a5
created by k8s.io/kubernetes/pkg/kubelet/volumemanager.(*volumeManager).Run in goroutine 335
        k8s.io/kubernetes/pkg/kubelet/volumemanager/volume_manager.go:286 +0x14f
```


#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/kubernetes/issues/126317
#### Special notes for your reviewer:
/priority critical-urgent
cc @dims
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
