### PR TITLE
kuberuntime_manager: fix container success check.

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -534,10 +534,11 @@ func shouldRestartOnFailure(pod *v1.Pod) bool {
 
 func containerSucceeded(c *v1.Container, podStatus *kubecontainer.PodStatus) bool {
 	cStatus := podStatus.FindContainerStatusByName(c.Name)
-	if cStatus == nil || cStatus.State == kubecontainer.ContainerStateRunning {
+	if cStatus == nil {
 		return false
 	}
-	return cStatus.ExitCode == 0
+	// Container has exited, with an exit code of 0.
+	return cStatus.State == kubecontainer.ContainerStateExited && cStatus.ExitCode == 0
 }
 
 func isInPlacePodVerticalScalingAllowed(pod *v1.Pod) bool {


### PR DESCRIPTION
When evaluating whether a container ran to completion, we only check whether the CRI container status `ExitCode` is 0.

But, the ExitCode is only meaningful if the container has actually run and exited.

There are other states, eg: `Created` where the container runtime never set an ExitCode - we shouldn't read it in that case.

/kind bug

Fixes #123839

```release-note
NONE
```