### PR TITLE
Add helpers to handle startup taints

### DIFF
--- a/staging/src/k8s.io/api/core/v1/taint.go
+++ b/staging/src/k8s.io/api/core/v1/taint.go
@@ -24,6 +24,11 @@ func (t *Taint) MatchTaint(taintToMatch *Taint) bool {
 	return t.Key == taintToMatch.Key && t.Effect == taintToMatch.Effect
 }
 
+// MatchTaintByKey checks if the taint key matches taintToMatch key
+func (t *Taint) MatchTaintByKey(taintToMatch *Taint) bool {
+	return t.Key == taintToMatch.Key
+}
+
 // taint.ToString() converts taint struct to string in format '<key>=<value>:<effect>', '<key>=<value>:', '<key>:<effect>', or '<key>'.
 func (t *Taint) ToString() string {
 	if len(t.Effect) == 0 {

--- a/staging/src/k8s.io/api/core/v1/taint_test.go
+++ b/staging/src/k8s.io/api/core/v1/taint_test.go
@@ -133,3 +133,71 @@ func TestMatchTaint(t *testing.T) {
 		}
 	}
 }
+
+func TestMatchTaintByKey(t *testing.T) {
+	testCases := []struct {
+		description  string
+		taint        *Taint
+		taintToMatch Taint
+		expectMatch  bool
+	}{
+		{
+			description: "two taints with the same key should match",
+			taint: &Taint{
+				Key: "foo",
+			},
+			taintToMatch: Taint{
+				Key: "foo",
+			},
+			expectMatch: true,
+		},
+		{
+			description: "two taints with the same key but different value should match",
+			taint: &Taint{
+				Key:    "foo",
+				Value:  "bar",
+				Effect: TaintEffectNoSchedule,
+			},
+			taintToMatch: Taint{
+				Key:    "foo",
+				Value:  "different-value",
+				Effect: TaintEffectNoSchedule,
+			},
+			expectMatch: true,
+		},
+		{
+			description: "two taints with the different key cannot match",
+			taint: &Taint{
+				Key:    "foo",
+				Value:  "bar",
+				Effect: TaintEffectNoSchedule,
+			},
+			taintToMatch: Taint{
+				Key:    "different-key",
+				Value:  "bar",
+				Effect: TaintEffectNoSchedule,
+			},
+			expectMatch: false,
+		},
+		{
+			description: "two taints with the same key but different effect should match",
+			taint: &Taint{
+				Key:    "foo",
+				Value:  "bar",
+				Effect: TaintEffectNoSchedule,
+			},
+			taintToMatch: Taint{
+				Key:    "foo",
+				Value:  "bar",
+				Effect: TaintEffectPreferNoSchedule,
+			},
+			expectMatch: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		if tc.expectMatch != tc.taint.MatchTaintByKey(&tc.taintToMatch) {
+			t.Errorf("[%s] expect taint %s match taint %s", tc.description, tc.taint.ToString(), tc.taintToMatch.ToString())
+		}
+	}
+}

--- a/staging/src/k8s.io/cloud-provider/node/helpers/taints_test.go
+++ b/staging/src/k8s.io/cloud-provider/node/helpers/taints_test.go
@@ -17,10 +17,17 @@ limitations under the License.
 package helpers
 
 import (
+	"context"
+	"errors"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/kubernetes/test/utils/ktesting"
 	"reflect"
 	"testing"
-
-	"k8s.io/api/core/v1"
 )
 
 func TestTaintExists(t *testing.T) {
@@ -40,27 +47,49 @@ func TestTaintExists(t *testing.T) {
 	cases := []struct {
 		name           string
 		taintToFind    *v1.Taint
+		matchingFn     matchTaintFunc
 		expectedResult bool
 	}{
 		{
 			name:           "taint exists",
 			taintToFind:    &v1.Taint{Key: "foo_1", Value: "bar_1", Effect: v1.TaintEffectNoExecute},
+			matchingFn:     (*v1.Taint).MatchTaint,
 			expectedResult: true,
 		},
 		{
 			name:           "different key",
 			taintToFind:    &v1.Taint{Key: "no_such_key", Value: "bar_1", Effect: v1.TaintEffectNoExecute},
+			matchingFn:     (*v1.Taint).MatchTaint,
 			expectedResult: false,
 		},
 		{
 			name:           "different effect",
 			taintToFind:    &v1.Taint{Key: "foo_1", Value: "bar_1", Effect: v1.TaintEffectNoSchedule},
+			matchingFn:     (*v1.Taint).MatchTaint,
+			expectedResult: false,
+		},
+		{
+			name:           "same key, match by key",
+			taintToFind:    &v1.Taint{Key: "foo_1", Value: "bar_1", Effect: v1.TaintEffectNoSchedule},
+			matchingFn:     (*v1.Taint).MatchTaintByKey,
+			expectedResult: true,
+		},
+		{
+			name:           "different effect, match by key",
+			taintToFind:    &v1.Taint{Key: "foo_1", Value: "bar_1", Effect: v1.TaintEffectNoSchedule},
+			matchingFn:     (*v1.Taint).MatchTaintByKey,
+			expectedResult: true,
+		},
+		{
+			name:           "different key, match by key",
+			taintToFind:    &v1.Taint{Key: "no_such_key", Value: "bar_1", Effect: v1.TaintEffectNoSchedule},
+			matchingFn:     (*v1.Taint).MatchTaintByKey,
 			expectedResult: false,
 		},
 	}
 
 	for _, c := range cases {
-		result := taintExists(testingTaints, c.taintToFind)
+		result := taintExists(testingTaints, c.taintToFind, c.matchingFn)
 
 		if result != c.expectedResult {
 			t.Errorf("[%s] unexpected results: %v", c.name, result)
@@ -74,6 +103,7 @@ func TestRemoveTaint(t *testing.T) {
 		name           string
 		node           *v1.Node
 		taintToRemove  *v1.Taint
+		matchingFn     matchTaintFunc
 		expectedTaints []v1.Taint
 		expectedResult bool
 	}{
@@ -93,6 +123,7 @@ func TestRemoveTaint(t *testing.T) {
 				Key:    "foo_1",
 				Effect: v1.TaintEffectNoSchedule,
 			},
+			matchingFn: (*v1.Taint).MatchTaint,
 			expectedTaints: []v1.Taint{
 				{
 					Key:    "foo",
@@ -117,6 +148,7 @@ func TestRemoveTaint(t *testing.T) {
 				Key:    "foo",
 				Effect: v1.TaintEffectNoSchedule,
 			},
+			matchingFn:     (*v1.Taint).MatchTaint,
 			expectedTaints: []v1.Taint{},
 			expectedResult: true,
 		},
@@ -131,13 +163,14 @@ func TestRemoveTaint(t *testing.T) {
 				Key:    "foo",
 				Effect: v1.TaintEffectNoSchedule,
 			},
+			matchingFn:     (*v1.Taint).MatchTaint,
 			expectedTaints: []v1.Taint{},
 			expectedResult: false,
 		},
 	}
 
 	for _, c := range cases {
-		newNode, result, err := removeTaint(c.node, c.taintToRemove)
+		newNode, result, err := removeMatchingTaint(c.node, c.taintToRemove, c.matchingFn)
 		if err != nil {
 			t.Errorf("[%s] should not raise error but got: %v", c.name, err)
 		}
@@ -155,6 +188,7 @@ func TestDeleteTaint(t *testing.T) {
 		name           string
 		taints         []v1.Taint
 		taintToDelete  *v1.Taint
+		matchingFn     matchTaintFunc
 		expectedTaints []v1.Taint
 		expectedResult bool
 	}{
@@ -167,6 +201,7 @@ func TestDeleteTaint(t *testing.T) {
 				},
 			},
 			taintToDelete: &v1.Taint{Key: "foo_1", Effect: v1.TaintEffectNoSchedule},
+			matchingFn:    (*v1.Taint).MatchTaint,
 			expectedTaints: []v1.Taint{
 				{
 					Key:    "foo",
@@ -184,6 +219,7 @@ func TestDeleteTaint(t *testing.T) {
 				},
 			},
 			taintToDelete: &v1.Taint{Key: "foo", Effect: v1.TaintEffectNoExecute},
+			matchingFn:    (*v1.Taint).MatchTaint,
 			expectedTaints: []v1.Taint{
 				{
 					Key:    "foo",
@@ -201,6 +237,7 @@ func TestDeleteTaint(t *testing.T) {
 				},
 			},
 			taintToDelete:  &v1.Taint{Key: "foo", Effect: v1.TaintEffectNoSchedule},
+			matchingFn:     (*v1.Taint).MatchTaint,
 			expectedTaints: []v1.Taint{},
 			expectedResult: true,
 		},
@@ -208,18 +245,120 @@ func TestDeleteTaint(t *testing.T) {
 			name:           "delete taint from empty taint array",
 			taints:         []v1.Taint{},
 			taintToDelete:  &v1.Taint{Key: "foo", Effect: v1.TaintEffectNoSchedule},
+			matchingFn:     (*v1.Taint).MatchTaint,
 			expectedTaints: []v1.Taint{},
 			expectedResult: false,
 		},
 	}
 
 	for _, c := range cases {
-		taints, result := deleteTaint(c.taints, c.taintToDelete)
+		taints, result := deleteMatchingTaint(c.taints, c.taintToDelete, c.matchingFn)
 		if result != c.expectedResult {
 			t.Errorf("[%s] should return %t, but got: %t", c.name, c.expectedResult, result)
 		}
 		if !reflect.DeepEqual(taints, c.expectedTaints) {
 			t.Errorf("[%s] the result taints should be %v, but got: %v", c.name, c.expectedTaints, taints)
 		}
+	}
+}
+
+func ready(_ context.Context, _ clientset.Interface, _, _ string) error {
+	return nil
+}
+
+func notReady(_ context.Context, _ clientset.Interface, _, _ string) error {
+	return errors.New("not ready")
+}
+
+func TestRemoveNotReadyTaint(t *testing.T) {
+	cases := []struct {
+		name           string
+		c              kubernetes.Interface
+		nodeName       string
+		componentName  string
+		readyFn        ComponentReadyFunc
+		expectedTaints []v1.Taint
+		shouldErr      bool
+	}{
+		{
+			name: "remove single taint",
+			c: fake.NewSimpleClientset(&v1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: "node1"},
+				Spec:       v1.NodeSpec{Taints: []v1.Taint{{Key: "driver/agent-not-ready", Effect: v1.TaintEffectNoExecute}}},
+			}),
+			nodeName:       "node1",
+			componentName:  "driver",
+			expectedTaints: nil,
+			readyFn:        ready,
+			shouldErr:      false,
+		},
+		{
+			name: "remove several taints",
+			c: fake.NewSimpleClientset(&v1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: "node1"},
+				Spec: v1.NodeSpec{Taints: []v1.Taint{
+					{Key: "driver/agent-not-ready", Effect: v1.TaintEffectNoExecute},
+					{Key: "driver/agent-not-ready", Effect: v1.TaintEffectNoSchedule},
+				}},
+			}),
+			nodeName:       "node1",
+			componentName:  "driver",
+			expectedTaints: nil,
+			readyFn:        ready,
+			shouldErr:      false,
+		},
+		{
+			name: "remove only matching taints",
+			c: fake.NewSimpleClientset(&v1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: "node1"},
+				Spec: v1.NodeSpec{Taints: []v1.Taint{
+					{Key: "driver/agent-not-ready", Effect: v1.TaintEffectNoExecute},
+					{Key: "foo", Effect: v1.TaintEffectNoSchedule},
+				}},
+			}),
+			nodeName:       "node1",
+			componentName:  "driver",
+			expectedTaints: []v1.Taint{{Key: "foo", Effect: v1.TaintEffectNoSchedule}},
+			readyFn:        ready,
+			shouldErr:      false,
+		},
+		{
+			name: "don't remove taint if not ready",
+			c: fake.NewSimpleClientset(&v1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: "node1"},
+				Spec:       v1.NodeSpec{Taints: []v1.Taint{{Key: "driver/agent-not-ready", Effect: v1.TaintEffectNoExecute}}},
+			}),
+			nodeName:       "node1",
+			componentName:  "driver",
+			expectedTaints: []v1.Taint{{Key: "driver/agent-not-ready", Effect: v1.TaintEffectNoExecute}},
+			readyFn:        notReady,
+			shouldErr:      true,
+		},
+		{
+			name: "noop if taint doesn't exist",
+			c: fake.NewSimpleClientset(&v1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: "node1"},
+				Spec:       v1.NodeSpec{},
+			}),
+			nodeName:       "node1",
+			componentName:  "driver",
+			expectedTaints: nil,
+			readyFn:        ready,
+			shouldErr:      false,
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			_, ctx := ktesting.NewTestContext(t)
+			err := RemoveNotReadyTaint(tt.c, tt.nodeName, tt.componentName, tt.readyFn)
+			if tt.shouldErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			actualNode, err := tt.c.CoreV1().Nodes().Get(ctx, tt.nodeName, metav1.GetOptions{})
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expectedTaints, actualNode.Spec.Taints)
+		})
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature


#### What this PR does / why we need it:

This adds some helpers to ease startup taint managements. Startup taints are used on several CSI drivers as well as for Cilium and this leads to duplicated code (see https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/1588/files and https://github.com/kubernetes-sigs/azuredisk-csi-driver/pull/2309/files for example)

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
