### PR TITLE
fix: draining remote stream after port-forward connection broken

### DIFF
--- a/staging/src/k8s.io/client-go/tools/portforward/portforward.go
+++ b/staging/src/k8s.io/client-go/tools/portforward/portforward.go
@@ -406,6 +406,11 @@ func (pf *PortForwarder) handleConnection(conn net.Conn, port ForwardedPort) {
 	case <-remoteDone:
 	case <-localError:
 	}
+	/*
+		reset dataStream to discard any unsent data, preventing port forwarding from being blocked.
+		we must reset dataStream before waiting on errorChan, otherwise, the blocking data will affect errorStream and cause <-errorChan to block indefinitely.
+	*/
+	_ = dataStream.Reset()
 
 	// always expect something on errorChan (it may be nil)
 	err = <-errorChan


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
When using port-forward to access a network service that returns a large amount of data, if the connection encounters an exception during data transmission for some reason, there may still be a large amount of unprocessed data from the pod in the remote stream of port-forward. This can cause the entire spdystream frame processing flow to hang, and kubectl will be unable to handle new connections. 
Below is the error log that kubectl prints when this issue occurs:
```
❯ kubectl port-forward pod/http 8080:8080
Forwarding from 0.0.0.0:8080 -> 8080
Handling connection for 8080
E0815 22:38:07.766600  576100 portforward.go:385] error copying from remote stream to local connection: readfrom tcp4 127.0.0.1:8080->127.0.0.1:60904: write tcp4 127.0.0.1:8080->127.0.0.1:60904: write: broken pipe
Handling connection for 8080
Handling connection for 8080
Handling connection for 8080
Handling connection for 8080
E0815 22:39:36.813324  576100 portforward.go:351] error creating error stream for port 8080 -> 8080: Timeout occurred
E0815 22:39:42.928322  576100 portforward.go:351] error creating error stream for port 8080 -> 8080: Timeout occurred
E0815 22:39:45.403275  576100 portforward.go:351] error creating error stream for port 8080 -> 8080: Timeout occurred
E0815 22:39:47.111137  576100 portforward.go:351] error creating error stream for port 8080 -> 8080: Timeout occurred
Handling connection for 8080
Handling connection for 8080
E0815 22:40:43.709215  576100 portforward.go:351] error creating error stream for port 8080 -> 8080: Timeout occurred
E0815 22:40:46.759928  576100 portforward.go:351] error creating error stream for port 8080 -> 8080: Timeout occurred
```
code used by http pod:
```golang
package main

import (
        "net/http"
)

func hello(w http.ResponseWriter, req *http.Request) {
        for i := 0; i < 1024*1024*3; i++ {
                w.Write([]byte("x"))
        }
}

func main() {
        http.HandleFunc("/", hello)
        http.ListenAndServe(":8080", nil)
}
```
test client:
```golang
package main

import (
	"net"
	"strings"
)

func main() {
	tcpAddr, _ := net.ResolveTCPAddr("tcp", "localhost:8080")
	conn, _ := net.DialTCP("tcp", nil, tcpAddr)

	req := `GET / HTTP/1.1
Host: localhost:8080
User-Agent: Go-http-client/1.1
`
	data := strings.Split(req, "\n")
	for _, d := range data {
		_, _ = conn.Write([]byte(d))
		conn.Write([]byte("\r\n"))
	}
	conn.Close()
}

```
some records during the debugging process:
`spdystream` frame process hangon queue push operation:
![img_v3_02dp_9144ddfe-a964-4c50-84e3-efa727f5322g](https://github.com/user-attachments/assets/9b4956bb-88b2-4d7b-8517-8d9f2619c3a3)
![img_v3_02dp_fc5151be-293d-487e-8220-84df182aaf1g](https://github.com/user-attachments/assets/a537ee42-2a60-42e3-9c62-ca5d6da2d53b)
the queue is full, but `port-forward` don't consume it after connection broken:
![img_v3_02dp_d2f64342-c8b0-473f-b638-c81ad5b6b7eg](https://github.com/user-attachments/assets/084c4cf2-5e6f-4161-b9c9-431ac9a48357)
the data blocked in the socket's receive queue(include data for new connections) is no longer processed by kubectl:
![image](https://github.com/user-attachments/assets/a3aa81b3-6a4d-46d6-8241-1bd05610c2af)



#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/74551 https://github.com/kubernetes/kubernetes/issues/78446  https://github.com/kubernetes/kubernetes/issues/113163

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
