### PR TITLE
Fix hugepages e2e test assertion

### DIFF
--- a/test/e2e_node/hugepages_test.go
+++ b/test/e2e_node/hugepages_test.go
@@ -225,12 +225,12 @@ var _ = SIGDescribe("HugePages", framework.WithSerial(), feature.HugePages, "[No
 		restartKubelet(true)
 
 		ginkgo.By("verifying that the hugepages-3Mi resource no longer is present")
-		gomega.Eventually(ctx, func() resource.Quantity {
+		gomega.Eventually(ctx, func() bool {
 			node, err = f.ClientSet.CoreV1().Nodes().Get(ctx, framework.TestContext.NodeName, metav1.GetOptions{})
 			framework.ExpectNoError(err, "while getting node status")
-			// abc, error := node.Status.Capacity["hugepages-3Mi"]
-			return node.Status.Capacity["hugepages-3Mi"]
-		}, 30*time.Second, framework.Poll).Should(gomega.BeNil())
+			_, isPresent := node.Status.Capacity["hugepages-3Mi"]
+			return isPresent
+		}, 30*time.Second, framework.Poll).Should(gomega.BeFalseBecause("hugepages resource should not be present"))
 	})
 
 	ginkgo.It("should add resources for new huge page sizes on kubelet restart", func(ctx context.Context) {
@@ -245,11 +245,12 @@ var _ = SIGDescribe("HugePages", framework.WithSerial(), feature.HugePages, "[No
 		startKubelet()
 
 		ginkgo.By("verifying that the hugepages-2Mi resource is present")
-		gomega.Eventually(ctx, func() resource.Quantity {
+		gomega.Eventually(ctx, func() bool {
 			node, err := f.ClientSet.CoreV1().Nodes().Get(ctx, framework.TestContext.NodeName, metav1.GetOptions{})
 			framework.ExpectNoError(err, "while getting node status")
-			return node.Status.Capacity["hugepages-2Mi"]
-		}, 30*time.Second, framework.Poll).ShouldNot(gomega.BeNil())
+			_, isPresent := node.Status.Capacity["hugepages-2Mi"]
+			return isPresent
+		}, 30*time.Second, framework.Poll).Should(gomega.BeTrueBecause("hugepages resource should be present"))
 	})
 
 	ginkgo.When("start the pod", func() {


### PR DESCRIPTION



#### What type of PR is this?


/kind failing-test


#### What this PR does / why we need it:
This causes failures in:

- https://testgrid.k8s.io/sig-node-cri-o#ci-crio-cgroupv2-node-e2e-hugepages
- https://testgrid.k8s.io/sig-node-cri-o#ci-crio-cgroupv1-node-e2e-hugepages

#### Which issue(s) this PR fixes:

Follow-up on https://github.com/kubernetes/kubernetes/pull/121888

#### Special notes for your reviewer:
cc @SD-13 

PTAL @kubernetes/sig-node-pr-reviews 
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
