### PR TITLE
New implementation of watch cache using btree data structure.

### DIFF
--- a/staging/src/k8s.io/apiserver/go.mod
+++ b/staging/src/k8s.io/apiserver/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/fsnotify/fsnotify v1.7.0
 	github.com/go-logr/logr v1.4.2
 	github.com/gogo/protobuf v1.3.2
+	github.com/google/btree v1.0.1
 	github.com/google/cel-go v0.21.0
 	github.com/google/gnostic-models v0.6.8
 	github.com/google/go-cmp v0.6.0
@@ -81,7 +82,6 @@ require (
 	github.com/golang-jwt/jwt/v4 v4.5.0 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
-	github.com/google/btree v1.0.1 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.20.0 // indirect

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/store.go
@@ -19,6 +19,8 @@ package cacher
 import (
 	"fmt"
 
+	"github.com/google/btree"
+
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -52,6 +54,12 @@ type storeElement struct {
 	Labels labels.Set
 	Fields fields.Set
 }
+
+func (t *storeElement) Less(than btree.Item) bool {
+	return t.Key < than.(*storeElement).Key
+}
+
+var _ btree.Item = (*storeElement)(nil)
 
 func storeElementKey(obj interface{}) (string, error) {
 	elem, ok := obj.(*storeElement)

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/store_btree.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/store_btree.go
@@ -1,0 +1,393 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cacher
+
+import (
+	"fmt"
+	"math"
+	"strings"
+	"sync"
+
+	"github.com/google/btree"
+	"k8s.io/client-go/tools/cache"
+)
+
+// newThreadedBtreeStoreIndexer returns a storage for cacher by adding locking over the two 2 data structures:
+// * btree based storage for efficient LIST operation on prefix
+// * map based indexer for retrieving values by index.
+// This separation is used to allow independent snapshotting those two storages in the future.
+// Intention is to utilize btree for its cheap snapshots that don't require locking if don't mutate data.
+func newThreadedBtreeStoreIndexer(indexers cache.Indexers, degree int) *threadedStoreIndexer {
+	return &threadedStoreIndexer{
+		store:   newBtreeStore(degree),
+		indexer: newIndexer(indexers),
+	}
+}
+
+type threadedStoreIndexer struct {
+	lock    sync.RWMutex
+	store   btreeStore
+	indexer indexer
+}
+
+func (si *threadedStoreIndexer) Add(obj interface{}) error {
+	return si.addOrUpdate(obj)
+}
+
+func (si *threadedStoreIndexer) Update(obj interface{}) error {
+	return si.addOrUpdate(obj)
+}
+
+func (si *threadedStoreIndexer) addOrUpdate(obj interface{}) error {
+	if obj == nil {
+		return fmt.Errorf("obj cannot be nil")
+	}
+	newElem, ok := obj.(*storeElement)
+	if !ok {
+		return fmt.Errorf("obj not a storeElement: %#v", obj)
+	}
+	si.lock.Lock()
+	defer si.lock.Unlock()
+	oldElem := si.store.addOrUpdateElem(newElem)
+	return si.indexer.updateElem(newElem.Key, oldElem, newElem)
+}
+
+func (si *threadedStoreIndexer) Delete(obj interface{}) error {
+	storeElem, ok := obj.(*storeElement)
+	if !ok {
+		return fmt.Errorf("obj not a storeElement: %#v", obj)
+	}
+	si.lock.Lock()
+	defer si.lock.Unlock()
+	oldObj := si.store.deleteElem(storeElem)
+	if oldObj == nil {
+		return nil
+	}
+	return si.indexer.updateElem(storeElem.Key, oldObj.(*storeElement), nil)
+}
+
+func (si *threadedStoreIndexer) List() []interface{} {
+	si.lock.RLock()
+	defer si.lock.RUnlock()
+	return si.store.List()
+}
+
+func (si *threadedStoreIndexer) ListPrefix(prefix, continueKey string, limit int) ([]interface{}, bool) {
+	si.lock.RLock()
+	defer si.lock.RUnlock()
+	return si.store.ListPrefix(prefix, continueKey, limit)
+}
+
+func (si *threadedStoreIndexer) ListKeys() []string {
+	si.lock.RLock()
+	defer si.lock.RUnlock()
+	return si.store.ListKeys()
+}
+
+func (si *threadedStoreIndexer) Get(obj interface{}) (item interface{}, exists bool, err error) {
+	si.lock.RLock()
+	defer si.lock.RUnlock()
+	return si.store.Get(obj)
+}
+
+func (si *threadedStoreIndexer) GetByKey(key string) (item interface{}, exists bool, err error) {
+	si.lock.RLock()
+	defer si.lock.RUnlock()
+	return si.store.GetByKey(key)
+}
+
+func (si *threadedStoreIndexer) Replace(objs []interface{}, resourceVersion string) error {
+	si.lock.Lock()
+	defer si.lock.Unlock()
+	err := si.store.Replace(objs, resourceVersion)
+	if err != nil {
+		return err
+	}
+	return si.indexer.Replace(objs, resourceVersion)
+}
+
+func (si *threadedStoreIndexer) ByIndex(indexName, indexValue string) ([]interface{}, error) {
+	si.lock.RLock()
+	defer si.lock.RUnlock()
+	return si.indexer.ByIndex(indexName, indexValue)
+}
+
+func newBtreeStore(degree int) btreeStore {
+	return btreeStore{
+		tree: btree.New(degree),
+	}
+}
+
+type btreeStore struct {
+	tree *btree.BTree
+}
+
+func (s *btreeStore) Add(obj interface{}) error {
+	if obj == nil {
+		return fmt.Errorf("obj cannot be nil")
+	}
+	storeElem, ok := obj.(*storeElement)
+	if !ok {
+		return fmt.Errorf("obj not a storeElement: %#v", obj)
+	}
+	s.addOrUpdateElem(storeElem)
+	return nil
+}
+
+func (s *btreeStore) Update(obj interface{}) error {
+	if obj == nil {
+		return fmt.Errorf("obj cannot be nil")
+	}
+	storeElem, ok := obj.(*storeElement)
+	if !ok {
+		return fmt.Errorf("obj not a storeElement: %#v", obj)
+	}
+	s.addOrUpdateElem(storeElem)
+	return nil
+}
+
+func (s *btreeStore) Delete(obj interface{}) error {
+	if obj == nil {
+		return fmt.Errorf("obj cannot be nil")
+	}
+	storeElem, ok := obj.(*storeElement)
+	if !ok {
+		return fmt.Errorf("obj not a storeElement: %#v", obj)
+	}
+	s.deleteElem(storeElem)
+	return nil
+}
+
+func (s *btreeStore) deleteElem(storeElem *storeElement) interface{} {
+	return s.tree.Delete(storeElem)
+}
+
+func (s *btreeStore) List() []interface{} {
+	items := make([]interface{}, 0, s.tree.Len())
+	s.tree.Ascend(func(i btree.Item) bool {
+		items = append(items, i.(interface{}))
+		return true
+	})
+	return items
+}
+
+func (s *btreeStore) ListKeys() []string {
+	items := make([]string, 0, s.tree.Len())
+	s.tree.Ascend(func(i btree.Item) bool {
+		items = append(items, i.(*storeElement).Key)
+		return true
+	})
+	return items
+}
+
+func (s *btreeStore) Get(obj interface{}) (item interface{}, exists bool, err error) {
+	storeElem, ok := obj.(*storeElement)
+	if !ok {
+		return nil, false, fmt.Errorf("obj is not a storeElement")
+	}
+	item = s.tree.Get(storeElem)
+	if item == nil {
+		return nil, false, nil
+	}
+	return item, true, nil
+}
+
+func (s *btreeStore) GetByKey(key string) (item interface{}, exists bool, err error) {
+	return s.getByKey(key)
+}
+
+func (s *btreeStore) Replace(objs []interface{}, _ string) error {
+	s.tree.Clear(false)
+	for _, obj := range objs {
+		storeElem, ok := obj.(*storeElement)
+		if !ok {
+			return fmt.Errorf("obj not a storeElement: %#v", obj)
+		}
+		s.addOrUpdateElem(storeElem)
+	}
+	return nil
+}
+
+// addOrUpdateLocked assumes a lock is held and is used for Add
+// and Update operations.
+func (s *btreeStore) addOrUpdateElem(storeElem *storeElement) *storeElement {
+	oldObj := s.tree.ReplaceOrInsert(storeElem)
+	if oldObj == nil {
+		return nil
+	}
+	return oldObj.(*storeElement)
+}
+
+func (s *btreeStore) getByKey(key string) (item interface{}, exists bool, err error) {
+	keyElement := &storeElement{Key: key}
+	item = s.tree.Get(keyElement)
+	return item, item != nil, nil
+}
+
+func (s *btreeStore) ListPrefix(prefix, continueKey string, limit int) ([]interface{}, bool) {
+	if limit < 0 {
+		return nil, false
+	}
+	if continueKey == "" {
+		continueKey = prefix
+	}
+	var result []interface{}
+	var hasMore bool
+	if limit == 0 {
+		limit = math.MaxInt
+	}
+	s.tree.AscendGreaterOrEqual(&storeElement{Key: continueKey}, func(i btree.Item) bool {
+		elementKey := i.(*storeElement).Key
+		if !strings.HasPrefix(elementKey, prefix) {
+			return false
+		}
+		// TODO: Might be worth to lookup one more item to provide more accurate HasMore.
+		if len(result) >= limit {
+			hasMore = true
+			return false
+		}
+		result = append(result, i.(interface{}))
+		return true
+	})
+	return result, hasMore
+}
+
+func (s *btreeStore) Count(prefix, continueKey string) (count int) {
+	if continueKey == "" {
+		continueKey = prefix
+	}
+	s.tree.AscendGreaterOrEqual(&storeElement{Key: continueKey}, func(i btree.Item) bool {
+		elementKey := i.(*storeElement).Key
+		if !strings.HasPrefix(elementKey, prefix) {
+			return false
+		}
+		count++
+		return true
+	})
+	return count
+}
+
+// newIndexer returns a indexer similar to storeIndex from client-go/tools/cache.
+// TODO: Unify the indexer code with client-go/cache package.
+// Major differences is type of values stored and their mutability:
+// * Indexer in client-go stores object keys, that are not mutable.
+// * Indexer in cacher stores whole objects, which is mutable.
+// Indexer in client-go uses keys as it is used in conjunction with map[key]value
+// allowing for fast value retrieval, while btree used in cacher would provide additional overhead.
+// Difference in mutability of stored values is used for optimizing some operations in client-go Indexer.
+func newIndexer(indexers cache.Indexers) indexer {
+	return indexer{
+		indices:  map[string]map[string]map[string]*storeElement{},
+		indexers: indexers,
+	}
+}
+
+type indexer struct {
+	indices  map[string]map[string]map[string]*storeElement
+	indexers cache.Indexers
+}
+
+func (i *indexer) ByIndex(indexName, indexValue string) ([]interface{}, error) {
+	indexFunc := i.indexers[indexName]
+	if indexFunc == nil {
+		return nil, fmt.Errorf("index with name %s does not exist", indexName)
+	}
+	index := i.indices[indexName]
+	set := index[indexValue]
+	list := make([]interface{}, 0, len(set))
+	for _, obj := range set {
+		list = append(list, obj)
+	}
+	return list, nil
+}
+
+func (i *indexer) Replace(objs []interface{}, resourceVersion string) error {
+	i.indices = map[string]map[string]map[string]*storeElement{}
+	for _, obj := range objs {
+		storeElem, ok := obj.(*storeElement)
+		if !ok {
+			return fmt.Errorf("obj not a storeElement: %#v", obj)
+		}
+		err := i.updateElem(storeElem.Key, nil, storeElem)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (i *indexer) updateElem(key string, oldObj, newObj *storeElement) (err error) {
+	var oldIndexValues, indexValues []string
+	for name, indexFunc := range i.indexers {
+		if oldObj != nil {
+			oldIndexValues, err = indexFunc(oldObj)
+		} else {
+			oldIndexValues = oldIndexValues[:0]
+		}
+		if err != nil {
+			return fmt.Errorf("unable to calculate an index entry for key %q on index %q: %w", key, name, err)
+		}
+		if newObj != nil {
+			indexValues, err = indexFunc(newObj)
+		} else {
+			indexValues = indexValues[:0]
+		}
+		if err != nil {
+			return fmt.Errorf("unable to calculate an index entry for key %q on index %q: %w", key, name, err)
+		}
+		index := i.indices[name]
+		if index == nil {
+			index = map[string]map[string]*storeElement{}
+			i.indices[name] = index
+		}
+		if len(indexValues) == 1 && len(oldIndexValues) == 1 && indexValues[0] == oldIndexValues[0] {
+			// We optimize for the most common case where indexFunc returns a single value which has not been changed
+			i.add(key, indexValues[0], newObj, index)
+			continue
+		}
+		for _, value := range oldIndexValues {
+			i.delete(key, value, index)
+		}
+		for _, value := range indexValues {
+			i.add(key, value, newObj, index)
+		}
+	}
+	return nil
+}
+
+func (i *indexer) add(key, value string, obj *storeElement, index map[string]map[string]*storeElement) {
+	set := index[value]
+	if set == nil {
+		set = map[string]*storeElement{}
+		index[value] = set
+	}
+	set[key] = obj
+}
+
+func (i *indexer) delete(key, value string, index map[string]map[string]*storeElement) {
+	set := index[value]
+	if set == nil {
+		return
+	}
+	delete(set, key)
+	// If we don's delete the set when zero, indices with high cardinality
+	// short lived resources can cause memory to increase over time from
+	// unused empty sets. See `kubernetes/kubernetes/issues/84959`.
+	if len(set) == 0 {
+		delete(index, value)
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/store_btree_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/store_btree_test.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cacher
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStoreListOrdered(t *testing.T) {
+	store := newThreadedBtreeStoreIndexer(nil, 32)
+	assert.NoError(t, store.Add(testStorageElement("foo3", "bar3", 1)))
+	assert.NoError(t, store.Add(testStorageElement("foo1", "bar2", 2)))
+	assert.NoError(t, store.Add(testStorageElement("foo2", "bar1", 3)))
+	assert.Equal(t, []interface{}{
+		testStorageElement("foo1", "bar2", 2),
+		testStorageElement("foo2", "bar1", 3),
+		testStorageElement("foo3", "bar3", 1),
+	}, store.List())
+}
+
+func TestStoreListPrefix(t *testing.T) {
+	store := newThreadedBtreeStoreIndexer(nil, 32)
+	assert.NoError(t, store.Add(testStorageElement("foo3", "bar3", 1)))
+	assert.NoError(t, store.Add(testStorageElement("foo1", "bar2", 2)))
+	assert.NoError(t, store.Add(testStorageElement("foo2", "bar1", 3)))
+	assert.NoError(t, store.Add(testStorageElement("bar", "baz", 4)))
+
+	items, hasMore := store.ListPrefix("foo", "", 0)
+	assert.False(t, hasMore)
+	assert.Equal(t, []interface{}{
+		testStorageElement("foo1", "bar2", 2),
+		testStorageElement("foo2", "bar1", 3),
+		testStorageElement("foo3", "bar3", 1),
+	}, items)
+
+	items, hasMore = store.ListPrefix("foo2", "", 0)
+	assert.False(t, hasMore)
+	assert.Equal(t, []interface{}{
+		testStorageElement("foo2", "bar1", 3),
+	}, items)
+
+	items, hasMore = store.ListPrefix("foo", "", 1)
+	assert.True(t, hasMore)
+	assert.Equal(t, []interface{}{
+		testStorageElement("foo1", "bar2", 2),
+	}, items)
+
+	items, hasMore = store.ListPrefix("foo", "foo1\x00", 1)
+	assert.True(t, hasMore)
+	assert.Equal(t, []interface{}{
+		testStorageElement("foo2", "bar1", 3),
+	}, items)
+
+	items, hasMore = store.ListPrefix("foo", "foo2\x00", 1)
+	assert.False(t, hasMore)
+	assert.Equal(t, []interface{}{
+		testStorageElement("foo3", "bar3", 1),
+	}, items)
+
+	items, hasMore = store.ListPrefix("bar", "", 0)
+	assert.False(t, hasMore)
+	assert.Equal(t, []interface{}{
+		testStorageElement("bar", "baz", 4),
+	}, items)
+}

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/store_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/store_test.go
@@ -28,7 +28,17 @@ import (
 )
 
 func TestStoreSingleKey(t *testing.T) {
-	store := newStoreIndexer(nil)
+	t.Run("cache.Indexer", func(t *testing.T) {
+		store := newStoreIndexer(testStoreIndexers())
+		testStoreSingleKey(t, store)
+	})
+	t.Run("btree", func(t *testing.T) {
+		store := newThreadedBtreeStoreIndexer(storeElementIndexers(testStoreIndexers()), 32)
+		testStoreSingleKey(t, store)
+	})
+}
+
+func testStoreSingleKey(t *testing.T, store storeIndexer) {
 	assertStoreEmpty(t, store, "foo")
 
 	require.NoError(t, store.Add(testStorageElement("foo", "bar", 1)))
@@ -50,7 +60,17 @@ func TestStoreSingleKey(t *testing.T) {
 }
 
 func TestStoreIndexerSingleKey(t *testing.T) {
-	store := newStoreIndexer(testStoreIndexers())
+	t.Run("cache.Indexer", func(t *testing.T) {
+		store := newStoreIndexer(testStoreIndexers())
+		testStoreIndexerSingleKey(t, store)
+	})
+	t.Run("btree", func(t *testing.T) {
+		store := newThreadedBtreeStoreIndexer(storeElementIndexers(testStoreIndexers()), 32)
+		testStoreIndexerSingleKey(t, store)
+	})
+}
+
+func testStoreIndexerSingleKey(t *testing.T, store storeIndexer) {
 	items, err := store.ByIndex("by_val", "bar")
 	require.NoError(t, err)
 	assert.Empty(t, items)

--- a/staging/src/k8s.io/cloud-provider/go.mod
+++ b/staging/src/k8s.io/cloud-provider/go.mod
@@ -47,6 +47,7 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
+	github.com/google/btree v1.0.1 // indirect
 	github.com/google/cel-go v0.21.0 // indirect
 	github.com/google/gnostic-models v0.6.8 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect

--- a/staging/src/k8s.io/kube-aggregator/go.mod
+++ b/staging/src/k8s.io/kube-aggregator/go.mod
@@ -51,6 +51,7 @@ require (
 	github.com/go-openapi/swag v0.23.0 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
+	github.com/google/btree v1.0.1 // indirect
 	github.com/google/cel-go v0.21.0 // indirect
 	github.com/google/gnostic-models v0.6.8 // indirect
 	github.com/google/uuid v1.6.0 // indirect

--- a/staging/src/k8s.io/kube-controller-manager/go.sum
+++ b/staging/src/k8s.io/kube-controller-manager/go.sum
@@ -31,6 +31,7 @@ github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
+github.com/google/btree v1.0.1/go.mod h1:xXMiIv4Fb/0kKde4SpL7qlzvu5cMJDRkFDxJfI9uaxA=
 github.com/google/cel-go v0.21.0/go.mod h1:rHUlWCcBKgyEk+eV03RPdZUekPp6YcJwV0FxuUksYxc=
 github.com/google/gnostic-models v0.6.8/go.mod h1:5n7qKqH0f5wFt+aWF8CW6pZLLNOfYuF5OpfBSENuI8U=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=

--- a/staging/src/k8s.io/pod-security-admission/go.mod
+++ b/staging/src/k8s.io/pod-security-admission/go.mod
@@ -45,6 +45,7 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
+	github.com/google/btree v1.0.1 // indirect
 	github.com/google/cel-go v0.21.0 // indirect
 	github.com/google/gnostic-models v0.6.8 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect

--- a/staging/src/k8s.io/sample-apiserver/go.mod
+++ b/staging/src/k8s.io/sample-apiserver/go.mod
@@ -43,6 +43,7 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
+	github.com/google/btree v1.0.1 // indirect
 	github.com/google/cel-go v0.21.0 // indirect
 	github.com/google/gnostic-models v0.6.8 // indirect
 	github.com/google/go-cmp v0.6.0 // indirect


### PR DESCRIPTION
Continuing work of https://github.com/kubernetes/kubernetes/pull/108392

Started from taking the exact implementation by @MadhavJivrajani, however updated the btree factor to 32.

Using btree without any changes already is faster than existing ThreadedSafeStore. There are still many improvements that could be implemented. 

Btree is awesome for watch cache due to:
* Support key ranges
* Returns ordered results

Also etcd uses btree to serve ranges too.

Performance improvement:
* 25% improvement in operations per second
* 15% less bytes allocated

```
goos: linux
goarch: amd64
pkg: k8s.io/apiserver/pkg/storage/cacher
cpu: AMD Ryzen 5 7600X 6-Core Processor
                                                  │  base.txt   │            btree.txt             │
                                                  │   sec/op    │   sec/op     vs base                │
StoreListCreate/RV=NotOlderThan-12                  698.8µ ± 4%   227.9µ ± 2%  -67.39% (p=0.000 n=10)
StoreListCreate/RV=ExactMatch-12                    356.4µ ± 2%   358.7µ ± 2%        ~ (p=0.631 n=10)
StoreList/RV=Empty-12                               982.5µ ± 6%   722.9µ ± 4%  -26.43% (p=0.000 n=10)
StoreList/RV=NotOlderThan-12                        972.3µ ± 2%   700.7µ ± 2%  -27.93% (p=0.000 n=10)
StoreList/RV=MatchExact-12                          16.55m ± 3%   16.38m ± 2%        ~ (p=0.218 n=10)
StoreList/Paginate/RV=Empty-12                      18.55m ± 1%   18.49m ± 1%        ~ (p=0.353 n=10)
StoreList/Paginate/RV=NotOlderThan-12               18.39m ± 3%   18.45m ± 1%        ~ (p=0.971 n=10)
StoreList/Paginate/RV=MatchExact-12                 18.28m ± 1%   18.47m ± 1%   +1.03% (p=0.003 n=10)
StoreList/NodeIndexed/RV=Empty-12                   1.791m ± 3%   1.796m ± 2%        ~ (p=0.796 n=10)
StoreList/NodeIndexed/RV=NotOlderThan-12            1.234m ± 4%   1.250m ± 3%        ~ (p=0.796 n=10)
StoreList/NodeIndexed/RV=MatchExact-12               7.460 ± 1%    7.455 ± 1%        ~ (p=0.796 n=10)
StoreList/NodeIndexed/Paginate/RV=Empty-12          70.41m ± 1%   64.66m ± 4%   -8.17% (p=0.000 n=10)
StoreList/NodeIndexed/Paginate/RV=NotOlderThan-12   69.42m ± 1%   63.59m ± 1%   -8.39% (p=0.000 n=10)
StoreList/NodeIndexed/Paginate/RV=MatchExact-12      8.077 ± 1%    8.088 ± 1%        ~ (p=0.165 n=10)
StoreList/Namespace/RV=Empty-12                     6.421m ± 1%   1.675m ± 1%  -73.91% (p=0.000 n=10)
StoreList/Namespace/RV=NotOlderThan-12              5.670m ± 2%   1.069m ± 1%  -81.14% (p=0.000 n=10)
StoreList/Namespace/RV=MatchExact-12                15.84m ± 2%   16.33m ± 3%   +3.09% (p=0.000 n=10)
geomean                                             13.05m        9.789m       -24.98%

                                                  │   base.txt    │             btree.txt             │
                                                  │     B/op      │     B/op      vs base                │
StoreListCreate/RV=NotOlderThan-12                   293.7Ki ± 4%   233.1Ki ± 4%  -20.65% (p=0.000 n=10)
StoreListCreate/RV=ExactMatch-12                     115.0Ki ± 0%   114.9Ki ± 0%   -0.09% (p=0.000 n=10)
StoreList/RV=Empty-12                                6.179Mi ± 0%   6.023Mi ± 0%   -2.53% (p=0.000 n=10)
StoreList/RV=NotOlderThan-12                         6.163Mi ± 0%   6.007Mi ± 0%   -2.53% (p=0.000 n=10)
StoreList/RV=MatchExact-12                           60.32Mi ± 0%   60.29Mi ± 0%        ~ (p=0.529 n=10)
StoreList/Paginate/RV=Empty-12                       64.29Mi ± 0%   64.05Mi ± 0%   -0.37% (p=0.000 n=10)
StoreList/Paginate/RV=NotOlderThan-12                64.27Mi ± 0%   64.04Mi ± 0%   -0.35% (p=0.000 n=10)
StoreList/Paginate/RV=MatchExact-12                  63.64Mi ± 0%   63.56Mi ± 0%   -0.12% (p=0.000 n=10)
StoreList/NodeIndexed/RV=Empty-12                    7.928Mi ± 1%   7.929Mi ± 1%   +0.01% (p=0.035 n=10)
StoreList/NodeIndexed/RV=NotOlderThan-12             6.328Mi ± 0%   6.328Mi ± 0%        ~ (p=0.739 n=10)
StoreList/NodeIndexed/RV=MatchExact-12               5.785Gi ± 0%   5.782Gi ± 0%        ~ (p=0.315 n=10)
StoreList/NodeIndexed/Paginate/RV=Empty-12           284.0Mi ± 0%   257.0Mi ± 0%   -9.51% (p=0.000 n=10)
StoreList/NodeIndexed/Paginate/RV=NotOlderThan-12    282.2Mi ± 0%   255.3Mi ± 0%   -9.55% (p=0.000 n=10)
StoreList/NodeIndexed/Paginate/RV=MatchExact-12      6.073Gi ± 0%   6.048Gi ± 0%   -0.42% (p=0.000 n=10)
StoreList/Namespace/RV=Empty-12                     23.745Mi ± 0%   8.123Mi ± 0%  -65.79% (p=0.000 n=10)
StoreList/Namespace/RV=NotOlderThan-12              22.143Mi ± 0%   6.521Mi ± 0%  -70.55% (p=0.000 n=10)
StoreList/Namespace/RV=MatchExact-12                 63.39Mi ± 0%   63.32Mi ± 0%   -0.11% (p=0.000 n=10)
geomean                                              33.76Mi        28.64Mi       -15.15%

                                                  │  base.txt   │            btree.txt            │
                                                  │  allocs/op  │  allocs/op   vs base               │
StoreListCreate/RV=NotOlderThan-12                   561.0 ± 0%    559.0 ± 0%  -0.36% (p=0.000 n=10)
StoreListCreate/RV=ExactMatch-12                     874.5 ± 0%    875.0 ± 0%       ~ (p=0.407 n=10)
StoreList/RV=Empty-12                                346.5 ± 1%    345.0 ± 2%       ~ (p=0.236 n=10)
StoreList/RV=NotOlderThan-12                         88.00 ± 1%    87.00 ± 1%  -1.14% (p=0.002 n=10)
StoreList/RV=MatchExact-12                          460.6k ± 0%   456.8k ± 0%  -0.83% (p=0.000 n=10)
StoreList/Paginate/RV=Empty-12                      490.6k ± 0%   486.8k ± 0%  -0.77% (p=0.000 n=10)
StoreList/Paginate/RV=NotOlderThan-12               490.4k ± 0%   486.6k ± 0%  -0.78% (p=0.000 n=10)
StoreList/Paginate/RV=MatchExact-12                 492.9k ± 0%   489.1k ± 0%  -0.77% (p=0.000 n=10)
StoreList/NodeIndexed/RV=Empty-12                   32.08k ± 0%   32.10k ± 0%       ~ (p=0.061 n=10)
StoreList/NodeIndexed/RV=NotOlderThan-12            6.614k ± 1%   6.614k ± 1%       ~ (p=0.642 n=10)
StoreList/NodeIndexed/RV=MatchExact-12              46.96M ± 0%   46.58M ± 0%  -0.81% (p=0.000 n=10)
StoreList/NodeIndexed/Paginate/RV=Empty-12          2.147M ± 0%   1.948M ± 0%  -9.28% (p=0.000 n=10)
StoreList/NodeIndexed/Paginate/RV=NotOlderThan-12   2.119M ± 0%   1.920M ± 0%  -9.38% (p=0.000 n=10)
StoreList/NodeIndexed/Paginate/RV=MatchExact-12     47.93M ± 0%   47.46M ± 0%  -0.97% (p=0.000 n=10)
StoreList/Namespace/RV=Empty-12                     31.84k ± 0%   31.72k ± 0%  -0.39% (p=0.000 n=10)
StoreList/Namespace/RV=NotOlderThan-12              6.314k ± 0%   6.218k ± 0%  -1.53% (p=0.000 n=10)
StoreList/Namespace/RV=MatchExact-12                490.1k ± 0%   486.4k ± 0%  -0.76% (p=0.000 n=10)
geomean                                             78.82k        77.48k       -1.69%

```

/kind feature

```release-note
NONE
```
