### PR TITLE
adds watchListEndpointRestrictions for watchlist requests

### DIFF
--- a/staging/src/k8s.io/client-go/util/consistencydetector/list_data_consistency_detector.go
+++ b/staging/src/k8s.io/client-go/util/consistencydetector/list_data_consistency_detector.go
@@ -32,6 +32,12 @@ func init() {
 	dataConsistencyDetectionForListFromCacheEnabled, _ = strconv.ParseBool(os.Getenv("KUBE_LIST_FROM_CACHE_INCONSISTENCY_DETECTOR"))
 }
 
+// IsDataConsistencyDetectionForListEnabled returns true when
+// the KUBE_LIST_FROM_CACHE_INCONSISTENCY_DETECTOR environment variable was set during a binary startup.
+func IsDataConsistencyDetectionForListEnabled() bool {
+	return dataConsistencyDetectionForListFromCacheEnabled
+}
+
 // CheckListFromCacheDataConsistencyIfRequested performs a data consistency check only when
 // the KUBE_LIST_FROM_CACHE_INCONSISTENCY_DETECTOR environment variable was set during a binary startup
 // for requests that have a high chance of being served from the watch-cache.
@@ -50,7 +56,7 @@ func init() {
 // the cache (even though this might not be true for some requests)
 // and issue the second call to get data from etcd for comparison.
 func CheckListFromCacheDataConsistencyIfRequested[T runtime.Object](ctx context.Context, identity string, listItemsFn ListFunc[T], optionsUsedToReceiveList metav1.ListOptions, receivedList runtime.Object) {
-	if !dataConsistencyDetectionForListFromCacheEnabled {
+	if !IsDataConsistencyDetectionForListEnabled() {
 		return
 	}
 	checkListFromCacheDataConsistencyIfRequestedInternal(ctx, identity, listItemsFn, optionsUsedToReceiveList, receivedList)

--- a/test/e2e/apimachinery/watchlist.go
+++ b/test/e2e/apimachinery/watchlist.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net/http"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
@@ -164,16 +165,86 @@ var _ = SIGDescribe("API Streaming (aka. WatchList)", framework.WithSerial(), fe
 		expectedRequestMadeByMetaClient := getExpectedRequestMadeByClientFor(secretMetaList.GetResourceVersion())
 		gomega.Expect(rt.actualRequests).To(gomega.Equal(expectedRequestMadeByMetaClient))
 	})
+
+	// Validates unsupported Accept headers in WatchList.
+	// Sets AcceptContentType to "application/json;as=Table", which the API doesn't support, returning a 406 error.
+	// After the 406, the client falls back to a regular list request.
+	ginkgo.It("doesn't support receiving resources as Tables", func(ctx context.Context) {
+		featuregatetesting.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), utilfeature.DefaultFeatureGate, featuregate.Feature(clientfeatures.WatchListClient), true)
+
+		ginkgo.By(fmt.Sprintf("Adding 5 secrets to %s namespace", f.Namespace.Name))
+		_ = addWellKnownUnstructuredSecrets(ctx, f)
+
+		rt, clientConfig := clientConfigWithRoundTripper(f)
+		modifiedClientConfig := dynamic.ConfigFor(clientConfig)
+		modifiedClientConfig.AcceptContentTypes = strings.Join([]string{
+			fmt.Sprintf("application/json;as=Table;v=%s;g=%s", metav1.SchemeGroupVersion.Version, metav1.GroupName),
+		}, ",")
+		modifiedClientConfig.GroupVersion = &v1.SchemeGroupVersion
+		restClient, err := rest.RESTClientFor(modifiedClientConfig)
+		framework.ExpectNoError(err)
+		wrappedDynamicClient := dynamic.New(restClient)
+
+		// note that the client in case of an error (406) will fall back
+		// to a standard list request thus the overall call passes
+		ginkgo.By("Streaming secrets as Table from the server")
+		secretTable, err := wrappedDynamicClient.Resource(v1.SchemeGroupVersion.WithResource("secrets")).Namespace(f.Namespace.Name).List(ctx, metav1.ListOptions{})
+		framework.ExpectNoError(err)
+		gomega.Expect(secretTable.GetObjectKind().GroupVersionKind()).To(gomega.Equal(metav1.SchemeGroupVersion.WithKind("Table")))
+
+		ginkgo.By("Verifying if expected response was sent by the server")
+		gomega.Expect(rt.actualResponseStatuses[0]).To(gomega.Equal("406 Not Acceptable"))
+		expectedRequestMadeByDynamicClient := getExpectedRequestMadeByClientWhenFallbackToListFor(secretTable.GetResourceVersion())
+		gomega.Expect(rt.actualRequests).To(gomega.Equal(expectedRequestMadeByDynamicClient))
+
+	})
+
+	// Sets AcceptContentType to both "application/json;as=Table" and "application/json".
+	// Unlike the previous test, no 406 error occurs, as the API falls back to "application/json" and returns a valid response.
+	ginkgo.It("falls backs to supported content type when when receiving resources as Tables was requested", func(ctx context.Context) {
+		featuregatetesting.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), utilfeature.DefaultFeatureGate, featuregate.Feature(clientfeatures.WatchListClient), true)
+
+		ginkgo.By(fmt.Sprintf("Adding 5 secrets to %s namespace", f.Namespace.Name))
+		expectedSecrets := addWellKnownUnstructuredSecrets(ctx, f)
+
+		rt, clientConfig := clientConfigWithRoundTripper(f)
+		modifiedClientConfig := dynamic.ConfigFor(clientConfig)
+		modifiedClientConfig.AcceptContentTypes = strings.Join([]string{
+			fmt.Sprintf("application/json;as=Table;v=%s;g=%s", metav1.SchemeGroupVersion.Version, metav1.GroupName),
+			"application/json",
+		}, ",")
+		modifiedClientConfig.GroupVersion = &v1.SchemeGroupVersion
+		restClient, err := rest.RESTClientFor(modifiedClientConfig)
+		framework.ExpectNoError(err)
+		wrappedDynamicClient := dynamic.New(restClient)
+
+		ginkgo.By("Streaming secrets from the server")
+		secretList, err := wrappedDynamicClient.Resource(v1.SchemeGroupVersion.WithResource("secrets")).Namespace(f.Namespace.Name).List(ctx, metav1.ListOptions{})
+		framework.ExpectNoError(err)
+
+		ginkgo.By("Verifying if the secret list was properly streamed")
+		streamedSecrets := secretList.Items
+		gomega.Expect(cmp.Equal(expectedSecrets, streamedSecrets)).To(gomega.BeTrueBecause("data received via watchlist must match the added data"))
+
+		ginkgo.By("Verifying if expected requests were sent to the server")
+		expectedRequestMadeByDynamicClient := getExpectedRequestMadeByClientFor(secretList.GetResourceVersion())
+		gomega.Expect(rt.actualRequests).To(gomega.Equal(expectedRequestMadeByDynamicClient))
+	})
 })
 
 type roundTripper struct {
-	actualRequests []string
-	delegate       http.RoundTripper
+	actualRequests         []string
+	actualResponseStatuses []string
+	delegate               http.RoundTripper
 }
 
 func (r *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	r.actualRequests = append(r.actualRequests, req.URL.RawQuery)
-	return r.delegate.RoundTrip(req)
+	rsp, err := r.delegate.RoundTrip(req)
+	if rsp != nil {
+		r.actualResponseStatuses = append(r.actualResponseStatuses, rsp.Status)
+	}
+	return rsp, err
 }
 
 func (r *roundTripper) Wrap(delegate http.RoundTripper) http.RoundTripper {
@@ -204,12 +275,27 @@ func verifyStore(ctx context.Context, expectedSecrets []v1.Secret, store cache.S
 	framework.ExpectNoError(err)
 }
 
+// corresponds to a streaming request made by the client to stream the secrets
+const expectedStreamingRequestMadeByClient string = "allowWatchBookmarks=true&resourceVersionMatch=NotOlderThan&sendInitialEvents=true&watch=true"
+
 func getExpectedRequestMadeByClientFor(rv string) []string {
 	expectedRequestMadeByClient := []string{
-		// corresponds to a streaming request made by the client to stream the secrets
-		"allowWatchBookmarks=true&resourceVersionMatch=NotOlderThan&sendInitialEvents=true&watch=true",
+		expectedStreamingRequestMadeByClient,
 	}
 	if consistencydetector.IsDataConsistencyDetectionForWatchListEnabled() {
+		// corresponds to a standard list request made by the consistency detector build in into the client
+		expectedRequestMadeByClient = append(expectedRequestMadeByClient, fmt.Sprintf("resourceVersion=%s&resourceVersionMatch=Exact", rv))
+	}
+	return expectedRequestMadeByClient
+}
+
+func getExpectedRequestMadeByClientWhenFallbackToListFor(rv string) []string {
+	expectedRequestMadeByClient := []string{
+		expectedStreamingRequestMadeByClient,
+		// corresponds to a list request made by the client
+		"",
+	}
+	if consistencydetector.IsDataConsistencyDetectionForListEnabled() {
 		// corresponds to a standard list request made by the consistency detector build in into the client
 		expectedRequestMadeByClient = append(expectedRequestMadeByClient, fmt.Sprintf("resourceVersion=%s&resourceVersionMatch=Exact", rv))
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->
/kind feature
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
adds the watchListEndpointRestrictions, which ensures that the WatchList returns a 406 (Not Acceptable) error when an unsupported `AcceptContentType` is requested. Specifically, if the a`pplication/json;as=Table` content type is requested and is not supported, the WatchList will respond with a 406 error. This helps to ensure that unsupported formats, such as Table representations, are correctly rejected.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
xref: https://github.com/kubernetes/enhancements/issues/3157

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
If a client makes an API streaming requests and specifies an `application/json;as=Table` content type, the API server now responds with a 406 (Not Acceptable) error.
This change helps to ensure that unsupported formats, such as `Table` representations are correctly rejected.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
