### PR TITLE
Automated cherry pick of #126429: Fix kubelet cadvisor stats runtime panic

### DIFF
--- a/pkg/kubelet/stats/cadvisor_stats_provider_test.go
+++ b/pkg/kubelet/stats/cadvisor_stats_provider_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/golang/mock/gomock"
 	cadvisorapiv2 "github.com/google/cadvisor/info/v2"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -553,6 +554,86 @@ func TestCadvisorImagesFsStatsKubeletSeparateDiskOff(t *testing.T) {
 	assert.Equal(imageFsInfo.InodesFree, stats.InodesFree)
 	assert.Equal(imageFsInfo.Inodes, stats.Inodes)
 	assert.Equal(*imageFsInfo.Inodes-*imageFsInfo.InodesFree, *stats.InodesUsed)
+}
+
+func TestImageFsStatsCustomResponse(t *testing.T) {
+	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.KubeletSeparateDiskGC, true)()
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	for desc, tc := range map[string]struct {
+		response                       *runtimeapi.ImageFsInfoResponse
+		callContainerFsInfo, shouldErr bool
+	}{
+		"image stats are nil": {
+			shouldErr: true,
+		},
+		"no image filesystems in image stats": {
+			response: &runtimeapi.ImageFsInfoResponse{
+				ImageFilesystems:     []*runtimeapi.FilesystemUsage{},
+				ContainerFilesystems: []*runtimeapi.FilesystemUsage{{}},
+			},
+			shouldErr: true,
+		},
+		"no container filesystems in image stats": {
+			response: &runtimeapi.ImageFsInfoResponse{
+				ImageFilesystems:     []*runtimeapi.FilesystemUsage{{}},
+				ContainerFilesystems: []*runtimeapi.FilesystemUsage{},
+			},
+			shouldErr: true,
+		},
+		"image and container filesystem identifiers are nil": {
+			response: &runtimeapi.ImageFsInfoResponse{
+				ImageFilesystems:     []*runtimeapi.FilesystemUsage{{}},
+				ContainerFilesystems: []*runtimeapi.FilesystemUsage{{}},
+			},
+			shouldErr: false,
+		},
+		"using different mountpoints but no used bytes set": {
+			response: &runtimeapi.ImageFsInfoResponse{
+				ImageFilesystems: []*runtimeapi.FilesystemUsage{{
+					FsId: &runtimeapi.FilesystemIdentifier{Mountpoint: "mnt-1"},
+				}},
+				ContainerFilesystems: []*runtimeapi.FilesystemUsage{{
+					FsId: &runtimeapi.FilesystemIdentifier{Mountpoint: "mnt-2"},
+				}},
+			},
+			callContainerFsInfo: true,
+			shouldErr:           false,
+		},
+		"using different mountpoints and set used bytes": {
+			response: &runtimeapi.ImageFsInfoResponse{
+				ImageFilesystems: []*runtimeapi.FilesystemUsage{{
+					FsId:      &runtimeapi.FilesystemIdentifier{Mountpoint: "mnt-1"},
+					UsedBytes: &runtimeapi.UInt64Value{Value: 10},
+				}},
+				ContainerFilesystems: []*runtimeapi.FilesystemUsage{{
+					FsId:      &runtimeapi.FilesystemIdentifier{Mountpoint: "mnt-2"},
+					UsedBytes: &runtimeapi.UInt64Value{Value: 20},
+				}},
+			},
+			callContainerFsInfo: true,
+			shouldErr:           false,
+		},
+	} {
+		ctx := context.Background()
+		mockCadvisor := cadvisortest.NewMockInterface(mockCtrl)
+		mockRuntime := containertest.NewMockRuntime(mockCtrl)
+
+		res := getTestFsInfo(1000)
+		mockCadvisor.EXPECT().ImagesFsInfo().Return(res, nil)
+		mockRuntime.EXPECT().ImageFsInfo(ctx).Return(tc.response, nil)
+		mockCadvisor.EXPECT().ContainerFsInfo().Return(res, nil)
+
+		provider := newCadvisorStatsProvider(mockCadvisor, &fakeResourceAnalyzer{}, mockRuntime, nil, NewFakeHostStatsProvider())
+		stats, containerfs, err := provider.ImageFsStats(ctx)
+		if tc.shouldErr {
+			require.Error(t, err, desc)
+			assert.Nil(t, stats)
+			assert.Nil(t, containerfs)
+		} else {
+			assert.NoError(t, err, desc)
+		}
+	}
 }
 
 func TestCadvisorImagesFsStats(t *testing.T) {


### PR DESCRIPTION
Cherry pick of #126429 on release-1.30.

#126429: Fix kubelet cadvisor stats runtime panic

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```