### PR TITLE
Add validation for pod reference one PVC multi times in volumes

### DIFF
--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -3634,6 +3634,24 @@ func TestValidateCSIPersistentVolumeSource(t *testing.T) {
 	}
 }
 
+func TestValidateVolumesForPVCs(t *testing.T) {
+	volumes := []core.Volume{
+		{Name: "abc", VolumeSource: core.VolumeSource{PersistentVolumeClaim: &core.PersistentVolumeClaimVolumeSource{ClaimName: "testclaim1"}}},
+		{Name: "abc-123", VolumeSource: core.VolumeSource{PersistentVolumeClaim: &core.PersistentVolumeClaimVolumeSource{ClaimName: "testclaim1"}}},
+		{Name: "def", VolumeSource: core.VolumeSource{HostPath: &core.HostPathVolumeSource{Path: "/foo/baz", Type: newHostPathType(string(core.HostPathUnset))}}},
+	}
+	fldPath := field.NewPath("field")
+	_, v1err := ValidateVolumes(volumes, nil, field.NewPath("field"), PodValidationOptions{})
+	if len(v1err) == 0 {
+		t.Errorf("Invalid test volumes - expected failed %v", field.Duplicate(fldPath.Child("persistentVolumeClaim").Child("claimName"), "testclaim1"))
+		return
+	}
+
+	if v1err[0].Type != field.ErrorTypeDuplicate {
+		t.Errorf("unexpected error type: got %v, want %v", v1err[0].Type, field.ErrorTypeDuplicate)
+	}
+}
+
 // This test is a little too top-to-bottom.  Ideally we would test each volume
 // type on its own, but we want to also make sure that the logic works through
 // the one-of wrapper, so we just do it all in one place.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Since the volumemanager builds volumes cache unique key with pvName for pvc volumes,  not the outer volume spec name(my-csi-volume1, my-csi-volume2), so we can't refrence one pvc more than ones like below,  nor the pod would be wait for volume mount forever.

```
      volumeMounts:
      - mountPath: "/data1"
        name: my-csi-volume1
      - mountPath: "/data2"
        name: my-csi-volume2
  volumes:
    - name: my-csi-volume1
      persistentVolumeClaim:
        claimName: csi-pvc 
    - name: my-csi-volume2
      persistentVolumeClaim:
        claimName: csi-pvc 
```
for this case, the my-csi-volume2 will override  my-csi-volume1, and  my-csi-volume1 could not be mounted by volumemananger.

we should add the validation for pod creation.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
