### PR TITLE
kubeadm: increase ut coverage for util/dryrun

### DIFF
--- a/cmd/kubeadm/app/util/dryrun/dryrun_test.go
+++ b/cmd/kubeadm/app/util/dryrun/dryrun_test.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dryrun
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestPrintDryRunFiles(t *testing.T) {
+	tmpdir, err := os.MkdirTemp("", "")
+	if err != nil {
+		t.Fatalf("Couldn't create tmpdir: %v", err)
+	}
+	defer func() {
+		if err = os.RemoveAll(tmpdir); err != nil {
+			t.Fatalf("Couldn't remove tmpdir: %v", err)
+		}
+	}()
+	fileContents := "apiVersion: kubeadm.k8s.io/unknownVersion"
+	filename := "testfile"
+	cfgPath := filepath.Join(tmpdir, filename)
+	err = os.WriteFile(cfgPath, []byte(fileContents), 0644)
+	if err != nil {
+		t.Fatalf("Couldn't write context to file: %v", err)
+	}
+
+	tests := []struct {
+		name    string
+		files   []FileToPrint
+		wantW   string
+		wantErr bool
+	}{
+		{
+			name: "RealPath is empty",
+			files: []FileToPrint{
+				{
+					RealPath:  "",
+					PrintPath: cfgPath,
+				},
+			},
+			wantW:   "",
+			wantErr: false,
+		},
+		{
+			name: "RealPath is a file that does not exist",
+			files: []FileToPrint{
+				{
+					RealPath:  tmpdir + "/missingfile",
+					PrintPath: cfgPath,
+				},
+			},
+			wantW:   "",
+			wantErr: true,
+		},
+		{
+			name: "RealPath is a readable file",
+			files: []FileToPrint{
+				{
+					RealPath:  cfgPath,
+					PrintPath: "",
+				},
+			},
+			wantW: "[dryrun] Would write file \"" + cfgPath + "\" with content:\n" +
+				"	apiVersion: kubeadm.k8s.io/unknownVersion\n",
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := &bytes.Buffer{}
+			if err := PrintDryRunFiles(tt.files, w); (err != nil) != tt.wantErr {
+				t.Errorf("error: %v, expected error: %v", err, tt.wantErr)
+				return
+			}
+			if gotW := w.String(); gotW != tt.wantW {
+				t.Errorf("output: %v, expected output: %v", gotW, tt.wantW)
+			}
+		})
+	}
+}
+
+func TestNewFileToPrint(t *testing.T) {
+	tests := []struct {
+		realPath  string
+		printPath string
+		want      FileToPrint
+	}{
+		{
+			realPath:  "",
+			printPath: "",
+			want:      FileToPrint{},
+		},
+		{
+			realPath:  "/etc/kubernetes",
+			printPath: "/tmp/kubernetes",
+			want: FileToPrint{
+				"/etc/kubernetes",
+				"/tmp/kubernetes",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run("TestNewFileToPrint", func(t *testing.T) {
+			if got := NewFileToPrint(tt.realPath, tt.printPath); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("got: %v, want: %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

kubeadm: increase ut coverage for util/dryrun

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
