### PR TITLE
kubectl(top): modify the percentage display of the top command

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/metricsutil/metrics_printer.go
+++ b/staging/src/k8s.io/kubectl/pkg/metricsutil/metrics_printer.go
@@ -32,7 +32,7 @@ var (
 		v1.ResourceCPU,
 		v1.ResourceMemory,
 	}
-	NodeColumns     = []string{"NAME", "CPU(cores)", "CPU%", "MEMORY(bytes)", "MEMORY%"}
+	NodeColumns     = []string{"NAME", "CPU(cores)", "CPU(%)", "MEMORY(bytes)", "MEMORY(%)"}
 	PodColumns      = []string{"NAME", "CPU(cores)", "MEMORY(bytes)"}
 	NamespaceColumn = "NAMESPACE"
 	PodColumn       = "POD"

--- a/staging/src/k8s.io/kubectl/pkg/metricsutil/metrics_printer_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/metricsutil/metrics_printer_test.go
@@ -1,0 +1,396 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metricsutil
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+	metricsapi "k8s.io/metrics/pkg/apis/metrics"
+)
+
+func TestPrintNodeMetrics(t *testing.T) {
+
+	tests := []struct {
+		name           string
+		nodeMetric     []metricsapi.NodeMetrics
+		nodes          []*v1.Node
+		noHeader       bool
+		sortBy         string
+		expectedErr    error
+		expectedOutput string
+	}{
+		{
+			name:  "Single node with default header",
+			nodes: []*v1.Node{newNode("node1")},
+			nodeMetric: []metricsapi.NodeMetrics{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "node1", ResourceVersion: "10", Labels: map[string]string{"key": "value"}},
+					Window:     metav1.Duration{Duration: time.Minute},
+					Usage: v1.ResourceList{
+						v1.ResourceCPU:    resource.MustParse("1"),
+						v1.ResourceMemory: resource.MustParse("1Gi"),
+					},
+				},
+			},
+			expectedOutput: `NAME    CPU(cores)   CPU(%)   MEMORY(bytes)   MEMORY(%)   
+node1   1000m        10%      1024Mi          10%         
+`,
+		},
+		{
+			name:  "Single node without header",
+			nodes: []*v1.Node{newNode("node1")},
+			nodeMetric: []metricsapi.NodeMetrics{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "node1", ResourceVersion: "10", Labels: map[string]string{"key": "value"}},
+					Window:     metav1.Duration{Duration: time.Minute},
+					Usage: v1.ResourceList{
+						v1.ResourceCPU:    resource.MustParse("1"),
+						v1.ResourceMemory: resource.MustParse("1Gi"),
+					},
+				},
+			},
+			noHeader: true,
+			expectedOutput: `node1   1000m   10%   1024Mi   10%   
+`,
+		},
+		{
+			name:  "Multiple nodes with one missing metrics",
+			nodes: []*v1.Node{newNode("node1"), newNode("node2")},
+			nodeMetric: []metricsapi.NodeMetrics{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "node1", ResourceVersion: "10", Labels: map[string]string{"key": "value"}},
+					Window:     metav1.Duration{Duration: time.Minute},
+					Usage: v1.ResourceList{
+						v1.ResourceCPU:    resource.MustParse("1"),
+						v1.ResourceMemory: resource.MustParse("1Gi"),
+					},
+				},
+			},
+			expectedOutput: `NAME    CPU(cores)   CPU(%)      MEMORY(bytes)   MEMORY(%)   
+node1   1000m        10%         1024Mi          10%         
+node2   <unknown>    <unknown>   <unknown>       <unknown>   
+`,
+		},
+		{
+			name:  "Multiple nodes with metrics sorted by memory",
+			nodes: []*v1.Node{newNode("node1"), newNode("node2")},
+			nodeMetric: []metricsapi.NodeMetrics{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "node1", ResourceVersion: "10", Labels: map[string]string{"key": "value"}},
+					Window:     metav1.Duration{Duration: time.Minute},
+					Usage: v1.ResourceList{
+						v1.ResourceCPU:    resource.MustParse("1"),
+						v1.ResourceMemory: resource.MustParse("1Gi"),
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "node2", ResourceVersion: "10", Labels: map[string]string{"key": "value"}},
+					Window:     metav1.Duration{Duration: time.Minute},
+					Usage: v1.ResourceList{
+						v1.ResourceCPU:    resource.MustParse("2"),
+						v1.ResourceMemory: resource.MustParse("5Gi"),
+					},
+				},
+			},
+			sortBy: "memory",
+			expectedOutput: `NAME    CPU(cores)   CPU(%)   MEMORY(bytes)   MEMORY(%)   
+node2   2000m        20%      5120Mi          50%         
+node1   1000m        10%      1024Mi          10%         
+`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// Create a new TopCmdPrinter with a test writer.
+			_, _, out, _ := genericiooptions.NewTestIOStreams()
+
+			availableResources := make(map[string]v1.ResourceList)
+			for _, n := range test.nodes {
+				availableResources[n.Name] = n.Status.Capacity
+			}
+			top := NewTopCmdPrinter(out)
+			err := top.PrintNodeMetrics(test.nodeMetric, availableResources, test.noHeader, test.sortBy)
+			assert.Equal(t, test.expectedErr, err)
+			assert.Equal(t, test.expectedOutput, out.String())
+		})
+	}
+}
+
+func TestPrintPodMetrics(t *testing.T) {
+
+	tests := []struct {
+		name            string
+		podMetric       []metricsapi.PodMetrics
+		printContainers bool
+		withNamespace   bool
+		noHeader        bool
+		sortBy          string
+		sum             bool
+		expectedErr     error
+		expectedOutput  string
+	}{
+		{
+			name: "Single Pod with Multiple Containers",
+			podMetric: []metricsapi.PodMetrics{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test",
+						Namespace: "default",
+					},
+					Timestamp: metav1.Time{Time: time.Now()},
+					Window:    metav1.Duration{Duration: time.Minute},
+					Containers: []metricsapi.ContainerMetrics{
+						{
+							Name: "container1",
+							Usage: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("0.2"),
+								v1.ResourceMemory: resource.MustParse("1Gi"),
+							},
+						},
+						{
+							Name: "container2",
+							Usage: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("0.2"),
+								v1.ResourceMemory: resource.MustParse("1Gi"),
+							},
+						},
+					},
+				},
+			},
+			expectedOutput: `NAME   CPU(cores)   MEMORY(bytes)   
+test   400m         2048Mi          
+`,
+		},
+		{
+			name: "Single Pod with Multiple Containers - Print Containers",
+			podMetric: []metricsapi.PodMetrics{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test",
+						Namespace: "default",
+					},
+					Timestamp: metav1.Time{Time: time.Now()},
+					Window:    metav1.Duration{Duration: time.Minute},
+					Containers: []metricsapi.ContainerMetrics{
+						{
+							Name: "container1",
+							Usage: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("0.2"),
+								v1.ResourceMemory: resource.MustParse("1Gi"),
+							},
+						},
+						{
+							Name: "container2",
+							Usage: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("0.2"),
+								v1.ResourceMemory: resource.MustParse("1Gi"),
+							},
+						},
+					},
+				},
+			},
+			printContainers: true,
+			expectedOutput: `POD    NAME         CPU(cores)   MEMORY(bytes)   
+test   container1   200m         1024Mi          
+test   container2   200m         1024Mi          
+`,
+		},
+		{
+			name: "Single Pod with Multiple Containers - Calculate Resource Usage Without Header",
+			podMetric: []metricsapi.PodMetrics{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test",
+						Namespace: "default",
+					},
+					Timestamp: metav1.Time{Time: time.Now()},
+					Window:    metav1.Duration{Duration: time.Minute},
+					Containers: []metricsapi.ContainerMetrics{
+						{
+							Name: "container1",
+							Usage: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("0.2"),
+								v1.ResourceMemory: resource.MustParse("1Gi"),
+							},
+						},
+						{
+							Name: "container2",
+							Usage: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("0.2"),
+								v1.ResourceMemory: resource.MustParse("1Gi"),
+							},
+						},
+					},
+				},
+			},
+			noHeader: true,
+			expectedOutput: `test   400m   2048Mi   
+`,
+		},
+		{
+			name: "Multiple Pods with Multiple Containers - Sort by Memory Usage",
+			podMetric: []metricsapi.PodMetrics{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test",
+						Namespace: "default",
+					},
+					Timestamp: metav1.Time{Time: time.Now()},
+					Window:    metav1.Duration{Duration: time.Minute},
+					Containers: []metricsapi.ContainerMetrics{
+						{
+							Name: "container1",
+							Usage: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("0.2"),
+								v1.ResourceMemory: resource.MustParse("1Gi"),
+							},
+						},
+						{
+							Name: "container2",
+							Usage: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("0.2"),
+								v1.ResourceMemory: resource.MustParse("1Gi"),
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-1",
+						Namespace: "default",
+					},
+					Timestamp: metav1.Time{Time: time.Now()},
+					Window:    metav1.Duration{Duration: time.Minute},
+					Containers: []metricsapi.ContainerMetrics{
+						{
+							Name: "container1",
+							Usage: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("0.2"),
+								v1.ResourceMemory: resource.MustParse("3Gi"),
+							},
+						},
+						{
+							Name: "container2",
+							Usage: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("0.2"),
+								v1.ResourceMemory: resource.MustParse("2Gi"),
+							},
+						},
+					},
+				},
+			},
+			sortBy: "memory",
+			expectedOutput: `NAME     CPU(cores)   MEMORY(bytes)   
+test-1   400m         5120Mi          
+test     400m         2048Mi          
+`,
+		},
+		{
+			name: "Multiple Pods with Multiple Containers - Calculate Total Resource Usage",
+			podMetric: []metricsapi.PodMetrics{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test",
+						Namespace: "default",
+					},
+					Timestamp: metav1.Time{Time: time.Now()},
+					Window:    metav1.Duration{Duration: time.Minute},
+					Containers: []metricsapi.ContainerMetrics{
+						{
+							Name: "container1",
+							Usage: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("0.2"),
+								v1.ResourceMemory: resource.MustParse("1Gi"),
+							},
+						},
+						{
+							Name: "container2",
+							Usage: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("0.2"),
+								v1.ResourceMemory: resource.MustParse("1Gi"),
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-1",
+						Namespace: "default",
+					},
+					Timestamp: metav1.Time{Time: time.Now()},
+					Window:    metav1.Duration{Duration: time.Minute},
+					Containers: []metricsapi.ContainerMetrics{
+						{
+							Name: "container1",
+							Usage: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("0.2"),
+								v1.ResourceMemory: resource.MustParse("3Gi"),
+							},
+						},
+						{
+							Name: "container2",
+							Usage: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("0.2"),
+								v1.ResourceMemory: resource.MustParse("2Gi"),
+							},
+						},
+					},
+				},
+			},
+			sum: true,
+			expectedOutput: `NAME     CPU(cores)   MEMORY(bytes)   
+test     400m         2048Mi          
+test-1   400m         5120Mi          
+         ________     ________        
+         800m         7168Mi          
+`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// Create a new TopCmdPrinter with a test writer.
+			_, _, out, _ := genericiooptions.NewTestIOStreams()
+
+			top := NewTopCmdPrinter(out)
+			err := top.PrintPodMetrics(test.podMetric, test.printContainers,
+				test.withNamespace, test.noHeader, test.sortBy, test.sum)
+			assert.Equal(t, test.expectedErr, err)
+			assert.Equal(t, test.expectedOutput, out.String())
+		})
+	}
+}
+
+func newNode(name string) *v1.Node {
+	return &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Status: v1.NodeStatus{
+			Capacity: v1.ResourceList{
+				v1.ResourceName(v1.ResourceCPU):    resource.MustParse("10"),
+				v1.ResourceName(v1.ResourceMemory): resource.MustParse("10Gi"),
+			},
+		},
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup
#### What this PR does / why we need it:
- modify the percentage display of the top command
```
// original
NAME    CPU(cores)   CPU%   MEMORY(bytes)   MEMORY%   
node1   1000m        10%    1024Mi          10%  

// change
NAME    CPU(cores)   CPU(%)   MEMORY(bytes)   MEMORY(%)   
node1   1000m        10%      1024Mi          10%     
```
- add unit test
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
The percentage display in kubectl top node is changed from % -> (%)
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
