### PR TITLE
e2e: refactor FilterNonRestartablePods function

### DIFF
--- a/test/e2e/cloud/gcp/restart.go
+++ b/test/e2e/cloud/gcp/restart.go
@@ -70,7 +70,7 @@ var _ = SIGDescribe("Restart", framework.WithDisruptive(), func() {
 
 		ginkgo.By("ensuring all pods are running and ready")
 		allPods := ps.List()
-		pods := e2epod.FilterNonRestartablePods(allPods)
+		pods := e2epod.FilterRecreatablePods(allPods)
 
 		originalPodNames = make([]string, len(pods))
 		for i, p := range pods {

--- a/test/e2e/framework/pod/resource.go
+++ b/test/e2e/framework/pod/resource.go
@@ -259,16 +259,12 @@ func DumpAllPodInfoForNamespace(ctx context.Context, c clientset.Interface, name
 	logPodLogs(ctx, c, namespace, pods.Items, reportDir)
 }
 
-// FilterNonRestartablePods filters out pods that will never get recreated if
+// FilterRecreatablePods retains only pods that will get recreated if
 // deleted after termination.
-func FilterNonRestartablePods(pods []*v1.Pod) []*v1.Pod {
+func FilterRecreatablePods(pods []*v1.Pod) []*v1.Pod {
 	var results []*v1.Pod
 	for _, p := range pods {
-		if isNotRestartAlwaysMirrorPod(p) {
-			// Mirror pods with restart policy == Never will not get
-			// recreated if they are deleted after the pods have
-			// terminated. For now, we discount such pods.
-			// https://github.com/kubernetes/kubernetes/issues/34003
+		if !isPodRecreatedIfDeleted(p) {
 			continue
 		}
 		results = append(results, p)
@@ -276,12 +272,25 @@ func FilterNonRestartablePods(pods []*v1.Pod) []*v1.Pod {
 	return results
 }
 
-func isNotRestartAlwaysMirrorPod(p *v1.Pod) bool {
-	// Check if the pod is a mirror pod
-	if _, ok := p.Annotations[v1.MirrorPodAnnotationKey]; !ok {
-		return false
+// isPodRecreatedIfDeleted returns true if the pod would be recreated if deleted.
+func isPodRecreatedIfDeleted(p *v1.Pod) bool {
+	// Check if it's a mirror pod
+	if _, isMirrorPod := p.Annotations[v1.MirrorPodAnnotationKey]; isMirrorPod {
+		// Mirror pods with restart policy == Always will get recreated
+		// https://github.com/kubernetes/kubernetes/issues/130288
+		return p.Spec.RestartPolicy == v1.RestartPolicyAlways
 	}
-	return p.Spec.RestartPolicy != v1.RestartPolicyAlways
+
+	// Check if it's a Job pod (Jobs don't recreate pods that are deleted)
+	for _, owner := range p.OwnerReferences {
+		if owner.Kind == v1.SchemeGroupVersion.WithKind("Job").Kind {
+			return false
+		}
+	}
+
+	// A pod with an owner reference will be recreated by its controller
+	// Naked pods (without owner references) won't be recreated
+	return len(p.OwnerReferences) > 0
 }
 
 // NewAgnhostPod returns a pod that uses the agnhost image. The image's binary supports various subcommands

--- a/test/e2e/framework/pod/wait.go
+++ b/test/e2e/framework/pod/wait.go
@@ -743,7 +743,7 @@ func WaitForNRestartablePods(ctx context.Context, ps *testutils.PodStore, expect
 	}
 
 	match := func(allPods []*v1.Pod) (func() string, error) {
-		pods = FilterNonRestartablePods(allPods)
+		pods = FilterRecreatablePods(allPods)
 		if len(pods) != expect {
 			return func() string {
 				return fmt.Sprintf("expected to find non-restartable %d pods, but found %d:\n%s", expect, len(pods), format.Object(pods, 1))


### PR DESCRIPTION
/kind cleanup
/kind e2e


#### What this PR does / why we need it:
- Refactors and renames the FilterNonRestartablePods function to FilterNonRecreatablePods to better reflect its purpose of filtering out pods that will not be **recreated if deleted after termination.**
- Adds a safeguard in the isPodNotRecreatedIfDeleted function by introducing a condition to exclude naked pods (those not managed by a controller) from being considered for recreation after deletion ( mirror (static) pods are handled separately).

#### Which issue(s) this PR fixes:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes https://github.com/kubernetes/kubernetes/issues/109703.

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```