### PR TITLE
Update rsync rules for building images

### DIFF
--- a/build/build-image/rsyncd.sh
+++ b/build/build-image/rsyncd.sh
@@ -33,7 +33,7 @@ VOLUME=${HOME}
 
 # Assume that this is running in Docker on a bridge.  Allow connections from
 # anything on the local subnet.
-ALLOW=$(ip route | awk  '/^default via/ { reg = "^[0-9./]+ dev "$5 } ; $0 ~ reg { print $1 }')
+ALLOW=$(ip route | awk  '/^default via/ { reg = "^[0-9./]+ dev "$5 } ; $0 ~ reg { print $1 }' | tr '\n' ' ')
 
 CONFDIR="/tmp/rsync.k8s"
 PIDFILE="${CONFDIR}/rsyncd.pid"

--- a/build/common.sh
+++ b/build/common.sh
@@ -611,7 +611,7 @@ function kube::build::start_rsyncd_container() {
   V=3 kube::log::status "Starting rsyncd container"
   kube::build::run_build_command_ex \
     "${KUBE_RSYNC_CONTAINER_NAME}" -p 127.0.0.1:"${KUBE_RSYNC_PORT}":"${KUBE_CONTAINER_RSYNC_PORT}" -d \
-    -e ALLOW_HOST="$(${IPTOOL} | grep -Eo 'inet (addr:)?([0-9]*\.){3}[0-9]*' | grep -Eo '([0-9]*\.){3}[0-9]*' | grep -v '127.0.0.1' | tr '\n' ' ')" \
+    -e ALLOW_HOST="$(${IPTOOL} | grep -Eo 'inet (addr:)?([0-9]*\.){3}[0-9]*' | grep -Eo '([0-9]*\.){3}[0-9]*' | tr '\n' ' ')" \
     -- /rsyncd.sh >/dev/null
 
   local mapped_port


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
This contains 2 fixes:
1. When parsing ALLOW list we need to make sure new lines are replaced with spaces.
2. When using podman the host connecting to rsyncd reports 127.0.0.1, so don't remove it from ALLOW_HOST.

Ad. 1.
While debugging errors when building with podman I found this in rsyncd log:
```
2024/08/14 11:03:32 [11] params.c:Parameter() - Ignoring badly formed line in config file: 192.168.1.1 127.0.0.1 192.168.1.11 10.39.193.253
```
and when looking into `/tmp/rsync.k8s/rsyncd.conf` I've noticed:
```
...
  hosts deny = *
  hosts allow = 192.168.1.0/24
192.168.1.1 192.168.1.11 10.39.193.253 
  auth users = k8s
...
```
With the fix, all of those lines are properly a single line. 

Ad. 2.
I've run into this error:
```
+++ [0814 11:03:31] Syncing sources to container
@ERROR: access denied to k8s from UNDETERMINED (127.0.0.1)
```
partially reported in https://github.com/kubernetes/kubernetes/issues/99025. 
Which seems like we don't allow localhost to access the rsyncd, which for some reason is a thing when using podman. 

I've traced 127.0.0.1 being dropped all the way to the original PR (https://github.com/kubernetes/kubernetes/pull/51004) adding these rules, so my gut feeling is that's one of the small differences between docker and podman :sweat: 

#### Special notes for your reviewer:
/assign @dims @BenTheElder 

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
