### PR TITLE
fix: prevent OOM by adjusting memory.min for guaranteed QoS pods

### DIFF
--- a/pkg/kubelet/cm/cgroup_manager_linux.go
+++ b/pkg/kubelet/cm/cgroup_manager_linux.go
@@ -43,7 +43,8 @@ const (
 	// systemdSuffix is the cgroup name suffix for systemd
 	systemdSuffix string = ".slice"
 	// Cgroup2MemoryMin is memory.min for cgroup v2
-	Cgroup2MemoryMin string = "memory.min"
+	Cgroup2MemoryMin       string  = "memory.min"
+	Cgroup2MemoryMinFactor float64 = 0.9
 	// Cgroup2MemoryHigh is memory.high for cgroup v2
 	Cgroup2MemoryHigh      string = "memory.high"
 	Cgroup2MaxCpuLimit     string = "max"


### PR DESCRIPTION
When the memory QoS feature is enabled in Kubernetes using cgroup v2, setting
memory.min equal to memory.max for pods with guaranteed QoS prevents the system
from reclaiming page cache that would otherwise be reclaimable.

For example, in a pod with guaranteed QoS (requests and limits set to 1 CPU and
1GB memory), running the following command will trigger an OOM:

dd if=/dev/zero of=/tmp/2gbfile bs=10M count=200

However, there are still benefits to setting memory.min. So, let's set it just
a bit lower than memory.max for pods with guaranteed QoS.