### PR TITLE
Add required FieldManager for validatingadmissionpolicy e2e

### DIFF
--- a/test/e2e/apimachinery/validatingadmissionpolicy.go
+++ b/test/e2e/apimachinery/validatingadmissionpolicy.go
@@ -370,7 +370,7 @@ var _ = SIGDescribe("ValidatingAdmissionPolicy [Privileged:ClusterAdmin]", func(
 							"touched": time.Now().String(),
 							"random":  fmt.Sprintf("%d", rand.Int()),
 						})
-						_, err := client.AdmissionregistrationV1().ValidatingAdmissionPolicies().Apply(ctx, applyConfig, metav1.ApplyOptions{})
+						_, err := client.AdmissionregistrationV1().ValidatingAdmissionPolicies().Apply(ctx, applyConfig, metav1.ApplyOptions{FieldManager: "validatingadmissionpolicy-e2e"})
 						return false, err
 					}
 					return true, nil


### PR DESCRIPTION
This line would fail if the code path happened to execute, which may not
happen in upstream, but does trigger occasionally in OpenShift testing.

Error is:

```
{  fail [k8s.io/kubernetes/test/e2e/apimachinery/validatingadmissionpolicy.go:380]: wait for type checking: PatchOptions.meta.k8s.io "" is invalid: fieldManager: Required value: is required for apply patch
Error: exit with code 1
Ginkgo exit error 1: exit with code 1}
```


```release-note
NONE
```
