### PR TITLE
chore(staging/pod-security-admission): rm ioutil

### DIFF
--- a/staging/src/k8s.io/pod-security-admission/admission/api/load/load_test.go
+++ b/staging/src/k8s.io/pod-security-admission/admission/api/load/load_test.go
@@ -18,7 +18,7 @@ package load
 
 import (
 	"bytes"
-	"io/ioutil"
+	"os"
 	"reflect"
 	"strings"
 	"testing"
@@ -40,14 +40,14 @@ var defaultConfig = &api.PodSecurityConfiguration{
 
 func writeTempFile(t *testing.T, content string) string {
 	t.Helper()
-	file, err := ioutil.TempFile("", "podsecurityconfig")
+	file, err := os.CreateTemp("", "podsecurityconfig")
 	if err != nil {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() {
 		utiltesting.CloseAndRemove(t, file)
 	})
-	if err := ioutil.WriteFile(file.Name(), []byte(content), 0600); err != nil {
+	if err := os.WriteFile(file.Name(), []byte(content), 0600); err != nil {
 		t.Fatal(err)
 	}
 	return file.Name()

--- a/staging/src/k8s.io/pod-security-admission/cmd/webhook/server/server.go
+++ b/staging/src/k8s.io/pod-security-admission/cmd/webhook/server/server.go
@@ -23,7 +23,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -182,7 +181,7 @@ func (s *Server) HandleValidate(w http.ResponseWriter, r *http.Request) {
 
 	defer r.Body.Close()
 	limitedReader := &io.LimitedReader{R: r.Body, N: maxRequestSize}
-	if body, err = ioutil.ReadAll(limitedReader); err != nil {
+	if body, err = io.ReadAll(limitedReader); err != nil {
 		logger.Error(err, "unable to read the body from the incoming request")
 		http.Error(w, "unable to read the body from the incoming request", http.StatusBadRequest)
 		return

--- a/staging/src/k8s.io/pod-security-admission/test/fixtures_test.go
+++ b/staging/src/k8s.io/pod-security-admission/test/fixtures_test.go
@@ -18,7 +18,6 @@ package test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -137,7 +136,7 @@ func testFixtureFile(t *testing.T, dir, name string, pod *corev1.Pod) string {
 	pod = pod.DeepCopy()
 	pod.Name = name
 
-	expectedYAML, _ := ioutil.ReadFile(filename)
+	expectedYAML, _ := os.ReadFile(filename)
 
 	jsonData, err := runtime.Encode(scheme.Codecs.LegacyCodec(corev1.SchemeGroupVersion), pod)
 	if err != nil {
@@ -160,7 +159,7 @@ func testFixtureFile(t *testing.T, dir, name string, pod *corev1.Pod) string {
 			if err := os.MkdirAll(dir, os.FileMode(0755)); err != nil {
 				t.Fatal(err)
 			}
-			if err := ioutil.WriteFile(filename, []byte(yamlData), os.FileMode(0755)); err == nil {
+			if err := os.WriteFile(filename, []byte(yamlData), os.FileMode(0755)); err == nil {
 				t.Logf("Updated data in %s", filename)
 				t.Logf("Verify the diff, commit changes, and rerun the tests")
 			} else {


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/kind deprecation

#### What this PR does / why we need it:
This PR removes/resolves all references of the [ioutil](https://pkg.go.dev/io/ioutil#pkg-overview) pkg which has been deprecated since go1.16.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
I previously opened [this](https://github.com/kubernetes/kubernetes/pull/127030) PR but closed it to create multiple smaller ones, for easier reviewing.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
