### PR TITLE
Kubelet should honour the VolumeAttributes which are reported by the volume plugin

### DIFF
--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -327,7 +327,7 @@ func makeMounts(pod *v1.Pod, podDir string, container *v1.Container, hostName, h
 
 				err = volumevalidation.ValidatePathNoBacksteps(subPath)
 				if err != nil {
-					return nil, cleanupAction, fmt.Errorf("unable to provision SubPath `%s`: %v", subPath, err)
+					return nil, cleanupAction, fmt.Errorf("unable to provision SubPath `%s`: %w", subPath, err)
 				}
 
 				volumePath := hostPath

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -277,18 +277,6 @@ func makeMounts(pod *v1.Pod, podDir string, container *v1.Container, hostName, h
 	mounts := []kubecontainer.Mount{}
 	var cleanupAction func()
 	for i, mount := range container.VolumeMounts {
-		// Check if the mount is referencing an OCI volume
-		if imageVolumes != nil && utilfeature.DefaultFeatureGate.Enabled(features.ImageVolume) {
-			if image, ok := imageVolumes[mount.Name]; ok {
-				mounts = append(mounts, kubecontainer.Mount{
-					Name:          mount.Name,
-					ContainerPath: mount.MountPath,
-					Image:         image,
-				})
-				continue
-			}
-		}
-
 		// do not mount /etc/hosts if container is already mounting on the path
 		mountEtcHostsFile = mountEtcHostsFile && (mount.MountPath != etcHostsPath)
 		vol, ok := podVolumes[mount.Name]
@@ -306,69 +294,82 @@ func makeMounts(pod *v1.Pod, podDir string, container *v1.Container, hostName, h
 			vol.SELinuxLabeled = true
 			relabelVolume = true
 		}
-		hostPath, err := volumeutil.GetPath(vol.Mounter)
-		if err != nil {
-			return nil, cleanupAction, err
+
+		var (
+			hostPath string
+			image    *runtimeapi.ImageSpec
+			err      error
+		)
+
+		if imageVolumes != nil && utilfeature.DefaultFeatureGate.Enabled(features.ImageVolume) {
+			image = imageVolumes[mount.Name]
 		}
 
-		subPath := mount.SubPath
-		if mount.SubPathExpr != "" {
-			subPath, err = kubecontainer.ExpandContainerVolumeMounts(mount, expandEnvs)
-
+		if image == nil {
+			hostPath, err = volumeutil.GetPath(vol.Mounter)
 			if err != nil {
 				return nil, cleanupAction, err
 			}
-		}
 
-		if subPath != "" {
-			if utilfs.IsAbs(subPath) {
-				return nil, cleanupAction, fmt.Errorf("error SubPath `%s` must not be an absolute path", subPath)
-			}
+			subPath := mount.SubPath
+			if mount.SubPathExpr != "" {
+				subPath, err = kubecontainer.ExpandContainerVolumeMounts(mount, expandEnvs)
 
-			err = volumevalidation.ValidatePathNoBacksteps(subPath)
-			if err != nil {
-				return nil, cleanupAction, fmt.Errorf("unable to provision SubPath `%s`: %v", subPath, err)
-			}
-
-			volumePath := hostPath
-			hostPath = filepath.Join(volumePath, subPath)
-
-			if subPathExists, err := hu.PathExists(hostPath); err != nil {
-				klog.ErrorS(nil, "Could not determine if subPath exists, will not attempt to change its permissions", "path", hostPath)
-			} else if !subPathExists {
-				// Create the sub path now because if it's auto-created later when referenced, it may have an
-				// incorrect ownership and mode. For example, the sub path directory must have at least g+rwx
-				// when the pod specifies an fsGroup, and if the directory is not created here, Docker will
-				// later auto-create it with the incorrect mode 0750
-				// Make extra care not to escape the volume!
-				perm, err := hu.GetMode(volumePath)
 				if err != nil {
 					return nil, cleanupAction, err
 				}
-				if err := subpather.SafeMakeDir(subPath, volumePath, perm); err != nil {
+			}
+
+			if subPath != "" {
+				if utilfs.IsAbs(subPath) {
+					return nil, cleanupAction, fmt.Errorf("error SubPath `%s` must not be an absolute path", subPath)
+				}
+
+				err = volumevalidation.ValidatePathNoBacksteps(subPath)
+				if err != nil {
+					return nil, cleanupAction, fmt.Errorf("unable to provision SubPath `%s`: %v", subPath, err)
+				}
+
+				volumePath := hostPath
+				hostPath = filepath.Join(volumePath, subPath)
+
+				if subPathExists, err := hu.PathExists(hostPath); err != nil {
+					klog.ErrorS(nil, "Could not determine if subPath exists, will not attempt to change its permissions", "path", hostPath)
+				} else if !subPathExists {
+					// Create the sub path now because if it's auto-created later when referenced, it may have an
+					// incorrect ownership and mode. For example, the sub path directory must have at least g+rwx
+					// when the pod specifies an fsGroup, and if the directory is not created here, Docker will
+					// later auto-create it with the incorrect mode 0750
+					// Make extra care not to escape the volume!
+					perm, err := hu.GetMode(volumePath)
+					if err != nil {
+						return nil, cleanupAction, err
+					}
+					if err := subpather.SafeMakeDir(subPath, volumePath, perm); err != nil {
+						// Don't pass detailed error back to the user because it could give information about host filesystem
+						klog.ErrorS(err, "Failed to create subPath directory for volumeMount of the container", "containerName", container.Name, "volumeMountName", mount.Name)
+						return nil, cleanupAction, fmt.Errorf("failed to create subPath directory for volumeMount %q of container %q", mount.Name, container.Name)
+					}
+				}
+				hostPath, cleanupAction, err = subpather.PrepareSafeSubpath(subpath.Subpath{
+					VolumeMountIndex: i,
+					Path:             hostPath,
+					VolumeName:       vol.InnerVolumeSpecName,
+					VolumePath:       volumePath,
+					PodDir:           podDir,
+					ContainerName:    container.Name,
+				})
+				if err != nil {
 					// Don't pass detailed error back to the user because it could give information about host filesystem
-					klog.ErrorS(err, "Failed to create subPath directory for volumeMount of the container", "containerName", container.Name, "volumeMountName", mount.Name)
-					return nil, cleanupAction, fmt.Errorf("failed to create subPath directory for volumeMount %q of container %q", mount.Name, container.Name)
+					klog.ErrorS(err, "Failed to prepare subPath for volumeMount of the container", "containerName", container.Name, "volumeMountName", mount.Name)
+					return nil, cleanupAction, fmt.Errorf("failed to prepare subPath for volumeMount %q of container %q", mount.Name, container.Name)
 				}
 			}
-			hostPath, cleanupAction, err = subpather.PrepareSafeSubpath(subpath.Subpath{
-				VolumeMountIndex: i,
-				Path:             hostPath,
-				VolumeName:       vol.InnerVolumeSpecName,
-				VolumePath:       volumePath,
-				PodDir:           podDir,
-				ContainerName:    container.Name,
-			})
-			if err != nil {
-				// Don't pass detailed error back to the user because it could give information about host filesystem
-				klog.ErrorS(err, "Failed to prepare subPath for volumeMount of the container", "containerName", container.Name, "volumeMountName", mount.Name)
-				return nil, cleanupAction, fmt.Errorf("failed to prepare subPath for volumeMount %q of container %q", mount.Name, container.Name)
-			}
-		}
 
-		// Docker Volume Mounts fail on Windows if it is not of the form C:/
-		if volumeutil.IsWindowsLocalPath(runtime.GOOS, hostPath) {
-			hostPath = volumeutil.MakeAbsolutePath(runtime.GOOS, hostPath)
+			// Docker Volume Mounts fail on Windows if it is not of the form C:/
+			if hostPath != "" && volumeutil.IsWindowsLocalPath(runtime.GOOS, hostPath) {
+				hostPath = volumeutil.MakeAbsolutePath(runtime.GOOS, hostPath)
+			}
 		}
 
 		containerPath := mount.MountPath
@@ -396,6 +397,7 @@ func makeMounts(pod *v1.Pod, podDir string, container *v1.Container, hostName, h
 			Name:              mount.Name,
 			ContainerPath:     containerPath,
 			HostPath:          hostPath,
+			Image:             image,
 			ReadOnly:          mount.ReadOnly || mustMountRO,
 			RecursiveReadOnly: rro,
 			SELinuxRelabel:    relabelVolume,

--- a/pkg/kubelet/kubelet_volumes_test.go
+++ b/pkg/kubelet/kubelet_volumes_test.go
@@ -689,7 +689,8 @@ func TestVolumeUnmountAndDetachControllerEnabled(t *testing.T) {
 }
 
 type stubVolume struct {
-	path string
+	path       string
+	attributes volume.Attributes
 	volume.MetricsNil
 }
 
@@ -698,7 +699,7 @@ func (f *stubVolume) GetPath() string {
 }
 
 func (f *stubVolume) GetAttributes() volume.Attributes {
-	return volume.Attributes{}
+	return f.attributes
 }
 
 func (f *stubVolume) SetUp(mounterArgs volume.MounterArgs) error {

--- a/pkg/volume/image/image.go
+++ b/pkg/volume/image/image.go
@@ -67,8 +67,8 @@ func (o *imagePlugin) ConstructVolumeSpec(volumeName, mountPath string) (volume.
 func (o *imagePlugin) GetAttributes() volume.Attributes {
 	return volume.Attributes{
 		ReadOnly:       true,
-		Managed:        true,
-		SELinuxRelabel: true,
+		Managed:        false,
+		SELinuxRelabel: false,
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

**pods.yaml**

```
apiVersion: v1
kind: Pod
metadata:
  name: pod1
  namespace: default
spec:
  containers:
  - image: registry.k8s.io/e2e-test-images/echoserver:2.3
    imagePullPolicy: IfNotPresent
    name: test
    volumeMounts:
    - mountPath: /volume
      name: volume
  volumes:
  - image:
      pullPolicy: IfNotPresent
      reference: quay.io/crio/artifact:v1
    name: volume
---
apiVersion: v1
kind: Pod
metadata:
  name: pod2
  namespace: default
spec:
  containers:
  - image: registry.k8s.io/e2e-test-images/echoserver:2.3
    imagePullPolicy: IfNotPresent
    name: test
    volumeMounts:
    - mountPath: /volume
      name: volume
  volumes:
  - image:
      pullPolicy: IfNotPresent
      reference: quay.io/crio/artifact:v1
    name: volume
---
apiVersion: v1
kind: Pod
metadata:
  name: pod3
  namespace: default
spec:
  containers:
  - image: registry.k8s.io/e2e-test-images/echoserver:2.3
    imagePullPolicy: IfNotPresent
    name: test
    volumeMounts:
    - mountPath: /etc/hosts
      name: volume
  volumes:
  - image:
      pullPolicy: IfNotPresent
      reference: quay.io/crio/artifact:v1
    name: volume
---
apiVersion: v1
kind: Pod
metadata:
  name: pod4
  namespace: default
spec:
  containers:
  - image: registry.k8s.io/e2e-test-images/echoserver:2.3
    imagePullPolicy: IfNotPresent
    name: test
    volumeMounts:
    - mountPath: /etc/hosts
      name: volume
  volumes:
  - emptyDir: {}
    name: volume
```

- pod1 and pod2 share the same `image` volume source type and are mounted to `/volume` in the container.
- pod3 and pod4 mount the volume to `/etc/hosts` in the container but use different volume source types.

**without this fix** 

pod3 is running but pod4 has `CreateContainerError` status.

```
(base) ➜  kubernetes git:(fix-image-volume-mount) kubectl get po
NAME   READY   STATUS                 RESTARTS   AGE
pod1   1/1     Running                0          29s
pod2   1/1     Running                0          29s
pod3   1/1     Running                0          29s
pod4   0/1     CreateContainerError   0          29s
```

pod1 mount with `rw` option

```
root@crio2-control-plane:/# crictl inspect 5c76497deb40c |  jq .status.mounts[0]
{
  "containerPath": "/volume",
  "gidMappings": [],
  "hostPath": "/var/lib/containers/storage/overlay/82099f56ba7822d8408ac8517b90bde2aa036ac32ee2dd3db810348302edd618/merged",
  "propagation": "PROPAGATION_PRIVATE",
  "readonly": false,
  "recursiveReadOnly": false,
  "selinuxRelabel": false,
  "uidMappings": []
}

root@crio2-control-plane:/# crictl inspect 5c76497deb40c | jq .info.runtimeSpec.mounts[10]
{
  "destination": "/volume",
  "type": "bind",
  "source": "/var/lib/containers/storage/overlay/82099f56ba7822d8408ac8517b90bde2aa036ac32ee2dd3db810348302edd618/merged",
  "options": [
    "rbind",
    "rprivate",
    "rw",
    "bind"
  ]
}
```

**with this fix** 

pod3 and pod4 has `CreateContainerError` status.

```
(base) ➜  kubernetes git:(fix-image-volume-mount) kubectl get po
NAME   READY   STATUS                 RESTARTS   AGE
pod1   1/1     Running                0          44m
pod2   1/1     Running                0          44m
pod3   0/1     CreateContainerError   0          44m
pod4   0/1     CreateContainerError   0          44m

(base) ➜  kubernetes git:(fix-image-volume-mount) kubectl describe po pod3
Events:
  Type     Reason     Age                  From               Message
  ----     ------     ----                 ----               -------
  Normal   Scheduled  51m                  default-scheduler  Successfully assigned default/pod3 to crio-control-plane
  Normal   Pulled     50m (x8 over 51m)    kubelet            Container image "registry.k8s.io/e2e-test-images/echoserver:2.3" already present on machine
  Warning  Failed     50m (x8 over 51m)    kubelet            Error: container create failed: mount `/var/lib/containers/storage/overlay/82099f56ba7822d8408ac8517b90bde2aa036ac32ee2dd3db810348302edd618/merged` to `etc/hosts`: Not a directory
  Normal   Pulled     78s (x229 over 51m)  kubelet            Container image "quay.io/crio/artifact:v1" already present on machine

(base) ➜  kubernetes git:(fix-image-volume-mount) kubectl describe po pod4
Events:
  Type     Reason     Age                  From               Message
  ----     ------     ----                 ----               -------
  Normal   Scheduled  51m                  default-scheduler  Successfully assigned default/pod4 to crio-control-plane
  Warning  Failed     49m (x12 over 51m)   kubelet            Error: container create failed: mount `/var/lib/kubelet/pods/983847e3-109e-4a2e-89f6-5cd0fef3b4cc/volumes/kubernetes.io~empty-dir/volume` to `etc/hosts`: Not a directory
  Normal   Pulled     81s (x233 over 51m)  kubelet            Container image "registry.k8s.io/e2e-test-images/echoserver:2.3" already present on machine
```

pod1 mount with `ro` option

```
(base) ➜  kubernetes git:(fix-image-volume-mount) docker exec -it 92a9726219db bash
root@crio-control-plane:/# crictl inspect 90e489c2aa5e2 | jq .status.mounts[0]
{
  "containerPath": "/volume",
  "gidMappings": [],
  "hostPath": "/var/lib/containers/storage/overlay/82099f56ba7822d8408ac8517b90bde2aa036ac32ee2dd3db810348302edd618/merged",
  "propagation": "PROPAGATION_PRIVATE",
  "readonly": true,
  "recursiveReadOnly": false,
  "selinuxRelabel": false,
  "uidMappings": []
}

root@crio-control-plane:/# crictl inspect 90e489c2aa5e2 | jq .info.runtimeSpec.mounts[10]
{
  "destination": "/volume",
  "type": "bind",
  "source": "/var/lib/containers/storage/overlay/82099f56ba7822d8408ac8517b90bde2aa036ac32ee2dd3db810348302edd618/merged",
  "options": [
    "rbind",
    "rprivate",
    "ro",
    "bind"
  ]
}
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Related to https://github.com/kubernetes/enhancements/issues/4639

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
1. When the kubelet constructs the cri mounts for the container which references an `image` volume source type, It passes the missing mount attributes to the CRI implementation, including `readOnly`, `propagation`, and `recursiveReadOnly`. When the readOnly field of the containerMount is explicitly set to false, the kubelet will take the `readOnly`as true to the CRI implementation because the image volume plugin requires the mount to be read-only. 
2. Fix a bug where the pod is unexpectedly running when the `image` volume source type is used and mounted to `/etc/hosts` in the container.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
