### PR TITLE
when kubectl command run ,if the apiresource has no categories ,then add it to "none" category，so that It can't be show when run the command like "kubectl get none,all,api-extensions -A"

### DIFF
--- a/staging/src/k8s.io/client-go/restmapper/category_expansion.go
+++ b/staging/src/k8s.io/client-go/restmapper/category_expansion.go
@@ -71,13 +71,19 @@ func (e discoveryCategoryExpander) Expand(category string) ([]schema.GroupResour
 		}
 		// Collect GroupVersions by categories
 		for _, apiResource := range apiResourceList.APIResources {
+			groupResource := schema.GroupResource{
+				Group:    gv.Group,
+				Resource: apiResource.Name,
+			}
 			if categories := apiResource.Categories; len(categories) > 0 {
 				for _, category := range categories {
-					groupResource := schema.GroupResource{
-						Group:    gv.Group,
-						Resource: apiResource.Name,
-					}
 					discoveredExpansions[category] = append(discoveredExpansions[category], groupResource)
+				}
+			} else {
+				// if there is no categories ,then add it to "none" category
+				if apiResource.StorageVersionHash != "" {
+			        category := "none"
+				    discoveredExpansions[category]=append(discoveredExpansions[category], groupResource)
 				}
 			}
 		}


### PR DESCRIPTION
when kubectl command run ,if the apiresource has no categories ,then add it to "none" category，so that It can't be show when run the command like "kubectl get none,all,api-extensions -A"