### PR TITLE
Fix the ShouldResetExtendedResourceCapacity method for device plugin.

### DIFF
--- a/pkg/kubelet/checkpointmanager/checkpoint_manager.go
+++ b/pkg/kubelet/checkpointmanager/checkpoint_manager.go
@@ -18,6 +18,7 @@ package checkpointmanager
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 
 	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager/errors"
@@ -106,5 +107,12 @@ func (manager *impl) ListCheckpoints() ([]string, error) {
 	if err != nil {
 		return []string{}, fmt.Errorf("failed to list checkpoint store: %v", err)
 	}
-	return keys, nil
+	// Filter out sockets, as they are not checkpoints.
+	var checkpointNames []string
+	for _, key := range keys {
+		if !strings.HasSuffix(key, ".sock") {
+			checkpointNames = append(checkpointNames, key)
+		}
+	}
+	return checkpointNames, nil
 }

--- a/pkg/kubelet/cm/devicemanager/manager.go
+++ b/pkg/kubelet/cm/devicemanager/manager.go
@@ -1165,7 +1165,15 @@ func (m *ManagerImpl) ShouldResetExtendedResourceCapacity() bool {
 	if err != nil {
 		return false
 	}
-	return len(checkpoints) == 0
+
+	// Currently, the checkpoint file name for the device plugin is only kubelet_internal_checkpoint.
+	// If there are any changes in the future, corresponding adjustments will be needed.
+	for _, checkpointName := range checkpoints {
+		if checkpointName == kubeletDeviceManagerCheckpoint {
+			return false
+		}
+	}
+	return true
 }
 
 func (m *ManagerImpl) setPodPendingAdmission(pod *v1.Pod) {

--- a/pkg/kubelet/cm/devicemanager/manager.go
+++ b/pkg/kubelet/cm/devicemanager/manager.go
@@ -1165,15 +1165,7 @@ func (m *ManagerImpl) ShouldResetExtendedResourceCapacity() bool {
 	if err != nil {
 		return false
 	}
-
-	// Currently, the checkpoint file name for the device plugin is only kubelet_internal_checkpoint.
-	// If there are any changes in the future, corresponding adjustments will be needed.
-	for _, checkpointName := range checkpoints {
-		if checkpointName == kubeletDeviceManagerCheckpoint {
-			return false
-		}
-	}
-	return true
+	return len(checkpoints) == 0
 }
 
 func (m *ManagerImpl) setPodPendingAdmission(pod *v1.Pod) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
The `checkpointdir(/var/lib/kubelet/device-plugins/)` for `devicemanager` is currently the same as the `sockdir` for `kubelet`. The `ListCheckpoints` method does not effectively distinguish between filenames, resulting in incorrect output from ListCheckpoints.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #126943

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
