### PR TITLE
cloud-provider: Fix regex format to escape dot . to match it as string

### DIFF
--- a/staging/src/k8s.io/cloud-provider/controllers/node/node_controller.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/node/node_controller.go
@@ -550,7 +550,7 @@ func (cnc *CloudNodeController) getNodeModifiersFromCloudProvider(
 				n.Labels = map[string]string{}
 			}
 
-			k8sNamespaceRegex := regexp.MustCompile("(kubernetes|k8s).io/")
+			k8sNamespaceRegex := regexp.MustCompile(`(^|\.)(kubernetes|k8s)\.io/`)
 			for k, v := range instanceMeta.AdditionalLabels {
 				// Cloud provider should not be using kubernetes namespaces in labels
 				if isK8sNamespace := k8sNamespaceRegex.MatchString(k); isK8sNamespace {

--- a/staging/src/k8s.io/cloud-provider/controllers/node/node_controller_test.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/node/node_controller_test.go
@@ -1598,9 +1598,14 @@ func Test_syncNode(t *testing.T) {
 					// and should be discarded
 					"topology.kubernetes.io/region": "us-other-west",
 					"topology.k8s.io/region":        "us-other-west",
+					"kubernetes.io/region":          "us-other-west",
+					"k8s.io/region":                 "us-other-west",
 					// Should discard labels that already exist
 					"my.custom.label/foo": "bar",
 					"my.custom.label/bar": "foo",
+					// Should add labels that not match regex
+					"app.k8snio/bar": "foo",
+					"k8snio/bar":     "foo",
 				},
 			},
 			existingNode: &v1.Node{
@@ -1661,6 +1666,8 @@ func Test_syncNode(t *testing.T) {
 						"topology.kubernetes.io/zone":              "us-west-1a",
 						"my.custom.label/foo":                      "fizz",
 						"my.custom.label/bar":                      "foo",
+						"app.k8snio/bar":                           "foo",
+						"k8snio/bar":                               "foo",
 					},
 				},
 				Spec: v1.NodeSpec{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Fix regex format to escape dot . to match it as string. This allows additional labels with name like "app.k8snio/name" to be added
This PR is to fix the incorrect regex issue. dot . in regex should be escaped.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/126453

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
