### PR TITLE
Fix for GenericPersistentVolume/Disruptive test failures

### DIFF
--- a/test/e2e/storage/generic_persistent_volume-disruptive.go
+++ b/test/e2e/storage/generic_persistent_volume-disruptive.go
@@ -109,9 +109,6 @@ func createPodPVCFromSC(ctx context.Context, f *framework.Framework, c clientset
 	pvc, err = c.CoreV1().PersistentVolumeClaims(pvc.Namespace).Create(ctx, pvc, metav1.CreateOptions{})
 	framework.ExpectNoError(err, "Error creating pvc")
 	pvcClaims := []*v1.PersistentVolumeClaim{pvc}
-	pvs, err := e2epv.WaitForPVClaimBoundPhase(ctx, c, pvcClaims, framework.ClaimProvisionTimeout)
-	framework.ExpectNoError(err, "Failed waiting for PVC to be bound %v", err)
-	gomega.Expect(pvs).To(gomega.HaveLen(1))
 
 	ginkgo.By("Creating a pod with dynamically provisioned volume")
 	podConfig := e2epod.Config{
@@ -121,5 +118,11 @@ func createPodPVCFromSC(ctx context.Context, f *framework.Framework, c clientset
 	}
 	pod, err := e2epod.CreateSecPod(ctx, c, &podConfig, f.Timeouts.PodStart)
 	framework.ExpectNoError(err, "While creating pods for kubelet restart test")
+
+	ginkgo.By("Checking for bound PVC")
+	pvs, err := e2epv.WaitForPVClaimBoundPhase(ctx, c, pvcClaims, framework.ClaimProvisionTimeout)
+	framework.ExpectNoError(err, "Failed waiting for PVC to be bound %v", err)
+	gomega.Expect(pvs).To(gomega.HaveLen(1))
+
 	return pod, pvc, pvs[0]
 }


### PR DESCRIPTION
Failures from:
https://storage.googleapis.com/k8s-triage/index.html?pr=1&test=GenericPersistentVolume

![image](https://github.com/user-attachments/assets/7b1079b0-ea06-4cd7-b521-4ac197e8c563)

log snippet from [here](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/e2e-ci-kubernetes-e2e-cos-gce-disruptive-canary/1828799837512929280):
```
I0828 15:34:27.984435 15422 pv.go:806] PersistentVolumeClaim pvc-9w7hs found but phase is Pending instead of Bound.
I0828 15:34:29.988184 15422 pv.go:806] PersistentVolumeClaim pvc-9w7hs found but phase is Pending instead of Bound.
I0828 15:34:31.994368 15422 pv.go:806] PersistentVolumeClaim pvc-9w7hs found but phase is Pending instead of Bound.
I0828 15:34:33.999633 15422 pv.go:806] PersistentVolumeClaim pvc-9w7hs found but phase is Pending instead of Bound.
I0828 15:34:36.003500 15422 pv.go:806] PersistentVolumeClaim pvc-9w7hs found but phase is Pending instead of Bound.
I0828 15:34:38.008763 15422 pv.go:806] PersistentVolumeClaim pvc-9w7hs found but phase is Pending instead of Bound.
I0828 15:34:40.012572 15422 pv.go:806] PersistentVolumeClaim pvc-9w7hs found but phase is Pending instead of Bound.
I0828 15:34:42.017598 15422 pv.go:806] PersistentVolumeClaim pvc-9w7hs found but phase is Pending instead of Bound.
I0828 15:34:44.022297 15422 pv.go:806] PersistentVolumeClaim pvc-9w7hs found but phase is Pending instead of Bound.
I0828 15:34:46.022489 15422 generic_persistent_volume-disruptive.go:113] Unexpected error: Failed waiting for PVC to be bound PersistentVolumeClaims [pvc-9w7hs] not all in phase Bound within 5m0s: 
    <*errors.errorString | 0xc00445e1b0>: 
    PersistentVolumeClaims [pvc-9w7hs] not all in phase Bound within 5m0s
    {
        s: "PersistentVolumeClaims [pvc-9w7hs] not all in phase Bound within 5m0s",
    }
[FAILED] Failed waiting for PVC to be bound PersistentVolumeClaims [pvc-9w7hs] not all in phase Bound within 5m0s: PersistentVolumeClaims [pvc-9w7hs] not all in phase Bound within 5m0s
In [BeforeEach] at: k8s.io/kubernetes/test/e2e/storage/generic_persistent_volume-disruptive.go:113 @ 08/28/24 15:34:46.022
< Exit [BeforeEach] When kubelet restarts - k8s.io/kubernetes/test/e2e/storage/generic_persistent_volume-disruptive.go:76 @ 08/28/24 15:34:46.022 (5m0.754s)
> Enter [AfterEach] When kubelet restarts - k8s.io/kubernetes/test/e2e/storage/generic_persistent_volume-disruptive.go:90 @ 08/28/24 15:34:46.022
I0828 15:34:46.022950 15422 generic_persistent_volume-disruptive.go:91] Tearing down test spec
[PANICKED] Test Panicked
In [AfterEach] at: runtime/panic.go:261 @ 08/28/24 15:34:46.023

runtime error: invalid memory address or nil pointer dereference

Full Stack Trace
  k8s.io/kubernetes/test/e2e/storage.tearDownTestCase({0x7f2584339070, 0xc00457e7e0}, {0x54095a8, 0xc000c58700}, 0xc00064a330?, {0xc003145260, 0x1a}, 0xc0022d0f48?, 0x0, 0x0, ...)
  	k8s.io/kubernetes/test/e2e/storage/nfs_persistent_volume-disruptive.go:331 +0x57
  k8s.io/kubernetes/test/e2e/storage.init.func10.2.3({0x7f2584339070, 0xc00457e7e0})
  	k8s.io/kubernetes/test/e2e/storage/generic_persistent_volume-disruptive.go:92 +0xdb
< Exit [AfterEach] When kubelet restarts - k8s.io/kubernetes/test/e2e/storage/generic_persistent_volume-disruptive.go:90 @ 08/28/24 15:34:46.023 (0s)
> Enter [DeferCleanup (Each)] [sig-storage] GenericPersistentVolume [Disruptive] - k8s.io/kubernetes/test/e2e/framework/metrics/init/init.go:35 @ 08/28/24 15:34:46.023
< Exit [DeferCleanup (Each)] [sig-storage] GenericPersistentVolume [Disruptive] - k8s.io/kubernetes/test/e2e/framework/metrics/init/init.go:35 @ 08/28/24 15:34:46.023 (0s)
> Enter [DeferCleanup (Each)] [sig-storage] GenericPersistentVolume [Disruptive] - k8s.io/kubernetes/test/e2e/framework/node/init/init.go:34 @ 08/28/24 15:34:46.023
I0828 15:34:46.023178 15422 helper.go:122] Waiting up to 7m0s for all (but 0) nodes to be ready
< Exit [DeferCleanup (Each)] [sig-storage] GenericPersistentVolume [Disruptive] - k8s.io/kubernetes/test/e2e/framework/node/init/init.go:34 @ 08/28/24 15:34:46.028 (6ms)
> Enter [DeferCleanup (Each)] [sig-storage] GenericPersistentVolume [Disruptive] - dump namespaces | framework.go:218 @ 08/28/24 15:34:46.028
STEP: dump namespace information after failure - k8s.io/kubernetes/test/e2e/framework/framework.go:297 @ 08/28/24 15:34:46.028
STEP: Collecting events from namespace "generic-disruptive-pv-2492". - k8s.io/kubernetes/test/e2e/framework/debug/dump.go:42 @ 08/28/24 15:34:46.028
STEP: Found 1 events. - k8s.io/kubernetes/test/e2e/framework/debug/dump.go:46 @ 08/28/24 15:34:46.039
I0828 15:34:46.039738 15422 dump.go:53] At 2024-08-28 15:29:45 +0000 UTC - event for pvc-9w7hs: {persistentvolume-controller } WaitForFirstConsumer: waiting for first consumer to be created before binding
```

Looks like there's an event that says `waiting for first consumer to be created before binding` so should we be creating the pod *before* we wait for pvc to be bound in `WaitForPVClaimBoundPhase`?

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/kind failing-test

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
