### PR TITLE
refactor(kubelet preemption): merge TestEvictPodsToFreeRequests() method in ut

### DIFF
--- a/pkg/kubelet/preemption/preemption_test.go
+++ b/pkg/kubelet/preemption/preemption_test.go
@@ -90,59 +90,20 @@ func getTestCriticalPodAdmissionHandler(podProvider *fakePodProvider, podKiller 
 	}
 }
 
-func TestEvictPodsToFreeRequestsWithError(t *testing.T) {
-	type testRun struct {
-		testName              string
-		inputPods             []*v1.Pod
-		insufficientResources admissionRequirementList
-		expectErr             bool
-		expectedOutput        []*v1.Pod
-	}
-	podProvider := newFakePodProvider()
-	podKiller := newFakePodKiller(true)
-	criticalPodAdmissionHandler := getTestCriticalPodAdmissionHandler(podProvider, podKiller)
-	allPods := getTestPods()
-	runs := []testRun{
-		{
-			testName: "multiple pods eviction error",
-			inputPods: []*v1.Pod{
-				allPods[clusterCritical], allPods[bestEffort], allPods[burstable], allPods[highRequestBurstable],
-				allPods[guaranteed], allPods[highRequestGuaranteed]},
-			insufficientResources: getAdmissionRequirementList(0, 550, 0),
-			expectErr:             false,
-			expectedOutput:        nil,
-		},
-	}
-	for _, r := range runs {
-		podProvider.setPods(r.inputPods)
-		outErr := criticalPodAdmissionHandler.evictPodsToFreeRequests(allPods[clusterCritical], r.insufficientResources)
-		outputPods := podKiller.getKilledPods()
-		if !r.expectErr && outErr != nil {
-			t.Errorf("evictPodsToFreeRequests returned an unexpected error during the %s test.  Err: %v", r.testName, outErr)
-		} else if r.expectErr && outErr == nil {
-			t.Errorf("evictPodsToFreeRequests expected an error but returned a successful output=%v during the %s test.", outputPods, r.testName)
-		} else if !podListEqual(r.expectedOutput, outputPods) {
-			t.Errorf("evictPodsToFreeRequests expected %v but got %v during the %s test.", r.expectedOutput, outputPods, r.testName)
-		}
-		podKiller.clear()
-	}
-}
-
 func TestEvictPodsToFreeRequests(t *testing.T) {
 	type testRun struct {
 		testName              string
+		isPodKillerWithError  bool
 		inputPods             []*v1.Pod
 		insufficientResources admissionRequirementList
 		expectErr             bool
 		expectedOutput        []*v1.Pod
 	}
-	podProvider := newFakePodProvider()
-	podKiller := newFakePodKiller(false)
-	criticalPodAdmissionHandler := getTestCriticalPodAdmissionHandler(podProvider, podKiller)
 	allPods := getTestPods()
 	runs := []testRun{
 		{
 			testName:              "critical pods cannot be preempted",
+			isPodKillerWithError:  false,
 			inputPods:             []*v1.Pod{allPods[clusterCritical]},
 			insufficientResources: getAdmissionRequirementList(0, 0, 1),
 			expectErr:             true,
@@ -150,13 +111,15 @@ func TestEvictPodsToFreeRequests(t *testing.T) {
 		},
 		{
 			testName:              "best effort pods are not preempted when attempting to free resources",
+			isPodKillerWithError:  false,
 			inputPods:             []*v1.Pod{allPods[bestEffort]},
 			insufficientResources: getAdmissionRequirementList(0, 1, 0),
 			expectErr:             true,
 			expectedOutput:        nil,
 		},
 		{
-			testName: "multiple pods evicted",
+			testName:             "multiple pods evicted",
+			isPodKillerWithError: false,
 			inputPods: []*v1.Pod{
 				allPods[clusterCritical], allPods[bestEffort], allPods[burstable], allPods[highRequestBurstable],
 				allPods[guaranteed], allPods[highRequestGuaranteed]},
@@ -164,19 +127,34 @@ func TestEvictPodsToFreeRequests(t *testing.T) {
 			expectErr:             false,
 			expectedOutput:        []*v1.Pod{allPods[highRequestBurstable], allPods[highRequestGuaranteed]},
 		},
+		{
+			testName:             "multiple pods with eviction error",
+			isPodKillerWithError: true,
+			inputPods: []*v1.Pod{
+				allPods[clusterCritical], allPods[bestEffort], allPods[burstable], allPods[highRequestBurstable],
+				allPods[guaranteed], allPods[highRequestGuaranteed]},
+			insufficientResources: getAdmissionRequirementList(0, 550, 0),
+			expectErr:             false,
+			expectedOutput:        nil,
+		},
 	}
 	for _, r := range runs {
-		podProvider.setPods(r.inputPods)
-		outErr := criticalPodAdmissionHandler.evictPodsToFreeRequests(allPods[clusterCritical], r.insufficientResources)
-		outputPods := podKiller.getKilledPods()
-		if !r.expectErr && outErr != nil {
-			t.Errorf("evictPodsToFreeRequests returned an unexpected error during the %s test.  Err: %v", r.testName, outErr)
-		} else if r.expectErr && outErr == nil {
-			t.Errorf("evictPodsToFreeRequests expected an error but returned a successful output=%v during the %s test.", outputPods, r.testName)
-		} else if !podListEqual(r.expectedOutput, outputPods) {
-			t.Errorf("evictPodsToFreeRequests expected %v but got %v during the %s test.", r.expectedOutput, outputPods, r.testName)
-		}
-		podKiller.clear()
+		t.Run(r.testName, func(t *testing.T) {
+			podProvider := newFakePodProvider()
+			podKiller := newFakePodKiller(r.isPodKillerWithError)
+			criticalPodAdmissionHandler := getTestCriticalPodAdmissionHandler(podProvider, podKiller)
+			podProvider.setPods(r.inputPods)
+			outErr := criticalPodAdmissionHandler.evictPodsToFreeRequests(allPods[clusterCritical], r.insufficientResources)
+			outputPods := podKiller.getKilledPods()
+			if !r.expectErr && outErr != nil {
+				t.Errorf("evictPodsToFreeRequests returned an unexpected error during the %s test.  Err: %v", r.testName, outErr)
+			} else if r.expectErr && outErr == nil {
+				t.Errorf("evictPodsToFreeRequests expected an error but returned a successful output=%v during the %s test.", outputPods, r.testName)
+			} else if !podListEqual(r.expectedOutput, outputPods) {
+				t.Errorf("evictPodsToFreeRequests expected %v but got %v during the %s test.", r.expectedOutput, outputPods, r.testName)
+			}
+			podKiller.clear()
+		})
 	}
 }
 
@@ -305,14 +283,16 @@ func TestGetPodsToPreempt(t *testing.T) {
 	}
 
 	for _, r := range runs {
-		outputPods, outErr := getPodsToPreempt(r.preemptor, r.inputPods, r.insufficientResources)
-		if !r.expectErr && outErr != nil {
-			t.Errorf("getPodsToPreempt returned an unexpected error during the %s test.  Err: %v", r.testName, outErr)
-		} else if r.expectErr && outErr == nil {
-			t.Errorf("getPodsToPreempt expected an error but returned a successful output=%v during the %s test.", outputPods, r.testName)
-		} else if !podListEqual(r.expectedOutput, outputPods) {
-			t.Errorf("getPodsToPreempt expected %v but got %v during the %s test.", r.expectedOutput, outputPods, r.testName)
-		}
+		t.Run(r.testName, func(t *testing.T) {
+			outputPods, outErr := getPodsToPreempt(r.preemptor, r.inputPods, r.insufficientResources)
+			if !r.expectErr && outErr != nil {
+				t.Errorf("getPodsToPreempt returned an unexpected error during the %s test.  Err: %v", r.testName, outErr)
+			} else if r.expectErr && outErr == nil {
+				t.Errorf("getPodsToPreempt expected an error but returned a successful output=%v during the %s test.", outputPods, r.testName)
+			} else if !podListEqual(r.expectedOutput, outputPods) {
+				t.Errorf("getPodsToPreempt expected %v but got %v during the %s test.", r.expectedOutput, outputPods, r.testName)
+			}
+		})
 	}
 }
 
@@ -351,10 +331,12 @@ func TestAdmissionRequirementsDistance(t *testing.T) {
 		},
 	}
 	for _, run := range runs {
-		output := run.requirements.distance(run.inputPod)
-		if output != run.expectedOutput {
-			t.Errorf("expected: %f, got: %f for %s test", run.expectedOutput, output, run.testName)
-		}
+		t.Run(run.testName, func(t *testing.T) {
+			output := run.requirements.distance(run.inputPod)
+			if output != run.expectedOutput {
+				t.Errorf("expected: %f, got: %f for %s test", run.expectedOutput, output, run.testName)
+			}
+		})
 	}
 }
 
@@ -399,10 +381,12 @@ func TestAdmissionRequirementsSubtract(t *testing.T) {
 		},
 	}
 	for _, run := range runs {
-		output := run.initial.subtract(run.inputPod)
-		if !admissionRequirementListEqual(output, run.expectedOutput) {
-			t.Errorf("expected: %s, got: %s for %s test", run.expectedOutput.toString(), output.toString(), run.testName)
-		}
+		t.Run(run.testName, func(t *testing.T) {
+			output := run.initial.subtract(run.inputPod)
+			if !admissionRequirementListEqual(output, run.expectedOutput) {
+				t.Errorf("expected: %s, got: %s for %s test", run.expectedOutput.toString(), output.toString(), run.testName)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
- `TestEvictPodsToFreeRequests` and  `TestEvictPodsToFreeRequestsWithError ` 
these two methods are almost the same, only the `podKiller := newFakePodKiller(true) method` is different. We should merge the two methods to reduce unnecessary code.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
It is a part of https://github.com/kubernetes/kubernetes/issues/109717#issuecomment-2294814698

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
