### PR TITLE
show image volume when kubectl describe a pod with image volume

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/describe/describe.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/describe.go
@@ -1000,6 +1000,8 @@ func describeVolumes(volumes []corev1.Volume, w PrefixWriter, space string) {
 			printProjectedVolumeSource(volume.VolumeSource.Projected, w)
 		case volume.VolumeSource.CSI != nil:
 			printCSIVolumeSource(volume.VolumeSource.CSI, w)
+		case volume.VolumeSource.Image != nil:
+			printImageVolumeSource(volume.VolumeSource.Image, w)
 		default:
 			w.Write(LEVEL_1, "<unknown>\n")
 		}
@@ -1479,6 +1481,13 @@ func printCSIPersistentVolumeAttributesMultilineIndent(w PrefixWriter, initialIn
 			w.Write(LEVEL_2, "%s\n", line)
 		}
 	}
+}
+
+func printImageVolumeSource(image *corev1.ImageVolumeSource, w PrefixWriter) {
+	w.Write(LEVEL_2, "Type:\tImage (a container image or OCI artifact)\n"+
+		"    Reference:\t%v\n"+
+		"    PullPolicy:\t%v\n",
+		image.Reference, image.PullPolicy)
 }
 
 type PersistentVolumeDescriber struct {

--- a/staging/src/k8s.io/kubectl/pkg/describe/describe_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/describe_test.go
@@ -268,6 +268,53 @@ func TestDescribePodTolerations(t *testing.T) {
 	}
 }
 
+func TestDescribePodVolumes(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "bar",
+			Namespace: "foo",
+		},
+		Spec: corev1.PodSpec{
+			Volumes: []corev1.Volume{
+				{
+					Name:         "image",
+					VolumeSource: corev1.VolumeSource{Image: &corev1.ImageVolumeSource{Reference: "image", PullPolicy: corev1.PullIfNotPresent}},
+				},
+			},
+		},
+	}
+
+	expected := dedent.Dedent(`
+				Name:         bar
+				Namespace:    foo
+				Node:         <none>
+				Labels:       <none>
+				Annotations:  <none>
+				Status:       
+				IP:           
+				IPs:          <none>
+				Containers: <none>
+				Volumes:
+				  image:
+				    Type:        Image (a container image or OCI artifact)
+				    Reference:   image
+				    PullPolicy:  IfNotPresent
+				QoS Class:       BestEffort
+				Node-Selectors:  <none>
+				Tolerations:     <none>
+				Events:          <none>
+			`)[1:]
+
+	fakeClient := fake.NewSimpleClientset(pod)
+	c := &describeClient{T: t, Namespace: "foo", Interface: fakeClient}
+	d := PodDescriber{c}
+	out, err := d.Describe("foo", "bar", DescriberSettings{ShowEvents: true})
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	assert.Equal(t, expected, out)
+}
+
 func TestDescribeTopologySpreadConstraints(t *testing.T) {
 	fake := fake.NewSimpleClientset(&corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

**pod.yaml**
```yaml
apiVersion: v1
kind: Pod
metadata:
  name: pod
  annotations:
    example.com/foo: v
spec:
  containers:
    - name: test
      image: registry.k8s.io/e2e-test-images/echoserver:2.3
      env:
        - name: k
          valueFrom:
            fieldRef:
              fieldPath: metadata.annotations['example.com/foo']
      volumeMounts:
        - name: volume
          mountPath: /volume
  volumes:
    - name: volume
      image:
        reference: quay.io/crio/artifact:v1
        pullPolicy: IfNotPresent
```


```
(base) ➜  kubernetes git:(kubectl-describe-image-volume) kubectl describe po
Name:             pod
Namespace:        default
Priority:         0
Service Account:  default
Node:             crio-control-plane/172.18.0.2
Start Time:       Thu, 15 Aug 2024 17:07:19 +0800
Labels:           <none>
Annotations:      example.com/foo: v
Status:           Running
IP:               10.244.0.5
IPs:
  IP:  10.244.0.5
Containers:
  test:
    Container ID:   cri-o://074b1d107a561ef22013dcca58c7a78419923d34035f81535f83751425a99707
    Image:          registry.k8s.io/e2e-test-images/echoserver:2.3
    Image ID:       registry.k8s.io/e2e-test-images/echoserver@sha256:60bd75eb661054404b49f745694714b0c3298c698d8f08d21180189581e6a0f2
    Port:           <none>
    Host Port:      <none>
    State:          Running
      Started:      Thu, 15 Aug 2024 17:07:37 +0800
    Ready:          True
    Restart Count:  0
    Environment:
      k:   (v1:metadata.annotations['example.com/foo'])
    Mounts:
      /var/run/secrets/kubernetes.io/serviceaccount from kube-api-access-7lxfd (ro)
      /volume from volume (rw)
Conditions:
  Type                        Status
  PodReadyToStartContainers   True
  Initialized                 True
  Ready                       True
  ContainersReady             True
  PodScheduled                True
Volumes:
  volume:
  <unknown>
  kube-api-access-7lxfd:
    Type:                    Projected (a volume that contains injected data from multiple sources)
    TokenExpirationSeconds:  3607
    ConfigMapName:           kube-root-ca.crt
    ConfigMapOptional:       <nil>
    DownwardAPI:             true
QoS Class:                   BestEffort
Node-Selectors:              <none>
Tolerations:                 node.kubernetes.io/not-ready:NoExecute op=Exists for 300s
                             node.kubernetes.io/unreachable:NoExecute op=Exists for 300s
Events:
  Type    Reason     Age                 From               Message
  ----    ------     ----                ----               -------
  Normal  Scheduled  55m                 default-scheduler  Successfully assigned default/pod to crio-control-plane
  Normal  Pulling    55m                 kubelet            Pulling image "quay.io/crio/artifact:v1"
  Normal  Pulled     55m                 kubelet            Successfully pulled image "quay.io/crio/artifact:v1" in 9.747s (9.747s including waiting). Image size: 11235 bytes.
  Normal  Pulling    55m                 kubelet            Pulling image "registry.k8s.io/e2e-test-images/echoserver:2.3"
  Normal  Pulled     55m                 kubelet            Successfully pulled image "registry.k8s.io/e2e-test-images/echoserver:2.3" in 7.892s (7.892s including waiting). Image size: 24838677 bytes.
  Normal  Created    55m                 kubelet            Created container test
  Normal  Started    55m                 kubelet            Started container test
  Normal  Pulled     11s (x46 over 55m)  kubelet            Container image "quay.io/crio/artifact:v1" already present on machine
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of https://github.com/kubernetes/enhancements/issues/4639

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix kubectl doesn't print image volume when kubectl describe a pod with that volume
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/4639
```
