### PR TITLE
wait: don't lowercase condition in --for argument

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/wait/wait.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/wait/wait.go
@@ -195,8 +195,8 @@ func conditionFuncFor(condition string, errOut io.Writer) (ConditionFunc, error)
 	case lowercaseCond == "create":
 		return IsCreated, nil
 
-	case strings.HasPrefix(lowercaseCond, "condition="):
-		conditionName := lowercaseCond[len("condition="):]
+	case strings.HasPrefix(condition, "condition="):
+		conditionName := strings.TrimPrefix(condition, "condition=")
 		conditionValue := "true"
 		if equalsIndex := strings.Index(conditionName, "="); equalsIndex != -1 {
 			conditionValue = conditionName[equalsIndex+1:]
@@ -209,8 +209,8 @@ func conditionFuncFor(condition string, errOut io.Writer) (ConditionFunc, error)
 			errOut:          errOut,
 		}.IsConditionMet, nil
 
-	case strings.HasPrefix(lowercaseCond, "jsonpath="):
-		jsonPathInput := strings.TrimPrefix(lowercaseCond, "jsonpath=")
+	case strings.HasPrefix(condition, "jsonpath="):
+		jsonPathInput := strings.TrimPrefix(condition, "jsonpath=")
 		jsonPathExp, jsonPathValue, err := processJSONPathInput(jsonPathInput)
 		if err != nil {
 			return nil, err

--- a/test/cmd/wait.sh
+++ b/test/cmd/wait.sh
@@ -51,6 +51,12 @@ run_wait_tests() {
     # Post-Condition: Wait failed
     kube::test::if_has_string "${output_message}" 'timed out'
 
+    # wait with mixed case jsonpath
+    output_message=$(kubectl wait --for=jsonpath=.status.unavailableReplicas=1 deploy/test-1 2>&1)
+
+    # Post-Condition: Wait failed
+    kube::test::if_has_string "${output_message}" 'test-1 condition met'
+
     # Delete all deployments async to kubectl wait
     ( sleep 2 && kubectl delete deployment --all ) &
 


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/kind regression
/sig cli

#### What this PR does / why we need it:
In https://github.com/kubernetes/kubernetes/pull/125868/files#r1713843179 I unnecessarily lowercased the condition part in both jsonpath and condition arguments for `--for`, which is problematic, because some jsonpaths can contain lower and upper case. 

#### Which issue(s) this PR fixes:
Fixes #126637

#### Special notes for your reviewer:
/assign @liggitt 

#### Does this PR introduce a user-facing change?
```release-note
Fixed kubectl wait --for=jsonpath lowercasing in the condition part of the argument
```

