### PR TITLE
Fix broken A/D Controller metrics test

### DIFF
--- a/test/e2e/storage/volume_metrics.go
+++ b/test/e2e/storage/volume_metrics.go
@@ -431,13 +431,6 @@ var _ = utils.SIGDescribe(framework.WithSerial(), "Volume metrics", func() {
 			e2eskipper.Skipf("Could not get controller-manager metrics - skipping")
 		}
 
-		// Forced detach metric should be present
-		forceDetachKey := "attachdetach_controller_forced_detaches"
-		_, ok := updatedControllerMetrics[forceDetachKey]
-		if !ok {
-			framework.Failf("Key %q not found in A/D Controller metrics", forceDetachKey)
-		}
-
 		// Wait and validate
 		totalVolumesKey := "attachdetach_controller_total_volumes"
 		states := []string{"actual_state_of_world", "desired_state_of_world"}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation

/kind flake
/kind regression
-->

/kind failing-test

#### What this PR does / why we need it:

Test `[sig-storage] [Serial] Volume metrics PVC should create metrics for total number of volumes in A/D Controller` has been failing due to attach due to: 

```
[FAILED] Key "attachdetach_controller_forced_detaches" not found in A/D Controller metrics
```

Seems that metric is not being emitted during test, likely because force detach is not being exercised within it  ->  metric never initialized.

No required pre-submits run this test, and most periodicals skip it because this test requires certain providers or a default storage class. However,`e2e-ci-kubernetes-e2e-cos-gce-serial-canary` & `e2e-ci-kubernetes-e2e-al2023-aws-serial-canary` have been failing for a while. 

Has this test really been broken for years? @torredil showed yes by looking all the way back to 2022... 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #126505

#### Special notes for your reviewer:

Tests pass locally on kOps cluster. 

These volume metrics tests are not currently run on any presubmit... See #126345 

TLDR no pre-submit is serial && is one of non-skipped provider && and has defaultSC set up...

```
❯ ginkgo run --focus 'should create metrics for total number of volumes in A/D Controller' ./test/e2e --fast-fail -- --provider aws
  I0801 21:59:30.076478 1975610 e2e.go:109] Starting e2e run "821bb17b-343c-43aa-81b1-9cc13c3b70d6" on Ginkgo node 1
Running Suite: Kubernetes e2e suite - /home/andsirey/workplace/kubernetes/test/e2e
==================================================================================
Random Seed: 1722549557 - will randomize all specs

Will run 2 of 6603 specs
...

Ran 2 of 6603 Specs in 44.872 seconds
SUCCESS! -- 2 Passed | 0 Failed | 0 Pending | 6601 Skipped
PASS

Ginkgo ran 1 suite in 57.150179803s
Test Suite Passed
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
