### PR TITLE
memorymanager: fix checkpoint file comparison

### DIFF
--- a/pkg/kubelet/cm/memorymanager/policy_static.go
+++ b/pkg/kubelet/cm/memorymanager/policy_static.go
@@ -681,27 +681,38 @@ func areMachineStatesEqual(ms1, ms2 state.NUMANodeMap) bool {
 				return false
 			}
 
-			if memoryState1.TotalMemSize != memoryState2.TotalMemSize || memoryState1.SystemReserved != memoryState2.SystemReserved || memoryState1.Allocatable != memoryState2.Allocatable {
-				klog.ErrorS(nil, "Memory states for the NUMA node and resource are different", "node", nodeID, "resource", resourceName, "memoryState1", *memoryState1, "memoryState2", *memoryState2)
+			if memoryState1.TotalMemSize != memoryState2.TotalMemSize {
+				klog.ErrorS(nil, "Memory states for the NUMA node and resource are different", "node", nodeID, "resource", resourceName, "field", "TotalMemSize", "TotalMemSize1", memoryState1.TotalMemSize, "TotalMemSize2", memoryState2.TotalMemSize, "memoryState1", *memoryState1, "memoryState2", *memoryState2)
 				return false
 			}
 
-			totalFree1 := uint64(0)
-			totalReserved1 := uint64(0)
-			totalFree2 := uint64(0)
-			totalReserved2 := uint64(0)
-			for _, nodeId := range nodeState1.Cells {
-				totalFree1 += ms1[nodeId].MemoryMap[resourceName].Free
-				totalReserved1 += ms1[nodeId].MemoryMap[resourceName].Reserved
-				totalFree2 += ms2[nodeId].MemoryMap[resourceName].Free
-				totalReserved2 += ms2[nodeId].MemoryMap[resourceName].Reserved
-			}
-
-			if totalFree1 != totalFree2 || totalReserved1 != totalReserved2 {
-				klog.ErrorS(nil, "Memory states for the NUMA node and resource are different", "node", nodeID, "resource", resourceName, "memoryState1", *memoryState1, "memoryState2", *memoryState2)
+			if memoryState1.SystemReserved != memoryState2.SystemReserved {
+				klog.ErrorS(nil, "Memory states for the NUMA node and resource are different", "node", nodeID, "resource", resourceName, "field", "SystemReserved", "SystemReserved1", memoryState1.SystemReserved, "SystemReserved2", memoryState2.SystemReserved, "memoryState1", *memoryState1, "memoryState2", *memoryState2)
 				return false
 			}
 
+			if memoryState1.Allocatable != memoryState2.Allocatable {
+				klog.ErrorS(nil, "Memory states for the NUMA node and resource are different", "node", nodeID, "resource", resourceName, "field", "Allocatable", "Allocatable1", memoryState1.Allocatable, "Allocatable2", memoryState2.Allocatable, "memoryState1", *memoryState1, "memoryState2", *memoryState2)
+				return false
+			}
+
+			tmpState1 := state.MemoryTable{}
+			tmpState2 := state.MemoryTable{}
+			for _, nodeID := range nodeState1.Cells {
+				tmpState1.Free += ms1[nodeID].MemoryMap[resourceName].Free
+				tmpState1.Reserved += ms1[nodeID].MemoryMap[resourceName].Reserved
+				tmpState2.Free += ms2[nodeID].MemoryMap[resourceName].Free
+				tmpState2.Reserved += ms2[nodeID].MemoryMap[resourceName].Reserved
+			}
+
+			if tmpState1.Free != tmpState2.Free {
+				klog.InfoS("Memory states for the NUMA node and resource are different", "node", nodeID, "resource", resourceName, "field", "free", "free1", tmpState1.Free, "free2", tmpState2.Free, "memoryState1", *memoryState1, "memoryState2", *memoryState2)
+				return false
+			}
+			if tmpState1.Reserved != tmpState2.Reserved {
+				klog.InfoS("Memory states for the NUMA node and resource are different", "node", nodeID, "resource", resourceName, "field", "reserved", "reserved1", tmpState1.Reserved, "reserved2", tmpState2.Reserved, "memoryState1", *memoryState1, "memoryState2", *memoryState2)
+				return false
+			}
 		}
 	}
 	return true

--- a/pkg/kubelet/cm/memorymanager/policy_static.go
+++ b/pkg/kubelet/cm/memorymanager/policy_static.go
@@ -681,17 +681,7 @@ func areMachineStatesEqual(ms1, ms2 state.NUMANodeMap) bool {
 				return false
 			}
 
-			if memoryState1.TotalMemSize != memoryState2.TotalMemSize {
-				klog.ErrorS(nil, "Memory states for the NUMA node and resource are different", "node", nodeID, "resource", resourceName, "memoryState1", *memoryState1, "memoryState2", *memoryState2)
-				return false
-			}
-
-			if memoryState1.SystemReserved != memoryState2.SystemReserved {
-				klog.ErrorS(nil, "Memory states for the NUMA node and resource are different", "node", nodeID, "resource", resourceName, "memoryState1", *memoryState1, "memoryState2", *memoryState2)
-				return false
-			}
-
-			if memoryState1.Allocatable != memoryState2.Allocatable {
+			if memoryState1.TotalMemSize != memoryState2.TotalMemSize || memoryState1.SystemReserved != memoryState2.SystemReserved || memoryState1.Allocatable != memoryState2.Allocatable {
 				klog.ErrorS(nil, "Memory states for the NUMA node and resource are different", "node", nodeID, "resource", resourceName, "memoryState1", *memoryState1, "memoryState2", *memoryState2)
 				return false
 			}

--- a/pkg/kubelet/cm/memorymanager/policy_static.go
+++ b/pkg/kubelet/cm/memorymanager/policy_static.go
@@ -681,18 +681,7 @@ func areMachineStatesEqual(ms1, ms2 state.NUMANodeMap) bool {
 				return false
 			}
 
-			if memoryState1.TotalMemSize != memoryState2.TotalMemSize {
-				klog.ErrorS(nil, "Memory states for the NUMA node and resource are different", "node", nodeID, "resource", resourceName, "field", "TotalMemSize", "TotalMemSize1", memoryState1.TotalMemSize, "TotalMemSize2", memoryState2.TotalMemSize, "memoryState1", *memoryState1, "memoryState2", *memoryState2)
-				return false
-			}
-
-			if memoryState1.SystemReserved != memoryState2.SystemReserved {
-				klog.ErrorS(nil, "Memory states for the NUMA node and resource are different", "node", nodeID, "resource", resourceName, "field", "SystemReserved", "SystemReserved1", memoryState1.SystemReserved, "SystemReserved2", memoryState2.SystemReserved, "memoryState1", *memoryState1, "memoryState2", *memoryState2)
-				return false
-			}
-
-			if memoryState1.Allocatable != memoryState2.Allocatable {
-				klog.ErrorS(nil, "Memory states for the NUMA node and resource are different", "node", nodeID, "resource", resourceName, "field", "Allocatable", "Allocatable1", memoryState1.Allocatable, "Allocatable2", memoryState2.Allocatable, "memoryState1", *memoryState1, "memoryState2", *memoryState2)
+			if !areMemoryStatesEqual(memoryState1, memoryState2, nodeID, resourceName) {
 				return false
 			}
 
@@ -714,6 +703,24 @@ func areMachineStatesEqual(ms1, ms2 state.NUMANodeMap) bool {
 				return false
 			}
 		}
+	}
+	return true
+}
+
+func areMemoryStatesEqual(memoryState1, memoryState2 *state.MemoryTable, nodeID int, resourceName v1.ResourceName) bool {
+	if memoryState1.TotalMemSize != memoryState2.TotalMemSize {
+		klog.ErrorS(nil, "Memory states for the NUMA node and resource are different", "node", nodeID, "resource", resourceName, "field", "TotalMemSize", "TotalMemSize1", memoryState1.TotalMemSize, "TotalMemSize2", memoryState2.TotalMemSize, "memoryState1", *memoryState1, "memoryState2", *memoryState2)
+		return false
+	}
+
+	if memoryState1.SystemReserved != memoryState2.SystemReserved {
+		klog.ErrorS(nil, "Memory states for the NUMA node and resource are different", "node", nodeID, "resource", resourceName, "field", "SystemReserved", "SystemReserved1", memoryState1.SystemReserved, "SystemReserved2", memoryState2.SystemReserved, "memoryState1", *memoryState1, "memoryState2", *memoryState2)
+		return false
+	}
+
+	if memoryState1.Allocatable != memoryState2.Allocatable {
+		klog.ErrorS(nil, "Memory states for the NUMA node and resource are different", "node", nodeID, "resource", resourceName, "field", "Allocatable", "Allocatable1", memoryState1.Allocatable, "Allocatable2", memoryState2.Allocatable, "memoryState1", *memoryState1, "memoryState2", *memoryState2)
+		return false
 	}
 	return true
 }

--- a/pkg/kubelet/cm/memorymanager/policy_static.go
+++ b/pkg/kubelet/cm/memorymanager/policy_static.go
@@ -18,7 +18,6 @@ package memorymanager
 
 import (
 	"fmt"
-	"reflect"
 	"sort"
 
 	cadvisorapi "github.com/google/cadvisor/info/v1"
@@ -682,10 +681,37 @@ func areMachineStatesEqual(ms1, ms2 state.NUMANodeMap) bool {
 				return false
 			}
 
-			if !reflect.DeepEqual(*memoryState1, *memoryState2) {
+			if memoryState1.TotalMemSize != memoryState2.TotalMemSize {
 				klog.ErrorS(nil, "Memory states for the NUMA node and resource are different", "node", nodeID, "resource", resourceName, "memoryState1", *memoryState1, "memoryState2", *memoryState2)
 				return false
 			}
+
+			if memoryState1.SystemReserved != memoryState2.SystemReserved {
+				klog.ErrorS(nil, "Memory states for the NUMA node and resource are different", "node", nodeID, "resource", resourceName, "memoryState1", *memoryState1, "memoryState2", *memoryState2)
+				return false
+			}
+
+			if memoryState1.Allocatable != memoryState2.Allocatable {
+				klog.ErrorS(nil, "Memory states for the NUMA node and resource are different", "node", nodeID, "resource", resourceName, "memoryState1", *memoryState1, "memoryState2", *memoryState2)
+				return false
+			}
+
+			totalFree1 := uint64(0)
+			totalReserved1 := uint64(0)
+			totalFree2 := uint64(0)
+			totalReserved2 := uint64(0)
+			for _, nodeId := range nodeState1.Cells {
+				totalFree1 += ms1[nodeId].MemoryMap[resourceName].Free
+				totalReserved1 += ms1[nodeId].MemoryMap[resourceName].Reserved
+				totalFree2 += ms2[nodeId].MemoryMap[resourceName].Free
+				totalReserved2 += ms2[nodeId].MemoryMap[resourceName].Reserved
+			}
+
+			if totalFree1 != totalFree2 || totalReserved1 != totalReserved2 {
+				klog.ErrorS(nil, "Memory states for the NUMA node and resource are different", "node", nodeID, "resource", resourceName, "memoryState1", *memoryState1, "memoryState2", *memoryState2)
+				return false
+			}
+
 		}
 	}
 	return true

--- a/pkg/kubelet/cm/memorymanager/policy_static_test.go
+++ b/pkg/kubelet/cm/memorymanager/policy_static_test.go
@@ -1025,7 +1025,7 @@ func TestStaticPolicyStart(t *testing.T) {
 			},
 		},
 		{
-			description: "shoud equal",
+			description: "should validate the totalFree and totalReserved size for a resource within a group",
 			expectedAssignments: state.ContainerMemoryAssignments{
 				"pod1": map[string][]state.Block{
 					"container1": {

--- a/pkg/kubelet/cm/memorymanager/policy_static_test.go
+++ b/pkg/kubelet/cm/memorymanager/policy_static_test.go
@@ -1024,6 +1024,125 @@ func TestStaticPolicyStart(t *testing.T) {
 				},
 			},
 		},
+		{
+			description: "shoud equal",
+			expectedAssignments: state.ContainerMemoryAssignments{
+				"pod1": map[string][]state.Block{
+					"container1": {
+						{
+							NUMAAffinity: []int{0, 1},
+							Type:         v1.ResourceMemory,
+							Size:         240 * mb,
+						},
+					},
+				},
+				"pod2": map[string][]state.Block{
+					"container2": {
+						{
+							NUMAAffinity: []int{0, 1},
+							Type:         v1.ResourceMemory,
+							Size:         10 * mb,
+						},
+					},
+				},
+			},
+			assignments: state.ContainerMemoryAssignments{
+				"pod1": map[string][]state.Block{
+					"container1": {
+						{
+							NUMAAffinity: []int{0, 1},
+							Type:         v1.ResourceMemory,
+							Size:         240 * mb,
+						},
+					},
+				},
+				"pod2": map[string][]state.Block{
+					"container2": {
+						{
+							NUMAAffinity: []int{0, 1},
+							Type:         v1.ResourceMemory,
+							Size:         10 * mb,
+						},
+					},
+				},
+			},
+			expectedMachineState: state.NUMANodeMap{
+				0: &state.NUMANodeState{
+					MemoryMap: map[v1.ResourceName]*state.MemoryTable{
+						v1.ResourceMemory: {
+							Allocatable:    220 * mb,
+							Free:           30 * mb,
+							Reserved:       190 * mb,
+							SystemReserved: 20 * mb,
+							TotalMemSize:   240 * mb,
+						},
+					},
+					Cells:               []int{0, 1},
+					NumberOfAssignments: 2,
+				},
+				1: &state.NUMANodeState{
+					MemoryMap: map[v1.ResourceName]*state.MemoryTable{
+						v1.ResourceMemory: {
+							Allocatable:    220 * mb,
+							Free:           160 * mb,
+							Reserved:       60 * mb,
+							SystemReserved: 20 * mb,
+							TotalMemSize:   240 * mb,
+						},
+					},
+					Cells:               []int{0, 1},
+					NumberOfAssignments: 2,
+				},
+			},
+			machineState: state.NUMANodeMap{
+				0: &state.NUMANodeState{
+					MemoryMap: map[v1.ResourceName]*state.MemoryTable{
+						v1.ResourceMemory: {
+							Allocatable:    220 * mb,
+							Free:           10 * mb,
+							Reserved:       210 * mb,
+							SystemReserved: 20 * mb,
+							TotalMemSize:   240 * mb,
+						},
+					},
+					Cells:               []int{0, 1},
+					NumberOfAssignments: 2,
+				},
+				1: &state.NUMANodeState{
+					MemoryMap: map[v1.ResourceName]*state.MemoryTable{
+						v1.ResourceMemory: {
+							Allocatable:    220 * mb,
+							Free:           180 * mb,
+							Reserved:       40 * mb,
+							SystemReserved: 20 * mb,
+							TotalMemSize:   240 * mb,
+						},
+					},
+					Cells:               []int{0, 1},
+					NumberOfAssignments: 2,
+				},
+			},
+			systemReserved: systemReservedMemory{
+				0: map[v1.ResourceName]uint64{
+					v1.ResourceMemory: 20 * mb,
+				},
+				1: map[v1.ResourceName]uint64{
+					v1.ResourceMemory: 20 * mb,
+				},
+			},
+			machineInfo: &cadvisorapi.MachineInfo{
+				Topology: []cadvisorapi.Node{
+					{
+						Id:     0,
+						Memory: 240 * mb,
+					},
+					{
+						Id:     1,
+						Memory: 240 * mb,
+					},
+				},
+			},
+		},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

For a resource within a group, such as memory,
we should validate the total `Free` and total `Reserved` size of the expected `machineState` and state restored from checkpoint file after kubelet start.
If total `Free` and total `Reserved` are equal, the restored state is valid.
    
The old comparison however was done by reflection.
    
There're times when the memory accounting is equals
but the allocations across the NUMA nodes are varies.
    
In such cases we still need to consider the states as equals.

#### Which issue(s) this PR fixes:

Fixes #https://github.com/kubernetes/kubernetes/issues/113130 

#### Special notes for your reviewer:

This PR use as a replacement for https://github.com/kubernetes/kubernetes/pull/114501 which is not active for a long time now and is needed for MemoryManager GA graduation.
see: https://github.com/kubernetes/enhancements/issues/1769#issuecomment-2317059714

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/1769-memory-manager#design-overview
```
