### PR TITLE
chore: migrate kube feature RelaxedEnvironmentVariableValidation to new versioned kube feature file and syntax

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -1144,8 +1144,6 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 
 	RecoverVolumeExpansionFailure: {Default: false, PreRelease: featuregate.Alpha},
 
-	RelaxedEnvironmentVariableValidation: {Default: false, PreRelease: featuregate.Alpha},
-
 	ReloadKubeletServerCertificateFile: {Default: true, PreRelease: featuregate.Beta},
 
 	ResourceHealthStatus: {Default: false, PreRelease: featuregate.Alpha},

--- a/pkg/features/versioned_kube_features.go
+++ b/pkg/features/versioned_kube_features.go
@@ -17,6 +17,7 @@ limitations under the License.
 package features
 
 import (
+	"k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/component-base/featuregate"
 )
 
@@ -27,8 +28,7 @@ import (
 // Entries are separated from each other with blank lines to avoid sweeping gofmt changes
 // when adding or removing one entry.
 var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate.VersionedSpecs{
-	// Example:
-	// genericfeatures.EmulationVersion: {
-	// 	{Version: version.MustParse("1.30"), Default: false, PreRelease: featuregate.Alpha},
-	// },
+	RelaxedEnvironmentVariableValidation: {
+		{Version: version.MustParse("1.30"), Default: false, PreRelease: featuregate.Alpha},
+	},
 }

--- a/test/featuregates_linter/test_data/unversioned_feature_list.yaml
+++ b/test/featuregates_linter/test_data/unversioned_feature_list.yaml
@@ -628,12 +628,6 @@
     lockToDefault: false
     preRelease: Beta
     version: ""
-- name: RelaxedEnvironmentVariableValidation
-  versionedSpecs:
-  - default: false
-    lockToDefault: false
-    preRelease: Alpha
-    version: ""
 - name: ReloadKubeletServerCertificateFile
   versionedSpecs:
   - default: true

--- a/test/featuregates_linter/test_data/versioned_feature_list.yaml
+++ b/test/featuregates_linter/test_data/versioned_feature_list.yaml
@@ -1,1 +1,6 @@
-[]
+- name: RelaxedEnvironmentVariableValidation
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.30"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR is part of work required for #125031 (part of https://github.com/kubernetes/enhancements/issues/4330).  This PR migrates a single existing alpha feature, `RelaxedEnvironmentVariableValidation`,  to use the new versioned feature gate syntax.  Attempting a small change like this initially to show users how to migrate features to the new versioned feature gate syntax with some manual testing is currently preferred vs doing many in a batch change with the idea being that other community members will start porting features.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #125031 

#### Special notes for your reviewer:
Manually tested that the feature gate - `RelaxedEnvironmentVariableValidation` works as expected after this change was made.  Below snippets and log outputs are from a branch with this PR included:

envvar-test-pod.yaml
```
apiVersion: v1
kind: Pod
metadata:
  name: envvar-test-pod
spec:
  containers:
  - name: test-container
    image: busybox
    command: [ "sh", "-c", "env; sleep 3600" ]
    env:
    - name: "SPECIAL_CHAR_ENV_VAR:LOGLEVEL:DEFAULT"
      value: "Debug"
```

Test that feature gate is disabled as expected via `hack/local-up-cluster.sh` (kubectl apply fails as expected for pod w/ colon in envvar w/o this feature enabled)
```
$ sudo hack/local-up-cluster.sh # RelaxedEnvironmentVariableValidation=false
...
$ cat /tmp/kube-apiserver.log
...
I0822 20:48:32.235380 3115786 flags.go:64] FLAG: --feature-gates=":AllAlpha=false"
$ aprindle@aprindle-ssd ~/kubernetes  [master]kubectl --kubeconfig=/var/run/kubernetes/admin.kubeconfig apply -f ~/env-var-allow/envvar-test-pod.yaml
The Pod "envvar-test-pod" is invalid: spec.containers[0].env[0].name: Invalid value: "SPECIAL_CHAR_ENV_VAR:LOGLEVEL:DEFAULT": a valid environment variable name must consist of alphabetic characters, digits, '_', '-', or '.', and must not start with a digit (e.g. 'my.env-name',  or 'MY_ENV.NAME',  or 'MyEnvName1', regex used for validation is '[-._a-zA-Z][-._a-zA-Z0-9]*')
```

Test that feature gate is enabled as expected via `hack/local-up-cluster.sh`: (kubectl apply succeeds as expected for pod w/ colon in envvar w/ this feature enabled)
```
$ FEATURE_GATES="AllAlpha=false,RelaxedEnvironmentVariableValidation=true" sudo -E hack/local-up-cluster.sh
...
$ cat /tmp/kube-apiserver.log
...
I0822 20:51:46.016323 3129964 flags.go:64] FLAG: --feature-gates=":AllAlpha=false,:RelaxedEnvironmentVariableValidation=true"
$ aprindle@aprindle-ssd ~/kubernetes  [emu-version-feat-gate-v3]kubectl --kubeconfig=/var/run/kubernetes/admin.kubeconfig apply -f ~/env-var-allow/
pod/envvar-test-pod created

```

For unit testing of features moved from kube_features.go to versioned_kube_features.go, there are already tests in place from https://github.com/kubernetes/kubernetes/commit/403301bfdf2c7312591077827abd2e72f445a53a in `pkg/features/kube_features_test.go`:
```
	if err := knownFeatureGates.AddVersioned(defaultVersionedKubernetesFeatureGates); err != nil {
		t.Fatal(err)
	}
```
as well as in:
- https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/component-base/featuregate/feature_gate_test.go 
- https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/component-base/featuregate/testing/feature_gate_test.go. 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
https://github.com/kubernetes/enhancements/issues/4330
```
