### PR TITLE
Fix the localhost nodeport metrics test to not fail under non-kube-proxy

### DIFF
--- a/test/e2e/network/kube_proxy.go
+++ b/test/e2e/network/kube_proxy.go
@@ -284,7 +284,9 @@ var _ = common.SIGDescribe("KubeProxy", func() {
 
 		// get proxyMode
 		stdout, err := e2epodoutput.RunHostCmd(fr.Namespace.Name, hostExecPodName, fmt.Sprintf("curl --silent 127.0.0.1:%d/proxyMode", ports.ProxyStatusPort))
-		framework.ExpectNoError(err)
+		if err != nil {
+			e2eskipper.Skipf("kube-proxy is not running or could not determine kube-proxy mode (%v)", err)
+		}
 		proxyMode := strings.TrimSpace(stdout)
 
 		// get value of route_localnet


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
If the cluster is using a non-kube-proxy service proxy, the `curl` will presumably fail; this should not be considered a hard failure.

#### Which issue(s) this PR fixes:
none; discovered during the OpenShift 1.31 rebase

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/assign @aroradaman 
/sig network
/triage accepted