### PR TITLE
chore: rm deprecated ioutil package references

### DIFF
--- a/cmd/dependencyverifier/dependencyverifier.go
+++ b/cmd/dependencyverifier/dependencyverifier.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -275,7 +274,7 @@ func main() {
 		}
 	}
 
-	vendorModulesTxt, err := ioutil.ReadFile("vendor/modules.txt")
+	vendorModulesTxt, err := os.ReadFile("vendor/modules.txt")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/auth/authorizer/abac/abac_test.go
+++ b/pkg/auth/authorizer/abac/abac_test.go
@@ -18,7 +18,6 @@ package abac
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"testing"
@@ -817,14 +816,14 @@ func TestSubjectMatches(t *testing.T) {
 }
 
 func newWithContents(t *testing.T, contents string) (PolicyList, error) {
-	f, err := ioutil.TempFile("", "abac_test")
+	f, err := os.CreateTemp("", "abac_test")
 	if err != nil {
 		t.Fatalf("unexpected error creating policyfile: %v", err)
 	}
 	f.Close()
 	defer os.Remove(f.Name())
 
-	if err := ioutil.WriteFile(f.Name(), []byte(contents), 0700); err != nil {
+	if err := os.WriteFile(f.Name(), []byte(contents), 0700); err != nil {
 		t.Fatalf("unexpected error writing policyfile: %v", err)
 	}
 

--- a/pkg/client/tests/remotecommand_test.go
+++ b/pkg/client/tests/remotecommand_test.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -336,7 +335,7 @@ func TestDial(t *testing.T) {
 		conn:          &fakeConnection{},
 		resp: &http.Response{
 			StatusCode: http.StatusSwitchingProtocols,
-			Body:       ioutil.NopCloser(&bytes.Buffer{}),
+			Body:       io.NopCloser(&bytes.Buffer{}),
 		},
 	}
 	dialer := spdy.NewDialer(upgrader, &http.Client{Transport: upgrader}, "POST", &url.URL{Host: "something.com", Scheme: "https"})

--- a/pkg/controller/certificates/signer/signer_test.go
+++ b/pkg/controller/certificates/signer/signer_test.go
@@ -23,8 +23,8 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
-	"io/ioutil"
 	"math/rand"
+	"os"
 	"testing"
 	"time"
 
@@ -49,7 +49,7 @@ func TestSigner(t *testing.T) {
 		t.Fatalf("failed to create signer: %v", err)
 	}
 
-	csrb, err := ioutil.ReadFile("./testdata/kubelet.csr")
+	csrb, err := os.ReadFile("./testdata/kubelet.csr")
 	if err != nil {
 		t.Fatalf("failed to read CSR: %v", err)
 	}

--- a/pkg/volume/configmap/configmap_test.go
+++ b/pkg/volume/configmap/configmap_test.go
@@ -18,7 +18,6 @@ package configmap
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -292,7 +291,7 @@ func TestMakePayload(t *testing.T) {
 }
 
 func newTestHost(t *testing.T, clientset clientset.Interface) (string, volume.VolumeHost) {
-	tempDir, err := ioutil.TempDir("", "configmap_volume_test.")
+	tempDir, err := os.MkdirTemp("", "configmap_volume_test.")
 	if err != nil {
 		t.Fatalf("can't make a temp rootdir: %v", err)
 	}
@@ -513,7 +512,7 @@ func TestPluginOptional(t *testing.T) {
 	}
 	datadirPath := filepath.Join(volumePath, datadir)
 
-	infos, err := ioutil.ReadDir(volumePath)
+	infos, err := os.ReadDir(volumePath)
 	if err != nil {
 		t.Fatalf("couldn't find volume path, %s", volumePath)
 	}
@@ -525,7 +524,7 @@ func TestPluginOptional(t *testing.T) {
 		}
 	}
 
-	infos, err = ioutil.ReadDir(datadirPath)
+	infos, err = os.ReadDir(datadirPath)
 	if err != nil {
 		t.Fatalf("couldn't find volume data path, %s", datadirPath)
 	}
@@ -703,7 +702,7 @@ func doTestConfigMapDataInVolume(volumePath string, configMap v1.ConfigMap, t *t
 		if _, err := os.Stat(configMapDataHostPath); err != nil {
 			t.Fatalf("SetUp() failed, couldn't find configMap data on disk: %v", configMapDataHostPath)
 		} else {
-			actualValue, err := ioutil.ReadFile(configMapDataHostPath)
+			actualValue, err := os.ReadFile(configMapDataHostPath)
 			if err != nil {
 				t.Fatalf("Couldn't read configMap data from: %v", configMapDataHostPath)
 			}

--- a/pkg/volume/git_repo/git_repo.go
+++ b/pkg/volume/git_repo/git_repo.go
@@ -18,7 +18,7 @@ package git_repo
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -197,7 +197,7 @@ func (b *gitRepoVolumeMounter) SetUpAt(dir string, mounterArgs volume.MounterArg
 			strings.Join(args, " "), output, err)
 	}
 
-	files, err := ioutil.ReadDir(dir)
+	files, err := os.ReadDir(dir)
 	if err != nil {
 		return err
 	}

--- a/pkg/volume/git_repo/git_repo_test.go
+++ b/pkg/volume/git_repo/git_repo_test.go
@@ -18,7 +18,6 @@ package git_repo
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -37,7 +36,7 @@ import (
 )
 
 func newTestHost(t *testing.T) (string, volume.VolumeHost) {
-	tempDir, err := ioutil.TempDir("", "git_repo_test.")
+	tempDir, err := os.MkdirTemp("", "git_repo_test.")
 	if err != nil {
 		t.Fatalf("can't make a temp rootdir: %v", err)
 	}

--- a/pkg/volume/iscsi/iscsi_util.go
+++ b/pkg/volume/iscsi/iscsi_util.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -74,12 +73,14 @@ var (
 		"discovery.sendtargets.auth.username",
 		"discovery.sendtargets.auth.password",
 		"discovery.sendtargets.auth.username_in",
-		"discovery.sendtargets.auth.password_in"}
+		"discovery.sendtargets.auth.password_in",
+	}
 	chapSess = []string{
 		"node.session.auth.username",
 		"node.session.auth.password",
 		"node.session.auth.username_in",
-		"node.session.auth.password_in"}
+		"node.session.auth.password_in",
+	}
 	ifaceTransportNameRe = regexp.MustCompile(`iface.transport_name = (.*)\n`)
 	ifaceRe              = regexp.MustCompile(`.+/iface-([^/]+)/.+`)
 )
@@ -927,7 +928,7 @@ func isSessionBusy(host volume.VolumeHost, portal, iqn string) bool {
 func getVolCount(dir, portal, iqn string) (int, error) {
 	// For FileSystem volumes, the topmost dirs are named after the ifaces, e.g., iface-default or iface-127.0.0.1:3260:pv0.
 	// For Block volumes, the default topmost dir is volumeDevices.
-	contents, err := ioutil.ReadDir(dir)
+	contents, err := os.ReadDir(dir)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return 0, nil
@@ -943,7 +944,7 @@ func getVolCount(dir, portal, iqn string) (int, error) {
 			continue
 		}
 
-		mounts, err := ioutil.ReadDir(filepath.Join(dir, c.Name()))
+		mounts, err := os.ReadDir(filepath.Join(dir, c.Name()))
 		if err != nil {
 			return 0, err
 		}

--- a/pkg/volume/iscsi/iscsi_util_test.go
+++ b/pkg/volume/iscsi/iscsi_util_test.go
@@ -20,7 +20,6 @@ limitations under the License.
 package iscsi
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -442,7 +441,7 @@ func TestGetVolCount(t *testing.T) {
 }
 
 func createFakePluginDirs() (string, error) {
-	dir, err := ioutil.TempDir("", "refcounter")
+	dir, err := os.MkdirTemp("", "refcounter")
 	if err != nil {
 		return "", err
 	}

--- a/pkg/volume/secret/secret_test.go
+++ b/pkg/volume/secret/secret_test.go
@@ -18,7 +18,6 @@ package secret
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -263,7 +262,7 @@ func TestMakePayload(t *testing.T) {
 }
 
 func newTestHost(t *testing.T, clientset clientset.Interface) (string, volume.VolumeHost) {
-	tempDir, err := ioutil.TempDir("", "secret_volume_test.")
+	tempDir, err := os.MkdirTemp("", "secret_volume_test.")
 	if err != nil {
 		t.Fatalf("can't make a temp rootdir: %v", err)
 	}
@@ -537,7 +536,7 @@ func TestPluginOptional(t *testing.T) {
 	}
 	datadirPath := filepath.Join(volumePath, datadir)
 
-	infos, err := ioutil.ReadDir(volumePath)
+	infos, err := os.ReadDir(volumePath)
 	if err != nil {
 		t.Fatalf("couldn't find volume path, %s", volumePath)
 	}
@@ -549,7 +548,7 @@ func TestPluginOptional(t *testing.T) {
 		}
 	}
 
-	infos, err = ioutil.ReadDir(datadirPath)
+	infos, err = os.ReadDir(datadirPath)
 	if err != nil {
 		t.Fatalf("couldn't find volume data path, %s", datadirPath)
 	}
@@ -670,7 +669,7 @@ func doTestSecretDataInVolume(volumePath string, secret v1.Secret, t *testing.T)
 		if _, err := os.Stat(secretDataHostPath); err != nil {
 			t.Fatalf("SetUp() failed, couldn't find secret data on disk: %v", secretDataHostPath)
 		} else {
-			actualSecretBytes, err := ioutil.ReadFile(secretDataHostPath)
+			actualSecretBytes, err := os.ReadFile(secretDataHostPath)
 			if err != nil {
 				t.Fatalf("Couldn't read secret data from: %v", secretDataHostPath)
 			}

--- a/pkg/volume/util/io_util.go
+++ b/pkg/volume/util/io_util.go
@@ -17,7 +17,6 @@ limitations under the License.
 package util
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 )
@@ -41,7 +40,21 @@ func (handler *osIOHandler) ReadFile(filename string) ([]byte, error) {
 	return os.ReadFile(filename)
 }
 func (handler *osIOHandler) ReadDir(dirname string) ([]os.FileInfo, error) {
-	return ioutil.ReadDir(dirname)
+	ents, err := os.ReadDir(dirname)
+	if err != nil {
+		return nil, err
+	}
+
+	fi := make([]os.FileInfo, len(ents))
+	for i, e := range ents {
+		info, err := e.Info()
+		if err != nil {
+			return nil, err
+		}
+		fi[i] = info
+	}
+
+	return fi, nil
 }
 func (handler *osIOHandler) Lstat(name string) (os.FileInfo, error) {
 	return os.Lstat(name)

--- a/pkg/volume/util/subpath/subpath_linux.go
+++ b/pkg/volume/util/subpath/subpath_linux.go
@@ -21,7 +21,6 @@ package subpath
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -148,7 +147,7 @@ func prepareSubpathTarget(mounter mount.Interface, subpath Subpath) (bool, strin
 		// A file is enough for all possible targets (symlink, device, pipe,
 		// socket, ...), bind-mounting them into a file correctly changes type
 		// of the target file.
-		if err = ioutil.WriteFile(bindPathTarget, []byte{}, 0640); err != nil {
+		if err = os.WriteFile(bindPathTarget, []byte{}, 0640); err != nil {
 			return false, "", fmt.Errorf("error creating file %s: %s", bindPathTarget, err)
 		}
 	}
@@ -243,7 +242,7 @@ func doCleanSubPaths(mounter mount.Interface, podDir string, volumeName string) 
 	subPathDir := filepath.Join(podDir, containerSubPathDirectoryName, volumeName)
 	klog.V(4).Infof("Cleaning up subpath mounts for %s", subPathDir)
 
-	containerDirs, err := ioutil.ReadDir(subPathDir)
+	containerDirs, err := os.ReadDir(subPathDir)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil

--- a/pkg/volume/util/subpath/subpath_linux_test.go
+++ b/pkg/volume/util/subpath/subpath_linux_test.go
@@ -21,7 +21,6 @@ package subpath
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -196,7 +195,7 @@ func TestSafeMakeDir(t *testing.T) {
 		{
 			"non-directory",
 			func(base string) error {
-				return ioutil.WriteFile(filepath.Join(base, "test"), []byte{}, defaultPerm)
+				return os.WriteFile(filepath.Join(base, "test"), []byte{}, defaultPerm)
 			},
 			"test/directory",
 			"",
@@ -206,7 +205,7 @@ func TestSafeMakeDir(t *testing.T) {
 		{
 			"non-directory-final",
 			func(base string) error {
-				return ioutil.WriteFile(filepath.Join(base, "test"), []byte{}, defaultPerm)
+				return os.WriteFile(filepath.Join(base, "test"), []byte{}, defaultPerm)
 			},
 			"test",
 			"",
@@ -257,7 +256,7 @@ func TestSafeMakeDir(t *testing.T) {
 	for i := range tests {
 		test := tests[i]
 		t.Run(test.name, func(t *testing.T) {
-			base, err := ioutil.TempDir("", "safe-make-dir-"+test.name+"-")
+			base, err := os.MkdirTemp("", "safe-make-dir-"+test.name+"-")
 			if err != nil {
 				t.Fatalf(err.Error())
 			}
@@ -367,7 +366,7 @@ func TestRemoveEmptyDirs(t *testing.T) {
 				if err := os.MkdirAll(filepath.Join(base, "a/b"), defaultPerm); err != nil {
 					return err
 				}
-				return ioutil.WriteFile(filepath.Join(base, "a/b", "c"), []byte{}, defaultPerm)
+				return os.WriteFile(filepath.Join(base, "a/b", "c"), []byte{}, defaultPerm)
 			},
 			validate: func(base string) error {
 				if err := validateDirExists(filepath.Join(base, "a/b")); err != nil {
@@ -383,7 +382,7 @@ func TestRemoveEmptyDirs(t *testing.T) {
 
 	for _, test := range tests {
 		klog.V(4).Infof("test %q", test.name)
-		base, err := ioutil.TempDir("", "remove-empty-dirs-"+test.name+"-")
+		base, err := os.MkdirTemp("", "remove-empty-dirs-"+test.name+"-")
 		if err != nil {
 			t.Fatalf(err.Error())
 		}
@@ -449,7 +448,7 @@ func TestCleanSubPaths(t *testing.T) {
 				if err := os.MkdirAll(path, defaultPerm); err != nil {
 					return nil, err
 				}
-				return nil, ioutil.WriteFile(filepath.Join(path, "0"), []byte{}, defaultPerm)
+				return nil, os.WriteFile(filepath.Join(path, "0"), []byte{}, defaultPerm)
 			},
 			validate: func(base string) error {
 				return validateDirNotExists(filepath.Join(base, containerSubPathDirectoryName))
@@ -463,7 +462,7 @@ func TestCleanSubPaths(t *testing.T) {
 				if err := os.MkdirAll(path, defaultPerm); err != nil {
 					return nil, err
 				}
-				return nil, ioutil.WriteFile(filepath.Join(path, "container1"), []byte{}, defaultPerm)
+				return nil, os.WriteFile(filepath.Join(path, "container1"), []byte{}, defaultPerm)
 			},
 			validate: func(base string) error {
 				return validateDirExists(filepath.Join(base, containerSubPathDirectoryName, testVol))
@@ -477,7 +476,7 @@ func TestCleanSubPaths(t *testing.T) {
 				if err := os.MkdirAll(filepath.Join(path, "container1"), defaultPerm); err != nil {
 					return nil, err
 				}
-				return nil, ioutil.WriteFile(filepath.Join(path, "container2"), []byte{}, defaultPerm)
+				return nil, os.WriteFile(filepath.Join(path, "container2"), []byte{}, defaultPerm)
 			},
 			validate: func(base string) error {
 				path := filepath.Join(base, containerSubPathDirectoryName, testVol)
@@ -560,7 +559,7 @@ func TestCleanSubPaths(t *testing.T) {
 				}
 
 				file0 := filepath.Join(containerPath, "0")
-				if err := ioutil.WriteFile(file0, []byte{}, defaultPerm); err != nil {
+				if err := os.WriteFile(file0, []byte{}, defaultPerm); err != nil {
 					return nil, err
 				}
 
@@ -575,7 +574,7 @@ func TestCleanSubPaths(t *testing.T) {
 				}
 
 				file3 := filepath.Join(containerPath, "3")
-				if err := ioutil.WriteFile(file3, []byte{}, defaultPerm); err != nil {
+				if err := os.WriteFile(file3, []byte{}, defaultPerm); err != nil {
 					return nil, err
 				}
 
@@ -613,7 +612,7 @@ func TestCleanSubPaths(t *testing.T) {
 
 	for _, test := range tests {
 		klog.V(4).Infof("test %q", test.name)
-		base, err := ioutil.TempDir("", "clean-subpaths-"+test.name+"-")
+		base, err := os.MkdirTemp("", "clean-subpaths-"+test.name+"-")
 		if err != nil {
 			t.Fatalf(err.Error())
 		}
@@ -701,7 +700,7 @@ func TestBindSubPath(t *testing.T) {
 				if err := os.MkdirAll(volpath, defaultPerm); err != nil {
 					return nil, "", "", err
 				}
-				return nil, volpath, subpath, ioutil.WriteFile(subpath, []byte{}, defaultPerm)
+				return nil, volpath, subpath, os.WriteFile(subpath, []byte{}, defaultPerm)
 			},
 			expectError: false,
 		},
@@ -750,7 +749,7 @@ func TestBindSubPath(t *testing.T) {
 					return nil, "", "", err
 				}
 				// touch file outside
-				if err := ioutil.WriteFile(child, []byte{}, defaultPerm); err != nil {
+				if err := os.WriteFile(child, []byte{}, defaultPerm); err != nil {
 					return nil, "", "", err
 				}
 
@@ -785,7 +784,7 @@ func TestBindSubPath(t *testing.T) {
 					return nil, "", "", err
 				}
 				// touch file outside
-				if err := ioutil.WriteFile(child, []byte{}, defaultPerm); err != nil {
+				if err := os.WriteFile(child, []byte{}, defaultPerm); err != nil {
 					return nil, "", "", err
 				}
 
@@ -870,7 +869,7 @@ func TestBindSubPath(t *testing.T) {
 
 	for _, test := range tests {
 		klog.V(4).Infof("test %q", test.name)
-		base, err := ioutil.TempDir("", "bind-subpath-"+test.name+"-")
+		base, err := os.MkdirTemp("", "bind-subpath-"+test.name+"-")
 		if err != nil {
 			t.Fatalf(err.Error())
 		}
@@ -984,7 +983,7 @@ func TestSubpath_PrepareSafeSubpath(t *testing.T) {
 	}
 	for _, test := range tests {
 		klog.V(4).Infof("test %q", test.name)
-		base, err := ioutil.TempDir("", "bind-subpath-"+test.name+"-")
+		base, err := os.MkdirTemp("", "bind-subpath-"+test.name+"-")
 		if err != nil {
 			t.Fatalf(err.Error())
 		}
@@ -1142,7 +1141,7 @@ func TestSafeOpen(t *testing.T) {
 		{
 			"non-directory",
 			func(base string) error {
-				return ioutil.WriteFile(filepath.Join(base, "test"), []byte{}, defaultPerm)
+				return os.WriteFile(filepath.Join(base, "test"), []byte{}, defaultPerm)
 			},
 			"test/directory",
 			true,
@@ -1150,7 +1149,7 @@ func TestSafeOpen(t *testing.T) {
 		{
 			"non-directory-final",
 			func(base string) error {
-				return ioutil.WriteFile(filepath.Join(base, "test"), []byte{}, defaultPerm)
+				return os.WriteFile(filepath.Join(base, "test"), []byte{}, defaultPerm)
 			},
 			"test",
 			false,
@@ -1218,7 +1217,7 @@ func TestSafeOpen(t *testing.T) {
 
 	for _, test := range tests {
 		klog.V(4).Infof("test %q", test.name)
-		base, err := ioutil.TempDir("", "safe-open-"+test.name+"-")
+		base, err := os.MkdirTemp("", "safe-open-"+test.name+"-")
 		if err != nil {
 			t.Fatalf(err.Error())
 		}
@@ -1365,7 +1364,7 @@ func TestFindExistingPrefix(t *testing.T) {
 
 	for _, test := range tests {
 		klog.V(4).Infof("test %q", test.name)
-		base, err := ioutil.TempDir("", "find-prefix-"+test.name+"-")
+		base, err := os.MkdirTemp("", "find-prefix-"+test.name+"-")
 		if err != nil {
 			t.Fatalf(err.Error())
 		}
@@ -1394,7 +1393,7 @@ func TestFindExistingPrefix(t *testing.T) {
 }
 
 func validateDirEmpty(dir string) error {
-	files, err := ioutil.ReadDir(dir)
+	files, err := os.ReadDir(dir)
 	if err != nil {
 		return err
 	}
@@ -1406,7 +1405,7 @@ func validateDirEmpty(dir string) error {
 }
 
 func validateDirExists(dir string) error {
-	_, err := ioutil.ReadDir(dir)
+	_, err := os.ReadDir(dir)
 	if err != nil {
 		return err
 	}
@@ -1414,7 +1413,7 @@ func validateDirExists(dir string) error {
 }
 
 func validateDirNotExists(dir string) error {
-	_, err := ioutil.ReadDir(dir)
+	_, err := os.ReadDir(dir)
 	if os.IsNotExist(err) {
 		return nil
 	}

--- a/pkg/volume/util/subpath/subpath_windows_test.go
+++ b/pkg/volume/util/subpath/subpath_windows_test.go
@@ -21,7 +21,6 @@ package subpath
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -38,7 +37,7 @@ func makeLink(link, target string) error {
 }
 
 func TestDoSafeMakeDir(t *testing.T) {
-	base, err := ioutil.TempDir("", "TestDoSafeMakeDir")
+	base, err := os.MkdirTemp("", "TestDoSafeMakeDir")
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -134,7 +133,7 @@ func TestDoSafeMakeDir(t *testing.T) {
 }
 
 func TestLockAndCheckSubPath(t *testing.T) {
-	base, err := ioutil.TempDir("", "TestLockAndCheckSubPath")
+	base, err := os.MkdirTemp("", "TestLockAndCheckSubPath")
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -238,7 +237,7 @@ func TestLockAndCheckSubPath(t *testing.T) {
 }
 
 func TestLockAndCheckSubPathWithoutSymlink(t *testing.T) {
-	base, err := ioutil.TempDir("", "TestLockAndCheckSubPathWithoutSymlink")
+	base, err := os.MkdirTemp("", "TestLockAndCheckSubPathWithoutSymlink")
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -342,7 +341,7 @@ func TestLockAndCheckSubPathWithoutSymlink(t *testing.T) {
 }
 
 func TestFindExistingPrefix(t *testing.T) {
-	base, err := ioutil.TempDir("", "TestFindExistingPrefix")
+	base, err := os.MkdirTemp("", "TestFindExistingPrefix")
 	if err != nil {
 		t.Fatalf(err.Error())
 	}

--- a/staging/src/k8s.io/apimachinery/pkg/api/apitesting/roundtrip/compatibility.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/apitesting/roundtrip/compatibility.go
@@ -19,7 +19,6 @@ package roundtrip
 import (
 	"bytes"
 	gojson "encoding/json"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -333,11 +332,11 @@ func (c *CompatibilityTestOptions) encode(t *testing.T, obj runtime.Object) (jso
 
 func read(dir string, gvk schema.GroupVersionKind, suffix string, usedFiles sets.String) (json, yaml, proto []byte, err error) {
 	jsonFilename := makeName(gvk) + suffix + ".json"
-	actualJSON, jsonErr := ioutil.ReadFile(filepath.Join(dir, jsonFilename))
+	actualJSON, jsonErr := os.ReadFile(filepath.Join(dir, jsonFilename))
 	yamlFilename := makeName(gvk) + suffix + ".yaml"
-	actualYAML, yamlErr := ioutil.ReadFile(filepath.Join(dir, yamlFilename))
+	actualYAML, yamlErr := os.ReadFile(filepath.Join(dir, yamlFilename))
 	protoFilename := makeName(gvk) + suffix + ".pb"
-	actualProto, protoErr := ioutil.ReadFile(filepath.Join(dir, protoFilename))
+	actualProto, protoErr := os.ReadFile(filepath.Join(dir, protoFilename))
 	if usedFiles != nil {
 		usedFiles.Insert(jsonFilename)
 		usedFiles.Insert(yamlFilename)
@@ -359,7 +358,7 @@ func writeFile(t *testing.T, dir string, gvk schema.GroupVersionKind, suffix, ex
 	if err := os.MkdirAll(dir, os.FileMode(0755)); err != nil {
 		t.Fatal("error making directory", err)
 	}
-	if err := ioutil.WriteFile(filepath.Join(dir, makeName(gvk)+suffix+"."+extension), data, os.FileMode(0644)); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, makeName(gvk)+suffix+"."+extension), data, os.FileMode(0644)); err != nil {
 		t.Fatalf("error writing %s: %v", extension, err)
 	}
 }

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/helpers_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/helpers_test.go
@@ -17,7 +17,7 @@ limitations under the License.
 package unstructured
 
 import (
-	"io/ioutil"
+	"io"
 	"sync"
 	"testing"
 
@@ -38,7 +38,7 @@ func TestCodecOfUnstructuredList(t *testing.T) {
 	for i := 0; i < concurrency; i++ {
 		go func() {
 			defer wg.Done()
-			assert.NoError(t, UnstructuredJSONScheme.Encode(&list, ioutil.Discard))
+			assert.NoError(t, UnstructuredJSONScheme.Encode(&list, io.Discard))
 		}()
 	}
 	wg.Wait()

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/encoder_with_allocator_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/encoder_with_allocator_test.go
@@ -18,7 +18,7 @@ package serializer
 
 import (
 	"crypto/rand"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -49,7 +49,7 @@ func benchmarkEncodeFor(b *testing.B, target runtime.Encoder) {
 		b.Run(tc.name, func(b *testing.B) {
 			b.ReportAllocs()
 			for n := 0; n < b.N; n++ {
-				err := target.Encode(tc.obj, ioutil.Discard)
+				err := target.Encode(tc.obj, io.Discard)
 				if err != nil {
 					b.Fatal(err)
 				}
@@ -64,7 +64,7 @@ func benchmarkEncodeWithAllocatorFor(b *testing.B, target runtime.EncoderWithAll
 			b.ReportAllocs()
 			allocator := &runtime.Allocator{}
 			for n := 0; n < b.N; n++ {
-				err := target.EncodeWithAllocator(tc.obj, ioutil.Discard, allocator)
+				err := target.EncodeWithAllocator(tc.obj, io.Discard, allocator)
 				if err != nil {
 					b.Fatal(err)
 				}

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/streaming/streaming_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/streaming/streaming_test.go
@@ -19,7 +19,6 @@ package streaming
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -41,7 +40,7 @@ func (d *fakeDecoder) Decode(data []byte, gvk *schema.GroupVersionKind, into run
 func TestEmptyDecoder(t *testing.T) {
 	buf := bytes.NewBuffer([]byte{})
 	d := &fakeDecoder{}
-	_, _, err := NewDecoder(ioutil.NopCloser(buf), d).Decode(nil, nil)
+	_, _, err := NewDecoder(io.NopCloser(buf), d).Decode(nil, nil)
 	if err != io.EOF {
 		t.Fatal(err)
 	}

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/versioning/versioning_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/versioning/versioning_test.go
@@ -19,7 +19,6 @@ package versioning
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"reflect"
 	"testing"
 
@@ -112,7 +111,7 @@ func TestNestedEncode(t *testing.T) {
 		schema.GroupVersion{Group: "other"}, nil,
 		"TestNestedEncode",
 	)
-	if err := codec.Encode(n, ioutil.Discard); err != n2.nestedErr {
+	if err := codec.Encode(n, io.Discard); err != n2.nestedErr {
 		t.Errorf("unexpected error: %v", err)
 	}
 	if n.nestedCalled || !n2.nestedCalled {
@@ -135,7 +134,7 @@ func TestNestedEncodeError(t *testing.T) {
 		schema.GroupVersion{Group: "other", Version: "v2"}, nil,
 		"TestNestedEncodeError",
 	)
-	if err := codec.Encode(n, ioutil.Discard); err != n.nestedErr {
+	if err := codec.Encode(n, io.Discard); err != n.nestedErr {
 		t.Errorf("unexpected error: %v", err)
 	}
 	if n.GroupVersionKind() != gvk1 {
@@ -371,7 +370,7 @@ func TestDirectCodecEncode(t *testing.T) {
 		Encoder:     &serializer,
 		ObjectTyper: &typer,
 	}
-	c.Encode(&testDecodable{}, ioutil.Discard)
+	c.Encode(&testDecodable{}, io.Discard)
 	if e, a := "expected_group", serializer.encodingObjGVK.Group; e != a {
 		t.Errorf("expected group to be %v, got %v", e, a)
 	}

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/versioning/versioning_unstructured_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/versioning/versioning_unstructured_test.go
@@ -18,7 +18,7 @@ package versioning
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -133,7 +133,7 @@ func TestEncodeUnstructured(t *testing.T) {
 	for _, testCase := range testCases {
 		serializer := &mockSerializer{}
 		codec := NewCodec(serializer, serializer, testCase.convertor, nil, testCase.typer, nil, testCase.targetVersion, nil, "noxu-scheme")
-		err := codec.Encode(testCase.outObj, ioutil.Discard)
+		err := codec.Encode(testCase.outObj, io.Discard)
 		if testCase.errFunc != nil {
 			if !testCase.errFunc(err) {
 				t.Errorf("%v: failed: %v", testCase.name, err)

--- a/staging/src/k8s.io/apiserver/pkg/audit/policy/reader.go
+++ b/staging/src/k8s.io/apiserver/pkg/audit/policy/reader.go
@@ -18,7 +18,7 @@ package policy
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -47,7 +47,7 @@ func LoadPolicyFromFile(filePath string) (*auditinternal.Policy, error) {
 	if filePath == "" {
 		return nil, fmt.Errorf("file path not specified")
 	}
-	policyDef, err := ioutil.ReadFile(filePath)
+	policyDef, err := os.ReadFile(filePath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read file path %q: %+v", filePath, err)
 	}

--- a/staging/src/k8s.io/apiserver/pkg/audit/policy/reader_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/audit/policy/reader_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package policy
 
 import (
-	"io/ioutil"
 	"os"
 	"reflect"
 	"strings"
@@ -158,7 +157,7 @@ kind: Policy`,
 }
 
 func writePolicy(t *testing.T, policy string) (string, error) {
-	f, err := ioutil.TempFile("", "policy.yaml")
+	f, err := os.CreateTemp("", "policy.yaml")
 	require.NoError(t, err)
 
 	_, err = f.WriteString(policy)

--- a/staging/src/k8s.io/apiserver/pkg/authentication/request/x509/x509_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/request/x509/x509_test.go
@@ -21,7 +21,6 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"errors"
-	"io/ioutil"
 	"net/http"
 	"sort"
 	"testing"
@@ -956,7 +955,7 @@ func getCertsFromFile(t *testing.T, names ...string) []*x509.Certificate {
 	certs := []*x509.Certificate{}
 	for _, name := range names {
 		filename := "testdata/" + name + ".pem"
-		data, err := ioutil.ReadFile(filename)
+		data, err := os.ReadFile(filename)
 		if err != nil {
 			t.Fatalf("error reading %s: %v", filename, err)
 		}

--- a/staging/src/k8s.io/apiserver/pkg/authentication/token/tokenfile/tokenfile_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/token/tokenfile/tokenfile_test.go
@@ -18,7 +18,6 @@ package tokenfile
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"testing"
@@ -137,14 +136,14 @@ func TestEmptyTokenTokenFile(t *testing.T) {
 }
 
 func newWithContents(t *testing.T, contents string) (auth *TokenAuthenticator, err error) {
-	f, err := ioutil.TempFile("", "tokenfile_test")
+	f, err := os.CreateTemp("", "tokenfile_test")
 	if err != nil {
 		t.Fatalf("unexpected error creating tokenfile: %v", err)
 	}
 	f.Close()
 	defer os.Remove(f.Name())
 
-	if err := ioutil.WriteFile(f.Name(), []byte(contents), 0700); err != nil {
+	if err := os.WriteFile(f.Name(), []byte(contents), 0700); err != nil {
 		t.Fatalf("unexpected error writing tokenfile: %v", err)
 	}
 

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/apiserver_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/apiserver_test.go
@@ -24,7 +24,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"net/http"
 	"net/http/httptest"
@@ -704,7 +703,7 @@ func (storage *SimpleTypedStorage) GetSingularName() string {
 
 func bodyOrDie(response *http.Response) string {
 	defer response.Body.Close()
-	body, err := ioutil.ReadAll(response.Body)
+	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		panic(err)
 	}
@@ -717,7 +716,7 @@ func extractBody(response *http.Response, object runtime.Object) (string, error)
 
 func extractBodyDecoder(response *http.Response, object runtime.Object, decoder runtime.Decoder) (string, error) {
 	defer response.Body.Close()
-	body, err := ioutil.ReadAll(response.Body)
+	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		return string(body), err
 	}
@@ -726,7 +725,7 @@ func extractBodyDecoder(response *http.Response, object runtime.Object, decoder 
 
 func extractBodyObject(response *http.Response, decoder runtime.Decoder) (runtime.Object, string, error) {
 	defer response.Body.Close()
-	body, err := ioutil.ReadAll(response.Body)
+	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		return nil, string(body), err
 	}
@@ -889,7 +888,7 @@ func TestUnimplementedRESTStorage(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		defer response.Body.Close()
-		data, err := ioutil.ReadAll(response.Body)
+		data, err := io.ReadAll(response.Body)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -958,7 +957,7 @@ func TestSomeUnimplementedRESTStorage(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		defer response.Body.Close()
-		data, err := ioutil.ReadAll(response.Body)
+		data, err := io.ReadAll(response.Body)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1123,7 +1122,7 @@ func TestList(t *testing.T) {
 		defer resp.Body.Close()
 		if resp.StatusCode != http.StatusOK {
 			t.Errorf("%d: unexpected status: %d from url %s, Expected: %d, %#v", i, resp.StatusCode, testCase.url, http.StatusOK, resp)
-			body, err := ioutil.ReadAll(resp.Body)
+			body, err := io.ReadAll(resp.Body)
 			if err != nil {
 				t.Errorf("%d: unexpected error: %v", i, err)
 				continue
@@ -1181,7 +1180,7 @@ func TestRequestsWithInvalidQuery(t *testing.T) {
 		defer resp.Body.Close()
 		if resp.StatusCode != http.StatusBadRequest {
 			t.Errorf("%d: unexpected status: %d from url %s, Expected: %d, %#v", i, resp.StatusCode, url, http.StatusBadRequest, resp)
-			body, err := ioutil.ReadAll(resp.Body)
+			body, err := io.ReadAll(resp.Body)
 			if err != nil {
 				t.Errorf("%d: unexpected error: %v", i, err)
 				continue
@@ -1246,7 +1245,7 @@ func TestListCompression(t *testing.T) {
 		defer resp.Body.Close()
 		if resp.StatusCode != http.StatusOK {
 			t.Errorf("%d: unexpected status: %d from url %s, Expected: %d, %#v", i, resp.StatusCode, testCase.url, http.StatusOK, resp)
-			body, err := ioutil.ReadAll(resp.Body)
+			body, err := io.ReadAll(resp.Body)
 			if err != nil {
 				t.Errorf("%d: unexpected error: %v", i, err)
 				continue
@@ -1300,7 +1299,7 @@ func TestLogs(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 
-	body, err := ioutil.ReadAll(response.Body)
+	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1349,7 +1348,7 @@ func TestNonEmptyList(t *testing.T) {
 
 	if resp.StatusCode != http.StatusOK {
 		t.Errorf("Unexpected status: %d, Expected: %d, %#v", resp.StatusCode, http.StatusOK, resp)
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1462,7 +1461,7 @@ func BenchmarkGet(b *testing.B) {
 		if resp.StatusCode != http.StatusOK {
 			b.Fatalf("unexpected response: %#v", resp)
 		}
-		if _, err := io.Copy(ioutil.Discard, resp.Body); err != nil {
+		if _, err := io.Copy(io.Discard, resp.Body); err != nil {
 			b.Fatalf("unable to read body")
 		}
 	}
@@ -1498,7 +1497,7 @@ func BenchmarkGetNoCompression(b *testing.B) {
 		if resp.StatusCode != http.StatusOK {
 			b.Fatalf("unexpected response: %#v", resp)
 		}
-		if _, err := io.Copy(ioutil.Discard, resp.Body); err != nil {
+		if _, err := io.Copy(io.Discard, resp.Body); err != nil {
 			b.Fatalf("unable to read body")
 		}
 	}
@@ -1557,7 +1556,7 @@ func TestGetCompression(t *testing.T) {
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			t.Errorf("unexpected error reading body: %v", err)
 		}
@@ -2044,12 +2043,12 @@ func TestWatchTable(t *testing.T) {
 				test.send(simpleStorage.fakeWatch)
 			}()
 
-			body, err := ioutil.ReadAll(resp.Body)
+			body, err := io.ReadAll(resp.Body)
 			if err != nil {
 				t.Fatal(err)
 			}
 			t.Logf("Body:\n%s", string(body))
-			d := watcher(resp.Header.Get("Content-Type"), ioutil.NopCloser(bytes.NewReader(body)))
+			d := watcher(resp.Header.Get("Content-Type"), io.NopCloser(bytes.NewReader(body)))
 			var actual []*metav1.WatchEvent
 			for {
 				var event metav1.WatchEvent
@@ -2245,7 +2244,7 @@ func TestGetPartialObjectMetadata(t *testing.T) {
 			}
 			body = d
 		} else {
-			d, err := ioutil.ReadAll(resp.Body)
+			d, err := io.ReadAll(resp.Body)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -2284,7 +2283,7 @@ func TestGetBinary(t *testing.T) {
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("unexpected response: %#v", resp)
 	}
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -2539,7 +2538,7 @@ func TestConnect(t *testing.T) {
 		t.Errorf("unexpected response: %#v", resp)
 	}
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -2577,7 +2576,7 @@ func TestConnectResponderObject(t *testing.T) {
 		t.Errorf("unexpected response: %#v", resp)
 	}
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -2618,7 +2617,7 @@ func TestConnectResponderError(t *testing.T) {
 		t.Errorf("unexpected response: %#v", resp)
 	}
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -2687,7 +2686,7 @@ func TestConnectWithOptions(t *testing.T) {
 		t.Errorf("unexpected response: %#v", resp)
 	}
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -2737,7 +2736,7 @@ func TestConnectWithOptionsAndPath(t *testing.T) {
 		t.Errorf("unexpected response: %#v", resp)
 	}
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -2814,7 +2813,7 @@ func TestDeleteWithOptions(t *testing.T) {
 	}
 	if res.StatusCode != http.StatusOK {
 		t.Errorf("unexpected response: %s %#v", request.URL, res)
-		s, err := ioutil.ReadAll(res.Body)
+		s, err := io.ReadAll(res.Body)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -2854,7 +2853,7 @@ func TestDeleteWithOptionsQuery(t *testing.T) {
 	}
 	if res.StatusCode != http.StatusOK {
 		t.Errorf("unexpected response: %s %#v", request.URL, res)
-		s, err := ioutil.ReadAll(res.Body)
+		s, err := io.ReadAll(res.Body)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -2897,7 +2896,7 @@ func TestDeleteWithOptionsQueryAndBody(t *testing.T) {
 	}
 	if res.StatusCode != http.StatusOK {
 		t.Errorf("unexpected response: %s %#v", request.URL, res)
-		s, err := ioutil.ReadAll(res.Body)
+		s, err := io.ReadAll(res.Body)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -3287,7 +3286,7 @@ func TestCreateChecksDecode(t *testing.T) {
 	if response.StatusCode != http.StatusBadRequest {
 		t.Errorf("Unexpected response %#v", response)
 	}
-	b, err := ioutil.ReadAll(response.Body)
+	b, err := io.ReadAll(response.Body)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	} else if !strings.Contains(string(b), "cannot be handled as a Simple") {
@@ -3567,7 +3566,7 @@ func TestUpdateChecksDecode(t *testing.T) {
 	if response.StatusCode != http.StatusBadRequest {
 		t.Errorf("Unexpected response %#v\n%s", response, readBodyOrDie(response.Body))
 	}
-	b, err := ioutil.ReadAll(response.Body)
+	b, err := io.ReadAll(response.Body)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	} else if !strings.Contains(string(b), "cannot be handled as a Simple") {
@@ -3934,7 +3933,7 @@ func TestCreateChecksAPIVersion(t *testing.T) {
 	if response.StatusCode != http.StatusBadRequest {
 		t.Errorf("Unexpected response %#v", response)
 	}
-	b, err := ioutil.ReadAll(response.Body)
+	b, err := io.ReadAll(response.Body)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	} else if !strings.Contains(string(b), "does not match the expected API version") {
@@ -3999,7 +3998,7 @@ func TestUpdateChecksAPIVersion(t *testing.T) {
 	if response.StatusCode != http.StatusBadRequest {
 		t.Errorf("Unexpected response %#v", response)
 	}
-	b, err := ioutil.ReadAll(response.Body)
+	b, err := io.ReadAll(response.Body)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	} else if !strings.Contains(string(b), "does not match the expected API version") {
@@ -4397,7 +4396,7 @@ func TestXGSubresource(t *testing.T) {
 }
 
 func readBodyOrDie(r io.Reader) []byte {
-	body, err := ioutil.ReadAll(r)
+	body, err := io.ReadAll(r)
 	if err != nil {
 		panic(err)
 	}
@@ -4438,10 +4437,10 @@ func BenchmarkUpdateProtobuf(b *testing.B) {
 			b.Fatalf("unexpected error: %v", err)
 		}
 		if response.StatusCode != http.StatusBadRequest {
-			body, _ := ioutil.ReadAll(response.Body)
+			body, _ := io.ReadAll(response.Body)
 			b.Fatalf("Unexpected response %#v\n%s", response, body)
 		}
-		_, _ = ioutil.ReadAll(response.Body)
+		_, _ = io.ReadAll(response.Body)
 		response.Body.Close()
 	}
 	b.StopTimer()

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/discovery/root_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/discovery/root_test.go
@@ -19,7 +19,6 @@ package discovery
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -54,7 +53,7 @@ func init() {
 func decodeResponse(t *testing.T, resp *http.Response, obj interface{}) error {
 	defer resp.Body.Close()
 
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := os.ReadAll(resp.Body)
 	t.Log(string(data))
 	if err != nil {
 		return err

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/bench_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/bench_test.go
@@ -19,7 +19,7 @@ package fieldmanager_test
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -38,7 +38,7 @@ import (
 )
 
 var fakeTypeConverter = func() managedfields.TypeConverter {
-	data, err := ioutil.ReadFile(filepath.Join(strings.Repeat(".."+string(filepath.Separator), 8),
+	data, err := os.ReadFile(filepath.Join(strings.Repeat(".."+string(filepath.Separator), 8),
 		"api", "openapi-spec", "swagger.json"))
 	if err != nil {
 		panic(err)
@@ -60,7 +60,7 @@ var fakeTypeConverter = func() managedfields.TypeConverter {
 }()
 
 func getObjectBytes(file string) []byte {
-	s, err := ioutil.ReadFile(file)
+	s, err := os.ReadFile(file)
 	if err != nil {
 		panic(err)
 	}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers_test.go
@@ -24,7 +24,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"net/http"
 	"net/http/httptest"
@@ -363,7 +362,7 @@ func TestSerializeObject(t *testing.T) {
 			if !reflect.DeepEqual(result.Header, tt.wantHeaders) {
 				t.Fatal(cmp.Diff(tt.wantHeaders, result.Header))
 			}
-			body, _ := ioutil.ReadAll(result.Body)
+			body, _ := os.ReadAll(result.Body)
 			if !bytes.Equal(tt.wantBody, body) {
 				t.Fatalf("wanted:\n%s\ngot:\n%s", hex.Dump(tt.wantBody), hex.Dump(body))
 			}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest.go
@@ -21,7 +21,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
@@ -373,13 +372,13 @@ func summarizeData(data []byte, maxLength int) string {
 func limitedReadBody(req *http.Request, limit int64) ([]byte, error) {
 	defer req.Body.Close()
 	if limit <= 0 {
-		return ioutil.ReadAll(req.Body)
+		return io.ReadAll(req.Body)
 	}
 	lr := &io.LimitedReader{
 		R: req.Body,
 		N: limit + 1,
 	}
-	data, err := ioutil.ReadAll(lr)
+	data, err := io.ReadAll(lr)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/watch_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/watch_test.go
@@ -22,7 +22,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -239,7 +238,7 @@ func TestWatchClientClose(t *testing.T) {
 	}
 
 	if response.StatusCode != http.StatusOK {
-		b, _ := ioutil.ReadAll(response.Body)
+		b, _ := os.ReadAll(response.Body)
 		t.Fatalf("Unexpected response: %#v\n%s", response, string(b))
 	}
 
@@ -283,7 +282,7 @@ func TestWatchRead(t *testing.T) {
 		}
 
 		if response.StatusCode != http.StatusOK {
-			b, _ := ioutil.ReadAll(response.Body)
+			b, _ := os.ReadAll(response.Body)
 			t.Fatalf("Unexpected response for accept: %q: %#v\n%s", accept, response, string(b))
 		}
 		return response.Body, response.Header.Get("Content-Type")
@@ -929,7 +928,7 @@ func runWatchHTTPBenchmark(b *testing.B, items []runtime.Object, contentType str
 	wg.Add(1)
 	go func() {
 		defer response.Body.Close()
-		if _, err := io.Copy(ioutil.Discard, response.Body); err != nil {
+		if _, err := io.Copy(io.Discard, response.Body); err != nil {
 			b.Error(err)
 		}
 		wg.Done()
@@ -969,7 +968,7 @@ func BenchmarkWatchWebsocket(b *testing.B) {
 	wg.Add(1)
 	go func() {
 		defer ws.Close()
-		if _, err := io.Copy(ioutil.Discard, ws); err != nil {
+		if _, err := io.Copy(io.Discard, ws); err != nil {
 			b.Error(err)
 		}
 		wg.Done()

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/rest/response_checker.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/rest/response_checker.go
@@ -19,7 +19,6 @@ package rest
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -47,7 +46,7 @@ type GenericHttpResponseChecker struct {
 func (checker GenericHttpResponseChecker) Check(resp *http.Response) error {
 	if resp.StatusCode < http.StatusOK || resp.StatusCode > http.StatusPartialContent {
 		defer resp.Body.Close()
-		bodyBytes, err := ioutil.ReadAll(io.LimitReader(resp.Body, maxReadLength))
+		bodyBytes, err := io.ReadAll(io.LimitReader(resp.Body, maxReadLength))
 		if err != nil {
 			return errors.NewInternalError(err)
 		}

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/rest/response_checker_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/rest/response_checker_test.go
@@ -19,7 +19,7 @@ package rest
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"reflect"
 	"strings"
@@ -39,7 +39,7 @@ func TestGenericHttpResponseChecker(t *testing.T) {
 	}{
 		{
 			resp: &http.Response{
-				Body:       ioutil.NopCloser(bytes.NewBufferString("Success")),
+				Body:       io.NopCloser(bytes.NewBufferString("Success")),
 				StatusCode: http.StatusOK,
 			},
 			expectError: false,
@@ -47,7 +47,7 @@ func TestGenericHttpResponseChecker(t *testing.T) {
 		},
 		{
 			resp: &http.Response{
-				Body:       ioutil.NopCloser(bytes.NewBufferString("Invalid request.")),
+				Body:       io.NopCloser(bytes.NewBufferString("Invalid request.")),
 				StatusCode: http.StatusBadRequest,
 			},
 			expectError: true,
@@ -56,7 +56,7 @@ func TestGenericHttpResponseChecker(t *testing.T) {
 		},
 		{
 			resp: &http.Response{
-				Body:       ioutil.NopCloser(bytes.NewBufferString("Pod does not exist.")),
+				Body:       io.NopCloser(bytes.NewBufferString("Pod does not exist.")),
 				StatusCode: http.StatusInternalServerError,
 			},
 			expectError: true,
@@ -82,7 +82,7 @@ func TestGenericHttpResponseCheckerLimitReader(t *testing.T) {
 	responseChecker := NewGenericHttpResponseChecker(v1.Resource("pods"), "foo")
 	excessedString := strings.Repeat("a", (maxReadLength + 10000))
 	resp := &http.Response{
-		Body:       ioutil.NopCloser(bytes.NewBufferString(excessedString)),
+		Body:       io.NopCloser(bytes.NewBufferString(excessedString)),
 		StatusCode: http.StatusBadRequest,
 	}
 	err := responseChecker.Check(resp)

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/rest/streamer_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/rest/streamer_test.go
@@ -21,7 +21,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -54,7 +53,7 @@ func TestInputStreamReader(t *testing.T) {
 		return
 	}
 	defer readCloser.Close()
-	result, _ := ioutil.ReadAll(readCloser)
+	result, _ := os.ReadAll(readCloser)
 	if string(result) != resultString {
 		t.Errorf("Stream content does not match. Got: %s. Expected: %s.", string(result), resultString)
 	}
@@ -117,7 +116,7 @@ func TestInputStreamTransport(t *testing.T) {
 		return
 	}
 	defer readCloser.Close()
-	result, _ := ioutil.ReadAll(readCloser)
+	result, _ := os.ReadAll(readCloser)
 	if string(result) != message {
 		t.Errorf("Stream content does not match. Got: %s. Expected: %s.", string(result), message)
 	}

--- a/staging/src/k8s.io/apiserver/pkg/server/filters/goaway_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/goaway_test.go
@@ -22,7 +22,6 @@ import (
 	"crypto/tls"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"net"
 	"net/http"
@@ -142,7 +141,7 @@ func newTestGOAWAYServer() (*httptest.Server, error) {
 		return
 	})
 	postHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		reqBody, err := ioutil.ReadAll(r.Body)
+		reqBody, err := os.ReadAll(r.Body)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
@@ -208,7 +207,7 @@ func requestGOAWAYServer(client *http.Client, serverBaseURL, url string) (<-chan
 
 	if resp.StatusCode != http.StatusOK {
 		defer resp.Body.Close()
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := os.ReadAll(resp.Body)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read response body and status code is %d, error: %v", resp.StatusCode, err)
 		}
@@ -248,7 +247,7 @@ func requestGOAWAYServer(client *http.Client, serverBaseURL, url string) (<-chan
 	}
 
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := os.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response body, error: %v", err)
 	}

--- a/staging/src/k8s.io/apiserver/pkg/server/filters/timeout_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/timeout_test.go
@@ -23,7 +23,6 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -121,7 +120,7 @@ func TestTimeout(t *testing.T) {
 	if res.StatusCode != http.StatusOK {
 		t.Errorf("got res.StatusCode %d; expected %d", res.StatusCode, http.StatusOK)
 	}
-	body, _ := ioutil.ReadAll(res.Body)
+	body, _ := os.ReadAll(res.Body)
 	if string(body) != resp {
 		t.Errorf("got body %q; expected %q", string(body), resp)
 	}
@@ -143,7 +142,7 @@ func TestTimeout(t *testing.T) {
 	if res.StatusCode != http.StatusGatewayTimeout {
 		t.Errorf("got res.StatusCode %d; expected %d", res.StatusCode, http.StatusGatewayTimeout)
 	}
-	body, _ = ioutil.ReadAll(res.Body)
+	body, _ = os.ReadAll(res.Body)
 	status := &metav1.Status{}
 	if err := json.Unmarshal(body, status); err != nil {
 		t.Fatal(err)

--- a/staging/src/k8s.io/apiserver/pkg/server/options/audit_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/audit_test.go
@@ -19,7 +19,6 @@ package options
 import (
 	stdjson "encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -271,7 +270,7 @@ func makeTmpWebhookConfig(t *testing.T) string {
 			{Cluster: v1.Cluster{Server: "localhost", InsecureSkipTLSVerify: true}},
 		},
 	}
-	f, err := ioutil.TempFile("", "k8s_audit_webhook_test_")
+	f, err := os.CreateTemp("", "k8s_audit_webhook_test_")
 	require.NoError(t, err, "creating temp file")
 	require.NoError(t, stdjson.NewEncoder(f).Encode(config), "writing webhook kubeconfig")
 	require.NoError(t, f.Close())
@@ -289,7 +288,7 @@ func makeTmpPolicy(t *testing.T) string {
 			},
 		},
 	}
-	f, err := ioutil.TempFile("", "k8s_audit_policy_test_")
+	f, err := os.CreateTemp("", "k8s_audit_policy_test_")
 	require.NoError(t, err, "creating temp file")
 	require.NoError(t, stdjson.NewEncoder(f).Encode(pol), "writing policy file")
 	require.NoError(t, f.Close())

--- a/staging/src/k8s.io/apiserver/pkg/server/options/authentication_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/authentication_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package options
 
 import (
-	"io/ioutil"
 	"net/http"
 	"os"
 	"reflect"
@@ -85,13 +84,13 @@ func TestToAuthenticationRequestHeaderConfig(t *testing.T) {
 
 func TestApplyToFallback(t *testing.T) {
 
-	f, err := ioutil.TempFile("", "authkubeconfig")
+	f, err := os.CreateTemp("", "authkubeconfig")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer os.Remove(f.Name())
 
-	if err := ioutil.WriteFile(f.Name(), []byte(`
+	if err := os.WriteFile(f.Name(), []byte(`
 apiVersion: v1
 kind: Config
 clusters:

--- a/staging/src/k8s.io/apiserver/pkg/server/options/serving_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/serving_test.go
@@ -28,7 +28,6 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	"net"
 	"os"
@@ -405,13 +404,13 @@ func getOrCreateTestCertFiles(certFileName, keyFileName string, spec TestCertSpe
 	}
 
 	os.MkdirAll(filepath.Dir(certFileName), os.FileMode(0755))
-	err = ioutil.WriteFile(certFileName, certPem, os.FileMode(0755))
+	err = os.WriteFile(certFileName, certPem, os.FileMode(0755))
 	if err != nil {
 		return err
 	}
 
 	os.MkdirAll(filepath.Dir(keyFileName), os.FileMode(0755))
-	err = ioutil.WriteFile(keyFileName, keyPem, os.FileMode(0755))
+	err = os.WriteFile(keyFileName, keyPem, os.FileMode(0755))
 	if err != nil {
 		return err
 	}
@@ -420,7 +419,7 @@ func getOrCreateTestCertFiles(certFileName, keyFileName string, spec TestCertSpe
 }
 
 func caCertFromBundle(bundlePath string) (*x509.Certificate, error) {
-	pemData, err := ioutil.ReadFile(bundlePath)
+	pemData, err := os.ReadFile(bundlePath)
 	if err != nil {
 		return nil, err
 	}
@@ -433,7 +432,6 @@ func caCertFromBundle(bundlePath string) (*x509.Certificate, error) {
 		if nextBlock == nil {
 			if block == nil {
 				return nil, fmt.Errorf("no certificate found in %q", bundlePath)
-
 			}
 			return x509.ParseCertificate(block.Bytes)
 		}

--- a/staging/src/k8s.io/apiserver/pkg/server/options/tracing.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/tracing.go
@@ -19,8 +19,8 @@ package options
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net"
+	"os"
 
 	"github.com/spf13/pflag"
 	"go.opentelemetry.io/otel"
@@ -153,7 +153,7 @@ func ReadTracingConfiguration(configFilePath string) (*tracingapi.TracingConfigu
 	if configFilePath == "" {
 		return nil, fmt.Errorf("tracing config file was empty")
 	}
-	data, err := ioutil.ReadFile(configFilePath)
+	data, err := os.ReadFile(configFilePath)
 	if err != nil {
 		return nil, fmt.Errorf("unable to read tracing configuration from %q: %v", configFilePath, err)
 	}

--- a/staging/src/k8s.io/apiserver/pkg/server/options/tracing_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/tracing_test.go
@@ -18,7 +18,6 @@ package options
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"strings"
@@ -156,12 +155,12 @@ spec:
 		t.Run(tc.name, func(t *testing.T) {
 			proxyConfig := fmt.Sprintf("test-tracing-config-%s", tc.name)
 			if tc.createFile {
-				f, err := ioutil.TempFile("", proxyConfig)
+				f, err := os.CreateTemp("", proxyConfig)
 				if err != nil {
 					t.Fatal(err)
 				}
 				defer os.Remove(f.Name())
-				if err := ioutil.WriteFile(f.Name(), []byte(tc.contents), os.FileMode(0755)); err != nil {
+				if err := os.WriteFile(f.Name(), []byte(tc.contents), os.FileMode(0755)); err != nil {
 					t.Fatal(err)
 				}
 				proxyConfig = f.Name()

--- a/staging/src/k8s.io/apiserver/pkg/server/routes/flags.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/routes/flags.go
@@ -19,7 +19,7 @@ package routes
 import (
 	"fmt"
 	"html/template"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"path"
 	"sync"
@@ -98,7 +98,7 @@ func StringFlagPutHandler(setter StringFlagSetterFunc) http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		switch {
 		case req.Method == "PUT":
-			body, err := ioutil.ReadAll(req.Body)
+			body, err := io.ReadAll(req.Body)
 			if err != nil {
 				writePlainText(http.StatusBadRequest, "error reading request body: "+err.Error(), w)
 				return

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store_test.go
@@ -19,8 +19,8 @@ package etcd3
 import (
 	"context"
 	"crypto/rand"
+	"io"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"strings"
@@ -49,8 +49,10 @@ import (
 	"k8s.io/klog/v2"
 )
 
-var scheme = runtime.NewScheme()
-var codecs = serializer.NewCodecFactory(scheme)
+var (
+	scheme = runtime.NewScheme()
+	codecs = serializer.NewCodecFactory(scheme)
+)
 
 const defaultTestPrefix = "test!"
 
@@ -59,7 +61,7 @@ func init() {
 	utilruntime.Must(example.AddToScheme(scheme))
 	utilruntime.Must(examplev1.AddToScheme(scheme))
 
-	grpclog.SetLoggerV2(grpclog.NewLoggerV2(ioutil.Discard, ioutil.Discard, os.Stderr))
+	grpclog.SetLoggerV2(grpclog.NewLoggerV2(io.Discard, io.Discard, os.Stderr))
 }
 
 func newPod() runtime.Object {

--- a/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/tls_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/tls_test.go
@@ -18,7 +18,6 @@ package factory
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -94,20 +93,20 @@ func TestTLSConnection(t *testing.T) {
 
 func configureTLSCerts(t *testing.T) (certFile, keyFile, caFile string) {
 	baseDir := os.TempDir()
-	tempDir, err := ioutil.TempDir(baseDir, "etcd_certificates")
+	tempDir, err := os.MkdirTemp(baseDir, "etcd_certificates")
 	if err != nil {
 		t.Fatal(err)
 	}
 	certFile = path.Join(tempDir, "etcdcert.pem")
-	if err := ioutil.WriteFile(certFile, []byte(testingcert.CertFileContent), 0644); err != nil {
+	if err := os.WriteFile(certFile, []byte(testingcert.CertFileContent), 0644); err != nil {
 		t.Fatal(err)
 	}
 	keyFile = path.Join(tempDir, "etcdkey.pem")
-	if err := ioutil.WriteFile(keyFile, []byte(testingcert.KeyFileContent), 0644); err != nil {
+	if err := os.WriteFile(keyFile, []byte(testingcert.KeyFileContent), 0644); err != nil {
 		t.Fatal(err)
 	}
 	caFile = path.Join(tempDir, "ca.pem")
-	if err := ioutil.WriteFile(caFile, []byte(testingcert.CAFileContent), 0644); err != nil {
+	if err := os.WriteFile(caFile, []byte(testingcert.CAFileContent), 0644); err != nil {
 		t.Fatal(err)
 	}
 	return certFile, keyFile, caFile

--- a/staging/src/k8s.io/apiserver/plugin/pkg/audit/webhook/webhook_test.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/audit/webhook/webhook_test.go
@@ -20,7 +20,6 @@ import (
 	stdjson "encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -65,7 +64,7 @@ type testWebhookHandler struct {
 
 func (t *testWebhookHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	err := func() error {
-		body, err := ioutil.ReadAll(r.Body)
+		body, err := os.ReadAll(r.Body)
 		if err != nil {
 			return fmt.Errorf("read webhook request body: %v", err)
 		}
@@ -96,7 +95,7 @@ func newWebhook(t *testing.T, endpoint string, groupVersion schema.GroupVersion)
 			{Cluster: v1.Cluster{Server: endpoint, InsecureSkipTLSVerify: true}},
 		},
 	}
-	f, err := ioutil.TempFile("", "k8s_audit_webhook_test_")
+	f, err := os.CreateTemp("", "k8s_audit_webhook_test_")
 	require.NoError(t, err, "creating temp file")
 
 	defer func() {

--- a/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/oidc/oidc.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/oidc/oidc.go
@@ -33,9 +33,9 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/url"
+	"io"
 	"reflect"
 	"strings"
 	"sync"
@@ -969,7 +969,7 @@ func getClaimJWT(ctx context.Context, client *http.Client, url, accessToken stri
 	if response.StatusCode < http.StatusOK || response.StatusCode > http.StatusIMUsed {
 		return "", fmt.Errorf("error while getting distributed claim JWT: %v", response.Status)
 	}
-	responseBytes, err := ioutil.ReadAll(response.Body)
+	responseBytes, err := io.ReadAll(response.Body)
 	if err != nil {
 		return "", fmt.Errorf("could not decode distributed claim response")
 	}

--- a/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/webhook/webhook_v1_test.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/webhook/webhook_v1_test.go
@@ -22,7 +22,6 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -89,7 +88,7 @@ func NewV1TestServer(s V1Service, cert, key, caCert []byte) (*httptest.Server, e
 		}
 
 		var review authenticationv1.TokenReview
-		bodyData, _ := ioutil.ReadAll(r.Body)
+		bodyData, _ := os.ReadAll(r.Body)
 		if err := json.Unmarshal(bodyData, &review); err != nil {
 			http.Error(w, fmt.Sprintf("failed to decode body: %v", err), http.StatusBadRequest)
 			return
@@ -180,7 +179,7 @@ func (m *mockV1Service) HTTPStatusCode() int { return m.statusCode }
 // newV1TokenAuthenticator creates a temporary kubeconfig file from the provided
 // arguments and attempts to load a new WebhookTokenAuthenticator from it.
 func newV1TokenAuthenticator(serverURL string, clientCert, clientKey, ca []byte, cacheTime time.Duration, implicitAuds authenticator.Audiences, metrics AuthenticatorMetrics) (authenticator.Token, error) {
-	tempfile, err := ioutil.TempFile("", "")
+	tempfile, err := os.CreateTemp("", "")
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/webhook/webhook_v1beta1_test.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/webhook/webhook_v1beta1_test.go
@@ -22,7 +22,6 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -83,7 +82,7 @@ func NewV1beta1TestServer(s V1beta1Service, cert, key, caCert []byte) (*httptest
 		}
 
 		var review authenticationv1beta1.TokenReview
-		bodyData, _ := ioutil.ReadAll(r.Body)
+		bodyData, _ := os.ReadAll(r.Body)
 		if err := json.Unmarshal(bodyData, &review); err != nil {
 			http.Error(w, fmt.Sprintf("failed to decode body: %v", err), http.StatusBadRequest)
 			return
@@ -174,7 +173,7 @@ func (m *mockV1beta1Service) HTTPStatusCode() int { return m.statusCode }
 // newV1beta1TokenAuthenticator creates a temporary kubeconfig file from the provided
 // arguments and attempts to load a new WebhookTokenAuthenticator from it.
 func newV1beta1TokenAuthenticator(serverURL string, clientCert, clientKey, ca []byte, cacheTime time.Duration, implicitAuds authenticator.Audiences) (authenticator.Token, error) {
-	tempfile, err := ioutil.TempFile("", "")
+	tempfile, err := os.CreateTemp("", "")
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/apiserver/plugin/pkg/authorizer/webhook/webhook_v1_test.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/authorizer/webhook/webhook_v1_test.go
@@ -22,7 +22,6 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -66,7 +65,7 @@ var testRetryBackoff = wait.Backoff{
 }
 
 func TestV1NewFromConfig(t *testing.T) {
-	dir, err := ioutil.TempDir("", "")
+	dir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -91,7 +90,7 @@ func TestV1NewFromConfig(t *testing.T) {
 		{data.Key, clientKey},
 	}
 	for _, file := range files {
-		if err := ioutil.WriteFile(file.name, file.data, 0400); err != nil {
+		if err := os.WriteFile(file.name, file.data, 0400); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -194,7 +193,7 @@ current-context: default
 	for _, tt := range tests {
 		// Use a closure so defer statements trigger between loop iterations.
 		err := func() error {
-			tempfile, err := ioutil.TempFile("", "")
+			tempfile, err := os.CreateTemp("", "")
 			if err != nil {
 				return err
 			}
@@ -268,7 +267,7 @@ func NewV1TestServer(s V1Service, cert, key, caCert []byte) (*httptest.Server, e
 		}
 
 		var review authorizationv1.SubjectAccessReview
-		bodyData, _ := ioutil.ReadAll(r.Body)
+		bodyData, _ := os.ReadAll(r.Body)
 		if err := json.Unmarshal(bodyData, &review); err != nil {
 			http.Error(w, fmt.Sprintf("failed to decode body: %v", err), http.StatusBadRequest)
 			return
@@ -338,7 +337,7 @@ func (m *mockV1Service) HTTPStatusCode() int { return m.statusCode }
 // newV1Authorizer creates a temporary kubeconfig file from the provided arguments and attempts to load
 // a new WebhookAuthorizer from it.
 func newV1Authorizer(callbackURL string, clientCert, clientKey, ca []byte, cacheTime time.Duration, metrics metrics.AuthorizerMetrics, expressions []apiserver.WebhookMatchCondition, authzName string) (*WebhookAuthorizer, error) {
-	tempfile, err := ioutil.TempFile("", "")
+	tempfile, err := os.CreateTemp("", "")
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/apiserver/plugin/pkg/authorizer/webhook/webhook_v1beta1_test.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/authorizer/webhook/webhook_v1beta1_test.go
@@ -22,7 +22,6 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -46,7 +45,7 @@ import (
 )
 
 func TestV1beta1NewFromConfig(t *testing.T) {
-	dir, err := ioutil.TempDir("", "")
+	dir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -71,7 +70,7 @@ func TestV1beta1NewFromConfig(t *testing.T) {
 		{data.Key, clientKey},
 	}
 	for _, file := range files {
-		if err := ioutil.WriteFile(file.name, file.data, 0400); err != nil {
+		if err := os.WriteFile(file.name, file.data, 0400); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -174,7 +173,7 @@ current-context: default
 	for _, tt := range tests {
 		// Use a closure so defer statements trigger between loop iterations.
 		err := func() error {
-			tempfile, err := ioutil.TempFile("", "")
+			tempfile, err := os.CreateTemp("", "")
 			if err != nil {
 				return err
 			}
@@ -248,7 +247,7 @@ func NewV1beta1TestServer(s V1beta1Service, cert, key, caCert []byte) (*httptest
 		}
 
 		var review authorizationv1beta1.SubjectAccessReview
-		bodyData, _ := ioutil.ReadAll(r.Body)
+		bodyData, _ := os.ReadAll(r.Body)
 		if err := json.Unmarshal(bodyData, &review); err != nil {
 			http.Error(w, fmt.Sprintf("failed to decode body: %v", err), http.StatusBadRequest)
 			return
@@ -311,7 +310,7 @@ func (m *mockV1beta1Service) HTTPStatusCode() int { return m.statusCode }
 // newV1beta1Authorizer creates a temporary kubeconfig file from the provided arguments and attempts to load
 // a new WebhookAuthorizer from it.
 func newV1beta1Authorizer(callbackURL string, clientCert, clientKey, ca []byte, cacheTime time.Duration) (*WebhookAuthorizer, error) {
-	tempfile, err := ioutil.TempFile("", "")
+	tempfile, err := os.CreateTemp("", "")
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/cloud-provider/app/testing/testserver.go
+++ b/staging/src/k8s.io/cloud-provider/app/testing/testserver.go
@@ -19,7 +19,6 @@ package testing
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"strings"
@@ -99,7 +98,7 @@ func StartTestServer(ctx context.Context, customFlags []string) (result TestServ
 		}
 	}()
 
-	result.TmpDir, err = ioutil.TempDir("", "cloud-controller-manager")
+	result.TmpDir, err = os.MkdirTemp("", "cloud-controller-manager")
 	if err != nil {
 		return result, fmt.Errorf("failed to create temp dir: %v", err)
 	}

--- a/staging/src/k8s.io/pod-security-admission/admission/api/load/load_test.go
+++ b/staging/src/k8s.io/pod-security-admission/admission/api/load/load_test.go
@@ -18,7 +18,6 @@ package load
 
 import (
 	"bytes"
-	"io/ioutil"
 	"reflect"
 	"strings"
 	"testing"
@@ -40,14 +39,14 @@ var defaultConfig = &api.PodSecurityConfiguration{
 
 func writeTempFile(t *testing.T, content string) string {
 	t.Helper()
-	file, err := ioutil.TempFile("", "podsecurityconfig")
+	file, err := os.CreateTemp("", "podsecurityconfig")
 	if err != nil {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() {
 		utiltesting.CloseAndRemove(t, file)
 	})
-	if err := ioutil.WriteFile(file.Name(), []byte(content), 0600); err != nil {
+	if err := os.WriteFile(file.Name(), []byte(content), 0600); err != nil {
 		t.Fatal(err)
 	}
 	return file.Name()

--- a/staging/src/k8s.io/pod-security-admission/cmd/webhook/server/server.go
+++ b/staging/src/k8s.io/pod-security-admission/cmd/webhook/server/server.go
@@ -23,7 +23,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -182,7 +181,7 @@ func (s *Server) HandleValidate(w http.ResponseWriter, r *http.Request) {
 
 	defer r.Body.Close()
 	limitedReader := &io.LimitedReader{R: r.Body, N: maxRequestSize}
-	if body, err = ioutil.ReadAll(limitedReader); err != nil {
+	if body, err = io.ReadAll(limitedReader); err != nil {
 		logger.Error(err, "unable to read the body from the incoming request")
 		http.Error(w, "unable to read the body from the incoming request", http.StatusBadRequest)
 		return

--- a/staging/src/k8s.io/pod-security-admission/test/fixtures_test.go
+++ b/staging/src/k8s.io/pod-security-admission/test/fixtures_test.go
@@ -18,7 +18,6 @@ package test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -137,7 +136,7 @@ func testFixtureFile(t *testing.T, dir, name string, pod *corev1.Pod) string {
 	pod = pod.DeepCopy()
 	pod.Name = name
 
-	expectedYAML, _ := ioutil.ReadFile(filename)
+	expectedYAML, _ := os.ReadFile(filename)
 
 	jsonData, err := runtime.Encode(scheme.Codecs.LegacyCodec(corev1.SchemeGroupVersion), pod)
 	if err != nil {
@@ -160,7 +159,7 @@ func testFixtureFile(t *testing.T, dir, name string, pod *corev1.Pod) string {
 			if err := os.MkdirAll(dir, os.FileMode(0755)); err != nil {
 				t.Fatal(err)
 			}
-			if err := ioutil.WriteFile(filename, []byte(yamlData), os.FileMode(0755)); err == nil {
+			if err := os.WriteFile(filename, []byte(yamlData), os.FileMode(0755)); err == nil {
 				t.Logf("Updated data in %s", filename)
 				t.Logf("Verify the diff, commit changes, and rerun the tests")
 			} else {


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/kind deprecation

#### What this PR does / why we need it:
This PR removes/resolves all references of the [ioutil](https://pkg.go.dev/io/ioutil#pkg-overview) pkg which has been deprecated since go1.16, except in the vendor and third_party directories, because I'm not sure if that should be done for those too.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:


#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
