### PR TITLE
Realign conformance metadata

### DIFF
--- a/test/e2e/storage/volume_attachment.go
+++ b/test/e2e/storage/volume_attachment.go
@@ -39,21 +39,21 @@ var _ = utils.SIGDescribe("VolumeAttachment", func() {
 
 	f := framework.NewDefaultFramework("volumeattachment")
 
-	/*
-		Release: v1.30
-		Testname: VolumeAttachment, lifecycle
-		Description: Creating an initial VolumeAttachment MUST succeed. Reading the VolumeAttachment
-		MUST succeed with with required name retrieved. Patching a VolumeAttachment MUST
-		succeed with its new label found. Listing VolumeAttachment with a labelSelector
-		MUST succeed with a single item retrieved. Deleting a VolumeAttachment MUST succeed
-		and it MUST be confirmed. Creating a second VolumeAttachment MUST succeed. Updating
-		the second VolumentAttachment with a new label MUST succeed with its new label
-		found. Creating a third VolumeAttachment MUST succeed. Updating the third VolumentAttachment
-		with a new label MUST succeed with its new label found. Deleting both VolumeAttachments
-		via deleteCollection MUST succeed and it MUST be confirmed.
-	*/
 	ginkgo.Describe("Conformance", func() {
 
+		/*
+			Release: v1.30
+			Testname: VolumeAttachment, lifecycle
+			Description: Creating an initial VolumeAttachment MUST succeed. Reading the VolumeAttachment
+			MUST succeed with with required name retrieved. Patching a VolumeAttachment MUST
+			succeed with its new label found. Listing VolumeAttachment with a labelSelector
+			MUST succeed with a single item retrieved. Deleting a VolumeAttachment MUST succeed
+			and it MUST be confirmed. Creating a second VolumeAttachment MUST succeed. Updating
+			the second VolumentAttachment with a new label MUST succeed with its new label
+			found. Creating a third VolumeAttachment MUST succeed. Updating the third VolumentAttachment
+			with a new label MUST succeed with its new label found. Deleting both VolumeAttachments
+			via deleteCollection MUST succeed and it MUST be confirmed.
+		*/
 		framework.ConformanceIt("should run through the lifecycle of a VolumeAttachment", func(ctx context.Context) {
 
 			vaClient := f.ClientSet.StorageV1().VolumeAttachments()


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
Realigns conformance metadata for "should run through the lifecycle of a VolumeAttachment" e2e test

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
/sig storage
/sig architecture
/area conformance