### PR TITLE
Include additional verbs to can-i

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/auth/cani.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/auth/cani.go
@@ -105,7 +105,7 @@ var (
 		# List all allowed actions in namespace "foo"
 		kubectl auth can-i --list --namespace=foo`)
 
-	resourceVerbs       = sets.NewString("get", "list", "watch", "create", "update", "patch", "delete", "deletecollection", "use", "bind", "impersonate", "*", "approve")
+	resourceVerbs       = sets.NewString("get", "list", "watch", "create", "update", "patch", "delete", "deletecollection", "use", "bind", "impersonate", "*", "approve", "sign", "escalate", "attest")
 	nonResourceURLVerbs = sets.NewString("get", "put", "post", "head", "options", "delete", "patch", "*")
 	// holds all the server-supported resources that cannot be discovered by clients. i.e. users and groups for the impersonate verb
 	nonStandardResourceNames = sets.NewString("users", "groups")


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Add missing verbs to `kubectl auth can-i` command. Both verbs are valid, but were not included in the existing list.

#### Which issue(s) this PR fixes:

N/A

#### Special notes for your reviewer:

N/A

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

/sig auth
