### PR TITLE
Fix: ensure containerMap.GetContainerID get latest containerID

### DIFF
--- a/pkg/kubelet/cm/helpers_test.go
+++ b/pkg/kubelet/cm/helpers_test.go
@@ -183,7 +183,7 @@ func TestBuildContainerMapAndRunningSetFromRuntime(t *testing.T) {
 		}
 		fakeRuntimeService.Containers = containers
 
-		gotContainerMap, gotRunningSet := buildContainerMapAndRunningSetFromRuntime(context.TODO(), fakeRuntimeService)
+		gotContainerMap, gotRunningSet := buildContainerMapAndRunningSetFromRuntime(ctx, fakeRuntimeService)
 		if !reflect.DeepEqual(gotContainerMap, ts.expectContainerMap) {
 			t.Errorf("%s:ContainerMap is wrong, got:%v,expect:%v", ts.name, gotContainerMap, ts.expectContainerMap)
 		}

--- a/pkg/kubelet/cm/helpers_test.go
+++ b/pkg/kubelet/cm/helpers_test.go
@@ -1,0 +1,198 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cm
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/uuid"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+	apitest "k8s.io/cri-api/pkg/apis/testing"
+	"k8s.io/kubernetes/pkg/kubelet/cm/containermap"
+)
+
+func makeFakePodSandbox(name, namespace string) *apitest.FakePodSandbox {
+	uid := fmt.Sprintf("pod-innerId-%s", strings.ReplaceAll(string(uuid.NewUUID()), "-", ""))
+	p := &apitest.FakePodSandbox{
+		PodSandboxStatus: runtimeapi.PodSandboxStatus{
+			Metadata: &runtimeapi.PodSandboxMetadata{
+				Name:      name,
+				Uid:       uid,
+				Namespace: namespace,
+			},
+			State:     runtimeapi.PodSandboxState_SANDBOX_READY,
+			CreatedAt: time.Now().UnixNano(),
+		},
+	}
+	p.PodSandboxStatus.Id = uid
+	return p
+}
+
+func makeFakeContainer(sandbox *apitest.FakePodSandbox, name string, attempt uint32, terminated bool, createTime int, containerID string) *apitest.FakeContainer {
+	sandboxID := sandbox.PodSandboxStatus.Id
+	c := &apitest.FakeContainer{
+		SandboxID: sandboxID,
+		ContainerStatus: runtimeapi.ContainerStatus{
+			Metadata:  &runtimeapi.ContainerMetadata{Name: name, Attempt: attempt},
+			Image:     &runtimeapi.ImageSpec{},
+			ImageRef:  "fake-image-ref",
+			CreatedAt: time.Now().UnixNano(),
+		},
+	}
+	c.ContainerStatus.Labels = map[string]string{
+		"io.kubernetes.pod.name":       sandbox.Metadata.Name,
+		"io.kubernetes.pod.uid":        sandbox.Metadata.Uid,
+		"io.kubernetes.pod.namespace":  sandbox.Metadata.Namespace,
+		"io.kubernetes.container.name": name,
+	}
+	if terminated {
+		c.ContainerStatus.State = runtimeapi.ContainerState_CONTAINER_EXITED
+	} else {
+		c.ContainerStatus.State = runtimeapi.ContainerState_CONTAINER_RUNNING
+	}
+	c.ContainerStatus.Id = containerID
+	c.CreatedAt = int64(createTime)
+	return c
+}
+func TestBuildContainerMapAndRunningSetFromRuntime(t *testing.T) {
+	pod1 := makeFakePodSandbox("pod1", "default")
+	pod1container1 := makeFakeContainer(pod1, "test1", 0, true, time.Now().Add(-time.Second*50).Nanosecond(), fmt.Sprintf("containerId0-%s", strings.ReplaceAll(string(uuid.NewUUID()), "-", "")))
+	pod1container2 := makeFakeContainer(pod1, "test1", 1, true, time.Now().Add(-time.Second*40).Nanosecond(), fmt.Sprintf("containerId0-%s", strings.ReplaceAll(string(uuid.NewUUID()), "-", "")))
+	pod1container3 := makeFakeContainer(pod1, "test1", 2, true, time.Now().Add(-time.Second*30).Nanosecond(), fmt.Sprintf("containerId0-%s", strings.ReplaceAll(string(uuid.NewUUID()), "-", "")))
+	pod1container4 := makeFakeContainer(pod1, "test1", 3, true, time.Now().Add(-time.Second*20).Nanosecond(), fmt.Sprintf("containerId0-%s", strings.ReplaceAll(string(uuid.NewUUID()), "-", "")))
+	pod1container5 := makeFakeContainer(pod1, "test1", 4, false, time.Now().Nanosecond(), fmt.Sprintf("containerId1-%s", strings.ReplaceAll(string(uuid.NewUUID()), "-", "")))
+
+	pod2 := makeFakePodSandbox("pod2", "default")
+	pod2container1 := makeFakeContainer(pod2, "test1", 0, true, time.Now().Add(-time.Second*50).Nanosecond(), fmt.Sprintf("containerId0-%s", strings.ReplaceAll(string(uuid.NewUUID()), "-", "")))
+	pod2container2 := makeFakeContainer(pod2, "test1", 1, true, time.Now().Add(-time.Second*40).Nanosecond(), fmt.Sprintf("containerId0-%s", strings.ReplaceAll(string(uuid.NewUUID()), "-", "")))
+	pod2container3 := makeFakeContainer(pod2, "test1", 2, true, time.Now().Add(-time.Second*30).Nanosecond(), fmt.Sprintf("containerId0-%s", strings.ReplaceAll(string(uuid.NewUUID()), "-", "")))
+	pod2container4 := makeFakeContainer(pod2, "test1", 3, true, time.Now().Add(-time.Second*20).Nanosecond(), fmt.Sprintf("containerId0-%s", strings.ReplaceAll(string(uuid.NewUUID()), "-", "")))
+	pod2container5 := makeFakeContainer(pod2, "test1", 4, true, time.Now().Add(-time.Second*10).Nanosecond(), fmt.Sprintf("containerId0-%s", strings.ReplaceAll(string(uuid.NewUUID()), "-", "")))
+	pod2container6 := makeFakeContainer(pod2, "test1", 5, false, time.Now().Nanosecond(), fmt.Sprintf("containerId1-%s", strings.ReplaceAll(string(uuid.NewUUID()), "-", "")))
+
+	testcases := []struct {
+		name               string
+		pods               []*apitest.FakePodSandbox
+		containers         []*apitest.FakeContainer
+		expectContainerMap containermap.ContainerMap
+		expectRunningSet   sets.Set[string]
+	}{
+		{
+			name: "one pod,one container",
+			pods: []*apitest.FakePodSandbox{
+				pod1,
+			},
+			containers: []*apitest.FakeContainer{
+				pod1container5,
+			},
+			expectContainerMap: func() containermap.ContainerMap {
+				cm := containermap.NewContainerMap()
+				cm.Add(pod1.Id, pod1container5.Metadata.Name, pod1container5.Id)
+				return cm
+			}(),
+			expectRunningSet: func() sets.Set[string] {
+				return sets.New(pod1container5.Id)
+			}(),
+		},
+		{
+			name: "one pod,multi container",
+			pods: []*apitest.FakePodSandbox{
+				pod1,
+			},
+			containers: []*apitest.FakeContainer{
+				// descending order, to check if the function will sort
+				pod1container5, pod1container4, pod1container3, pod1container2, pod1container1,
+			},
+			expectContainerMap: func() containermap.ContainerMap {
+				cm := containermap.NewContainerMap()
+				cm.Add(pod1.Id, pod1container5.Metadata.Name, pod1container5.Id)
+				return cm
+			}(),
+			expectRunningSet: func() sets.Set[string] {
+				return sets.New(pod1container5.Id)
+			}(),
+		},
+		{
+			name: "multi pod,one container",
+			pods: []*apitest.FakePodSandbox{
+				pod1, pod2,
+			},
+			containers: []*apitest.FakeContainer{
+				pod1container5, pod2container6,
+			},
+			expectContainerMap: func() containermap.ContainerMap {
+				cm := containermap.NewContainerMap()
+				cm.Add(pod1.Id, pod1container5.Metadata.Name, pod1container5.Id)
+				cm.Add(pod2.Id, pod2container6.Metadata.Name, pod2container6.Id)
+				return cm
+			}(),
+			expectRunningSet: func() sets.Set[string] {
+				return sets.New(pod1container5.Id, pod2container6.Id)
+			}(),
+		},
+		{
+			name: "multi pod,multi container",
+			pods: []*apitest.FakePodSandbox{
+				pod1, pod2,
+			},
+			containers: []*apitest.FakeContainer{
+				pod1container5, pod1container4, pod1container3, pod1container2, pod1container1,
+				pod2container6, pod2container5, pod2container4, pod2container3, pod2container2, pod2container1,
+			},
+			expectContainerMap: func() containermap.ContainerMap {
+				cm := containermap.NewContainerMap()
+				cm.Add(pod1.Id, pod1container5.Metadata.Name, pod1container5.Id)
+				cm.Add(pod2.Id, pod2container6.Metadata.Name, pod2container6.Id)
+				return cm
+			}(),
+			expectRunningSet: func() sets.Set[string] {
+				return sets.New(pod1container5.Id, pod2container6.Id)
+			}(),
+		},
+	}
+
+	for _, ts := range testcases {
+		fakeRuntimeService := apitest.NewFakeRuntimeService()
+
+		sandboxes := map[string]*apitest.FakePodSandbox{}
+		for _, pod := range ts.pods {
+			sandboxes[pod.Id] = pod
+		}
+		fakeRuntimeService.Sandboxes = sandboxes
+
+		containers := map[string]*apitest.FakeContainer{}
+		for _, container := range ts.containers {
+			containers[container.Id] = container
+		}
+		fakeRuntimeService.Containers = containers
+
+		gotContainerMap, gotRunningSet := buildContainerMapAndRunningSetFromRuntime(context.TODO(), fakeRuntimeService)
+		if !reflect.DeepEqual(gotContainerMap, ts.expectContainerMap) {
+			t.Errorf("%s:ContainerMap is wrong, got:%v,expect:%v", ts.name, gotContainerMap, ts.expectContainerMap)
+		}
+		if !reflect.DeepEqual(gotRunningSet, ts.expectRunningSet) {
+			t.Errorf("%s:RunningSet is wrong, got:%v,expect:%v", ts.name, gotRunningSet, ts.expectRunningSet)
+		}
+	}
+
+}

--- a/pkg/kubelet/cm/helpers_test.go
+++ b/pkg/kubelet/cm/helpers_test.go
@@ -52,25 +52,23 @@ func makeFakeContainer(sandbox *apitest.FakePodSandbox, name string, attempt uin
 	c := &apitest.FakeContainer{
 		SandboxID: sandboxID,
 		ContainerStatus: runtimeapi.ContainerStatus{
+			Id:        containerID,
 			Metadata:  &runtimeapi.ContainerMetadata{Name: name, Attempt: attempt},
 			Image:     &runtimeapi.ImageSpec{},
 			ImageRef:  "fake-image-ref",
-			CreatedAt: time.Now().UnixNano(),
+			CreatedAt: int64(createTime),
+			Labels: map[string]string{
+				"io.kubernetes.pod.name":       sandbox.Metadata.Name,
+				"io.kubernetes.pod.uid":        sandbox.Metadata.Uid,
+				"io.kubernetes.pod.namespace":  sandbox.Metadata.Namespace,
+				"io.kubernetes.container.name": name,
+			},
+			State: runtimeapi.ContainerState_CONTAINER_RUNNING,
 		},
 	}
-	c.ContainerStatus.Labels = map[string]string{
-		"io.kubernetes.pod.name":       sandbox.Metadata.Name,
-		"io.kubernetes.pod.uid":        sandbox.Metadata.Uid,
-		"io.kubernetes.pod.namespace":  sandbox.Metadata.Namespace,
-		"io.kubernetes.container.name": name,
-	}
 	if terminated {
-		c.ContainerStatus.State = runtimeapi.ContainerState_CONTAINER_EXITED
-	} else {
-		c.ContainerStatus.State = runtimeapi.ContainerState_CONTAINER_RUNNING
+		c.State = runtimeapi.ContainerState_CONTAINER_EXITED
 	}
-	c.ContainerStatus.Id = containerID
-	c.CreatedAt = int64(createTime)
 	return c
 }
 func TestBuildContainerMapAndRunningSetFromRuntime(t *testing.T) {

--- a/pkg/kubelet/cm/helpers_test.go
+++ b/pkg/kubelet/cm/helpers_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package cm
 
 import (
-	"context"
 	"fmt"
 	"reflect"
 	"strings"
@@ -29,6 +28,7 @@ import (
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	apitest "k8s.io/cri-api/pkg/apis/testing"
 	"k8s.io/kubernetes/pkg/kubelet/cm/containermap"
+	"k8s.io/kubernetes/test/utils/ktesting"
 )
 
 func makeFakePodSandbox(name, namespace string) *apitest.FakePodSandbox {
@@ -72,6 +72,7 @@ func makeFakeContainer(sandbox *apitest.FakePodSandbox, name string, attempt uin
 	return c
 }
 func TestBuildContainerMapAndRunningSetFromRuntime(t *testing.T) {
+	ctx := ktesting.Init(t)
 	pod1 := makeFakePodSandbox("pod1", "default")
 	pod1container1 := makeFakeContainer(pod1, "test1", 0, true, time.Now().Add(-time.Second*50).Nanosecond(), fmt.Sprintf("containerId0-%s", strings.ReplaceAll(string(uuid.NewUUID()), "-", "")))
 	pod1container2 := makeFakeContainer(pod1, "test1", 1, true, time.Now().Add(-time.Second*40).Nanosecond(), fmt.Sprintf("containerId0-%s", strings.ReplaceAll(string(uuid.NewUUID()), "-", "")))

--- a/pkg/kubelet/cm/helpers_test.go
+++ b/pkg/kubelet/cm/helpers_test.go
@@ -33,19 +33,18 @@ import (
 
 func makeFakePodSandbox(name, namespace string) *apitest.FakePodSandbox {
 	uid := fmt.Sprintf("pod-innerId-%s", strings.ReplaceAll(string(uuid.NewUUID()), "-", ""))
-	p := &apitest.FakePodSandbox{
+	return &apitest.FakePodSandbox{
 		PodSandboxStatus: runtimeapi.PodSandboxStatus{
 			Metadata: &runtimeapi.PodSandboxMetadata{
 				Name:      name,
 				Uid:       uid,
 				Namespace: namespace,
 			},
+			Id:        uid,
 			State:     runtimeapi.PodSandboxState_SANDBOX_READY,
 			CreatedAt: time.Now().UnixNano(),
 		},
 	}
-	p.PodSandboxStatus.Id = uid
-	return p
 }
 
 func makeFakeContainer(sandbox *apitest.FakePodSandbox, name string, attempt uint32, terminated bool, createTime int, containerID string) *apitest.FakeContainer {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

If a pod container has been restarted, there are two container in the runtime(one is exited, one is running).  For now `buildContainerMapAndRunningSetFromRuntime` will add container into `containerMap`. When `GetContainerID` from the containerMap, it may get the exited container instead of the running container.  

When kubelet restarts, the deviceplugin manager will allocate device for every container.  In `devicesToAllocate`, it will check container is running, it depends on `containerMap` and `containerRunningSet`. The exited container make the `isContainerAlreadyRunning` failed, and the pod will failed with `UnexpectedAdmissionError `. 


Some reproduce log
```
Aug 15 15:55:25 host1 kubelet[2549721]: I0815 15:55:25.918141 2549721 helpers.go:73] "Container reported running" podSandboxId="ea2f60da846879be1ec807ab85d31df2c0e6a9c963b745e109a966afbe7e193e" podUID="2012b4dd-30cd-49c1-8dde-ed1f7d160fc1" containerName="vk" containerId="4c1cb0ddff2ccb9845a401205f10b187434ceee0072a06dc2826ac2612b94519"

// it got a previous exited container
Aug 15 15:55:26 host1 kubelet[2549721]: I0815 15:55:26.632841 2549721 manager.go:1095] "container not present in the initial running set" podUID="2012b4dd-30cd-49c1-8dde-ed1f7d160fc1" containerName="vk" containerID="f291a9a094e9afd5efd927b13ff5c76de817f00aa3df99cc6a929c328994c806"

Aug 15 15:55:26 host1 kubelet[2549721]: I0815 15:55:26.632849 2549721 manager.go:580] "Need devices to allocate for pod" deviceNumber=0 resourceName="aliyun/eni" podUID="2012b4dd-30cd-49c1-8dde-ed1f7d160fc1" containerName="vk"

```

pod status:
```
Aug 15 15:55:14 host1 kubelet[2500119]: I0815 15:55:14.587109 2500119 status_manager.go:558] "Ignoring same status for pod" pod="c849db0330c7a4c8789ab6ac58b066c2d/virtual-kubelet-868bbf9ff4-z7kwd" status={Phase:Running Conditions:[{Type:Initialized Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2024-08-13 10:51:59 +0800 CST Reason: Message:} {Type:Ready Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2024-08-15 15:24:53 +0800 CST Reason: Message:} {Type:ContainersReady Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2024-08-15 15:24:53 +0800 CST Reason: Message:} {Type:PodScheduled Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2024-08-13 10:51:59 +0800 CST Reason: Message:}] Message: Reason: NominatedNodeName: HostIP:7.0.4.17 PodIP:7.8.114.67 PodIPs:[{IP:7.8.114.67}] StartTime:2024-08-13 10:51:59 +0800 CST InitContainerStatuses:[] ContainerStatuses:[{Name:vk State:{Waiting:nil Running:&ContainerStateRunning{StartedAt:2024-08-13 10:52:13 +0800 CST,} Terminated:nil} LastTerminationState:{Waiting:nil Running:nil Terminated:&ContainerStateTerminated{ExitCode:2,Signal:0,Reason:Error,Message:,StartedAt:2024-08-13 10:52:08 +0800 CST,FinishedAt:2024-08-13 10:52:12 +0800 CST,ContainerID:containerd://f291a9a094e9afd5efd927b13ff5c76de817f00aa3df99cc6a929c328994c806,}} Ready:true RestartCount:1 Image:registry-eu-central-1-vpc.ack.aliyuncs.com/acs/virtual-nodes-eci:v2.12.0 ImageID:registry-eu-central-1-vpc.ack.aliyuncs.com/acs/virtual-nodes-eci@sha256:f1bfcc61a3992041fb331a91749db3a5ecd325bfeeb4cab64298f73944654337 ContainerID:containerd://4c1cb0ddff2ccb9845a401205f10b187434ceee0072a06dc2826ac2612b94519 Started:0xc0074d5ce0}] QOSClass:Burstable EphemeralContainerStatuses:[]}
```


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix: ensure containerMap.GetContainerID get latest containerID
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
