### PR TITLE
Set scheduling throughput thresholds in scheduler_perf tests

### DIFF
--- a/test/integration/scheduler_perf/config/performance-config.yaml
+++ b/test/integration/scheduler_perf/config/performance-config.yaml
@@ -48,6 +48,7 @@
       measurePods: 1000
   - name: 5000Nodes_10000Pods
     labels: [performance]
+    threshold: 270
     params:
       initNodes: 5000
       initPods: 1000
@@ -89,6 +90,7 @@
       measurePods: 1000
   - name: 5000Nodes_2000Pods
     labels: [performance]
+    threshold: 70
     params:
       initNodes: 5000
       initPods: 1000
@@ -125,6 +127,7 @@
       measurePods: 1000
   - name: 5000Nodes_10000Pods
     labels: [performance]
+    threshold: 260
     params:
       initNodes: 5000
       initPods: 1000
@@ -164,6 +167,7 @@
       measurePods: 1000
   - name: 5000Nodes_2000Pods
     labels: [performance]
+    threshold: 90
     params:
       initNodes: 5000
       initPods: 1000
@@ -212,6 +216,7 @@
       measurePods: 1000
   - name: 5000Nodes_5000Pods
     labels: [performance]
+    threshold: 35
     params:
       initNodes: 5000
       initPods: 5000
@@ -258,6 +263,7 @@
       measurePods: 1000
   - name: 5000Nodes_5000Pods
     labels: [performance]
+    threshold: 48
     params:
       initNodes: 5000
       initPods: 5000
@@ -303,6 +309,7 @@
       measurePods: 1000
   - name: 5000Nodes_5000Pods
     labels: [performance]
+    threshold: 35
     params:
       initNodes: 5000
       initPods: 5000
@@ -344,6 +351,7 @@
       measurePods: 1000
   - name: 5000Nodes_5000Pods
     labels: [performance]
+    threshold: 90
     params:
       initNodes: 5000
       initPods: 5000
@@ -385,6 +393,7 @@
       measurePods: 1000
   - name: 5000Nodes_5000Pods
     labels: [performance]
+    threshold: 90
     params:
       initNodes: 5000
       initPods: 5000
@@ -418,6 +427,7 @@
       measurePods: 10
   - name: 15000Nodes
     labels: [performance, fast]
+    threshold: 390
     params:
       initNodes: 15000
       measurePods: 30000
@@ -457,6 +467,7 @@
       measurePods: 1000
   - name: 5000Nodes_10000Pods
     labels: [performance]
+    threshold: 220
     params:
       initNodes: 5000
       initPods: 5000
@@ -498,6 +509,7 @@
       measurePods: 2000
   - name: 5000Nodes_5000Pods
     labels: [performance]
+    threshold: 85
     params:
       initNodes: 5000
       initPods: 5000
@@ -539,6 +551,7 @@
       measurePods: 2000
   - name: 5000Nodes_5000Pods
     labels: [performance]
+    threshold: 125
     params:
       initNodes: 5000
       initPods: 5000
@@ -599,6 +612,7 @@
       measurePods: 1000
   - name: 5000Nodes_5000Pods
     labels: [performance]
+    threshold: 140
     params:
       initNodes: 5000
       initPods: 2000
@@ -624,6 +638,7 @@
       measurePods: 5
   - name: 500Nodes
     labels: [performance, fast]
+    threshold: 18
     params:
       initNodes: 500
       initPods: 2000
@@ -659,6 +674,7 @@
       measurePods: 5
   - name: 500Nodes
     labels: [performance, fast]
+    threshold: 18
     params:
       initNodes: 500
       initPods: 2000
@@ -705,6 +721,7 @@
       measurePods: 5000
   - name: 5000Nodes/200InitPods/10000Pods
     labels: [performance]
+    threshold: 300
     params:
       initNodes: 5000
       initPods: 200
@@ -749,6 +766,7 @@
       measurePods: 2000
   - name: 5000Nodes_10000Pods
     labels: [performance]
+    threshold: 265
     params:
       initNodes: 5000
       measurePods: 10000
@@ -800,6 +818,7 @@
       measurePods: 1000
   - name: 5000Nodes_2000Pods
     labels: [performance]
+    threshold: 35
     params:
       initNodes: 6000
       initPodsPerNamespace: 40
@@ -853,6 +872,7 @@
       measurePods: 1000
   - name: 5000Nodes_2000Pods
     labels: [performance]
+    threshold: 55
     params:
       initNodes: 5000
       initPodsPerNamespace: 40
@@ -909,6 +929,7 @@
       measurePods: 1000
   - name: 5000Nodes_2000Pods
     labels: [performance]
+    threshold: 35
     params:
       initNodes: 5000
       initPodsPerNamespace: 50
@@ -962,6 +983,7 @@
       measurePods: 1000
   - name: 5000Nodes_5000Pods
     labels: [performance]
+    threshold: 90
     params:
       initNodes: 5000
       initPodsPerNamespace: 50
@@ -996,6 +1018,7 @@
       measurePods: 400
   - name: 5000Nodes
     labels: [performance, fast]
+    threshold: 68
     params:
       taintNodes: 1000
       normalNodes: 4000
@@ -1326,6 +1349,7 @@
       measurePods: 100
   - name: 1Node_10000GatedPods
     labels: [performance, fast]
+    threshold: 130
     params:
       gatedPods: 10000
       deletingPods: 20000
@@ -1358,6 +1382,7 @@
       measurePods: 10
   - name: 1Node_10000GatedPods
     labels: [performance, fast]
+    threshold: 110
     params:
       gatedPods: 10000
       measurePods: 20000


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR sets scheduling throughput thresholds for scheduler_perf test cases, to be able to catch the possible regressions in the future. The way the thresholds were calculated is described in the PR's comment. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #124774

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
