### PR TITLE
Add timeout cancellation to kubectl cp destination path check

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/cp/cp.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/cp/cp.go
@@ -18,7 +18,6 @@ package cp
 
 import (
 	"archive/tar"
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -269,8 +268,8 @@ func (o *CopyOptions) checkDestinationIsDir(dest fileSpec) error {
 	options := &exec.ExecOptions{
 		StreamOptions: exec.StreamOptions{
 			IOStreams: genericiooptions.IOStreams{
-				Out:    bytes.NewBuffer([]byte{}),
-				ErrOut: bytes.NewBuffer([]byte{}),
+				Out:    io.Discard,
+				ErrOut: io.Discard,
 			},
 
 			Namespace: dest.PodNamespace,


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
This PR bounds the destination path check mechanism with predefined timeout value.

#### Which issue(s) this PR fixes:
Fixes #
#### Does this PR introduce a user-facing change?
```release-note
Discarded the output streams of destination path check in kubectl cp when copying from local to pod and added a 3 seconds timeout to this check 
```