### PR TITLE
scheduler: document behavior of Error status returned by Filter

### DIFF
--- a/pkg/scheduler/framework/interface.go
+++ b/pkg/scheduler/framework/interface.go
@@ -432,6 +432,9 @@ type FilterPlugin interface {
 	// All FilterPlugins should return "Success" to declare that
 	// the given node fits the pod. If Filter doesn't return "Success",
 	// it will return "Unschedulable", "UnschedulableAndUnresolvable" or "Error".
+	//
+	// "Error" aborts pod scheduling and puts the pod into the backoff queue.
+	//
 	// For the node being evaluated, Filter plugins should look at the passed
 	// nodeInfo reference for this particular node's information (e.g., pods
 	// considered to be running on the node) instead of looking it up in the


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This behavior was useful for https://github.com/kubernetes/kubernetes/pull/125488 but wasn't obvious when reading the documentation.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/cc @Huang-Wei @kerthcet 