### PR TITLE
Reduce memory usage/allocations during wait for volume attachment

### DIFF
--- a/pkg/kubelet/volumemanager/cache/actual_state_of_world.go
+++ b/pkg/kubelet/volumemanager/cache/actual_state_of_world.go
@@ -120,6 +120,9 @@ type ActualStateOfWorld interface {
 	// and false is returned.
 	PodRemovedFromVolume(podName volumetypes.UniquePodName, volumeName v1.UniqueVolumeName) bool
 
+	// PodHasMountedVolumes returns true if any volume is mounted on the given pod
+	PodHasMountedVolumes(podName volumetypes.UniquePodName) bool
+
 	// VolumeExistsWithSpecName returns true if the given volume specified with the
 	// volume spec name (a.k.a., InnerVolumeSpecName) exists in the list of
 	// volumes that should be attached to this node.
@@ -145,6 +148,10 @@ type ActualStateOfWorld interface {
 	// successfully attached and mounted for the specified pod based on the
 	// current actual state of the world.
 	GetMountedVolumesForPod(podName volumetypes.UniquePodName) []MountedVolume
+
+	// GetMountedVolumeForPodByOuterVolumeSpecName returns the volume and true if
+	// the given outerVolumeSpecName is mounted on the given pod.
+	GetMountedVolumeForPodByOuterVolumeSpecName(podName volumetypes.UniquePodName, outerVolumeSpecName string) (MountedVolume, bool)
 
 	// GetPossiblyMountedVolumesForPod generates and returns a list of volumes for
 	// the specified pod that either are attached and mounted or are "uncertain",
@@ -948,6 +955,20 @@ func (asw *actualStateOfWorld) PodExistsInVolume(podName volumetypes.UniquePodNa
 	return podExists, volumeObj.devicePath, nil
 }
 
+func (asw *actualStateOfWorld) PodHasMountedVolumes(podName volumetypes.UniquePodName) bool {
+	asw.RLock()
+	defer asw.RUnlock()
+	for _, volumeObj := range asw.attachedVolumes {
+		if podObj, hasPod := volumeObj.mountedPods[podName]; hasPod {
+			if podObj.volumeMountStateForPod == operationexecutor.VolumeMounted {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
 func (asw *actualStateOfWorld) volumeNeedsExpansion(volumeObj attachedVolume, desiredVolumeSize resource.Quantity) (resource.Quantity, bool) {
 	currentSize := resource.Quantity{}
 	if volumeObj.persistentVolumeSize != nil {
@@ -1061,7 +1082,7 @@ func (asw *actualStateOfWorld) GetMountedVolumesForPod(
 	podName volumetypes.UniquePodName) []MountedVolume {
 	asw.RLock()
 	defer asw.RUnlock()
-	mountedVolume := make([]MountedVolume, 0 /* len */, len(asw.attachedVolumes) /* cap */)
+	mountedVolume := make([]MountedVolume, 0 /* len */)
 	for _, volumeObj := range asw.attachedVolumes {
 		for mountedPodName, podObj := range volumeObj.mountedPods {
 			if mountedPodName == podName && podObj.volumeMountStateForPod == operationexecutor.VolumeMounted {
@@ -1073,6 +1094,21 @@ func (asw *actualStateOfWorld) GetMountedVolumesForPod(
 	}
 
 	return mountedVolume
+}
+
+func (asw *actualStateOfWorld) GetMountedVolumeForPodByOuterVolumeSpecName(
+	podName volumetypes.UniquePodName, outerVolumeSpecName string) (MountedVolume, bool) {
+	asw.RLock()
+	defer asw.RUnlock()
+	for _, volumeObj := range asw.attachedVolumes {
+		if podObj, hasPod := volumeObj.mountedPods[podName]; hasPod {
+			if podObj.volumeMountStateForPod == operationexecutor.VolumeMounted && podObj.outerVolumeSpecName == outerVolumeSpecName {
+				return getMountedVolume(&podObj, &volumeObj), true
+			}
+		}
+	}
+
+	return MountedVolume{}, false
 }
 
 func (asw *actualStateOfWorld) GetPossiblyMountedVolumesForPod(

--- a/pkg/kubelet/volumemanager/volume_manager.go
+++ b/pkg/kubelet/volumemanager/volume_manager.go
@@ -514,7 +514,13 @@ func (vm *volumeManager) verifyVolumesMountedFunc(podName types.UniquePodName, e
 		if errs := vm.desiredStateOfWorld.PopPodErrors(podName); len(errs) > 0 {
 			return true, errors.New(strings.Join(errs, "; "))
 		}
-		return len(vm.getUnmountedVolumes(podName, expectedVolumes)) == 0, nil
+		for _, expectedVolume := range expectedVolumes {
+			_, found := vm.actualStateOfWorld.GetMountedVolumeForPodByOuterVolumeSpecName(podName, expectedVolume)
+			if !found {
+				return false, nil
+			}
+		}
+		return true, nil
 	}
 }
 
@@ -525,7 +531,7 @@ func (vm *volumeManager) verifyVolumesUnmountedFunc(podName types.UniquePodName)
 		if errs := vm.desiredStateOfWorld.PopPodErrors(podName); len(errs) > 0 {
 			return true, errors.New(strings.Join(errs, "; "))
 		}
-		return len(vm.actualStateOfWorld.GetMountedVolumesForPod(podName)) == 0, nil
+		return !vm.actualStateOfWorld.PodHasMountedVolumes(podName), nil
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/kind cleanup

#### What this PR does / why we need it:

After a node restart kubelet tries to (re)attach all volumes to the pods. We poll the `verifyVolumesMountedFunc` every 300ms to check whether the mount has succeeded. This function called the
`GetMountedVolumesForPod` function that allocates memory for every volumes on every pod (`len(asw.attachedVolumes)`). Because this function is executed for every pod simultaneously, it results in exponential memory usage and high cpu usage due to garbage collection. We already know the exact volume names and pod name and are able to completely remove the slice allocation.

With hundred of pods each mounting multiple volumes this resulted in very large memory allocations and cpu usage (>3000%) in GOs garbage collection. This slows down the whole system, resulting in even slower volume mounts. After temporarily disabling the garbage collection (GOGC=off), the memory usage grew to over 200GB.

![image](https://github.com/user-attachments/assets/a44a513d-f2f2-4119-abe2-edd2965e1321)

A small follow up commit uses the new function in a different location to reduce memory allocations in the `desiredStateOfWorldPopulator` loop(every 100ms), specifically the `findAndAddNewPods` function. 
Should this commit be part of this MR? https://github.com/Lucaber/kubernetes/commit/ba1a3eb1f5719226c9d12a3f563f0ac58f60e3f0
![image](https://github.com/user-attachments/assets/770cbc91-9afe-4022-9516-f91a485711e1)




```release-note
Reduce memory usage/allocations during wait for volume attachment
```