### PR TITLE
Fix segfault if nil interface passed to `ToUnstructured`

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/runtime/converter.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/converter.go
@@ -578,7 +578,6 @@ func (c *unstructuredConverter) ToUnstructured(obj interface{}) (map[string]inte
 
 	var u map[string]interface{}
 	var err error
-	
 	if unstr, ok := obj.(Unstructured); ok {
 		u = unstr.UnstructuredContent()
 	} else {

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/converter.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/converter.go
@@ -572,11 +572,13 @@ func interfaceFromUnstructured(sv, dv reflect.Value) error {
 // ToUnstructured converts an object into map[string]interface{} representation.
 // It uses encoding/json/Marshaler if object implements it or reflection if not.
 func (c *unstructuredConverter) ToUnstructured(obj interface{}) (map[string]interface{}, error) {
-	var u map[string]interface{}
-	var err error
 	if obj == nil {
 		return nil, fmt.Errorf("ToUnstructured requires a non-nil pointer to an object, got nil")
 	}
+
+	var u map[string]interface{}
+	var err error
+	
 	if unstr, ok := obj.(Unstructured); ok {
 		u = unstr.UnstructuredContent()
 	} else {

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/converter.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/converter.go
@@ -574,6 +574,9 @@ func interfaceFromUnstructured(sv, dv reflect.Value) error {
 func (c *unstructuredConverter) ToUnstructured(obj interface{}) (map[string]interface{}, error) {
 	var u map[string]interface{}
 	var err error
+	if obj == nil {
+		return nil, fmt.Errorf("ToUnstructured requires a non-nil pointer to an object, got nil")
+	}
 	if unstr, ok := obj.(Unstructured); ok {
 		u = unstr.UnstructuredContent()
 	} else {


### PR DESCRIPTION
Sometimes when I do`dynamicClient.Resource([...]).Watch([...])` and receive the `watch.Event` from the event channel, the `event.Object` can be "just" a nil Interface (nil itself), rather than a pointer to a nil interface like the one we expect on line 585 in `runtime/converter.go`, which will then segfault as in this example: https://go.dev/play/p/VjIKLFMn1ad

```
package main

import (
	"fmt"
	"reflect"
)

type MaybeNil interface{}

func main() {
	var pobj *MaybeNil

	t := reflect.TypeOf(pobj)
	value := reflect.ValueOf(pobj)
	if t.Kind() != reflect.Pointer || value.IsNil() {
		fmt.Println("we're OK with a pointer to a nil interface")
	}

	// sometimes, we get nil events from our watcher that looks like this. At the moment, they segfault like this when we call ToUnstructured
	var obj MaybeNil

	t = reflect.TypeOf(obj)
	value = reflect.ValueOf(obj)
	if t.Kind() != reflect.Pointer || value.IsNil() {
		fmt.Println("we panic and never reach here if the nil interface is not a pointer")
	}
}
```

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
fixes a segfault if we pass nil to `ToUnstructured`
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
`ToUnstructured` will error rather than segfault when passed a nil Interface
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
