### PR TITLE
fix evented pleg global pod cache update issue

### DIFF
--- a/pkg/kubelet/pleg/evented.go
+++ b/pkg/kubelet/pleg/evented.go
@@ -35,7 +35,7 @@ import (
 // The frequency with which global timestamp of the cache is to
 // is to be updated periodically. If pod workers get stuck at cache.GetNewerThan
 // call, after this period it will be unblocked.
-const globalCacheUpdatePeriod = 5 * time.Second
+const globalCacheUpdatePeriod = 60 * time.Second
 
 var (
 	eventedPLEGUsage   = false
@@ -144,10 +144,10 @@ func (e *EventedPLEG) Stop() {
 // In case the Evented PLEG experiences undetectable issues in the underlying
 // GRPC connection there is a remote chance the pod might get stuck in a
 // given state while it has progressed in its life cycle. This function will be
-// called periodically to update the global timestamp of the cache so that those
-// pods stuck at GetNewerThan in pod workers will get unstuck.
+// called periodically to update the global timestamp of the cache by Generic PLEG
+// Relist so that those pods stuck at GetNewerThan in pod workers will get unstuck.
 func (e *EventedPLEG) updateGlobalCache() {
-	e.cache.UpdateTime(time.Now())
+	e.Relist()
 }
 
 // Update the relisting period and threshold


### PR DESCRIPTION
This PR is also a try to fix #123087 
The latest CI reproduce is in #127063, and the failed test is [pull-kubernetes-e2e-kind-alpha-features](https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/127063/pull-kubernetes-e2e-kind-alpha-features/1830544265197916160)

The failed pod(with dup container) is [etcd-kind-control-plane](https://gcsweb.k8s.io/gcs/kubernetes-jenkins/pr-logs/pull/127063/pull-kubernetes-e2e-kind-alpha-features/1830544265197916160/artifacts/kind-control-plane/pods/kube-system_etcd-kind-control-plane_8576f269a22e23776703c0b546bd96cd/etcd/) where the second container start failed with error `"discovery failed","error":"listen tcp 172.18.0.2:2380: bind: address already in use"`

I checked the [kubelet.log](https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/127063/pull-kubernetes-e2e-kind-alpha-features/1830544265197916160/artifacts/kind-control-plane/kubelet.log) for the pod etcd-kind-control-plane, and I found the second [SyncPod](https://github.com/kubernetes/kubernetes/blob/bce499c13661a9b6c376caa53655a132d903d79b/pkg/kubelet/kubelet.go#L1750) function is called before the pod app container `Started` event arrived in EventedPLEG which makes the second [SyncPod](https://github.com/kubernetes/kubernetes/blob/bce499c13661a9b6c376caa53655a132d903d79b/pkg/kubelet/kubelet.go#L1750) work only got the `Created`  state for the pod app container, then the dup container was created.

```
Sep 02 10:03:25 kind-control-plane kubelet[256]: I0902 10:03:25.131007     256 kubelet.go:1758] "SyncPod enter" pod="kube-system/etcd-kind-control-plane" podUID="8576f269a22e23776703c0b546bd96cd"

Sep 02 10:03:25 kind-control-plane kubelet[256]: I0902 10:03:25.132798     256 evented.go:295] "Received Container Started Event" event="&ContainerEventResponse{ContainerId:9c970048c3076261a8641ecc39b7bcea0b902fdf3be732c30dcda56671257661,ContainerEventType:CONTAINER_STARTED_EVENT,CreatedAt:1725271405127989525,PodSandboxStatus:&PodSandboxStatus{Id:86cd2a05f3aa427058a85365f466a8520e9c160bb6a8ab83d5f93e8b02f88de1,Metadata:&PodSandboxMetadata{Name:etcd-kind-control-plane,Uid:8576f269a22e23776703c0b546bd96cd,Namespace:kube-system,Attempt:0,},State:SANDBOX_READY,CreatedAt:1725271402556627049,Network:&PodSandboxNetworkStatus{Ip:,AdditionalIps:[]*PodIP{},},Linux:&LinuxPodSandboxStatus{Namespaces:&Namespace{Options:&NamespaceOption{Network:NODE,Pid:CONTAINER,Ipc:POD,TargetId:,UsernsOptions:&UserNamespace{Mode:NODE,Uids:[]*IDMapping{},Gids:[]*IDMapping{},},},},},Labels:map[string]string{component: etcd,io.kubernetes.pod.name: etcd-kind-control-plane,io.kubernetes.pod.namespace: kube-system,io.kubernetes.pod.uid: 8576f269a22e23776703c0b546bd96cd,tier: control-plane,},Annotations:map[string]string{kubeadm.kubernetes.io/etcd.advertise-client-urls: https://172.18.0.2:2379,kubernetes.io/config.hash: 8576f269a22e23776703c0b546bd96cd,kubernetes.io/config.seen: 2024-09-02T10:03:22.097057905Z,kubernetes.io/config.source: file,},RuntimeHandler:,},ContainersStatuses:[]*ContainerStatus{&ContainerStatus{Id:9c970048c3076261a8641ecc39b7bcea0b902fdf3be732c30dcda56671257661,Metadata:&ContainerMetadata{Name:etcd,Attempt:0,},State:CONTAINER_RUNNING,CreatedAt:1725271404930307430,StartedAt:1725271405125058026,FinishedAt:0,ExitCode:0,Image:&ImageSpec{Image:registry.k8s.io/etcd:3.5.15-0,Annotations:map[string]string{},UserSpecifiedImage:,RuntimeHandler:,},ImageRef:sha256:2e96e5913fc06e3d26915af3d0f2ca5048cc4b6327e661e80da792cbf8d8d9d4,Reason:,Message:,Labels:map[string]string{io.kubernetes.container.name: etcd,io.kubernetes.pod.name: etcd-kind-control-plane,io.kubernetes.pod.namespace: kube-system,io.kubernetes.pod.uid: 8576f269a22e23776703c0b546bd96cd,},Annotations:map[string]string{io.kubernetes.container.hash: cdf7d3fa,io.kubernetes.container.restartCount: 0,io.kubernetes.container.terminationMessagePath: /dev/termination-log,io.kubernetes.container.terminationMessagePolicy: File,io.kubernetes.pod.terminationGracePeriod: 30,},Mounts:[]*Mount{&Mount{ContainerPath:/var/lib/etcd,HostPath:/var/lib/etcd,Readonly:false,SelinuxRelabel:false,Propagation:PROPAGATION_PRIVATE,UidMappings:[]*IDMapping{},GidMappings:[]*IDMapping{},RecursiveReadOnly:false,Image:nil,},&Mount{ContainerPath:/etc/kubernetes/pki/etcd,HostPath:/etc/kubernetes/pki/etcd,Readonly:false,SelinuxRelabel:false,Propagation:PROPAGATION_PRIVATE,UidMappings:[]*IDMapping{},GidMappings:[]*IDMapping{},RecursiveReadOnly:false,Image:nil,},&Mount{ContainerPath:/etc/hosts,HostPath:/var/lib/kubelet/pods/8576f269a22e23776703c0b546bd96cd/etc-hosts,Readonly:false,SelinuxRelabel:false,Propagation:PROPAGATION_PRIVATE,UidMappings:[]*IDMapping{},GidMappings:[]*IDMapping{},RecursiveReadOnly:false,Image:nil,},&Mount{ContainerPath:/dev/termination-log,HostPath:/var/lib/kubelet/pods/8576f269a22e23776703c0b546bd96cd/containers/etcd/93996d20,Readonly:false,SelinuxRelabel:false,Propagation:PROPAGATION_PRIVATE,UidMappings:[]*IDMapping{},GidMappings:[]*IDMapping{},RecursiveReadOnly:false,Image:nil,},},LogPath:/var/log/pods/kube-system_etcd-kind-control-plane_8576f269a22e23776703c0b546bd96cd/etcd/0.log,Resources:&ContainerResources{Linux:&LinuxContainerResources{CpuPeriod:100000,CpuQuota:0,CpuShares:102,MemoryLimitInBytes:0,OomScoreAdj:-997,CpusetCpus:,CpusetMems:,HugepageLimits:[]*HugepageLimit{},Unified:map[string]string{},MemorySwapLimitInBytes:0,},Windows:nil,},ImageId:,User:nil,},},}"
```
In normally, the `Started` event timeline is always ahead of the the second [SyncPod](https://github.com/kubernetes/kubernetes/blob/bce499c13661a9b6c376caa53655a132d903d79b/pkg/kubelet/kubelet.go#L1750) function call , so the podWorkerLoop function will be blocked in [GetNewerThan](https://github.com/kubernetes/kubernetes/blob/fe25e97403e2244cb74120cf01d28d4067c78c60/pkg/kubelet/pod_workers.go#L1256) until the pod cache was updated.

I continue checked the [getIfNewerThan](https://github.com/kubernetes/kubernetes/blob/fe25e97403e2244cb74120cf01d28d4067c78c60/pkg/kubelet/container/cache.go#L166) function, and found may be the `globalTimestampIsNewer` caused the 'unblock' in  [GetNewerThan](https://github.com/kubernetes/kubernetes/blob/fe25e97403e2244cb74120cf01d28d4067c78c60/pkg/kubelet/pod_workers.go#L1256). For EventedPLEG, the `globalTimestampIsNewer` is updated in [updateGlobalCache](https://github.com/kubernetes/kubernetes/blob/fe25e97403e2244cb74120cf01d28d4067c78c60/pkg/kubelet/pleg/evented.go#L149), actually it did nothing and just update the global cahce timeline every 5 seconds. This is not right and would break the dependency for timeline in [podWorkerLoop](https://github.com/kubernetes/kubernetes/blob/fe25e97403e2244cb74120cf01d28d4067c78c60/pkg/kubelet/pod_workers.go#L1214)

This PR add `GenericPLEG Relist` call every 60 seconds in EvnetedPLEG to update the gloabl pod cache, maybe the `60 seconds` is too long for the pod reconcile performence.

Anyway, let's first confirm the root cause for #123087 