### PR TITLE
feategates_linter: take versioned into account in the error message

### DIFF
--- a/test/featuregates_linter/cmd/feature_gates.go
+++ b/test/featuregates_linter/cmd/feature_gates.go
@@ -167,7 +167,11 @@ func verifyOrUpdateFeatureList(rootPath, featureListFile string, update, version
 	}
 
 	if diff := cmp.Diff(featureList, baseFeatureList); diff != "" {
-		return fmt.Errorf("detected diff in unversioned feature list, diff: \n%s", diff)
+		if versioned {
+			return fmt.Errorf("detected diff in versioned feature list (%s), diff: \n%s", versionedFeatureListFile, diff)
+		} else {
+			return fmt.Errorf("detected diff in unversioned feature list (%s), diff: \n%s", unversionedFeatureListFile, diff)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fix the error message in featuregates_linter so it reflect the versioned/unversioned nature of the list.

I've gone through the process of trying to add a feature gate and this mislead me into hunting a unversioned entry somewhere.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
