### PR TITLE
show namespace on delete

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete.go
@@ -520,7 +520,11 @@ func (o *DeleteOptions) PrintObj(info *resource.Info) {
 	}
 
 	// understandable output by default
-	fmt.Fprintf(o.Out, "%s \"%s\" %s\n", kindString, info.Name, operation)
+	if info.Namespaced() {
+		fmt.Fprintf(o.Out, "%s %s \"%s\" %s\n", info.Namespace, kindString, info.Name, operation)
+	} else {
+		fmt.Fprintf(o.Out, "%s \"%s\" %s\n", kindString, info.Name, operation)
+	}
 }
 
 func (o *DeleteOptions) confirmation(infos []*resource.Info) bool {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete.go
@@ -506,6 +506,10 @@ func (o *DeleteOptions) PrintObj(info *resource.Info) {
 		operation = "force deleted"
 	}
 
+	if info.Namespaced() {
+		operation = fmt.Sprintf("%s from %s namespace", operation, info.Namespace)
+	}
+
 	switch o.DryRunStrategy {
 	case cmdutil.DryRunClient:
 		operation = fmt.Sprintf("%s (dry run)", operation)
@@ -520,11 +524,7 @@ func (o *DeleteOptions) PrintObj(info *resource.Info) {
 	}
 
 	// understandable output by default
-	if info.Namespaced() {
-		fmt.Fprintf(o.Out, "%s %s \"%s\" %s\n", info.Namespace, kindString, info.Name, operation)
-	} else {
-		fmt.Fprintf(o.Out, "%s \"%s\" %s\n", kindString, info.Name, operation)
-	}
+	fmt.Fprintf(o.Out, "%s \"%s\" %s\n", kindString, info.Name, operation)
 }
 
 func (o *DeleteOptions) confirmation(infos []*resource.Info) bool {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete_test.go
@@ -972,3 +972,50 @@ func TestResourceErrors(t *testing.T) {
 		})
 	}
 }
+
+func TestDeleteMessageOutput(t *testing.T) {
+	cmdtesting.InitTestErrorHandler(t)
+	_, _, rc := cmdtesting.TestData()
+
+	tf := cmdtesting.NewTestFactory().WithNamespace("test-specific")
+	defer tf.Cleanup()
+
+	codec := scheme.Codecs.LegacyCodec(scheme.Scheme.PrioritizedVersionsAllGroups()...)
+
+	tf.UnstructuredClient = &fake.RESTClient{
+		NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
+		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+			switch p, m := req.URL.Path, req.Method; {
+			case p == "/namespaces/test-specific/replicationcontrollers/redis-master" && m == "DELETE":
+				return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &rc.Items[0])}, nil
+			default:
+				t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
+				return nil, nil
+			}
+		}),
+	}
+
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
+	cmd := NewCmdDelete(tf, streams)
+	err := cmd.Flags().Set("filename", "../../../testdata/redis-master-controller.yaml")
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	cmd.Run(cmd, []string{})
+
+	if !strings.Contains(buf.String(), "replicationcontroller") {
+		t.Errorf("message doesn't contain type (replicationcontroller): %s", buf.String())
+	}
+
+	if !strings.Contains(buf.String(), "deleted") {
+		t.Errorf("message doesn't contain action (deleted): %s", buf.String())
+	}
+
+	if !strings.Contains(buf.String(), "redis-master") {
+		t.Errorf("message doesn't contain name (redis-master): %s", buf.String())
+	}
+
+	if !strings.Contains(buf.String(), "test-specific") {
+		t.Errorf("message doesn't contain namespace (test-specific): %s", buf.String())
+	}
+}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete_test.go
@@ -1003,19 +1003,8 @@ func TestDeleteMessageOutput(t *testing.T) {
 	}
 	cmd.Run(cmd, []string{})
 
-	if !strings.Contains(buf.String(), "replicationcontroller") {
-		t.Errorf("message doesn't contain type (replicationcontroller): %s", buf.String())
+	if buf.String() != "replicationcontroller \"redis-master\" deleted from test-specific namespace\n" {
+		t.Errorf("unexpected output: %s", buf.String())
 	}
 
-	if !strings.Contains(buf.String(), "deleted") {
-		t.Errorf("message doesn't contain action (deleted): %s", buf.String())
-	}
-
-	if !strings.Contains(buf.String(), "redis-master") {
-		t.Errorf("message doesn't contain name (redis-master): %s", buf.String())
-	}
-
-	if !strings.Contains(buf.String(), "test-specific") {
-		t.Errorf("message doesn't contain namespace (test-specific): %s", buf.String())
-	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:

Included namespace in the output of the kubectl delete command.

current:
```
$ kubectl delete -f ... --dry-run=server
deployment.apps "myapp" deleted (server dry run)
$
```
changed:
(Updated based on feedback)
```
$ kubectl delete -f ... --dry-run=server
deployment.apps "myapp" deleted from myapp-prod namespace (server dry run)
$
```

Why is this needed:

The current output is ambiguous, as the resource name should be identifiable as unique.

When working with multiple namespaces like "myapp-prod" and "myapp-dev", and intending to tear down some resources in "myapp-dev", the command might look like this:
```
$ kustomize build . | kubectl delete -f - --dry-run=server
deployment.apps "kube-prometheus-stack-kube-state-metrics" deleted (server dry run)
$
```
From this output, it's unclear whether the manifest targets "myapp-dev" or "myapp-prod". This ambiguity requires additional checks to ensure the correct namespace is being targeted.

Printing the namespace in the dry-run output would enhance clarity and confidence in identifying the targeted resources.

##### Other considerations
This change can be applied for other operations like apply and replace. However, non-delete operations can be validate with the "diff" command.
Therefore, I think it is acceptable to add this feature only for the delete operation.

#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/kubectl/issues/1621

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Included namespace in the output of the kubectl delete for clearer identification of resources.
```
