### PR TITLE
automatically retry GET requests when http2 connection lost

### DIFF
--- a/staging/src/k8s.io/client-go/rest/request.go
+++ b/staging/src/k8s.io/client-go/rest/request.go
@@ -1143,7 +1143,7 @@ func (r *Request) request(ctx context.Context, fn func(*http.Request, *http.Resp
 			return false
 		}
 		// For connection errors and apiserver shutdown errors retry.
-		if net.IsConnectionReset(err) || net.IsProbableEOF(err) {
+		if net.IsConnectionReset(err) || net.IsProbableEOF(err) || net.IsHTTP2ConnectionLost(err) {
 			return true
 		}
 		return false


### PR DESCRIPTION
For discussion.  I'm unclear on why this condition isn't already present.  I'm seeing it in some cases when kube-apiservers are being replaced behind a load balancer.

If we decide not to retry on `IsHTTP2ConnectionLost`, I'll update this PR to add a comment explaining why not.

/cc @enj @jpbetz @liggitt 

```release-note
NONE
```

/kind bug
/priority important-soon