### PR TITLE
WIP: tests: use the nodename when we are verifying nodes

### DIFF
--- a/test/e2e/common/network/networking.go
+++ b/test/e2e/common/network/networking.go
@@ -40,7 +40,7 @@ var _ = SIGDescribe("Networking", func() {
 			// First time, we'll quickly try all pods, breadth first.
 			for _, endpointPod := range config.EndpointPods {
 				framework.Logf("Breadth first check of %v on host %v...", endpointPod.Status.PodIP, endpointPod.Status.HostIP)
-				if err := config.DialFromTestContainer(ctx, protocol, endpointPod.Status.PodIP, port, 1, 0, sets.NewString(endpointPod.Name)); err != nil {
+				if err := config.DialFromTestContainer(ctx, protocol, endpointPod.Status.PodIP, port, 1, 0, sets.New(endpointPod.Name)); err != nil {
 					if _, ok := failedPodsByHost[endpointPod.Status.HostIP]; !ok {
 						failedPodsByHost[endpointPod.Status.HostIP] = []*v1.Pod{}
 					}
@@ -55,7 +55,7 @@ var _ = SIGDescribe("Networking", func() {
 				framework.Logf("Doublechecking %v pods in host %v which weren't seen the first time.", len(failedPods), host)
 				for _, endpointPod := range failedPods {
 					framework.Logf("Now attempting to probe pod [[[ %v ]]]", endpointPod.Status.PodIP)
-					if err := config.DialFromTestContainer(ctx, protocol, endpointPod.Status.PodIP, port, config.MaxTries, 0, sets.NewString(endpointPod.Name)); err != nil {
+					if err := config.DialFromTestContainer(ctx, protocol, endpointPod.Status.PodIP, port, config.MaxTries, 0, sets.New(endpointPod.Name)); err != nil {
 						errors = append(errors, err)
 					} else {
 						framework.Logf("Was able to reach %v on %v ", endpointPod.Status.PodIP, endpointPod.Status.HostIP)
@@ -108,7 +108,7 @@ var _ = SIGDescribe("Networking", func() {
 		framework.ConformanceIt("should function for node-pod communication: http [LinuxOnly]", f.WithNodeConformance(), func(ctx context.Context) {
 			config := e2enetwork.NewCoreNetworkingTestConfig(ctx, f, true)
 			for _, endpointPod := range config.EndpointPods {
-				err := config.DialFromNode(ctx, "http", endpointPod.Status.PodIP, e2enetwork.EndpointHTTPPort, config.MaxTries, 0, sets.NewString(endpointPod.Name))
+				err := config.DialFromNode(ctx, "http", endpointPod.Status.PodIP, e2enetwork.EndpointHTTPPort, config.MaxTries, 0, sets.New(endpointPod.Name))
 				if err != nil {
 					framework.Failf("Error dialing HTTP node to pod %v", err)
 				}
@@ -125,7 +125,7 @@ var _ = SIGDescribe("Networking", func() {
 		framework.ConformanceIt("should function for node-pod communication: udp [LinuxOnly]", f.WithNodeConformance(), func(ctx context.Context) {
 			config := e2enetwork.NewCoreNetworkingTestConfig(ctx, f, true)
 			for _, endpointPod := range config.EndpointPods {
-				err := config.DialFromNode(ctx, "udp", endpointPod.Status.PodIP, e2enetwork.EndpointUDPPort, config.MaxTries, 0, sets.NewString(endpointPod.Name))
+				err := config.DialFromNode(ctx, "udp", endpointPod.Status.PodIP, e2enetwork.EndpointUDPPort, config.MaxTries, 0, sets.New(endpointPod.Name))
 				if err != nil {
 					framework.Failf("Error dialing UDP from node to pod: %v", err)
 				}
@@ -141,7 +141,7 @@ var _ = SIGDescribe("Networking", func() {
 			ginkgo.Skip("Skipping SCTP node to pod test until DialFromNode supports SCTP #96482")
 			config := e2enetwork.NewNetworkingTestConfig(ctx, f, e2enetwork.EnableSCTP)
 			for _, endpointPod := range config.EndpointPods {
-				err := config.DialFromNode(ctx, "sctp", endpointPod.Status.PodIP, e2enetwork.EndpointSCTPPort, config.MaxTries, 0, sets.NewString(endpointPod.Name))
+				err := config.DialFromNode(ctx, "sctp", endpointPod.Status.PodIP, e2enetwork.EndpointSCTPPort, config.MaxTries, 0, sets.New(endpointPod.Name))
 				if err != nil {
 					framework.Failf("Error dialing SCTP from node to pod: %v", err)
 				}

--- a/test/e2e/network/networking.go
+++ b/test/e2e/network/networking.go
@@ -371,7 +371,7 @@ var _ = common.SIGDescribe("Networking", func() {
 			// #106770 MaxTries can be very large on large clusters, with the risk that a new NodePort is created by another test and start to answer traffic.
 			// Since we only want to assert that traffic is not being forwarded anymore and the retry timeout is 2 seconds, consider the test is correct
 			// if the service doesn't answer after 10 tries.
-			err = config.DialFromNode(ctx, "http", config.NodeIP, config.NodeHTTPPort, 10, 10, sets.NewString())
+			err = config.DialFromNode(ctx, "http", config.NodeIP, config.NodeHTTPPort, 10, 10, sets.New[string]())
 			if err != nil {
 				framework.Failf("Failure validating that node port service STOPPED removed properly: %v", err)
 			}
@@ -403,7 +403,7 @@ var _ = common.SIGDescribe("Networking", func() {
 			// #106770 MaxTries can be very large on large clusters, with the risk that a new NodePort is created by another test and start to answer traffic.
 			// Since we only want to assert that traffic is not being forwarded anymore and the retry timeout is 2 seconds, consider the test is correct
 			// if the service doesn't answer after 10 tries.
-			err = config.DialFromNode(ctx, "udp", config.NodeIP, config.NodeUDPPort, 10, 10, sets.NewString())
+			err = config.DialFromNode(ctx, "udp", config.NodeIP, config.NodeUDPPort, 10, 10, sets.New[string]())
 			if err != nil {
 				framework.Failf("Failure validating that node port service STOPPED removed properly: %v", err)
 			}

--- a/test/e2e/network/networking.go
+++ b/test/e2e/network/networking.go
@@ -469,17 +469,17 @@ var _ = common.SIGDescribe("Networking", func() {
 		// because the pods will try to acquire the same port in the host.
 		// We run the test in serial, to avoid port conflicts.
 		ginkgo.It("should function for service endpoints using hostNetwork", func(ctx context.Context) {
-			config := e2enetwork.NewNetworkingTestConfig(ctx, f, e2enetwork.UseHostNetwork, e2enetwork.EndpointsUseHostNetwork)
+			config := e2enetwork.NewNetworkingTestConfig(ctx, f, e2enetwork.UseHostNetwork, e2enetwork.EndpointsUseHostNetwork, e2enetwork.EchoNodeName)
 
 			ginkgo.By("pod-Service(hostNetwork): http")
 
 			ginkgo.By(fmt.Sprintf("dialing(http) %v --> %v:%v (config.clusterIP)", config.TestContainerPod.Name, config.ClusterIP, e2enetwork.ClusterHTTPPort))
-			err := config.DialFromTestContainer(ctx, "http", config.ClusterIP, e2enetwork.ClusterHTTPPort, config.MaxTries, 0, config.EndpointHostnames())
+			err := config.DialFromTestContainer(ctx, "http", config.ClusterIP, e2enetwork.ClusterHTTPPort, config.MaxTries, 0, config.EndpointNodeNames())
 			if err != nil {
 				framework.Failf("failed dialing endpoint, %v", err)
 			}
 			ginkgo.By(fmt.Sprintf("dialing(http) %v --> %v:%v (nodeIP)", config.TestContainerPod.Name, config.NodeIP, config.NodeHTTPPort))
-			err = config.DialFromTestContainer(ctx, "http", config.NodeIP, config.NodeHTTPPort, config.MaxTries, 0, config.EndpointHostnames())
+			err = config.DialFromTestContainer(ctx, "http", config.NodeIP, config.NodeHTTPPort, config.MaxTries, 0, config.EndpointNodeNames())
 			if err != nil {
 				framework.Failf("failed dialing endpoint, %v", err)
 			}
@@ -487,13 +487,13 @@ var _ = common.SIGDescribe("Networking", func() {
 			ginkgo.By("pod-Service(hostNetwork): udp")
 
 			ginkgo.By(fmt.Sprintf("dialing(udp) %v --> %v:%v (config.clusterIP)", config.TestContainerPod.Name, config.ClusterIP, e2enetwork.ClusterUDPPort))
-			err = config.DialFromTestContainer(ctx, "udp", config.ClusterIP, e2enetwork.ClusterUDPPort, config.MaxTries, 0, config.EndpointHostnames())
+			err = config.DialFromTestContainer(ctx, "udp", config.ClusterIP, e2enetwork.ClusterUDPPort, config.MaxTries, 0, config.EndpointNodeNames())
 			if err != nil {
 				framework.Failf("failed dialing endpoint, %v", err)
 			}
 
 			ginkgo.By(fmt.Sprintf("dialing(udp) %v --> %v:%v (nodeIP)", config.TestContainerPod.Name, config.NodeIP, config.NodeUDPPort))
-			err = config.DialFromTestContainer(ctx, "udp", config.NodeIP, config.NodeUDPPort, config.MaxTries, 0, config.EndpointHostnames())
+			err = config.DialFromTestContainer(ctx, "udp", config.NodeIP, config.NodeUDPPort, config.MaxTries, 0, config.EndpointNodeNames())
 			if err != nil {
 				framework.Failf("failed dialing endpoint, %v", err)
 			}
@@ -501,24 +501,24 @@ var _ = common.SIGDescribe("Networking", func() {
 			ginkgo.By("node-Service(hostNetwork): http")
 
 			ginkgo.By(fmt.Sprintf("dialing(http) %v (node) --> %v:%v (config.clusterIP)", config.NodeIP, config.ClusterIP, e2enetwork.ClusterHTTPPort))
-			err = config.DialFromNode(ctx, "http", config.ClusterIP, e2enetwork.ClusterHTTPPort, config.MaxTries, 0, config.EndpointHostnames())
+			err = config.DialFromNode(ctx, "http", config.ClusterIP, e2enetwork.ClusterHTTPPort, config.MaxTries, 0, config.EndpointNodeNames())
 			if err != nil {
 				framework.Failf("failed dialing endpoint, %v", err)
 			}
 			ginkgo.By(fmt.Sprintf("dialing(http) %v (node) --> %v:%v (nodeIP)", config.NodeIP, config.NodeIP, config.NodeHTTPPort))
-			err = config.DialFromNode(ctx, "http", config.NodeIP, config.NodeHTTPPort, config.MaxTries, 0, config.EndpointHostnames())
+			err = config.DialFromNode(ctx, "http", config.NodeIP, config.NodeHTTPPort, config.MaxTries, 0, config.EndpointNodeNames())
 			if err != nil {
 				framework.Failf("failed dialing endpoint, %v", err)
 			}
 			ginkgo.By("node-Service(hostNetwork): udp")
 
 			ginkgo.By(fmt.Sprintf("dialing(udp) %v (node) --> %v:%v (config.clusterIP)", config.NodeIP, config.ClusterIP, e2enetwork.ClusterUDPPort))
-			err = config.DialFromNode(ctx, "udp", config.ClusterIP, e2enetwork.ClusterUDPPort, config.MaxTries, 0, config.EndpointHostnames())
+			err = config.DialFromNode(ctx, "udp", config.ClusterIP, e2enetwork.ClusterUDPPort, config.MaxTries, 0, config.EndpointNodeNames())
 			if err != nil {
 				framework.Failf("failed dialing endpoint, %v", err)
 			}
 			ginkgo.By(fmt.Sprintf("dialing(udp) %v (node) --> %v:%v (nodeIP)", config.NodeIP, config.NodeIP, config.NodeUDPPort))
-			err = config.DialFromNode(ctx, "udp", config.NodeIP, config.NodeUDPPort, config.MaxTries, 0, config.EndpointHostnames())
+			err = config.DialFromNode(ctx, "udp", config.NodeIP, config.NodeUDPPort, config.MaxTries, 0, config.EndpointNodeNames())
 			if err != nil {
 				framework.Failf("failed dialing endpoint, %v", err)
 			}

--- a/test/images/agnhost/serve-hostname/serve_hostname.go
+++ b/test/images/agnhost/serve-hostname/serve_hostname.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// A small utility to just serve the hostname on TCP and/or UDP.
+// A small utility to just serve the hostname on HTTP / TCP / UDP.
 
 package servehostname
 
@@ -58,7 +58,7 @@ func init() {
 
 func main(cmd *cobra.Command, args []string) {
 	if doHTTP && (doTCP || doUDP) {
-		log.Fatalf("Can't server TCP/UDP mode and HTTP mode at the same time")
+		log.Fatalf("Can't serve TCP/UDP mode and HTTP mode at the same time")
 	}
 
 	hostname, err := os.Hostname()


### PR DESCRIPTION
This avoids ambiguous behaviour around node name vs hostname.
