### PR TITLE
Move ConsistentListFromCache to Beta default again

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -1264,7 +1264,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 
 	genericfeatures.AuthorizeWithSelectors: {Default: false, PreRelease: featuregate.Alpha},
 
-	genericfeatures.ConsistentListFromCache: {Default: false, PreRelease: featuregate.Alpha},
+	genericfeatures.ConsistentListFromCache: {Default: true, PreRelease: featuregate.Beta},
 
 	genericfeatures.CoordinatedLeaderElection: {Default: false, PreRelease: featuregate.Alpha},
 

--- a/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
+++ b/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
@@ -312,6 +312,7 @@ const (
 	// owner: @serathius
 	// kep: http://kep.k8s.io/2340
 	// alpha: v1.28
+	// beta: v1.31
 	//
 	// Allow the API server to serve consistent lists from cache
 	ConsistentListFromCache featuregate.Feature = "ConsistentListFromCache"
@@ -414,7 +415,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 
 	WatchList: {Default: false, PreRelease: featuregate.Alpha},
 
-	ConsistentListFromCache: {Default: false, PreRelease: featuregate.Alpha},
+	ConsistentListFromCache: {Default: true, PreRelease: featuregate.Beta},
 
 	ZeroLimitedNominalConcurrencyShares: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.32
 }


### PR DESCRIPTION
With https://github.com/kubernetes/kubernetes/pull/126467 we got green light from api machinery to move forward with beta.

Reverts https://github.com/kubernetes/kubernetes/pull/126139
#### What type of PR is this?

/triage accepted
/kind feature
/kind api-change
/priority important-soon

```release-note
Move ConsistentListFromCache feature flag to Beta and enable it by default
```
cc @liggitt @deads2k @wojtek-t 