### PR TITLE
proxy/metrics: refactor nfacct metrics

### DIFF
--- a/pkg/proxy/metrics/metrics.go
+++ b/pkg/proxy/metrics/metrics.go
@@ -147,8 +147,7 @@ var (
 		"kubeproxy_iptables_ct_state_invalid_dropped_packets_total",
 		"packets dropped by iptables to work around conntrack problems",
 		nil, nil, metrics.ALPHA, "")
-	IPTablesCTStateInvalidDroppedNFAcctCounter   = "ct_state_invalid_dropped_pkts"
-	iptablesCTStateInvalidDroppedMetricCollector = newNFAcctMetricCollector(IPTablesCTStateInvalidDroppedNFAcctCounter, iptablesCTStateInvalidDroppedPacketsDescription)
+	IPTablesCTStateInvalidDroppedNFAcctCounter = "ct_state_invalid_dropped_pkts"
 
 	// IPTablesRestoreFailuresTotal is the number of iptables restore failures that the proxy has
 	// seen.
@@ -273,8 +272,7 @@ var (
 		"kubeproxy_iptables_localhost_nodeports_accepted_packets_total",
 		"Number of packets accepted on nodeports of loopback interface",
 		nil, nil, metrics.ALPHA, "")
-	LocalhostNodePortAcceptedNFAcctCounter     = "localhost_nps_accepted_pkts"
-	localhostNodePortsAcceptedMetricsCollector = newNFAcctMetricCollector(LocalhostNodePortAcceptedNFAcctCounter, localhostNodePortsAcceptedPacketsDescription)
+	LocalhostNodePortAcceptedNFAcctCounter = "localhost_nps_accepted_pkts"
 )
 
 var registerMetricsOnce sync.Once
@@ -299,9 +297,11 @@ func RegisterMetrics(mode kubeproxyconfig.ProxyMode) {
 
 		switch mode {
 		case kubeproxyconfig.ProxyModeIPTables:
+			iptablesCTStateInvalidDroppedMetricCollector := newNFAcctMetricCollector(IPTablesCTStateInvalidDroppedNFAcctCounter, iptablesCTStateInvalidDroppedPacketsDescription)
 			if iptablesCTStateInvalidDroppedMetricCollector != nil {
 				legacyregistry.CustomMustRegister(iptablesCTStateInvalidDroppedMetricCollector)
 			}
+			localhostNodePortsAcceptedMetricsCollector := newNFAcctMetricCollector(LocalhostNodePortAcceptedNFAcctCounter, localhostNodePortsAcceptedPacketsDescription)
 			if localhostNodePortsAcceptedMetricsCollector != nil {
 				legacyregistry.CustomMustRegister(localhostNodePortsAcceptedMetricsCollector)
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
With this PR nfacct client for kube-proxy metrics will only be initialized when RegisterMetrics is called, preventing unnecessary initialisation .
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #126951

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
