### PR TITLE
Kubelet: Skip blocking while image with same id is pulling.

### DIFF
--- a/pkg/kubelet/images/types.go
+++ b/pkg/kubelet/images/types.go
@@ -41,6 +41,12 @@ var (
 	ErrInvalidImageName = errors.New("InvalidImageName")
 )
 
+const (
+	// RuntimeNoEffectAnnotationKey is the annotation keys to filter annotation
+	// which has no effect to runtime.
+	RuntimeNoEffectAnnotationKey = "node.kubernetes.io/runtime-no-effect-annotations"
+)
+
 // ImageManager provides an interface to manage the lifecycle of images.
 // Implementations of this interface are expected to deal with pulling (downloading),
 // managing, and deleting container images.


### PR DESCRIPTION
#### What type of PR is this?

/kind feature


#### What this PR does / why we need it:

If there is multiple pods with same image are in the same node, when we update pods image, these update requests with same imageID will queue up and block other pod update.
"queue up and block " with same imageID pull req is meaninglessly.

It is a very common scenario that different pods of the same node use the same image, which is widely found in in automatic scaling of services, offline computing scenarios such as big data and ML. In order to increase revenue, production environments will deploy together.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes  https://github.com/kubernetes/kubernetes/issues/121137 https://github.com/kubernetes/kubernetes/issues/125164

#### Does this PR introduce a user-facing change:
```release-note
Image pull requests with the same image spec will not be executed concurrently. This ensures that if a Node serving numerous Pods with the same image `X` and one Pod with the different image `Y`, The same image name will be pulled serially, instead of `Y` waiting on `maxParallelImagePulls`'s pulls of `X`.
Annotation with name `node.kubernetes.io/runtime-no-effect-annotations` can be used as filter out annotation which is meaningless for runtime.
