### PR TITLE
[WIP] APF: manage panic from the spawned watch init goroutine

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/util/panic/panic.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/panic/panic.go
@@ -1,0 +1,199 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package panic
+
+import (
+	"fmt"
+	"net/http"
+	"runtime"
+)
+
+// Invoker propagates panic from a spawned goroutine to the request handler
+/* func(w http.ResponseWriter, req *http.Request) {
+        startHandler := make(chan struct{})
+	invoker := NewInvoker()
+	go invoker.InvokeWithPanicProtection(func() {
+		// decide whether we want to run the handler
+                close(startHandler)
+	})
+
+	select {
+	case <-startHandler:
+                // WrapPanic will wrap it if the handler panics
+                invoker.WrapPanic(func() {
+			handler.ServeHTTP(w, req)
+		})
+	case err := <-invoker.Done():
+                if err != nil {
+			// the spawned goroutine panicked
+			panic(err)
+		}
+	}
+}
+*/
+type Invoker interface {
+	// InvokeWithPanicProtection invokes the given func with panic
+	// protection, if the function panics then:
+	// a) the panic is recovered
+	// b) the stack trace is caprured
+	// c) both the panic value and the stacktrace are captured into an
+	// error object, so it can be propagated to the parent (request
+	// handler goroutine) via a channel
+	// The request handler uses this function to spawn a new goroutine
+	InvokeWithPanicProtection(func())
+
+	// WrapPanic invokes the given function, and it ensures that the panic
+	// from the spawned goroutine is included in the error
+	WrapPanic(func())
+
+	// Done returns nil if the spawned goroutine did not panic, otherwise
+	// it returns a non nil interface{} that holds the captured panic
+	// value and corresponding stack trace
+	// The request handler uses this to wait for the spawned
+	// goroutine to finish
+	Done() <-chan interface{}
+}
+
+func NewInvoker() *invoker {
+	return &invoker{ch: make(chan interface{}, 1)}
+}
+
+// FormatPanicValueWithStackTrace formats the given panic value
+// specified in 'recovered' to an error object.
+// If the given panic value is nil, then the function return nil.
+// The returned error object includes the runtime stack
+// trace from the calling goroutine.
+// If the panic value is the sentinel ErrAbortHandler
+// then the sentinel is returned as is.
+func FormatPanicValueWithStackTrace(recovered interface{}) interface{} {
+	if recovered == nil {
+		return nil
+	}
+
+	// nolint:errorlint // the sentinel ErrAbortHandler panic value is not wrapped
+	if recovered == http.ErrAbortHandler {
+		return recovered
+	}
+
+	// Same as stdlib http server code. Manually allocate stack
+	// trace buffer size to prevent excessively large logs
+	const size = 64 << 10
+	buf := make([]byte, size)
+	buf = buf[:runtime.Stack(buf, false)]
+	return &recoveredPanicError{
+		reason:     recovered,
+		stackTrace: buf,
+	}
+}
+
+// WrapRecoveredPanic wraps the recovered panic value given in
+// 'own' and the given panic value in 'other'.
+// - own is the recovered panic value from the caller's goroutine
+// - other is the recovered panic value from the other goroutine
+// via a receiving channel in the caller's goroutine
+// If both the caller goroutine and the other/spawned
+// goroutine panic, then:
+// a) the spawned goroutine should use FormatPanicValueWithStackTrace
+// to convert the panic value to an error object and then return
+// it to the caller goroutine via the channel
+// b) The parent goroutine should use WrapRecoveredPanic to wrap its own
+// recovered panic value and the panic value from the spawned goroutine
+func WrapRecoveredPanic(own, other interface{}) interface{} {
+	switch {
+	// both the caller goroutine and the spawned goroutine panicked
+	case own != nil && other != nil:
+		return &wrappedPanicError{
+			own:   own,
+			other: other,
+		}
+	// only the spawned goroutine panicked, no need to wrap
+	case other != nil:
+		return other
+	// only the caller goroutine panicked, no need to wrap
+	case own != nil:
+		return own
+	default:
+		return nil
+	}
+}
+
+type invoker struct {
+	ch chan interface{}
+}
+
+func (i *invoker) Done() <-chan interface{} { return i.ch }
+
+func (i *invoker) InvokeWithPanicProtection(f func()) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			i.ch <- FormatPanicValueWithStackTrace(recovered)
+		}
+	}()
+
+	f()
+	i.ch <- nil
+}
+
+func (i *invoker) WrapPanic(f func()) {
+	defer func() {
+		own := recover()
+		other := <-i.ch
+		if err := WrapRecoveredPanic(own, other); err != nil {
+			// one or both goroutines have panicked
+			panic(err)
+		}
+	}()
+
+	f()
+}
+
+// recoveredPanicError holds a recovered panic value and the
+// coresponding runtime stack trace of the goroutine that panicked
+type recoveredPanicError struct {
+	// reason is the recovered panic value
+	reason interface{}
+	// the runtime stack trace of the goroutine that panicked
+	stackTrace []byte
+}
+
+func (e *recoveredPanicError) Unwrap() error {
+	if err, ok := e.reason.(error); ok {
+		return err
+	}
+	return nil
+}
+
+func (e *recoveredPanicError) Error() string {
+	return fmt.Sprintf("%v\n%s", e.reason, e.stackTrace)
+}
+
+type wrappedPanicError struct {
+	own   interface{}
+	other interface{}
+}
+
+func (e *wrappedPanicError) Unwrap() error {
+	// own takes preceence, in order to maintain current behavior
+	if err, ok := e.own.(error); ok {
+		return err
+	}
+	return nil
+}
+
+func (e *wrappedPanicError) Error() string {
+	return fmt.Sprintf("the other goroutine panicked with: %v\n%v", e.other, e.own)
+}

--- a/staging/src/k8s.io/apiserver/pkg/util/panic/panic_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/panic/panic_test.go
@@ -1,0 +1,304 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package panic
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+func TestPanicWrap(t *testing.T) {
+	tests := []struct {
+		name               string
+		senderPanicsWith   interface{}
+		receiverPanicsWith interface{}
+		err                error
+	}{
+		{
+			name:               "no panic",
+			senderPanicsWith:   nil,
+			receiverPanicsWith: nil,
+			err:                nil,
+		},
+		{
+			name:               "sender panics",
+			senderPanicsWith:   fmt.Errorf("sender error"),
+			receiverPanicsWith: nil,
+			err:                io.EOF,
+		},
+		{
+			name:               "sender panics with http.ErrAbortHandler",
+			senderPanicsWith:   http.ErrAbortHandler,
+			receiverPanicsWith: nil,
+			err:                io.EOF,
+		},
+		{
+			name:               "receiver panics",
+			senderPanicsWith:   nil,
+			receiverPanicsWith: fmt.Errorf("receiver error"),
+			err:                io.EOF,
+		},
+		{
+			name:               "both sender and receiver panic",
+			senderPanicsWith:   fmt.Errorf("sender error"),
+			receiverPanicsWith: fmt.Errorf("receiver error"),
+			err:                io.EOF,
+		},
+	}
+
+	// a) the request handler spawns a new goroutine, we refer to
+	// it as the sender goroutine
+	// b) we refer to the goroutine in which the request handler
+	// runs as the receiver goroutine
+	// c) the receiver waits for the sender to return using a channel
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			handler := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				// a) kick off the sender goroutine
+				senderDone := make(chan interface{}, 1)
+				go func() {
+					defer func() {
+						err := recover()
+						// the panic from the sender is converted to
+						// an error object and sent to the receiver
+						senderDone <- FormatPanicValueWithStackTrace(err)
+					}()
+
+					if test.senderPanicsWith != nil {
+						// sender panics here
+						panic(test.senderPanicsWith)
+					}
+				}()
+
+				select {
+				// c) the receiver waits for the sender to return
+				case senderErr := <-senderDone:
+					func() {
+						defer func() {
+							receiverErr := recover()
+							// the receiver wraps its own panic value and the
+							// panic value it received from the sender
+							// with an error object
+							if err := WrapRecoveredPanic(receiverErr, senderErr); err != nil {
+								panic(err)
+							}
+						}()
+
+						if test.receiverPanicsWith != nil {
+							// receiver panics here
+							panic(test.receiverPanicsWith)
+						}
+					}()
+				case <-time.After(wait.ForeverTestTimeout):
+					t.Errorf("timed out waiting for child goroutine to return")
+				}
+			})
+
+			handlerDone := make(chan struct{})
+			verifierFn := func(inner http.Handler) http.Handler {
+				return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+					// this handler verifies that the panic was wrapped appropriately
+					defer close(handlerDone)
+					defer func() {
+						errGot := recover()
+						switch {
+						// both sender and receiver are expected to panic
+						case test.senderPanicsWith != nil && test.receiverPanicsWith != nil:
+							verifyWrappedPanic(t, errGot, test.senderPanicsWith, test.receiverPanicsWith)
+						// only the sender panics
+						case test.senderPanicsWith != nil:
+							verifyRecoveredPanicError(t, errGot, test.senderPanicsWith)
+						// only the receiver panics
+						case test.receiverPanicsWith != nil:
+							if want, got := test.receiverPanicsWith, errGot; want != got {
+								t.Errorf("expected the receiver to panic with: %v, but got: %v", want, got)
+							}
+						// neither the sender, nor the receiver panics
+						default:
+							if errGot != nil {
+								t.Errorf("unexpected panic from the receiver")
+							}
+						}
+
+						// rethrow the panic so net/http can deal with it.
+						if errGot != nil {
+							panic(errGot)
+						}
+					}()
+
+					inner.ServeHTTP(w, req)
+				})
+			}
+
+			server := httptest.NewUnstartedServer(verifierFn(handler))
+			defer server.Close()
+			server.StartTLS()
+
+			client := server.Client()
+			client.Timeout = wait.ForeverTestTimeout
+			_, err := client.Get(server.URL)
+			switch {
+			case test.err == nil:
+				if err != nil {
+					t.Errorf("unexpected error from Get: %v", err)
+				}
+			default:
+				if !errors.Is(err, test.err) {
+					t.Errorf("expected error: %v, but got: %v", test.err, err)
+				}
+			}
+
+			select {
+			case <-handlerDone:
+			case <-time.After(wait.ForeverTestTimeout):
+				t.Errorf("timed out waiting for request handler to return")
+			}
+		})
+	}
+}
+
+func TestInvoker(t *testing.T) {
+	builder := func(handler http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			startHandler := make(chan struct{})
+			invoker := NewInvoker()
+			// split the hanlder by kicking off a new goroutine
+			go invoker.InvokeWithPanicProtection(func() {
+				// do something
+				time.Sleep(time.Millisecond)
+
+				// resume the original handler
+				close(startHandler)
+				panic("the worker goroutine panics")
+			})
+
+			select {
+			case <-startHandler:
+				invoker.WrapPanic(func() {
+					// WrapPanic will wrap it if the handler panics
+					handler.ServeHTTP(w, req)
+				})
+			case err := <-invoker.Done():
+				if err != nil {
+					// the handler  panics
+					panic(err)
+				}
+			}
+		})
+	}
+
+	handler := builder(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		panic("the request handler goroutine panics")
+	}))
+	server := httptest.NewUnstartedServer(handler)
+	defer server.Close()
+	server.StartTLS()
+
+	client := server.Client()
+	client.Timeout = wait.ForeverTestTimeout
+	if _, err := client.Get(server.URL); !errors.Is(err, io.EOF) {
+		t.Errorf("expected error: %v, but got: %v", io.EOF, err)
+	}
+}
+
+func verifyWrappedPanic(t *testing.T, wrapped interface{}, senderReason, receiverReason interface{}) {
+	t.Helper()
+
+	if wrapped == nil {
+		t.Errorf("expected a panic")
+		return
+	}
+	if _, ok := wrapped.(error); !ok {
+		t.Errorf("expected the panic to be wrapped with an error object, but got: %v", wrapped)
+		return
+	}
+	var err *wrappedPanicError
+	if !errors.As(wrapped.(error), &err) {
+		t.Errorf("expected the panic to be wrapped with an error of type: %T, but got: %v", &wrappedPanicError{}, wrapped)
+		return
+	}
+	if want, got := receiverReason, err.own; want != got {
+		t.Errorf("expected panic reason: %v: but got: %v", want, got)
+	}
+
+	if want := fmt.Sprintf("the other goroutine panicked with: %v", senderReason); !strings.Contains(err.Error(), want) {
+		t.Errorf("expected error message to conatin: %q, but got: %v", want, err.Error())
+	}
+	if want := fmt.Sprintf("%v", senderReason); !strings.Contains(err.Error(), want) {
+		t.Errorf("expected error message to conatin: %q, but got: %v", want, err.Error())
+	}
+
+	verifyRecoveredPanicError(t, err.other, senderReason)
+}
+
+func verifyRecoveredPanicError(t *testing.T, converted interface{}, senderReason interface{}) {
+	t.Helper()
+
+	if converted == nil {
+		t.Errorf("expected a panic from the sender")
+		return
+	}
+
+	switch {
+	// nolint:errorlint // this is a controlled test, so assert with exact
+	// match and we don't expect http.ErrAbortHandler to be wrapped
+	case senderReason == http.ErrAbortHandler:
+		if want, got := http.ErrAbortHandler, senderReason; want != got {
+			t.Errorf("expected panic reason: %v, but got: %v", want, got)
+		}
+	default:
+		if _, ok := converted.(error); !ok {
+			t.Errorf("expected the panic from the sender to be an error object, but got: %v", converted)
+			return
+		}
+
+		var err *recoveredPanicError
+		if !errors.As(converted.(error), &err) {
+			t.Errorf("expected the panic from the sender to be of type: %T, but got: %v", &recoveredPanicError{}, converted)
+			return
+		}
+
+		// nolint:errorlint // this is a controlled test, assert with exact match
+		if want, got := senderReason, err.reason; want != got {
+			t.Errorf("expected panic reason: %v, but got: %v", want, got)
+		}
+
+		switch {
+		// nolint:errorlint // this is a controlled test, so assert with exact
+		// match and we don't expect http.ErrAbortHandler to be wrapped
+		case err.reason != http.ErrAbortHandler:
+			if len(err.stackTrace) == 0 {
+				t.Errorf("expected stack trace from the sender to be captured")
+			}
+
+		// nolint:errorlint // this is a controlled test, so assert with exact
+		// match and we don't expect http.ErrAbortHandler to be wrapped
+		case err.reason == http.ErrAbortHandler:
+			if len(err.stackTrace) > 0 {
+				t.Errorf("did not expect stack trace from the sender to be captured, but got: %s", string(err.stackTrace))
+			}
+		}
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

There are a few code sites where the request handler goroutine (the one spawned by net/http) spawns a child goroutine to get some work done. If the child goroutine panics and we don't handle it then the apiserer will crash. We need to handle the panic, and propagate the panic value/stack trace in a more structured, and reusable way.

This PR introduces a package that provides handling and propagation of panic, it offers:
- panic protection: so a panic from the child goroutine does not cause the apiserver to crash
- propagation: it formats the panic value and stack trace into an error object so it can be propagated to the parent goroutine via a channel
- both goroutines panic: although it may be rare, I believe we should handle it for completeness. the package will wrap the panics from both the goroutines into an error object and propagate it so it can be handled appropriately, the log will show both panics in one place in the log

This package has its own tests, so we can verify the expected behavior, this package can be moved to a separate PR if you want

This PR uses the package to manage the watch init goroutine. 


#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
