### PR TITLE
hack/local-up-cluster: optimize for MacOS workflow

### DIFF
--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -173,6 +173,21 @@ function usage {
             echo "           hack/local-up-cluster.sh (build a local copy of the source with full-pcpus-only CPU Management policy)"
 }
 
+function sudo {
+    if [ "$UID" = "0" ]; then
+        while [ $# -gt 0 ]; do
+            case "$1" in
+                --) shift; break;;
+                -*) shift;;
+                *) break;;
+            esac
+        done
+        "$@"
+    else
+        command sudo "$@"
+    fi
+}
+
 # This function guesses where the existing cached binary build is for the `-O`
 # flag
 function guess_built_binary_path {
@@ -1188,7 +1203,6 @@ function parse_eviction {
 }
 
 function update_packages {
-  apt-get update && apt-get install -y sudo
   apt-get remove -y systemd
 
   # Do not update docker / containerd / runc

--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -433,15 +433,15 @@ cleanup()
 
   # Check if the API server is still running
   [[ -n "${APISERVER_PID-}" ]] && kube::util::read-array APISERVER_PIDS < <(pgrep -P "${APISERVER_PID}" ; ps -o pid= -p "${APISERVER_PID}")
-  [[ -n "${APISERVER_PIDS-}" ]] && sudo kill "${APISERVER_PIDS[@]}" 2>/dev/null
+  [[ -n "${APISERVER_PIDS-}" ]] && ${CONTROLPLANE_SUDO} kill "${APISERVER_PIDS[@]}" 2>/dev/null
 
   # Check if the controller-manager is still running
   [[ -n "${CTLRMGR_PID-}" ]] && kube::util::read-array CTLRMGR_PIDS < <(pgrep -P "${CTLRMGR_PID}" ; ps -o pid= -p "${CTLRMGR_PID}")
-  [[ -n "${CTLRMGR_PIDS-}" ]] && sudo kill "${CTLRMGR_PIDS[@]}" 2>/dev/null
+  [[ -n "${CTLRMGR_PIDS-}" ]] && ${CONTROLPLANE_SUDO} kill "${CTLRMGR_PIDS[@]}" 2>/dev/null
 
   # Check if the cloud-controller-manager is still running
   [[ -n "${CLOUD_CTLRMGR_PID-}" ]] && kube::util::read-array CLOUD_CTLRMGR_PIDS < <(pgrep -P "${CLOUD_CTLRMGR_PID}" ; ps -o pid= -p "${CLOUD_CTLRMGR_PID}")
-  [[ -n "${CLOUD_CTLRMGR_PIDS-}" ]] && sudo kill "${CLOUD_CTLRMGR_PIDS[@]}" 2>/dev/null
+  [[ -n "${CLOUD_CTLRMGR_PIDS-}" ]] && ${CONTROLPLANE_SUDO} kill "${CLOUD_CTLRMGR_PIDS[@]}" 2>/dev/null
 
   # Check if the kubelet is still running
   [[ -n "${KUBELET_PID-}" ]] && kube::util::read-array KUBELET_PIDS < <(pgrep -P "${KUBELET_PID}" ; ps -o pid= -p "${KUBELET_PID}")
@@ -453,7 +453,7 @@ cleanup()
 
   # Check if the scheduler is still running
   [[ -n "${SCHEDULER_PID-}" ]] && kube::util::read-array SCHEDULER_PIDS < <(pgrep -P "${SCHEDULER_PID}" ; ps -o pid= -p "${SCHEDULER_PID}")
-  [[ -n "${SCHEDULER_PIDS-}" ]] && sudo kill "${SCHEDULER_PIDS[@]}" 2>/dev/null
+  [[ -n "${SCHEDULER_PIDS-}" ]] && ${CONTROLPLANE_SUDO} kill "${SCHEDULER_PIDS[@]}" 2>/dev/null
 
   # Check if the etcd is still running
   [[ -n "${ETCD_PID-}" ]] && kube::etcd::stop
@@ -467,12 +467,12 @@ cleanup()
 # Check if all processes are still running. Prints a warning once each time
 # a process dies unexpectedly.
 function healthcheck {
-  if [[ -n "${APISERVER_PID-}" ]] && ! sudo kill -0 "${APISERVER_PID}" 2>/dev/null; then
+  if [[ -n "${APISERVER_PID-}" ]] && ! ${CONTROLPLANE_SUDO} kill -0 "${APISERVER_PID}" 2>/dev/null; then
     warning_log "API server terminated unexpectedly, see ${APISERVER_LOG}"
     APISERVER_PID=
   fi
 
-  if [[ -n "${CTLRMGR_PID-}" ]] && ! sudo kill -0 "${CTLRMGR_PID}" 2>/dev/null; then
+  if [[ -n "${CTLRMGR_PID-}" ]] && ! ${CONTROLPLANE_SUDO} kill -0 "${CTLRMGR_PID}" 2>/dev/null; then
     warning_log "kube-controller-manager terminated unexpectedly, see ${CTLRMGR_LOG}"
     CTLRMGR_PID=
   fi
@@ -487,12 +487,12 @@ function healthcheck {
     PROXY_PID=
   fi
 
-  if [[ -n "${SCHEDULER_PID-}" ]] && ! sudo kill -0 "${SCHEDULER_PID}" 2>/dev/null; then
+  if [[ -n "${SCHEDULER_PID-}" ]] && ! ${CONTROLPLANE_SUDO} kill -0 "${SCHEDULER_PID}" 2>/dev/null; then
     warning_log "scheduler terminated unexpectedly, see ${SCHEDULER_LOG}"
     SCHEDULER_PID=
   fi
 
-  if [[ -n "${ETCD_PID-}" ]] && ! sudo kill -0 "${ETCD_PID}" 2>/dev/null; then
+  if [[ -n "${ETCD_PID-}" ]] && ! ${CONTROLPLANE_SUDO} kill -0 "${ETCD_PID}" 2>/dev/null; then
     warning_log "etcd terminated unexpectedly"
     ETCD_PID=
   fi


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

- add a sudo wrapper to avoid install sudo in container
  I'm trying to run kubelet + kubeproxy in a container
- better parse of START_MODE
  added a worker mode, to start kubelet + kubeproxy in another env (e.g. container).
- don't always kill control-plane with sudo
  avoids inputing password frequently

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

I've managed to use this script to bring up a podman container as worker, connecting to the control-plane running natively on darwin, so that I have a fully working cluster on my MacBook.

Control-plane:

```bash
sudo ifconfig lo0 alias 10.123.0.8
PRESERVE_ETCD=true ETCD_DIR=~/etcd-dev CERT_DIR=~/k8s-dev REUSE_CERTS=true \
    API_HOST=10.123.0.8 API_HOST_IP=10.123.0.8 ./hack/local-up-cluster.sh -O
```

Worker:
```
KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
CERT_DIR=${CERT_DIR:-"$HOME/k8s-dev"}

podman volume create kubelet-var
podman run -t --rm --privileged --name=kubelet \
    --volume "${KUBE_ROOT}":/src \
    --volume "${CERT_DIR}":/root/k8s-dev \
    --volume "${KUBE_ROOT}"/hack/local-kubelet/containerd.toml:/etc/containerd/config.toml:ro \
    --volume "${KUBE_ROOT}"/hack/local-kubelet/cni.json:/etc/cni/net.d/10-containerd-net.conflist:ro \
    --volume "${KUBE_ROOT}"/third_party/cni:/opt/cni/bin:ro \
    --volume kubelet-var:/var \
    --publish 127.0.0.1:10250:10250 \
    --tmpfs /tmp \
    --tmpfs /run \
    --cgroupns=private \
    --detach \
    docker.io/kindest/base:v20240701-2cec31c3
podman exec -it \
    -e START_MODE=worker \
    -e CERT_DIR=/root/k8s-dev \
    -e CGROUP_DRIVER=systemd \
    -e CGROUP_ROOT=/kubelet \
    -e API_HOST=10.123.0.8 \
    -e KUBELET_HOST=0.0.0.0 \
    -e REUSE_CERTS=true \
    -e PATH=/src/third_party/cfssl:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
    kubelet \
    bash -c '/kind/bin/create-kubelet-cgroup-v2.sh && /src/hack/local-up-cluster.sh -O'
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
