### PR TITLE
kubeadm: remove the deprecated sub-phase of 'init kubelet-finilize' called `experimental-cert-rotation`

### DIFF
--- a/cmd/kubeadm/app/cmd/phases/init/kubeletfinalize.go
+++ b/cmd/kubeadm/app/cmd/phases/init/kubeletfinalize.go
@@ -39,9 +39,6 @@ var (
 		# Updates settings relevant to the kubelet after TLS bootstrap"
 		kubeadm init phase kubelet-finalize all --config
 		`)
-	// TODO: remove with 'experimental-cert-rotation'.
-	// https://github.com/kubernetes/kubeadm/issues/3046
-	enableClientCertRotationRun = false
 )
 
 // NewKubeletFinalizePhase creates a kubeadm workflow phase that updates settings
@@ -65,43 +62,14 @@ func NewKubeletFinalizePhase() workflow.Phase {
 				InheritFlags: []string{options.CfgPath, options.CertificatesDir, options.DryRun},
 				Run:          runKubeletFinalizeEnableClientCertRotation,
 			},
-			// TODO: remove this phase in 1.32.
-			// also remove the "enableClientCertRotationRun" variable.
-			// https://github.com/kubernetes/kubeadm/issues/3046
-			{
-				Name:         "experimental-cert-rotation",
-				Short:        "Enable kubelet client certificate rotation (DEPRECATED: use 'enable-client-cert-rotation' instead)",
-				InheritFlags: []string{options.CfgPath, options.CertificatesDir, options.DryRun},
-				Run:          runKubeletFinalizeEnableClientCertRotationWrapped,
-			},
 		},
 	}
-}
-
-// runKubeletFinalizeEnableClientCertRotationWrapped wraps runKubeletFinalizeEnableClientCertRotation
-// and prints a deprecation message when the phase is executed directly. If 'all' is used this
-// function should just return nil because 'enable-client-cert-rotation' sets 'enableClientCertRotationRun'.
-// TODO: remove in 1.32.
-// https://github.com/kubernetes/kubeadm/issues/3046
-func runKubeletFinalizeEnableClientCertRotationWrapped(c workflow.RunData) error {
-	if enableClientCertRotationRun {
-		return nil
-	}
-	klog.Warning("The phase 'experimental-cert-rotation' is deprecated and will be removed in a future release. " +
-		"Use 'enable-client-cert-rotation' instead")
-	return runKubeletFinalizeEnableClientCertRotation(c)
 }
 
 // runKubeletFinalizeEnableClientCertRotation detects if the kubelet certificate rotation is enabled
 // and updates the kubelet.conf file to point to a rotatable certificate and key for the
 // Node user.
 func runKubeletFinalizeEnableClientCertRotation(c workflow.RunData) error {
-	// Set 'enableClientCertRotationRun' to make sure that if 'all' is called,
-	// runKubeletFinalizeEnableClientCertRotationWrapped will return nil early.
-	// TODO: remove in 1.32.
-	// https://github.com/kubernetes/kubeadm/issues/3046
-	enableClientCertRotationRun = true
-
 	data, ok := c.(InitData)
 	if !ok {
 		return errors.New("kubelet-finalize phase invoked with an invalid data struct")


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/kubeadm/issues/3046

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
kubeadm: remove the deprecated sub-phase of 'init kubelet-finilize' called `experimental-cert-rotation`, and use 'enable-client-cert-rotation' instead.

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
