### PR TITLE
Automated cherry pick of #126012: Updating kubelet on Windows to query uuid from registry

### DIFF
--- a/pkg/kubelet/winstats/perfcounter_nodestats.go
+++ b/pkg/kubelet/winstats/perfcounter_nodestats.go
@@ -20,10 +20,7 @@ limitations under the License.
 package winstats
 
 import (
-	"errors"
-	"fmt"
 	"os"
-	"os/exec"
 	"runtime"
 	"strconv"
 	"strings"
@@ -33,6 +30,7 @@ import (
 	"unsafe"
 
 	cadvisorapi "github.com/google/cadvisor/info/v1"
+	"github.com/pkg/errors"
 	"golang.org/x/sys/windows"
 	"golang.org/x/sys/windows/registry"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -256,15 +254,21 @@ func (p *perfCounterNodeStatsClient) getCPUUsageNanoCores() uint64 {
 }
 
 func getSystemUUID() (string, error) {
-	result, err := exec.Command("wmic", "csproduct", "get", "UUID").Output()
+	k, err := registry.OpenKey(registry.LOCAL_MACHINE, `SYSTEM\HardwareConfig`, registry.QUERY_VALUE)
 	if err != nil {
-		return "", err
+		return "", errors.Wrap(err, "failed to open registry key HKLM\\SYSTEM\\HardwareConfig")
 	}
-	fields := strings.Fields(string(result))
-	if len(fields) != 2 {
-		return "", fmt.Errorf("received unexpected value retrieving vm uuid: %q", string(result))
+	defer k.Close()
+
+	uuid, _, err := k.GetStringValue("LastConfig")
+	if err != nil {
+		return "", errors.Wrap(err, "failed to read registry value LastConfig from key HKLM\\SYSTEM\\HardwareConfig")
 	}
-	return fields[1], nil
+
+	uuid = strings.Trim(uuid, "{")
+	uuid = strings.Trim(uuid, "}")
+	uuid = strings.ToUpper(uuid)
+	return uuid, nil
 }
 
 func getPhysicallyInstalledSystemMemoryBytes() (uint64, error) {

--- a/pkg/kubelet/winstats/perfcounter_nodestats_test.go
+++ b/pkg/kubelet/winstats/perfcounter_nodestats_test.go
@@ -21,7 +21,9 @@ package winstats
 
 import (
 	"os"
+	"os/exec"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -187,4 +189,14 @@ func testGetPhysicallyInstalledSystemMemoryBytes(t *testing.T) {
 	totalMemory, err := getPhysicallyInstalledSystemMemoryBytes()
 	assert.NoError(t, err)
 	assert.NotZero(t, totalMemory)
+}
+
+func TestGetSystemUUID(t *testing.T) {
+	uuidFromRegistry, err := getSystemUUID()
+	assert.NoError(t, err)
+
+	uuidFromWmi, err := exec.Command("powershell.exe", "Get-WmiObject", "Win32_ComputerSystemProduct", "|", "Select-Object", "-ExpandProperty UUID").Output()
+	assert.NoError(t, err)
+	uuidFromWmiString := strings.Trim(string(uuidFromWmi), "\r\n")
+	assert.Equal(t, uuidFromWmiString, uuidFromRegistry)
 }


### PR DESCRIPTION
Cherry pick of #126012 on release-1.30.

#126012: Updating kubelet on Windows to query uuid from registry

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```