### PR TITLE
avoid dead loop in pvc controller

### DIFF
--- a/pkg/controller/volume/pvcprotection/pvc_protection_controller.go
+++ b/pkg/controller/volume/pvcprotection/pvc_protection_controller.go
@@ -193,19 +193,19 @@ func (c *Controller) runProcessNamespaceWorker(ctx context.Context) {
 }
 
 func (c *Controller) processNextWorkItem() bool {
-	queueLength := c.queue.Len()
-	for i := 0; i < queueLength; i++ {
-		pvcKey, quit := c.queue.Get()
-		if quit {
-			return false
-		}
-		pvcNamespace, pvcName, err := cache.SplitMetaNamespaceKey(pvcKey)
-		if err != nil {
-			utilruntime.HandleError(fmt.Errorf("error parsing PVC key %q: %w", pvcKey, err))
-		}
-		c.pvcProcessingStore.addOrUpdate(pvcNamespace, pvcKey, pvcName)
+	pvcKey, quit := c.queue.Get()
+	if quit {
+		return false
 	}
-	return !c.queue.ShuttingDown()
+
+	pvcNamespace, pvcName, err := cache.SplitMetaNamespaceKey(pvcKey)
+	if err != nil {
+		utilruntime.HandleError(fmt.Errorf("error parsing PVC key %q: %w", pvcKey, err))
+		return true
+	}
+
+	c.pvcProcessingStore.addOrUpdate(pvcNamespace, pvcKey, pvcName)
+	return true
 }
 
 func (c *Controller) processPVCsByNamespace(ctx context.Context) bool {

--- a/pkg/controller/volume/pvcprotection/pvc_protection_controller_test.go
+++ b/pkg/controller/volume/pvcprotection/pvc_protection_controller_test.go
@@ -558,7 +558,9 @@ func TestPVCProtectionController(t *testing.T) {
 			if ctrl.queue.Len() > 0 {
 				logger.V(5).Info("Non-empty queue, processing one", "test", test.name, "queueLength", ctrl.queue.Len())
 				ctx := context.TODO()
-				ctrl.processNextWorkItem()
+				for ctrl.queue.Len() > 0 {
+					ctrl.processNextWorkItem()
+				}
 				for ctrl.pvcProcessingStore.namespaceQueue.Len() != 0 {
 					ctrl.processPVCsByNamespace(ctx)
 				}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind regression 

#### What this PR does / why we need it:
when the pvc queue is empty, kube-controller-manager occurs  dead loop.

#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/kubernetes/issues/126704

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
