### PR TITLE
Fix etcd failures in ci-kubernetes-e2e-cos-gce-disruptive-canary

### DIFF
--- a/test/e2e/apimachinery/etcd_failure.go
+++ b/test/e2e/apimachinery/etcd_failure.go
@@ -34,6 +34,7 @@ import (
 	admissionapi "k8s.io/pod-security-admission/api"
 
 	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
 )
 
 var _ = SIGDescribe("Etcd failure", framework.WithDisruptive(), func() {
@@ -47,7 +48,7 @@ var _ = SIGDescribe("Etcd failure", framework.WithDisruptive(), func() {
 		// - master access
 		// ... so the provider check should be identical to the intersection of
 		// providers that provide those capabilities.
-		e2eskipper.SkipUnlessProviderIs("gce")
+		e2eskipper.SkipUnlessProviderIs("gce", "aws")
 		e2eskipper.SkipUnlessSSHKeyPresent()
 
 		err := e2erc.RunRC(ctx, testutils.RCConfig{
@@ -80,7 +81,7 @@ var _ = SIGDescribe("Etcd failure", framework.WithDisruptive(), func() {
 })
 
 func etcdFailTest(ctx context.Context, f *framework.Framework, failCommand, fixCommand string) {
-	doEtcdFailure(ctx, failCommand, fixCommand)
+	doEtcdFailure(ctx, f, failCommand, fixCommand)
 
 	checkExistingRCRecovers(ctx, f)
 
@@ -94,17 +95,30 @@ func etcdFailTest(ctx context.Context, f *framework.Framework, failCommand, fixC
 // master and go on to assert that etcd and kubernetes components recover.
 const etcdFailureDuration = 20 * time.Second
 
-func doEtcdFailure(ctx context.Context, failCommand, fixCommand string) {
+func doEtcdFailure(ctx context.Context, f *framework.Framework, failCommand, fixCommand string) {
 	ginkgo.By("failing etcd")
 
-	masterExec(ctx, failCommand)
+	masterExec(ctx, f, failCommand)
 	time.Sleep(etcdFailureDuration)
-	masterExec(ctx, fixCommand)
+	masterExec(ctx, f, fixCommand)
 }
 
-func masterExec(ctx context.Context, cmd string) {
-	host := framework.APIAddress() + ":22"
+func masterExec(ctx context.Context, f *framework.Framework, cmd string) {
+	nodes := framework.GetControlPlaneNodes(ctx, f.ClientSet)
+	// checks if there is at least one control-plane node
+
+	gomega.Expect(nodes.Items).NotTo(gomega.BeEmpty(),
+		"at least one node with label %s should exist.", framework.ControlPlaneLabel)
+
+	ips := framework.GetNodeExternalIPs(&nodes.Items[0])
+	gomega.Expect(ips).NotTo(gomega.BeEmpty(), "at least one external ip should exist.")
+
+	host := ips[0] + ":22"
 	result, err := e2essh.SSH(ctx, cmd, host, framework.TestContext.Provider)
+	framework.ExpectNoError(err)
+	e2essh.LogResult(result)
+
+	result, err = e2essh.SSH(ctx, cmd, host, framework.TestContext.Provider)
 	framework.ExpectNoError(err, "failed to SSH to host %s on provider %s and run command: %q", host, framework.TestContext.Provider, cmd)
 	if result.Code != 0 {
 		e2essh.LogResult(result)

--- a/test/e2e_kubeadm/controlplane_nodes_test.go
+++ b/test/e2e_kubeadm/controlplane_nodes_test.go
@@ -20,19 +20,12 @@ import (
 	"context"
 
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
-	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 	admissionapi "k8s.io/pod-security-admission/api"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
-)
-
-const (
-	controlPlaneLabel = "node-role.kubernetes.io/control-plane"
 )
 
 // Define container for all the test specification aimed at verifying
@@ -51,22 +44,14 @@ var _ = Describe("control-plane node", func() {
 	// in case you can skip this test with SKIP=multi-node
 	ginkgo.It("should be labelled and tainted [multi-node]", func(ctx context.Context) {
 		// get all control-plane nodes (and this implicitly checks that node are properly labeled)
-		controlPlanes := getControlPlaneNodes(ctx, f.ClientSet)
+		controlPlanes := framework.GetControlPlaneNodes(ctx, f.ClientSet)
 
 		// checks if there is at least one control-plane node
-		gomega.Expect(controlPlanes.Items).NotTo(gomega.BeEmpty(), "at least one node with label %s should exist. if you are running test on a single-node cluster, you can skip this test with SKIP=multi-node", controlPlaneLabel)
+		gomega.Expect(controlPlanes.Items).NotTo(gomega.BeEmpty(), "at least one node with label %s should exist. if you are running test on a single-node cluster, you can skip this test with SKIP=multi-node", framework.ControlPlaneLabel)
 
 		// checks that the control-plane nodes have the expected taints
 		for _, cp := range controlPlanes.Items {
-			e2enode.ExpectNodeHasTaint(ctx, f.ClientSet, cp.GetName(), &corev1.Taint{Key: controlPlaneLabel, Effect: corev1.TaintEffectNoSchedule})
+			e2enode.ExpectNodeHasTaint(ctx, f.ClientSet, cp.GetName(), &corev1.Taint{Key: framework.ControlPlaneLabel, Effect: corev1.TaintEffectNoSchedule})
 		}
 	})
 })
-
-func getControlPlaneNodes(ctx context.Context, c clientset.Interface) *corev1.NodeList {
-	selector := labels.Set{controlPlaneLabel: ""}.AsSelector()
-	cpNodes, err := c.CoreV1().Nodes().
-		List(ctx, metav1.ListOptions{LabelSelector: selector.String()})
-	framework.ExpectNoError(err, "error reading control-plane nodes")
-	return cpNodes
-}


### PR DESCRIPTION
etcd_failure.go was assuming that the API address for the cluster is where etcd process runs which is not true. So just like we did in daemon_restart.go, we should find the external IP for the control plane nodes and use that one.

- Reuse the same bits of code across etcd_failure.go, daemon_restart.go and controlplane_nodes.test.go
- Move the shared code into a common place.
- Switch etcd_failure.go to use the new methods for the external ip for the control plane node.
- Run this test on `aws` as well!

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
