### PR TITLE
Fix flag documentation kube-controller-manager and cloud-provider

### DIFF
--- a/cmd/kube-controller-manager/app/options/nodeipamcontroller.go
+++ b/cmd/kube-controller-manager/app/options/nodeipamcontroller.go
@@ -35,7 +35,7 @@ func (o *NodeIPAMControllerOptions) AddFlags(fs *pflag.FlagSet) {
 	if o == nil {
 		return
 	}
-	fs.StringVar(&o.ServiceCIDR, "service-cluster-ip-range", o.ServiceCIDR, "CIDR Range for Services in cluster. Requires --allocate-node-cidrs to be true")
+	fs.StringVar(&o.ServiceCIDR, "service-cluster-ip-range", o.ServiceCIDR, "CIDR Range for Services in cluster. Only used when --allocate-node-cidrs=true; if false, this option will be ignored.")
 	fs.Int32Var(&o.NodeCIDRMaskSize, "node-cidr-mask-size", o.NodeCIDRMaskSize, "Mask size for node cidr in cluster. Default is 24 for IPv4 and 64 for IPv6.")
 	fs.Int32Var(&o.NodeCIDRMaskSizeIPv4, "node-cidr-mask-size-ipv4", o.NodeCIDRMaskSizeIPv4, "Mask size for IPv4 node cidr in dual-stack cluster. Default is 24.")
 	fs.Int32Var(&o.NodeCIDRMaskSizeIPv6, "node-cidr-mask-size-ipv6", o.NodeCIDRMaskSizeIPv6, "Mask size for IPv6 node cidr in dual-stack cluster. Default is 64.")

--- a/staging/src/k8s.io/cloud-provider/options/kubecloudshared.go
+++ b/staging/src/k8s.io/cloud-provider/options/kubecloudshared.go
@@ -61,8 +61,8 @@ func (o *KubeCloudSharedOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.DurationVar(&o.NodeMonitorPeriod.Duration, "node-monitor-period", o.NodeMonitorPeriod.Duration,
 		fmt.Sprintf("The period for syncing NodeStatus in %s.", names.CloudNodeLifecycleController))
 	fs.StringVar(&o.ClusterName, "cluster-name", o.ClusterName, "The instance prefix for the cluster.")
-	fs.StringVar(&o.ClusterCIDR, "cluster-cidr", o.ClusterCIDR, "CIDR Range for Pods in cluster. Requires --allocate-node-cidrs to be true")
-	fs.BoolVar(&o.AllocateNodeCIDRs, "allocate-node-cidrs", false, "Should CIDRs for Pods be allocated and set on the cloud provider.")
+	fs.StringVar(&o.ClusterCIDR, "cluster-cidr", o.ClusterCIDR, "CIDR Range for Pods in cluster. Only used when --allocate-node-cidrs=true; if false, this option will be ignored.")
+	fs.BoolVar(&o.AllocateNodeCIDRs, "allocate-node-cidrs", false, "Should CIDRs for Pods be allocated and set on the cloud provider. Requires --cluster-cidr.")
 	fs.StringVar(&o.CIDRAllocatorType, "cidr-allocator-type", "RangeAllocator", "Type of CIDR allocator to use")
 	fs.BoolVar(&o.ConfigureCloudRoutes, "configure-cloud-routes", true, "Should CIDRs allocated by allocate-node-cidrs be configured on the cloud provider.")
 


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

This PR solved issue #119066 

Currently, the documentation of the following kube-controller-flags flags are ambiguos:
```
--allocate-node-cidrs Should CIDRs for Pods be allocated and set on the cloud provider.
--cluster-cidr CIDR Range for Pods in cluster. Requires --allocate-node-cidrs to be true
--service-cluster-ip-range CIDR Range for Services in cluster. Requires --allocate-node-cidrs to be true
```
Both restrictions on `--cluster-cidr` and `--service-cluster-ip-range` regarding `--allocate-node-cidrs=true` are incorrect since it is possible to run `kube-controller-manager` with those flags together with `--allocate-node-cidrs=false`. 

Basically, `--allocate-node-cidrs=true` activates the controller `nodeipam` for which `--cluster-cidr` and `--service-cluster-ip-range` are *mandatory*.  However, if `--allocate-node-cidrs=false` , flags `--cluster-cidr` and `--service-cluster-ip-range` are *ignored*

Thus, the documentation of these flags is corrected to the following:

```
--allocate-node-cidrs Should CIDRs for Pods be allocated and set on the cloud provider. Requires --cluster-cidr.
--cluster-cidr CIDR Range for Pods in cluster. Only used when --allocate-node-cidrs=true; if false, this option will be ignored.
--service-cluster-ip-range CIDR Range for Services in cluster. Only used when --allocate-node-cidrs=true; if false, this option will be ignored.
```


#### Which issue(s) this PR fixes:

Fixes #119066

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Clarified the kube-controller-manager documentation for --allocate-node-cidrs, --cluster-cidr, and --service-cluster-ip-range flags to accurately reflect their dependencies and usage conditions.
```
