### PR TITLE
[InPlacePodVerticalScaling] fix restore checkpoint bug: failed to verify pod status checkpoint checksum because of different behaviors of func Quantity.Marshal and Quantity.Unmarshal

### DIFF
--- a/pkg/kubelet/status/state/checkpoint.go
+++ b/pkg/kubelet/status/state/checkpoint.go
@@ -18,6 +18,7 @@ package state
 
 import (
 	"encoding/json"
+	"fmt"
 	"k8s.io/api/core/v1"
 	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager"
 	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager/checksum"
@@ -32,7 +33,7 @@ type PodResourceAllocationInfo struct {
 
 // Checkpoint represents a structure to store pod resource allocation checkpoint data
 type Checkpoint struct {
-	// Data is a JSON serialized checkpoint data
+	// Data is a serialized PodResourceAllocationInfo
 	Data string `json:"data"`
 	// Checksum is a checksum of Data
 	Checksum checksum.Checksum `json:"checksum"`
@@ -47,7 +48,7 @@ func NewCheckpoint(allocations *PodResourceAllocationInfo) (*Checkpoint, error) 
 	}
 
 	cp := &Checkpoint{
-		Data: string(praData),
+		Data: string(serializedAllocations),
 	}
 	cp.Checksum = checksum.New(cp.Data)
 	return cp, nil

--- a/pkg/kubelet/status/state/checkpoint.go
+++ b/pkg/kubelet/status/state/checkpoint.go
@@ -19,7 +19,8 @@ package state
 import (
 	"encoding/json"
 	"fmt"
-	"k8s.io/api/core/v1"
+
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager"
 	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager/checksum"
 )

--- a/pkg/kubelet/status/state/checkpoint.go
+++ b/pkg/kubelet/status/state/checkpoint.go
@@ -39,9 +39,9 @@ type Checkpoint struct {
 }
 
 // NewCheckpoint creates a new checkpoint from a list of claim info states
-func NewCheckpoint(data *PodResourceAllocationInfo) (*Checkpoint, error) {
+func NewCheckpoint(allocations *PodResourceAllocationInfo) (*Checkpoint, error) {
 
-	praData, err := json.Marshal(data)
+	serializedAllocations, err := json.Marshal(allocations)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kubelet/status/state/checkpoint.go
+++ b/pkg/kubelet/status/state/checkpoint.go
@@ -18,48 +18,62 @@ package state
 
 import (
 	"encoding/json"
-
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager"
 	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager/checksum"
 )
 
-var _ checkpointmanager.Checkpoint = &PodResourceAllocationCheckpoint{}
+var _ checkpointmanager.Checkpoint = &Checkpoint{}
 
-// PodResourceAllocationCheckpoint is used to store resources allocated to a pod in checkpoint
-type PodResourceAllocationCheckpoint struct {
+type PodResourceAllocationInfo struct {
 	AllocationEntries   map[string]map[string]v1.ResourceRequirements `json:"allocationEntries,omitempty"`
 	ResizeStatusEntries map[string]v1.PodResizeStatus                 `json:"resizeStatusEntries,omitempty"`
-	Checksum            checksum.Checksum                             `json:"checksum"`
 }
 
-// NewPodResourceAllocationCheckpoint returns an instance of Checkpoint
-func NewPodResourceAllocationCheckpoint() *PodResourceAllocationCheckpoint {
-	//lint:ignore unexported-type-in-api user-facing error message
-	return &PodResourceAllocationCheckpoint{
-		AllocationEntries:   make(map[string]map[string]v1.ResourceRequirements),
-		ResizeStatusEntries: make(map[string]v1.PodResizeStatus),
+// Checkpoint represents a structure to store pod resource allocation checkpoint data
+type Checkpoint struct {
+	// Data is a JSON serialized checkpoint data
+	Data string `json:"data"`
+	// Checksum is a checksum of Data
+	Checksum checksum.Checksum `json:"checksum"`
+}
+
+// NewCheckpoint creates a new checkpoint from a list of claim info states
+func NewCheckpoint(data *PodResourceAllocationInfo) (*Checkpoint, error) {
+
+	praData, err := json.Marshal(data)
+	if err != nil {
+		return nil, err
 	}
+
+	cp := &Checkpoint{
+		Data: string(praData),
+	}
+	cp.Checksum = checksum.New(cp.Data)
+	return cp, nil
 }
 
-// MarshalCheckpoint returns marshalled checkpoint
-func (prc *PodResourceAllocationCheckpoint) MarshalCheckpoint() ([]byte, error) {
-	// make sure checksum wasn't set before so it doesn't affect output checksum
-	prc.Checksum = 0
-	prc.Checksum = checksum.New(prc)
-	return json.Marshal(*prc)
+func (cp *Checkpoint) MarshalCheckpoint() ([]byte, error) {
+	return json.Marshal(cp)
 }
 
-// UnmarshalCheckpoint tries to unmarshal passed bytes to checkpoint
-func (prc *PodResourceAllocationCheckpoint) UnmarshalCheckpoint(blob []byte) error {
-	return json.Unmarshal(blob, prc)
+// UnmarshalCheckpoint unmarshals checkpoint from JSON
+func (cp *Checkpoint) UnmarshalCheckpoint(blob []byte) error {
+	return json.Unmarshal(blob, cp)
 }
 
-// VerifyChecksum verifies that current checksum of checkpoint is valid
-func (prc *PodResourceAllocationCheckpoint) VerifyChecksum() error {
-	ck := prc.Checksum
-	prc.Checksum = 0
-	err := ck.Verify(prc)
-	prc.Checksum = ck
-	return err
+// VerifyChecksum verifies that current checksum
+// of checkpointed Data is valid
+func (cp *Checkpoint) VerifyChecksum() error {
+	return cp.Checksum.Verify(cp.Data)
+}
+
+// GetPodResourceAllocationInfo returns Pod Resource Allocation info states from checkpoint
+func (cp *Checkpoint) GetPodResourceAllocationInfo() (*PodResourceAllocationInfo, error) {
+	var data PodResourceAllocationInfo
+	if err := json.Unmarshal([]byte(cp.Data), &data); err != nil {
+		return nil, err
+	}
+
+	return &data, nil
 }

--- a/pkg/kubelet/status/state/checkpoint.go
+++ b/pkg/kubelet/status/state/checkpoint.go
@@ -43,7 +43,7 @@ func NewCheckpoint(allocations *PodResourceAllocationInfo) (*Checkpoint, error) 
 
 	serializedAllocations, err := json.Marshal(allocations)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to serialize allocations for checkpointing: %w", err)
 	}
 
 	cp := &Checkpoint{

--- a/pkg/kubelet/status/state/state_checkpoint.go
+++ b/pkg/kubelet/status/state/state_checkpoint.go
@@ -98,8 +98,7 @@ func (sc *stateCheckpoint) storeState() error {
 		ResizeStatusEntries: podResizeStatus,
 	})
 	if err != nil {
-		klog.ErrorS(err, "Failed to create checkpoint")
-		return err
+		return fmt.Errorf("failed to create checkpoint: %w", err)
 	}
 	err = sc.checkpointManager.CreateCheckpoint(sc.checkpointName, checkpoint)
 	if err != nil {

--- a/pkg/kubelet/status/state/state_checkpoint.go
+++ b/pkg/kubelet/status/state/state_checkpoint.go
@@ -61,7 +61,10 @@ func (sc *stateCheckpoint) restoreState() error {
 	defer sc.mux.Unlock()
 	var err error
 
-	checkpoint := NewPodResourceAllocationCheckpoint()
+	checkpoint, err := NewCheckpoint(nil)
+	if err != nil {
+		return fmt.Errorf("failed to create new checkpoint: %w", err)
+	}
 
 	if err = sc.checkpointManager.GetCheckpoint(sc.checkpointName, checkpoint); err != nil {
 		if err == errors.ErrCheckpointNotFound {
@@ -69,32 +72,36 @@ func (sc *stateCheckpoint) restoreState() error {
 		}
 		return err
 	}
-
-	sc.cache.SetPodResourceAllocation(checkpoint.AllocationEntries)
-	sc.cache.SetResizeStatus(checkpoint.ResizeStatusEntries)
+	praInfo, err := checkpoint.GetPodResourceAllocationInfo()
+	if err != nil {
+		return fmt.Errorf("failed to get pod resource allocation info: %w", err)
+	}
+	err = sc.cache.SetPodResourceAllocation(praInfo.AllocationEntries)
+	if err != nil {
+		return fmt.Errorf("failed to set pod resource allocation: %w", err)
+	}
+	err = sc.cache.SetResizeStatus(praInfo.ResizeStatusEntries)
+	if err != nil {
+		return fmt.Errorf("failed to set resize status: %w", err)
+	}
 	klog.V(2).InfoS("State checkpoint: restored pod resource allocation state from checkpoint")
 	return nil
 }
 
 // saves state to a checkpoint, caller is responsible for locking
 func (sc *stateCheckpoint) storeState() error {
-	checkpoint := NewPodResourceAllocationCheckpoint()
-
 	podAllocation := sc.cache.GetPodResourceAllocation()
-	for pod := range podAllocation {
-		checkpoint.AllocationEntries[pod] = make(map[string]v1.ResourceRequirements)
-		for container, alloc := range podAllocation[pod] {
-			checkpoint.AllocationEntries[pod][container] = alloc
-		}
-	}
 
 	podResizeStatus := sc.cache.GetResizeStatus()
-	checkpoint.ResizeStatusEntries = make(map[string]v1.PodResizeStatus)
-	for pUID, rStatus := range podResizeStatus {
-		checkpoint.ResizeStatusEntries[pUID] = rStatus
+	checkpoint, err := NewCheckpoint(&PodResourceAllocationInfo{
+		AllocationEntries:   podAllocation,
+		ResizeStatusEntries: podResizeStatus,
+	})
+	if err != nil {
+		klog.ErrorS(err, "Failed to create checkpoint")
+		return err
 	}
-
-	err := sc.checkpointManager.CreateCheckpoint(sc.checkpointName, checkpoint)
+	err = sc.checkpointManager.CreateCheckpoint(sc.checkpointName, checkpoint)
 	if err != nil {
 		klog.ErrorS(err, "Failed to save pod allocation checkpoint")
 		return err

--- a/pkg/kubelet/status/state/state_checkpoint_test.go
+++ b/pkg/kubelet/status/state/state_checkpoint_test.go
@@ -1,0 +1,175 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package state
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager"
+)
+
+func newTestStateCheckpoint(t *testing.T) *stateCheckpoint {
+	// create temp dir
+	testingDir, err := os.MkdirTemp("", "pod_resource_allocation_state_test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := os.RemoveAll(testingDir); err != nil {
+			t.Fatal(err)
+		}
+	}()
+	cache := NewStateMemory()
+	checkpointManager, err := checkpointmanager.NewCheckpointManager(testingDir)
+	require.NoError(t, err, "failed to create checkpoint manager")
+	checkpointName := "pod_state_checkpoint"
+	sc := &stateCheckpoint{
+		cache:             cache,
+		checkpointManager: checkpointManager,
+		checkpointName:    checkpointName,
+	}
+	return sc
+}
+
+func Test_stateCheckpoint_storeState(t *testing.T) {
+	sc := newTestStateCheckpoint(t)
+	type args struct {
+		podResourceAllocation PodResourceAllocation
+	}
+
+	tests := []struct {
+		name string
+		args args
+	}{}
+	suffix := []string{"Ki", "Mi", "Gi", "Ti", "Pi", "Ei", "n", "u", "m", "k", "M", "G", "T", "P", "E", ""}
+	factor := []string{"1", "0.1", "0.03", "10", "100", "512", "1000", "1024", "700", "10000"}
+	for _, fact := range factor {
+		for _, suf := range suffix {
+			if (suf == "E" || suf == "Ei") && (fact == "1000" || fact == "10000") {
+				// when fact is 1000 or 10000, suffix "E" or "Ei", the quantity value is overflow
+				// see detail https://github.com/kubernetes/apimachinery/blob/95b78024e3feada7739b40426690b4f287933fd8/pkg/api/resource/quantity.go#L301
+				continue
+			}
+			tests = append(tests, struct {
+				name string
+				args args
+			}{
+				name: fmt.Sprintf("resource - %s%s", fact, suf),
+				args: args{
+					podResourceAllocation: PodResourceAllocation{
+						"pod1": {
+							"container1": {
+								Requests: v1.ResourceList{
+									v1.ResourceCPU:    resource.MustParse(fmt.Sprintf("%s%s", fact, suf)),
+									v1.ResourceMemory: resource.MustParse(fmt.Sprintf("%s%s", fact, suf)),
+								},
+							},
+						},
+					},
+				},
+			})
+		}
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := sc.cache.ClearState()
+			require.NoError(t, err, "failed to clear state")
+
+			defer func() {
+				err = sc.checkpointManager.RemoveCheckpoint(sc.checkpointName)
+				require.NoError(t, err, "failed to remove checkpoint")
+			}()
+
+			err = sc.cache.SetPodResourceAllocation(tt.args.podResourceAllocation)
+			require.NoError(t, err, "failed to set pod resource allocation")
+
+			err = sc.storeState()
+			require.NoError(t, err, "failed to store state")
+
+			// deep copy cache
+			originCache := NewStateMemory()
+			podAllocation := sc.cache.GetPodResourceAllocation()
+			err = originCache.SetPodResourceAllocation(podAllocation)
+			require.NoError(t, err, "failed to set pod resource allocation")
+
+			err = sc.cache.ClearState()
+			require.NoError(t, err, "failed to clear state")
+
+			err = sc.restoreState()
+			require.NoError(t, err, "failed to restore state")
+
+			restoredCache := sc.cache
+			require.Equal(t, len(originCache.GetPodResourceAllocation()), len(restoredCache.GetPodResourceAllocation()), "restored pod resource allocation is not equal to original pod resource allocation")
+			for podUID, containerResourceList := range originCache.GetPodResourceAllocation() {
+				require.Equal(t, len(containerResourceList), len(restoredCache.GetPodResourceAllocation()[podUID]), "restored pod resource allocation is not equal to original pod resource allocation")
+				for containerName, resourceList := range containerResourceList {
+					for name, quantity := range resourceList.Requests {
+						if !quantity.Equal(restoredCache.GetPodResourceAllocation()[podUID][containerName].Requests[name]) {
+							t.Errorf("restored pod resource allocation is not equal to original pod resource allocation")
+						}
+					}
+				}
+			}
+		})
+	}
+}
+
+func Test_stateCheckpoint_formatUpgraded(t *testing.T) {
+	// Based on the PodResourceAllocationInfo struct, it's mostly possible that new field will be added
+	// in struct PodResourceAllocationInfo, rather than in struct PodResourceAllocationInfo.AllocationEntries.
+	// Emulate upgrade scenario by pretending that `ResizeStatusEntries` is a new field.
+	// The checkpoint content doesn't have it and that shouldn't prevent the checkpoint from being loaded.
+	sc := newTestStateCheckpoint(t)
+
+	// prepare old checkpoint, ResizeStatusEntries is unset,
+	// pretend that the old checkpoint is unaware for the field ResizeStatusEntries
+	checkpointContent := `{"data":"{\"allocationEntries\":{\"pod1\":{\"container1\":{\"requests\":{\"cpu\":\"1Ki\",\"memory\":\"1Ki\"}}}}}","checksum":1555601526}`
+	checkpoint := &Checkpoint{}
+	err := checkpoint.UnmarshalCheckpoint([]byte(checkpointContent))
+	require.NoError(t, err, "failed to unmarshal checkpoint")
+
+	err = sc.checkpointManager.CreateCheckpoint(sc.checkpointName, checkpoint)
+	require.NoError(t, err, "failed to create old checkpoint")
+
+	err = sc.restoreState()
+	require.NoError(t, err, "failed to restore state")
+
+	expectedPodResourceAllocationInfo := &PodResourceAllocationInfo{
+		AllocationEntries: map[string]map[string]v1.ResourceRequirements{
+			"pod1": {
+				"container1": {
+					Requests: v1.ResourceList{
+						v1.ResourceCPU:    resource.MustParse("1Ki"),
+						v1.ResourceMemory: resource.MustParse("1Ki"),
+					},
+				},
+			},
+		},
+		ResizeStatusEntries: map[string]v1.PodResizeStatus{},
+	}
+	actualPodResourceAllocationInfo := &PodResourceAllocationInfo{}
+	actualPodResourceAllocationInfo.AllocationEntries = sc.cache.GetPodResourceAllocation()
+	actualPodResourceAllocationInfo.ResizeStatusEntries = sc.cache.GetResizeStatus()
+	require.NoError(t, err, "failed to get pod resource allocation info")
+	require.Equal(t, expectedPodResourceAllocationInfo, actualPodResourceAllocationInfo, "pod resource allocation info is not equal")
+}

--- a/pkg/kubelet/status/state/state_checkpoint_test.go
+++ b/pkg/kubelet/status/state/state_checkpoint_test.go
@@ -131,7 +131,7 @@ func Test_stateCheckpoint_storeState(t *testing.T) {
 			require.NoError(t, err)
 
 			actual = newSC.GetPodResourceAllocation()
-			verifyPodResourceAllocation(t, &tt.args.podResourceAllocation, &actual, "stored pod resource allocation is not equal to original pod resource allocation")
+			verifyPodResourceAllocation(t, &tt.args.podResourceAllocation, &actual, "restored pod resource allocation is not equal to original pod resource allocation")
 		})
 	}
 }

--- a/pkg/kubelet/status/state/state_checkpoint_test.go
+++ b/pkg/kubelet/status/state/state_checkpoint_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors.
+Copyright 2024 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/kubelet/status/state/state_checkpoint_test.go
+++ b/pkg/kubelet/status/state/state_checkpoint_test.go
@@ -145,7 +145,7 @@ func Test_stateCheckpoint_formatUpgraded(t *testing.T) {
 
 	// prepare old checkpoint, ResizeStatusEntries is unset,
 	// pretend that the old checkpoint is unaware for the field ResizeStatusEntries
-	checkpointContent := `{"data":"{\"allocationEntries\":{\"pod1\":{\"container1\":{\"requests\":{\"cpu\":\"1Ki\",\"memory\":\"1Ki\"}}}}}","checksum":1555601526}`
+	const checkpointContent = `{"data":"{\"allocationEntries\":{\"pod1\":{\"container1\":{\"requests\":{\"cpu\":\"1Ki\",\"memory\":\"1Ki\"}}}}}","checksum":1555601526}`
 	checkpoint := &Checkpoint{}
 	err := checkpoint.UnmarshalCheckpoint([]byte(checkpointContent))
 	require.NoError(t, err, "failed to unmarshal checkpoint")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Fix one bug of the feature `pod in-place resource resize, feature gate: InPlacePodVerticalScaling`
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/128375

#### Special notes for your reviewer:
One line bug description: the content func [stateCheckpoint.storeState](https://github.com/kubernetes/kubernetes/blob/60c4c2b2521fb454ce69dee737e3eb91a25e0535/pkg/kubelet/status/state/state_checkpoint.go#L80) writes into the file `/var/lib/kubelet/pod_status_manager_state` is different from it func [stateCheckpoint.restoreState](https://github.com/kubernetes/kubernetes/blob/60c4c2b2521fb454ce69dee737e3eb91a25e0535/pkg/kubelet/status/state/state_checkpoint.go#L59) reads from the same file, which causes function [VerifyChecksum](https://github.com/kubernetes/kubernetes/blob/60c4c2b2521fb454ce69dee737e3eb91a25e0535/pkg/kubelet/status/state/checkpoint.go#L59) always fails for some format of Quantity value. It should only happen for static pods in static dir.

**How to reproduce? **

1. prepare a pod spec with content below
```json
{
  "apiVersion": "v1",
  "kind": "Pod",
  "metadata": {
    "name": "nginx2"
  },
  "spec": {
    "containers": [
      {
        "name": "nginx",
        "image": "nginx:1.14.2",
        "ports": [
          {
            "containerPort": 80
          }
        ],
        "resources": {
          "requests": {
            "cpu": "0.4",
            "memory": "1Gi"
          },
          "limits": {
            "cpu": "1.5",
            "memory": "1Gi"
          }
        }
      }
    ]
  }
}
```
2. copy the pod spec into dir `/etc/kubernetes/manifest/` in master node
3.  restart the kubelet `systemctl restart kubelet`
4.  the kubelet will crash all the time until the file `/var/lib/kubelet/pod_status_manager_state` is deleted
5. error message would be like below
```shell
Aug 10 04:39:38 minikube systemd[1]: kubelet.service: Failed with result 'exit-code'.
Aug 10 04:39:38 minikube systemd[1]: kubelet.service: Main process exited, code=exited, status=2/INVALIDARGUMENT
Aug 10 04:39:38 minikube kubelet[1190750]:         k8s.io/kubernetes/cmd/kubelet/app/server.go:1239 +0x90
Aug 10 04:39:38 minikube kubelet[1190750]: created by k8s.io/kubernetes/cmd/kubelet/app.startKubelet in goroutine 1
Aug 10 04:39:38 minikube kubelet[1190750]:         k8s.io/kubernetes/pkg/kubelet/kubelet.go:1628 +0x658
Aug 10 04:39:38 minikube kubelet[1190750]: k8s.io/kubernetes/pkg/kubelet.(*Kubelet).Run(0x4000ccac08, 0x4000ca1140)
Aug 10 04:39:38 minikube kubelet[1190750]:         k8s.io/kubernetes/pkg/kubelet/status/status_manager.go:204 +0x28c
Aug 10 04:39:38 minikube kubelet[1190750]: k8s.io/kubernetes/pkg/kubelet/status.(*manager).Start(0x40007a3a70)
Aug 10 04:39:38 minikube kubelet[1190750]: goroutine 239 [running]:
Aug 10 04:39:38 minikube kubelet[1190750]: panic: could not restore state from checkpoint: checkpoint is corrupted, please drain this node and delete pod allocation checkpoint file "/var/lib/kubelet/pod_status_manager_state" before restarting Kubelet
Aug 10 04:39:38 minikube kubelet[1190750]: E0810 04:39:38.722303 1190750 status_manager.go:203] "Could not initialize pod allocation checkpoint manager, please drain node and remove policy state file" err="could not restore state from checkpoint: checkpoint is corrupted, please drain this node and delete pod allocation checkpoint file \"/var/lib/kubelet/pod_status_manager_state\" before restarting Kubelet"
```


**Root cause**
The json marshal function of Quantity type will convert itself to `CanonicalBytes`
https://github.com/kubernetes/apimachinery/blob/95b78024e3feada7739b40426690b4f287933fd8/pkg/api/resource/quantity.go#L452C25-L452C41
But the json unmarshal function of Quantity type won't do that.
https://github.com/kubernetes/apimachinery/blob/95b78024e3feada7739b40426690b4f287933fd8/pkg/api/resource/quantity.go#L701
For some formats for Quantity value, the Quantity contents, wrote to and read from the same file, might be different.
For example, if the pod cpu request is defined as `cpu: "0.4"`, the Quantity content is `cpu:{{4 -1} {<nil>}  DecimalSI` before writing it into the file, but the content is `cpu:{{400 -3} {<nil>} 400m DecimalSI` after reading from the same file.

According to the reason above, the function [VerifyChecksum](https://github.com/kubernetes/kubernetes/blob/60c4c2b2521fb454ce69dee737e3eb91a25e0535/pkg/kubelet/status/state/checkpoint.go#L59) might fail.

**Detailed test case**
<details>

```text
=== RUN   Test_stateCheckpoint_storeState
=== RUN   Test_stateCheckpoint_storeState/format_0_-_cpu_1Ki
=== RUN   Test_stateCheckpoint_storeState/format_1_-_cpu_1Mi
=== RUN   Test_stateCheckpoint_storeState/format_2_-_cpu_1Gi
=== RUN   Test_stateCheckpoint_storeState/format_3_-_cpu_1Ti
=== RUN   Test_stateCheckpoint_storeState/format_4_-_cpu_1Pi
=== RUN   Test_stateCheckpoint_storeState/format_5_-_cpu_1Ei
=== RUN   Test_stateCheckpoint_storeState/format_6_-_cpu_1n
=== RUN   Test_stateCheckpoint_storeState/format_7_-_cpu_1u
=== RUN   Test_stateCheckpoint_storeState/format_8_-_cpu_1m
=== RUN   Test_stateCheckpoint_storeState/format_9_-_cpu_1k
=== RUN   Test_stateCheckpoint_storeState/format_10_-_cpu_1M
=== RUN   Test_stateCheckpoint_storeState/format_11_-_cpu_1G
=== RUN   Test_stateCheckpoint_storeState/format_12_-_cpu_1T
=== RUN   Test_stateCheckpoint_storeState/format_13_-_cpu_1P
=== RUN   Test_stateCheckpoint_storeState/format_14_-_cpu_1E
=== RUN   Test_stateCheckpoint_storeState/format_15_-_cpu_1
=== RUN   Test_stateCheckpoint_storeState/format_16_-_cpu_0.1Ki
    state_checkpoint_test.go:82: failed to restore state: checkpoint is corrupted
=== RUN   Test_stateCheckpoint_storeState/format_17_-_cpu_0.1Mi
    state_checkpoint_test.go:82: failed to restore state: checkpoint is corrupted
=== RUN   Test_stateCheckpoint_storeState/format_18_-_cpu_0.1Gi
    state_checkpoint_test.go:82: failed to restore state: checkpoint is corrupted
=== RUN   Test_stateCheckpoint_storeState/format_19_-_cpu_0.1Ti
    state_checkpoint_test.go:82: failed to restore state: checkpoint is corrupted
=== RUN   Test_stateCheckpoint_storeState/format_20_-_cpu_0.1Pi
    state_checkpoint_test.go:82: failed to restore state: checkpoint is corrupted
=== RUN   Test_stateCheckpoint_storeState/format_21_-_cpu_0.1Ei
    state_checkpoint_test.go:82: failed to restore state: checkpoint is corrupted
=== RUN   Test_stateCheckpoint_storeState/format_22_-_cpu_0.1n
    state_checkpoint_test.go:82: failed to restore state: checkpoint is corrupted
=== RUN   Test_stateCheckpoint_storeState/format_23_-_cpu_0.1u
    state_checkpoint_test.go:82: failed to restore state: checkpoint is corrupted
=== RUN   Test_stateCheckpoint_storeState/format_24_-_cpu_0.1m
    state_checkpoint_test.go:82: failed to restore state: checkpoint is corrupted
=== RUN   Test_stateCheckpoint_storeState/format_25_-_cpu_0.1k
    state_checkpoint_test.go:82: failed to restore state: checkpoint is corrupted
=== RUN   Test_stateCheckpoint_storeState/format_26_-_cpu_0.1M
    state_checkpoint_test.go:82: failed to restore state: checkpoint is corrupted
=== RUN   Test_stateCheckpoint_storeState/format_27_-_cpu_0.1G
    state_checkpoint_test.go:82: failed to restore state: checkpoint is corrupted
=== RUN   Test_stateCheckpoint_storeState/format_28_-_cpu_0.1T
    state_checkpoint_test.go:82: failed to restore state: checkpoint is corrupted
=== RUN   Test_stateCheckpoint_storeState/format_29_-_cpu_0.1P
    state_checkpoint_test.go:82: failed to restore state: checkpoint is corrupted
=== RUN   Test_stateCheckpoint_storeState/format_30_-_cpu_0.1E
    state_checkpoint_test.go:82: failed to restore state: checkpoint is corrupted
=== RUN   Test_stateCheckpoint_storeState/format_31_-_cpu_0.1
    state_checkpoint_test.go:82: failed to restore state: checkpoint is corrupted
=== RUN   Test_stateCheckpoint_storeState/format_32_-_cpu_0.03Ki
    state_checkpoint_test.go:82: failed to restore state: checkpoint is corrupted
=== RUN   Test_stateCheckpoint_storeState/format_33_-_cpu_0.03Mi
    state_checkpoint_test.go:82: failed to restore state: checkpoint is corrupted
=== RUN   Test_stateCheckpoint_storeState/format_34_-_cpu_0.03Gi
    state_checkpoint_test.go:82: failed to restore state: checkpoint is corrupted
=== RUN   Test_stateCheckpoint_storeState/format_35_-_cpu_0.03Ti
    state_checkpoint_test.go:82: failed to restore state: checkpoint is corrupted
=== RUN   Test_stateCheckpoint_storeState/format_36_-_cpu_0.03Pi
    state_checkpoint_test.go:82: failed to restore state: checkpoint is corrupted
=== RUN   Test_stateCheckpoint_storeState/format_37_-_cpu_0.03Ei
    state_checkpoint_test.go:82: failed to restore state: checkpoint is corrupted
=== RUN   Test_stateCheckpoint_storeState/format_38_-_cpu_0.03n
    state_checkpoint_test.go:82: failed to restore state: checkpoint is corrupted
=== RUN   Test_stateCheckpoint_storeState/format_39_-_cpu_0.03u
    state_checkpoint_test.go:82: failed to restore state: checkpoint is corrupted
=== RUN   Test_stateCheckpoint_storeState/format_40_-_cpu_0.03m
    state_checkpoint_test.go:82: failed to restore state: checkpoint is corrupted
=== RUN   Test_stateCheckpoint_storeState/format_41_-_cpu_0.03k
    state_checkpoint_test.go:82: failed to restore state: checkpoint is corrupted
=== RUN   Test_stateCheckpoint_storeState/format_42_-_cpu_0.03M
    state_checkpoint_test.go:82: failed to restore state: checkpoint is corrupted
=== RUN   Test_stateCheckpoint_storeState/format_43_-_cpu_0.03G
    state_checkpoint_test.go:82: failed to restore state: checkpoint is corrupted
=== RUN   Test_stateCheckpoint_storeState/format_44_-_cpu_0.03T
    state_checkpoint_test.go:82: failed to restore state: checkpoint is corrupted
=== RUN   Test_stateCheckpoint_storeState/format_45_-_cpu_0.03P
    state_checkpoint_test.go:82: failed to restore state: checkpoint is corrupted
=== RUN   Test_stateCheckpoint_storeState/format_46_-_cpu_0.03E
    state_checkpoint_test.go:82: failed to restore state: checkpoint is corrupted
=== RUN   Test_stateCheckpoint_storeState/format_47_-_cpu_0.03
    state_checkpoint_test.go:82: failed to restore state: checkpoint is corrupted
=== RUN   Test_stateCheckpoint_storeState/format_48_-_cpu_10Ki
=== RUN   Test_stateCheckpoint_storeState/format_49_-_cpu_10Mi
=== RUN   Test_stateCheckpoint_storeState/format_50_-_cpu_10Gi
=== RUN   Test_stateCheckpoint_storeState/format_51_-_cpu_10Ti
=== RUN   Test_stateCheckpoint_storeState/format_52_-_cpu_10Pi
=== RUN   Test_stateCheckpoint_storeState/format_53_-_cpu_10Ei
    state_checkpoint_test.go:82: failed to restore state: checkpoint is corrupted
=== RUN   Test_stateCheckpoint_storeState/format_54_-_cpu_10n
=== RUN   Test_stateCheckpoint_storeState/format_55_-_cpu_10u
=== RUN   Test_stateCheckpoint_storeState/format_56_-_cpu_10m
=== RUN   Test_stateCheckpoint_storeState/format_57_-_cpu_10k
=== RUN   Test_stateCheckpoint_storeState/format_58_-_cpu_10M
=== RUN   Test_stateCheckpoint_storeState/format_59_-_cpu_10G
=== RUN   Test_stateCheckpoint_storeState/format_60_-_cpu_10T
=== RUN   Test_stateCheckpoint_storeState/format_61_-_cpu_10P
=== RUN   Test_stateCheckpoint_storeState/format_62_-_cpu_10E
=== RUN   Test_stateCheckpoint_storeState/format_63_-_cpu_10
=== RUN   Test_stateCheckpoint_storeState/format_64_-_cpu_100Ki
=== RUN   Test_stateCheckpoint_storeState/format_65_-_cpu_100Mi
=== RUN   Test_stateCheckpoint_storeState/format_66_-_cpu_100Gi
=== RUN   Test_stateCheckpoint_storeState/format_67_-_cpu_100Ti
=== RUN   Test_stateCheckpoint_storeState/format_68_-_cpu_100Pi
=== RUN   Test_stateCheckpoint_storeState/format_69_-_cpu_100Ei
    state_checkpoint_test.go:82: failed to restore state: checkpoint is corrupted
=== RUN   Test_stateCheckpoint_storeState/format_70_-_cpu_100n
=== RUN   Test_stateCheckpoint_storeState/format_71_-_cpu_100u
=== RUN   Test_stateCheckpoint_storeState/format_72_-_cpu_100m
=== RUN   Test_stateCheckpoint_storeState/format_73_-_cpu_100k
=== RUN   Test_stateCheckpoint_storeState/format_74_-_cpu_100M
=== RUN   Test_stateCheckpoint_storeState/format_75_-_cpu_100G
=== RUN   Test_stateCheckpoint_storeState/format_76_-_cpu_100T
=== RUN   Test_stateCheckpoint_storeState/format_77_-_cpu_100P
=== RUN   Test_stateCheckpoint_storeState/format_78_-_cpu_100E
=== RUN   Test_stateCheckpoint_storeState/format_79_-_cpu_100
=== RUN   Test_stateCheckpoint_storeState/format_80_-_cpu_512Ki
=== RUN   Test_stateCheckpoint_storeState/format_81_-_cpu_512Mi
=== RUN   Test_stateCheckpoint_storeState/format_82_-_cpu_512Gi
=== RUN   Test_stateCheckpoint_storeState/format_83_-_cpu_512Ti
=== RUN   Test_stateCheckpoint_storeState/format_84_-_cpu_512Pi
=== RUN   Test_stateCheckpoint_storeState/format_85_-_cpu_512Ei
    state_checkpoint_test.go:82: failed to restore state: checkpoint is corrupted
=== RUN   Test_stateCheckpoint_storeState/format_86_-_cpu_512n
=== RUN   Test_stateCheckpoint_storeState/format_87_-_cpu_512u
=== RUN   Test_stateCheckpoint_storeState/format_88_-_cpu_512m
=== RUN   Test_stateCheckpoint_storeState/format_89_-_cpu_512k
=== RUN   Test_stateCheckpoint_storeState/format_90_-_cpu_512M
=== RUN   Test_stateCheckpoint_storeState/format_91_-_cpu_512G
=== RUN   Test_stateCheckpoint_storeState/format_92_-_cpu_512T
=== RUN   Test_stateCheckpoint_storeState/format_93_-_cpu_512P
=== RUN   Test_stateCheckpoint_storeState/format_94_-_cpu_512E
=== RUN   Test_stateCheckpoint_storeState/format_95_-_cpu_512
=== RUN   Test_stateCheckpoint_storeState/format_96_-_cpu_1000Ki
=== RUN   Test_stateCheckpoint_storeState/format_97_-_cpu_1000Mi
=== RUN   Test_stateCheckpoint_storeState/format_98_-_cpu_1000Gi
=== RUN   Test_stateCheckpoint_storeState/format_99_-_cpu_1000Ti
=== RUN   Test_stateCheckpoint_storeState/format_100_-_cpu_1000Pi
=== RUN   Test_stateCheckpoint_storeState/format_101_-_cpu_1000Ei
    state_checkpoint_test.go:82: failed to restore state: checkpoint is corrupted
=== RUN   Test_stateCheckpoint_storeState/format_102_-_cpu_1000n
    state_checkpoint_test.go:82: failed to restore state: checkpoint is corrupted
=== RUN   Test_stateCheckpoint_storeState/format_103_-_cpu_1000u
    state_checkpoint_test.go:82: failed to restore state: checkpoint is corrupted
=== RUN   Test_stateCheckpoint_storeState/format_104_-_cpu_1000m
    state_checkpoint_test.go:82: failed to restore state: checkpoint is corrupted
=== RUN   Test_stateCheckpoint_storeState/format_105_-_cpu_1000k
    state_checkpoint_test.go:82: failed to restore state: checkpoint is corrupted
=== RUN   Test_stateCheckpoint_storeState/format_106_-_cpu_1000M
    state_checkpoint_test.go:82: failed to restore state: checkpoint is corrupted
=== RUN   Test_stateCheckpoint_storeState/format_107_-_cpu_1000G
    state_checkpoint_test.go:82: failed to restore state: checkpoint is corrupted
=== RUN   Test_stateCheckpoint_storeState/format_108_-_cpu_1000T
    state_checkpoint_test.go:82: failed to restore state: checkpoint is corrupted
=== RUN   Test_stateCheckpoint_storeState/format_109_-_cpu_1000P
    state_checkpoint_test.go:82: failed to restore state: checkpoint is corrupted
=== RUN   Test_stateCheckpoint_storeState/format_110_-_cpu_1000E
    state_checkpoint_test.go:82: failed to restore state: checkpoint is corrupted
=== RUN   Test_stateCheckpoint_storeState/format_111_-_cpu_1000
    state_checkpoint_test.go:82: failed to restore state: checkpoint is corrupted
=== RUN   Test_stateCheckpoint_storeState/format_112_-_cpu_1024Ki
    state_checkpoint_test.go:82: failed to restore state: checkpoint is corrupted
=== RUN   Test_stateCheckpoint_storeState/format_113_-_cpu_1024Mi
    state_checkpoint_test.go:82: failed to restore state: checkpoint is corrupted
=== RUN   Test_stateCheckpoint_storeState/format_114_-_cpu_1024Gi
    state_checkpoint_test.go:82: failed to restore state: checkpoint is corrupted
=== RUN   Test_stateCheckpoint_storeState/format_115_-_cpu_1024Ti
=== RUN   Test_stateCheckpoint_storeState/format_116_-_cpu_1024Pi
=== RUN   Test_stateCheckpoint_storeState/format_117_-_cpu_1024Ei
    state_checkpoint_test.go:82: failed to restore state: checkpoint is corrupted
=== RUN   Test_stateCheckpoint_storeState/format_118_-_cpu_1024n
=== RUN   Test_stateCheckpoint_storeState/format_119_-_cpu_1024u
=== RUN   Test_stateCheckpoint_storeState/format_120_-_cpu_1024m
=== RUN   Test_stateCheckpoint_storeState/format_121_-_cpu_1024k
=== RUN   Test_stateCheckpoint_storeState/format_122_-_cpu_1024M
=== RUN   Test_stateCheckpoint_storeState/format_123_-_cpu_1024G
=== RUN   Test_stateCheckpoint_storeState/format_124_-_cpu_1024T
=== RUN   Test_stateCheckpoint_storeState/format_125_-_cpu_1024P
=== RUN   Test_stateCheckpoint_storeState/format_126_-_cpu_1024E
=== RUN   Test_stateCheckpoint_storeState/format_127_-_cpu_1024
=== RUN   Test_stateCheckpoint_storeState/format_128_-_cpu_700Ki
=== RUN   Test_stateCheckpoint_storeState/format_129_-_cpu_700Mi
=== RUN   Test_stateCheckpoint_storeState/format_130_-_cpu_700Gi
=== RUN   Test_stateCheckpoint_storeState/format_131_-_cpu_700Ti
=== RUN   Test_stateCheckpoint_storeState/format_132_-_cpu_700Pi
=== RUN   Test_stateCheckpoint_storeState/format_133_-_cpu_700Ei
    state_checkpoint_test.go:82: failed to restore state: checkpoint is corrupted
=== RUN   Test_stateCheckpoint_storeState/format_134_-_cpu_700n
=== RUN   Test_stateCheckpoint_storeState/format_135_-_cpu_700u
=== RUN   Test_stateCheckpoint_storeState/format_136_-_cpu_700m
=== RUN   Test_stateCheckpoint_storeState/format_137_-_cpu_700k
=== RUN   Test_stateCheckpoint_storeState/format_138_-_cpu_700M
=== RUN   Test_stateCheckpoint_storeState/format_139_-_cpu_700G
=== RUN   Test_stateCheckpoint_storeState/format_140_-_cpu_700T
=== RUN   Test_stateCheckpoint_storeState/format_141_-_cpu_700P
=== RUN   Test_stateCheckpoint_storeState/format_142_-_cpu_700E
=== RUN   Test_stateCheckpoint_storeState/format_143_-_cpu_700
=== RUN   Test_stateCheckpoint_storeState/format_144_-_cpu_10000Ki
=== RUN   Test_stateCheckpoint_storeState/format_145_-_cpu_10000Mi
=== RUN   Test_stateCheckpoint_storeState/format_146_-_cpu_10000Gi
=== RUN   Test_stateCheckpoint_storeState/format_147_-_cpu_10000Ti
=== RUN   Test_stateCheckpoint_storeState/format_148_-_cpu_10000Pi
    state_checkpoint_test.go:82: failed to restore state: checkpoint is corrupted
=== RUN   Test_stateCheckpoint_storeState/format_149_-_cpu_10000Ei
    state_checkpoint_test.go:82: failed to restore state: checkpoint is corrupted
=== RUN   Test_stateCheckpoint_storeState/format_150_-_cpu_10000n
    state_checkpoint_test.go:82: failed to restore state: checkpoint is corrupted
=== RUN   Test_stateCheckpoint_storeState/format_151_-_cpu_10000u
    state_checkpoint_test.go:82: failed to restore state: checkpoint is corrupted
=== RUN   Test_stateCheckpoint_storeState/format_152_-_cpu_10000m
    state_checkpoint_test.go:82: failed to restore state: checkpoint is corrupted
=== RUN   Test_stateCheckpoint_storeState/format_153_-_cpu_10000k
    state_checkpoint_test.go:82: failed to restore state: checkpoint is corrupted
=== RUN   Test_stateCheckpoint_storeState/format_154_-_cpu_10000M
    state_checkpoint_test.go:82: failed to restore state: checkpoint is corrupted
=== RUN   Test_stateCheckpoint_storeState/format_155_-_cpu_10000G
    state_checkpoint_test.go:82: failed to restore state: checkpoint is corrupted
=== RUN   Test_stateCheckpoint_storeState/format_156_-_cpu_10000T
    state_checkpoint_test.go:82: failed to restore state: checkpoint is corrupted
=== RUN   Test_stateCheckpoint_storeState/format_157_-_cpu_10000P
    state_checkpoint_test.go:82: failed to restore state: checkpoint is corrupted
=== RUN   Test_stateCheckpoint_storeState/format_158_-_cpu_10000E
    state_checkpoint_test.go:82: failed to restore state: checkpoint is corrupted
=== RUN   Test_stateCheckpoint_storeState/format_159_-_cpu_10000
    state_checkpoint_test.go:82: failed to restore state: checkpoint is corrupted
--- FAIL: Test_stateCheckpoint_storeState (1.43s)
    --- PASS: Test_stateCheckpoint_storeState/format_0_-_cpu_1Ki (0.02s)
    --- PASS: Test_stateCheckpoint_storeState/format_1_-_cpu_1Mi (0.04s)
    --- PASS: Test_stateCheckpoint_storeState/format_2_-_cpu_1Gi (0.03s)
    --- PASS: Test_stateCheckpoint_storeState/format_3_-_cpu_1Ti (0.01s)
    --- PASS: Test_stateCheckpoint_storeState/format_4_-_cpu_1Pi (0.01s)
    --- PASS: Test_stateCheckpoint_storeState/format_5_-_cpu_1Ei (0.01s)
    --- PASS: Test_stateCheckpoint_storeState/format_6_-_cpu_1n (0.01s)
    --- PASS: Test_stateCheckpoint_storeState/format_7_-_cpu_1u (0.01s)
    --- PASS: Test_stateCheckpoint_storeState/format_8_-_cpu_1m (0.01s)
    --- PASS: Test_stateCheckpoint_storeState/format_9_-_cpu_1k (0.01s)
    --- PASS: Test_stateCheckpoint_storeState/format_10_-_cpu_1M (0.00s)
    --- PASS: Test_stateCheckpoint_storeState/format_11_-_cpu_1G (0.01s)
    --- PASS: Test_stateCheckpoint_storeState/format_12_-_cpu_1T (0.01s)
    --- PASS: Test_stateCheckpoint_storeState/format_13_-_cpu_1P (0.01s)
    --- PASS: Test_stateCheckpoint_storeState/format_14_-_cpu_1E (0.01s)
    --- PASS: Test_stateCheckpoint_storeState/format_15_-_cpu_1 (0.01s)
    --- FAIL: Test_stateCheckpoint_storeState/format_16_-_cpu_0.1Ki (0.01s)
    --- FAIL: Test_stateCheckpoint_storeState/format_17_-_cpu_0.1Mi (0.01s)
    --- FAIL: Test_stateCheckpoint_storeState/format_18_-_cpu_0.1Gi (0.01s)
    --- FAIL: Test_stateCheckpoint_storeState/format_19_-_cpu_0.1Ti (0.01s)
    --- FAIL: Test_stateCheckpoint_storeState/format_20_-_cpu_0.1Pi (0.01s)
    --- FAIL: Test_stateCheckpoint_storeState/format_21_-_cpu_0.1Ei (0.01s)
    --- FAIL: Test_stateCheckpoint_storeState/format_22_-_cpu_0.1n (0.01s)
    --- FAIL: Test_stateCheckpoint_storeState/format_23_-_cpu_0.1u (0.01s)
    --- FAIL: Test_stateCheckpoint_storeState/format_24_-_cpu_0.1m (0.01s)
    --- FAIL: Test_stateCheckpoint_storeState/format_25_-_cpu_0.1k (0.01s)
    --- FAIL: Test_stateCheckpoint_storeState/format_26_-_cpu_0.1M (0.01s)
    --- FAIL: Test_stateCheckpoint_storeState/format_27_-_cpu_0.1G (0.01s)
    --- FAIL: Test_stateCheckpoint_storeState/format_28_-_cpu_0.1T (0.00s)
    --- FAIL: Test_stateCheckpoint_storeState/format_29_-_cpu_0.1P (0.01s)
    --- FAIL: Test_stateCheckpoint_storeState/format_30_-_cpu_0.1E (0.01s)
    --- FAIL: Test_stateCheckpoint_storeState/format_31_-_cpu_0.1 (0.01s)
    --- FAIL: Test_stateCheckpoint_storeState/format_32_-_cpu_0.03Ki (0.01s)
    --- FAIL: Test_stateCheckpoint_storeState/format_33_-_cpu_0.03Mi (0.01s)
    --- FAIL: Test_stateCheckpoint_storeState/format_34_-_cpu_0.03Gi (0.01s)
    --- FAIL: Test_stateCheckpoint_storeState/format_35_-_cpu_0.03Ti (0.01s)
    --- FAIL: Test_stateCheckpoint_storeState/format_36_-_cpu_0.03Pi (0.01s)
    --- FAIL: Test_stateCheckpoint_storeState/format_37_-_cpu_0.03Ei (0.01s)
    --- FAIL: Test_stateCheckpoint_storeState/format_38_-_cpu_0.03n (0.01s)
    --- FAIL: Test_stateCheckpoint_storeState/format_39_-_cpu_0.03u (0.02s)
    --- FAIL: Test_stateCheckpoint_storeState/format_40_-_cpu_0.03m (0.01s)
    --- FAIL: Test_stateCheckpoint_storeState/format_41_-_cpu_0.03k (0.01s)
    --- FAIL: Test_stateCheckpoint_storeState/format_42_-_cpu_0.03M (0.01s)
    --- FAIL: Test_stateCheckpoint_storeState/format_43_-_cpu_0.03G (0.01s)
    --- FAIL: Test_stateCheckpoint_storeState/format_44_-_cpu_0.03T (0.01s)
    --- FAIL: Test_stateCheckpoint_storeState/format_45_-_cpu_0.03P (0.01s)
    --- FAIL: Test_stateCheckpoint_storeState/format_46_-_cpu_0.03E (0.01s)
    --- FAIL: Test_stateCheckpoint_storeState/format_47_-_cpu_0.03 (0.01s)
    --- PASS: Test_stateCheckpoint_storeState/format_48_-_cpu_10Ki (0.01s)
    --- PASS: Test_stateCheckpoint_storeState/format_49_-_cpu_10Mi (0.01s)
    --- PASS: Test_stateCheckpoint_storeState/format_50_-_cpu_10Gi (0.01s)
    --- PASS: Test_stateCheckpoint_storeState/format_51_-_cpu_10Ti (0.01s)
    --- PASS: Test_stateCheckpoint_storeState/format_52_-_cpu_10Pi (0.01s)
    --- FAIL: Test_stateCheckpoint_storeState/format_53_-_cpu_10Ei (0.01s)
    --- PASS: Test_stateCheckpoint_storeState/format_54_-_cpu_10n (0.01s)
    --- PASS: Test_stateCheckpoint_storeState/format_55_-_cpu_10u (0.01s)
    --- PASS: Test_stateCheckpoint_storeState/format_56_-_cpu_10m (0.01s)
    --- PASS: Test_stateCheckpoint_storeState/format_57_-_cpu_10k (0.01s)
    --- PASS: Test_stateCheckpoint_storeState/format_58_-_cpu_10M (0.01s)
    --- PASS: Test_stateCheckpoint_storeState/format_59_-_cpu_10G (0.01s)
    --- PASS: Test_stateCheckpoint_storeState/format_60_-_cpu_10T (0.01s)
    --- PASS: Test_stateCheckpoint_storeState/format_61_-_cpu_10P (0.01s)
    --- PASS: Test_stateCheckpoint_storeState/format_62_-_cpu_10E (0.01s)
    --- PASS: Test_stateCheckpoint_storeState/format_63_-_cpu_10 (0.01s)
    --- PASS: Test_stateCheckpoint_storeState/format_64_-_cpu_100Ki (0.01s)
    --- PASS: Test_stateCheckpoint_storeState/format_65_-_cpu_100Mi (0.01s)
    --- PASS: Test_stateCheckpoint_storeState/format_66_-_cpu_100Gi (0.01s)
    --- PASS: Test_stateCheckpoint_storeState/format_67_-_cpu_100Ti (0.01s)
    --- PASS: Test_stateCheckpoint_storeState/format_68_-_cpu_100Pi (0.01s)
    --- FAIL: Test_stateCheckpoint_storeState/format_69_-_cpu_100Ei (0.01s)
    --- PASS: Test_stateCheckpoint_storeState/format_70_-_cpu_100n (0.01s)
    --- PASS: Test_stateCheckpoint_storeState/format_71_-_cpu_100u (0.01s)
    --- PASS: Test_stateCheckpoint_storeState/format_72_-_cpu_100m (0.01s)
    --- PASS: Test_stateCheckpoint_storeState/format_73_-_cpu_100k (0.01s)
    --- PASS: Test_stateCheckpoint_storeState/format_74_-_cpu_100M (0.01s)
    --- PASS: Test_stateCheckpoint_storeState/format_75_-_cpu_100G (0.01s)
    --- PASS: Test_stateCheckpoint_storeState/format_76_-_cpu_100T (0.01s)
    --- PASS: Test_stateCheckpoint_storeState/format_77_-_cpu_100P (0.01s)
    --- PASS: Test_stateCheckpoint_storeState/format_78_-_cpu_100E (0.01s)
    --- PASS: Test_stateCheckpoint_storeState/format_79_-_cpu_100 (0.01s)
    --- PASS: Test_stateCheckpoint_storeState/format_80_-_cpu_512Ki (0.01s)
    --- PASS: Test_stateCheckpoint_storeState/format_81_-_cpu_512Mi (0.01s)
    --- PASS: Test_stateCheckpoint_storeState/format_82_-_cpu_512Gi (0.01s)
    --- PASS: Test_stateCheckpoint_storeState/format_83_-_cpu_512Ti (0.01s)
    --- PASS: Test_stateCheckpoint_storeState/format_84_-_cpu_512Pi (0.01s)
    --- FAIL: Test_stateCheckpoint_storeState/format_85_-_cpu_512Ei (0.01s)
    --- PASS: Test_stateCheckpoint_storeState/format_86_-_cpu_512n (0.01s)
    --- PASS: Test_stateCheckpoint_storeState/format_87_-_cpu_512u (0.01s)
    --- PASS: Test_stateCheckpoint_storeState/format_88_-_cpu_512m (0.01s)
    --- PASS: Test_stateCheckpoint_storeState/format_89_-_cpu_512k (0.01s)
    --- PASS: Test_stateCheckpoint_storeState/format_90_-_cpu_512M (0.01s)
    --- PASS: Test_stateCheckpoint_storeState/format_91_-_cpu_512G (0.01s)
    --- PASS: Test_stateCheckpoint_storeState/format_92_-_cpu_512T (0.01s)
    --- PASS: Test_stateCheckpoint_storeState/format_93_-_cpu_512P (0.01s)
    --- PASS: Test_stateCheckpoint_storeState/format_94_-_cpu_512E (0.01s)
    --- PASS: Test_stateCheckpoint_storeState/format_95_-_cpu_512 (0.01s)
    --- PASS: Test_stateCheckpoint_storeState/format_96_-_cpu_1000Ki (0.01s)
    --- PASS: Test_stateCheckpoint_storeState/format_97_-_cpu_1000Mi (0.01s)
    --- PASS: Test_stateCheckpoint_storeState/format_98_-_cpu_1000Gi (0.01s)
    --- PASS: Test_stateCheckpoint_storeState/format_99_-_cpu_1000Ti (0.01s)
    --- PASS: Test_stateCheckpoint_storeState/format_100_-_cpu_1000Pi (0.01s)
    --- FAIL: Test_stateCheckpoint_storeState/format_101_-_cpu_1000Ei (0.01s)
    --- FAIL: Test_stateCheckpoint_storeState/format_102_-_cpu_1000n (0.01s)
    --- FAIL: Test_stateCheckpoint_storeState/format_103_-_cpu_1000u (0.01s)
    --- FAIL: Test_stateCheckpoint_storeState/format_104_-_cpu_1000m (0.01s)
    --- FAIL: Test_stateCheckpoint_storeState/format_105_-_cpu_1000k (0.01s)
    --- FAIL: Test_stateCheckpoint_storeState/format_106_-_cpu_1000M (0.01s)
    --- FAIL: Test_stateCheckpoint_storeState/format_107_-_cpu_1000G (0.01s)
    --- FAIL: Test_stateCheckpoint_storeState/format_108_-_cpu_1000T (0.01s)
    --- FAIL: Test_stateCheckpoint_storeState/format_109_-_cpu_1000P (0.01s)
    --- FAIL: Test_stateCheckpoint_storeState/format_110_-_cpu_1000E (0.01s)
    --- FAIL: Test_stateCheckpoint_storeState/format_111_-_cpu_1000 (0.01s)
    --- FAIL: Test_stateCheckpoint_storeState/format_112_-_cpu_1024Ki (0.01s)
    --- FAIL: Test_stateCheckpoint_storeState/format_113_-_cpu_1024Mi (0.01s)
    --- FAIL: Test_stateCheckpoint_storeState/format_114_-_cpu_1024Gi (0.01s)
    --- PASS: Test_stateCheckpoint_storeState/format_115_-_cpu_1024Ti (0.01s)
    --- PASS: Test_stateCheckpoint_storeState/format_116_-_cpu_1024Pi (0.01s)
    --- FAIL: Test_stateCheckpoint_storeState/format_117_-_cpu_1024Ei (0.01s)
    --- PASS: Test_stateCheckpoint_storeState/format_118_-_cpu_1024n (0.01s)
    --- PASS: Test_stateCheckpoint_storeState/format_119_-_cpu_1024u (0.01s)
    --- PASS: Test_stateCheckpoint_storeState/format_120_-_cpu_1024m (0.01s)
    --- PASS: Test_stateCheckpoint_storeState/format_121_-_cpu_1024k (0.01s)
    --- PASS: Test_stateCheckpoint_storeState/format_122_-_cpu_1024M (0.01s)
    --- PASS: Test_stateCheckpoint_storeState/format_123_-_cpu_1024G (0.01s)
    --- PASS: Test_stateCheckpoint_storeState/format_124_-_cpu_1024T (0.01s)
    --- PASS: Test_stateCheckpoint_storeState/format_125_-_cpu_1024P (0.01s)
    --- PASS: Test_stateCheckpoint_storeState/format_126_-_cpu_1024E (0.01s)
    --- PASS: Test_stateCheckpoint_storeState/format_127_-_cpu_1024 (0.01s)
    --- PASS: Test_stateCheckpoint_storeState/format_128_-_cpu_700Ki (0.01s)
    --- PASS: Test_stateCheckpoint_storeState/format_129_-_cpu_700Mi (0.01s)
    --- PASS: Test_stateCheckpoint_storeState/format_130_-_cpu_700Gi (0.02s)
    --- PASS: Test_stateCheckpoint_storeState/format_131_-_cpu_700Ti (0.01s)
    --- PASS: Test_stateCheckpoint_storeState/format_132_-_cpu_700Pi (0.01s)
    --- FAIL: Test_stateCheckpoint_storeState/format_133_-_cpu_700Ei (0.01s)
    --- PASS: Test_stateCheckpoint_storeState/format_134_-_cpu_700n (0.01s)
    --- PASS: Test_stateCheckpoint_storeState/format_135_-_cpu_700u (0.01s)
    --- PASS: Test_stateCheckpoint_storeState/format_136_-_cpu_700m (0.01s)
    --- PASS: Test_stateCheckpoint_storeState/format_137_-_cpu_700k (0.01s)
    --- PASS: Test_stateCheckpoint_storeState/format_138_-_cpu_700M (0.01s)
    --- PASS: Test_stateCheckpoint_storeState/format_139_-_cpu_700G (0.01s)
    --- PASS: Test_stateCheckpoint_storeState/format_140_-_cpu_700T (0.01s)
    --- PASS: Test_stateCheckpoint_storeState/format_141_-_cpu_700P (0.03s)
    --- PASS: Test_stateCheckpoint_storeState/format_142_-_cpu_700E (0.02s)
    --- PASS: Test_stateCheckpoint_storeState/format_143_-_cpu_700 (0.01s)
    --- PASS: Test_stateCheckpoint_storeState/format_144_-_cpu_10000Ki (0.01s)
    --- PASS: Test_stateCheckpoint_storeState/format_145_-_cpu_10000Mi (0.01s)
    --- PASS: Test_stateCheckpoint_storeState/format_146_-_cpu_10000Gi (0.02s)
    --- PASS: Test_stateCheckpoint_storeState/format_147_-_cpu_10000Ti (0.01s)
    --- FAIL: Test_stateCheckpoint_storeState/format_148_-_cpu_10000Pi (0.01s)
    --- FAIL: Test_stateCheckpoint_storeState/format_149_-_cpu_10000Ei (0.01s)
    --- FAIL: Test_stateCheckpoint_storeState/format_150_-_cpu_10000n (0.01s)
    --- FAIL: Test_stateCheckpoint_storeState/format_151_-_cpu_10000u (0.01s)
    --- FAIL: Test_stateCheckpoint_storeState/format_152_-_cpu_10000m (0.01s)
    --- FAIL: Test_stateCheckpoint_storeState/format_153_-_cpu_10000k (0.02s)
    --- FAIL: Test_stateCheckpoint_storeState/format_154_-_cpu_10000M (0.01s)
    --- FAIL: Test_stateCheckpoint_storeState/format_155_-_cpu_10000G (0.01s)
    --- FAIL: Test_stateCheckpoint_storeState/format_156_-_cpu_10000T (0.01s)
    --- FAIL: Test_stateCheckpoint_storeState/format_157_-_cpu_10000P (0.01s)
    --- FAIL: Test_stateCheckpoint_storeState/format_158_-_cpu_10000E (0.01s)
    --- FAIL: Test_stateCheckpoint_storeState/format_159_-_cpu_10000 (0.02s)
FAIL
```

</details>

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix the bug of InPlacePodVerticalScaling state un-marshalling. State stored in `/var/lib/kubelet/pod_status_manager_state` is now can always be read back after kubelet restart.

Action Required: Since the checkpoint format was changed to fix the issue, if you are using the feature `InPlacePodVerticalScaling`, please clean up the state file `/var/lib/kubelet/pod_status_manager_state` when upgrading the kubelet as failrue to do it will lead to incompatible state formats and kubelet's failure to start.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
None
<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
