### PR TITLE
Update default compatible version for 1.32

### DIFF
--- a/cmd/kube-apiserver/app/options/validation.go
+++ b/cmd/kube-apiserver/app/options/validation.go
@@ -24,7 +24,6 @@ import (
 
 	genericoptions "k8s.io/apiserver/pkg/server/options"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
-	utilversion "k8s.io/apiserver/pkg/util/version"
 	netutils "k8s.io/utils/net"
 
 	controlplaneapiserver "k8s.io/kubernetes/pkg/controlplane/apiserver/options"
@@ -140,12 +139,6 @@ func (s CompletedOptions) Validate() []error {
 
 	if s.MasterCount <= 0 {
 		errs = append(errs, fmt.Errorf("--apiserver-count should be a positive number, but value '%d' provided", s.MasterCount))
-	}
-
-	// TODO(#125980): remove in 1.32
-	effectiveVersion := s.GenericServerRunOptions.ComponentGlobalsRegistry.EffectiveVersionFor(s.GenericServerRunOptions.ComponentName)
-	if err := utilversion.ValidateKubeEffectiveVersion(effectiveVersion); err != nil {
-		errs = append(errs, err)
 	}
 
 	return errs

--- a/cmd/kube-controller-manager/app/options/options.go
+++ b/cmd/kube-controller-manager/app/options/options.go
@@ -437,7 +437,6 @@ func (s *KubeControllerManagerOptions) Validate(allControllers []string, disable
 	errs = append(errs, s.Authentication.Validate()...)
 	errs = append(errs, s.Authorization.Validate()...)
 	errs = append(errs, s.Metrics.Validate()...)
-	errs = append(errs, utilversion.ValidateKubeEffectiveVersion(s.ComponentGlobalsRegistry.EffectiveVersionFor(utilversion.DefaultKubeComponent)))
 
 	// TODO: validate component config, master and kubeconfig
 

--- a/cmd/kube-scheduler/app/options/options.go
+++ b/cmd/kube-scheduler/app/options/options.go
@@ -279,12 +279,6 @@ func (o *Options) Validate() []error {
 	errs = append(errs, o.Authorization.Validate()...)
 	errs = append(errs, o.Metrics.Validate()...)
 
-	// TODO(#125980): remove in 1.32
-	effectiveVersion := o.ComponentGlobalsRegistry.EffectiveVersionFor(utilversion.DefaultKubeComponent)
-	if err := utilversion.ValidateKubeEffectiveVersion(effectiveVersion); err != nil {
-		errs = append(errs, err)
-	}
-
 	return errs
 }
 

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/compilation_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/compilation_test.go
@@ -693,8 +693,9 @@ func TestCelCompilation(t *testing.T) {
 				},
 			},
 			expectedResults: []validationMatcher{
-				invalidError("undefined field 'namespace'"),
-				invalidError("undefined field 'if'"),
+				// starting 1.32, the preserved keyword as field name would be supported.
+				noError(),
+				noError(),
 				invalidError("found no matching overload"),
 			},
 		},

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/validation_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/validation_test.go
@@ -2104,6 +2104,26 @@ func TestValidationExpressions(t *testing.T) {
 				`cidr('::1/128').ip().family() == 6`,
 			},
 		},
+		{name: "format",
+			obj:    objs("20", "200M"),
+			schema: schemas(stringType, stringType),
+			valid: []string{
+				`format.dns1123Label().validate("my-label-name") == optional.none()`,
+				`format.dns1123Subdomain().validate("apiextensions.k8s.io") == optional.none()`,
+				`format.qualifiedName().validate("apiextensions.k8s.io/v1beta1") == optional.none()`,
+				`format.dns1123LabelPrefix().validate("my-label-prefix-") == optional.none()`,
+				`format.dns1123SubdomainPrefix().validate("mysubdomain.prefix.-") == optional.none()`,
+				`format.dns1035LabelPrefix().validate("my-label-prefix-") == optional.none()`,
+				`format.uri().validate("http://example.com") == optional.none()`,
+				`format.uuid().validate("123e4567-e89b-12d3-a456-426614174000") == optional.none()`,
+				`format.byte().validate("aGVsbG8=") == optional.none()`,
+				`format.date().validate("2021-01-01") == optional.none()`,
+				`format.datetime().validate("2021-01-01T00:00:00Z") == optional.none()`,
+				`format.named("dns1123Label").value().validate("my-name") == optional.none()`,
+				`format.dns1123Label().validate("contains a space").value()[0] == "a lowercase RFC 1123 label must consist of lower case alphanumeric characters or \'-\', and must start and end with an alphanumeric character (e.g. \'my-name\',  or \'123-abc\', regex used for validation is \'[a-z0-9]([-a-z0-9]*[a-z0-9])?\')"`,
+				`!format.named("unknown").hasValue()`,
+			},
+		},
 	}
 
 	for i := range tests {

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/cel/filter_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/cel/filter_test.go
@@ -913,8 +913,8 @@ func TestFilter(t *testing.T) {
 			}
 			require.Equal(t, len(evalResults), len(tc.results))
 			for i, result := range tc.results {
-				if result.Error != nil && !strings.Contains(evalResults[i].Error.Error(), result.Error.Error()) {
-					t.Errorf("Expected result '%v' but got '%v'", result.Error, evalResults[i].Error)
+				if result.Error != nil && evalResults[i].Error != nil && !strings.Contains(evalResults[i].Error.Error(), result.Error.Error()) {
+					t.Errorf("Expected result error: '%v' but got error: '%v'", result.Error, evalResults[i].Error)
 				}
 				if result.Error == nil && evalResults[i].Error != nil {
 					t.Errorf("Expected result '%v' but got error '%v'", result.EvalResult, evalResults[i].Error)

--- a/staging/src/k8s.io/apiserver/pkg/cel/environment/base.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/environment/base.go
@@ -167,6 +167,7 @@ var baseOptsWithoutStrictCost = []VersionedOptions{
 		EnvOptions: []cel.EnvOption{
 			library.AuthzSelectors(),
 		},
+		// RecognizeKeywordAsFieldName support has been introduced in 1.31 in https://github.com/kubernetes/kubernetes/blob/v1.31.0/staging/src/k8s.io/apiserver/pkg/cel/environment/environment.go#L270-L272
 	},
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/util/version/version.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/version/version.go
@@ -167,15 +167,3 @@ func DefaultKubeEffectiveVersion() MutableEffectiveVersion {
 	binaryVersion := version.MustParse(baseversion.DefaultKubeBinaryVersion).WithInfo(baseversion.Get())
 	return newEffectiveVersion(binaryVersion, false)
 }
-
-// ValidateKubeEffectiveVersion validates the EmulationVersion is equal to the binary version at 1.31 for kube components.
-// TODO: remove in 1.32
-// emulationVersion is introduced in 1.31, so it is only allowed to be equal to the binary version at 1.31.
-func ValidateKubeEffectiveVersion(effectiveVersion EffectiveVersion) error {
-	binaryVersion := version.MajorMinor(effectiveVersion.BinaryVersion().Major(), effectiveVersion.BinaryVersion().Minor())
-	if binaryVersion.EqualTo(version.MajorMinor(1, 31)) && !effectiveVersion.EmulationVersion().EqualTo(binaryVersion) {
-		return fmt.Errorf("emulation version needs to be equal to binary version(%s) in compatibility-version alpha, got %s",
-			binaryVersion.String(), effectiveVersion.EmulationVersion().String())
-	}
-	return nil
-}

--- a/staging/src/k8s.io/component-base/version/base.go
+++ b/staging/src/k8s.io/component-base/version/base.go
@@ -66,5 +66,5 @@ const (
 	// DefaultKubeBinaryVersion is the hard coded k8 binary version based on the latest K8s release.
 	// It is supposed to be consistent with gitMajor and gitMinor, except for local tests, where gitMajor and gitMinor are "".
 	// Should update for each minor release!
-	DefaultKubeBinaryVersion = "1.31"
+	DefaultKubeBinaryVersion = "1.32"
 )


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Update default compatible version for 1.32, add tests for previous added cel lib.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
To enhance usability and developer experience, CRD validation rules now support direct use of (CEL) reserved keywords as field names in object validation expressions.
Name format CEL library is supported in new expressions.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
