### PR TITLE
kmsv2: set authority to localhost

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/kmsv2/grpc_service.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/kmsv2/grpc_service.go
@@ -58,6 +58,7 @@ func NewGRPCService(ctx context.Context, endpoint, providerName string, callTime
 	s := &gRPCService{callTimeout: callTimeout}
 	s.connection, err = grpc.Dial(
 		addr,
+		grpc.WithAuthority("localhost"),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithDefaultCallOptions(grpc.WaitForReady(true)),
 		grpc.WithContextDialer(


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
KMS Plugins require communication via grpc UDS. Currently, the k8s grpc client sets the authority header to the socket path which is marked as invalid preventing successful socket communication.

This issue was addressed in other parts of the code base but not here. Since the only way to communicate with KMSv2 according to the [documentation](https://kubernetes.io/docs/tasks/administer-cluster/kms-provider/#configuring-the-kms-provider-kms-v2) is via UDS and grpc, it seems essential that this fix should be applied here as well.

#### Which issue(s) this PR fixes:
Fixes [#126929](https://github.com/kubernetes/kubernetes/issues/126929)

#### Special notes for your reviewer:
This fix is in line with previous solutions for an identical problem. [The previous solution can be found here](https://github.com/kubernetes/kubernetes/pull/112597)


#### Does this PR introduce a user-facing change?

```release-note
Fixed an issue where requests sent by the KMSv2 service would be rejected due to having an invalid authority header.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
```
