### PR TITLE
kubeadm: sort the merged env vars and improve related tests

### DIFF
--- a/cmd/kubeadm/app/phases/addons/proxy/proxy.go
+++ b/cmd/kubeadm/app/phases/addons/proxy/proxy.go
@@ -259,7 +259,7 @@ func createKubeProxyAddon(cfg *kubeadmapi.ClusterConfiguration, client clientset
 	}
 	// Propagate the http/https proxy host environment variables to the container
 	env := &kubeproxyDaemonSet.Spec.Template.Spec.Containers[0].Env
-	*env = append(*env, kubeadmutil.MergeKubeadmEnvVars(kubeadmutil.GetProxyEnvVars())...)
+	*env = append(*env, kubeadmutil.MergeKubeadmEnvVars(kubeadmutil.GetProxyEnvVars(nil))...)
 
 	// Create the DaemonSet for kube-proxy or update it in case it already exists
 	return []byte(""), apiclient.CreateOrUpdateDaemonSet(client, kubeproxyDaemonSet)

--- a/cmd/kubeadm/app/phases/controlplane/manifests.go
+++ b/cmd/kubeadm/app/phases/controlplane/manifests.go
@@ -52,7 +52,7 @@ func GetStaticPodSpecs(cfg *kubeadmapi.ClusterConfiguration, endpoint *kubeadmap
 	// Get the required hostpath mounts
 	mounts := getHostPathVolumesForTheControlPlane(cfg)
 	if proxyEnvs == nil {
-		proxyEnvs = kubeadmutil.GetProxyEnvVars()
+		proxyEnvs = kubeadmutil.GetProxyEnvVars(nil)
 	}
 	componentHealthCheckTimeout := kubeadmapi.GetActiveTimeouts().ControlPlaneComponentHealthCheck
 

--- a/cmd/kubeadm/app/util/env.go
+++ b/cmd/kubeadm/app/util/env.go
@@ -18,6 +18,7 @@ package util
 
 import (
 	"os"
+	"sort"
 	"strings"
 
 	v1 "k8s.io/api/core/v1"
@@ -63,5 +64,8 @@ func MergeKubeadmEnvVars(envList ...[]kubeadmapi.EnvVar) []v1.EnvVar {
 	for _, v := range m {
 		merged = append(merged, v)
 	}
+	sort.Slice(merged, func(i, j int) bool {
+		return merged[i].Name < merged[j].Name
+	})
 	return merged
 }

--- a/cmd/kubeadm/app/util/env.go
+++ b/cmd/kubeadm/app/util/env.go
@@ -25,13 +25,17 @@ import (
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 )
 
-// GetProxyEnvVars builds a list of environment variables in order to use the right proxy
-func GetProxyEnvVars() []kubeadmapi.EnvVar {
+// GetProxyEnvVars builds a list of environment variables in order to use the right proxy.
+// Passing nil for environment will make the function use the OS environment.
+func GetProxyEnvVars(environment []string) []kubeadmapi.EnvVar {
 	envs := []kubeadmapi.EnvVar{}
-	for _, env := range os.Environ() {
+	if environment == nil {
+		environment = os.Environ()
+	}
+	for _, env := range environment {
 		pos := strings.Index(env, "=")
 		if pos == -1 {
-			// malformed environment variable, skip it.
+			// Malformed environment variable, skip it.
 			continue
 		}
 		name := env[:pos]

--- a/cmd/kubeadm/app/util/env_test.go
+++ b/cmd/kubeadm/app/util/env_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package util
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -84,6 +85,54 @@ func TestMergeKubeadmEnvVars(t *testing.T) {
 			envs := MergeKubeadmEnvVars(test.proxyEnv, test.extraEnv)
 			if !assert.ElementsMatch(t, envs, test.mergedEnv) {
 				t.Errorf("expected env: %v, got: %v", test.mergedEnv, envs)
+			}
+		})
+	}
+}
+
+func TestGetProxyEnvVars(t *testing.T) {
+	var tests = []struct {
+		name        string
+		environment []string
+		expected    []kubeadmapi.EnvVar
+	}{
+		{
+			name: "environment with lowercase proxy vars",
+			environment: []string{
+				"http_proxy=p1",
+				"foo1=bar1",
+				"https_proxy=p2",
+				"foo2=bar2",
+				"no_proxy=p3",
+			},
+			expected: []kubeadmapi.EnvVar{
+				{EnvVar: v1.EnvVar{Name: "http_proxy", Value: "p1"}},
+				{EnvVar: v1.EnvVar{Name: "https_proxy", Value: "p2"}},
+				{EnvVar: v1.EnvVar{Name: "no_proxy", Value: "p3"}},
+			},
+		},
+		{
+			name: "environment with uppercase proxy vars",
+			environment: []string{
+				"HTTP_PROXY=p1",
+				"foo1=bar1",
+				"HTTPS_PROXY=p2",
+				"foo2=bar2",
+				"NO_PROXY=p3",
+			},
+			expected: []kubeadmapi.EnvVar{
+				{EnvVar: v1.EnvVar{Name: "HTTP_PROXY", Value: "p1"}},
+				{EnvVar: v1.EnvVar{Name: "HTTPS_PROXY", Value: "p2"}},
+				{EnvVar: v1.EnvVar{Name: "NO_PROXY", Value: "p3"}},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			envs := GetProxyEnvVars(test.environment)
+			if !reflect.DeepEqual(envs, test.expected) {
+				t.Errorf("expected env: %v, got: %v", test.expected, envs)
 			}
 		})
 	}

--- a/cmd/kubeadm/app/util/env_test.go
+++ b/cmd/kubeadm/app/util/env_test.go
@@ -20,8 +20,6 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	v1 "k8s.io/api/core/v1"
 
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
@@ -41,10 +39,10 @@ func TestMergeKubeadmEnvVars(t *testing.T) {
 			name: "normal case without duplicated env",
 			proxyEnv: []kubeadmapi.EnvVar{
 				{
-					EnvVar: v1.EnvVar{Name: "Foo1", Value: "Bar1"},
+					EnvVar: v1.EnvVar{Name: "Foo2", Value: "Bar2"},
 				},
 				{
-					EnvVar: v1.EnvVar{Name: "Foo2", Value: "Bar2"},
+					EnvVar: v1.EnvVar{Name: "Foo1", Value: "Bar1"},
 				},
 			},
 			extraEnv: []kubeadmapi.EnvVar{
@@ -83,7 +81,7 @@ func TestMergeKubeadmEnvVars(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			envs := MergeKubeadmEnvVars(test.proxyEnv, test.extraEnv)
-			if !assert.ElementsMatch(t, envs, test.mergedEnv) {
+			if !reflect.DeepEqual(envs, test.mergedEnv) {
 				t.Errorf("expected env: %v, got: %v", test.mergedEnv, envs)
 			}
 		})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:

contains two commits:
```
kubeadm: add unit test for GetProxyEnvVars

kubeadm: sort the results of MergeKubeadmEnvVars 
```

@[neolit123](https://github.com/kubernetes/kubernetes/commits?author=neolit123)
neolit123 committed 3 minutes ago
[kubeadm: sort the results of MergeKubeadmEnvVars](https://github.com/kubernetes/kubernetes/commit/d899d9049574e63c9e9cf07e84274a0f502fb469)

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
NONE

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubeadm: make sure the extra environment variables written to a kubeadm managed PodSpec are sorted alpha-numerically by the environment variable name.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
