### PR TITLE
chore: add unit tests for RecordFlags and ChangeCauseRecorder functionality

### DIFF
--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/record_flags_test.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/record_flags_test.go
@@ -1,0 +1,108 @@
+package genericclioptions
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestRecordFlags_ToRecorder(t *testing.T) {
+	tests := []struct {
+		name      string
+		record    bool
+		expectErr bool
+	}{
+		{
+			name:      "Record is true",
+			record:    true,
+			expectErr: false,
+		},
+		{
+			name:      "Record is false",
+			record:    false,
+			expectErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			flags := &RecordFlags{
+				Record: &tt.record,
+			}
+			recorder, err := flags.ToRecorder()
+			if (err != nil) != tt.expectErr {
+				t.Errorf("ToRecorder() error = %v, expectErr %v", err, tt.expectErr)
+				return
+			}
+
+			if tt.record {
+				if _, ok := recorder.(*ChangeCauseRecorder); !ok {
+					t.Errorf("expected ChangeCauseRecorder, got %T", recorder)
+				}
+			} else {
+				if _, ok := recorder.(NoopRecorder); !ok {
+					t.Errorf("expected NoopRecorder, got %T", recorder)
+				}
+			}
+		})
+	}
+}
+
+func TestRecordFlags_Complete(t *testing.T) {
+	cmd := &cobra.Command{
+		Use: "test",
+		Run: func(cmd *cobra.Command, args []string) {},
+	}
+	flags := NewRecordFlags()
+	flags.AddFlags(cmd)
+
+	cmd.SetArgs([]string{"--record=true"})
+
+	err := cmd.Execute()
+	if err != nil {
+		t.Fatalf("Execute() failed: %v", err)
+	}
+
+	err = flags.Complete(cmd)
+	if err != nil {
+		t.Fatalf("Complete() failed: %v", err)
+	}
+
+	if flags.changeCause == "" {
+		t.Errorf("expected changeCause to be set, got empty string")
+	}
+}
+
+func TestChangeCauseRecorder_Record(t *testing.T) {
+	obj := &unstructured.Unstructured{}
+	recorder := ChangeCauseRecorder{
+		changeCause: "test change",
+	}
+
+	err := recorder.Record(obj)
+	if err != nil {
+		t.Fatalf("Record() failed: %v", err)
+	}
+
+	annotations := obj.GetAnnotations()
+	if annotations[ChangeCauseAnnotation] != "test change" {
+		t.Errorf("expected changeCause annotation to be set, got %v", annotations[ChangeCauseAnnotation])
+	}
+}
+
+func TestChangeCauseRecorder_MakeRecordMergePatch(t *testing.T) {
+	obj := &unstructured.Unstructured{}
+	recorder := ChangeCauseRecorder{
+		changeCause: "test change",
+	}
+
+	patch, err := recorder.MakeRecordMergePatch(obj)
+	if err != nil {
+		t.Fatalf("MakeRecordMergePatch() failed: %v", err)
+	}
+
+	if len(patch) == 0 {
+		t.Errorf("expected non-empty patch, got empty patch")
+	}
+}


### PR DESCRIPTION
This PR adds unit tests for the RecordFlags and ChangeCauseRecorder components of the Kubernetes CLI application. The new tests cover the following scenarios:

TestRecordFlags_ToRecorder:

Verifies that the ToRecorder method returns the correct recorder type (ChangeCauseRecorder or NoopRecorder) based on the record flag.
TestRecordFlags_Complete:

Ensures the Complete method correctly sets the changeCause value using the provided cobra.Command.
TestChangeCauseRecorder_Record:

Checks that the Record method properly adds the changeCause annotation to a given object.
TestChangeCauseRecorder_MakeRecordMergePatch:

Validates that the MakeRecordMergePatch method generates a non-empty patch for updating the recording annotation.
These tests enhance the reliability and stability of the RecordFlags and ChangeCauseRecorder functionalities, ensuring they behave as expected in different scenarios.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
