### PR TITLE
chore(staging/apimachinery): rm ioutil

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/apitesting/roundtrip/compatibility.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/apitesting/roundtrip/compatibility.go
@@ -19,7 +19,6 @@ package roundtrip
 import (
 	"bytes"
 	gojson "encoding/json"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -333,11 +332,11 @@ func (c *CompatibilityTestOptions) encode(t *testing.T, obj runtime.Object) (jso
 
 func read(dir string, gvk schema.GroupVersionKind, suffix string, usedFiles sets.String) (json, yaml, proto []byte, err error) {
 	jsonFilename := makeName(gvk) + suffix + ".json"
-	actualJSON, jsonErr := ioutil.ReadFile(filepath.Join(dir, jsonFilename))
+	actualJSON, jsonErr := os.ReadFile(filepath.Join(dir, jsonFilename))
 	yamlFilename := makeName(gvk) + suffix + ".yaml"
-	actualYAML, yamlErr := ioutil.ReadFile(filepath.Join(dir, yamlFilename))
+	actualYAML, yamlErr := os.ReadFile(filepath.Join(dir, yamlFilename))
 	protoFilename := makeName(gvk) + suffix + ".pb"
-	actualProto, protoErr := ioutil.ReadFile(filepath.Join(dir, protoFilename))
+	actualProto, protoErr := os.ReadFile(filepath.Join(dir, protoFilename))
 	if usedFiles != nil {
 		usedFiles.Insert(jsonFilename)
 		usedFiles.Insert(yamlFilename)
@@ -359,7 +358,7 @@ func writeFile(t *testing.T, dir string, gvk schema.GroupVersionKind, suffix, ex
 	if err := os.MkdirAll(dir, os.FileMode(0755)); err != nil {
 		t.Fatal("error making directory", err)
 	}
-	if err := ioutil.WriteFile(filepath.Join(dir, makeName(gvk)+suffix+"."+extension), data, os.FileMode(0644)); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, makeName(gvk)+suffix+"."+extension), data, os.FileMode(0644)); err != nil {
 		t.Fatalf("error writing %s: %v", extension, err)
 	}
 }

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/helpers_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/helpers_test.go
@@ -17,7 +17,7 @@ limitations under the License.
 package unstructured
 
 import (
-	"io/ioutil"
+	"io"
 	"sync"
 	"testing"
 
@@ -38,7 +38,7 @@ func TestCodecOfUnstructuredList(t *testing.T) {
 	for i := 0; i < concurrency; i++ {
 		go func() {
 			defer wg.Done()
-			assert.NoError(t, UnstructuredJSONScheme.Encode(&list, ioutil.Discard))
+			assert.NoError(t, UnstructuredJSONScheme.Encode(&list, io.Discard))
 		}()
 	}
 	wg.Wait()

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/encoder_with_allocator_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/encoder_with_allocator_test.go
@@ -18,7 +18,7 @@ package serializer
 
 import (
 	"crypto/rand"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -49,7 +49,7 @@ func benchmarkEncodeFor(b *testing.B, target runtime.Encoder) {
 		b.Run(tc.name, func(b *testing.B) {
 			b.ReportAllocs()
 			for n := 0; n < b.N; n++ {
-				err := target.Encode(tc.obj, ioutil.Discard)
+				err := target.Encode(tc.obj, io.Discard)
 				if err != nil {
 					b.Fatal(err)
 				}
@@ -64,7 +64,7 @@ func benchmarkEncodeWithAllocatorFor(b *testing.B, target runtime.EncoderWithAll
 			b.ReportAllocs()
 			allocator := &runtime.Allocator{}
 			for n := 0; n < b.N; n++ {
-				err := target.EncodeWithAllocator(tc.obj, ioutil.Discard, allocator)
+				err := target.EncodeWithAllocator(tc.obj, io.Discard, allocator)
 				if err != nil {
 					b.Fatal(err)
 				}

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/streaming/streaming_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/streaming/streaming_test.go
@@ -19,7 +19,6 @@ package streaming
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -41,7 +40,7 @@ func (d *fakeDecoder) Decode(data []byte, gvk *schema.GroupVersionKind, into run
 func TestEmptyDecoder(t *testing.T) {
 	buf := bytes.NewBuffer([]byte{})
 	d := &fakeDecoder{}
-	_, _, err := NewDecoder(ioutil.NopCloser(buf), d).Decode(nil, nil)
+	_, _, err := NewDecoder(io.NopCloser(buf), d).Decode(nil, nil)
 	if err != io.EOF {
 		t.Fatal(err)
 	}

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/versioning/versioning_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/versioning/versioning_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package versioning
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"reflect"
@@ -111,7 +112,7 @@ func TestNestedEncode(t *testing.T) {
 		schema.GroupVersion{Group: "other"}, nil,
 		"TestNestedEncode",
 	)
-	if err := codec.Encode(n, io.Discard); err != n2.nestedErr {
+	if err := codec.Encode(n, io.Discard); !errors.Is(err, n2.nestedErr) {
 		t.Errorf("unexpected error: %v", err)
 	}
 	if n.nestedCalled || !n2.nestedCalled {
@@ -134,7 +135,7 @@ func TestNestedEncodeError(t *testing.T) {
 		schema.GroupVersion{Group: "other", Version: "v2"}, nil,
 		"TestNestedEncodeError",
 	)
-	if err := codec.Encode(n, io.Discard); err != n.nestedErr {
+	if err := codec.Encode(n, io.Discard); !errors.Is(err, n.nestedErr) {
 		t.Errorf("unexpected error: %v", err)
 	}
 	if n.GroupVersionKind() != gvk1 {
@@ -370,7 +371,11 @@ func TestDirectCodecEncode(t *testing.T) {
 		Encoder:     &serializer,
 		ObjectTyper: &typer,
 	}
-	c.Encode(&testDecodable{}, io.Discard)
+
+	if err := c.Encode(&testDecodable{}, io.Discard); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
 	if e, a := "expected_group", serializer.encodingObjGVK.Group; e != a {
 		t.Errorf("expected group to be %v, got %v", e, a)
 	}

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/versioning/versioning_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/versioning/versioning_test.go
@@ -19,7 +19,6 @@ package versioning
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"reflect"
 	"testing"
 
@@ -112,7 +111,7 @@ func TestNestedEncode(t *testing.T) {
 		schema.GroupVersion{Group: "other"}, nil,
 		"TestNestedEncode",
 	)
-	if err := codec.Encode(n, ioutil.Discard); err != n2.nestedErr {
+	if err := codec.Encode(n, io.Discard); err != n2.nestedErr {
 		t.Errorf("unexpected error: %v", err)
 	}
 	if n.nestedCalled || !n2.nestedCalled {
@@ -135,7 +134,7 @@ func TestNestedEncodeError(t *testing.T) {
 		schema.GroupVersion{Group: "other", Version: "v2"}, nil,
 		"TestNestedEncodeError",
 	)
-	if err := codec.Encode(n, ioutil.Discard); err != n.nestedErr {
+	if err := codec.Encode(n, io.Discard); err != n.nestedErr {
 		t.Errorf("unexpected error: %v", err)
 	}
 	if n.GroupVersionKind() != gvk1 {
@@ -371,7 +370,7 @@ func TestDirectCodecEncode(t *testing.T) {
 		Encoder:     &serializer,
 		ObjectTyper: &typer,
 	}
-	c.Encode(&testDecodable{}, ioutil.Discard)
+	c.Encode(&testDecodable{}, io.Discard)
 	if e, a := "expected_group", serializer.encodingObjGVK.Group; e != a {
 		t.Errorf("expected group to be %v, got %v", e, a)
 	}

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/versioning/versioning_unstructured_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/versioning/versioning_unstructured_test.go
@@ -18,7 +18,7 @@ package versioning
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -133,7 +133,7 @@ func TestEncodeUnstructured(t *testing.T) {
 	for _, testCase := range testCases {
 		serializer := &mockSerializer{}
 		codec := NewCodec(serializer, serializer, testCase.convertor, nil, testCase.typer, nil, testCase.targetVersion, nil, "noxu-scheme")
-		err := codec.Encode(testCase.outObj, ioutil.Discard)
+		err := codec.Encode(testCase.outObj, io.Discard)
 		if testCase.errFunc != nil {
 			if !testCase.errFunc(err) {
 				t.Errorf("%v: failed: %v", testCase.name, err)


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/kind deprecation

#### What this PR does / why we need it:
This PR removes/resolves all references of the [ioutil](https://pkg.go.dev/io/ioutil#pkg-overview) pkg which has been deprecated since go1.16.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
I previously opened [this](https://github.com/kubernetes/kubernetes/pull/127030) PR but closed it to create multiple smaller ones, for easier reviewing.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
