### PR TITLE
enable MultiCIDRServiceAllocator by default

### DIFF
--- a/pkg/controlplane/instance.go
+++ b/pkg/controlplane/instance.go
@@ -499,5 +499,14 @@ func DefaultAPIResourceConfigSource() *serverstorage.ResourceConfig {
 	// enable the legacy beta resources that were present before stopped serving new beta APIs by default.
 	ret.EnableResources(legacyBetaEnabledByDefaultResources...)
 
+	// There are some features that require some APIs resources and versions to be enabled.
+	// In order to avoid users to break their clusters by enabling the feature gate but
+	// not enabling the corresponding API groups, we can conditionally enable these APIs for them.
+	if utilfeature.DefaultFeatureGate.Enabled(features.MultiCIDRServiceAllocator) {
+		ret.EnableResources(
+			networkingapiv1beta1.SchemeGroupVersion.WithResource("ipaddresses"),
+			networkingapiv1beta1.SchemeGroupVersion.WithResource("servicecidrs"),
+		)
+	}
 	return ret
 }

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -1125,7 +1125,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 
 	MinDomainsInPodTopologySpread: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.32
 
-	MultiCIDRServiceAllocator: {Default: false, PreRelease: featuregate.Beta},
+	MultiCIDRServiceAllocator: {Default: true, PreRelease: featuregate.Beta},
 
 	NewVolumeManagerReconstruction: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.32
 


### PR DESCRIPTION
/kind feature

```release-note
Graduated the multi-CIDR allocator to beta. The `MultiCIDRServiceAllocator` feature gate is now enabled
by default; also introduced a feature gate `DisableAllocatorDualWrite`.
Kubernetes' allocator logic defaults to writing allocation data to the legacy bitmap allocator records (held within etcd), in order to remain compatible with older API server versions, to support downgrades, and to mitigate the risk of leaking ClusterIPs during upgrades. Cluster administrators can enable `DisableAllocatorDualWrite` to skip the legacy allocation data updates.
```


Based on the KEP-1880 and the discussion during the PRR review, we enabled beta by default in this release but the apiserver still will keep writing to the old bitmap allocator to deal with skew issues

https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/1880-multiple-service-cidrs#upgrade--downgrade--version-skew-strategy

/sig network