### PR TITLE
improve verify output of the verify-featuregate.sh script

### DIFF
--- a/hack/verify-featuregates.sh
+++ b/hack/verify-featuregates.sh
@@ -28,4 +28,14 @@ source "${KUBE_ROOT}/hack/lib/init.sh"
 
 cd "${KUBE_ROOT}"
 
-go run test/featuregates_linter/main.go feature-gates verify
+if ! output=$(go run test/featuregates_linter/main.go feature-gates verify 2>&1)
+then
+	echo "$output"
+	echo
+	echo "FAILURE: please execute hack/update-featuregates.sh."
+	exit 1
+else
+	echo "$output"
+	echo
+  echo "SUCCESS"
+fi


### PR DESCRIPTION

/kind cleanup
```release-note
NONE
```

linter and verify scripts should return a meaningful output so developers can understand the origin of the problem and fix it.

With this change it shows
```
hack/verify-featuregates.sh 
found 158 features in FeatureSpecMap var defaultKubernetesFeatureGates in file: /usr/local/google/home/aojea/src/kubernetes/pkg/features/kube_features.go
found 2 features in FeatureSpecMap var defaultKubernetesFeatureGates in file: /usr/local/google/home/aojea/src/kubernetes/staging/src/k8s.io/apiextensions-apiserver/pkg/features/kube_features.go
found 37 features in FeatureSpecMap var defaultKubernetesFeatureGates in file: /usr/local/google/home/aojea/src/kubernetes/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
found 3 features in FeatureSpecMap of func featureGates in file: /usr/local/google/home/aojea/src/kubernetes/staging/src/k8s.io/component-base/logs/api/v1/kube_features.go
found 1 features in FeatureSpecMap of func featureGates in file: /usr/local/google/home/aojea/src/kubernetes/staging/src/k8s.io/component-base/metrics/features/kube_features.go
found 3 features in FeatureSpecMap var cloudPublicFeatureGates in file: /usr/local/google/home/aojea/src/kubernetes/staging/src/k8s.io/controller-manager/pkg/features/kube_features.go
panic: feature MultiCIDRServiceAllocator changed with diff:   cmd.featureInfo{
                Name:     "MultiCIDRServiceAllocator",
                FullName: "",
                VersionedSpecs: []cmd.featureSpec{
                        {
        -                       Default:       false,
        +                       Default:       true,
                                LockToDefault: false,
                                PreRelease:    "Beta",
                                Version:       "",
                        },
                },
          }


goroutine 1 [running]:
k8s.io/kubernetes/test/featuregates_linter/cmd.verifyFeatureListFunc(0xc0001f4200?, {0x69953d?, 0x4?, 0x6994ed?})
        /usr/local/google/home/aojea/src/kubernetes/test/featuregates_linter/cmd/feature_gates.go:99 +0x8e
github.com/spf13/cobra.(*Command).execute(0xc0001fc308, {0x8c8000, 0x0, 0x0})
        /usr/local/google/home/aojea/src/kubernetes/vendor/github.com/spf13/cobra/command.go:989 +0xa91
github.com/spf13/cobra.(*Command).ExecuteC(0x8a3dc0)
        /usr/local/google/home/aojea/src/kubernetes/vendor/github.com/spf13/cobra/command.go:1117 +0x3ff
github.com/spf13/cobra.(*Command).Execute(...)
        /usr/local/google/home/aojea/src/kubernetes/vendor/github.com/spf13/cobra/command.go:1041
k8s.io/kubernetes/test/featuregates_linter/cmd.Execute()
        /usr/local/google/home/aojea/src/kubernetes/test/featuregates_linter/cmd/root.go:32 +0x1a
main.main()
        /usr/local/google/home/aojea/src/kubernetes/test/featuregates_linter/main.go:22 +0xf
exit status 2

FAILURE: please execute hack/update-featuregates.sh.

```

Related to https://github.com/kubernetes/kubernetes/issues/126741