### PR TITLE
KEP-2862: Fine-grained Kubelet API Authorization

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -369,6 +369,13 @@ const (
 	// fallback to using it's cgroupDriver option.
 	KubeletCgroupDriverFromCRI featuregate.Feature = "KubeletCgroupDriverFromCRI"
 
+	// owner: @vinayakankugoyal
+	// kep: http://kep.k8s.io/2862
+	//
+	// Enable fine-grained kubelet API authorization for webhook based
+	// authorization.
+	KubeletFineGrainedAuthz featuregate.Feature = "KubeletFineGrainedAuthz"
+
 	// owner: @AkihiroSuda
 	// alpha: v1.22
 	//

--- a/pkg/features/versioned_kube_features.go
+++ b/pkg/features/versioned_kube_features.go
@@ -374,6 +374,10 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 		{Version: version.MustParse("1.31"), Default: true, PreRelease: featuregate.Beta},
 	},
 
+	KubeletFineGrainedAuthz: {
+		{Version: version.MustParse("1.32"), Default: false, PreRelease: featuregate.Alpha},
+	},
+
 	KubeletInUserNamespace: {
 		{Version: version.MustParse("1.22"), Default: false, PreRelease: featuregate.Alpha},
 	},

--- a/pkg/kubelet/server/auth_test.go
+++ b/pkg/kubelet/server/auth_test.go
@@ -24,6 +24,9 @@ import (
 	"github.com/stretchr/testify/require"
 	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	"k8s.io/kubernetes/pkg/features"
 )
 
 func TestIsSubPath(t *testing.T) {
@@ -61,16 +64,19 @@ func TestIsSubPath(t *testing.T) {
 }
 
 func TestGetRequestAttributes(t *testing.T) {
-	for _, test := range AuthzTestCases() {
-		t.Run(test.Method+":"+test.Path, func(t *testing.T) {
-			getter := NewNodeAuthorizerAttributesGetter(authzTestNodeName)
+	for _, fineGrained := range []bool{false, true} {
+		featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.KubeletFineGrainedAuthz, fineGrained)
+		for _, test := range AuthzTestCases(fineGrained) {
+			t.Run(test.Method+":"+test.Path, func(t *testing.T) {
+				getter := NewNodeAuthorizerAttributesGetter(authzTestNodeName)
 
-			req, err := http.NewRequest(test.Method, "https://localhost:1234"+test.Path, nil)
-			require.NoError(t, err)
-			attrs := getter.GetRequestAttributes(AuthzTestUser(), req)
+				req, err := http.NewRequest(test.Method, "https://localhost:1234"+test.Path, nil)
+				require.NoError(t, err)
+				attrs := getter.GetRequestAttributes(AuthzTestUser(), req)
 
-			test.AssertAttributes(t, attrs)
-		})
+				test.AssertAttributes(t, attrs)
+			})
+		}
 	}
 }
 
@@ -82,60 +88,78 @@ const (
 type AuthzTestCase struct {
 	Method, Path string
 
-	ExpectedVerb, ExpectedSubresource string
+	ExpectedVerb         string
+	ExpectedSubresources []string
 }
 
-func (a *AuthzTestCase) AssertAttributes(t *testing.T, attrs authorizer.Attributes) {
-	expectedAttributes := authorizer.AttributesRecord{
-		User:            AuthzTestUser(),
-		APIGroup:        "",
-		APIVersion:      "v1",
-		Verb:            a.ExpectedVerb,
-		Resource:        "nodes",
-		Name:            authzTestNodeName,
-		Subresource:     a.ExpectedSubresource,
-		ResourceRequest: true,
-		Path:            a.Path,
+func (a *AuthzTestCase) AssertAttributes(t *testing.T, attrs []authorizer.Attributes) {
+	var expectedAttributes []authorizer.AttributesRecord
+	for _, subresource := range a.ExpectedSubresources {
+		expectedAttributes = append(expectedAttributes, authorizer.AttributesRecord{
+			User:            AuthzTestUser(),
+			APIGroup:        "",
+			APIVersion:      "v1",
+			Verb:            a.ExpectedVerb,
+			Resource:        "nodes",
+			Name:            authzTestNodeName,
+			Subresource:     subresource,
+			ResourceRequest: true,
+			Path:            a.Path,
+		})
 	}
 
-	assert.Equal(t, expectedAttributes, attrs)
+	assert.Equal(t, len(attrs), len(expectedAttributes))
+	for i := range attrs {
+		assert.Equal(t, attrs[i], expectedAttributes[i])
+	}
 }
 
 func AuthzTestUser() user.Info {
 	return &user.DefaultInfo{Name: authzTestUserName}
 }
 
-func AuthzTestCases() []AuthzTestCase {
+func AuthzTestCases(fineGrained bool) []AuthzTestCase {
 	// Path -> ExpectedSubresource
-	testPaths := map[string]string{
-		"/attach/{podNamespace}/{podID}/{containerName}":       "proxy",
-		"/attach/{podNamespace}/{podID}/{uid}/{containerName}": "proxy",
-		"/checkpoint/{podNamespace}/{podID}/{containerName}":   "checkpoint",
-		"/configz": "proxy",
-		"/containerLogs/{podNamespace}/{podID}/{containerName}": "proxy",
-		"/debug/flags/v":                                     "proxy",
-		"/debug/pprof/{subpath:*}":                           "proxy",
-		"/exec/{podNamespace}/{podID}/{containerName}":       "proxy",
-		"/exec/{podNamespace}/{podID}/{uid}/{containerName}": "proxy",
-		"/healthz":                            "proxy",
-		"/healthz/log":                        "proxy",
-		"/healthz/ping":                       "proxy",
-		"/healthz/syncloop":                   "proxy",
-		"/logs/":                              "log",
-		"/logs/{logpath:*}":                   "log",
-		"/metrics":                            "metrics",
-		"/metrics/cadvisor":                   "metrics",
-		"/metrics/probes":                     "metrics",
-		"/metrics/resource":                   "metrics",
-		"/pods/":                              "proxy",
-		"/portForward/{podNamespace}/{podID}": "proxy",
-		"/portForward/{podNamespace}/{podID}/{uid}":         "proxy",
-		"/run/{podNamespace}/{podID}/{containerName}":       "proxy",
-		"/run/{podNamespace}/{podID}/{uid}/{containerName}": "proxy",
-		"/runningpods/":  "proxy",
-		"/stats/":        "stats",
-		"/stats/summary": "stats",
+	testPaths := map[string][]string{
+		"/attach/{podNamespace}/{podID}/{containerName}":       {"proxy"},
+		"/attach/{podNamespace}/{podID}/{uid}/{containerName}": {"proxy"},
+		"/checkpoint/{podNamespace}/{podID}/{containerName}":   {"checkpoint"},
+		"/configz": {"proxy"},
+		"/containerLogs/{podNamespace}/{podID}/{containerName}": {"proxy"},
+		"/debug/flags/v":                                     {"proxy"},
+		"/debug/pprof/{subpath:*}":                           {"proxy"},
+		"/exec/{podNamespace}/{podID}/{containerName}":       {"proxy"},
+		"/exec/{podNamespace}/{podID}/{uid}/{containerName}": {"proxy"},
+		"/healthz":                            {"proxy"},
+		"/healthz/log":                        {"proxy"},
+		"/healthz/ping":                       {"proxy"},
+		"/healthz/syncloop":                   {"proxy"},
+		"/logs/":                              {"log"},
+		"/logs/{logpath:*}":                   {"log"},
+		"/metrics":                            {"metrics"},
+		"/metrics/cadvisor":                   {"metrics"},
+		"/metrics/probes":                     {"metrics"},
+		"/metrics/resource":                   {"metrics"},
+		"/pods/":                              {"proxy"},
+		"/portForward/{podNamespace}/{podID}": {"proxy"},
+		"/portForward/{podNamespace}/{podID}/{uid}":         {"proxy"},
+		"/run/{podNamespace}/{podID}/{containerName}":       {"proxy"},
+		"/run/{podNamespace}/{podID}/{uid}/{containerName}": {"proxy"},
+		"/runningpods/":  {"proxy"},
+		"/stats/":        {"stats"},
+		"/stats/summary": {"stats"},
 	}
+
+	if fineGrained {
+		testPaths["/healthz"] = append([]string{"healthz"}, testPaths["/healthz"]...)
+		testPaths["/healthz/log"] = append([]string{"healthz"}, testPaths["/healthz/log"]...)
+		testPaths["/healthz/ping"] = append([]string{"healthz"}, testPaths["/healthz/ping"]...)
+		testPaths["/healthz/syncloop"] = append([]string{"healthz"}, testPaths["/healthz/syncloop"]...)
+		testPaths["/pods/"] = append([]string{"pods"}, testPaths["/pods/"]...)
+		testPaths["/runningpods/"] = append([]string{"pods"}, testPaths["/runningpods/"]...)
+		testPaths["/configz"] = append([]string{"configz"}, testPaths["/configz"]...)
+	}
+
 	testCases := []AuthzTestCase{}
 	for path, subresource := range testPaths {
 		testCases = append(testCases,

--- a/pkg/kubelet/server/server_test.go
+++ b/pkg/kubelet/server/server_test.go
@@ -291,14 +291,14 @@ func (*fakeKubelet) GetCgroupCPUAndMemoryStats(cgroupName string, updateStats bo
 
 type fakeAuth struct {
 	authenticateFunc func(*http.Request) (*authenticator.Response, bool, error)
-	attributesFunc   func(user.Info, *http.Request) authorizer.Attributes
+	attributesFunc   func(user.Info, *http.Request) []authorizer.Attributes
 	authorizeFunc    func(authorizer.Attributes) (authorized authorizer.Decision, reason string, err error)
 }
 
 func (f *fakeAuth) AuthenticateRequest(req *http.Request) (*authenticator.Response, bool, error) {
 	return f.authenticateFunc(req)
 }
-func (f *fakeAuth) GetRequestAttributes(u user.Info, req *http.Request) authorizer.Attributes {
+func (f *fakeAuth) GetRequestAttributes(u user.Info, req *http.Request) []authorizer.Attributes {
 	return f.attributesFunc(u, req)
 }
 func (f *fakeAuth) Authorize(ctx context.Context, a authorizer.Attributes) (authorized authorizer.Decision, reason string, err error) {
@@ -349,8 +349,8 @@ func newServerTestWithDebuggingHandlers(kubeCfg *kubeletconfiginternal.KubeletCo
 		authenticateFunc: func(req *http.Request) (*authenticator.Response, bool, error) {
 			return &authenticator.Response{User: &user.DefaultInfo{Name: "test"}}, true, nil
 		},
-		attributesFunc: func(u user.Info, req *http.Request) authorizer.Attributes {
-			return &authorizer.AttributesRecord{User: u}
+		attributesFunc: func(u user.Info, req *http.Request) []authorizer.Attributes {
+			return []authorizer.Attributes{&authorizer.AttributesRecord{User: u}}
 		},
 		authorizeFunc: func(a authorizer.Attributes) (decision authorizer.Decision, reason string, err error) {
 			return authorizer.DecisionAllow, "", nil
@@ -546,7 +546,7 @@ func TestAuthzCoverage(t *testing.T) {
 		}
 	}
 
-	for _, tc := range AuthzTestCases() {
+	for _, tc := range AuthzTestCases(false) {
 		expectedCases[tc.Method+":"+tc.Path] = true
 	}
 
@@ -566,7 +566,7 @@ func TestAuthFilters(t *testing.T) {
 
 	attributesGetter := NewNodeAuthorizerAttributesGetter(authzTestNodeName)
 
-	for _, tc := range AuthzTestCases() {
+	for _, tc := range AuthzTestCases(false) {
 		t.Run(tc.Method+":"+tc.Path, func(t *testing.T) {
 			var (
 				expectedUser = AuthzTestUser()
@@ -580,14 +580,14 @@ func TestAuthFilters(t *testing.T) {
 				calledAuthenticate = true
 				return &authenticator.Response{User: expectedUser}, true, nil
 			}
-			fw.fakeAuth.attributesFunc = func(u user.Info, req *http.Request) authorizer.Attributes {
+			fw.fakeAuth.attributesFunc = func(u user.Info, req *http.Request) []authorizer.Attributes {
 				calledAttributes = true
 				require.Equal(t, expectedUser, u)
 				return attributesGetter.GetRequestAttributes(u, req)
 			}
 			fw.fakeAuth.authorizeFunc = func(a authorizer.Attributes) (decision authorizer.Decision, reason string, err error) {
 				calledAuthorize = true
-				tc.AssertAttributes(t, a)
+				tc.AssertAttributes(t, []authorizer.Attributes{a})
 				return authorizer.DecisionNoOpinion, "", nil
 			}
 
@@ -609,7 +609,7 @@ func TestAuthFilters(t *testing.T) {
 func TestAuthenticationError(t *testing.T) {
 	var (
 		expectedUser       = &user.DefaultInfo{Name: "test"}
-		expectedAttributes = &authorizer.AttributesRecord{User: expectedUser}
+		expectedAttributes = []authorizer.Attributes{&authorizer.AttributesRecord{User: expectedUser}}
 
 		calledAuthenticate = false
 		calledAuthorize    = false
@@ -622,7 +622,7 @@ func TestAuthenticationError(t *testing.T) {
 		calledAuthenticate = true
 		return &authenticator.Response{User: expectedUser}, true, nil
 	}
-	fw.fakeAuth.attributesFunc = func(u user.Info, req *http.Request) authorizer.Attributes {
+	fw.fakeAuth.attributesFunc = func(u user.Info, req *http.Request) []authorizer.Attributes {
 		calledAttributes = true
 		return expectedAttributes
 	}
@@ -647,7 +647,7 @@ func TestAuthenticationError(t *testing.T) {
 func TestAuthenticationFailure(t *testing.T) {
 	var (
 		expectedUser       = &user.DefaultInfo{Name: "test"}
-		expectedAttributes = &authorizer.AttributesRecord{User: expectedUser}
+		expectedAttributes = []authorizer.Attributes{&authorizer.AttributesRecord{User: expectedUser}}
 
 		calledAuthenticate = false
 		calledAuthorize    = false
@@ -660,7 +660,7 @@ func TestAuthenticationFailure(t *testing.T) {
 		calledAuthenticate = true
 		return nil, false, nil
 	}
-	fw.fakeAuth.attributesFunc = func(u user.Info, req *http.Request) authorizer.Attributes {
+	fw.fakeAuth.attributesFunc = func(u user.Info, req *http.Request) []authorizer.Attributes {
 		calledAttributes = true
 		return expectedAttributes
 	}
@@ -685,7 +685,7 @@ func TestAuthenticationFailure(t *testing.T) {
 func TestAuthorizationSuccess(t *testing.T) {
 	var (
 		expectedUser       = &user.DefaultInfo{Name: "test"}
-		expectedAttributes = &authorizer.AttributesRecord{User: expectedUser}
+		expectedAttributes = []authorizer.Attributes{&authorizer.AttributesRecord{User: expectedUser}}
 
 		calledAuthenticate = false
 		calledAuthorize    = false
@@ -698,7 +698,7 @@ func TestAuthorizationSuccess(t *testing.T) {
 		calledAuthenticate = true
 		return &authenticator.Response{User: expectedUser}, true, nil
 	}
-	fw.fakeAuth.attributesFunc = func(u user.Info, req *http.Request) authorizer.Attributes {
+	fw.fakeAuth.attributesFunc = func(u user.Info, req *http.Request) []authorizer.Attributes {
 		calledAttributes = true
 		return expectedAttributes
 	}
@@ -1526,5 +1526,109 @@ func TestTrimURLPath(t *testing.T) {
 
 	for _, test := range tests {
 		assert.Equalf(t, test.expected, getURLRootPath(test.path), "path is: %s", test.path)
+	}
+}
+
+func TestFineGrainedAuthz(t *testing.T) {
+	// Enable features.ContainerCheckpoint during test
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.KubeletFineGrainedAuthz, true)
+
+	fw := newServerTest()
+	defer fw.testHTTPServer.Close()
+
+	attributesGetter := NewNodeAuthorizerAttributesGetter(authzTestNodeName)
+
+	testCases := []struct {
+		name                     string
+		path                     string
+		expectedSubResources     []string
+		authorizer               func(authorizer.Attributes) (authorized authorizer.Decision, reason string, err error)
+		wantStatusCode           int
+		wantCalledAuthorizeCount int
+	}{
+		{
+			name:                 "both subresources rejected",
+			path:                 "/configz",
+			expectedSubResources: []string{"configz", "proxy"},
+			authorizer: func(authorizer.Attributes) (authorized authorizer.Decision, reason string, err error) {
+				return authorizer.DecisionNoOpinion, "", nil
+			},
+			wantStatusCode:           403,
+			wantCalledAuthorizeCount: 2,
+		},
+		{
+			name:                 "fine grained rejected, proxy accepted",
+			path:                 "/configz",
+			expectedSubResources: []string{"configz", "proxy"},
+			authorizer: func(a authorizer.Attributes) (authorized authorizer.Decision, reason string, err error) {
+				switch a.GetSubresource() {
+				case "configz":
+					return authorizer.DecisionNoOpinion, "", nil
+				case "proxy":
+					return authorizer.DecisionAllow, "", nil
+				default:
+					return authorizer.DecisionNoOpinion, "", fmt.Errorf("unexpected subresource %v", a.GetSubresource())
+				}
+			},
+			wantStatusCode:           200,
+			wantCalledAuthorizeCount: 2,
+		},
+		{
+			name:                 "fine grained accepted",
+			path:                 "/configz",
+			expectedSubResources: []string{"configz", "proxy"},
+			authorizer: func(a authorizer.Attributes) (authorized authorizer.Decision, reason string, err error) {
+				switch a.GetSubresource() {
+				case "configz":
+					return authorizer.DecisionAllow, "", nil
+				case "proxy":
+					return authorizer.DecisionNoOpinion, "", fmt.Errorf("did not expect code to reach here")
+				default:
+					return authorizer.DecisionNoOpinion, "", fmt.Errorf("unexpected subresource %v", a.GetSubresource())
+				}
+			},
+			wantStatusCode:           200,
+			wantCalledAuthorizeCount: 1,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			calledAuthenticate := false
+			calledAuthorizeCount := 0
+			calledAttributes := false
+
+			fw.fakeAuth.authenticateFunc = func(req *http.Request) (*authenticator.Response, bool, error) {
+				calledAuthenticate = true
+				return &authenticator.Response{User: AuthzTestUser()}, true, nil
+			}
+			fw.fakeAuth.attributesFunc = func(u user.Info, req *http.Request) []authorizer.Attributes {
+				calledAttributes = true
+				attrs := attributesGetter.GetRequestAttributes(u, req)
+				var gotSubresources []string
+				for _, attr := range attrs {
+					gotSubresources = append(gotSubresources, attr.GetSubresource())
+				}
+				require.Equal(t, tc.expectedSubResources, gotSubresources)
+				return attrs
+			}
+			fw.fakeAuth.authorizeFunc = func(a authorizer.Attributes) (authorized authorizer.Decision, reason string, err error) {
+				calledAuthorizeCount += 1
+				return tc.authorizer(a)
+			}
+
+			req, err := http.NewRequest("GET", fw.testHTTPServer.URL+tc.path, nil)
+			require.NoError(t, err)
+
+			resp, err := http.DefaultClient.Do(req)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+
+			assert.Equal(t, tc.wantStatusCode, resp.StatusCode)
+			assert.True(t, calledAuthenticate, "Authenticate was not called")
+			assert.True(t, calledAttributes, "Attributes were not called")
+			assert.Equal(t, tc.wantCalledAuthorizeCount, calledAuthorizeCount)
+		})
 	}
 }

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
@@ -389,17 +389,6 @@ func ClusterRoles() []rbacv1.ClusterRole {
 			},
 		},
 		{
-			// a role to use for full access to the kubelet API
-			ObjectMeta: metav1.ObjectMeta{Name: "system:kubelet-api-admin"},
-			Rules: []rbacv1.PolicyRule{
-				// Allow read-only access to the Node API objects
-				rbacv1helpers.NewRule("get", "list", "watch").Groups(legacyGroup).Resources("nodes").RuleOrDie(),
-				// Allow all API calls to the nodes
-				rbacv1helpers.NewRule("proxy").Groups(legacyGroup).Resources("nodes").RuleOrDie(),
-				rbacv1helpers.NewRule("*").Groups(legacyGroup).Resources("nodes/proxy", "nodes/metrics", "nodes/stats", "nodes/log").RuleOrDie(),
-			},
-		},
-		{
 			// a role to use for bootstrapping a node's client certificates
 			ObjectMeta: metav1.ObjectMeta{Name: "system:node-bootstrapper"},
 			Rules: []rbacv1.PolicyRule{
@@ -528,6 +517,25 @@ func ClusterRoles() []rbacv1.ClusterRole {
 				"/openid/v1/jwks/",
 			).RuleOrDie(),
 		},
+	})
+
+	// Add the cluster role system:kubelet-api-admin
+	kubeletAPIAdminRules := []rbacv1.PolicyRule{
+		// Allow read-only access to the Node API objects
+		rbacv1helpers.NewRule("get", "list", "watch").Groups(legacyGroup).Resources("nodes").RuleOrDie(),
+		// Allow all API calls to the nodes
+		rbacv1helpers.NewRule("proxy").Groups(legacyGroup).Resources("nodes").RuleOrDie(),
+		rbacv1helpers.NewRule("*").Groups(legacyGroup).Resources("nodes/proxy", "nodes/metrics", "nodes/stats", "nodes/log").RuleOrDie(),
+	}
+
+	if utilfeature.DefaultFeatureGate.Enabled(features.KubeletFineGrainedAuthz) {
+		kubeletAPIAdminRules = append(kubeletAPIAdminRules, rbacv1helpers.NewRule("*").Groups(legacyGroup).Resources("nodes/pods", "nodes/healthz", "nodes/configz").RuleOrDie())
+	}
+
+	roles = append(roles, rbacv1.ClusterRole{
+		// a role to use for full access to the kubelet API
+		ObjectMeta: metav1.ObjectMeta{Name: "system:kubelet-api-admin"},
+		Rules:      kubeletAPIAdminRules,
 	})
 
 	// node-proxier role is used by kube-proxy.

--- a/staging/src/k8s.io/apiserver/pkg/server/healthz/healthz.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/healthz/healthz.go
@@ -35,6 +35,8 @@ import (
 	"k8s.io/klog/v2"
 )
 
+const DefaultHealthzPath = "/healthz"
+
 // HealthChecker is a named healthz checker.
 type HealthChecker interface {
 	Name() string
@@ -154,7 +156,7 @@ func NamedCheck(name string, check func(r *http.Request) error) HealthChecker {
 // exactly one call to InstallHandler. Calling InstallHandler more
 // than once for the same mux will result in a panic.
 func InstallHandler(mux mux, checks ...HealthChecker) {
-	InstallPathHandler(mux, "/healthz", checks...)
+	InstallPathHandler(mux, DefaultHealthzPath, checks...)
 }
 
 // InstallReadyzHandler registers handlers for health checking on the path

--- a/staging/src/k8s.io/component-base/configz/configz.go
+++ b/staging/src/k8s.io/component-base/configz/configz.go
@@ -47,6 +47,8 @@ import (
 	"sync"
 )
 
+const DefaultConfigzPath = "/configz"
+
 var (
 	configsGuard sync.RWMutex
 	configs      = map[string]*Config{}
@@ -61,7 +63,7 @@ type Config struct {
 // InstallHandler adds an HTTP handler on the given mux for the "/configz"
 // endpoint which serves all registered ComponentConfigs in JSON format.
 func InstallHandler(m mux) {
-	m.Handle("/configz", http.HandlerFunc(handle))
+	m.Handle(DefaultConfigzPath, http.HandlerFunc(handle))
 }
 
 type mux interface {

--- a/test/featuregates_linter/test_data/versioned_feature_list.yaml
+++ b/test/featuregates_linter/test_data/versioned_feature_list.yaml
@@ -494,6 +494,12 @@
     lockToDefault: false
     preRelease: Beta
     version: "1.31"
+- name: KubeletFineGrainedAuthz
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.32"
 - name: KubeletInUserNamespace
   versionedSpecs:
   - default: false


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it: 

Adds fine-grained kubelet API Authz checks for kubelet `/configz`, `/healthz` and `/pods` API. This allows users to acess the kubelet API without granting the `nodes/proxy` resource permission to the caller. Instead the caller can be granted `nodes/configz`, `nodes/healthz` and `nodes/pods` respectively.

Note: existing callers who have `nodes/proxy` will still be authorized for kubelet's `/configz`, `/healthz` and `/pods` endpoints.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Revised the Kubelet API Authorization with new subresources, that allow finer-grained authorization checks and access control for kubelet endpoints.
Provided you enable the `KubeletFineGrainedAuthz` feature gate, you can access kubelet's `/healthz` endpoint by granting the caller `nodes/helathz` permission in RBAC.
Similarly you can also access  kubelet's `/pods` endpoint to fetch a list of Pods bound to that node by granting the caller `nodes/pods` permission in RBAC.
Similarly you can also access kubelet's `/configz` endpoint to fetch kubelet's configuration by granting the caller `nodes/configz` permission in RBAC.
You can still access kubelet's `/healthz`, `/pods` and `/configz` by granting the caller `nodes/proxy` permission in RBAC but that also grants the caller permissions to exec, run and attach to containers on the nodes and doing so does not follow the least privilege principle. Granting callers more permissions than they need can give attackers an opportunity to escalate privileges.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: https://github.com/kubernetes/enhancements/issues/2862
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/2862
```
