### PR TITLE
Fix e2e daemon restart

### DIFF
--- a/test/e2e/apps/daemon_restart.go
+++ b/test/e2e/apps/daemon_restart.go
@@ -107,10 +107,10 @@ func (r *RestartDaemonConfig) waitUp(ctx context.Context) {
 	var healthzCheck string
 	if r.enableHTTPS {
 		healthzCheck = fmt.Sprintf(
-			"curl -sk -o %v -I -w \"%%{http_code}\" https://127.0.0.1:%v/healthz", nullDev, r.healthzPort)
+			"curl -sk -o %v -I -w \"%%{http_code}\" https://localhost:%v/healthz", nullDev, r.healthzPort)
 	} else {
 		healthzCheck = fmt.Sprintf(
-			"curl -s -o %v -I -w \"%%{http_code}\" http://127.0.0.1:%v/healthz", nullDev, r.healthzPort)
+			"curl -s -o %v -I -w \"%%{http_code}\" http://localhost:%v/healthz", nullDev, r.healthzPort)
 
 	}
 


### PR DESCRIPTION

/kind failing-test
```release-note
NONE
```


Fixes: https://github.com/kubernetes/kubernetes/issues/126833

After https://github.com/kubernetes/kubernetes/pull/127033 these jobs  started failing

https://testgrid.k8s.io/sig-network-gce#gci-gce-serial-kube-dns
https://testgrid.k8s.io/sig-network-gce#gci-gce-serial-kube-dns-nodecache
https://testgrid.k8s.io/sig-network-gce#gci-gce-serial


[kube-up scripts does not add labels to the control plane nodes](https://storage.googleapis.com/kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-serial/1830403873093718016/artifacts/nodes.yaml), however, it adds the taint that we can use to identify the control plane nodes, in addition to the labels

It also restores the probe request to use localhost so the test can work for both IPv4 and IPv6