### PR TITLE
chore: port all non deprecated, non apiserver/controller-manager referenced features to versioned

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -432,7 +432,7 @@ const (
 	// owner: @sanposhiho
 	// kep: https://kep.k8s.io/3633
 	// alpha: v1.29
-	// beta: v1.30
+	// beta: v1.31
 	//
 	// Enables the MatchLabelKeys and MismatchLabelKeys in PodAffinity and PodAntiAffinity.
 	MatchLabelKeysInPodAffinity featuregate.Feature = "MatchLabelKeysInPodAffinity"

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -759,7 +759,7 @@ const (
 	SizeMemoryBackedVolumes featuregate.Feature = "SizeMemoryBackedVolumes"
 
 	// owner: @mattcary
-	// alpha: v1.22
+	// alpha: v1.23
 	// beta: v1.27
 	//
 	// Enables policies controlling deletion of PVCs created by a StatefulSet.

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -78,13 +78,13 @@ const (
 	AuthorizeNodeWithSelectors featuregate.Feature = "AuthorizeNodeWithSelectors"
 
 	// owner: @ahmedtd
-	// alpha: v1.26
+	// alpha: v1.27
 	//
 	// Enable ClusterTrustBundle objects and Kubelet integration.
 	ClusterTrustBundle featuregate.Feature = "ClusterTrustBundle"
 
 	// owner: @ahmedtd
-	// alpha: v1.28
+	// alpha: v1.29
 	//
 	// Enable ClusterTrustBundle Kubelet projected volumes.  Depends on ClusterTrustBundle.
 	ClusterTrustBundleProjection featuregate.Feature = "ClusterTrustBundleProjection"

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -574,7 +574,7 @@ const (
 	PodIndexLabel featuregate.Feature = "PodIndexLabel"
 
 	// owner: @ddebroy, @kannon92
-	// alpha: v1.25
+	// alpha: v1.28
 	// beta: v1.29
 	//
 	// Enables reporting of PodReadyToStartContainersCondition condition in pod status after pod
@@ -912,7 +912,7 @@ const (
 	ImageMaximumGCAge featuregate.Feature = "ImageMaximumGCAge"
 
 	// owner: @saschagrunert
-	// alpha: v1.28
+	// alpha: v1.29
 	//
 	// Enables user namespace support for Pod Security Standards. Enabling this
 	// feature will modify all Pod Security Standard rules to allow setting:

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -677,6 +677,7 @@ const (
 	// owner: @danielvegamyhre
 	// kep: https://kep.k8s.io/2413
 	// beta: v1.27
+	// stable: v1.31
 	//
 	// Allows mutating spec.completions for Indexed job when done in tandem with
 	// spec.parallelism. Specifically, spec.completions is mutable iff spec.completions
@@ -979,225 +980,9 @@ func init() {
 // Entries are separated from each other with blank lines to avoid sweeping gofmt changes
 // when adding or removing one entry.
 var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
-	CrossNamespaceVolumeDataSource: {Default: false, PreRelease: featuregate.Alpha},
-
 	AllowDNSOnlyNodeCSR: {Default: false, PreRelease: featuregate.Deprecated}, // remove after 1.33
 
-	AnyVolumeDataSource: {Default: true, PreRelease: featuregate.Beta}, // on by default in 1.24
-
-	AppArmor: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.33
-
-	AppArmorFields: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.33
-
-	AuthorizeNodeWithSelectors: {Default: false, PreRelease: featuregate.Alpha},
-
-	ClusterTrustBundle: {Default: false, PreRelease: featuregate.Alpha},
-
-	ClusterTrustBundleProjection: {Default: false, PreRelease: featuregate.Alpha},
-
-	CPUCFSQuotaPeriod: {Default: false, PreRelease: featuregate.Alpha},
-
-	CPUManager: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // GA in 1.26
-
-	CPUManagerPolicyAlphaOptions: {Default: false, PreRelease: featuregate.Alpha},
-
-	CPUManagerPolicyBetaOptions: {Default: true, PreRelease: featuregate.Beta},
-
-	CPUManagerPolicyOptions: {Default: true, PreRelease: featuregate.Beta},
-
-	CSIMigrationPortworx: {Default: true, PreRelease: featuregate.Beta}, // On by default (requires Portworx CSI driver)
-
-	CSIVolumeHealth: {Default: false, PreRelease: featuregate.Alpha},
-
-	CloudControllerManagerWebhook: {Default: false, PreRelease: featuregate.Alpha},
-
-	ContainerCheckpoint: {Default: true, PreRelease: featuregate.Beta},
-
-	CronJobsScheduledAnnotation: {Default: true, PreRelease: featuregate.Beta},
-
-	DisableAllocatorDualWrite: {Default: false, PreRelease: featuregate.Alpha}, // remove after MultiCIDRServiceAllocator is GA
-
-	DisableCloudProviders: {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
-
-	DisableKubeletCloudCredentialProviders: {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
-
 	DisableNodeKubeProxyVersion: {Default: false, PreRelease: featuregate.Deprecated}, // default on in 1.33
-
-	DevicePluginCDIDevices: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.33
-
-	DRAControlPlaneController: {Default: false, PreRelease: featuregate.Alpha},
-
-	DynamicResourceAllocation: {Default: false, PreRelease: featuregate.Alpha},
-
-	EventedPLEG: {Default: false, PreRelease: featuregate.Alpha},
-
-	ExecProbeTimeout: {Default: true, PreRelease: featuregate.GA}, // lock to default and remove after v1.22 based on KEP #1972 update
-
-	RetryGenerateName: {Default: true, PreRelease: featuregate.Beta},
-
-	GracefulNodeShutdown: {Default: true, PreRelease: featuregate.Beta},
-
-	GracefulNodeShutdownBasedOnPodPriority: {Default: true, PreRelease: featuregate.Beta},
-
-	HPAContainerMetrics: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.32
-
-	HonorPVReclaimPolicy: {Default: true, PreRelease: featuregate.Beta},
-
-	ImageMaximumGCAge: {Default: true, PreRelease: featuregate.Beta},
-
-	InTreePluginPortworxUnregister: {Default: false, PreRelease: featuregate.Alpha},
-
-	JobBackoffLimitPerIndex: {Default: true, PreRelease: featuregate.Beta},
-
-	JobManagedBy: {Default: false, PreRelease: featuregate.Alpha},
-
-	JobPodFailurePolicy: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.33
-
-	JobPodReplacementPolicy: {Default: true, PreRelease: featuregate.Beta},
-
-	JobSuccessPolicy: {Default: true, PreRelease: featuregate.Beta},
-
-	KubeletCgroupDriverFromCRI: {Default: true, PreRelease: featuregate.Beta},
-
-	KubeletInUserNamespace: {Default: false, PreRelease: featuregate.Alpha},
-
-	KubeletPodResourcesDynamicResources: {Default: false, PreRelease: featuregate.Alpha},
-
-	KubeletPodResourcesGet: {Default: false, PreRelease: featuregate.Alpha},
-
-	KubeletSeparateDiskGC: {Default: true, PreRelease: featuregate.Beta},
-
-	KubeletTracing: {Default: true, PreRelease: featuregate.Beta},
-
-	KubeProxyDrainingTerminatingNodes: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // GA in 1.31; remove in 1.33
-
-	LocalStorageCapacityIsolationFSQuotaMonitoring: {Default: false, PreRelease: featuregate.Beta},
-
-	LogarithmicScaleDown: {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
-
-	MatchLabelKeysInPodAffinity: {Default: true, PreRelease: featuregate.Beta},
-
-	MatchLabelKeysInPodTopologySpread: {Default: true, PreRelease: featuregate.Beta},
-
-	MaxUnavailableStatefulSet: {Default: false, PreRelease: featuregate.Alpha},
-
-	MemoryManager: {Default: true, PreRelease: featuregate.Beta},
-
-	MemoryQoS: {Default: false, PreRelease: featuregate.Alpha},
-
-	MinDomainsInPodTopologySpread: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.32
-
-	MultiCIDRServiceAllocator: {Default: false, PreRelease: featuregate.Beta},
-
-	NewVolumeManagerReconstruction: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.32
-
-	NFTablesProxyMode: {Default: true, PreRelease: featuregate.Beta},
-
-	NodeLogQuery: {Default: false, PreRelease: featuregate.Beta},
-
-	NodeOutOfServiceVolumeDetach: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.31
-
-	NodeSwap: {Default: true, PreRelease: featuregate.Beta},
-
-	PDBUnhealthyPodEvictionPolicy: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.33
-
-	PersistentVolumeLastPhaseTransitionTime: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.33
-
-	PodAndContainerStatsFromCRI: {Default: false, PreRelease: featuregate.Alpha},
-
-	PodDeletionCost: {Default: true, PreRelease: featuregate.Beta},
-
-	PodDisruptionConditions: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.33
-
-	PodReadyToStartContainersCondition: {Default: true, PreRelease: featuregate.Beta},
-
-	PodHostIPs: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.32
-
-	PodLifecycleSleepAction: {Default: true, PreRelease: featuregate.Beta},
-
-	PodSchedulingReadiness: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // GA in 1.30; remove in 1.32
-
-	PortForwardWebsockets: {Default: true, PreRelease: featuregate.Beta},
-
-	ProcMountType: {Default: false, PreRelease: featuregate.Beta},
-
-	QOSReserved: {Default: false, PreRelease: featuregate.Alpha},
-
-	RecoverVolumeExpansionFailure: {Default: false, PreRelease: featuregate.Alpha},
-
-	ReloadKubeletServerCertificateFile: {Default: true, PreRelease: featuregate.Beta},
-
-	ResourceHealthStatus: {Default: false, PreRelease: featuregate.Alpha},
-
-	RotateKubeletServerCertificate: {Default: true, PreRelease: featuregate.Beta},
-
-	RuntimeClassInImageCriAPI: {Default: false, PreRelease: featuregate.Alpha},
-
-	ElasticIndexedJob: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // GA in 1.31, remove in 1.32
-
-	SchedulerQueueingHints: {Default: false, PreRelease: featuregate.Beta},
-
-	SeparateTaintEvictionController: {Default: true, PreRelease: featuregate.Beta},
-
-	ServiceAccountTokenJTI: {Default: true, PreRelease: featuregate.Beta},
-
-	ServiceAccountTokenPodNodeInfo: {Default: true, PreRelease: featuregate.Beta},
-
-	ServiceAccountTokenNodeBinding: {Default: true, PreRelease: featuregate.Beta},
-
-	ServiceAccountTokenNodeBindingValidation: {Default: true, PreRelease: featuregate.Beta},
-
-	ServiceTrafficDistribution: {Default: true, PreRelease: featuregate.Beta},
-
-	SidecarContainers: {Default: true, PreRelease: featuregate.Beta},
-
-	SizeMemoryBackedVolumes: {Default: true, PreRelease: featuregate.Beta},
-
-	StatefulSetAutoDeletePVC: {Default: true, PreRelease: featuregate.Beta},
-
-	StatefulSetStartOrdinal: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // GA in 1.31, remove in 1.33
-
-	StorageVersionMigrator: {Default: false, PreRelease: featuregate.Alpha},
-
-	TopologyAwareHints: {Default: true, PreRelease: featuregate.Beta},
-
-	TopologyManagerPolicyAlphaOptions: {Default: false, PreRelease: featuregate.Alpha},
-
-	TopologyManagerPolicyBetaOptions: {Default: true, PreRelease: featuregate.Beta},
-
-	TopologyManagerPolicyOptions: {Default: true, PreRelease: featuregate.Beta},
-
-	TranslateStreamCloseWebsocketRequests: {Default: true, PreRelease: featuregate.Beta},
-
-	UnknownVersionInteroperabilityProxy: {Default: false, PreRelease: featuregate.Alpha},
-
-	VolumeCapacityPriority: {Default: false, PreRelease: featuregate.Alpha},
-
-	UserNamespacesSupport: {Default: false, PreRelease: featuregate.Beta},
-
-	WinDSR: {Default: false, PreRelease: featuregate.Alpha},
-
-	WinOverlay: {Default: true, PreRelease: featuregate.Beta},
-
-	WindowsHostNetwork: {Default: true, PreRelease: featuregate.Alpha},
-
-	NodeInclusionPolicyInPodTopologySpread: {Default: true, PreRelease: featuregate.Beta},
-
-	SELinuxMountReadWriteOncePod: {Default: true, PreRelease: featuregate.Beta},
-
-	InPlacePodVerticalScaling: {Default: false, PreRelease: featuregate.Alpha},
-
-	PodIndexLabel: {Default: true, PreRelease: featuregate.Beta},
-
-	LoadBalancerIPMode: {Default: true, PreRelease: featuregate.Beta},
-
-	UserNamespacesPodSecurityStandards: {Default: false, PreRelease: featuregate.Alpha},
-
-	SELinuxMount: {Default: false, PreRelease: featuregate.Alpha},
-
-	SupplementalGroupsPolicy: {Default: false, PreRelease: featuregate.Alpha},
-
-	ImageVolume: {Default: false, PreRelease: featuregate.Alpha},
 
 	// inherited features from generic apiserver, relisted here to get a conflict if it is changed
 	// unintentionally on either side:
@@ -1268,6 +1053,14 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	apiextensionsfeatures.CRDValidationRatcheting: {Default: true, PreRelease: featuregate.Beta},
 
 	apiextensionsfeatures.CustomResourceFieldSelectors: {Default: true, PreRelease: featuregate.Beta},
+
+	// features with duplicate definition in apiserver/controller-manager
+
+	CloudControllerManagerWebhook: {Default: false, PreRelease: featuregate.Alpha},
+
+	InPlacePodVerticalScaling: {Default: false, PreRelease: featuregate.Alpha},
+
+	RetryGenerateName: {Default: true, PreRelease: featuregate.Beta},
 
 	// features that enable backwards compatibility but are scheduled to be removed
 	// ...

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -328,7 +328,7 @@ const (
 	// kep: https://kep.k8s.io/3329
 	// alpha: v1.25
 	// beta: v1.26
-	// stable: v1.31
+	// GA: v1.31
 	//
 	// Allow users to specify handling of pod failures based on container exit codes
 	// and pod conditions.
@@ -406,7 +406,7 @@ const (
 	// kep: http://kep.k8s.io/3836
 	// alpha: v1.28
 	// beta: v1.30
-	// stable: v1.31
+	// GA: v1.31
 	//
 	// Implement connection draining for terminating nodes for
 	// `externalTrafficPolicy: Cluster` services.
@@ -560,7 +560,7 @@ const (
 	// kep: https://kep.k8s.io/3329
 	// alpha: v1.25
 	// beta: v1.26
-	// stable: v1.31
+	// GA: v1.31
 	//
 	// Enables support for appending a dedicated pod condition indicating that
 	// the pod is being deleted due to a disruption.
@@ -602,7 +602,7 @@ const (
 	// kep: https://kep.k8s.io/3521
 	// alpha: v1.26
 	// beta: v1.27
-	// stable: v1.30
+	// GA: v1.30
 	//
 	// Enable users to specify when a Pod is ready for scheduling.
 	PodSchedulingReadiness featuregate.Feature = "PodSchedulingReadiness"
@@ -677,7 +677,7 @@ const (
 	// owner: @danielvegamyhre
 	// kep: https://kep.k8s.io/2413
 	// beta: v1.27
-	// stable: v1.31
+	// GA: v1.31
 	//
 	// Allows mutating spec.completions for Indexed job when done in tandem with
 	// spec.parallelism. Specifically, spec.completions is mutable iff spec.completions
@@ -768,7 +768,7 @@ const (
 	// owner: @psch
 	// alpha: v1.26
 	// beta: v1.27
-	// stable: v1.31
+	// GA: v1.31
 	//
 	// Enables a StatefulSet to start from an arbitrary non zero ordinal
 	StatefulSetStartOrdinal featuregate.Feature = "StatefulSetStartOrdinal"

--- a/pkg/features/versioned_kube_features.go
+++ b/pkg/features/versioned_kube_features.go
@@ -210,7 +210,8 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 	},
 	MinDomainsInPodTopologySpread: {
 		{Version: version.MustParse("1.24"), Default: false, PreRelease: featuregate.Alpha},
-		{Version: version.MustParse("1.25"), Default: true, PreRelease: featuregate.Beta},
+		{Version: version.MustParse("1.25"), Default: false, PreRelease: featuregate.Beta},
+		{Version: version.MustParse("1.27"), Default: true, PreRelease: featuregate.Beta},
 		{Version: version.MustParse("1.30"), Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.32
 	},
 	MultiCIDRServiceAllocator: {
@@ -370,7 +371,8 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 	},
 	TopologyAwareHints: {
 		{Version: version.MustParse("1.21"), Default: false, PreRelease: featuregate.Alpha},
-		{Version: version.MustParse("1.23"), Default: true, PreRelease: featuregate.Beta},
+		{Version: version.MustParse("1.23"), Default: false, PreRelease: featuregate.Beta},
+		{Version: version.MustParse("1.24"), Default: true, PreRelease: featuregate.Beta},
 	},
 	TopologyManagerPolicyAlphaOptions: {
 		{Version: version.MustParse("1.26"), Default: false, PreRelease: featuregate.Alpha},

--- a/pkg/features/versioned_kube_features.go
+++ b/pkg/features/versioned_kube_features.go
@@ -29,6 +29,274 @@ import (
 // Entries are alphabetized and separated from each other with blank lines to avoid sweeping gofmt changes
 // when adding or removing one entry.
 var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate.VersionedSpecs{
+	CrossNamespaceVolumeDataSource: {
+		{Version: version.MustParse("1.26"), Default: false, PreRelease: featuregate.Alpha},
+	},
+	AnyVolumeDataSource: {
+		{Version: version.MustParse("1.18"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("1.24"), Default: true, PreRelease: featuregate.Beta},
+	},
+	AppArmor: {
+		{Version: version.MustParse("1.4"), Default: true, PreRelease: featuregate.Beta},
+		{Version: version.MustParse("1.31"), Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.33
+	},
+	AppArmorFields: {
+		{Version: version.MustParse("1.30"), Default: true, PreRelease: featuregate.Beta},
+		{Version: version.MustParse("1.31"), Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.33
+	},
+	AuthorizeNodeWithSelectors: {
+		{Version: version.MustParse("1.31"), Default: false, PreRelease: featuregate.Alpha},
+	},
+	ClusterTrustBundle: {
+		{Version: version.MustParse("1.26"), Default: false, PreRelease: featuregate.Alpha},
+	},
+	ClusterTrustBundleProjection: {
+		{Version: version.MustParse("1.28"), Default: false, PreRelease: featuregate.Alpha},
+	},
+	CPUCFSQuotaPeriod: {
+		{Version: version.MustParse("1.12"), Default: false, PreRelease: featuregate.Alpha},
+	},
+	CPUManager: {
+		{Version: version.MustParse("1.8"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("1.10"), Default: true, PreRelease: featuregate.Beta},
+		{Version: version.MustParse("1.26"), Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // GA in 1.26
+	},
+	CPUManagerPolicyAlphaOptions: {
+		{Version: version.MustParse("1.23"), Default: false, PreRelease: featuregate.Alpha},
+	},
+	CPUManagerPolicyBetaOptions: {
+		{Version: version.MustParse("1.23"), Default: true, PreRelease: featuregate.Beta},
+	},
+	CPUManagerPolicyOptions: {
+		{Version: version.MustParse("1.22"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("1.23"), Default: true, PreRelease: featuregate.Beta},
+	},
+	CSIMigrationPortworx: {
+		{Version: version.MustParse("1.23"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("1.25"), Default: false, PreRelease: featuregate.Beta},
+		{Version: version.MustParse("1.31"), Default: true, PreRelease: featuregate.Beta}, // On by default (requires Portworx CSI driver)
+	},
+	CSIVolumeHealth: {
+		{Version: version.MustParse("1.21"), Default: false, PreRelease: featuregate.Alpha},
+	},
+	ContainerCheckpoint: {
+		{Version: version.MustParse("1.25"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("1.30"), Default: true, PreRelease: featuregate.Beta},
+	},
+	CronJobsScheduledAnnotation: {
+		{Version: version.MustParse("1.28"), Default: true, PreRelease: featuregate.Beta},
+	},
+	DevicePluginCDIDevices: {
+		{Version: version.MustParse("1.28"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("1.29"), Default: true, PreRelease: featuregate.Beta},
+		{Version: version.MustParse("1.31"), Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.33
+	},
+	DisableAllocatorDualWrite: {
+		{Version: version.MustParse("1.31"), Default: false, PreRelease: featuregate.Alpha}, // remove after MultiCIDRServiceAllocator is GA
+	},
+	DisableCloudProviders: {
+		{Version: version.MustParse("1.22"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("1.29"), Default: true, PreRelease: featuregate.Beta},
+		{Version: version.MustParse("1.31"), Default: true, PreRelease: featuregate.GA, LockToDefault: true},
+	},
+	DisableKubeletCloudCredentialProviders: {
+		{Version: version.MustParse("1.23"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("1.29"), Default: true, PreRelease: featuregate.Beta},
+	},
+	DRAControlPlaneController: {
+		{Version: version.MustParse("1.26"), Default: false, PreRelease: featuregate.Alpha},
+	},
+	DynamicResourceAllocation: {
+		{Version: version.MustParse("1.29"), Default: false, PreRelease: featuregate.Alpha},
+	},
+	EventedPLEG: {
+		{Version: version.MustParse("1.25"), Default: false, PreRelease: featuregate.Alpha},
+	},
+	ExecProbeTimeout: {
+		{Version: version.MustParse("1.20"), Default: true, PreRelease: featuregate.GA}, // lock to default and remove after v1.22 based on KEP #1972 update
+	},
+	GracefulNodeShutdown: {
+		{Version: version.MustParse("1.20"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("1.21"), Default: true, PreRelease: featuregate.Beta},
+	},
+	GracefulNodeShutdownBasedOnPodPriority: {
+		{Version: version.MustParse("1.23"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("1.24"), Default: true, PreRelease: featuregate.Beta},
+	},
+	HPAContainerMetrics: {
+		{Version: version.MustParse("1.20"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("1.27"), Default: true, PreRelease: featuregate.Beta},
+		{Version: version.MustParse("1.30"), Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.32
+	},
+	HonorPVReclaimPolicy: {
+		{Version: version.MustParse("1.23"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("1.31"), Default: true, PreRelease: featuregate.Beta},
+	},
+	InTreePluginPortworxUnregister: {
+		{Version: version.MustParse("1.23"), Default: false, PreRelease: featuregate.Alpha},
+	},
+	JobBackoffLimitPerIndex: {
+		{Version: version.MustParse("1.28"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("1.29"), Default: true, PreRelease: featuregate.Beta},
+	},
+	JobManagedBy: {
+		{Version: version.MustParse("1.30"), Default: false, PreRelease: featuregate.Alpha},
+	},
+	JobPodFailurePolicy: {
+		{Version: version.MustParse("1.25"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("1.26"), Default: true, PreRelease: featuregate.Beta},
+		{Version: version.MustParse("1.31"), Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.33
+	},
+	JobPodReplacementPolicy: {
+		{Version: version.MustParse("1.28"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("1.29"), Default: true, PreRelease: featuregate.Beta},
+	},
+	JobSuccessPolicy: {
+		{Version: version.MustParse("1.30"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("1.31"), Default: true, PreRelease: featuregate.Beta},
+	},
+	KubeletCgroupDriverFromCRI: {
+		{Version: version.MustParse("1.28"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("1.31"), Default: true, PreRelease: featuregate.Beta},
+	},
+	KubeletInUserNamespace: {
+		{Version: version.MustParse("1.22"), Default: false, PreRelease: featuregate.Alpha},
+	},
+	KubeletPodResourcesDynamicResources: {
+		{Version: version.MustParse("1.27"), Default: false, PreRelease: featuregate.Alpha},
+	},
+	KubeletPodResourcesGet: {
+		{Version: version.MustParse("1.27"), Default: false, PreRelease: featuregate.Alpha},
+	},
+	KubeletSeparateDiskGC: {
+		{Version: version.MustParse("1.29"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("1.31"), Default: true, PreRelease: featuregate.Beta},
+	},
+	KubeletTracing: {
+		{Version: version.MustParse("1.25"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("1.27"), Default: true, PreRelease: featuregate.Beta},
+	},
+	KubeProxyDrainingTerminatingNodes: {
+		{Version: version.MustParse("1.28"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("1.30"), Default: true, PreRelease: featuregate.Beta},
+		{Version: version.MustParse("1.31"), Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // GA in 1.31; remove in 1.33
+	},
+	LocalStorageCapacityIsolationFSQuotaMonitoring: {
+		{Version: version.MustParse("1.15"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("1.31"), Default: false, PreRelease: featuregate.Beta},
+	},
+	LogarithmicScaleDown: {
+		{Version: version.MustParse("1.21"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("1.22"), Default: true, PreRelease: featuregate.Beta},
+		{Version: version.MustParse("1.31"), Default: true, PreRelease: featuregate.GA, LockToDefault: true},
+	},
+	MatchLabelKeysInPodAffinity: {
+		{Version: version.MustParse("1.29"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("1.30"), Default: true, PreRelease: featuregate.Beta},
+	},
+	MatchLabelKeysInPodTopologySpread: {
+		{Version: version.MustParse("1.25"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("1.27"), Default: true, PreRelease: featuregate.Beta},
+	},
+	MaxUnavailableStatefulSet: {
+		{Version: version.MustParse("1.24"), Default: false, PreRelease: featuregate.Alpha},
+	},
+	MemoryManager: {
+		{Version: version.MustParse("1.21"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("1.22"), Default: true, PreRelease: featuregate.Beta},
+	},
+	MemoryQoS: {
+		{Version: version.MustParse("1.22"), Default: false, PreRelease: featuregate.Alpha},
+	},
+	MinDomainsInPodTopologySpread: {
+		{Version: version.MustParse("1.24"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("1.25"), Default: true, PreRelease: featuregate.Beta},
+		{Version: version.MustParse("1.30"), Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.32
+	},
+	MultiCIDRServiceAllocator: {
+		{Version: version.MustParse("1.27"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("1.31"), Default: false, PreRelease: featuregate.Beta},
+	},
+	NewVolumeManagerReconstruction: {
+		{Version: version.MustParse("1.25"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("1.27"), Default: true, PreRelease: featuregate.Beta},
+		{Version: version.MustParse("1.30"), Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.32
+	},
+	NFTablesProxyMode: {
+		{Version: version.MustParse("1.29"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("1.31"), Default: true, PreRelease: featuregate.Beta},
+	},
+	NodeLogQuery: {
+		{Version: version.MustParse("1.27"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("1.30"), Default: false, PreRelease: featuregate.Beta},
+	},
+	NodeOutOfServiceVolumeDetach: {
+		{Version: version.MustParse("1.24"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("1.26"), Default: true, PreRelease: featuregate.Beta},
+		{Version: version.MustParse("1.28"), Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.31
+	},
+	NodeSwap: {
+		{Version: version.MustParse("1.22"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("1.28"), Default: false, PreRelease: featuregate.Beta},
+		{Version: version.MustParse("1.30"), Default: true, PreRelease: featuregate.Beta},
+	},
+	PDBUnhealthyPodEvictionPolicy: {
+		{Version: version.MustParse("1.26"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("1.27"), Default: true, PreRelease: featuregate.Beta},
+		{Version: version.MustParse("1.31"), Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.33
+	},
+	PersistentVolumeLastPhaseTransitionTime: {
+		{Version: version.MustParse("1.28"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("1.29"), Default: true, PreRelease: featuregate.Beta},
+		{Version: version.MustParse("1.31"), Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.33
+	},
+	PodAndContainerStatsFromCRI: {
+		{Version: version.MustParse("1.23"), Default: false, PreRelease: featuregate.Alpha},
+	},
+	PodDeletionCost: {
+		{Version: version.MustParse("1.21"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("1.22"), Default: true, PreRelease: featuregate.Beta},
+	},
+	PodDisruptionConditions: {
+		{Version: version.MustParse("1.25"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("1.26"), Default: true, PreRelease: featuregate.Beta},
+		{Version: version.MustParse("1.31"), Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.33
+	},
+	PodIndexLabel: {
+		{Version: version.MustParse("1.28"), Default: true, PreRelease: featuregate.Beta},
+	},
+	PodReadyToStartContainersCondition: {
+		{Version: version.MustParse("1.25"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("1.29"), Default: true, PreRelease: featuregate.Beta},
+	},
+	PodHostIPs: {
+		{Version: version.MustParse("1.28"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("1.29"), Default: true, PreRelease: featuregate.Beta},
+		{Version: version.MustParse("1.30"), Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.32
+	},
+	PodLifecycleSleepAction: {
+		{Version: version.MustParse("1.29"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("1.30"), Default: true, PreRelease: featuregate.Beta},
+	},
+	PodSchedulingReadiness: {
+		{Version: version.MustParse("1.26"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("1.27"), Default: true, PreRelease: featuregate.Beta},
+		{Version: version.MustParse("1.30"), Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // GA in 1.30; remove in 1.32
+	},
+	PortForwardWebsockets: {
+		{Version: version.MustParse("1.30"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("1.31"), Default: true, PreRelease: featuregate.Beta},
+	},
+	ProcMountType: {
+		{Version: version.MustParse("1.12"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("1.31"), Default: false, PreRelease: featuregate.Beta},
+	},
+	QOSReserved: {
+		{Version: version.MustParse("1.11"), Default: false, PreRelease: featuregate.Alpha},
+	},
+	RecoverVolumeExpansionFailure: {
+		{Version: version.MustParse("1.23"), Default: false, PreRelease: featuregate.Alpha},
+	},
 	genericfeatures.AnonymousAuthConfigurableEndpoints: {
 		{Version: version.MustParse("1.31"), Default: false, PreRelease: featuregate.Alpha},
 		{Version: version.MustParse("1.32"), Default: true, PreRelease: featuregate.Beta},
@@ -37,9 +305,136 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 	RelaxedEnvironmentVariableValidation: {
 		{Version: version.MustParse("1.30"), Default: false, PreRelease: featuregate.Alpha},
 	},
-
+	ReloadKubeletServerCertificateFile: {
+		{Version: version.MustParse("1.31"), Default: true, PreRelease: featuregate.Beta},
+	},
+	ResourceHealthStatus: {
+		{Version: version.MustParse("1.31"), Default: false, PreRelease: featuregate.Alpha},
+	},
+	RotateKubeletServerCertificate: {
+		{Version: version.MustParse("1.7"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("1.12"), Default: true, PreRelease: featuregate.Beta},
+	},
+	RuntimeClassInImageCriAPI: {
+		{Version: version.MustParse("1.29"), Default: false, PreRelease: featuregate.Alpha},
+	},
+	ElasticIndexedJob: {
+		{Version: version.MustParse("1.27"), Default: true, PreRelease: featuregate.Beta},
+		{Version: version.MustParse("1.31"), Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // GA in 1.31, remove in 1.32
+	},
+	SchedulerQueueingHints: {
+		{Version: version.MustParse("1.28"), Default: false, PreRelease: featuregate.Beta},
+	},
+	SeparateTaintEvictionController: {
+		{Version: version.MustParse("1.29"), Default: true, PreRelease: featuregate.Beta},
+	},
+	ServiceAccountTokenJTI: {
+		{Version: version.MustParse("1.29"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("1.30"), Default: true, PreRelease: featuregate.Beta},
+	},
+	ServiceAccountTokenNodeBinding: {
+		{Version: version.MustParse("1.29"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("1.31"), Default: true, PreRelease: featuregate.Beta},
+	},
+	ServiceAccountTokenNodeBindingValidation: {
+		{Version: version.MustParse("1.29"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("1.30"), Default: true, PreRelease: featuregate.Beta},
+	},
+	ServiceAccountTokenPodNodeInfo: {
+		{Version: version.MustParse("1.29"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("1.30"), Default: true, PreRelease: featuregate.Beta},
+	},
+	ServiceTrafficDistribution: {
+		{Version: version.MustParse("1.30"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("1.31"), Default: true, PreRelease: featuregate.Beta},
+	},
+	SidecarContainers: {
+		{Version: version.MustParse("1.28"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("1.29"), Default: true, PreRelease: featuregate.Beta},
+	},
+	SizeMemoryBackedVolumes: {
+		{Version: version.MustParse("1.20"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("1.22"), Default: true, PreRelease: featuregate.Beta},
+	},
+	StatefulSetAutoDeletePVC: {
+		{Version: version.MustParse("1.22"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("1.27"), Default: true, PreRelease: featuregate.Beta},
+	},
+	StatefulSetStartOrdinal: {
+		{Version: version.MustParse("1.26"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("1.27"), Default: true, PreRelease: featuregate.Beta},
+		{Version: version.MustParse("1.31"), Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // GA in 1.31, remove in 1.33
+	},
+	StorageVersionMigrator: {
+		{Version: version.MustParse("1.30"), Default: false, PreRelease: featuregate.Alpha},
+	},
+	TopologyAwareHints: {
+		{Version: version.MustParse("1.21"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("1.23"), Default: true, PreRelease: featuregate.Beta},
+	},
+	TopologyManagerPolicyAlphaOptions: {
+		{Version: version.MustParse("1.26"), Default: false, PreRelease: featuregate.Alpha},
+	},
+	TopologyManagerPolicyBetaOptions: {
+		{Version: version.MustParse("1.26"), Default: true, PreRelease: featuregate.Beta},
+	},
+	TopologyManagerPolicyOptions: {
+		{Version: version.MustParse("1.26"), Default: true, PreRelease: featuregate.Beta},
+	},
+	TranslateStreamCloseWebsocketRequests: {
+		{Version: version.MustParse("1.29"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("1.30"), Default: true, PreRelease: featuregate.Beta},
+	},
+	UnknownVersionInteroperabilityProxy: {
+		{Version: version.MustParse("1.28"), Default: false, PreRelease: featuregate.Alpha},
+	},
+	UserNamespacesSupport: {
+		{Version: version.MustParse("1.25"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("1.30"), Default: false, PreRelease: featuregate.Beta},
+	},
 	VolumeAttributesClass: {
 		{Version: version.MustParse("1.29"), Default: false, PreRelease: featuregate.Alpha},
 		{Version: version.MustParse("1.31"), Default: false, PreRelease: featuregate.Beta},
+	},
+	VolumeCapacityPriority: {
+		{Version: version.MustParse("1.21"), Default: false, PreRelease: featuregate.Alpha},
+	},
+	WinDSR: {
+		{Version: version.MustParse("1.14"), Default: false, PreRelease: featuregate.Alpha},
+	},
+	WinOverlay: {
+		{Version: version.MustParse("1.14"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("1.20"), Default: true, PreRelease: featuregate.Beta},
+	},
+	WindowsHostNetwork: {
+		{Version: version.MustParse("1.26"), Default: true, PreRelease: featuregate.Alpha},
+	},
+	NodeInclusionPolicyInPodTopologySpread: {
+		{Version: version.MustParse("1.25"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("1.26"), Default: true, PreRelease: featuregate.Beta},
+	},
+	SELinuxMountReadWriteOncePod: {
+		{Version: version.MustParse("1.25"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("1.27"), Default: true, PreRelease: featuregate.Beta},
+	},
+	LoadBalancerIPMode: {
+		{Version: version.MustParse("1.29"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("1.30"), Default: true, PreRelease: featuregate.Beta},
+	},
+	ImageMaximumGCAge: {
+		{Version: version.MustParse("1.29"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("1.30"), Default: true, PreRelease: featuregate.Beta},
+	},
+	UserNamespacesPodSecurityStandards: {
+		{Version: version.MustParse("1.28"), Default: false, PreRelease: featuregate.Alpha},
+	},
+	SELinuxMount: {
+		{Version: version.MustParse("1.30"), Default: false, PreRelease: featuregate.Alpha},
+	},
+	SupplementalGroupsPolicy: {
+		{Version: version.MustParse("1.31"), Default: false, PreRelease: featuregate.Alpha},
+	},
+	ImageVolume: {
+		{Version: version.MustParse("1.31"), Default: false, PreRelease: featuregate.Alpha},
 	},
 }

--- a/pkg/features/versioned_kube_features.go
+++ b/pkg/features/versioned_kube_features.go
@@ -220,7 +220,8 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 	},
 	NewVolumeManagerReconstruction: {
 		{Version: version.MustParse("1.25"), Default: false, PreRelease: featuregate.Alpha},
-		{Version: version.MustParse("1.27"), Default: true, PreRelease: featuregate.Beta},
+		{Version: version.MustParse("1.27"), Default: false, PreRelease: featuregate.Beta},
+		{Version: version.MustParse("1.28"), Default: true, PreRelease: featuregate.Beta},
 		{Version: version.MustParse("1.30"), Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.32
 	},
 	NFTablesProxyMode: {
@@ -267,7 +268,7 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 		{Version: version.MustParse("1.28"), Default: true, PreRelease: featuregate.Beta},
 	},
 	PodReadyToStartContainersCondition: {
-		{Version: version.MustParse("1.25"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("1.28"), Default: false, PreRelease: featuregate.Alpha},
 		{Version: version.MustParse("1.29"), Default: true, PreRelease: featuregate.Beta},
 	},
 	PodHostIPs: {
@@ -324,6 +325,7 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 		{Version: version.MustParse("1.31"), Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // GA in 1.31, remove in 1.32
 	},
 	SchedulerQueueingHints: {
+		{Version: version.MustParse("1.27"), Default: true, PreRelease: featuregate.Beta},
 		{Version: version.MustParse("1.28"), Default: false, PreRelease: featuregate.Beta},
 	},
 	SeparateTaintEvictionController: {
@@ -378,7 +380,8 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 		{Version: version.MustParse("1.26"), Default: false, PreRelease: featuregate.Alpha},
 	},
 	TopologyManagerPolicyBetaOptions: {
-		{Version: version.MustParse("1.26"), Default: true, PreRelease: featuregate.Beta},
+		{Version: version.MustParse("1.26"), Default: false, PreRelease: featuregate.Beta},
+		{Version: version.MustParse("1.28"), Default: true, PreRelease: featuregate.Beta},
 	},
 	TopologyManagerPolicyOptions: {
 		{Version: version.MustParse("1.26"), Default: true, PreRelease: featuregate.Beta},
@@ -417,7 +420,8 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 	},
 	SELinuxMountReadWriteOncePod: {
 		{Version: version.MustParse("1.25"), Default: false, PreRelease: featuregate.Alpha},
-		{Version: version.MustParse("1.27"), Default: true, PreRelease: featuregate.Beta},
+		{Version: version.MustParse("1.27"), Default: false, PreRelease: featuregate.Beta},
+		{Version: version.MustParse("1.28"), Default: true, PreRelease: featuregate.Beta},
 	},
 	LoadBalancerIPMode: {
 		{Version: version.MustParse("1.29"), Default: false, PreRelease: featuregate.Alpha},
@@ -428,7 +432,7 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 		{Version: version.MustParse("1.30"), Default: true, PreRelease: featuregate.Beta},
 	},
 	UserNamespacesPodSecurityStandards: {
-		{Version: version.MustParse("1.28"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("1.29"), Default: false, PreRelease: featuregate.Alpha},
 	},
 	SELinuxMount: {
 		{Version: version.MustParse("1.30"), Default: false, PreRelease: featuregate.Alpha},

--- a/pkg/features/versioned_kube_features.go
+++ b/pkg/features/versioned_kube_features.go
@@ -192,7 +192,7 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 	},
 	MatchLabelKeysInPodAffinity: {
 		{Version: version.MustParse("1.29"), Default: false, PreRelease: featuregate.Alpha},
-		{Version: version.MustParse("1.30"), Default: true, PreRelease: featuregate.Beta},
+		{Version: version.MustParse("1.31"), Default: true, PreRelease: featuregate.Beta},
 	},
 	MatchLabelKeysInPodTopologySpread: {
 		{Version: version.MustParse("1.25"), Default: false, PreRelease: featuregate.Alpha},

--- a/pkg/features/versioned_kube_features.go
+++ b/pkg/features/versioned_kube_features.go
@@ -360,7 +360,7 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 		{Version: version.MustParse("1.22"), Default: true, PreRelease: featuregate.Beta},
 	},
 	StatefulSetAutoDeletePVC: {
-		{Version: version.MustParse("1.22"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("1.23"), Default: false, PreRelease: featuregate.Alpha},
 		{Version: version.MustParse("1.27"), Default: true, PreRelease: featuregate.Beta},
 	},
 	StatefulSetStartOrdinal: {

--- a/pkg/features/versioned_kube_features.go
+++ b/pkg/features/versioned_kube_features.go
@@ -48,10 +48,10 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 		{Version: version.MustParse("1.31"), Default: false, PreRelease: featuregate.Alpha},
 	},
 	ClusterTrustBundle: {
-		{Version: version.MustParse("1.26"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("1.27"), Default: false, PreRelease: featuregate.Alpha},
 	},
 	ClusterTrustBundleProjection: {
-		{Version: version.MustParse("1.28"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("1.29"), Default: false, PreRelease: featuregate.Alpha},
 	},
 	CPUCFSQuotaPeriod: {
 		{Version: version.MustParse("1.12"), Default: false, PreRelease: featuregate.Alpha},

--- a/test/featuregates_linter/test_data/unversioned_feature_list.yaml
+++ b/test/featuregates_linter/test_data/unversioned_feature_list.yaml
@@ -22,11 +22,11 @@
     lockToDefault: false
     preRelease: Deprecated
     version: ""
-- name: AnyVolumeDataSource
+- name: AnonymousAuthConfigurableEndpoints
   versionedSpecs:
-  - default: true
+  - default: false
     lockToDefault: false
-    preRelease: Beta
+    preRelease: Alpha
     version: ""
 - name: APIListChunking
   versionedSpecs:
@@ -58,24 +58,6 @@
     lockToDefault: false
     preRelease: Alpha
     version: ""
-- name: AppArmor
-  versionedSpecs:
-  - default: true
-    lockToDefault: true
-    preRelease: GA
-    version: ""
-- name: AppArmorFields
-  versionedSpecs:
-  - default: true
-    lockToDefault: true
-    preRelease: GA
-    version: ""
-- name: AuthorizeNodeWithSelectors
-  versionedSpecs:
-  - default: false
-    lockToDefault: false
-    preRelease: Alpha
-    version: ""
 - name: AuthorizeWithSelectors
   versionedSpecs:
   - default: false
@@ -83,18 +65,6 @@
     preRelease: Alpha
     version: ""
 - name: CloudControllerManagerWebhook
-  versionedSpecs:
-  - default: false
-    lockToDefault: false
-    preRelease: Alpha
-    version: ""
-- name: ClusterTrustBundle
-  versionedSpecs:
-  - default: false
-    lockToDefault: false
-    preRelease: Alpha
-    version: ""
-- name: ClusterTrustBundleProjection
   versionedSpecs:
   - default: false
     lockToDefault: false
@@ -118,12 +88,6 @@
     lockToDefault: false
     preRelease: Beta
     version: ""
-- name: ContainerCheckpoint
-  versionedSpecs:
-  - default: true
-    lockToDefault: false
-    preRelease: Beta
-    version: ""
 - name: ContextualLogging
   versionedSpecs:
   - default: true
@@ -136,65 +100,11 @@
     lockToDefault: false
     preRelease: Alpha
     version: ""
-- name: CPUCFSQuotaPeriod
-  versionedSpecs:
-  - default: false
-    lockToDefault: false
-    preRelease: Alpha
-    version: ""
-- name: CPUManager
-  versionedSpecs:
-  - default: true
-    lockToDefault: true
-    preRelease: GA
-    version: ""
-- name: CPUManagerPolicyAlphaOptions
-  versionedSpecs:
-  - default: false
-    lockToDefault: false
-    preRelease: Alpha
-    version: ""
-- name: CPUManagerPolicyBetaOptions
-  versionedSpecs:
-  - default: true
-    lockToDefault: false
-    preRelease: Beta
-    version: ""
-- name: CPUManagerPolicyOptions
-  versionedSpecs:
-  - default: true
-    lockToDefault: false
-    preRelease: Beta
-    version: ""
 - name: CRDValidationRatcheting
   versionedSpecs:
   - default: true
     lockToDefault: false
     preRelease: Beta
-    version: ""
-- name: CronJobsScheduledAnnotation
-  versionedSpecs:
-  - default: true
-    lockToDefault: false
-    preRelease: Beta
-    version: ""
-- name: CrossNamespaceVolumeDataSource
-  versionedSpecs:
-  - default: false
-    lockToDefault: false
-    preRelease: Alpha
-    version: ""
-- name: CSIMigrationPortworx
-  versionedSpecs:
-  - default: true
-    lockToDefault: false
-    preRelease: Beta
-    version: ""
-- name: CSIVolumeHealth
-  versionedSpecs:
-  - default: false
-    lockToDefault: false
-    preRelease: Alpha
     version: ""
 - name: CustomResourceFieldSelectors
   versionedSpecs:
@@ -202,91 +112,13 @@
     lockToDefault: false
     preRelease: Beta
     version: ""
-- name: DevicePluginCDIDevices
-  versionedSpecs:
-  - default: true
-    lockToDefault: true
-    preRelease: GA
-    version: ""
-- name: DisableAllocatorDualWrite
-  versionedSpecs:
-  - default: false
-    lockToDefault: false
-    preRelease: Alpha
-    version: ""
-- name: DisableCloudProviders
-  versionedSpecs:
-  - default: true
-    lockToDefault: true
-    preRelease: GA
-    version: ""
-- name: DisableKubeletCloudCredentialProviders
-  versionedSpecs:
-  - default: true
-    lockToDefault: true
-    preRelease: GA
-    version: ""
 - name: DisableNodeKubeProxyVersion
   versionedSpecs:
   - default: false
     lockToDefault: false
     preRelease: Deprecated
     version: ""
-- name: DRAControlPlaneController
-  versionedSpecs:
-  - default: false
-    lockToDefault: false
-    preRelease: Alpha
-    version: ""
-- name: DynamicResourceAllocation
-  versionedSpecs:
-  - default: false
-    lockToDefault: false
-    preRelease: Alpha
-    version: ""
 - name: EfficientWatchResumption
-  versionedSpecs:
-  - default: true
-    lockToDefault: true
-    preRelease: GA
-    version: ""
-- name: ElasticIndexedJob
-  versionedSpecs:
-  - default: true
-    lockToDefault: true
-    preRelease: GA
-    version: ""
-- name: EventedPLEG
-  versionedSpecs:
-  - default: false
-    lockToDefault: false
-    preRelease: Alpha
-    version: ""
-- name: ExecProbeTimeout
-  versionedSpecs:
-  - default: true
-    lockToDefault: false
-    preRelease: GA
-    version: ""
-- name: GracefulNodeShutdown
-  versionedSpecs:
-  - default: true
-    lockToDefault: false
-    preRelease: Beta
-    version: ""
-- name: GracefulNodeShutdownBasedOnPodPriority
-  versionedSpecs:
-  - default: true
-    lockToDefault: false
-    preRelease: Beta
-    version: ""
-- name: HonorPVReclaimPolicy
-  versionedSpecs:
-  - default: true
-    lockToDefault: false
-    preRelease: Beta
-    version: ""
-- name: HPAContainerMetrics
   versionedSpecs:
   - default: true
     lockToDefault: true
@@ -298,125 +130,17 @@
     lockToDefault: false
     preRelease: Alpha
     version: ""
-- name: ImageMaximumGCAge
-  versionedSpecs:
-  - default: true
-    lockToDefault: false
-    preRelease: Beta
-    version: ""
-- name: ImageVolume
-  versionedSpecs:
-  - default: false
-    lockToDefault: false
-    preRelease: Alpha
-    version: ""
 - name: InPlacePodVerticalScaling
   versionedSpecs:
   - default: false
     lockToDefault: false
     preRelease: Alpha
     version: ""
-- name: InTreePluginPortworxUnregister
-  versionedSpecs:
-  - default: false
-    lockToDefault: false
-    preRelease: Alpha
-    version: ""
-- name: JobBackoffLimitPerIndex
-  versionedSpecs:
-  - default: true
-    lockToDefault: false
-    preRelease: Beta
-    version: ""
-- name: JobManagedBy
-  versionedSpecs:
-  - default: false
-    lockToDefault: false
-    preRelease: Alpha
-    version: ""
-- name: JobPodFailurePolicy
-  versionedSpecs:
-  - default: true
-    lockToDefault: true
-    preRelease: GA
-    version: ""
-- name: JobPodReplacementPolicy
-  versionedSpecs:
-  - default: true
-    lockToDefault: false
-    preRelease: Beta
-    version: ""
-- name: JobSuccessPolicy
-  versionedSpecs:
-  - default: true
-    lockToDefault: false
-    preRelease: Beta
-    version: ""
 - name: KMSv1
   versionedSpecs:
   - default: false
     lockToDefault: false
     preRelease: Deprecated
-    version: ""
-- name: KubeletCgroupDriverFromCRI
-  versionedSpecs:
-  - default: true
-    lockToDefault: false
-    preRelease: Beta
-    version: ""
-- name: KubeletInUserNamespace
-  versionedSpecs:
-  - default: false
-    lockToDefault: false
-    preRelease: Alpha
-    version: ""
-- name: KubeletPodResourcesDynamicResources
-  versionedSpecs:
-  - default: false
-    lockToDefault: false
-    preRelease: Alpha
-    version: ""
-- name: KubeletPodResourcesGet
-  versionedSpecs:
-  - default: false
-    lockToDefault: false
-    preRelease: Alpha
-    version: ""
-- name: KubeletSeparateDiskGC
-  versionedSpecs:
-  - default: true
-    lockToDefault: false
-    preRelease: Beta
-    version: ""
-- name: KubeletTracing
-  versionedSpecs:
-  - default: true
-    lockToDefault: false
-    preRelease: Beta
-    version: ""
-- name: KubeProxyDrainingTerminatingNodes
-  versionedSpecs:
-  - default: true
-    lockToDefault: true
-    preRelease: GA
-    version: ""
-- name: LoadBalancerIPMode
-  versionedSpecs:
-  - default: true
-    lockToDefault: false
-    preRelease: Beta
-    version: ""
-- name: LocalStorageCapacityIsolationFSQuotaMonitoring
-  versionedSpecs:
-  - default: false
-    lockToDefault: false
-    preRelease: Beta
-    version: ""
-- name: LogarithmicScaleDown
-  versionedSpecs:
-  - default: true
-    lockToDefault: true
-    preRelease: GA
     version: ""
 - name: LoggingAlphaOptions
   versionedSpecs:
@@ -430,89 +154,11 @@
     lockToDefault: false
     preRelease: Beta
     version: ""
-- name: MatchLabelKeysInPodAffinity
-  versionedSpecs:
-  - default: true
-    lockToDefault: false
-    preRelease: Beta
-    version: ""
-- name: MatchLabelKeysInPodTopologySpread
-  versionedSpecs:
-  - default: true
-    lockToDefault: false
-    preRelease: Beta
-    version: ""
-- name: MaxUnavailableStatefulSet
-  versionedSpecs:
-  - default: false
-    lockToDefault: false
-    preRelease: Alpha
-    version: ""
-- name: MemoryManager
-  versionedSpecs:
-  - default: true
-    lockToDefault: false
-    preRelease: Beta
-    version: ""
-- name: MemoryQoS
-  versionedSpecs:
-  - default: false
-    lockToDefault: false
-    preRelease: Alpha
-    version: ""
-- name: MinDomainsInPodTopologySpread
-  versionedSpecs:
-  - default: true
-    lockToDefault: true
-    preRelease: GA
-    version: ""
-- name: MultiCIDRServiceAllocator
-  versionedSpecs:
-  - default: false
-    lockToDefault: false
-    preRelease: Beta
-    version: ""
 - name: MutatingAdmissionPolicy
   versionedSpecs:
   - default: false
     lockToDefault: false
     preRelease: Alpha
-    version: ""
-- name: NewVolumeManagerReconstruction
-  versionedSpecs:
-  - default: true
-    lockToDefault: true
-    preRelease: GA
-    version: ""
-- name: NFTablesProxyMode
-  versionedSpecs:
-  - default: true
-    lockToDefault: false
-    preRelease: Beta
-    version: ""
-- name: NodeInclusionPolicyInPodTopologySpread
-  versionedSpecs:
-  - default: true
-    lockToDefault: false
-    preRelease: Beta
-    version: ""
-- name: NodeLogQuery
-  versionedSpecs:
-  - default: false
-    lockToDefault: false
-    preRelease: Beta
-    version: ""
-- name: NodeOutOfServiceVolumeDetach
-  versionedSpecs:
-  - default: true
-    lockToDefault: true
-    preRelease: GA
-    version: ""
-- name: NodeSwap
-  versionedSpecs:
-  - default: true
-    lockToDefault: false
-    preRelease: Beta
     version: ""
 - name: OpenAPIEnums
   versionedSpecs:
@@ -520,97 +166,7 @@
     lockToDefault: false
     preRelease: Beta
     version: ""
-- name: PDBUnhealthyPodEvictionPolicy
-  versionedSpecs:
-  - default: true
-    lockToDefault: true
-    preRelease: GA
-    version: ""
-- name: PersistentVolumeLastPhaseTransitionTime
-  versionedSpecs:
-  - default: true
-    lockToDefault: true
-    preRelease: GA
-    version: ""
-- name: PodAndContainerStatsFromCRI
-  versionedSpecs:
-  - default: false
-    lockToDefault: false
-    preRelease: Alpha
-    version: ""
-- name: PodDeletionCost
-  versionedSpecs:
-  - default: true
-    lockToDefault: false
-    preRelease: Beta
-    version: ""
-- name: PodDisruptionConditions
-  versionedSpecs:
-  - default: true
-    lockToDefault: true
-    preRelease: GA
-    version: ""
-- name: PodHostIPs
-  versionedSpecs:
-  - default: true
-    lockToDefault: true
-    preRelease: GA
-    version: ""
-- name: PodIndexLabel
-  versionedSpecs:
-  - default: true
-    lockToDefault: false
-    preRelease: Beta
-    version: ""
-- name: PodLifecycleSleepAction
-  versionedSpecs:
-  - default: true
-    lockToDefault: false
-    preRelease: Beta
-    version: ""
-- name: PodReadyToStartContainersCondition
-  versionedSpecs:
-  - default: true
-    lockToDefault: false
-    preRelease: Beta
-    version: ""
-- name: PodSchedulingReadiness
-  versionedSpecs:
-  - default: true
-    lockToDefault: true
-    preRelease: GA
-    version: ""
-- name: PortForwardWebsockets
-  versionedSpecs:
-  - default: true
-    lockToDefault: false
-    preRelease: Beta
-    version: ""
-- name: ProcMountType
-  versionedSpecs:
-  - default: false
-    lockToDefault: false
-    preRelease: Beta
-    version: ""
-- name: QOSReserved
-  versionedSpecs:
-  - default: false
-    lockToDefault: false
-    preRelease: Alpha
-    version: ""
-- name: RecoverVolumeExpansionFailure
-  versionedSpecs:
-  - default: false
-    lockToDefault: false
-    preRelease: Alpha
-    version: ""
 - name: RecursiveReadOnlyMounts
-  versionedSpecs:
-  - default: true
-    lockToDefault: false
-    preRelease: Beta
-    version: ""
-- name: ReloadKubeletServerCertificateFile
   versionedSpecs:
   - default: true
     lockToDefault: false
@@ -628,43 +184,7 @@
     lockToDefault: false
     preRelease: Beta
     version: ""
-- name: ResourceHealthStatus
-  versionedSpecs:
-  - default: false
-    lockToDefault: false
-    preRelease: Alpha
-    version: ""
 - name: RetryGenerateName
-  versionedSpecs:
-  - default: true
-    lockToDefault: false
-    preRelease: Beta
-    version: ""
-- name: RotateKubeletServerCertificate
-  versionedSpecs:
-  - default: true
-    lockToDefault: false
-    preRelease: Beta
-    version: ""
-- name: RuntimeClassInImageCriAPI
-  versionedSpecs:
-  - default: false
-    lockToDefault: false
-    preRelease: Alpha
-    version: ""
-- name: SchedulerQueueingHints
-  versionedSpecs:
-  - default: false
-    lockToDefault: false
-    preRelease: Beta
-    version: ""
-- name: SELinuxMount
-  versionedSpecs:
-  - default: false
-    lockToDefault: false
-    preRelease: Alpha
-    version: ""
-- name: SELinuxMountReadWriteOncePod
   versionedSpecs:
   - default: true
     lockToDefault: false
@@ -675,66 +195,6 @@
   - default: true
     lockToDefault: false
     preRelease: Beta
-    version: ""
-- name: SeparateTaintEvictionController
-  versionedSpecs:
-  - default: true
-    lockToDefault: false
-    preRelease: Beta
-    version: ""
-- name: ServiceAccountTokenJTI
-  versionedSpecs:
-  - default: true
-    lockToDefault: false
-    preRelease: Beta
-    version: ""
-- name: ServiceAccountTokenNodeBinding
-  versionedSpecs:
-  - default: true
-    lockToDefault: false
-    preRelease: Beta
-    version: ""
-- name: ServiceAccountTokenNodeBindingValidation
-  versionedSpecs:
-  - default: true
-    lockToDefault: false
-    preRelease: Beta
-    version: ""
-- name: ServiceAccountTokenPodNodeInfo
-  versionedSpecs:
-  - default: true
-    lockToDefault: false
-    preRelease: Beta
-    version: ""
-- name: ServiceTrafficDistribution
-  versionedSpecs:
-  - default: true
-    lockToDefault: false
-    preRelease: Beta
-    version: ""
-- name: SidecarContainers
-  versionedSpecs:
-  - default: true
-    lockToDefault: false
-    preRelease: Beta
-    version: ""
-- name: SizeMemoryBackedVolumes
-  versionedSpecs:
-  - default: true
-    lockToDefault: false
-    preRelease: Beta
-    version: ""
-- name: StatefulSetAutoDeletePVC
-  versionedSpecs:
-  - default: true
-    lockToDefault: false
-    preRelease: Beta
-    version: ""
-- name: StatefulSetStartOrdinal
-  versionedSpecs:
-  - default: true
-    lockToDefault: true
-    preRelease: GA
     version: ""
 - name: StorageNamespaceIndex
   versionedSpecs:
@@ -753,12 +213,6 @@
   - default: true
     lockToDefault: false
     preRelease: Beta
-    version: ""
-- name: StorageVersionMigrator
-  versionedSpecs:
-  - default: false
-    lockToDefault: false
-    preRelease: Alpha
     version: ""
 - name: StrictCostEnforcementForVAP
   versionedSpecs:
@@ -784,71 +238,11 @@
     lockToDefault: false
     preRelease: Beta
     version: ""
-- name: SupplementalGroupsPolicy
-  versionedSpecs:
-  - default: false
-    lockToDefault: false
-    preRelease: Alpha
-    version: ""
-- name: TopologyAwareHints
-  versionedSpecs:
-  - default: true
-    lockToDefault: false
-    preRelease: Beta
-    version: ""
-- name: TopologyManagerPolicyAlphaOptions
-  versionedSpecs:
-  - default: false
-    lockToDefault: false
-    preRelease: Alpha
-    version: ""
-- name: TopologyManagerPolicyBetaOptions
-  versionedSpecs:
-  - default: true
-    lockToDefault: false
-    preRelease: Beta
-    version: ""
-- name: TopologyManagerPolicyOptions
-  versionedSpecs:
-  - default: true
-    lockToDefault: false
-    preRelease: Beta
-    version: ""
-- name: TranslateStreamCloseWebsocketRequests
-  versionedSpecs:
-  - default: true
-    lockToDefault: false
-    preRelease: Beta
-    version: ""
 - name: UnauthenticatedHTTP2DOSMitigation
   versionedSpecs:
   - default: true
     lockToDefault: false
     preRelease: Beta
-    version: ""
-- name: UnknownVersionInteroperabilityProxy
-  versionedSpecs:
-  - default: false
-    lockToDefault: false
-    preRelease: Alpha
-    version: ""
-- name: UserNamespacesPodSecurityStandards
-  versionedSpecs:
-  - default: false
-    lockToDefault: false
-    preRelease: Alpha
-    version: ""
-- name: UserNamespacesSupport
-  versionedSpecs:
-  - default: false
-    lockToDefault: false
-    preRelease: Beta
-    version: ""
-- name: VolumeCapacityPriority
-  versionedSpecs:
-  - default: false
-    lockToDefault: false
-    preRelease: Alpha
     version: ""
 - name: WatchBookmark
   versionedSpecs:
@@ -873,24 +267,6 @@
   - default: false
     lockToDefault: false
     preRelease: Alpha
-    version: ""
-- name: WindowsHostNetwork
-  versionedSpecs:
-  - default: true
-    lockToDefault: false
-    preRelease: Alpha
-    version: ""
-- name: WinDSR
-  versionedSpecs:
-  - default: false
-    lockToDefault: false
-    preRelease: Alpha
-    version: ""
-- name: WinOverlay
-  versionedSpecs:
-  - default: true
-    lockToDefault: false
-    preRelease: Beta
     version: ""
 - name: ZeroLimitedNominalConcurrencyShares
   versionedSpecs:

--- a/test/featuregates_linter/test_data/unversioned_feature_list.yaml
+++ b/test/featuregates_linter/test_data/unversioned_feature_list.yaml
@@ -22,12 +22,6 @@
     lockToDefault: false
     preRelease: Deprecated
     version: ""
-- name: AnonymousAuthConfigurableEndpoints
-  versionedSpecs:
-  - default: false
-    lockToDefault: false
-    preRelease: Alpha
-    version: ""
 - name: APIListChunking
   versionedSpecs:
   - default: true

--- a/test/featuregates_linter/test_data/versioned_feature_list.yaml
+++ b/test/featuregates_linter/test_data/versioned_feature_list.yaml
@@ -1,18 +1,934 @@
-- name: AnonymousAuthConfigurableEndpoints
+- name: AnyVolumeDataSource
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.18"
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.24"
+- name: AppArmor
+  versionedSpecs:
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.4"
+  - default: true
+    lockToDefault: true
+    preRelease: GA
+    version: "1.31"
+- name: AppArmorFields
+  versionedSpecs:
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.30"
+  - default: true
+    lockToDefault: true
+    preRelease: GA
+    version: "1.31"
+- name: AuthorizeNodeWithSelectors
   versionedSpecs:
   - default: false
     lockToDefault: false
     preRelease: Alpha
     version: "1.31"
+- name: ClusterTrustBundle
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.26"
+- name: ClusterTrustBundleProjection
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.28"
+- name: ContainerCheckpoint
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.25"
   - default: true
     lockToDefault: false
     preRelease: Beta
-    version: "1.32"
+    version: "1.30"
+- name: CPUCFSQuotaPeriod
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.12"
+- name: CPUManager
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.8"
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.10"
+  - default: true
+    lockToDefault: true
+    preRelease: GA
+    version: "1.26"
+- name: CPUManagerPolicyAlphaOptions
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.23"
+- name: CPUManagerPolicyBetaOptions
+  versionedSpecs:
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.23"
+- name: CPUManagerPolicyOptions
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.22"
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.23"
+- name: CronJobsScheduledAnnotation
+  versionedSpecs:
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.28"
+- name: CrossNamespaceVolumeDataSource
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.26"
+- name: CSIMigrationPortworx
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.23"
+  - default: false
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.25"
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.31"
+- name: CSIVolumeHealth
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.21"
+- name: DevicePluginCDIDevices
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.28"
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.29"
+  - default: true
+    lockToDefault: true
+    preRelease: GA
+    version: "1.31"
+- name: DisableAllocatorDualWrite
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.31"
+- name: DisableCloudProviders
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.22"
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.29"
+  - default: true
+    lockToDefault: true
+    preRelease: GA
+    version: "1.31"
+- name: DisableKubeletCloudCredentialProviders
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.23"
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.29"
+- name: DRAControlPlaneController
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.26"
+- name: DynamicResourceAllocation
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.29"
+- name: ElasticIndexedJob
+  versionedSpecs:
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.27"
+  - default: true
+    lockToDefault: true
+    preRelease: GA
+    version: "1.31"
+- name: EventedPLEG
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.25"
+- name: ExecProbeTimeout
+  versionedSpecs:
+  - default: true
+    lockToDefault: false
+    preRelease: GA
+    version: "1.20"
+- name: GracefulNodeShutdown
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.20"
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.21"
+- name: GracefulNodeShutdownBasedOnPodPriority
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.23"
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.24"
+- name: HonorPVReclaimPolicy
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.23"
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.31"
+- name: HPAContainerMetrics
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.20"
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.27"
+  - default: true
+    lockToDefault: true
+    preRelease: GA
+    version: "1.30"
+- name: ImageMaximumGCAge
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.29"
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.30"
+- name: ImageVolume
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.31"
+- name: InTreePluginPortworxUnregister
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.23"
+- name: JobBackoffLimitPerIndex
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.28"
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.29"
+- name: JobManagedBy
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.30"
+- name: JobPodFailurePolicy
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.25"
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.26"
+  - default: true
+    lockToDefault: true
+    preRelease: GA
+    version: "1.31"
+- name: JobPodReplacementPolicy
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.28"
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.29"
+- name: JobSuccessPolicy
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.30"
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.31"
+- name: KubeletCgroupDriverFromCRI
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.28"
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.31"
+- name: KubeletInUserNamespace
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.22"
+- name: KubeletPodResourcesDynamicResources
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.27"
+- name: KubeletPodResourcesGet
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.27"
+- name: KubeletSeparateDiskGC
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.29"
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.31"
+- name: KubeletTracing
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.25"
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.27"
+- name: KubeProxyDrainingTerminatingNodes
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.28"
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.30"
+  - default: true
+    lockToDefault: true
+    preRelease: GA
+    version: "1.31"
+- name: LoadBalancerIPMode
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.29"
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.30"
+- name: LocalStorageCapacityIsolationFSQuotaMonitoring
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.15"
+  - default: false
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.31"
+- name: LogarithmicScaleDown
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.21"
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.22"
+  - default: true
+    lockToDefault: true
+    preRelease: GA
+    version: "1.31"
+- name: MatchLabelKeysInPodAffinity
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.29"
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.30"
+- name: MatchLabelKeysInPodTopologySpread
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.25"
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.27"
+- name: MaxUnavailableStatefulSet
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.24"
+- name: MemoryManager
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.21"
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.22"
+- name: MemoryQoS
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.22"
+- name: MinDomainsInPodTopologySpread
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.24"
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.25"
+  - default: true
+    lockToDefault: true
+    preRelease: GA
+    version: "1.30"
+- name: MultiCIDRServiceAllocator
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.27"
+  - default: false
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.31"
+- name: NewVolumeManagerReconstruction
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.25"
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.27"
+  - default: true
+    lockToDefault: true
+    preRelease: GA
+    version: "1.30"
+- name: NFTablesProxyMode
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.29"
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.31"
+- name: NodeInclusionPolicyInPodTopologySpread
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.25"
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.26"
+- name: NodeLogQuery
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.27"
+  - default: false
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.30"
+- name: NodeOutOfServiceVolumeDetach
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.24"
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.26"
+  - default: true
+    lockToDefault: true
+    preRelease: GA
+    version: "1.28"
+- name: NodeSwap
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.22"
+  - default: false
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.28"
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.30"
+- name: PDBUnhealthyPodEvictionPolicy
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.26"
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.27"
+  - default: true
+    lockToDefault: true
+    preRelease: GA
+    version: "1.31"
+- name: PersistentVolumeLastPhaseTransitionTime
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.28"
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.29"
+  - default: true
+    lockToDefault: true
+    preRelease: GA
+    version: "1.31"
+- name: PodAndContainerStatsFromCRI
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.23"
+- name: PodDeletionCost
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.21"
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.22"
+- name: PodDisruptionConditions
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.25"
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.26"
+  - default: true
+    lockToDefault: true
+    preRelease: GA
+    version: "1.31"
+- name: PodHostIPs
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.28"
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.29"
+  - default: true
+    lockToDefault: true
+    preRelease: GA
+    version: "1.30"
+- name: PodIndexLabel
+  versionedSpecs:
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.28"
+- name: PodLifecycleSleepAction
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.29"
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.30"
+- name: PodReadyToStartContainersCondition
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.25"
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.29"
+- name: PodSchedulingReadiness
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.26"
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.27"
+  - default: true
+    lockToDefault: true
+    preRelease: GA
+    version: "1.30"
+- name: PortForwardWebsockets
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.30"
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.31"
+- name: ProcMountType
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.12"
+  - default: false
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.31"
+- name: QOSReserved
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.11"
+- name: RecoverVolumeExpansionFailure
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.23"
 - name: RelaxedEnvironmentVariableValidation
   versionedSpecs:
   - default: false
     lockToDefault: false
     preRelease: Alpha
+    version: "1.30"
+- name: ReloadKubeletServerCertificateFile
+  versionedSpecs:
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.31"
+- name: ResourceHealthStatus
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.31"
+- name: RotateKubeletServerCertificate
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.7"
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.12"
+- name: RuntimeClassInImageCriAPI
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.29"
+- name: SchedulerQueueingHints
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.28"
+- name: SELinuxMount
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.30"
+- name: SELinuxMountReadWriteOncePod
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.25"
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.27"
+- name: SeparateTaintEvictionController
+  versionedSpecs:
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.29"
+- name: ServiceAccountTokenJTI
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.29"
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.30"
+- name: ServiceAccountTokenNodeBinding
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.29"
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.31"
+- name: ServiceAccountTokenNodeBindingValidation
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.29"
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.30"
+- name: ServiceAccountTokenPodNodeInfo
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.29"
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.30"
+- name: ServiceTrafficDistribution
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.30"
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.31"
+- name: SidecarContainers
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.28"
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.29"
+- name: SizeMemoryBackedVolumes
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.20"
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.22"
+- name: StatefulSetAutoDeletePVC
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.22"
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.27"
+- name: StatefulSetStartOrdinal
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.26"
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.27"
+  - default: true
+    lockToDefault: true
+    preRelease: GA
+    version: "1.31"
+- name: StorageVersionMigrator
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.30"
+- name: SupplementalGroupsPolicy
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.31"
+- name: TopologyAwareHints
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.21"
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.23"
+- name: TopologyManagerPolicyAlphaOptions
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.26"
+- name: TopologyManagerPolicyBetaOptions
+  versionedSpecs:
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.26"
+- name: TopologyManagerPolicyOptions
+  versionedSpecs:
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.26"
+- name: TranslateStreamCloseWebsocketRequests
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.29"
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.30"
+- name: UnknownVersionInteroperabilityProxy
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.28"
+- name: UserNamespacesPodSecurityStandards
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.28"
+- name: UserNamespacesSupport
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.25"
+  - default: false
+    lockToDefault: false
+    preRelease: Beta
     version: "1.30"
 - name: VolumeAttributesClass
   versionedSpecs:
@@ -24,3 +940,31 @@
     lockToDefault: false
     preRelease: Beta
     version: "1.31"
+- name: VolumeCapacityPriority
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.21"
+- name: WindowsHostNetwork
+  versionedSpecs:
+  - default: true
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.26"
+- name: WinDSR
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.14"
+- name: WinOverlay
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.14"
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.20"

--- a/test/featuregates_linter/test_data/versioned_feature_list.yaml
+++ b/test/featuregates_linter/test_data/versioned_feature_list.yaml
@@ -865,7 +865,7 @@
   - default: false
     lockToDefault: false
     preRelease: Alpha
-    version: "1.22"
+    version: "1.23"
   - default: true
     lockToDefault: false
     preRelease: Beta

--- a/test/featuregates_linter/test_data/versioned_feature_list.yaml
+++ b/test/featuregates_linter/test_data/versioned_feature_list.yaml
@@ -468,10 +468,14 @@
     lockToDefault: false
     preRelease: Alpha
     version: "1.24"
-  - default: true
+  - default: false
     lockToDefault: false
     preRelease: Beta
     version: "1.25"
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.27"
   - default: true
     lockToDefault: true
     preRelease: GA
@@ -876,10 +880,14 @@
     lockToDefault: false
     preRelease: Alpha
     version: "1.21"
-  - default: true
+  - default: false
     lockToDefault: false
     preRelease: Beta
     version: "1.23"
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.24"
 - name: TopologyManagerPolicyAlphaOptions
   versionedSpecs:
   - default: false

--- a/test/featuregates_linter/test_data/versioned_feature_list.yaml
+++ b/test/featuregates_linter/test_data/versioned_feature_list.yaml
@@ -429,7 +429,7 @@
   - default: true
     lockToDefault: false
     preRelease: Beta
-    version: "1.30"
+    version: "1.31"
 - name: MatchLabelKeysInPodTopologySpread
   versionedSpecs:
   - default: false

--- a/test/featuregates_linter/test_data/versioned_feature_list.yaml
+++ b/test/featuregates_linter/test_data/versioned_feature_list.yaml
@@ -39,13 +39,13 @@
   - default: false
     lockToDefault: false
     preRelease: Alpha
-    version: "1.26"
+    version: "1.27"
 - name: ClusterTrustBundleProjection
   versionedSpecs:
   - default: false
     lockToDefault: false
     preRelease: Alpha
-    version: "1.28"
+    version: "1.29"
 - name: ContainerCheckpoint
   versionedSpecs:
   - default: false

--- a/test/featuregates_linter/test_data/versioned_feature_list.yaml
+++ b/test/featuregates_linter/test_data/versioned_feature_list.yaml
@@ -1,3 +1,13 @@
+- name: AnonymousAuthConfigurableEndpoints
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.31"
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.32"
 - name: AnyVolumeDataSource
   versionedSpecs:
   - default: false
@@ -496,10 +506,14 @@
     lockToDefault: false
     preRelease: Alpha
     version: "1.25"
-  - default: true
+  - default: false
     lockToDefault: false
     preRelease: Beta
     version: "1.27"
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.28"
   - default: true
     lockToDefault: true
     preRelease: GA
@@ -655,7 +669,7 @@
   - default: false
     lockToDefault: false
     preRelease: Alpha
-    version: "1.25"
+    version: "1.28"
   - default: true
     lockToDefault: false
     preRelease: Beta
@@ -742,6 +756,10 @@
     version: "1.29"
 - name: SchedulerQueueingHints
   versionedSpecs:
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.27"
   - default: false
     lockToDefault: false
     preRelease: Beta
@@ -758,10 +776,14 @@
     lockToDefault: false
     preRelease: Alpha
     version: "1.25"
-  - default: true
+  - default: false
     lockToDefault: false
     preRelease: Beta
     version: "1.27"
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.28"
 - name: SeparateTaintEvictionController
   versionedSpecs:
   - default: true
@@ -896,10 +918,14 @@
     version: "1.26"
 - name: TopologyManagerPolicyBetaOptions
   versionedSpecs:
-  - default: true
+  - default: false
     lockToDefault: false
     preRelease: Beta
     version: "1.26"
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.28"
 - name: TopologyManagerPolicyOptions
   versionedSpecs:
   - default: true
@@ -927,7 +953,7 @@
   - default: false
     lockToDefault: false
     preRelease: Alpha
-    version: "1.28"
+    version: "1.29"
 - name: UserNamespacesSupport
   versionedSpecs:
   - default: false


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Continuation of https://github.com/kubernetes/kubernetes/pull/126878 and https://github.com/kubernetes/kubernetes/issues/125031. Migrate all features that are not deprecated and not redefined in other places like apiserver and controller manager (they have their own feature gates).

As of 8/29/2024, there are 150 unversioned features and 2 versioned features. After this PR, there will be 45 unversioned features and 107 versioned features. The cardinality is the same so we can guarantee that all features that existed before still exist after the PR.

Obviously this doesn't 100% guarantee that version information is correct, I've taken the version information in the comments from https://github.com/kubernetes/kubernetes/blob/master/pkg/features/kube_features.go#L28 and constructed it in `versioned_feature_gates.go`, preserving the current comments like `// remove after 1.33` as much as possible. These were manually cross referenced by both me and aaron-prindle.

Before 

```
kubernetes ❯ ./hack/verify-featuregates.sh 
found 150 features in FeatureSpecMap var defaultKubernetesFeatureGates in file: /usr/local/google/home/jying/gospace/src/k8s.io/kubernetes/pkg/features/kube_features.go
...
found 2 features in FeatureSpecMap var defaultVersionedKubernetesFeatureGates in file: /usr/local/google/home/jying/gospace/src/k8s.io/kubernetes/pkg/features/versioned_kube_features.go
```

After: 

```
kubernetes ❯ ./hack/verify-featuregates.sh
found 45 features in FeatureSpecMap var defaultKubernetesFeatureGates in file: /usr/local/google/home/jying/gospace/src/k8s.io/kubernete
s/pkg/features/kube_features.go
...
found 107 features in FeatureSpecMap var defaultVersionedKubernetesFeatureGates in file: /usr/local/google/home/jying/gospace/src/k8s.io/kubernetes/pkg/features/versioned_kube_features.go
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

Follow ups:
- CSIMigrationPortworx needs a beta switch in the website

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
