### PR TITLE
hostNetwork pods mount /etc/hosts without network

### DIFF
--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -245,10 +245,10 @@ func (kl *Kubelet) makeBlockVolumes(pod *v1.Pod, container *v1.Container, podVol
 // - container is not an infrastructure (pause) container
 // - container is not already mounting on /etc/hosts
 // Kubernetes will not mount /etc/hosts if:
-// - when the Pod sandbox is being created, its IP is still unknown. Hence, PodIP will not have been set.
-// - Windows pod contains a hostProcess container
+// - the Pod is on the pod network and PodIP has not yet been set (e.g., Pod sandbox is being created).
+// - the Pod is on Windows, and contains a hostProcess container.
 func shouldMountHostsFile(pod *v1.Pod, podIPs []string) bool {
-	shouldMount := len(podIPs) > 0
+	shouldMount := len(podIPs) > 0 || pod.Spec.HostNetwork
 	if runtime.GOOS == "windows" {
 		return shouldMount && !kubecontainer.HasWindowsHostProcessContainer(pod)
 	}


### PR DESCRIPTION
/kind bug
Fixes #119852


The kubelet wait for the PodIPs to be present to mount the etc hosts files

https://github.com/kubernetes/kubernetes/blob/17d7d286201ae4b8e60014d8d0c41792d741d969/pkg/kubelet/kubelet_pods.go#L243-L256

however, it does not check if the pod is host network.

If the Pod is using hostNetwork, then it seems the PodIPs are ignored

https://github.com/kubernetes/kubernetes/blob/17d7d286201ae4b8e60014d8d0c41792d741d969/pkg/kubelet/kubelet_pods.go#L449-L473

A host network Pod, specially the ones used as static pods, may not have the PodIPs assigned at the star time, but that should not be a dependency for mounting the hosts file, since these pods does not depend on PodIPs for this.

#### Special notes for your reviewer:

hostNetwork pods mount the /etc/hosts from the root namespace, hence does not depend on PodIPs to be populated to mount the /etc/hosts file and add the arguments specified in the Pod.Spec like hostAliases.


```release-note
hostNetwork pods no longer depend on the PodIPs to be assigned to configure the defined hostAliases on the Pod
```

/sig node
/sig network