### PR TITLE
Use allocatedResources as new size for finishing volume expansion on the node

### DIFF
--- a/pkg/kubelet/volumemanager/cache/actual_state_of_world.go
+++ b/pkg/kubelet/volumemanager/cache/actual_state_of_world.go
@@ -960,7 +960,7 @@ func (asw *actualStateOfWorld) volumeNeedsExpansion(volumeObj attachedVolume, de
 		return currentSize, false
 	}
 
-	klog.V(5).Infof("NodeExpandVolume checking size, actual size %s, desired size %s, for volume %s", volumeObj.persistentVolumeSize.String(), desiredVolumeSize.String(), volumeObj.volumeName)
+	klog.V(5).InfoS("NodeExpandVolume checking size", "actualSize", volumeObj.persistentVolumeSize.String(), "desiredSize", desiredVolumeSize.String(), "volume", volumeObj.volumeName)
 
 	if desiredVolumeSize.Cmp(*volumeObj.persistentVolumeSize) > 0 {
 		volumePlugin, err := asw.volumePluginMgr.FindNodeExpandablePluginBySpec(volumeObj.spec)

--- a/pkg/kubelet/volumemanager/cache/actual_state_of_world.go
+++ b/pkg/kubelet/volumemanager/cache/actual_state_of_world.go
@@ -960,6 +960,8 @@ func (asw *actualStateOfWorld) volumeNeedsExpansion(volumeObj attachedVolume, de
 		return currentSize, false
 	}
 
+	klog.V(5).Infof("NodeExpandVolume checking size, actual size %s, desired size %s, for volume %s", volumeObj.persistentVolumeSize.String(), desiredVolumeSize.String(), volumeObj.volumeName)
+
 	if desiredVolumeSize.Cmp(*volumeObj.persistentVolumeSize) > 0 {
 		volumePlugin, err := asw.volumePluginMgr.FindNodeExpandablePluginBySpec(volumeObj.spec)
 		if err != nil || volumePlugin == nil {

--- a/pkg/kubelet/volumemanager/populator/desired_state_of_world_populator.go
+++ b/pkg/kubelet/volumemanager/populator/desired_state_of_world_populator.go
@@ -380,10 +380,11 @@ func (dswp *desiredStateOfWorldPopulator) checkVolumeFSResize(
 		klog.V(5).InfoS("Skip file system resize check for the volume, as the volume is mounted as readonly", "pod", klog.KObj(pod), "volumeName", podVolume.Name)
 		return
 	}
+
 	pvCap := volumeSpec.PersistentVolume.Spec.Capacity.Storage()
 	pvcStatusCap := pvc.Status.Capacity.Storage()
 	dswp.desiredStateOfWorld.UpdatePersistentVolumeSize(uniqueVolumeName, pvCap)
-
+	klog.V(5).Infof("NodeExpandVolume updating size, actual size %s, desired size %s, for volume %s", pvcStatusCap.String(), pvCap.String(), uniqueVolumeName)
 	// in case the actualStateOfWorld was rebuild after kubelet restart ensure that claimSize is set to accurate value
 	dswp.actualStateOfWorld.InitializeClaimSize(klog.TODO(), uniqueVolumeName, pvcStatusCap)
 }

--- a/pkg/kubelet/volumemanager/populator/desired_state_of_world_populator.go
+++ b/pkg/kubelet/volumemanager/populator/desired_state_of_world_populator.go
@@ -384,7 +384,7 @@ func (dswp *desiredStateOfWorldPopulator) checkVolumeFSResize(
 	pvCap := volumeSpec.PersistentVolume.Spec.Capacity.Storage()
 	pvcStatusCap := pvc.Status.Capacity.Storage()
 	dswp.desiredStateOfWorld.UpdatePersistentVolumeSize(uniqueVolumeName, pvCap)
-	klog.V(5).Infof("NodeExpandVolume updating size, actual size %s, desired size %s, for volume %s", pvcStatusCap.String(), pvCap.String(), uniqueVolumeName)
+	klog.V(5).InfoS("NodeExpandVolume updating size", "actualSize", pvcStatusCap.String(), "desiredSize", pvCap.String(), "volumeName", uniqueVolumeName)
 	// in case the actualStateOfWorld was rebuild after kubelet restart ensure that claimSize is set to accurate value
 	dswp.actualStateOfWorld.InitializeClaimSize(klog.TODO(), uniqueVolumeName, pvcStatusCap)
 }

--- a/pkg/volume/util/operationexecutor/node_expander.go
+++ b/pkg/volume/util/operationexecutor/node_expander.go
@@ -175,7 +175,7 @@ func (ne *NodeExpander) expandOnPlugin() (bool, resource.Quantity, error, testRe
 	// File system resize succeeded, now update the PVC's Capacity to match the PV's
 	ne.pvc, err = util.MarkFSResizeFinished(ne.pvc, ne.pluginResizeOpts.NewSize, ne.kubeClient)
 	if err != nil {
-		return true, ne.pluginResizeOpts.NewSize, fmt.Errorf("mountVolume.NodeExpandVolume update pvc status failed: %v", err), testResponseData{true, true}
+		return true, ne.pluginResizeOpts.NewSize, fmt.Errorf("mountVolume.NodeExpandVolume update pvc status failed: %w", err), testResponseData{true, true}
 	}
 	return true, ne.pluginResizeOpts.NewSize, nil, testResponseData{true, true}
 }

--- a/pkg/volume/util/operationexecutor/node_expander.go
+++ b/pkg/volume/util/operationexecutor/node_expander.go
@@ -36,7 +36,6 @@ type NodeExpander struct {
 
 	// computed via precheck
 	pvcStatusCap resource.Quantity
-	pvCap        resource.Quantity
 	resizeStatus v1.ClaimResourceStatus
 
 	// indicates that if volume expansion failed on the node, then current expansion should be marked
@@ -76,7 +75,6 @@ type testResponseData struct {
 // it returns false.
 func (ne *NodeExpander) runPreCheck() bool {
 	ne.pvcStatusCap = ne.pvc.Status.Capacity[v1.ResourceStorage]
-	ne.pvCap = ne.pv.Spec.Capacity[v1.ResourceStorage]
 
 	allocatedResourceStatus := ne.pvc.Status.AllocatedResourceStatuses
 	if currentStatus, ok := allocatedResourceStatus[v1.ResourceStorage]; ok {
@@ -120,6 +118,7 @@ func (ne *NodeExpander) runPreCheck() bool {
 func (ne *NodeExpander) expandOnPlugin() (bool, error, testResponseData) {
 	allowExpansion := ne.runPreCheck()
 	if !allowExpansion {
+		klog.V(3).Infof("NodeExpandVolume is not allowed to proceed for volume %s with resizeStatus %s", ne.vmt.VolumeName, ne.resizeStatus)
 		return false, nil, testResponseData{false, true}
 	}
 

--- a/pkg/volume/util/operationexecutor/node_expander_test.go
+++ b/pkg/volume/util/operationexecutor/node_expander_test.go
@@ -162,7 +162,8 @@ func TestNodeExpander(t *testing.T) {
 			ogInstance, _ := og.(*operationGenerator)
 			nodeExpander := newNodeExpander(resizeOp, ogInstance.kubeClient, ogInstance.recorder)
 
-			_, _, err, expansionResponse := nodeExpander.expandOnPlugin()
+			_, _, err := nodeExpander.expandOnPlugin()
+			expansionResponse := nodeExpander.testStatus
 
 			pvc = nodeExpander.pvc
 			pvcStatusCap := pvc.Status.Capacity[v1.ResourceStorage]

--- a/pkg/volume/util/operationexecutor/node_expander_test.go
+++ b/pkg/volume/util/operationexecutor/node_expander_test.go
@@ -162,7 +162,7 @@ func TestNodeExpander(t *testing.T) {
 			ogInstance, _ := og.(*operationGenerator)
 			nodeExpander := newNodeExpander(resizeOp, ogInstance.kubeClient, ogInstance.recorder)
 
-			_, err, expansionResponse := nodeExpander.expandOnPlugin()
+			_, _, err, expansionResponse := nodeExpander.expandOnPlugin()
 
 			pvc = nodeExpander.pvc
 			pvcStatusCap := pvc.Status.Capacity[v1.ResourceStorage]

--- a/pkg/volume/util/operationexecutor/operation_generator.go
+++ b/pkg/volume/util/operationexecutor/operation_generator.go
@@ -2013,7 +2013,7 @@ func (og *operationGenerator) expandVolumeDuringMount(volumeToMount VolumeToMoun
 				rsOpts.NewSize = pvc.Status.AllocatedResources[v1.ResourceStorage]
 				resizeOp.pluginResizeOpts = rsOpts
 				nodeExpander := newNodeExpander(resizeOp, og.kubeClient, og.recorder)
-				resizeFinished, _, err, _ := nodeExpander.expandOnPlugin()
+				resizeFinished, _, err := nodeExpander.expandOnPlugin()
 				return resizeFinished, err
 			} else {
 				return og.legacyCallNodeExpandOnPlugin(resizeOp)
@@ -2081,7 +2081,7 @@ func (og *operationGenerator) nodeExpandVolume(
 				rsOpts.NewSize = newSize
 				resizeOp.pluginResizeOpts.NewSize = newSize
 				nodeExpander := newNodeExpander(resizeOp, og.kubeClient, og.recorder)
-				resizeFinished, newSize, err, _ := nodeExpander.expandOnPlugin()
+				resizeFinished, newSize, err := nodeExpander.expandOnPlugin()
 				return resizeFinished, newSize, err
 			} else {
 				resizeFinished, err := og.legacyCallNodeExpandOnPlugin(resizeOp)

--- a/pkg/volume/util/operationexecutor/operation_generator.go
+++ b/pkg/volume/util/operationexecutor/operation_generator.go
@@ -2056,7 +2056,7 @@ func (og *operationGenerator) nodeExpandVolume(
 			currentSize := pvc.Status.Capacity.Storage()
 			if err != nil {
 				// Return error rather than leave the file system un-resized, caller will log and retry
-				return false, *currentSize, fmt.Errorf("mountVolume.NodeExpandVolume get PVC failed : %v", err)
+				return false, *currentSize, fmt.Errorf("mountVolume.NodeExpandVolume get PVC failed : %w", err)
 			}
 
 			if volumeToMount.VolumeSpec.ReadOnly {

--- a/pkg/volume/util/operationexecutor/operation_generator.go
+++ b/pkg/volume/util/operationexecutor/operation_generator.go
@@ -2009,6 +2009,9 @@ func (og *operationGenerator) expandVolumeDuringMount(volumeToMount VolumeToMoun
 				actualStateOfWorld: actualStateOfWorld,
 			}
 			if og.checkForRecoveryFromExpansion(pvc, volumeToMount) {
+				// if recovery feature is enabled, we can use allocated size from PVC status as new size
+				rsOpts.NewSize = pvc.Status.AllocatedResources[v1.ResourceStorage]
+				resizeOp.pluginResizeOpts = rsOpts
 				nodeExpander := newNodeExpander(resizeOp, og.kubeClient, og.recorder)
 				resizeFinished, err, _ := nodeExpander.expandOnPlugin()
 				return resizeFinished, err
@@ -2072,6 +2075,9 @@ func (og *operationGenerator) nodeExpandVolume(
 			}
 
 			if og.checkForRecoveryFromExpansion(pvc, volumeToMount) {
+				// if recovery feature is enabled, we can use allocated size from PVC status as new size
+				rsOpts.NewSize = pvc.Status.AllocatedResources[v1.ResourceStorage]
+				resizeOp.pluginResizeOpts = rsOpts
 				nodeExpander := newNodeExpander(resizeOp, og.kubeClient, og.recorder)
 				resizeFinished, err, _ := nodeExpander.expandOnPlugin()
 				return resizeFinished, err

--- a/pkg/volume/util/operationexecutor/operation_generator_test.go
+++ b/pkg/volume/util/operationexecutor/operation_generator_test.go
@@ -305,7 +305,7 @@ func TestOperationGenerator_nodeExpandVolume(t *testing.T) {
 			asow := newFakeActualStateOfWorld()
 
 			ogInstance, _ := og.(*operationGenerator)
-			_, err := ogInstance.nodeExpandVolume(vmt, asow, pluginResizeOpts)
+			_, _, err := ogInstance.nodeExpandVolume(vmt, asow, pluginResizeOpts)
 
 			if !test.expectError && err != nil {
 				t.Errorf("For test %s, expected no error got: %v", test.name, err)

--- a/test/e2e/storage/csimock/base.go
+++ b/test/e2e/storage/csimock/base.go
@@ -96,6 +96,7 @@ type testParameters struct {
 	enableNodeExpansion bool   // enable node expansion for CSI mock driver
 	// just disable resizing on driver it overrides enableResizing flag for CSI mock driver
 	disableResizingOnDriver       bool
+	disableControllerExpansion    bool
 	enableSnapshot                bool
 	enableVolumeMountGroup        bool // enable the VOLUME_MOUNT_GROUP node capability in the CSI mock driver.
 	enableNodeVolumeCondition     bool
@@ -172,6 +173,7 @@ func (m *mockDriverSetup) init(ctx context.Context, tp testParameters) {
 		EnableResizing:                tp.enableResizing,
 		EnableNodeExpansion:           tp.enableNodeExpansion,
 		EnableNodeVolumeCondition:     tp.enableNodeVolumeCondition,
+		DisableControllerExpansion:    tp.disableControllerExpansion,
 		EnableSnapshot:                tp.enableSnapshot,
 		EnableVolumeMountGroup:        tp.enableVolumeMountGroup,
 		TokenRequests:                 tp.tokenRequests,

--- a/test/e2e/storage/csimock/csi_volume_expansion.go
+++ b/test/e2e/storage/csimock/csi_volume_expansion.go
@@ -569,7 +569,7 @@ func validateRecoveryBehaviour(ctx context.Context, pvc *v1.PersistentVolumeClai
 func validateExpansionSuccess(ctx context.Context, pvc *v1.PersistentVolumeClaim, m *mockDriverSetup, test recoveryTest, expectedAllocatedSize string) {
 	var err error
 	ginkgo.By(fmt.Sprintf("Waiting for PV %s to be expanded to %s", pvc.Spec.VolumeName, test.recoverySize.String()))
-	err = testsuites.WaitForRecoveryPVSize(pvc, m.cs, csiResizeWaitPeriod)
+	err = testsuites.WaitForControllerVolumeResize(ctx, pvc, m.cs, csiResizeWaitPeriod)
 	framework.ExpectNoError(err, "While waiting for PV resize to finish")
 
 	ginkgo.By(fmt.Sprintf("Waiting for PVC %s to be expanded to %s", pvc.Name, test.recoverySize.String()))

--- a/test/e2e/storage/csimock/csi_volume_expansion.go
+++ b/test/e2e/storage/csimock/csi_volume_expansion.go
@@ -45,8 +45,10 @@ type expansionStatus int
 
 const (
 	expansionSuccess = iota
-	expansionFailedOnController
-	expansionFailedOnNode
+	expansionFailedOnControllerWithInfeasibleError
+	expansionFailedOnControllerWithFinalError
+	expansionFailedOnNodeWithInfeasibleError
+	expansionFailedOnNodeWithFinalError
 	expansionFailedMissingStagingPath
 )
 
@@ -61,12 +63,13 @@ var (
 )
 
 type recoveryTest struct {
-	name                    string
-	pvcRequestSize          string
-	allocatedResource       string
-	simulatedCSIDriverError expansionStatus
-	expectedResizeStatus    v1.ClaimResourceStatus
-	recoverySize            resource.Quantity
+	name                       string
+	pvcRequestSize             string
+	allocatedResource          string
+	simulatedCSIDriverError    expansionStatus
+	disableControllerExpansion bool
+	expectedResizeStatus       v1.ClaimResourceStatus
+	recoverySize               resource.Quantity
 }
 
 var _ = utils.SIGDescribe("CSI Mock volume expansion", func() {
@@ -400,27 +403,57 @@ var _ = utils.SIGDescribe("CSI Mock volume expansion", func() {
 	f.Context("Expansion with recovery", feature.RecoverVolumeExpansionFailure, func() {
 		tests := []recoveryTest{
 			{
-				name:                    "should record target size in allocated resources",
-				pvcRequestSize:          "4Gi",
-				allocatedResource:       "4Gi",
-				simulatedCSIDriverError: expansionSuccess,
-				expectedResizeStatus:    "",
+				name:                       "should record target size in allocated resources",
+				pvcRequestSize:             "4Gi",
+				allocatedResource:          "4Gi",
+				disableControllerExpansion: false,
+				simulatedCSIDriverError:    expansionSuccess,
+				expectedResizeStatus:       "",
 			},
 			{
-				name:                    "should allow recovery if controller expansion fails with final error",
-				pvcRequestSize:          "11Gi", // expansion to 11Gi will cause expansion to fail on controller
-				allocatedResource:       "11Gi",
-				simulatedCSIDriverError: expansionFailedOnController,
-				expectedResizeStatus:    v1.PersistentVolumeClaimControllerResizeInfeasible,
-				recoverySize:            resource.MustParse("4Gi"),
+				name:                       "should allow recovery if controller expansion fails with infeasible error",
+				pvcRequestSize:             "11Gi", // expansion to 11Gi will cause expansion to fail on controller
+				allocatedResource:          "11Gi",
+				disableControllerExpansion: false,
+				simulatedCSIDriverError:    expansionFailedOnControllerWithInfeasibleError,
+				expectedResizeStatus:       v1.PersistentVolumeClaimControllerResizeInfeasible,
+				recoverySize:               resource.MustParse("4Gi"),
 			},
 			{
-				name:                    "recovery should not be possible in partially expanded volumes",
-				pvcRequestSize:          "9Gi", // expansion to 9Gi will cause expansion to fail on node
-				allocatedResource:       "9Gi",
-				simulatedCSIDriverError: expansionFailedOnNode,
-				expectedResizeStatus:    v1.PersistentVolumeClaimNodeResizeInfeasible,
-				recoverySize:            resource.MustParse("5Gi"),
+				name:                       "should allow recovery if controller expansion fails with final error",
+				pvcRequestSize:             "11Gi", // expansion to 11Gi will cause expansion to fail on controller
+				allocatedResource:          "11Gi",
+				disableControllerExpansion: false,
+				simulatedCSIDriverError:    expansionFailedOnControllerWithFinalError,
+				expectedResizeStatus:       v1.PersistentVolumeClaimControllerResizeInProgress,
+				recoverySize:               resource.MustParse("4Gi"),
+			},
+			{
+				name:                       "recovery should not be possible in partially expanded volumes",
+				pvcRequestSize:             "9Gi", // expansion to 9Gi will cause expansion to fail on node
+				allocatedResource:          "9Gi",
+				disableControllerExpansion: false,
+				simulatedCSIDriverError:    expansionFailedOnNodeWithInfeasibleError,
+				expectedResizeStatus:       v1.PersistentVolumeClaimNodeResizeInfeasible,
+				recoverySize:               resource.MustParse("5Gi"),
+			},
+			{
+				name:                       "recovery should be possible for node-only expanded volumes with infeasible error",
+				pvcRequestSize:             "9Gi", // expansion to 9Gi will cause expansion to fail on node
+				allocatedResource:          "9Gi",
+				disableControllerExpansion: true,
+				simulatedCSIDriverError:    expansionFailedOnNodeWithInfeasibleError,
+				expectedResizeStatus:       v1.PersistentVolumeClaimNodeResizeInfeasible,
+				recoverySize:               resource.MustParse("5Gi"),
+			},
+			{
+				name:                       "recovery should be possible for node-only expanded volumes with final error",
+				pvcRequestSize:             "9Gi", // expansion to 9Gi will cause expansion to fail on node
+				allocatedResource:          "9Gi",
+				disableControllerExpansion: true,
+				simulatedCSIDriverError:    expansionFailedOnNodeWithFinalError,
+				expectedResizeStatus:       v1.PersistentVolumeClaimNodeResizeInProgress,
+				recoverySize:               resource.MustParse("5Gi"),
 			},
 		}
 
@@ -428,7 +461,7 @@ var _ = utils.SIGDescribe("CSI Mock volume expansion", func() {
 			test := t
 			ginkgo.It(test.name, func(ctx context.Context) {
 				var err error
-				params := testParameters{enableResizing: true, enableNodeExpansion: true, enableRecoverExpansionFailure: true}
+				params := testParameters{enableResizing: true, enableNodeExpansion: true, enableRecoverExpansionFailure: true, disableControllerExpansion: test.disableControllerExpansion}
 
 				if test.simulatedCSIDriverError != expansionSuccess {
 					params.hooks = createExpansionHook(test.simulatedCSIDriverError)
@@ -476,9 +509,15 @@ func validateRecoveryBehaviour(ctx context.Context, pvc *v1.PersistentVolumeClai
 	err = waitForAllocatedResource(ctx, pvc, m, test.allocatedResource)
 	framework.ExpectNoError(err, "While waiting for allocated resource to be updated")
 
-	ginkgo.By("Waiting for resizer to set resize status")
-	err = waitForResizeStatus(ctx, pvc, m.cs, test.expectedResizeStatus)
-	framework.ExpectNoError(err, "While waiting for resize status to be set")
+	if test.expectedResizeStatus == v1.PersistentVolumeClaimNodeResizeInfeasible {
+		ginkgo.By("Waiting for kubelet to fail expansion on the node")
+		err = waitForResizeToFailOnNode(ctx, pvc, m.cs)
+		framework.ExpectNoError(err, "While waiting for resize status to be set")
+	} else {
+		ginkgo.By("Waiting for resizer to set resize status")
+		err = waitForResizeStatus(ctx, pvc, m.cs, test.expectedResizeStatus)
+		framework.ExpectNoError(err, "While waiting for resize status to be set")
+	}
 
 	ginkgo.By("Recover pvc size")
 	newPVC, err := testsuites.ExpandPVCSize(ctx, pvc, test.recoverySize, m.cs)
@@ -492,16 +531,25 @@ func validateRecoveryBehaviour(ctx context.Context, pvc *v1.PersistentVolumeClai
 	}
 
 	// if expansion failed on controller with final error, then recovery should be possible
-	if test.simulatedCSIDriverError == expansionFailedOnController {
+	if test.simulatedCSIDriverError == expansionFailedOnControllerWithInfeasibleError {
+		validateExpansionSuccess(ctx, pvc, m, test, test.recoverySize.String())
+		return
+	}
+
+	// if expansion failed on node with final error but volume was only expanded on the node
+	// then recovery should be possible
+	if test.disableControllerExpansion &&
+		(test.simulatedCSIDriverError == expansionFailedOnNodeWithInfeasibleError ||
+			test.simulatedCSIDriverError == expansionFailedOnNodeWithFinalError) {
 		validateExpansionSuccess(ctx, pvc, m, test, test.recoverySize.String())
 		return
 	}
 
 	// if expansion succeeded on controller but failed on the node
-	if test.simulatedCSIDriverError == expansionFailedOnNode {
+	if test.simulatedCSIDriverError == expansionFailedOnNodeWithInfeasibleError {
 		ginkgo.By("Wait for expansion to fail on node again")
-		err = waitForResizeStatus(ctx, pvc, m.cs, v1.PersistentVolumeClaimNodeResizeInfeasible)
-		framework.ExpectNoError(err, "While waiting for resize status to be set to expansion-failed-on-node")
+		err = waitForResizeToFailOnNode(ctx, pvc, m.cs)
+		framework.ExpectNoError(err, "While waiting for resize status to be set")
 
 		ginkgo.By("verify allocated resources after recovery")
 		pvc, err = m.cs.CoreV1().PersistentVolumeClaims(pvc.Namespace).Get(context.TODO(), pvc.Name, metav1.GetOptions{})
@@ -520,11 +568,11 @@ func validateRecoveryBehaviour(ctx context.Context, pvc *v1.PersistentVolumeClai
 
 func validateExpansionSuccess(ctx context.Context, pvc *v1.PersistentVolumeClaim, m *mockDriverSetup, test recoveryTest, expectedAllocatedSize string) {
 	var err error
-	ginkgo.By("Waiting for persistent volume resize to finish")
-	err = testsuites.WaitForControllerVolumeResize(ctx, pvc, m.cs, csiResizeWaitPeriod)
+	ginkgo.By(fmt.Sprintf("Waiting for PV %s to be expanded to %s", pvc.Spec.VolumeName, test.recoverySize.String()))
+	err = testsuites.WaitForRecoveryPVSize(pvc, m.cs, csiResizeWaitPeriod)
 	framework.ExpectNoError(err, "While waiting for PV resize to finish")
 
-	ginkgo.By("Waiting for PVC resize to finish")
+	ginkgo.By(fmt.Sprintf("Waiting for PVC %s to be expanded to %s", pvc.Name, test.recoverySize.String()))
 	pvc, err = testsuites.WaitForFSResize(ctx, pvc, m.cs)
 	framework.ExpectNoError(err, "while waiting for PVC to finish")
 
@@ -557,6 +605,31 @@ func waitForResizeStatus(ctx context.Context, pvc *v1.PersistentVolumeClaim, c c
 	})
 	if waitErr != nil {
 		return fmt.Errorf("error while waiting for resize status to sync to %v, actualStatus %s: %w", expectedState, actualResizeStatus, waitErr)
+	}
+	return nil
+}
+
+func waitForResizeToFailOnNode(ctx context.Context, pvc *v1.PersistentVolumeClaim, c clientset.Interface) error {
+	var finalConditions []v1.PersistentVolumeClaimCondition
+	waitErr := wait.PollUntilContextTimeout(ctx, resizePollInterval, csiResizeWaitPeriod, true, func(pollContext context.Context) (bool, error) {
+		var err error
+		updatedPVC, err := c.CoreV1().PersistentVolumeClaims(pvc.Namespace).Get(pollContext, pvc.Name, metav1.GetOptions{})
+
+		if err != nil {
+			return false, fmt.Errorf("error fetching pvc %q for checking for resize status: %w", pvc.Name, err)
+		}
+		pvcConditions := updatedPVC.Status.Conditions
+		for _, cond := range pvcConditions {
+			if cond.Type == v1.PersistentVolumeClaimNodeResizeError {
+				return true, nil
+			}
+		}
+		finalConditions = pvcConditions
+		return false, nil
+	})
+
+	if waitErr != nil {
+		return fmt.Errorf("error while waiting for resize condition sync to NodeResizeError, actualStatus %+v: %w", finalConditions, waitErr)
 	}
 	return nil
 }
@@ -596,7 +669,7 @@ func createExpansionHook(expectedExpansionStatus expansionStatus) *drivers.Hooks
 					}
 
 				}
-			case expansionFailedOnController:
+			case expansionFailedOnControllerWithInfeasibleError:
 				expansionRequest, ok := request.(*csipbv1.ControllerExpandVolumeRequest)
 				if ok {
 					requestedSize := resource.NewQuantity(expansionRequest.CapacityRange.RequiredBytes, resource.BinarySI)
@@ -604,7 +677,16 @@ func createExpansionHook(expectedExpansionStatus expansionStatus) *drivers.Hooks
 						return nil, status.Error(codes.InvalidArgument, "invalid expansion request")
 					}
 				}
-			case expansionFailedOnNode:
+			case expansionFailedOnControllerWithFinalError:
+				// This simulates a condition that a final, but not infeasible error is returned when expansion fails in the controller.
+				expansionRequest, ok := request.(*csipbv1.ControllerExpandVolumeRequest)
+				if ok {
+					requestedSize := resource.NewQuantity(expansionRequest.CapacityRange.RequiredBytes, resource.BinarySI)
+					if requestedSize.Cmp(maxControllerSizeLimit) > 0 {
+						return nil, status.Error(codes.PermissionDenied, "permission denied for expansion")
+					}
+				}
+			case expansionFailedOnNodeWithInfeasibleError:
 				expansionRequest, ok := request.(*csipbv1.NodeExpandVolumeRequest)
 				if ok {
 					requestedSize := resource.NewQuantity(expansionRequest.CapacityRange.RequiredBytes, resource.BinarySI)
@@ -612,6 +694,14 @@ func createExpansionHook(expectedExpansionStatus expansionStatus) *drivers.Hooks
 						return nil, status.Error(codes.InvalidArgument, "invalid node expansion request")
 					}
 
+				}
+			case expansionFailedOnNodeWithFinalError:
+				expansionRequest, ok := request.(*csipbv1.NodeExpandVolumeRequest)
+				if ok {
+					requestedSize := resource.NewQuantity(expansionRequest.CapacityRange.RequiredBytes, resource.BinarySI)
+					if requestedSize.Cmp(maxNodeExpansionLimit) > 0 {
+						return nil, status.Error(codes.PermissionDenied, "permission denied for expansion")
+					}
 				}
 			}
 

--- a/test/e2e/storage/drivers/csi.go
+++ b/test/e2e/storage/drivers/csi.go
@@ -350,6 +350,7 @@ type mockCSIDriver struct {
 	embeddedCSIDriver             *mockdriver.CSIDriver
 	enableSELinuxMount            *bool
 	enableRecoverExpansionFailure bool
+	disableControllerExpansion    bool
 	enableHonorPVReclaimPolicy    bool
 
 	// Additional values set during PrepareTest
@@ -392,6 +393,7 @@ type CSIMockDriverOpts struct {
 	EnableTopology                bool
 	EnableResizing                bool
 	EnableNodeExpansion           bool
+	DisableControllerExpansion    bool
 	EnableSnapshot                bool
 	EnableVolumeMountGroup        bool
 	EnableNodeVolumeCondition     bool
@@ -550,6 +552,7 @@ func InitMockCSIDriver(driverOpts CSIMockDriverOpts) MockCSITestDriver {
 		attachLimit:                   driverOpts.AttachLimit,
 		enableNodeExpansion:           driverOpts.EnableNodeExpansion,
 		enableNodeVolumeCondition:     driverOpts.EnableNodeVolumeCondition,
+		disableControllerExpansion:    driverOpts.DisableControllerExpansion,
 		tokenRequests:                 driverOpts.TokenRequests,
 		requiresRepublish:             driverOpts.RequiresRepublish,
 		fsGroupPolicy:                 driverOpts.FSGroupPolicy,
@@ -628,6 +631,7 @@ func (m *mockCSIDriver) PrepareTest(ctx context.Context, f *framework.Framework)
 			DriverName:                  "csi-mock-" + f.UniqueName,
 			AttachLimit:                 int64(m.attachLimit),
 			NodeExpansionRequired:       m.enableNodeExpansion,
+			DisableControllerExpansion:  m.disableControllerExpansion,
 			NodeVolumeConditionRequired: m.enableNodeVolumeCondition,
 			VolumeMountGroupRequired:    m.enableVolumeMountGroup,
 			EnableTopology:              m.enableTopology,

--- a/test/e2e/storage/testsuites/volume_expand.go
+++ b/test/e2e/storage/testsuites/volume_expand.go
@@ -184,7 +184,7 @@ func (v *volumeExpandTestSuite) DefineTests(driver storageframework.TestDriver, 
 			newSize := currentPvcSize.DeepCopy()
 			newSize.Add(resource.MustParse("1Gi"))
 			framework.Logf("currentPvcSize %v, newSize %v", currentPvcSize, newSize)
-			_, err = ExpandPVCSize(ctx, l.resource.Pvc, newSize, f.ClientSet)
+			_, err = ExpandPVCSizeToError(ctx, l.resource.Pvc, newSize, f.ClientSet)
 			gomega.Expect(err).To(gomega.MatchError(apierrors.IsForbidden, "While updating non-expandable PVC"))
 		})
 	} else {
@@ -343,6 +343,42 @@ func ExpandPVCSize(ctx context.Context, origPVC *v1.PersistentVolumeClaim, size 
 	return updatedPVC, nil
 }
 
+func ExpandPVCSizeToError(ctx context.Context, origPVC *v1.PersistentVolumeClaim, size resource.Quantity, c clientset.Interface) (*v1.PersistentVolumeClaim, error) {
+	pvcName := origPVC.Name
+	updatedPVC := origPVC.DeepCopy()
+
+	var lastUpdateError error
+
+	waitErr := wait.PollUntilContextTimeout(ctx, resizePollInterval, 30*time.Second, true, func(pollContext context.Context) (bool, error) {
+		var err error
+		updatedPVC, err = c.CoreV1().PersistentVolumeClaims(origPVC.Namespace).Get(pollContext, pvcName, metav1.GetOptions{})
+		if err != nil {
+			return false, fmt.Errorf("error fetching pvc %q for resizing: %w", pvcName, err)
+		}
+
+		updatedPVC.Spec.Resources.Requests[v1.ResourceStorage] = size
+		updatedPVC, err = c.CoreV1().PersistentVolumeClaims(origPVC.Namespace).Update(pollContext, updatedPVC, metav1.UpdateOptions{})
+		if err == nil {
+			return false, fmt.Errorf("pvc %s should not be allowed to be updated", pvcName)
+		} else {
+			lastUpdateError = err
+			if apierrors.IsForbidden(err) {
+				return true, nil
+			}
+			framework.Logf("Error updating pvc %s: %v", pvcName, err)
+			return false, nil
+		}
+	})
+
+	if wait.Interrupted(waitErr) {
+		return nil, fmt.Errorf("timed out attempting to update PVC size. last update error: %w", lastUpdateError)
+	}
+	if waitErr != nil {
+		return nil, fmt.Errorf("failed to expand PVC size (check logs for error): %w", waitErr)
+	}
+	return updatedPVC, lastUpdateError
+}
+
 // WaitForResizingCondition waits for the pvc condition to be PersistentVolumeClaimResizing
 func WaitForResizingCondition(ctx context.Context, pvc *v1.PersistentVolumeClaim, c clientset.Interface, duration time.Duration) error {
 	waitErr := wait.PollUntilContextTimeout(ctx, resizePollInterval, duration, true, func(ctx context.Context) (bool, error) {
@@ -392,34 +428,6 @@ func WaitForControllerVolumeResize(ctx context.Context, pvc *v1.PersistentVolume
 	return nil
 }
 
-// WaitForRecoveryPVSize waits for the controller resize to be finished when we are reducing volume size
-// This is different from WaitForControllerVolumeResize which just waits for PV to report bigger size than
-// size requested.
-func WaitForRecoveryPVSize(pvc *v1.PersistentVolumeClaim, c clientset.Interface, timeout time.Duration) error {
-	pvName := pvc.Spec.VolumeName
-	waitErr := wait.PollImmediate(resizePollInterval, timeout, func() (bool, error) {
-		pvcSpecSize := pvc.Spec.Resources.Requests.Storage()
-
-		pv, err := c.CoreV1().PersistentVolumes().Get(context.TODO(), pvName, metav1.GetOptions{})
-		if err != nil {
-			return false, fmt.Errorf("error fetching pv %q for resizing %v", pvName, err)
-		}
-
-		pvSize := pv.Spec.Capacity[v1.ResourceStorage]
-
-		// If pv size is greater than what is mentioned in pvc's status that means control-plane
-		// volume expansion is finished.
-		if pvSize.Cmp(*pvcSpecSize) == 0 {
-			return true, nil
-		}
-		return false, nil
-	})
-	if waitErr != nil {
-		return fmt.Errorf("error while waiting for controller resize to finish: %v", waitErr)
-	}
-	return nil
-}
-
 // WaitForPendingFSResizeCondition waits for pvc to have resize condition
 func WaitForPendingFSResizeCondition(ctx context.Context, pvc *v1.PersistentVolumeClaim, c clientset.Interface) (*v1.PersistentVolumeClaim, error) {
 	var updatedPVC *v1.PersistentVolumeClaim
@@ -451,9 +459,9 @@ func WaitForPendingFSResizeCondition(ctx context.Context, pvc *v1.PersistentVolu
 // WaitForFSResize waits for the filesystem in the pv to be resized
 func WaitForFSResize(ctx context.Context, pvc *v1.PersistentVolumeClaim, c clientset.Interface) (*v1.PersistentVolumeClaim, error) {
 	var updatedPVC *v1.PersistentVolumeClaim
-	waitErr := wait.PollImmediate(resizePollInterval, totalResizeWaitPeriod, func() (bool, error) {
+	waitErr := wait.PollUntilContextTimeout(ctx, resizePollInterval, totalResizeWaitPeriod, true, func(pollContext context.Context) (bool, error) {
 		var err error
-		updatedPVC, err = c.CoreV1().PersistentVolumeClaims(pvc.Namespace).Get(context.TODO(), pvc.Name, metav1.GetOptions{})
+		updatedPVC, err = c.CoreV1().PersistentVolumeClaims(pvc.Namespace).Get(pollContext, pvc.Name, metav1.GetOptions{})
 
 		if err != nil {
 			return false, fmt.Errorf("error fetching pvc %q for checking for resize status : %w", pvc.Name, err)


### PR DESCRIPTION
Also add new tests for node only expansion modes


xref https://github.com/kubernetes/enhancements/issues/1790

```release-note
Use allocatedResources on PVC for node expansion in kubelet
```
