### PR TITLE
apimachinery/reflect: add DeepEqualWithOptions to support option IgnoreUnexportedFields

### DIFF
--- a/staging/src/k8s.io/apimachinery/third_party/forked/golang/reflect/deep_equal.go
+++ b/staging/src/k8s.io/apimachinery/third_party/forked/golang/reflect/deep_equal.go
@@ -282,12 +282,12 @@ func (e Equalities) DeepEqualWithNilDifferentFromEmpty(a1, a2 interface{}) bool 
 }
 
 type DeepEqualOptions struct {
-	EquateNilAndEmpty      bool
+	DoNotEquateNilAndEmpty bool
 	IgnoreUnexportedFields bool
 }
 
 func (e Equalities) DeepEqualWithOptions(a1, a2 interface{}, opts *DeepEqualOptions) bool {
-	return e.deepEqual(a1, a2, opts.EquateNilAndEmpty, opts.IgnoreUnexportedFields)
+	return e.deepEqual(a1, a2, !opts.DoNotEquateNilAndEmpty, opts.IgnoreUnexportedFields)
 }
 
 func (e Equalities) deepEqual(a1, a2 interface{}, equateNilAndEmpty, ignoreUnexportedFields bool) bool {

--- a/staging/src/k8s.io/apimachinery/third_party/forked/golang/reflect/deep_equal_test.go
+++ b/staging/src/k8s.io/apimachinery/third_party/forked/golang/reflect/deep_equal_test.go
@@ -98,6 +98,40 @@ func TestEqualities(t *testing.T) {
 	}
 }
 
+func TestPublicEqualities(t *testing.T) {
+	e := Equalities{}
+
+	type Foo struct {
+		X int
+		y int
+	}
+
+	variantA := Foo{1, 2}
+	variantB := Foo{2, 2}
+	variantC := Foo{2, 2}
+
+	opts := &DeepEqualOptions{
+		IgnoreUnexportedFields: true,
+	}
+
+	if e.DeepEqualWithOptions(variantA, variantB, opts) {
+		t.Errorf("[DeepEqualWithOptions] Expected %v to not be equal to %v but was not", variantA, variantB)
+	}
+
+	if !e.DeepEqualWithOptions(variantB, variantC, opts) {
+		t.Errorf("[DeepEqualWithOptions] Expected %v to be equal to %v but was not", variantB, variantC)
+	}
+
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Errorf("[DeepEqual] did not panic but should have")
+		}
+	}()
+
+	e.DeepEqual(variantB, variantC)
+}
+
 func TestDerivatives(t *testing.T) {
 	e := Equalities{}
 	type Bar struct {

--- a/staging/src/k8s.io/apimachinery/third_party/forked/golang/reflect/deep_equal_test.go
+++ b/staging/src/k8s.io/apimachinery/third_party/forked/golang/reflect/deep_equal_test.go
@@ -110,6 +110,10 @@ func TestPublicEqualities(t *testing.T) {
 		y int
 	}
 
+	type PointingPrivateFoo struct {
+		X *PrivateFoo
+	}
+
 	type NestedFoo struct {
 		X Foo
 	}
@@ -124,6 +128,34 @@ func TestPublicEqualities(t *testing.T) {
 
 	type NestedMapFoo struct {
 		X MapFoo
+	}
+
+	type packagePrivate struct {
+		X int
+	}
+
+	type PublicWrapperOfPackagePrivate struct {
+		X packagePrivate
+	}
+
+	type ExportedStruct struct {
+		X int
+	}
+
+	type unexportedStruct struct {
+		x int
+	}
+
+	type EmbeddingExportedStruct struct {
+		ExportedStruct
+	}
+
+	type EmbeddingUnexportedStruct struct {
+		unexportedStruct
+	}
+
+	type unexportedEmbeddedTypeWithExportedField struct {
+		ExportedStruct
 	}
 
 	type Case struct {
@@ -242,6 +274,104 @@ func TestPublicEqualities(t *testing.T) {
 			[]NestedPrivateFoo{{PrivateFoo{2, 1}}},
 			[]NestedPrivateFoo{{PrivateFoo{2, 2}}},
 			&DeepEqualOptions{IgnoreUnexportedFields: true}, true, false,
+		},
+
+		{
+			"structs exposing private structs does not panic, and considers equality",
+			PublicWrapperOfPackagePrivate{packagePrivate{1}},
+			PublicWrapperOfPackagePrivate{packagePrivate{1}},
+			&DeepEqualOptions{}, true, false,
+		},
+		{
+			"structs exposing private structs does not panic, and considers inequality",
+			PublicWrapperOfPackagePrivate{packagePrivate{1}},
+			PublicWrapperOfPackagePrivate{packagePrivate{2}},
+			&DeepEqualOptions{}, false, false,
+		},
+
+		{
+			"struct with pointer to unexported struct containers panic",
+			PointingPrivateFoo{&PrivateFoo{1, 1}},
+			PointingPrivateFoo{&PrivateFoo{1, 1}},
+			&DeepEqualOptions{}, true, true,
+		},
+		{
+			"struct with pointer to unexported struct containers do not panic when ignore unexported fields",
+			PointingPrivateFoo{&PrivateFoo{1, 1}},
+			PointingPrivateFoo{&PrivateFoo{1, 1}},
+			&DeepEqualOptions{IgnoreUnexportedFields: true}, true, false,
+		},
+
+		{
+			"embedding exported structs are considered equal",
+			func() EmbeddingExportedStruct {
+				ret := EmbeddingExportedStruct{}
+				ret.X = 1
+				return ret
+			}(),
+			func() EmbeddingExportedStruct {
+				ret := EmbeddingExportedStruct{}
+				ret.X = 1
+				return ret
+			}(),
+			&DeepEqualOptions{}, true, false,
+		},
+		{
+			"embedding exported structs are considered unequal",
+			func() EmbeddingExportedStruct {
+				ret := EmbeddingExportedStruct{}
+				ret.X = 1
+				return ret
+			}(),
+			func() EmbeddingExportedStruct {
+				ret := EmbeddingExportedStruct{}
+				ret.X = 2
+				return ret
+			}(),
+			&DeepEqualOptions{}, false, false,
+		},
+		{
+			"embedding unexported structs panics",
+			func() EmbeddingUnexportedStruct {
+				ret := EmbeddingUnexportedStruct{}
+				ret.x = 1
+				return ret
+			}(),
+			func() EmbeddingUnexportedStruct {
+				ret := EmbeddingUnexportedStruct{}
+				ret.x = 1
+				return ret
+			}(),
+			&DeepEqualOptions{}, true, true,
+		},
+		{
+			"embedding unexported structs do not panic when ignoring unexported fields",
+			func() EmbeddingUnexportedStruct {
+				ret := EmbeddingUnexportedStruct{}
+				ret.x = 1
+				return ret
+			}(),
+			func() EmbeddingUnexportedStruct {
+				ret := EmbeddingUnexportedStruct{}
+				ret.x = 1
+				return ret
+			}(),
+			&DeepEqualOptions{IgnoreUnexportedFields: true}, true, false,
+		},
+
+		{
+			"unexported embedded structs consisting of exported field do not panic",
+			func() unexportedEmbeddedTypeWithExportedField {
+				ret := unexportedEmbeddedTypeWithExportedField{}
+				ret.X = 1
+				return ret
+			}(),
+			func() unexportedEmbeddedTypeWithExportedField {
+				ret := unexportedEmbeddedTypeWithExportedField{}
+				ret.X = 1
+				return ret
+			}(),
+			&DeepEqualOptions{}, true, false,
 		},
 	}
 

--- a/staging/src/k8s.io/apimachinery/third_party/forked/golang/reflect/deep_equal_test.go
+++ b/staging/src/k8s.io/apimachinery/third_party/forked/golang/reflect/deep_equal_test.go
@@ -158,6 +158,14 @@ func TestPublicEqualities(t *testing.T) {
 		ExportedStruct
 	}
 
+	type doublyNestedUnexportedTypeInner struct {
+		x PrivateFoo
+	}
+
+	type doublyNestedUnexportedTypeOuter struct {
+		x doublyNestedUnexportedTypeInner
+	}
+
 	type Case struct {
 		name          string
 		a, b          interface{}
@@ -165,6 +173,17 @@ func TestPublicEqualities(t *testing.T) {
 		shouldBeEqual bool
 		shouldPanic   bool
 	}
+
+	concreteFoo := Foo{1}
+	concretePrivateFoo := PrivateFoo{1, 1}
+	concretePrivateFooIdentical := PrivateFoo{1, 1}
+	concreteHard := map[string]string{"foo": "bar"}
+	concreteHardVariant := map[string]string{"foo": "bar"}
+
+	var pointerToInterface interface{}
+	var anotherInterface interface{} // nil == nil without same address
+	var pointerToFunc func()
+	var anotherFunc func()
 
 	table := []Case{
 		{"equal values are considered equal", 1, 1, &DeepEqualOptions{}, true, false},
@@ -195,6 +214,18 @@ func TestPublicEqualities(t *testing.T) {
 			NestedPrivateFoo{PrivateFoo{1, 1}}, NestedPrivateFoo{PrivateFoo{1, 1}},
 			&DeepEqualOptions{IgnoreUnexportedFields: true},
 			true, false,
+		},
+		{
+			"doubly nested unexported fields panic",
+			doublyNestedUnexportedTypeOuter{doublyNestedUnexportedTypeInner{PrivateFoo{1, 1}}},
+			doublyNestedUnexportedTypeOuter{doublyNestedUnexportedTypeInner{PrivateFoo{1, 1}}},
+			&DeepEqualOptions{}, false, true,
+		},
+		{
+			"doubly nested unexported fields do not panic when ignoring unexported fields",
+			doublyNestedUnexportedTypeOuter{doublyNestedUnexportedTypeInner{PrivateFoo{1, 1}}},
+			struct{}{},
+			&DeepEqualOptions{IgnoreUnexportedFields: true}, false, false,
 		},
 
 		{
@@ -371,6 +402,58 @@ func TestPublicEqualities(t *testing.T) {
 				ret.X = 1
 				return ret
 			}(),
+			&DeepEqualOptions{}, true, false,
+		},
+
+		{"nil equals nil", nil, nil, &DeepEqualOptions{}, true, false},
+		{"pointer to nil equals pointer to nil", pointerToInterface, pointerToInterface, &DeepEqualOptions{}, true, false},
+		{"pointer to nil equals pointer to nil", pointerToInterface, anotherInterface, &DeepEqualOptions{}, true, false},
+		{
+			"pointer to same object is equal",
+			&concreteFoo, &concreteFoo,
+			&DeepEqualOptions{}, true, false,
+		},
+		{
+			"pointer to similar objects with unexported fields panics", // not same object because then addr equality
+			&concretePrivateFoo, &concretePrivateFooIdentical,
+			&DeepEqualOptions{}, true, true,
+		},
+		{
+			"pointer to same hard object is equal",
+			concreteHard, concreteHard,
+			&DeepEqualOptions{}, true, false,
+		},
+		{
+			"pointer to similar hard object is equal",
+			concreteHard, concreteHardVariant,
+			&DeepEqualOptions{}, true, false,
+		},
+		{
+			"nil pointer to func is considered equal",
+			pointerToFunc, pointerToFunc,
+			&DeepEqualOptions{}, true, false,
+		},
+		{
+			"nil pointer to another func is considered equal",
+			pointerToFunc, anotherFunc,
+			&DeepEqualOptions{}, true, false,
+		},
+		{
+			"pointer to interface is considered equal",
+			func() interface{} {
+				var ret interface{}
+				return &ret
+			}(),
+			func() interface{} {
+				var ret interface{}
+				return &ret
+			}(),
+			&DeepEqualOptions{}, true, false,
+		},
+		{
+			"slice of concrete types is equal",
+			[]map[string]string{{"foo": "bar"}, {"bar": "foo"}},
+			[]map[string]string{{"foo": "bar"}, {"bar": "foo"}},
 			&DeepEqualOptions{}, true, false,
 		},
 	}

--- a/staging/src/k8s.io/apimachinery/third_party/forked/golang/reflect/deep_equal_test.go
+++ b/staging/src/k8s.io/apimachinery/third_party/forked/golang/reflect/deep_equal_test.go
@@ -6,6 +6,7 @@ package reflect
 
 import (
 	"testing"
+	"time"
 )
 
 func TestEqualities(t *testing.T) {
@@ -156,6 +157,11 @@ func TestPublicEqualities(t *testing.T) {
 
 	type unexportedEmbeddedTypeWithExportedField struct {
 		ExportedStruct
+	}
+
+	type TimeTest struct {
+		X int
+		t time.Time
 	}
 
 	type doublyNestedUnexportedTypeInner struct {
@@ -455,6 +461,12 @@ func TestPublicEqualities(t *testing.T) {
 			[]map[string]string{{"foo": "bar"}, {"bar": "foo"}},
 			[]map[string]string{{"foo": "bar"}, {"bar": "foo"}},
 			&DeepEqualOptions{}, true, false,
+		},
+		{
+			"unexported time.Time does not affect equality check",
+			TimeTest{1, time.Time{}},
+			TimeTest{1, time.Time{}.Add(time.Hour)},
+			&DeepEqualOptions{IgnoreUnexportedFields: true}, true, false,
 		},
 	}
 

--- a/staging/src/k8s.io/apimachinery/third_party/forked/golang/reflect/deep_equal_test.go
+++ b/staging/src/k8s.io/apimachinery/third_party/forked/golang/reflect/deep_equal_test.go
@@ -468,6 +468,30 @@ func TestPublicEqualities(t *testing.T) {
 			TimeTest{1, time.Time{}.Add(time.Hour)},
 			&DeepEqualOptions{IgnoreUnexportedFields: true}, true, false,
 		},
+		{
+			"default equates nil and empty map",
+			map[string]int(nil),
+			map[string]int{},
+			&DeepEqualOptions{}, true, false,
+		},
+		{
+			"DoNotEquateNilAndEmpty does not equate nil and empty map",
+			map[string]int(nil),
+			map[string]int{},
+			&DeepEqualOptions{DoNotEquateNilAndEmpty: true}, false, false,
+		},
+		{
+			"default equates nil and empty slice",
+			[]string(nil),
+			[]string{},
+			&DeepEqualOptions{}, true, false,
+		},
+		{
+			"DoNotEquateNilAndEmpty does not equate nil and empty slice",
+			[]string(nil),
+			[]string{},
+			&DeepEqualOptions{DoNotEquateNilAndEmpty: true}, false, false,
+		},
 	}
 
 	for _, tc := range table {

--- a/staging/src/k8s.io/apimachinery/third_party/forked/golang/reflect/deep_equal_test.go
+++ b/staging/src/k8s.io/apimachinery/third_party/forked/golang/reflect/deep_equal_test.go
@@ -470,13 +470,12 @@ func TestPublicEqualities(t *testing.T) {
 		},
 	}
 
-	for _, testCase := range table {
-		func(tc *Case) {
-
+	for _, tc := range table {
+		t.Run(tc.name, func(t *testing.T) {
 			defer func() {
 				r := recover()
 				if r == nil && tc.shouldPanic {
-					t.Errorf("%s: did not panic but should have", tc.name)
+					t.Errorf("did not panic but should have")
 				}
 
 				if r != nil && !tc.shouldPanic {
@@ -487,13 +486,13 @@ func TestPublicEqualities(t *testing.T) {
 			eq := e.DeepEqualWithOptions(tc.a, tc.b, tc.options)
 
 			if eq && !tc.shouldBeEqual {
-				t.Errorf("%s: expected inequality but got equality for %v and %v", tc.name, tc.a, tc.b)
+				t.Errorf("expected inequality but got equality for %v and %v", tc.a, tc.b)
 			}
 
 			if !eq && tc.shouldBeEqual {
-				t.Errorf("%s: expected equality but got inequality for %v and %v", tc.name, tc.a, tc.b)
+				t.Errorf("expected equality but got inequality for %v and %v", tc.a, tc.b)
 			}
-		}(&testCase)
+		})
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

#### What this PR does / why we need it:

relates to kubernetes/kubernetes#124154

this change changes the call signature of the wrapped method deepValueEqual, leaving the wrapped behaviour the same

we also add a new function PublicDeepEqual which does not panic when encountering an unexported field

for use cases like the controller-runtime, we are fetching info from the k8s API and then comparing it via reflection with an in-memory representation of what the state of the entity should be. If there are differences then an update needs to happen (ie in the CreateOrUpdate fn)

there are CRD users like Istio and Cilium which use structs with unexported fields (eg the structs are used via grpc/proto and have some protocol level state bookkeeping), it should be possible to use these in a controller without having to redefine the structs, hence ignoring unexported fields - especially since unexported fields are not going to get serialized when sending/retrieving to/from the k8s API

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Relates to kubernetes/kubernetes#124154

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
New helper PublicDeepEqual added to apimachinery reflection package
```
