### PR TITLE
Fix: skip completed initContainer device allocate when kubelet restart

### DIFF
--- a/pkg/kubelet/cm/devicemanager/topology_hints_test.go
+++ b/pkg/kubelet/cm/devicemanager/topology_hints_test.go
@@ -441,7 +441,7 @@ func TestTopologyAlignedAllocation(t *testing.T) {
 			}
 		}
 
-		allocated, err := m.devicesToAllocate("podUID", "containerName", tc.resource, tc.request, sets.New[string]())
+		allocated, err := m.devicesToAllocate("podUID", "containerName", tc.resource, tc.request, sets.New[string](), false)
 		if err != nil {
 			t.Errorf("Unexpected error: %v", err)
 			continue
@@ -639,7 +639,7 @@ func TestGetPreferredAllocationParameters(t *testing.T) {
 			opts: &pluginapi.DevicePluginOptions{GetPreferredAllocationAvailable: true},
 		}
 
-		_, err := m.devicesToAllocate("podUID", "containerName", tc.resource, tc.request, sets.New[string](tc.reusableDevices...))
+		_, err := m.devicesToAllocate("podUID", "containerName", tc.resource, tc.request, sets.New[string](tc.reusableDevices...), false)
 		if err != nil {
 			t.Errorf("Unexpected error: %v", err)
 			continue


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR is dealing with the same type of problem as https://github.com/kubernetes/kubernetes/pull/126707.

If a pod has a init container which request a device, this device will be reused. The init container will be completed during the pod startup.

When the kubelet restart, we should skip allocate device for the completed init container. Otherwise we will got a `UnexpectedAdmissionError`.

We can use this daemonset to reproduce this bug
```
apiVersion: apps/v1
kind: DaemonSet
metadata:
  name: startup-test
  labels:
    k8s-app: startup-test
spec:
  selector:
    matchLabels:
      name: startup-test
  template:
    metadata:
      labels:
        name: startup-test
    spec:
      initContainers:
      - name: init-myservice
        image: alibaba-cloud-linux-2-registry.cn-hangzhou.cr.aliyuncs.com/alinux2/alinux2:latest
        command: ['sh', '-c', "echo ihello"]
        resources:
          requests:
            aliyun/member-eni: 1
          limits:
            aliyun/member-eni: 1
      containers:
      - name: liveness
        image: alibaba-cloud-linux-2-registry.cn-hangzhou.cr.aliyuncs.com/alinux2/alinux2:latest
        resources:
          requests:
            aliyun/member-eni: 1
          limits:
            aliyun/member-eni: 1
        args:
        - /bin/sh
        - -c
        - touch /tmp/healthy; sleep infinity
        startupProbe:
          exec:
            command:
            - /bin/sh
            - -c
            - sleep 10; echo hello
          initialDelaySeconds: 6
          timeoutSeconds: 15
```


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix: skip completed initContainer device allocate when kubelet restart
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
