### PR TITLE
kubectl apply honors fieldManager

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply.go
@@ -576,6 +576,7 @@ func (o *ApplyOptions) applyOneObject(info *resource.Info) error {
 
 		options := metav1.PatchOptions{
 			Force: &o.ForceConflicts,
+			FieldManager: o.FieldManager,
 		}
 		obj, err := helper.Patch(
 			info.Namespace,
@@ -863,7 +864,9 @@ func (o *ApplyOptions) saveLastApplyAnnotationIfNecessary(
 		info.Name,
 		types.ApplyPatchType,
 		modified,
-		nil,
+		&metav1.PatchOptions{
+			FieldManager: o.FieldManager,
+		},
 	)
 
 	if err != nil {


### PR DESCRIPTION
/kind bug

Previously some code paths through `apply` would ignore the configured `AppylOptions.FieldManager` and instead use the default. Fix.

