### PR TITLE
Automated cherry pick of #126652: Add timeout cancellation to kubectl cp destination path

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/cp/cp.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/cp/cp.go
@@ -18,7 +18,6 @@ package cp
 
 import (
 	"archive/tar"
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -269,8 +268,8 @@ func (o *CopyOptions) checkDestinationIsDir(dest fileSpec) error {
 	options := &exec.ExecOptions{
 		StreamOptions: exec.StreamOptions{
 			IOStreams: genericiooptions.IOStreams{
-				Out:    bytes.NewBuffer([]byte{}),
-				ErrOut: bytes.NewBuffer([]byte{}),
+				Out:    io.Discard,
+				ErrOut: io.Discard,
 			},
 
 			Namespace: dest.PodNamespace,


### PR DESCRIPTION
Cherry pick of #126652 on release-1.30.

#126652: Add timeout cancellation to kubectl cp destination path

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
None
```