### PR TITLE
remove resource flowschemas and prioritylevelconfigurations from legacyBetaEnabledByDefaultResources in v1.32

### DIFF
--- a/pkg/controlplane/instance.go
+++ b/pkg/controlplane/instance.go
@@ -452,14 +452,6 @@ var (
 		flowcontrolv1.SchemeGroupVersion,
 	}
 
-	// legacyBetaEnabledByDefaultResources is the list of beta resources we enable.  You may only add to this list
-	// if your resource is already enabled by default in a beta level we still serve AND there is no stable API for it.
-	// see https://github.com/kubernetes/enhancements/tree/master/keps/sig-architecture/3136-beta-apis-off-by-default
-	// for more details.
-	legacyBetaEnabledByDefaultResources = []schema.GroupVersionResource{
-		flowcontrolv1beta3.SchemeGroupVersion.WithResource("flowschemas"),                 // deprecate in 1.29, remove in 1.32
-		flowcontrolv1beta3.SchemeGroupVersion.WithResource("prioritylevelconfigurations"), // deprecate in 1.29, remove in 1.32
-	}
 	// betaAPIGroupVersionsDisabledByDefault is for all future beta groupVersions.
 	betaAPIGroupVersionsDisabledByDefault = []schema.GroupVersion{
 		admissionregistrationv1beta1.SchemeGroupVersion,
@@ -495,9 +487,6 @@ func DefaultAPIResourceConfigSource() *serverstorage.ResourceConfig {
 	// disable alpha and beta versions explicitly so we have a full list of what's possible to serve
 	ret.DisableVersions(betaAPIGroupVersionsDisabledByDefault...)
 	ret.DisableVersions(alphaAPIGroupVersionsDisabledByDefault...)
-
-	// enable the legacy beta resources that were present before stopped serving new beta APIs by default.
-	ret.EnableResources(legacyBetaEnabledByDefaultResources...)
 
 	return ret
 }

--- a/pkg/controlplane/instance_test.go
+++ b/pkg/controlplane/instance_test.go
@@ -66,7 +66,6 @@ import (
 	netutils "k8s.io/utils/net"
 
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
-	flowcontrolv1bet3 "k8s.io/kubernetes/pkg/apis/flowcontrol/v1beta3"
 	controlplaneapiserver "k8s.io/kubernetes/pkg/controlplane/apiserver"
 	"k8s.io/kubernetes/pkg/controlplane/reconcilers"
 	"k8s.io/kubernetes/pkg/controlplane/storageversionhashdata"
@@ -426,14 +425,6 @@ func TestDefaultVars(t *testing.T) {
 		}
 	}
 
-	// legacyBetaEnabledByDefaultResources should contain only beta version
-	for i := range legacyBetaEnabledByDefaultResources {
-		gv := legacyBetaEnabledByDefaultResources[i]
-		if !strings.Contains(gv.Version, "beta") {
-			t.Errorf("legacyBetaEnabledByDefaultResources should contain beta version, but found: %q", gv.String())
-		}
-	}
-
 	// betaAPIGroupVersionsDisabledByDefault should contain only beta version
 	for i := range betaAPIGroupVersionsDisabledByDefault {
 		gv := betaAPIGroupVersionsDisabledByDefault[i]
@@ -466,15 +457,6 @@ func TestNewBetaResourcesEnabledByDefault(t *testing.T) {
 		storageapiv1beta1.SchemeGroupVersion.WithResource("csinodes"):                     true,
 	}
 
-	// legacyBetaResourcesWithoutStableEquivalents contains those groupresources that were enabled by default as beta
-	// before we changed that policy and do not have stable versions. These resources are allowed to have additional
-	// beta versions enabled by default.  Nothing new should be added here.  There are no future exceptions because there
-	// are no more beta resources enabled by default.
-	legacyBetaResourcesWithoutStableEquivalents := map[schema.GroupResource]bool{
-		flowcontrolv1bet3.SchemeGroupVersion.WithResource("flowschemas").GroupResource():                 true,
-		flowcontrolv1bet3.SchemeGroupVersion.WithResource("prioritylevelconfigurations").GroupResource(): true,
-	}
-
 	config := DefaultAPIResourceConfigSource()
 	for gvr, enable := range config.ResourceConfigs {
 		if !strings.Contains(gvr.Version, "beta") {
@@ -485,9 +467,6 @@ func TestNewBetaResourcesEnabledByDefault(t *testing.T) {
 		}
 		if legacyEnabledBetaResources[gvr] {
 			continue // this is a legacy beta resource
-		}
-		if legacyBetaResourcesWithoutStableEquivalents[gvr.GroupResource()] {
-			continue // this is another beta of a legacy beta resource with no stable equivalent
 		}
 		t.Errorf("no new beta resources can be enabled by default, see https://github.com/kubernetes/enhancements/blob/0ad0fc8269165ca300d05ca51c7ce190a79976a5/keps/sig-architecture/3136-beta-apis-off-by-default/README.md: %v", gvr)
 	}

--- a/pkg/controlplane/storageversionhashdata/data.go
+++ b/pkg/controlplane/storageversionhashdata/data.go
@@ -84,8 +84,6 @@ var GVRToStorageVersionHash = map[string]string{
 	"admissionregistration.k8s.io/v1/validatingadmissionpolicies":       "6OxvlMmQ6is=",
 	"admissionregistration.k8s.io/v1/validatingadmissionpolicybindings": "v9715VZqakg=",
 	"events.k8s.io/v1/events":                                           "r2yiGXH7wu8=",
-	"flowcontrol.apiserver.k8s.io/v1beta3/flowschemas":                  "GJVAJZSZBIw=",
-	"flowcontrol.apiserver.k8s.io/v1beta3/prioritylevelconfigurations":  "Kir5PVfvNeI=",
 	"flowcontrol.apiserver.k8s.io/v1/flowschemas":                       "GJVAJZSZBIw=",
 	"flowcontrol.apiserver.k8s.io/v1/prioritylevelconfigurations":       "Kir5PVfvNeI=",
 }

--- a/pkg/registry/flowcontrol/rest/storage_flowcontrol.go
+++ b/pkg/registry/flowcontrol/rest/storage_flowcontrol.go
@@ -37,8 +37,6 @@ import (
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	"k8s.io/kubernetes/pkg/apis/flowcontrol"
 	flowcontrolapisv1 "k8s.io/kubernetes/pkg/apis/flowcontrol/v1"
-	flowcontrolapisv1beta1 "k8s.io/kubernetes/pkg/apis/flowcontrol/v1beta1"
-	flowcontrolapisv1beta2 "k8s.io/kubernetes/pkg/apis/flowcontrol/v1beta2"
 	flowcontrolapisv1beta3 "k8s.io/kubernetes/pkg/apis/flowcontrol/v1beta3"
 	"k8s.io/kubernetes/pkg/registry/flowcontrol/ensurer"
 	flowschemastore "k8s.io/kubernetes/pkg/registry/flowcontrol/flowschema/storage"
@@ -58,18 +56,6 @@ const PostStartHookName = "priority-and-fairness-config-producer"
 // NewRESTStorage creates a new rest storage for flow-control api models.
 func (p RESTStorageProvider) NewRESTStorage(apiResourceConfigSource serverstorage.APIResourceConfigSource, restOptionsGetter generic.RESTOptionsGetter) (genericapiserver.APIGroupInfo, error) {
 	apiGroupInfo := genericapiserver.NewDefaultAPIGroupInfo(flowcontrol.GroupName, legacyscheme.Scheme, legacyscheme.ParameterCodec, legacyscheme.Codecs)
-
-	if storageMap, err := p.storage(apiResourceConfigSource, restOptionsGetter, flowcontrolapisv1beta1.SchemeGroupVersion); err != nil {
-		return genericapiserver.APIGroupInfo{}, err
-	} else if len(storageMap) > 0 {
-		apiGroupInfo.VersionedResourcesStorageMap[flowcontrolapisv1beta1.SchemeGroupVersion.Version] = storageMap
-	}
-
-	if storageMap, err := p.storage(apiResourceConfigSource, restOptionsGetter, flowcontrolapisv1beta2.SchemeGroupVersion); err != nil {
-		return genericapiserver.APIGroupInfo{}, err
-	} else if len(storageMap) > 0 {
-		apiGroupInfo.VersionedResourcesStorageMap[flowcontrolapisv1beta2.SchemeGroupVersion.Version] = storageMap
-	}
 
 	if storageMap, err := p.storage(apiResourceConfigSource, restOptionsGetter, flowcontrolapisv1beta3.SchemeGroupVersion); err != nil {
 		return genericapiserver.APIGroupInfo{}, err

--- a/test/integration/apiserver/no_new_betas_test.go
+++ b/test/integration/apiserver/no_new_betas_test.go
@@ -24,23 +24,6 @@ import (
 )
 
 func TestNoNewBetaAPIsByDefault(t *testing.T) {
-	// yes, this *is* a copy/paste from somewhere else.  We really do mean it when we say you shouldn't be modifying
-	// this list and this test was created to make it more painful.
-	// legacyBetaEnabledByDefaultResources is the list of beta resources we enable.  You may not add to this list
-	legacyBetaEnabledByDefaultResources := map[schema.GroupVersionResource]bool{
-		gvr("flowcontrol.apiserver.k8s.io", "v1beta2", "flowschemas"):                 true, // remove in 1.29
-		gvr("flowcontrol.apiserver.k8s.io", "v1beta2", "prioritylevelconfigurations"): true, // remove in 1.29
-	}
-
-	// legacyBetaResourcesWithoutStableEquivalents contains those groupresources that were enabled by default as beta
-	// before we changed that policy and do not have stable versions. These resources are allowed to have additional
-	// beta versions enabled by default.  Nothing new should be added here.  There are no future exceptions because there
-	// are no more beta resources enabled by default.
-	legacyBetaResourcesWithoutStableEquivalents := map[schema.GroupResource]bool{
-		gvr("flowcontrol.apiserver.k8s.io", "v1beta1", "flowschemas").GroupResource():                 true,
-		gvr("flowcontrol.apiserver.k8s.io", "v1beta1", "prioritylevelconfigurations").GroupResource(): true,
-	}
-
 	// if you found this because you want to create an integration test for your new beta API, the method you're looking for
 	// is this setupWithResources method and you need to pass the resource you want to enable into it.
 	_, kubeClient, _, tearDownFn := setupWithResources(t,
@@ -66,12 +49,6 @@ func TestNoNewBetaAPIsByDefault(t *testing.T) {
 				Group:    currResource.Group,
 				Version:  currResource.Version,
 				Resource: currResource.Name,
-			}
-			if legacyBetaEnabledByDefaultResources[enabledGVR] {
-				continue
-			}
-			if legacyBetaResourcesWithoutStableEquivalents[enabledGVR.GroupResource()] {
-				continue
 			}
 
 			t.Errorf("%v is a new beta API.  New beta APIs may not be enabled by default.  "+


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

See https://kubernetes.io/docs/reference/using-api/deprecation-guide/#flowcontrol-resources-v132

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
The `flowcontrol.apiserver.k8s.io/v1beta3` API version of `FlowSchema` and `PriorityLevelConfiguration` is no longer served in v1.32. Migrate manifests and API clients to use the `flowcontrol.apiserver.k8s.io/v1` API version, available since v1.29. More information is at https://kubernetes.io/docs/reference/using-api/deprecation-guide/#flowcontrol-resources-v132
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
