### PR TITLE
test: skip normalizing `go test` targets

### DIFF
--- a/hack/make-rules/test-integration.sh
+++ b/hack/make-rules/test-integration.sh
@@ -81,13 +81,13 @@ runTests() {
   # empty here to ensure that we aren't unintentionally consuming them from the
   # previous make invocation.
   KUBE_TEST_ARGS="${SHORT:--short=true} --vmodule=${KUBE_TEST_VMODULE} ${KUBE_TEST_ARGS}" \
+      KUBE_SKIP_TARGET_NORMALIZATION="${KUBE_SKIP_TARGET_NORMALIZATION:-$(if [ -z "${WHAT:-}" ]; then echo y; else echo n; fi)}" \
       WHAT="${WHAT:-$(kube::test::find_integration_test_dirs | paste -sd' ' -)}" \
       GOFLAGS="${GOFLAGS:-}" \
       KUBE_TIMEOUT="${KUBE_TIMEOUT}" \
       KUBE_RACE="" \
       MAKEFLAGS="" \
       make -C "${KUBE_ROOT}" test
-
   cleanup
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Normalizing `go test` targets takes ~3 minutes on a fast desktop with a populated build
cache because Go gets invoked multiple times to list packages. The output of
`go test` and `gotestsum` is the same without normalization, so it seems safe
to skip it.

#### Special notes for your reviewer:

Based on https://github.com/kubernetes/kubernetes/pull/125534.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
