### PR TITLE
add ordered set

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/sets/byte.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/sets/byte.go
@@ -18,10 +18,10 @@ package sets
 
 // Byte is a set of bytes, implemented via map[byte]struct{} for minimal memory consumption.
 //
-// Deprecated: use generic Set instead.
+// Deprecated: use generic OrderedSet instead.
 // new ways:
-// s1 := Set[byte]{}
-// s2 := New[byte]()
+// s1 := OrderedSet[byte]{}
+// s2 := NewOrdered[byte]()
 type Byte map[byte]Empty
 
 // NewByte creates a Byte from a list of values.

--- a/staging/src/k8s.io/apimachinery/pkg/util/sets/byte.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/sets/byte.go
@@ -22,7 +22,7 @@ package sets
 // new ways:
 // s1 := OrderedSet[byte]{}
 // s2 := NewOrdered[byte]()
-type Byte map[byte]Empty
+type Byte = OrderedSet[byte]
 
 // NewByte creates a Byte from a list of values.
 func NewByte(items ...byte) Byte {
@@ -33,105 +33,4 @@ func NewByte(items ...byte) Byte {
 // If the value passed in is not actually a map, this will panic.
 func ByteKeySet[T any](theMap map[byte]T) Byte {
 	return Byte(KeySet(theMap))
-}
-
-// Insert adds items to the set.
-func (s Byte) Insert(items ...byte) Byte {
-	return Byte(cast(s).Insert(items...))
-}
-
-// Delete removes all items from the set.
-func (s Byte) Delete(items ...byte) Byte {
-	return Byte(cast(s).Delete(items...))
-}
-
-// Has returns true if and only if item is contained in the set.
-func (s Byte) Has(item byte) bool {
-	return cast(s).Has(item)
-}
-
-// HasAll returns true if and only if all items are contained in the set.
-func (s Byte) HasAll(items ...byte) bool {
-	return cast(s).HasAll(items...)
-}
-
-// HasAny returns true if any items are contained in the set.
-func (s Byte) HasAny(items ...byte) bool {
-	return cast(s).HasAny(items...)
-}
-
-// Clone returns a new set which is a copy of the current set.
-func (s Byte) Clone() Byte {
-	return Byte(cast(s).Clone())
-}
-
-// Difference returns a set of objects that are not in s2.
-// For example:
-// s1 = {a1, a2, a3}
-// s2 = {a1, a2, a4, a5}
-// s1.Difference(s2) = {a3}
-// s2.Difference(s1) = {a4, a5}
-func (s1 Byte) Difference(s2 Byte) Byte {
-	return Byte(cast(s1).Difference(cast(s2)))
-}
-
-// SymmetricDifference returns a set of elements which are in either of the sets, but not in their intersection.
-// For example:
-// s1 = {a1, a2, a3}
-// s2 = {a1, a2, a4, a5}
-// s1.SymmetricDifference(s2) = {a3, a4, a5}
-// s2.SymmetricDifference(s1) = {a3, a4, a5}
-func (s1 Byte) SymmetricDifference(s2 Byte) Byte {
-	return Byte(cast(s1).SymmetricDifference(cast(s2)))
-}
-
-// Union returns a new set which includes items in either s1 or s2.
-// For example:
-// s1 = {a1, a2}
-// s2 = {a3, a4}
-// s1.Union(s2) = {a1, a2, a3, a4}
-// s2.Union(s1) = {a1, a2, a3, a4}
-func (s1 Byte) Union(s2 Byte) Byte {
-	return Byte(cast(s1).Union(cast(s2)))
-}
-
-// Intersection returns a new set which includes the item in BOTH s1 and s2
-// For example:
-// s1 = {a1, a2}
-// s2 = {a2, a3}
-// s1.Intersection(s2) = {a2}
-func (s1 Byte) Intersection(s2 Byte) Byte {
-	return Byte(cast(s1).Intersection(cast(s2)))
-}
-
-// IsSuperset returns true if and only if s1 is a superset of s2.
-func (s1 Byte) IsSuperset(s2 Byte) bool {
-	return cast(s1).IsSuperset(cast(s2))
-}
-
-// Equal returns true if and only if s1 is equal (as a set) to s2.
-// Two sets are equal if their membership is identical.
-// (In practice, this means same elements, order doesn't matter)
-func (s1 Byte) Equal(s2 Byte) bool {
-	return cast(s1).Equal(cast(s2))
-}
-
-// List returns the contents as a sorted byte slice.
-func (s Byte) List() []byte {
-	return List(cast(s))
-}
-
-// UnsortedList returns the slice with contents in random order.
-func (s Byte) UnsortedList() []byte {
-	return cast(s).UnsortedList()
-}
-
-// PopAny returns a single element from the set.
-func (s Byte) PopAny() (byte, bool) {
-	return cast(s).PopAny()
-}
-
-// Len returns the size of the set.
-func (s Byte) Len() int {
-	return len(s)
 }

--- a/staging/src/k8s.io/apimachinery/pkg/util/sets/int.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/sets/int.go
@@ -22,7 +22,7 @@ package sets
 // new ways:
 // s1 := OrderedSet[int]{}
 // s2 := NewOrdered[int]()
-type Int map[int]Empty
+type Int = OrderedSet[int]
 
 // NewInt creates a Int from a list of values.
 func NewInt(items ...int) Int {
@@ -33,105 +33,4 @@ func NewInt(items ...int) Int {
 // If the value passed in is not actually a map, this will panic.
 func IntKeySet[T any](theMap map[int]T) Int {
 	return Int(KeySet(theMap))
-}
-
-// Insert adds items to the set.
-func (s Int) Insert(items ...int) Int {
-	return Int(cast(s).Insert(items...))
-}
-
-// Delete removes all items from the set.
-func (s Int) Delete(items ...int) Int {
-	return Int(cast(s).Delete(items...))
-}
-
-// Has returns true if and only if item is contained in the set.
-func (s Int) Has(item int) bool {
-	return cast(s).Has(item)
-}
-
-// HasAll returns true if and only if all items are contained in the set.
-func (s Int) HasAll(items ...int) bool {
-	return cast(s).HasAll(items...)
-}
-
-// HasAny returns true if any items are contained in the set.
-func (s Int) HasAny(items ...int) bool {
-	return cast(s).HasAny(items...)
-}
-
-// Clone returns a new set which is a copy of the current set.
-func (s Int) Clone() Int {
-	return Int(cast(s).Clone())
-}
-
-// Difference returns a set of objects that are not in s2.
-// For example:
-// s1 = {a1, a2, a3}
-// s2 = {a1, a2, a4, a5}
-// s1.Difference(s2) = {a3}
-// s2.Difference(s1) = {a4, a5}
-func (s1 Int) Difference(s2 Int) Int {
-	return Int(cast(s1).Difference(cast(s2)))
-}
-
-// SymmetricDifference returns a set of elements which are in either of the sets, but not in their intersection.
-// For example:
-// s1 = {a1, a2, a3}
-// s2 = {a1, a2, a4, a5}
-// s1.SymmetricDifference(s2) = {a3, a4, a5}
-// s2.SymmetricDifference(s1) = {a3, a4, a5}
-func (s1 Int) SymmetricDifference(s2 Int) Int {
-	return Int(cast(s1).SymmetricDifference(cast(s2)))
-}
-
-// Union returns a new set which includes items in either s1 or s2.
-// For example:
-// s1 = {a1, a2}
-// s2 = {a3, a4}
-// s1.Union(s2) = {a1, a2, a3, a4}
-// s2.Union(s1) = {a1, a2, a3, a4}
-func (s1 Int) Union(s2 Int) Int {
-	return Int(cast(s1).Union(cast(s2)))
-}
-
-// Intersection returns a new set which includes the item in BOTH s1 and s2
-// For example:
-// s1 = {a1, a2}
-// s2 = {a2, a3}
-// s1.Intersection(s2) = {a2}
-func (s1 Int) Intersection(s2 Int) Int {
-	return Int(cast(s1).Intersection(cast(s2)))
-}
-
-// IsSuperset returns true if and only if s1 is a superset of s2.
-func (s1 Int) IsSuperset(s2 Int) bool {
-	return cast(s1).IsSuperset(cast(s2))
-}
-
-// Equal returns true if and only if s1 is equal (as a set) to s2.
-// Two sets are equal if their membership is identical.
-// (In practice, this means same elements, order doesn't matter)
-func (s1 Int) Equal(s2 Int) bool {
-	return cast(s1).Equal(cast(s2))
-}
-
-// List returns the contents as a sorted int slice.
-func (s Int) List() []int {
-	return List(cast(s))
-}
-
-// UnsortedList returns the slice with contents in random order.
-func (s Int) UnsortedList() []int {
-	return cast(s).UnsortedList()
-}
-
-// PopAny returns a single element from the set.
-func (s Int) PopAny() (int, bool) {
-	return cast(s).PopAny()
-}
-
-// Len returns the size of the set.
-func (s Int) Len() int {
-	return len(s)
 }

--- a/staging/src/k8s.io/apimachinery/pkg/util/sets/int.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/sets/int.go
@@ -18,10 +18,10 @@ package sets
 
 // Int is a set of ints, implemented via map[int]struct{} for minimal memory consumption.
 //
-// Deprecated: use generic Set instead.
+// Deprecated: use generic OrderedSet instead.
 // new ways:
-// s1 := Set[int]{}
-// s2 := New[int]()
+// s1 := OrderedSet[int]{}
+// s2 := NewOrdered[int]()
 type Int map[int]Empty
 
 // NewInt creates a Int from a list of values.

--- a/staging/src/k8s.io/apimachinery/pkg/util/sets/int32.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/sets/int32.go
@@ -22,7 +22,7 @@ package sets
 // new ways:
 // s1 := OrderedSet[int32]{}
 // s2 := NewOrdered[int32]()
-type Int32 map[int32]Empty
+type Int32 = OrderedSet[int32]
 
 // NewInt32 creates a Int32 from a list of values.
 func NewInt32(items ...int32) Int32 {
@@ -33,105 +33,4 @@ func NewInt32(items ...int32) Int32 {
 // If the value passed in is not actually a map, this will panic.
 func Int32KeySet[T any](theMap map[int32]T) Int32 {
 	return Int32(KeySet(theMap))
-}
-
-// Insert adds items to the set.
-func (s Int32) Insert(items ...int32) Int32 {
-	return Int32(cast(s).Insert(items...))
-}
-
-// Delete removes all items from the set.
-func (s Int32) Delete(items ...int32) Int32 {
-	return Int32(cast(s).Delete(items...))
-}
-
-// Has returns true if and only if item is contained in the set.
-func (s Int32) Has(item int32) bool {
-	return cast(s).Has(item)
-}
-
-// HasAll returns true if and only if all items are contained in the set.
-func (s Int32) HasAll(items ...int32) bool {
-	return cast(s).HasAll(items...)
-}
-
-// HasAny returns true if any items are contained in the set.
-func (s Int32) HasAny(items ...int32) bool {
-	return cast(s).HasAny(items...)
-}
-
-// Clone returns a new set which is a copy of the current set.
-func (s Int32) Clone() Int32 {
-	return Int32(cast(s).Clone())
-}
-
-// Difference returns a set of objects that are not in s2.
-// For example:
-// s1 = {a1, a2, a3}
-// s2 = {a1, a2, a4, a5}
-// s1.Difference(s2) = {a3}
-// s2.Difference(s1) = {a4, a5}
-func (s1 Int32) Difference(s2 Int32) Int32 {
-	return Int32(cast(s1).Difference(cast(s2)))
-}
-
-// SymmetricDifference returns a set of elements which are in either of the sets, but not in their intersection.
-// For example:
-// s1 = {a1, a2, a3}
-// s2 = {a1, a2, a4, a5}
-// s1.SymmetricDifference(s2) = {a3, a4, a5}
-// s2.SymmetricDifference(s1) = {a3, a4, a5}
-func (s1 Int32) SymmetricDifference(s2 Int32) Int32 {
-	return Int32(cast(s1).SymmetricDifference(cast(s2)))
-}
-
-// Union returns a new set which includes items in either s1 or s2.
-// For example:
-// s1 = {a1, a2}
-// s2 = {a3, a4}
-// s1.Union(s2) = {a1, a2, a3, a4}
-// s2.Union(s1) = {a1, a2, a3, a4}
-func (s1 Int32) Union(s2 Int32) Int32 {
-	return Int32(cast(s1).Union(cast(s2)))
-}
-
-// Intersection returns a new set which includes the item in BOTH s1 and s2
-// For example:
-// s1 = {a1, a2}
-// s2 = {a2, a3}
-// s1.Intersection(s2) = {a2}
-func (s1 Int32) Intersection(s2 Int32) Int32 {
-	return Int32(cast(s1).Intersection(cast(s2)))
-}
-
-// IsSuperset returns true if and only if s1 is a superset of s2.
-func (s1 Int32) IsSuperset(s2 Int32) bool {
-	return cast(s1).IsSuperset(cast(s2))
-}
-
-// Equal returns true if and only if s1 is equal (as a set) to s2.
-// Two sets are equal if their membership is identical.
-// (In practice, this means same elements, order doesn't matter)
-func (s1 Int32) Equal(s2 Int32) bool {
-	return cast(s1).Equal(cast(s2))
-}
-
-// List returns the contents as a sorted int32 slice.
-func (s Int32) List() []int32 {
-	return List(cast(s))
-}
-
-// UnsortedList returns the slice with contents in random order.
-func (s Int32) UnsortedList() []int32 {
-	return cast(s).UnsortedList()
-}
-
-// PopAny returns a single element from the set.
-func (s Int32) PopAny() (int32, bool) {
-	return cast(s).PopAny()
-}
-
-// Len returns the size of the set.
-func (s Int32) Len() int {
-	return len(s)
 }

--- a/staging/src/k8s.io/apimachinery/pkg/util/sets/int32.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/sets/int32.go
@@ -18,10 +18,10 @@ package sets
 
 // Int32 is a set of int32s, implemented via map[int32]struct{} for minimal memory consumption.
 //
-// Deprecated: use generic Set instead.
+// Deprecated: use generic OrderedSet instead.
 // new ways:
-// s1 := Set[int32]{}
-// s2 := New[int32]()
+// s1 := OrderedSet[int32]{}
+// s2 := NewOrdered[int32]()
 type Int32 map[int32]Empty
 
 // NewInt32 creates a Int32 from a list of values.

--- a/staging/src/k8s.io/apimachinery/pkg/util/sets/int64.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/sets/int64.go
@@ -22,7 +22,7 @@ package sets
 // new ways:
 // s1 := OrderedSet[int64]{}
 // s2 := NewOrdered[int64]()
-type Int64 map[int64]Empty
+type Int64 = OrderedSet[int64]
 
 // NewInt64 creates a Int64 from a list of values.
 func NewInt64(items ...int64) Int64 {
@@ -33,105 +33,4 @@ func NewInt64(items ...int64) Int64 {
 // If the value passed in is not actually a map, this will panic.
 func Int64KeySet[T any](theMap map[int64]T) Int64 {
 	return Int64(KeySet(theMap))
-}
-
-// Insert adds items to the set.
-func (s Int64) Insert(items ...int64) Int64 {
-	return Int64(cast(s).Insert(items...))
-}
-
-// Delete removes all items from the set.
-func (s Int64) Delete(items ...int64) Int64 {
-	return Int64(cast(s).Delete(items...))
-}
-
-// Has returns true if and only if item is contained in the set.
-func (s Int64) Has(item int64) bool {
-	return cast(s).Has(item)
-}
-
-// HasAll returns true if and only if all items are contained in the set.
-func (s Int64) HasAll(items ...int64) bool {
-	return cast(s).HasAll(items...)
-}
-
-// HasAny returns true if any items are contained in the set.
-func (s Int64) HasAny(items ...int64) bool {
-	return cast(s).HasAny(items...)
-}
-
-// Clone returns a new set which is a copy of the current set.
-func (s Int64) Clone() Int64 {
-	return Int64(cast(s).Clone())
-}
-
-// Difference returns a set of objects that are not in s2.
-// For example:
-// s1 = {a1, a2, a3}
-// s2 = {a1, a2, a4, a5}
-// s1.Difference(s2) = {a3}
-// s2.Difference(s1) = {a4, a5}
-func (s1 Int64) Difference(s2 Int64) Int64 {
-	return Int64(cast(s1).Difference(cast(s2)))
-}
-
-// SymmetricDifference returns a set of elements which are in either of the sets, but not in their intersection.
-// For example:
-// s1 = {a1, a2, a3}
-// s2 = {a1, a2, a4, a5}
-// s1.SymmetricDifference(s2) = {a3, a4, a5}
-// s2.SymmetricDifference(s1) = {a3, a4, a5}
-func (s1 Int64) SymmetricDifference(s2 Int64) Int64 {
-	return Int64(cast(s1).SymmetricDifference(cast(s2)))
-}
-
-// Union returns a new set which includes items in either s1 or s2.
-// For example:
-// s1 = {a1, a2}
-// s2 = {a3, a4}
-// s1.Union(s2) = {a1, a2, a3, a4}
-// s2.Union(s1) = {a1, a2, a3, a4}
-func (s1 Int64) Union(s2 Int64) Int64 {
-	return Int64(cast(s1).Union(cast(s2)))
-}
-
-// Intersection returns a new set which includes the item in BOTH s1 and s2
-// For example:
-// s1 = {a1, a2}
-// s2 = {a2, a3}
-// s1.Intersection(s2) = {a2}
-func (s1 Int64) Intersection(s2 Int64) Int64 {
-	return Int64(cast(s1).Intersection(cast(s2)))
-}
-
-// IsSuperset returns true if and only if s1 is a superset of s2.
-func (s1 Int64) IsSuperset(s2 Int64) bool {
-	return cast(s1).IsSuperset(cast(s2))
-}
-
-// Equal returns true if and only if s1 is equal (as a set) to s2.
-// Two sets are equal if their membership is identical.
-// (In practice, this means same elements, order doesn't matter)
-func (s1 Int64) Equal(s2 Int64) bool {
-	return cast(s1).Equal(cast(s2))
-}
-
-// List returns the contents as a sorted int64 slice.
-func (s Int64) List() []int64 {
-	return List(cast(s))
-}
-
-// UnsortedList returns the slice with contents in random order.
-func (s Int64) UnsortedList() []int64 {
-	return cast(s).UnsortedList()
-}
-
-// PopAny returns a single element from the set.
-func (s Int64) PopAny() (int64, bool) {
-	return cast(s).PopAny()
-}
-
-// Len returns the size of the set.
-func (s Int64) Len() int {
-	return len(s)
 }

--- a/staging/src/k8s.io/apimachinery/pkg/util/sets/int64.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/sets/int64.go
@@ -18,10 +18,10 @@ package sets
 
 // Int64 is a set of int64s, implemented via map[int64]struct{} for minimal memory consumption.
 //
-// Deprecated: use generic Set instead.
+// Deprecated: use generic OrderedSet instead.
 // new ways:
-// s1 := Set[int64]{}
-// s2 := New[int64]()
+// s1 := OrderedSet[int64]{}
+// s2 := NewOrdered[int64]()
 type Int64 map[int64]Empty
 
 // NewInt64 creates a Int64 from a list of values.

--- a/staging/src/k8s.io/apimachinery/pkg/util/sets/set.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/sets/set.go
@@ -24,6 +24,11 @@ import (
 // Set is a set of the same type elements, implemented via map[comparable]struct{} for minimal memory consumption.
 type Set[T comparable] map[T]Empty
 
+// OrderedSet is the ordered set type
+type OrderedSet[T cmp.Ordered] struct {
+	Set[T]
+}
+
 // cast transforms specified set to generic Set[T].
 func cast[T comparable](s map[T]Empty) Set[T] { return s }
 
@@ -33,6 +38,14 @@ func New[T comparable](items ...T) Set[T] {
 	ss := make(Set[T], len(items))
 	ss.Insert(items...)
 	return ss
+}
+
+// NewOrdered creates a Set from a list of values.
+// NOTE: type param must be explicitly instantiated if given items are empty.
+func NewOrdered[T cmp.Ordered](items ...T) OrderedSet[T] {
+	ss := make(Set[T], len(items))
+	ss.Insert(items...)
+	return OrderedSet[T]{ss}
 }
 
 // KeySet creates a Set from a keys of a map[comparable](? extends interface{}).
@@ -205,6 +218,10 @@ func List[T cmp.Ordered](s Set[T]) []T {
 	}
 	sort.Sort(res)
 	return res
+}
+
+func (s OrderedSet[T]) List() []T {
+	return List((s.Set))
 }
 
 // UnsortedList returns the slice with contents in random order.

--- a/staging/src/k8s.io/apimachinery/pkg/util/sets/set.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/sets/set.go
@@ -24,9 +24,6 @@ import (
 // Set is a set of the same type elements, implemented via map[comparable]struct{} for minimal memory consumption.
 type Set[T comparable] map[T]Empty
 
-// cast transforms specified set to generic Set[T].
-func cast[T comparable](s map[T]Empty) Set[T] { return s }
-
 // New creates a Set from a list of values.
 // NOTE: type param must be explicitly instantiated if given items are empty.
 func New[T comparable](items ...T) Set[T] {

--- a/staging/src/k8s.io/apimachinery/pkg/util/sets/set_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/sets/set_test.go
@@ -99,6 +99,13 @@ func TestStringSetList(t *testing.T) {
 	if !reflect.DeepEqual(s.List(), []string{"a", "x", "y", "z"}) {
 		t.Errorf("List gave unexpected result: %#v", s.List())
 	}
+
+	styped := NewOrdered("z", "y", "x", "a")
+
+	if !reflect.DeepEqual(styped.List(), []string{"a", "x", "y", "z"}) {
+		t.Errorf("List gave unexpected result: %#v", styped.List())
+	}
+
 }
 
 func TestStringSetDifference(t *testing.T) {

--- a/staging/src/k8s.io/apimachinery/pkg/util/sets/string.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/sets/string.go
@@ -22,7 +22,7 @@ package sets
 // new ways:
 // s1 := OrderedSet[string]{}
 // s2 := NewOrdered[string]()
-type String map[string]Empty
+type String = OrderedSet[string]
 
 // NewString creates a String from a list of values.
 func NewString(items ...string) String {
@@ -33,105 +33,4 @@ func NewString(items ...string) String {
 // If the value passed in is not actually a map, this will panic.
 func StringKeySet[T any](theMap map[string]T) String {
 	return String(KeySet(theMap))
-}
-
-// Insert adds items to the set.
-func (s String) Insert(items ...string) String {
-	return String(cast(s).Insert(items...))
-}
-
-// Delete removes all items from the set.
-func (s String) Delete(items ...string) String {
-	return String(cast(s).Delete(items...))
-}
-
-// Has returns true if and only if item is contained in the set.
-func (s String) Has(item string) bool {
-	return cast(s).Has(item)
-}
-
-// HasAll returns true if and only if all items are contained in the set.
-func (s String) HasAll(items ...string) bool {
-	return cast(s).HasAll(items...)
-}
-
-// HasAny returns true if any items are contained in the set.
-func (s String) HasAny(items ...string) bool {
-	return cast(s).HasAny(items...)
-}
-
-// Clone returns a new set which is a copy of the current set.
-func (s String) Clone() String {
-	return String(cast(s).Clone())
-}
-
-// Difference returns a set of objects that are not in s2.
-// For example:
-// s1 = {a1, a2, a3}
-// s2 = {a1, a2, a4, a5}
-// s1.Difference(s2) = {a3}
-// s2.Difference(s1) = {a4, a5}
-func (s1 String) Difference(s2 String) String {
-	return String(cast(s1).Difference(cast(s2)))
-}
-
-// SymmetricDifference returns a set of elements which are in either of the sets, but not in their intersection.
-// For example:
-// s1 = {a1, a2, a3}
-// s2 = {a1, a2, a4, a5}
-// s1.SymmetricDifference(s2) = {a3, a4, a5}
-// s2.SymmetricDifference(s1) = {a3, a4, a5}
-func (s1 String) SymmetricDifference(s2 String) String {
-	return String(cast(s1).SymmetricDifference(cast(s2)))
-}
-
-// Union returns a new set which includes items in either s1 or s2.
-// For example:
-// s1 = {a1, a2}
-// s2 = {a3, a4}
-// s1.Union(s2) = {a1, a2, a3, a4}
-// s2.Union(s1) = {a1, a2, a3, a4}
-func (s1 String) Union(s2 String) String {
-	return String(cast(s1).Union(cast(s2)))
-}
-
-// Intersection returns a new set which includes the item in BOTH s1 and s2
-// For example:
-// s1 = {a1, a2}
-// s2 = {a2, a3}
-// s1.Intersection(s2) = {a2}
-func (s1 String) Intersection(s2 String) String {
-	return String(cast(s1).Intersection(cast(s2)))
-}
-
-// IsSuperset returns true if and only if s1 is a superset of s2.
-func (s1 String) IsSuperset(s2 String) bool {
-	return cast(s1).IsSuperset(cast(s2))
-}
-
-// Equal returns true if and only if s1 is equal (as a set) to s2.
-// Two sets are equal if their membership is identical.
-// (In practice, this means same elements, order doesn't matter)
-func (s1 String) Equal(s2 String) bool {
-	return cast(s1).Equal(cast(s2))
-}
-
-// List returns the contents as a sorted string slice.
-func (s String) List() []string {
-	return List(cast(s))
-}
-
-// UnsortedList returns the slice with contents in random order.
-func (s String) UnsortedList() []string {
-	return cast(s).UnsortedList()
-}
-
-// PopAny returns a single element from the set.
-func (s String) PopAny() (string, bool) {
-	return cast(s).PopAny()
-}
-
-// Len returns the size of the set.
-func (s String) Len() int {
-	return len(s)
 }

--- a/staging/src/k8s.io/apimachinery/pkg/util/sets/string.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/sets/string.go
@@ -18,10 +18,10 @@ package sets
 
 // String is a set of strings, implemented via map[string]struct{} for minimal memory consumption.
 //
-// Deprecated: use generic Set instead.
+// Deprecated: use generic OrderedSet instead.
 // new ways:
-// s1 := Set[string]{}
-// s2 := New[string]()
+// s1 := OrderedSet[string]{}
+// s2 := NewOrdered[string]()
 type String map[string]Empty
 
 // NewString creates a String from a list of values.

--- a/staging/src/k8s.io/apimachinery/pkg/util/sets/string.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/sets/string.go
@@ -18,10 +18,10 @@ package sets
 
 // String is a set of strings, implemented via map[string]struct{} for minimal memory consumption.
 //
-// Deprecated: use generic OrderedSet instead.
+// Deprecated: use generic Set instead.
 // new ways:
-// s1 := OrderedSet[string]{}
-// s2 := NewOrdered[string]()
+// s1 := Set[string]{}
+// s2 := New[string]()
 type String map[string]Empty
 
 // NewString creates a String from a list of values.


### PR DESCRIPTION
#### What type of PR is this?


Add one of the following kinds:
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind deprecation


#### What this PR does / why we need it:
use generic OrderedSet instead of sets.String, sets.Int. So the List() method just works, not just the List() function.

so we can just replace sets.String with sets.Set[string] .
