### PR TITLE
If old pod spec has used image volume source, we must allow it

### DIFF
--- a/pkg/api/pod/util.go
+++ b/pkg/api/pod/util.go
@@ -416,6 +416,9 @@ func GetValidationOptionsFromPodSpecAndMeta(podSpec, oldPodSpec *api.PodSpec, po
 				}
 			}
 		}
+
+		// if old spec has used image volume source, we must allow it
+		opts.AllowImageVolumeSource = opts.AllowImageVolumeSource || hasUsedImageVolumeSourceWithPodSpec(oldPodSpec)
 	}
 	if oldPodMeta != nil && !opts.AllowInvalidPodDeletionCost {
 		// This is an update, so validate only if the existing object was valid.
@@ -575,6 +578,19 @@ func hasUsedDownwardAPIFieldPathWithContainer(container *api.Container, fieldPat
 		if env.ValueFrom != nil &&
 			env.ValueFrom.FieldRef != nil &&
 			env.ValueFrom.FieldRef.FieldPath == fieldPath {
+			return true
+		}
+	}
+	return false
+}
+
+func hasUsedImageVolumeSourceWithPodSpec(podSpec *api.PodSpec) bool {
+	if podSpec == nil {
+		return false
+	}
+
+	for _, vol := range podSpec.Volumes {
+		if vol.Image != nil {
 			return true
 		}
 	}

--- a/pkg/api/pod/util.go
+++ b/pkg/api/pod/util.go
@@ -385,7 +385,6 @@ func GetValidationOptionsFromPodSpecAndMeta(podSpec, oldPodSpec *api.PodSpec, po
 		AllowInvalidTopologySpreadConstraintLabelSelector: false,
 		AllowNamespacedSysctlsForHostNetAndHostIPC:        false,
 		AllowNonLocalProjectedTokenPath:                   false,
-		AllowImageVolumeSource:                            utilfeature.DefaultFeatureGate.Enabled(features.ImageVolume),
 	}
 
 	// If old spec uses relaxed validation or enabled the RelaxedEnvironmentVariableValidation feature gate,
@@ -416,9 +415,6 @@ func GetValidationOptionsFromPodSpecAndMeta(podSpec, oldPodSpec *api.PodSpec, po
 				}
 			}
 		}
-
-		// if old spec has used image volume source, we must allow it
-		opts.AllowImageVolumeSource = opts.AllowImageVolumeSource || hasUsedImageVolumeSourceWithPodSpec(oldPodSpec)
 	}
 	if oldPodMeta != nil && !opts.AllowInvalidPodDeletionCost {
 		// This is an update, so validate only if the existing object was valid.
@@ -578,19 +574,6 @@ func hasUsedDownwardAPIFieldPathWithContainer(container *api.Container, fieldPat
 		if env.ValueFrom != nil &&
 			env.ValueFrom.FieldRef != nil &&
 			env.ValueFrom.FieldRef.FieldPath == fieldPath {
-			return true
-		}
-	}
-	return false
-}
-
-func hasUsedImageVolumeSourceWithPodSpec(podSpec *api.PodSpec) bool {
-	if podSpec == nil {
-		return false
-	}
-
-	for _, vol := range podSpec.Volumes {
-		if vol.Image != nil {
 			return true
 		}
 	}

--- a/pkg/api/pod/util_test.go
+++ b/pkg/api/pod/util_test.go
@@ -2553,48 +2553,6 @@ func TestValidateAllowNonLocalProjectedTokenPathOption(t *testing.T) {
 	}
 }
 
-func TestValidateAllowImageVolumeSourceOption(t *testing.T) {
-	testCases := []struct {
-		name           string
-		oldPodSpec     *api.PodSpec
-		featureEnabled bool
-		wantOption     bool
-	}{
-		{
-			name:           "CreateFeatureEnabled",
-			featureEnabled: true,
-			wantOption:     true,
-		},
-		{
-			name:           "CreateFeatureDisabled",
-			featureEnabled: false,
-			wantOption:     false,
-		},
-		{
-			name:           "UpdateFeatureDisabled",
-			oldPodSpec:     &api.PodSpec{Volumes: []api.Volume{{VolumeSource: api.VolumeSource{Image: &api.ImageVolumeSource{Reference: "image"}}}}},
-			featureEnabled: false,
-			wantOption:     true,
-		},
-		{
-			name:           "UpdateFeatureEnabled",
-			oldPodSpec:     &api.PodSpec{Volumes: []api.Volume{{VolumeSource: api.VolumeSource{Image: &api.ImageVolumeSource{Reference: "image"}}}}},
-			featureEnabled: true,
-			wantOption:     true,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ImageVolume, tc.featureEnabled)
-			gotOptions := GetValidationOptionsFromPodSpecAndMeta(nil, tc.oldPodSpec, nil, nil)
-			if tc.wantOption != gotOptions.AllowImageVolumeSource {
-				t.Errorf("unexpected diff, want: %v, got: %v", tc.wantOption, gotOptions.AllowImageVolumeSource)
-			}
-		})
-	}
-}
-
 func TestDropInPlacePodVerticalScaling(t *testing.T) {
 	podWithInPlaceVerticalScaling := func() *api.Pod {
 		return &api.Pod{

--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -741,7 +741,7 @@ func validateVolumeSource(source *core.VolumeSource, fldPath *field.Path, volNam
 			}
 		}
 	}
-	if opts.AllowImageVolumeSource && source.Image != nil {
+	if source.Image != nil {
 		if numVolumes > 0 {
 			allErrs = append(allErrs, field.Forbidden(fldPath.Child("image"), "may not specify more than 1 volume type"))
 		} else {
@@ -2940,14 +2940,12 @@ func ValidateVolumeMounts(mounts []core.VolumeMount, voldevices map[string]strin
 		}
 
 		// Disallow subPath/subPathExpr for image volumes
-		if opts.AllowImageVolumeSource {
-			if v, ok := volumes[mnt.Name]; ok && v.Image != nil {
-				if len(mnt.SubPath) != 0 {
-					allErrs = append(allErrs, field.Invalid(idxPath.Child("subPath"), mnt.SubPath, "not allowed in image volume sources"))
-				}
-				if len(mnt.SubPathExpr) != 0 {
-					allErrs = append(allErrs, field.Invalid(idxPath.Child("subPathExpr"), mnt.SubPathExpr, "not allowed in image volume sources"))
-				}
+		if v, ok := volumes[mnt.Name]; ok && v.Image != nil {
+			if len(mnt.SubPath) != 0 {
+				allErrs = append(allErrs, field.Invalid(idxPath.Child("subPath"), mnt.SubPath, "not allowed in image volume sources"))
+			}
+			if len(mnt.SubPathExpr) != 0 {
+				allErrs = append(allErrs, field.Invalid(idxPath.Child("subPathExpr"), mnt.SubPathExpr, "not allowed in image volume sources"))
 			}
 		}
 
@@ -4049,8 +4047,6 @@ type PodValidationOptions struct {
 	ResourceIsPod bool
 	// Allow relaxed validation of environment variable names
 	AllowRelaxedEnvironmentVariableValidation bool
-	// Allow the use of the ImageVolumeSource API.
-	AllowImageVolumeSource bool
 	// Allow the use of a relaxed DNS search
 	AllowRelaxedDNSSearchValidation bool
 }

--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -5378,19 +5378,14 @@ func TestValidateVolumes(t *testing.T) {
 					},
 				},
 			},
-			opts: PodValidationOptions{AllowImageVolumeSource: true},
+			opts: PodValidationOptions{},
 		}, {
-			name: "feature disabled",
+			name: "no volume source",
 			vol: core.Volume{
-				Name: "image-volume",
-				VolumeSource: core.VolumeSource{
-					Image: &core.ImageVolumeSource{
-						Reference:  "quay.io/my/artifact:v1",
-						PullPolicy: "IfNotPresent",
-					},
-				},
+				Name:         "volume",
+				VolumeSource: core.VolumeSource{},
 			},
-			opts: PodValidationOptions{AllowImageVolumeSource: false},
+			opts: PodValidationOptions{},
 			errs: []verr{{
 				etype:  field.ErrorTypeRequired,
 				field:  "field[0]",
@@ -5407,7 +5402,7 @@ func TestValidateVolumes(t *testing.T) {
 					},
 				},
 			},
-			opts: PodValidationOptions{AllowImageVolumeSource: true},
+			opts: PodValidationOptions{},
 			errs: []verr{{
 				etype: field.ErrorTypeRequired,
 				field: "name",
@@ -5423,7 +5418,7 @@ func TestValidateVolumes(t *testing.T) {
 					},
 				},
 			},
-			opts: PodValidationOptions{AllowImageVolumeSource: true, ResourceIsPod: true},
+			opts: PodValidationOptions{ResourceIsPod: true},
 			errs: []verr{{
 				etype: field.ErrorTypeRequired,
 				field: "image.reference",
@@ -5439,7 +5434,7 @@ func TestValidateVolumes(t *testing.T) {
 					},
 				},
 			},
-			opts: PodValidationOptions{AllowImageVolumeSource: true, ResourceIsPod: false},
+			opts: PodValidationOptions{ResourceIsPod: false},
 		}, {
 			name: "image volume with wrong pullPolicy",
 			vol: core.Volume{
@@ -5451,7 +5446,7 @@ func TestValidateVolumes(t *testing.T) {
 					},
 				},
 			},
-			opts: PodValidationOptions{AllowImageVolumeSource: true},
+			opts: PodValidationOptions{},
 			errs: []verr{{
 				etype: field.ErrorTypeNotSupported,
 				field: "image.pullPolicy",
@@ -7066,7 +7061,7 @@ func TestValidateVolumeMounts(t *testing.T) {
 		}}}},
 		{Name: "image-volume", VolumeSource: core.VolumeSource{Image: &core.ImageVolumeSource{Reference: "quay.io/my/artifact:v1", PullPolicy: "IfNotPresent"}}},
 	}
-	opts := PodValidationOptions{AllowImageVolumeSource: true}
+	opts := PodValidationOptions{}
 	vols, v1err := ValidateVolumes(volumes, nil, field.NewPath("field"), opts)
 	if len(v1err) > 0 {
 		t.Errorf("Invalid test volume - expected success %v", v1err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Related to https://github.com/kubernetes/enhancements/issues/4639

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
If an old pod spec has used image volume source, we must allow it when updating the resource even if the feature-gate ImageVolume is disabled.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
