### PR TITLE
Fix formatting of the authnz config usage.

### DIFF
--- a/pkg/kubeapiserver/options/authentication.go
+++ b/pkg/kubeapiserver/options/authentication.go
@@ -311,11 +311,10 @@ func (o *BuiltInAuthenticationOptions) AddFlags(fs *pflag.FlagSet) {
 
 	fs.StringVar(&o.AuthenticationConfigFile, "authentication-config", o.AuthenticationConfigFile, ""+
 		"File with Authentication Configuration to configure the JWT Token authenticator or the anonymous authenticator. "+
-		"Note: This feature is in Alpha since v1.29."+
-		"--feature-gate=StructuredAuthenticationConfiguration=true needs to be set for enabling this feature."+
-		"This feature is mutually exclusive with the oidc-* flags."+
-		"To configure anonymous authenticator you need to enable --feature-gate=AnonymousAuthConfigurableEndpoints."+
-		"When you configure anonymous authenticator in the authentication config you cannot use the --anonymous-auth flag.")
+		"Requires the StructuredAuthenticationConfiguration feature gate. "+
+		"Also requires the feature gate AnonymousAuthConfigurableEndpoints to configure the anonymous authenticator in the config file. "+
+		"This flag is mutually exclusive with the --oidc-* flags if the file configures the JWT Token authenticator. "+
+		"This flag is mutually exclusive with --anonymous-auth if the file configures the Anonymous authenticator.")
 
 	fs.StringSliceVar(&o.APIAudiences, "api-audiences", o.APIAudiences, ""+
 		"Identifiers of the API. The service account token authenticator will validate that "+

--- a/pkg/kubeapiserver/options/authorization.go
+++ b/pkg/kubeapiserver/options/authorization.go
@@ -188,10 +188,9 @@ func (o *BuiltInAuthorizationOptions) AddFlags(fs *pflag.FlagSet) {
 		"The duration to cache 'unauthorized' responses from the webhook authorizer.")
 
 	fs.StringVar(&o.AuthorizationConfigurationFile, authorizationConfigFlag, o.AuthorizationConfigurationFile, ""+
-		"File with Authorization Configuration to configure the authorizer chain."+
-		"Note: This feature is in Alpha since v1.29."+
-		"--feature-gate=StructuredAuthorizationConfiguration=true feature flag needs to be set to true for enabling the functionality."+
-		"This feature is mutually exclusive with the other --authorization-mode and --authorization-webhook-* flags.")
+		"File with Authorization Configuration to configure the authorizer chain. "+
+		"Requires feature gate StructuredAuthorizationConfiguration. "+
+		"This flag is mutually exclusive with the other --authorization-mode and --authorization-webhook-* flags.")
 
 	// preserves compatibility with any method set during initialization
 	oldAreLegacyFlagsSet := o.AreLegacyFlagsSet


### PR DESCRIPTION

/kind bug
/kind documentation

#### What this PR does / why we need it:

Some improvements to the --authorization/--authentication-config flag 
usage documentation. 

- Reword to be less verbose, more in line with the writing style in other flags.
- Add spaces after the end of sentences.

```release-note
NONE
```