### PR TITLE
[perf] improve performance of ReadLogs

### DIFF
--- a/staging/src/k8s.io/cri-client/pkg/logs/logs_test.go
+++ b/staging/src/k8s.io/cri-client/pkg/logs/logs_test.go
@@ -289,7 +289,8 @@ func TestReadRotatedLog(t *testing.T) {
 	err = file.Close()
 	assert.NoErrorf(t, err, "could not close file.")
 
-	time.Sleep(20 * time.Millisecond)
+	// waitLog.wait may wait 1 second
+	time.Sleep(1500 * time.Millisecond)
 	// Make the function ReadLogs end.
 	fakeRuntimeService.Lock()
 	fakeRuntimeService.Containers[containerID].State = runtimeapi.ContainerState_CONTAINER_EXITED


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
 Reduce write events from fsnotify.Watcher to reduce calling function isContainerRunning.

When container output logs quickly, and user run command `kubectl logs CONTAINER_ID -f`, then there will be too much function call of `isContainerRunning`. This will consume CPU time of kubelet and containerd.

log generation code
```
package main

import (
     "fmt"
     "time"
     "flag"
)

var dur = flag.Duration("duration", 1 * time.Microsecond, "duration")

func main() {
     i := 0
     flag.Parse()
     for range time.Tick(*dur) {
             fmt.Printf("print log to stand out %d\n", i)
             i++
     }
}
```
1. kubelet pprof with 1000 lines of log per second. ReadLogs takes 19.8% CPU time.
![image](https://github.com/user-attachments/assets/0119fd2d-771b-4721-adee-c6bc0da44734)
2. containerd pprof with 1000 lines of log per second. ContainerStatus_handler takes 20.5% CPU time.
![image](https://github.com/user-attachments/assets/59cdfccf-34d4-40b1-a9e2-550371039df7)
3. kubelet pprof with 100 lines of log per second. ReadLogs takes 14.5% CPU time.
![image](https://github.com/user-attachments/assets/9322ac55-329c-4bee-96b4-c29532475a4a)
4. containerd pprof with 100 lines of log per second. ContainerStatus_handler takes 20.5% CPU time.
![image](https://github.com/user-attachments/assets/abfe340b-062e-4d53-b482-58068b47c91c)
5. kubelet pprof with 1000 lines of log per second. ReadLogs takes 7.7% CPU time.  Write event deduplicated.
![image](https://github.com/user-attachments/assets/9790ccce-ee55-43ec-80fc-d15112896019)
6. containerd pprof with 1000 lines of log per second. ContainerStatus_handler takes 5% CPU time.  Write event deduplicated.
![image](https://github.com/user-attachments/assets/d7bd92b0-820a-4db1-bc9d-d17a7179c645)
7. kubelet pprof with 100 lines of log per second. ReadLogs takes 14.5% CPU time.  Write event deduplicated.
![image](https://github.com/user-attachments/assets/2c6397d3-a23c-4362-8ab4-623952b79cc3)
8. containerd pprof with 100 lines of log per second. ContainerStatus_handler takes 25% CPU time.  Write event deduplicated.
![image](https://github.com/user-attachments/assets/17c98e96-c194-4e0e-a4e8-517041e015d5)


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
/area kubelet