### PR TITLE
Fix a warning message about the gce in-tree cloud provider state

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -221,6 +221,7 @@ const (
 	// owner: @andrewsykim
 	// alpha: v1.23
 	// beta: v1.29
+	// GA: v1.31
 	//
 	// Disable in-tree functionality in kubelet to authenticate to cloud provider container registries for image pull credentials.
 	DisableKubeletCloudCredentialProviders featuregate.Feature = "DisableKubeletCloudCredentialProviders"

--- a/staging/src/k8s.io/cloud-provider/plugins.go
+++ b/staging/src/k8s.io/cloud-provider/plugins.go
@@ -40,7 +40,7 @@ var (
 		external bool
 		detail   string
 	}{
-		{"gce", false, "The GCE provider is deprecated and will be removed in a future release. Please use https://github.com/kubernetes/cloud-provider-gcp"},
+		{"gce", true, "The GCE built-in cloud provider was removed. Please use https://github.com/kubernetes/cloud-provider-gcp"},
 	}
 )
 

--- a/staging/src/k8s.io/cloud-provider/plugins.go
+++ b/staging/src/k8s.io/cloud-provider/plugins.go
@@ -39,9 +39,7 @@ var (
 		name     string
 		external bool
 		detail   string
-	}{
-		{"gce", true, "The GCE built-in cloud provider was removed. Please use https://github.com/kubernetes/cloud-provider-gcp"},
-	}
+	}{}
 )
 
 const externalCloudProvider = "external"

--- a/staging/src/k8s.io/cloud-provider/sample/README.md
+++ b/staging/src/k8s.io/cloud-provider/sample/README.md
@@ -11,7 +11,7 @@ Begin with 1.20, all cloud providers should not copy over or vendor in `k8s.io/k
 1. Have your external repo under k8s.io. e.g. `k8s.io/cloud-provider-<provider>`
 2. Create `main.go` file under your external repo CCM directory. Please refer to `basic_main.go` for a minimum working sample.
 Note: If you have a requirement of adding/deleting controllers within CCM, please refer to `k8s.io/kubernetes/cmd/cloud-controller-manager/main.go` for extra details.
-3. Build/release CCM from your external repo. For existing cloud providers, the option to import legacy providers from `k8s.io/legacy-cloud-provider/<provider>` is still available.
+3. Build/release CCM from your external repo. For existing cloud providers, the option to import legacy providers from `k8s.io/legacy-cloud-provider/<provider>` is still available until 1.31.
 
 ## Things you should NOT do
 

--- a/staging/src/k8s.io/cloud-provider/sample/README.md
+++ b/staging/src/k8s.io/cloud-provider/sample/README.md
@@ -11,7 +11,7 @@ Begin with 1.20, all cloud providers should not copy over or vendor in `k8s.io/k
 1. Have your external repo under k8s.io. e.g. `k8s.io/cloud-provider-<provider>`
 2. Create `main.go` file under your external repo CCM directory. Please refer to `basic_main.go` for a minimum working sample.
 Note: If you have a requirement of adding/deleting controllers within CCM, please refer to `k8s.io/kubernetes/cmd/cloud-controller-manager/main.go` for extra details.
-3. Build/release CCM from your external repo. For existing cloud providers, the option to import legacy providers from `k8s.io/legacy-cloud-provider/<provider>` is still available until 1.31.
+3. Build/release CCM from your external repo. For existing cloud providers, the option to import legacy providers from `k8s.io/legacy-cloud-provider/<provider>` is not available since 1.31.
 
 ## Things you should NOT do
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

https://github.com/kubernetes/kubernetes/pull/124519 removed gce provider but forgot to update its state.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix a warning message about the gce in-tree cloud provider state
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```