### PR TITLE
Allow kubectl to wait for any one of multiple conditions, delimited by a comma

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/wait/condition.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/wait/condition.go
@@ -58,10 +58,11 @@ func (w ConditionalWait) checkCondition(obj *unstructured.Unstructured) (bool, e
 	if !found {
 		return false, nil
 	}
+	conditionNames := strings.Split(w.conditionName, ",")
 	for _, conditionUncast := range conditions {
 		condition := conditionUncast.(map[string]interface{})
 		name, found, err := unstructured.NestedString(condition, "type")
-		if !found || err != nil || !strings.EqualFold(name, w.conditionName) {
+		if !found || err != nil || !containsEqualFold(conditionNames, name) {
 			continue
 		}
 		status, found, err := unstructured.NestedString(condition, "status")
@@ -79,6 +80,15 @@ func (w ConditionalWait) checkCondition(obj *unstructured.Unstructured) (bool, e
 	}
 
 	return false, nil
+}
+
+func containsEqualFold(slice []string, s string) bool {
+	for _, item := range slice {
+		if strings.EqualFold(item, s) {
+			return true
+		}
+	}
+	return false
 }
 
 func (w ConditionalWait) isConditionMet(event watch.Event) (bool, error) {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/wait/wait.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/wait/wait.go
@@ -64,6 +64,9 @@ var (
 		# The default value of status condition is true; you can wait for other targets after an equal delimiter (compared after Unicode simple case folding, which is a more general form of case-insensitivity)
 		kubectl wait --for=condition=Ready=false pod/busybox1
 
+		# Wait for any one of multiple conditions by separating them with a comma
+		kubectl wait --for=condition=Complete,Failed job/somejob
+
 		# Wait for the pod "busybox1" to contain the status phase to be "Running"
 		kubectl wait --for=jsonpath='{.status.phase}'=Running pod/busybox1
 


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
kubectl provides a way to wait for a single condition, but in some cases, like waiting for a job to complete or fail, you need to be able to wait for any one of multiple conditions.

This PR takes a simple approach to this by allowing you to provide a comma-delimited string for condition, in which case it will wait until one of the specified conditions is met.

Usage would be like this:
```
kubectl wait --for=condition=Complete,Failed job/somejob
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
I'm creating this as a draft, to get feedback on this approach

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
