### PR TITLE
Automated cherry pick of #126644: fix a scheduler preemption issue that victim is not patched

### DIFF
--- a/pkg/scheduler/framework/preemption/preemption.go
+++ b/pkg/scheduler/framework/preemption/preemption.go
@@ -366,7 +366,7 @@ func (ev *Evaluator) prepareCandidate(ctx context.Context, c Candidate, pod *v1.
 				Reason:  v1.PodReasonPreemptionByScheduler,
 				Message: fmt.Sprintf("%s: preempting to accommodate a higher priority pod", pod.Spec.SchedulerName),
 			}
-			newStatus := pod.Status.DeepCopy()
+			newStatus := victim.Status.DeepCopy()
 			updated := apipod.UpdatePodCondition(newStatus, condition)
 			if updated {
 				if err := util.PatchPodStatus(ctx, cs, victim, newStatus); err != nil {


### PR DESCRIPTION
Cherry pick of #126644 on release-1.31.

#126644: fix a scheduler preemption issue that victim is not patched

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fix a 1.29 scheduler preemption regression where the victim pod was not deleted due to incorrect status patching. This issue occurred when the preemptor and victim pods had different QoS classes in their status, causing the preemption to fail entirely.
```

/kind bug
/kind regression