### PR TITLE
Initialize feature enablement metrics after the metrics options are a…

### DIFF
--- a/staging/src/k8s.io/component-base/featuregate/feature_gate.go
+++ b/staging/src/k8s.io/component-base/featuregate/feature_gate.go
@@ -67,6 +67,8 @@ var (
 		allAlphaGate: setUnsetAlphaGates,
 		allBetaGate:  setUnsetBetaGates,
 	}
+
+	addMetrics sync.Once
 )
 
 type FeatureSpec struct {
@@ -633,6 +635,9 @@ func (f *featureGate) AddFlag(fs *pflag.FlagSet) {
 }
 
 func (f *featureGate) AddMetrics() {
+	addMetrics.Do(func() {
+		featuremetrics.Init()
+	})
 	for feature, featureSpec := range f.GetAll() {
 		featuremetrics.RecordFeatureInfo(context.Background(), string(feature), string(featureSpec.PreRelease), f.Enabled(feature))
 	}

--- a/staging/src/k8s.io/component-base/metrics/metric.go
+++ b/staging/src/k8s.io/component-base/metrics/metric.go
@@ -76,6 +76,10 @@ type lazyMetric struct {
 }
 
 func (r *lazyMetric) IsCreated() bool {
+	if r == nil {
+		return false
+	}
+
 	r.createLock.RLock()
 	defer r.createLock.RUnlock()
 	return r.isCreated
@@ -129,6 +133,10 @@ func (r *lazyMetric) preprocessMetric(version semver.Version) {
 }
 
 func (r *lazyMetric) IsHidden() bool {
+	if r == nil {
+		return false
+	}
+
 	return r.isHidden
 }
 

--- a/staging/src/k8s.io/component-base/metrics/prometheus/feature/metrics_test.go
+++ b/staging/src/k8s.io/component-base/metrics/prometheus/feature/metrics_test.go
@@ -30,6 +30,7 @@ var (
 )
 
 func TestObserveHealthcheck(t *testing.T) {
+	Init()
 	defer legacyregistry.Reset()
 	defer ResetFeatureInfoMetric()
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:
Delays initialization of metrics until after the allow-metric-labels flag is processed during bootstrap. This guarantees the metrics can utilize the flag's value when they are created.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Issue #126526

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Unallowed label values will show up as "unexpected" in kubernetes_feature_enabled metric
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->

For a scheduler config specifying `"--allow-metric-labels": "kubernetes_feature_enabled,stage=BETA"`

Before
```docs
# TYPE kubernetes_feature_enabled gauge
kubernetes_feature_enabled{name="APIListChunking",stage=""} 1
kubernetes_feature_enabled{name="APIResponseCompression",stage="BETA"} 1
kubernetes_feature_enabled{name="APIServerIdentity",stage="BETA"} 1
kubernetes_feature_enabled{name="APIServerTracing",stage="BETA"} 1
kubernetes_feature_enabled{name="APIServingWithRoutine",stage="ALPHA"} 0
kubernetes_feature_enabled{name="AdmissionWebhookMatchConditions",stage=""} 1
kubernetes_feature_enabled{name="AggregatedDiscoveryEndpoint",stage=""} 1
kubernetes_feature_enabled{name="AllAlpha",stage="ALPHA"} 0
kubernetes_feature_enabled{name="AllBeta",stage="BETA"} 0
kubernetes_feature_enabled{name="AllowDNSOnlyNodeCSR",stage="DEPRECATED"} 0

```

After
```docs
# TYPE kubernetes_feature_enabled gauge
kubernetes_feature_enabled{name="APIListChunking",stage="unexpected"} 1
kubernetes_feature_enabled{name="APIResponseCompression",stage="BETA"} 1
kubernetes_feature_enabled{name="APIServerIdentity",stage="BETA"} 1
kubernetes_feature_enabled{name="APIServerTracing",stage="BETA"} 1
kubernetes_feature_enabled{name="APIServingWithRoutine",stage="unexpected"} 0
kubernetes_feature_enabled{name="AdmissionWebhookMatchConditions",stage="unexpected"} 1
kubernetes_feature_enabled{name="AggregatedDiscoveryEndpoint",stage="unexpected"} 1
kubernetes_feature_enabled{name="AllAlpha",stage="unexpected"} 0
kubernetes_feature_enabled{name="AllBeta",stage="BETA"} 0
```
