### PR TITLE
kubelet: adapt the sleep period (reconciler & desired state of world)…

### DIFF
--- a/pkg/kubelet/volumemanager/reconciler/reconciler_common.go
+++ b/pkg/kubelet/volumemanager/reconciler/reconciler_common.go
@@ -105,6 +105,7 @@ func NewReconciler(
 		kubeClient:                      kubeClient,
 		controllerAttachDetachEnabled:   controllerAttachDetachEnabled,
 		loopSleepDuration:               loopSleepDuration,
+		initialLoopSleepDuration:        loopSleepDuration,
 		waitForAttachTimeout:            waitForAttachTimeout,
 		nodeName:                        nodeName,
 		desiredStateOfWorld:             desiredStateOfWorld,
@@ -126,6 +127,7 @@ type reconciler struct {
 	kubeClient                    clientset.Interface
 	controllerAttachDetachEnabled bool
 	loopSleepDuration             time.Duration
+	initialLoopSleepDuration      time.Duration
 	waitForAttachTimeout          time.Duration
 	nodeName                      types.NodeName
 	desiredStateOfWorld           cache.DesiredStateOfWorld

--- a/staging/src/k8s.io/apimachinery/pkg/util/wait/wait_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/wait/wait_test.go
@@ -657,6 +657,35 @@ func TestPollUntil(t *testing.T) {
 	close(called)
 }
 
+func TestDyanmicPeriodUntil(t *testing.T) {
+	stopCh := make(chan struct{})
+	i := 0
+	loopPeriod := 1 * time.Second
+	startIterationNow := time.Now()
+	jitered := 0.0
+	DyanmicPeriodUntil(func() {
+		t.Logf("Current date and time is: %v ", startIterationNow.String())
+		//  i = 0,1,2,3,4 = 1 second
+		//  i = 5,6,7,8,9 = 2 seconds
+		if i < 5 {
+			t.Logf("i <= 5 , i = %v", i)
+		} else if i >= 5 && i < 10 {
+			t.Logf("i >= 5 , i = %v ", i)
+			loopPeriod = 2 * time.Second
+		} else if i >= 10 {
+			difference := time.Since(startIterationNow)
+
+			if difference.Seconds() < 15 {
+				t.Errorf("end - start = %v,  expected >= %v ", difference.Seconds(), 15)
+			}
+			close(stopCh)
+		}
+		i++
+	}, func() time.Duration {
+		return loopPeriod
+	}, jitered, true, stopCh)
+}
+
 func TestBackoff_Step(t *testing.T) {
 	tests := []struct {
 		initial *Backoff


### PR DESCRIPTION
… based on the stat

#### What type of PR is this?
/kind feature


#### What this PR does / why we need it:
change the timer instead of removing the loop completely , ref : 
https://github.com/kubernetes/kubernetes/issues/126049#issuecomment-2278659439

```release-note
This PR aims to optimize the loop iteration period (100 ms) in the reconciler and desired state of the world by increasing the sleep period (by * 10) when no changes are detected. 
```

#### Which issue(s) this PR fixes:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes https://github.com/kubernetes/kubernetes/issues/126049.