### PR TITLE
Collect more info for debugging #124136

### DIFF
--- a/test/integration/volume/util_test.go
+++ b/test/integration/volume/util_test.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package volume
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+
+	"k8s.io/klog/v2"
+)
+
+func reportToArtifacts(filename string, obj any) {
+	if os.Getenv("ARTIFACTS") == "" {
+		return
+	}
+	path := filepath.Join(os.Getenv("ARTIFACTS"), filename)
+	file, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		klog.Error("Error opening file:", err)
+		return
+	}
+	defer func() {
+		if err := file.Close(); err != nil {
+			klog.Error("Error closing file:", err)
+		}
+	}()
+
+	content, err := json.Marshal(obj)
+	if err != nil {
+		klog.Error("Error marshalling to json:", err)
+		return
+	}
+	content = append(content, '\n')
+	_, err = file.Write(content)
+	if err != nil {
+		klog.Error("Error writing to file:", err)
+		return
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind flake

#### What this PR does / why we need it:

Collect more debug info.  https://gcsweb.k8s.io/gcs/kubernetes-jenkins/pr-logs/pull/126556/pull-kubernetes-integration/1820719881008451584/artifacts/

![image](https://github.com/user-attachments/assets/8cd257c6-8521-4e09-8ac8-160e5d866857)

```
(base) ➜  /tmp cat TestPersistentVolumeProvisionMultiPVCs-events.text | jq -s '.' | grep reason
            "f:reason": {},
    "reason": "ProvisioningSucceeded",
            "f:reason": {},
    "reason": "ProvisioningSucceeded",

(base) ➜  /tmp cat TestPersistentVolumeProvisionMultiPVCswatch-pvcs.text | jq -s '.' | head
[
  {
    "metadata": {
      "name": "pvc-provision-0",
      "namespace": "provision-multi-pvs",
      "uid": "e7904744-6cb7-467d-a82c-82136873c037",
      "resourceVersion": "1000",
      "creationTimestamp": "2024-08-06T06:24:25Z",
      "managedFields": [
        {
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Ref #124136

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
