### PR TITLE
Make apiserver watchCache sliding window event to be Cachingobject

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
@@ -1137,9 +1137,11 @@ func (c *Cacher) dispatchEvent(event *watchCacheEvent) {
 		// it unconditionally to ensure safety and reduce deep-copying.
 		//
 		// Make a shallow copy to allow overwriting Object and PrevObject.
-		wcEvent := *event
-		setCachingObjects(&wcEvent, c.versioner)
-		event = &wcEvent
+		if _, ok := event.Object.(*cachingObject); !ok {
+			wcEvent := *event
+			setCachingObjects(&wcEvent, c.versioner)
+			event = &wcEvent
+		}
 
 		c.blockedWatchers = c.blockedWatchers[:0]
 		for _, watcher := range c.watchersBuffer {

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache.go
@@ -279,6 +279,12 @@ func (w *watchCache) processEvent(event watch.Event, resourceVersion uint64, upd
 		wcEvent.PrevObjFields = previousElem.Fields
 	}
 
+	if wcEvent.Type != watch.Bookmark {
+		internalEvent := *wcEvent
+		setCachingObjects(&internalEvent, w.versioner)
+		wcEvent = &internalEvent
+	}
+
 	if err := func() error {
 		w.Lock()
 		defer w.Unlock()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature


<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

For cilium scenario, each pod has a CiliumEndpoint/CiliumIdentity, when we update namespace, agent will patch all CiliumEndpoint/CiliumIdentity. Most watchers will be force closed due to unresponsiveness.

Then these agents will create new watchers. For these watchers, it will `processInterval` to send init event,  and deep copy the object to each new watcher, make the cpu load high and oom.

![image](https://github.com/user-attachments/assets/990c7050-27e6-42b8-8885-4143e718d9ed)

We has removed selfLink, so I think we can make events to  cachingobject  in sliding window. It may take some memory consumption. The sliding window has `defaultUpperBoundCapacity` 100 * 1024, I think it is accepted. 


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
make apiserver watchCache sliding window event to be Cachingobject
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
