### PR TITLE
kube-proxy: initialization wait for node and serviceCIDR synced

### DIFF
--- a/pkg/proxy/config/config.go
+++ b/pkg/proxy/config/config.go
@@ -300,11 +300,10 @@ type NodeConfig struct {
 // NewNodeConfig creates a new NodeConfig.
 func NewNodeConfig(ctx context.Context, nodeInformer v1informers.NodeInformer, resyncPeriod time.Duration) *NodeConfig {
 	result := &NodeConfig{
-		listerSynced: nodeInformer.Informer().HasSynced,
-		logger:       klog.FromContext(ctx),
+		logger: klog.FromContext(ctx),
 	}
 
-	_, _ = nodeInformer.Informer().AddEventHandlerWithResyncPeriod(
+	handlerRegistration, _ := nodeInformer.Informer().AddEventHandlerWithResyncPeriod(
 		cache.ResourceEventHandlerFuncs{
 			AddFunc:    result.handleAddNode,
 			UpdateFunc: result.handleUpdateNode,
@@ -312,6 +311,8 @@ func NewNodeConfig(ctx context.Context, nodeInformer v1informers.NodeInformer, r
 		},
 		resyncPeriod,
 	)
+
+	result.listerSynced = handlerRegistration.HasSynced
 
 	return result
 }
@@ -403,12 +404,11 @@ type ServiceCIDRConfig struct {
 // NewServiceCIDRConfig creates a new ServiceCIDRConfig.
 func NewServiceCIDRConfig(ctx context.Context, serviceCIDRInformer networkingv1beta1informers.ServiceCIDRInformer, resyncPeriod time.Duration) *ServiceCIDRConfig {
 	result := &ServiceCIDRConfig{
-		listerSynced: serviceCIDRInformer.Informer().HasSynced,
-		cidrs:        sets.New[string](),
-		logger:       klog.FromContext(ctx),
+		cidrs:  sets.New[string](),
+		logger: klog.FromContext(ctx),
 	}
 
-	_, _ = serviceCIDRInformer.Informer().AddEventHandlerWithResyncPeriod(
+	handlerRegistration, _ := serviceCIDRInformer.Informer().AddEventHandlerWithResyncPeriod(
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
 				result.handleServiceCIDREvent(nil, obj)
@@ -422,6 +422,9 @@ func NewServiceCIDRConfig(ctx context.Context, serviceCIDRInformer networkingv1b
 		},
 		resyncPeriod,
 	)
+
+	result.listerSynced = handlerRegistration.HasSynced
+
 	return result
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Follow-on from https://github.com/kubernetes/kubernetes/pull/126532 to wait for pre-sync events delivered for the remaining two informers in kube-proxy (node and serviceCIDR).

#### Which issue(s) this PR fixes:

N/A

#### Special notes for your reviewer:

Discussed this change as follow-on work here: https://github.com/kubernetes/kubernetes/pull/126532#issuecomment-2269396857

#### Does this PR introduce a user-facing change?

```release-note
kube-proxy initialization waits for all pre-sync events from node and serviceCIDR informers to be delivered.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

N/A
