### PR TITLE
e2e/storage: get driver name from storage class

### DIFF
--- a/test/e2e/storage/testsuites/volumelimits.go
+++ b/test/e2e/storage/testsuites/volumelimits.go
@@ -112,7 +112,7 @@ func (t *volumeLimitsTestSuite) DefineTests(driver storageframework.TestDriver, 
 		podNames []string
 
 		// All created PVs, incl. the one in resource
-		pvNames sets.String
+		pvNames sets.Set[string]
 	}
 	var (
 		l local
@@ -279,7 +279,7 @@ func (t *volumeLimitsTestSuite) DefineTests(driver storageframework.TestDriver, 
 	})
 }
 
-func cleanupTest(ctx context.Context, cs clientset.Interface, ns string, podNames, pvcNames []string, pvNames sets.String, timeout time.Duration) error {
+func cleanupTest(ctx context.Context, cs clientset.Interface, ns string, podNames, pvcNames []string, pvNames sets.Set[string], timeout time.Duration) error {
 	var cleanupErrors []string
 	for _, podName := range podNames {
 		err := cs.CoreV1().Pods(ns).Delete(ctx, podName, metav1.DeleteOptions{})
@@ -326,8 +326,8 @@ func cleanupTest(ctx context.Context, cs clientset.Interface, ns string, podName
 }
 
 // waitForAllPVCsBound waits until the given PVCs are all bound. It then returns the bound PVC names as a set.
-func waitForAllPVCsBound(ctx context.Context, cs clientset.Interface, timeout time.Duration, ns string, pvcNames []string) (sets.String, error) {
-	pvNames := sets.NewString()
+func waitForAllPVCsBound(ctx context.Context, cs clientset.Interface, timeout time.Duration, ns string, pvcNames []string) (sets.Set[string], error) {
+	pvNames := sets.New[string]()
 	err := wait.Poll(5*time.Second, timeout, func() (bool, error) {
 		unbound := 0
 		for _, pvcName := range pvcNames {

--- a/test/e2e/storage/testsuites/volumelimits.go
+++ b/test/e2e/storage/testsuites/volumelimits.go
@@ -39,6 +39,7 @@ import (
 	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	e2epv "k8s.io/kubernetes/test/e2e/framework/pv"
+	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 	storageframework "k8s.io/kubernetes/test/e2e/storage/framework"
 	storageutils "k8s.io/kubernetes/test/e2e/storage/utils"
 	admissionapi "k8s.io/pod-security-admission/api"
@@ -86,6 +87,13 @@ func (t *volumeLimitsTestSuite) GetTestSuiteInfo() storageframework.TestSuiteInf
 }
 
 func (t *volumeLimitsTestSuite) SkipUnsupportedTests(driver storageframework.TestDriver, pattern storageframework.TestPattern) {
+	if pattern.VolType != storageframework.DynamicPV {
+		e2eskipper.Skipf("Suite %q does not support %v", t.tsInfo.Name, pattern.VolType)
+	}
+	dInfo := driver.GetDriverInfo()
+	if !dInfo.Capabilities[storageframework.CapVolumeLimits] {
+		e2eskipper.Skipf("Driver %s does not support volume limits", dInfo.Name)
+	}
 }
 
 func (t *volumeLimitsTestSuite) DefineTests(driver storageframework.TestDriver, pattern storageframework.TestPattern) {
@@ -108,12 +116,18 @@ func (t *volumeLimitsTestSuite) DefineTests(driver storageframework.TestDriver, 
 	}
 	var (
 		l local
+
+		dDriver storageframework.DynamicPVTestDriver
 	)
 
 	// Beware that it also registers an AfterEach which renders f unusable. Any code using
 	// f must run inside an It or Context callback.
 	f := framework.NewFrameworkWithCustomTimeouts("volumelimits", storageframework.GetDriverTimeouts(driver))
 	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
+
+	ginkgo.BeforeEach(func() {
+		dDriver = driver.(storageframework.DynamicPVTestDriver)
+	})
 
 	// This checks that CSIMaxVolumeLimitChecker works as expected.
 	// A randomly chosen node should be able to handle as many CSI volumes as
@@ -125,14 +139,6 @@ func (t *volumeLimitsTestSuite) DefineTests(driver storageframework.TestDriver, 
 	// BEWARE: the test may create lot of volumes and it's really slow.
 	f.It("should support volume limits", f.WithSerial(), func(ctx context.Context) {
 		driverInfo := driver.GetDriverInfo()
-		if !driverInfo.Capabilities[storageframework.CapVolumeLimits] {
-			ginkgo.Skip(fmt.Sprintf("driver %s does not support volume limits", driverInfo.Name))
-		}
-		var dDriver storageframework.DynamicPVTestDriver
-		if dDriver = driver.(storageframework.DynamicPVTestDriver); dDriver == nil {
-			framework.Failf("Test driver does not provide dynamically created volumes")
-		}
-
 		l.ns = f.Namespace
 		l.cs = f.ClientSet
 
@@ -150,7 +156,7 @@ func (t *volumeLimitsTestSuite) DefineTests(driver storageframework.TestDriver, 
 		framework.Logf("Selected node %s", nodeName)
 
 		ginkgo.By("Checking node limits")
-		limit, err := getNodeLimits(ctx, l.cs, l.config, nodeName, driverInfo)
+		limit, err := getNodeLimits(ctx, l.cs, l.config, nodeName, dDriver)
 		framework.ExpectNoError(err)
 
 		framework.Logf("Node %s can handle %d volumes of driver %s", nodeName, limit, driverInfo.Name)
@@ -265,7 +271,7 @@ func (t *volumeLimitsTestSuite) DefineTests(driver storageframework.TestDriver, 
 
 		for _, nodeName := range nodeNames {
 			ginkgo.By("Checking csinode limits")
-			_, err := getNodeLimits(ctx, l.cs, l.config, nodeName, driverInfo)
+			_, err := getNodeLimits(ctx, l.cs, l.config, nodeName, dDriver)
 			if err != nil {
 				framework.Failf("Expected volume limits to be set, error: %v", err)
 			}
@@ -347,21 +353,24 @@ func waitForAllPVCsBound(ctx context.Context, cs clientset.Interface, timeout ti
 	return pvNames, nil
 }
 
-func getNodeLimits(ctx context.Context, cs clientset.Interface, config *storageframework.PerTestConfig, nodeName string, driverInfo *storageframework.DriverInfo) (int, error) {
-	if len(driverInfo.InTreePluginName) == 0 {
-		return getCSINodeLimits(ctx, cs, config, nodeName, driverInfo)
+func getNodeLimits(ctx context.Context, cs clientset.Interface, config *storageframework.PerTestConfig, nodeName string, driver storageframework.DynamicPVTestDriver) (int, error) {
+	driverInfo := driver.GetDriverInfo()
+	if len(driverInfo.InTreePluginName) > 0 {
+		return getInTreeNodeLimits(ctx, cs, nodeName, driverInfo.InTreePluginName)
 	}
-	return getInTreeNodeLimits(ctx, cs, nodeName, driverInfo)
+
+	sc := driver.GetDynamicProvisionStorageClass(ctx, config, "")
+	return getCSINodeLimits(ctx, cs, config, nodeName, sc.Provisioner)
 }
 
-func getInTreeNodeLimits(ctx context.Context, cs clientset.Interface, nodeName string, driverInfo *storageframework.DriverInfo) (int, error) {
+func getInTreeNodeLimits(ctx context.Context, cs clientset.Interface, nodeName, driverName string) (int, error) {
 	node, err := cs.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
 	if err != nil {
 		return 0, err
 	}
 
 	var allocatableKey string
-	switch driverInfo.InTreePluginName {
+	switch driverName {
 	case migrationplugins.AWSEBSInTreePluginName:
 		allocatableKey = volumeutil.EBSVolumeLimitKey
 	case migrationplugins.GCEPDInTreePluginName:
@@ -371,17 +380,17 @@ func getInTreeNodeLimits(ctx context.Context, cs clientset.Interface, nodeName s
 	case migrationplugins.AzureDiskInTreePluginName:
 		allocatableKey = volumeutil.AzureVolumeLimitKey
 	default:
-		return 0, fmt.Errorf("Unknown in-tree volume plugin name: %s", driverInfo.InTreePluginName)
+		return 0, fmt.Errorf("Unknown in-tree volume plugin name: %s", driverName)
 	}
 
 	limit, ok := node.Status.Allocatable[v1.ResourceName(allocatableKey)]
 	if !ok {
-		return 0, fmt.Errorf("Node %s does not contain status.allocatable[%s] for volume plugin %s", nodeName, allocatableKey, driverInfo.InTreePluginName)
+		return 0, fmt.Errorf("Node %s does not contain status.allocatable[%s] for volume plugin %s", nodeName, allocatableKey, driverName)
 	}
 	return int(limit.Value()), nil
 }
 
-func getCSINodeLimits(ctx context.Context, cs clientset.Interface, config *storageframework.PerTestConfig, nodeName string, driverInfo *storageframework.DriverInfo) (int, error) {
+func getCSINodeLimits(ctx context.Context, cs clientset.Interface, config *storageframework.PerTestConfig, nodeName, driverName string) (int, error) {
 	// Retry with a timeout, the driver might just have been installed and kubelet takes a while to publish everything.
 	var limit int
 	err := wait.PollImmediate(2*time.Second, csiNodeInfoTimeout, func() (bool, error) {
@@ -392,26 +401,26 @@ func getCSINodeLimits(ctx context.Context, cs clientset.Interface, config *stora
 		}
 		var csiDriver *storagev1.CSINodeDriver
 		for i, c := range csiNode.Spec.Drivers {
-			if c.Name == driverInfo.Name || c.Name == config.GetUniqueDriverName() {
+			if c.Name == driverName || c.Name == config.GetUniqueDriverName() {
 				csiDriver = &csiNode.Spec.Drivers[i]
 				break
 			}
 		}
 		if csiDriver == nil {
-			framework.Logf("CSINodeInfo does not have driver %s yet", driverInfo.Name)
+			framework.Logf("CSINodeInfo does not have driver %s yet", driverName)
 			return false, nil
 		}
 		if csiDriver.Allocatable == nil {
-			return false, fmt.Errorf("CSINodeInfo does not have Allocatable for driver %s", driverInfo.Name)
+			return false, fmt.Errorf("CSINodeInfo does not have Allocatable for driver %s", driverName)
 		}
 		if csiDriver.Allocatable.Count == nil {
-			return false, fmt.Errorf("CSINodeInfo does not have Allocatable.Count for driver %s", driverInfo.Name)
+			return false, fmt.Errorf("CSINodeInfo does not have Allocatable.Count for driver %s", driverName)
 		}
 		limit = int(*csiDriver.Allocatable.Count)
 		return true, nil
 	})
 	if err != nil {
-		return 0, fmt.Errorf("could not get CSINode limit for driver %s: %w", driverInfo.Name, err)
+		return 0, fmt.Errorf("could not get CSINode limit for driver %s: %w", driverName, err)
 	}
 	return limit, nil
 }

--- a/test/e2e/storage/testsuites/volumelimits.go
+++ b/test/e2e/storage/testsuites/volumelimits.go
@@ -238,7 +238,7 @@ func (t *volumeLimitsTestSuite) DefineTests(driver storageframework.TestDriver, 
 				}
 			}
 			if pod.Status.Phase != v1.PodPending {
-				return true, fmt.Errorf("Expected pod to be in phase Pending, but got phase: %v", pod.Status.Phase)
+				return true, fmt.Errorf("expected pod to be in phase Pending, but got phase: %v", pod.Status.Phase)
 			}
 			return false, nil
 		})
@@ -380,12 +380,12 @@ func getInTreeNodeLimits(ctx context.Context, cs clientset.Interface, nodeName, 
 	case migrationplugins.AzureDiskInTreePluginName:
 		allocatableKey = volumeutil.AzureVolumeLimitKey
 	default:
-		return 0, fmt.Errorf("Unknown in-tree volume plugin name: %s", driverName)
+		return 0, fmt.Errorf("unknown in-tree volume plugin name: %s", driverName)
 	}
 
 	limit, ok := node.Status.Allocatable[v1.ResourceName(allocatableKey)]
 	if !ok {
-		return 0, fmt.Errorf("Node %s does not contain status.allocatable[%s] for volume plugin %s", nodeName, allocatableKey, driverName)
+		return 0, fmt.Errorf("node %s does not contain status.allocatable[%s] for volume plugin %s", nodeName, allocatableKey, driverName)
 	}
 	return int(limit.Value()), nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

e2e/storage: get driver name from storage class

Do not use the `driverInfo.Name`, it is for display only, and may be different from the name of CSI driver

with some cleanups to the same file:
- error strings should not be capitalized
- replace sets.String with sets.Set[string] 
- replace deprecated wait.Poll

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

Background: we are trying to test different parameters of the same driver, by specifying `-storage.testdriver` multiple times

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
