### PR TITLE
Make smaller workloads for scheduler_perf integration tests

### DIFF
--- a/test/integration/scheduler_perf/README.md
+++ b/test/integration/scheduler_perf/README.md
@@ -110,9 +110,12 @@ make test-integration WHAT=./test/integration/scheduler_perf KUBE_TEST_ARGS=-use
 ```
 
 Integration testing uses the same `config/performance-config.yaml` as
-benchmarking. By default, workloads labeled as `integration-test` are executed
-as part of integration testing. `-test-scheduling-label-filter` can be used to
-change that.
+benchmarking. By default, workloads labeled as `integration-test`
+are executed as part of integration testing. `-test-scheduling-label-filter` can be used to
+change that. 
 
-We should make each test case with `integration-test` label very small,
+Running the integration tests as above will only execute the workloads labeled as `short`.
+ `SHORT=--short=false` variable added to the command can be used to disable this filtering.
+
+We should make each test case with `short` label very small,
 so that all tests with the label should take less than 5 min to complete.

--- a/test/integration/scheduler_perf/README.md
+++ b/test/integration/scheduler_perf/README.md
@@ -111,11 +111,21 @@ make test-integration WHAT=./test/integration/scheduler_perf KUBE_TEST_ARGS=-use
 
 Integration testing uses the same `config/performance-config.yaml` as
 benchmarking. By default, workloads labeled as `integration-test`
-are executed as part of integration testing. `-test-scheduling-label-filter` can be used to
-change that. 
+are executed as part of integration testing (in ci-kubernetes-integration-master job).
+`-test-scheduling-label-filter` can be used to change that.
+All test cases should have at least one workload labeled as `integration-test`.
 
-Running the integration tests as above will only execute the workloads labeled as `short`.
- `SHORT=--short=false` variable added to the command can be used to disable this filtering.
+Running the integration tests with command above will only execute the workloads labeled as `short`.
+`SHORT=--short=false` variable added to the command can be used to disable this filtering.
 
 We should make each test case with `short` label very small,
 so that all tests with the label should take less than 5 min to complete.
+The test cases labeled as `short` are executed in pull-kubernetes-integration job.
+
+### Labels used by CI jobs
+
+| CI Job                           | Labels                 |
+|----------------------------------|------------------------|
+| ci-kubernetes-integration-master | integration-test       |
+| pull-kubernetes-integration      | integration-test,short |
+| ci-benchmark-scheduler-perf      | performance            |

--- a/test/integration/scheduler_perf/README.md
+++ b/test/integration/scheduler_perf/README.md
@@ -113,3 +113,6 @@ Integration testing uses the same `config/performance-config.yaml` as
 benchmarking. By default, workloads labeled as `integration-test` are executed
 as part of integration testing. `-test-scheduling-label-filter` can be used to
 change that.
+
+We should make each test case with `integration-test` label very small,
+so that all tests with the label should take less than 5 min to complete.

--- a/test/integration/scheduler_perf/config/performance-config.yaml
+++ b/test/integration/scheduler_perf/config/performance-config.yaml
@@ -1,10 +1,13 @@
 # The following labels are used in this file:
 # - fast: short execution time, ideally less than 30 seconds
 # - integration-test: used to select workloads that
-#   run in pull-kubernetes-integration. Choosing those tests
+#   run in ci-kubernetes-integration-master. Choosing those tests
 #   is a tradeoff between code coverage and overall runtime.
-#   We should make each test case with integration-test label very small,
+# - short: used to select workloads that
+#   run in pull-kubernetes-integration.
+#   We should make each test case with short label very small,
 #   so that all tests with the label should take less than 5 min to complete.
+#   They can be run using --short=true flag.
 # - performance: used to select workloads that run
 #   in ci-benchmark-scheduler-perf. Such workloads
 #   must run long enough (ideally, longer than 10 seconds)

--- a/test/integration/scheduler_perf/config/performance-config.yaml
+++ b/test/integration/scheduler_perf/config/performance-config.yaml
@@ -29,7 +29,7 @@
     collectMetrics: true
   workloads:
   - name: 5Nodes
-    labels: [integration-test, fast]
+    labels: [integration-test, fast, short]
     params:
       initNodes: 5
       initPods: 5
@@ -70,7 +70,7 @@
     namespace: sched-1
   workloads:
   - name: 5Nodes
-    labels: [integration-test, fast]
+    labels: [integration-test, fast, short]
     params:
       initNodes: 5
       initPods: 1
@@ -106,7 +106,7 @@
     collectMetrics: true
   workloads:
   - name: 5Nodes
-    labels: [integration-test, fast]
+    labels: [integration-test, fast, short]
     params:
       initNodes: 5
       initPods: 5
@@ -239,7 +239,7 @@
     collectMetrics: true
   workloads:
   - name: 5Nodes
-    labels: [integration-test, fast]
+    labels: [integration-test, fast, short]
     params:
       initNodes: 5
       initPods: 5
@@ -438,7 +438,7 @@
     collectMetrics: true
   workloads:
   - name: 5Nodes
-    labels: [integration-test, fast]
+    labels: [integration-test, fast, short]
     params:
       initNodes: 5
       initPods: 5
@@ -479,7 +479,7 @@
     collectMetrics: true
   workloads:
   - name: 5Nodes
-    labels: [integration-test, fast]
+    labels: [integration-test, fast, short]
     params:
       initNodes: 5
       initPods: 10
@@ -617,7 +617,7 @@
     collectMetrics: true
   workloads:
   - name: 5Nodes
-    labels: [integration-test, fast]
+    labels: [integration-test, fast, short]
     params:
       initNodes: 5
       initPods: 20
@@ -686,7 +686,7 @@
     collectMetrics: true
   workloads:
   - name: 5Nodes/2InitPods
-    labels: [integration-test, fast]
+    labels: [integration-test, fast, short]
     params:
       initNodes: 5
       initPods: 2
@@ -1181,7 +1181,7 @@
     collectMetrics: true
   workloads:
   - name: fast
-    labels: [integration-test, fast]
+    labels: [integration-test, fast, short]
     params:
       # This testcase runs through all code paths without
       # taking too long overall.

--- a/test/integration/scheduler_perf/config/performance-config.yaml
+++ b/test/integration/scheduler_perf/config/performance-config.yaml
@@ -3,6 +3,8 @@
 # - integration-test: used to select workloads that
 #   run in pull-kubernetes-integration. Choosing those tests
 #   is a tradeoff between code coverage and overall runtime.
+#   We should make each test case with integration-test label very small,
+#   so that all tests with the label should take less than 5 min to complete.
 # - performance: used to select workloads that run
 #   in ci-benchmark-scheduler-perf. Such workloads
 #   must run long enough (ideally, longer than 10 seconds)
@@ -23,6 +25,12 @@
     countParam: $measurePods
     collectMetrics: true
   workloads:
+  - name: 5Nodes
+    labels: [integration-test, fast]
+    params:
+      initNodes: 5
+      initPods: 5
+      measurePods: 10
   - name: 500Nodes
     labels: [integration-test, fast]
     params:
@@ -58,6 +66,12 @@
     collectMetrics: true
     namespace: sched-1
   workloads:
+  - name: 5Nodes
+    labels: [integration-test, fast]
+    params:
+      initNodes: 5
+      initPods: 1
+      measurePods: 4
   - name: 500Nodes
     labels: [integration-test, fast]
     params:
@@ -88,8 +102,14 @@
     countParam: $measurePods
     collectMetrics: true
   workloads:
+  - name: 5Nodes
+    labels: [integration-test, fast]
+    params:
+      initNodes: 5
+      initPods: 5
+      measurePods: 10
   - name: 500Nodes
-    labels: [fast]
+    labels: [integration-test, fast]
     params:
       initNodes: 500
       initPods: 500
@@ -121,13 +141,20 @@
     persistentVolumeClaimTemplatePath: config/templates/pvc.yaml
     collectMetrics: true
   workloads:
+  - name: 5Nodes
+    labels: [integration-test, fast]
+    params:
+      initNodes: 5
+      initPods: 5
+      measurePods: 10
   - name: 500Nodes
-    labels: [fast]
+    labels: [integration-test, performance, fast]
     params:
       initNodes: 500
       initPods: 500
       measurePods: 1000
   - name: 5000Nodes
+    labels: [performance]
     params:
       initNodes: 5000
       initPods: 5000
@@ -162,13 +189,20 @@
     persistentVolumeClaimTemplatePath: config/templates/pvc.yaml
     collectMetrics: true
   workloads:
+  - name: 5Nodes
+    labels: [integration-test, fast]
+    params:
+      initNodes: 5
+      initPods: 5
+      measurePods: 10
   - name: 500Nodes
-    labels: [fast]
+    labels: [integration-test, performance, fast]
     params:
       initNodes: 500
       initPods: 500
       measurePods: 1000
   - name: 5000Nodes
+    labels: [performance]
     params:
       initNodes: 5000
       initPods: 5000
@@ -201,13 +235,20 @@
     persistentVolumeClaimTemplatePath: config/templates/pvc.yaml
     collectMetrics: true
   workloads:
-  - name: 500Nodes
+  - name: 5Nodes
     labels: [integration-test, fast]
+    params:
+      initNodes: 5
+      initPods: 5
+      measurePods: 10
+  - name: 500Nodes
+    labels: [integration-test, performance, fast]
     params:
       initNodes: 500
       initPods: 500
       measurePods: 1000
   - name: 5000Nodes
+    labels: [performance]
     params:
       initNodes: 5000
       initPods: 5000
@@ -239,8 +280,14 @@
     namespace: sched-1
     collectMetrics: true
   workloads:
+  - name: 5Nodes
+    labels: [integration-test, fast]
+    params:
+      initNodes: 5
+      initPods: 5
+      measurePods: 10
   - name: 500Nodes
-    labels: [fast]
+    labels: [integration-test, fast]
     params:
       initNodes: 500
       initPods: 500
@@ -274,13 +321,20 @@
     namespace: sched-1
     collectMetrics: true
   workloads:
-  - name: 500Nodes
+  - name: 5Nodes
     labels: [integration-test, fast]
+    params:
+      initNodes: 5
+      initPods: 5
+      measurePods: 10
+  - name: 500Nodes
+    labels: [integration-test, performance, fast]
     params:
       initNodes: 500
       initPods: 500
       measurePods: 1000
   - name: 5000Nodes
+    labels: [performance]
     params:
       initNodes: 5000
       initPods: 5000
@@ -308,8 +362,14 @@
     namespace: sched-1
     collectMetrics: true
   workloads:
+  - name: 5Nodes
+    labels: [integration-test, fast]
+    params:
+      initNodes: 5
+      initPods: 5
+      measurePods: 10
   - name: 500Nodes
-    labels: [fast]
+    labels: [integration-test, fast]
     params:
       initNodes: 500
       initPods: 500
@@ -348,6 +408,11 @@
     countParam: $measurePods
     collectMetrics: true
   workloads:
+  - name: 5Nodes
+    labels: [integration-test, fast]
+    params:
+      initNodes: 5
+      measurePods: 10
   - name: 15000Nodes
     labels: [performance, fast]
     params:
@@ -369,8 +434,14 @@
     countParam: $measurePods
     collectMetrics: true
   workloads:
+  - name: 5Nodes
+    labels: [integration-test, fast]
+    params:
+      initNodes: 5
+      initPods: 5
+      measurePods: 10
   - name: 500Nodes
-    labels: [fast]
+    labels: [integration-test, fast]
     params:
       initNodes: 500
       initPods: 500
@@ -404,6 +475,12 @@
     podTemplatePath: config/templates/pod-with-topology-spreading.yaml
     collectMetrics: true
   workloads:
+  - name: 5Nodes
+    labels: [integration-test, fast]
+    params:
+      initNodes: 5
+      initPods: 10
+      measurePods: 10
   - name: 500Nodes
     labels: [integration-test, fast]
     params:
@@ -439,13 +516,20 @@
     podTemplatePath: config/templates/pod-with-preferred-topology-spreading.yaml
     collectMetrics: true
   workloads:
+  - name: 5Nodes
+    labels: [integration-test, fast]
+    params:
+      initNodes: 5
+      initPods: 10
+      measurePods: 10
   - name: 500Nodes
-    labels: [fast]
+    labels: [integration-test, performance, fast]
     params:
       initNodes: 500
       initPods: 1000
       measurePods: 1000
   - name: 5000Nodes
+    labels: [performance]
     params:
       initNodes: 5000
       initPods: 5000
@@ -492,13 +576,20 @@
     countParam: $measurePods
     collectMetrics: true
   workloads:
-  - name: 500Nodes
+  - name: 5Nodes
     labels: [integration-test, fast]
+    params:
+      initNodes: 5
+      initPods: 2
+      measurePods: 10
+  - name: 500Nodes
+    labels: [integration-test, performance, fast]
     params:
       initNodes: 500
       initPods: 200
       measurePods: 1000
   - name: 5000Nodes
+    labels: [performance]
     params:
       initNodes: 5000
       initPods: 2000
@@ -511,7 +602,6 @@
       measurePods: 5000
 
 - name: PreemptionBasic
-  labels: [performance]
   workloadTemplate:
   - opcode: createNodes
     countParam: $initNodes
@@ -523,8 +613,14 @@
     podTemplatePath: config/templates/pod-high-priority.yaml
     collectMetrics: true
   workloads:
+  - name: 5Nodes
+    labels: [integration-test, fast]
+    params:
+      initNodes: 5
+      initPods: 20
+      measurePods: 5
   - name: 500Nodes
-    labels: [fast]
+    labels: [performance, fast]
     params:
       initNodes: 500
       initPods: 2000
@@ -539,7 +635,6 @@
 #      measurePods: 5000
 
 - name: PreemptionPVs
-  labels: [performance]
   workloadTemplate:
   - opcode: createNodes
     countParam: $initNodes
@@ -553,8 +648,14 @@
     persistentVolumeClaimTemplatePath: config/templates/pvc.yaml
     collectMetrics: true
   workloads:
+  - name: 5Nodes
+    labels: [integration-test, fast]
+    params:
+      initNodes: 5
+      initPods: 20
+      measurePods: 5
   - name: 500Nodes
-    labels: [fast]
+    labels: [performance, fast]
     params:
       initNodes: 500
       initPods: 2000
@@ -581,8 +682,14 @@
     podTemplatePath: config/templates/pod-default.yaml
     collectMetrics: true
   workloads:
+  - name: 5Nodes/2InitPods
+    labels: [integration-test, fast]
+    params:
+      initNodes: 5
+      initPods: 2
+      measurePods: 10
   - name: 500Nodes/200InitPods
-    labels: [fast]
+    labels: [integration-test, fast]
     params:
       initNodes: 500
       initPods: 200
@@ -622,6 +729,11 @@
     podTemplatePath: config/templates//pod-default.yaml
     collectMetrics: true
   workloads:
+  - name: 10Nodes
+    labels: [integration-test, fast]
+    params:
+      initNodes: 10
+      measurePods: 100
   - name: 1000Nodes
     labels: [integration-test, fast]
     params:
@@ -662,14 +774,22 @@
     collectMetrics: true
     namespace: measure-ns-0
   workloads:
+  - name: 10Nodes
+    labels: [integration-test, fast]
+    params:
+      initNodes: 10
+      initPodsPerNamespace: 2
+      initNamespaces: 2
+      measurePods: 6
   - name: 500Nodes
-    labels: [fast]
+    labels: [performance, fast]
     params:
       initNodes: 500
       initPodsPerNamespace: 4
       initNamespaces: 10
       measurePods: 100
   - name: 5000Nodes
+    labels: [performance]
     params:
       initNodes: 5000
       initPodsPerNamespace: 40
@@ -707,14 +827,22 @@
     collectMetrics: true
     namespace: measure-ns-0
   workloads:
+  - name: 10Nodes
+    labels: [integration-test, fast]
+    params:
+      initNodes: 10
+      initPodsPerNamespace: 2
+      initNamespaces: 2
+      measurePods: 10
   - name: 500Nodes
-    labels: [fast]
+    labels: [performance, fast]
     params:
       initNodes: 500
       initPodsPerNamespace: 4
       initNamespaces: 10
       measurePods: 100
   - name: 5000Nodes
+    labels: [performance]
     params:
       initNodes: 5000
       initPodsPerNamespace: 40
@@ -755,14 +883,22 @@
     collectMetrics: true
     namespace: measure-ns-0
   workloads:
+  - name: 10Nodes
+    labels: [integration-test, fast]
+    params:
+      initNodes: 10
+      initPodsPerNamespace: 2
+      initNamespaces: 2
+      measurePods: 10
   - name: 500Nodes
-    labels: [fast]
+    labels: [performance, fast]
     params:
       initNodes: 500
       initPodsPerNamespace: 4
       initNamespaces: 10
       measurePods: 100
   - name: 5000Nodes
+    labels: [performance]
     params:
       initNodes: 5000
       initPodsPerNamespace: 50
@@ -800,14 +936,22 @@
     collectMetrics: true
     namespace: measure-ns-0
   workloads:
+  - name: 10Nodes
+    labels: [integration-test, fast]
+    params:
+      initNodes: 10
+      initPodsPerNamespace: 2
+      initNamespaces: 2
+      measurePods: 10
   - name: 500Nodes
-    labels: [fast]
+    labels: [performance, fast]
     params:
       initNodes: 500
       initPodsPerNamespace: 4
       initNamespaces: 10
       measurePods: 100
   - name: 5000Nodes
+    labels: [performance]
     params:
       initNodes: 5000
       initPodsPerNamespace: 50
@@ -835,8 +979,14 @@
     countParam: $measurePods
     collectMetrics: true
   workloads:
+  - name: 5Nodes
+    labels: [integration-test, fast]
+    params:
+      taintNodes: 1
+      normalNodes: 4
+      measurePods: 4
   - name: 500Nodes
-    labels: [fast]
+    labels: [integration-test, fast]
     params:
       taintNodes: 100
       normalNodes: 400
@@ -1165,7 +1315,13 @@
     countParam: $measurePods
     collectMetrics: true
   workloads:
-  - name: 1Node
+  - name: 1Node_10GatedPods
+    labels: [integration-test, fast]
+    params:
+      gatedPods: 10
+      deletingPods: 100
+      measurePods: 100
+  - name: 1Node_10000GatedPods
     labels: [performance, fast]
     params:
       gatedPods: 10000
@@ -1192,7 +1348,12 @@
     countParam: $measurePods
     collectMetrics: true
   workloads:
-  - name: 1000Node
+  - name: 1Node_10GatedPods
+    labels: [integration-test, fast]
+    params:
+      gatedPods: 10
+      measurePods: 10
+  - name: 1Node_10000GatedPods
     labels: [performance, fast]
     params:
       gatedPods: 10000

--- a/test/integration/scheduler_perf/scheduler_test.go
+++ b/test/integration/scheduler_perf/scheduler_test.go
@@ -18,6 +18,8 @@ package benchmark
 
 import (
 	"testing"
+
+	"k8s.io/utils/ptr"
 )
 
 func TestScheduling(t *testing.T) {
@@ -27,6 +29,10 @@ func TestScheduling(t *testing.T) {
 	}
 	if err = validateTestCases(testCases); err != nil {
 		t.Fatal(err)
+	}
+
+	if testing.Short() {
+		testSchedulingLabelFilter = ptr.To(*testSchedulingLabelFilter + ",+short")
 	}
 
 	for _, tc := range testCases {

--- a/test/integration/scheduler_perf/scheduler_test.go
+++ b/test/integration/scheduler_perf/scheduler_test.go
@@ -18,8 +18,6 @@ package benchmark
 
 import (
 	"testing"
-
-	"k8s.io/utils/ptr"
 )
 
 func TestScheduling(t *testing.T) {
@@ -32,7 +30,7 @@ func TestScheduling(t *testing.T) {
 	}
 
 	if testing.Short() {
-		testSchedulingLabelFilter = ptr.To(*testSchedulingLabelFilter + ",+short")
+		*testSchedulingLabelFilter += ",+short"
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:

To achieve better test coverage, we want to run all scheduler_perf test cases as integration tests. This PR introduces very small workloads for each case, that should cover the code paths, but won't take too long overall. 

All `integration-test` workloads runs for almost 300s in total (on one core), so it meets our [expectations](https://github.com/kubernetes/kubernetes/issues/126202#issuecomment-2237100235). 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #126202

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
