### PR TITLE
remove duplicate call for ServeMux

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/handler.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/handler.go
@@ -77,7 +77,6 @@ func NewAPIServerHandler(name string, s runtime.NegotiatedSerializer, handlerCha
 	}
 
 	gorestfulContainer := restful.NewContainer()
-	gorestfulContainer.ServeMux = http.NewServeMux()
 	gorestfulContainer.Router(restful.CurlyRouter{}) // e.g. for proxy/{kind}/{name}/{*}
 	gorestfulContainer.RecoverHandler(func(panicReason interface{}, httpWriter http.ResponseWriter) {
 		logStackOnRecover(s, panicReason, httpWriter)


### PR DESCRIPTION
Remove duplicate call for ServeMux due to already have been initialized when calling restful.NewContainer()

Fixes #126547
