### PR TITLE
DRA: fix failing test

### DIFF
--- a/pkg/kubelet/cm/dra/plugin/client_test.go
+++ b/pkg/kubelet/cm/dra/plugin/client_test.go
@@ -109,8 +109,9 @@ func TestGRPCConnIsReused(t *testing.T) {
 	m := sync.Mutex{}
 
 	p := &Plugin{
-		backgroundCtx: ctx,
-		endpoint:      addr,
+		backgroundCtx:     ctx,
+		endpoint:          addr,
+		clientCallTimeout: defaultClientCallTimeout,
 	}
 
 	conn, err := p.getOrCreateGRPCConn()
@@ -148,7 +149,8 @@ func TestGRPCConnIsReused(t *testing.T) {
 					},
 				},
 			}
-			client.NodePrepareResources(context.TODO(), req)
+			_, err = client.NodePrepareResources(context.TODO(), req)
+			assert.NoError(t, err)
 
 			client.mutex.Lock()
 			conn := client.conn


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind failing-test

#### What this PR does / why we need it:

`TestGRPCConnIsReused` test case silently fails `NodePrepareResources` call with "rpc error: code = DeadlineExceeded desc = context deadline exceeded". Fixed by explicitly setting `clientCallTimeout` for the plugin.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```