### PR TITLE
Rename kubelet CSR admission feature gate

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -228,9 +228,10 @@ const (
 	// owner: @micahhausler
 	// Deprecated: v1.31
 	//
-	// Disable Node Admission plugin validation of CSRs for kubelet signers where CN=system:node:$nodeName.
+	// Setting AllowInsecureKubeletCertificateSigningRequests to true disables node admission validation of CSRs
+	// for kubelet signers where CN=system:node:$nodeName.
 	// Remove in v1.33
-	DisableKubeletCSRAdmissionValidation featuregate.Feature = "DisableKubeletCSRAdmissionValidation"
+	AllowInsecureKubeletCertificateSigningRequests featuregate.Feature = "AllowInsecureKubeletCertificateSigningRequests"
 
 	// owner: @HirazawaUi
 	// kep: http://kep.k8s.io/4004
@@ -1326,7 +1327,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	// ...
 	HPAScaleToZero: {Default: false, PreRelease: featuregate.Alpha},
 
-	DisableKubeletCSRAdmissionValidation: {Default: false, PreRelease: featuregate.Deprecated}, // remove in 1.33
+	AllowInsecureKubeletCertificateSigningRequests: {Default: false, PreRelease: featuregate.Deprecated}, // remove in 1.33
 
 	StorageNamespaceIndex: {Default: true, PreRelease: featuregate.Beta},
 

--- a/plugin/pkg/admission/noderestriction/admission.go
+++ b/plugin/pkg/admission/noderestriction/admission.go
@@ -74,9 +74,9 @@ type Plugin struct {
 	podsGetter     corev1lister.PodLister
 	nodesGetter    corev1lister.NodeLister
 
-	expansionRecoveryEnabled              bool
-	dynamicResourceAllocationEnabled      bool
-	kubeletCSRAdmissionValidationDisabled bool
+	expansionRecoveryEnabled                       bool
+	dynamicResourceAllocationEnabled               bool
+	allowInsecureKubeletCertificateSigningRequests bool
 }
 
 var (
@@ -89,7 +89,7 @@ var (
 func (p *Plugin) InspectFeatureGates(featureGates featuregate.FeatureGate) {
 	p.expansionRecoveryEnabled = featureGates.Enabled(features.RecoverVolumeExpansionFailure)
 	p.dynamicResourceAllocationEnabled = featureGates.Enabled(features.DynamicResourceAllocation)
-	p.kubeletCSRAdmissionValidationDisabled = featureGates.Enabled(features.DisableKubeletCSRAdmissionValidation)
+	p.allowInsecureKubeletCertificateSigningRequests = featureGates.Enabled(features.AllowInsecureKubeletCertificateSigningRequests)
 }
 
 // SetExternalKubeInformerFactory registers an informer factory into Plugin
@@ -176,7 +176,7 @@ func (p *Plugin) Admit(ctx context.Context, a admission.Attributes, o admission.
 		return p.admitResourceSlice(nodeName, a)
 
 	case csrResource:
-		if p.kubeletCSRAdmissionValidationDisabled {
+		if p.allowInsecureKubeletCertificateSigningRequests {
 			return nil
 		}
 		return p.admitCSR(nodeName, a)

--- a/plugin/pkg/admission/noderestriction/admission_test.go
+++ b/plugin/pkg/admission/noderestriction/admission_test.go
@@ -1278,7 +1278,7 @@ func Test_nodePlugin_Admit(t *testing.T) {
 			features:   feature.DefaultFeatureGate,
 			setupFunc: func(t *testing.T) {
 				t.Helper()
-				featuregatetesting.SetFeatureGateDuringTest(t, feature.DefaultFeatureGate, features.DisableKubeletCSRAdmissionValidation, true)
+				featuregatetesting.SetFeatureGateDuringTest(t, feature.DefaultFeatureGate, features.AllowInsecureKubeletCertificateSigningRequests, true)
 			},
 		},
 		{


### PR DESCRIPTION
Retitle the feature to the affirmative ("AllowInsecure...=false") instead of a double-negative ("Disable$NEWTHING...=false") for clarity

Resolves #126410

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

Fixes #126410

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
The Node Admission plugin now rejects CSR requests created by a node identity for the signers `kubernetes.io/kubelet-serving` or `kubernetes.io/kube-apiserver-client-kubelet` with a CN starting with `system:node:`, but where the CN is not `system:node:${node-name}`. The feature gate `AllowInsecureKubeletCertificateSigningRequests` defaults to `false`, but can be enabled to revert to the previous behavior. This feature gate will be removed in Kubernetes v1.33
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

* kubernetes/website#47121
* #126015
* #126410
