### PR TITLE
Cleanup: Refactor fmt.Errorf to use %w for wrapping errors

### DIFF
--- a/pkg/kubelet/kubelet_getters.go
+++ b/pkg/kubelet/kubelet_getters.go
@@ -26,7 +26,6 @@ import (
 	cadvisorapiv1 "github.com/google/cadvisor/info/v1"
 	cadvisorv2 "github.com/google/cadvisor/info/v2"
 	"k8s.io/klog/v2"
-	"k8s.io/mount-utils"
 	utilpath "k8s.io/utils/path"
 	utilstrings "k8s.io/utils/strings"
 
@@ -311,7 +310,7 @@ func (kl *Kubelet) GetPodCgroupRoot() string {
 func (kl *Kubelet) GetHostIPs() ([]net.IP, error) {
 	node, err := kl.GetNode()
 	if err != nil {
-		return nil, fmt.Errorf("cannot get node: %v", err)
+		return nil, fmt.Errorf("cannot get node: %w", err)
 	}
 	return utilnode.GetNodeHostIPs(node)
 }
@@ -340,7 +339,7 @@ func (kl *Kubelet) getPodVolumePathListFromDisk(podUID types.UID) ([]string, err
 	podVolDir := kl.getPodVolumesDir(podUID)
 
 	if pathExists, pathErr := mount.PathExists(podVolDir); pathErr != nil {
-		return volumes, fmt.Errorf("error checking if path %q exists: %v", podVolDir, pathErr)
+		return volumes, fmt.Errorf("error checking if path %q exists: %w", podVolDir, pathErr)
 	} else if !pathExists {
 		klog.V(6).InfoS("Path does not exist", "path", podVolDir)
 		return volumes, nil
@@ -356,7 +355,7 @@ func (kl *Kubelet) getPodVolumePathListFromDisk(podUID types.UID) ([]string, err
 		volumePluginPath := filepath.Join(podVolDir, volumePluginName)
 		volumeDirs, err := utilpath.ReadDirNoStat(volumePluginPath)
 		if err != nil {
-			return volumes, fmt.Errorf("could not read directory %s: %v", volumePluginPath, err)
+			return volumes, fmt.Errorf("could not read directory %s: %w", volumePluginPath, err)
 		}
 		unescapePluginName := utilstrings.UnescapeQualifiedName(volumePluginName)
 
@@ -393,7 +392,7 @@ func (kl *Kubelet) getMountedVolumePathListFromDisk(podUID types.UID) ([]string,
 	for _, volumePath := range volumePaths {
 		isNotMount, err := kl.mounter.IsLikelyNotMountPoint(volumePath)
 		if err != nil {
-			return mountedVolumes, fmt.Errorf("fail to check mount point %q: %v", volumePath, err)
+			return mountedVolumes, fmt.Errorf("fail to check mount point %q: %w", volumePath, err)
 		}
 		if !isNotMount {
 			mountedVolumes = append(mountedVolumes, volumePath)
@@ -409,7 +408,7 @@ func (kl *Kubelet) getPodVolumeSubpathListFromDisk(podUID types.UID) ([]string, 
 	podSubpathsDir := kl.getPodVolumeSubpathsDir(podUID)
 
 	if pathExists, pathErr := mount.PathExists(podSubpathsDir); pathErr != nil {
-		return nil, fmt.Errorf("error checking if path %q exists: %v", podSubpathsDir, pathErr)
+		return nil, fmt.Errorf("error checking if path %q exists: %w", podSubpathsDir, pathErr)
 	} else if !pathExists {
 		return volumes, nil
 	}
@@ -425,7 +424,7 @@ func (kl *Kubelet) getPodVolumeSubpathListFromDisk(podUID types.UID) ([]string, 
 		volumePluginPath := filepath.Join(podSubpathsDir, volumePluginName)
 		containerDirs, err := os.ReadDir(volumePluginPath)
 		if err != nil {
-			return volumes, fmt.Errorf("could not read directory %s: %v", volumePluginPath, err)
+			return volumes, fmt.Errorf("could not read directory %s: %w", volumePluginPath, err)
 		}
 		for _, containerDir := range containerDirs {
 			containerName := containerDir.Name()
@@ -434,7 +433,7 @@ func (kl *Kubelet) getPodVolumeSubpathListFromDisk(podUID types.UID) ([]string, 
 			// mount points that may not be responsive
 			subPaths, err := utilpath.ReadDirNoStat(containerPath)
 			if err != nil {
-				return volumes, fmt.Errorf("could not read directory %s: %v", containerPath, err)
+				return volumes, fmt.Errorf("could not read directory %s: %w", containerPath, err)
 			}
 			for _, subPathDir := range subPaths {
 				volumes = append(volumes, filepath.Join(containerPath, subPathDir))

--- a/pkg/kubelet/kubelet_network.go
+++ b/pkg/kubelet/kubelet_network.go
@@ -56,7 +56,7 @@ func (kl *Kubelet) updatePodCIDR(ctx context.Context, cidr string) (bool, error)
 	if err := kl.getRuntime().UpdatePodCIDR(ctx, cidr); err != nil {
 		// If updatePodCIDR would fail, theoretically pod CIDR could not change.
 		// But it is better to be on the safe side to still return true here.
-		return true, fmt.Errorf("failed to update pod CIDR: %v", err)
+		return true, fmt.Errorf("failed to update pod CIDR: %w", err)
 	}
 	klog.InfoS("Updating Pod CIDR", "originalPodCIDR", podCIDR, "newPodCIDR", cidr)
 	kl.runtimeState.setPodCIDR(cidr)

--- a/pkg/kubelet/kubelet_node_status.go
+++ b/pkg/kubelet/kubelet_node_status.go
@@ -402,7 +402,7 @@ func (kl *Kubelet) initialNode(ctx context.Context) (*v1.Node, error) {
 		if ok {
 			zone, err := zones.GetZone(ctx)
 			if err != nil {
-				return nil, fmt.Errorf("failed to get zone from cloud provider: %v", err)
+				return nil, fmt.Errorf("failed to get zone from cloud provider: %w", err)
 			}
 			if zone.FailureDomain != "" {
 				klog.InfoS("Adding node label from cloud provider", "labelKey", v1.LabelFailureDomainBetaZone, "labelValue", zone.FailureDomain)
@@ -559,7 +559,7 @@ func (kl *Kubelet) tryUpdateNodeStatus(ctx context.Context, tryNumber int) error
 		originalNode, err = kl.heartbeatClient.CoreV1().Nodes().Get(ctx, string(kl.nodeName), opts)
 	}
 	if err != nil {
-		return fmt.Errorf("error getting node %q: %v", kl.nodeName, err)
+		return fmt.Errorf("error getting node %q: %w", kl.nodeName, err)
 	}
 	if originalNode == nil {
 		return fmt.Errorf("nil %q node object", kl.nodeName)

--- a/pkg/kubelet/kubelet_node_status_test.go
+++ b/pkg/kubelet/kubelet_node_status_test.go
@@ -118,16 +118,16 @@ func generateImageTags() []string {
 func applyNodeStatusPatch(originalNode *v1.Node, patch []byte) (*v1.Node, error) {
 	original, err := json.Marshal(originalNode)
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal original node %#v: %v", originalNode, err)
+		return nil, fmt.Errorf("failed to marshal original node %#v: %w", originalNode, err)
 	}
 	updated, err := strategicpatch.StrategicMergePatch(original, patch, v1.Node{})
 	if err != nil {
-		return nil, fmt.Errorf("failed to apply strategic merge patch %q on node %#v: %v",
+		return nil, fmt.Errorf("failed to apply strategic merge patch %q on node %#v: %w",
 			patch, originalNode, err)
 	}
 	updatedNode := &v1.Node{}
 	if err := json.Unmarshal(updated, updatedNode); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal updated node %q: %v", updated, err)
+		return nil, fmt.Errorf("failed to unmarshal updated node %q: %w", updated, err)
 	}
 	return updatedNode, nil
 }

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -312,7 +312,7 @@ func makeMounts(pod *v1.Pod, podDir string, container *v1.Container, hostName, h
 
 			err = volumevalidation.ValidatePathNoBacksteps(subPath)
 			if err != nil {
-				return nil, cleanupAction, fmt.Errorf("unable to provision SubPath `%s`: %v", subPath, err)
+				return nil, cleanupAction, fmt.Errorf("unable to provision SubPath `%s`: %w", subPath, err)
 			}
 
 			volumePath := hostPath
@@ -1130,7 +1130,7 @@ func (kl *Kubelet) HandlePodCleanups(ctx context.Context) error {
 		pcm := kl.containerManager.NewPodContainerManager()
 		cgroupPods, err = pcm.GetAllPodsFromCgroups()
 		if err != nil {
-			return fmt.Errorf("failed to get list of pods that still exist on cgroup mounts: %v", err)
+			return fmt.Errorf("failed to get list of pods that still exist on cgroup mounts: %w", err)
 		}
 	}
 
@@ -1509,7 +1509,7 @@ func (kl *Kubelet) GetKubeletContainerLogs(ctx context.Context, podFullName, con
 	// caught up yet). Just assume the pod is not ready yet.
 	name, namespace, err := kubecontainer.ParsePodFullName(podFullName)
 	if err != nil {
-		return fmt.Errorf("unable to parse pod full name %q: %v", podFullName, err)
+		return fmt.Errorf("unable to parse pod full name %q: %w", podFullName, err)
 	}
 
 	pod, ok := kl.GetPodByName(namespace, name)

--- a/pkg/kubelet/runonce.go
+++ b/pkg/kubelet/runonce.go
@@ -119,7 +119,7 @@ func (kl *Kubelet) runPod(ctx context.Context, pod *v1.Pod, retryDelay time.Dura
 	for !isTerminal {
 		status, err := kl.containerRuntime.GetPodStatus(ctx, pod.UID, pod.Name, pod.Namespace)
 		if err != nil {
-			return fmt.Errorf("unable to get status for pod %q: %v", format.Pod(pod), err)
+			return fmt.Errorf("unable to get status for pod %q: %w", format.Pod(pod), err)
 		}
 
 		if kl.isPodRunning(pod, status) {
@@ -134,7 +134,7 @@ func (kl *Kubelet) runPod(ctx context.Context, pod *v1.Pod, retryDelay time.Dura
 		}
 		mirrorPod, _ := kl.podManager.GetMirrorPodByPod(pod)
 		if isTerminal, err = kl.SyncPod(ctx, kubetypes.SyncPodUpdate, pod, mirrorPod, status); err != nil {
-			return fmt.Errorf("error syncing pod %q: %v", format.Pod(pod), err)
+			return fmt.Errorf("error syncing pod %q: %w", format.Pod(pod), err)
 		}
 		if retry >= runOnceMaxRetries {
 			return fmt.Errorf("timeout error: pod %q containers not running after %d retries", format.Pod(pod), runOnceMaxRetries)
@@ -164,7 +164,7 @@ func (kl *Kubelet) isPodRunning(pod *v1.Pod, status *kubecontainer.PodStatus) bo
 func (kl *Kubelet) getFailedContainers(ctx context.Context, pod *v1.Pod) ([]string, error) {
 	status, err := kl.containerRuntime.GetPodStatus(ctx, pod.UID, pod.Name, pod.Namespace)
 	if err != nil {
-		return nil, fmt.Errorf("unable to get status for pod %q: %v", format.Pod(pod), err)
+		return nil, fmt.Errorf("unable to get status for pod %q: %w", format.Pod(pod), err)
 	}
 	var containerNames []string
 	for _, cs := range status.ContainerStatuses {

--- a/pkg/kubelet/runtime.go
+++ b/pkg/kubelet/runtime.go
@@ -125,7 +125,7 @@ func (s *runtimeState) runtimeErrors() error {
 	}
 	for _, hc := range s.healthChecks {
 		if ok, err := hc.fn(); !ok {
-			errs = append(errs, fmt.Errorf("%s is not healthy: %v", hc.name, err))
+			errs = append(errs, fmt.Errorf("%s is not healthy: %w", hc.name, err))
 		}
 	}
 	if s.runtimeError != nil {

--- a/pkg/kubelet/volume_host.go
+++ b/pkg/kubelet/volume_host.go
@@ -22,7 +22,6 @@ import (
 	"runtime"
 
 	"k8s.io/klog/v2"
-	"k8s.io/mount-utils"
 	utilexec "k8s.io/utils/exec"
 
 	authenticationv1 "k8s.io/api/authentication/v1"
@@ -91,7 +90,7 @@ func NewInitializedVolumePluginMgr(
 
 	if err := kvh.volumePluginMgr.InitPlugins(plugins, prober, kvh); err != nil {
 		return nil, fmt.Errorf(
-			"could not initialize volume plugins for KubeletVolumePluginMgr: %v",
+			"could not initialize volume plugins for KubeletVolumePluginMgr: %w",
 			err)
 	}
 
@@ -234,7 +233,7 @@ func (kvh *kubeletVolumeHost) GetHostIP() (net.IP, error) {
 func (kvh *kubeletVolumeHost) GetNodeAllocatable() (v1.ResourceList, error) {
 	node, err := kvh.kubelet.getNodeAnyWay()
 	if err != nil {
-		return nil, fmt.Errorf("error retrieving node: %v", err)
+		return nil, fmt.Errorf("error retrieving node: %w", err)
 	}
 	return node.Status.Allocatable, nil
 }
@@ -276,7 +275,7 @@ func (kvh *kubeletVolumeHost) GetTrustAnchorsBySigner(signerName string, labelSe
 func (kvh *kubeletVolumeHost) GetNodeLabels() (map[string]string, error) {
 	node, err := kvh.kubelet.GetNode()
 	if err != nil {
-		return nil, fmt.Errorf("error retrieving node: %v", err)
+		return nil, fmt.Errorf("error retrieving node: %w", err)
 	}
 	return node.Labels, nil
 }
@@ -284,7 +283,7 @@ func (kvh *kubeletVolumeHost) GetNodeLabels() (map[string]string, error) {
 func (kvh *kubeletVolumeHost) GetAttachedVolumesFromNodeStatus() (map[v1.UniqueVolumeName]string, error) {
 	node, err := kvh.kubelet.GetNode()
 	if err != nil {
-		return nil, fmt.Errorf("error retrieving node: %v", err)
+		return nil, fmt.Errorf("error retrieving node: %w", err)
 	}
 	attachedVolumes := node.Status.VolumesAttached
 	result := map[v1.UniqueVolumeName]string{}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR refactors instances of fmt.Errorf in the codebase where the %v verb is used for error formatting to use %w instead. The %w verb is specifically designed for error wrapping in Go, providing better stack trace propagation and allowing for more informative error handling. This change improves the consistency and reliability of error handling across the codebase.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
