### PR TITLE
Remove KMSv2 and KMSv2KDF feature gates

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -1274,10 +1274,6 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 
 	genericfeatures.KMSv1: {Default: false, PreRelease: featuregate.Deprecated},
 
-	genericfeatures.KMSv2: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.31
-
-	genericfeatures.KMSv2KDF: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.31
-
 	genericfeatures.MutatingAdmissionPolicy: {Default: false, PreRelease: featuregate.Alpha},
 
 	genericfeatures.OpenAPIEnums: {Default: true, PreRelease: featuregate.Beta},

--- a/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
+++ b/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
@@ -137,23 +137,6 @@ const (
 	// Enables KMS v1 API for encryption at rest.
 	KMSv1 featuregate.Feature = "KMSv1"
 
-	// owner: @aramase
-	// kep: https://kep.k8s.io/3299
-	// alpha: v1.25
-	// beta: v1.27
-	// stable: v1.29
-	//
-	// Enables KMS v2 API for encryption at rest.
-	KMSv2 featuregate.Feature = "KMSv2"
-
-	// owner: @enj
-	// kep: https://kep.k8s.io/3299
-	// beta: v1.28
-	// stable: v1.29
-	//
-	// Enables the use of derived encryption keys with KMS v2.
-	KMSv2KDF featuregate.Feature = "KMSv2KDF"
-
 	// owner: @alexzielenski, @cici37, @jiahuif
 	// kep: https://kep.k8s.io/3962
 	// alpha: v1.30
@@ -379,10 +362,6 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	EfficientWatchResumption: {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 
 	KMSv1: {Default: false, PreRelease: featuregate.Deprecated},
-
-	KMSv2: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.31
-
-	KMSv2KDF: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.31
 
 	OpenAPIEnums: {Default: true, PreRelease: featuregate.Beta},
 

--- a/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/config.go
@@ -760,10 +760,6 @@ func kmsPrefixTransformer(ctx context.Context, config *apiserver.KMSConfiguratio
 		}, nil
 
 	case kmsAPIVersionV2:
-		if !utilfeature.DefaultFeatureGate.Enabled(features.KMSv2) {
-			return storagevalue.PrefixTransformer{}, nil, nil, fmt.Errorf("could not configure KMSv2 plugin %q, KMSv2 feature is not enabled", kmsName)
-		}
-
 		envelopeService, err := EnvelopeKMSv2ServiceFactory(ctx, config.Endpoint, config.Name, config.Timeout.Duration)
 		if err != nil {
 			return storagevalue.PrefixTransformer{}, nil, nil, fmt.Errorf("could not configure KMSv2-Plugin's probe %q, error: %w", kmsName, err)

--- a/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/config_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/config_test.go
@@ -391,15 +391,13 @@ func TestKMSvsEnablement(t *testing.T) {
 	}
 	tts := []struct {
 		name            string
-		kmsv2Enabled    bool
 		expectedErr     string
 		expectedTimeout time.Duration
 		config          apiserver.EncryptionConfiguration
 		wantV2Used      bool
 	}{
 		{
-			name:         "with kmsv1 and kmsv2, KMSv2=true",
-			kmsv2Enabled: true,
+			name: "with kmsv1 and kmsv2, KMSv2=true",
 			config: apiserver.EncryptionConfiguration{
 				Resources: []apiserver.ResourceConfiguration{
 					{
@@ -440,8 +438,6 @@ func TestKMSvsEnablement(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// Just testing KMSv2 feature flag
 			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.KMSv1, true)
-
-			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.KMSv2, tt.kmsv2Enabled)
 
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel() // cancel this upfront so the kms v2 checks do not block

--- a/test/e2e/testing-manifests/auth/encrypt/kind.yaml
+++ b/test/e2e/testing-manifests/auth/encrypt/kind.yaml
@@ -26,7 +26,6 @@ nodes:
       apiServer:
         extraArgs:
           encryption-provider-config: "/etc/kubernetes/encryption-config.yaml"
-          feature-gates: "KMSv2=true"
           v: "5"
         extraVolumes:
         - name: encryption-config

--- a/test/featuregates_linter/test_data/unversioned_feature_list.yaml
+++ b/test/featuregates_linter/test_data/unversioned_feature_list.yaml
@@ -376,18 +376,6 @@
     lockToDefault: false
     preRelease: Deprecated
     version: ""
-- name: KMSv2
-  versionedSpecs:
-  - default: true
-    lockToDefault: true
-    preRelease: GA
-    version: ""
-- name: KMSv2KDF
-  versionedSpecs:
-  - default: true
-    lockToDefault: true
-    preRelease: GA
-    version: ""
 - name: KubeletCgroupDriverFromCRI
   versionedSpecs:
   - default: true

--- a/test/integration/controlplane/transformation/kmsv2_transformation_test.go
+++ b/test/integration/controlplane/transformation/kmsv2_transformation_test.go
@@ -168,9 +168,6 @@ func TestDefaultValues(t *testing.T) {
 	if encryptionconfig.GetKDF() != true {
 		t.Fatalf("without updating the feature flags, default value of KMSv2KDF should be enabled.")
 	}
-	if utilfeature.DefaultFeatureGate.Enabled(features.KMSv2) != true {
-		t.Fatalf("without updating the feature flags, default value of KMSv2 should be enabled.")
-	}
 	if utilfeature.DefaultFeatureGate.Enabled(features.KMSv1) != false {
 		t.Fatalf("without updating the feature flags, default value of KMSv1 should be disabled.")
 	}


### PR DESCRIPTION
These have been GA since v1.29 and can be safely removed.

/kind cleanup
/assign aramase
/priority important-longterm
/triage accepted

```release-note
Removed the `KMSv2` and `KMSv2KDF` feature gates. The associated features graduated to stable in the Kubernetes v1.29 release.
```