### PR TITLE
[WIP] [FG:InPlacePodVerticalScaling] Pass only admitted resize request to pod workers

### DIFF
--- a/pkg/kubelet/status/fake_status_manager.go
+++ b/pkg/kubelet/status/fake_status_manager.go
@@ -70,7 +70,7 @@ func (m *fakeManager) GetContainerResourceAllocation(podUID string, containerNam
 
 func (m *fakeManager) GetPodResizeStatus(podUID string) (v1.PodResizeStatus, bool) {
 	klog.InfoS("GetPodResizeStatus()")
-	return "", false
+	return m.state.GetPodResizeStatus(podUID)
 }
 
 func (m *fakeManager) SetPodAllocation(pod *v1.Pod) error {
@@ -87,7 +87,7 @@ func (m *fakeManager) SetPodAllocation(pod *v1.Pod) error {
 
 func (m *fakeManager) SetPodResizeStatus(podUID types.UID, resizeStatus v1.PodResizeStatus) error {
 	klog.InfoS("SetPodResizeStatus()")
-	return nil
+	return m.state.SetPodResizeStatus(string(podUID), resizeStatus)
 }
 
 // NewFakeManager creates empty/fake memory manager


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:
This PR runs the admission process to a pod resize request before passing the request to a pod worker. Otherwise, the pod worker can refer to an unacceptable spec for container life cycle actions such as creating and restarting the container when the resize request is unacceptable.

This fix is inspired by the following comment:
https://github.com/kubernetes/kubernetes/blob/60c4c2b2521fb454ce69dee737e3eb91a25e0535/pkg/kubelet/kubelet.go#L1943-L1951

This PR also uses the latest pod status at resizing like #125958. By copying `apiPodStatus`, which is generated from the latest pod status that a pod worker gets from the PLEG cache, to `pod`, computePodResizeAction() can calculate actions based on the latest pod status.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #126527, Fixes #126033, Fixes  #125205

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed the following bugs regarding the `InPlacePodVerticalScaling` feature:
- An unacceptable resize is actuated when a container is restarted along with its exit while its `resize` status is stuck in `Deferred` or `Infeasible`.
- An unacceptable resize is actuated if the resize is requested before the container is created.
- It takes one more minute till a pod with the `RestartContainer` resize policy is resized when resize requests to the pod are posted a couple of times quickly.
- A pod status is sometimes regressed to outdated information when resize requests are posted to a pod with the `RestartContainer` resize policy a couple of times quickly.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
