### PR TITLE
Add paging tests

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_test.go
@@ -166,6 +166,12 @@ func TestPreconditionalDeleteWithSuggestionPass(t *testing.T) {
 	storagetesting.RunTestPreconditionalDeleteWithOnlySuggestionPass(ctx, t, cacher)
 }
 
+func TestListPaging(t *testing.T) {
+	ctx, cacher, terminate := testSetup(t)
+	t.Cleanup(terminate)
+	storagetesting.RunTestListPaging(ctx, t, cacher)
+}
+
 func TestList(t *testing.T) {
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ConsistentListFromCache, false)
 	ctx, cacher, server, terminate := testSetupWithEtcdServer(t)

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store_test.go
@@ -161,6 +161,11 @@ func TestPreconditionalDeleteWithSuggestionPass(t *testing.T) {
 	storagetesting.RunTestPreconditionalDeleteWithOnlySuggestionPass(ctx, t, store)
 }
 
+func TestListPaging(t *testing.T) {
+	ctx, store, _ := testSetup(t)
+	storagetesting.RunTestListPaging(ctx, t, store)
+}
+
 func TestGetListNonRecursive(t *testing.T) {
 	ctx, store, client := testSetup(t)
 	storagetesting.RunTestGetListNonRecursive(ctx, t, compactStorage(client), store)


### PR DESCRIPTION
/kind regression

When working on implementing pagination for watch cache I noticed that I passed all the unit tests, but I broke integrations tests, which allowed me to notice that we don't have any unit tests for pagination of watch cache. Added this test to help me iterate faster on WC pagination.

/cc @jpbetz @deads2k @wojtek-t 

```release-note
NONE
```