### PR TITLE
apiserver: declare kubeClient and dynamicClient as interface types to avoid panic

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/options/recommended.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/recommended.go
@@ -120,8 +120,8 @@ func (o *RecommendedOptions) ApplyTo(config *server.RecommendedConfig) error {
 	if err := o.CoreAPI.ApplyTo(config); err != nil {
 		return err
 	}
-	var kubeClient *kubernetes.Clientset
-	var dynamicClient *dynamic.DynamicClient
+	var kubeClient kubernetes.Interface
+	var dynamicClient dynamic.Interface
 	if config.ClientConfig != nil {
 		var err error
 		kubeClient, err = kubernetes.NewForConfig(config.ClientConfig)


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
If `config.ClientConfig` is nil, kubeClient and dynamicClient  will not be initialized.
https://github.com/kubernetes/kubernetes/blob/099a88370d017dacf16e67306ebcdec8394fae83/staging/src/k8s.io/apiserver/pkg/server/options/recommended.go#L123-L136

This is expected to return `invalid configuration: ...`. However, it does not, because `clientset` is an interface so it does not enter the if condition.
https://github.com/kubernetes/kubernetes/blob/099a88370d017dacf16e67306ebcdec8394fae83/staging/src/k8s.io/apiserver/pkg/server/options/feature.go#L74-L76

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #https://github.com/kubernetes/apiserver/issues/111

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
NONE

