### PR TITLE
kube-proxy: initialization wait for service and endpoint handlers synced

### DIFF
--- a/pkg/proxy/config/config.go
+++ b/pkg/proxy/config/config.go
@@ -78,11 +78,10 @@ type EndpointSliceConfig struct {
 // NewEndpointSliceConfig creates a new EndpointSliceConfig.
 func NewEndpointSliceConfig(ctx context.Context, endpointSliceInformer discoveryv1informers.EndpointSliceInformer, resyncPeriod time.Duration) *EndpointSliceConfig {
 	result := &EndpointSliceConfig{
-		listerSynced: endpointSliceInformer.Informer().HasSynced,
-		logger:       klog.FromContext(ctx),
+		logger: klog.FromContext(ctx),
 	}
 
-	_, _ = endpointSliceInformer.Informer().AddEventHandlerWithResyncPeriod(
+	handlerRegistration, _ := endpointSliceInformer.Informer().AddEventHandlerWithResyncPeriod(
 		cache.ResourceEventHandlerFuncs{
 			AddFunc:    result.handleAddEndpointSlice,
 			UpdateFunc: result.handleUpdateEndpointSlice,
@@ -90,6 +89,8 @@ func NewEndpointSliceConfig(ctx context.Context, endpointSliceInformer discovery
 		},
 		resyncPeriod,
 	)
+
+	result.listerSynced = handlerRegistration.HasSynced
 
 	return result
 }
@@ -171,11 +172,10 @@ type ServiceConfig struct {
 // NewServiceConfig creates a new ServiceConfig.
 func NewServiceConfig(ctx context.Context, serviceInformer v1informers.ServiceInformer, resyncPeriod time.Duration) *ServiceConfig {
 	result := &ServiceConfig{
-		listerSynced: serviceInformer.Informer().HasSynced,
-		logger:       klog.FromContext(ctx),
+		logger: klog.FromContext(ctx),
 	}
 
-	_, _ = serviceInformer.Informer().AddEventHandlerWithResyncPeriod(
+	handlerRegistration, _ := serviceInformer.Informer().AddEventHandlerWithResyncPeriod(
 		cache.ResourceEventHandlerFuncs{
 			AddFunc:    result.handleAddService,
 			UpdateFunc: result.handleUpdateService,
@@ -183,6 +183,8 @@ func NewServiceConfig(ctx context.Context, serviceInformer v1informers.ServiceIn
 		},
 		resyncPeriod,
 	)
+
+	result.listerSynced = handlerRegistration.HasSynced
 
 	return result
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Ensure kube-proxy waits for the services/endpointslices informer caches to be synced *and* all pre-sync events delivered before setting isInitialized=true. Otherwise, in clusters with many services, some services may be missing from svcPortMap when kube-proxy starts (e.g. during daemonset rollout). This can cause kube-proxy to temporarily remove service DNAT rules and then skip cleanup of UDP conntrack entries to a service VIP.

#### Which issue(s) this PR fixes:

Fixes #126468

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Fix race condition in kube-proxy initialization that could blackhole UDP traffic to service VIP.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

N/A
