### PR TITLE
Kubectl: Add namespace to delete dry run output

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete.go
@@ -505,8 +505,10 @@ func (o *DeleteOptions) PrintObj(info *resource.Info) {
 
 	switch o.DryRunStrategy {
 	case cmdutil.DryRunClient:
+		kindString = fmt.Sprintf("%s %s", info.Namespace, kindString)
 		operation = fmt.Sprintf("%s (dry run)", operation)
 	case cmdutil.DryRunServer:
+		kindString = fmt.Sprintf("%s %s", info.Namespace, kindString)
 		operation = fmt.Sprintf("%s (server dry run)", operation)
 	}
 
@@ -515,7 +517,7 @@ func (o *DeleteOptions) PrintObj(info *resource.Info) {
 		fmt.Fprintf(o.Out, "%s/%s\n", kindString, info.Name)
 		return
 	}
-
+	
 	// understandable output by default
 	fmt.Fprintf(o.Out, "%s \"%s\" %s\n", kindString, info.Name, operation)
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete.go
@@ -505,11 +505,14 @@ func (o *DeleteOptions) PrintObj(info *resource.Info) {
 
 	switch o.DryRunStrategy {
 	case cmdutil.DryRunClient:
-		kindString = fmt.Sprintf("%s %s", info.Namespace, kindString)
 		operation = fmt.Sprintf("%s (dry run)", operation)
 	case cmdutil.DryRunServer:
-		kindString = fmt.Sprintf("%s %s", info.Namespace, kindString)
 		operation = fmt.Sprintf("%s (server dry run)", operation)
+	}
+
+	deletedName := kindString
+	if o.DryRunStrategy == cmdutil.DryRunClient || o.DryRunStrategy == cmdutil.DryRunServer {
+		deletedName = fmt.Sprintf("%s %s", info.Namespace, kindString)
 	}
 
 	if o.Output == "name" {
@@ -517,9 +520,9 @@ func (o *DeleteOptions) PrintObj(info *resource.Info) {
 		fmt.Fprintf(o.Out, "%s/%s\n", kindString, info.Name)
 		return
 	}
-	
-	// understandable output by default
-	fmt.Fprintf(o.Out, "%s \"%s\" %s\n", kindString, info.Name, operation)
+
+	// understandable output by default, with namespace in dry-run
+	fmt.Fprintf(o.Out, "%s \"%s\" %s\n", deletedName, info.Name, operation)
 }
 
 func (o *DeleteOptions) confirmation(infos []*resource.Info) bool {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete_test.go
@@ -947,11 +947,9 @@ func TestDeleteSetDryRun(t *testing.T) {
 
 	t.Run("server side dry run", func(t *testing.T) {
 		ioStreams, _, buf, _ := genericiooptions.NewTestIOStreams()
-		cmdtesting.WithAlphaEnvs([]cmdutil.FeatureGate{cmdutil.ApplySet}, t, func(t *testing.T) {
-			cmd := NewCmdDelete(tf, ioStreams)
-			cmd.Flags().Set("dry-run", "server")
-			cmd.Run(cmd, []string{"replicationcontrollers/redis-master"})
-		})
+		cmd := NewCmdDelete(tf, ioStreams)
+		cmd.Flags().Set("dry-run", "server")
+		cmd.Run(cmd, []string{"replicationcontrollers/redis-master"})
 		if buf.String() != "resourceNamespace replicationcontroller \"redis-master\" deleted (server dry run)\n" {
 			t.Errorf("unexpected output: %s", buf.String())
 		}
@@ -959,11 +957,9 @@ func TestDeleteSetDryRun(t *testing.T) {
 
 	t.Run("client side dry run", func(t *testing.T) {
 		ioStreams, _, buf, _ := genericiooptions.NewTestIOStreams()
-		cmdtesting.WithAlphaEnvs([]cmdutil.FeatureGate{cmdutil.ApplySet}, t, func(t *testing.T) {
-			cmd := NewCmdDelete(tf, ioStreams)
-			cmd.Flags().Set("dry-run", "client")
-			cmd.Run(cmd, []string{"replicationcontrollers/redis-master"})
-		})
+		cmd := NewCmdDelete(tf, ioStreams)
+		cmd.Flags().Set("dry-run", "client")
+		cmd.Run(cmd, []string{"replicationcontrollers/redis-master"})
 		if buf.String() != "resourceNamespace replicationcontroller \"redis-master\" deleted (dry run)\n" {
 			t.Errorf("unexpected output: %s", buf.String())
 		}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete_test.go
@@ -948,7 +948,10 @@ func TestDeleteSetDryRun(t *testing.T) {
 	t.Run("server side dry run", func(t *testing.T) {
 		ioStreams, _, buf, _ := genericiooptions.NewTestIOStreams()
 		cmd := NewCmdDelete(tf, ioStreams)
-		cmd.Flags().Set("dry-run", "server")
+		err := cmd.Flags().Set("dry-run", "server")
+		if err != nil {
+			t.Errorf("unexpected error %v", err)
+		}
 		cmd.Run(cmd, []string{"replicationcontrollers/redis-master"})
 		if buf.String() != "resourceNamespace replicationcontroller \"redis-master\" deleted (server dry run)\n" {
 			t.Errorf("unexpected output: %s", buf.String())
@@ -958,7 +961,10 @@ func TestDeleteSetDryRun(t *testing.T) {
 	t.Run("client side dry run", func(t *testing.T) {
 		ioStreams, _, buf, _ := genericiooptions.NewTestIOStreams()
 		cmd := NewCmdDelete(tf, ioStreams)
-		cmd.Flags().Set("dry-run", "client")
+		err := cmd.Flags().Set("dry-run", "client")
+		if err != nil {
+			t.Errorf("unexpected error %v", err)
+		}
 		cmd.Run(cmd, []string{"replicationcontrollers/redis-master"})
 		if buf.String() != "resourceNamespace replicationcontroller \"redis-master\" deleted (dry run)\n" {
 			t.Errorf("unexpected output: %s", buf.String())


### PR DESCRIPTION
As requiested in issue #https://github.com/kubernetes/kubectl/issues/1621
The kubectl should display namespace when kubectl delete is used with dry-run.
Example output before and after:
```
$ kubectl delete replicationcontroller redis-master -n redis-ns --dry-run=client
replicationcontroller "redis-master" deleted (dry run)
$ ./kubectl delete replicationcontroller redis-master -n redis-ns --dry-run=client
redis-ns replicationcontroller "redis-master" deleted (dry run)
```

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

It helps to identify resources to be removed.

#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes/kubectl/issues/1621

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
- Kubectl delete [kind]/[resource] --dry-run=[client/server] now display namespace in front of resource
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:


```docs

```
