### PR TITLE
fix pods of the same priority cannot be scheduled when other pod has been previously nominated to the same node

### DIFF
--- a/pkg/scheduler/framework/runtime/framework.go
+++ b/pkg/scheduler/framework/runtime/framework.go
@@ -974,14 +974,14 @@ func (f *frameworkImpl) RunFilterPluginsWithNominatedPods(ctx context.Context, s
 	var status *framework.Status
 
 	podsAdded := false
-	// We run filters twice in some cases. If the node has greater or equal priority
+	// We run filters twice in some cases. If the node has greater priority
 	// nominated pods, we run them when those pods are added to PreFilter state and nodeInfo.
 	// If all filters succeed in this pass, we run them again when these
 	// nominated pods are not added. This second pass is necessary because some
 	// filters such as inter-pod affinity may not pass without the nominated pods.
 	// If there are no nominated pods for the node or if the first run of the
 	// filters fail, we don't run the second pass.
-	// We consider only equal or higher priority pods in the first pass, because
+	// We consider only higher priority pods in the first pass, because
 	// those are the current "pod" must yield to them and not take a space opened
 	// for running them. It is ok if the current "pod" take resources freed for
 	// lower priority pods.
@@ -1017,7 +1017,7 @@ func (f *frameworkImpl) RunFilterPluginsWithNominatedPods(ctx context.Context, s
 	return status
 }
 
-// addNominatedPods adds pods with equal or greater priority which are nominated
+// addNominatedPods adds pods with greater priority which are nominated
 // to run on the node. It returns 1) whether any pod was added, 2) augmented cycleState,
 // 3) augmented nodeInfo.
 func addNominatedPods(ctx context.Context, fh framework.Handle, pod *v1.Pod, state *framework.CycleState, nodeInfo *framework.NodeInfo) (bool, *framework.CycleState, *framework.NodeInfo, error) {
@@ -1033,7 +1033,7 @@ func addNominatedPods(ctx context.Context, fh framework.Handle, pod *v1.Pod, sta
 	stateOut := state.Clone()
 	podsAdded := false
 	for _, pi := range nominatedPodInfos {
-		if corev1.PodPriority(pi.Pod) >= corev1.PodPriority(pod) && pi.Pod.UID != pod.UID {
+		if corev1.PodPriority(pi.Pod) > corev1.PodPriority(pod) && pi.Pod.UID != pod.UID {
 			nodeInfoOut.AddPodInfo(pi)
 			status := fh.RunPreFilterExtensionAddPod(ctx, stateOut, pod, pi, nodeInfoOut)
 			if !status.IsSuccess() {


### PR DESCRIPTION
#### What type of PR is this?
pods of the same priority should not assume that resources are already occupied by the nominated node, because they are all of the same priority. This is unfair to the later pods of the same priority, and the resources required by the later pods may be sufficient, but they are assumed to be occupied by the previous pods.

/kind bug


#### What this PR does / why we need it:
And this can speed up the scheduling. Pods with the same priority should compete fairly for node resources.

#### Which issue(s) this PR fixes:
Fixes #126700

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
pods with the same priority compete fairly for nominated node resources.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
