### PR TITLE
KEP-1967: promote size backed memory volumes to stable

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -592,7 +592,9 @@ const (
 	// owner: @derekwaynecarr
 	//
 	// Enables kubelet support to size memory backed volumes
-	SizeMemoryBackedVolumes featuregate.Feature = "SizeMemoryBackedVolumes" // remove in 1.35
+	// This is a kubelet only feature gate.
+	// Code can be removed in 1.35 without any consideration for emulated versions.
+	SizeMemoryBackedVolumes featuregate.Feature = "SizeMemoryBackedVolumes"
 
 	// owner: @mattcary
 	//

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -592,7 +592,7 @@ const (
 	// owner: @derekwaynecarr
 	//
 	// Enables kubelet support to size memory backed volumes
-	SizeMemoryBackedVolumes featuregate.Feature = "SizeMemoryBackedVolumes"
+	SizeMemoryBackedVolumes featuregate.Feature = "SizeMemoryBackedVolumes" // remove in 1.35
 
 	// owner: @mattcary
 	//

--- a/pkg/features/versioned_kube_features.go
+++ b/pkg/features/versioned_kube_features.go
@@ -667,6 +667,7 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 	SizeMemoryBackedVolumes: {
 		{Version: version.MustParse("1.20"), Default: false, PreRelease: featuregate.Alpha},
 		{Version: version.MustParse("1.22"), Default: true, PreRelease: featuregate.Beta},
+		{Version: version.MustParse("1.32"), Default: true, LockToDefault: true, PreRelease: featuregate.GA},
 	},
 
 	StatefulSetAutoDeletePVC: {

--- a/pkg/volume/emptydir/empty_dir_test.go
+++ b/pkg/volume/emptydir/empty_dir_test.go
@@ -21,20 +21,18 @@ package emptydir
 
 import (
 	"fmt"
-	"k8s.io/kubernetes/pkg/kubelet/util/swap"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"k8s.io/kubernetes/pkg/kubelet/util/swap"
+
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	utiltesting "k8s.io/client-go/util/testing"
-	featuregatetesting "k8s.io/component-base/featuregate/testing"
-	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/volume"
 	volumetest "k8s.io/kubernetes/pkg/volume/testing"
 	volumeutil "k8s.io/kubernetes/pkg/volume/util"
@@ -963,27 +961,7 @@ func TestCalculateEmptyDirMemorySize(t *testing.T) {
 		nodeAllocatableMemory resource.Quantity
 		emptyDirSizeLimit     resource.Quantity
 		expectedResult        resource.Quantity
-		featureGateEnabled    bool
 	}{
-		"SizeMemoryBackedVolumesDisabled": {
-			pod: &v1.Pod{
-				Spec: v1.PodSpec{
-					Containers: []v1.Container{
-						{
-							Resources: v1.ResourceRequirements{
-								Requests: v1.ResourceList{
-									v1.ResourceName("memory"): resource.MustParse("10Gi"),
-								},
-							},
-						},
-					},
-				},
-			},
-			nodeAllocatableMemory: resource.MustParse("16Gi"),
-			emptyDirSizeLimit:     resource.MustParse("1Gi"),
-			expectedResult:        resource.MustParse("0"),
-			featureGateEnabled:    false,
-		},
 		"EmptyDirLocalLimit": {
 			pod: &v1.Pod{
 				Spec: v1.PodSpec{
@@ -1001,7 +979,6 @@ func TestCalculateEmptyDirMemorySize(t *testing.T) {
 			nodeAllocatableMemory: resource.MustParse("16Gi"),
 			emptyDirSizeLimit:     resource.MustParse("1Gi"),
 			expectedResult:        resource.MustParse("1Gi"),
-			featureGateEnabled:    true,
 		},
 		"PodLocalLimit": {
 			pod: &v1.Pod{
@@ -1020,7 +997,6 @@ func TestCalculateEmptyDirMemorySize(t *testing.T) {
 			nodeAllocatableMemory: resource.MustParse("16Gi"),
 			emptyDirSizeLimit:     resource.MustParse("0"),
 			expectedResult:        resource.MustParse("10Gi"),
-			featureGateEnabled:    true,
 		},
 		"NodeAllocatableLimit": {
 			pod: &v1.Pod{
@@ -1039,13 +1015,11 @@ func TestCalculateEmptyDirMemorySize(t *testing.T) {
 			nodeAllocatableMemory: resource.MustParse("16Gi"),
 			emptyDirSizeLimit:     resource.MustParse("0"),
 			expectedResult:        resource.MustParse("16Gi"),
-			featureGateEnabled:    true,
 		},
 	}
 
 	for testCaseName, testCase := range testCases {
 		t.Run(testCaseName, func(t *testing.T) {
-			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.SizeMemoryBackedVolumes, testCase.featureGateEnabled)
 			spec := &volume.Spec{
 				Volume: &v1.Volume{
 					VolumeSource: v1.VolumeSource{

--- a/test/featuregates_linter/test_data/versioned_feature_list.yaml
+++ b/test/featuregates_linter/test_data/versioned_feature_list.yaml
@@ -1092,6 +1092,10 @@
     lockToDefault: false
     preRelease: Beta
     version: "1.22"
+  - default: true
+    lockToDefault: true
+    preRelease: GA
+    version: "1.32"
 - name: StatefulSetAutoDeletePVC
   versionedSpecs:
   - default: false


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Promote KEP-1967 to stable.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Promote SizeMemoryBackedVolumes to stable
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
