### PR TITLE
feat: implement Pod smaller update events

### DIFF
--- a/pkg/scheduler/framework/events_test.go
+++ b/pkg/scheduler/framework/events_test.go
@@ -370,6 +370,24 @@ func Test_podSchedulingPropertiesChange(t *testing.T) {
 			oldPod: st.MakePod().Annotation("foo", "bar2").Obj(),
 			want:   []ClusterEvent{assignedPodOtherUpdate},
 		},
+		{
+			name:   "scheduling gate is eliminated",
+			newPod: st.MakePod().SchedulingGates([]string{}).Obj(),
+			oldPod: st.MakePod().SchedulingGates([]string{"foo"}).Obj(),
+			want:   []ClusterEvent{PodSchedulingGateEliminatedChange},
+		},
+		{
+			name:   "scheduling gate is removed, but not completely eliminated",
+			newPod: st.MakePod().SchedulingGates([]string{"foo"}).Obj(),
+			oldPod: st.MakePod().SchedulingGates([]string{"foo", "bar"}).Obj(),
+			want:   []ClusterEvent{assignedPodOtherUpdate},
+		},
+		{
+			name:   "pod's tolerations are updated",
+			newPod: st.MakePod().Toleration("key").Toleration("key2").Obj(),
+			oldPod: st.MakePod().Toleration("key").Obj(),
+			want:   []ClusterEvent{PodTolerationChange},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/scheduler/framework/plugins/schedulinggates/scheduling_gates.go
+++ b/pkg/scheduler/framework/plugins/schedulinggates/scheduling_gates.go
@@ -68,7 +68,7 @@ func (pl *SchedulingGates) EventsToRegister(_ context.Context) ([]framework.Clus
 	// https://github.com/kubernetes/kubernetes/pull/122234
 	return []framework.ClusterEventWithHint{
 		// Pods can be more schedulable once it's gates are removed
-		{Event: framework.ClusterEvent{Resource: framework.Pod, ActionType: framework.Update}, QueueingHintFn: pl.isSchedulableAfterPodChange},
+		{Event: framework.ClusterEvent{Resource: framework.Pod, ActionType: framework.UpdatePodSchedulingGatesEliminated}, QueueingHintFn: pl.isSchedulableAfterUpdatePodSchedulingGatesEliminated},
 	}, nil
 }
 
@@ -79,7 +79,7 @@ func New(_ context.Context, _ runtime.Object, _ framework.Handle, fts feature.Fe
 	}, nil
 }
 
-func (pl *SchedulingGates) isSchedulableAfterPodChange(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (framework.QueueingHint, error) {
+func (pl *SchedulingGates) isSchedulableAfterUpdatePodSchedulingGatesEliminated(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (framework.QueueingHint, error) {
 	_, modifiedPod, err := util.As[*v1.Pod](oldObj, newObj)
 	if err != nil {
 		return framework.Queue, err
@@ -90,8 +90,5 @@ func (pl *SchedulingGates) isSchedulableAfterPodChange(logger klog.Logger, pod *
 		return framework.QueueSkip, nil
 	}
 
-	if len(modifiedPod.Spec.SchedulingGates) == 0 {
-		return framework.Queue, nil
-	}
-	return framework.QueueSkip, nil
+	return framework.Queue, nil
 }

--- a/pkg/scheduler/framework/plugins/schedulinggates/scheduling_gates_test.go
+++ b/pkg/scheduler/framework/plugins/schedulinggates/scheduling_gates_test.go
@@ -88,13 +88,7 @@ func Test_isSchedulableAfterPodChange(t *testing.T) {
 			newObj:       st.MakePod().Name("p1").SchedulingGates([]string{"foo"}).UID("uid1").Obj(),
 			expectedHint: framework.QueueSkip,
 		},
-		"skip-queue-on-gates-not-empty": {
-			pod:          st.MakePod().Name("p").SchedulingGates([]string{"foo", "bar"}).Obj(),
-			oldObj:       st.MakePod().Name("p").SchedulingGates([]string{"foo", "bar"}).Obj(),
-			newObj:       st.MakePod().Name("p").SchedulingGates([]string{"foo"}).Obj(),
-			expectedHint: framework.QueueSkip,
-		},
-		"queue-on-gates-become-empty": {
+		"queue-on-the-unsched-pod-updated": {
 			pod:          st.MakePod().Name("p").SchedulingGates([]string{"foo"}).Obj(),
 			oldObj:       st.MakePod().Name("p").SchedulingGates([]string{"foo"}).Obj(),
 			newObj:       st.MakePod().Name("p").SchedulingGates([]string{}).Obj(),
@@ -109,7 +103,7 @@ func Test_isSchedulableAfterPodChange(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Creating plugin: %v", err)
 			}
-			actualHint, err := p.(*SchedulingGates).isSchedulableAfterPodChange(logger, tc.pod, tc.oldObj, tc.newObj)
+			actualHint, err := p.(*SchedulingGates).isSchedulableAfterUpdatePodSchedulingGatesEliminated(logger, tc.pod, tc.oldObj, tc.newObj)
 			if tc.expectedErr {
 				require.Error(t, err)
 				return

--- a/pkg/scheduler/framework/plugins/tainttoleration/taint_toleration_test.go
+++ b/pkg/scheduler/framework/plugins/tainttoleration/taint_toleration_test.go
@@ -421,7 +421,7 @@ func TestIsSchedulableAfterNodeChange(t *testing.T) {
 	}
 }
 
-func Test_isSchedulableAfterPodChange(t *testing.T) {
+func Test_isSchedulableAfterPodTolerationChange(t *testing.T) {
 	testcases := map[string]struct {
 		pod            *v1.Pod
 		oldObj, newObj interface{}
@@ -472,27 +472,6 @@ func Test_isSchedulableAfterPodChange(t *testing.T) {
 			expectedHint: framework.QueueSkip,
 			expectedErr:  false,
 		},
-		"skip-updates-not-toleration": {
-			pod: &v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "pod-1",
-					Namespace: "ns-1",
-				}},
-			oldObj: &v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "pod-1",
-					Namespace: "ns-1",
-				}},
-			newObj: &v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "pod-1",
-					Namespace: "ns-1",
-					Labels:    map[string]string{"foo": "bar"},
-				},
-			},
-			expectedHint: framework.QueueSkip,
-			expectedErr:  false,
-		},
 		"queue-on-toleration-added": {
 			pod: &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
@@ -530,7 +509,7 @@ func Test_isSchedulableAfterPodChange(t *testing.T) {
 			if err != nil {
 				t.Fatalf("creating plugin: %v", err)
 			}
-			actualHint, err := p.(*TaintToleration).isSchedulableAfterPodChange(logger, tc.pod, tc.oldObj, tc.newObj)
+			actualHint, err := p.(*TaintToleration).isSchedulableAfterPodTolerationChange(logger, tc.pod, tc.oldObj, tc.newObj)
 			if tc.expectedErr {
 				if err == nil {
 					t.Errorf("unexpected success")

--- a/pkg/scheduler/framework/types.go
+++ b/pkg/scheduler/framework/types.go
@@ -68,6 +68,10 @@ const (
 	UpdatePodLabel
 	// UpdatePodScaleDown is an update for pod's scale down (i.e., any resource request is reduced).
 	UpdatePodScaleDown
+	// UpdatePodTolerations is an update for pod's tolerations.
+	UpdatePodTolerations
+	// UpdatePodSchedulingGatesEliminated is an update for pod's scheduling gates, which eliminates all scheduling gates in the Pod.
+	UpdatePodSchedulingGatesEliminated
 
 	// updatePodOther is a update for pod's other fields.
 	// It's used only for the internal event handling, and thus unexported.
@@ -76,7 +80,7 @@ const (
 	All ActionType = 1<<iota - 1
 
 	// Use the general Update type if you don't either know or care the specific sub-Update type to use.
-	Update = UpdateNodeAllocatable | UpdateNodeLabel | UpdateNodeTaint | UpdateNodeCondition | UpdateNodeAnnotation | UpdatePodLabel | UpdatePodScaleDown | updatePodOther
+	Update = UpdateNodeAllocatable | UpdateNodeLabel | UpdateNodeTaint | UpdateNodeCondition | UpdateNodeAnnotation | UpdatePodLabel | UpdatePodScaleDown | UpdatePodTolerations | UpdatePodSchedulingGatesEliminated | updatePodOther
 )
 
 // GVK is short for group/version/kind, which can uniquely represent a particular API resource.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

implement new Pod smaller update events; `UpdatePodSchedulingGatesEliminated` and `UpdatePodTolerations`.
It's a continuous work from https://github.com/kubernetes/kubernetes/pull/122628, I intentionally didn't support those update events in #122628:
> EDIT(2024/Jun/28): Actually even after this PR there are some remaining Pod/Update events, which are added in https://github.com/kubernetes/kubernetes/pull/122234. I'll deal with them as a follow up so that I don't make this PR even bigger from where has been reviewed so far.

and the motivation are:
- We can reduce the number of events subscribed by the scheduler, thus reducing the amount of memory consumed for in-flight events.
- We can clarify Pod update events before events go to the queue, instead of QHints. It should reduce the latency of QHints execution.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of https://github.com/kubernetes/kubernetes/issues/120622

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Implement new cluster events UpdatePodSchedulingGatesEliminated and UpdatePodTolerations for scheduler plugins.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
