### PR TITLE
Don't panic when popping from empty scheduling queue

### DIFF
--- a/pkg/scheduler/backend/heap/heap.go
+++ b/pkg/scheduler/backend/heap/heap.go
@@ -85,6 +85,9 @@ func (h *data[T]) Len() int { return len(h.queue) }
 // Swap implements swapping of two elements in the heap. This is a part of standard
 // heap interface and should never be called directly.
 func (h *data[T]) Swap(i, j int) {
+	if i < 0 || j < 0 {
+		return
+	}
 	h.queue[i], h.queue[j] = h.queue[j], h.queue[i]
 	item := h.items[h.queue[i]]
 	item.index = i
@@ -102,6 +105,9 @@ func (h *data[T]) Push(kv interface{}) {
 
 // Pop is supposed to be called by container/heap.Pop only.
 func (h *data[T]) Pop() interface{} {
+	if len(h.queue) == 0 {
+		return nil
+	}
 	key := h.queue[len(h.queue)-1]
 	h.queue = h.queue[0 : len(h.queue)-1]
 	item, ok := h.items[key]

--- a/pkg/scheduler/backend/heap/heap_test.go
+++ b/pkg/scheduler/backend/heap/heap_test.go
@@ -94,6 +94,11 @@ func TestHeapBasic(t *testing.T) {
 		}
 		prevNum = num
 	}
+
+	_, err := h.Pop()
+	if err == nil {
+		t.Errorf("expected Pop() to error on empty heap")
+	}
 }
 
 // TestHeap_AddOrUpdate_Add tests add capabilities of Heap.AddOrUpdate


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:

This scenario is not possible to happen now, but we could prevent the panic in the future. To do so, `Swap()` and `Pop()` methods on heap need to be able to handle negative indices. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
