### PR TITLE
ensure tlsCacheKey is strictly comparable to avoid runtime panics

### DIFF
--- a/staging/src/k8s.io/client-go/transport/cache_go118.go
+++ b/staging/src/k8s.io/client-go/transport/cache_go118.go
@@ -18,7 +18,29 @@ limitations under the License.
 
 package transport
 
+// this is just to make the "unused" linter rule happy
+var _ = isCacheKeyComparable[tlsCacheKey]
+
 // assert at compile time that tlsCacheKey is comparable in a way that will never panic at runtime.
-var _ = isComparable[tlsCacheKey]
+//
+// Golang 1.20 introduced an exception to type constraints that allows comparable, but not
+// necessarily strictly comparable type arguments to satisfy the `comparable` type constraint,
+// thus allowing interfaces to fulfil the `comparable` constraint.
+// However, by definition, "A comparison of two interface values with identical
+// dynamic types causes a run-time panic if that type is not comparable".
+//
+// We want to make sure that comparing two `tlsCacheKey` elements won't cause a
+// runtime panic. In order to do that, we'll force the `tlsCacheKey` to be strictly
+// comparable, thus making it impossible for it to contain interfaces.
+// To assert strict comparability, we'll use another definition: "Type
+// parameters are comparable if they are strictly comparable".
+// Below, we first construct a type parameter from the `tlsCacheKey` type so that
+// we can then push this type parameter to a comparable check, thus checking these
+// are strictly comparable.
+//
+// Original suggestion from https://github.com/golang/go/issues/56548#issuecomment-1317673963
+func isCacheKeyComparable[K tlsCacheKey]() {
+	_ = isComparable[K]
+}
 
 func isComparable[T comparable]() {}


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
The PR adds a build-time check to make sure `tlsCacheKey` struct can be used as a map key without runtime panics.

#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/kubernetes/issues/116562

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
-->
```docs
- [Other doc]: Golang comparison definitions https://go.dev/ref/spec#Comparison_operators
- [Other doc]: Golang type constraints + how to satisfy them (the chapter below this one) https://go.dev/ref/spec#Type_constraints
```

/assign enj 
/cc liggitt 
