### PR TITLE
Respect controllers on PVCs for retention policy

### DIFF
--- a/pkg/controller/statefulset/stateful_pod_control_test.go
+++ b/pkg/controller/statefulset/stateful_pod_control_test.go
@@ -502,7 +502,7 @@ func TestStatefulPodControlDeleteFailure(t *testing.T) {
 }
 
 func TestStatefulPodControlClaimsMatchDeletionPolcy(t *testing.T) {
-	// The claimOwnerMatchesSetAndPod is tested exhaustively in stateful_set_utils_test; this
+	// The isClaimOwnerUpToDate is tested exhaustively in stateful_set_utils_test; this
 	// test is for the wiring to the method tested there.
 	_, ctx := ktesting.NewTestContext(t)
 	fakeClient := &fake.Clientset{}
@@ -542,38 +542,66 @@ func TestStatefulPodControlUpdatePodClaimForRetentionPolicy(t *testing.T) {
 	testFn := func(t *testing.T) {
 		_, ctx := ktesting.NewTestContext(t)
 		defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.StatefulSetAutoDeletePVC, true)()
-		fakeClient := &fake.Clientset{}
-		indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
-		claimLister := corelisters.NewPersistentVolumeClaimLister(indexer)
-		fakeClient.AddReactor("update", "persistentvolumeclaims", func(action core.Action) (bool, runtime.Object, error) {
-			update := action.(core.UpdateAction)
-			indexer.Update(update.GetObject())
-			return true, update.GetObject(), nil
-		})
-		set := newStatefulSet(3)
-		set.GetObjectMeta().SetUID("set-123")
-		pod := newStatefulSetPod(set, 0)
-		claims := getPersistentVolumeClaims(set, pod)
-		for k := range claims {
-			claim := claims[k]
-			indexer.Add(&claim)
+
+		trueVar := true
+
+		testCases := []struct {
+			name      string
+			ownerRef  []metav1.OwnerReference
+			expectRef bool
+		}{
+			{
+				name:      "bare PVC",
+				expectRef: true,
+			},
+			{
+				name:      "PVC already controller",
+				ownerRef:  []metav1.OwnerReference{{Controller: &trueVar, Name: "foobar"}},
+				expectRef: false,
+			},
 		}
-		control := NewStatefulPodControl(fakeClient, nil, claimLister, &noopRecorder{})
-		set.Spec.PersistentVolumeClaimRetentionPolicy = &apps.StatefulSetPersistentVolumeClaimRetentionPolicy{
-			WhenDeleted: apps.DeletePersistentVolumeClaimRetentionPolicyType,
-			WhenScaled:  apps.RetainPersistentVolumeClaimRetentionPolicyType,
-		}
-		if err := control.UpdatePodClaimForRetentionPolicy(ctx, set, pod); err != nil {
-			t.Errorf("Unexpected error for UpdatePodClaimForRetentionPolicy (retain): %v", err)
-		}
-		expectRef := utilfeature.DefaultFeatureGate.Enabled(features.StatefulSetAutoDeletePVC)
-		for k := range claims {
-			claim, err := claimLister.PersistentVolumeClaims(claims[k].Namespace).Get(claims[k].Name)
-			if err != nil {
-				t.Errorf("Unexpected error getting Claim %s/%s: %v", claim.Namespace, claim.Name, err)
+
+		for _, tc := range testCases {
+			fakeClient := &fake.Clientset{}
+			indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+			claimLister := corelisters.NewPersistentVolumeClaimLister(indexer)
+			fakeClient.AddReactor("update", "persistentvolumeclaims", func(action core.Action) (bool, runtime.Object, error) {
+				update := action.(core.UpdateAction)
+				if err := indexer.Update(update.GetObject()); err != nil {
+					t.Fatalf("could not update index: %v", err)
+				}
+				return true, update.GetObject(), nil
+			})
+			set := newStatefulSet(3)
+			set.GetObjectMeta().SetUID("set-123")
+			pod0 := newStatefulSetPod(set, 0)
+			claims0 := getPersistentVolumeClaims(set, pod0)
+			for k := range claims0 {
+				claim := claims0[k]
+				if tc.ownerRef != nil {
+					claim.SetOwnerReferences(tc.ownerRef)
+				}
+				if err := indexer.Add(&claim); err != nil {
+					t.Errorf("Could not add claim %s: %v", k, err)
+				}
 			}
-			if hasOwnerRef(claim, set) != expectRef {
-				t.Errorf("Claim %s/%s bad set owner ref", claim.Namespace, claim.Name)
+			control := NewStatefulPodControl(fakeClient, nil, claimLister, &noopRecorder{})
+			set.Spec.PersistentVolumeClaimRetentionPolicy = &apps.StatefulSetPersistentVolumeClaimRetentionPolicy{
+				WhenDeleted: apps.DeletePersistentVolumeClaimRetentionPolicyType,
+				WhenScaled:  apps.RetainPersistentVolumeClaimRetentionPolicyType,
+			}
+			if err := control.UpdatePodClaimForRetentionPolicy(ctx, set, pod0); err != nil {
+				t.Errorf("Unexpected error for UpdatePodClaimForRetentionPolicy (retain), pod0: %v", err)
+			}
+			expectRef := tc.expectRef && utilfeature.DefaultFeatureGate.Enabled(features.StatefulSetAutoDeletePVC)
+			for k := range claims0 {
+				claim, err := claimLister.PersistentVolumeClaims(claims0[k].Namespace).Get(claims0[k].Name)
+				if err != nil {
+					t.Errorf("Unexpected error getting Claim %s/%s: %v", claim.Namespace, claim.Name, err)
+				}
+				if hasOwnerRef(claim, set) != expectRef {
+					t.Errorf("%s: Claim %s/%s bad set owner ref", tc.name, claim.Namespace, claim.Name)
+				}
 			}
 		}
 	}
@@ -663,12 +691,22 @@ func TestPodClaimIsStale(t *testing.T) {
 				claimIndexer.Add(&claim)
 			case stale:
 				claim.SetOwnerReferences([]metav1.OwnerReference{
-					{Name: "set-3", UID: types.UID("stale")},
+					{
+						Name:       "set-3",
+						UID:        types.UID("stale"),
+						APIVersion: "v1",
+						Kind:       "Pod",
+					},
 				})
 				claimIndexer.Add(&claim)
 			case withRef:
 				claim.SetOwnerReferences([]metav1.OwnerReference{
-					{Name: "set-3", UID: types.UID("123")},
+					{
+						Name:       "set-3",
+						UID:        types.UID("123"),
+						APIVersion: "v1",
+						Kind:       "Pod",
+					},
 				})
 				claimIndexer.Add(&claim)
 			}
@@ -710,7 +748,8 @@ func TestStatefulPodControlRetainDeletionPolicyUpdate(t *testing.T) {
 		}
 		for k := range claims {
 			claim := claims[k]
-			setOwnerRef(&claim, set, &set.TypeMeta) // This ownerRef should be removed in the update.
+			// This ownerRef should be removed in the update.
+			claim.SetOwnerReferences(addControllerRef(claim.GetOwnerReferences(), set, controllerKind))
 			claimIndexer.Add(&claim)
 		}
 		control := NewStatefulPodControl(fakeClient, podLister, claimLister, recorder)

--- a/pkg/controller/statefulset/stateful_set.go
+++ b/pkg/controller/statefulset/stateful_set.go
@@ -49,6 +49,9 @@ import (
 // controllerKind contains the schema.GroupVersionKind for this controller type.
 var controllerKind = apps.SchemeGroupVersion.WithKind("StatefulSet")
 
+// podKind contains the schema.GroupVersionKind for pods.
+var podKind = v1.SchemeGroupVersion.WithKind("Pod")
+
 // StatefulSetController controls statefulsets.
 type StatefulSetController struct {
 	// client interface

--- a/pkg/controller/statefulset/stateful_set_utils.go
+++ b/pkg/controller/statefulset/stateful_set_utils.go
@@ -26,6 +26,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
@@ -170,9 +171,100 @@ func getPersistentVolumeClaimRetentionPolicy(set *apps.StatefulSet) apps.Statefu
 	return policy
 }
 
-// claimOwnerMatchesSetAndPod returns false if the ownerRefs of the claim are not set consistently with the
+// matchesRef returns true when the object matches the owner reference, that is the name and GVK are the same.
+func matchesRef(ref *metav1.OwnerReference, obj metav1.Object, gvk schema.GroupVersionKind) bool {
+	return gvk.GroupVersion().String() == ref.APIVersion && gvk.Kind == ref.Kind && ref.Name == obj.GetName()
+}
+
+// hasUnexpectedController returns true if the set has a retention policy and there is a controller
+// for the claim that's not the set or pod. Since the retention policy may have been changed, it is
+// always valid for the set or pod to be a controller.
+func hasUnexpectedController(claim *v1.PersistentVolumeClaim, set *apps.StatefulSet, pod *v1.Pod) bool {
+	policy := getPersistentVolumeClaimRetentionPolicy(set)
+	const retain = apps.RetainPersistentVolumeClaimRetentionPolicyType
+	if policy.WhenScaled == retain && policy.WhenDeleted == retain {
+		// On a retain policy, it's not a problem for different controller to be managing the claims.
+		return false
+	}
+	for _, ownerRef := range claim.GetOwnerReferences() {
+		if matchesRef(&ownerRef, set, controllerKind) {
+			if ownerRef.UID != set.GetUID() {
+				// A UID mismatch means that pods were incorrectly orphaned. Treating this as an unexpected
+				// controller means we won't touch the PVCs (eg, leave it to the garbage collector to clean
+				// up if appropriate).
+				return true
+			}
+			continue // This is us.
+		}
+
+		if matchesRef(&ownerRef, pod, podKind) {
+			if ownerRef.UID != pod.GetUID() {
+				// This is the same situation as the set UID mismatch, above.
+				return true
+			}
+			continue // This is us.
+		}
+		if ownerRef.Controller != nil && *ownerRef.Controller {
+			return true // This is another controller.
+		}
+	}
+	return false
+}
+
+// hasNonControllerOwner returns true if the pod or set is an owner but not controller of the claim.
+func hasNonControllerOwner(claim *v1.PersistentVolumeClaim, set *apps.StatefulSet, pod *v1.Pod) bool {
+	for _, ownerRef := range claim.GetOwnerReferences() {
+		if ownerRef.UID == set.GetUID() || ownerRef.UID == pod.GetUID() {
+			if ownerRef.Controller == nil || !*ownerRef.Controller {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// removeRefs removes any owner refs from the list matching predicate. Returns true if the list was changed and
+// the new (or unchanged list).
+func removeRefs(refs []metav1.OwnerReference, predicate func(ref *metav1.OwnerReference) bool) []metav1.OwnerReference {
+	newRefs := []metav1.OwnerReference{}
+	for _, ownerRef := range refs {
+		if !predicate(&ownerRef) {
+			newRefs = append(newRefs, ownerRef)
+		}
+	}
+	return newRefs
+}
+
+// isClaimOwnerUpToDate returns false if the ownerRefs of the claim are not set consistently with the
 // PVC deletion policy for the StatefulSet.
-func claimOwnerMatchesSetAndPod(logger klog.Logger, claim *v1.PersistentVolumeClaim, set *apps.StatefulSet, pod *v1.Pod) bool {
+//
+// If there are stale references or unexpected controllers, this returns true in order to not touch
+// PVCs that have gotten into this unknown state. Otherwise the ownerships are checked to match the
+// PVC retention policy:
+//
+//	Retain on scaling and set deletion: no owner ref
+//	Retain on scaling and delete on set deletion: owner ref on the set only
+//	Delete on scaling and retain on set deletion: owner ref on the pod only
+//	Delete on scaling and set deletion: owner refs on both set and pod.
+func isClaimOwnerUpToDate(logger klog.Logger, claim *v1.PersistentVolumeClaim, set *apps.StatefulSet, pod *v1.Pod) bool {
+	if hasStaleOwnerRef(claim, set, controllerKind) || hasStaleOwnerRef(claim, pod, podKind) {
+		// The claim is being managed by previous, presumably deleted, version of the controller. It should not be touched.
+		return true
+	}
+
+	if hasUnexpectedController(claim, set, pod) {
+		if hasOwnerRef(claim, set) || hasOwnerRef(claim, pod) {
+			return false // Need to clean up the conflicting controllers
+		}
+		// The claim refs are good, we don't want to add any controllers on top of the unexpected one.
+		return true
+	}
+
+	if hasNonControllerOwner(claim, set, pod) {
+		// Some resource has an owner ref, but there is no controller. This needs to be updated.
+		return false
+	}
+
 	policy := getPersistentVolumeClaimRetentionPolicy(set)
 	const retain = apps.RetainPersistentVolumeClaimRetentionPolicyType
 	const delete = apps.DeletePersistentVolumeClaimRetentionPolicyType
@@ -214,64 +306,53 @@ func claimOwnerMatchesSetAndPod(logger klog.Logger, claim *v1.PersistentVolumeCl
 
 // updateClaimOwnerRefForSetAndPod updates the ownerRefs for the claim according to the deletion policy of
 // the StatefulSet. Returns true if the claim was changed and should be updated and false otherwise.
-func updateClaimOwnerRefForSetAndPod(logger klog.Logger, claim *v1.PersistentVolumeClaim, set *apps.StatefulSet, pod *v1.Pod) bool {
-	needsUpdate := false
-	// Sometimes the version and kind are not set {pod,set}.TypeMeta. These are necessary for the ownerRef.
-	// This is the case both in real clusters and the unittests.
-	// TODO: there must be a better way to do this other than hardcoding the pod version?
-	updateMeta := func(tm *metav1.TypeMeta, kind string) {
-		if tm.APIVersion == "" {
-			if kind == "StatefulSet" {
-				tm.APIVersion = "apps/v1"
-			} else {
-				tm.APIVersion = "v1"
-			}
-		}
-		if tm.Kind == "" {
-			tm.Kind = kind
-		}
+// isClaimOwnerUpToDate should be called before this to avoid an expensive update operation.
+func updateClaimOwnerRefForSetAndPod(logger klog.Logger, claim *v1.PersistentVolumeClaim, set *apps.StatefulSet, pod *v1.Pod) {
+	refs := claim.GetOwnerReferences()
+
+	unexpectedController := hasUnexpectedController(claim, set, pod)
+
+	// Scrub any ownerRefs to our set & pod.
+	refs = removeRefs(refs, func(ref *metav1.OwnerReference) bool {
+		return matchesRef(ref, set, controllerKind) || matchesRef(ref, pod, podKind)
+	})
+
+	if unexpectedController {
+		// Leave ownerRefs to our set & pod scrubed and return without creating new ones.
+		claim.SetOwnerReferences(refs)
+		return
 	}
-	podMeta := pod.TypeMeta
-	updateMeta(&podMeta, "Pod")
-	setMeta := set.TypeMeta
-	updateMeta(&setMeta, "StatefulSet")
+
 	policy := getPersistentVolumeClaimRetentionPolicy(set)
 	const retain = apps.RetainPersistentVolumeClaimRetentionPolicyType
 	const delete = apps.DeletePersistentVolumeClaimRetentionPolicyType
 	switch {
 	default:
 		logger.Error(nil, "Unknown policy, treating as Retain", "policy", set.Spec.PersistentVolumeClaimRetentionPolicy)
-		fallthrough
+		// Nothing to do
 	case policy.WhenScaled == retain && policy.WhenDeleted == retain:
-		needsUpdate = removeOwnerRef(claim, set) || needsUpdate
-		needsUpdate = removeOwnerRef(claim, pod) || needsUpdate
+		// Nothing to do
 	case policy.WhenScaled == retain && policy.WhenDeleted == delete:
-		needsUpdate = setOwnerRef(claim, set, &setMeta) || needsUpdate
-		needsUpdate = removeOwnerRef(claim, pod) || needsUpdate
+		refs = addControllerRef(refs, set, controllerKind)
 	case policy.WhenScaled == delete && policy.WhenDeleted == retain:
-		needsUpdate = removeOwnerRef(claim, set) || needsUpdate
 		podScaledDown := !podInOrdinalRange(pod, set)
 		if podScaledDown {
-			needsUpdate = setOwnerRef(claim, pod, &podMeta) || needsUpdate
-		}
-		if !podScaledDown {
-			needsUpdate = removeOwnerRef(claim, pod) || needsUpdate
+			refs = addControllerRef(refs, pod, podKind)
 		}
 	case policy.WhenScaled == delete && policy.WhenDeleted == delete:
 		podScaledDown := !podInOrdinalRange(pod, set)
 		if podScaledDown {
-			needsUpdate = removeOwnerRef(claim, set) || needsUpdate
-			needsUpdate = setOwnerRef(claim, pod, &podMeta) || needsUpdate
+			refs = addControllerRef(refs, pod, podKind)
 		}
 		if !podScaledDown {
-			needsUpdate = setOwnerRef(claim, set, &setMeta) || needsUpdate
-			needsUpdate = removeOwnerRef(claim, pod) || needsUpdate
+			refs = addControllerRef(refs, set, controllerKind)
 		}
 	}
-	return needsUpdate
+	claim.SetOwnerReferences(refs)
 }
 
-// hasOwnerRef returns true if target has an ownerRef to owner.
+// hasOwnerRef returns true if target has an ownerRef to owner (as its UID).
+// This does not check if the owner is a controller.
 func hasOwnerRef(target, owner metav1.Object) bool {
 	ownerUID := owner.GetUID()
 	for _, ownerRef := range target.GetOwnerReferences() {
@@ -282,53 +363,28 @@ func hasOwnerRef(target, owner metav1.Object) bool {
 	return false
 }
 
-// hasStaleOwnerRef returns true if target has a ref to owner that appears to be stale.
-func hasStaleOwnerRef(target, owner metav1.Object) bool {
+// hasStaleOwnerRef returns true if target has a ref to owner that appears to be stale, that is,
+// the ref matches the object but not the UID.
+func hasStaleOwnerRef(target *v1.PersistentVolumeClaim, obj metav1.Object, gvk schema.GroupVersionKind) bool {
 	for _, ownerRef := range target.GetOwnerReferences() {
-		if ownerRef.Name == owner.GetName() && ownerRef.UID != owner.GetUID() {
-			return true
+		if matchesRef(&ownerRef, obj, gvk) {
+			return ownerRef.UID != obj.GetUID()
 		}
 	}
 	return false
 }
 
-// setOwnerRef adds owner to the ownerRefs of target, if necessary. Returns true if target needs to be
-// updated and false otherwise.
-func setOwnerRef(target, owner metav1.Object, ownerType *metav1.TypeMeta) bool {
-	if hasOwnerRef(target, owner) {
-		return false
-	}
-	ownerRefs := append(
-		target.GetOwnerReferences(),
-		metav1.OwnerReference{
-			APIVersion: ownerType.APIVersion,
-			Kind:       ownerType.Kind,
-			Name:       owner.GetName(),
-			UID:        owner.GetUID(),
-		})
-	target.SetOwnerReferences(ownerRefs)
-	return true
-}
-
-// removeOwnerRef removes owner from the ownerRefs of target, if necessary. Returns true if target needs
-// to be updated and false otherwise.
-func removeOwnerRef(target, owner metav1.Object) bool {
-	if !hasOwnerRef(target, owner) {
-		return false
-	}
-	ownerUID := owner.GetUID()
-	oldRefs := target.GetOwnerReferences()
-	newRefs := make([]metav1.OwnerReference, len(oldRefs)-1)
-	skip := 0
-	for i := range oldRefs {
-		if oldRefs[i].UID == ownerUID {
-			skip = -1
-		} else {
-			newRefs[i+skip] = oldRefs[i]
+// addControllerRef returns refs with owner added as a controller, if necessary.
+func addControllerRef(refs []metav1.OwnerReference, owner metav1.Object, gvk schema.GroupVersionKind) []metav1.OwnerReference {
+	for _, ref := range refs {
+		if ref.UID == owner.GetUID() {
+			// Already added. Since we scrub our refs before making any changes, we know it's already
+			// a controller if appropriate.
+			return refs
 		}
 	}
-	target.SetOwnerReferences(newRefs)
-	return true
+
+	return append(refs, *metav1.NewControllerRef(owner, gvk))
 }
 
 // getPersistentVolumeClaims gets a map of PersistentVolumeClaims to their template names, as defined in set. The

--- a/pkg/controller/statefulset/stateful_set_utils_test.go
+++ b/pkg/controller/statefulset/stateful_set_utils_test.go
@@ -23,19 +23,20 @@ import (
 	"regexp"
 	"sort"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
+	apps "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/klog/v2"
 	"k8s.io/klog/v2/ktesting"
-
-	apps "k8s.io/api/apps/v1"
-	v1 "k8s.io/api/core/v1"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/controller/history"
 	"k8s.io/utils/pointer"
@@ -61,6 +62,88 @@ func getClaimPodName(set *apps.StatefulSet, claim *v1.PersistentVolumeClaim) str
 		return podName
 	}
 	return matches[1]
+}
+
+// ownerRefsChanged returns true if newRefs does not match originalRefs.
+func ownerRefsChanged(originalRefs, newRefs []metav1.OwnerReference) bool {
+	if len(originalRefs) != len(newRefs) {
+		return true
+	}
+	key := func(ref *metav1.OwnerReference) string {
+		return fmt.Sprintf("%s-%s-%s", ref.APIVersion, ref.Kind, ref.Name)
+	}
+	refs := map[string]bool{}
+	for i := range originalRefs {
+		refs[key(&originalRefs[i])] = true
+	}
+	for i := range newRefs {
+		k := key(&newRefs[i])
+		if val, found := refs[k]; !found || !val {
+			return true
+		}
+		refs[k] = false
+	}
+	return false
+}
+
+func TestOwnerRefsChanged(t *testing.T) {
+	toRefs := func(strs []string) []metav1.OwnerReference {
+		refs := []metav1.OwnerReference{}
+		for _, s := range strs {
+			pieces := strings.Split(s, "/")
+			refs = append(refs, metav1.OwnerReference{
+				APIVersion: pieces[0],
+				Kind:       pieces[1],
+				Name:       pieces[2],
+			})
+		}
+		return refs
+	}
+	testCases := []struct {
+		orig, new []string
+		changed   bool
+	}{
+		{
+			orig:    []string{"v1/pod/foo"},
+			new:     []string{},
+			changed: true,
+		},
+		{
+			orig:    []string{"v1/pod/foo"},
+			new:     []string{"v1/pod/foo"},
+			changed: false,
+		},
+		{
+			orig:    []string{"v1/pod/foo"},
+			new:     []string{"v1/pod/bar"},
+			changed: true,
+		},
+		{
+			orig:    []string{"v1/pod/foo", "v1/set/bob"},
+			new:     []string{"v1/pod/foo", "v1/set/alice"},
+			changed: true,
+		},
+		{
+			orig:    []string{"v1/pod/foo", "v1/set/bob"},
+			new:     []string{"v1/pod/foo", "v1/set/bob"},
+			changed: false,
+		},
+		{
+			orig:    []string{"v1/pod/foo", "v1/set/bob"},
+			new:     []string{"v1/pod/foo", "v1/set/bob", "v1/set/bob"},
+			changed: true,
+		},
+		{
+			orig:    []string{"v1/pod/foo", "v1/set/bob"},
+			new:     []string{"v1/set/bob", "v1/pod/foo"},
+			changed: false,
+		},
+	}
+	for _, tc := range testCases {
+		if ownerRefsChanged(toRefs(tc.orig), toRefs(tc.new)) != tc.changed {
+			t.Errorf("Expected change=%t but got %t for %v vs %v", tc.changed, !tc.changed, tc.orig, tc.new)
+		}
+	}
 }
 
 func TestGetParentNameAndOrdinal(t *testing.T) {
@@ -253,7 +336,84 @@ func TestGetPersistentVolumeClaimRetentionPolicy(t *testing.T) {
 	}
 }
 
-func TestClaimOwnerMatchesSetAndPod(t *testing.T) {
+func TestMatchesRef(t *testing.T) {
+	testCases := []struct {
+		name        string
+		ref         metav1.OwnerReference
+		obj         metav1.ObjectMeta
+		schema      schema.GroupVersionKind
+		shouldMatch bool
+	}{
+		{
+			name: "full match",
+			ref: metav1.OwnerReference{
+				APIVersion: "v1",
+				Kind:       "Pod",
+				Name:       "fred",
+				UID:        "abc",
+			},
+			obj: metav1.ObjectMeta{
+				Name: "fred",
+				UID:  "abc",
+			},
+			schema:      podKind,
+			shouldMatch: true,
+		},
+		{
+			name: "match without UID",
+			ref: metav1.OwnerReference{
+				APIVersion: "v1",
+				Kind:       "Pod",
+				Name:       "fred",
+				UID:        "abc",
+			},
+			obj: metav1.ObjectMeta{
+				Name: "fred",
+				UID:  "not-matching",
+			},
+			schema:      podKind,
+			shouldMatch: true,
+		},
+		{
+			name: "mismatch name",
+			ref: metav1.OwnerReference{
+				APIVersion: "v1",
+				Kind:       "Pod",
+				Name:       "fred",
+				UID:        "abc",
+			},
+			obj: metav1.ObjectMeta{
+				Name: "joan",
+				UID:  "abc",
+			},
+			schema:      podKind,
+			shouldMatch: false,
+		},
+		{
+			name: "wrong schema",
+			ref: metav1.OwnerReference{
+				APIVersion: "beta2",
+				Kind:       "Pod",
+				Name:       "fred",
+				UID:        "abc",
+			},
+			obj: metav1.ObjectMeta{
+				Name: "fred",
+				UID:  "abc",
+			},
+			schema:      podKind,
+			shouldMatch: false,
+		},
+	}
+	for _, tc := range testCases {
+		got := matchesRef(&tc.ref, &tc.obj, tc.schema)
+		if got != tc.shouldMatch {
+			t.Errorf("Failed %s: got %t, expected %t", tc.name, got, tc.shouldMatch)
+		}
+	}
+}
+
+func TestIsClaimOwnerUpToDate(t *testing.T) {
 	testCases := []struct {
 		name            string
 		scaleDownPolicy apps.PersistentVolumeClaimRetentionPolicyType
@@ -334,24 +494,32 @@ func TestClaimOwnerMatchesSetAndPod(t *testing.T) {
 						WhenDeleted: tc.setDeletePolicy,
 					}
 					set.Spec.Replicas = &tc.replicas
+					claimRefs := claim.GetOwnerReferences()
 					if setPodRef {
-						setOwnerRef(&claim, &pod, &pod.TypeMeta)
+						claimRefs = addControllerRef(claimRefs, &pod, podKind)
 					}
 					if setSetRef {
-						setOwnerRef(&claim, &set, &set.TypeMeta)
+						claimRefs = addControllerRef(claimRefs, &set, controllerKind)
 					}
 					if useOtherRefs {
-						randomObject1 := v1.Pod{}
-						randomObject1.Name = "rand1"
-						randomObject1.GetObjectMeta().SetUID("rand1-abc")
-						randomObject2 := v1.Pod{}
-						randomObject2.Name = "rand2"
-						randomObject2.GetObjectMeta().SetUID("rand2-def")
-						setOwnerRef(&claim, &randomObject1, &randomObject1.TypeMeta)
-						setOwnerRef(&claim, &randomObject2, &randomObject2.TypeMeta)
+						claimRefs = append(
+							claimRefs,
+							metav1.OwnerReference{
+								Name:       "rand1",
+								APIVersion: "v1",
+								Kind:       "Pod",
+								UID:        "rand1-uid",
+							},
+							metav1.OwnerReference{
+								Name:       "rand2",
+								APIVersion: "v1",
+								Kind:       "Pod",
+								UID:        "rand2-uid",
+							})
 					}
+					claim.SetOwnerReferences(claimRefs)
 					shouldMatch := setPodRef == tc.needsPodRef && setSetRef == tc.needsSetRef
-					if claimOwnerMatchesSetAndPod(logger, &claim, &set, &pod) != shouldMatch {
+					if isClaimOwnerUpToDate(logger, &claim, &set, &pod) != shouldMatch {
 						t.Errorf("Bad match for %s with pod=%v,set=%v,others=%v", tc.name, setPodRef, setSetRef, useOtherRefs)
 					}
 				}
@@ -360,14 +528,197 @@ func TestClaimOwnerMatchesSetAndPod(t *testing.T) {
 	}
 }
 
-func TestUpdateClaimOwnerRefForSetAndPod(t *testing.T) {
+func TestClaimOwnerUpToDateEdgeCases(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
+	logger := klog.FromContext(ctx)
+
+	trueVar := true
 	testCases := []struct {
-		name            string
-		scaleDownPolicy apps.PersistentVolumeClaimRetentionPolicyType
-		setDeletePolicy apps.PersistentVolumeClaimRetentionPolicyType
-		condemned       bool
-		needsPodRef     bool
-		needsSetRef     bool
+		name        string
+		ownerRefs   []metav1.OwnerReference
+		policy      apps.StatefulSetPersistentVolumeClaimRetentionPolicy
+		shouldMatch bool
+	}{
+		{
+			name: "normal controller, pod",
+			ownerRefs: []metav1.OwnerReference{
+				{
+					Name:       "pod-1",
+					APIVersion: "v1",
+					Kind:       "Pod",
+					UID:        "pod-123",
+					Controller: &trueVar,
+				},
+			},
+			policy: apps.StatefulSetPersistentVolumeClaimRetentionPolicy{
+				WhenScaled:  apps.DeletePersistentVolumeClaimRetentionPolicyType,
+				WhenDeleted: apps.DeletePersistentVolumeClaimRetentionPolicyType,
+			},
+			shouldMatch: true,
+		},
+		{
+			name: "non-controller causes policy mismatch, pod",
+			ownerRefs: []metav1.OwnerReference{
+				{
+					Name:       "pod-1",
+					APIVersion: "v1",
+					Kind:       "Pod",
+					UID:        "pod-123",
+				},
+			},
+			policy: apps.StatefulSetPersistentVolumeClaimRetentionPolicy{
+				WhenScaled:  apps.DeletePersistentVolumeClaimRetentionPolicyType,
+				WhenDeleted: apps.DeletePersistentVolumeClaimRetentionPolicyType,
+			},
+			shouldMatch: false,
+		},
+		{
+			name: "stale controller does not affect policy, pod",
+			ownerRefs: []metav1.OwnerReference{
+				{
+					Name:       "pod-1",
+					APIVersion: "v1",
+					Kind:       "Pod",
+					UID:        "pod-stale",
+					Controller: &trueVar,
+				},
+			},
+			policy: apps.StatefulSetPersistentVolumeClaimRetentionPolicy{
+				WhenScaled:  apps.DeletePersistentVolumeClaimRetentionPolicyType,
+				WhenDeleted: apps.DeletePersistentVolumeClaimRetentionPolicyType,
+			},
+			shouldMatch: true,
+		},
+		{
+			name: "unexpected controller causes policy mismatch, pod",
+			ownerRefs: []metav1.OwnerReference{
+				{
+					Name:       "pod-1",
+					APIVersion: "v1",
+					Kind:       "Pod",
+					UID:        "pod-123",
+					Controller: &trueVar,
+				},
+				{
+					Name:       "Random",
+					APIVersion: "v1",
+					Kind:       "Pod",
+					UID:        "random",
+					Controller: &trueVar,
+				},
+			},
+			policy: apps.StatefulSetPersistentVolumeClaimRetentionPolicy{
+				WhenScaled:  apps.DeletePersistentVolumeClaimRetentionPolicyType,
+				WhenDeleted: apps.DeletePersistentVolumeClaimRetentionPolicyType,
+			},
+			shouldMatch: false,
+		},
+		{
+			name: "normal controller, set",
+			ownerRefs: []metav1.OwnerReference{
+				{
+					Name:       "stateful-set",
+					APIVersion: "apps/v1",
+					Kind:       "StatefulSet",
+					UID:        "ss-456",
+					Controller: &trueVar,
+				},
+			},
+			policy: apps.StatefulSetPersistentVolumeClaimRetentionPolicy{
+				WhenScaled:  apps.RetainPersistentVolumeClaimRetentionPolicyType,
+				WhenDeleted: apps.DeletePersistentVolumeClaimRetentionPolicyType,
+			},
+			shouldMatch: true,
+		},
+		{
+			name: "non-controller causes policy mismatch, set",
+			ownerRefs: []metav1.OwnerReference{
+				{
+					Name:       "stateful-set",
+					APIVersion: "appsv1",
+					Kind:       "StatefulSet",
+					UID:        "ss-456",
+				},
+			},
+			policy: apps.StatefulSetPersistentVolumeClaimRetentionPolicy{
+				WhenScaled:  apps.RetainPersistentVolumeClaimRetentionPolicyType,
+				WhenDeleted: apps.DeletePersistentVolumeClaimRetentionPolicyType,
+			},
+			shouldMatch: false,
+		},
+		{
+			name: "stale controller ignored, set",
+			ownerRefs: []metav1.OwnerReference{
+				{
+					Name:       "stateful-set",
+					APIVersion: "apps/v1",
+					Kind:       "StatefulSet",
+					UID:        "set-stale",
+					Controller: &trueVar,
+				},
+			},
+			policy: apps.StatefulSetPersistentVolumeClaimRetentionPolicy{
+				WhenScaled:  apps.RetainPersistentVolumeClaimRetentionPolicyType,
+				WhenDeleted: apps.DeletePersistentVolumeClaimRetentionPolicyType,
+			},
+			shouldMatch: true,
+		},
+		{
+			name: "unexpected controller causes policy mismatch, set",
+			ownerRefs: []metav1.OwnerReference{
+				{
+					Name:       "stateful-set",
+					APIVersion: "apps/v1",
+					Kind:       "StatefulSet",
+					UID:        "ss-456",
+					Controller: &trueVar,
+				},
+				{
+					Name:       "Random",
+					APIVersion: "apps/v1",
+					Kind:       "StatefulSet",
+					UID:        "random",
+					Controller: &trueVar,
+				},
+			},
+			policy: apps.StatefulSetPersistentVolumeClaimRetentionPolicy{
+				WhenScaled:  apps.RetainPersistentVolumeClaimRetentionPolicyType,
+				WhenDeleted: apps.DeletePersistentVolumeClaimRetentionPolicyType,
+			},
+			shouldMatch: false,
+		},
+	}
+
+	one := int32(1)
+	for _, tc := range testCases {
+		claim := v1.PersistentVolumeClaim{}
+		claim.Name = "target-claim"
+		pod := v1.Pod{}
+		pod.Name = "pod-1"
+		pod.GetObjectMeta().SetUID("pod-123")
+		set := apps.StatefulSet{}
+		set.Name = "stateful-set"
+		set.GetObjectMeta().SetUID("ss-456")
+		set.Spec.PersistentVolumeClaimRetentionPolicy = &tc.policy
+		set.Spec.Replicas = &one
+		claim.SetOwnerReferences(tc.ownerRefs)
+		got := isClaimOwnerUpToDate(logger, &claim, &set, &pod)
+		if got != tc.shouldMatch {
+			t.Errorf("Unexpected match for %s, got %t expected %t", tc.name, got, tc.shouldMatch)
+		}
+	}
+}
+
+func TestUpdateClaimOwnerRefForSetAndPod(t *testing.T) {
+	trueVar := true
+	testCases := []struct {
+		name                 string
+		scaleDownPolicy      apps.PersistentVolumeClaimRetentionPolicyType
+		setDeletePolicy      apps.PersistentVolumeClaimRetentionPolicyType
+		condemned            bool
+		needsPodRef          bool
+		needsSetRef          bool
+		unexpectedController bool
 	}{
 		{
 			name:            "retain",
@@ -417,71 +768,664 @@ func TestUpdateClaimOwnerRefForSetAndPod(t *testing.T) {
 			needsPodRef:     true,
 			needsSetRef:     false,
 		},
+		{
+			name:                 "unexpected controller",
+			scaleDownPolicy:      apps.DeletePersistentVolumeClaimRetentionPolicyType,
+			setDeletePolicy:      apps.DeletePersistentVolumeClaimRetentionPolicyType,
+			condemned:            true,
+			needsPodRef:          false,
+			needsSetRef:          false,
+			unexpectedController: true,
+		},
 	}
 	for _, tc := range testCases {
-		for _, hasPodRef := range []bool{true, false} {
-			for _, hasSetRef := range []bool{true, false} {
-				_, ctx := ktesting.NewTestContext(t)
-				logger := klog.FromContext(ctx)
-				set := apps.StatefulSet{}
-				set.Name = "ss"
-				numReplicas := int32(5)
-				set.Spec.Replicas = &numReplicas
-				set.SetUID("ss-123")
-				set.Spec.PersistentVolumeClaimRetentionPolicy = &apps.StatefulSetPersistentVolumeClaimRetentionPolicy{
-					WhenScaled:  tc.scaleDownPolicy,
-					WhenDeleted: tc.setDeletePolicy,
-				}
-				pod := v1.Pod{}
-				if tc.condemned {
-					pod.Name = "pod-8"
-				} else {
-					pod.Name = "pod-1"
-				}
-				pod.SetUID("pod-456")
-				claim := v1.PersistentVolumeClaim{}
-				if hasPodRef {
-					setOwnerRef(&claim, &pod, &pod.TypeMeta)
-				}
-				if hasSetRef {
-					setOwnerRef(&claim, &set, &set.TypeMeta)
-				}
-				needsUpdate := hasPodRef != tc.needsPodRef || hasSetRef != tc.needsSetRef
-				shouldUpdate := updateClaimOwnerRefForSetAndPod(logger, &claim, &set, &pod)
-				if shouldUpdate != needsUpdate {
-					t.Errorf("Bad update for %s hasPodRef=%v hasSetRef=%v", tc.name, hasPodRef, hasSetRef)
-				}
-				if hasOwnerRef(&claim, &pod) != tc.needsPodRef {
-					t.Errorf("Bad pod ref for %s hasPodRef=%v hasSetRef=%v", tc.name, hasPodRef, hasSetRef)
-				}
-				if hasOwnerRef(&claim, &set) != tc.needsSetRef {
-					t.Errorf("Bad set ref for %s hasPodRef=%v hasSetRef=%v", tc.name, hasPodRef, hasSetRef)
-				}
+		for variations := 0; variations < 8; variations++ {
+			hasPodRef := (variations & 1) != 0
+			hasSetRef := (variations & 2) != 0
+			extraOwner := (variations & 3) != 0
+			_, ctx := ktesting.NewTestContext(t)
+			logger := klog.FromContext(ctx)
+			set := apps.StatefulSet{}
+			set.Name = "ss"
+			numReplicas := int32(5)
+			set.Spec.Replicas = &numReplicas
+			set.SetUID("ss-123")
+			set.Spec.PersistentVolumeClaimRetentionPolicy = &apps.StatefulSetPersistentVolumeClaimRetentionPolicy{
+				WhenScaled:  tc.scaleDownPolicy,
+				WhenDeleted: tc.setDeletePolicy,
 			}
+			pod := v1.Pod{}
+			if tc.condemned {
+				pod.Name = "pod-8"
+			} else {
+				pod.Name = "pod-1"
+			}
+			pod.SetUID("pod-456")
+			claim := v1.PersistentVolumeClaim{}
+			claimRefs := claim.GetOwnerReferences()
+			if hasPodRef {
+				claimRefs = addControllerRef(claimRefs, &pod, podKind)
+			}
+			if hasSetRef {
+				claimRefs = addControllerRef(claimRefs, &set, controllerKind)
+			}
+			if extraOwner {
+				// Note the extra owner should not affect our owner references.
+				claimRefs = append(claimRefs, metav1.OwnerReference{
+					APIVersion: "custom/v1",
+					Kind:       "random",
+					Name:       "random",
+					UID:        "abc",
+				})
+			}
+			if tc.unexpectedController {
+				claimRefs = append(claimRefs, metav1.OwnerReference{
+					APIVersion: "custom/v1",
+					Kind:       "Unknown",
+					Name:       "unknown",
+					UID:        "xyz",
+					Controller: &trueVar,
+				})
+			}
+			claim.SetOwnerReferences(claimRefs)
+			updateClaimOwnerRefForSetAndPod(logger, &claim, &set, &pod)
+			// Confirm that after the update, the specified owner is set as the only controller.
+			// Any other controllers will be cleaned update by the update.
+			check := func(target, owner metav1.Object) bool {
+				for _, ref := range target.GetOwnerReferences() {
+					if ref.UID == owner.GetUID() {
+						return ref.Controller != nil && *ref.Controller
+					}
+				}
+				return false
+			}
+			if check(&claim, &pod) != tc.needsPodRef {
+				t.Errorf("Bad pod ref for %s hasPodRef=%v hasSetRef=%v", tc.name, hasPodRef, hasSetRef)
+			}
+			if check(&claim, &set) != tc.needsSetRef {
+				t.Errorf("Bad set ref for %s hasPodRef=%v hasSetRef=%v", tc.name, hasPodRef, hasSetRef)
+			}
+		}
+	}
+}
+
+func TestUpdateClaimControllerRef(t *testing.T) {
+	trueVar := true
+	testCases := []struct {
+		name         string
+		originalRefs []metav1.OwnerReference
+		expectedRefs []metav1.OwnerReference
+	}{
+		{
+			name: "set correctly",
+			originalRefs: []metav1.OwnerReference{
+				{
+					APIVersion: "apps/v1",
+					Kind:       "StatefulSet",
+					Name:       "sts",
+					UID:        "123",
+					Controller: &trueVar,
+				},
+				{
+					APIVersion: "someone",
+					Kind:       "Else",
+					Name:       "foo",
+				},
+			},
+			expectedRefs: []metav1.OwnerReference{
+				{
+					APIVersion: "apps/v1",
+					Kind:       "StatefulSet",
+					Name:       "sts",
+					UID:        "123",
+					Controller: &trueVar,
+				},
+				{
+					APIVersion: "someone",
+					Kind:       "Else",
+					Name:       "foo",
+				},
+			},
+		},
+		{
+			name: "missing controller",
+			originalRefs: []metav1.OwnerReference{
+				{
+					APIVersion: "apps/v1",
+					Kind:       "StatefulSet",
+					Name:       "sts",
+					UID:        "123",
+				},
+			},
+			expectedRefs: []metav1.OwnerReference{
+				{
+					APIVersion: "apps/v1",
+					Kind:       "StatefulSet",
+					Name:       "sts",
+					UID:        "123",
+					Controller: &trueVar,
+				},
+			},
+		},
+		{
+			name: "matching name but missing",
+			originalRefs: []metav1.OwnerReference{
+				{
+					APIVersion: "someone",
+					Kind:       "else",
+					Name:       "sts",
+					UID:        "456",
+				},
+			},
+			expectedRefs: []metav1.OwnerReference{
+				{
+					APIVersion: "someone",
+					Kind:       "else",
+					Name:       "sts",
+					UID:        "456",
+				},
+				{
+					APIVersion: "apps/v1",
+					Kind:       "StatefulSet",
+					Name:       "sts",
+					UID:        "123",
+					Controller: &trueVar,
+				},
+			},
+		},
+		{
+			name:         "not present",
+			originalRefs: []metav1.OwnerReference{},
+			expectedRefs: []metav1.OwnerReference{
+				{
+					APIVersion: "apps/v1",
+					Kind:       "StatefulSet",
+					Name:       "sts",
+					UID:        "123",
+					Controller: &trueVar,
+				},
+			},
+		},
+		{
+			name: "controller, but no UID",
+			originalRefs: []metav1.OwnerReference{
+				{
+					APIVersion: "apps/v1",
+					Kind:       "StatefulSet",
+					Name:       "sts",
+					Controller: &trueVar,
+				},
+			},
+			// The missing UID is interpreted as an unexpected stale reference.
+			expectedRefs: []metav1.OwnerReference{},
+		},
+		{
+			name: "neither controller nor UID",
+			originalRefs: []metav1.OwnerReference{
+				{
+					APIVersion: "apps/v1",
+					Kind:       "StatefulSet",
+					Name:       "sts",
+				},
+			},
+			// The missing UID is interpreted as an unexpected stale reference.
+			expectedRefs: []metav1.OwnerReference{},
+		},
+	}
+	one := int32(1)
+	for _, tc := range testCases {
+		_, ctx := ktesting.NewTestContext(t)
+		logger := klog.FromContext(ctx)
+		set := apps.StatefulSet{}
+		set.Name = "sts"
+		set.Spec.Replicas = &one
+		set.SetUID("123")
+		set.Spec.PersistentVolumeClaimRetentionPolicy = &apps.StatefulSetPersistentVolumeClaimRetentionPolicy{
+			WhenScaled:  apps.DeletePersistentVolumeClaimRetentionPolicyType,
+			WhenDeleted: apps.DeletePersistentVolumeClaimRetentionPolicyType,
+		}
+		pod := v1.Pod{}
+		pod.Name = "pod-0"
+		pod.SetUID("456")
+		claim := v1.PersistentVolumeClaim{}
+		claim.SetOwnerReferences(tc.originalRefs)
+		updateClaimOwnerRefForSetAndPod(logger, &claim, &set, &pod)
+		if ownerRefsChanged(tc.expectedRefs, claim.GetOwnerReferences()) {
+			t.Errorf("%s: expected %v, got %v", tc.name, tc.expectedRefs, claim.GetOwnerReferences())
 		}
 	}
 }
 
 func TestHasOwnerRef(t *testing.T) {
 	target := v1.Pod{}
+	trueVar := true
+	falseVar := false
 	target.SetOwnerReferences([]metav1.OwnerReference{
-		{UID: "123"}, {UID: "456"}})
-	ownerA := v1.Pod{}
-	ownerA.GetObjectMeta().SetUID("123")
-	ownerB := v1.Pod{}
-	ownerB.GetObjectMeta().SetUID("789")
-	if !hasOwnerRef(&target, &ownerA) {
-		t.Error("Missing owner")
+		{UID: "123", Controller: &trueVar},
+		{UID: "456", Controller: &falseVar},
+		{UID: "789"},
+	})
+	testCases := []struct {
+		uid    types.UID
+		hasRef bool
+	}{
+		{
+			uid:    "123",
+			hasRef: true,
+		},
+		{
+			uid:    "456",
+			hasRef: true,
+		},
+		{
+			uid:    "789",
+			hasRef: true,
+		},
+		{
+			uid:    "012",
+			hasRef: false,
+		},
 	}
-	if hasOwnerRef(&target, &ownerB) {
-		t.Error("Unexpected owner")
+	for _, tc := range testCases {
+		owner := v1.Pod{}
+		owner.GetObjectMeta().SetUID(tc.uid)
+		got := hasOwnerRef(&target, &owner)
+		if got != tc.hasRef {
+			t.Errorf("Expected %t for %s, got %t", tc.hasRef, tc.uid, got)
+		}
+	}
+}
+
+func TestHasUnexpectedController(t *testing.T) {
+	trueVar := true
+	falseVar := false
+	// Each test case will be tested against a StatefulSet named "set" and a Pod named "pod" with UIDs "123".
+	testCases := []struct {
+		name                             string
+		refs                             []metav1.OwnerReference
+		shouldReportUnexpectedController bool
+	}{
+		{
+			name: "custom controller",
+			refs: []metav1.OwnerReference{
+				{
+					APIVersion: "chipmunks/v1",
+					Kind:       "CustomController",
+					Name:       "simon",
+					UID:        "other-uid",
+					Controller: &trueVar,
+				},
+			},
+			shouldReportUnexpectedController: true,
+		},
+		{
+			name: "custom non-controller",
+			refs: []metav1.OwnerReference{
+				{
+					APIVersion: "chipmunks/v1",
+					Kind:       "CustomController",
+					Name:       "simon",
+					UID:        "other-uid",
+					Controller: &falseVar,
+				},
+			},
+			shouldReportUnexpectedController: false,
+		},
+		{
+			name: "custom unspecified controller",
+			refs: []metav1.OwnerReference{
+				{
+					APIVersion: "chipmunks/v1",
+					Kind:       "CustomController",
+					Name:       "simon",
+					UID:        "other-uid",
+				},
+			},
+			shouldReportUnexpectedController: false,
+		},
+		{
+			name: "other pod controller",
+			refs: []metav1.OwnerReference{
+				{
+					APIVersion: "v1",
+					Kind:       "Pod",
+					Name:       "simon",
+					UID:        "other-uid",
+					Controller: &trueVar,
+				},
+			},
+			shouldReportUnexpectedController: true,
+		},
+		{
+			name: "other set controller",
+			refs: []metav1.OwnerReference{
+				{
+					APIVersion: "apps/v1",
+					Kind:       "Set",
+					Name:       "simon",
+					UID:        "other-uid",
+					Controller: &trueVar,
+				},
+			},
+			shouldReportUnexpectedController: true,
+		},
+		{
+			name: "own set controller",
+			refs: []metav1.OwnerReference{
+				{
+					APIVersion: "apps/v1",
+					Kind:       "StatefulSet",
+					Name:       "set",
+					UID:        "set-uid",
+					Controller: &trueVar,
+				},
+			},
+			shouldReportUnexpectedController: false,
+		},
+		{
+			name: "own set controller, stale uid",
+			refs: []metav1.OwnerReference{
+				{
+					APIVersion: "apps/v1",
+					Kind:       "StatefulSet",
+					Name:       "set",
+					UID:        "stale-uid",
+					Controller: &trueVar,
+				},
+			},
+			shouldReportUnexpectedController: true,
+		},
+		{
+			name: "own pod controller",
+			refs: []metav1.OwnerReference{
+				{
+					APIVersion: "v1",
+					Kind:       "Pod",
+					Name:       "pod",
+					UID:        "pod-uid",
+					Controller: &trueVar,
+				},
+			},
+			shouldReportUnexpectedController: false,
+		},
+		{
+			name: "own pod controller, stale uid",
+			refs: []metav1.OwnerReference{
+				{
+					APIVersion: "v1",
+					Kind:       "Pod",
+					Name:       "pod",
+					UID:        "stale-uid",
+					Controller: &trueVar,
+				},
+			},
+			shouldReportUnexpectedController: true,
+		},
+		{
+			// API validation should prevent two controllers from being set,
+			// but for completeness it is still tested.
+			name: "own controller and another",
+			refs: []metav1.OwnerReference{
+				{
+					APIVersion: "v1",
+					Kind:       "Pod",
+					Name:       "pod",
+					UID:        "pod-uid",
+					Controller: &trueVar,
+				},
+				{
+					APIVersion: "chipmunks/v1",
+					Kind:       "CustomController",
+					Name:       "simon",
+					UID:        "other-uid",
+					Controller: &trueVar,
+				},
+			},
+			shouldReportUnexpectedController: true,
+		},
+		{
+			name: "own controller and a non-controller",
+			refs: []metav1.OwnerReference{
+				{
+					APIVersion: "v1",
+					Kind:       "Pod",
+					Name:       "pod",
+					UID:        "pod-uid",
+					Controller: &trueVar,
+				},
+				{
+					APIVersion: "chipmunks/v1",
+					Kind:       "CustomController",
+					Name:       "simon",
+					UID:        "other-uid",
+					Controller: &falseVar,
+				},
+			},
+			shouldReportUnexpectedController: false,
+		},
+	}
+	for _, tc := range testCases {
+		target := &v1.PersistentVolumeClaim{}
+		target.SetOwnerReferences(tc.refs)
+		set := &apps.StatefulSet{}
+		set.SetName("set")
+		set.SetUID("set-uid")
+		pod := &v1.Pod{}
+		pod.SetName("pod")
+		pod.SetUID("pod-uid")
+		set.Spec.PersistentVolumeClaimRetentionPolicy = nil
+		if hasUnexpectedController(target, set, pod) {
+			t.Errorf("Any controller should be allowed when no retention policy (retain behavior) is specified. Incorrectly identified unexpected controller at %s", tc.name)
+		}
+		for _, policy := range []apps.StatefulSetPersistentVolumeClaimRetentionPolicy{
+			{WhenDeleted: "Retain", WhenScaled: "Delete"},
+			{WhenDeleted: "Delete", WhenScaled: "Retain"},
+			{WhenDeleted: "Delete", WhenScaled: "Delete"},
+		} {
+			set.Spec.PersistentVolumeClaimRetentionPolicy = &policy
+			got := hasUnexpectedController(target, set, pod)
+			if got != tc.shouldReportUnexpectedController {
+				t.Errorf("Unexpected controller mismatch at %s (policy %v)", tc.name, policy)
+			}
+		}
+	}
+}
+
+func TestNonController(t *testing.T) {
+	trueVar := true
+	falseVar := false
+	testCases := []struct {
+		name string
+		refs []metav1.OwnerReference
+		// The set and pod objets will be created with names "set" and "pod", respectively.
+		setUID        types.UID
+		podUID        types.UID
+		nonController bool
+	}{
+		{
+			// API validation should prevent two controllers from being set,
+			// but for completeness the semantics here are tested.
+			name: "set and pod controller",
+			refs: []metav1.OwnerReference{
+				{
+					APIVersion: "v1",
+					Kind:       "Pod",
+					Name:       "pod",
+					UID:        "pod",
+					Controller: &trueVar,
+				},
+				{
+					APIVersion: "apps/v1",
+					Kind:       "Set",
+					Name:       "set",
+					UID:        "set",
+					Controller: &trueVar,
+				},
+			},
+			setUID:        "set",
+			podUID:        "pod",
+			nonController: false,
+		},
+		{
+			name: "set controller, pod noncontroller",
+			refs: []metav1.OwnerReference{
+				{
+					APIVersion: "v1",
+					Kind:       "Pod",
+					Name:       "pod",
+					UID:        "pod",
+				},
+				{
+					APIVersion: "apps/v1",
+					Kind:       "Set",
+					Name:       "set",
+					UID:        "set",
+					Controller: &trueVar,
+				},
+			},
+			setUID:        "set",
+			podUID:        "pod",
+			nonController: true,
+		},
+		{
+			name: "set noncontroller, pod controller",
+			refs: []metav1.OwnerReference{
+				{
+					APIVersion: "v1",
+					Kind:       "Pod",
+					Name:       "pod",
+					UID:        "pod",
+					Controller: &trueVar,
+				},
+				{
+					APIVersion: "apps/v1",
+					Kind:       "Set",
+					Name:       "set",
+					UID:        "set",
+				},
+			},
+			setUID:        "set",
+			podUID:        "pod",
+			nonController: true,
+		},
+		{
+			name: "set controller",
+			refs: []metav1.OwnerReference{
+				{
+					APIVersion: "apps/v1",
+					Kind:       "Set",
+					Name:       "set",
+					UID:        "set",
+					Controller: &trueVar,
+				},
+			},
+			setUID:        "set",
+			podUID:        "pod",
+			nonController: false,
+		},
+		{
+			name: "pod controller",
+			refs: []metav1.OwnerReference{
+				{
+					APIVersion: "v1",
+					Kind:       "Pod",
+					Name:       "pod",
+					UID:        "pod",
+					Controller: &trueVar,
+				},
+			},
+			setUID:        "set",
+			podUID:        "pod",
+			nonController: false,
+		},
+		{
+			name:          "nothing",
+			refs:          []metav1.OwnerReference{},
+			setUID:        "set",
+			podUID:        "pod",
+			nonController: false,
+		},
+		{
+			name: "set noncontroller",
+			refs: []metav1.OwnerReference{
+				{
+					APIVersion: "apps/v1",
+					Kind:       "Set",
+					Name:       "set",
+					UID:        "set",
+				},
+			},
+			setUID:        "set",
+			podUID:        "pod",
+			nonController: true,
+		},
+		{
+			name: "set noncontroller with ptr",
+			refs: []metav1.OwnerReference{
+				{
+					APIVersion: "apps/v1",
+					Kind:       "Set",
+					Name:       "set",
+					UID:        "set",
+					Controller: &falseVar,
+				},
+			},
+			setUID:        "set",
+			podUID:        "pod",
+			nonController: true,
+		},
+		{
+			name: "pod noncontroller",
+			refs: []metav1.OwnerReference{
+				{
+					APIVersion: "v1",
+					Kind:       "pod",
+					Name:       "pod",
+					UID:        "pod",
+				},
+			},
+			setUID:        "set",
+			podUID:        "pod",
+			nonController: true,
+		},
+		{
+			name: "other noncontroller",
+			refs: []metav1.OwnerReference{
+				{
+					APIVersion: "v1",
+					Kind:       "pod",
+					Name:       "pod",
+					UID:        "not-matching",
+				},
+			},
+			setUID:        "set",
+			podUID:        "pod",
+			nonController: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		claim := v1.PersistentVolumeClaim{}
+		claim.SetOwnerReferences(tc.refs)
+		pod := v1.Pod{}
+		pod.SetUID(tc.podUID)
+		pod.SetName("pod")
+		set := apps.StatefulSet{}
+		set.SetUID(tc.setUID)
+		set.SetName("set")
+		got := hasNonControllerOwner(&claim, &set, &pod)
+		if got != tc.nonController {
+			t.Errorf("Failed %s: got %t, expected %t", tc.name, got, tc.nonController)
+		}
 	}
 }
 
 func TestHasStaleOwnerRef(t *testing.T) {
-	target := v1.Pod{}
+	target := v1.PersistentVolumeClaim{}
 	target.SetOwnerReferences([]metav1.OwnerReference{
-		{Name: "bob", UID: "123"}, {Name: "shirley", UID: "456"}})
+		{Name: "bob", UID: "123", APIVersion: "v1", Kind: "Pod"},
+		{Name: "shirley", UID: "456", APIVersion: "v1", Kind: "Pod"},
+	})
 	ownerA := v1.Pod{}
 	ownerA.SetUID("123")
 	ownerA.Name = "bob"
@@ -491,90 +1435,14 @@ func TestHasStaleOwnerRef(t *testing.T) {
 	ownerC := v1.Pod{}
 	ownerC.Name = "yvonne"
 	ownerC.SetUID("345")
-	if hasStaleOwnerRef(&target, &ownerA) {
+	if hasStaleOwnerRef(&target, &ownerA, podKind) {
 		t.Error("ownerA should not be stale")
 	}
-	if !hasStaleOwnerRef(&target, &ownerB) {
+	if !hasStaleOwnerRef(&target, &ownerB, podKind) {
 		t.Error("ownerB should be stale")
 	}
-	if hasStaleOwnerRef(&target, &ownerC) {
+	if hasStaleOwnerRef(&target, &ownerC, podKind) {
 		t.Error("ownerC should not be stale")
-	}
-}
-
-func TestSetOwnerRef(t *testing.T) {
-	target := v1.Pod{}
-	ownerA := v1.Pod{}
-	ownerA.Name = "A"
-	ownerA.GetObjectMeta().SetUID("ABC")
-	if setOwnerRef(&target, &ownerA, &ownerA.TypeMeta) != true {
-		t.Errorf("Unexpected lack of update")
-	}
-	ownerRefs := target.GetObjectMeta().GetOwnerReferences()
-	if len(ownerRefs) != 1 {
-		t.Errorf("Unexpected owner ref count: %d", len(ownerRefs))
-	}
-	if ownerRefs[0].UID != "ABC" {
-		t.Errorf("Unexpected owner UID %v", ownerRefs[0].UID)
-	}
-	if setOwnerRef(&target, &ownerA, &ownerA.TypeMeta) != false {
-		t.Errorf("Unexpected update")
-	}
-	if len(target.GetObjectMeta().GetOwnerReferences()) != 1 {
-		t.Error("Unexpected duplicate reference")
-	}
-	ownerB := v1.Pod{}
-	ownerB.Name = "B"
-	ownerB.GetObjectMeta().SetUID("BCD")
-	if setOwnerRef(&target, &ownerB, &ownerB.TypeMeta) != true {
-		t.Error("Unexpected lack of second update")
-	}
-	ownerRefs = target.GetObjectMeta().GetOwnerReferences()
-	if len(ownerRefs) != 2 {
-		t.Errorf("Unexpected owner ref count: %d", len(ownerRefs))
-	}
-	if ownerRefs[0].UID != "ABC" || ownerRefs[1].UID != "BCD" {
-		t.Errorf("Bad second ownerRefs: %v", ownerRefs)
-	}
-}
-
-func TestRemoveOwnerRef(t *testing.T) {
-	target := v1.Pod{}
-	ownerA := v1.Pod{}
-	ownerA.Name = "A"
-	ownerA.GetObjectMeta().SetUID("ABC")
-	if removeOwnerRef(&target, &ownerA) != false {
-		t.Error("Unexpected update on empty remove")
-	}
-	setOwnerRef(&target, &ownerA, &ownerA.TypeMeta)
-	if removeOwnerRef(&target, &ownerA) != true {
-		t.Error("Unexpected lack of update")
-	}
-	if len(target.GetObjectMeta().GetOwnerReferences()) != 0 {
-		t.Error("Unexpected owner reference remains")
-	}
-
-	ownerB := v1.Pod{}
-	ownerB.Name = "B"
-	ownerB.GetObjectMeta().SetUID("BCD")
-
-	setOwnerRef(&target, &ownerA, &ownerA.TypeMeta)
-	if removeOwnerRef(&target, &ownerB) != false {
-		t.Error("Unexpected update for mismatched owner")
-	}
-	if len(target.GetObjectMeta().GetOwnerReferences()) != 1 {
-		t.Error("Missing ref after no-op remove")
-	}
-	setOwnerRef(&target, &ownerB, &ownerB.TypeMeta)
-	if removeOwnerRef(&target, &ownerA) != true {
-		t.Error("Missing update for second remove")
-	}
-	ownerRefs := target.GetObjectMeta().GetOwnerReferences()
-	if len(ownerRefs) != 1 {
-		t.Error("Extra ref after second remove")
-	}
-	if ownerRefs[0].UID != "BCD" {
-		t.Error("Bad UID after second remove")
 	}
 }
 


### PR DESCRIPTION
Cherry-pick of #122499

/fixes #122400

/sig storage

```release-note
StatefulSet autodelete will respect controlling owners on PVC claims as described in https://github.com/kubernetes/enhancements/pull/4375

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
- [KEP] https://github.com/kubernetes/enhancements/issues/1847
- [Other doc]: https://github.com/kubernetes/enhancements/pull/4375 
```