### PR TITLE
Fix validation of `NodeSelectorTerm` in pod.nodeAffinity

### DIFF
--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -4445,6 +4445,11 @@ func ValidateNodeSelectorTerm(term core.NodeSelectorTerm, fldPath *field.Path) f
 		allErrs = append(allErrs, ValidateNodeFieldSelectorRequirement(req, fldPath.Child("matchFields").Index(j))...)
 	}
 
+	termFldPath := fldPath.Child("nodeSelectorTerms")
+	if len(term.MatchExpressions) == 0 && len(term.MatchFields) == 0 {
+		return append(allErrs, field.Required(termFldPath, "must have at least one node selector term"))
+	}
+
 	return allErrs
 }
 

--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -10334,13 +10334,23 @@ func TestValidatePod(t *testing.T) {
 					NodeAffinity: &core.NodeAffinity{
 						RequiredDuringSchedulingIgnoredDuringExecution: &core.NodeSelector{
 							NodeSelectorTerms: []core.NodeSelectorTerm{{
-								MatchExpressions: []core.NodeSelectorRequirement{},
+								MatchExpressions: []core.NodeSelectorRequirement{
+									{
+										Key:      "key1",
+										Operator: core.NodeSelectorOpExists,
+									},
+								},
 							}},
 						},
 						PreferredDuringSchedulingIgnoredDuringExecution: []core.PreferredSchedulingTerm{{
 							Weight: 10,
 							Preference: core.NodeSelectorTerm{
-								MatchExpressions: []core.NodeSelectorRequirement{},
+								MatchExpressions: []core.NodeSelectorRequirement{
+									{
+										Key:      "key1",
+										Operator: core.NodeSelectorOpExists,
+									},
+								},
 							},
 						}},
 					},
@@ -11058,13 +11068,152 @@ func TestValidatePod(t *testing.T) {
 			),
 		},
 		"invalid requiredDuringSchedulingIgnoredDuringExecution node selector, nodeSelectorTerms must have at least one term": {
-			expectedError: "spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms",
+			expectedError: "must have at least one node selector term",
 			spec: *podtest.MakePod("123",
 				podtest.SetAffinity(&core.Affinity{
 					NodeAffinity: &core.NodeAffinity{
 						RequiredDuringSchedulingIgnoredDuringExecution: &core.NodeSelector{
 							NodeSelectorTerms: []core.NodeSelectorTerm{},
 						},
+					},
+				}),
+			),
+		},
+		"invalid requiredDuringSchedulingIgnoredDuringExecution node selector, nodeSelectorTerms must have at least one term 2": {
+			expectedError: "must have at least one node selector term",
+			spec: *podtest.MakePod("123",
+				podtest.SetAffinity(&core.Affinity{
+					NodeAffinity: &core.NodeAffinity{
+						RequiredDuringSchedulingIgnoredDuringExecution: &core.NodeSelector{
+							NodeSelectorTerms: []core.NodeSelectorTerm{
+								{
+									MatchExpressions: []core.NodeSelectorRequirement{},
+								},
+							},
+						},
+					},
+				}),
+			),
+		},
+		"invalid requiredDuringSchedulingIgnoredDuringExecution node selector, nodeSelectorTerms must have at least one term 3": {
+			expectedError: "must have at least one node selector term",
+			spec: *podtest.MakePod("123",
+				podtest.SetAffinity(&core.Affinity{
+					NodeAffinity: &core.NodeAffinity{
+						RequiredDuringSchedulingIgnoredDuringExecution: &core.NodeSelector{
+							NodeSelectorTerms: []core.NodeSelectorTerm{
+								{
+									MatchExpressions: []core.NodeSelectorRequirement{},
+									MatchFields:      []core.NodeSelectorRequirement{},
+								},
+							},
+						},
+					},
+				}),
+			),
+		},
+		"invalid requiredDuringSchedulingIgnoredDuringExecution node selector, nodeSelectorTerms must have at least one term 4": {
+			expectedError: "must have at least one node selector term",
+			spec: *podtest.MakePod("123",
+				podtest.SetAffinity(&core.Affinity{
+					NodeAffinity: &core.NodeAffinity{
+						RequiredDuringSchedulingIgnoredDuringExecution: &core.NodeSelector{
+							NodeSelectorTerms: []core.NodeSelectorTerm{},
+						},
+						PreferredDuringSchedulingIgnoredDuringExecution: []core.PreferredSchedulingTerm{{
+							Weight:     10,
+							Preference: core.NodeSelectorTerm{},
+						}},
+					},
+				}),
+			),
+		},
+		"invalid requiredDuringSchedulingIgnoredDuringExecution node selector, nodeSelectorTerms must have at least one term 5": {
+			expectedError: "must have at least one node selector term",
+			spec: *podtest.MakePod("123",
+				podtest.SetAffinity(&core.Affinity{
+					NodeAffinity: &core.NodeAffinity{
+						RequiredDuringSchedulingIgnoredDuringExecution: &core.NodeSelector{
+							NodeSelectorTerms: []core.NodeSelectorTerm{
+								{
+									MatchExpressions: []core.NodeSelectorRequirement{},
+								},
+							},
+						},
+						PreferredDuringSchedulingIgnoredDuringExecution: []core.PreferredSchedulingTerm{{
+							Weight: 10,
+							Preference: core.NodeSelectorTerm{
+								MatchExpressions: []core.NodeSelectorRequirement{},
+							},
+						}},
+					},
+				}),
+			),
+		},
+		"invalid requiredDuringSchedulingIgnoredDuringExecution node selector, nodeSelectorTerms must have at least one term 6": {
+			expectedError: "must have at least one node selector term",
+			spec: *podtest.MakePod("123",
+				podtest.SetAffinity(&core.Affinity{
+					NodeAffinity: &core.NodeAffinity{
+						RequiredDuringSchedulingIgnoredDuringExecution: &core.NodeSelector{
+							NodeSelectorTerms: []core.NodeSelectorTerm{
+								{
+									MatchExpressions: []core.NodeSelectorRequirement{},
+									MatchFields:      []core.NodeSelectorRequirement{},
+								},
+							},
+						},
+						PreferredDuringSchedulingIgnoredDuringExecution: []core.PreferredSchedulingTerm{{
+							Weight: 10,
+							Preference: core.NodeSelectorTerm{
+								MatchExpressions: []core.NodeSelectorRequirement{},
+								MatchFields:      []core.NodeSelectorRequirement{},
+							},
+						}},
+					},
+				}),
+			),
+		},
+		"invalid preferredDuringSchedulingIgnoredDuringExecution node selector, nodeSelectorTerms must have at least one term": {
+			expectedError: "must have at least one node selector term",
+			spec: *podtest.MakePod("123",
+				podtest.SetAffinity(&core.Affinity{
+					NodeAffinity: &core.NodeAffinity{
+						PreferredDuringSchedulingIgnoredDuringExecution: []core.PreferredSchedulingTerm{{
+							Weight:     10,
+							Preference: core.NodeSelectorTerm{},
+						}},
+					},
+				}),
+			),
+		},
+		"invalid preferredDuringSchedulingIgnoredDuringExecution node selector, nodeSelectorTerms must have at least one term 2": {
+			expectedError: "must have at least one node selector term",
+			spec: *podtest.MakePod("123",
+				podtest.SetAffinity(&core.Affinity{
+					NodeAffinity: &core.NodeAffinity{
+						PreferredDuringSchedulingIgnoredDuringExecution: []core.PreferredSchedulingTerm{{
+							Weight: 10,
+							Preference: core.NodeSelectorTerm{
+								MatchExpressions: []core.NodeSelectorRequirement{},
+							},
+						}},
+					},
+				}),
+			),
+		},
+		"invalid preferredDuringSchedulingIgnoredDuringExecution node selector, nodeSelectorTerms must have at least one term 3": {
+			expectedError: "must have at least one node selector term",
+			spec: *podtest.MakePod("123",
+				podtest.SetAffinity(&core.Affinity{
+					NodeAffinity: &core.NodeAffinity{
+						PreferredDuringSchedulingIgnoredDuringExecution: []core.PreferredSchedulingTerm{{
+							Weight: 10,
+							Preference: core.NodeSelectorTerm{
+								MatchExpressions: []core.NodeSelectorRequirement{},
+								MatchFields:      []core.NodeSelectorRequirement{},
+							},
+						}},
 					},
 				}),
 			),


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
To add validation of `NodeSelectorTerm` in pod.nodeAffinity.

#### Which issue(s) this PR fixes:
Fixes #126325

#### Special notes for your reviewer:
Also added some test cases covering this scenario.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```