### PR TITLE
Update publishing-bot rules to Go 1.22.6

### DIFF
--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -6,12 +6,6 @@ rules:
       branch: master
       dirs:
       - staging/src/k8s.io/apimachinery
-  - name: release-1.27
-    go: 1.22.6
-    source:
-      branch: release-1.27
-      dirs:
-      - staging/src/k8s.io/apimachinery
   - name: release-1.28
     go: 1.22.6
     source:
@@ -45,15 +39,6 @@ rules:
       branch: master
     source:
       branch: master
-      dirs:
-      - staging/src/k8s.io/api
-  - name: release-1.27
-    go: 1.22.6
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.27
-    source:
-      branch: release-1.27
       dirs:
       - staging/src/k8s.io/api
   - name: release-1.28
@@ -103,21 +88,6 @@ rules:
       branch: master
     source:
       branch: master
-      dirs:
-      - staging/src/k8s.io/client-go
-    smoke-test: |
-      # assumes GO111MODULE=on
-      go build -mod=mod ./...
-      go test -mod=mod ./...
-  - name: release-1.27
-    go: 1.22.6
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.27
-    - repository: api
-      branch: release-1.27
-    source:
-      branch: release-1.27
       dirs:
       - staging/src/k8s.io/client-go
     smoke-test: |
@@ -195,12 +165,6 @@ rules:
       branch: master
       dirs:
       - staging/src/k8s.io/code-generator
-  - name: release-1.27
-    go: 1.22.6
-    source:
-      branch: release-1.27
-      dirs:
-      - staging/src/k8s.io/code-generator
   - name: release-1.28
     go: 1.22.6
     source:
@@ -243,19 +207,6 @@ rules:
       branch: master
     source:
       branch: master
-      dirs:
-      - staging/src/k8s.io/component-base
-  - name: release-1.27
-    go: 1.22.6
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.27
-    - repository: api
-      branch: release-1.27
-    - repository: client-go
-      branch: release-1.27
-    source:
-      branch: release-1.27
       dirs:
       - staging/src/k8s.io/component-base
   - name: release-1.28
@@ -325,19 +276,6 @@ rules:
       branch: master
       dirs:
       - staging/src/k8s.io/component-helpers
-  - name: release-1.27
-    go: 1.22.6
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.27
-    - repository: api
-      branch: release-1.27
-    - repository: client-go
-      branch: release-1.27
-    source:
-      branch: release-1.27
-      dirs:
-      - staging/src/k8s.io/component-helpers
   - name: release-1.28
     go: 1.22.6
     dependencies:
@@ -401,19 +339,6 @@ rules:
       branch: master
       dirs:
       - staging/src/k8s.io/kms
-  - name: release-1.27
-    go: 1.22.6
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.27
-    - repository: api
-      branch: release-1.27
-    - repository: client-go
-      branch: release-1.27
-    source:
-      branch: release-1.27
-      dirs:
-      - staging/src/k8s.io/kms
   - name: release-1.28
     go: 1.22.6
     dependencies:
@@ -471,23 +396,6 @@ rules:
       branch: master
     source:
       branch: master
-      dirs:
-      - staging/src/k8s.io/apiserver
-  - name: release-1.27
-    go: 1.22.6
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.27
-    - repository: api
-      branch: release-1.27
-    - repository: client-go
-      branch: release-1.27
-    - repository: component-base
-      branch: release-1.27
-    - repository: kms
-      branch: release-1.27
-    source:
-      branch: release-1.27
       dirs:
       - staging/src/k8s.io/apiserver
   - name: release-1.28
@@ -579,27 +487,6 @@ rules:
       branch: master
     source:
       branch: master
-      dirs:
-      - staging/src/k8s.io/kube-aggregator
-  - name: release-1.27
-    go: 1.22.6
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.27
-    - repository: api
-      branch: release-1.27
-    - repository: client-go
-      branch: release-1.27
-    - repository: apiserver
-      branch: release-1.27
-    - repository: component-base
-      branch: release-1.27
-    - repository: kms
-      branch: release-1.27
-    - repository: code-generator
-      branch: release-1.27
-    source:
-      branch: release-1.27
       dirs:
       - staging/src/k8s.io/kube-aggregator
   - name: release-1.28
@@ -706,32 +593,6 @@ rules:
       branch: master
     source:
       branch: master
-      dirs:
-      - staging/src/k8s.io/sample-apiserver
-    required-packages:
-    - k8s.io/code-generator
-    smoke-test: |
-      # assumes GO111MODULE=on
-      go build -mod=mod .
-  - name: release-1.27
-    go: 1.22.6
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.27
-    - repository: api
-      branch: release-1.27
-    - repository: client-go
-      branch: release-1.27
-    - repository: apiserver
-      branch: release-1.27
-    - repository: code-generator
-      branch: release-1.27
-    - repository: kms
-      branch: release-1.27
-    - repository: component-base
-      branch: release-1.27
-    source:
-      branch: release-1.27
       dirs:
       - staging/src/k8s.io/sample-apiserver
     required-packages:
@@ -864,26 +725,6 @@ rules:
     smoke-test: |
       # assumes GO111MODULE=on
       go build -mod=mod .
-  - name: release-1.27
-    go: 1.22.6
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.27
-    - repository: api
-      branch: release-1.27
-    - repository: client-go
-      branch: release-1.27
-    - repository: code-generator
-      branch: release-1.27
-    source:
-      branch: release-1.27
-      dirs:
-      - staging/src/k8s.io/sample-controller
-    required-packages:
-    - k8s.io/code-generator
-    smoke-test: |
-      # assumes GO111MODULE=on
-      go build -mod=mod .
   - name: release-1.28
     go: 1.22.6
     dependencies:
@@ -984,29 +825,6 @@ rules:
       branch: master
     source:
       branch: master
-      dirs:
-      - staging/src/k8s.io/apiextensions-apiserver
-    required-packages:
-    - k8s.io/code-generator
-  - name: release-1.27
-    go: 1.22.6
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.27
-    - repository: api
-      branch: release-1.27
-    - repository: client-go
-      branch: release-1.27
-    - repository: apiserver
-      branch: release-1.27
-    - repository: code-generator
-      branch: release-1.27
-    - repository: component-base
-      branch: release-1.27
-    - repository: kms
-      branch: release-1.27
-    source:
-      branch: release-1.27
       dirs:
       - staging/src/k8s.io/apiextensions-apiserver
     required-packages:
@@ -1119,21 +937,6 @@ rules:
       branch: master
       dirs:
       - staging/src/k8s.io/metrics
-  - name: release-1.27
-    go: 1.22.6
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.27
-    - repository: api
-      branch: release-1.27
-    - repository: client-go
-      branch: release-1.27
-    - repository: code-generator
-      branch: release-1.27
-    source:
-      branch: release-1.27
-      dirs:
-      - staging/src/k8s.io/metrics
   - name: release-1.28
     go: 1.22.6
     dependencies:
@@ -1209,19 +1012,6 @@ rules:
       branch: master
       dirs:
       - staging/src/k8s.io/cli-runtime
-  - name: release-1.27
-    go: 1.22.6
-    dependencies:
-    - repository: api
-      branch: release-1.27
-    - repository: apimachinery
-      branch: release-1.27
-    - repository: client-go
-      branch: release-1.27
-    source:
-      branch: release-1.27
-      dirs:
-      - staging/src/k8s.io/cli-runtime
   - name: release-1.28
     go: 1.22.6
     dependencies:
@@ -1289,21 +1079,6 @@ rules:
       branch: master
     source:
       branch: master
-      dirs:
-      - staging/src/k8s.io/sample-cli-plugin
-  - name: release-1.27
-    go: 1.22.6
-    dependencies:
-    - repository: api
-      branch: release-1.27
-    - repository: apimachinery
-      branch: release-1.27
-    - repository: cli-runtime
-      branch: release-1.27
-    - repository: client-go
-      branch: release-1.27
-    source:
-      branch: release-1.27
       dirs:
       - staging/src/k8s.io/sample-cli-plugin
   - name: release-1.28
@@ -1382,21 +1157,6 @@ rules:
       branch: master
       dirs:
       - staging/src/k8s.io/kube-proxy
-  - name: release-1.27
-    go: 1.22.6
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.27
-    - repository: component-base
-      branch: release-1.27
-    - repository: api
-      branch: release-1.27
-    - repository: client-go
-      branch: release-1.27
-    source:
-      branch: release-1.27
-      dirs:
-      - staging/src/k8s.io/kube-proxy
   - name: release-1.28
     go: 1.22.6
     dependencies:
@@ -1463,12 +1223,6 @@ rules:
   - name: master
     source:
       branch: master
-      dirs:
-      - staging/src/k8s.io/cri-api
-  - name: release-1.27
-    go: 1.22.6
-    source:
-      branch: release-1.27
       dirs:
       - staging/src/k8s.io/cri-api
   - name: release-1.28
@@ -1552,21 +1306,6 @@ rules:
       branch: master
     source:
       branch: master
-      dirs:
-      - staging/src/k8s.io/kubelet
-  - name: release-1.27
-    go: 1.22.6
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.27
-    - repository: api
-      branch: release-1.27
-    - repository: client-go
-      branch: release-1.27
-    - repository: component-base
-      branch: release-1.27
-    source:
-      branch: release-1.27
       dirs:
       - staging/src/k8s.io/kubelet
   - name: release-1.28
@@ -1670,21 +1409,6 @@ rules:
       branch: master
       dirs:
       - staging/src/k8s.io/kube-scheduler
-  - name: release-1.27
-    go: 1.22.6
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.27
-    - repository: component-base
-      branch: release-1.27
-    - repository: api
-      branch: release-1.27
-    - repository: client-go
-      branch: release-1.27
-    source:
-      branch: release-1.27
-      dirs:
-      - staging/src/k8s.io/kube-scheduler
   - name: release-1.28
     go: 1.22.6
     dependencies:
@@ -1764,25 +1488,6 @@ rules:
       branch: master
     source:
       branch: master
-      dirs:
-      - staging/src/k8s.io/controller-manager
-  - name: release-1.27
-    go: 1.22.6
-    dependencies:
-    - repository: api
-      branch: release-1.27
-    - repository: apimachinery
-      branch: release-1.27
-    - repository: client-go
-      branch: release-1.27
-    - repository: component-base
-      branch: release-1.27
-    - repository: apiserver
-      branch: release-1.27
-    - repository: kms
-      branch: release-1.27
-    source:
-      branch: release-1.27
       dirs:
       - staging/src/k8s.io/controller-manager
   - name: release-1.28
@@ -1884,29 +1589,6 @@ rules:
       branch: master
     source:
       branch: master
-      dirs:
-      - staging/src/k8s.io/cloud-provider
-  - name: release-1.27
-    go: 1.22.6
-    dependencies:
-    - repository: api
-      branch: release-1.27
-    - repository: apimachinery
-      branch: release-1.27
-    - repository: apiserver
-      branch: release-1.27
-    - repository: client-go
-      branch: release-1.27
-    - repository: component-base
-      branch: release-1.27
-    - repository: controller-manager
-      branch: release-1.27
-    - repository: component-helpers
-      branch: release-1.27
-    - repository: kms
-      branch: release-1.27
-    source:
-      branch: release-1.27
       dirs:
       - staging/src/k8s.io/cloud-provider
   - name: release-1.28
@@ -2028,31 +1710,6 @@ rules:
       branch: master
       dirs:
       - staging/src/k8s.io/kube-controller-manager
-  - name: release-1.27
-    go: 1.22.6
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.27
-    - repository: apiserver
-      branch: release-1.27
-    - repository: component-base
-      branch: release-1.27
-    - repository: api
-      branch: release-1.27
-    - repository: client-go
-      branch: release-1.27
-    - repository: controller-manager
-      branch: release-1.27
-    - repository: cloud-provider
-      branch: release-1.27
-    - repository: component-helpers
-      branch: release-1.27
-    - repository: kms
-      branch: release-1.27
-    source:
-      branch: release-1.27
-      dirs:
-      - staging/src/k8s.io/kube-controller-manager
   - name: release-1.28
     go: 1.22.6
     dependencies:
@@ -2166,17 +1823,6 @@ rules:
       branch: master
       dirs:
       - staging/src/k8s.io/cluster-bootstrap
-  - name: release-1.27
-    go: 1.22.6
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.27
-    - repository: api
-      branch: release-1.27
-    source:
-      branch: release-1.27
-      dirs:
-      - staging/src/k8s.io/cluster-bootstrap
   - name: release-1.28
     go: 1.22.6
     dependencies:
@@ -2234,17 +1880,6 @@ rules:
       branch: master
       dirs:
       - staging/src/k8s.io/csi-translation-lib
-  - name: release-1.27
-    go: 1.22.6
-    dependencies:
-    - repository: api
-      branch: release-1.27
-    - repository: apimachinery
-      branch: release-1.27
-    source:
-      branch: release-1.27
-      dirs:
-      - staging/src/k8s.io/csi-translation-lib
   - name: release-1.28
     go: 1.22.6
     dependencies:
@@ -2297,12 +1932,6 @@ rules:
       branch: master
       dirs:
       - staging/src/k8s.io/mount-utils
-  - name: release-1.27
-    go: 1.22.6
-    source:
-      branch: release-1.27
-      dirs:
-      - staging/src/k8s.io/mount-utils
   - name: release-1.28
     go: 1.22.6
     source:
@@ -2330,31 +1959,6 @@ rules:
   library: true
 - destination: legacy-cloud-providers
   branches:
-  - name: release-1.27
-    go: 1.22.6
-    dependencies:
-    - repository: api
-      branch: release-1.27
-    - repository: apimachinery
-      branch: release-1.27
-    - repository: client-go
-      branch: release-1.27
-    - repository: cloud-provider
-      branch: release-1.27
-    - repository: apiserver
-      branch: release-1.27
-    - repository: component-base
-      branch: release-1.27
-    - repository: controller-manager
-      branch: release-1.27
-    - repository: component-helpers
-      branch: release-1.27
-    - repository: kms
-      branch: release-1.27
-    source:
-      branch: release-1.27
-      dirs:
-      - staging/src/k8s.io/legacy-cloud-providers
   - name: release-1.28
     go: 1.22.6
     dependencies:
@@ -2453,29 +2057,6 @@ rules:
       branch: master
     source:
       branch: master
-      dirs:
-      - staging/src/k8s.io/kubectl
-  - name: release-1.27
-    go: 1.22.6
-    dependencies:
-    - repository: api
-      branch: release-1.27
-    - repository: apimachinery
-      branch: release-1.27
-    - repository: cli-runtime
-      branch: release-1.27
-    - repository: client-go
-      branch: release-1.27
-    - repository: code-generator
-      branch: release-1.27
-    - repository: component-base
-      branch: release-1.27
-    - repository: component-helpers
-      branch: release-1.27
-    - repository: metrics
-      branch: release-1.27
-    source:
-      branch: release-1.27
       dirs:
       - staging/src/k8s.io/kubectl
   - name: release-1.28
@@ -2591,25 +2172,6 @@ rules:
       branch: master
       dirs:
       - staging/src/k8s.io/pod-security-admission
-  - name: release-1.27
-    go: 1.22.6
-    dependencies:
-    - repository: api
-      branch: release-1.27
-    - repository: apimachinery
-      branch: release-1.27
-    - repository: apiserver
-      branch: release-1.27
-    - repository: client-go
-      branch: release-1.27
-    - repository: component-base
-      branch: release-1.27
-    - repository: kms
-      branch: release-1.27
-    source:
-      branch: release-1.27
-      dirs:
-      - staging/src/k8s.io/pod-security-admission
   - name: release-1.28
     go: 1.22.6
     dependencies:
@@ -2711,23 +2273,6 @@ rules:
       branch: master
     source:
       branch: master
-      dirs:
-      - staging/src/k8s.io/dynamic-resource-allocation
-  - name: release-1.27
-    go: 1.22.6
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.27
-    - repository: api
-      branch: release-1.27
-    - repository: client-go
-      branch: release-1.27
-    - repository: component-base
-      branch: release-1.27
-    - repository: kubelet
-      branch: release-1.27
-    source:
-      branch: release-1.27
       dirs:
       - staging/src/k8s.io/dynamic-resource-allocation
   - name: release-1.28

--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -7,31 +7,31 @@ rules:
       dirs:
       - staging/src/k8s.io/apimachinery
   - name: release-1.27
-    go: 1.22.5
+    go: 1.22.6
     source:
       branch: release-1.27
       dirs:
       - staging/src/k8s.io/apimachinery
   - name: release-1.28
-    go: 1.22.5
+    go: 1.22.6
     source:
       branch: release-1.28
       dirs:
       - staging/src/k8s.io/apimachinery
   - name: release-1.29
-    go: 1.22.5
+    go: 1.22.6
     source:
       branch: release-1.29
       dirs:
       - staging/src/k8s.io/apimachinery
   - name: release-1.30
-    go: 1.22.5
+    go: 1.22.6
     source:
       branch: release-1.30
       dirs:
       - staging/src/k8s.io/apimachinery
   - name: release-1.31
-    go: 1.22.5
+    go: 1.22.6
     source:
       branch: release-1.31
       dirs:
@@ -48,7 +48,7 @@ rules:
       dirs:
       - staging/src/k8s.io/api
   - name: release-1.27
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -57,7 +57,7 @@ rules:
       dirs:
       - staging/src/k8s.io/api
   - name: release-1.28
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -66,7 +66,7 @@ rules:
       dirs:
       - staging/src/k8s.io/api
   - name: release-1.29
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -75,7 +75,7 @@ rules:
       dirs:
       - staging/src/k8s.io/api
   - name: release-1.30
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -84,7 +84,7 @@ rules:
       dirs:
       - staging/src/k8s.io/api
   - name: release-1.31
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: apimachinery
       branch: release-1.31
@@ -110,7 +110,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.27
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -125,7 +125,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.28
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -140,7 +140,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.29
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -155,7 +155,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.30
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -170,7 +170,7 @@ rules:
       go build -mod=mod ./...
       go test -mod=mod ./...
   - name: release-1.31
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: apimachinery
       branch: release-1.31
@@ -196,25 +196,25 @@ rules:
       dirs:
       - staging/src/k8s.io/code-generator
   - name: release-1.27
-    go: 1.22.5
+    go: 1.22.6
     source:
       branch: release-1.27
       dirs:
       - staging/src/k8s.io/code-generator
   - name: release-1.28
-    go: 1.22.5
+    go: 1.22.6
     source:
       branch: release-1.28
       dirs:
       - staging/src/k8s.io/code-generator
   - name: release-1.29
-    go: 1.22.5
+    go: 1.22.6
     source:
       branch: release-1.29
       dirs:
       - staging/src/k8s.io/code-generator
   - name: release-1.30
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -223,7 +223,7 @@ rules:
       dirs:
       - staging/src/k8s.io/code-generator
   - name: release-1.31
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: apimachinery
       branch: release-1.31
@@ -246,7 +246,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-base
   - name: release-1.27
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -259,7 +259,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-base
   - name: release-1.28
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -272,7 +272,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-base
   - name: release-1.29
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -285,7 +285,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-base
   - name: release-1.30
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -298,7 +298,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-base
   - name: release-1.31
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: apimachinery
       branch: release-1.31
@@ -326,7 +326,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-helpers
   - name: release-1.27
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -339,7 +339,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-helpers
   - name: release-1.28
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -352,7 +352,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-helpers
   - name: release-1.29
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -365,7 +365,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-helpers
   - name: release-1.30
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -378,7 +378,7 @@ rules:
       dirs:
       - staging/src/k8s.io/component-helpers
   - name: release-1.31
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: apimachinery
       branch: release-1.31
@@ -402,7 +402,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kms
   - name: release-1.27
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -415,7 +415,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kms
   - name: release-1.28
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -428,7 +428,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kms
   - name: release-1.29
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -437,7 +437,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kms
   - name: release-1.30
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -446,7 +446,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kms
   - name: release-1.31
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: apimachinery
       branch: release-1.31
@@ -474,7 +474,7 @@ rules:
       dirs:
       - staging/src/k8s.io/apiserver
   - name: release-1.27
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -491,7 +491,7 @@ rules:
       dirs:
       - staging/src/k8s.io/apiserver
   - name: release-1.28
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -508,7 +508,7 @@ rules:
       dirs:
       - staging/src/k8s.io/apiserver
   - name: release-1.29
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -525,7 +525,7 @@ rules:
       dirs:
       - staging/src/k8s.io/apiserver
   - name: release-1.30
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -542,7 +542,7 @@ rules:
       dirs:
       - staging/src/k8s.io/apiserver
   - name: release-1.31
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: apimachinery
       branch: release-1.31
@@ -582,7 +582,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-aggregator
   - name: release-1.27
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -603,7 +603,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-aggregator
   - name: release-1.28
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -624,7 +624,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-aggregator
   - name: release-1.29
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -645,7 +645,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-aggregator
   - name: release-1.30
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -666,7 +666,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-aggregator
   - name: release-1.31
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: apimachinery
       branch: release-1.31
@@ -714,7 +714,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.27
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -740,7 +740,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.28
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -766,7 +766,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.29
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -792,7 +792,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.30
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -818,7 +818,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.31
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: apimachinery
       branch: release-1.31
@@ -865,7 +865,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.27
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -885,7 +885,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.28
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -905,7 +905,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.29
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -925,7 +925,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.30
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -945,7 +945,7 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod .
   - name: release-1.31
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: apimachinery
       branch: release-1.31
@@ -989,7 +989,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.27
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -1012,7 +1012,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.28
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -1035,7 +1035,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.29
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -1058,7 +1058,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.30
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -1081,7 +1081,7 @@ rules:
     required-packages:
     - k8s.io/code-generator
   - name: release-1.31
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: apimachinery
       branch: release-1.31
@@ -1120,7 +1120,7 @@ rules:
       dirs:
       - staging/src/k8s.io/metrics
   - name: release-1.27
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -1135,7 +1135,7 @@ rules:
       dirs:
       - staging/src/k8s.io/metrics
   - name: release-1.28
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -1150,7 +1150,7 @@ rules:
       dirs:
       - staging/src/k8s.io/metrics
   - name: release-1.29
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -1165,7 +1165,7 @@ rules:
       dirs:
       - staging/src/k8s.io/metrics
   - name: release-1.30
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -1180,7 +1180,7 @@ rules:
       dirs:
       - staging/src/k8s.io/metrics
   - name: release-1.31
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: apimachinery
       branch: release-1.31
@@ -1210,7 +1210,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cli-runtime
   - name: release-1.27
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: api
       branch: release-1.27
@@ -1223,7 +1223,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cli-runtime
   - name: release-1.28
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: api
       branch: release-1.28
@@ -1236,7 +1236,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cli-runtime
   - name: release-1.29
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: api
       branch: release-1.29
@@ -1249,7 +1249,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cli-runtime
   - name: release-1.30
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: api
       branch: release-1.30
@@ -1262,7 +1262,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cli-runtime
   - name: release-1.31
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: api
       branch: release-1.31
@@ -1292,7 +1292,7 @@ rules:
       dirs:
       - staging/src/k8s.io/sample-cli-plugin
   - name: release-1.27
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: api
       branch: release-1.27
@@ -1307,7 +1307,7 @@ rules:
       dirs:
       - staging/src/k8s.io/sample-cli-plugin
   - name: release-1.28
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: api
       branch: release-1.28
@@ -1322,7 +1322,7 @@ rules:
       dirs:
       - staging/src/k8s.io/sample-cli-plugin
   - name: release-1.29
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: api
       branch: release-1.29
@@ -1337,7 +1337,7 @@ rules:
       dirs:
       - staging/src/k8s.io/sample-cli-plugin
   - name: release-1.30
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: api
       branch: release-1.30
@@ -1352,7 +1352,7 @@ rules:
       dirs:
       - staging/src/k8s.io/sample-cli-plugin
   - name: release-1.31
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: api
       branch: release-1.31
@@ -1383,7 +1383,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-proxy
   - name: release-1.27
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -1398,7 +1398,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-proxy
   - name: release-1.28
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -1413,7 +1413,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-proxy
   - name: release-1.29
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -1428,7 +1428,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-proxy
   - name: release-1.30
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -1443,7 +1443,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-proxy
   - name: release-1.31
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: apimachinery
       branch: release-1.31
@@ -1466,31 +1466,31 @@ rules:
       dirs:
       - staging/src/k8s.io/cri-api
   - name: release-1.27
-    go: 1.22.5
+    go: 1.22.6
     source:
       branch: release-1.27
       dirs:
       - staging/src/k8s.io/cri-api
   - name: release-1.28
-    go: 1.22.5
+    go: 1.22.6
     source:
       branch: release-1.28
       dirs:
       - staging/src/k8s.io/cri-api
   - name: release-1.29
-    go: 1.22.5
+    go: 1.22.6
     source:
       branch: release-1.29
       dirs:
       - staging/src/k8s.io/cri-api
   - name: release-1.30
-    go: 1.22.5
+    go: 1.22.6
     source:
       branch: release-1.30
       dirs:
       - staging/src/k8s.io/cri-api
   - name: release-1.31
-    go: 1.22.5
+    go: 1.22.6
     source:
       branch: release-1.31
       dirs:
@@ -1515,7 +1515,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cri-client
   - name: release-1.31
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: api
       branch: release-1.31
@@ -1555,7 +1555,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubelet
   - name: release-1.27
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -1570,7 +1570,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubelet
   - name: release-1.28
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -1591,7 +1591,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubelet
   - name: release-1.29
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -1612,7 +1612,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubelet
   - name: release-1.30
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -1633,7 +1633,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubelet
   - name: release-1.31
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: apimachinery
       branch: release-1.31
@@ -1671,7 +1671,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-scheduler
   - name: release-1.27
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -1686,7 +1686,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-scheduler
   - name: release-1.28
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -1701,7 +1701,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-scheduler
   - name: release-1.29
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -1716,7 +1716,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-scheduler
   - name: release-1.30
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -1731,7 +1731,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-scheduler
   - name: release-1.31
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: apimachinery
       branch: release-1.31
@@ -1767,7 +1767,7 @@ rules:
       dirs:
       - staging/src/k8s.io/controller-manager
   - name: release-1.27
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: api
       branch: release-1.27
@@ -1786,7 +1786,7 @@ rules:
       dirs:
       - staging/src/k8s.io/controller-manager
   - name: release-1.28
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: api
       branch: release-1.28
@@ -1805,7 +1805,7 @@ rules:
       dirs:
       - staging/src/k8s.io/controller-manager
   - name: release-1.29
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: api
       branch: release-1.29
@@ -1824,7 +1824,7 @@ rules:
       dirs:
       - staging/src/k8s.io/controller-manager
   - name: release-1.30
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: api
       branch: release-1.30
@@ -1843,7 +1843,7 @@ rules:
       dirs:
       - staging/src/k8s.io/controller-manager
   - name: release-1.31
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: api
       branch: release-1.31
@@ -1887,7 +1887,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cloud-provider
   - name: release-1.27
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: api
       branch: release-1.27
@@ -1910,7 +1910,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cloud-provider
   - name: release-1.28
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: api
       branch: release-1.28
@@ -1933,7 +1933,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cloud-provider
   - name: release-1.29
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: api
       branch: release-1.29
@@ -1956,7 +1956,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cloud-provider
   - name: release-1.30
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: api
       branch: release-1.30
@@ -1979,7 +1979,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cloud-provider
   - name: release-1.31
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: api
       branch: release-1.31
@@ -2029,7 +2029,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-controller-manager
   - name: release-1.27
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -2054,7 +2054,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-controller-manager
   - name: release-1.28
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -2079,7 +2079,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-controller-manager
   - name: release-1.29
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -2104,7 +2104,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-controller-manager
   - name: release-1.30
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -2129,7 +2129,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kube-controller-manager
   - name: release-1.31
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: apimachinery
       branch: release-1.31
@@ -2167,7 +2167,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cluster-bootstrap
   - name: release-1.27
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -2178,7 +2178,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cluster-bootstrap
   - name: release-1.28
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -2189,7 +2189,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cluster-bootstrap
   - name: release-1.29
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -2200,7 +2200,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cluster-bootstrap
   - name: release-1.30
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -2211,7 +2211,7 @@ rules:
       dirs:
       - staging/src/k8s.io/cluster-bootstrap
   - name: release-1.31
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: apimachinery
       branch: release-1.31
@@ -2235,7 +2235,7 @@ rules:
       dirs:
       - staging/src/k8s.io/csi-translation-lib
   - name: release-1.27
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: api
       branch: release-1.27
@@ -2246,7 +2246,7 @@ rules:
       dirs:
       - staging/src/k8s.io/csi-translation-lib
   - name: release-1.28
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: api
       branch: release-1.28
@@ -2257,7 +2257,7 @@ rules:
       dirs:
       - staging/src/k8s.io/csi-translation-lib
   - name: release-1.29
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: api
       branch: release-1.29
@@ -2268,7 +2268,7 @@ rules:
       dirs:
       - staging/src/k8s.io/csi-translation-lib
   - name: release-1.30
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: api
       branch: release-1.30
@@ -2279,7 +2279,7 @@ rules:
       dirs:
       - staging/src/k8s.io/csi-translation-lib
   - name: release-1.31
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: api
       branch: release-1.31
@@ -2298,31 +2298,31 @@ rules:
       dirs:
       - staging/src/k8s.io/mount-utils
   - name: release-1.27
-    go: 1.22.5
+    go: 1.22.6
     source:
       branch: release-1.27
       dirs:
       - staging/src/k8s.io/mount-utils
   - name: release-1.28
-    go: 1.22.5
+    go: 1.22.6
     source:
       branch: release-1.28
       dirs:
       - staging/src/k8s.io/mount-utils
   - name: release-1.29
-    go: 1.22.5
+    go: 1.22.6
     source:
       branch: release-1.29
       dirs:
       - staging/src/k8s.io/mount-utils
   - name: release-1.30
-    go: 1.22.5
+    go: 1.22.6
     source:
       branch: release-1.30
       dirs:
       - staging/src/k8s.io/mount-utils
   - name: release-1.31
-    go: 1.22.5
+    go: 1.22.6
     source:
       branch: release-1.31
       dirs:
@@ -2331,7 +2331,7 @@ rules:
 - destination: legacy-cloud-providers
   branches:
   - name: release-1.27
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: api
       branch: release-1.27
@@ -2356,7 +2356,7 @@ rules:
       dirs:
       - staging/src/k8s.io/legacy-cloud-providers
   - name: release-1.28
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: api
       branch: release-1.28
@@ -2381,7 +2381,7 @@ rules:
       dirs:
       - staging/src/k8s.io/legacy-cloud-providers
   - name: release-1.29
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: api
       branch: release-1.29
@@ -2406,7 +2406,7 @@ rules:
       dirs:
       - staging/src/k8s.io/legacy-cloud-providers
   - name: release-1.30
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: api
       branch: release-1.30
@@ -2456,7 +2456,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubectl
   - name: release-1.27
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: api
       branch: release-1.27
@@ -2479,7 +2479,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubectl
   - name: release-1.28
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: api
       branch: release-1.28
@@ -2502,7 +2502,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubectl
   - name: release-1.29
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: api
       branch: release-1.29
@@ -2525,7 +2525,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubectl
   - name: release-1.30
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: api
       branch: release-1.30
@@ -2548,7 +2548,7 @@ rules:
       dirs:
       - staging/src/k8s.io/kubectl
   - name: release-1.31
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: api
       branch: release-1.31
@@ -2592,7 +2592,7 @@ rules:
       dirs:
       - staging/src/k8s.io/pod-security-admission
   - name: release-1.27
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: api
       branch: release-1.27
@@ -2611,7 +2611,7 @@ rules:
       dirs:
       - staging/src/k8s.io/pod-security-admission
   - name: release-1.28
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: api
       branch: release-1.28
@@ -2630,7 +2630,7 @@ rules:
       dirs:
       - staging/src/k8s.io/pod-security-admission
   - name: release-1.29
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: api
       branch: release-1.29
@@ -2649,7 +2649,7 @@ rules:
       dirs:
       - staging/src/k8s.io/pod-security-admission
   - name: release-1.30
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: api
       branch: release-1.30
@@ -2668,7 +2668,7 @@ rules:
       dirs:
       - staging/src/k8s.io/pod-security-admission
   - name: release-1.31
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: api
       branch: release-1.31
@@ -2714,7 +2714,7 @@ rules:
       dirs:
       - staging/src/k8s.io/dynamic-resource-allocation
   - name: release-1.27
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: apimachinery
       branch: release-1.27
@@ -2731,7 +2731,7 @@ rules:
       dirs:
       - staging/src/k8s.io/dynamic-resource-allocation
   - name: release-1.28
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: apimachinery
       branch: release-1.28
@@ -2752,7 +2752,7 @@ rules:
       dirs:
       - staging/src/k8s.io/dynamic-resource-allocation
   - name: release-1.29
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: apimachinery
       branch: release-1.29
@@ -2773,7 +2773,7 @@ rules:
       dirs:
       - staging/src/k8s.io/dynamic-resource-allocation
   - name: release-1.30
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: apimachinery
       branch: release-1.30
@@ -2796,7 +2796,7 @@ rules:
       dirs:
       - staging/src/k8s.io/dynamic-resource-allocation
   - name: release-1.31
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: apimachinery
       branch: release-1.31
@@ -2837,7 +2837,7 @@ rules:
       dirs:
       - staging/src/k8s.io/endpointslice
   - name: release-1.28
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: api
       branch: release-1.28
@@ -2852,7 +2852,7 @@ rules:
       dirs:
       - staging/src/k8s.io/endpointslice
   - name: release-1.29
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: api
       branch: release-1.29
@@ -2867,7 +2867,7 @@ rules:
       dirs:
       - staging/src/k8s.io/endpointslice
   - name: release-1.30
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: api
       branch: release-1.30
@@ -2882,7 +2882,7 @@ rules:
       dirs:
       - staging/src/k8s.io/endpointslice
   - name: release-1.31
-    go: 1.22.5
+    go: 1.22.6
     dependencies:
     - repository: api
       branch: release-1.31


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Update publishing-bot rules to Go 1.22.6

#### Which issue(s) this PR fixes:

xref https://github.com/kubernetes/release/issues/3723

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```

/assign @saschagrunert @xmudrii  @dims 
cc @kubernetes/release-engineering 